### PR TITLE
Enhance Docker login condition and version parsing in CI workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,7 @@ jobs:
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Login to Docker Hub
+        if: ${{ inputs.dry_run != true }}
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ on:
           - canary
           - stable
       ref:
-        description: Git ref to build the release from
+        description: Branch, tag, or commit SHA to build the release from
         required: true
         type: string
       promote_latest:
@@ -40,9 +40,12 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.event.pull_request.base.ref }}
+          # Always check out the workflow branch so pnpm tooling is current.
+          # release.ts handles checking out the target ref internally.
 
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
+        with:
+          version: 11.1.2
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,6 @@ jobs:
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Login to Docker Hub
-        if: ${{ inputs.dry_run != true }}
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}

--- a/packages/zero/tool/release.ts
+++ b/packages/zero/tool/release.ts
@@ -59,7 +59,6 @@ async function main() {
     );
 
     let localRefHash;
-    let remoteRefHash;
 
     // Get local ref hash
     try {
@@ -70,35 +69,45 @@ async function main() {
       process.exit(1);
     }
 
-    // Get remote ref hash
-    try {
-      // For branches, check remote/branch
-      // For tags, just check the tag (tags are fetched from remote)
-      remoteRefHash = execute(`git rev-parse ${remote}/${from}`, {
-        stdio: 'pipe',
-      });
-    } catch {
-      // If remote/from doesn't exist, try just the ref (works for tags)
+    // For full commit SHAs, skip remote ref lookup — the commit is present
+    // locally after a full fetch, which means it was pushed.
+    const isCommitSHA = /^[0-9a-f]{40}$/.test(from);
+    if (!isCommitSHA) {
+      let remoteRefHash;
       try {
-        // For tags, we need to ensure we have the latest from remote
-        execute(`git fetch ${remote} tag ${from}`, {stdio: 'pipe'});
-        remoteRefHash = execute(`git rev-parse ${from}`, {stdio: 'pipe'});
+        // For branches, check remote/branch
+        remoteRefHash = execute(`git rev-parse ${remote}/${from}`, {
+          stdio: 'pipe',
+        });
       } catch {
-        console.error(`Could not resolve remote ref: ${from}`);
-        console.error(`Make sure the branch/tag has been pushed to ${remote}`);
+        // If remote/from doesn't exist, try just the ref (works for tags)
+        try {
+          // For tags, we need to ensure we have the latest from remote
+          execute(`git fetch ${remote} tag ${from}`, {stdio: 'pipe'});
+          remoteRefHash = execute(`git rev-parse ${from}`, {stdio: 'pipe'});
+        } catch {
+          console.error(`Could not resolve remote ref: ${from}`);
+          console.error(
+            `Make sure the branch/tag has been pushed to ${remote}`,
+          );
+          process.exit(1);
+        }
+      }
+
+      if (localRefHash !== remoteRefHash) {
+        console.error(`Local and remote versions of ${from} do not match`);
+        console.error(`Local:  ${localRefHash}`);
+        console.error(`Remote: ${remoteRefHash}`);
+        console.error(`Perhaps you need to push your changes?`);
         process.exit(1);
       }
     }
 
-    if (localRefHash !== remoteRefHash) {
-      console.error(`Local and remote versions of ${from} do not match`);
-      console.error(`Local:  ${localRefHash}`);
-      console.error(`Remote: ${remoteRefHash}`);
-      console.error(`Perhaps you need to push your changes?`);
-      process.exit(1);
-    }
-
-    console.log(`✓ Ref ${from} matches between local and remote`);
+    console.log(
+      isCommitSHA
+        ? `✓ Commit ${from} exists locally`
+        : `✓ Ref ${from} matches between local and remote`,
+    );
 
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'zero-build-'));
 
@@ -589,13 +598,15 @@ async function confirmRelease(yes: boolean) {
 }
 
 function build(version: string) {
+  const usePnpm = fs.existsSync(basePath('pnpm-lock.yaml'));
+  const pnpm = (x: string) => execute(usePnpm ? `pnpm ${x}` : `npm ${x}`);
   // Installs turbo and other build dependencies needed for packaging.
-  execute('pnpm install');
+  pnpm('install');
   setVersionInWorkspace(version);
-  execute('pnpm install');
-  execute('pnpm run build');
-  execute('pnpm run format');
-  execute('pnpmx syncpack fix');
+  pnpm('install');
+  pnpm('run build');
+  pnpm('run format');
+  pnpm('exec syncpack fix');
   execute('git status');
 }
 


### PR DESCRIPTION
This pull request updates the release workflow and build tooling to improve flexibility and reliability when building releases from different types of Git references. The most notable changes are improvements to how refs are handled (especially commit SHAs), updates to the release workflow to ensure up-to-date tooling, and enhancements to the build process for better compatibility with both `pnpm` and `npm`.

**Release workflow improvements:**

* Clarified the `ref` input description in `.github/workflows/release.yml` to indicate it now accepts a branch, tag, or commit SHA, making the workflow more flexible for different release scenarios.
* Updated the checkout step to always check out the workflow branch, ensuring `pnpm` tooling is current, and specified the `pnpm` version used in the workflow for consistency.

**Ref handling enhancements:**

* In `packages/zero/tool/release.ts`, changed the behavior to skip remote ref lookup for full commit SHAs, since a full fetch guarantees the commit is present locally, improving reliability when releasing from a commit SHA.
* Improved messaging and error handling when resolving refs, providing clearer feedback if a branch or tag hasn't been pushed to the remote. [[1]](diffhunk://#diff-505e3040ffdec40e655eaefd47d06835492f2ebd1895fe36b527efed0ecf7219L88-R92) [[2]](diffhunk://#diff-505e3040ffdec40e655eaefd47d06835492f2ebd1895fe36b527efed0ecf7219R104-R110)

**Build process improvements:**

* Updated the build process in `release.ts` to detect whether to use `pnpm` or `npm` based on the presence of `pnpm-lock.yaml`, improving compatibility for different developer setups. Also switched to using `pnpm exec` for running `syncpack fix`.