### PR TITLE
chore(zero-client): Update PROTOCOL_VERSION to 51 in tests

### DIFF
--- a/packages/zero-client/src/client/protocol-version-url.test.ts
+++ b/packages/zero-client/src/client/protocol-version-url.test.ts
@@ -35,5 +35,5 @@ test('When the URL changes we need to update the protocol version', async () => 
   // might not understand it. You may need to bump the PROTOCOL_VERSION and
   // update the expected values.
   expect(hash).toBe('10r2tfvet9a3s');
-  expect(PROTOCOL_VERSION).toBe(50);
+  expect(PROTOCOL_VERSION).toBe(51);
 });

--- a/packages/zero-client/src/client/zero-idb.test.ts
+++ b/packages/zero-client/src/client/zero-idb.test.ts
@@ -166,7 +166,7 @@ test('logged-out client uses a private storage sentinel for idb naming', async (
   });
 
   expect(zero.idbName).toEqual(
-    `rep:zero-${LOGGED_OUT_STORAGE_USER_ID}-o92aeop6ci3f:7:50.32bj126fs2e3f`,
+    `rep:zero-${LOGGED_OUT_STORAGE_USER_ID}-o92aeop6ci3f:7:51.32bj126fs2e3f`,
   );
 
   await zero.close();


### PR DESCRIPTION
This pull request updates the protocol version used in the zero client, ensuring consistency across tests and storage naming. The changes are minor and primarily involve incrementing the protocol version number from 50 to 51.
