### PR TITLE
chore(pnpm): add phantom TS dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31139,6 +31139,7 @@
         "otel": "0.0.0",
         "oxfmt": "^0.45.0",
         "shared": "0.0.0",
+        "typescript": "~6.0.2",
         "vitest": "^4.1.5",
         "zero-cache": "0.0.0",
         "zero-client": "0.0.0",
@@ -31149,6 +31150,20 @@
         "zqlite": "0.0.0"
       }
     },
+    "packages/analyze-query/node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "packages/ast-to-zql": {
       "version": "0.0.0",
       "dependencies": {
@@ -31157,6 +31172,7 @@
       "devDependencies": {
         "@faker-js/faker": "^9.6.0",
         "shared": "0.0.0",
+        "typescript": "~6.0.2",
         "zero-cache": "0.0.0",
         "zero-protocol": "0.0.0",
         "zero-schema": "0.0.0",
@@ -31513,6 +31529,20 @@
       "license": "MIT",
       "engines": {
         "node": "^20.0.0 || >=22.0.0"
+      }
+    },
+    "packages/ast-to-zql/node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "packages/datadog": {
@@ -32142,12 +32172,27 @@
         "oxfmt": "^0.45.0",
         "pg": "^8.16.3",
         "shared": "0.0.0",
+        "typescript": "~6.0.2",
         "vitest": "^4.1.5",
         "zero-cache": "0.0.0",
         "zero-protocol": "0.0.0",
         "zero-schema": "0.0.0",
         "zero-types": "0.0.0",
         "zql": "0.0.0"
+      }
+    },
+    "packages/z2s/node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "packages/zero": {
@@ -32403,9 +32448,24 @@
       "devDependencies": {
         "@vitest/runner": "^4.1.5",
         "oxfmt": "^0.45.0",
+        "typescript": "~6.0.2",
         "vitest": "^4.1.5",
         "zero-cache": "0.0.0",
         "zero-server": "0.0.0"
+      }
+    },
+    "packages/zero-pg/node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "packages/zero-protocol": {
@@ -32442,6 +32502,7 @@
         "oxfmt": "^0.45.0",
         "react": "^18.3.1",
         "shared": "0.0.0",
+        "typescript": "~6.0.2",
         "zero-client": "0.0.0",
         "zero-schema": "0.0.0",
         "zql": "0.0.0"
@@ -32459,7 +32520,36 @@
       "devDependencies": {
         "oxfmt": "^0.45.0",
         "replicache": "15.2.1",
-        "shared": "0.0.0"
+        "shared": "0.0.0",
+        "typescript": "~6.0.2"
+      }
+    },
+    "packages/zero-react-native/node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "packages/zero-react/node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "packages/zero-schema": {
@@ -32467,9 +32557,24 @@
       "devDependencies": {
         "oxfmt": "^0.45.0",
         "shared": "0.0.0",
+        "typescript": "~6.0.2",
         "zero-protocol": "0.0.0",
         "zero-types": "0.0.0",
         "zql": "0.0.0"
+      }
+    },
+    "packages/zero-schema/node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "packages/zero-server": {
@@ -32489,6 +32594,7 @@
         "postgres": "3.4.7",
         "prisma": "^7.7.0",
         "shared": "0.0.0",
+        "typescript": "~6.0.2",
         "vitest": "^4.1.5",
         "z2s": "0.0.0",
         "zero-cache": "0.0.0",
@@ -32498,6 +32604,20 @@
         "zql": "0.0.0"
       }
     },
+    "packages/zero-server/node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "packages/zero-solid": {
       "version": "0.0.0",
       "devDependencies": {
@@ -32505,12 +32625,27 @@
         "oxfmt": "^0.45.0",
         "shared": "0.0.0",
         "solid-js": "^1.9.4",
+        "typescript": "~6.0.2",
         "vite-plugin-solid": "^2.11.11",
         "zero-client": "0.0.0",
         "zql": "0.0.0"
       },
       "peerDependencies": {
         "solid-js": "^1.9.4"
+      }
+    },
+    "packages/zero-solid/node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "packages/zero-types": {
@@ -33102,7 +33237,22 @@
       "devDependencies": {
         "oxfmt": "^0.45.0",
         "shared": "0.0.0",
+        "typescript": "~6.0.2",
         "zero-protocol": "0.0.0"
+      }
+    },
+    "tools/client-simulator/node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "tools/load-generator": {
@@ -33116,7 +33266,22 @@
       },
       "devDependencies": {
         "oxfmt": "^0.45.0",
-        "shared": "0.0.0"
+        "shared": "0.0.0",
+        "typescript": "~6.0.2"
+      }
+    },
+    "tools/load-generator/node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "tools/process-tracker": {
@@ -33129,7 +33294,22 @@
       "devDependencies": {
         "@types/pidusage": "^2.0.5",
         "oxfmt": "^0.45.0",
-        "shared": "0.0.0"
+        "shared": "0.0.0",
+        "typescript": "~6.0.2"
+      }
+    },
+    "tools/process-tracker/node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "tools/sqlite-io-yield-simulator": {
@@ -33142,7 +33322,22 @@
       },
       "devDependencies": {
         "oxfmt": "^0.45.0",
-        "shared": "0.0.0"
+        "shared": "0.0.0",
+        "typescript": "~6.0.2"
+      }
+    },
+    "tools/sqlite-io-yield-simulator/node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "tools/verify-package-deps": {

--- a/packages/analyze-query/package.json
+++ b/packages/analyze-query/package.json
@@ -24,6 +24,7 @@
     "otel": "0.0.0",
     "oxfmt": "^0.45.0",
     "shared": "0.0.0",
+    "typescript": "~6.0.2",
     "vitest": "^4.1.5",
     "zero-cache": "0.0.0",
     "zero-client": "0.0.0",

--- a/packages/ast-to-zql/package.json
+++ b/packages/ast-to-zql/package.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "@faker-js/faker": "^9.6.0",
     "shared": "0.0.0",
+    "typescript": "~6.0.2",
     "zero-cache": "0.0.0",
     "zero-protocol": "0.0.0",
     "zero-schema": "0.0.0",

--- a/packages/z2s/package.json
+++ b/packages/z2s/package.json
@@ -34,6 +34,7 @@
     "oxfmt": "^0.45.0",
     "pg": "^8.16.3",
     "shared": "0.0.0",
+    "typescript": "~6.0.2",
     "vitest": "^4.1.5",
     "zero-cache": "0.0.0",
     "zero-protocol": "0.0.0",

--- a/packages/zero-pg/package.json
+++ b/packages/zero-pg/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@vitest/runner": "^4.1.5",
     "oxfmt": "^0.45.0",
+    "typescript": "~6.0.2",
     "vitest": "^4.1.5",
     "zero-cache": "0.0.0",
     "zero-server": "0.0.0"

--- a/packages/zero-react-native/package.json
+++ b/packages/zero-react-native/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "oxfmt": "^0.45.0",
     "replicache": "15.2.1",
-    "shared": "0.0.0"
+    "shared": "0.0.0",
+    "typescript": "~6.0.2"
   }
 }

--- a/packages/zero-react/package.json
+++ b/packages/zero-react/package.json
@@ -27,6 +27,7 @@
     "oxfmt": "^0.45.0",
     "react": "^18.3.1",
     "shared": "0.0.0",
+    "typescript": "~6.0.2",
     "zero-client": "0.0.0",
     "zero-schema": "0.0.0",
     "zql": "0.0.0"

--- a/packages/zero-schema/package.json
+++ b/packages/zero-schema/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "oxfmt": "^0.45.0",
     "shared": "0.0.0",
+    "typescript": "~6.0.2",
     "zero-protocol": "0.0.0",
     "zero-types": "0.0.0",
     "zql": "0.0.0"

--- a/packages/zero-server/package.json
+++ b/packages/zero-server/package.json
@@ -32,6 +32,7 @@
     "postgres": "3.4.7",
     "prisma": "^7.7.0",
     "shared": "0.0.0",
+    "typescript": "~6.0.2",
     "vitest": "^4.1.5",
     "z2s": "0.0.0",
     "zero-cache": "0.0.0",

--- a/packages/zero-solid/package.json
+++ b/packages/zero-solid/package.json
@@ -26,6 +26,7 @@
     "oxfmt": "^0.45.0",
     "shared": "0.0.0",
     "solid-js": "^1.9.4",
+    "typescript": "~6.0.2",
     "vite-plugin-solid": "^2.11.11",
     "zero-client": "0.0.0",
     "zql": "0.0.0"

--- a/tools/client-simulator/package.json
+++ b/tools/client-simulator/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "oxfmt": "^0.45.0",
     "shared": "0.0.0",
+    "typescript": "~6.0.2",
     "zero-protocol": "0.0.0"
   }
 }

--- a/tools/load-generator/package.json
+++ b/tools/load-generator/package.json
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "oxfmt": "^0.45.0",
-    "shared": "0.0.0"
+    "shared": "0.0.0",
+    "typescript": "~6.0.2"
   }
 }

--- a/tools/process-tracker/package.json
+++ b/tools/process-tracker/package.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "@types/pidusage": "^2.0.5",
     "oxfmt": "^0.45.0",
-    "shared": "0.0.0"
+    "shared": "0.0.0",
+    "typescript": "~6.0.2"
   }
 }

--- a/tools/sqlite-io-yield-simulator/package.json
+++ b/tools/sqlite-io-yield-simulator/package.json
@@ -20,6 +20,7 @@
   },
   "devDependencies": {
     "oxfmt": "^0.45.0",
-    "shared": "0.0.0"
+    "shared": "0.0.0",
+    "typescript": "~6.0.2"
   }
 }


### PR DESCRIPTION
Many of our packages have phantom dependencies which prevents updating to pnpm. pnpm requires all packages to explicitly list the deps they use.

This adds TS everywhere it is used.