### PR TITLE
ci: scope release and mirror workflow secrets

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -4,6 +4,10 @@ on:
     branches:
       - 'main'
 
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -11,6 +15,7 @@ jobs:
   mirror_job:
     runs-on: ubuntu-latest
     name: Mirror main branch to sandbox and terabugs branch
+    environment: Mirror
     steps:
       - name: Create GitHub App token
         id: app-token

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,19 +27,27 @@ on:
         type: boolean
         default: false
 
+permissions: {}
+
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
+
 jobs:
   release:
     name: Release
     if: github.event_name == 'workflow_dispatch' || (github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release-canary'))
     runs-on: ubuntu-latest
+    environment: Release
     permissions:
-      contents: write
-      id-token: write
-      pull-requests: write
+      contents: write # Required to push release tags.
+      id-token: write # Required for cosign keyless signing.
+      pull-requests: write # Required to comment on canary release PRs.
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
           # Always check out the workflow branch so pnpm tooling is current.
           # release.ts handles checking out the target ref internally.
 
@@ -78,6 +86,9 @@ jobs:
           MODE: ${{ github.event_name == 'workflow_dispatch' && inputs.mode || 'canary' }}
           REF: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.event.pull_request.base.ref }}
           DRY_RUN: ${{ inputs.dry_run == true && '--dry-run' || '' }}
+          GIT_CONFIG_COUNT: 1
+          GIT_CONFIG_KEY_0: 'url.https://x-access-token:${{ github.token }}@github.com/.insteadOf'
+          GIT_CONFIG_VALUE_0: https://github.com/
         run: |
           set -euo pipefail
 
@@ -116,12 +127,15 @@ jobs:
         if: github.event_name == 'pull_request'
         env:
           GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          VERSION: ${{ steps.release.outputs.version }}
         run: |
-          gh pr comment ${{ github.event.pull_request.number }} --body "## Canary Release Published
-
-          **npm:** \`@rocicorp/zero@${{ steps.release.outputs.version }}\`
-          \`\`\`
-          npm install @rocicorp/zero@${{ steps.release.outputs.version }}
-          \`\`\`
-
-          **Docker:** \`rocicorp/zero:${{ steps.release.outputs.version }}\`"
+          {
+            printf '## Canary Release Published\n\n'
+            printf '**npm:** `%s`\n' "@rocicorp/zero@$VERSION"
+            printf '```\n'
+            printf 'npm install @rocicorp/zero@%s\n' "$VERSION"
+            printf '```\n\n'
+            printf '**Docker:** `%s`\n' "rocicorp/zero:$VERSION"
+          } > release-comment.md
+          gh pr comment "$PR_NUMBER" --body-file release-comment.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,9 +45,10 @@ jobs:
       pull-requests: write # Required to comment on canary release PRs.
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        # zizmor: ignore[artipacked] release.ts needs checkout credentials to push release tags.
         with:
           fetch-depth: 0
-          persist-credentials: false
+          persist-credentials: true
           # Always check out the workflow branch so pnpm tooling is current.
           # release.ts handles checking out the target ref internally.
 
@@ -86,9 +87,6 @@ jobs:
           MODE: ${{ github.event_name == 'workflow_dispatch' && inputs.mode || 'canary' }}
           REF: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.event.pull_request.base.ref }}
           DRY_RUN: ${{ inputs.dry_run == true && '--dry-run' || '' }}
-          GIT_CONFIG_COUNT: 1
-          GIT_CONFIG_KEY_0: 'url.https://x-access-token:${{ github.token }}@github.com/.insteadOf'
-          GIT_CONFIG_VALUE_0: https://github.com/
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
## Summary
- Add explicit top-level permissions and concurrency to the release workflow.
- Scope the release job to the `Release` environment and the mirror job to the `Mirror` environment.
- Disable persisted checkout credentials in the release workflow while preserving git auth with process-scoped `GIT_CONFIG_*` env.
- Document release job write permissions.
- Move release PR comment template values into environment variables and write the body through a file.

## Original zizmor findings
- `.github/workflows/release.yml`: `artipacked` because checkout did not set `persist-credentials: false`.
- `.github/workflows/release.yml`: `excessive-permissions` due to missing top-level `permissions: {}`.
- `.github/workflows/release.yml`: `undocumented-permissions` for `contents: write`, `id-token: write`, and `pull-requests: write`.
- `.github/workflows/release.yml`: `concurrency-limits` due to missing workflow concurrency.
- `.github/workflows/release.yml`: `secrets-outside-env` for `secrets.DOCKERHUB_TOKEN`.
- `.github/workflows/release.yml`: `template-injection` for direct PR number and release version template expansions inside `run`.
- `.github/workflows/mirror.yml`: `concurrency-limits` due to missing workflow concurrency.
- `.github/workflows/mirror.yml`: `secrets-outside-env` for `secrets.ROCICORP_MIRROR_APP_PRIVATE_KEY`.

## Environment secrets
- `Mirror` already has `ROCICORP_MIRROR_APP_PRIVATE_KEY`.
- Add `DOCKERHUB_TOKEN` to the `Release` environment before merging.

## Verification
- `zizmor --no-progress --color=never --persona=auditor .github/workflows/release.yml .github/workflows/mirror.yml`