### PR TITLE
fix(release): stop mutating apps/* package.json during release

### DIFF
--- a/packages/zero/tool/release.ts
+++ b/packages/zero/tool/release.ts
@@ -626,19 +626,6 @@ function setVersionInWorkspace(version: string) {
   const currentPackageData = getPackageData(zeroPackageJsonPathInTemp);
   currentPackageData.version = version;
   writePackageData(zeroPackageJsonPathInTemp, currentPackageData);
-
-  const dependencyPaths = [
-    basePath('apps', 'zbugs', 'package.json'),
-    basePath('apps', 'zql-viz', 'package.json'),
-  ];
-
-  dependencyPaths.forEach(p => {
-    const data = getPackageData(p);
-    if (data.dependencies && data.dependencies['@rocicorp/zero']) {
-      data.dependencies['@rocicorp/zero'] = version;
-      writePackageData(p, data);
-    }
-  });
 }
 
 function pushGit(


### PR DESCRIPTION
setVersionInWorkspace previously rewrote @rocicorp/zero in apps/zbugs and apps/zql-viz to point at the new canary version (replacing workspace:*). That mutation was load-bearing for nothing: neither app is published from this script, and workspace:* already resolves to the bumped local packages/zero version via pnpm's linkWorkspacePackages.

The mutation had two costs:
* It diverged the lockfile from package.json on every release, which caused the canary CI dry-run to fail under pnpm's CI-default --frozen-lockfile (run 26179682012).
* It changed apps/* manifests in the temp clone for no observable benefit, making the release commit noisier than it needed to be.

After this change, setVersionInWorkspace only touches packages/zero/package.json's version field, the lockfile stays in sync, and the second pnpm install runs cleanly under CI's frozen default.