### PR TITLE
perf(zero-cache): skip inactive table diff materialization

### DIFF
--- a/packages/zero-cache/bench/view-syncer-digestion/README.md
+++ b/packages/zero-cache/bench/view-syncer-digestion/README.md
@@ -1,0 +1,35 @@
+# View-Syncer Digestion Benchmark
+
+This benchmark isolates the part of view-syncer catchup that happens after the
+replica has already accepted upstream changes. Each view syncer starts from the
+same snapshot, the benchmark applies a backlog, then every view syncer advances
+its snapshot diff.
+
+```
+replica changeLog
+       |
+       v
+  SnapshotDiff  -> active query tables -> pipeline/CVR work
+       |
+       `-------> unobserved table rows should not be materialized
+```
+
+The benchmark reports the old diff behavior and the filtered diff behavior in
+one run. The delta is expected to be large when the backlog mostly touches
+tables that no active query reads, and close to zero when every changed row is
+part of the active query table set.
+
+Run:
+
+```sh
+npm --workspace=zero-cache run perf:vs-digestion
+```
+
+Useful knobs:
+
+```sh
+ZERO_VS_DIGESTION_VIEW_SYNCERS=16
+ZERO_VS_DIGESTION_TX=1000
+ZERO_VS_DIGESTION_ROWS_PER_TX=10
+ZERO_VS_DIGESTION_OUT=/tmp/vs-digestion.json
+```

--- a/packages/zero-cache/bench/view-syncer-digestion/fixtures.ts
+++ b/packages/zero-cache/bench/view-syncer-digestion/fixtures.ts
@@ -1,0 +1,45 @@
+import {envInt} from './perf-utils.ts';
+import type {DigestScenario} from './types.ts';
+
+export const APP_ID = 'bench';
+export const INITIAL_VERSION = '000000000001';
+export const ACTIVE_TABLE = 'active_rows';
+export const BACKGROUND_TABLE = 'background_rows';
+
+export const TABLES = {
+  active: ACTIVE_TABLE,
+  background: BACKGROUND_TABLE,
+} as const;
+
+export function loadScenarios(): DigestScenario[] {
+  const transactions = envInt('ZERO_VS_DIGESTION_TX', 1_000);
+  const rowsPerTransaction = envInt('ZERO_VS_DIGESTION_ROWS_PER_TX', 10);
+
+  return [
+    {
+      name: 'unobserved-heavy',
+      transactions,
+      rowsPerTransaction,
+      activeRowsPerTransaction: 0,
+    },
+    {
+      name: 'mixed-10pct-active',
+      transactions,
+      rowsPerTransaction,
+      activeRowsPerTransaction: Math.max(
+        1,
+        Math.floor(rowsPerTransaction / 10),
+      ),
+    },
+    {
+      name: 'all-active',
+      transactions,
+      rowsPerTransaction,
+      activeRowsPerTransaction: rowsPerTransaction,
+    },
+  ];
+}
+
+export function watermark(index: number): string {
+  return index.toString(16).padStart(12, '0');
+}

--- a/packages/zero-cache/bench/view-syncer-digestion/index.ts
+++ b/packages/zero-cache/bench/view-syncer-digestion/index.ts
@@ -1,0 +1,258 @@
+/* oxlint-disable no-console */
+import {tmpdir} from 'node:os';
+import {performance} from 'node:perf_hooks';
+import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
+import {Database} from '../../../zqlite/src/db.ts';
+import {deleteLiteDB} from '../../src/db/delete-lite-db.ts';
+import {computeZqlSpecs, listTables} from '../../src/db/lite-tables.ts';
+import type {LiteAndZqlSpec} from '../../src/db/specs.ts';
+import type {DataOrSchemaChange} from '../../src/services/change-source/protocol/current/data.ts';
+import {populateFromExistingTables} from '../../src/services/replicator/schema/column-metadata.ts';
+import {initReplicationState} from '../../src/services/replicator/schema/replication-state.ts';
+import {
+  fakeReplicator,
+  ReplicationMessages,
+} from '../../src/services/replicator/test-utils.ts';
+import {Snapshotter} from '../../src/services/view-syncer/snapshotter.ts';
+import type {Change} from '../../src/services/view-syncer/snapshotter.ts';
+import type {RowValue} from '../../src/types/row-key.ts';
+import {
+  ACTIVE_TABLE,
+  APP_ID,
+  BACKGROUND_TABLE,
+  INITIAL_VERSION,
+  loadScenarios,
+  watermark,
+} from './fixtures.ts';
+import {
+  argValue,
+  envInt,
+  formatRate,
+  percentile,
+  writeJsonSummary,
+} from './perf-utils.ts';
+import type {
+  DigestScenario,
+  DigestStats,
+  ScenarioSummary,
+  Summary,
+} from './types.ts';
+
+const lc = createSilentLogContext();
+const viewSyncerCount = envInt('ZERO_VS_DIGESTION_VIEW_SYNCERS', 16);
+const activeTables = new Set([ACTIVE_TABLE]);
+const messages = new ReplicationMessages({
+  [ACTIVE_TABLE]: 'id',
+  [BACKGROUND_TABLE]: 'id',
+} as const);
+
+const summaries: ScenarioSummary[] = [];
+for (const scenario of loadScenarios()) {
+  summaries.push(runScenario(scenario));
+}
+
+const summary: Summary = {
+  name: 'zero-cache-view-syncer-digestion',
+  generatedAt: new Date().toISOString(),
+  viewSyncerCount,
+  scenarios: summaries,
+};
+
+for (const result of summary.scenarios) {
+  const pct = ((result.speedup - 1) * 100).toFixed(1);
+  console.log(
+    `${result.name}: old ${result.old.elapsedMs.toFixed(1)} ms | ` +
+      `filtered ${result.filtered.elapsedMs.toFixed(1)} ms | ` +
+      `${pct}% faster | ` +
+      `materialized ${formatRate(result.old.materializedChanges)} -> ` +
+      `${formatRate(result.filtered.materializedChanges)}`,
+  );
+}
+console.log(JSON.stringify(summary));
+
+await writeJsonSummary(
+  summary,
+  argValue('out') ?? process.env.ZERO_VS_DIGESTION_OUT,
+);
+
+function runScenario(scenario: DigestScenario): ScenarioSummary {
+  const dbFile = `${tmpdir()}/zero-cache-vs-digestion-${process.pid}-${scenario.name}.db`;
+  deleteLiteDB(dbFile);
+
+  const db = new Database(lc, dbFile);
+  const oldDigesters: Snapshotter[] = [];
+  const filteredDigesters: Snapshotter[] = [];
+
+  try {
+    setupReplica(db);
+    const tableSpecs = computeZqlSpecs(lc, db, {
+      includeBackfillingColumns: false,
+    });
+    const allTableNames = new Set(tableSpecs.keys());
+
+    for (let i = 0; i < viewSyncerCount; i++) {
+      oldDigesters.push(createDigester(dbFile));
+      filteredDigesters.push(createDigester(dbFile));
+    }
+
+    applyBacklog(db, scenario);
+
+    const totalRows = scenario.transactions * scenario.rowsPerTransaction;
+    const filtered = digest(
+      filteredDigesters,
+      tableSpecs,
+      allTableNames,
+      activeTables,
+      true,
+      totalRows,
+    );
+    const old = digest(
+      oldDigesters,
+      tableSpecs,
+      allTableNames,
+      activeTables,
+      false,
+      totalRows,
+    );
+
+    const activeRows =
+      scenario.transactions * scenario.activeRowsPerTransaction;
+    return {
+      name: scenario.name,
+      transactions: scenario.transactions,
+      rowsPerTransaction: scenario.rowsPerTransaction,
+      activeRowsPerTransaction: scenario.activeRowsPerTransaction,
+      totalRows,
+      activeRows,
+      old,
+      filtered,
+      speedup:
+        filtered.elapsedMs === 0
+          ? Number.POSITIVE_INFINITY
+          : old.elapsedMs / filtered.elapsedMs,
+      elapsedDeltaMs: old.elapsedMs - filtered.elapsedMs,
+      materializedChangeDelta:
+        old.materializedChanges - filtered.materializedChanges,
+    };
+  } finally {
+    for (const snapshotter of [...oldDigesters, ...filteredDigesters]) {
+      snapshotter.destroy();
+    }
+    db.close();
+    deleteLiteDB(dbFile);
+  }
+}
+
+function createDigester(dbFile: string): Snapshotter {
+  return new Snapshotter(lc, dbFile, {appID: APP_ID}).init();
+}
+
+function setupReplica(db: Database) {
+  db.pragma('journal_mode = WAL2');
+  db.exec(/*sql*/ `
+    CREATE TABLE "${APP_ID}.permissions" (
+      "lock"        INT PRIMARY KEY,
+      "permissions" JSON,
+      "hash"        TEXT,
+      _0_version    TEXT NOT NULL
+    );
+    INSERT INTO "${APP_ID}.permissions" ("lock", "_0_version")
+      VALUES (1, '${INITIAL_VERSION}');
+
+    CREATE TABLE "${ACTIVE_TABLE}" (
+      id TEXT PRIMARY KEY,
+      value INTEGER,
+      _0_version TEXT NOT NULL
+    );
+    CREATE TABLE "${BACKGROUND_TABLE}" (
+      id TEXT PRIMARY KEY,
+      value INTEGER,
+      _0_version TEXT NOT NULL
+    );
+  `);
+  initReplicationState(
+    db,
+    ['zero-cache-view-syncer-digestion'],
+    INITIAL_VERSION,
+  );
+  populateFromExistingTables(db, listTables(db, false));
+}
+
+function applyBacklog(db: Database, scenario: DigestScenario) {
+  const replicator = fakeReplicator(lc, db);
+  let rowID = 0;
+  for (let tx = 0; tx < scenario.transactions; tx++) {
+    const changes: DataOrSchemaChange[] = [];
+    for (let row = 0; row < scenario.rowsPerTransaction; row++) {
+      const table =
+        row < scenario.activeRowsPerTransaction
+          ? ACTIVE_TABLE
+          : BACKGROUND_TABLE;
+      const value = tx * scenario.rowsPerTransaction + row;
+      changes.push(insert(table, {id: `${table}-${rowID++}`, value}));
+    }
+    replicator.processTransaction(watermark(tx + 2), ...changes);
+  }
+}
+
+function insert(
+  table: typeof ACTIVE_TABLE | typeof BACKGROUND_TABLE,
+  row: RowValue,
+) {
+  return table === ACTIVE_TABLE
+    ? messages.insert(ACTIVE_TABLE, row)
+    : messages.insert(BACKGROUND_TABLE, row);
+}
+
+function digest(
+  digesters: readonly Snapshotter[],
+  tableSpecs: Map<string, LiteAndZqlSpec>,
+  allTableNames: Set<string>,
+  activeTableNames: ReadonlySet<string>,
+  filterInactiveTables: boolean,
+  sourceChangeLogEntriesPerDigester: number,
+): DigestStats {
+  const timings: number[] = [];
+  let selectedChangeLogEntries = 0;
+  let materializedChanges = 0;
+  let activeChanges = 0;
+  const start = performance.now();
+
+  for (const snapshotter of digesters) {
+    const digesterStart = performance.now();
+    const diff = snapshotter.advance(
+      tableSpecs,
+      allTableNames,
+      filterInactiveTables ? activeTableNames : undefined,
+    );
+    selectedChangeLogEntries += diff.changes;
+    for (const change of diff) {
+      materializedChanges++;
+      if (isActiveChange(change, activeTableNames)) {
+        activeChanges++;
+      }
+    }
+    timings.push(performance.now() - digesterStart);
+  }
+
+  const elapsedMs = performance.now() - start;
+  const changeLogEntries = sourceChangeLogEntriesPerDigester * digesters.length;
+  return {
+    elapsedMs,
+    changeLogEntries,
+    selectedChangeLogEntries,
+    materializedChanges,
+    activeChanges,
+    viewSyncerCount: digesters.length,
+    p50ViewSyncerMs: percentile(timings, 50),
+    p95ViewSyncerMs: percentile(timings, 95),
+    rowsPerSecond: elapsedMs === 0 ? 0 : (changeLogEntries / elapsedMs) * 1000,
+  };
+}
+
+function isActiveChange(
+  change: Change,
+  activeTableNames: ReadonlySet<string>,
+): boolean {
+  return activeTableNames.has(change.table);
+}

--- a/packages/zero-cache/bench/view-syncer-digestion/perf-utils.ts
+++ b/packages/zero-cache/bench/view-syncer-digestion/perf-utils.ts
@@ -1,0 +1,58 @@
+import {writeFile} from 'node:fs/promises';
+
+export function argValue(name: string): string | undefined {
+  const long = `--${name}`;
+  const withEquals = `${long}=`;
+  for (let i = 2; i < process.argv.length; i++) {
+    const arg = process.argv[i];
+    if (arg === long) {
+      return process.argv[i + 1];
+    }
+    if (arg?.startsWith(withEquals)) {
+      return arg.slice(withEquals.length);
+    }
+  }
+  return undefined;
+}
+
+export function envString(name: string, fallback?: string): string | undefined {
+  const value = process.env[name];
+  return value === undefined || value === '' ? fallback : value;
+}
+
+export function envInt(name: string, fallback: number): number {
+  const value = envString(name);
+  if (value === undefined) {
+    return fallback;
+  }
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`Invalid integer ${name}=${value}`);
+  }
+  return parsed;
+}
+
+export function percentile(values: readonly number[], p: number): number {
+  if (values.length === 0) {
+    return 0;
+  }
+  const sorted = values.toSorted((a, b) => a - b);
+  const index = Math.min(
+    sorted.length - 1,
+    Math.max(0, Math.ceil((p / 100) * sorted.length) - 1),
+  );
+  return sorted[index] ?? 0;
+}
+
+export function formatRate(value: number): string {
+  return value.toLocaleString('en-US', {maximumFractionDigits: 1});
+}
+
+export async function writeJsonSummary(
+  summary: unknown,
+  outputPath: string | undefined,
+): Promise<void> {
+  if (outputPath !== undefined) {
+    await writeFile(outputPath, JSON.stringify(summary, null, 2) + '\n');
+  }
+}

--- a/packages/zero-cache/bench/view-syncer-digestion/types.ts
+++ b/packages/zero-cache/bench/view-syncer-digestion/types.ts
@@ -1,0 +1,39 @@
+export type DigestScenario = {
+  readonly name: string;
+  readonly transactions: number;
+  readonly rowsPerTransaction: number;
+  readonly activeRowsPerTransaction: number;
+};
+
+export type DigestStats = {
+  readonly elapsedMs: number;
+  readonly changeLogEntries: number;
+  readonly selectedChangeLogEntries: number;
+  readonly materializedChanges: number;
+  readonly activeChanges: number;
+  readonly viewSyncerCount: number;
+  readonly p50ViewSyncerMs: number;
+  readonly p95ViewSyncerMs: number;
+  readonly rowsPerSecond: number;
+};
+
+export type ScenarioSummary = {
+  readonly name: string;
+  readonly transactions: number;
+  readonly rowsPerTransaction: number;
+  readonly activeRowsPerTransaction: number;
+  readonly totalRows: number;
+  readonly activeRows: number;
+  readonly old: DigestStats;
+  readonly filtered: DigestStats;
+  readonly speedup: number;
+  readonly elapsedDeltaMs: number;
+  readonly materializedChangeDelta: number;
+};
+
+export type Summary = {
+  readonly name: 'zero-cache-view-syncer-digestion';
+  readonly generatedAt: string;
+  readonly viewSyncerCount: number;
+  readonly scenarios: readonly ScenarioSummary[];
+};

--- a/packages/zero-cache/package.json
+++ b/packages/zero-cache/package.json
@@ -28,6 +28,7 @@
     "start": "node ./src/server/runner/main.ts",
     "benchdb": "node ./bench/bench.ts",
     "double": "node ./bench/double.ts",
+    "perf:vs-digestion": "node ./bench/view-syncer-digestion/index.ts",
     "wal_bench": "node ./bench/wal-bench.ts",
     "wal2_bench": "node ./bench/wal2-bench.ts",
     "fmt": "oxfmt .",

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
@@ -660,6 +660,7 @@ export class PipelineDriver {
     const diff = this.#snapshotter.advance(
       this.#tableSpecs,
       this.#allTableNames,
+      new Set(this.#tables.keys()),
     );
     const {prev, curr, changes} = diff;
     this.#lc.debug?.(

--- a/packages/zero-cache/src/services/view-syncer/snapshotter.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/snapshotter.test.ts
@@ -249,6 +249,40 @@ describe('view-syncer/snapshotter', () => {
     `);
   });
 
+  test('inactive syncable table data changes are skipped', () => {
+    expect(s.current().version).toBe('01');
+
+    replicator.processTransaction(
+      '09',
+      messages.insert('users', {id: 30, handle: 'bob'}),
+      messages.insert('issues', {id: 4, owner: 20}),
+    );
+    replicator.processTransaction('09');
+
+    const diff = s.advance(tableSpecs, allTableNames, new Set(['issues']));
+    expect(diff.prev.version).toBe('01');
+    expect(diff.curr.version).toBe('09');
+    expect(diff.changes).toBe(1);
+
+    expect([...diff]).toMatchInlineSnapshot(`
+      [
+        {
+          "nextValue": {
+            "_0_version": "09",
+            "desc": null,
+            "id": 4,
+            "owner": 20,
+          },
+          "prevValues": [],
+          "rowKey": {
+            "id": 4,
+          },
+          "table": "issues",
+        },
+      ]
+    `);
+  });
+
   test('concurrent snapshot diffs', () => {
     const s1 = new Snapshotter(lc, dbFile.path, {appID: 'my_app'}).init();
     const s2 = new Snapshotter(lc, dbFile.path, {appID: 'my_app'}).init();
@@ -609,6 +643,26 @@ describe('view-syncer/snapshotter', () => {
     expect(() => [...diff]).toThrowError(ResetPipelinesSignal);
   });
 
+  test('permissions changes are not filtered as inactive table data', () => {
+    expect(s.current().version).toBe('01');
+
+    replicator.processTransaction(
+      '07',
+      messages.update('my_app.permissions', {
+        lock: 1,
+        permissions: '{"tables":{}}',
+        hash: '12345',
+      }),
+    );
+
+    const diff = s.advance(tableSpecs, allTableNames, new Set(['issues']));
+    expect(diff.prev.version).toBe('01');
+    expect(diff.curr.version).toBe('07');
+    expect(diff.changes).toBe(1);
+
+    expect(() => [...diff]).toThrowError(ResetPipelinesSignal);
+  });
+
   test('changelog iterator cleaned up on aborted iteration', () => {
     const {version} = s.current();
 
@@ -653,7 +707,7 @@ describe('view-syncer/snapshotter', () => {
       messages.addColumn('comments', 'likes', {dataType: 'INT4', pos: 0}),
     );
 
-    const diff = s.advance(tableSpecs, allTableNames);
+    const diff = s.advance(tableSpecs, allTableNames, new Set(['issues']));
     expect(diff.prev.version).toBe('01');
     expect(diff.curr.version).toBe('07');
     expect(diff.changes).toBe(1);

--- a/packages/zero-cache/src/services/view-syncer/snapshotter.ts
+++ b/packages/zero-cache/src/services/view-syncer/snapshotter.ts
@@ -465,7 +465,7 @@ class Diff implements SnapshotDiff {
     this.#activeTableNames = activeTableNames;
     this.#tableFilter = activeTableNames
       ? {
-          tableNames: [...activeTableNames].sort(),
+          tableNames: [...activeTableNames].toSorted(),
           permissionsTable: this.#permissionsTable,
         }
       : undefined;

--- a/packages/zero-cache/src/services/view-syncer/snapshotter.ts
+++ b/packages/zero-cache/src/services/view-syncer/snapshotter.ts
@@ -29,6 +29,28 @@ import {
   ZERO_VERSION_COLUMN_NAME as ROW_VERSION,
 } from '../replicator/schema/replication-state.ts';
 
+type ActiveTableFilter = {
+  readonly tableNames: readonly string[];
+  readonly permissionsTable: string;
+};
+
+function changeLogTableFilter(filter: ActiveTableFilter | undefined): string {
+  if (!filter) {
+    return '';
+  }
+  const activeTables =
+    filter.tableNames.length === 0
+      ? ''
+      : `"table" IN (${filter.tableNames.map(() => '?').join(',')}) OR `;
+  return ` AND (${activeTables}"table" = ? OR "op" IN ('${RESET_OP}', '${TRUNCATE_OP}'))`;
+}
+
+function changeLogTableFilterArgs(
+  filter: ActiveTableFilter | undefined,
+): readonly string[] {
+  return filter ? [...filter.tableNames, filter.permissionsTable] : [];
+}
+
 /**
  * A `Snapshotter` manages the progression of database snapshots for a
  * ViewSyncer.
@@ -171,13 +193,25 @@ export class Snapshotter {
    * change-applying iterations, the caller must (1) create a save point
    * on `prev` before each iteration, and (2) rollback to the save point after
    * the iteration.
+   *
+   * When supplied, `activeTableNames` limits data-row materialization to tables
+   * currently read by pipelines. Schema and permissions changes still pass
+   * through because they can change how future queries are interpreted.
    */
   advance(
     syncableTables: Map<string, LiteAndZqlSpec>,
     allTableNames: Set<string>,
+    activeTableNames?: ReadonlySet<string>,
   ): SnapshotDiff {
     const {prev, curr} = this.advanceWithoutDiff();
-    return new Diff(this.#appID, syncableTables, allTableNames, prev, curr);
+    return new Diff(
+      this.#appID,
+      syncableTables,
+      allTableNames,
+      prev,
+      curr,
+      activeTableNames,
+    );
   }
 
   advanceWithoutDiff() {
@@ -315,23 +349,35 @@ class Snapshot {
     this.version = stateVersion;
   }
 
-  numChangesSince(prevVersion: string) {
-    const {count} = this.db.get(
-      'SELECT COUNT(*) AS count FROM "_zero.changeLog2" WHERE stateVersion > ?',
-      prevVersion,
+  numChangesSince(prevVersion: string, tableFilter?: ActiveTableFilter) {
+    const cached = this.db.statementCache.get(
+      `SELECT COUNT(*) AS count FROM "_zero.changeLog2"
+         WHERE "stateVersion" > ?${changeLogTableFilter(tableFilter)}`,
     );
-    return count;
+    try {
+      const {count} = cached.statement.get(
+        prevVersion,
+        ...changeLogTableFilterArgs(tableFilter),
+      ) as {count: number};
+      return count;
+    } finally {
+      this.db.statementCache.return(cached);
+    }
   }
 
-  changesSince(prevVersion: string) {
+  changesSince(prevVersion: string, tableFilter?: ActiveTableFilter) {
     // Note: The queried fields are constrained to only those that are relevant
     // to the snapshot diff, i.e. those defined in the changeLogEntrySchema.
     const cached = this.db.statementCache.get(
       `SELECT "stateVersion", "table", "rowKey", "op" FROM "_zero.changeLog2"
-         WHERE "stateVersion" > ? ORDER BY "stateVersion" ASC, "pos" ASC`,
+         WHERE "stateVersion" > ?${changeLogTableFilter(tableFilter)}
+         ORDER BY "stateVersion" ASC, "pos" ASC`,
     );
     return {
-      changes: cached.statement.iterate(prevVersion),
+      changes: cached.statement.iterate(
+        prevVersion,
+        ...changeLogTableFilterArgs(tableFilter),
+      ),
       cleanup: () => this.db.statementCache.return(cached),
     };
   }
@@ -399,6 +445,8 @@ class Diff implements SnapshotDiff {
   readonly #permissionsTable: string;
   readonly #syncableTables: Map<string, LiteAndZqlSpec>;
   readonly #allTableNames: Set<string>;
+  readonly #activeTableNames: ReadonlySet<string> | undefined;
+  readonly #tableFilter: ActiveTableFilter | undefined;
   readonly prev: Snapshot;
   readonly curr: Snapshot;
   readonly changes: number;
@@ -409,17 +457,28 @@ class Diff implements SnapshotDiff {
     allTableNames: Set<string>,
     prev: Snapshot,
     curr: Snapshot,
+    activeTableNames: ReadonlySet<string> | undefined,
   ) {
     this.#permissionsTable = `${appID}.permissions`;
     this.#syncableTables = syncableTables;
     this.#allTableNames = allTableNames;
+    this.#activeTableNames = activeTableNames;
+    this.#tableFilter = activeTableNames
+      ? {
+          tableNames: [...activeTableNames].sort(),
+          permissionsTable: this.#permissionsTable,
+        }
+      : undefined;
     this.prev = prev;
     this.curr = curr;
-    this.changes = curr.numChangesSince(prev.version);
+    this.changes = curr.numChangesSince(prev.version, this.#tableFilter);
   }
 
   [Symbol.iterator](): Iterator<Change> {
-    const {changes, cleanup: done} = this.curr.changesSince(this.prev.version);
+    const {changes, cleanup: done} = this.curr.changesSince(
+      this.prev.version,
+      this.#tableFilter,
+    );
 
     const cleanup = () => {
       try {
@@ -463,6 +522,13 @@ class Diff implements SnapshotDiff {
               throw new Error(`change for unknown table ${table}`);
             }
             const {tableSpec, zqlSpec} = specs;
+            if (
+              table !== this.#permissionsTable &&
+              this.#activeTableNames &&
+              !this.#activeTableNames.has(table)
+            ) {
+              continue;
+            }
 
             // Sanity check: All change log ops should have a stateVersion
             // greater than minRowVersion in the table metadata. This is a


### PR DESCRIPTION
**This teaches each view syncer to skip diff materialization for tables that no active query pipeline currently reads.** In the catchup path, we were paying to materialize row diffs that `PipelineDriver` already knew it would throw away.

For reviewers who do not live in this corner of Zero: once upstream writes have already landed in the replica, a view syncer advances from an older snapshot to the current one by reading `_zero.changeLog2`, materializing old/new row values, and pushing those row changes through the active query pipelines that produce client-visible result updates and pokes. Before this change, that advancement step was version-aware but not pipeline-aware, so it walked changelog rows for every syncable table even when connected clients only had live queries over a small subset of tables.

The old behavior was plausible: `Snapshotter` knew "go from version X to version Y," but it did not know which tables any live `TableSource` actually cared about. That meant writes to table `B` and `C` still got materialized into row diffs even if every active pipeline only read table `A`.

```text
before

_zero.changeLog2
   -> materialize row diffs for every syncable table
   -> PipelineDriver keeps rows for active tables
   -> drops the rest

after

_zero.changeLog2
   WHERE table IN activeTables
      OR table = permissionsTable
      OR op IN (RESET, TRUNCATE)
   -> materialize only rows that can affect live pipelines
   -> JS guard still drops any inactive data row that slips through
```

`PipelineDriver` now passes `new Set(this.#tables.keys())` into `Snapshotter.advance()`. `Snapshotter` builds a deterministic active-table filter from those live tables plus the permissions table, and threads it into the SQLite changelog queries in `numChangesSince()` and `changesSince()`. I also kept the JS-side inactive-row guard, so the SQL filter is not the only line of defense. The new tests cover the three cases that matter here: inactive syncable-table data is skipped, permissions changes are still emitted, and schema changes still trigger `ResetPipelinesSignal` even when an active-table filter is present.

**The win is biggest exactly where catchup hurts today: many lagging view syncers, a long backlog, and lots of writes to tables nobody is observing.** The waste is multiplicative because every lagging view syncer repeats it.

```text
8 view syncers x 10,000 backlog rows x 90% unobserved writes

old path:       80,000 row diffs materialized
filtered path:   8,000 relevant row diffs + reset/perm rows
waste removed:  72,000 materializations
```

That is CPU and row lookup work burned during the same outage or overload window where we most want view syncers to catch up quickly. It can also hold snapshots and related read work open longer for no client-visible benefit.

**This is a narrowing optimization, not a protocol change.** It does not change replica contents, changelog writes, client-visible ordering, or the wire format. It only narrows which changelog rows a given view syncer considers during one advancement step, and only to tables already represented by active pipeline `TableSource`s. If no active query pipeline reads a table, changes to rows in that table cannot affect any current client result. If a client later starts querying that table, hydration reads from the current replica snapshot anyway. Permissions-table changes always stay in the stream because authorization can change query meaning even when queried tables are unchanged. `RESET` and `TRUNCATE` also always stay in the stream because schema or table-wide operations may require pipeline reset rather than ordinary row diff application.

There is also an honest worst-case story here: if everything is active, this is basically a wash. The filter adds a little overhead, and the `all-active` benchmark is included on purpose to show that this is not "free speed everywhere." On the clean 16-view-syncer run, `all-active` is `1089.3 ms -> 1125.7 ms`, with the same `160,000` rows materialized in both cases. So the trade here is very specific: small overhead when every table matters, large wins when backlog is dominated by tables no live query currently observes.

To make that concrete, I added `bench/view-syncer-digestion/*` plus `npm --workspace=zero-cache run perf:vs-digestion`. The harness creates one SQLite replica with `active_rows` and `background_rows`, initializes `N` snapshotters at the same old version, applies `1000` transactions with `10` rows each, and then has each snapshotter advance. It runs the old behavior by not passing active table names, and the new behavior by passing them. The view syncer count is configurable with `ZERO_VS_DIGESTION_VIEW_SYNCERS=4`, `8`, or `16` (default `16`). This benchmark is intentionally isolating view-syncer digestion after upstream writes have already landed; it is not claiming RM fanout or client socket throughput.

| VS | workload | old ms | filtered ms | materialized rows |
|---:|---|---:|---:|---:|
| 4 | unobserved-heavy | 266.2 | 8.5 | 40,000 -> 0 |
| 4 | mixed-10pct-active | 297.4 | 36.5 | 40,000 -> 4,000 |
| 4 | all-active | 244.6 | 252.5 | 40,000 -> 40,000 |
| 8 | unobserved-heavy | 526.2 | 16.2 | 80,000 -> 0 |
| 8 | mixed-10pct-active | 511.1 | 71.7 | 80,000 -> 8,000 |
| 8 | all-active | 517.1 | 480.1 | 80,000 -> 80,000 |
| 16 | unobserved-heavy | 1346.8 | 51.8 | 160,000 -> 0 |
| 16 | mixed-10pct-active | 1115.0 | 145.7 | 160,000 -> 16,000 |
| 16 | all-active | 1089.3 | 1125.7 | 160,000 -> 160,000 |

The shape is the point: when most backlog writes are irrelevant to live pipelines, asking SQLite to prefilter the changelog removes almost all of the wasted materialization work. When the backlog is mostly relevant, the result trends toward parity. That is exactly the contract I want from this change.

I checked the change with:

```sh
npm --workspace=zero-cache run check-types -- --pretty false
npm --workspace=zero-cache run test -- --run src/services/view-syncer/snapshotter.test.ts src/services/view-syncer/pipeline-driver.test.ts
npm --workspace=zero-cache run perf:vs-digestion
git diff --check
```

Draft note: this PR was prepared with AI assistance. I am keeping it draft while the benchmark story and review surface are checked carefully.
