### PR TITLE
fix(zero): restore flat out/ layout by setting preserveModulesRoot

### DIFF
--- a/packages/zero/tool/build.ts
+++ b/packages/zero/tool/build.ts
@@ -137,6 +137,7 @@ async function getViteConfig(): Promise<InlineConfig> {
           entryFileNames: '[name].js',
           chunkFileNames: 'chunks/[name]-[hash].js',
           preserveModules: true,
+          preserveModulesRoot: resolve('..'),
         },
       },
     },


### PR DESCRIPTION
Since the pnpm migration (#5997), Rollup's preserveModules emitted transitive chunks under out/packages/<pkg>/... instead of out/<pkg>/..., because under pnpm's isolated linker the resolved module paths run through .pnpm/ symlinks and Rollup's implicit common-ancestor root ends up at mono/ rather than mono/packages/. This split .js chunks away from their sibling .d.ts files (tsc still emits to the flat tree) and broke imports like @rocicorp/zero/server/adapters/pg at runtime.

Pinning preserveModulesRoot to packages/ makes chunk paths install-state independent and restores the layout shipped through 1.5.0.