### PR TITLE
chore(docker): use pnpm to gate transitive install scripts

### DIFF
--- a/packages/zero/Dockerfile
+++ b/packages/zero/Dockerfile
@@ -27,10 +27,11 @@ RUN test -n "$ZERO_VERSION"
 RUN apk add --update curl
 RUN apk add --no-cache readline readline-dev
 
-# Install pnpm: its onlyBuiltDependencies allowlist (v10+) blocks lifecycle
-# scripts from transitive deps unless explicitly opted in, shrinking the
-# postinstall supply-chain surface to packages we name below.
-RUN npm install -g pnpm@10
+# Install pnpm via corepack (bundled with Node). pnpm's onlyBuiltDependencies
+# allowlist (v10+) blocks lifecycle scripts from transitive deps unless
+# explicitly opted in, shrinking the postinstall supply-chain surface to
+# packages we name below.
+RUN corepack enable && corepack prepare pnpm@10 --activate
 
 RUN mkdir -p /opt/app
 WORKDIR /opt/app

--- a/packages/zero/Dockerfile
+++ b/packages/zero/Dockerfile
@@ -36,10 +36,6 @@ RUN corepack enable && corepack prepare pnpm@10 --activate
 RUN mkdir -p /opt/app
 WORKDIR /opt/app
 
-# Flat node_modules so downstream paths (zero-sqlite3 symlink, config.yml) stay
-# resolvable without walking pnpm's virtual store.
-RUN printf 'node-linker=hoisted\n' > .npmrc
-
 # Allowlist for lifecycle scripts. zero-sqlite3 ships no native binary in its
 # tarball (see its package.json `files`) — its `install` script runs
 # prebuild-install to fetch one, so it must be allowed. esbuild is pulled in
@@ -71,9 +67,6 @@ RUN if echo "$ZERO_VERSION" | grep -q "\.tgz$"; then \
     echo "Installing from npm @rocicorp/zero@$ZERO_VERSION" && \
     pnpm add @rocicorp/zero@${ZERO_VERSION}; \
   fi
-
-# Add zero-sqlite3 to path
-RUN ln -s /opt/app/node_modules/@rocicorp/zero-sqlite3/build/Release/zero_sqlite3  /usr/local/bin/zero-sqlite3
 
 # Put zero's bin shims on PATH so `zero-cache` resolves without npx.
 ENV PATH="/opt/app/node_modules/.bin:${PATH}"

--- a/packages/zero/Dockerfile
+++ b/packages/zero/Dockerfile
@@ -27,8 +27,35 @@ RUN test -n "$ZERO_VERSION"
 RUN apk add --update curl
 RUN apk add --no-cache readline readline-dev
 
+# Install pnpm: its onlyBuiltDependencies allowlist (v10+) blocks lifecycle
+# scripts from transitive deps unless explicitly opted in, shrinking the
+# postinstall supply-chain surface to packages we name below.
+RUN npm install -g pnpm@10
+
 RUN mkdir -p /opt/app
 WORKDIR /opt/app
+
+# Flat node_modules so downstream paths (zero-sqlite3 symlink, config.yml) stay
+# resolvable without walking pnpm's virtual store.
+RUN printf 'node-linker=hoisted\n' > .npmrc
+
+# Allowlist for lifecycle scripts. zero-sqlite3 ships no native binary in its
+# tarball (see its package.json `files`) — its `install` script runs
+# prebuild-install to fetch one, so it must be allowed. esbuild is pulled in
+# transitively via tsx and downloads a platform binary in postinstall; keep it
+# allowlisted unless runtime testing confirms tsx is never invoked.
+RUN cat > package.json <<'EOF'
+{
+  "name": "zero-runtime",
+  "private": true,
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@rocicorp/zero-sqlite3",
+      "esbuild"
+    ]
+  }
+}
+EOF
 
 COPY pkgs/ /tmp/pkgs/
 
@@ -37,20 +64,23 @@ RUN if echo "$ZERO_VERSION" | grep -q "\.tgz$"; then \
     FILENAME=$(basename $ZERO_VERSION) && \
     echo "Installing from local tarball $FILENAME" && \
     cp /tmp/pkgs/$FILENAME . && \
-    npm install -g ./$FILENAME && \
-    rm -rf /tmp/pkgs; \
+    pnpm add ./$FILENAME && \
+    rm -rf /tmp/pkgs ./$FILENAME; \
   else \
     echo "Installing from npm @rocicorp/zero@$ZERO_VERSION" && \
-    npm install -g @rocicorp/zero@${ZERO_VERSION}; \
+    pnpm add @rocicorp/zero@${ZERO_VERSION}; \
   fi
 
 # Add zero-sqlite3 to path
-RUN ln -s /usr/local/lib/node_modules/@rocicorp/zero/node_modules/@rocicorp/zero-sqlite3/build/Release/zero_sqlite3  /usr/local/bin/zero-sqlite3
+RUN ln -s /opt/app/node_modules/@rocicorp/zero-sqlite3/build/Release/zero_sqlite3  /usr/local/bin/zero-sqlite3
+
+# Put zero's bin shims on PATH so `zero-cache` resolves without npx.
+ENV PATH="/opt/app/node_modules/.bin:${PATH}"
 
 # Copy litestream executable and config.yml
 COPY --from=litestream /usr/local/bin/litestream /usr/local/bin/litestream
 COPY --from=litestream-v5 /usr/local/bin/litestream /usr/local/bin/litestream-v5
-RUN cp /usr/local/lib/node_modules/@rocicorp/zero/out/zero-cache/src/services/litestream/config.yml /etc/litestream.yml
+RUN cp /opt/app/node_modules/@rocicorp/zero/out/zero-cache/src/services/litestream/config.yml /etc/litestream.yml
 
 ENV ZERO_LITESTREAM_EXECUTABLE=/usr/local/bin/litestream
 ENV ZERO_LITESTREAM_EXECUTABLE_V5=/usr/local/bin/litestream-v5
@@ -61,4 +91,4 @@ ENV ZERO_IN_CONTAINER=1
 
 EXPOSE 4848 4849
 ENTRYPOINT ["/bin/sh", "-c"]
-CMD ["npx zero-cache"]
+CMD ["zero-cache"]


### PR DESCRIPTION
`npm install -g` of zero's tarball runs install/postinstall scripts for every transitive dep. Switch to `pnpm add` with
`pnpm.onlyBuiltDependencies` in /opt/app/package.json; pnpm v10+ ignores dependency lifecycle scripts by default and only runs them for allowlisted packages.

Allowlist: `@rocicorp/zero-sqlite3` (its `install` runs prebuild-install to fetch the native binary, which isn't in its tarball) and `esbuild` (via tsx; included defensively until runtime confirms tsx is unused).

Install is local to /opt/app with `node-linker=hoisted` so the existing zero-sqlite3 symlink and config.yml copy paths still resolve; PATH is extended so CMD drops `npx`.