### PR TITLE
fix(zero-client): Fixes regression where assert got triggered

### DIFF
--- a/packages/zero-client/src/client/query-manager.ts
+++ b/packages/zero-client/src/client/query-manager.ts
@@ -445,13 +445,13 @@ export class QueryManager implements InspectorDelegate {
         const lruQueryID = this.#recentQueries.values().next().value;
         assert(lruQueryID, 'Expected LRU query ID to exist');
         const evictedAST = this.getAST(lruQueryID);
-        const evictedMetrics = this.#queryMetrics.get(lruQueryID);
+        const evictedMetrics =
+          this.#queryMetrics.get(lruQueryID) ?? newPerQueryMetrics();
         this.#queries.delete(lruQueryID);
         this.#recentQueries.delete(lruQueryID);
         this.#queryMetrics.delete(lruQueryID);
         this.#queueQueryChange({op: 'del', hash: lruQueryID});
         assert(evictedAST, 'Expected evicted AST to exist');
-        assert(evictedMetrics, 'Expected evicted metrics to exist');
         this.#queryEvictedCallback?.(lruQueryID, evictedAST, evictedMetrics);
       }
     }


### PR DESCRIPTION
PR #5924 introduced a bug where removing a query could trigger an assert.