### PR TITLE
fix(zero-client): handle WebSocket close code 1009 to prevent reconnect loop

### DIFF
--- a/packages/zero-client/src/client/test-utils.ts
+++ b/packages/zero-client/src/client/test-utils.ts
@@ -260,9 +260,11 @@ export class TestZero<
     return this.triggerMessage(msg);
   }
 
-  async triggerClose(): Promise<void> {
+  async triggerClose(code?: number | undefined): Promise<void> {
     const socket = await this.socket;
-    socket.dispatchEvent(new CloseEvent('close'));
+    socket.dispatchEvent(
+      new CloseEvent('close', code !== undefined ? {code} : undefined),
+    );
   }
 
   async triggerGotQueriesPatch(

--- a/packages/zero-client/src/client/zero.test.ts
+++ b/packages/zero-client/src/client/zero.test.ts
@@ -3047,6 +3047,23 @@ test('close code 1009 (Message Too Big) disables client group and reloads', asyn
   expect(z.connectionStatus).toBe(ConnectionStatus.Connected);
   expect(hasMemStore(z.idbName)).toBe(true);
 
+  // Send a push message directly to populate the recent sent messages buffer
+  await z.pusher({
+    profileID: 'p1',
+    clientGroupID: 'c1',
+    mutations: [
+      {
+        clientID: 'c1',
+        id: 1,
+        name: 'issues.insert',
+        args: {id: '1', value: 'a large payload'},
+        timestamp: 123,
+      },
+    ],
+    pushVersion: 1,
+    schemaVersion: '1',
+  }, 'req-1');
+
   await z.triggerClose(1009);
 
   await vi.waitUntil(() => storage[RELOAD_REASON_STORAGE_KEY] !== undefined);
@@ -3060,8 +3077,12 @@ test('close code 1009 (Message Too Big) disables client group and reloads', asyn
   expect(hasMemStore(z.idbName)).toBe(true);
   expect(storage[RELOAD_REASON_STORAGE_KEY]).toContain('InvalidMessage');
   expect(storage[RELOAD_REASON_STORAGE_KEY]).toContain(
-    'ZERO_WEBSOCKET_MAX_PAYLOAD_BYTES',
+    'exceeded the server message size limit',
   );
+  // Assert recent messages logic worked
+  expect(storage[RELOAD_REASON_STORAGE_KEY]).toContain('Recent sent messages:');
+  expect(storage[RELOAD_REASON_STORAGE_KEY]).toContain('push');
+  expect(storage[RELOAD_REASON_STORAGE_KEY]).toContain('a large payload');
 });
 
 test('close code 1009 with custom onClientStateNotFound defers reload', async () => {
@@ -3088,7 +3109,7 @@ test('close code 1009 with custom onClientStateNotFound defers reload', async ()
   assert(state.name === ConnectionStatus.Error);
   expect(state.reason).toBeInstanceOf(ClientError);
   expect(state.reason.kind).toBe(ClientErrorKind.InvalidMessage);
-  expect(state.reason.message).toContain('ZERO_WEBSOCKET_MAX_PAYLOAD_BYTES');
+  expect(state.reason.message).toContain('exceeded the server message size limit');
 });
 
 test('Constructing Zero with a negative hiddenTabDisconnectDelay option throws an error', () => {

--- a/packages/zero-client/src/client/zero.test.ts
+++ b/packages/zero-client/src/client/zero.test.ts
@@ -3033,6 +3033,59 @@ test('local onClientStateNotFound default handler', async () => {
   );
 });
 
+test('close code 1009 (Message Too Big) disables client group and reloads', async () => {
+  const storage: Record<string, string> = {};
+  vi.spyOn(window, 'sessionStorage', 'get').mockImplementation(() =>
+    storageMock(storage),
+  );
+  const {promise, resolve} = resolver();
+  const reload = vi.fn(resolve);
+  const z = zeroForTest();
+  z.reload = reload;
+
+  await z.triggerConnected();
+  expect(z.connectionStatus).toBe(ConnectionStatus.Connected);
+  expect(hasMemStore(z.idbName)).toBe(true);
+
+  await z.triggerClose(1009);
+
+  await vi.waitUntil(() => storage[RELOAD_REASON_STORAGE_KEY] !== undefined);
+  await promise;
+
+  expect(reload).toHaveBeenCalledTimes(1);
+  // disableClientGroup does not drop the database, just the client group
+  expect(hasMemStore(z.idbName)).toBe(true);
+  expect(storage[RELOAD_REASON_STORAGE_KEY]).toBe(
+    '["InvalidMessage","A mutation exceeded the server message size limit. Local state has been reset."]',
+  );
+});
+
+test('close code 1009 with custom onClientStateNotFound handler', async () => {
+  const {promise, resolve} = resolver();
+  let z: TestZero<Schema>;
+  const fake = vi.fn(() => {
+    // disableClientGroup does not drop the database
+    expect(hasMemStore(z.idbName)).toBe(true);
+    resolve();
+  });
+  z = zeroForTest({onClientStateNotFound: fake});
+  const reload = vi.fn();
+  z.reload = reload;
+
+  await z.triggerConnected();
+  expect(z.connectionStatus).toBe(ConnectionStatus.Connected);
+  expect(hasMemStore(z.idbName)).toBe(true);
+
+  await z.triggerClose(1009);
+
+  await promise;
+
+  expect(fake).toHaveBeenCalledTimes(1);
+  expect(fake).toHaveBeenCalledWith();
+  expect(reload).not.toHaveBeenCalled();
+  expect(hasMemStore(z.idbName)).toBe(true);
+});
+
 test('Constructing Zero with a negative hiddenTabDisconnectDelay option throws an error', () => {
   let expected;
   try {

--- a/packages/zero-client/src/client/zero.test.ts
+++ b/packages/zero-client/src/client/zero.test.ts
@@ -3048,21 +3048,24 @@ test('close code 1009 (Message Too Big) disables client group and reloads', asyn
   expect(hasMemStore(z.idbName)).toBe(true);
 
   // Send a push message directly to populate the recent sent messages buffer
-  await z.pusher({
-    profileID: 'p1',
-    clientGroupID: 'c1',
-    mutations: [
-      {
-        clientID: 'c1',
-        id: 1,
-        name: 'issues.insert',
-        args: {id: '1', value: 'a large payload'},
-        timestamp: 123,
-      },
-    ],
-    pushVersion: 1,
-    schemaVersion: '1',
-  }, 'req-1');
+  await z.pusher(
+    {
+      profileID: 'p1',
+      clientGroupID: 'c1',
+      mutations: [
+        {
+          clientID: 'c1',
+          id: 1,
+          name: 'issues.insert',
+          args: {id: '1', value: 'a large payload'},
+          timestamp: 123,
+        },
+      ],
+      pushVersion: 1,
+      schemaVersion: '1',
+    },
+    'req-1',
+  );
 
   await z.triggerClose(1009);
 
@@ -3109,7 +3112,9 @@ test('close code 1009 with custom onClientStateNotFound defers reload', async ()
   assert(state.name === ConnectionStatus.Error);
   expect(state.reason).toBeInstanceOf(ClientError);
   expect(state.reason.kind).toBe(ClientErrorKind.InvalidMessage);
-  expect(state.reason.message).toContain('exceeded the server message size limit');
+  expect(state.reason.message).toContain(
+    'exceeded the server message size limit',
+  );
 });
 
 test('Constructing Zero with a negative hiddenTabDisconnectDelay option throws an error', () => {

--- a/packages/zero-client/src/client/zero.test.ts
+++ b/packages/zero-client/src/client/zero.test.ts
@@ -3040,7 +3040,7 @@ test('close code 1009 (Message Too Big) disables client group and reloads', asyn
   );
   const {promise, resolve} = resolver();
   const reload = vi.fn(resolve);
-  const z = zeroForTest();
+  const z = zeroForTest(undefined, false);
   z.reload = reload;
 
   await z.triggerConnected();
@@ -3050,25 +3050,24 @@ test('close code 1009 (Message Too Big) disables client group and reloads', asyn
   await z.triggerClose(1009);
 
   await vi.waitUntil(() => storage[RELOAD_REASON_STORAGE_KEY] !== undefined);
+  await vi.advanceTimersToNextTimerAsync();
   await promise;
 
+  // Connection transitions to Error state (observable by customers)
+  expect(z.connectionStatus).toBe(ConnectionStatus.Error);
   expect(reload).toHaveBeenCalledTimes(1);
   // disableClientGroup does not drop the database, just the client group
   expect(hasMemStore(z.idbName)).toBe(true);
-  expect(storage[RELOAD_REASON_STORAGE_KEY]).toBe(
-    '["InvalidMessage","A mutation exceeded the server message size limit. Local state has been reset."]',
+  expect(storage[RELOAD_REASON_STORAGE_KEY]).toContain('InvalidMessage');
+  expect(storage[RELOAD_REASON_STORAGE_KEY]).toContain(
+    'ZERO_WEBSOCKET_MAX_PAYLOAD_BYTES',
   );
 });
 
-test('close code 1009 with custom onClientStateNotFound handler', async () => {
+test('close code 1009 with custom onClientStateNotFound defers reload', async () => {
   const {promise, resolve} = resolver();
-  let z: TestZero<Schema>;
-  const fake = vi.fn(() => {
-    // disableClientGroup does not drop the database
-    expect(hasMemStore(z.idbName)).toBe(true);
-    resolve();
-  });
-  z = zeroForTest({onClientStateNotFound: fake});
+  const fake = vi.fn(resolve);
+  const z = zeroForTest({onClientStateNotFound: fake}, false);
   const reload = vi.fn();
   z.reload = reload;
 
@@ -3077,13 +3076,19 @@ test('close code 1009 with custom onClientStateNotFound handler', async () => {
   expect(hasMemStore(z.idbName)).toBe(true);
 
   await z.triggerClose(1009);
-
   await promise;
 
+  // Custom handler is called instead of reload
   expect(fake).toHaveBeenCalledTimes(1);
-  expect(fake).toHaveBeenCalledWith();
   expect(reload).not.toHaveBeenCalled();
-  expect(hasMemStore(z.idbName)).toBe(true);
+
+  // Connection is in Error state with actionable details
+  expect(z.connectionStatus).toBe(ConnectionStatus.Error);
+  const state = z.connectionState;
+  assert(state.name === ConnectionStatus.Error);
+  expect(state.reason).toBeInstanceOf(ClientError);
+  expect(state.reason.kind).toBe(ClientErrorKind.InvalidMessage);
+  expect(state.reason.message).toContain('ZERO_WEBSOCKET_MAX_PAYLOAD_BYTES');
 });
 
 test('Constructing Zero with a negative hiddenTabDisconnectDelay option throws an error', () => {

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -1361,7 +1361,7 @@ export class Zero<
     }
   };
 
-  #onClose = (e: CloseEvent) => {
+  #onClose = async (e: CloseEvent) => {
     let lc = this.#lc;
     try {
       assert(this.#socket, 'Socket is not set before onClose');
@@ -1393,6 +1393,27 @@ export class Zero<
       );
       this.#connectResolver.reject(closeError);
       this.#disconnect(lc, closeError);
+
+      // 1009 = Message Too Big. The server rejected an oversized WebSocket
+      // frame (e.g. a mutation containing a large base64-encoded blob).
+      // Because the mutation is persisted in IndexedDB, the client would
+      // otherwise reconnect and immediately re-send it, causing an infinite
+      // reconnect loop. Drop the local database to remove the stuck mutation
+      // and reload.
+      if (code === 1009) {
+        lc.error?.(
+          'Server closed connection with 1009 (Message Too Big). ' +
+            'Dropping local database to remove oversized mutation.',
+        );
+        await dropReplicacheDatabase(this.#rep.idbName, {
+          kvStore: this.#kvStore,
+        });
+        this.#onClientStateNotFound(
+          ErrorKind.InvalidMessage,
+          'A mutation exceeded the server message size limit. ' +
+            'Local state has been reset.',
+        );
+      }
     } catch (e) {
       lc.error?.('Unhandled error in onClose', e);
       const internalError = new ClientError(

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -1398,16 +1398,14 @@ export class Zero<
       // frame (e.g. a mutation containing a large base64-encoded blob).
       // Because the mutation is persisted in IndexedDB, the client would
       // otherwise reconnect and immediately re-send it, causing an infinite
-      // reconnect loop. Drop the local database to remove the stuck mutation
-      // and reload.
+      // reconnect loop. Disable the client group to abandon the stuck
+      // mutation and reload with a fresh client group.
       if (code === 1009) {
         lc.error?.(
           'Server closed connection with 1009 (Message Too Big). ' +
-            'Dropping local database to remove oversized mutation.',
+            'Disabling client group to remove oversized mutation.',
         );
-        await dropReplicacheDatabase(this.#rep.idbName, {
-          kvStore: this.#kvStore,
-        });
+        await this.#rep.disableClientGroup();
         this.#onClientStateNotFound(
           ErrorKind.InvalidMessage,
           'A mutation exceeded the server message size limit. ' +

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -551,7 +551,8 @@ export class Zero<
 
     this.#mutationTracker = new MutationTracker(
       lc,
-      (upTo: MutationID) => this.#sendIfConnected(['ackMutationResponses', upTo]),
+      (upTo: MutationID) =>
+        this.#sendIfConnected(['ackMutationResponses', upTo]),
       error => this.#disconnect(lc, error),
     );
 
@@ -1572,7 +1573,7 @@ export class Zero<
     this.#lastMutationIDSent = NULL_LAST_MUTATION_ID_SENT;
 
     lc.debug?.('Resolving connect resolver');
-    const socket = must(this.#socket);
+    must(this.#socket);
     const queriesPatch = await this.#rep.query(tx =>
       this.#queryManager.getQueriesPatch(tx, this.#initConnectionQueries),
     );
@@ -1921,8 +1922,7 @@ export class Zero<
     await this.#connectResolver.promise;
     const lc = this.#lc.withContext('requestID', requestID);
     lc.debug?.(`pushing ${req.mutations.length} mutations`);
-    const socket = this.#socket;
-    assert(socket, 'Expected socket to be connected for push');
+    assert(this.#socket, 'Expected socket to be connected for push');
 
     const isMutationRecoveryPush =
       req.clientGroupID !== (await this.clientGroupID);
@@ -2279,9 +2279,8 @@ export class Zero<
 
     // If we are connecting we wait until we are connected.
     await this.#connectResolver.promise;
-    const socket = this.#socket;
     assert(
-      socket,
+      this.#socket,
       'Expected socket to be connected for mutation recovery pull',
     );
     // Mutation recovery pull.

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -118,7 +118,7 @@ import {
 import type {ConditionalSchemaQuery} from '../../../zql/src/query/schema-query.ts';
 import type {TypedView} from '../../../zql/src/query/typed-view.ts';
 import {nanoid} from '../util/nanoid.ts';
-import {send} from '../util/socket.ts';
+
 import {ActiveClientsManager} from './active-clients-manager.ts';
 import {ClientErrorKind} from './client-error-kind.ts';
 import {
@@ -551,7 +551,7 @@ export class Zero<
 
     this.#mutationTracker = new MutationTracker(
       lc,
-      (upTo: MutationID) => this.#send(['ackMutationResponses', upTo]),
+      (upTo: MutationID) => this.#sendIfConnected(['ackMutationResponses', upTo]),
       error => this.#disconnect(lc, error),
     );
 
@@ -776,7 +776,7 @@ export class Zero<
           };
         }
 
-        this.#send([msg[0], body]);
+        this.#sendIfConnected([msg[0], body]);
       },
       rep.experimentalWatch.bind(rep),
       maxRecentQueries,
@@ -790,7 +790,7 @@ export class Zero<
     this.#clientToServer = clientToServer(schema.tables);
 
     this.#deleteClientsManager = new DeleteClientsManager(
-      msg => this.#send(msg),
+      msg => this.#sendIfConnected(msg),
       rep.perdag,
       this.#lc,
       this.#rep.clientGroupID,
@@ -894,21 +894,26 @@ export class Zero<
     }
   }
 
+  #sendIfConnected(msg: Upstream): void {
+    if (this.#connectionManager.is(ConnectionStatus.Connected)) {
+      this.#send(msg);
+    }
+  }
+
   #send(msg: Upstream): void {
-    if (
-      this.#socket &&
-      this.#connectionManager.is(ConnectionStatus.Connected)
-    ) {
+    if (this.#socket) {
       const json = JSON.stringify(msg);
-      const history = this.#recentSentMessages;
-      if (history.length >= 5) {
-        history.shift();
+      if (msg[0] !== 'ping') {
+        const history = this.#recentSentMessages;
+        if (history.length >= 5) {
+          history.shift();
+        }
+        history.push({
+          type: msg[0],
+          size: json.length,
+          snippet: json.slice(0, 200),
+        });
       }
-      history.push({
-        type: msg[0],
-        size: json.length,
-        snippet: json.slice(0, 200),
-      });
       this.#socket.send(json);
     }
   }
@@ -1407,19 +1412,23 @@ export class Zero<
       // The reload is routed through onClientStateNotFound so customers can
       // override it (e.g. to show UI, defer reload, or report to Sentry).
       if (code === 1009) {
+        const recentMessagesInfo =
+          this.#recentSentMessages.length > 0
+            ? '\nRecent sent messages:\n' +
+              JSON.stringify(this.#recentSentMessages, null, 2)
+            : '';
         const messageTooLargeError = new ClientError({
           kind: ClientErrorKind.InvalidMessage,
           message:
-            'A WebSocket message exceeded the server message size limit ' +
-            '(ZERO_WEBSOCKET_MAX_PAYLOAD_BYTES). ' +
-            'This is usually caused by a mutation containing a large ' +
+            'A WebSocket message exceeded the server message size limit. ' +
+            "This is usually caused by a mutation's args containing a large " +
             'value such as a base64-encoded image. Consider uploading ' +
-            'large files to object storage and storing only the URL in Zero.',
+            'large files to object storage and storing only the URL in Zero.' +
+            recentMessagesInfo,
         });
         lc.error?.(
           'Server closed connection with 1009 (Message Too Big).',
           messageTooLargeError,
-          {recentMessages: this.#recentSentMessages},
         );
         this.#connectResolver.reject(messageTooLargeError);
         this.#disconnect(lc, messageTooLargeError);
@@ -1574,14 +1583,14 @@ export class Zero<
 
     const maybeSendDeletedClients = () => {
       if (hasDeletedClients()) {
-        send(socket, ['deleteClients', this.#deletedClients!]);
+        this.#send(['deleteClients', this.#deletedClients!]);
         this.#deletedClients = undefined;
       }
     };
 
     if (queriesPatch.size > 0 && this.#initConnectionQueries !== undefined) {
       maybeSendDeletedClients();
-      send(socket, [
+      this.#send([
         'changeDesiredQueries',
         {
           desiredQueriesPatch: [...queriesPatch.values()],
@@ -1592,7 +1601,7 @@ export class Zero<
       // if #initConnectionQueries was undefined that means we never
       // sent `initConnection` to the server inside the sec-protocol header.
       const clientSchema = this.#clientSchema;
-      send(socket, [
+      this.#send([
         'initConnection',
         {
           desiredQueriesPatch: [...queriesPatch.values()],
@@ -1964,7 +1973,7 @@ export class Zero<
           traceparent: this.#options.getTraceparent?.(),
         },
       ];
-      send(socket, msg);
+      this.#send(msg);
       if (!isMutationRecoveryPush) {
         this.#lastMutationIDSent = {clientID: m.clientID, id: m.id};
       }
@@ -2290,7 +2299,7 @@ export class Zero<
         requestID,
       },
     ];
-    send(socket, pullRequestMessage);
+    this.#send(pullRequestMessage);
     const pullResponseResolver: Resolver<PullResponseBody> = resolver();
     this.#pendingPullsByRequestID.set(requestID, pullResponseResolver);
     try {
@@ -2345,7 +2354,7 @@ export class Zero<
     this.#rep.auth = toReplicacheAuthToken(auth);
 
     if (auth) {
-      this.#send(['updateAuth', {auth}]);
+      this.#sendIfConnected(['updateAuth', {auth}]);
     }
   }
 
@@ -2382,7 +2391,7 @@ export class Zero<
     const pingMessage: PingMessage = ['ping', {}];
     const t0 = performance.now();
     assert(this.#socket, 'Expected socket to be connected for ping');
-    send(this.#socket, pingMessage);
+    this.#send(pingMessage);
 
     const raceResult = await promiseRace({
       waitForPong: promise,

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -1428,10 +1428,6 @@ export class Zero<
             'large files to object storage and storing only the URL in Zero.' +
             recentMessagesInfo,
         });
-        lc.error?.(
-          'Server closed connection with 1009 (Message Too Big).',
-          messageTooLargeError,
-        );
         this.#connectResolver.reject(messageTooLargeError);
         this.#disconnect(lc, messageTooLargeError);
 

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -392,8 +392,9 @@ export class Zero<
 
   #forceEnableRefresh = false;
 
-  // Ring buffer of recent outbound messages (type + serialized size)
-  // for diagnostics when a 1009 (Message Too Big) close occurs.
+  // Ring buffer of up to 5 recent outbound messages (excluding pings).
+  // Tracks type, serialized size, and a 200-character snippet for diagnostics
+  // when a 1009 (Message Too Big) close occurs.
   #recentSentMessages: {type: string; size: number; snippet: string}[] = [];
 
   /**

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -392,6 +392,10 @@ export class Zero<
 
   #forceEnableRefresh = false;
 
+  // Ring buffer of recent outbound messages (type + serialized size)
+  // for diagnostics when a 1009 (Message Too Big) close occurs.
+  #recentSentMessages: {type: string; size: number; snippet: string}[] = [];
+
   /**
    * The timeout in milliseconds for ping operations. Controls both:
    * - How long to wait in idle before sending a ping
@@ -895,7 +899,17 @@ export class Zero<
       this.#socket &&
       this.#connectionManager.is(ConnectionStatus.Connected)
     ) {
-      send(this.#socket, msg);
+      const json = JSON.stringify(msg);
+      const history = this.#recentSentMessages;
+      if (history.length >= 5) {
+        history.shift();
+      }
+      history.push({
+        type: msg[0],
+        size: json.length,
+        snippet: json.slice(0, 200),
+      });
+      this.#socket.send(json);
     }
   }
 
@@ -1380,37 +1394,55 @@ export class Zero<
         });
       }
 
-      const closeError = new ClientError(
-        wasClean
-          ? {
-              kind: ClientErrorKind.CleanClose,
-              message: 'WebSocket connection closed cleanly',
-            }
-          : {
-              kind: ClientErrorKind.AbruptClose,
-              message: 'WebSocket connection closed abruptly',
-            },
-      );
-      this.#connectResolver.reject(closeError);
-      this.#disconnect(lc, closeError);
-
       // 1009 = Message Too Big. The server rejected an oversized WebSocket
-      // frame (e.g. a mutation containing a large base64-encoded blob).
-      // Because the mutation is persisted in IndexedDB, the client would
-      // otherwise reconnect and immediately re-send it, causing an infinite
-      // reconnect loop. Disable the client group to abandon the stuck
-      // mutation and reload with a fresh client group.
+      // message, most likely a mutation containing a large value (e.g. a
+      // base64-encoded image), but possibly a large changeDesiredQueries
+      // payload. Because mutations are persisted in IndexedDB, the client
+      // would otherwise reconnect and immediately re-send the message,
+      // causing an infinite reconnect loop. Disable the client group to
+      // abandon the stuck message and reload with a fresh client group.
+      //
+      // Using InvalidMessage as the error kind transitions the connection
+      // to Error state, making it observable via connection.state.subscribe().
+      // The reload is routed through onClientStateNotFound so customers can
+      // override it (e.g. to show UI, defer reload, or report to Sentry).
       if (code === 1009) {
+        const messageTooLargeError = new ClientError({
+          kind: ClientErrorKind.InvalidMessage,
+          message:
+            'A WebSocket message exceeded the server message size limit ' +
+            '(ZERO_WEBSOCKET_MAX_PAYLOAD_BYTES). ' +
+            'This is usually caused by a mutation containing a large ' +
+            'value such as a base64-encoded image. Consider uploading ' +
+            'large files to object storage and storing only the URL in Zero.',
+        });
         lc.error?.(
-          'Server closed connection with 1009 (Message Too Big). ' +
-            'Disabling client group to remove oversized mutation.',
+          'Server closed connection with 1009 (Message Too Big).',
+          messageTooLargeError,
+          {recentMessages: this.#recentSentMessages},
         );
+        this.#connectResolver.reject(messageTooLargeError);
+        this.#disconnect(lc, messageTooLargeError);
+
         await this.#rep.disableClientGroup();
         this.#onClientStateNotFound(
           ErrorKind.InvalidMessage,
-          'A mutation exceeded the server message size limit. ' +
-            'Local state has been reset.',
+          messageTooLargeError.message,
         );
+      } else {
+        const closeError = new ClientError(
+          wasClean
+            ? {
+                kind: ClientErrorKind.CleanClose,
+                message: 'WebSocket connection closed cleanly',
+              }
+            : {
+                kind: ClientErrorKind.AbruptClose,
+                message: 'WebSocket connection closed abruptly',
+              },
+        );
+        this.#connectResolver.reject(closeError);
+        this.#disconnect(lc, closeError);
       }
     } catch (e) {
       lc.error?.('Unhandled error in onClose', e);

--- a/packages/zero-client/src/util/socket.ts
+++ b/packages/zero-client/src/util/socket.ts
@@ -1,5 +1,0 @@
-import type {Upstream} from '../../../zero-protocol/src/up.ts';
-
-export function send(ws: WebSocket, data: Upstream) {
-  ws.send(JSON.stringify(data));
-}


### PR DESCRIPTION
Problem
=======
When a client has an oversized mutation in IndexedDB (e.g. a base64-encoded image), every reconnect re-sends it, the server rejects it (exceeds `maxPayload`), and the client reconnects — looping forever.

Fix
===
Detect close code 1009 (Message Too Big) in `#onClose`, disable the client group to abandon the stuck mutation, and reload. Same pattern as `ClientNotFound` / `SchemaVersionNotSupported`.
The server-side max payload was introduced in #5434 and is configurable via `ZERO_WEBSOCKET_MAX_PAYLOAD_BYTES` (default 10MB, see `zeroOptions.websocketMaxPayloadBytes` in `zero-config.ts`).