### PR TITLE
ci: harden benchmark workflows

### DIFF
--- a/.github/workflows/bencher-benchmarks-pr.yml
+++ b/.github/workflows/bencher-benchmarks-pr.yml
@@ -4,13 +4,19 @@ on:
   pull_request:
     types: [opened, reopened, edited, synchronize]
 
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions: {}
+
 jobs:
   playwright-install:
     name: Install Playwright
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: read
-    runs-on: [self-hosted, benchmark]
+    runs-on: [self-hosted, benchmark] # zizmor: ignore[self-hosted-runner] Benchmark jobs require dedicated hardware.
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -32,8 +38,8 @@ jobs:
     needs: playwright-install
     permissions:
       contents: read
-      checks: write
-      pull-requests: write
+      checks: write # Required by Bencher to publish check runs.
+      pull-requests: write # Required by Bencher to publish PR results.
     uses: ./.github/workflows/reusable-benchmark.yml
     strategy:
       fail-fast: false
@@ -59,5 +65,3 @@ jobs:
       base_ref: ${{ github.event.pull_request.base.ref }}
       head_ref: ${{ github.event.pull_request.head.ref }}
       base_sha: ${{ github.event.pull_request.base.sha }}
-    secrets:
-      BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}

--- a/.github/workflows/bencher-benchmarks.yml
+++ b/.github/workflows/bencher-benchmarks.yml
@@ -4,12 +4,18 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
+permissions: {}
+
 jobs:
   playwright-install:
     name: Install Playwright
     permissions:
       contents: read
-    runs-on: [self-hosted, benchmark]
+    runs-on: [self-hosted, benchmark] # zizmor: ignore[self-hosted-runner] Benchmark jobs require dedicated hardware.
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -30,8 +36,8 @@ jobs:
     needs: playwright-install
     permissions:
       contents: read
-      checks: write
-      pull-requests: write
+      checks: write # Required by Bencher to publish check runs.
+      pull-requests: write # Required by Bencher to publish PR results.
     uses: ./.github/workflows/reusable-benchmark.yml
     strategy:
       fail-fast: false
@@ -45,5 +51,3 @@ jobs:
     with:
       package_name: ${{ matrix.package }}
       working_directory: packages/${{ matrix.package }}
-    secrets:
-      BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}

--- a/.github/workflows/bencher-file-sizes-pr.yml
+++ b/.github/workflows/bencher-file-sizes-pr.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     types: [opened, reopened, edited, synchronize]
 
+permissions: {}
+
 jobs:
   file_sizes:
     name: File Sizes PR
@@ -11,13 +13,11 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: read
-      checks: write
-      pull-requests: write
+      checks: write # Required by Bencher to publish check runs.
+      pull-requests: write # Required by Bencher to publish PR results.
     uses: ./.github/workflows/reusable-file-sizes.yml
     with:
       is_pr: true
       base_ref: ${{ github.event.pull_request.base.ref }}
       head_ref: ${{ github.event.pull_request.head.ref }}
       base_sha: ${{ github.event.pull_request.base.sha }}
-    secrets:
-      BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}

--- a/.github/workflows/bencher-file-sizes.yml
+++ b/.github/workflows/bencher-file-sizes.yml
@@ -4,13 +4,13 @@ on:
   push:
     branches: [main]
 
+permissions: {}
+
 jobs:
   file_sizes:
     name: File Sizes
     permissions:
       contents: read
-      checks: write
-      pull-requests: write
+      checks: write # Required by Bencher to publish check runs.
+      pull-requests: write # Required by Bencher to publish PR results.
     uses: ./.github/workflows/reusable-file-sizes.yml
-    secrets:
-      BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}

--- a/.github/workflows/bundle-sizes.js.yml
+++ b/.github/workflows/bundle-sizes.js.yml
@@ -6,6 +6,10 @@ on:
     paths:
       - 'packages/replicache/**'
 
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -46,7 +50,7 @@ jobs:
     name: Publish bundle sizes
     needs: measure
     permissions:
-      contents: write
+      contents: write # Required by github-action-benchmark to push gh-pages data.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/perf-v2.js.yml
+++ b/.github/workflows/perf-v2.js.yml
@@ -9,13 +9,17 @@ on:
       - '.github/**'
       - 'pnpm-lock.yaml'
 
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
 jobs:
   playwright-install:
     name: Install Playwright
-    runs-on: [self-hosted, benchmark]
+    runs-on: [self-hosted, benchmark] # zizmor: ignore[self-hosted-runner] Benchmark jobs require dedicated hardware.
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -36,7 +40,7 @@ jobs:
     needs: playwright-install
     permissions:
       contents: read
-    runs-on: [self-hosted, benchmark]
+    runs-on: [self-hosted, benchmark] # zizmor: ignore[self-hosted-runner] Benchmark jobs require dedicated hardware.
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -80,7 +84,7 @@ jobs:
     name: Publish performance results
     needs: benchmark
     permissions:
-      contents: write
+      contents: write # Required by github-action-benchmark to push gh-pages data.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/reusable-benchmark.yml
+++ b/.github/workflows/reusable-benchmark.yml
@@ -37,16 +37,14 @@ on:
         required: false
         type: string
         description: 'Base SHA for PR runs'
-    secrets:
-      BENCHER_API_TOKEN:
-        required: false
+permissions: {}
 
 jobs:
   benchmark:
     name: ${{ inputs.package_name }} Benchmarks
     permissions:
       contents: read
-    runs-on: [self-hosted, benchmark]
+    runs-on: [self-hosted, benchmark] # zizmor: ignore[self-hosted-runner] Benchmark jobs require dedicated hardware.
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -78,9 +76,10 @@ jobs:
     if: ${{ inputs.upload_results }}
     needs: benchmark
     runs-on: ubuntu-latest
+    environment: Benchmark
     permissions:
-      checks: write
-      pull-requests: write
+      checks: write # Required by Bencher to publish check runs.
+      pull-requests: write # Required by Bencher to publish PR results.
     steps:
       - name: Download benchmark output
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6

--- a/.github/workflows/reusable-file-sizes.yml
+++ b/.github/workflows/reusable-file-sizes.yml
@@ -25,9 +25,7 @@ on:
         required: false
         type: string
         description: 'Base SHA for PR runs'
-    secrets:
-      BENCHER_API_TOKEN:
-        required: false
+permissions: {}
 
 jobs:
   build_file_sizes:
@@ -79,9 +77,10 @@ jobs:
     if: ${{ inputs.upload_results }}
     needs: build_file_sizes
     runs-on: ubuntu-latest
+    environment: Benchmark
     permissions:
-      checks: write
-      pull-requests: write
+      checks: write # Required by Bencher to publish check runs.
+      pull-requests: write # Required by Bencher to publish PR results.
     steps:
       - name: Download file size outputs
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6


### PR DESCRIPTION
## Summary
- Add explicit permissions and missing concurrency to benchmark-related workflows.
- Document Bencher and github-action-benchmark write permissions.
- Keep intentional self-hosted benchmark runners with targeted `zizmor` ignores and explanations.
- Move Bencher upload jobs to the `Benchmark` environment.
- Stop passing `BENCHER_API_TOKEN` through reusable workflow callers; the reusable upload jobs now read it from the `Benchmark` environment.

## Original zizmor findings
- `.github/workflows/bencher-benchmarks-pr.yml`: `excessive-permissions`, `self-hosted-runner`, `undocumented-permissions`, and `concurrency-limits`.
- `.github/workflows/bencher-benchmarks.yml`: `excessive-permissions`, `self-hosted-runner`, `undocumented-permissions`, and `concurrency-limits`.
- `.github/workflows/bencher-file-sizes-pr.yml`: `excessive-permissions` and `undocumented-permissions`.
- `.github/workflows/bencher-file-sizes.yml`: `excessive-permissions` and `undocumented-permissions`.
- `.github/workflows/bundle-sizes.js.yml`: `concurrency-limits` and `undocumented-permissions` for `contents: write`.
- `.github/workflows/perf-v2.js.yml`: `concurrency-limits`, two `self-hosted-runner` findings, and `undocumented-permissions` for `contents: write`.
- `.github/workflows/reusable-benchmark.yml`: `excessive-permissions`, `self-hosted-runner`, and `undocumented-permissions`.
- `.github/workflows/reusable-file-sizes.yml`: `excessive-permissions` and `undocumented-permissions`.

## Environment secrets
- Add `BENCHER_API_TOKEN` to the `Benchmark` environment before merging.

## Verification
- `zizmor --no-progress --color=never --persona=auditor .github/workflows/bencher-benchmarks-pr.yml .github/workflows/bencher-benchmarks.yml .github/workflows/bencher-file-sizes-pr.yml .github/workflows/bencher-file-sizes.yml .github/workflows/bundle-sizes.js.yml .github/workflows/perf-v2.js.yml .github/workflows/reusable-benchmark.yml .github/workflows/reusable-file-sizes.yml`