### PR TITLE
perf(zero-cache): cache DML SQL plans

### DIFF
--- a/packages/zero-cache/src/services/replicator/change-processor.bench.ts
+++ b/packages/zero-cache/src/services/replicator/change-processor.bench.ts
@@ -1,0 +1,136 @@
+import {bench, describe, use} from '../../../../shared/src/bench.ts';
+import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
+import {Database} from '../../../../zqlite/src/db.ts';
+import {StatementRunner} from '../../db/statements.ts';
+import type {DataOrSchemaChange} from '../change-source/protocol/current/data.ts';
+import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
+import {ChangeProcessor} from './change-processor.ts';
+import {initReplicationState} from './schema/replication-state.ts';
+import {ReplicationMessages} from './test-utils.ts';
+
+const ROWS = 1_000;
+const lc = createSilentLogContext();
+const messages = new ReplicationMessages({foo: ['id', 'shard']});
+
+describe('change-processor DML apply', () => {
+  const stableInsertChanges = transaction(
+    '10',
+    Array.from({length: ROWS}, (_, i) =>
+      messages.insert('foo', {
+        id: i,
+        shard: i % 10,
+        alpha: i * 2,
+        beta: i * 3,
+      }),
+    ),
+  );
+  const stableInsertUncached = setupBenchmark(false);
+  const stableInsertCached = setupBenchmark(true);
+
+  bench(
+    '1k stable-shape inserts (uncached plans)',
+    () => {
+      use(apply(stableInsertUncached, stableInsertChanges));
+    },
+    {min_cpu_time: 5e8, min_samples: 20},
+  );
+
+  bench(
+    '1k stable-shape inserts (cached plans)',
+    () => {
+      use(apply(stableInsertCached, stableInsertChanges));
+    },
+    {min_cpu_time: 5e8, min_samples: 20},
+  );
+
+  const mixedDmlChanges = transaction('20', [
+    ...Array.from({length: ROWS}, (_, i) =>
+      messages.insert('foo', {
+        id: i,
+        shard: i % 10,
+        alpha: i * 2,
+        beta: i * 3,
+      }),
+    ),
+    ...Array.from({length: ROWS}, (_, i) =>
+      i % 2 === 0
+        ? messages.update('foo', {
+            id: i,
+            shard: i % 10,
+            alpha: i * 5,
+            beta: i * 7,
+          })
+        : messages.update('foo', {
+            beta: i * 7,
+            shard: i % 10,
+            id: i,
+            alpha: i * 5,
+          }),
+    ),
+    ...Array.from({length: ROWS}, (_, i) =>
+      i % 2 === 0
+        ? messages.delete('foo', {id: i, shard: i % 10})
+        : messages.delete('foo', {shard: i % 10, id: i}),
+    ),
+  ]);
+  const mixedDmlUncached = setupBenchmark(false);
+  const mixedDmlCached = setupBenchmark(true);
+
+  bench(
+    '1k inserts + updates + deletes (uncached plans)',
+    () => {
+      use(apply(mixedDmlUncached, mixedDmlChanges));
+    },
+    {min_cpu_time: 5e8, min_samples: 20},
+  );
+
+  bench(
+    '1k inserts + updates + deletes (cached plans)',
+    () => {
+      use(apply(mixedDmlCached, mixedDmlChanges));
+    },
+    {min_cpu_time: 5e8, min_samples: 20},
+  );
+});
+
+function setupBenchmark(cacheDmlSqlPlans: boolean) {
+  const replica = new Database(lc, ':memory:');
+  initReplicationState(replica, ['zero_data'], '02');
+  replica.exec(`
+    CREATE TABLE foo(
+      id INTEGER,
+      shard INTEGER,
+      alpha INTEGER,
+      beta INTEGER,
+      _0_version TEXT,
+      PRIMARY KEY(id, shard)
+    );
+  `);
+  return new ChangeProcessor(
+    new StatementRunner(replica),
+    'backup',
+    (_, err) => {
+      throw err;
+    },
+    {cacheDmlSqlPlans},
+  );
+}
+
+function transaction(
+  watermark: string,
+  dataMessages: DataOrSchemaChange[],
+): ChangeStreamData[] {
+  return [
+    ['begin', messages.begin(), {commitWatermark: watermark}],
+    ...dataMessages.map(msg => ['data', msg] as ChangeStreamData),
+    ['commit', messages.commit(), {watermark}],
+  ];
+}
+
+function apply(processor: ChangeProcessor, changes: ChangeStreamData[]) {
+  let result = null;
+  for (const change of changes) {
+    result = processor.processMessage(lc, change);
+  }
+  return result;
+}

--- a/packages/zero-cache/src/services/replicator/change-processor.test.ts
+++ b/packages/zero-cache/src/services/replicator/change-processor.test.ts
@@ -3639,6 +3639,51 @@ describe('replicator/change-processor', () => {
       }
     });
   }
+
+  test('DML plan cache binds repeated shapes by column name', () => {
+    initDB(
+      servingReplica,
+      `
+      CREATE TABLE foo(
+        id INTEGER,
+        shard INTEGER,
+        alpha INTEGER,
+        beta INTEGER,
+        _0_version TEXT,
+        PRIMARY KEY(id, shard)
+      );
+      `,
+    );
+
+    const foo = new ReplicationMessages({foo: ['id', 'shard']});
+    for (const change of [
+      ['begin', foo.begin(), {commitWatermark: '07'}],
+      ['data', foo.insert('foo', {id: 1, shard: 10, alpha: 100, beta: 200})],
+      ['data', foo.insert('foo', {beta: 400, shard: 20, id: 2, alpha: 300})],
+      ['data', foo.update('foo', {id: 1, shard: 10, alpha: 101, beta: 201})],
+      ['data', foo.update('foo', {beta: 401, shard: 20, id: 2, alpha: 301})],
+      ['data', foo.delete('foo', {shard: 20, id: 2})],
+      ['commit', foo.commit(), {watermark: '07'}],
+    ] satisfies ChangeStreamData[]) {
+      servingProcessor.processMessage(lc, change);
+    }
+
+    expectTables(
+      servingReplica,
+      {
+        foo: [
+          {
+            id: 1n,
+            shard: 10n,
+            alpha: 101n,
+            beta: 201n,
+            ['_0_version']: '07',
+          },
+        ],
+      },
+      'bigint',
+    );
+  });
 });
 
 describe('replicator/change-processor-errors', () => {

--- a/packages/zero-cache/src/services/replicator/change-processor.ts
+++ b/packages/zero-cache/src/services/replicator/change-processor.ts
@@ -73,6 +73,276 @@ export type CommitResult = {
   changeLogUpdated: boolean;
 };
 
+type ChangeProcessorOptions = {
+  readonly cacheDmlSqlPlans?: boolean;
+};
+
+type UpsertPlan = {
+  readonly rowColumns: readonly string[];
+  readonly sql: string;
+};
+
+type UpdatePlan = {
+  readonly rowColumns: readonly string[];
+  readonly keyColumns: readonly string[];
+  readonly sql: string;
+};
+
+type DeletePlan = {
+  readonly keyColumns: readonly string[];
+  readonly sql: string;
+};
+
+class DmlSqlPlanCache {
+  readonly #enabled: boolean;
+  readonly #upsertPlans = new Map<string, UpsertPlan>();
+  readonly #updatePlans = new Map<string, UpdatePlan>();
+  readonly #deletePlans = new Map<string, DeletePlan>();
+  readonly #lastUpsertPlan = new Map<string, UpsertPlan>();
+  readonly #lastUpdatePlan = new Map<string, UpdatePlan>();
+  readonly #lastDeletePlan = new Map<string, DeletePlan>();
+
+  constructor(enabled: boolean) {
+    this.#enabled = enabled;
+  }
+
+  clear() {
+    this.#upsertPlans.clear();
+    this.#updatePlans.clear();
+    this.#deletePlans.clear();
+    this.#lastUpsertPlan.clear();
+    this.#lastUpdatePlan.clear();
+    this.#lastDeletePlan.clear();
+  }
+
+  getUpsertPlan(table: string, row: LiteRow, numCols: number): UpsertPlan {
+    if (!this.#enabled) {
+      return createUpsertPlan(table, columnsForRow(row, numCols));
+    }
+
+    const last = this.#lastUpsertPlan.get(table);
+    if (last && rowHasColumns(row, numCols, last.rowColumns)) {
+      return last;
+    }
+
+    const rowColumns = columnsForRow(row, numCols);
+    const cacheKey = shapeKey(table, rowColumns);
+    let plan = this.#upsertPlans.get(cacheKey);
+    if (!plan) {
+      plan = createUpsertPlan(table, rowColumns);
+      this.#upsertPlans.set(cacheKey, plan);
+    }
+    this.#lastUpsertPlan.set(table, plan);
+    return plan;
+  }
+
+  getUpdatePlan(
+    table: string,
+    row: LiteRow,
+    numCols: number,
+    keyColumns: readonly string[],
+  ): UpdatePlan {
+    if (!this.#enabled) {
+      return createUpdatePlan(table, columnsForRow(row, numCols), keyColumns);
+    }
+
+    const last = this.#lastUpdatePlan.get(table);
+    if (
+      last &&
+      rowHasColumns(row, numCols, last.rowColumns) &&
+      sameColumns(keyColumns, last.keyColumns)
+    ) {
+      return last;
+    }
+
+    const rowColumns = columnsForRow(row, numCols);
+    const cacheKey = shapeKey(table, rowColumns, keyColumns);
+    let plan = this.#updatePlans.get(cacheKey);
+    if (!plan) {
+      plan = createUpdatePlan(table, rowColumns, keyColumns);
+      this.#updatePlans.set(cacheKey, plan);
+    }
+    this.#lastUpdatePlan.set(table, plan);
+    return plan;
+  }
+
+  getDeletePlan(table: string, keyColumns: readonly string[]): DeletePlan {
+    if (!this.#enabled) {
+      return createDeletePlan(table, keyColumns);
+    }
+
+    const last = this.#lastDeletePlan.get(table);
+    if (last && sameColumns(keyColumns, last.keyColumns)) {
+      return last;
+    }
+
+    const cacheKey = shapeKey(table, keyColumns);
+    let plan = this.#deletePlans.get(cacheKey);
+    if (!plan) {
+      plan = createDeletePlan(table, keyColumns);
+      this.#deletePlans.set(cacheKey, plan);
+    }
+    this.#lastDeletePlan.set(table, plan);
+    return plan;
+  }
+}
+
+function createUpsertPlan(
+  table: string,
+  rowColumns: readonly string[],
+): UpsertPlan {
+  const insertColumns = [...rowColumns, ZERO_VERSION_COLUMN_NAME];
+  const columnsSQL = insertColumns.map(c => id(c)).join(',');
+  return {
+    rowColumns,
+    sql: /*sql*/ `
+      INSERT OR REPLACE INTO ${id(table)} (${columnsSQL})
+        VALUES (${placeholders(insertColumns.length)})
+      `,
+  };
+}
+
+function createUpdatePlan(
+  table: string,
+  rowColumns: readonly string[],
+  keyColumns: readonly string[],
+): UpdatePlan {
+  const setExprs = [...rowColumns, ZERO_VERSION_COLUMN_NAME].map(
+    col => `${id(col)}=?`,
+  );
+  const conds = keyColumns.map(col => `${id(col)}=?`);
+  return {
+    rowColumns,
+    keyColumns,
+    sql: /*sql*/ `
+      UPDATE ${id(table)}
+        SET ${setExprs.join(',')}
+        WHERE ${conds.join(' AND ')}
+      `,
+  };
+}
+
+function createDeletePlan(
+  table: string,
+  keyColumns: readonly string[],
+): DeletePlan {
+  const conds = keyColumns.map(col => `${id(col)}=?`);
+  return {
+    keyColumns,
+    sql: `DELETE FROM ${id(table)} WHERE ${conds.join(' AND ')}`,
+  };
+}
+
+function columnsForRow(row: LiteRow, numCols: number): string[] {
+  const columns: string[] = [];
+  columns.length = numCols;
+  let i = 0;
+  for (const col in row) {
+    columns[i++] = col;
+  }
+  assert(i === numCols, `Expected ${numCols} columns, got ${i}`);
+  return columns;
+}
+
+function rowHasColumns(
+  row: LiteRow,
+  numCols: number,
+  columns: readonly string[],
+) {
+  if (numCols !== columns.length) {
+    return false;
+  }
+  for (const col of columns) {
+    if (!Object.hasOwn(row, col)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function sameColumns(left: readonly string[], right: readonly string[]) {
+  if (left.length !== right.length) {
+    return false;
+  }
+  for (let i = 0; i < left.length; i++) {
+    if (left[i] !== right[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function shapeKey(
+  table: string,
+  columns: readonly string[],
+  extraColumns?: readonly string[],
+) {
+  let key = columnKeyPart(table) + columnListKeyPart(columns);
+  if (extraColumns) {
+    key += columnListKeyPart(extraColumns);
+  }
+  return key;
+}
+
+function columnListKeyPart(columns: readonly string[]) {
+  let key = `#${columns.length}`;
+  for (const col of columns) {
+    key += columnKeyPart(col);
+  }
+  return key;
+}
+
+function columnKeyPart(col: string) {
+  return `${col.length}:${col}`;
+}
+
+function placeholders(length: number) {
+  return Array.from({length}).fill('?').join(',');
+}
+
+function upsertValues(
+  row: LiteRow,
+  columns: readonly string[],
+  version: LexiVersion,
+) {
+  const values: (LiteValueType | LexiVersion)[] = [];
+  values.length = columns.length + 1;
+  for (let i = 0; i < columns.length; i++) {
+    values[i] = row[columns[i]];
+  }
+  values[columns.length] = version;
+  return values;
+}
+
+function updateValues(
+  row: LiteRow,
+  rowColumns: readonly string[],
+  key: LiteRowKey,
+  keyColumns: readonly string[],
+  version: LexiVersion,
+) {
+  const values: (LiteValueType | LexiVersion)[] = [];
+  values.length = rowColumns.length + keyColumns.length + 1;
+  let pos = 0;
+  for (const col of rowColumns) {
+    values[pos++] = row[col];
+  }
+  values[pos++] = version;
+  for (const col of keyColumns) {
+    values[pos++] = key[col];
+  }
+  return values;
+}
+
+function keyValues(key: LiteRowKey, keyColumns: readonly string[]) {
+  const values: LiteValueType[] = [];
+  values.length = keyColumns.length;
+  for (let i = 0; i < keyColumns.length; i++) {
+    values[i] = key[keyColumns[i]];
+  }
+  return values;
+}
+
 /**
  * The ChangeProcessor partitions the stream of messages into transactions
  * by creating a {@link TransactionProcessor} when a transaction begins, and dispatching
@@ -95,6 +365,7 @@ export class ChangeProcessor {
   // and reloads them after a schema change. It is cached here to avoid
   // reading them from the DB on every transaction.
   readonly #tableSpecs = new Map<string, LiteTableSpecWithReplicationStatus>();
+  readonly #dmlSqlPlans: DmlSqlPlanCache;
 
   #currentTx: TransactionProcessor | null = null;
 
@@ -104,12 +375,14 @@ export class ChangeProcessor {
     db: StatementRunner,
     mode: ChangeProcessorMode,
     failService: (lc: LogContext, err: unknown) => void,
+    {cacheDmlSqlPlans = true}: ChangeProcessorOptions = {},
   ) {
     this.#db = db;
     this.#changeLog = new ChangeLog(db.db);
     this.#tableMetadata = new TableMetadataTracker(db.db);
     this.#mode = mode;
     this.#failService = failService;
+    this.#dmlSqlPlans = new DmlSqlPlanCache(cacheDmlSqlPlans);
   }
 
   #fail(lc: LogContext, err: unknown) {
@@ -186,6 +459,7 @@ export class ChangeProcessor {
           this.#changeLog,
           this.#tableMetadata,
           this.#tableSpecs,
+          this.#dmlSqlPlans,
           commitVersion,
           jsonFormat,
         );
@@ -328,6 +602,7 @@ class TransactionProcessor {
   readonly #changeLog: ChangeLog;
   readonly #tableMetadata: TableMetadataTracker;
   readonly #tableSpecs: Map<string, LiteTableSpecWithReplicationStatus>;
+  readonly #dmlSqlPlans: DmlSqlPlanCache;
   readonly #jsonFormat: JSONFormat;
   readonly #columnMetadata: ColumnMetadataStore;
 
@@ -342,6 +617,7 @@ class TransactionProcessor {
     changeLog: ChangeLog,
     tableMetadata: TableMetadataTracker,
     tableSpecs: Map<string, LiteTableSpecWithReplicationStatus>,
+    dmlSqlPlans: DmlSqlPlanCache,
     commitVersion: LexiVersion,
     jsonFormat: JSONFormat,
   ) {
@@ -380,6 +656,7 @@ class TransactionProcessor {
     this.#changeLog = changeLog;
     this.#tableMetadata = tableMetadata;
     this.#tableSpecs = tableSpecs;
+    this.#dmlSqlPlans = dmlSqlPlans;
     // The column_metadata table is guaranteed to exist since the
     // replica-schema.ts migration to v8.
     this.#columnMetadata = must(ColumnMetadataStore.getInstance(db.db));
@@ -391,6 +668,7 @@ class TransactionProcessor {
 
   #reloadTableSpecs() {
     this.#tableSpecs.clear();
+    this.#dmlSqlPlans.clear();
     // zqlSpecs include the primary key derived from unique indexes
     const zqlSpecs = computeZqlSpecs(this.#lc, this.#db.db, {
       includeBackfillingColumns: true,
@@ -412,10 +690,7 @@ class TransactionProcessor {
     return must(this.#tableSpecs.get(name), `Unknown table ${name}`);
   }
 
-  #getKey(
-    {row, numCols}: {row: LiteRow; numCols: number},
-    {relation}: {relation: MessageRelation},
-  ): LiteRowKey {
+  #getKeyColumns({relation}: {relation: MessageRelation}) {
     const keyColumns =
       relation.rowKey.type !== 'full'
         ? relation.rowKey.columns // already a suitable key
@@ -425,6 +700,14 @@ class TransactionProcessor {
         `Cannot replicate table "${relation.name}" without a PRIMARY KEY or UNIQUE INDEX`,
       );
     }
+    return keyColumns;
+  }
+
+  #getKey(
+    {row, numCols}: {row: LiteRow; numCols: number},
+    {relation}: {relation: MessageRelation},
+    keyColumns = this.#getKeyColumns({relation}),
+  ): LiteRowKey {
     // For the common case (replica identity default), the row is already the
     // key for deletes and updates, in which case a new object can be avoided.
     if (numCols === keyColumns.length) {
@@ -442,10 +725,7 @@ class TransactionProcessor {
     const tableSpec = this.#tableSpec(table);
     const newRow = liteRow(insert.new, tableSpec, this.#jsonFormat);
 
-    this.#upsert(table, {
-      ...newRow.row,
-      [ZERO_VERSION_COLUMN_NAME]: this.#version,
-    });
+    this.#upsert(table, newRow);
 
     if (insert.relation.rowKey.columns.length === 0) {
       // INSERTs can be replicated for rows without a PRIMARY KEY or a
@@ -461,15 +741,9 @@ class TransactionProcessor {
     this.#logSetOp(table, key, getBackfilledColumns(newRow.row, tableSpec));
   }
 
-  #upsert(table: string, row: LiteRow) {
-    const columns = Object.keys(row).map(c => id(c));
-    this.#db.run(
-      `
-      INSERT OR REPLACE INTO ${id(table)} (${columns.join(',')})
-        VALUES (${Array.from({length: columns.length}).fill('?').join(',')})
-      `,
-      Object.values(row),
-    );
+  #upsert(table: string, {row, numCols}: {row: LiteRow; numCols: number}) {
+    const plan = this.#dmlSqlPlans.getUpsertPlan(table, row, numCols);
+    this.#db.run(plan.sql, upsertValues(row, plan.rowColumns, this.#version));
   }
 
   // Updates by default are applied as UPDATE commands to support partial
@@ -488,16 +762,17 @@ class TransactionProcessor {
     const table = liteTableName(update.relation);
     const tableSpec = this.#tableSpec(table);
     const newRow = liteRow(update.new, tableSpec, this.#jsonFormat);
-    const row = {...newRow.row, [ZERO_VERSION_COLUMN_NAME]: this.#version};
+    const keyColumns = this.#getKeyColumns(update);
 
     // update.key is set with the old values if the key has changed.
     const oldKey = update.key
       ? this.#getKey(
           liteRow(update.key, this.#tableSpec(table), this.#jsonFormat),
           update,
+          keyColumns,
         )
       : null;
-    const newKey = this.#getKey(newRow, update);
+    const newKey = this.#getKey(newRow, update, keyColumns);
 
     if (oldKey) {
       this.#logDeleteOp(table, oldKey, tableSpec.backfilling);
@@ -505,43 +780,48 @@ class TransactionProcessor {
     this.#logSetOp(table, newKey, getBackfilledColumns(newRow.row, tableSpec));
 
     const currKey = oldKey ?? newKey;
-    const conds = Object.keys(currKey).map(col => `${id(col)}=?`);
-    const setExprs = Object.keys(row).map(col => `${id(col)}=?`);
+    const plan = this.#dmlSqlPlans.getUpdatePlan(
+      table,
+      newRow.row,
+      newRow.numCols,
+      keyColumns,
+    );
 
     const {changes} = this.#db.run(
-      `
-      UPDATE ${id(table)}
-        SET ${setExprs.join(',')}
-        WHERE ${conds.join(' AND ')}
-      `,
-      [...Object.values(row), ...Object.values(currKey)],
+      plan.sql,
+      updateValues(
+        newRow.row,
+        plan.rowColumns,
+        currKey,
+        plan.keyColumns,
+        this.#version,
+      ),
     );
 
     // If the UPDATE did not affect any rows, perform an UPSERT of the
     // new row for resumptive replication.
     if (changes === 0) {
-      this.#upsert(table, row);
+      this.#upsert(table, newRow);
     }
   }
 
   processDelete(del: MessageDelete) {
     const table = liteTableName(del.relation);
     const tableSpec = this.#tableSpec(table);
+    const keyColumns = this.#getKeyColumns(del);
     const rowKey = this.#getKey(
       liteRow(del.key, tableSpec, this.#jsonFormat),
       del,
+      keyColumns,
     );
 
-    this.#delete(table, rowKey);
+    this.#delete(table, rowKey, keyColumns);
     this.#logDeleteOp(table, rowKey, tableSpec.backfilling);
   }
 
-  #delete(table: string, rowKey: LiteRowKey) {
-    const conds = Object.keys(rowKey).map(col => `${id(col)}=?`);
-    this.#db.run(
-      `DELETE FROM ${id(table)} WHERE ${conds.join(' AND ')}`,
-      Object.values(rowKey),
-    );
+  #delete(table: string, rowKey: LiteRowKey, keyColumns: readonly string[]) {
+    const plan = this.#dmlSqlPlans.getDeletePlan(table, keyColumns);
+    this.#db.run(plan.sql, keyValues(rowKey, plan.keyColumns));
   }
 
   processTruncate(truncate: MessageTruncate) {


### PR DESCRIPTION
**AI-generated draft.** This PR was produced by an automated analysis pass and requires human review before merging. The code, tests, and benchmarks are real; the prose is AI-authored.

## Why This Is Worth It

The replicator applies many rows with the same DML shape: same table, same columns, different values. The hot path currently rebuilds SQL strings for each insert/update/delete even when the statement shape is identical to the last thousand rows.

This PR caches those DML SQL plans by table and column shape, then binds values by column name.

```
Before
  row 1 -> build SQL -> bind -> run
  row 2 -> build SQL -> bind -> run
  row 3 -> build SQL -> bind -> run

After
  row 1 -> build SQL -> cache plan -> bind -> run
  row 2 -> cache hit -------------> bind -> run
  row 3 -> cache hit -------------> bind -> run
```

## Clean PR Set

These PRs are intentionally not stacked. Each branch is based on `main`, can be reviewed independently, and can be landed or rejected without forcing the others. The benchmark style follows the benchmark-suite work in [#5959](https://github.com/rocicorp/mono/pull/5959).

```
main
 |-- #5968 batch changeLog inserts
 |-- #5972 head-indexed queues
 |-- #5971 suppress no-op CVR row writes
 |-- #5969 cache DML SQL plans                  (this PR)
 `-- #5970 flow-control catchup backlog
```

| PR | Role | Link |
| --- | --- | --- |
| Benchmark suite | Shared benchmark harness/style | [#5959](https://github.com/rocicorp/mono/pull/5959) |
| Storer batching | Reduce RM -> changeDB write amplification | [#5968](https://github.com/rocicorp/mono/pull/5968) |
| Queue drains | Remove O(n) FIFO drain costs under backlog | [#5972](https://github.com/rocicorp/mono/pull/5972) |
| CVR no-op rows | Avoid persisting unchanged CVR rows | [#5971](https://github.com/rocicorp/mono/pull/5971) |
| DML plans | Avoid rebuilding repeated replica SQL | [#5969](https://github.com/rocicorp/mono/pull/5969) |
| Catchup backlog | Make catchup handoff obey downstream consumption | [#5970](https://github.com/rocicorp/mono/pull/5970) |

## Shared 1 RM / 16 VS Benchmark Matrix

This same matrix appears in every PR in this set. It is not a cumulative stack result: each column is one independent branch checked out against `main` with the [#5959](https://github.com/rocicorp/mono/pull/5959) benchmark harness overlaid.

```text
1 replication manager
  -> ChangeProcessor
  -> Storer/Postgres changeLog
  -> Forwarder
  -> 16 view-syncer-side subscribers
       healthy:        all subscribers ACK immediately
       slow/reconnect: every 4th subscriber waits 2 ms,
                       and one subscriber reconnects mid-run
```

Command shape:

```bash
ZERO_RM_VS_FULL=1 \
ZERO_RM_VS_DURATION_MS=1500 \
ZERO_RM_VS_SUBSCRIBERS=16 \
npm --workspace=zero-cache run perf:rm-vs-load:full
```

Healthy mode sets `ZERO_RM_VS_SLOW_EVERY=0`. Slow/reconnect mode sets `ZERO_RM_VS_SLOW_EVERY=4`, `ZERO_RM_VS_SLOW_ACK_DELAY_MS=2`, and `ZERO_RM_VS_RECONNECT_LAG_TX=2`.

Rows/s is source-row throughput for the whole RM -> storer -> forwarder -> subscriber run after storer drain/settle. Percent cells are branch-vs-`main` deltas. Negative cells are shown on purpose; those are the cases reviewers should ask about.

| E2E scenario | `main` rows/s | #5968 Storer | #5969 DML | #5970 Catchup | #5971 CVR | #5972 Queue |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| healthy / single-row-flood, 1 small row/tx | 487.3 | +12.7% | -5.5% | +19.2% | -1.4% | +7.2% |
| healthy / medium-batch-pressure, 10 medium rows/tx | 3,737.4 | +3.5% | +3.5% | +3.0% | +3.5% | +2.4% |
| healthy / large-row-burst, 50 large rows/tx | 3,867.5 | -0.0% | -0.1% | -0.1% | +0.0% | -0.1% |
| slow/reconnect / single-row-flood | 116.3 | +3.0% | +1.3% | +2.2% | -0.4% | +2.5% |
| slow/reconnect / medium-batch-pressure | 277.3 | +0.1% | +0.6% | -3.4% | -1.9% | +1.4% |
| slow/reconnect / large-row-burst | 310.8 | -7.4% | +1.6% | -3.1% | -2.8% | -1.1% |

How to read this: the shared e2e matrix is the "does this hurt the whole bridge?" check. The component benchmark below is the sharper proof for this PR's exact mechanism.

## This PR's Read

The e2e matrix says this change is mostly neutral in the full RM -> VS bridge, with a small healthy-medium gain (+3.5%) and no large-row movement. That is expected: this PR removes repeated SQL string construction inside `ChangeProcessor`, but the mixed e2e harness also includes Postgres changeLog writes, forwarding, subscriber ACKs, and reconnect timing.

The sharper question for this PR is not "does the whole bridge get faster every time?" It is "can repeated-shape replica writes reuse SQL without changing bindings?" The component benchmark below isolates that path and shows the stable repeated-shape case dropping 30.2%. The safety section then explains why a cache hit cannot bind the wrong values.

## Benchmark

Command:

```bash
npm --workspace=zero-cache run bench -- change-processor.bench.ts
```

| Scenario | `main` / uncached | This PR / cached | Delta |
| --- | ---: | ---: | ---: |
| 1k stable-shape inserts | 3.05 ms/iter | 2.13 ms/iter | -30.2% |
| 1k inserts + updates + deletes | 7.74 ms/iter | 5.81 ms/iter | -24.9% |

## What Changed

- Add a small `DmlSqlPlanCache` for insert/upsert, update, and delete statement shapes.
- Cache by table plus column-shape key.
- Keep a "last plan per table" fast path for the common repeated-shape case.
- Bind values by the cached column list, not by current object property order.
- Clear the DML plan cache whenever table specs reload.
- Add a regression test that reorders object properties between repeated DML calls.
- Add a `change-processor.bench.ts` benchmark comparing cached and uncached processors.

## Why This Is Safe

The dangerous failure mode is not "cache missed"; it is "cache hit with the wrong bindings." This PR avoids that by separating SQL shape from value lookup. The cached plan owns the column order, and value arrays are built by reading those column names from the row/key objects.

Worst case: schema changes while a cached plan still exists. The cache is cleared on table-spec reload, so the next DML call rebuilds the SQL plan against the new table shape. Cache keys are length-prefixed (`table`, `column count`, `column names`) to avoid accidental collisions.

Object property order is explicitly tested: the same table gets rows with `{id, shard, alpha, beta}` and `{beta, shard, id, alpha}`. The cached plan still binds the right values to the right columns.

## Expected Risks

- This touches the replicator write path, so correctness beats the 25-30% benchmark win.
- If a rare DML shape appears once, the cache adds minor map work. The common case is repeated shapes in a transaction.
- Schema reload invalidation is the key review point.

## Validation

```bash
npm --workspace=zero-cache run test:no-pg -- change-processor.test.ts
npm --workspace=zero-cache run bench -- change-processor.bench.ts
npx oxfmt --check packages/zero-cache/src/services/replicator/change-processor.ts packages/zero-cache/src/services/replicator/change-processor.test.ts packages/zero-cache/src/services/replicator/change-processor.bench.ts
git diff --check
```
