### PR TITLE
perf(shared): O(n²) → O(1) amortized Queue.dequeue()

### DIFF
--- a/packages/shared/src/queue.test.ts
+++ b/packages/shared/src/queue.test.ts
@@ -219,4 +219,30 @@ describe('Queue', () => {
     queue.enqueue(3);
     await promise;
   });
+
+  test('large queue drains efficiently (O(n) not O(n^2))', () => {
+    const queue = new Queue<number>();
+    const n = 100_000;
+    for (let i = 0; i < n; i++) {
+      queue.enqueue(i);
+    }
+    expect(queue.size()).toBe(n);
+
+    // When items are already enqueued, dequeue() returns T synchronously.
+    // This isolates the data structure cost from async/Promise overhead.
+    const start = performance.now();
+    let sum = 0;
+    for (let i = 0; i < n; i++) {
+      sum += queue.dequeue() as number;
+    }
+    const elapsed = performance.now() - start;
+
+    // Verify all values were dequeued correctly.
+    expect(sum).toBe((n * (n - 1)) / 2);
+    expect(queue.size()).toBe(0);
+
+    // With O(n^2) Array.shift(), 100k items takes ~1000ms.
+    // With O(1) cursor-based dequeue, it takes ~2ms.
+    expect(elapsed).toBeLessThan(200);
+  });
 });

--- a/packages/shared/src/queue.ts
+++ b/packages/shared/src/queue.ts
@@ -1,5 +1,6 @@
 import {resolver, type Resolver} from '@rocicorp/resolver';
 import {assert} from './asserts.ts';
+import {RingBuffer} from './ring-buffer.ts';
 
 /**
  * A Queue allows the consumers to await (possibly future) values,
@@ -7,9 +8,9 @@ import {assert} from './asserts.ts';
  */
 export class Queue<T> {
   // Consumers waiting for entries to be produced.
-  readonly #consumers: Consumer<T>[] = [];
+  readonly #consumers = new RingBuffer<Consumer<T>>();
   // Produced entries waiting to be consumed.
-  readonly #produced: Produced<T>[] = [];
+  readonly #produced = new RingBuffer<Produced<T>>();
 
   enqueue(value: T): void {
     const consumer = this.#consumers.shift();
@@ -43,12 +44,14 @@ export class Queue<T> {
   delete(value: T): number {
     assert(value !== undefined, 'Queue delete value must not be undefined');
 
+    // Drain, filter, and re-push. This is O(n) but delete() is rare.
+    const items = this.#produced.drain();
     let count = 0;
-    for (let i = this.#produced.length - 1; i >= 0; i--) {
-      const p = this.#produced[i];
+    for (const p of items) {
       if (p.value === value) {
-        this.#produced.splice(i, 1);
         count++;
+      } else {
+        this.#produced.push(p);
       }
     }
     return count;
@@ -66,17 +69,17 @@ export class Queue<T> {
       return produced.value ?? Promise.reject(produced.rejection);
     }
     const r = resolver<T>();
+    const consumer: Consumer<T> = {resolver: r, timeoutID: undefined};
     const timeoutID =
       timeoutValue === undefined
         ? undefined
         : setTimeout(() => {
-            const i = this.#consumers.findIndex(c => c.resolver === r);
-            if (i >= 0) {
-              const [consumer] = this.#consumers.splice(i, 1);
+            if (this.#consumers.delete(consumer) > 0) {
               consumer.resolver.resolve(timeoutValue);
             }
           }, timeoutMs);
-    this.#consumers.push({resolver: r, timeoutID});
+    consumer.timeoutID = timeoutID;
+    this.#consumers.push(consumer);
     return r.promise;
   }
 
@@ -95,13 +98,7 @@ export class Queue<T> {
    * ```
    */
   drain(): (T | undefined)[] {
-    const ret: (T | undefined)[] = [];
-    for (const p of this.#produced) {
-      ret.push(p.value);
-    }
-    this.#produced.length = 0;
-
-    return ret;
+    return this.#produced.drain().map(p => p.value);
   }
 
   /**
@@ -111,7 +108,7 @@ export class Queue<T> {
    *          handed to the consumer and the Queue's size remains 0.
    */
   size(): number {
-    return this.#produced.length;
+    return this.#produced.size;
   }
 
   asAsyncIterable(cleanup = NOOP): AsyncIterable<T> {

--- a/packages/shared/src/ring-buffer.test.ts
+++ b/packages/shared/src/ring-buffer.test.ts
@@ -1,0 +1,137 @@
+import {describe, expect, test} from 'vitest';
+import {RingBuffer} from './ring-buffer.ts';
+
+describe('RingBuffer', () => {
+  test('push and shift in FIFO order', () => {
+    const buf = new RingBuffer<string>();
+    buf.push('a');
+    buf.push('b');
+    buf.push('c');
+    expect(buf.size).toBe(3);
+    expect(buf.shift()).toBe('a');
+    expect(buf.shift()).toBe('b');
+    expect(buf.shift()).toBe('c');
+    expect(buf.size).toBe(0);
+    expect(buf.shift()).toBeUndefined();
+  });
+
+  test('grows when capacity is exceeded', () => {
+    const buf = new RingBuffer<number>(16);
+    for (let i = 0; i < 100; i++) {
+      buf.push(i);
+    }
+    expect(buf.size).toBe(100);
+    for (let i = 0; i < 100; i++) {
+      expect(buf.shift()).toBe(i);
+    }
+    expect(buf.size).toBe(0);
+  });
+
+  test('wraps around correctly', () => {
+    // Use minimum capacity (16) and cycle through to force wrapping
+    const buf = new RingBuffer<number>(16);
+    // Fill half
+    for (let i = 0; i < 10; i++) buf.push(i);
+    // Remove some to advance head
+    for (let i = 0; i < 8; i++) expect(buf.shift()).toBe(i);
+    // Now head is at index 8, push more to wrap around
+    for (let i = 10; i < 25; i++) buf.push(i);
+    // Verify FIFO order
+    for (let i = 8; i < 25; i++) {
+      expect(buf.shift()).toBe(i);
+    }
+    expect(buf.size).toBe(0);
+  });
+
+  test('drain returns all elements in order', () => {
+    const buf = new RingBuffer<number>(16);
+    // Advance head to force wrap-around
+    for (let i = 0; i < 10; i++) buf.push(i);
+    for (let i = 0; i < 8; i++) buf.shift();
+    for (let i = 10; i < 18; i++) buf.push(i);
+
+    expect(buf.size).toBe(10);
+    const drained = buf.drain();
+    expect(drained).toEqual([8, 9, 10, 11, 12, 13, 14, 15, 16, 17]);
+    expect(buf.size).toBe(0);
+  });
+
+  test('delete removes matching elements', () => {
+    const buf = new RingBuffer<string>();
+    buf.push('a');
+    buf.push('b');
+    buf.push('a');
+    buf.push('c');
+    buf.push('a');
+    expect(buf.delete('a')).toBe(3);
+    expect(buf.size).toBe(2);
+    expect(buf.shift()).toBe('b');
+    expect(buf.shift()).toBe('c');
+  });
+
+  test('delete with identity equality', () => {
+    const obj1 = {id: 1};
+    const obj2 = {id: 1}; // same shape, different identity
+    const buf = new RingBuffer<{id: number}>();
+    buf.push(obj1);
+    buf.push(obj2);
+    expect(buf.delete(obj1)).toBe(1);
+    expect(buf.size).toBe(1);
+    expect(buf.shift()).toBe(obj2);
+  });
+
+  test('delete returns 0 when nothing matches', () => {
+    const buf = new RingBuffer<string>();
+    buf.push('a');
+    buf.push('b');
+    expect(buf.delete('c')).toBe(0);
+    expect(buf.size).toBe(2);
+  });
+
+  test('empty buffer operations', () => {
+    const buf = new RingBuffer<number>();
+    expect(buf.size).toBe(0);
+    expect(buf.shift()).toBeUndefined();
+    expect(buf.drain()).toEqual([]);
+    expect(buf.delete(42)).toBe(0);
+  });
+
+  test('interleaved push/shift maintains order', () => {
+    const buf = new RingBuffer<number>();
+    const values: number[] = [];
+    for (let i = 0; i < 1000; i++) {
+      buf.push(i);
+      if (i % 3 === 0) {
+        values.push(buf.shift()!);
+      }
+    }
+    // Drain remaining
+    while (buf.size > 0) {
+      values.push(buf.shift()!);
+    }
+    // All values should be 0..999 in order
+    expect(values).toEqual(Array.from({length: 1000}, (_, i) => i));
+  });
+
+  test('large buffer drains efficiently (O(n) not O(n^2))', () => {
+    const buf = new RingBuffer<number>();
+    const n = 100_000;
+    for (let i = 0; i < n; i++) {
+      buf.push(i);
+    }
+    expect(buf.size).toBe(n);
+
+    const start = performance.now();
+    let sum = 0;
+    for (let i = 0; i < n; i++) {
+      sum += buf.shift()!;
+    }
+    const elapsed = performance.now() - start;
+
+    expect(sum).toBe((n * (n - 1)) / 2);
+    expect(buf.size).toBe(0);
+
+    // With O(1) ring buffer shift, 100k items takes ~2ms.
+    expect(elapsed).toBeLessThan(200);
+  });
+});

--- a/packages/shared/src/ring-buffer.ts
+++ b/packages/shared/src/ring-buffer.ts
@@ -1,0 +1,143 @@
+const DEFAULT_INITIAL_CAPACITY = 16;
+const MIN_CAPACITY = 16;
+
+/**
+ * A FIFO ring buffer backed by a circular array. Provides:
+ *
+ * - `push()` — O(1) amortized (O(n) on resize)
+ * - `shift()` — O(1)
+ * - `size`    — O(1)
+ * - `drain()` — O(n)
+ *
+ * The buffer grows (doubles) when full and shrinks (halves) when
+ * utilization drops below 25%, bounded by {@link MIN_CAPACITY}.
+ */
+export class RingBuffer<T> {
+  #buffer: (T | undefined)[];
+  #head = 0;
+  #size = 0;
+  #capacity: number;
+
+  constructor(initialCapacity = DEFAULT_INITIAL_CAPACITY) {
+    this.#capacity = Math.max(MIN_CAPACITY, initialCapacity);
+    this.#buffer = Array.from({length: initialCapacity});
+  }
+
+  get size(): number {
+    return this.#size;
+  }
+
+  push(value: T): void {
+    if (this.#size === this.#capacity) {
+      this.#grow();
+    }
+    this.#buffer[(this.#head + this.#size) % this.#capacity] = value;
+    this.#size++;
+  }
+
+  /** Removes and returns the front element, or `undefined` if empty. */
+  shift(): T | undefined {
+    if (this.#size === 0) {
+      return undefined;
+    }
+    const value = this.#buffer[this.#head];
+    this.#buffer[this.#head] = undefined; // allow GC of removed element
+    this.#head = (this.#head + 1) % this.#capacity;
+    this.#size--;
+
+    // Shrink when utilization drops below 25%, keeping a minimum capacity.
+    if (
+      this.#size > 0 &&
+      this.#size < this.#capacity >> 2 &&
+      this.#capacity > MIN_CAPACITY
+    ) {
+      this.#shrink();
+    }
+
+    return value;
+  }
+
+  /**
+   * Removes all elements matching `value` (by identity `===`).
+   *
+   * This is O(n) — suitable for rare operations like cancellation.
+   *
+   * @returns The number of elements removed.
+   */
+  delete(value: T): number {
+    if (this.#size === 0) {
+      return 0;
+    }
+    // Rebuild the buffer without matching elements.
+    const newBuffer: (T | undefined)[] = Array.from({length: this.#capacity});
+    let newSize = 0;
+    let count = 0;
+    for (let i = 0; i < this.#size; i++) {
+      const item = this.#buffer[(this.#head + i) % this.#capacity];
+      if (item === value) {
+        count++;
+      } else {
+        newBuffer[newSize++] = item;
+      }
+    }
+    this.#buffer = newBuffer;
+    this.#head = 0;
+    this.#size = newSize;
+    return count;
+  }
+
+  /**
+   * Removes and returns all elements in FIFO order, resetting the buffer.
+   */
+  drain(): T[] {
+    const result = Array.from<T>({length: this.#size});
+    for (let i = 0; i < this.#size; i++) {
+      result[i] = this.#buffer[(this.#head + i) % this.#capacity] as T;
+    }
+    this.#head = 0;
+    this.#size = 0;
+    this.#buffer = Array.from({length: this.#capacity});
+    return result;
+  }
+
+  /**
+   * Grows the buffer in place by doubling its length and relocating
+   * only the wrapped-around elements (those before #head) into the
+   * newly available space. No new array is allocated.
+   */
+  #grow(): void {
+    const oldLen = this.#buffer.length;
+    const newLen = oldLen * 2;
+    this.#buffer.length = newLen;
+    this.#capacity = newLen;
+
+    // Copy wrapped-around elements (indices 0..head-1) into the new space.
+    for (let i = 0; i < this.#head; i++) {
+      this.#buffer[oldLen + i] = this.#buffer[i];
+      this.#buffer[i] = undefined; // ensure gc when the element is removed
+    }
+  }
+
+  /**
+   * Shrinks the buffer in place by halving its length. Elements whose
+   * indices fall in the removed half are relocated into the lower half,
+   * then the array is truncated.
+   */
+  #shrink(): void {
+    const oldLen = this.#buffer.length;
+    const newLen = Math.max(MIN_CAPACITY, oldLen >> 1);
+
+    // Move elements that sit in the upper half down by newLen.
+    const left = Math.max(newLen, this.#head);
+    const right = Math.min(this.#head + this.#size, oldLen);
+    for (let i = left; i < right; i++) {
+      this.#buffer[i - newLen] = this.#buffer[i];
+    }
+
+    if (this.#head >= newLen) {
+      this.#head -= newLen;
+    }
+    this.#buffer.length = newLen;
+    this.#capacity = newLen;
+  }
+}


### PR DESCRIPTION
### Problem

CPU profiling of the replication manager under heavy transaction load revealed that **`Queue.dequeue()` consumed up to 85% of CPU time** (19–52s out of 61s profiles). The root cause: `Queue` uses an array as a FIFO, calling `Array.shift()` to dequeue.

V8 optimizes `Array.shift()` to O(1) via backing-store pointer adjustment for arrays under ~10k elements, but falls back to O(n) element copying above that threshold. Under heavy replication load, the storer queue routinely grows to tens or hundreds of thousands of changes, well past this threshold, causing **O(n²) total drain cost**.

This directly impacts throughput in the `Storer.#processQueue()` loop, which `await`s `dequeue()` on every change in the replication stream.

### Fix

Introduce a `RingBuffer<T>` class — a circular array with O(1) `push`/`shift` — and refactor `Queue` to use it as its backing store.

**`RingBuffer` (`ring-buffer.ts`):**
- Circular array with `#head` pointer and `#size` counter
- `push()` — O(1) amortized (doubles capacity when full, in-place)
- `shift()` — O(1) always (advance head pointer, no copying)
- In-place `#grow()` — extends array length, relocates only wrapped-around elements
- In-place `#shrink()` — moves elements down and truncates when utilization < 25%
- `drain()` / `delete()` for bulk operations

**`Queue` (`queue.ts`):**
- Replaced manual array + cursor management with `RingBuffer<Consumer>` and `RingBuffer<Produced>`
- Simplified timeout handler (uses `RingBuffer.delete()` by identity instead of `indexOf` + `find` + `splice`)
- No API changes — drop-in replacement

### Performance Results

Profiled processing the same transaction on CloudZero, with and without the fix:

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| **Queue.dequeue() CPU** | 19.9s (31%) | 0.03s | **Eliminated** |
| **Active CPU time** | 62.8s | 33.4s | **−47%** |
| **Idle headroom** | 1.0s (1.5%) | 28.5s (46%) | **System no longer CPU-bound** |
| writev (WebSocket sends) | 8.0s | 2.7s | −66% |
| GC pressure | 6.0s | 3.6s | −39% |
| JSON stringify | 2.2s | 0.7s | −70% |
| Promise/async overhead | 3.3s | 3.0s | −9% |

The CPU went from **98.5% saturated** to **54% utilized** under the same workload. The downstream improvements (writev, GC, stringify) are a cascading effect — without the dequeue bottleneck, messages flow through without backlog, reducing contention and memory pressure across the entire pipeline.

Ring buffer microbenchmark (100k items push + shift):
- `Array.shift()`: ~1150ms
- Allocating resize: ~12ms
- In-place ring buffer: ~1ms

### Changes

- **`packages/shared/src/ring-buffer.ts`** [NEW] — Generic FIFO ring buffer with O(1) push/shift, in-place grow/shrink
- **`packages/shared/src/ring-buffer.test.ts`** [NEW] — 10 tests: FIFO ordering, growth, wrap-around, drain, delete, interleaved ops, performance regression
- **`packages/shared/src/queue.ts`** — Refactored to delegate to `RingBuffer` instead of managing arrays directly
- **`packages/shared/src/queue.test.ts`** — Added performance regression test (100k dequeue in <200ms)


[control1.cpuprofile](https://github.com/user-attachments/files/27816665/control1.cpuprofile)
[test1.cpuprofile](https://github.com/user-attachments/files/27816666/test1.cpuprofile)

yellow is test with this change
green is control
<img width="1263" height="499" alt="image" src="https://github.com/user-attachments/assets/5a506233-0bb8-4970-9ae7-a5ca899cf91f" />
