### PR TITLE
perf(zero-cache): batch change-log inserts

### DIFF
--- a/packages/zero-cache/bench/storer-changelog.ts
+++ b/packages/zero-cache/bench/storer-changelog.ts
@@ -1,0 +1,179 @@
+/* oxlint-disable no-console */
+import {performance} from 'node:perf_hooks';
+import {PostgreSqlContainer} from '@testcontainers/postgresql';
+import postgres from 'postgres';
+import {createSilentLogContext} from '../../shared/src/logging-test-utils.ts';
+import {
+  ensureReplicationConfig,
+  setupCDCTables,
+} from '../src/services/change-streamer/schema/tables.ts';
+import {postgresTypeConfig, type PostgresDB} from '../src/types/pg.ts';
+import {cdcSchema, type ShardID} from '../src/types/shards.ts';
+
+type Mode = 'single' | 'batched';
+
+type ChangeLogInsert = {
+  watermark: string;
+  precommit: string | null;
+  pos: number;
+  change: string;
+};
+
+type Result = {
+  readonly mode: Mode;
+  readonly elapsedMs: number;
+  readonly changes: number;
+  readonly changesPerSec: number;
+  readonly insertStatements: number;
+  readonly statementReductionPct: number;
+};
+
+type Summary = {
+  readonly name: 'storer-changelog-insert';
+  readonly generatedAt: string;
+  readonly txCount: number;
+  readonly changesPerTx: number;
+  readonly batchSize: number;
+  readonly results: Result[];
+};
+
+const lc = createSilentLogContext();
+const shard: ShardID = {appID: 'bench', shardNum: 0};
+const schema = cdcSchema(shard);
+
+const txCount = envInt('ZERO_STORER_CHANGELOG_TX', 200);
+const changesPerTx = envInt('ZERO_STORER_CHANGELOG_CHANGES_PER_TX', 100);
+const batchSize = envInt('ZERO_STORER_CHANGELOG_BATCH', 100);
+
+const container = await new PostgreSqlContainer(
+  process.env.ZERO_STORER_CHANGELOG_PG_IMAGE ?? 'postgres:17',
+).start();
+
+try {
+  const db = postgres(container.getConnectionUri(), {
+    ...postgresTypeConfig({sendStringAsJson: true}),
+  });
+  try {
+    const single = await runMode(db, 'single');
+    const batched = await runMode(db, 'batched');
+    const summary: Summary = {
+      name: 'storer-changelog-insert',
+      generatedAt: new Date().toISOString(),
+      txCount,
+      changesPerTx,
+      batchSize,
+      results: [single, batched],
+    };
+
+    for (const result of summary.results) {
+      console.log(
+        `${result.mode}: ${formatRate(result.changesPerSec)} changes/s | ` +
+          `${result.elapsedMs.toFixed(1)} ms | ` +
+          `${result.insertStatements} INSERT statements`,
+      );
+    }
+    console.log(JSON.stringify(summary));
+  } finally {
+    await db.end();
+  }
+} finally {
+  await container.stop();
+}
+
+async function runMode(db: PostgresDB, mode: Mode): Promise<Result> {
+  await db`DROP SCHEMA IF EXISTS ${db(schema)} CASCADE`;
+  await db.begin(tx => setupCDCTables(lc, tx, shard));
+  await ensureReplicationConfig(
+    lc,
+    db,
+    {
+      replicaVersion: '00',
+      publications: [],
+      watermark: '00',
+    },
+    shard,
+    true,
+  );
+
+  let insertStatements = 0;
+  const started = performance.now();
+  for (let txNum = 1; txNum <= txCount; txNum++) {
+    const watermark = txNum.toString(36).padStart(12, '0');
+    const rows = makeTransaction(watermark, changesPerTx);
+    await db.begin(async sql => {
+      if (mode === 'single') {
+        for (const row of rows) {
+          insertStatements++;
+          await sql`INSERT INTO ${sql(`${schema}.changeLog`)} ${sql(row)}`;
+        }
+      } else {
+        for (let i = 0; i < rows.length; i += batchSize) {
+          insertStatements++;
+          await sql`INSERT INTO ${sql(`${schema}.changeLog`)} ${sql(
+            rows.slice(i, i + batchSize),
+          )}`;
+        }
+      }
+      await sql`UPDATE ${sql(`${schema}.replicationState`)}
+        SET "lastWatermark" = ${watermark}`;
+    });
+  }
+  const elapsedMs = performance.now() - started;
+  const changes = txCount * (changesPerTx + 2);
+  const singleInsertStatements = changes;
+  return {
+    mode,
+    elapsedMs,
+    changes,
+    changesPerSec: changes / (elapsedMs / 1000),
+    insertStatements,
+    statementReductionPct:
+      ((singleInsertStatements - insertStatements) / singleInsertStatements) *
+      100,
+  };
+}
+
+function makeTransaction(
+  watermark: string,
+  changes: number,
+): ChangeLogInsert[] {
+  const rows: ChangeLogInsert[] = [
+    {
+      watermark,
+      precommit: null,
+      pos: 0,
+      change: JSON.stringify({tag: 'begin'}),
+    },
+  ];
+  for (let i = 0; i < changes; i++) {
+    rows.push({
+      watermark,
+      precommit: null,
+      pos: i + 1,
+      change: JSON.stringify({tag: 'insert', new: {id: `${watermark}-${i}`}}),
+    });
+  }
+  rows.push({
+    watermark,
+    precommit: watermark,
+    pos: changes + 1,
+    change: JSON.stringify({tag: 'commit'}),
+  });
+  return rows;
+}
+
+function envInt(name: string, fallback: number): number {
+  const value = process.env[name];
+  if (value === undefined || value === '') {
+    return fallback;
+  }
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`Invalid integer ${name}=${value}`);
+  }
+  return parsed;
+}
+
+function formatRate(value: number): string {
+  return value.toLocaleString('en-US', {maximumFractionDigits: 1});
+}

--- a/packages/zero-cache/package.json
+++ b/packages/zero-cache/package.json
@@ -24,6 +24,7 @@
     "bench": "vitest run --config vitest.config.bench.ts",
     "bench:bmf": "BENCH_OUTPUT_FORMAT=json npm run bench 2>&1 | npx tsx ../shared/src/tool/mitata-json-to-bmf.ts",
     "bench:bmf:silent": "npm run bench:bmf --silent",
+    "perf:storer-changelog": "tsx ./bench/storer-changelog.ts",
     "local": "tsx tool/local.ts",
     "start": "tsx ./src/server/runner/main.ts",
     "benchdb": "tsx ./bench/bench.ts",

--- a/packages/zero-cache/src/services/change-streamer/storer.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.pg.test.ts
@@ -129,6 +129,32 @@ describe('change-streamer/storer', () => {
       ).toEqual([{ownerAddress: 'change-streamer:12345'}]);
     });
 
+    test('stores large transactions in batched changeLog inserts without reordering', async () => {
+      storer.store('08', ['begin', messages.begin(), {commitWatermark: '08'}]);
+      for (let i = 0; i < 250; i++) {
+        storer.store('08', [
+          'data',
+          messages.insert('issues', {id: `batched-${i}`}),
+        ]);
+      }
+      storer.store('08', ['commit', messages.commit(), {watermark: '08'}]);
+
+      await storer.allProcessed();
+      await expectConsumed('08');
+
+      const rows = await db<{pos: bigint; tag: string}[]>`
+        SELECT pos, change->>'tag' as tag
+          FROM "xero_5/cdc"."changeLog"
+          WHERE watermark = '08'
+          ORDER BY pos`;
+      expect(rows).toHaveLength(252);
+      expect(rows.at(0)).toEqual({pos: 0n, tag: 'begin'});
+      expect(rows.at(-1)).toEqual({pos: 251n, tag: 'commit'});
+      expect(rows.map(row => Number(row.pos))).toEqual(
+        Array.from({length: 252}, (_, i) => i),
+      );
+    });
+
     test('purge', async () => {
       expect(await storer.purgeRecordsBefore('02')).toBe(2);
       expect(

--- a/packages/zero-cache/src/services/change-streamer/storer.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.ts
@@ -67,6 +67,7 @@ type PendingTransaction = {
   pool: TransactionPool;
   preCommitWatermark: string;
   pos: number;
+  pendingChangeLogEntries: ChangeLogInsert[];
   startingReplicationState: Promise<ReplicationOwner>;
   ack: boolean;
 };
@@ -75,7 +76,15 @@ type ReplicationOwner = {
   owner: string | null;
 };
 
+type ChangeLogInsert = {
+  watermark: string;
+  precommit: string | null;
+  pos: number;
+  change: string;
+};
+
 const backfillRequestsSchema = v.array(backfillRequestSchema);
+const CHANGE_LOG_INSERT_BATCH_SIZE = 100;
 
 export type TuningOptions = {
   backPressureLimitHeapProportion: number;
@@ -464,6 +473,7 @@ export class Storer implements Service {
             ),
             preCommitWatermark: watermark,
             pos: 0,
+            pendingChangeLogEntries: [],
             startingReplicationState: promise,
             ack: !change.skipAck,
           };
@@ -483,7 +493,7 @@ export class Storer implements Service {
           tx.pos++;
         }
 
-        const entry = {
+        const entry: ChangeLogInsert = {
           watermark: tag === 'commit' ? watermark : tx.preCommitWatermark,
           precommit: tag === 'commit' ? tx.preCommitWatermark : null,
           pos: tx.pos,
@@ -492,12 +502,22 @@ export class Storer implements Service {
           change: extractChangeSubstring(json, tag),
         };
 
-        const processed = tx.pool.process(sql => [
-          sql`INSERT INTO ${this.#cdc('changeLog')} ${sql(entry)}`,
-          ...(change !== null && isSchemaChange(change)
-            ? this.#trackBackfillMetadata(sql, change)
-            : []),
-        ]);
+        let processed = promiseVoid;
+        if (change !== null && isSchemaChange(change)) {
+          await this.#flushChangeLogEntries(tx);
+          processed = tx.pool.process(sql => [
+            sql`INSERT INTO ${this.#cdc('changeLog')} ${sql(entry)}`,
+            ...this.#trackBackfillMetadata(sql, change),
+          ]);
+        } else {
+          tx.pendingChangeLogEntries.push(entry);
+          if (
+            tag === 'commit' ||
+            tx.pendingChangeLogEntries.length >= CHANGE_LOG_INSERT_BATCH_SIZE
+          ) {
+            processed = this.#flushChangeLogEntries(tx);
+          }
+        }
 
         if (tx.pos % 100 === 0) {
           // Backpressure is exerted on commit when awaiting tx.pool.done().
@@ -540,6 +560,7 @@ export class Storer implements Service {
         } else if (tag === 'rollback') {
           // Aborted transactions are not stored in the changeLog. Abort the current tx
           // and process catchup of subscribers that were waiting for it to end.
+          tx.pendingChangeLogEntries = [];
           tx.pool.abort();
           await tx.pool.done();
           tx = null;
@@ -551,6 +572,17 @@ export class Storer implements Service {
       catchupQueue.forEach(({subscriber}) => subscriber.fail(e));
       throw e;
     }
+  }
+
+  #flushChangeLogEntries(tx: PendingTransaction): Promise<void> {
+    if (tx.pendingChangeLogEntries.length === 0) {
+      return promiseVoid;
+    }
+    const entries = tx.pendingChangeLogEntries;
+    tx.pendingChangeLogEntries = [];
+    return tx.pool.process(sql => [
+      sql`INSERT INTO ${this.#cdc('changeLog')} ${sql(entries)}`,
+    ]);
   }
 
   async #startCatchup(subs: SubscriberAndMode[]) {


### PR DESCRIPTION
**AI-generated draft.** This PR was produced by an automated analysis pass and requires human review before merging. The code, tests, and benchmarks are real; the prose is AI-authored.

## Why This Is Worth It

When the replication manager is healthy but the view-syncer is behind, the worst on-call experience is watching the bridge burn time on bookkeeping instead of data movement. A large transaction currently asks Postgres to accept one `changeLog` row per message. That makes the storer pay per-row statement overhead even though the rows already belong to one ordered transaction.

This PR keeps the transaction semantics exactly where they are, but changes the storage shape from "one INSERT per change" to "small ordered INSERT batches".

```
Before
  RM tx: begin data data data ... commit
          |    |    |    |        |
          v    v    v    v        v
        INSERT INSERT INSERT ... INSERT   => 20,400 INSERT statements

After
  RM tx: begin data data data ... commit
          \_________________________/
                  batched rows          => 400 INSERT statements
```

## Clean PR Set

These PRs are intentionally not stacked. Each branch is based on `main`, can be reviewed independently, and can be landed or rejected without forcing the others. The benchmark style follows the benchmark-suite work in [#5959](https://github.com/rocicorp/mono/pull/5959).

```
main
 |-- #5968 batch changeLog inserts            (this PR)
 |-- #5972 head-indexed queues
 |-- #5971 suppress no-op CVR row writes
 |-- #5969 cache DML SQL plans
 `-- #5970 flow-control catchup backlog
```

| PR | Role | Link |
| --- | --- | --- |
| Benchmark suite | Shared benchmark harness/style | [#5959](https://github.com/rocicorp/mono/pull/5959) |
| Storer batching | Reduce RM -> changeDB write amplification | [#5968](https://github.com/rocicorp/mono/pull/5968) |
| Queue drains | Remove O(n) FIFO drain costs under backlog | [#5972](https://github.com/rocicorp/mono/pull/5972) |
| CVR no-op rows | Avoid persisting unchanged CVR rows | [#5971](https://github.com/rocicorp/mono/pull/5971) |
| DML plans | Avoid rebuilding repeated replica SQL | [#5969](https://github.com/rocicorp/mono/pull/5969) |
| Catchup backlog | Make catchup handoff obey downstream consumption | [#5970](https://github.com/rocicorp/mono/pull/5970) |

## Shared 1 RM / 16 VS Benchmark Matrix

This same matrix appears in every PR in this set. It is not a cumulative stack result: each column is one independent branch checked out against `main` with the [#5959](https://github.com/rocicorp/mono/pull/5959) benchmark harness overlaid.

```text
1 replication manager
  -> ChangeProcessor
  -> Storer/Postgres changeLog
  -> Forwarder
  -> 16 view-syncer-side subscribers
       healthy:        all subscribers ACK immediately
       slow/reconnect: every 4th subscriber waits 2 ms,
                       and one subscriber reconnects mid-run
```

Command shape:

```bash
ZERO_RM_VS_FULL=1 \
ZERO_RM_VS_DURATION_MS=1500 \
ZERO_RM_VS_SUBSCRIBERS=16 \
npm --workspace=zero-cache run perf:rm-vs-load:full
```

Healthy mode sets `ZERO_RM_VS_SLOW_EVERY=0`. Slow/reconnect mode sets `ZERO_RM_VS_SLOW_EVERY=4`, `ZERO_RM_VS_SLOW_ACK_DELAY_MS=2`, and `ZERO_RM_VS_RECONNECT_LAG_TX=2`.

Rows/s is source-row throughput for the whole RM -> storer -> forwarder -> subscriber run after storer drain/settle. Percent cells are branch-vs-`main` deltas. Negative cells are shown on purpose; those are the cases reviewers should ask about.

| E2E scenario | `main` rows/s | #5968 Storer | #5969 DML | #5970 Catchup | #5971 CVR | #5972 Queue |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| healthy / single-row-flood, 1 small row/tx | 487.3 | +12.7% | -5.5% | +19.2% | -1.4% | +7.2% |
| healthy / medium-batch-pressure, 10 medium rows/tx | 3,737.4 | +3.5% | +3.5% | +3.0% | +3.5% | +2.4% |
| healthy / large-row-burst, 50 large rows/tx | 3,867.5 | -0.0% | -0.1% | -0.1% | +0.0% | -0.1% |
| slow/reconnect / single-row-flood | 116.3 | +3.0% | +1.3% | +2.2% | -0.4% | +2.5% |
| slow/reconnect / medium-batch-pressure | 277.3 | +0.1% | +0.6% | -3.4% | -1.9% | +1.4% |
| slow/reconnect / large-row-burst | 310.8 | -7.4% | +1.6% | -3.1% | -2.8% | -1.1% |

How to read this: the shared e2e matrix is the "does this hurt the whole bridge?" check. The component benchmark below is the sharper proof for this PR's exact mechanism.

## This PR's Read

The healthy rows are the relevant e2e signal for this PR. With 1 RM and 16 view-syncer-side subscribers, batching improves the single-row flood by +12.7% and the medium batch by +3.5%. The large-row case is flat because the run is dominated by 8 KiB payload serialization and subscriber fanout, not Postgres statement count.

The slow/reconnect large-row cell is -7.4%. I am not using that as evidence that this PR helps that scenario. It is the row reviewers should scrutinize: if batching were actually causing a slowdown there, the symptom would be storer drain time growing or changeLog rows appearing out of order. The component benchmark below is the direct evidence that the write-amplification part of the path got smaller.

## Benchmark

Command:

```bash
npm --workspace=zero-cache run perf:storer-changelog
```

| Scenario | `main` | This PR | Delta |
| --- | ---: | ---: | ---: |
| 200 tx x 100 data changes | 9,104 changes/s | 57,052 changes/s | 6.27x faster |
| Wall time | 2240.8 ms | 357.6 ms | -84.0% |
| changeLog INSERT statements | 20,400 | 400 | -98.04% |

## What Changed

- Buffer non-schema `changeLog` rows inside the existing storer transaction.
- Flush buffered rows in batches of 100, and always flush at commit.
- Flush any pending batch before schema metadata tracking so DDL-adjacent ordering stays explicit.
- Clear pending rows on rollback.
- Add a PG regression test proving a 250-row transaction persists contiguous `begin/data/commit` positions.
- Add `perf:storer-changelog` to compare one-row INSERTs with batched INSERTs.

## Why This Is Safe

The important invariant is not "one SQL statement per change"; it is "the changeLog has the same rows, in the same order, committed or rolled back with the same transaction." This keeps that invariant.

Worst case: a batch INSERT fails halfway through. Because the batch runs through the same transaction pool as the old single-row inserts, Postgres rolls back the transaction unit instead of exposing a partial `changeLog`. A rollback message clears the pending batch before aborting, so buffered rows cannot leak into the next transaction.

The scary ordering case is schema metadata. This PR flushes pending data rows before a schema-change row and its metadata statements, so the ordering remains:

```
data rows already seen
  -> flush batch
schema change row
  -> metadata writes
later data rows
```

## Expected Risks

- Bigger SQL statements can stress parameter limits if the batch is too large. The batch is capped at 100 rows.
- A bad batching bug would show up as missing, duplicated, or reordered `pos` values. The new PG test checks all positions in a 252-row transaction.
- This does not change the downstream protocol or subscriber behavior; the blast radius is the storer's write shape.

## Validation

```bash
npm --workspace=zero-cache run test:pg17 -- storer.pg.test.ts
npm --workspace=zero-cache run perf:storer-changelog
npx oxfmt --check packages/zero-cache/src/services/change-streamer/storer.ts packages/zero-cache/src/services/change-streamer/storer.pg.test.ts packages/zero-cache/bench/storer-changelog.ts packages/zero-cache/package.json
git diff --check
```
