### PR TITLE
chore(ci): update file size workflows

### DIFF
--- a/.github/workflows/bencher-file-sizes-pr.yml
+++ b/.github/workflows/bencher-file-sizes-pr.yml
@@ -17,4 +17,3 @@ jobs:
       base_sha: ${{ github.event.pull_request.base.sha }}
     secrets:
       BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}

--- a/.github/workflows/bundle-sizes.js.yml
+++ b/.github/workflows/bundle-sizes.js.yml
@@ -6,12 +6,19 @@ on:
     paths:
       - 'packages/replicache/**'
 
+permissions:
+  contents: read
+
 jobs:
-  bundle-size:
-    name: Bundle Sizes Check
+  measure:
+    name: Measure bundle sizes
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24.x
@@ -25,6 +32,31 @@ jobs:
         run: npx tsx tool/bundle-sizes.ts --bundles replicache.mjs replicache.mjs.br replicache.min.mjs replicache.min.mjs.br | tee bundle-sizes.json
         working-directory: packages/replicache
 
+      - name: Upload bundle size output
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: bundle-size-output
+          path: packages/replicache/bundle-sizes.json
+          if-no-files-found: error
+          retention-days: 1
+
+  publish:
+    name: Publish bundle sizes
+    needs: measure
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Download bundle size output
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
+        with:
+          name: bundle-size-output
+          path: packages/replicache
+
       # Run `github-action-benchmark` action
       - name: Store bundle size
         uses: rhysd/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1
@@ -33,7 +65,7 @@ jobs:
           tool: 'customSmallerIsBetter'
           output-file-path: packages/replicache/bundle-sizes.json
           fail-on-alert: true
-          github-token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
+          github-token: ${{ github.token }}
           benchmark-data-dir-path: bundle-sizes
           auto-push: true
           alert-threshold: '105%'

--- a/.github/workflows/reusable-file-sizes.yml
+++ b/.github/workflows/reusable-file-sizes.yml
@@ -3,6 +3,11 @@ name: Reusable File Sizes Workflow
 on:
   workflow_call:
     inputs:
+      upload_results:
+        required: false
+        type: boolean
+        default: true
+        description: 'Whether to upload file size results to Bencher'
       is_pr:
         required: false
         type: boolean
@@ -22,27 +27,22 @@ on:
         description: 'Base SHA for PR runs'
     secrets:
       BENCHER_API_TOKEN:
-        required: true
-      TURBO_TOKEN:
         required: false
 
 jobs:
-  file_sizes:
+  build_file_sizes:
     name: File Sizes
     permissions:
-      checks: write
-      pull-requests: write
+      contents: read
     runs-on: ubuntu-latest
-    env:
-      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: rocicorp
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24.x
           cache: 'npm'
-      - uses: bencherdev/bencher@a495d2b34f9ab1f3b0f581848f85b389fb0bcda0 # main
 
       - run: npm ci
       - run: npm run build
@@ -61,15 +61,46 @@ jobs:
         working-directory: packages/zero
         run: brotli out/zero.js
 
-      - name: Upload benchmarks results to bencher.dev (main)
+      - name: Upload file size outputs
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: file-size-output
+          path: |
+            packages/zero/out/zero-package.tgz
+            packages/zero/out/zero.js.br
+            packages/zero/out/zero.js
+          if-no-files-found: error
+          retention-days: 1
+
+  upload:
+    name: Upload File Sizes
+    if: ${{ inputs.upload_results }}
+    needs: build_file_sizes
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      pull-requests: write
+    steps:
+      - name: Download file size outputs
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6
+        with:
+          name: file-size-output
+          path: packages/zero/out
+
+      - uses: bencherdev/bencher@a495d2b34f9ab1f3b0f581848f85b389fb0bcda0 # main
+
+      - name: Upload benchmarks results to bencher.dev
         if: ${{ !inputs.is_pr }}
         working-directory: packages/zero
+        env:
+          BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           bencher run \
           --project zero \
-          --token '${{ secrets.BENCHER_API_TOKEN }}' \
+          --token "$BENCHER_API_TOKEN" \
           --adapter json \
-          --github-actions '${{ secrets.GITHUB_TOKEN }}' \
+          --github-actions "$GITHUB_TOKEN" \
           --start-point main \
           --threshold-measure file-size \
           --threshold-test percentage \
@@ -83,16 +114,22 @@ jobs:
       - name: Upload PR benchmarks results to bencher.dev
         if: ${{ inputs.is_pr }}
         working-directory: packages/zero
+        env:
+          BASE_REF: ${{ inputs.base_ref }}
+          BASE_SHA: ${{ inputs.base_sha }}
+          BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
+          HEAD_REF: ${{ inputs.head_ref }}
         run: |
           bencher run \
           --project zero \
-          --token '${{ secrets.BENCHER_API_TOKEN }}' \
+          --token "$BENCHER_API_TOKEN" \
           --adapter json \
-          --github-actions '${{ secrets.GITHUB_TOKEN }}' \
+          --github-actions "$GITHUB_TOKEN" \
           --ci-id size \
-          --branch "${{ inputs.head_ref }}" \
-          --start-point "${{ inputs.base_ref }}" \
-          --start-point-hash '${{ inputs.base_sha }}' \
+          --branch "$HEAD_REF" \
+          --start-point "$BASE_REF" \
+          --start-point-hash "$BASE_SHA" \
           --start-point-clone-thresholds \
           --start-point-reset \
           --threshold-measure file-size \


### PR DESCRIPTION
Updates file size and bundle size workflows to pass generated outputs between jobs. This keeps measurement and publishing steps more clearly separated.