### PR TITLE
ci(replicache): harden release asset workflow

### DIFF
--- a/packages/replicache/.github/workflows/upload-release-assets.yml
+++ b/packages/replicache/.github/workflows/upload-release-assets.yml
@@ -5,18 +5,29 @@ on:
     tags:
       - 'v*.*.*'
 
+permissions: {}
+
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.ref }}'
+  cancel-in-progress: true
+
 jobs:
   build:
+    name: Build and upload assets
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # Required to create releases and upload release assets.
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24.x
-          cache: 'pnpm'
+          package-manager-cache: false
 
       - run: pnpm install --frozen-lockfile
 
@@ -27,9 +38,15 @@ jobs:
         run: ls -al out/*.map
 
       - name: Release
-        uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
-        with:
-          files: |
-            out/*.map
-            out/*.d.ts
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release upload "$TAG" out/*.map out/*.d.ts --clobber
+          else
+            gh release create "$TAG" out/*.map out/*.d.ts --title "$TAG"
+          fi


### PR DESCRIPTION
## Summary

I don't think this is used anymore but alas it's being updated just in case.

- Add explicit permissions, job name, and concurrency to the Replicache release asset workflow.
- Pin all workflow actions to commit SHAs.
- Disable persisted checkout credentials.
- Disable setup-node package-manager caching in the release artifact workflow.
- Replace `softprops/action-gh-release` with the built-in `gh release` CLI for release asset upload/create behavior.

## Original zizmor findings
- `packages/replicache/.github/workflows/upload-release-assets.yml`: `artipacked` because checkout did not set `persist-credentials: false`.
- `packages/replicache/.github/workflows/upload-release-assets.yml`: `excessive-permissions` due to missing explicit `permissions`.
- `packages/replicache/.github/workflows/upload-release-assets.yml`: `unpinned-uses` for tag-pinned `actions/checkout`, `pnpm/action-setup`, `actions/setup-node`, and `softprops/action-gh-release`.
- `packages/replicache/.github/workflows/upload-release-assets.yml`: `cache-poisoning` because a tag-triggered release artifact workflow enabled setup-node package-manager caching.
- `packages/replicache/.github/workflows/upload-release-assets.yml`: `anonymous-definition` because the job had no `name`.
- `packages/replicache/.github/workflows/upload-release-assets.yml`: `concurrency-limits` due to missing workflow concurrency.
- `packages/replicache/.github/workflows/upload-release-assets.yml`: `superfluous-actions` because `zizmor` recommends using `gh release` instead of `softprops/action-gh-release`.

## Verification
- `zizmor --no-progress --color=never --persona=auditor packages/replicache/.github/workflows/upload-release-assets.yml`