### PR TITLE
chore(ci): fix install and deploy order

### DIFF
--- a/.github/workflows/sst-gigabugs-deploy.yml
+++ b/.github/workflows/sst-gigabugs-deploy.yml
@@ -21,6 +21,15 @@ jobs:
           node-version: 24.x
           cache: 'npm'
 
+      - name: Install dependencies
+        run: |
+          npm run build-ci
+
+      - name: Install SST dependencies
+        run: |
+          cd prod/sst
+          npm install
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2
         with:
@@ -44,9 +53,6 @@ jobs:
       - name: Login to Amazon ECR
         run: |
           aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com
-      - name: Install dependencies
-        run: |
-          npm run build-ci
       - name: Resolve Zero protocol versions
         run: |
           node --experimental-strip-types -e "
@@ -93,7 +99,6 @@ jobs:
           ZERO_ADMIN_PASSWORD: ${{ secrets.ZERO_ADMIN_PASSWORD }}
         run: |
           cd prod/sst
-          npm install
           npx sst deploy --stage gigabugs-ebs
       - name: Deploy SST app non ebs
         env:
@@ -113,5 +118,4 @@ jobs:
           ZERO_ADMIN_PASSWORD: ${{ secrets.ZERO_ADMIN_PASSWORD }}
         run: |
           cd prod/sst
-          npm install
           npx sst deploy --stage gigabugs

--- a/.github/workflows/sst-prod-deploy.yml
+++ b/.github/workflows/sst-prod-deploy.yml
@@ -21,6 +21,15 @@ jobs:
           node-version: 24.x
           cache: 'npm'
 
+      - name: Install dependencies
+        run: |
+          npm run build-ci
+
+      - name: Install SST dependencies
+        run: |
+          cd prod/sst
+          npm install
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2
         with:
@@ -44,9 +53,6 @@ jobs:
       - name: Login to Amazon ECR
         run: |
           aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com
-      - name: Install dependencies
-        run: |
-          npm run build-ci
       - name: Resolve Zero protocol versions
         run: |
           node --experimental-strip-types -e "
@@ -91,5 +97,4 @@ jobs:
           OTEL_RESOURCE_ATTRIBUTES: ${{ vars.PROD_OTEL_RESOURCE_ATTRIBUTES }}
         run: |
           cd prod/sst
-          npm install
           npx sst deploy --stage production

--- a/.github/workflows/sst-sandbox-deploy.yml
+++ b/.github/workflows/sst-sandbox-deploy.yml
@@ -21,6 +21,15 @@ jobs:
           node-version: 24.x
           cache: 'npm'
 
+      - name: Install dependencies
+        run: |
+          npm run build-ci
+
+      - name: Install SST dependencies
+        run: |
+          cd prod/sst
+          npm install
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2
         with:
@@ -44,9 +53,6 @@ jobs:
       - name: Login to Amazon ECR
         run: |
           aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com
-      - name: Install dependencies
-        run: |
-          npm run build-ci
       - name: Resolve Zero protocol versions
         run: |
           node --experimental-strip-types -e "
@@ -88,5 +94,4 @@ jobs:
           ZERO_ADMIN_PASSWORD: ${{ secrets.ZERO_ADMIN_PASSWORD }}
         run: |
           cd prod/sst
-          npm install
           npx sst deploy --stage sandbox


### PR DESCRIPTION
Install dependencies before secrets are in scope. This way no aws secrets are in the env until after `npm install` completes