### PR TITLE
feat(zero-cache): add replication.last_total_lag gauge

### DIFF
--- a/packages/zero-cache/src/services/replicator/reporter/recorder.test.ts
+++ b/packages/zero-cache/src/services/replicator/reporter/recorder.test.ts
@@ -33,22 +33,26 @@ test('replication report recorder', () => {
   expectObserved(recorder.reportUpstreamLag, 200);
   expectObserved(recorder.reportReplicaLag, 350);
   expectObserved(recorder.reportTotalLag, 550);
+  expectObserved(recorder.reportLastTotalLag, 550);
 
   now = 11_550;
 
   expectObserved(recorder.reportUpstreamLag, 200);
   expectObserved(recorder.reportReplicaLag, 350);
   expectObserved(recorder.reportTotalLag, 550);
+  expectObserved(recorder.reportLastTotalLag, 550);
 
   now = 12_123;
   expectObserved(recorder.reportUpstreamLag, 200);
   expectObserved(recorder.reportReplicaLag, 350);
   expectObserved(recorder.reportTotalLag, 1123);
+  expectObserved(recorder.reportLastTotalLag, 550);
 
   now = 12_246;
   expectObserved(recorder.reportUpstreamLag, 200);
   expectObserved(recorder.reportReplicaLag, 350);
   expectObserved(recorder.reportTotalLag, 1246);
+  expectObserved(recorder.reportLastTotalLag, 550);
 
   recorder.record({
     lastTimings: {
@@ -63,4 +67,5 @@ test('replication report recorder', () => {
   expectObserved(recorder.reportUpstreamLag, 250);
   expectObserved(recorder.reportReplicaLag, 400);
   expectObserved(recorder.reportTotalLag, 650);
+  expectObserved(recorder.reportLastTotalLag, 650);
 });

--- a/packages/zero-cache/src/services/replicator/reporter/recorder.ts
+++ b/packages/zero-cache/src/services/replicator/reporter/recorder.ts
@@ -57,6 +57,17 @@ export class ReplicationReportRecorder {
           `time has exceeded the previous report's total lag.`,
         unit: 'millisecond',
       }).addCallback(this.reportTotalLag);
+
+      getOrCreateGauge('replication', 'last_total_lag', {
+        description:
+          'Latency from sending the most recently received upstream ' +
+          'replication report to its reaching the replica. Unlike ' +
+          'replication.total_lag, this value does not grow when reports ' +
+          'stop arriving — it reflects only the actual measured round-trip ' +
+          'of the last received report. Compare against replication.total_lag ' +
+          'to distinguish real lag from a stalled report stream.',
+        unit: 'millisecond',
+      }).addCallback(this.reportLastTotalLag);
     }
   }
 
@@ -83,6 +94,13 @@ export class ReplicationReportRecorder {
         ? timings.replicateTimeMs - timings.sendTimeMs
         : 0;
       o.observe(Math.max(lastLag, nextLagEstimate));
+    }
+  };
+
+  readonly reportLastTotalLag = (o: ObservableResult) => {
+    const last = this.#last?.lastTimings;
+    if (last) {
+      o.observe(last.replicateTimeMs - last.sendTimeMs);
     }
   };
 }


### PR DESCRIPTION
Is replication lag high or did the replication stream just stop entirely?

Adds a fourth replication-lag gauge that reports only the measured round-trip from the most recently received lag report, without the watchdog `max(..., now - nextSendTimeMs)` component of total_lag. When the report stream stalls, total_lag grows linearly while last_total_lag stays flat at the last real measurement — comparing the two distinguishes actual replication lag from a stuck change-source connection.

This incident was the impetus for this: https://rocicorp.slack.com/archives/C013XFG80JC/p1779331755395539