### PR TITLE
ci(canary-release): scope OIDC id-token to the job

### DIFF
--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -4,16 +4,15 @@ on:
   pull_request:
     types: [closed]
 
-permissions:
-  contents: write
-  id-token: write
-  pull-requests: write
-
 jobs:
   canary-release:
     name: Canary Release
     if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release-canary')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:


### PR DESCRIPTION
Moves \`permissions\` (\`contents: write\`, \`id-token: write\`, \`pull-requests: write\`) from **workflow-level** to the **canary-release job**.

Only that one job needs them; scoping limits which job/context can mint an OIDC token for npm trusted publishing of \`@rocicorp/zero\` (least privilege, per the OIDC supply-chain advisory). Functionally identical (single job).

Follow-ups (not in this PR — registry/settings side):
- Pin the npmjs.com **Trusted Publisher** for \`@rocicorp/zero\` to repo \`rocicorp/mono\` + workflow file \`canary-release.yml\`, ideally gated by a GitHub **Environment**.
- This workflow triggers on \`pull_request: [closed]\`; the OIDC subject is PR-context. Consider a dedicated release trigger if tighter subject pinning is desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)