### PR TITLE
ci: fix permissions and pnpm install

### DIFF
--- a/.github/workflows/bencher-benchmarks-pr.yml
+++ b/.github/workflows/bencher-benchmarks-pr.yml
@@ -28,6 +28,10 @@ jobs:
     # DO NOT REMOVE: For handling Fork PRs see Pull Requests from Forks
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     needs: playwright-install
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
     uses: ./.github/workflows/reusable-benchmark.yml
     strategy:
       fail-fast: false

--- a/.github/workflows/bencher-benchmarks-pr.yml
+++ b/.github/workflows/bencher-benchmarks-pr.yml
@@ -16,6 +16,8 @@ jobs:
         with:
           persist-credentials: false
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
+        with:
+          dest: ${{ runner.temp }}/setup-pnpm
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
 
         with:

--- a/.github/workflows/bencher-benchmarks.yml
+++ b/.github/workflows/bencher-benchmarks.yml
@@ -15,6 +15,8 @@ jobs:
         with:
           persist-credentials: false
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
+        with:
+          dest: ${{ runner.temp }}/setup-pnpm
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
 
         with:

--- a/.github/workflows/bencher-benchmarks.yml
+++ b/.github/workflows/bencher-benchmarks.yml
@@ -2,7 +2,7 @@ name: Bencher
 
 on:
   push:
-    branches: main
+    branches: [main]
 
 jobs:
   playwright-install:
@@ -26,6 +26,10 @@ jobs:
   perf:
     name: Perf
     needs: playwright-install
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
     uses: ./.github/workflows/reusable-benchmark.yml
     strategy:
       fail-fast: false

--- a/.github/workflows/bencher-file-sizes-pr.yml
+++ b/.github/workflows/bencher-file-sizes-pr.yml
@@ -9,6 +9,10 @@ jobs:
     name: File Sizes PR
     # DO NOT REMOVE: For handling Fork PRs see Pull Requests from Forks
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
     uses: ./.github/workflows/reusable-file-sizes.yml
     with:
       is_pr: true

--- a/.github/workflows/bencher-file-sizes.yml
+++ b/.github/workflows/bencher-file-sizes.yml
@@ -2,11 +2,15 @@ name: Bencher File Sizes
 
 on:
   push:
-    branches: main
+    branches: [main]
 
 jobs:
   file_sizes:
     name: File Sizes
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
     uses: ./.github/workflows/reusable-file-sizes.yml
     secrets:
       BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}

--- a/.github/workflows/perf-v2.js.yml
+++ b/.github/workflows/perf-v2.js.yml
@@ -21,6 +21,8 @@ jobs:
         with:
           persist-credentials: false
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
+        with:
+          dest: ${{ runner.temp }}/setup-pnpm
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
 
         with:
@@ -40,6 +42,8 @@ jobs:
         with:
           persist-credentials: false
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
+        with:
+          dest: ${{ runner.temp }}/setup-pnpm
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
 
         with:

--- a/.github/workflows/reusable-benchmark.yml
+++ b/.github/workflows/reusable-benchmark.yml
@@ -52,6 +52,8 @@ jobs:
         with:
           persist-credentials: false
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
+        with:
+          dest: ${{ runner.temp }}/setup-pnpm
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
 
         with:

--- a/.github/workflows/sst-gigabugs-deploy.yml
+++ b/.github/workflows/sst-gigabugs-deploy.yml
@@ -24,6 +24,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
+
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
@@ -76,6 +79,9 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.github/workflows/sst-prod-deploy.yml
+++ b/.github/workflows/sst-prod-deploy.yml
@@ -24,6 +24,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
+
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
@@ -76,6 +79,9 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.github/workflows/sst-sandbox-deploy.yml
+++ b/.github/workflows/sst-sandbox-deploy.yml
@@ -24,6 +24,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
+
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
@@ -76,6 +79,9 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6


### PR DESCRIPTION
- install pnpm before setup-node in SST deploy workflows so pnpm cache/install steps can run
- grant reusable Bencher caller jobs the contents/checks/pull-requests permissions requested by nested jobs
- apply the same fixes to PR Bencher callers and the Gigabugs SST workflow