### PR TITLE
perf(zero-cache): release fanout flow control precisely

### DIFF
--- a/packages/zero-cache/src/config/zero-config.test.ts
+++ b/packages/zero-cache/src/config/zero-config.test.ts
@@ -406,11 +406,11 @@ test('zero-cache --help', () => {
                                                                         rather, it protects the system when the upstream throughput exceeds the downstream                                         
                                                                         throughput.                                                                                                                
                                                                                                                                                                                                    
-     --change-streamer-flow-control-consensus-padding-seconds number    default: 1                                                                                                                 
+     --change-streamer-flow-control-consensus-padding-seconds number    default: 0.1                                                                                                               
        ZERO_CHANGE_STREAMER_FLOW_CONTROL_CONSENSUS_PADDING_SECONDS env                                                                                                                             
-                                                                        During periodic flow control checks (every 64kb), the amount of time to wait after the                                     
-                                                                        majority of subscribers have acked, after which replication will continue even if                                          
-                                                                        some subscribers have yet to ack. (Note that this is not a timeout for the entire send,                                    
+                                                                        During flow control flushes, the amount of time to wait after the majority of                                              
+                                                                        subscribers have acked, after which replication will continue even if some subscribers                                     
+                                                                        have yet to ack. (Note that this is not a timeout for the entire send,                                                     
                                                                         but a timeout that starts after the majority of receivers have acked.)                                                     
                                                                                                                                                                                                    
                                                                         This allows a bounded amount of time for backlogged subscribers to catch up on each flush                                  

--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -651,11 +651,11 @@ export const zeroOptions = {
     },
 
     flowControlConsensusPaddingSeconds: {
-      type: v.number().default(1),
+      type: v.number().default(0.1),
       desc: [
-        `During periodic flow control checks (every 64kb), the amount of time to wait after the`,
-        `majority of subscribers have acked, after which replication will continue even if`,
-        `some subscribers have yet to ack. (Note that this is not a timeout for the {italic entire} send,`,
+        `During flow control flushes, the amount of time to wait after the majority of`,
+        `subscribers have acked, after which replication will continue even if some subscribers`,
+        `have yet to ack. (Note that this is not a timeout for the {italic entire} send,`,
         `but a timeout that starts {italic after} the majority of receivers have acked.)`,
         ``,
         `This allows a bounded amount of time for backlogged subscribers to catch up on each flush`,

--- a/packages/zero-cache/src/services/change-streamer/broadcast.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/broadcast.test.ts
@@ -1,9 +1,11 @@
-import {describe, expect, test} from 'vitest';
+import {afterEach, describe, expect, test, vi} from 'vitest';
 import {BigIntJSON} from '../../../../shared/src/bigint-json.ts';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
 import {sleep} from '../../../../shared/src/sleep.ts';
+import type {Subscription} from '../../types/subscription.ts';
 import {ReplicationMessages} from '../replicator/test-utils.ts';
 import {Broadcast} from './broadcast.ts';
+import type {Subscriber} from './subscriber.ts';
 import {createSubscriber} from './test-utils.ts';
 
 const json = BigIntJSON.stringify;
@@ -11,6 +13,58 @@ const json = BigIntJSON.stringify;
 describe('change-streamer/broadcast', () => {
   const messages = new ReplicationMessages({issues: 'id'});
   const lc = createSilentLogContext();
+  const change: [string, 'begin', string] = [
+    '11',
+    'begin',
+    json(['begin', messages.begin(), {commitWatermark: '13'}]),
+  ];
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  async function consumeOne(downstream: Subscription<string>) {
+    const pipeline = downstream.pipeline;
+    if (pipeline === undefined) {
+      throw new Error('Expected pipelined subscription');
+    }
+    const next = await pipeline[Symbol.asyncIterator]().next();
+    if (next.done) {
+      throw new Error('Expected subscription message');
+    }
+    next.value.consumed();
+  }
+
+  async function flushCompletions() {
+    await Promise.resolve();
+    await Promise.resolve();
+  }
+
+  async function makeSubscribers(count: number) {
+    const subscribers: Subscriber[] = [];
+    const downstreams: Subscription<string>[] = [];
+    for (let i = 0; i < count; i++) {
+      const [subscriber, , downstream] = createSubscriber('00', true);
+      subscribers.push(subscriber);
+      downstreams.push(downstream);
+    }
+    await Promise.all(downstreams.map(consumeOne));
+    await flushCompletions();
+    return {subscribers, downstreams};
+  }
+
+  async function consumeChange(downstream: Subscription<string>) {
+    await consumeOne(downstream);
+    await flushCompletions();
+  }
+
+  async function closeAll(subscribers: readonly Subscriber[]) {
+    for (const sub of subscribers) {
+      sub.close();
+    }
+    await flushCompletions();
+  }
 
   test('without tracking', () => {
     const [sub1, stream1] = createSubscriber('00', true);
@@ -74,6 +128,102 @@ describe('change-streamer/broadcast', () => {
         ['begin', {tag: 'begin'}, {commitWatermark: '13'}],
       ]);
     }
+  });
+
+  test('flow control releases after majority plus padding', async () => {
+    vi.useFakeTimers();
+    const {subscribers, downstreams} = await makeSubscribers(4);
+    const broadcast = new Broadcast(subscribers, change, {
+      lc,
+      flowControlConsensusPaddingMs: 50,
+    });
+
+    await consumeChange(downstreams[0]);
+    await consumeChange(downstreams[1]);
+    await vi.advanceTimersByTimeAsync(100);
+    expect(broadcast.isDone).toBe(false);
+
+    await consumeChange(downstreams[2]);
+    await vi.advanceTimersByTimeAsync(49);
+    expect(broadcast.isDone).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await broadcast.done;
+    expect(broadcast.isDone).toBe(true);
+
+    await closeAll(subscribers);
+  });
+
+  test('flow control timer resets after post-majority progress', async () => {
+    vi.useFakeTimers();
+    const {subscribers, downstreams} = await makeSubscribers(5);
+    const broadcast = new Broadcast(subscribers, change, {
+      lc,
+      flowControlConsensusPaddingMs: 50,
+    });
+
+    await consumeChange(downstreams[0]);
+    await consumeChange(downstreams[1]);
+    await consumeChange(downstreams[2]);
+    await vi.advanceTimersByTimeAsync(30);
+    await consumeChange(downstreams[3]);
+
+    await vi.advanceTimersByTimeAsync(49);
+    expect(broadcast.isDone).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await broadcast.done;
+    expect(broadcast.isDone).toBe(true);
+
+    await closeAll(subscribers);
+  });
+
+  test('flow control timer is cleared when all subscribers complete', async () => {
+    vi.useFakeTimers();
+    const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout');
+    const {subscribers, downstreams} = await makeSubscribers(4);
+    const broadcast = new Broadcast(subscribers, change, {
+      lc,
+      flowControlConsensusPaddingMs: 50,
+    });
+
+    await consumeChange(downstreams[0]);
+    await consumeChange(downstreams[1]);
+    await consumeChange(downstreams[2]);
+    expect(broadcast.isDone).toBe(false);
+
+    await consumeChange(downstreams[3]);
+    await broadcast.done;
+    expect(broadcast.isDone).toBe(true);
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(50);
+    expect(broadcast.isDone).toBe(true);
+    await closeAll(subscribers);
+  });
+
+  test('negative flow control padding disables early release', async () => {
+    vi.useFakeTimers();
+    const {subscribers, downstreams} = await makeSubscribers(4);
+    const broadcast = new Broadcast(subscribers, change, {
+      lc,
+      flowControlConsensusPaddingMs: -1,
+    });
+
+    await consumeChange(downstreams[0]);
+    await consumeChange(downstreams[1]);
+    await consumeChange(downstreams[2]);
+    expect(broadcast.checkProgress(lc, -1, performance.now() + 1000)).toBe(
+      false,
+    );
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(broadcast.isDone).toBe(false);
+
+    await consumeChange(downstreams[3]);
+    await broadcast.done;
+    expect(broadcast.isDone).toBe(true);
+
+    await closeAll(subscribers);
   });
 
   test('checkProgress', async () => {

--- a/packages/zero-cache/src/services/change-streamer/broadcast.ts
+++ b/packages/zero-cache/src/services/change-streamer/broadcast.ts
@@ -10,9 +10,9 @@ import type {Subscriber} from './subscriber.ts';
  * Creating a `Broadcast` automatically initiates the send.
  *
  * By default, {@link Broadcast.done} resolves when all subscribers
- * have acked the change. However, {@link Broadcast.checkProgress()}
- * can be called to resolve the broadcast earlier based on the flow
- * control policy.
+ * have acked the change. When flow control options are supplied,
+ * {@link Broadcast.done} resolves after majority consensus plus the
+ * configured padding.
  */
 export class Broadcast {
   /**
@@ -31,7 +31,9 @@ export class Broadcast {
   readonly #pending: Set<Subscriber>;
   readonly #completed: Completed[];
   readonly #done = resolver();
+  readonly #flowControl: FlowControlOptions | undefined;
   #isDone = false;
+  #flowControlTimer: ReturnType<typeof setTimeout> | undefined;
 
   readonly #watermark: string;
   readonly #majority: number;
@@ -43,9 +45,14 @@ export class Broadcast {
    * Broadcasts the `change` to the `subscribers` and tracks their
    * completion.
    */
-  constructor(subscribers: Iterable<Subscriber>, change: WatermarkedChange) {
+  constructor(
+    subscribers: Iterable<Subscriber>,
+    change: WatermarkedChange,
+    flowControl: FlowControlOptions | undefined = undefined,
+  ) {
     this.#pending = new Set(subscribers);
     this.#completed = [];
+    this.#flowControl = flowControl;
     this.#watermark = change[0];
     this.#majority = Math.floor(this.#pending.size / 2) + 1;
 
@@ -69,12 +76,67 @@ export class Broadcast {
     this.#pending.delete(sub);
     if (this.#pending.size === 0) {
       this.#setDone();
+    } else {
+      this.#resetConsensusTimer();
     }
   }
 
-  #setDone() {
+  #setDone(): boolean {
+    if (this.#isDone) {
+      return false;
+    }
     this.#isDone = true;
+    this.#clearConsensusTimer();
     this.#done.resolve();
+    return true;
+  }
+
+  #resetConsensusTimer() {
+    if (
+      this.#isDone ||
+      this.#flowControl === undefined ||
+      !(this.#flowControl.flowControlConsensusPaddingMs >= 0) ||
+      this.#completed.length < this.#majority
+    ) {
+      return;
+    }
+    this.#clearConsensusTimer();
+    this.#flowControlTimer = setTimeout(
+      this.#releaseAfterConsensusPadding,
+      this.#flowControl.flowControlConsensusPaddingMs,
+    );
+  }
+
+  readonly #releaseAfterConsensusPadding = () => {
+    this.#flowControlTimer = undefined;
+    const flowControl = this.#flowControl;
+    if (
+      this.#isDone ||
+      flowControl === undefined ||
+      this.#pending.size === 0 ||
+      this.#completed.length < this.#majority
+    ) {
+      return;
+    }
+    const now = performance.now();
+    if (
+      now - this.#latestCompleted <
+      flowControl.flowControlConsensusPaddingMs
+    ) {
+      this.#resetConsensusTimer();
+      return;
+    }
+    this.#logWithState(
+      flowControl.lc,
+      `continuing with ${this.#pending.size} subscriber(s) still pending`,
+      now - this.#start,
+    );
+    this.#setDone();
+  };
+
+  #clearConsensusTimer() {
+    clearTimeout(this.#flowControlTimer);
+    this.#flowControlTimer = undefined;
   }
 
   get isDone(): boolean {
@@ -159,8 +221,14 @@ export class Broadcast {
     flowControlConsensusPaddingMs: number,
     now: number,
   ) {
+    if (this.#isDone) {
+      return true;
+    }
     if (this.#pending.size === 0) {
       return true;
+    }
+    if (!(flowControlConsensusPaddingMs >= 0)) {
+      return false;
     }
     const elapsed = now - this.#start;
     if (this.#completed.length < this.#majority) {
@@ -213,4 +281,9 @@ type Completed = {
   changes: number;
   /** The elapsed milliseconds. */
   elapsed: number;
+};
+
+export type FlowControlOptions = {
+  readonly lc: LogContext;
+  readonly flowControlConsensusPaddingMs: number;
 };

--- a/packages/zero-cache/src/services/change-streamer/forwarder.ts
+++ b/packages/zero-cache/src/services/change-streamer/forwarder.ts
@@ -21,7 +21,7 @@ export class Forwarder {
 
   constructor(
     lc: LogContext,
-    opts: ProgressMonitorOptions = {flowControlConsensusPaddingSeconds: 1},
+    opts: ProgressMonitorOptions = {flowControlConsensusPaddingSeconds: 0.1},
   ) {
     this.#lc = lc.withContext('component', 'progress-monitor');
     this.#progressMonitorOptions = opts;
@@ -97,7 +97,16 @@ export class Forwarder {
    * Promise that resolves when replication should continue.
    */
   async forwardWithFlowControl(entry: WatermarkedChange) {
-    const broadcast = new Broadcast(this.#active.values(), entry);
+    const {flowControlConsensusPaddingSeconds} = this.#progressMonitorOptions;
+    const flowControlConsensusPaddingMs =
+      flowControlConsensusPaddingSeconds * 1000;
+    const broadcast = new Broadcast(
+      this.#active.values(),
+      entry,
+      flowControlConsensusPaddingMs >= 0
+        ? {lc: this.#lc, flowControlConsensusPaddingMs}
+        : undefined,
+    );
     this.#updateActiveSubscribers(entry[1]);
 
     // set for progress tracking


### PR DESCRIPTION
## AI-generated draft

This draft PR was prepared by an AI coding agent. It is intentionally still draft, but it is a clean production PR against `main`; benchmark-only stack layers have been removed.

## Why This Is Worth It

Flow control is supposed to keep replication from outrunning downstream subscribers. The current policy is already the right shape: once a majority of subscribers have ACKed a flushed change, wait a little longer for stragglers, then let replication continue.

The bug is timing. The code says "wait for majority plus padding," but the release check is tied to a 1 second progress-monitor tick. That makes a 100 ms padding target mostly theoretical.

For a reviewer, the user-facing version is: a healthy majority can be ready, but replication still waits for the next monitor tick. In a subscribed view, that is the kind of stale window that feels like "I wrote something, why is everyone else still behind?"

```text
Before
------
t=000ms  majority ACKs
t=100ms  desired release point
t=1000ms progress monitor notices and releases

After
-----
t=000ms  majority ACKs
t=100ms  Broadcast timer releases
```

This PR moves the timer to the object that actually observes majority completion: `Broadcast`.

## Clean PR Set

Base for the cleaned branches: `rocicorp/mono@65f1461f761936288a11fde0585d100432ce9aef`.

| PR | Role | Relationship |
|---|---|---|
| [#5959](https://github.com/rocicorp/mono/pull/5959) | Benchmark suite | Related measurement work |
| [#5960](https://github.com/rocicorp/mono/pull/5960) | Production byte-aware poke flushing | Independent |
| [#5963](https://github.com/rocicorp/mono/pull/5963) | Production cumulative ACKs | Independent |
| [#5964](https://github.com/rocicorp/mono/pull/5964) | This PR | Production precise majority-padding fanout release |

## What Changed

- `Broadcast` can receive flow-control options.
- Once a majority completes, `Broadcast` arms a padding timer directly.
- If another subscriber completes after majority, the timer resets so padding is measured from the latest completion, preserving the existing intent.
- If all subscribers complete, `Broadcast` resolves immediately and clears the timer.
- Negative padding still disables early release.
- Default consensus padding changes from `1s` to `0.1s`.

```text
Broadcast state machine
-----------------------
send change
  |
  v
wait for majority
  |
  v
majority complete
  |
  v
start/reset padding timer
  |
  +-- all subscribers done
  |      |
  |      v
  |   resolve Broadcast.done -> replication can continue
  |
  +-- padding expires with minority still pending
         |
         v
      resolve Broadcast.done -> replication can continue
```

## Benchmark Headline

The fanout benchmark was run against this PR's development branch because it exercises the new `Broadcast` timer API introduced here. The production PR keeps that benchmark scaffolding out of the diff so reviewers can focus on runtime behavior.

Command used:

```sh
npm --workspace=zero-cache run perf:fanout
```

The config-only column is the important control. It shows that changing the default from 1s to 100ms is not enough while the release path is still polled at 1s. The mechanism change is load-bearing.

| Scenario | Main / polling 1s monitor, 1s padding | Config-only polling 1s monitor, 100ms padding | This PR / precise 100ms padding | Delta vs main |
|---|---:|---:|---:|---|
| 4 subscribers, 1 slow subscriber | p95 wait 2001.2 ms, 0.7 flushes/s, max lag 4 | p95 wait 1001.2 ms, 1.0 flushes/s, max lag 4 | p95 wait 101.4 ms, 9.8 flushes/s, max lag 4 | p95 -1899.8 ms (-94.9%); flush cadence about 13.1x |
| 8 subscribers, 1 slow subscriber | p95 wait 2001.0 ms, 0.7 flushes/s, max lag 4 | p95 wait 1000.9 ms, 1.0 flushes/s, max lag 4 | p95 wait 101.1 ms, 9.9 flushes/s, max lag 4 | p95 -1899.9 ms (-94.9%); flush cadence about 13.2x |
| 16 subscribers, 1 slow subscriber | p95 wait 1001.6 ms, 1.0 flushes/s, max lag 4 | p95 wait 1000.6 ms, 1.0 flushes/s, max lag 4 | p95 wait 201.4 ms, 7.4 flushes/s, max lag 4 | p95 -800.3 ms (-79.9%); flush cadence about 7.4x |

In this benchmark, `max lag 4` means the slow subscriber remains about four benchmark changes behind. The PR improves majority release timing without increasing that measured lag in these scenarios.

The 16-subscriber row starts from a lower main p95 than the 4- and 8-subscriber rows, so the absolute delta is smaller. The control still tells the same story: config-only 100 ms padding does not buy the intended win until the release mechanism moves out of the 1 second polling cadence.

## Safety Story: Review Contract

- Cannot release before majority. The timer is not armed until `completed.length >= floor(subscriberCount / 2) + 1`.
- Cannot drop slow subscribers. It resolves the flow-control wait; subscribers still exist and continue processing.
- Cannot change the majority rule. The rule remains `floor(subscriberCount / 2) + 1`.
- Cannot cut the padding short after post-majority progress. The timer resets when another subscriber completes.
- Cannot leave stale release callbacks after everyone finishes. The timer is cleared when `Broadcast` resolves.
- Cannot remove the emergency disable path. Negative padding still disables early release.
- Cannot double-release if the progress monitor and direct timer race. Both paths go through the same idempotent `#setDone()` path.

## What Reviewers Should Be Skeptical About

- The default changes from 1s to 100ms, a 10x tightening. The mechanism and default could be split if reviewers want a more conservative rollout.
- Slow minority subscribers can lag more in production because the majority is no longer held hostage to the 1 second polling cadence. The benchmark did not show worse max lag, but production subscriber mix can be different.
- Releasing more often can increase upstream/send pressure in high-fanout rooms.
- Timer lifecycle bugs would be bad here, so the tests focus on arming, resetting, clearing, disabling, and all-subscriber completion.
- The original reason for the 1s default is not proven in this PR. The new 100ms value is configurable, so production signals can push it back without reverting the mechanism.

## Validation

- `npm --workspace=zero-cache run check-types`
- `npm --workspace=zero-cache run lint`
- `npm --workspace=zero-cache run test:no-pg -- broadcast.test.ts zero-config.test.ts`
