### PR TITLE
chore(zero-cache): backoff when cvr purging fails

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/cvr-purger.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr-purger.ts
@@ -73,6 +73,7 @@ export class CVRPurger implements Service {
         const start = performance.now();
         const {purged, remaining} =
           await this.purgeInactiveCVRs(maxCVRsPerPurge);
+        this.#state.resetBackoff();
 
         if (purgeable !== undefined && remaining > purgeable) {
           // If the number of purgeable CVRs has grown even after the purge,
@@ -92,7 +93,7 @@ export class CVRPurger implements Service {
         );
         await this.#state.sleep(purgeInterval);
       } catch (e) {
-        this.#lc.warn?.(`error encountered while garbage collecting CVRs`, e);
+        await this.#state.backoff(this.#lc, e);
       }
     }
   }


### PR DESCRIPTION
A failure to purge the CVR currently results in an immediate retry. This results in a tight loop for permanent errors.

Use the usual backoff logic to slow down the rate of retries. This will also facilitate consolidating the logic for aborting on permanent errors.

Context:
* https://rocicorp.slack.com/archives/C0B2D25EXSA

<img width="1418" height="403" alt="Screenshot 2026-05-14 at 18 25 37" src="https://github.com/user-attachments/assets/e773cf99-c3e3-485d-b073-0da6ef69469f" />
