### PR TITLE
fix(inspector): Make inspector server compat with older clients 

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/inspect-handler.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/inspect-handler.test.ts
@@ -1,0 +1,102 @@
+import {TDigest} from 'shared/src/tdigest.ts';
+import {describe, expect, test} from 'vitest';
+import type {QueryServerMetrics} from 'zero-protocol/src/inspect-down.ts';
+import {metricsForProtocol} from './inspect-handler.ts';
+
+describe('metricsForProtocol', () => {
+  test('returns null unchanged', () => {
+    expect(metricsForProtocol(null, 51)).toBeNull();
+    expect(metricsForProtocol(null, 50)).toBeNull();
+    expect(metricsForProtocol(null, 1)).toBeNull();
+  });
+
+  test('protocol >= 51: returns metrics as-is', () => {
+    const updateDigest = new TDigest();
+    updateDigest.add(10);
+    updateDigest.add(20);
+    const metrics = {
+      'query-hydration-server-ms': 42,
+      'query-update-server': updateDigest.toJSON(),
+    };
+    expect(metricsForProtocol(metrics, 51)).toBe(metrics);
+    expect(metricsForProtocol(metrics, 52)).toBe(metrics);
+    expect(metricsForProtocol(metrics, 100)).toBe(metrics);
+  });
+
+  test('protocol >= 51: returns metrics with no fields as-is', () => {
+    const metrics = {} as unknown as QueryServerMetrics;
+    expect(metricsForProtocol(metrics, 51)).toBe(metrics);
+  });
+
+  test('protocol < 51: wraps hydration ms into legacy TDigest field', () => {
+    const updateDigest = new TDigest();
+    updateDigest.add(5);
+    const updateJSON = updateDigest.toJSON();
+
+    const metrics = {
+      'query-hydration-server-ms': 100,
+      'query-update-server': updateJSON,
+    };
+
+    const result = metricsForProtocol(metrics, 50);
+    expect(result).not.toBeNull();
+
+    // Should have the legacy field, not the new one
+    expect(result).not.toHaveProperty('query-hydration-server-ms');
+    expect(result).toHaveProperty('query-materialization-server');
+    expect(result).toHaveProperty('query-update-server', updateJSON);
+
+    // The legacy TDigest should contain the single hydration value
+    const materializationDigest = TDigest.fromJSON(
+      (result as Record<string, unknown>)[
+        'query-materialization-server'
+      ] as ReturnType<TDigest['toJSON']>,
+    );
+    expect(materializationDigest.count()).toBe(1);
+    expect(materializationDigest.quantile(0.5)).toBe(100);
+  });
+
+  test('protocol < 51: handles missing hydration-ms (wraps empty TDigest)', () => {
+    const updateDigest = new TDigest();
+    updateDigest.add(7);
+    const updateJSON = updateDigest.toJSON();
+
+    const metrics = {
+      'query-update-server': updateJSON,
+    };
+
+    const result = metricsForProtocol(metrics, 50);
+    expect(result).not.toBeNull();
+    expect(result).toHaveProperty('query-materialization-server');
+    expect(result).toHaveProperty('query-update-server', updateJSON);
+
+    // The legacy TDigest should be empty (no value was added)
+    const materializationDigest = TDigest.fromJSON(
+      (result as Record<string, unknown>)[
+        'query-materialization-server'
+      ] as ReturnType<TDigest['toJSON']>,
+    );
+    expect(materializationDigest.count()).toBe(0);
+  });
+
+  test('protocol < 51: handles undefined update-server', () => {
+    const metrics = {
+      'query-hydration-server-ms': 25,
+    } as unknown as QueryServerMetrics;
+
+    const result = metricsForProtocol(metrics, 1);
+    expect(result).not.toBeNull();
+    expect(result).toHaveProperty('query-materialization-server');
+    expect(
+      (result as Record<string, unknown>)['query-update-server'],
+    ).toBeUndefined();
+
+    const materializationDigest = TDigest.fromJSON(
+      (result as Record<string, unknown>)[
+        'query-materialization-server'
+      ] as ReturnType<TDigest['toJSON']>,
+    );
+    expect(materializationDigest.count()).toBe(1);
+    expect(materializationDigest.quantile(0.5)).toBe(25);
+  });
+});

--- a/packages/zero-cache/src/services/view-syncer/inspect-handler.ts
+++ b/packages/zero-cache/src/services/view-syncer/inspect-handler.ts
@@ -1,8 +1,13 @@
 import type {LogContext} from '@rocicorp/logger';
 import {unreachable} from 'shared/src/asserts.ts';
 import {must} from 'shared/src/must.ts';
+import {TDigest} from 'shared/src/tdigest.ts';
+import type {
+  QueryServerMetrics,
+  ServerMetrics,
+} from 'zero-protocol/src/inspect-down.ts';
 import type {InspectUpBody} from 'zero-protocol/src/inspect-up.ts';
-import {Database} from '../../../../zqlite/src/db.ts';
+import {Database} from 'zqlite/src/db.ts';
 import {loadPermissions} from '../../auth/load-permissions.ts';
 import type {NormalizedZeroConfig} from '../../config/normalize.ts';
 import {
@@ -58,7 +63,10 @@ export async function handleInspect(
         const enhancedRows = queryRows.map(row => ({
           ...row,
           ast: row.ast ?? inspectorDelegate.getASTForQuery(row.queryID) ?? null,
-          metrics: inspectorDelegate.getMetricsJSONForQuery(row.queryID),
+          metrics: metricsForProtocol(
+            inspectorDelegate.getMetricsJSONForQuery(row.queryID),
+            ctx.protocolVersion,
+          ),
         }));
 
         client.sendInspectResponse(lc, {
@@ -168,4 +176,40 @@ export async function handleInspect(
       value: (e as Error).message,
     });
   }
+}
+
+/**
+ * Converts per-query server metrics to the appropriate wire format based on the
+ * client's protocol version.
+ *
+ * Protocol >= 51: new format — `query-hydration-server-ms` (plain number) +
+ *   `query-update-server` (TDigest).
+ * Protocol < 51: old format — `query-materialization-server` (TDigest) +
+ *   `query-update-server` (TDigest). The scalar hydration time is wrapped into a
+ *   one-point TDigest for backward compatibility.
+ *
+ * @visibleForTesting
+ */
+export function metricsForProtocol(
+  metrics: QueryServerMetrics | null,
+  protocolVersion: number,
+): QueryServerMetrics | null {
+  if (protocolVersion >= 51 || metrics === null) {
+    return metrics;
+  }
+  // Backward compat: wrap the scalar hydration ms into a one-point TDigest
+  // under the old field name so that 1.5 clients can parse the response.
+  const hydrateDigest = new TDigest();
+  const hydrateMs = metrics['query-hydration-server-ms'];
+  if (hydrateMs !== undefined) {
+    hydrateDigest.add(hydrateMs);
+  }
+  const legacyMetrics: ServerMetrics = {
+    'query-materialization-server': hydrateDigest.toJSON(),
+    'query-update-server': metrics['query-update-server'],
+  };
+  // Cast to QueryServerMetrics: this is intentional — for old-protocol clients
+  // we send the legacy ServerMetrics wire shape under the QueryServerMetrics type
+  // to satisfy TypeScript while preserving backward compatibility.
+  return legacyMetrics as unknown as QueryServerMetrics;
 }

--- a/packages/zero-protocol/src/inspect-down.ts
+++ b/packages/zero-protocol/src/inspect-down.ts
@@ -1,6 +1,6 @@
 import {jsonSchema} from 'shared/src/json-schema.ts';
 import {tdigestSchema} from 'shared/src/tdigest-schema.ts';
-import * as v from '../../shared/src/valita.ts';
+import * as v from 'shared/src/valita.ts';
 import {analyzeQueryResultSchema} from './analyze-query-result.ts';
 import {astSchema} from './ast.ts';
 


### PR DESCRIPTION
The format of the inspector metrics changed slightly. Have the server
check the protocol version to determine what to return.