### PR TITLE
fix(perf-v2): disable git hooks before github-action-benchmark steps

### DIFF
--- a/.github/workflows/perf-v2.js.yml
+++ b/.github/workflows/perf-v2.js.yml
@@ -49,6 +49,10 @@ jobs:
           npx tsx tool/split-perf.ts perf-temp-output.json perf-v2-output.json perf-v2-p95-output.json
         shell: bash
 
+      # Disable git hooks so github-action-benchmark can commit to gh-pages
+      # (the pre-commit hook references tools/ which doesn't exist on gh-pages)
+      - run: git config core.hooksPath /dev/null
+
       # Run `github-action-benchmark` action
       - name: Store benchmark result
         uses: rhysd/github-action-benchmark@v1

--- a/packages/replicache-perf/src/runner.ts
+++ b/packages/replicache-perf/src/runner.ts
@@ -343,9 +343,9 @@ async function runInBrowser(
     await waitForBenchmarks();
   }
   if (options.format === 'json') {
-    process.stdout.write(JSON.stringify(jsonEntries, undefined, 2) + '\n');
+    process.stdout.write(JSON.stringify(jsonEntries, jsonReplacer, 2) + '\n');
   } else if (options.format === 'bmf') {
-    process.stdout.write(JSON.stringify(bmf, undefined, 2) + '\n');
+    process.stdout.write(JSON.stringify(bmf, jsonReplacer, 2) + '\n');
   }
 }
 
@@ -359,6 +359,15 @@ function logLine(s: string, options: commandLineArgs.CommandLineOptions) {
   if (options.format !== 'json' && options.format !== 'bmf') {
     process.stdout.write(s + '\n');
   }
+}
+
+function jsonReplacer(_key: string, value: unknown): unknown {
+  if (typeof value === 'number' && !Number.isFinite(value)) {
+    throw new Error(
+      `Non-finite number in benchmark output: ${value}. This indicates a bug in the benchmark runner.`,
+    );
+  }
+  return value;
 }
 
 function wait(n: number) {


### PR DESCRIPTION
The self-hosted runner has a `.git/hooks/pre-commit` hook that calls `./tools/git-hooks/pre-commit.ts`. When `github-action-benchmark` switches to the `gh-pages` branch to store results, that file doesn't exist on that branch, causing the commit to fail with `not found` and then `git checkout -` to fail because of uncommitted changes.

Fix: add `git config core.hooksPath /dev/null` before the store steps to disable hooks for the remainder of the job.