### PR TITLE
chore: Refactor permissions into a separate package

### DIFF
--- a/packages/zero-cache/src/auth/read-authorizer.query.test.ts
+++ b/packages/zero-cache/src/auth/read-authorizer.query.test.ts
@@ -5,6 +5,11 @@ import {assert} from '../../../shared/src/asserts.ts';
 import {h128} from '../../../shared/src/hash.ts';
 import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
 import {must} from '../../../shared/src/must.ts';
+import {
+  ANYONE_CAN,
+  ANYONE_CAN_DO_ANYTHING,
+  definePermissions,
+} from '../../../zero-permissions/src/permissions.ts';
 import type {
   DeleteOp,
   InsertOp,
@@ -18,11 +23,6 @@ import {
   string,
   table,
 } from '../../../zero-schema/src/builder/table-builder.ts';
-import {
-  ANYONE_CAN,
-  ANYONE_CAN_DO_ANYTHING,
-  definePermissions,
-} from '../../../zero-schema/src/permissions.ts';
 import type {ValueType} from '../../../zero-schema/src/table-schema.ts';
 import type {Schema as ZeroSchema} from '../../../zero-types/src/schema.ts';
 import {

--- a/packages/zero-cache/src/auth/read-authorizer.test.ts
+++ b/packages/zero-cache/src/auth/read-authorizer.test.ts
@@ -1,14 +1,14 @@
 import {describe, expect, test} from 'vitest';
 import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
 import {must} from '../../../shared/src/must.ts';
+import {
+  ANYONE_CAN,
+  definePermissions,
+} from '../../../zero-permissions/src/permissions.ts';
 import type {AST} from '../../../zero-protocol/src/ast.ts';
 import {relationships} from '../../../zero-schema/src/builder/relationship-builder.ts';
 import {createSchema} from '../../../zero-schema/src/builder/schema-builder.ts';
 import {string, table} from '../../../zero-schema/src/builder/table-builder.ts';
-import {
-  ANYONE_CAN,
-  definePermissions,
-} from '../../../zero-schema/src/permissions.ts';
 import type {ExpressionBuilder} from '../../../zql/src/query/expression.ts';
 import {asQueryInternals} from '../../../zql/src/query/query-internals.ts';
 import type {Query} from '../../../zql/src/query/query.ts';

--- a/packages/zero-cache/src/integration/integration.pg.test.ts
+++ b/packages/zero-cache/src/integration/integration.pg.test.ts
@@ -11,16 +11,16 @@ import type {JSONValue} from '../../../shared/src/json.ts';
 import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
 import {Queue} from '../../../shared/src/queue.ts';
 import {randInt} from '../../../shared/src/rand.ts';
+import {
+  ANYONE_CAN_DO_ANYTHING,
+  definePermissions,
+} from '../../../zero-permissions/src/permissions.ts';
 import type {AST} from '../../../zero-protocol/src/ast.ts';
 import type {InitConnectionMessage} from '../../../zero-protocol/src/connect.ts';
 import type {PokeStartMessage} from '../../../zero-protocol/src/poke.ts';
 import {PROTOCOL_VERSION} from '../../../zero-protocol/src/protocol-version.ts';
 import {createSchema} from '../../../zero-schema/src/builder/schema-builder.ts';
 import {string, table} from '../../../zero-schema/src/builder/table-builder.ts';
-import {
-  ANYONE_CAN_DO_ANYTHING,
-  definePermissions,
-} from '../../../zero-schema/src/permissions.ts';
 import type {ChangeStreamMessage} from '../services/change-source/protocol/current/downstream.ts';
 import {
   changeSourceUpstreamSchema,

--- a/packages/zero-cache/src/scripts/schema-permissions-test.ts
+++ b/packages/zero-cache/src/scripts/schema-permissions-test.ts
@@ -1,10 +1,10 @@
-import {relationships} from '../../../zero-schema/src/builder/relationship-builder.ts';
-import {createSchema} from '../../../zero-schema/src/builder/schema-builder.ts';
-import {string, table} from '../../../zero-schema/src/builder/table-builder.ts';
 import {
   ANYONE_CAN_DO_ANYTHING,
   definePermissions,
-} from '../../../zero-schema/src/permissions.ts';
+} from '../../../zero-permissions/src/permissions.ts';
+import {relationships} from '../../../zero-schema/src/builder/relationship-builder.ts';
+import {createSchema} from '../../../zero-schema/src/builder/schema-builder.ts';
+import {string, table} from '../../../zero-schema/src/builder/table-builder.ts';
 
 const member = table('member')
   .columns({

--- a/packages/zero-cache/src/services/mutagen/mutagen.authz.pg.test.ts
+++ b/packages/zero-cache/src/services/mutagen/mutagen.authz.pg.test.ts
@@ -2,6 +2,11 @@ import {beforeEach, describe, expect} from 'vitest';
 import {testLogConfig} from '../../../../otel/src/test-log-config.ts';
 import {h128} from '../../../../shared/src/hash.ts';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
+import {
+  ANYONE_CAN,
+  definePermissions,
+  NOBODY_CAN,
+} from '../../../../zero-permissions/src/permissions.ts';
 import * as MutationType from '../../../../zero-protocol/src/mutation-type-enum.ts';
 import {createSchema} from '../../../../zero-schema/src/builder/schema-builder.ts';
 import {
@@ -11,11 +16,6 @@ import {
   string,
   table,
 } from '../../../../zero-schema/src/builder/table-builder.ts';
-import {
-  ANYONE_CAN,
-  definePermissions,
-  NOBODY_CAN,
-} from '../../../../zero-schema/src/permissions.ts';
 import type {Schema as ZeroSchema} from '../../../../zero-types/src/schema.ts';
 import type {ExpressionBuilder} from '../../../../zql/src/query/expression.ts';
 import type {Row} from '../../../../zql/src/query/query.ts';

--- a/packages/zero-cache/src/services/view-syncer/view-syncer-test-util.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer-test-util.ts
@@ -4,6 +4,10 @@ import {testLogConfig} from '../../../../otel/src/test-log-config.ts';
 import {h128} from '../../../../shared/src/hash.ts';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
 import {Queue} from '../../../../shared/src/queue.ts';
+import {
+  ANYONE_CAN_DO_ANYTHING,
+  definePermissions,
+} from '../../../../zero-permissions/src/permissions.ts';
 import type {AST} from '../../../../zero-protocol/src/ast.ts';
 import {type ClientSchema} from '../../../../zero-protocol/src/client-schema.ts';
 import type {
@@ -26,10 +30,6 @@ import {
   table,
 } from '../../../../zero-schema/src/builder/table-builder.ts';
 import type {PermissionsConfig} from '../../../../zero-schema/src/compiled-permissions.ts';
-import {
-  ANYONE_CAN_DO_ANYTHING,
-  definePermissions,
-} from '../../../../zero-schema/src/permissions.ts';
 import type {ExpressionBuilder} from '../../../../zql/src/query/expression.ts';
 import {
   CREATE_STORAGE_TABLE,

--- a/packages/zero-client/src/mod.ts
+++ b/packages/zero-client/src/mod.ts
@@ -87,12 +87,12 @@ export {
   ANYONE_CAN_DO_ANYTHING,
   definePermissions,
   NOBODY_CAN,
-} from '../../zero-schema/src/permissions.ts';
+} from '../../zero-permissions/src/permissions.ts';
 export type {
   AssetPermissions,
   PermissionRule,
   PermissionsConfig,
-} from '../../zero-schema/src/permissions.ts';
+} from '../../zero-permissions/src/permissions.ts';
 export {type TableSchema} from '../../zero-schema/src/table-schema.ts';
 export type {
   SchemaValue,

--- a/packages/zero-permissions/package.json
+++ b/packages/zero-permissions/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "zero-permissions",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "check-types": "tsc",
+    "check-types:watch": "tsc --watch",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "format": "oxfmt .",
+    "check-format": "oxfmt --check .",
+    "lint": "oxlint --quiet --config ../../oxlint.config.ts",
+    "fmt": "oxfmt .",
+    "check-fmt": "oxfmt --check ."
+  },
+  "dependencies": {
+    "shared": "workspace:*",
+    "zero-protocol": "workspace:*",
+    "zero-schema": "workspace:*",
+    "zero-types": "workspace:*",
+    "zql": "workspace:*"
+  },
+  "devDependencies": {
+    "oxfmt": "^0.45.0",
+    "typescript": "~6.0.2",
+    "vitest": "^4.1.6"
+  }
+}

--- a/packages/zero-permissions/src/env.d.ts
+++ b/packages/zero-permissions/src/env.d.ts
@@ -1,0 +1,3 @@
+interface ImportMeta {
+  readonly env?: {readonly VITEST?: string | boolean};
+}

--- a/packages/zero-permissions/src/permissions.test.ts
+++ b/packages/zero-permissions/src/permissions.test.ts
@@ -1,8 +1,8 @@
 import {expect, test} from 'vitest';
+import {createSchema} from '../../zero-schema/src/builder/schema-builder.ts';
+import {column, table} from '../../zero-schema/src/builder/table-builder.ts';
 import type {Schema as ZeroSchema} from '../../zero-types/src/schema.ts';
 import type {ExpressionBuilder} from '../../zql/src/query/expression.ts';
-import {createSchema} from './builder/schema-builder.ts';
-import {column, table} from './builder/table-builder.ts';
 import {definePermissions} from './permissions.ts';
 
 const {string} = column;

--- a/packages/zero-permissions/src/permissions.ts
+++ b/packages/zero-permissions/src/permissions.ts
@@ -5,17 +5,17 @@ import {
   type Condition,
   type Parameter,
 } from '../../zero-protocol/src/ast.ts';
-import type {Schema} from '../../zero-types/src/schema.ts';
-import type {ExpressionBuilder} from '../../zql/src/query/expression.ts';
-import type {Query} from '../../zql/src/query/query.ts';
-import {newExpressionBuilder} from '../../zql/src/query/static-query.ts';
 import type {
   AssetPermissions as CompiledAssetPermissions,
   PermissionsConfig as CompiledPermissionsConfig,
   TablePermissions,
-} from './compiled-permissions.ts';
-import type {NameMapper} from './name-mapper.ts';
-import {clientToServer} from './name-mapper.ts';
+} from '../../zero-schema/src/compiled-permissions.ts';
+import type {NameMapper} from '../../zero-schema/src/name-mapper.ts';
+import {clientToServer} from '../../zero-schema/src/name-mapper.ts';
+import type {Schema} from '../../zero-types/src/schema.ts';
+import type {ExpressionBuilder} from '../../zql/src/query/expression.ts';
+import type {Query} from '../../zql/src/query/query.ts';
+import {newExpressionBuilder} from '../../zql/src/query/static-query.ts';
 
 export const ANYONE_CAN = [
   (_: unknown, eb: ExpressionBuilder<never, Schema>) => eb.and(),

--- a/packages/zero-permissions/tsconfig.json
+++ b/packages/zero-permissions/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src"]
+}

--- a/packages/zero-permissions/vitest.config.ts
+++ b/packages/zero-permissions/vitest.config.ts
@@ -1,0 +1,13 @@
+import {defineConfig, mergeConfig} from 'vitest/config';
+import config from '../shared/src/tool/vitest-config.ts';
+
+export default mergeConfig(
+  config,
+  defineConfig({
+    test: {
+      browser: {
+        enabled: false,
+      },
+    },
+  }),
+);

--- a/packages/zero-schema/src/mod.ts
+++ b/packages/zero-schema/src/mod.ts
@@ -1,3 +1,0 @@
-export {createSchema} from './builder/schema-builder.ts';
-export {definePermissions} from './permissions.ts';
-export {type TableSchema} from './table-schema.ts';

--- a/packages/zql/src/query/query.test.ts
+++ b/packages/zql/src/query/query.test.ts
@@ -1,5 +1,6 @@
 import {describe, expectTypeOf, test} from 'vitest';
 import type {ReadonlyJSONValue} from '../../../shared/src/json.ts';
+import {staticParam} from '../../../zero-permissions/src/permissions.ts';
 import {toStaticParam} from '../../../zero-protocol/src/ast.ts';
 import {relationships} from '../../../zero-schema/src/builder/relationship-builder.ts';
 import {createSchema} from '../../../zero-schema/src/builder/schema-builder.ts';
@@ -11,7 +12,6 @@ import {
   string,
   table,
 } from '../../../zero-schema/src/builder/table-builder.ts';
-import {staticParam} from '../../../zero-schema/src/permissions.ts';
 import {type Opaque} from '../../../zero-schema/src/table-schema.ts';
 import type {TableSchema} from '../../../zero-types/src/schema.ts';
 import type {ExpressionFactory} from './expression.ts';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -253,7 +253,7 @@ importers:
         version: 0.45.0
       postcss-preset-env:
         specifier: ^7.4.3
-        version: 7.8.3(postcss@8.5.14)
+        version: 7.8.3(postcss@8.5.15)
       rehype-video:
         specifier: ^2.3.0
         version: 2.3.1
@@ -889,7 +889,7 @@ importers:
         version: 6.1.7
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@electric-sql/pglite@0.4.1)(@op-engineering/op-sqlite@15.2.14(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1))(react@18.3.1))(@opentelemetry/api@1.9.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@18.3.5(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@6.0.3))(typescript@6.0.3))(@types/pg@8.20.0)(expo-sqlite@55.0.16(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1))(react@18.3.1))(kysely@0.28.17)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.7)(prisma@7.8.0(@types/react-dom@18.3.5(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@6.0.3))
+        version: 0.45.2(@electric-sql/pglite@0.4.1)(@op-engineering/op-sqlite@15.2.14(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@18.3.1))(react@18.3.1))(@opentelemetry/api@1.9.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@18.3.5(@types/react@19.2.15))(@types/react@19.2.15)(magicast@0.5.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@6.0.3))(typescript@6.0.3))(@types/pg@8.20.0)(expo-sqlite@55.0.16(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@18.3.1))(react@18.3.1))(kysely@0.28.17)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.7)(prisma@7.8.0(@types/react-dom@18.3.5(@types/react@19.2.15))(@types/react@19.2.15)(magicast@0.5.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@6.0.3))
       eventemitter3:
         specifier: ^5.0.1
         version: 5.0.4
@@ -1265,6 +1265,34 @@ importers:
       shared:
         specifier: workspace:*
         version: link:../shared
+      typescript:
+        specifier: ~6.0.2
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.6
+        version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0))
+
+  packages/zero-permissions:
+    dependencies:
+      shared:
+        specifier: workspace:*
+        version: link:../shared
+      zero-protocol:
+        specifier: workspace:*
+        version: link:../zero-protocol
+      zero-schema:
+        specifier: workspace:*
+        version: link:../zero-schema
+      zero-types:
+        specifier: workspace:*
+        version: link:../zero-types
+      zql:
+        specifier: workspace:*
+        version: link:../zql
+    devDependencies:
+      oxfmt:
+        specifier: ^0.45.0
+        version: 0.45.0
       typescript:
         specifier: ~6.0.2
         version: 6.0.3
@@ -3739,16 +3767,9 @@ packages:
   '@expo/metro@55.1.1':
     resolution: {integrity: sha512-/wfXo5hTuAVpVLG/4hzlmD9NBGJkzkmBEMm/4VICajYRbj7y8OmqqPWbbymzHiBiHB6tI9BnsyXpQM6zVZEECg==}
 
-  '@expo/osascript@2.4.3':
-    resolution: {integrity: sha512-wbuj3EebM7W9hN/Wp4xTzKd6rQ2zKJzAxkFxkOOwyysLp0HOAgQ4/5RINyoS241pZUX2rUHq7mAJ7pcCQ8U0Ow==}
-    engines: {node: '>=12'}
-
   '@expo/osascript@2.6.0':
     resolution: {integrity: sha512-QvqDBlJXa8CS2vRORJ4wEflY1m0vVI07uSJdIRgBrLxRPBcsrXxrtU7+wXRXMqfq9zLwNP9XbvRsXF2omoDylg==}
     engines: {node: '>=12'}
-
-  '@expo/package-manager@1.10.5':
-    resolution: {integrity: sha512-nCP9Mebfl3jvOr0/P6VAuyah6PAtun+aihIL2zAtuE8uSe94JWkVZ7051i0MUVO+y3gFpBqnr8IIH5ch+VJjHA==}
 
   '@expo/package-manager@1.12.0':
     resolution: {integrity: sha512-SWr6093nwBjn94cvElsYZNUnhvs+XtUatUz3h0vAn0IbaWG0B6l/V5ZfOBptX/xq6rMpFG5ibIf/eckLSXw8Gg==}
@@ -3767,28 +3788,6 @@ packages:
       typescript: ^5.0.0 || ^5.0.0-0
     peerDependenciesMeta:
       typescript:
-        optional: true
-
-  '@expo/router-server@55.0.16':
-    resolution: {integrity: sha512-LvAdrm039nQBG+95+ff5Rc4CsBuoc/giDhjQrgxB9lKJqC/ZTq1xbwfEZFNq6yokX6fOCs/vlxdhmSkOjMIrvg==}
-    peerDependencies:
-      '@expo/metro-runtime': ^55.0.11
-      expo: '*'
-      expo-constants: ^55.0.16
-      expo-font: ^55.0.7
-      expo-router: '*'
-      expo-server: ^55.0.9
-      react: '*'
-      react-dom: '*'
-      react-server-dom-webpack: ~19.0.1 || ~19.1.2 || ~19.2.1
-    peerDependenciesMeta:
-      '@expo/metro-runtime':
-        optional: true
-      expo-router:
-        optional: true
-      react-dom:
-        optional: true
-      react-server-dom-webpack:
         optional: true
 
   '@expo/router-server@55.0.17':
@@ -3818,10 +3817,6 @@ packages:
 
   '@expo/sdk-runtime-versions@1.0.0':
     resolution: {integrity: sha512-Doz2bfiPndXYFPMRwPyGa1k5QaKDVpY806UJj570epIiMzWaYyCtobasyfC++qfIXVb5Ocy7r3tP9d62hAQ7IQ==}
-
-  '@expo/spawn-async@1.7.2':
-    resolution: {integrity: sha512-QdWi16+CHB9JYP7gma19OVVg0BFkvU8zNj9GjWorYI8Iv8FUxjOCcYRuAmX4s/h91e4e7BPsskc8cSrZYho9Ew==}
-    engines: {node: '>=12'}
 
   '@expo/spawn-async@1.8.0':
     resolution: {integrity: sha512-eb9xxd/LbuEGSdua4NumCu/McVB9EM+F/JxB9pWgnERw4HQ9XyTNH1KapG6oqLWR8TuRK2LQfzJlmNi94CVobw==}
@@ -6229,9 +6224,6 @@ packages:
   '@types/react@18.3.28':
     resolution: {integrity: sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==}
 
-  '@types/react@19.2.14':
-    resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
-
   '@types/react@19.2.15':
     resolution: {integrity: sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==}
 
@@ -6748,21 +6740,6 @@ packages:
 
   babel-plugin-transform-flow-enums@0.0.2:
     resolution: {integrity: sha512-g4aaCrDDOsWjbm0PUUeVnkcVd6AKJsVc/MbnPhEotEpkeJQP6b8nzewohQi7+QS8UyPehOhGWn0nOwjvWpmMvQ==}
-
-  babel-preset-expo@55.0.21:
-    resolution: {integrity: sha512-anXoUZBcxydLdVs2L+r3bWKGUvZv2FtgOl8xRJ12i/YfKICBpwTGZWSTiEYTqBByZ6GkA3mE9+3TW97X2ocFTQ==}
-    peerDependencies:
-      '@babel/runtime': ^7.20.0
-      expo: '*'
-      expo-widgets: ^55.0.17
-      react-refresh: '>=0.14.0 <1.0.0'
-    peerDependenciesMeta:
-      '@babel/runtime':
-        optional: true
-      expo:
-        optional: true
-      expo-widgets:
-        optional: true
 
   babel-preset-expo@55.0.22:
     resolution: {integrity: sha512-Se6kPnvCNN13jJVIa6JJvlmImVoVRzu9stagAbivCPcfrq2VNrsEiYpJZ1+H32kXinKW/y797/wctGuxPy0APw==}
@@ -8166,23 +8143,10 @@ packages:
       expo: '*'
       react-native: '*'
 
-  expo-file-system@55.0.20:
-    resolution: {integrity: sha512-sBCHhNlCT3EiqCcE6xSbyvOLUAlKx7+p0qjo+c+UPyC/gMrXUdva99g25uptM+fEMwy2co25MUQQ0U0guQLOQA==}
-    peerDependencies:
-      expo: '*'
-      react-native: '*'
-
   expo-file-system@55.0.21:
     resolution: {integrity: sha512-+qGqMGufxDRzWs3RiH1qzHwxWfl8sd6B82pydTf4GwU8ciyQ84u0XVuliAxAAk4iCGf537nzPeCSgl7eLeBxFg==}
     peerDependencies:
       expo: '*'
-      react-native: '*'
-
-  expo-font@55.0.7:
-    resolution: {integrity: sha512-oH39Xb+3i6Y69b7YRP+P+5WLx7621t+ep/RAgLwJJYpTjs7CnSohUG+873rEtqsTAuQGi63ms7x9ZeHj1E9LYw==}
-    peerDependencies:
-      expo: '*'
-      react: '*'
       react-native: '*'
 
   expo-font@55.0.8:
@@ -8214,10 +8178,6 @@ packages:
 
   expo-server@55.0.10:
     resolution: {integrity: sha512-EcCiV902fTP45fbzbZE0VJEqQ50a3mxnKKAccg2RoQGddTJisePh+QREaoeliyT45s8BiF0TworWKyImqzsdhg==}
-    engines: {node: '>=20.16.0'}
-
-  expo-server@55.0.9:
-    resolution: {integrity: sha512-N5Ipn1NwqaJzEm+G97o0Jbe4g/th3R/16N1DabnYryXKCiZwDkK13/w3VfGkQN9LOOaBP+JIRxGf4M8lQKPzyA==}
     engines: {node: '>=20.16.0'}
 
   expo-sqlite@55.0.16:
@@ -14290,10 +14250,10 @@ snapshots:
       '@csstools/utilities': 2.0.0(postcss@8.5.14)
       postcss: 8.5.14
 
-  '@csstools/postcss-cascade-layers@1.1.1(postcss@8.5.14)':
+  '@csstools/postcss-cascade-layers@1.1.1(postcss@8.5.15)':
     dependencies:
       '@csstools/selector-specificity': 2.2.0(postcss-selector-parser@6.1.2)
-      postcss: 8.5.14
+      postcss: 8.5.15
       postcss-selector-parser: 6.1.2
 
   '@csstools/postcss-cascade-layers@5.0.2(postcss@8.5.14)':
@@ -14311,10 +14271,10 @@ snapshots:
       '@csstools/utilities': 2.0.0(postcss@8.5.14)
       postcss: 8.5.14
 
-  '@csstools/postcss-color-function@1.1.1(postcss@8.5.14)':
+  '@csstools/postcss-color-function@1.1.1(postcss@8.5.15)':
     dependencies:
-      '@csstools/postcss-progressive-custom-properties': 1.3.0(postcss@8.5.14)
-      postcss: 8.5.14
+      '@csstools/postcss-progressive-custom-properties': 1.3.0(postcss@8.5.15)
+      postcss: 8.5.15
       postcss-value-parser: 4.2.0
 
   '@csstools/postcss-color-function@4.0.12(postcss@8.5.14)':
@@ -14368,9 +14328,9 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
       postcss: 8.5.14
 
-  '@csstools/postcss-font-format-keywords@1.0.1(postcss@8.5.14)':
+  '@csstools/postcss-font-format-keywords@1.0.1(postcss@8.5.15)':
     dependencies:
-      postcss: 8.5.14
+      postcss: 8.5.15
       postcss-value-parser: 4.2.0
 
   '@csstools/postcss-font-format-keywords@4.0.0(postcss@8.5.14)':
@@ -14395,9 +14355,9 @@ snapshots:
       '@csstools/utilities': 2.0.0(postcss@8.5.14)
       postcss: 8.5.14
 
-  '@csstools/postcss-hwb-function@1.0.2(postcss@8.5.14)':
+  '@csstools/postcss-hwb-function@1.0.2(postcss@8.5.15)':
     dependencies:
-      postcss: 8.5.14
+      postcss: 8.5.15
       postcss-value-parser: 4.2.0
 
   '@csstools/postcss-hwb-function@4.0.12(postcss@8.5.14)':
@@ -14409,10 +14369,10 @@ snapshots:
       '@csstools/utilities': 2.0.0(postcss@8.5.14)
       postcss: 8.5.14
 
-  '@csstools/postcss-ic-unit@1.0.1(postcss@8.5.14)':
+  '@csstools/postcss-ic-unit@1.0.1(postcss@8.5.15)':
     dependencies:
-      '@csstools/postcss-progressive-custom-properties': 1.3.0(postcss@8.5.14)
-      postcss: 8.5.14
+      '@csstools/postcss-progressive-custom-properties': 1.3.0(postcss@8.5.15)
+      postcss: 8.5.15
       postcss-value-parser: 4.2.0
 
   '@csstools/postcss-ic-unit@4.0.4(postcss@8.5.14)':
@@ -14426,10 +14386,10 @@ snapshots:
     dependencies:
       postcss: 8.5.14
 
-  '@csstools/postcss-is-pseudo-class@2.0.7(postcss@8.5.14)':
+  '@csstools/postcss-is-pseudo-class@2.0.7(postcss@8.5.15)':
     dependencies:
       '@csstools/selector-specificity': 2.2.0(postcss-selector-parser@6.1.2)
-      postcss: 8.5.14
+      postcss: 8.5.15
       postcss-selector-parser: 6.1.2
 
   '@csstools/postcss-is-pseudo-class@5.0.3(postcss@8.5.14)':
@@ -14484,9 +14444,9 @@ snapshots:
       '@csstools/media-query-list-parser': 4.0.3(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       postcss: 8.5.14
 
-  '@csstools/postcss-nested-calc@1.0.0(postcss@8.5.14)':
+  '@csstools/postcss-nested-calc@1.0.0(postcss@8.5.15)':
     dependencies:
-      postcss: 8.5.14
+      postcss: 8.5.15
       postcss-value-parser: 4.2.0
 
   '@csstools/postcss-nested-calc@4.0.0(postcss@8.5.14)':
@@ -14495,9 +14455,9 @@ snapshots:
       postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
-  '@csstools/postcss-normalize-display-values@1.0.1(postcss@8.5.14)':
+  '@csstools/postcss-normalize-display-values@1.0.1(postcss@8.5.15)':
     dependencies:
-      postcss: 8.5.14
+      postcss: 8.5.15
       postcss-value-parser: 4.2.0
 
   '@csstools/postcss-normalize-display-values@4.0.1(postcss@8.5.14)':
@@ -14505,10 +14465,10 @@ snapshots:
       postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
-  '@csstools/postcss-oklab-function@1.1.1(postcss@8.5.14)':
+  '@csstools/postcss-oklab-function@1.1.1(postcss@8.5.15)':
     dependencies:
-      '@csstools/postcss-progressive-custom-properties': 1.3.0(postcss@8.5.14)
-      postcss: 8.5.14
+      '@csstools/postcss-progressive-custom-properties': 1.3.0(postcss@8.5.15)
+      postcss: 8.5.15
       postcss-value-parser: 4.2.0
 
   '@csstools/postcss-oklab-function@4.0.12(postcss@8.5.14)':
@@ -14524,9 +14484,9 @@ snapshots:
     dependencies:
       postcss: 8.5.14
 
-  '@csstools/postcss-progressive-custom-properties@1.3.0(postcss@8.5.14)':
+  '@csstools/postcss-progressive-custom-properties@1.3.0(postcss@8.5.15)':
     dependencies:
-      postcss: 8.5.14
+      postcss: 8.5.15
       postcss-value-parser: 4.2.0
 
   '@csstools/postcss-progressive-custom-properties@4.2.1(postcss@8.5.14)':
@@ -14568,9 +14528,9 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
       postcss: 8.5.14
 
-  '@csstools/postcss-stepped-value-functions@1.0.1(postcss@8.5.14)':
+  '@csstools/postcss-stepped-value-functions@1.0.1(postcss@8.5.15)':
     dependencies:
-      postcss: 8.5.14
+      postcss: 8.5.15
       postcss-value-parser: 4.2.0
 
   '@csstools/postcss-stepped-value-functions@4.0.9(postcss@8.5.14)':
@@ -14591,9 +14551,9 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
       postcss: 8.5.14
 
-  '@csstools/postcss-text-decoration-shorthand@1.0.0(postcss@8.5.14)':
+  '@csstools/postcss-text-decoration-shorthand@1.0.0(postcss@8.5.15)':
     dependencies:
-      postcss: 8.5.14
+      postcss: 8.5.15
       postcss-value-parser: 4.2.0
 
   '@csstools/postcss-text-decoration-shorthand@4.0.3(postcss@8.5.14)':
@@ -14602,9 +14562,9 @@ snapshots:
       postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
-  '@csstools/postcss-trigonometric-functions@1.0.2(postcss@8.5.14)':
+  '@csstools/postcss-trigonometric-functions@1.0.2(postcss@8.5.15)':
     dependencies:
-      postcss: 8.5.14
+      postcss: 8.5.15
       postcss-value-parser: 4.2.0
 
   '@csstools/postcss-trigonometric-functions@4.0.9(postcss@8.5.14)':
@@ -14614,9 +14574,9 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
       postcss: 8.5.14
 
-  '@csstools/postcss-unset-value@1.0.2(postcss@8.5.14)':
+  '@csstools/postcss-unset-value@1.0.2(postcss@8.5.15)':
     dependencies:
-      postcss: 8.5.14
+      postcss: 8.5.15
 
   '@csstools/postcss-unset-value@4.0.0(postcss@8.5.14)':
     dependencies:
@@ -15823,7 +15783,7 @@ snapshots:
       '@mdx-js/mdx': 3.1.1
       '@types/history': 4.7.11
       '@types/mdast': 4.0.4
-      '@types/react': 19.2.15
+      '@types/react': 18.3.28
       commander: 5.1.0
       joi: 17.13.3
       react: 18.3.1
@@ -16275,82 +16235,6 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@expo/cli@55.0.30(@expo/dom-webview@55.0.6)(expo-constants@55.0.16(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1)))(expo-font@55.0.7(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1))(react@18.3.1))(expo@55.0.24)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1))(react@18.3.1)(typescript@6.0.3)':
-    dependencies:
-      '@expo/code-signing-certificates': 0.0.6
-      '@expo/config': 55.0.17(typescript@6.0.3)
-      '@expo/config-plugins': 55.0.9
-      '@expo/devcert': 1.2.1
-      '@expo/env': 2.1.2
-      '@expo/image-utils': 0.8.14(typescript@6.0.3)
-      '@expo/json-file': 10.0.14
-      '@expo/log-box': 55.0.12(@expo/dom-webview@55.0.6)(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1))(react@18.3.1)
-      '@expo/metro': 55.1.1
-      '@expo/metro-config': 55.0.21(expo@55.0.24)(typescript@6.0.3)
-      '@expo/osascript': 2.4.3
-      '@expo/package-manager': 1.10.5
-      '@expo/plist': 0.5.3
-      '@expo/prebuild-config': 55.0.18(expo@55.0.24)(typescript@6.0.3)
-      '@expo/require-utils': 55.0.5(typescript@6.0.3)
-      '@expo/router-server': 55.0.16(expo-constants@55.0.16(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1)))(expo-font@55.0.7(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1))(react@18.3.1))(expo-server@55.0.9)(expo@55.0.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@expo/schema-utils': 55.0.4
-      '@expo/spawn-async': 1.7.2
-      '@expo/ws-tunnel': 1.0.6
-      '@expo/xcpretty': 4.4.4
-      '@react-native/dev-middleware': 0.83.6
-      accepts: 1.3.8
-      arg: 5.0.2
-      better-opn: 3.0.2
-      bplist-creator: 0.1.0
-      bplist-parser: 0.3.2
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      compression: 1.8.1
-      connect: 3.7.0
-      debug: 4.4.3
-      dnssd-advertise: 1.1.4
-      expo: 55.0.24(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1))(react@18.3.1)(typescript@6.0.3)
-      expo-server: 55.0.9
-      fetch-nodeshim: 0.4.10
-      getenv: 2.0.0
-      glob: 13.0.6
-      lan-network: 0.2.1
-      multitars: 1.0.0
-      node-forge: 1.4.0
-      npm-package-arg: 11.0.3
-      ora: 3.4.0
-      picomatch: 4.0.4
-      pretty-format: 29.7.0
-      progress: 2.0.3
-      prompts: 2.4.2
-      resolve-from: 5.0.0
-      semver: 7.8.0
-      send: 0.19.2
-      slugify: 1.6.9
-      source-map-support: 0.5.21
-      stacktrace-parser: 0.1.11
-      structured-headers: 0.4.1
-      terminal-link: 2.1.1
-      toqr: 0.1.1
-      wrap-ansi: 7.0.0
-      ws: 8.20.1
-      zod: 3.25.76
-    optionalDependencies:
-      react-native: 0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1)
-    transitivePeerDependencies:
-      - '@expo/dom-webview'
-      - '@expo/metro-runtime'
-      - bufferutil
-      - expo-constants
-      - expo-font
-      - react
-      - react-dom
-      - react-server-dom-webpack
-      - supports-color
-      - typescript
-      - utf-8-validate
-    optional: true
-
   '@expo/cli@55.0.30(@expo/dom-webview@55.0.6)(expo-constants@55.0.16(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@18.3.1)))(expo-font@55.0.8(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@18.3.1))(react@18.3.1))(expo@55.0.24)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@18.3.1))(react@18.3.1)(typescript@6.0.3)':
     dependencies:
       '@expo/code-signing-certificates': 0.0.6
@@ -16480,14 +16364,6 @@ snapshots:
       react: 18.3.1
       react-native: 0.85.3(@babel/core@7.29.0)(@types/react@18.3.28)(react@18.3.1)
 
-  '@expo/devtools@55.0.3(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      chalk: 4.1.2
-    optionalDependencies:
-      react: 18.3.1
-      react-native: 0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1)
-    optional: true
-
   '@expo/devtools@55.0.3(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@18.3.1))(react@18.3.1)':
     dependencies:
       chalk: 4.1.2
@@ -16500,13 +16376,6 @@ snapshots:
       expo: 55.0.24(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)(typescript@6.0.3)
       react: 18.3.1
       react-native: 0.85.3(@babel/core@7.29.0)(@types/react@18.3.28)(react@18.3.1)
-
-  '@expo/dom-webview@55.0.6(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      expo: 55.0.24(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1))(react@18.3.1)(typescript@6.0.3)
-      react: 18.3.1
-      react-native: 0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1)
-    optional: true
 
   '@expo/dom-webview@55.0.6(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -16586,16 +16455,6 @@ snapshots:
       react-native: 0.85.3(@babel/core@7.29.0)(@types/react@18.3.28)(react@18.3.1)
       stacktrace-parser: 0.1.11
 
-  '@expo/log-box@55.0.12(@expo/dom-webview@55.0.6)(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@expo/dom-webview': 55.0.6(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1))(react@18.3.1)
-      anser: 1.4.10
-      expo: 55.0.24(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1))(react@18.3.1)(typescript@6.0.3)
-      react: 18.3.1
-      react-native: 0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1)
-      stacktrace-parser: 0.1.11
-    optional: true
-
   '@expo/log-box@55.0.12(@expo/dom-webview@55.0.6)(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@expo/dom-webview': 55.0.6(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@18.3.1))(react@18.3.1)
@@ -16655,24 +16514,9 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@expo/osascript@2.4.3':
-    dependencies:
-      '@expo/spawn-async': 1.7.2
-    optional: true
-
   '@expo/osascript@2.6.0':
     dependencies:
       '@expo/spawn-async': 1.8.0
-
-  '@expo/package-manager@1.10.5':
-    dependencies:
-      '@expo/json-file': 10.0.14
-      '@expo/spawn-async': 1.7.2
-      chalk: 4.1.2
-      npm-package-arg: 11.0.3
-      ora: 3.4.0
-      resolve-workspace-root: 2.0.1
-    optional: true
 
   '@expo/package-manager@1.12.0':
     dependencies:
@@ -16716,20 +16560,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@expo/router-server@55.0.16(expo-constants@55.0.16(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1)))(expo-font@55.0.7(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1))(react@18.3.1))(expo-server@55.0.9)(expo@55.0.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      debug: 4.4.3
-      expo: 55.0.24(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1))(react@18.3.1)(typescript@6.0.3)
-      expo-constants: 55.0.16(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1))
-      expo-font: 55.0.7(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1))(react@18.3.1)
-      expo-server: 55.0.9
-      react: 18.3.1
-    optionalDependencies:
-      react-dom: 18.3.1(react@18.3.1)
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   '@expo/router-server@55.0.17(expo-constants@55.0.16(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@18.3.28)(react@18.3.1)))(expo-font@55.0.8(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(expo-server@55.0.10)(expo@55.0.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       debug: 4.4.3
@@ -16760,23 +16590,11 @@ snapshots:
 
   '@expo/sdk-runtime-versions@1.0.0': {}
 
-  '@expo/spawn-async@1.7.2':
-    dependencies:
-      cross-spawn: 7.0.6
-    optional: true
-
   '@expo/spawn-async@1.8.0':
     dependencies:
       cross-spawn: 7.0.6
 
   '@expo/sudo-prompt@9.3.2': {}
-
-  '@expo/vector-icons@15.1.1(expo-font@55.0.7(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1))(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      expo-font: 55.0.7(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1))(react@18.3.1)
-      react: 18.3.1
-      react-native: 0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1)
-    optional: true
 
   '@expo/vector-icons@15.1.1(expo-font@55.0.8(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -17344,12 +17162,6 @@ snapshots:
     dependencies:
       react: 18.3.1
       react-native: 0.85.3(@babel/core@7.29.0)(@types/react@18.3.28)(react@18.3.1)
-    optional: true
-
-  '@op-engineering/op-sqlite@15.2.14(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      react: 18.3.1
-      react-native: 0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1)
     optional: true
 
   '@op-engineering/op-sqlite@15.2.14(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@18.3.1))(react@18.3.1)':
@@ -18470,14 +18282,6 @@ snapshots:
       typescript: 6.0.3
     optional: true
 
-  '@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@18.3.5(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@6.0.3))(typescript@6.0.3)':
-    dependencies:
-      '@prisma/client-runtime-utils': 7.8.0
-    optionalDependencies:
-      prisma: 7.8.0(@types/react-dom@18.3.5(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@6.0.3)
-      typescript: 6.0.3
-    optional: true
-
   '@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@18.3.5(@types/react@19.2.15))(@types/react@19.2.15)(magicast@0.5.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@6.0.3))(typescript@6.0.3)':
     dependencies:
       '@prisma/client-runtime-utils': 7.8.0
@@ -18567,17 +18371,6 @@ snapshots:
       - '@types/react-dom'
     optional: true
 
-  '@prisma/studio-core@0.27.3(@types/react-dom@18.3.5(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@radix-ui/react-toggle': 1.1.10(@types/react-dom@18.3.5(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@types/react': 19.2.14
-      chart.js: 4.5.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-    transitivePeerDependencies:
-      - '@types/react-dom'
-    optional: true
-
   '@prisma/studio-core@0.27.3(@types/react-dom@18.3.5(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-toggle': 1.1.10(@types/react-dom@18.3.5(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -18620,13 +18413,6 @@ snapshots:
       '@types/react': 18.3.28
     optional: true
 
-  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.14)(react@18.3.1)':
-    dependencies:
-      react: 18.3.1
-    optionalDependencies:
-      '@types/react': 19.2.14
-    optional: true
-
   '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.15)(react@18.3.1)':
     dependencies:
       react: 18.3.1
@@ -18641,16 +18427,6 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.5(@types/react@18.3.28)
-    optional: true
-
-  '@radix-ui/react-primitive@2.1.3(@types/react-dom@18.3.5(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-    optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 18.3.5(@types/react@19.2.14)
     optional: true
 
   '@radix-ui/react-primitive@2.1.3(@types/react-dom@18.3.5(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
@@ -18670,14 +18446,6 @@ snapshots:
       '@types/react': 18.3.28
     optional: true
 
-  '@radix-ui/react-slot@1.2.3(@types/react@19.2.14)(react@18.3.1)':
-    dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@18.3.1)
-      react: 18.3.1
-    optionalDependencies:
-      '@types/react': 19.2.14
-    optional: true
-
   '@radix-ui/react-slot@1.2.3(@types/react@19.2.15)(react@18.3.1)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.15)(react@18.3.1)
@@ -18695,18 +18463,6 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.5(@types/react@18.3.28)
-    optional: true
-
-  '@radix-ui/react-toggle@1.1.10(@types/react-dom@18.3.5(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.5(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-    optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 18.3.5(@types/react@19.2.14)
     optional: true
 
   '@radix-ui/react-toggle@1.1.10(@types/react-dom@18.3.5(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
@@ -18729,15 +18485,6 @@ snapshots:
       '@types/react': 18.3.28
     optional: true
 
-  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.14)(react@18.3.1)':
-    dependencies:
-      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.14)(react@18.3.1)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@18.3.1)
-      react: 18.3.1
-    optionalDependencies:
-      '@types/react': 19.2.14
-    optional: true
-
   '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.15)(react@18.3.1)':
     dependencies:
       '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.15)(react@18.3.1)
@@ -18754,14 +18501,6 @@ snapshots:
       '@types/react': 18.3.28
     optional: true
 
-  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.14)(react@18.3.1)':
-    dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@18.3.1)
-      react: 18.3.1
-    optionalDependencies:
-      '@types/react': 19.2.14
-    optional: true
-
   '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.15)(react@18.3.1)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.15)(react@18.3.1)
@@ -18774,13 +18513,6 @@ snapshots:
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.28
-    optional: true
-
-  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.14)(react@18.3.1)':
-    dependencies:
-      react: 18.3.1
-    optionalDependencies:
-      '@types/react': 19.2.14
     optional: true
 
   '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.15)(react@18.3.1)':
@@ -18969,16 +18701,6 @@ snapshots:
       react-native: 0.85.3(@babel/core@7.29.0)(@types/react@18.3.28)(react@18.3.1)
     optionalDependencies:
       '@types/react': 18.3.28
-
-  '@react-native/virtualized-lists@0.85.3(@types/react@19.2.14)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      invariant: 2.2.4
-      nullthrows: 1.1.1
-      react: 18.3.1
-      react-native: 0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1)
-    optionalDependencies:
-      '@types/react': 19.2.14
-    optional: true
 
   '@react-native/virtualized-lists@0.85.3(@types/react@19.2.15)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -19635,11 +19357,6 @@ snapshots:
     dependencies:
       '@types/react': 18.3.28
 
-  '@types/react-dom@18.3.5(@types/react@19.2.14)':
-    dependencies:
-      '@types/react': 19.2.14
-    optional: true
-
   '@types/react-dom@18.3.5(@types/react@19.2.15)':
     dependencies:
       '@types/react': 19.2.15
@@ -19666,11 +19383,6 @@ snapshots:
     dependencies:
       '@types/prop-types': 15.7.15
       csstype: 3.2.3
-
-  '@types/react@19.2.14':
-    dependencies:
-      csstype: 3.2.3
-    optional: true
 
   '@types/react@19.2.15':
     dependencies:
@@ -20235,6 +19947,15 @@ snapshots:
       postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
+  autoprefixer@10.5.0(postcss@8.5.15):
+    dependencies:
+      browserslist: 4.28.2
+      caniuse-lite: 1.0.30001792
+      fraction.js: 5.3.4
+      picocolors: 1.1.1
+      postcss: 8.5.15
+      postcss-value-parser: 4.2.0
+
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
@@ -20327,40 +20048,6 @@ snapshots:
       '@babel/plugin-syntax-flow': 7.28.6(@babel/core@7.29.0)
     transitivePeerDependencies:
       - '@babel/core'
-
-  babel-preset-expo@55.0.21(@babel/core@7.29.0)(@babel/runtime@7.29.2)(expo@55.0.24)(react-refresh@0.14.2):
-    dependencies:
-      '@babel/generator': 7.29.1
-      '@babel/helper-module-imports': 7.28.6
-      '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
-      '@babel/plugin-proposal-export-default-from': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-syntax-export-default-from': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-class-static-block': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-flow-strip-types': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-object-rest-spread': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-private-methods': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-private-property-in-object': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-runtime': 7.29.0(@babel/core@7.29.0)
-      '@babel/preset-react': 7.28.5(@babel/core@7.29.0)
-      '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
-      '@react-native/babel-preset': 0.83.6(@babel/core@7.29.0)
-      babel-plugin-react-compiler: 1.0.0
-      babel-plugin-react-native-web: 0.21.2
-      babel-plugin-syntax-hermes-parser: 0.32.1
-      babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.29.0)
-      debug: 4.4.3
-      react-refresh: 0.14.2
-      resolve-from: 5.0.0
-    optionalDependencies:
-      '@babel/runtime': 7.29.2
-      expo: 55.0.24(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)(typescript@6.0.3)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
-    optional: true
 
   babel-preset-expo@55.0.22(@babel/core@7.29.0)(@babel/runtime@7.29.2)(expo@55.0.24)(react-refresh@0.14.2):
     dependencies:
@@ -21054,9 +20741,9 @@ snapshots:
     dependencies:
       type-fest: 1.4.0
 
-  css-blank-pseudo@3.0.3(postcss@8.5.14):
+  css-blank-pseudo@3.0.3(postcss@8.5.15):
     dependencies:
-      postcss: 8.5.14
+      postcss: 8.5.15
       postcss-selector-parser: 6.1.2
 
   css-blank-pseudo@7.0.1(postcss@8.5.14):
@@ -21068,9 +20755,9 @@ snapshots:
     dependencies:
       postcss: 8.5.14
 
-  css-has-pseudo@3.0.4(postcss@8.5.14):
+  css-has-pseudo@3.0.4(postcss@8.5.15):
     dependencies:
-      postcss: 8.5.14
+      postcss: 8.5.15
       postcss-selector-parser: 6.1.2
 
   css-has-pseudo@7.0.3(postcss@8.5.14):
@@ -21110,9 +20797,9 @@ snapshots:
     dependencies:
       postcss: 8.5.14
 
-  css-prefers-color-scheme@6.0.3(postcss@8.5.14):
+  css-prefers-color-scheme@6.0.3(postcss@8.5.15):
     dependencies:
-      postcss: 8.5.14
+      postcss: 8.5.15
 
   css-select@4.3.0:
     dependencies:
@@ -21465,20 +21152,6 @@ snapshots:
       postgres: 3.4.7
       prisma: 7.8.0(@types/react-dom@18.3.5(@types/react@18.3.28))(@types/react@18.3.28)(magicast@0.5.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@6.0.3)
 
-  drizzle-orm@0.45.2(@electric-sql/pglite@0.4.1)(@op-engineering/op-sqlite@15.2.14(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1))(react@18.3.1))(@opentelemetry/api@1.9.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@18.3.5(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@6.0.3))(typescript@6.0.3))(@types/pg@8.20.0)(expo-sqlite@55.0.16(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1))(react@18.3.1))(kysely@0.28.17)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.7)(prisma@7.8.0(@types/react-dom@18.3.5(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@6.0.3)):
-    optionalDependencies:
-      '@electric-sql/pglite': 0.4.1
-      '@op-engineering/op-sqlite': 15.2.14(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1))(react@18.3.1)
-      '@opentelemetry/api': 1.9.1
-      '@prisma/client': 7.8.0(prisma@7.8.0(@types/react-dom@18.3.5(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@6.0.3))(typescript@6.0.3)
-      '@types/pg': 8.20.0
-      expo-sqlite: 55.0.16(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1))(react@18.3.1)
-      kysely: 0.28.17
-      mysql2: 3.15.3
-      pg: 8.20.0
-      postgres: 3.4.7
-      prisma: 7.8.0(@types/react-dom@18.3.5(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@6.0.3)
-
   drizzle-orm@0.45.2(@electric-sql/pglite@0.4.1)(@op-engineering/op-sqlite@15.2.14(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@18.3.1))(react@18.3.1))(@opentelemetry/api@1.9.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@18.3.5(@types/react@19.2.15))(@types/react@19.2.15)(magicast@0.5.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@6.0.3))(typescript@6.0.3))(@types/pg@8.20.0)(expo-sqlite@55.0.16(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@18.3.1))(react@18.3.1))(kysely@0.28.17)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.7)(prisma@7.8.0(@types/react-dom@18.3.5(@types/react@19.2.15))(@types/react@19.2.15)(magicast@0.5.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@6.0.3)):
     optionalDependencies:
       '@electric-sql/pglite': 0.4.1
@@ -21761,18 +21434,6 @@ snapshots:
       - supports-color
       - typescript
 
-  expo-asset@55.0.17(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1))(react@18.3.1)(typescript@6.0.3):
-    dependencies:
-      '@expo/image-utils': 0.8.14(typescript@6.0.3)
-      expo: 55.0.24(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1))(react@18.3.1)(typescript@6.0.3)
-      expo-constants: 55.0.16(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1))
-      react: 18.3.1
-      react-native: 0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1)
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    optional: true
-
   expo-asset@55.0.17(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@18.3.1))(react@18.3.1)(typescript@6.0.3):
     dependencies:
       '@expo/image-utils': 0.8.14(typescript@6.0.3)
@@ -21792,15 +21453,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  expo-constants@55.0.16(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1)):
-    dependencies:
-      '@expo/env': 2.1.2
-      expo: 55.0.24(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1))(react@18.3.1)(typescript@6.0.3)
-      react-native: 0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1)
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   expo-constants@55.0.16(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@18.3.1)):
     dependencies:
       '@expo/env': 2.1.2
@@ -21808,12 +21460,6 @@ snapshots:
       react-native: 0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@18.3.1)
     transitivePeerDependencies:
       - supports-color
-
-  expo-file-system@55.0.20(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1)):
-    dependencies:
-      expo: 55.0.24(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1))(react@18.3.1)(typescript@6.0.3)
-      react-native: 0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1)
-    optional: true
 
   expo-file-system@55.0.21(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@18.3.28)(react@18.3.1)):
     dependencies:
@@ -21824,14 +21470,6 @@ snapshots:
     dependencies:
       expo: 55.0.24(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@18.3.1))(react@18.3.1)(typescript@6.0.3)
       react-native: 0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@18.3.1)
-
-  expo-font@55.0.7(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1))(react@18.3.1):
-    dependencies:
-      expo: 55.0.24(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1))(react@18.3.1)(typescript@6.0.3)
-      fontfaceobserver: 2.3.0
-      react: 18.3.1
-      react-native: 0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1)
-    optional: true
 
   expo-font@55.0.8(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@18.3.28)(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -21868,13 +21506,6 @@ snapshots:
       react: 18.3.1
       react-native: 0.85.3(@babel/core@7.29.0)(@types/react@18.3.28)(react@18.3.1)
 
-  expo-modules-core@55.0.25(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1))(react@18.3.1):
-    dependencies:
-      invariant: 2.2.4
-      react: 18.3.1
-      react-native: 0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1)
-    optional: true
-
   expo-modules-core@55.0.25(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@18.3.1))(react@18.3.1):
     dependencies:
       invariant: 2.2.4
@@ -21883,23 +21514,12 @@ snapshots:
 
   expo-server@55.0.10: {}
 
-  expo-server@55.0.9:
-    optional: true
-
   expo-sqlite@55.0.16(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@18.3.28)(react@18.3.1))(react@18.3.1):
     dependencies:
       await-lock: 2.2.2
       expo: 55.0.24(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)(typescript@6.0.3)
       react: 18.3.1
       react-native: 0.85.3(@babel/core@7.29.0)(@types/react@18.3.28)(react@18.3.1)
-    optional: true
-
-  expo-sqlite@55.0.16(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1))(react@18.3.1):
-    dependencies:
-      await-lock: 2.2.2
-      expo: 55.0.24(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1))(react@18.3.1)(typescript@6.0.3)
-      react: 18.3.1
-      react-native: 0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1)
     optional: true
 
   expo-sqlite@55.0.16(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@18.3.1))(react@18.3.1):
@@ -21949,48 +21569,6 @@ snapshots:
       - supports-color
       - typescript
       - utf-8-validate
-
-  expo@55.0.24(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1))(react@18.3.1)(typescript@6.0.3):
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@expo/cli': 55.0.30(@expo/dom-webview@55.0.6)(expo-constants@55.0.16(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1)))(expo-font@55.0.7(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1))(react@18.3.1))(expo@55.0.24)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1))(react@18.3.1)(typescript@6.0.3)
-      '@expo/config': 55.0.17(typescript@6.0.3)
-      '@expo/config-plugins': 55.0.9
-      '@expo/devtools': 55.0.3(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1))(react@18.3.1)
-      '@expo/fingerprint': 0.16.7
-      '@expo/local-build-cache-provider': 55.0.13(typescript@6.0.3)
-      '@expo/log-box': 55.0.12(@expo/dom-webview@55.0.6)(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1))(react@18.3.1)
-      '@expo/metro': 55.1.1
-      '@expo/metro-config': 55.0.21(expo@55.0.24)(typescript@6.0.3)
-      '@expo/vector-icons': 15.1.1(expo-font@55.0.7(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1))(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1))(react@18.3.1)
-      '@ungap/structured-clone': 1.3.1
-      babel-preset-expo: 55.0.21(@babel/core@7.29.0)(@babel/runtime@7.29.2)(expo@55.0.24)(react-refresh@0.14.2)
-      expo-asset: 55.0.17(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1))(react@18.3.1)(typescript@6.0.3)
-      expo-constants: 55.0.16(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1))
-      expo-file-system: 55.0.20(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1))
-      expo-font: 55.0.7(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1))(react@18.3.1)
-      expo-keep-awake: 55.0.8(expo@55.0.24)(react@18.3.1)
-      expo-modules-autolinking: 55.0.22(typescript@6.0.3)
-      expo-modules-core: 55.0.25(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1))(react@18.3.1)
-      pretty-format: 29.7.0
-      react: 18.3.1
-      react-native: 0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1)
-      react-refresh: 0.14.2
-      whatwg-url-minimum: 0.1.2
-    optionalDependencies:
-      '@expo/dom-webview': 55.0.6(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1))(react@18.3.1)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - bufferutil
-      - expo-router
-      - expo-widgets
-      - react-dom
-      - react-native-worklets
-      - react-server-dom-webpack
-      - supports-color
-      - typescript
-      - utf-8-validate
-    optional: true
 
   expo@55.0.24(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@18.3.1(react@18.3.1))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@18.3.1))(react@18.3.1)(typescript@6.0.3):
     dependencies:
@@ -24968,9 +24546,9 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-attribute-case-insensitive@5.0.2(postcss@8.5.14):
+  postcss-attribute-case-insensitive@5.0.2(postcss@8.5.15):
     dependencies:
-      postcss: 8.5.14
+      postcss: 8.5.15
       postcss-selector-parser: 6.1.2
 
   postcss-attribute-case-insensitive@7.0.1(postcss@8.5.14):
@@ -24989,9 +24567,14 @@ snapshots:
       postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
-  postcss-color-functional-notation@4.2.4(postcss@8.5.14):
+  postcss-clamp@4.1.0(postcss@8.5.15):
     dependencies:
-      postcss: 8.5.14
+      postcss: 8.5.15
+      postcss-value-parser: 4.2.0
+
+  postcss-color-functional-notation@4.2.4(postcss@8.5.15):
+    dependencies:
+      postcss: 8.5.15
       postcss-value-parser: 4.2.0
 
   postcss-color-functional-notation@7.0.12(postcss@8.5.14):
@@ -25009,9 +24592,9 @@ snapshots:
       postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
-  postcss-color-hex-alpha@8.0.4(postcss@8.5.14):
+  postcss-color-hex-alpha@8.0.4(postcss@8.5.15):
     dependencies:
-      postcss: 8.5.14
+      postcss: 8.5.15
       postcss-value-parser: 4.2.0
 
   postcss-color-rebeccapurple@10.0.0(postcss@8.5.14):
@@ -25020,9 +24603,9 @@ snapshots:
       postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
-  postcss-color-rebeccapurple@7.1.1(postcss@8.5.14):
+  postcss-color-rebeccapurple@7.1.1(postcss@8.5.15):
     dependencies:
-      postcss: 8.5.14
+      postcss: 8.5.15
       postcss-value-parser: 4.2.0
 
   postcss-colormin@6.1.0(postcss@8.5.14):
@@ -25047,14 +24630,14 @@ snapshots:
       '@csstools/media-query-list-parser': 4.0.3(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       postcss: 8.5.14
 
-  postcss-custom-media@8.0.2(postcss@8.5.14):
+  postcss-custom-media@8.0.2(postcss@8.5.15):
     dependencies:
-      postcss: 8.5.14
+      postcss: 8.5.15
       postcss-value-parser: 4.2.0
 
-  postcss-custom-properties@12.1.11(postcss@8.5.14):
+  postcss-custom-properties@12.1.11(postcss@8.5.15):
     dependencies:
-      postcss: 8.5.14
+      postcss: 8.5.15
       postcss-value-parser: 4.2.0
 
   postcss-custom-properties@14.0.6(postcss@8.5.14):
@@ -25066,9 +24649,9 @@ snapshots:
       postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
-  postcss-custom-selectors@6.0.3(postcss@8.5.14):
+  postcss-custom-selectors@6.0.3(postcss@8.5.15):
     dependencies:
-      postcss: 8.5.14
+      postcss: 8.5.15
       postcss-selector-parser: 6.1.2
 
   postcss-custom-selectors@8.0.5(postcss@8.5.14):
@@ -25079,9 +24662,9 @@ snapshots:
       postcss: 8.5.14
       postcss-selector-parser: 7.1.1
 
-  postcss-dir-pseudo-class@6.0.5(postcss@8.5.14):
+  postcss-dir-pseudo-class@6.0.5(postcss@8.5.15):
     dependencies:
-      postcss: 8.5.14
+      postcss: 8.5.15
       postcss-selector-parser: 6.1.2
 
   postcss-dir-pseudo-class@9.0.1(postcss@8.5.14):
@@ -25110,10 +24693,10 @@ snapshots:
       postcss: 8.5.14
       postcss-selector-parser: 6.1.2
 
-  postcss-double-position-gradients@3.1.2(postcss@8.5.14):
+  postcss-double-position-gradients@3.1.2(postcss@8.5.15):
     dependencies:
-      '@csstools/postcss-progressive-custom-properties': 1.3.0(postcss@8.5.14)
-      postcss: 8.5.14
+      '@csstools/postcss-progressive-custom-properties': 1.3.0(postcss@8.5.15)
+      postcss: 8.5.15
       postcss-value-parser: 4.2.0
 
   postcss-double-position-gradients@6.0.4(postcss@8.5.14):
@@ -25123,9 +24706,9 @@ snapshots:
       postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
-  postcss-env-function@4.0.6(postcss@8.5.14):
+  postcss-env-function@4.0.6(postcss@8.5.15):
     dependencies:
-      postcss: 8.5.14
+      postcss: 8.5.15
       postcss-value-parser: 4.2.0
 
   postcss-focus-visible@10.0.1(postcss@8.5.14):
@@ -25133,14 +24716,14 @@ snapshots:
       postcss: 8.5.14
       postcss-selector-parser: 7.1.1
 
-  postcss-focus-visible@6.0.4(postcss@8.5.14):
+  postcss-focus-visible@6.0.4(postcss@8.5.15):
     dependencies:
-      postcss: 8.5.14
+      postcss: 8.5.15
       postcss-selector-parser: 6.1.2
 
-  postcss-focus-within@5.0.4(postcss@8.5.14):
+  postcss-focus-within@5.0.4(postcss@8.5.15):
     dependencies:
-      postcss: 8.5.14
+      postcss: 8.5.15
       postcss-selector-parser: 6.1.2
 
   postcss-focus-within@9.0.1(postcss@8.5.14):
@@ -25152,17 +24735,21 @@ snapshots:
     dependencies:
       postcss: 8.5.14
 
-  postcss-gap-properties@3.0.5(postcss@8.5.14):
+  postcss-font-variant@5.0.0(postcss@8.5.15):
     dependencies:
-      postcss: 8.5.14
+      postcss: 8.5.15
+
+  postcss-gap-properties@3.0.5(postcss@8.5.15):
+    dependencies:
+      postcss: 8.5.15
 
   postcss-gap-properties@6.0.0(postcss@8.5.14):
     dependencies:
       postcss: 8.5.14
 
-  postcss-image-set-function@4.0.7(postcss@8.5.14):
+  postcss-image-set-function@4.0.7(postcss@8.5.15):
     dependencies:
-      postcss: 8.5.14
+      postcss: 8.5.15
       postcss-value-parser: 4.2.0
 
   postcss-image-set-function@7.0.0(postcss@8.5.14):
@@ -25178,19 +24765,19 @@ snapshots:
       read-cache: 1.0.0
       resolve: 1.22.12
 
-  postcss-initial@4.0.1(postcss@8.5.14):
+  postcss-initial@4.0.1(postcss@8.5.15):
     dependencies:
-      postcss: 8.5.14
+      postcss: 8.5.15
 
   postcss-js@4.1.0(postcss@8.5.14):
     dependencies:
       camelcase-css: 2.0.1
       postcss: 8.5.14
 
-  postcss-lab-function@4.2.1(postcss@8.5.14):
+  postcss-lab-function@4.2.1(postcss@8.5.15):
     dependencies:
-      '@csstools/postcss-progressive-custom-properties': 1.3.0(postcss@8.5.14)
-      postcss: 8.5.14
+      '@csstools/postcss-progressive-custom-properties': 1.3.0(postcss@8.5.15)
+      postcss: 8.5.15
       postcss-value-parser: 4.2.0
 
   postcss-lab-function@7.0.12(postcss@8.5.14):
@@ -25221,18 +24808,18 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  postcss-logical@5.0.4(postcss@8.5.14):
+  postcss-logical@5.0.4(postcss@8.5.15):
     dependencies:
-      postcss: 8.5.14
+      postcss: 8.5.15
 
   postcss-logical@8.1.0(postcss@8.5.14):
     dependencies:
       postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
-  postcss-media-minmax@5.0.0(postcss@8.5.14):
+  postcss-media-minmax@5.0.0(postcss@8.5.15):
     dependencies:
-      postcss: 8.5.14
+      postcss: 8.5.15
 
   postcss-merge-idents@6.0.3(postcss@8.5.14):
     dependencies:
@@ -25304,10 +24891,10 @@ snapshots:
       postcss: 8.5.14
       postcss-selector-parser: 6.1.2
 
-  postcss-nesting@10.2.0(postcss@8.5.14):
+  postcss-nesting@10.2.0(postcss@8.5.15):
     dependencies:
       '@csstools/selector-specificity': 2.2.0(postcss-selector-parser@6.1.2)
-      postcss: 8.5.14
+      postcss: 8.5.15
       postcss-selector-parser: 6.1.2
 
   postcss-nesting@13.0.2(postcss@8.5.14):
@@ -25362,9 +24949,9 @@ snapshots:
       postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
-  postcss-opacity-percentage@1.1.3(postcss@8.5.14):
+  postcss-opacity-percentage@1.1.3(postcss@8.5.15):
     dependencies:
-      postcss: 8.5.14
+      postcss: 8.5.15
 
   postcss-opacity-percentage@3.0.0(postcss@8.5.14):
     dependencies:
@@ -25376,9 +24963,9 @@ snapshots:
       postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
-  postcss-overflow-shorthand@3.0.4(postcss@8.5.14):
+  postcss-overflow-shorthand@3.0.4(postcss@8.5.15):
     dependencies:
-      postcss: 8.5.14
+      postcss: 8.5.15
       postcss-value-parser: 4.2.0
 
   postcss-overflow-shorthand@6.0.0(postcss@8.5.14):
@@ -25390,14 +24977,18 @@ snapshots:
     dependencies:
       postcss: 8.5.14
 
+  postcss-page-break@3.0.4(postcss@8.5.15):
+    dependencies:
+      postcss: 8.5.15
+
   postcss-place@10.0.0(postcss@8.5.14):
     dependencies:
       postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
-  postcss-place@7.0.5(postcss@8.5.14):
+  postcss-place@7.0.5(postcss@8.5.15):
     dependencies:
-      postcss: 8.5.14
+      postcss: 8.5.15
       postcss-value-parser: 4.2.0
 
   postcss-preset-env@10.6.1(postcss@8.5.14):
@@ -25475,57 +25066,57 @@ snapshots:
       postcss-replace-overflow-wrap: 4.0.0(postcss@8.5.14)
       postcss-selector-not: 8.0.1(postcss@8.5.14)
 
-  postcss-preset-env@7.8.3(postcss@8.5.14):
+  postcss-preset-env@7.8.3(postcss@8.5.15):
     dependencies:
-      '@csstools/postcss-cascade-layers': 1.1.1(postcss@8.5.14)
-      '@csstools/postcss-color-function': 1.1.1(postcss@8.5.14)
-      '@csstools/postcss-font-format-keywords': 1.0.1(postcss@8.5.14)
-      '@csstools/postcss-hwb-function': 1.0.2(postcss@8.5.14)
-      '@csstools/postcss-ic-unit': 1.0.1(postcss@8.5.14)
-      '@csstools/postcss-is-pseudo-class': 2.0.7(postcss@8.5.14)
-      '@csstools/postcss-nested-calc': 1.0.0(postcss@8.5.14)
-      '@csstools/postcss-normalize-display-values': 1.0.1(postcss@8.5.14)
-      '@csstools/postcss-oklab-function': 1.1.1(postcss@8.5.14)
-      '@csstools/postcss-progressive-custom-properties': 1.3.0(postcss@8.5.14)
-      '@csstools/postcss-stepped-value-functions': 1.0.1(postcss@8.5.14)
-      '@csstools/postcss-text-decoration-shorthand': 1.0.0(postcss@8.5.14)
-      '@csstools/postcss-trigonometric-functions': 1.0.2(postcss@8.5.14)
-      '@csstools/postcss-unset-value': 1.0.2(postcss@8.5.14)
-      autoprefixer: 10.5.0(postcss@8.5.14)
+      '@csstools/postcss-cascade-layers': 1.1.1(postcss@8.5.15)
+      '@csstools/postcss-color-function': 1.1.1(postcss@8.5.15)
+      '@csstools/postcss-font-format-keywords': 1.0.1(postcss@8.5.15)
+      '@csstools/postcss-hwb-function': 1.0.2(postcss@8.5.15)
+      '@csstools/postcss-ic-unit': 1.0.1(postcss@8.5.15)
+      '@csstools/postcss-is-pseudo-class': 2.0.7(postcss@8.5.15)
+      '@csstools/postcss-nested-calc': 1.0.0(postcss@8.5.15)
+      '@csstools/postcss-normalize-display-values': 1.0.1(postcss@8.5.15)
+      '@csstools/postcss-oklab-function': 1.1.1(postcss@8.5.15)
+      '@csstools/postcss-progressive-custom-properties': 1.3.0(postcss@8.5.15)
+      '@csstools/postcss-stepped-value-functions': 1.0.1(postcss@8.5.15)
+      '@csstools/postcss-text-decoration-shorthand': 1.0.0(postcss@8.5.15)
+      '@csstools/postcss-trigonometric-functions': 1.0.2(postcss@8.5.15)
+      '@csstools/postcss-unset-value': 1.0.2(postcss@8.5.15)
+      autoprefixer: 10.5.0(postcss@8.5.15)
       browserslist: 4.28.2
-      css-blank-pseudo: 3.0.3(postcss@8.5.14)
-      css-has-pseudo: 3.0.4(postcss@8.5.14)
-      css-prefers-color-scheme: 6.0.3(postcss@8.5.14)
+      css-blank-pseudo: 3.0.3(postcss@8.5.15)
+      css-has-pseudo: 3.0.4(postcss@8.5.15)
+      css-prefers-color-scheme: 6.0.3(postcss@8.5.15)
       cssdb: 7.11.2
-      postcss: 8.5.14
-      postcss-attribute-case-insensitive: 5.0.2(postcss@8.5.14)
-      postcss-clamp: 4.1.0(postcss@8.5.14)
-      postcss-color-functional-notation: 4.2.4(postcss@8.5.14)
-      postcss-color-hex-alpha: 8.0.4(postcss@8.5.14)
-      postcss-color-rebeccapurple: 7.1.1(postcss@8.5.14)
-      postcss-custom-media: 8.0.2(postcss@8.5.14)
-      postcss-custom-properties: 12.1.11(postcss@8.5.14)
-      postcss-custom-selectors: 6.0.3(postcss@8.5.14)
-      postcss-dir-pseudo-class: 6.0.5(postcss@8.5.14)
-      postcss-double-position-gradients: 3.1.2(postcss@8.5.14)
-      postcss-env-function: 4.0.6(postcss@8.5.14)
-      postcss-focus-visible: 6.0.4(postcss@8.5.14)
-      postcss-focus-within: 5.0.4(postcss@8.5.14)
-      postcss-font-variant: 5.0.0(postcss@8.5.14)
-      postcss-gap-properties: 3.0.5(postcss@8.5.14)
-      postcss-image-set-function: 4.0.7(postcss@8.5.14)
-      postcss-initial: 4.0.1(postcss@8.5.14)
-      postcss-lab-function: 4.2.1(postcss@8.5.14)
-      postcss-logical: 5.0.4(postcss@8.5.14)
-      postcss-media-minmax: 5.0.0(postcss@8.5.14)
-      postcss-nesting: 10.2.0(postcss@8.5.14)
-      postcss-opacity-percentage: 1.1.3(postcss@8.5.14)
-      postcss-overflow-shorthand: 3.0.4(postcss@8.5.14)
-      postcss-page-break: 3.0.4(postcss@8.5.14)
-      postcss-place: 7.0.5(postcss@8.5.14)
-      postcss-pseudo-class-any-link: 7.1.6(postcss@8.5.14)
-      postcss-replace-overflow-wrap: 4.0.0(postcss@8.5.14)
-      postcss-selector-not: 6.0.1(postcss@8.5.14)
+      postcss: 8.5.15
+      postcss-attribute-case-insensitive: 5.0.2(postcss@8.5.15)
+      postcss-clamp: 4.1.0(postcss@8.5.15)
+      postcss-color-functional-notation: 4.2.4(postcss@8.5.15)
+      postcss-color-hex-alpha: 8.0.4(postcss@8.5.15)
+      postcss-color-rebeccapurple: 7.1.1(postcss@8.5.15)
+      postcss-custom-media: 8.0.2(postcss@8.5.15)
+      postcss-custom-properties: 12.1.11(postcss@8.5.15)
+      postcss-custom-selectors: 6.0.3(postcss@8.5.15)
+      postcss-dir-pseudo-class: 6.0.5(postcss@8.5.15)
+      postcss-double-position-gradients: 3.1.2(postcss@8.5.15)
+      postcss-env-function: 4.0.6(postcss@8.5.15)
+      postcss-focus-visible: 6.0.4(postcss@8.5.15)
+      postcss-focus-within: 5.0.4(postcss@8.5.15)
+      postcss-font-variant: 5.0.0(postcss@8.5.15)
+      postcss-gap-properties: 3.0.5(postcss@8.5.15)
+      postcss-image-set-function: 4.0.7(postcss@8.5.15)
+      postcss-initial: 4.0.1(postcss@8.5.15)
+      postcss-lab-function: 4.2.1(postcss@8.5.15)
+      postcss-logical: 5.0.4(postcss@8.5.15)
+      postcss-media-minmax: 5.0.0(postcss@8.5.15)
+      postcss-nesting: 10.2.0(postcss@8.5.15)
+      postcss-opacity-percentage: 1.1.3(postcss@8.5.15)
+      postcss-overflow-shorthand: 3.0.4(postcss@8.5.15)
+      postcss-page-break: 3.0.4(postcss@8.5.15)
+      postcss-place: 7.0.5(postcss@8.5.15)
+      postcss-pseudo-class-any-link: 7.1.6(postcss@8.5.15)
+      postcss-replace-overflow-wrap: 4.0.0(postcss@8.5.15)
+      postcss-selector-not: 6.0.1(postcss@8.5.15)
       postcss-value-parser: 4.2.0
 
   postcss-pseudo-class-any-link@10.0.1(postcss@8.5.14):
@@ -25533,9 +25124,9 @@ snapshots:
       postcss: 8.5.14
       postcss-selector-parser: 7.1.1
 
-  postcss-pseudo-class-any-link@7.1.6(postcss@8.5.14):
+  postcss-pseudo-class-any-link@7.1.6(postcss@8.5.15):
     dependencies:
-      postcss: 8.5.14
+      postcss: 8.5.15
       postcss-selector-parser: 6.1.2
 
   postcss-reduce-idents@6.0.3(postcss@8.5.14):
@@ -25558,9 +25149,13 @@ snapshots:
     dependencies:
       postcss: 8.5.14
 
-  postcss-selector-not@6.0.1(postcss@8.5.14):
+  postcss-replace-overflow-wrap@4.0.0(postcss@8.5.15):
     dependencies:
-      postcss: 8.5.14
+      postcss: 8.5.15
+
+  postcss-selector-not@6.0.1(postcss@8.5.15):
+    dependencies:
+      postcss: 8.5.15
       postcss-selector-parser: 6.1.2
 
   postcss-selector-not@8.0.1(postcss@8.5.14):
@@ -25672,24 +25267,6 @@ snapshots:
       '@prisma/dev': 0.24.3(typescript@6.0.3)
       '@prisma/engines': 7.8.0
       '@prisma/studio-core': 0.27.3(@types/react-dom@18.3.5(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      mysql2: 3.15.3
-      postgres: 3.4.7
-    optionalDependencies:
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-      - magicast
-      - react
-      - react-dom
-    optional: true
-
-  prisma@7.8.0(@types/react-dom@18.3.5(@types/react@19.2.14))(@types/react@19.2.14)(magicast@0.5.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@6.0.3):
-    dependencies:
-      '@prisma/config': 7.8.0(magicast@0.5.3)
-      '@prisma/dev': 0.24.3(typescript@6.0.3)
-      '@prisma/engines': 7.8.0
-      '@prisma/studio-core': 0.27.3(@types/react-dom@18.3.5(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       mysql2: 3.15.3
       postgres: 3.4.7
     optionalDependencies:
@@ -25964,52 +25541,6 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
-
-  react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1):
-    dependencies:
-      '@react-native/assets-registry': 0.85.3
-      '@react-native/codegen': 0.85.3(@babel/core@7.29.0)
-      '@react-native/community-cli-plugin': 0.85.3
-      '@react-native/gradle-plugin': 0.85.3
-      '@react-native/js-polyfills': 0.85.3
-      '@react-native/normalize-colors': 0.85.3
-      '@react-native/virtualized-lists': 0.85.3(@types/react@19.2.14)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.14)(react@18.3.1))(react@18.3.1)
-      abort-controller: 3.0.0
-      anser: 1.4.10
-      ansi-regex: 5.0.1
-      babel-plugin-syntax-hermes-parser: 0.33.3
-      base64-js: 1.5.1
-      commander: 12.1.0
-      flow-enums-runtime: 0.0.6
-      hermes-compiler: 250829098.0.10
-      invariant: 2.2.4
-      memoize-one: 5.2.1
-      metro-runtime: 0.84.4
-      metro-source-map: 0.84.4
-      nullthrows: 1.1.1
-      pretty-format: 29.7.0
-      promise: 8.3.0
-      react: 18.3.1
-      react-devtools-core: 6.1.5
-      react-refresh: 0.14.2
-      regenerator-runtime: 0.13.11
-      scheduler: 0.27.0
-      semver: 7.8.0
-      stacktrace-parser: 0.1.11
-      tinyglobby: 0.2.16
-      whatwg-fetch: 3.6.20
-      ws: 7.5.10
-      yargs: 17.7.2
-    optionalDependencies:
-      '@types/react': 19.2.14
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@react-native-community/cli'
-      - '@react-native/metro-config'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-    optional: true
 
   react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@18.3.1):
     dependencies:


### PR DESCRIPTION
Extract permissions-related functionality from `zero-schema` into a new `zero-permissions` package to eliminate circular dependencies. Update all relevant consumers to utilize the new package. This change enhances modularity and maintainability of the codebase.