### PR TITLE
fix(zql): avoid O(N²) spread in Debug.rowVended

### DIFF
--- a/packages/zql/src/builder/debug-delegate.ts
+++ b/packages/zql/src/builder/debug-delegate.ts
@@ -69,7 +69,7 @@ export class Debug implements DebugDelegate {
       counts[query] = (counts[query] ?? 0) + 1;
     }
     if (rows) {
-      rows[query] = [...(rows[query] ?? []), row];
+      (rows[query] ??= []).push(row);
     }
   }
 


### PR DESCRIPTION
`Debug.rowVended` cloned the entire accumulated rows array on every call (`rows[query] = [...(rows[query] ?? []), row]`), making per-query overhead O(N) per row and O(N²) over the lifetime of a query. With high-fan-out queries this overhead can dominate wall-time — for one zbugs benchmark query (~475k rows vended into a single bucket) it accounted for 147s of 253s total runtime, scaling quadratically with row count.

Replace the spread with `(rows[query] ??= []).push(row)` — same semantics, O(1) per call.