### PR TITLE
chore(zero-cache): throw init error after publishing critical event

### DIFF
--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -245,8 +245,13 @@ export default async function runWorker(
 if (!singleProcessMode()) {
   void exitAfter(lc, () =>
     runWorker(must(parentWorker), process.env, ...process.argv.slice(2)).catch(
-      e =>
-        publishCriticalEvent(lc, replicationStatusError(lc, 'Initializing', e)),
+      async e => {
+        await publishCriticalEvent(
+          lc,
+          replicationStatusError(lc, 'Initializing', e),
+        );
+        throw e;
+      },
     ),
   );
 }


### PR DESCRIPTION
Fixes https://github.com/rocicorp/mono/pull/5956 to not swallow the error