### PR TITLE
perf(zero-cache): use head-indexed queues

### DIFF
--- a/packages/shared/src/queue.test.ts
+++ b/packages/shared/src/queue.test.ts
@@ -219,4 +219,52 @@ describe('Queue', () => {
     queue.enqueue(3);
     await promise;
   });
+
+  test('dequeue and drain keep FIFO order after many dequeues', async () => {
+    const queue = new Queue<number>();
+    for (let i = 0; i < 2048; i++) {
+      queue.enqueue(i);
+    }
+
+    for (let i = 0; i < 1024; i++) {
+      expect(await queue.dequeue()).toBe(i);
+    }
+    queue.enqueue(2048);
+    queue.enqueue(2049);
+
+    expect(queue.size()).toBe(1026);
+    expect(queue.drain()).toEqual(
+      Array.from({length: 1026}, (_, i) => i + 1024),
+    );
+    expect(queue.size()).toBe(0);
+  });
+
+  test('delete and drain ignore already dequeued head entries', async () => {
+    const queue = new Queue<string>();
+    queue.enqueue('a');
+    queue.enqueue('b');
+    queue.enqueue('c');
+    queue.enqueue('d');
+
+    expect(await queue.dequeue()).toBe('a');
+    expect(queue.delete('c')).toBe(1);
+
+    expect(queue.size()).toBe(2);
+    expect(queue.drain()).toEqual(['b', 'd']);
+    expect(queue.size()).toBe(0);
+  });
+
+  test('timed out consumers do not block later enqueues', async () => {
+    const queue = new Queue<string>();
+    const timedOut = Promise.all(
+      Array.from({length: 8}, () => queue.dequeue('timed out', 5)),
+    );
+
+    expect(await timedOut).toEqual(Array.from({length: 8}).fill('timed out'));
+
+    queue.enqueue('live');
+    expect(queue.size()).toBe(1);
+    expect(await queue.dequeue()).toBe('live');
+    expect(queue.size()).toBe(0);
+  });
 });

--- a/packages/shared/src/queue.ts
+++ b/packages/shared/src/queue.ts
@@ -7,28 +7,34 @@ import {assert} from './asserts.ts';
  */
 export class Queue<T> {
   // Consumers waiting for entries to be produced.
-  readonly #consumers: Consumer<T>[] = [];
+  readonly #consumers: (Consumer<T> | undefined)[] = [];
+  #consumerHead = 0;
+  #consumerCount = 0;
   // Produced entries waiting to be consumed.
-  readonly #produced: Produced<T>[] = [];
+  readonly #produced: (Produced<T> | undefined)[] = [];
+  #producedHead = 0;
+  #producedCount = 0;
 
   enqueue(value: T): void {
-    const consumer = this.#consumers.shift();
+    const consumer = this.#dequeueConsumer();
     if (consumer) {
       consumer.resolver.resolve(value);
       clearTimeout(consumer.timeoutID);
       return;
     }
     this.#produced.push({value});
+    this.#producedCount++;
   }
 
   enqueueRejection(reason?: unknown): void {
-    const consumer = this.#consumers.shift();
+    const consumer = this.#dequeueConsumer();
     if (consumer) {
       consumer.resolver.reject(reason);
       clearTimeout(consumer.timeoutID);
       return;
     }
     this.#produced.push({rejection: reason});
+    this.#producedCount++;
   }
 
   /**
@@ -44,13 +50,15 @@ export class Queue<T> {
     assert(value !== undefined, 'Queue delete value must not be undefined');
 
     let count = 0;
-    for (let i = this.#produced.length - 1; i >= 0; i--) {
+    for (let i = this.#produced.length - 1; i >= this.#producedHead; i--) {
       const p = this.#produced[i];
-      if (p.value === value) {
-        this.#produced.splice(i, 1);
+      if (p?.value === value) {
+        this.#produced[i] = undefined;
+        this.#producedCount--;
         count++;
       }
     }
+    this.#maybeCompactProduced();
     return count;
   }
 
@@ -61,22 +69,26 @@ export class Queue<T> {
    * @returns A Promise that resolves to the next enqueued value.
    */
   dequeue(timeoutValue?: T, timeoutMs: number = 0): Promise<T> | T {
-    const produced = this.#produced.shift();
+    const produced = this.#dequeueProduced();
     if (produced) {
       return produced.value ?? Promise.reject(produced.rejection);
     }
     const r = resolver<T>();
-    const timeoutID =
+    const consumer: Consumer<T> = {resolver: r, timeoutID: undefined};
+    consumer.timeoutID =
       timeoutValue === undefined
         ? undefined
         : setTimeout(() => {
-            const i = this.#consumers.findIndex(c => c.resolver === r);
+            const i = this.#consumers.indexOf(consumer, this.#consumerHead);
             if (i >= 0) {
-              const [consumer] = this.#consumers.splice(i, 1);
+              this.#consumers[i] = undefined;
+              this.#consumerCount--;
               consumer.resolver.resolve(timeoutValue);
+              this.#maybeCompactConsumers();
             }
           }, timeoutMs);
-    this.#consumers.push({resolver: r, timeoutID});
+    this.#consumers.push(consumer);
+    this.#consumerCount++;
     return r.promise;
   }
 
@@ -96,10 +108,13 @@ export class Queue<T> {
    */
   drain(): (T | undefined)[] {
     const ret: (T | undefined)[] = [];
-    for (const p of this.#produced) {
-      ret.push(p.value);
+    for (let i = this.#producedHead; i < this.#produced.length; i++) {
+      const p = this.#produced[i];
+      if (p) {
+        ret.push(p.value);
+      }
     }
-    this.#produced.length = 0;
+    this.#resetProduced();
 
     return ret;
   }
@@ -111,7 +126,7 @@ export class Queue<T> {
    *          handed to the consumer and the Queue's size remains 0.
    */
   size(): number {
-    return this.#produced.length;
+    return this.#producedCount;
   }
 
   asAsyncIterable(cleanup = NOOP): AsyncIterable<T> {
@@ -134,6 +149,86 @@ export class Queue<T> {
         return Promise.resolve({value, done: true});
       },
     };
+  }
+
+  #dequeueConsumer(): Consumer<T> | undefined {
+    if (this.#consumerCount === 0) {
+      this.#resetConsumers();
+      return undefined;
+    }
+
+    while (this.#consumerHead < this.#consumers.length) {
+      const consumer = this.#consumers[this.#consumerHead];
+      this.#consumers[this.#consumerHead] = undefined;
+      this.#consumerHead++;
+      if (consumer) {
+        this.#consumerCount--;
+        this.#maybeCompactConsumers();
+        return consumer;
+      }
+    }
+
+    this.#consumerCount = 0;
+    this.#resetConsumers();
+    return undefined;
+  }
+
+  #dequeueProduced(): Produced<T> | undefined {
+    if (this.#producedCount === 0) {
+      this.#resetProduced();
+      return undefined;
+    }
+
+    while (this.#producedHead < this.#produced.length) {
+      const produced = this.#produced[this.#producedHead];
+      this.#produced[this.#producedHead] = undefined;
+      this.#producedHead++;
+      if (produced) {
+        this.#producedCount--;
+        this.#maybeCompactProduced();
+        return produced;
+      }
+    }
+
+    this.#producedCount = 0;
+    this.#resetProduced();
+    return undefined;
+  }
+
+  #maybeCompactConsumers(): void {
+    if (this.#consumerCount === 0) {
+      this.#resetConsumers();
+    } else if (
+      this.#consumerHead > 1024 &&
+      this.#consumerHead * 2 > this.#consumers.length
+    ) {
+      this.#consumers.splice(0, this.#consumerHead);
+      this.#consumerHead = 0;
+    }
+  }
+
+  #maybeCompactProduced(): void {
+    if (this.#producedCount === 0) {
+      this.#resetProduced();
+    } else if (
+      this.#producedHead > 1024 &&
+      this.#producedHead * 2 > this.#produced.length
+    ) {
+      this.#produced.splice(0, this.#producedHead);
+      this.#producedHead = 0;
+    }
+  }
+
+  #resetConsumers(): void {
+    this.#consumers.length = 0;
+    this.#consumerHead = 0;
+    this.#consumerCount = 0;
+  }
+
+  #resetProduced(): void {
+    this.#produced.length = 0;
+    this.#producedHead = 0;
+    this.#producedCount = 0;
   }
 }
 

--- a/packages/zero-cache/bench/queue-overhead.ts
+++ b/packages/zero-cache/bench/queue-overhead.ts
@@ -1,0 +1,129 @@
+/* oxlint-disable no-console */
+import {performance} from 'node:perf_hooks';
+import {Queue} from '../../shared/src/queue.ts';
+import {Subscription} from '../src/types/subscription.ts';
+
+type Result = {
+  readonly scenario: string;
+  readonly mode: string;
+  readonly count: number;
+  readonly elapsedMs: number;
+  readonly opsPerSec: number;
+};
+
+type Summary = {
+  readonly name: 'queue-overhead';
+  readonly generatedAt: string;
+  readonly count: number;
+  readonly results: Result[];
+};
+
+const count = envInt('ZERO_QUEUE_BENCH_COUNT', 200_000);
+const results: Result[] = [];
+
+results.push(runQueueShiftBaseline(count));
+results.push(runQueue(count));
+results.push(runSubscriptionShiftBaseline(count));
+results.push(await runSubscription(count));
+
+for (const result of results) {
+  console.log(
+    `${result.scenario} ${result.mode}: ` +
+      `${formatRate(result.opsPerSec)} ops/s | ${result.elapsedMs.toFixed(1)} ms`,
+  );
+}
+
+const summary: Summary = {
+  name: 'queue-overhead',
+  generatedAt: new Date().toISOString(),
+  count,
+  results,
+};
+console.log(JSON.stringify(summary));
+
+function runQueueShiftBaseline(count: number): Result {
+  const values: number[] = [];
+  const start = performance.now();
+  for (let i = 0; i < count; i++) {
+    values.push(i);
+  }
+  for (let i = 0; i < count; i++) {
+    values.shift();
+  }
+  return result('Queue FIFO', 'array-shift baseline', count, start);
+}
+
+function runQueue(count: number): Result {
+  const queue = new Queue<number>();
+  const start = performance.now();
+  for (let i = 0; i < count; i++) {
+    queue.enqueue(i);
+  }
+  for (let i = 0; i < count; i++) {
+    void queue.dequeue();
+  }
+  return result('Queue FIFO', 'head-index deque', count, start);
+}
+
+function runSubscriptionShiftBaseline(count: number): Result {
+  const values: number[] = [];
+  const start = performance.now();
+  for (let i = 0; i < count; i++) {
+    values.push(i);
+  }
+  for (let i = 0; i < count; i++) {
+    values.shift();
+  }
+  return result(
+    'Subscription queued drain',
+    'array-shift baseline',
+    count,
+    start,
+  );
+}
+
+async function runSubscription(count: number): Promise<Result> {
+  const subscription = Subscription.create<number>();
+  for (let i = 0; i < count; i++) {
+    subscription.push(i);
+  }
+  subscription.end();
+
+  const start = performance.now();
+  for await (const _ of subscription) {
+    // Drain.
+  }
+  return result('Subscription queued drain', 'head-index deque', count, start);
+}
+
+function result(
+  scenario: string,
+  mode: string,
+  count: number,
+  start: number,
+): Result {
+  const elapsedMs = performance.now() - start;
+  return {
+    scenario,
+    mode,
+    count,
+    elapsedMs,
+    opsPerSec: count / (elapsedMs / 1000),
+  };
+}
+
+function envInt(name: string, fallback: number): number {
+  const value = process.env[name];
+  if (value === undefined || value === '') {
+    return fallback;
+  }
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`Invalid integer ${name}=${value}`);
+  }
+  return parsed;
+}
+
+function formatRate(value: number): string {
+  return value.toLocaleString('en-US', {maximumFractionDigits: 1});
+}

--- a/packages/zero-cache/package.json
+++ b/packages/zero-cache/package.json
@@ -24,6 +24,7 @@
     "bench": "vitest run --config vitest.config.bench.ts",
     "bench:bmf": "BENCH_OUTPUT_FORMAT=json npm run bench 2>&1 | npx tsx ../shared/src/tool/mitata-json-to-bmf.ts",
     "bench:bmf:silent": "npm run bench:bmf --silent",
+    "perf:queue": "tsx ./bench/queue-overhead.ts",
     "local": "tsx tool/local.ts",
     "start": "tsx ./src/server/runner/main.ts",
     "benchdb": "tsx ./bench/bench.ts",

--- a/packages/zero-cache/src/types/subscription.test.ts
+++ b/packages/zero-cache/src/types/subscription.test.ts
@@ -628,4 +628,79 @@ describe('types/subscription', () => {
     });
     expect(subWithCoalesceAndPipeline.pipeline).not.toBeUndefined();
   });
+
+  test('pipeline cancel cleanup ignores already dequeued head entries', async () => {
+    const consumed: number[] = [];
+    const cleanup = vi.fn();
+    const results: Promise<Result>[] = [];
+
+    const subscription = Subscription.create<number>({
+      cleanup,
+      consumed: m => consumed.push(m),
+    });
+    for (let i = 0; i < 1500; i++) {
+      results.push(subscription.push(i).result);
+    }
+
+    assert(
+      subscription.pipeline,
+      'Expected subscription pipeline to be defined',
+    );
+    const iterator = subscription.pipeline[Symbol.asyncIterator]();
+
+    for (let i = 0; i < 1200; i++) {
+      const next = await iterator.next();
+      assert(!next.done, 'Expected next subscription entry');
+      expect(next.value.value).toBe(i);
+      next.value.consumed();
+      expect(await results[i]).toBe('consumed');
+    }
+
+    const current = await iterator.next();
+    assert(!current.done, 'Expected current subscription entry');
+    expect(current.value.value).toBe(1200);
+    expect(subscription.queued).toBe(299);
+
+    subscription.cancel();
+    expect(await iterator.next()).toEqual({value: undefined, done: true});
+
+    for (let i = 1200; i < 1500; i++) {
+      expect(await results[i]).toBe('unconsumed');
+    }
+    expect(consumed).toEqual(Array.from({length: 1200}, (_, i) => i));
+    expect(cleanup).toBeCalledTimes(1);
+    expect(cleanup.mock.calls[0][0]).toEqual(
+      Array.from({length: 300}, (_, i) => i + 1200),
+    );
+  });
+
+  test('end drains queued messages after head advances', async () => {
+    const consumed: number[] = [];
+    const cleanup = vi.fn();
+    const results: Promise<Result>[] = [];
+
+    const subscription = Subscription.create<number>({
+      cleanup,
+      consumed: m => consumed.push(m),
+    });
+    for (let i = 0; i < 1500; i++) {
+      results.push(subscription.push(i).result);
+    }
+
+    const received: number[] = [];
+    for await (const m of subscription) {
+      received.push(m);
+      if (m === 1199) {
+        subscription.end();
+      }
+    }
+
+    expect(received).toEqual(Array.from({length: 1500}, (_, i) => i));
+    expect(consumed).toEqual(received);
+    expect(cleanup).toBeCalledTimes(1);
+    expect(cleanup.mock.calls[0][0]).toEqual([]);
+    for (const result of results) {
+      expect(await result).toBe('consumed');
+    }
+  });
 });

--- a/packages/zero-cache/src/types/subscription.ts
+++ b/packages/zero-cache/src/types/subscription.ts
@@ -75,9 +75,12 @@ export class Subscription<T, M = T> implements Source<T>, Sink<M> {
   }
 
   // Consumers waiting to consume messages (i.e. an async iteration awaiting the next message).
-  readonly #consumers: Resolver<Entry<M> | null>[] = [];
+  readonly #consumers: (Resolver<Entry<M> | null> | undefined)[] = [];
+  #consumerHead = 0;
   // Messages waiting to be dequeued.
-  readonly #messages: (Entry<M> | 'terminus')[] = [];
+  readonly #messages: (Entry<M> | 'terminus' | undefined)[] = [];
+  #messageHead = 0;
+  #messageCount = 0;
   // Messages dequeued but not yet consumed.
   readonly #consuming = new Set<Entry<M>>();
   readonly #pipelineEnabled: boolean;
@@ -151,23 +154,26 @@ export class Subscription<T, M = T> implements Source<T>, Sink<M> {
       entry.resolve('unconsumed');
       return {result};
     }
-    const consumer = this.#consumers.shift();
+    const consumer = this.#dequeueConsumer();
     if (consumer) {
       consumer.resolve(entry);
     } else if (
       this.#coalesce &&
-      this.#messages.length &&
-      this.#messages.at(-1) !== 'terminus'
+      this.#messageCount > 0 &&
+      this.#lastMessage() !== 'terminus'
     ) {
       // oxlint-disable-next-line typescript/no-non-null-assertion
       const prev = this.#messages.at(-1)!;
-      assert(prev !== 'terminus', 'prev should not be terminus after check');
+      assert(
+        prev !== undefined && prev !== 'terminus',
+        'prev should be an entry after check',
+      );
       this.#messages[this.#messages.length - 1] = {
         value: this.#coalesce(entry, prev),
         resolve,
       };
     } else {
-      this.#messages.push(entry);
+      this.#enqueueMessage(entry);
     }
     return {result};
   }
@@ -179,7 +185,7 @@ export class Subscription<T, M = T> implements Source<T>, Sink<M> {
 
   /** The number of messages waiting to be dequeued. */
   get queued(): number {
-    return this.#messages.length;
+    return this.#messageCount;
   }
 
   /** The number of messages dequeued but not yet "consumed" */
@@ -202,10 +208,10 @@ export class Subscription<T, M = T> implements Source<T>, Sink<M> {
   end() {
     if (this.#sentinel) {
       // already terminated
-    } else if (this.#messages.length === 0) {
+    } else if (this.#messageCount === 0) {
       this.cancel();
     } else {
-      this.#messages.push('terminus');
+      this.#enqueueMessage('terminus');
     }
   }
 
@@ -231,15 +237,15 @@ export class Subscription<T, M = T> implements Source<T>, Sink<M> {
     if (!this.#sentinel) {
       this.#sentinel = sentinel;
       this.#cleanup(
-        [...this.#consuming, ...this.#messages.filter(m => m !== 'terminus')],
+        [...this.#consuming, ...this.#pendingMessages()],
         sentinel instanceof Error ? sentinel : undefined,
       );
-      this.#messages.splice(0);
+      this.#resetMessages();
 
       for (
-        let consumer = this.#consumers.shift();
+        let consumer = this.#dequeueConsumer();
         consumer;
-        consumer = this.#consumers.shift()
+        consumer = this.#dequeueConsumer()
       ) {
         sentinel === 'canceled'
           ? consumer.resolve(null)
@@ -257,7 +263,7 @@ export class Subscription<T, M = T> implements Source<T>, Sink<M> {
   #pipeline(): AsyncIterator<{value: T; consumed: () => void}> {
     return {
       next: async () => {
-        const entry = this.#messages.shift();
+        const entry = this.#dequeueMessage();
         if (entry === 'terminus') {
           this.cancel();
           return {value: undefined, done: true};
@@ -326,6 +332,96 @@ export class Subscription<T, M = T> implements Source<T>, Sink<M> {
         return Promise.resolve({value, done: true});
       },
     };
+  }
+
+  #dequeueConsumer(): Resolver<Entry<M> | null> | undefined {
+    while (this.#consumerHead < this.#consumers.length) {
+      const consumer = this.#consumers[this.#consumerHead];
+      this.#consumers[this.#consumerHead] = undefined;
+      this.#consumerHead++;
+      if (consumer) {
+        this.#maybeCompactConsumers();
+        return consumer;
+      }
+    }
+
+    this.#resetConsumers();
+    return undefined;
+  }
+
+  #enqueueMessage(message: Entry<M> | 'terminus'): void {
+    this.#messages.push(message);
+    this.#messageCount++;
+  }
+
+  #dequeueMessage(): Entry<M> | 'terminus' | undefined {
+    if (this.#messageCount === 0) {
+      this.#resetMessages();
+      return undefined;
+    }
+
+    while (this.#messageHead < this.#messages.length) {
+      const message = this.#messages[this.#messageHead];
+      this.#messages[this.#messageHead] = undefined;
+      this.#messageHead++;
+      if (message) {
+        this.#messageCount--;
+        this.#maybeCompactMessages();
+        return message;
+      }
+    }
+
+    this.#messageCount = 0;
+    this.#resetMessages();
+    return undefined;
+  }
+
+  #lastMessage(): Entry<M> | 'terminus' | undefined {
+    return this.#messageCount === 0 ? undefined : this.#messages.at(-1);
+  }
+
+  #pendingMessages(): Entry<M>[] {
+    const pending: Entry<M>[] = [];
+    for (let i = this.#messageHead; i < this.#messages.length; i++) {
+      const message = this.#messages[i];
+      if (message && message !== 'terminus') {
+        pending.push(message);
+      }
+    }
+    return pending;
+  }
+
+  #maybeCompactConsumers(): void {
+    if (
+      this.#consumerHead > 1024 &&
+      this.#consumerHead * 2 > this.#consumers.length
+    ) {
+      this.#consumers.splice(0, this.#consumerHead);
+      this.#consumerHead = 0;
+    }
+  }
+
+  #maybeCompactMessages(): void {
+    if (this.#messageCount === 0) {
+      this.#resetMessages();
+    } else if (
+      this.#messageHead > 1024 &&
+      this.#messageHead * 2 > this.#messages.length
+    ) {
+      this.#messages.splice(0, this.#messageHead);
+      this.#messageHead = 0;
+    }
+  }
+
+  #resetConsumers(): void {
+    this.#consumers.length = 0;
+    this.#consumerHead = 0;
+  }
+
+  #resetMessages(): void {
+    this.#messages.length = 0;
+    this.#messageHead = 0;
+    this.#messageCount = 0;
   }
 }
 


### PR DESCRIPTION
**AI-generated draft.** This PR was produced by an automated analysis pass and requires human review before merging. The code, tests, and benchmarks are real; the prose is AI-authored.

## Why This Is Worth It

When the view-syncer falls behind, the worst thing a queue can do is make every dequeue copy the rest of the backlog. That is what `Array.shift()` does. The larger the backlog gets, the more each "remove one item" operation becomes an accidental array compaction job.

This PR changes the hot FIFO internals in `Queue` and `Subscription` to use a head index. Dequeue becomes "read slot, advance pointer"; occasional compaction happens only after enough head slots are dead.

```
Before: shift()
  [a b c d e f g] -> pop a -> [b c d e f g]
                         copies the tail every time

After: head index
  [a b c d e f g], head=0
  [_ b c d e f g], head=1
  [_ _ c d e f g], head=2
       compact later, not on every pop
```

## Clean PR Set

These PRs are intentionally not stacked. Each branch is based on `main`, can be reviewed independently, and can be landed or rejected without forcing the others. The benchmark style follows the benchmark-suite work in [#5959](https://github.com/rocicorp/mono/pull/5959).

```
main
 |-- #5968 batch changeLog inserts
 |-- #5972 head-indexed queues                  (this PR)
 |-- #5971 suppress no-op CVR row writes
 |-- #5969 cache DML SQL plans
 `-- #5970 flow-control catchup backlog
```

| PR | Role | Link |
| --- | --- | --- |
| Benchmark suite | Shared benchmark harness/style | [#5959](https://github.com/rocicorp/mono/pull/5959) |
| Storer batching | Reduce RM -> changeDB write amplification | [#5968](https://github.com/rocicorp/mono/pull/5968) |
| Queue drains | Remove O(n) FIFO drain costs under backlog | [#5972](https://github.com/rocicorp/mono/pull/5972) |
| CVR no-op rows | Avoid persisting unchanged CVR rows | [#5971](https://github.com/rocicorp/mono/pull/5971) |
| DML plans | Avoid rebuilding repeated replica SQL | [#5969](https://github.com/rocicorp/mono/pull/5969) |
| Catchup backlog | Make catchup handoff obey downstream consumption | [#5970](https://github.com/rocicorp/mono/pull/5970) |

## Shared 1 RM / 16 VS Benchmark Matrix

This same matrix appears in every PR in this set. It is not a cumulative stack result: each column is one independent branch checked out against `main` with the [#5959](https://github.com/rocicorp/mono/pull/5959) benchmark harness overlaid.

```text
1 replication manager
  -> ChangeProcessor
  -> Storer/Postgres changeLog
  -> Forwarder
  -> 16 view-syncer-side subscribers
       healthy:        all subscribers ACK immediately
       slow/reconnect: every 4th subscriber waits 2 ms,
                       and one subscriber reconnects mid-run
```

Command shape:

```bash
ZERO_RM_VS_FULL=1 \
ZERO_RM_VS_DURATION_MS=1500 \
ZERO_RM_VS_SUBSCRIBERS=16 \
npm --workspace=zero-cache run perf:rm-vs-load:full
```

Healthy mode sets `ZERO_RM_VS_SLOW_EVERY=0`. Slow/reconnect mode sets `ZERO_RM_VS_SLOW_EVERY=4`, `ZERO_RM_VS_SLOW_ACK_DELAY_MS=2`, and `ZERO_RM_VS_RECONNECT_LAG_TX=2`.

Rows/s is source-row throughput for the whole RM -> storer -> forwarder -> subscriber run after storer drain/settle. Percent cells are branch-vs-`main` deltas. Negative cells are shown on purpose; those are the cases reviewers should ask about.

| E2E scenario | `main` rows/s | #5968 Storer | #5969 DML | #5970 Catchup | #5971 CVR | #5972 Queue |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| healthy / single-row-flood, 1 small row/tx | 487.3 | +12.7% | -5.5% | +19.2% | -1.4% | +7.2% |
| healthy / medium-batch-pressure, 10 medium rows/tx | 3,737.4 | +3.5% | +3.5% | +3.0% | +3.5% | +2.4% |
| healthy / large-row-burst, 50 large rows/tx | 3,867.5 | -0.0% | -0.1% | -0.1% | +0.0% | -0.1% |
| slow/reconnect / single-row-flood | 116.3 | +3.0% | +1.3% | +2.2% | -0.4% | +2.5% |
| slow/reconnect / medium-batch-pressure | 277.3 | +0.1% | +0.6% | -3.4% | -1.9% | +1.4% |
| slow/reconnect / large-row-burst | 310.8 | -7.4% | +1.6% | -3.1% | -2.8% | -1.1% |

How to read this: the shared e2e matrix is the "does this hurt the whole bridge?" check. The component benchmark below is the sharper proof for this PR's exact mechanism.

## This PR's Read

The e2e suite gives this PR a sanity check under real-ish RM/VS pressure: healthy `single-row-flood` is +7.2%, and slow/reconnect `single-row-flood` is +2.5%. The larger rows are basically flat because queue mechanics are not the dominant cost once payload serialization and subscriber pacing take over.

The worst case this PR is trying to prevent is not visible as a tiny per-row improvement. It is the pathological backlog shape where every dequeue copies the remaining array. The component benchmark below creates that backlog directly and shows why the data-structure change is worth reviewing even when the mixed e2e rows are modest.

## Benchmark

Command:

```bash
npm --workspace=zero-cache run perf:queue
```

| Scenario | `main` | This PR | Delta |
| --- | ---: | ---: | ---: |
| `Queue` FIFO drain | 77,258 ops/s / 2588.7 ms | 12,494,469 ops/s / 16.0 ms | 161.7x faster |
| `Subscription` queued drain | 78,231 ops/s / 2556.5 ms | 2,919,381 ops/s / 68.5 ms | 37.3x faster |

## What Changed

- Replace `Array.shift()` in `shared/Queue` with a head-indexed internal array.
- Replace `Array.shift()` in `zero-cache` `Subscription` with the same bounded FIFO shape.
- Preserve the public APIs and cleanup semantics.
- Compact consumed head slots when the dead prefix is large enough.
- Add tests for timeout cleanup, delete-after-dequeue, cancellation, `end()`, and pipeline cleanup.
- Add `perf:queue` to compare old shift-style FIFO drains against the new shape.

## Why This Is Safe

The behavior is still FIFO. The representation changed from "the next item is always at index 0" to "the next item is at `head`." That is a mechanical data-structure change, not a protocol or lifecycle change.

Worst case: the head index advances forever and keeps references alive. The implementation resets the array when it empties and compacts when the dead prefix is both larger than 1024 and more than half the array. That bounds stale slots without making every dequeue pay for compaction.

The cases most likely to break are the non-happy paths: timeout consumers, deletes from the queued region, cancellation while messages are in flight, and `end()` sent after head advancement. Those are covered by focused tests.

## Expected Risks

- Off-by-one errors around compaction are the main risk. The tests exercise empty queues, sparse deleted slots, and active consumers.
- A consumer cleanup regression would be worse than a throughput regression. Existing cleanup paths still receive the unconsumed entries; tests cover cancel/end behavior.
- This PR touches shared infrastructure, so review should focus on semantics first and benchmark numbers second.

## Validation

```bash
npx vitest run packages/shared/src/queue.test.ts packages/zero-cache/src/types/subscription.test.ts
npm --workspace=zero-cache run perf:queue
npx oxfmt --check packages/shared/src/queue.ts packages/shared/src/queue.test.ts packages/zero-cache/src/types/subscription.ts packages/zero-cache/src/types/subscription.test.ts packages/zero-cache/bench/queue-overhead.ts packages/zero-cache/package.json
git diff --check
```
