### PR TITLE
fix(zero-cache): Abort on missing ChangeDB CDC table

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
@@ -1,12 +1,12 @@
 import {PG_LOCK_NOT_AVAILABLE} from '@drdgvhbh/postgres-error-codes';
-import type {LogContext} from '@rocicorp/logger';
+import {LogContext} from '@rocicorp/logger';
 import {resolver} from '@rocicorp/resolver';
 import postgres from 'postgres';
 import {beforeEach, describe, expect, vi, type Mock} from 'vitest';
 import {AbortError} from '../../../../shared/src/abort-error.ts';
 import {assert} from '../../../../shared/src/asserts.ts';
 import {BigIntJSON, stringify} from '../../../../shared/src/bigint-json.ts';
-import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
+import {TestLogSink} from '../../../../shared/src/logging-test-utils.ts';
 import {Queue} from '../../../../shared/src/queue.ts';
 import {sleep} from '../../../../shared/src/sleep.ts';
 import {Database} from '../../../../zqlite/src/db.ts';
@@ -18,6 +18,7 @@ import {Subscription, type Result} from '../../types/subscription.ts';
 import type {ChangeSource} from '../change-source/change-source.ts';
 import {type ChangeStreamMessage} from '../change-source/protocol/current/downstream.ts';
 import type {UpstreamStatusMessage} from '../change-source/protocol/current/status.ts';
+import {exitAfter} from '../life-cycle.ts';
 import {ReplicationStatusPublisher} from '../replicator/replication-status.ts';
 import {
   getSubscriptionState,
@@ -52,6 +53,7 @@ describe('change-streamer/service', () => {
   let changes: Subscription<ChangeStreamMessage>;
   let acks: Queue<UpstreamStatusMessage>;
   let streamerDone: Promise<void>;
+  let logSink: TestLogSink;
 
   // vi.useFakeTimers() does not play well with the postgres client.
   // Inject a manual mock instead.
@@ -61,7 +63,8 @@ describe('change-streamer/service', () => {
   const shard = {appID: 'zoro', shardNum: 3};
 
   beforeEach<PgTest>(async ({testDBs}) => {
-    lc = createSilentLogContext();
+    logSink = new TestLogSink();
+    lc = new LogContext('debug', undefined, logSink);
 
     sql = await testDBs.create('change_streamer_test_change_db', {
       typeOpts: {sendStringAsJson: true},
@@ -121,6 +124,26 @@ describe('change-streamer/service', () => {
     const down = await sub.dequeue();
     assert(down[0] !== 'error', `Unexpected error ${stringify(down)}`);
     return down[1];
+  }
+
+  async function expectStreamerToExitNormallyWithoutErrorLog(
+    deleteChangeDBObjects: () => Promise<unknown>,
+  ) {
+    const exit = vi
+      .spyOn(process, 'exit')
+      .mockImplementation(() => undefined as never);
+    try {
+      const done = exitAfter(lc, () => streamerDone);
+      await deleteChangeDBObjects();
+      changes.cancel(new Error('disconnected'));
+      await done;
+      expect(exit).toHaveBeenCalledWith(0);
+      expect(logSink.messages.filter(([level]) => level === 'error')).toEqual(
+        [],
+      );
+    } finally {
+      exit.mockRestore();
+    }
   }
 
   async function verifyNoMoreChanges(sub: Queue<Downstream>) {
@@ -973,6 +996,18 @@ describe('change-streamer/service', () => {
     void streamer.run();
 
     expect(await hasRetried).toBe(true);
+  });
+
+  test('shutdown if ChangeDB CDC table is missing when restarting stream', async () => {
+    await expectStreamerToExitNormallyWithoutErrorLog(
+      () => sql`DROP TABLE "zoro_3/cdc"."replicationState"`,
+    );
+  });
+
+  test('shutdown if ChangeDB CDC schema is missing when restarting stream', async () => {
+    await expectStreamerToExitNormallyWithoutErrorLog(
+      () => sql`DROP SCHEMA "zoro_3/cdc" CASCADE`,
+    );
   });
 
   test('starting point', async () => {

--- a/packages/zero-cache/src/services/running-state.ts
+++ b/packages/zero-cache/src/services/running-state.ts
@@ -1,7 +1,9 @@
+import {PG_UNDEFINED_TABLE} from '@drdgvhbh/postgres-error-codes';
 import type {LogContext} from '@rocicorp/logger';
 import {resolver} from '@rocicorp/resolver';
 import {AbortError} from '../../../shared/src/abort-error.ts';
 import {sleepWithAbort} from '../../../shared/src/sleep.ts';
+import {isPostgresError} from '../types/pg.ts';
 
 const DEFAULT_INITIAL_RETRY_DELAY_MS = 25;
 export const DEFAULT_MAX_RETRY_DELAY_MS = 10000;
@@ -149,6 +151,13 @@ export class RunningState {
   async backoff(lc: LogContext, err: unknown): Promise<void> {
     const delay = this.#retryDelay;
     this.#retryDelay = Math.min(delay * 2, this.#maxRetryDelay);
+
+    // Common failure mode when the user deletes a pg schema out from under
+    // us after init. Turn into an AbortError to force restart, which will
+    // restart and re-init the schema.
+    if (isPostgresError(err, PG_UNDEFINED_TABLE)) {
+      err = new AbortError('undefined table', {cause: err});
+    }
 
     if (err instanceof AbortError || err instanceof UnrecoverableError) {
       this.resetBackoff();

--- a/packages/zero-cache/src/services/view-syncer/cvr-purger.pg.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr-purger.pg.test.ts
@@ -1,10 +1,15 @@
+import {LogContext} from '@rocicorp/logger';
 import {resolver} from '@rocicorp/resolver';
-import {beforeEach, describe, expect} from 'vitest';
-import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
+import {beforeEach, describe, expect, vi} from 'vitest';
+import {
+  createSilentLogContext,
+  TestLogSink,
+} from '../../../../shared/src/logging-test-utils.ts';
 import {DEFAULT_TTL_MS} from '../../../../zql/src/query/ttl.ts';
 import {test, type PgTest} from '../../test/db.ts';
 import type {PostgresDB} from '../../types/pg.ts';
 import {cvrSchema} from '../../types/shards.ts';
+import {exitAfter} from '../life-cycle.ts';
 import {CVRPurger} from './cvr-purger.ts';
 import {
   setupCVRTables,
@@ -190,6 +195,34 @@ describe('view-syncer/cvr-purger', () => {
     return () => testDBs.drop(cvrDb);
   });
 
+  async function expectPurgerToExitNormallyWithoutErrorLog() {
+    const logSink = new TestLogSink();
+    const exit = vi
+      .spyOn(process, 'exit')
+      .mockImplementation(() => undefined as never);
+    try {
+      await exitAfter(new LogContext('debug', undefined, logSink), () =>
+        new CVRPurger(
+          new LogContext('debug', undefined, logSink),
+          cvrDb,
+          SHARD,
+          {
+            inactivityThresholdMs: INACTIVITY_THRESHOLD_MS,
+            initialBatchSize: 25,
+            initialIntervalMs: 60000,
+          },
+          TOMBSTONE_THRESHOLD_MS,
+        ).run(),
+      );
+      expect(exit).toHaveBeenCalledWith(0);
+      expect(logSink.messages.filter(([level]) => level === 'error')).toEqual(
+        [],
+      );
+    } finally {
+      exit.mockRestore();
+    }
+  }
+
   test('complete purge', async () => {
     expect(await purger.purgeInactiveCVRs(1000)).toEqual({
       purged: 3,
@@ -369,5 +402,17 @@ describe('view-syncer/cvr-purger', () => {
       // Let the locking transaction complete.
       releaseRowLock();
     }
+  });
+
+  test('shutdown if CVR table is missing', async () => {
+    await cvrDb`DROP TABLE "zapp_3/cvr".instances CASCADE`;
+
+    await expectPurgerToExitNormallyWithoutErrorLog();
+  });
+
+  test('shutdown if CVR schema is missing', async () => {
+    await cvrDb`DROP SCHEMA "zapp_3/cvr" CASCADE`;
+
+    await expectPurgerToExitNormallyWithoutErrorLog();
   });
 });


### PR DESCRIPTION
If tables go missing while we are running, there is no sense trying to recover.

We need to abort so that we can re-initialize the schema.

See https://app.incident.io/rocicorp/incidents/222