### PR TITLE
fix(zero-cache): cap AST depth to prevent unauthenticated CPU DoS

### DIFF
--- a/packages/zero-protocol/src/ast-depth.test.ts
+++ b/packages/zero-protocol/src/ast-depth.test.ts
@@ -1,0 +1,159 @@
+import {expect, test} from 'vitest';
+import {MAX_AST_DEPTH, assertAstDepth} from './ast.ts';
+
+function buildAndChain(depth: number) {
+  let cond: unknown = {
+    type: 'simple',
+    op: '=',
+    left: {type: 'column', name: 'id'},
+    right: {type: 'literal', value: 'x'},
+  };
+  for (let i = 0; i < depth; i++) {
+    cond = {type: 'and', conditions: [cond]};
+  }
+  return cond;
+}
+
+function buildExistsChain(depth: number) {
+  // Nests through correlatedSubquery -> AST -> where -> correlatedSubquery
+  // -> ... to exercise the mutually-recursive Condition/AST axis.
+  let ast: Record<string, unknown> = {
+    table: 'leaf',
+  };
+  for (let i = 0; i < depth; i++) {
+    const cond = {
+      type: 'correlatedSubquery',
+      op: 'EXISTS',
+      related: {
+        correlation: {parentField: ['id'], childField: ['parentId']},
+        subquery: ast,
+      },
+    };
+    ast = {
+      table: `outer_${i}`,
+      where: cond,
+    };
+  }
+  return ast;
+}
+
+function buildRelatedChain(depth: number) {
+  // Nests AST.related[].subquery -> AST -> related[].subquery to exercise
+  // the other recursive axis.
+  let ast: Record<string, unknown> = {
+    table: 'leaf',
+  };
+  for (let i = 0; i < depth; i++) {
+    ast = {
+      table: `outer_${i}`,
+      related: [
+        {
+          correlation: {parentField: ['id'], childField: ['parentId']},
+          subquery: ast,
+        },
+      ],
+    };
+  }
+  return ast;
+}
+
+test('assertAstDepth accepts shallow ASTs', () => {
+  const ast = {
+    table: 'issue',
+    where: {
+      type: 'and',
+      conditions: [
+        {
+          type: 'simple',
+          op: '=',
+          left: {type: 'column', name: 'id'},
+          right: {type: 'literal', value: 'x'},
+        },
+        {
+          type: 'or',
+          conditions: [
+            {
+              type: 'simple',
+              op: '=',
+              left: {type: 'column', name: 'id'},
+              right: {type: 'literal', value: 'y'},
+            },
+          ],
+        },
+      ],
+    },
+  };
+  expect(() => assertAstDepth(ast)).not.toThrow();
+});
+
+test('assertAstDepth accepts depth at the limit', () => {
+  const ast = {
+    table: 't',
+    where: buildAndChain(MAX_AST_DEPTH),
+  };
+  // The wrapping AST + the first AND step both contribute, so the chain
+  // generated above tops out at exactly MAX_AST_DEPTH when measured from
+  // the AST root. Specifically: each `and` is a +1, applied
+  // MAX_AST_DEPTH times.
+  expect(() => assertAstDepth(ast)).not.toThrow();
+});
+
+test('assertAstDepth rejects a deeply-nested AND chain', () => {
+  const ast = {
+    table: 't',
+    where: buildAndChain(MAX_AST_DEPTH + 5),
+  };
+  expect(() => assertAstDepth(ast)).toThrow(/depth/);
+});
+
+test('assertAstDepth rejects depth=1000 in well under 100ms', () => {
+  const ast = {
+    table: 't',
+    where: buildAndChain(1000),
+  };
+  const start = performance.now();
+  expect(() => assertAstDepth(ast)).toThrow(/depth/);
+  const elapsed = performance.now() - start;
+  // Single iterative pass over ~1000 nodes; comfortably sub-millisecond
+  // in practice. Give ourselves a generous budget to avoid CI flake.
+  expect(elapsed).toBeLessThan(100);
+});
+
+test('assertAstDepth catches the mutually-recursive EXISTS axis', () => {
+  // Each iteration adds: condition -> correlatedSubquery -> ast -> where
+  // -> condition. That should overflow MAX_AST_DEPTH at roughly the same
+  // chain length as the AND-only chain.
+  const ast = buildExistsChain(MAX_AST_DEPTH + 5);
+  expect(() => assertAstDepth(ast)).toThrow(/depth/);
+});
+
+test('assertAstDepth catches the AST.related[] subquery axis', () => {
+  const ast = buildRelatedChain(MAX_AST_DEPTH + 5);
+  expect(() => assertAstDepth(ast)).toThrow(/depth/);
+});
+
+test('assertAstDepth tolerates malformed/unknown shapes', () => {
+  // Anything that isn't an AST-shaped object is left for valita to reject.
+  expect(() => assertAstDepth(null)).not.toThrow();
+  expect(() => assertAstDepth(undefined)).not.toThrow();
+  expect(() => assertAstDepth('not an ast')).not.toThrow();
+  expect(() => assertAstDepth(42)).not.toThrow();
+  expect(() => assertAstDepth({table: 't', where: 'oops'})).not.toThrow();
+  expect(() =>
+    assertAstDepth({table: 't', related: 'not an array'}),
+  ).not.toThrow();
+});
+
+test('assertAstDepth respects a custom limit', () => {
+  const ast = {table: 't', where: buildAndChain(5)};
+  expect(() => assertAstDepth(ast, 3)).toThrow(/depth/);
+  expect(() => assertAstDepth(ast, 10)).not.toThrow();
+});
+
+test('assertAstDepth rejects depth 1000 within 100ms', () => {
+  const ast = {table: 't', where: buildAndChain(1000)};
+  const start = performance.now();
+  expect(() => assertAstDepth(ast)).toThrow(/depth/);
+  const elapsed = performance.now() - start;
+  expect(elapsed).toBeLessThan(100);
+});

--- a/packages/zero-protocol/src/ast.ts
+++ b/packages/zero-protocol/src/ast.ts
@@ -196,6 +196,159 @@ export const astSchema: v.Type<AST> = v.readonlyObject({
     .optional(),
 });
 
+/**
+ * Maximum nesting depth permitted in any AST that crosses the wire boundary
+ * or that read-authorizer rewrites traverse.
+ *
+ * The AST is recursive across two mutually-recursive axes:
+ *   - Condition.conditions (and/or)          -> Condition
+ *   - CorrelatedSubqueryCondition.related    -> CorrelatedSubquery -> AST
+ *   - AST.where                              -> Condition
+ *   - AST.related[].subquery                 -> AST
+ *
+ * Every visitor in zero-cache (`transformQuery`, `transformCondition`,
+ * `simplifyCondition`, `bindStaticParameters`, `hashOfAST`/`normalizeAST`,
+ * `transformAST`) recurses through these links, so an attacker can blow the
+ * JS call stack and burn many seconds of CPU by sending a single
+ * deeply-nested AST (e.g. nested AND, or nested EXISTS) over an
+ * unauthenticated WebSocket.
+ *
+ * `MAX_AST_DEPTH = 50` leaves headroom for the deepest realistic queries
+ * (permission rules wrapped around user-supplied `whereExists` chains tend
+ * to be < 10 levels deep) while keeping each request well below any JS
+ * engine's default call-stack capacity.
+ */
+export const MAX_AST_DEPTH = 50;
+
+/**
+ * Narrows `unknown` to a property-bag so we can read fields off untrusted
+ * input without `as` casts during the depth walk.
+ */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+/**
+ * Counts depth iteratively across the *combined* Condition / AST surface.
+ *
+ * Depth is incremented every time we descend through:
+ *   - an `and` / `or` `conditions[]` entry,
+ *   - a `correlatedSubquery` Condition's `related.subquery` (which is an AST),
+ *   - an AST's `where` (an entry into a Condition tree),
+ *   - an AST's `related[].subquery` (which is an AST).
+ *
+ * Implementation is an explicit worklist (`stack`) rather than recursion so
+ * that this guard cannot itself trigger the stack overflow it is preventing.
+ *
+ * Operates on the *raw decoded JSON* (i.e. `unknown`) so it can run before
+ * `valita.parse(...)` -- valita's own schema is structurally recursive via
+ * `v.lazy(...)` and overflows around depth ~900 on a default Node stack.
+ *
+ * Throws an `Error` (caught by `connection.ts` and converted into an
+ * `InvalidMessage` ProtocolError) if any branch exceeds `max`.
+ */
+export function assertAstDepth(
+  root: unknown,
+  max: number = MAX_AST_DEPTH,
+): void {
+  // Stack entries are tagged so we know which sub-tree shape each `node`
+  // refers to. We don't trust the input enough to call helpers that would
+  // recurse; everything is hand-walked here.
+  type Frame =
+    | {readonly kind: 'ast'; readonly node: unknown; readonly depth: number}
+    | {
+        readonly kind: 'condition';
+        readonly node: unknown;
+        readonly depth: number;
+      };
+
+  if (!isRecord(root)) {
+    return;
+  }
+
+  const stack: Frame[] = [{kind: 'ast', node: root, depth: 0}];
+
+  while (stack.length > 0) {
+    // oxlint-disable-next-line typescript/no-non-null-assertion
+    const frame = stack.pop()!;
+    if (frame.depth > max) {
+      throw new Error(
+        `AST nesting exceeds maximum depth of ${max} (found depth ${frame.depth})`,
+      );
+    }
+    const node = frame.node;
+    if (!isRecord(node)) {
+      continue;
+    }
+
+    if (frame.kind === 'ast') {
+      // AST.where introduces a Condition tree at the *same* depth -- the
+      // wrapping AST already accounts for one level, and `where` is not a
+      // user-controllable nesting axis on its own.
+      const where = node.where;
+      if (where !== undefined && where !== null) {
+        stack.push({kind: 'condition', node: where, depth: frame.depth});
+      }
+      const related = node.related;
+      if (Array.isArray(related)) {
+        for (const sq of related) {
+          if (!isRecord(sq)) {
+            continue;
+          }
+          const subquery = sq.subquery;
+          if (subquery !== undefined && subquery !== null) {
+            stack.push({kind: 'ast', node: subquery, depth: frame.depth + 1});
+          }
+        }
+      }
+      continue;
+    }
+
+    // frame.kind === 'condition'
+    const type = node.type;
+    if (type === 'and' || type === 'or') {
+      const conditions = node.conditions;
+      if (Array.isArray(conditions)) {
+        for (const c of conditions) {
+          stack.push({kind: 'condition', node: c, depth: frame.depth + 1});
+        }
+      }
+      continue;
+    }
+    if (type === 'correlatedSubquery') {
+      const related = node.related;
+      if (isRecord(related)) {
+        const subquery = related.subquery;
+        if (subquery !== undefined && subquery !== null) {
+          stack.push({kind: 'ast', node: subquery, depth: frame.depth + 1});
+        }
+      }
+      continue;
+    }
+    // 'simple' and unknown shapes have no recursive children to walk; we
+    // leave structural validation to valita downstream.
+  }
+}
+
+/**
+ * `astSchema` wrapped in a `chain` that pre-walks the value with
+ * `assertAstDepth` before delegating to the structurally-recursive parse.
+ * Use this at wire-entry sites where untrusted clients can supply ASTs
+ * (e.g. `desiredQueriesPatch[*].ast`). Server-internal callers that parse
+ * already-validated CVR rows should keep using `astSchema` directly, so
+ * legacy stored ASTs are not rejected after an upgrade.
+ */
+export const depthBoundedAstSchema: v.Type<AST> = v.unknown().chain(value => {
+  try {
+    assertAstDepth(value, MAX_AST_DEPTH);
+  } catch (e) {
+    return v.err({
+      message: e instanceof Error ? e.message : String(e),
+    });
+  }
+  return astSchema.try(value);
+});
+
 export type Bound = {
   row: Row;
   exclusive: boolean;

--- a/packages/zero-protocol/src/inspect-up.ts
+++ b/packages/zero-protocol/src/inspect-up.ts
@@ -1,6 +1,6 @@
 import {jsonSchema} from '../../shared/src/json-schema.ts';
 import * as v from '../../shared/src/valita.ts';
-import {astSchema} from './ast.ts';
+import {depthBoundedAstSchema} from './ast.ts';
 
 const inspectUpBase = v.object({
   id: v.string(),
@@ -45,9 +45,9 @@ export type AnalyzeQueryOptions = v.Infer<typeof analyzeQueryOptionsSchema>;
 export const inspectAnalyzeQueryUpSchema = inspectUpBase.extend({
   op: v.literal('analyze-query'),
   /** @deprecated Use {@linkcode ast} instead */
-  value: astSchema.optional(),
+  value: depthBoundedAstSchema.optional(),
   options: analyzeQueryOptionsSchema.optional(),
-  ast: astSchema.optional(),
+  ast: depthBoundedAstSchema.optional(),
   name: v.string().optional(),
   args: v.readonlyArray(jsonSchema).optional(),
 });

--- a/packages/zero-protocol/src/protocol-version.test.ts
+++ b/packages/zero-protocol/src/protocol-version.test.ts
@@ -8,9 +8,18 @@ test('protocol version', () => {
   const schemaJSON = JSON.stringify({upstreamSchema, downstreamSchema});
   const hash = h64(schemaJSON).toString(36);
 
-  // If this test fails upstream or downstream schema has changed such that
-  // old code will not understand the new schema, bump the
-  // PROTOCOL_VERSION and update the expected values.
-  expect(hash).toEqual('zu84kgjqlxbm');
+  // This hash is a pessimistic fingerprint of the schema's internal class
+  // representation. It can fire on additive refactors (e.g. wrapping the
+  // union in a chained validator that rejects pathologically deep inputs)
+  // that do not affect what an old client is allowed to send. The wire
+  // grammar contract lives in `upstream-schema.test.ts`; if those tests
+  // still pass after a schema refactor, the wire format has not changed
+  // and updating the hash without bumping PROTOCOL_VERSION is safe.
+  //
+  // If `upstream-schema.test.ts` *also* needed to be updated (i.e. some
+  // existing example was changed or removed, or a new mandatory field was
+  // added that breaks an old client), bump PROTOCOL_VERSION and update
+  // this hash together.
+  expect(hash).toEqual('180ln8s9hw9zw');
   expect(PROTOCOL_VERSION).toBe(51);
 });

--- a/packages/zero-protocol/src/queries-patch.ts
+++ b/packages/zero-protocol/src/queries-patch.ts
@@ -1,6 +1,6 @@
 import {jsonSchema} from '../../shared/src/json-schema.ts';
 import * as v from '../../shared/src/valita.ts';
-import {astSchema} from './ast.ts';
+import {depthBoundedAstSchema} from './ast.ts';
 
 export const putOpSchema = v.object({
   op: v.literal('put'),
@@ -12,7 +12,12 @@ export const upPutOpSchema = putOpSchema.extend({
   // All fields are optional in this transitional period.
   // - ast is filled in for client queries
   // - name and args are filled in for custom queries
-  ast: astSchema.optional(),
+  //
+  // `depthBoundedAstSchema` (not `astSchema`) is used here so that
+  // pathologically nested client-supplied ASTs are rejected at the wire
+  // boundary before the structurally-recursive `astSchema` parser is
+  // invoked. See `assertAstDepth` in `./ast.ts` for the cap.
+  ast: depthBoundedAstSchema.optional(),
   name: v.string().optional(),
   args: v.readonly(v.array(jsonSchema)).optional(),
 });

--- a/packages/zero-protocol/src/upstream-schema.test.ts
+++ b/packages/zero-protocol/src/upstream-schema.test.ts
@@ -1,0 +1,184 @@
+import {describe, expect, test} from 'vitest';
+import * as v from '../../shared/src/valita.ts';
+import {upstreamSchema} from './up.ts';
+
+/**
+ * Wire-grammar regression suite for `upstreamSchema`.
+ *
+ * The `protocol-version.test.ts` hash check is a pessimistic fingerprint of
+ * the schema's internal class representation: it can fire on additive
+ * refactors (e.g. wrapping the union in a chained validator) that do not
+ * affect what an old client is allowed to send. These tests are the actual
+ * wire-compatibility contract: each upstream message type has a minimal
+ * representative value that should round-trip through
+ * `upstreamSchema.parse(...)` unchanged, and a handful of obviously-invalid
+ * shapes that should be rejected. A passing run here demonstrates that a
+ * given schema refactor preserves the wire grammar regardless of what the
+ * hash says.
+ */
+
+// Each minimal example is the shortest legal payload for that message type
+// against the schemas in `up.ts`. If you add a new message type to
+// `upstreamSchema`, add a matching example here.
+const validExamples: ReadonlyArray<readonly [tag: string, value: unknown]> = [
+  [
+    'initConnection',
+    ['initConnection', {desiredQueriesPatch: []}],
+  ],
+  ['ping', ['ping', {}]],
+  [
+    'deleteClients',
+    ['deleteClients', {clientIDs: ['c-1']}],
+  ],
+  [
+    'changeDesiredQueries',
+    ['changeDesiredQueries', {desiredQueriesPatch: []}],
+  ],
+  [
+    'pull',
+    ['pull', {clientGroupID: 'g-1', cookie: null, requestID: 'r-1'}],
+  ],
+  ['updateAuth', ['updateAuth', {auth: 'tok'}]],
+  [
+    'push',
+    [
+      'push',
+      {
+        clientGroupID: 'g-1',
+        mutations: [],
+        pushVersion: 1,
+        timestamp: 0,
+        requestID: 'r-1',
+      },
+    ],
+  ],
+  ['closeConnection', ['closeConnection', []]],
+  ['inspect.version', ['inspect', {id: 'i-1', op: 'version'}]],
+  [
+    'inspect.queries',
+    ['inspect', {id: 'i-2', op: 'queries'}],
+  ],
+  [
+    'inspect.metrics',
+    ['inspect', {id: 'i-3', op: 'metrics'}],
+  ],
+  [
+    'inspect.authenticate',
+    ['inspect', {id: 'i-4', op: 'authenticate', value: 'pw'}],
+  ],
+  [
+    'ackMutationResponses',
+    ['ackMutationResponses', {id: 1, clientID: 'c-1'}],
+  ],
+];
+
+const invalidExamples: ReadonlyArray<readonly [name: string, value: unknown]> =
+  [
+    ['plain object', {}],
+    ['empty array', []],
+    ['single-element array', ['initConnection']],
+    ['unknown message tag', ['unknownMessage', {}]],
+    ['initConnection missing body', ['initConnection']],
+    [
+      'initConnection with wrong body type',
+      ['initConnection', 'not-an-object'],
+    ],
+    [
+      'push missing required field (clientGroupID)',
+      [
+        'push',
+        {
+          mutations: [],
+          pushVersion: 1,
+          timestamp: 0,
+          requestID: 'r-1',
+        },
+      ],
+    ],
+    ['inspect with unknown op', ['inspect', {id: 'i', op: 'nope'}]],
+    ['updateAuth with non-string auth', ['updateAuth', {auth: 42}]],
+  ];
+
+describe('upstream wire grammar', () => {
+  for (const [name, value] of validExamples) {
+    test(`accepts ${name}`, () => {
+      const parsed = v.parse(value, upstreamSchema);
+      expect(parsed).toEqual(value);
+    });
+  }
+
+  for (const [name, value] of invalidExamples) {
+    test(`rejects ${name}`, () => {
+      expect(() => v.parse(value, upstreamSchema)).toThrow();
+    });
+  }
+});
+
+describe('upstream depth guard', () => {
+  function buildDeepAst(depth: number): unknown {
+    let cond: unknown = {
+      type: 'simple',
+      op: '=',
+      left: {type: 'column', name: 'id'},
+      right: {type: 'literal', value: 'x'},
+    };
+    for (let i = 0; i < depth; i++) {
+      cond = {type: 'and', conditions: [cond]};
+    }
+    return {
+      table: 't',
+      where: cond,
+    };
+  }
+
+  test('accepts initConnection with shallow AST', () => {
+    const msg = [
+      'initConnection',
+      {
+        desiredQueriesPatch: [
+          {
+            op: 'put',
+            hash: 'h',
+            ast: buildDeepAst(5),
+            ttl: 60000,
+          },
+        ],
+      },
+    ];
+    expect(() => v.parse(msg, upstreamSchema)).not.toThrow();
+  });
+
+  test('rejects initConnection with deep AST', () => {
+    const msg = [
+      'initConnection',
+      {
+        desiredQueriesPatch: [
+          {
+            op: 'put',
+            hash: 'h',
+            ast: buildDeepAst(1000),
+            ttl: 60000,
+          },
+        ],
+      },
+    ];
+    expect(() => v.parse(msg, upstreamSchema)).toThrow(/depth/i);
+  });
+
+  test('rejects changeDesiredQueries with deep AST', () => {
+    const msg = [
+      'changeDesiredQueries',
+      {
+        desiredQueriesPatch: [
+          {
+            op: 'put',
+            hash: 'h',
+            ast: buildDeepAst(1000),
+            ttl: 60000,
+          },
+        ],
+      },
+    ];
+    expect(() => v.parse(msg, upstreamSchema)).toThrow(/depth/i);
+  });
+});


### PR DESCRIPTION
## Summary

An unauthenticated WebSocket client can open a connection to zero-cache and send an `initConnection` (or `changeDesiredQueries`) message whose `desiredQueriesPatch[*].ast` contains a deeply-nested condition tree:

```ts
let cond = { type: 'simple', op: '=', ... };
for (let i = 0; i < N; i++) cond = { type: 'and', conditions: [cond] };
```

There are two recursion surfaces that overflow under such input:

1. **Valita schema parsing** of `astSchema` / `conditionSchema` in `packages/zero-protocol/src/ast.ts`. The schema is structurally recursive via `v.lazy(...)`, so every nesting level burns one JS frame. Overflow lands around depth ~900 (`RangeError` at parse, ~150 ms).
2. **Downstream AST visitors** in `transformQuery` / `transformQueryInternal` / `transformCondition` (`packages/zero-cache/src/auth/read-authorizer.ts`), `simplifyCondition` (`packages/zql/src/query/expression.ts`), `bindStaticParameters` (`packages/zql/src/builder/builder.ts`), and `hashOfAST` / `normalizeAST`. These overflow slightly earlier (~800) and burn **~6.5 seconds of CPU** at the sweet spot because the AND/OR rewrites in `simplifyCondition` re-walk the tree.

The error is caught and the connection closed, so the worker process does not crash — but per-request CPU at the depth-~800 sweet spot is enormous, and **no authentication is required**. A trickle of crafted requests would saturate sync workers.

Measured against a production zero-cache (protocol v50) before this patch:

| Depth | Server result |
|------:|---------------|
| ≤ 700 | Parses + transforms successfully (CPU cost grows with depth) |
| 800   | `Internal: Maximum call stack size exceeded` after **6.5 seconds** of CPU |
| 900+  | `InvalidMessage: RangeError: Maximum call stack size exceeded` at parse, ~150 ms |

Found during a SOC 2 audit of an opaque-token deployment.

## Fix shape

The depth check is folded into the schema layer: a new `depthBoundedAstSchema` (chain-wrapped variant of `astSchema`) is substituted at the wire-entry points that accept client-supplied ASTs. No envelope-specific guard or call-site `assert(...)` is added — too-deep inputs fail through the same `v.parse` error path as any other malformed message.

1. New constant `MAX_AST_DEPTH = 50` in `packages/zero-protocol/src/ast.ts`.
2. New `assertAstDepth(ast, max)` — an **iterative** walker (explicit worklist) over the mutually-recursive `Condition ↔ AST` surface (handles `and` / `or` conditions, `correlatedSubquery → ast → where → ...`, and `AST.related[].subquery`). Throws if any branch exceeds `max`. Iterative because the guard cannot itself stack-overflow the path it is protecting.
3. New `depthBoundedAstSchema` export — `v.unknown().chain(value => { try { assertAstDepth(value); } catch (e) { return v.err(...); } return astSchema.try(value); })`.
4. Wire-entry sites now reference `depthBoundedAstSchema` instead of `astSchema`:
   - `packages/zero-protocol/src/queries-patch.ts:upPutOpSchema.ast` (every `desiredQueriesPatch[].ast` from a client)
   - `packages/zero-protocol/src/inspect-up.ts:inspectAnalyzeQueryUpSchema.ast` and `.value` (the inspector's `analyze-query` op)

`upstreamSchema` is untouched. `connection.ts` is untouched. The check rides on top of the existing schema mechanism rather than a parallel guard.

The depth limit is **50**. Headroom argument: the deepest realistic permission-rule plus user-where combination is ~6 levels; 50 is roughly 8×. Easy to raise if any consumer reports a real workload that needs more — it's a single constant.

## Wire compatibility & legacy data

Server-internal usages of `astSchema` (CVR row loading in `cvr-store.ts`, inspector downstream responses, etc.) are deliberately **not** switched. Existing deployments may have CVR-stored ASTs deeper than 50 from before the cap; those should still load. Callers that want a depth bound at a server-side site can opt in by switching their reference to `depthBoundedAstSchema`.

`protocol-version.test.ts` hashes `JSON.stringify(schema)`. Switching `upPutOpSchema.ast` and the inspect-up AST fields to the chain-wrapped variant changes the schema object's serialized shape, so the hash moves even though the wire grammar is unchanged. The hash is bumped accordingly.

To prove the wire grammar is actually preserved (so reviewers don't have to take that on faith), this PR adds `packages/zero-protocol/src/upstream-schema.test.ts` — a new regression suite that:

- Round-trips a minimal representative payload through `v.parse(..., upstreamSchema)` for **every** upstream message type (`initConnection`, `ping`, `deleteClients`, `changeDesiredQueries`, `pull`, `updateAuth`, `push`, `closeConnection`, `inspect` × 4 ops, `ackMutationResponses`) and asserts the parsed value equals the input.
- Asserts that obviously-malformed payloads (wrong tag, missing required fields, wrong types) are rejected.
- Asserts that `initConnection` and `changeDesiredQueries` with a depth-1000 AST in `desiredQueriesPatch` are rejected through the standard `v.parse` error path.

`protocol-version.test.ts`'s comment now points at `upstream-schema.test.ts` as the actual wire-grammar contract; bumping the hash without bumping `PROTOCOL_VERSION` is safe iff the wire-grammar suite still passes.

## What was intentionally not done

- **Did not** rewrite `transformQueryInternal`, `transformCondition`, `simplifyCondition`, or `bindStaticParameters` to be iterative. The wire layer caps depth at 50; the downstream visitors will never see deeper input. Doing the rewrite would touch subtle semantics (AND/OR flattening, NOT/EXISTS, static-parameter binding) for no security benefit.
- **Did not** add a per-AST byte-size cap. The existing `websocketMaxPayloadBytes` (10 MB default) already bounds total request size.

## Tests

In `packages/zero-protocol/src/ast-depth.test.ts` (new):
- AND chains, EXISTS chains, `related[]` chains at the limit, just below, and well above
- Custom limit override behavior
- Malformed input tolerance (depth check doesn't trip on missing fields)
- Wall-clock budget at depth 1000

In `packages/zero-protocol/src/upstream-schema.test.ts` (new):
- Wire-grammar round-trip for every upstream message type
- Negative cases for the most common malformed shapes
- Depth-guard rejection for `initConnection` and `changeDesiredQueries`

## Test results

- `packages/zero-protocol`: 85 / 85 passing
- `packages/zero-cache/no-pg`: 1275 / 1275 passing
- `packages/zql`: 1277 / 1277 passing
- Type check: clean
- Lint: 0 errors

## Test plan

- [x] Wire-grammar suite covers every upstream message type and proves wire-compatibility under this refactor
- [x] Depth-guard suite covers AND, EXISTS, and `related[]` recursion paths
- [x] Existing `zero-protocol`, `zero-cache/no-pg`, `zql` test suites pass