### PR TITLE
fix(zero-cache): run ddl event triggers as definer

### DIFF
--- a/packages/zero-cache/src/services/change-source/pg/schema/ddl.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/ddl.pg.test.ts
@@ -54,11 +54,12 @@ describe('change-source/tables/ddl', () => {
   ];
   const EXPECTED_NO_SHARD_PRIVILEGES = [
     {
+      ddlEntrypointExecute: false,
       schemaUsage: false,
       schemaCreate: false,
       publishedSchemaSelect: false,
       publishedSchemaUpdate: false,
-      memberOfShardOwner: false,
+      memberOfFunctionOwner: false,
     },
   ];
 
@@ -134,9 +135,9 @@ describe('change-source/tables/ddl', () => {
     CREATE PUBLICATION nonzeropub FOR TABLE pub.foo, pub.boo;
     `;
 
-  test('event trigger functions use the shard owner and locked search path', async () => {
-    const [{shardOwner}] = await upstream<{shardOwner: string}[]>`
-      SELECT current_user AS "shardOwner"
+  test('event trigger functions lock down their privileged execution context', async () => {
+    const [{functionOwner}] = await upstream<{functionOwner: string}[]>`
+      SELECT current_user AS "functionOwner"
     `;
 
     const eventTriggers = await upstream<
@@ -148,6 +149,8 @@ describe('change-source/tables/ddl', () => {
         owner: string;
         securityDefiner: boolean;
         config: string | null;
+        publicExecute: boolean;
+        publicSchemaCreate: boolean;
       }[]
     >`
       SELECT
@@ -157,7 +160,27 @@ describe('change-source/tables/ddl', () => {
         p.proname AS "functionName",
         pg_catalog.pg_get_userbyid(p.proowner) AS owner,
         p.prosecdef AS "securityDefiner",
-        array_to_string(p.proconfig, ',') AS config
+        array_to_string(p.proconfig, ',') AS config,
+        EXISTS (
+          SELECT FROM pg_catalog.aclexplode(
+            COALESCE(
+              p.proacl,
+              pg_catalog.acldefault('f', p.proowner)
+            )
+          ) AS acl
+          WHERE acl.grantee = 0
+            AND acl.privilege_type = 'EXECUTE'
+        ) AS "publicExecute",
+        EXISTS (
+          SELECT FROM pg_catalog.aclexplode(
+            COALESCE(
+              n.nspacl,
+              pg_catalog.acldefault('n', n.nspowner)
+            )
+          ) AS acl
+          WHERE acl.grantee = 0
+            AND acl.privilege_type = 'CREATE'
+        ) AS "publicSchemaCreate"
       FROM pg_catalog.pg_event_trigger e
       JOIN pg_catalog.pg_proc p ON p.oid = e.evtfoid
       JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
@@ -172,18 +195,22 @@ describe('change-source/tables/ddl', () => {
         event: 'ddl_command_end',
         enabled: 'O',
         functionName: DDL_END_FUNCTION,
-        owner: shardOwner,
+        owner: functionOwner,
         securityDefiner: true,
         config: LOCKED_SEARCH_PATH_CONFIG,
+        publicExecute: false,
+        publicSchemaCreate: false,
       },
       {
         triggerName: `${APP_ID}_ddl_start_${SHARD_NUM}`,
         event: 'ddl_command_start',
         enabled: 'O',
         functionName: DDL_START_FUNCTION,
-        owner: shardOwner,
+        owner: functionOwner,
         securityDefiner: true,
         config: LOCKED_SEARCH_PATH_CONFIG,
+        publicExecute: false,
+        publicSchemaCreate: false,
       },
     ]);
   });
@@ -194,8 +221,8 @@ describe('change-source/tables/ddl', () => {
     await testDBs.sql
       .unsafe(`DROP ROLE IF EXISTS ${id(RESTRICTED_ROLE)}`)
       .simple();
-    const [{shardOwner}] = await upstream<{shardOwner: string}[]>`
-      SELECT current_user AS "shardOwner"
+    const [{functionOwner}] = await upstream<{functionOwner: string}[]>`
+      SELECT current_user AS "functionOwner"
     `;
     await upstream.unsafe(/*sql*/ `
       CREATE ROLE ${id(RESTRICTED_ROLE)} NOINHERIT;
@@ -207,9 +234,10 @@ describe('change-source/tables/ddl', () => {
         {
           schemaUsage: boolean;
           schemaCreate: boolean;
+          ddlEntrypointExecute: boolean;
           publishedSchemaSelect: boolean;
           publishedSchemaUpdate: boolean;
-          memberOfShardOwner: boolean;
+          memberOfFunctionOwner: boolean;
         }[]
       >`
         SELECT
@@ -219,6 +247,15 @@ describe('change-source/tables/ddl', () => {
           pg_catalog.has_schema_privilege(
             ${RESTRICTED_ROLE}, ${SHARD_SCHEMA}, 'CREATE'
           ) AS "schemaCreate",
+          EXISTS (
+            SELECT FROM pg_catalog.pg_proc p
+            JOIN pg_catalog.pg_namespace pn ON pn.oid = p.pronamespace
+            WHERE pn.nspname = ${SHARD_SCHEMA}
+              AND p.proname IN (${DDL_END_FUNCTION}, ${DDL_START_FUNCTION})
+              AND pg_catalog.has_function_privilege(
+                ${RESTRICTED_ROLE}, p.oid, 'EXECUTE'
+              )
+          ) AS "ddlEntrypointExecute",
           pg_catalog.has_table_privilege(
             ${RESTRICTED_ROLE}, c.oid, 'SELECT'
           ) AS "publishedSchemaSelect",
@@ -226,8 +263,8 @@ describe('change-source/tables/ddl', () => {
             ${RESTRICTED_ROLE}, c.oid, 'UPDATE'
           ) AS "publishedSchemaUpdate",
           pg_catalog.pg_has_role(
-            ${RESTRICTED_ROLE}, ${shardOwner}, 'MEMBER'
-          ) AS "memberOfShardOwner"
+            ${RESTRICTED_ROLE}, ${functionOwner}, 'MEMBER'
+          ) AS "memberOfFunctionOwner"
         FROM pg_catalog.pg_class c
         JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
         WHERE n.nspname = ${SHARD_SCHEMA}

--- a/packages/zero-cache/src/services/change-source/pg/schema/ddl.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/ddl.pg.test.ts
@@ -5,6 +5,8 @@ import {Queue} from '../../../../../../shared/src/queue.ts';
 import * as v from '../../../../../../shared/src/valita.ts';
 import {test, type PgTest} from '../../../../test/db.ts';
 import type {PostgresDB} from '../../../../types/pg.ts';
+import {upstreamSchema, type ShardConfig} from '../../../../types/shards.ts';
+import {id} from '../../../../types/sql.ts';
 import type {
   Message,
   MessageMessage,
@@ -30,6 +32,35 @@ describe('change-source/tables/ddl', () => {
 
   const APP_ID = 'zap';
   const SHARD_NUM = 0;
+  const SHARD: ShardConfig = {
+    appID: APP_ID,
+    shardNum: SHARD_NUM,
+    publications: ['zero_all', 'zero_sum'],
+  };
+  const SHARD_SCHEMA = upstreamSchema(SHARD);
+  const RESTRICTED_ROLE = `${APP_ID}_app_migrator`;
+  const RESTRICTED_SCHEMA = `${APP_ID}_app_private`;
+  const UNPUBLISHED_TABLE = 'outside_zero';
+  const QUALIFIED_UNPUBLISHED_TABLE = `${RESTRICTED_SCHEMA}.${UNPUBLISHED_TABLE}`;
+  const PUBLISHED_SCHEMA_TABLE = 'publishedSchema';
+  const DDL_END_FUNCTION = 'emit_ddl_end';
+  const DDL_START_FUNCTION = 'emit_ddl_start';
+  const LOCKED_SEARCH_PATH_CONFIG = 'search_path=pg_catalog, pg_temp';
+  const EXPECTED_RESTRICTED_IDENTITY = [
+    {
+      currentUser: RESTRICTED_ROLE,
+      sessionUser: RESTRICTED_ROLE,
+    },
+  ];
+  const EXPECTED_NO_SHARD_PRIVILEGES = [
+    {
+      schemaUsage: false,
+      schemaCreate: false,
+      publishedSchemaSelect: false,
+      publishedSchemaUpdate: false,
+      memberOfShardOwner: false,
+    },
+  ];
 
   beforeEach<PgTest>(async ({testDBs}) => {
     notices = new Queue();
@@ -39,14 +70,8 @@ describe('change-source/tables/ddl', () => {
 
     await upstream.unsafe(STARTING_SCHEMA);
 
-    const shard = {
-      appID: APP_ID,
-      shardNum: SHARD_NUM,
-      publications: ['zero_all', 'zero_sum'],
-    };
-
-    await upstream.unsafe(createEventFunctionStatements(shard));
-    await upstream.unsafe(createEventTriggerStatements(shard));
+    await upstream.unsafe(createEventFunctionStatements(SHARD));
+    await upstream.unsafe(createEventTriggerStatements(SHARD));
 
     await upstream`SELECT pg_create_logical_replication_slot(${SLOT_NAME}, 'pgoutput')`;
 
@@ -71,6 +96,9 @@ describe('change-source/tables/ddl', () => {
     return async () => {
       sub.messages.cancel();
       await testDBs.drop(upstream);
+      await testDBs.sql
+        .unsafe(`RESET ROLE; DROP ROLE IF EXISTS ${id(RESTRICTED_ROLE)}`)
+        .simple();
     };
   });
 
@@ -105,6 +133,162 @@ describe('change-source/tables/ddl', () => {
     CREATE PUBLICATION zero_sum FOR TABLE pub.foo (id, name), pub.boo;
     CREATE PUBLICATION nonzeropub FOR TABLE pub.foo, pub.boo;
     `;
+
+  test('event trigger functions use the shard owner and locked search path', async () => {
+    const [{shardOwner}] = await upstream<{shardOwner: string}[]>`
+      SELECT current_user AS "shardOwner"
+    `;
+
+    const eventTriggers = await upstream<
+      {
+        triggerName: string;
+        event: string;
+        enabled: string;
+        functionName: string;
+        owner: string;
+        securityDefiner: boolean;
+        config: string | null;
+      }[]
+    >`
+      SELECT
+        e.evtname AS "triggerName",
+        e.evtevent AS event,
+        e.evtenabled AS enabled,
+        p.proname AS "functionName",
+        pg_catalog.pg_get_userbyid(p.proowner) AS owner,
+        p.prosecdef AS "securityDefiner",
+        array_to_string(p.proconfig, ',') AS config
+      FROM pg_catalog.pg_event_trigger e
+      JOIN pg_catalog.pg_proc p ON p.oid = e.evtfoid
+      JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+      WHERE n.nspname = ${SHARD_SCHEMA}
+        AND p.proname IN (${DDL_END_FUNCTION}, ${DDL_START_FUNCTION})
+      ORDER BY p.proname
+    `;
+
+    expect(eventTriggers).toEqual([
+      {
+        triggerName: `${APP_ID}_ddl_end_${SHARD_NUM}`,
+        event: 'ddl_command_end',
+        enabled: 'O',
+        functionName: DDL_END_FUNCTION,
+        owner: shardOwner,
+        securityDefiner: true,
+        config: LOCKED_SEARCH_PATH_CONFIG,
+      },
+      {
+        triggerName: `${APP_ID}_ddl_start_${SHARD_NUM}`,
+        event: 'ddl_command_start',
+        enabled: 'O',
+        functionName: DDL_START_FUNCTION,
+        owner: shardOwner,
+        securityDefiner: true,
+        config: LOCKED_SEARCH_PATH_CONFIG,
+      },
+    ]);
+  });
+
+  test('restricted roles can run unrelated DDL without Zero privileges', async ({
+    testDBs,
+  }) => {
+    await testDBs.sql
+      .unsafe(`DROP ROLE IF EXISTS ${id(RESTRICTED_ROLE)}`)
+      .simple();
+    const [{shardOwner}] = await upstream<{shardOwner: string}[]>`
+      SELECT current_user AS "shardOwner"
+    `;
+    await upstream.unsafe(/*sql*/ `
+      CREATE ROLE ${id(RESTRICTED_ROLE)} NOINHERIT;
+      CREATE SCHEMA ${id(RESTRICTED_SCHEMA)} AUTHORIZATION ${id(RESTRICTED_ROLE)};
+    `);
+
+    const getRestrictedRolePrivileges = () =>
+      upstream<
+        {
+          schemaUsage: boolean;
+          schemaCreate: boolean;
+          publishedSchemaSelect: boolean;
+          publishedSchemaUpdate: boolean;
+          memberOfShardOwner: boolean;
+        }[]
+      >`
+        SELECT
+          pg_catalog.has_schema_privilege(
+            ${RESTRICTED_ROLE}, ${SHARD_SCHEMA}, 'USAGE'
+          ) AS "schemaUsage",
+          pg_catalog.has_schema_privilege(
+            ${RESTRICTED_ROLE}, ${SHARD_SCHEMA}, 'CREATE'
+          ) AS "schemaCreate",
+          pg_catalog.has_table_privilege(
+            ${RESTRICTED_ROLE}, c.oid, 'SELECT'
+          ) AS "publishedSchemaSelect",
+          pg_catalog.has_table_privilege(
+            ${RESTRICTED_ROLE}, c.oid, 'UPDATE'
+          ) AS "publishedSchemaUpdate",
+          pg_catalog.pg_has_role(
+            ${RESTRICTED_ROLE}, ${shardOwner}, 'MEMBER'
+          ) AS "memberOfShardOwner"
+        FROM pg_catalog.pg_class c
+        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = ${SHARD_SCHEMA}
+          AND c.relname = ${PUBLISHED_SCHEMA_TABLE}
+      `;
+
+    expect(await getRestrictedRolePrivileges()).toEqual(
+      EXPECTED_NO_SHARD_PRIVILEGES,
+    );
+    expect(
+      await upstream`
+        SELECT pubname, schemaname, tablename
+        FROM pg_catalog.pg_publication_tables
+        WHERE schemaname = ${RESTRICTED_SCHEMA}
+      `,
+    ).toEqual([]);
+
+    while (notices.size()) {
+      await notices.dequeue();
+    }
+
+    await expect(
+      upstream.begin(async tx => {
+        await tx.unsafe(
+          `SET LOCAL SESSION AUTHORIZATION ${id(RESTRICTED_ROLE)}`,
+        );
+        const getIdentity = () =>
+          tx<{currentUser: string; sessionUser: string}[]>`
+            SELECT
+              current_user AS "currentUser",
+              session_user AS "sessionUser"
+          `;
+
+        expect(await getIdentity()).toEqual(EXPECTED_RESTRICTED_IDENTITY);
+        await tx.unsafe(
+          `CREATE TABLE ${id(RESTRICTED_SCHEMA)}.${id(UNPUBLISHED_TABLE)}(id TEXT PRIMARY KEY)`,
+        );
+        expect(await getIdentity()).toEqual(EXPECTED_RESTRICTED_IDENTITY);
+      }),
+    ).resolves.toBeUndefined();
+
+    expect((await notices.dequeue()).message).toMatch(
+      /Emitted .* ddlStart for CREATE TABLE/,
+    );
+    const ddlEndNotice = (await notices.dequeue()).message;
+    expect(ddlEndNotice).toContain('ignoring irrelevant CREATE TABLE');
+    expect(ddlEndNotice).toContain(QUALIFIED_UNPUBLISHED_TABLE);
+
+    expect(
+      await upstream<{owner: string}[]>`
+        SELECT pg_catalog.pg_get_userbyid(c.relowner) AS owner
+        FROM pg_catalog.pg_class c
+        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = ${RESTRICTED_SCHEMA}
+          AND c.relname = ${UNPUBLISHED_TABLE}
+      `,
+    ).toEqual([{owner: RESTRICTED_ROLE}]);
+    expect(await getRestrictedRolePrivileges()).toEqual(
+      EXPECTED_NO_SHARD_PRIVILEGES,
+    );
+  });
 
   // For zero_all, zero_sum
   const DDL_START: Omit<DdlStartEvent, 'context'> & {

--- a/packages/zero-cache/src/services/change-source/pg/schema/ddl.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/ddl.pg.test.ts
@@ -71,6 +71,7 @@ describe('change-source/tables/ddl', () => {
     return async () => {
       sub.messages.cancel();
       await testDBs.drop(upstream);
+      await testDBs.sql`RESET ROLE; DROP ROLE IF EXISTS zero_ddl_actor`.simple();
     };
   });
 
@@ -105,6 +106,65 @@ describe('change-source/tables/ddl', () => {
     CREATE PUBLICATION zero_sum FOR TABLE pub.foo (id, name), pub.boo;
     CREATE PUBLICATION nonzeropub FOR TABLE pub.foo, pub.boo;
     `;
+
+  test('event trigger functions run as the shard owner', async ({testDBs}) => {
+    await testDBs.sql`DROP ROLE IF EXISTS zero_ddl_actor`.simple();
+    await upstream.unsafe(/*sql*/ `
+      CREATE ROLE zero_ddl_actor NOINHERIT;
+      CREATE SCHEMA actor;
+      GRANT USAGE, CREATE ON SCHEMA actor TO zero_ddl_actor;
+    `);
+
+    const eventTriggerFunctions = await upstream<
+      {
+        functionName: string;
+        securityDefiner: boolean;
+        config: string;
+      }[]
+    >`
+      SELECT
+        p.proname AS "functionName",
+        p.prosecdef AS "securityDefiner",
+        array_to_string(p.proconfig, ',') AS config
+      FROM pg_catalog.pg_proc p
+      JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+      WHERE n.nspname = ${APP_ID + '_' + SHARD_NUM}
+        AND p.proname IN ('emit_ddl_start', 'emit_ddl_end')
+      ORDER BY p.proname
+    `;
+
+    expect(eventTriggerFunctions).toEqual([
+      {
+        functionName: 'emit_ddl_end',
+        securityDefiner: true,
+        config: 'search_path=pg_catalog, pg_temp',
+      },
+      {
+        functionName: 'emit_ddl_start',
+        securityDefiner: true,
+        config: 'search_path=pg_catalog, pg_temp',
+      },
+    ]);
+
+    await expect(
+      upstream.begin(async tx => {
+        await tx.unsafe('SET LOCAL ROLE zero_ddl_actor');
+        await tx.unsafe(
+          'CREATE TABLE actor.created_by_actor(id TEXT PRIMARY KEY)',
+        );
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(
+      await upstream<{owner: string}[]>`
+        SELECT pg_catalog.pg_get_userbyid(c.relowner) AS owner
+        FROM pg_catalog.pg_class c
+        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'actor'
+          AND c.relname = 'created_by_actor'
+      `,
+    ).toEqual([{owner: 'zero_ddl_actor'}]);
+  });
 
   // For zero_all, zero_sum
   const DDL_START: Omit<DdlStartEvent, 'context'> = {

--- a/packages/zero-cache/src/services/change-source/pg/schema/ddl.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/ddl.ts
@@ -270,7 +270,11 @@ $$ LANGUAGE plpgsql;
 
 
 CREATE OR REPLACE FUNCTION ${schema}.emit_ddl_start()
-RETURNS event_trigger AS $$
+RETURNS event_trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, pg_temp
+AS $$
 DECLARE
   schema_specs JSON;
   message TEXT;
@@ -279,11 +283,15 @@ BEGIN
   PERFORM pg_advisory_xact_lock(${DDL_SERIALIZATION_LOCK});
   PERFORM ${schema}.update_schemas('ddlStart', TG_TAG, NULL);
 END
-$$ LANGUAGE plpgsql;
+$$;
 
 
 CREATE OR REPLACE FUNCTION ${schema}.emit_ddl_end()
-RETURNS event_trigger AS $$
+RETURNS event_trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, pg_temp
+AS $$
 DECLARE
   publications TEXT[];
   target RECORD;
@@ -366,7 +374,7 @@ BEGIN
   END IF;
 
 END
-$$ LANGUAGE plpgsql;
+$$;
 `;
 }
 

--- a/packages/zero-cache/src/services/change-source/pg/schema/ddl.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/ddl.ts
@@ -174,6 +174,12 @@ export function createEventFunctionStatements(shard: ShardConfig) {
   return /*sql*/ `
 CREATE SCHEMA IF NOT EXISTS ${schema};
 
+-- The SECURITY DEFINER entrypoints below call helper functions in this schema.
+-- PUBLIC must not be able to add an overload that could be selected while the
+-- entrypoints are running with their owner's privileges. Explicit grants to
+-- trusted administration roles are left unchanged.
+REVOKE CREATE ON SCHEMA ${schema} FROM PUBLIC;
+
 CREATE OR REPLACE FUNCTION ${schema}.get_trigger_context()
 RETURNS record AS $$
 DECLARE
@@ -269,6 +275,12 @@ END
 $$ LANGUAGE plpgsql;
 
 
+-- These are the only privileged entrypoints in the DDL trigger stack. Event
+-- triggers are database-wide, so a role can invoke them indirectly without
+-- having access to this schema. Everything reached from these functions runs
+-- with the existing function owner's privileges: keep internal calls schema
+-- qualified, keep pg_catalog before pg_temp, and never introduce
+-- caller-controlled dynamic SQL anywhere in this call chain.
 CREATE OR REPLACE FUNCTION ${schema}.emit_ddl_start()
 RETURNS event_trigger
 LANGUAGE plpgsql
@@ -375,6 +387,15 @@ BEGIN
 
 END
 $$;
+
+
+-- Event triggers retain their function references by OID and do not require
+-- the role issuing DDL to call these entrypoints directly. PostgreSQL grants
+-- EXECUTE to PUBLIC on new functions. That did not cross a privilege boundary
+-- while these functions were SECURITY INVOKER, but is unnecessary once they
+-- run as their owner.
+REVOKE ALL ON FUNCTION ${schema}.emit_ddl_start() FROM PUBLIC;
+REVOKE ALL ON FUNCTION ${schema}.emit_ddl_end() FROM PUBLIC;
 `;
 }
 

--- a/packages/zero-cache/src/services/change-source/pg/schema/ddl.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/ddl.ts
@@ -244,7 +244,11 @@ $$ LANGUAGE plpgsql;
 
 
 CREATE OR REPLACE FUNCTION ${schema}.emit_ddl_start()
-RETURNS event_trigger AS $$
+RETURNS event_trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, pg_temp
+AS $$
 DECLARE
   schema_specs JSON;
   message TEXT;
@@ -253,11 +257,15 @@ BEGIN
   PERFORM pg_advisory_xact_lock(${DDL_SERIALIZATION_LOCK});
   PERFORM ${schema}.update_schemas('ddlStart', TG_TAG, NULL);
 END
-$$ LANGUAGE plpgsql;
+$$;
 
 
 CREATE OR REPLACE FUNCTION ${schema}.emit_ddl_end()
-RETURNS event_trigger AS $$
+RETURNS event_trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, pg_temp
+AS $$
 DECLARE
   publications TEXT[];
   target RECORD;
@@ -340,7 +348,7 @@ BEGIN
   END IF;
 
 END
-$$ LANGUAGE plpgsql;
+$$;
 `;
 }
 

--- a/packages/zero-cache/src/services/change-source/pg/schema/init.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/init.pg.test.ts
@@ -12,6 +12,7 @@ import {
   test,
 } from '../../../../test/db.ts';
 import type {PostgresDB} from '../../../../types/pg.ts';
+import {upstreamSchema, type ShardConfig} from '../../../../types/shards.ts';
 import {id} from '../../../../types/sql.ts';
 import {
   CURRENT_SCHEMA_VERSION,
@@ -22,6 +23,15 @@ import {createReplica, initReplica, metadataPublicationName} from './shard.ts';
 
 const APP_ID = 'zappz';
 const SHARD_NUM = 23;
+const PRE_DEFINER_SCHEMA_VERSION = 23;
+const TEST_REPLICA_VERSION = 'ddl-trigger-security-definer-test';
+const DDL_END_FUNCTION = 'emit_ddl_end';
+const DDL_START_FUNCTION = 'emit_ddl_start';
+const DDL_EVENT_TRIGGER_FUNCTIONS = [
+  DDL_END_FUNCTION,
+  DDL_START_FUNCTION,
+] as const;
+const LOCKED_SEARCH_PATH_CONFIG = 'search_path=pg_catalog, pg_temp';
 
 // Update as necessary.
 const CURRENT_SCHEMA_VERSIONS = {
@@ -235,4 +245,68 @@ describe('change-streamer/pg/schema/init', () => {
       await expectTablesToMatch(upstream, c.upstreamPostState);
     });
   }
+
+  test('upgrades existing DDL hooks to security definers with a locked search path', async () => {
+    const shard: ShardConfig = {
+      appID: APP_ID,
+      shardNum: SHARD_NUM,
+      publications: [],
+    };
+    const schema = upstreamSchema(shard);
+
+    await ensureShardSchema(lc, upstream, shard);
+    await upstream.unsafe(/*sql*/ `
+      ALTER FUNCTION ${id(schema)}.${id(DDL_START_FUNCTION)}() SECURITY INVOKER;
+      ALTER FUNCTION ${id(schema)}.${id(DDL_START_FUNCTION)}() RESET ALL;
+      ALTER FUNCTION ${id(schema)}.${id(DDL_END_FUNCTION)}() SECURITY INVOKER;
+      ALTER FUNCTION ${id(schema)}.${id(DDL_END_FUNCTION)}() RESET ALL;
+    `);
+    await upstream`
+      UPDATE ${upstream(schema)}."versionHistory"
+      SET "dataVersion" = ${PRE_DEFINER_SCHEMA_VERSION},
+          "schemaVersion" = ${PRE_DEFINER_SCHEMA_VERSION}
+    `;
+
+    const getEventTriggerFunctions = () =>
+      upstream<
+        {
+          functionName: string;
+          securityDefiner: boolean;
+          config: string | null;
+        }[]
+      >`
+        SELECT
+          p.proname AS "functionName",
+          p.prosecdef AS "securityDefiner",
+          array_to_string(p.proconfig, ',') AS config
+        FROM pg_catalog.pg_proc p
+        JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+        WHERE n.nspname = ${schema}
+          AND p.proname IN (${DDL_END_FUNCTION}, ${DDL_START_FUNCTION})
+        ORDER BY p.proname
+      `;
+
+    const expectedEventTriggerFunctions = (
+      securityDefiner: boolean,
+      config: string | null,
+    ) =>
+      DDL_EVENT_TRIGGER_FUNCTIONS.map(functionName => ({
+        functionName,
+        securityDefiner,
+        config,
+      }));
+
+    expect(await getEventTriggerFunctions()).toEqual(
+      expectedEventTriggerFunctions(false, null),
+    );
+
+    await updateShardSchema(lc, upstream, shard, TEST_REPLICA_VERSION);
+
+    expect(await getEventTriggerFunctions()).toEqual(
+      expectedEventTriggerFunctions(true, LOCKED_SEARCH_PATH_CONFIG),
+    );
+    await expectTablesToMatch(upstream, {
+      [`${schema}.versionHistory`]: [CURRENT_SCHEMA_VERSIONS],
+    });
+  });
 });

--- a/packages/zero-cache/src/services/change-source/pg/schema/init.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/init.pg.test.ts
@@ -246,7 +246,7 @@ describe('change-streamer/pg/schema/init', () => {
     });
   }
 
-  test('upgrades existing DDL hooks to security definers with a locked search path', async () => {
+  test('upgrades and locks down existing DDL hook security definers', async () => {
     const shard: ShardConfig = {
       appID: APP_ID,
       shardNum: SHARD_NUM,
@@ -260,6 +260,9 @@ describe('change-streamer/pg/schema/init', () => {
       ALTER FUNCTION ${id(schema)}.${id(DDL_START_FUNCTION)}() RESET ALL;
       ALTER FUNCTION ${id(schema)}.${id(DDL_END_FUNCTION)}() SECURITY INVOKER;
       ALTER FUNCTION ${id(schema)}.${id(DDL_END_FUNCTION)}() RESET ALL;
+      GRANT EXECUTE ON FUNCTION ${id(schema)}.${id(DDL_START_FUNCTION)}() TO PUBLIC;
+      GRANT EXECUTE ON FUNCTION ${id(schema)}.${id(DDL_END_FUNCTION)}() TO PUBLIC;
+      GRANT CREATE ON SCHEMA ${id(schema)} TO PUBLIC;
     `);
     await upstream`
       UPDATE ${upstream(schema)}."versionHistory"
@@ -271,14 +274,38 @@ describe('change-streamer/pg/schema/init', () => {
       upstream<
         {
           functionName: string;
+          owner: string;
           securityDefiner: boolean;
           config: string | null;
+          publicExecute: boolean;
+          publicSchemaCreate: boolean;
         }[]
       >`
         SELECT
           p.proname AS "functionName",
+          pg_catalog.pg_get_userbyid(p.proowner) AS owner,
           p.prosecdef AS "securityDefiner",
-          array_to_string(p.proconfig, ',') AS config
+          array_to_string(p.proconfig, ',') AS config,
+          EXISTS (
+            SELECT FROM pg_catalog.aclexplode(
+              COALESCE(
+                p.proacl,
+                pg_catalog.acldefault('f', p.proowner)
+              )
+            ) AS acl
+            WHERE acl.grantee = 0
+              AND acl.privilege_type = 'EXECUTE'
+          ) AS "publicExecute",
+          EXISTS (
+            SELECT FROM pg_catalog.aclexplode(
+              COALESCE(
+                n.nspacl,
+                pg_catalog.acldefault('n', n.nspowner)
+              )
+            ) AS acl
+            WHERE acl.grantee = 0
+              AND acl.privilege_type = 'CREATE'
+          ) AS "publicSchemaCreate"
         FROM pg_catalog.pg_proc p
         JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
         WHERE n.nspname = ${schema}
@@ -287,23 +314,36 @@ describe('change-streamer/pg/schema/init', () => {
       `;
 
     const expectedEventTriggerFunctions = (
+      owner: string,
       securityDefiner: boolean,
       config: string | null,
+      publicExecute: boolean,
+      publicSchemaCreate: boolean,
     ) =>
       DDL_EVENT_TRIGGER_FUNCTIONS.map(functionName => ({
         functionName,
+        owner,
         securityDefiner,
         config,
+        publicExecute,
+        publicSchemaCreate,
       }));
 
+    const [{owner}] = await getEventTriggerFunctions();
     expect(await getEventTriggerFunctions()).toEqual(
-      expectedEventTriggerFunctions(false, null),
+      expectedEventTriggerFunctions(owner, false, null, true, true),
     );
 
     await updateShardSchema(lc, upstream, shard, TEST_REPLICA_VERSION);
 
     expect(await getEventTriggerFunctions()).toEqual(
-      expectedEventTriggerFunctions(true, LOCKED_SEARCH_PATH_CONFIG),
+      expectedEventTriggerFunctions(
+        owner,
+        true,
+        LOCKED_SEARCH_PATH_CONFIG,
+        false,
+        false,
+      ),
     );
     await expectTablesToMatch(upstream, {
       [`${schema}.versionHistory`]: [CURRENT_SCHEMA_VERSIONS],

--- a/packages/zero-cache/src/services/change-source/pg/schema/init.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/init.ts
@@ -278,10 +278,14 @@ function getIncrementalMigrations(
     },
 
     // v24: Run the database wide DDL event trigger entrypoints as their
-    // trusted shard owner instead of the role issuing the DDL. This lets
+    // existing function owner instead of the role issuing the DDL. This lets
     // restricted roles change unrelated objects without requiring access to
-    // the shard's private schema. setupTriggers() also upgrades existing
-    // functions in place with a locked search_path.
+    // the shard's private schema.
+    //
+    // This is also the point where the entrypoint owner and ACL become a
+    // security boundary. setupTriggers() preserves the established function
+    // owner, locks search_path, removes PUBLIC's direct EXECUTE privilege, and
+    // prevents PUBLIC from adding overloads to the private helper schema.
     24: {
       migrateSchema: async (lc, sql) => {
         const [{publications}] = await sql<{publications: string[]}[]>`

--- a/packages/zero-cache/src/services/change-source/pg/schema/init.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/init.ts
@@ -276,6 +276,20 @@ function getIncrementalMigrations(
         lc.info?.(`Upgraded DDL event triggers`);
       },
     },
+
+    // v24: Run the database wide DDL event trigger entrypoints as their
+    // trusted shard owner instead of the role issuing the DDL. This lets
+    // restricted roles change unrelated objects without requiring access to
+    // the shard's private schema. setupTriggers() also upgrades existing
+    // functions in place with a locked search_path.
+    24: {
+      migrateSchema: async (lc, sql) => {
+        const [{publications}] = await sql<{publications: string[]}[]>`
+          SELECT publications FROM ${sql(shardConfigTable)}`;
+        await setupTriggers(lc, sql, {...shard, publications});
+        lc.info?.(`Upgraded DDL event trigger execution identity`);
+      },
+    },
   };
 }
 


### PR DESCRIPTION
## What we're seeing

We're getting failures when a custom database role, let's call it `foo`, tries to manage its own schema. `foo` owns `foo_private`, so creating a table there should be an ordinary operation, while its lack of access to Zero's internal shard schema is intentional.

```sql
CREATE TABLE foo_private.audit_log (
  id TEXT PRIMARY KEY
);
```

Zero's DDL hooks are installed for the whole database, so PostgreSQL wakes them up for this statement even though `foo_private.audit_log` is not published. Today those hooks run as the caller, which means they enter Zero's internal schema as `foo` and hit the permission boundary we wanted `foo` to have.

```text
foo creates foo_private.audit_log
  |
  v
PostgreSQL wakes Zero's DDL hooks
  |
  |  current_user = foo
  v
Zero's internal shard schema
  |
  v
permission denied, the whole CREATE TABLE rolls back
```

Giving `foo` access to Zero's schema would make the error disappear, but it would also undo that separation. Zero should do its small amount of internal bookkeeping using Zero's established function owner, then return control to `foo` so PostgreSQL can finish the original statement.

## What this changes

This PR makes the two outer hooks, `emit_ddl_start()` and `emit_ddl_end()`, run as `SECURITY DEFINER` with `search_path` fixed to `pg_catalog, pg_temp`. The hooks briefly use their existing owner's privileges, while the application's DDL still runs as `foo`, and the table it creates is still owned by `foo`.

On existing shards, migration v24 replaces the hooks in place and preserves their current owner. On new shards, they are owned by the role that sets the shard up. There is no hardcoded Zero actor role, since creating and administering one would be a separate operator contract that differs across PostgreSQL providers.

The same migration revokes direct `PUBLIC` execution on the two privileged entrypoints and revokes `PUBLIC` creation in Zero's helper schema. Those ACLs become security relevant in this migration because this is the first time the hooks can run with their owner's privileges. Event triggers keep calling the functions by OID, so restricted roles do not need direct `EXECUTE` permission for their DDL to work.

`update_schemas()` remains `SECURITY INVOKER`, and the two definer entrypoints take no arguments from the caller and use no dynamic SQL.

## Tests

The behavior test creates an unpublished table as a restricted role that has no access to Zero's schema, internal tables, function owner, or definer entrypoints, then confirms the DDL succeeds and the table still belongs to that role. The catalog and migration tests cover the function owner, definer flag, fixed search path, public ACLs, and the v23 to v24 upgrade.

The two focused test files pass with 37 tests on each supported version of PostgreSQL, 15 through 18. Formatting, lint, and type checking also pass.

## Versioning note

The staged `arv/lightweight-ddl-start-phase2` work also claims v24. If this lands first, that migration needs to become v25 and preserve these definer, search path, and ACL changes when it recreates the hooks.
