### PR TITLE
ci: fix core zizmor findings

### DIFF
--- a/.github/actions/playwright-install/action.yml
+++ b/.github/actions/playwright-install/action.yml
@@ -4,9 +4,6 @@ description: 'Install Playwright browsers and system dependencies with caching. 
 runs:
   using: 'composite'
   steps:
-    - name: Set PLAYWRIGHT_BROWSERS_PATH
-      run: echo "PLAYWRIGHT_BROWSERS_PATH=$HOME/.cache/ms-playwright" >> "$GITHUB_ENV"
-      shell: bash
     - name: Get Playwright version
       id: playwright-version
       run: echo "version=$(pnpm exec playwright --version | awk '{print $NF}')" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/api-snapshot.yml
+++ b/.github/workflows/api-snapshot.yml
@@ -11,6 +11,9 @@ concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions:
+  contents: read
+
 jobs:
   api-snapshot:
     name: API Snapshot

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -11,6 +11,9 @@ concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions:
+  contents: read
+
 jobs:
   # Gate jobs - must pass before other jobs run
   syncpack:
@@ -117,7 +120,9 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - uses: ./.github/actions/playwright-install
       - name: Run tests
-        run: TEST_PG_MODE=nopg pnpm run test --shard=${{ matrix.shard }}/3
+        env:
+          SHARD: ${{ matrix.shard }}
+        run: TEST_PG_MODE=nopg pnpm run test --shard="$SHARD"/3
 
   test-pg:
     name: Test PG ${{ matrix.pg-version }} (Shard ${{ matrix.shard }}/2)

--- a/.github/workflows/perf-smoke.yml
+++ b/.github/workflows/perf-smoke.yml
@@ -10,12 +10,17 @@ concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions:
+  contents: read
+
 jobs:
   benchmark-smoke:
     name: Performance runner smoke test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
 


### PR DESCRIPTION
## Summary
- Remove the Playwright composite action write to `GITHUB_ENV`.
- Add explicit read-only workflow permissions for API snapshot, JS CI, and perf smoke.
- Disable persisted checkout credentials in perf smoke.
- Move the JS test shard expression into an environment variable before shell use.

## Original zizmor findings
- `.github/actions/playwright-install/action.yml`: `github-env` for writing to `GITHUB_ENV`.
- `.github/workflows/api-snapshot.yml`: `excessive-permissions` due to missing explicit `permissions`.
- `.github/workflows/js.yml`: `excessive-permissions` due to missing explicit `permissions` across jobs.
- `.github/workflows/js.yml`: `template-injection` for direct `${{ matrix.shard }}` expansion in a `run` command.
- `.github/workflows/perf-smoke.yml`: `artipacked` because checkout did not set `persist-credentials: false`.
- `.github/workflows/perf-smoke.yml`: `excessive-permissions` due to missing explicit `permissions`.

## Verification
- `zizmor --no-progress --color=never --persona=auditor .github/actions/playwright-install/action.yml .github/workflows/api-snapshot.yml .github/workflows/js.yml .github/workflows/perf-smoke.yml`