### PR TITLE
perf(zero-cache): suppress no-op CVR row writes

### DIFF
--- a/packages/zero-cache/bench/cvr-noop.ts
+++ b/packages/zero-cache/bench/cvr-noop.ts
@@ -1,0 +1,158 @@
+/* oxlint-disable no-console */
+import {performance} from 'node:perf_hooks';
+import {deepEqual} from '../../shared/src/json.ts';
+import type {ReadonlyJSONValue} from '../../shared/src/json.ts';
+import type {
+  RowID,
+  RowRecord,
+} from '../src/services/view-syncer/schema/types.ts';
+
+type Result = {
+  readonly mode: string;
+  readonly rows: number;
+  readonly queuedRows: number;
+  readonly clearedRows: number;
+  readonly elapsedMs: number;
+  readonly rowsPerSec: number;
+};
+
+type Summary = {
+  readonly name: 'cvr-noop-row-suppression';
+  readonly generatedAt: string;
+  readonly rows: number;
+  readonly results: Result[];
+};
+
+const rows = envInt('ZERO_CVR_NOOP_ROWS', 100_000);
+const existing = Array.from({length: rows}, (_, i) => makeRowRecord(i));
+const candidates = existing.map(row => ({...row}));
+
+const results = [
+  runBaseline(existing, candidates),
+  runEarlySuppression(existing, candidates),
+];
+
+for (const result of results) {
+  console.log(
+    `${result.mode}: ${formatRate(result.rowsPerSec)} rows/s | ` +
+      `${result.elapsedMs.toFixed(1)} ms | queued=${result.queuedRows} | ` +
+      `cleared=${result.clearedRows}`,
+  );
+}
+
+const summary: Summary = {
+  name: 'cvr-noop-row-suppression',
+  generatedAt: new Date().toISOString(),
+  rows,
+  results,
+};
+console.log(JSON.stringify(summary));
+
+function runBaseline(
+  existing: readonly RowRecord[],
+  candidates: readonly RowRecord[],
+): Result {
+  const pending = new Map<string, RowRecord>();
+  const start = performance.now();
+  for (let i = 0; i < candidates.length; i++) {
+    const candidate = candidates[i];
+    pending.set(rowKey(candidate.id), candidate);
+  }
+  let queuedRows = pending.size;
+  for (let i = 0; i < existing.length; i++) {
+    const id = rowKey(existing[i].id);
+    const candidate = pending.get(id);
+    if (
+      candidate &&
+      deepEqual(
+        candidate as ReadonlyJSONValue,
+        existing[i] as ReadonlyJSONValue,
+      )
+    ) {
+      pending.delete(id);
+    }
+  }
+  queuedRows -= pending.size;
+  return result('baseline enqueue then flush-drop', rows, queuedRows, 0, start);
+}
+
+function runEarlySuppression(
+  existing: readonly RowRecord[],
+  candidates: readonly RowRecord[],
+): Result {
+  const pending = new Map<string, RowRecord>();
+  let clearedRows = 0;
+  const start = performance.now();
+  for (let i = 0; i < candidates.length; i++) {
+    const candidate = candidates[i];
+    if (
+      !deepEqual(
+        candidate as ReadonlyJSONValue,
+        existing[i] as ReadonlyJSONValue,
+      )
+    ) {
+      pending.set(rowKey(candidate.id), candidate);
+    } else {
+      pending.delete(rowKey(candidate.id));
+      clearedRows++;
+    }
+  }
+  return result(
+    'early no-op suppression',
+    rows,
+    pending.size,
+    clearedRows,
+    start,
+  );
+}
+
+function makeRowRecord(i: number): RowRecord {
+  return {
+    id: {
+      schema: 'public',
+      table: 'issues',
+      rowKey: {id: String(i)},
+    },
+    rowVersion: '03',
+    patchVersion: {stateVersion: '1a0'},
+    refCounts: {oneHash: 1},
+  };
+}
+
+function rowKey(id: RowID): string {
+  return `${id.schema}.${id.table}:${JSON.stringify(id.rowKey)}`;
+}
+
+function result(
+  mode: string,
+  rows: number,
+  queuedRows: number,
+  clearedRows: number,
+  start: number,
+): Result {
+  const elapsedMs = performance.now() - start;
+  return {
+    mode,
+    rows,
+    queuedRows,
+    clearedRows,
+    elapsedMs,
+    rowsPerSec: rows / (elapsedMs / 1000),
+  };
+}
+
+function envInt(name: string, fallback: number): number {
+  const value = process.env[name];
+  if (value === undefined || value === '') {
+    return fallback;
+  }
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`Invalid integer ${name}=${value}`);
+  }
+  return parsed;
+}
+
+function formatRate(value: number): string {
+  return value.toLocaleString('en-US', {maximumFractionDigits: 1});
+}

--- a/packages/zero-cache/package.json
+++ b/packages/zero-cache/package.json
@@ -24,6 +24,7 @@
     "bench": "vitest run --config vitest.config.bench.ts",
     "bench:bmf": "BENCH_OUTPUT_FORMAT=json npm run bench 2>&1 | npx tsx ../shared/src/tool/mitata-json-to-bmf.ts",
     "bench:bmf:silent": "npm run bench:bmf --silent",
+    "perf:cvr-noop": "tsx ./bench/cvr-noop.ts",
     "local": "tsx tool/local.ts",
     "start": "tsx ./src/server/runner/main.ts",
     "benchdb": "tsx ./bench/bench.ts",

--- a/packages/zero-cache/src/services/view-syncer/cvr-store.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr-store.ts
@@ -484,6 +484,11 @@ export class CVRStore {
     this.#pendingRowRecordUpdates.set(row.id, row);
   }
 
+  clearRowRecordUpdate(id: RowID): void {
+    this.#pendingRowRecordUpdates.delete(id);
+    this.#forceUpdates.delete(id);
+  }
+
   /**
    * Note: Removing a row from the CVR should be represented by a
    *       {@link putRowRecord()} with `refCounts: null` in order to properly

--- a/packages/zero-cache/src/services/view-syncer/cvr.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.test.ts
@@ -1,6 +1,22 @@
 import {expect, test} from 'vitest';
-import {getInactiveQueries, type CVR} from './cvr.ts';
-import type {ClientQueryRecord} from './schema/types.ts';
+import {CustomKeyMap} from '../../../../shared/src/custom-key-map.ts';
+import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
+import {rowIDString} from '../../types/row-key.ts';
+import type {PatchToVersion} from './client-handler.ts';
+import type {CVRStore} from './cvr-store.ts';
+import {
+  CVRQueryDrivenUpdater,
+  getInactiveQueries,
+  type CVR,
+  type CVRSnapshot,
+  type RowUpdate,
+} from './cvr.ts';
+import type {
+  ClientQueryRecord,
+  CVRVersion,
+  RowID,
+  RowRecord,
+} from './schema/types.ts';
 import {ttlClockFromNumber, type TTLClock} from './ttl-clock.ts';
 
 type QueryDef = {
@@ -234,4 +250,272 @@ test.each([
 ])('getInactiveQueries %o', ({clients, expected}) => {
   const cvr = makeCVR(clients);
   expect(getInactiveQueries(cvr)).toEqual(expected);
+});
+
+const lc = createSilentLogContext();
+const patchVersion: CVRVersion = {stateVersion: '1a0'};
+const updatedVersion: CVRVersion = {stateVersion: '1aa'};
+
+const ROW_ID1: RowID = {
+  schema: 'public',
+  table: 'issues',
+  rowKey: {id: '1'},
+};
+
+const ROW_ID2: RowID = {
+  schema: 'public',
+  table: 'issues',
+  rowKey: {id: '2'},
+};
+
+function makeQueryDrivenCVR(): CVRSnapshot {
+  return {
+    id: 'abc123',
+    version: {stateVersion: '1a9'},
+    lastActive: Date.UTC(2024, 1, 20),
+    ttlClock: ttlClockFromNumber(Date.UTC(2024, 1, 20)),
+    replicaVersion: '120',
+    clients: {
+      fooClient: {
+        id: 'fooClient',
+        desiredQueryIDs: ['oneHash'],
+      },
+    },
+    queries: {
+      oneHash: {
+        ast: {table: 'issues'},
+        type: 'client',
+        clientState: {
+          fooClient: {
+            inactivatedAt: undefined,
+            ttl: 1000,
+            version: {stateVersion: '1a9', configVersion: 1},
+          },
+        },
+        id: 'oneHash',
+        patchVersion,
+        transformationHash: 'serverOneHash',
+        transformationVersion: patchVersion,
+      },
+    },
+    clientSchema: null,
+    profileID: null,
+  };
+}
+
+function makeRowRecord(
+  id: RowID,
+  rowVersion: string,
+  refCounts: RowRecord['refCounts'] = {oneHash: 1},
+  recordPatchVersion: CVRVersion = patchVersion,
+): RowRecord {
+  return {
+    id,
+    rowVersion,
+    patchVersion: recordPatchVersion,
+    refCounts,
+  };
+}
+
+function makeStore(rowRecords: RowRecord[]) {
+  const rows = new CustomKeyMap<RowID, RowRecord>(rowIDString);
+  for (const row of rowRecords) {
+    rows.set(row.id, row);
+  }
+
+  const putRows: RowRecord[] = [];
+  const deletedRows: RowID[] = [];
+  const clearedRows: RowID[] = [];
+  const store = {
+    getRowRecords: () => Promise.resolve(rows),
+    putRowRecord: (row: RowRecord) => {
+      putRows.push(row);
+    },
+    clearRowRecordUpdate: (id: RowID) => {
+      clearedRows.push(id);
+    },
+    delRowRecord: (id: RowID) => {
+      deletedRows.push(id);
+    },
+    updateQuery: () => {},
+  } as unknown as CVRStore;
+
+  return {clearedRows, deletedRows, putRows, store};
+}
+
+function makeTrackedUpdater(store: CVRStore): CVRQueryDrivenUpdater {
+  const updater = new CVRQueryDrivenUpdater(
+    store,
+    makeQueryDrivenCVR(),
+    updatedVersion.stateVersion,
+    '120',
+  );
+  updater.trackQueries(
+    lc,
+    [{id: 'oneHash', transformationHash: 'serverOneHash'}],
+    [],
+  );
+  return updater;
+}
+
+test('received skips row persistence for unchanged records while emitting row patches', async () => {
+  const existing = makeRowRecord(ROW_ID1, '03');
+  const {deletedRows, putRows, store} = makeStore([existing]);
+  const updater = makeTrackedUpdater(store);
+
+  const update: RowUpdate = {
+    version: '03',
+    contents: {id: 'same-row-version'},
+    refCounts: {oneHash: 1},
+  };
+
+  expect(await updater.received(lc, new Map([[ROW_ID1, update]]))).toEqual([
+    {
+      toVersion: patchVersion,
+      patch: {
+        type: 'row',
+        op: 'put',
+        id: ROW_ID1,
+        contents: {id: 'same-row-version'},
+      },
+    },
+  ] satisfies PatchToVersion[]);
+  expect(putRows).toEqual([]);
+  expect(deletedRows).toEqual([]);
+});
+
+test('received persists changed and deleted row records with the correct patches', async () => {
+  const existing1 = makeRowRecord(ROW_ID1, '03');
+  const existing2 = makeRowRecord(ROW_ID2, '03');
+  const {clearedRows, deletedRows, putRows, store} = makeStore([
+    existing1,
+    existing2,
+  ]);
+  const updater = makeTrackedUpdater(store);
+
+  expect(
+    await updater.received(
+      lc,
+      new Map([
+        [
+          ROW_ID1,
+          {
+            version: '04',
+            contents: {id: 'changed'},
+            refCounts: {oneHash: 1},
+          },
+        ],
+      ]),
+    ),
+  ).toEqual([
+    {
+      toVersion: updatedVersion,
+      patch: {
+        type: 'row',
+        op: 'put',
+        id: ROW_ID1,
+        contents: {id: 'changed'},
+      },
+    },
+  ] satisfies PatchToVersion[]);
+  expect(putRows).toEqual([
+    {
+      ...existing1,
+      rowVersion: '04',
+      patchVersion: updatedVersion,
+    },
+  ]);
+
+  expect(
+    await updater.received(
+      lc,
+      new Map([
+        [
+          ROW_ID2,
+          {
+            refCounts: {oneHash: 0},
+          },
+        ],
+      ]),
+    ),
+  ).toEqual([
+    {
+      toVersion: updatedVersion,
+      patch: {
+        type: 'row',
+        op: 'del',
+        id: ROW_ID2,
+      },
+    },
+  ] satisfies PatchToVersion[]);
+  expect(putRows).toEqual([
+    {
+      ...existing1,
+      rowVersion: '04',
+      patchVersion: updatedVersion,
+    },
+    {
+      ...existing2,
+      patchVersion: updatedVersion,
+      refCounts: null,
+    },
+  ]);
+  expect(deletedRows).toEqual([]);
+  expect(clearedRows).toEqual([]);
+});
+
+test('received cancels a queued row update when the final row record is unchanged', async () => {
+  const existing = makeRowRecord(ROW_ID1, '03');
+  const {clearedRows, putRows, store} = makeStore([existing]);
+  const updater = makeTrackedUpdater(store);
+
+  expect(
+    await updater.received(
+      lc,
+      new Map([
+        [
+          ROW_ID1,
+          {
+            version: '04',
+            contents: {id: 'changed'},
+            refCounts: {oneHash: 1},
+          },
+        ],
+      ]),
+    ),
+  ).toEqual([
+    {
+      toVersion: updatedVersion,
+      patch: {
+        type: 'row',
+        op: 'put',
+        id: ROW_ID1,
+        contents: {id: 'changed'},
+      },
+    },
+  ] satisfies PatchToVersion[]);
+  expect(putRows).toEqual([
+    {
+      ...existing,
+      rowVersion: '04',
+      patchVersion: updatedVersion,
+    },
+  ]);
+
+  expect(
+    await updater.received(
+      lc,
+      new Map([
+        [
+          ROW_ID1,
+          {
+            version: '03',
+            contents: {id: 'original'},
+            refCounts: {oneHash: 0},
+          },
+        ],
+      ]),
+    ),
+  ).toEqual([]);
+  expect(clearedRows).toEqual([ROW_ID1]);
 });

--- a/packages/zero-cache/src/services/view-syncer/cvr.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.ts
@@ -685,7 +685,7 @@ export class CVRQueryDrivenUpdater extends CVRUpdater {
             results.size
           } (of ${total}) rows for executed / removed queries ${[
             ...this.#removedOrExecutedQueryIDs,
-          ]}`,
+          ].join(',')}`,
         );
         return results.values();
       },
@@ -882,12 +882,22 @@ export class CVRQueryDrivenUpdater extends CVRUpdater {
           // for that row, as the row with the old key will be removed.
           const rowVersion = version ?? existing?.rowVersion;
           if (rowVersion) {
-            this._cvrStore.putRowRecord({
+            const rowRecord: RowRecord = {
               id,
               rowVersion,
               patchVersion,
               refCounts: merged,
-            });
+            };
+            if (
+              !deepEqual(
+                rowRecord as ReadonlyJSONValue,
+                existing as ReadonlyJSONValue | undefined,
+              )
+            ) {
+              this._cvrStore.putRowRecord(rowRecord);
+            } else {
+              this._cvrStore.clearRowRecordUpdate(id);
+            }
           } else {
             // This means that a row that was not in the CVR was added during
             // this update, and then subsequently removed. Since there's no


### PR DESCRIPTION
**AI-generated draft.** This PR was produced by an automated analysis pass and requires human review before merging. The code, tests, and benchmarks are real; the prose is AI-authored.

## Why This Is Worth It

The view-syncer often sees rows whose effective CVR row record did not change. Today those rows can still enter the pending persistence map, only to be thrown away later during flush after another deep equality check. That is extra map churn and flush work on the path where the view-syncer is already trying to catch up.

This PR moves that no-op decision earlier.

```
Before
  row update -> build row record -> pendingRowRecordUpdates[100k]
             -> flush -> compare with existing -> drop unchanged row

After
  row update -> build row record -> compare with existing
             -> unchanged? clear pending update immediately
```

The user-facing patch path still runs. This only suppresses a persistence write that would have been dropped at flush time.

## Clean PR Set

These PRs are intentionally not stacked. Each branch is based on `main`, can be reviewed independently, and can be landed or rejected without forcing the others. The benchmark style follows the benchmark-suite work in [#5959](https://github.com/rocicorp/mono/pull/5959).

```
main
 |-- #5968 batch changeLog inserts
 |-- #5972 head-indexed queues
 |-- #5971 suppress no-op CVR row writes        (this PR)
 |-- #5969 cache DML SQL plans
 `-- #5970 flow-control catchup backlog
```

| PR | Role | Link |
| --- | --- | --- |
| Benchmark suite | Shared benchmark harness/style | [#5959](https://github.com/rocicorp/mono/pull/5959) |
| Storer batching | Reduce RM -> changeDB write amplification | [#5968](https://github.com/rocicorp/mono/pull/5968) |
| Queue drains | Remove O(n) FIFO drain costs under backlog | [#5972](https://github.com/rocicorp/mono/pull/5972) |
| CVR no-op rows | Avoid persisting unchanged CVR rows | [#5971](https://github.com/rocicorp/mono/pull/5971) |
| DML plans | Avoid rebuilding repeated replica SQL | [#5969](https://github.com/rocicorp/mono/pull/5969) |
| Catchup backlog | Make catchup handoff obey downstream consumption | [#5970](https://github.com/rocicorp/mono/pull/5970) |

## Shared 1 RM / 16 VS Benchmark Matrix

This same matrix appears in every PR in this set. It is not a cumulative stack result: each column is one independent branch checked out against `main` with the [#5959](https://github.com/rocicorp/mono/pull/5959) benchmark harness overlaid.

```text
1 replication manager
  -> ChangeProcessor
  -> Storer/Postgres changeLog
  -> Forwarder
  -> 16 view-syncer-side subscribers
       healthy:        all subscribers ACK immediately
       slow/reconnect: every 4th subscriber waits 2 ms,
                       and one subscriber reconnects mid-run
```

Command shape:

```bash
ZERO_RM_VS_FULL=1 \
ZERO_RM_VS_DURATION_MS=1500 \
ZERO_RM_VS_SUBSCRIBERS=16 \
npm --workspace=zero-cache run perf:rm-vs-load:full
```

Healthy mode sets `ZERO_RM_VS_SLOW_EVERY=0`. Slow/reconnect mode sets `ZERO_RM_VS_SLOW_EVERY=4`, `ZERO_RM_VS_SLOW_ACK_DELAY_MS=2`, and `ZERO_RM_VS_RECONNECT_LAG_TX=2`.

Rows/s is source-row throughput for the whole RM -> storer -> forwarder -> subscriber run after storer drain/settle. Percent cells are branch-vs-`main` deltas. Negative cells are shown on purpose; those are the cases reviewers should ask about.

| E2E scenario | `main` rows/s | #5968 Storer | #5969 DML | #5970 Catchup | #5971 CVR | #5972 Queue |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| healthy / single-row-flood, 1 small row/tx | 487.3 | +12.7% | -5.5% | +19.2% | -1.4% | +7.2% |
| healthy / medium-batch-pressure, 10 medium rows/tx | 3,737.4 | +3.5% | +3.5% | +3.0% | +3.5% | +2.4% |
| healthy / large-row-burst, 50 large rows/tx | 3,867.5 | -0.0% | -0.1% | -0.1% | +0.0% | -0.1% |
| slow/reconnect / single-row-flood | 116.3 | +3.0% | +1.3% | +2.2% | -0.4% | +2.5% |
| slow/reconnect / medium-batch-pressure | 277.3 | +0.1% | +0.6% | -3.4% | -1.9% | +1.4% |
| slow/reconnect / large-row-burst | 310.8 | -7.4% | +1.6% | -3.1% | -2.8% | -1.1% |

How to read this: the shared e2e matrix is the "does this hurt the whole bridge?" check. The component benchmark below is the sharper proof for this PR's exact mechanism.

## This PR's Read

The shared e2e matrix is a regression check for this PR, not the main evidence of improvement. `perf:rm-vs-load:full` exercises the RM -> storer -> forwarder -> subscriber bridge; this change lives one layer deeper in view-syncer CVR persistence after rows have already reached the view-syncer.

That is why the e2e cells are basically flat/noisy. The useful claim is narrower: when a view-syncer reconstructs a CVR row record and it deep-equals the existing one, we can avoid enqueueing a persistence write that flush would later drop anyway. The component benchmark below isolates that exact no-op CVR case.

## Benchmark

Command:

```bash
npm --workspace=zero-cache run perf:cvr-noop
```

| Scenario | `main` | This PR | Delta |
| --- | ---: | ---: | ---: |
| 100k unchanged CVR row records | 1,156,039 rows/s / 86.5 ms | 5,081,796 rows/s / 19.7 ms | 4.40x faster |
| Rows queued for persistence | 100,000 | 0 | removed |
| Rows cleared as no-op | 0 | 100,000 | explicit early suppression |

## What Changed

- Add `CVRStore.clearRowRecordUpdate()` for cancelling a pending row-record write.
- In `CVRQueryDrivenUpdater.received()`, compare the reconstructed row record with the existing CVR row record.
- If the row record is structurally identical, clear the pending persistence update instead of enqueueing it.
- Preserve normal persistence for changed rows, deleted rows, newly referenced rows, and forced updates.
- Add tests for unchanged rows, changed rows, deleted rows, and changed-then-restored rows.
- Add `perf:cvr-noop` to measure the old enqueue-then-drop shape versus early suppression.

## Why This Is Safe

The safety boundary is strict: only rows that deep-equal the existing CVR row are suppressed. If any field changes, the normal persistence path runs.

Worst case: a row changes and then changes back in the same advancement. That is exactly the scenario that can trick optimistic no-op logic. The test suite covers it. The changed leg still persists normally; the restored leg is suppressed only once the reconstructed row record is identical to what the CVR already has.

Importantly, this does not suppress row patches. The view-syncer can still emit the client-visible patch stream. The optimization only avoids writing a CVR row record that the flush path would later recognize as unchanged and drop.

## Expected Risks

- Moving the equality check earlier could hide a forced write if force state is not cleared with the pending update. `clearRowRecordUpdate()` clears both the pending row update and the force marker.
- Deep equality still has a cost, but the old flush path already performed the same kind of comparison after queueing. This PR avoids the map churn and later flush work.
- The change is scoped to CVR row-record persistence; query/client/desire config flushes are untouched.

## Validation

```bash
npm --workspace=zero-cache run test:no-pg -- cvr.test.ts
npm --workspace=zero-cache run perf:cvr-noop
npx oxfmt --check packages/zero-cache/src/services/view-syncer/cvr.ts packages/zero-cache/src/services/view-syncer/cvr-store.ts packages/zero-cache/src/services/view-syncer/cvr.test.ts packages/zero-cache/bench/cvr-noop.ts packages/zero-cache/package.json
git diff --check
```
