### PR TITLE
bench(zero-cache): add rm vs load benchmark harness

### DIFF
--- a/packages/zero-cache/bench/rm-vs-load/README.md
+++ b/packages/zero-cache/bench/rm-vs-load/README.md
@@ -1,0 +1,153 @@
+# RM vs Load Benchmark
+
+This folder is the reproducible e2e harness for storer/changeLog performance
+PRs. It exists so future perf work extends one shared scenario shape instead of
+inventing a new local script for every hypothesis.
+
+```text
+one replication-manager
+        |
+        v
+   Storer/changeLog  ---->  serving replica stream consumer(s)
+        |
+        `---------------->  optional reconnect catchup
+```
+
+Files:
+
+- `e2e.ts` pins the PR-review scenario: 1 RM stream consumer, 1 shared serving
+  replica applier, and a reconnecting consumer under heavy load.
+- `index.ts` owns the runner and emits JSON summaries.
+- `protocol.ts` isolates WebSocket/protocol experiments from the load driver.
+- `scenarios.ts` defines named load scenarios and env overrides.
+- `fixtures.ts` builds protocol messages and payload shapes.
+- `perf-utils.ts` keeps benchmark-only helpers out of production code.
+- `types.ts` keeps result shapes stable for scripts that compare branches.
+
+Default review run:
+
+```bash
+pnpm --filter zero-cache run perf:rm-vs-load:e2e -- --out /tmp/rm-vs-load.json
+```
+
+The default `e2e` wrapper focuses on the steady-state pressure point this
+folder is meant to protect:
+
+```text
+             15s target: 4k tx/s, 20 rows/tx
+
+  RM -> Storer/changeLog -> live serving-replica stream consumer
+          |                    |
+          |                    `-> parse + websocket ACK + SQLite apply
+          |                        |
+          |                        `-> 8 sync worker readers on same SQLite file
+          |
+          `-> 1 reconnecting consumer starts 500 tx behind during load
+              and shares the existing serving replica model
+```
+
+The headline question is not whether a quiet recovery path is faster. It is
+whether one serving process can keep accepting RM changes while a reconnecting
+consumer closes its starting gap instead of adding unbounded lag. Syncer workers
+inside that serving process share the serving replica file, so the default
+review scenario uses `ZERO_RM_VS_SUBSCRIBERS=1` and
+`ZERO_RM_VS_APPLY_LIMIT=1` rather than treating every syncer worker as an
+independent SQLite writer.
+
+The JSON summary includes the review metrics that tend to regress when this
+path gets changed: load-phase rows/s, reconnect catchup time, VS parse/apply
+timings, process CPU, heap/RSS pressure, websocket bytes, websocket frames, and
+ACK counts. For shared-replica scenarios it also reports sync worker read
+throughput, average read latency, max read latency, and read errors. It also
+reports insert/update/delete counts so reviewers can tell whether a run
+exercised the insert-only ingestion path or the mixed row-churn path.
+
+Real serving-replica load is not only new rows. Use the mixed scenario when a
+change might move costs between SQLite inserts, updates, deletes, and stream
+flow control:
+
+```bash
+ZERO_RM_VS_SCENARIO=mixed-hot-row-churn \
+  pnpm --filter zero-cache run perf:rm-vs-load:e2e -- \
+  --out /tmp/rm-vs-load-mixed.json
+```
+
+That scenario keeps the same 1 RM / 1 serving-replica applier / reconnecting
+consumer shape as the default review run, but the data rows follow a
+deterministic 40/40/20 insert/update/delete pattern after the first row exists:
+
+```text
+  tx stream: begin -> insert/update/delete x 20 -> commit
+
+  row churn:
+    insert: creates a new active row
+    update: rewrites an active row with the current tx payload
+    delete: removes an active row from the update/delete target set
+```
+
+Use `perf:rm-vs-load` directly only when intentionally changing scenario
+parameters with `ZERO_RM_VS_*` env vars.
+
+Useful view-syncer digestion knobs:
+
+- `ZERO_RM_VS_SUBSCRIBERS=4|8` changes the number of live RM stream consumers.
+  Use `1` for the corrected one-serving-process topology; larger values model
+  multiple independent serving replicas consuming the same RM stream.
+- `ZERO_RM_VS_SCENARIO=shared-replica-sync-workers` runs the scenario that adds
+  syncer read pressure on top of one serving-replica applier. This is the shape
+  for one VS process with one serving replica and several syncer workers sharing
+  one SQLite file.
+- `ZERO_RM_VS_SYNC_WORKERS=N` controls how many syncer reader workers open the
+  same serving SQLite file in scenarios that opt into shared replica reads. The
+  default for `shared-replica-sync-workers` is `8`.
+- `ZERO_RM_VS_SYNC_WORKER_READ_DELAY_MS=N` adds a delay after each syncer reader
+  query. The default is `1` ms so the readers apply steady shared-file pressure
+  without turning the benchmark into a pure SQLite read spin loop.
+- `ZERO_RM_VS_APPLY_MODE=direct|worker-message` makes each
+  simulated VS parse and apply the downstream stream into its own SQLite
+  replica. `worker-message` models the old production shape of one
+  write-worker handoff per replication message.
+- `ZERO_RM_VS_APPLY_LIMIT=N` keeps all simulated stream consumers connected but
+  only lets the first N apply into SQLite. The default `1` keeps the live
+  serving replica applying while the reconnecting consumer exercises stream
+  catchup without pretending it owns a second replica file.
+- `ZERO_RM_VS_CONSUMER_RUNTIME=inline|worker` controls where the simulated VS
+  websocket/parse/ACK loop runs. Use `worker` for host-shape experiments where
+  each VS instance should get its own JS thread, matching deployments that run
+  one VS process per vCPU. The default `inline` mode is faster to start and is
+  useful for small comparisons, but it intentionally shares one benchmark event
+  loop across all VS consumers.
+- `ZERO_RM_VS_APPLY_CLIENTS=1` is the legacy shorthand for
+  `ZERO_RM_VS_APPLY_MODE=direct`.
+- `ZERO_RM_VS_TRANSPORT=websocket` routes each simulated VS through the same
+  stringified WebSocket stream and ack protocol used between the change-streamer
+  and serving replicas. The default `in-process` mode is faster and useful when
+  isolating SQLite apply cost.
+- `ZERO_RM_VS_PROTOCOL=v6` pins the benchmark to the production RM stream
+  payload: one existing Downstream JSON message per replication message.
+- `ZERO_RM_VS_WS_ACK=per-message` pins the benchmark to the production v6
+  one-ACK-per-frame stream shape. Later optimization PRs can add more ACK modes
+  to this same harness.
+- `ZERO_RM_VS_WS_BATCH_MESSAGES=1` pins the benchmark to the production v6
+  one-message-per-frame stream shape. Later optimization PRs can add transport
+  batching to this same harness.
+- `ZERO_RM_VS_MIXED_INSERT_WEIGHT`, `ZERO_RM_VS_MIXED_UPDATE_WEIGHT`, and
+  `ZERO_RM_VS_MIXED_DELETE_WEIGHT` adjust the deterministic operation mix for
+  `mixed-hot-row-churn`. The default is `4/4/2`, i.e. roughly 40% inserts, 40%
+  updates, and 20% deletes.
+- `ZERO_RM_VS_WAL_AUTOCHECKPOINT=N` overrides the serving-replica
+  `wal_autocheckpoint` pragma applied to each simulated VS write worker. The
+  default follows the production serving-replica pragma so the review scenario
+  includes the same bounded checkpoint window.
+- `ZERO_RM_VS_SQLITE_SYNCHRONOUS=OFF|NORMAL|FULL` overrides the SQLite
+  `synchronous` pragma on each simulated VS replica connection. The default
+  remains `NORMAL`; use this only to measure durability/performance headroom.
+- `ZERO_RM_VS_CLIENT_CPU_US=N` burns `N` microseconds per downstream message to
+  model client/query work sharing the VS event loop.
+- `ZERO_RM_VS_FLUSH_BYTES=N` controls how many stream payload bytes the RM can
+  fan out before awaiting serving-replica flow control. The default mirrors the
+  production RM threshold.
+- `ZERO_RM_VS_SOURCE_APPLY=1` additionally applies every generated change into
+  a local benchmark SQLite replica before storer/fanout. Leave this off for the
+  default RM -> serving-replica stream benchmark; enable it only when
+  intentionally measuring an extra local apply path.

--- a/packages/zero-cache/bench/rm-vs-load/config.test.ts
+++ b/packages/zero-cache/bench/rm-vs-load/config.test.ts
@@ -1,0 +1,82 @@
+import {expect, test} from 'vitest';
+import {
+  BenchmarkConfigLoader,
+  EnvReader,
+  protocolVersionForMode,
+} from './config.ts';
+
+function loadConfig(
+  env: Record<string, string | undefined>,
+  argv: readonly string[] = ['node', 'bench'],
+) {
+  return new BenchmarkConfigLoader(new EnvReader(env, argv)).load();
+}
+
+test('loads smoke defaults from an explicit environment', () => {
+  const config = loadConfig({});
+
+  expect(config.mode).toBe('smoke');
+  expect(config.durationMs).toBe(1_000);
+  expect(config.settleMs).toBe(100);
+  expect(config.consumer.count).toBe(4);
+  expect(config.consumer.applyMode).toBe('none');
+  expect(config.consumer.transportMode).toBe('in-process');
+  expect(config.consumer.transportAckMode).toBe('per-message');
+  expect(config.consumer.protocolMode).toBe('v6');
+  expect(config.outputPath).toBeUndefined();
+});
+
+test('loads review shaped full config without touching process.env', () => {
+  const config = loadConfig(
+    {
+      ZERO_RM_VS_FULL: '1',
+      ZERO_RM_VS_SUBSCRIBERS: '1',
+      ZERO_RM_VS_APPLY_MODE: 'direct',
+      ZERO_RM_VS_APPLY_LIMIT: '1',
+      ZERO_RM_VS_CONSUMER_RUNTIME: 'worker',
+      ZERO_RM_VS_TRANSPORT: 'websocket',
+      ZERO_RM_VS_WS_ACK: 'per-message',
+      ZERO_RM_VS_WS_BATCH_MESSAGES: '1',
+      ZERO_RM_VS_SOURCE_APPLY: '1',
+      ZERO_RM_VS_PG_IMAGE: 'postgres:18',
+      ZERO_RM_VS_SYNC_WORKER_READ_DELAY_MS: '2',
+    },
+    ['node', 'bench', '--out', 'summary.json'],
+  );
+
+  expect(config.mode).toBe('full');
+  expect(config.consumer.count).toBe(1);
+  expect(config.consumer.applyMode).toBe('direct');
+  expect(config.consumer.applyLimit).toBe(1);
+  expect(config.consumer.runtime).toBe('worker');
+  expect(config.consumer.transportMode).toBe('websocket');
+  expect(config.consumer.transportAckMode).toBe('per-message');
+  expect(config.consumer.transportBatchMessages).toBe(1);
+  expect(config.sourceApply).toBe(true);
+  expect(config.pgImage).toBe('postgres:18');
+  expect(config.outputPath).toBe('summary.json');
+  expect(config.syncWorkerReadDelayMs).toBe(2);
+});
+
+test('preserves legacy apply client flag as direct apply mode', () => {
+  const config = loadConfig({ZERO_RM_VS_APPLY_CLIENTS: '1'});
+
+  expect(config.consumer.applyMode).toBe('direct');
+  expect(config.consumer.applyMessages).toBe(true);
+});
+
+test('rejects invalid enum values at config load time', () => {
+  expect(() => loadConfig({ZERO_RM_VS_TRANSPORT: 'udp'})).toThrow(
+    /Invalid ZERO_RM_VS_TRANSPORT=udp/,
+  );
+  expect(() => loadConfig({ZERO_RM_VS_WS_ACK: 'latest'})).toThrow(
+    /Invalid ZERO_RM_VS_WS_ACK=latest/,
+  );
+  expect(() => loadConfig({ZERO_RM_VS_PROTOCOL: 'v7'})).toThrow(
+    /Invalid ZERO_RM_VS_PROTOCOL=v7/,
+  );
+});
+
+test('maps protocol mode to the active stream protocol version', () => {
+  expect(protocolVersionForMode('v6')).toBe(6);
+});

--- a/packages/zero-cache/bench/rm-vs-load/config.ts
+++ b/packages/zero-cache/bench/rm-vs-load/config.ts
@@ -1,0 +1,227 @@
+import {PROTOCOL_VERSION} from '../../src/services/change-streamer/change-streamer.ts';
+import type {
+  BenchmarkConfig,
+  ConsumerApplyMode,
+  ConsumerConfig,
+  ConsumerProtocolMode,
+  ConsumerRuntime,
+  ConsumerTransportAckMode,
+  ConsumerTransportMode,
+} from './types.ts';
+
+const FORWARDER_FLOW_CONTROL_BYTES_THRESHOLD = 64 * 1024;
+const SERVING_REPLICA_WAL_AUTOCHECKPOINT_PAGES = 1_000;
+
+export class EnvReader {
+  readonly #env: Record<string, string | undefined>;
+  readonly #argv: readonly string[];
+
+  constructor(
+    env: Record<string, string | undefined> = process.env,
+    argv: readonly string[] = process.argv,
+  ) {
+    this.#env = env;
+    this.#argv = argv;
+  }
+
+  string(name: string, fallback?: string): string | undefined {
+    const value = this.#env[name];
+    return value === undefined || value === '' ? fallback : value;
+  }
+
+  int(name: string, fallback: number): number {
+    const value = this.string(name);
+    if (value === undefined) {
+      return fallback;
+    }
+    const parsed = Number.parseInt(value, 10);
+    if (!Number.isFinite(parsed)) {
+      throw new Error(`Invalid integer ${name}=${value}`);
+    }
+    return parsed;
+  }
+
+  optionalInt(name: string, defaultValue?: number): number | undefined {
+    const value = this.string(name);
+    if (value === undefined) {
+      return defaultValue;
+    }
+    return this.int(name, 0);
+  }
+
+  flag(name: string): boolean {
+    const value = this.string(name);
+    return value === '1' || value === 'true' || value === 'yes';
+  }
+
+  argValue(name: string): string | undefined {
+    const long = `--${name}`;
+    const withEquals = `${long}=`;
+    for (let i = 2; i < this.#argv.length; i++) {
+      const arg = this.#argv[i];
+      if (arg === long) {
+        return this.#argv[i + 1];
+      }
+      if (arg?.startsWith(withEquals)) {
+        return arg.slice(withEquals.length);
+      }
+    }
+    return undefined;
+  }
+}
+
+export class BenchmarkConfigLoader {
+  readonly #env: EnvReader;
+
+  constructor(env = new EnvReader()) {
+    this.#env = env;
+  }
+
+  load(): BenchmarkConfig {
+    const full = this.#env.flag('ZERO_RM_VS_FULL');
+    const applyMode = this.#applyMode();
+    const consumer = this.#consumerConfig(full, applyMode);
+    return {
+      mode: full ? 'full' : 'smoke',
+      full,
+      durationMs: this.#env.int('ZERO_RM_VS_DURATION_MS', full ? 2_500 : 1_000),
+      settleMs: this.#env.int('ZERO_RM_VS_SETTLE_MS', 100),
+      flushBytesThreshold: this.#env.int(
+        'ZERO_RM_VS_FLUSH_BYTES',
+        FORWARDER_FLOW_CONTROL_BYTES_THRESHOLD,
+      ),
+      reconnectLagTx: this.#env.int('ZERO_RM_VS_RECONNECT_LAG_TX', 64),
+      reconnectFinalCatchupTimeoutMs: this.#env.int(
+        'ZERO_RM_VS_FINAL_CATCHUP_TIMEOUT_MS',
+        full ? 15_000 : 5_000,
+      ),
+      sourceApply: this.#env.flag('ZERO_RM_VS_SOURCE_APPLY'),
+      pgImage: this.#env.string('ZERO_RM_VS_PG_IMAGE') ?? 'postgres:17',
+      outputPath:
+        this.#env.argValue('out') ?? this.#env.string('ZERO_RM_VS_OUT'),
+      syncWorkerReadDelayMs: this.#env.int(
+        'ZERO_RM_VS_SYNC_WORKER_READ_DELAY_MS',
+        1,
+      ),
+      consumer,
+    };
+  }
+
+  #consumerConfig(full: boolean, applyMode: ConsumerApplyMode): ConsumerConfig {
+    return {
+      count: this.#env.int('ZERO_RM_VS_SUBSCRIBERS', full ? 16 : 4),
+      ackDelayMs: this.#env.int('ZERO_RM_VS_ACK_DELAY_MS', 0),
+      runtime: this.#runtime(),
+      applyMode,
+      applyMessages: applyMode !== 'none',
+      applyLimit: this.#env.optionalInt('ZERO_RM_VS_APPLY_LIMIT'),
+      transportMode: this.#transportMode(),
+      transportAckMode: this.#transportAckMode(),
+      transportBatchMessages: this.#env.int('ZERO_RM_VS_WS_BATCH_MESSAGES', 1),
+      protocolMode: this.#protocolMode(),
+      synchronous: this.#synchronous(),
+      walAutocheckpoint: this.#env.optionalInt(
+        'ZERO_RM_VS_WAL_AUTOCHECKPOINT',
+        SERVING_REPLICA_WAL_AUTOCHECKPOINT_PAGES,
+      ),
+      clientCpuMicros: this.#env.int('ZERO_RM_VS_CLIENT_CPU_US', 0),
+      slowAckDelayMs: this.#env.int(
+        'ZERO_RM_VS_SLOW_ACK_DELAY_MS',
+        full ? 2 : 1,
+      ),
+      slowEvery: this.#env.int('ZERO_RM_VS_SLOW_EVERY', full ? 4 : 2),
+    };
+  }
+
+  #applyMode(): ConsumerApplyMode {
+    const mode = this.#env.string('ZERO_RM_VS_APPLY_MODE');
+    if (mode === undefined) {
+      return this.#env.flag('ZERO_RM_VS_APPLY_CLIENTS') ? 'direct' : 'none';
+    }
+    switch (mode) {
+      case 'none':
+      case 'direct':
+      case 'worker-message':
+        return mode;
+      default:
+        throw new Error(
+          `Invalid ZERO_RM_VS_APPLY_MODE=${mode}; expected ` +
+            'none, direct, or worker-message',
+        );
+    }
+  }
+
+  #runtime(): ConsumerRuntime {
+    const runtime = this.#env.string('ZERO_RM_VS_CONSUMER_RUNTIME') ?? 'inline';
+    switch (runtime) {
+      case 'inline':
+      case 'worker':
+        return runtime;
+      default:
+        throw new Error(
+          `Invalid ZERO_RM_VS_CONSUMER_RUNTIME=${runtime}; expected ` +
+            'inline or worker',
+        );
+    }
+  }
+
+  #synchronous(): 'OFF' | 'NORMAL' | 'FULL' | undefined {
+    const value = this.#env.string('ZERO_RM_VS_SQLITE_SYNCHRONOUS');
+    switch (value) {
+      case undefined:
+      case '':
+        return undefined;
+      case 'OFF':
+      case 'NORMAL':
+      case 'FULL':
+        return value;
+      default:
+        throw new Error(`Invalid ZERO_RM_VS_SQLITE_SYNCHRONOUS ${value}`);
+    }
+  }
+
+  #transportAckMode(): ConsumerTransportAckMode {
+    const mode = this.#env.string('ZERO_RM_VS_WS_ACK');
+    if (mode === undefined) {
+      return 'per-message';
+    }
+    switch (mode) {
+      case 'per-message':
+        return mode;
+      default:
+        throw new Error(
+          `Invalid ZERO_RM_VS_WS_ACK=${mode}; expected per-message`,
+        );
+    }
+  }
+
+  #transportMode(): ConsumerTransportMode {
+    const mode = this.#env.string('ZERO_RM_VS_TRANSPORT');
+    if (mode === undefined) {
+      return 'in-process';
+    }
+    switch (mode) {
+      case 'in-process':
+      case 'websocket':
+        return mode;
+      default:
+        throw new Error(
+          `Invalid ZERO_RM_VS_TRANSPORT=${mode}; expected in-process or websocket`,
+        );
+    }
+  }
+
+  #protocolMode(): ConsumerProtocolMode {
+    const mode = this.#env.string('ZERO_RM_VS_PROTOCOL') ?? 'v6';
+    switch (mode) {
+      case 'v6':
+        return mode;
+      default:
+        throw new Error(`Invalid ZERO_RM_VS_PROTOCOL=${mode}; expected v6`);
+    }
+  }
+}
+
+export function protocolVersionForMode(_mode: ConsumerProtocolMode): number {
+  return PROTOCOL_VERSION;
+}

--- a/packages/zero-cache/bench/rm-vs-load/consumer-worker.ts
+++ b/packages/zero-cache/bench/rm-vs-load/consumer-worker.ts
@@ -1,0 +1,223 @@
+import {performance} from 'node:perf_hooks';
+import {parentPort, workerData} from 'node:worker_threads';
+import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
+import {Database} from '../../../zqlite/src/db.ts';
+import type {ChangeStreamData} from '../../src/services/change-source/protocol/current/downstream.ts';
+import {ThreadWriteWorkerClient} from '../../src/services/replicator/write-worker-client.ts';
+import {sleep} from './perf-utils.ts';
+import {
+  connectConsumerWebSocket,
+  parseTransportBatch,
+  type TransportBatch,
+} from './protocol.ts';
+import {cleanupSQLite, initializeReplica} from './replica.ts';
+import type {ConsumerWorkerData, LoadConsumerStats} from './types.ts';
+
+if (parentPort === null) {
+  throw new Error('consumer-worker must run inside a worker_thread');
+}
+
+const workerPort = parentPort;
+const config = workerData as ConsumerWorkerData;
+const lc = createSilentLogContext();
+let active = true;
+let cpuSink = 0;
+
+let processed = 0;
+let totalParseMs = 0;
+let totalApplyMs = 0;
+let totalTxApplyMs = 0;
+let maxTxApplyMs = 0;
+let txApplySamples = 0;
+let txApplyStart: number | undefined;
+let totalClientCpuMs = 0;
+let samples = 0;
+
+function stats(): LoadConsumerStats {
+  const transportStats = transport?.stats() ?? {
+    messages: 0,
+    bytes: 0,
+    acks: 0,
+    ackBytes: 0,
+  };
+  return {
+    processed,
+    ackedWatermark: '',
+    watermark: '',
+    pending: 0,
+    transportMessages: transportStats.messages,
+    transportBytes: transportStats.bytes,
+    transportAcks: transportStats.acks,
+    transportAckBytes: transportStats.ackBytes,
+    maxAckLagMessages: 0,
+    totalAckLagMessages: 0,
+    totalParseMs,
+    totalApplyMs,
+    totalTxApplyMs,
+    maxTxApplyMs,
+    txApplySamples,
+    totalClientCpuMs,
+    samples,
+  };
+}
+
+let transport: Awaited<ReturnType<typeof connectConsumerWebSocket>> | undefined;
+
+workerPort.on('message', msg => {
+  if (typeof msg === 'object' && msg !== null && 'type' in msg) {
+    switch (msg.type) {
+      case 'stop':
+        active = false;
+        void transport?.close();
+        break;
+      case 'stats':
+        workerPort.postMessage({type: 'stats', stats: stats()});
+        break;
+    }
+  }
+});
+
+function postStats() {
+  workerPort.postMessage({type: 'stats', stats: stats()});
+}
+
+try {
+  await run();
+  workerPort.postMessage({type: 'done', stats: stats()});
+  workerPort.close();
+} catch (e) {
+  const error = e instanceof Error ? e : new Error(String(e));
+  workerPort.postMessage({
+    type: 'error',
+    error: {message: error.message, stack: error.stack},
+  });
+  workerPort.close();
+}
+
+async function run() {
+  let consumerReplica: Database | undefined;
+  let processor: ReturnType<typeof initializeReplica> | undefined;
+  let writeWorker: ThreadWriteWorkerClient | undefined;
+
+  if (config.sqlitePath !== undefined && config.applyMode !== 'none') {
+    cleanupSQLite(config.sqlitePath);
+    consumerReplica = new Database(lc, config.sqlitePath);
+    consumerReplica.pragma('journal_mode = WAL2');
+    consumerReplica.pragma(`synchronous = ${config.synchronous ?? 'NORMAL'}`);
+    processor = initializeReplica(lc, consumerReplica, config.replicaVersion);
+    if (config.applyMode !== 'direct') {
+      consumerReplica.close();
+      consumerReplica = undefined;
+      processor = undefined;
+      writeWorker = new ThreadWriteWorkerClient();
+      await writeWorker.init(
+        config.sqlitePath,
+        'serving',
+        {
+          busyTimeout: 30000,
+          analysisLimit: 1000,
+          walAutocheckpoint: config.walAutocheckpoint,
+        },
+        {level: 'error', format: 'text'},
+      );
+    }
+  }
+
+  const applyChange = (
+    change: ChangeStreamData | undefined,
+  ): Promise<unknown> | undefined => {
+    if (!change) {
+      return;
+    }
+    switch (config.applyMode) {
+      case 'none':
+        return;
+      case 'direct':
+        processor?.processMessage(lc, change);
+        return;
+      case 'worker-message':
+        return writeWorker?.processMessage(change);
+    }
+  };
+
+  const interval = setInterval(postStats, 25);
+  interval.unref();
+
+  try {
+    transport = await connectConsumerWebSocket(
+      lc,
+      config.url,
+      config.transportAckMode,
+      config.protocolMode,
+    );
+    workerPort.postMessage({type: 'ready'});
+
+    for await (const batch of transport.messages) {
+      if (!active) {
+        break;
+      }
+      await consumeBatch(batch, applyChange);
+    }
+  } finally {
+    clearInterval(interval);
+    await transport?.close();
+    await writeWorker?.stop();
+    consumerReplica?.close();
+    if (config.sqlitePath !== undefined) {
+      cleanupSQLite(config.sqlitePath);
+    }
+  }
+}
+
+async function consumeBatch(
+  batch: TransportBatch,
+  applyChange: (
+    change: ChangeStreamData | undefined,
+  ) => Promise<unknown> | undefined,
+) {
+  const parseStart = performance.now();
+  const changes = parseTransportBatch(batch);
+  totalParseMs += performance.now() - parseStart;
+
+  for (const change of changes) {
+    if (change?.[0] === 'begin') {
+      txApplyStart = performance.now();
+    }
+    const applyStart = performance.now();
+    const applyResult = applyChange(change);
+    if (applyResult) {
+      await applyResult;
+    }
+    totalApplyMs += performance.now() - applyStart;
+    if (change?.[0] === 'commit' || change?.[0] === 'rollback') {
+      if (txApplyStart !== undefined) {
+        const elapsed = performance.now() - txApplyStart;
+        totalTxApplyMs += elapsed;
+        maxTxApplyMs = Math.max(maxTxApplyMs, elapsed);
+        txApplySamples++;
+        txApplyStart = undefined;
+      }
+    }
+    const cpuStart = performance.now();
+    burnCpu(config.clientCpuMicros);
+    totalClientCpuMs += performance.now() - cpuStart;
+    if (config.ackDelayMs > 0) {
+      await sleep(config.ackDelayMs);
+    }
+    processed++;
+    samples++;
+  }
+}
+
+function burnCpu(micros: number) {
+  if (micros <= 0) {
+    return;
+  }
+
+  const end = performance.now() + micros / 1000;
+  let value = cpuSink;
+  while (performance.now() < end) {
+    value = (value + Math.imul(value + 1, 31)) % 1_000_003;
+  }
+  cpuSink = value;
+}

--- a/packages/zero-cache/bench/rm-vs-load/consumers.ts
+++ b/packages/zero-cache/bench/rm-vs-load/consumers.ts
@@ -1,0 +1,470 @@
+import {performance} from 'node:perf_hooks';
+import {Worker} from 'node:worker_threads';
+import type {LogContext} from '@rocicorp/logger';
+import {Database} from '../../../zqlite/src/db.ts';
+import type {ChangeStreamData} from '../../src/services/change-source/protocol/current/downstream.ts';
+import {Subscriber} from '../../src/services/change-streamer/subscriber.ts';
+import {ThreadWriteWorkerClient} from '../../src/services/replicator/write-worker-client.ts';
+import {Subscription} from '../../src/types/subscription.ts';
+import {protocolVersionForMode} from './config.ts';
+import {sleep} from './perf-utils.ts';
+import {
+  createConsumerTransport,
+  createConsumerWebSocketServer,
+  mergeTransportStats,
+  parseTransportBatch,
+} from './protocol.ts';
+import {cleanupSQLite, initializeReplica} from './replica.ts';
+import type {
+  ConsumerConfig,
+  ConsumerWorkerData,
+  LoadConsumer,
+  LoadConsumerStats,
+} from './types.ts';
+
+export type ConsumerFactoryOptions = {
+  readonly lc: LogContext;
+  readonly sqlitePath: string;
+  readonly replicaVersion: string;
+  readonly consumerWorkerUrl?: URL | undefined;
+};
+
+export class ConsumerFactory {
+  readonly #lc: LogContext;
+  readonly #sqlitePath: string;
+  readonly #replicaVersion: string;
+  readonly #consumerWorkerUrl: URL;
+  #cpuSink = 0;
+
+  constructor({
+    lc,
+    sqlitePath,
+    replicaVersion,
+    consumerWorkerUrl = new URL('./consumer-worker.ts', import.meta.url),
+  }: ConsumerFactoryOptions) {
+    this.#lc = lc;
+    this.#sqlitePath = sqlitePath;
+    this.#replicaVersion = replicaVersion;
+    this.#consumerWorkerUrl = consumerWorkerUrl;
+  }
+
+  createGroup(config: ConsumerConfig): Promise<LoadConsumer[]> {
+    return Promise.all(
+      Array.from({length: config.count}, (_, i) => {
+        const isSlow = config.slowEvery > 0 && (i + 1) % config.slowEvery === 0;
+        const consumerConfig = ConsumerFactory.configForApplySlot(config, i);
+        return this.create(
+          `vs-${i}`,
+          this.#replicaVersion,
+          isSlow ? consumerConfig.slowAckDelayMs : consumerConfig.ackDelayMs,
+          consumerConfig,
+          true,
+        );
+      }),
+    );
+  }
+
+  static configForApplySlot(
+    config: ConsumerConfig,
+    index: number,
+  ): ConsumerConfig {
+    if (config.applyLimit === undefined || index < config.applyLimit) {
+      return config;
+    }
+    return {
+      ...config,
+      applyMode: 'none',
+      applyMessages: false,
+    };
+  }
+
+  create(
+    id: string,
+    watermark: string,
+    ackDelayMs: number,
+    config: ConsumerConfig,
+    caughtUp: boolean,
+  ): Promise<LoadConsumer> {
+    const downstream = Subscription.create<string>();
+    const sub = new Subscriber(
+      protocolVersionForMode(config.protocolMode),
+      id,
+      watermark,
+      downstream,
+      () => ({
+        tag: 'status',
+      }),
+    );
+    if (caughtUp) {
+      sub.setCaughtUp();
+    }
+    if (config.runtime === 'worker') {
+      return this.#createWorkerRuntimeConsumer(
+        id,
+        sub,
+        downstream,
+        ackDelayMs,
+        config,
+      );
+    }
+    return this.#createInlineConsumer(id, sub, downstream, ackDelayMs, config);
+  }
+
+  async #createInlineConsumer(
+    id: string,
+    sub: Subscriber,
+    downstream: Subscription<string>,
+    ackDelayMs: number,
+    config: ConsumerConfig,
+  ): Promise<LoadConsumer> {
+    let active = true;
+    let processed = 0;
+    let maxAckLagMessages = 0;
+    let totalAckLagMessages = 0;
+    let totalParseMs = 0;
+    let totalApplyMs = 0;
+    let totalTxApplyMs = 0;
+    let maxTxApplyMs = 0;
+    let txApplySamples = 0;
+    let txApplyStart: number | undefined;
+    let totalClientCpuMs = 0;
+    let samples = 0;
+    let consumerReplica: Database | undefined;
+    let processor: ReturnType<typeof initializeReplica> | undefined;
+    let worker: ThreadWriteWorkerClient | undefined;
+    let consumerSQLitePath: string | undefined;
+
+    if (config.applyMode !== 'none') {
+      consumerSQLitePath = `${this.#sqlitePath}-${id}`;
+      cleanupSQLite(consumerSQLitePath);
+      consumerReplica = new Database(this.#lc, consumerSQLitePath);
+      consumerReplica.pragma('journal_mode = WAL2');
+      consumerReplica.pragma(`synchronous = ${config.synchronous ?? 'NORMAL'}`);
+      processor = initializeReplica(
+        this.#lc,
+        consumerReplica,
+        this.#replicaVersion,
+      );
+      if (config.applyMode !== 'direct') {
+        consumerReplica.close();
+        consumerReplica = undefined;
+        processor = undefined;
+        worker = new ThreadWriteWorkerClient();
+        await worker.init(
+          consumerSQLitePath,
+          'serving',
+          {
+            busyTimeout: 30000,
+            analysisLimit: 1000,
+            walAutocheckpoint: config.walAutocheckpoint,
+          },
+          {level: 'error', format: 'text'},
+        );
+      }
+    }
+
+    const applyChange = (
+      change: ChangeStreamData | undefined,
+    ): Promise<unknown> | undefined => {
+      if (!change) {
+        return;
+      }
+      switch (config.applyMode) {
+        case 'none':
+          return;
+        case 'direct':
+          processor?.processMessage(this.#lc, change);
+          return;
+        case 'worker-message':
+          return worker?.processMessage(change);
+      }
+    };
+
+    const transport = await createConsumerTransport(
+      this.#lc,
+      downstream,
+      config.transportMode,
+      config.transportAckMode,
+      config.transportBatchMessages,
+      config.protocolMode,
+    );
+
+    const done = (async () => {
+      try {
+        for await (const batch of transport.messages) {
+          if (!active) {
+            break;
+          }
+          const parseStart = performance.now();
+          const changes = parseTransportBatch(batch);
+          totalParseMs += performance.now() - parseStart;
+
+          for (const change of changes) {
+            if (change?.[0] === 'begin') {
+              txApplyStart = performance.now();
+            }
+            const applyStart = performance.now();
+            const applyResult = applyChange(change);
+            if (applyResult) {
+              await applyResult;
+            }
+            totalApplyMs += performance.now() - applyStart;
+            if (change?.[0] === 'commit' || change?.[0] === 'rollback') {
+              if (txApplyStart !== undefined) {
+                const elapsed = performance.now() - txApplyStart;
+                totalTxApplyMs += elapsed;
+                maxTxApplyMs = Math.max(maxTxApplyMs, elapsed);
+                txApplySamples++;
+                txApplyStart = undefined;
+              }
+            }
+            const cpuStart = performance.now();
+            this.#burnCpu(config.clientCpuMicros);
+            totalClientCpuMs += performance.now() - cpuStart;
+            if (ackDelayMs > 0) {
+              await sleep(ackDelayMs);
+            }
+            processed++;
+            const lag = sub.numPending;
+            maxAckLagMessages = Math.max(maxAckLagMessages, lag);
+            totalAckLagMessages += lag;
+            samples++;
+          }
+        }
+      } finally {
+        await transport.close();
+        await worker?.stop();
+        consumerReplica?.close();
+        if (consumerSQLitePath) {
+          cleanupSQLite(consumerSQLitePath);
+        }
+      }
+    })();
+
+    return {
+      sub,
+      sqlitePath: consumerSQLitePath,
+      done,
+      stop: () => {
+        active = false;
+        sub.close();
+      },
+      stats: () => ({
+        processed,
+        ackedWatermark: sub.acked,
+        watermark: sub.watermark,
+        pending: sub.numPending,
+        transportMessages: transport.stats().messages,
+        transportBytes: transport.stats().bytes,
+        transportAcks: transport.stats().acks,
+        transportAckBytes: transport.stats().ackBytes,
+        maxAckLagMessages,
+        totalAckLagMessages,
+        totalParseMs,
+        totalApplyMs,
+        totalTxApplyMs,
+        maxTxApplyMs,
+        txApplySamples,
+        totalClientCpuMs,
+        samples,
+      }),
+    };
+  }
+
+  async #createWorkerRuntimeConsumer(
+    id: string,
+    sub: Subscriber,
+    downstream: Subscription<string>,
+    ackDelayMs: number,
+    config: ConsumerConfig,
+  ): Promise<LoadConsumer> {
+    if (config.transportMode !== 'websocket') {
+      throw new Error(
+        'ZERO_RM_VS_CONSUMER_RUNTIME=worker requires ' +
+          'ZERO_RM_VS_TRANSPORT=websocket',
+      );
+    }
+
+    const server = await createConsumerWebSocketServer(
+      this.#lc,
+      downstream,
+      config.transportBatchMessages,
+      config.protocolMode,
+    );
+    const consumerSQLitePath =
+      config.applyMode === 'none' ? undefined : `${this.#sqlitePath}-${id}`;
+    const worker = new Worker(this.#consumerWorkerUrl, {
+      workerData: {
+        id,
+        url: server.url,
+        sqlitePath: consumerSQLitePath,
+        replicaVersion: this.#replicaVersion,
+        protocolMode: config.protocolMode,
+        transportAckMode: config.transportAckMode,
+        applyMode: config.applyMode,
+        synchronous: config.synchronous,
+        walAutocheckpoint: config.walAutocheckpoint,
+        clientCpuMicros: config.clientCpuMicros,
+        ackDelayMs,
+      } satisfies ConsumerWorkerData,
+    });
+
+    let latestWorkerStats = emptyConsumerStats();
+    let maxAckLagMessages = 0;
+    let totalAckLagMessages = 0;
+    let ackLagSamples = 0;
+    let lastObservedSamples = 0;
+    let complete = false;
+
+    const observeAckLag = () => {
+      const lag = sub.numPending;
+      maxAckLagMessages = Math.max(maxAckLagMessages, lag);
+      const delta = Math.max(
+        0,
+        latestWorkerStats.samples - lastObservedSamples,
+      );
+      if (delta > 0) {
+        totalAckLagMessages += lag * delta;
+        ackLagSamples += delta;
+        lastObservedSamples = latestWorkerStats.samples;
+      }
+    };
+    const ackLagInterval = setInterval(observeAckLag, 10);
+    ackLagInterval.unref();
+
+    let resolveReady!: () => void;
+    let rejectReady!: (err: Error) => void;
+    const ready = new Promise<void>((resolve, reject) => {
+      resolveReady = resolve;
+      rejectReady = reject;
+    });
+
+    let resolveDone!: () => void;
+    let rejectDone!: (err: Error) => void;
+    const workerDone = new Promise<void>((resolve, reject) => {
+      resolveDone = resolve;
+      rejectDone = reject;
+    });
+
+    const fail = (err: Error) => {
+      rejectReady(err);
+      rejectDone(err);
+    };
+
+    worker.on('message', msg => {
+      if (typeof msg !== 'object' || msg === null || !('type' in msg)) {
+        return;
+      }
+      switch (msg.type) {
+        case 'ready':
+          resolveReady();
+          break;
+        case 'stats':
+          latestWorkerStats = msg.stats as LoadConsumerStats;
+          observeAckLag();
+          break;
+        case 'done':
+          latestWorkerStats = msg.stats as LoadConsumerStats;
+          observeAckLag();
+          complete = true;
+          resolveDone();
+          break;
+        case 'error': {
+          const error = msg.error as {message?: unknown; stack?: unknown};
+          const message =
+            typeof error.message === 'string'
+              ? error.message
+              : 'consumer worker error';
+          const err = new Error(message);
+          if (typeof error.stack === 'string') {
+            err.stack = error.stack;
+          }
+          fail(err);
+          break;
+        }
+      }
+    });
+    worker.on('error', fail);
+    worker.on('exit', code => {
+      if (!complete && code !== 0) {
+        fail(new Error(`consumer worker ${id} exited with code ${code}`));
+      }
+    });
+
+    await ready;
+
+    const done = workerDone.finally(async () => {
+      clearInterval(ackLagInterval);
+      await server.close();
+      await worker.terminate();
+    });
+
+    return {
+      sub,
+      sqlitePath: consumerSQLitePath,
+      done,
+      stop: () => {
+        sub.close();
+        worker.postMessage({type: 'stop'});
+      },
+      stats: () => {
+        observeAckLag();
+        const serverStats = server.stats();
+        const transportStats = mergeTransportStats(serverStats, {
+          messages: 0,
+          bytes: 0,
+          acks: latestWorkerStats.transportAcks,
+          ackBytes: latestWorkerStats.transportAckBytes,
+        });
+        return {
+          ...latestWorkerStats,
+          ackedWatermark: sub.acked,
+          watermark: sub.watermark,
+          pending: sub.numPending,
+          transportMessages: transportStats.messages,
+          transportBytes: transportStats.bytes,
+          transportAcks: transportStats.acks,
+          transportAckBytes: transportStats.ackBytes,
+          maxAckLagMessages,
+          totalAckLagMessages,
+          samples: Math.max(latestWorkerStats.samples, ackLagSamples),
+        };
+      },
+    };
+  }
+
+  #burnCpu(micros: number) {
+    if (micros <= 0) {
+      return;
+    }
+
+    const end = performance.now() + micros / 1000;
+    let value = this.#cpuSink;
+    while (performance.now() < end) {
+      value = (value + Math.imul(value + 1, 31)) % 1_000_003;
+    }
+    this.#cpuSink = value;
+  }
+}
+
+function emptyConsumerStats(): LoadConsumerStats {
+  return {
+    processed: 0,
+    ackedWatermark: '',
+    watermark: '',
+    pending: 0,
+    transportMessages: 0,
+    transportBytes: 0,
+    transportAcks: 0,
+    transportAckBytes: 0,
+    maxAckLagMessages: 0,
+    totalAckLagMessages: 0,
+    totalParseMs: 0,
+    totalApplyMs: 0,
+    totalTxApplyMs: 0,
+    maxTxApplyMs: 0,
+    txApplySamples: 0,
+    totalClientCpuMs: 0,
+    samples: 0,
+  };
+}

--- a/packages/zero-cache/bench/rm-vs-load/e2e.ts
+++ b/packages/zero-cache/bench/rm-vs-load/e2e.ts
@@ -1,0 +1,83 @@
+/* oxlint-disable no-console */
+
+const defaults = {
+  // Pin the review scenario to the corrected serving topology: one RM stream
+  // consumer applies into one shared serving replica while a reconnecting
+  // consumer catches up under load. Syncer workers in the same serving process
+  // read the shared replica; they are not independent RM stream appliers.
+  ZERO_RM_VS_FULL: '1',
+  ZERO_RM_VS_DURATION_MS: '15000',
+  ZERO_RM_VS_SUBSCRIBERS: '1',
+  ZERO_RM_VS_APPLY_LIMIT: '1',
+  ZERO_RM_VS_SCENARIO: 'shared-replica-sync-workers',
+  ZERO_RM_VS_APPLY_MODE: 'worker-message',
+  ZERO_RM_VS_CONSUMER_RUNTIME: 'worker',
+  ZERO_RM_VS_TRANSPORT: 'websocket',
+  ZERO_RM_VS_PROTOCOL: 'v6',
+  ZERO_RM_VS_WS_ACK: 'per-message',
+  ZERO_RM_VS_WS_BATCH_MESSAGES: '1',
+  ZERO_RM_VS_CLIENT_CPU_US: '0',
+  ZERO_RM_VS_SOURCE_APPLY: '0',
+  ZERO_RM_VS_SLOW_EVERY: '0',
+  ZERO_RM_VS_RECONNECT_LAG_TX: '500',
+  ZERO_RM_VS_FINAL_CATCHUP_TIMEOUT_MS: '15000',
+  ZERO_RM_VS_SETTLE_MS: '50',
+  ZERO_RM_VS_SMALL_TARGET_TPS: '5000',
+  ZERO_RM_VS_MEDIUM_TARGET_TPS: '2000',
+  ZERO_RM_VS_MEDIUM_WIDE_TARGET_TPS: '4000',
+  ZERO_RM_VS_MIXED_TARGET_TPS: '4000',
+  ZERO_RM_VS_LARGE_TARGET_TPS: '600',
+  ZERO_RM_VS_SHARED_SYNC_TARGET_TPS: '4000',
+  ZERO_RM_VS_SYNC_WORKERS: '8',
+  ZERO_RM_VS_SYNC_WORKER_READ_DELAY_MS: '1',
+  ZERO_RM_VS_FLUSH_BYTES: String(2 * 1024 * 1024),
+} as const;
+
+for (const [name, value] of Object.entries(defaults)) {
+  process.env[name] ??= value;
+}
+
+console.log(
+  [
+    'rm-vs-load e2e benchmark',
+    '  rm: 1',
+    `  rm-stream-consumers: ${process.env.ZERO_RM_VS_SUBSCRIBERS}`,
+    `  duration-ms: ${process.env.ZERO_RM_VS_DURATION_MS}`,
+    `  apply-mode: ${
+      process.env.ZERO_RM_VS_APPLY_MODE ??
+      (process.env.ZERO_RM_VS_APPLY_CLIENTS === '1' ? 'direct' : 'none')
+    }`,
+    `  apply-limit: ${process.env.ZERO_RM_VS_APPLY_LIMIT ?? 'all'}`,
+    `  sync-workers: ${process.env.ZERO_RM_VS_SYNC_WORKERS ?? 'scenario-default'}`,
+    `  sync-worker-read-delay-ms: ${process.env.ZERO_RM_VS_SYNC_WORKER_READ_DELAY_MS ?? '1'}`,
+    `  consumer-runtime: ${process.env.ZERO_RM_VS_CONSUMER_RUNTIME ?? 'inline'}`,
+    `  transport: ${process.env.ZERO_RM_VS_TRANSPORT ?? 'in-process'}`,
+    `  protocol: ${process.env.ZERO_RM_VS_PROTOCOL ?? 'v6'}`,
+    `  ws-ack: ${process.env.ZERO_RM_VS_WS_ACK ?? 'per-message'}`,
+    `  ws-batch-messages: ${process.env.ZERO_RM_VS_WS_BATCH_MESSAGES ?? '1'}`,
+    `  flush-bytes: ${process.env.ZERO_RM_VS_FLUSH_BYTES}`,
+    `  sqlite-synchronous: ${process.env.ZERO_RM_VS_SQLITE_SYNCHRONOUS ?? 'NORMAL'}`,
+    `  wal-autocheckpoint: ${process.env.ZERO_RM_VS_WAL_AUTOCHECKPOINT ?? 'serving-default'}`,
+    `  apply-clients: ${process.env.ZERO_RM_VS_APPLY_CLIENTS}`,
+    `  client-cpu-us: ${process.env.ZERO_RM_VS_CLIENT_CPU_US}`,
+    `  source-apply: ${process.env.ZERO_RM_VS_SOURCE_APPLY}`,
+    `  reconnect-lag-tx: ${process.env.ZERO_RM_VS_RECONNECT_LAG_TX}`,
+    `  target-tps: small=${process.env.ZERO_RM_VS_SMALL_TARGET_TPS}, ` +
+      `medium=${process.env.ZERO_RM_VS_MEDIUM_TARGET_TPS}, ` +
+      `medium-wide=${process.env.ZERO_RM_VS_MEDIUM_WIDE_TARGET_TPS}, ` +
+      `shared-sync=${process.env.ZERO_RM_VS_SHARED_SYNC_TARGET_TPS}, ` +
+      `mixed=${process.env.ZERO_RM_VS_MIXED_TARGET_TPS}, ` +
+      `large=${process.env.ZERO_RM_VS_LARGE_TARGET_TPS}`,
+    '',
+    'flow:',
+    `  RM -> Storer -> changeLog -> ${process.env.ZERO_RM_VS_SUBSCRIBERS} serving replica stream consumer(s)`,
+    '                  |',
+    '                  +-> reconnect catchup consumer when enabled',
+    '',
+    'note:',
+    '  Syncer workers inside one serving process share the serving replica;',
+    '  this harness models them as shared SQLite readers, not independent RM stream appliers.',
+  ].join('\n'),
+);
+
+await import('./index.ts');

--- a/packages/zero-cache/bench/rm-vs-load/fixtures.ts
+++ b/packages/zero-cache/bench/rm-vs-load/fixtures.ts
@@ -1,0 +1,189 @@
+import type {TableSpec} from '../../src/db/specs.ts';
+import type {
+  DataOrSchemaChange,
+  MessageDelete,
+  IndexCreate,
+  MessageInsert,
+  MessageRelation,
+  MessageUpdate,
+} from '../../src/services/change-source/protocol/current/data.ts';
+import type {
+  Begin,
+  Commit,
+  Data,
+} from '../../src/services/change-source/protocol/current/downstream.ts';
+import {ReplicationMessages} from '../../src/services/replicator/test-utils.ts';
+
+type PayloadSize = 'small' | 'medium' | 'large';
+type TransactionMessage = Begin | Data | Commit;
+
+export type PayloadProfile = {
+  readonly size: PayloadSize;
+  readonly bytes: number;
+};
+
+const payloadBytes: Record<PayloadSize, number> = {
+  small: 96,
+  medium: 1024,
+  large: 8192,
+};
+
+export const loadPayloadProfiles: readonly PayloadProfile[] = [
+  {size: 'small', bytes: payloadBytes.small},
+  {size: 'medium', bytes: payloadBytes.medium},
+  {size: 'large', bytes: payloadBytes.large},
+];
+
+export const smokePayloadProfiles: readonly PayloadProfile[] = [
+  {size: 'small', bytes: payloadBytes.small},
+];
+
+export type LoadScenario = {
+  readonly rowsPerTx: number;
+  readonly payload: PayloadProfile;
+};
+
+export type GeneratedTransaction = {
+  readonly watermark: string;
+  readonly changes: TransactionMessage[];
+  readonly rows: number;
+  readonly operationCounts: OperationCounts;
+};
+
+export type OperationCounts = {
+  insert: number;
+  update: number;
+  delete: number;
+};
+
+export function emptyOperationCounts(): OperationCounts {
+  return {insert: 0, update: 0, delete: 0};
+}
+
+const tableName = 'bench_rows';
+const messages = new ReplicationMessages({[tableName]: 'id'});
+export const benchRelation: MessageRelation = {
+  schema: 'public',
+  name: tableName,
+  rowKey: {type: 'default', columns: ['id']},
+};
+
+export const benchTableSpec: TableSpec = {
+  schema: 'public',
+  name: tableName,
+  primaryKey: ['id'],
+  columns: {
+    id: {pos: 1, dataType: 'text', notNull: true},
+    tx: {pos: 2, dataType: 'int8', notNull: true},
+    seq: {pos: 3, dataType: 'int8', notNull: true},
+    bucket: {pos: 4, dataType: 'int4', notNull: true},
+    payload: {pos: 5, dataType: 'text', notNull: true},
+  },
+};
+
+export const benchPrimaryIndex: IndexCreate = messages.createIndex({
+  schema: 'public',
+  name: `${tableName}_pk`,
+  tableName,
+  unique: true,
+  columns: {id: 'ASC'},
+});
+
+const payloadPattern =
+  '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+const payloadCache = new Map<number, string>();
+
+function payloadFor(bytes: number): string {
+  let payload = payloadCache.get(bytes);
+  if (payload !== undefined) {
+    return payload;
+  }
+  payload = payloadPattern
+    .repeat(Math.ceil(bytes / payloadPattern.length))
+    .slice(0, bytes);
+  payloadCache.set(bytes, payload);
+  return payload;
+}
+
+export function watermarkFor(tx: number): string {
+  return tx.toString(36).padStart(12, '0');
+}
+
+export function makeInsert(
+  tx: number,
+  seq: number,
+  bytes: number,
+  id = rowID(tx, seq),
+): MessageInsert {
+  return {
+    tag: 'insert',
+    relation: benchRelation,
+    new: makeRow(id, tx, seq, bytes),
+  };
+}
+
+export function makeUpdate(
+  id: string,
+  tx: number,
+  seq: number,
+  bytes: number,
+): MessageUpdate {
+  return messages.update(tableName, makeRow(id, tx, seq, bytes));
+}
+
+export function makeDelete(id: string): MessageDelete {
+  return messages.delete(tableName, {id});
+}
+
+function rowID(tx: number, seq: number): string {
+  return `${tx.toString(36)}-${seq.toString(36)}`;
+}
+
+function makeRow(id: string, tx: number, seq: number, bytes: number) {
+  return {
+    id,
+    tx,
+    seq,
+    bucket: seq % 32,
+    payload: payloadFor(bytes),
+  };
+}
+
+export function makeTransaction(
+  tx: number,
+  rowsPerTx: number,
+  payload: PayloadProfile,
+): GeneratedTransaction {
+  const watermark = watermarkFor(tx);
+  const changes: TransactionMessage[] = [
+    ['begin', messages.begin(), {commitWatermark: watermark}],
+  ];
+
+  for (let i = 0; i < rowsPerTx; i++) {
+    changes.push(['data', makeInsert(tx, i, payload.bytes)]);
+  }
+
+  changes.push(['commit', messages.commit(), {watermark}]);
+
+  return {
+    watermark,
+    changes,
+    rows: rowsPerTx,
+    operationCounts: {insert: rowsPerTx, update: 0, delete: 0},
+  };
+}
+
+export function makeSchemaChanges(): DataOrSchemaChange[] {
+  return [messages.createTable(benchTableSpec), benchPrimaryIndex];
+}
+
+export function makeTransactions(
+  count: number,
+  rowsPerTx: number,
+  payload: PayloadProfile,
+  startTx = 1,
+): GeneratedTransaction[] {
+  return Array.from({length: count}, (_, i) =>
+    makeTransaction(startTx + i, rowsPerTx, payload),
+  );
+}

--- a/packages/zero-cache/bench/rm-vs-load/index.ts
+++ b/packages/zero-cache/bench/rm-vs-load/index.ts
@@ -1,0 +1,54 @@
+/* oxlint-disable no-console */
+import {BenchmarkConfigLoader, EnvReader} from './config.ts';
+import {formatRate, writeJsonSummary} from './perf-utils.ts';
+import {
+  BenchmarkSuite,
+  formatOperationCounts,
+  formatReconnectSummary,
+} from './runner.ts';
+import {describeScenarios, loadScenarios} from './scenarios.ts';
+
+const env = new EnvReader();
+const config = new BenchmarkConfigLoader(env).load();
+const scenarios = loadScenarios({full: config.full, env});
+
+console.log(`scenario bytes: ${describeScenarios(scenarios)}`);
+
+const summary = await new BenchmarkSuite(config, scenarios).run();
+
+for (const result of summary.scenarios) {
+  console.log(
+    `${result.name}: ${formatRate(result.writeLoopTxPerSec)} tx/s load | ` +
+      `${formatRate(result.writeLoopRowsPerSec)} rows/s load | ` +
+      `ops ${formatOperationCounts(result.operationCounts)} | ` +
+      `${formatRate(result.fanoutMessagesPerSec)} fanout msg/s | ` +
+      `p95 ${result.p95TxLatencyMs.toFixed(3)} ms | ` +
+      `vs-tx ${result.avgSubscriberTxApplyMs.toFixed(3)} ms | ` +
+      formatSyncWorkerSummary(result) +
+      `drain ${result.storerDrainMs.toFixed(1)} ms | ` +
+      `max lag ${result.maxAckLagMessages}` +
+      formatReconnectSummary(result),
+  );
+}
+
+console.log(JSON.stringify(summary));
+await writeJsonSummary(summary, config.outputPath);
+
+function formatSyncWorkerSummary(result: {
+  readonly syncWorkerCount: number;
+  readonly syncWorkerReadsPerSec: number;
+  readonly avgSyncWorkerReadMs: number;
+  readonly maxSyncWorkerReadMs: number;
+  readonly syncWorkerErrors: number;
+}) {
+  if (result.syncWorkerCount === 0) {
+    return '';
+  }
+  return (
+    `sync-workers ${result.syncWorkerCount} ` +
+    `${formatRate(result.syncWorkerReadsPerSec)} reads/s ` +
+    `avg ${result.avgSyncWorkerReadMs.toFixed(3)} ms ` +
+    `max ${result.maxSyncWorkerReadMs.toFixed(3)} ms ` +
+    `errors ${result.syncWorkerErrors} | `
+  );
+}

--- a/packages/zero-cache/bench/rm-vs-load/perf-utils.ts
+++ b/packages/zero-cache/bench/rm-vs-load/perf-utils.ts
@@ -1,0 +1,54 @@
+import {mkdir, writeFile} from 'node:fs/promises';
+import {dirname} from 'node:path';
+
+export function percentile(values: readonly number[], p: number): number {
+  if (values.length === 0) {
+    return 0;
+  }
+  const sorted = values.toSorted((a, b) => a - b);
+  const index = Math.min(
+    sorted.length - 1,
+    Math.max(0, Math.ceil((p / 100) * sorted.length) - 1),
+  );
+  return sorted[index] ?? 0;
+}
+
+export function sum(values: readonly number[]): number {
+  let total = 0;
+  for (const value of values) {
+    total += value;
+  }
+  return total;
+}
+
+export function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+  const units = ['KiB', 'MiB', 'GiB'] as const;
+  let value = bytes / 1024;
+  let unit: (typeof units)[number] = units[0];
+  for (let i = 1; i < units.length && value >= 1024; i++) {
+    value /= 1024;
+    unit = units[i];
+  }
+  return `${value.toFixed(value >= 10 ? 1 : 2)} ${unit}`;
+}
+
+export function formatRate(value: number): string {
+  return value.toLocaleString('en-US', {maximumFractionDigits: 1});
+}
+
+export async function writeJsonSummary(
+  summary: unknown,
+  outputPath: string | undefined,
+): Promise<void> {
+  if (outputPath !== undefined) {
+    await mkdir(dirname(outputPath), {recursive: true});
+    await writeFile(outputPath, JSON.stringify(summary, null, 2) + '\n');
+  }
+}

--- a/packages/zero-cache/bench/rm-vs-load/protocol.ts
+++ b/packages/zero-cache/bench/rm-vs-load/protocol.ts
@@ -1,0 +1,242 @@
+import {once} from 'node:events';
+import type {LogContext} from '@rocicorp/logger';
+import WebSocket, {WebSocketServer} from 'ws';
+import {assert} from '../../../shared/src/asserts.ts';
+import {BigIntJSON} from '../../../shared/src/bigint-json.ts';
+import type {ChangeStreamData} from '../../src/services/change-source/protocol/current/downstream.ts';
+import {
+  downstreamSchema,
+  type Downstream,
+} from '../../src/services/change-streamer/change-streamer.ts';
+import {streamIn, streamOutStringified} from '../../src/types/streams.ts';
+import type {Subscription} from '../../src/types/subscription.ts';
+import type {
+  ConsumerProtocolMode,
+  ConsumerTransportAckMode,
+  ConsumerTransportMode,
+} from './types.ts';
+
+export type TransportMessage = string | Downstream;
+
+export type TransportBatch = {
+  readonly kind: 'messages';
+  readonly messages: readonly TransportMessage[];
+};
+
+export type ConsumerTransportStats = {
+  readonly messages: number;
+  readonly bytes: number;
+  readonly acks: number;
+  readonly ackBytes: number;
+};
+
+export async function createConsumerTransport(
+  lc: LogContext,
+  downstream: Subscription<string>,
+  mode: ConsumerTransportMode,
+  ackMode: ConsumerTransportAckMode,
+  batchMessages: number,
+  protocolMode: ConsumerProtocolMode,
+): Promise<{
+  messages: AsyncIterable<TransportBatch>;
+  close: () => Promise<void>;
+  stats: () => ConsumerTransportStats;
+}> {
+  const stats = {messages: 0, bytes: 0, acks: 0, ackBytes: 0};
+  switch (mode) {
+    case 'in-process':
+      return {
+        messages: batchSingletonMessages(
+          flattenStringifiedMessages(downstream),
+        ),
+        close: () => Promise.resolve(),
+        stats: () => stats,
+      };
+    case 'websocket': {
+      const server = await createConsumerWebSocketServer(
+        lc,
+        downstream,
+        batchMessages,
+        protocolMode,
+      );
+      const client = await connectConsumerWebSocket(
+        lc,
+        server.url,
+        ackMode,
+        protocolMode,
+      );
+      return {
+        messages: client.messages,
+        close: async () => {
+          await client.close();
+          await server.close();
+        },
+        stats: () => mergeTransportStats(server.stats(), client.stats()),
+      };
+    }
+  }
+}
+
+export async function createConsumerWebSocketServer(
+  lc: LogContext,
+  downstream: Subscription<string>,
+  batchMessages: number,
+  protocolMode: ConsumerProtocolMode,
+): Promise<{
+  url: string;
+  close: () => Promise<void>;
+  stats: () => ConsumerTransportStats;
+}> {
+  const stats = {messages: 0, bytes: 0, acks: 0, ackBytes: 0};
+  const server = new WebSocketServer({host: '127.0.0.1', port: 0});
+  server.on('connection', ws => {
+    trackWebSocketSend(ws, data => {
+      stats.messages++;
+      stats.bytes += byteLength(data);
+    });
+    assert(protocolMode === 'v6', 'rm-vs-load only models v6 stream payloads');
+    assert(batchMessages === 1, 'main branch only supports unbatched streams');
+    void streamOutStringified(lc, downstream, ws);
+  });
+  await once(server, 'listening');
+  const address = server.address();
+  assert(
+    address !== null && typeof address !== 'string',
+    'expected websocket server address',
+  );
+  return {
+    url: `ws://127.0.0.1:${address.port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close(err => (err ? reject(err) : resolve()));
+      }),
+    stats: () => stats,
+  };
+}
+
+export async function connectConsumerWebSocket(
+  lc: LogContext,
+  url: string,
+  ackMode: ConsumerTransportAckMode,
+  protocolMode: ConsumerProtocolMode,
+): Promise<{
+  messages: AsyncIterable<TransportBatch>;
+  close: () => Promise<void>;
+  stats: () => ConsumerTransportStats;
+}> {
+  const stats = {messages: 0, bytes: 0, acks: 0, ackBytes: 0};
+  const ws = new WebSocket(url);
+  trackWebSocketSend(ws, data => {
+    stats.acks++;
+    stats.ackBytes += byteLength(data);
+  });
+  let cancelMessages: () => void;
+  let messages: AsyncIterable<TransportBatch>;
+  assert(protocolMode === 'v6', 'rm-vs-load only models v6 stream payloads');
+  assert(
+    ackMode === 'per-message',
+    'main branch only supports per-message ACKs',
+  );
+  const stream = await streamIn(lc, ws, downstreamSchema);
+  cancelMessages = () => stream.cancel();
+  messages = batchSingletonMessages(stream);
+  return {
+    messages,
+    close: () => {
+      cancelMessages();
+      ws.close();
+      return Promise.resolve();
+    },
+    stats: () => stats,
+  };
+}
+
+export function mergeTransportStats(
+  a: ConsumerTransportStats,
+  b: ConsumerTransportStats,
+): ConsumerTransportStats {
+  return {
+    messages: a.messages + b.messages,
+    bytes: a.bytes + b.bytes,
+    acks: a.acks + b.acks,
+    ackBytes: a.ackBytes + b.ackBytes,
+  };
+}
+
+function trackWebSocketSend(ws: WebSocket, onSend: (data: unknown) => void) {
+  const send = ws.send.bind(ws) as (...args: unknown[]) => void;
+  ws.send = ((data: unknown, ...args: unknown[]) => {
+    onSend(data);
+    return send(data, ...args);
+  }) as WebSocket['send'];
+}
+
+function byteLength(data: unknown): number {
+  if (typeof data === 'string') {
+    return Buffer.byteLength(data);
+  }
+  if (Buffer.isBuffer(data)) {
+    return data.byteLength;
+  }
+  if (data instanceof ArrayBuffer) {
+    return data.byteLength;
+  }
+  if (ArrayBuffer.isView(data)) {
+    return data.byteLength;
+  }
+  return Buffer.byteLength(String(data));
+}
+
+async function* batchSingletonMessages(
+  source: AsyncIterable<TransportMessage>,
+): AsyncIterable<TransportBatch> {
+  for await (const message of source) {
+    yield {kind: 'messages', messages: [message]};
+  }
+}
+
+async function* flattenStringifiedMessages(
+  source: AsyncIterable<string>,
+): AsyncIterable<string> {
+  for await (const payload of source) {
+    yield payload;
+  }
+}
+
+export function parseTransportBatch(
+  batch: TransportBatch,
+): (ChangeStreamData | undefined)[] {
+  const changes: (ChangeStreamData | undefined)[] = [];
+  for (const message of batch.messages) {
+    changes.push(
+      ...(typeof message === 'string'
+        ? parseChangeStreamData(message)
+        : downstreamToChangeStreamData(message)),
+    );
+  }
+  return changes;
+}
+
+function parseChangeStreamData(
+  message: string,
+): readonly (ChangeStreamData | undefined)[] {
+  return downstreamToChangeStreamData(BigIntJSON.parse(message) as Downstream);
+}
+
+function downstreamToChangeStreamData(
+  parsed: Downstream,
+): readonly (ChangeStreamData | undefined)[] {
+  switch (parsed[0]) {
+    case 'status':
+      return [undefined];
+    case 'error':
+      throw new Error(`subscription error: ${JSON.stringify(parsed[1])}`);
+    case 'begin':
+    case 'data':
+    case 'commit':
+    case 'rollback':
+      return [parsed];
+    default:
+      return [undefined];
+  }
+}

--- a/packages/zero-cache/bench/rm-vs-load/replica.ts
+++ b/packages/zero-cache/bench/rm-vs-load/replica.ts
@@ -1,0 +1,43 @@
+import {rmSync} from 'node:fs';
+import type {LogContext} from '@rocicorp/logger';
+import type {Database} from '../../../zqlite/src/db.ts';
+import {StatementRunner} from '../../src/db/statements.ts';
+import {ChangeProcessor} from '../../src/services/replicator/change-processor.ts';
+import {initReplicationState} from '../../src/services/replicator/schema/replication-state.ts';
+import {makeSchemaChanges} from './fixtures.ts';
+
+export function initializeReplica(
+  lc: LogContext,
+  db: Database,
+  replicaVersion: string,
+): ChangeProcessor {
+  initReplicationState(db, ['zero-cache-rm-vs-load'], replicaVersion);
+  const processor = new ChangeProcessor(
+    new StatementRunner(db),
+    'serving',
+    (_, err) => {
+      throw err;
+    },
+  );
+  processor.processMessage(lc, [
+    'begin',
+    {tag: 'begin'},
+    {commitWatermark: '000000000001'},
+  ]);
+  for (const change of makeSchemaChanges()) {
+    processor.processMessage(lc, ['data', change]);
+  }
+  processor.processMessage(lc, [
+    'commit',
+    {tag: 'commit'},
+    {watermark: '000000000001'},
+  ]);
+  return processor;
+}
+
+export function cleanupSQLite(path: string) {
+  rmSync(path, {force: true});
+  rmSync(`${path}-shm`, {force: true});
+  rmSync(`${path}-wal`, {force: true});
+  rmSync(`${path}-wal2`, {force: true});
+}

--- a/packages/zero-cache/bench/rm-vs-load/runner.ts
+++ b/packages/zero-cache/bench/rm-vs-load/runner.ts
@@ -1,0 +1,579 @@
+import {performance} from 'node:perf_hooks';
+import type {LogContext} from '@rocicorp/logger';
+import {PostgreSqlContainer} from '@testcontainers/postgresql';
+import postgres from 'postgres';
+import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
+import {Database} from '../../../zqlite/src/db.ts';
+import type {
+  ChangeTag,
+  WatermarkedChange,
+} from '../../src/services/change-streamer/change-streamer-service.ts';
+import {Forwarder} from '../../src/services/change-streamer/forwarder.ts';
+import {
+  ensureReplicationConfig,
+  setupCDCTables,
+} from '../../src/services/change-streamer/schema/tables.ts';
+import {Storer} from '../../src/services/change-streamer/storer.ts';
+import {postgresTypeConfig, type PostgresDB} from '../../src/types/pg.ts';
+import {cdcSchema, type ShardID} from '../../src/types/shards.ts';
+import {ConsumerFactory} from './consumers.ts';
+import {emptyOperationCounts, watermarkFor} from './fixtures.ts';
+import {percentile, sleep, sum} from './perf-utils.ts';
+import {cleanupSQLite, initializeReplica} from './replica.ts';
+import {SharedReplicaSyncWorkers} from './sync-workers.ts';
+import type {
+  BenchmarkConfig,
+  LoadConsumer,
+  Scenario,
+  ScenarioSummary,
+  Summary,
+} from './types.ts';
+import {
+  addOperationCounts,
+  createTransactionGenerator,
+  workloadName,
+} from './workloads.ts';
+
+const defaultShard: ShardID = {appID: 'bench', shardNum: 0};
+const defaultReplicaVersion = '000000000000';
+
+export type BenchmarkSuiteOptions = {
+  readonly lc?: LogContext | undefined;
+  readonly shard?: ShardID | undefined;
+  readonly replicaVersion?: string | undefined;
+  readonly sqlitePath?: string | undefined;
+};
+
+export class BenchmarkSuite {
+  readonly #config: BenchmarkConfig;
+  readonly #scenarios: readonly Scenario[];
+  readonly #lc: LogContext;
+  readonly #shard: ShardID;
+  readonly #replicaVersion: string;
+  readonly #sqlitePath: string;
+
+  constructor(
+    config: BenchmarkConfig,
+    scenarios: readonly Scenario[],
+    {
+      lc = createSilentLogContext(),
+      shard = defaultShard,
+      replicaVersion = defaultReplicaVersion,
+      sqlitePath = `/tmp/zero-cache-rm-vs-load-${process.pid}.db`,
+    }: BenchmarkSuiteOptions = {},
+  ) {
+    this.#config = config;
+    this.#scenarios = scenarios;
+    this.#lc = lc;
+    this.#shard = shard;
+    this.#replicaVersion = replicaVersion;
+    this.#sqlitePath = sqlitePath;
+  }
+
+  async run(): Promise<Summary> {
+    const container = await new PostgreSqlContainer(
+      this.#config.pgImage,
+    ).start();
+    try {
+      const changeDB = postgres(container.getConnectionUri(), {
+        ...postgresTypeConfig({sendStringAsJson: true}),
+        onnotice: () => {},
+      });
+      try {
+        const runner = new ScenarioRunner(changeDB, {
+          config: this.#config,
+          lc: this.#lc,
+          shard: this.#shard,
+          replicaVersion: this.#replicaVersion,
+          sqlitePath: this.#sqlitePath,
+        });
+        const scenarios: ScenarioSummary[] = [];
+        for (const scenario of this.#scenarios) {
+          scenarios.push(await runner.run(scenario));
+        }
+        return {
+          name: 'zero-cache-rm-vs-load',
+          mode: this.#config.mode,
+          generatedAt: new Date().toISOString(),
+          rmCount: 1,
+          viewSyncerCount: this.#config.consumer.count,
+          scenarios,
+        };
+      } finally {
+        await changeDB.end();
+      }
+    } finally {
+      await container.stop();
+      cleanupSQLite(this.#sqlitePath);
+    }
+  }
+}
+
+type ScenarioRunnerOptions = {
+  readonly config: BenchmarkConfig;
+  readonly lc: LogContext;
+  readonly shard: ShardID;
+  readonly replicaVersion: string;
+  readonly sqlitePath: string;
+};
+
+export class ScenarioRunner {
+  readonly #changeDB: PostgresDB;
+  readonly #config: BenchmarkConfig;
+  readonly #lc: LogContext;
+  readonly #shard: ShardID;
+  readonly #replicaVersion: string;
+  readonly #sqlitePath: string;
+  readonly #consumers: ConsumerFactory;
+
+  constructor(
+    changeDB: PostgresDB,
+    {config, lc, shard, replicaVersion, sqlitePath}: ScenarioRunnerOptions,
+  ) {
+    this.#changeDB = changeDB;
+    this.#config = config;
+    this.#lc = lc;
+    this.#shard = shard;
+    this.#replicaVersion = replicaVersion;
+    this.#sqlitePath = sqlitePath;
+    this.#consumers = new ConsumerFactory({
+      lc,
+      sqlitePath,
+      replicaVersion,
+    });
+  }
+
+  async run(scenario: Scenario): Promise<ScenarioSummary> {
+    cleanupSQLite(this.#sqlitePath);
+    let replica: Database | undefined;
+    let processor: ReturnType<typeof initializeReplica> | undefined;
+    if (this.#config.sourceApply) {
+      replica = new Database(this.#lc, this.#sqlitePath);
+      replica.pragma('journal_mode = WAL');
+      processor = initializeReplica(this.#lc, replica, this.#replicaVersion);
+    }
+
+    const forwarder = new Forwarder(this.#lc, {
+      flowControlConsensusPaddingSeconds: 0.001,
+    });
+    const consumers = await this.#consumers.createGroup(this.#config.consumer);
+    for (const {sub} of consumers) {
+      forwarder.add(sub);
+    }
+    let syncWorkers: SharedReplicaSyncWorkers | undefined;
+    const syncWorkerCount = scenario.syncWorkerCount ?? 0;
+    if (syncWorkerCount > 0) {
+      const sqlitePath = consumers.find(
+        consumer => consumer.sqlitePath !== undefined,
+      )?.sqlitePath;
+      if (sqlitePath === undefined) {
+        throw new Error(
+          `${scenario.name} requires at least one applying serving replica ` +
+            'consumer for shared sync worker reads',
+        );
+      }
+      syncWorkers = await SharedReplicaSyncWorkers.start({
+        count: syncWorkerCount,
+        sqlitePath,
+        readDelayMs: this.#config.syncWorkerReadDelayMs,
+      });
+    }
+
+    await this.#resetChangeDB();
+    const fatalErrors: Error[] = [];
+    const storer = new Storer(
+      this.#lc,
+      this.#shard,
+      `rm-vs-load-${scenario.name}`,
+      'bench-rm:12345',
+      'ws',
+      this.#changeDB,
+      this.#replicaVersion,
+      () => {},
+      err => fatalErrors.push(err),
+      {
+        backPressureLimitHeapProportion: 0.04,
+        statementTimeoutMs: 20_000,
+      },
+    );
+    await storer.assumeOwnership();
+    const storerDone = storer.run().catch(e => {
+      const err = e instanceof Error ? e : new Error(String(e));
+      fatalErrors.push(err);
+    });
+
+    const latencies: number[] = [];
+    let tx = 0;
+    let rows = 0;
+    const operationCounts = emptyOperationCounts();
+    let storerBytes = 0;
+    let fanoutMessages = 0;
+    let unflushedBytes = 0;
+    let reconnect: LoadConsumer | undefined;
+    let reconnectCatchupFrom: string | null = null;
+    let latestGeneratedWatermark: string | null = null;
+    let loadPhaseMs = 0;
+    let reconnectStartedAtTx: number | null = null;
+    let reconnectStartedAtMs: number | null = null;
+    let reconnectStartAbsoluteMs: number | null = null;
+    let reconnectJoinWatermark: string | null = null;
+    let reconnectCaughtUpToJoinMs: number | null = null;
+    let reconnectCaughtUpToJoinDuringLoad = false;
+    let reconnectCaughtUpToFinalMs: number | null = null;
+    let reconnectFinalCatchupWaitMs: number | null = null;
+    let summary: ScenarioSummary | undefined;
+    const cpuStart = process.cpuUsage();
+    const memoryStart = process.memoryUsage();
+    let maxHeapUsedBytes = memoryStart.heapUsed;
+    let maxRssBytes = memoryStart.rss;
+    const sampleMemory = () => {
+      const memory = process.memoryUsage();
+      maxHeapUsedBytes = Math.max(maxHeapUsedBytes, memory.heapUsed);
+      maxRssBytes = Math.max(maxRssBytes, memory.rss);
+      return memory;
+    };
+    const start = performance.now();
+    let nextDue = start;
+    const generator = createTransactionGenerator(scenario);
+
+    try {
+      while (performance.now() - start < this.#config.durationMs) {
+        tx++;
+        const generated = generator.next(tx + 1);
+        latestGeneratedWatermark = generated.watermark;
+        const txStart = performance.now();
+
+        for (const change of generated.changes) {
+          processor?.processMessage(this.#lc, change);
+          const watermark = generated.watermark;
+          const json = storer.store(watermark, change);
+          const jsonBytes = Buffer.byteLength(json);
+          const entry: WatermarkedChange = [
+            watermark,
+            change[1].tag as ChangeTag,
+            json,
+          ];
+
+          unflushedBytes += jsonBytes;
+          const shouldWaitForFanout =
+            unflushedBytes >= this.#config.flushBytesThreshold &&
+            change[0] === 'commit';
+          if (shouldWaitForFanout) {
+            await forwarder.forwardWithFlowControl(entry);
+            unflushedBytes = 0;
+          } else {
+            forwarder.forward(entry);
+          }
+          const readyForMore = storer.readyForMore();
+          if (readyForMore !== undefined) {
+            await readyForMore;
+          }
+          storerBytes += jsonBytes;
+        }
+
+        latencies.push(performance.now() - txStart);
+        rows += generated.rows;
+        addOperationCounts(operationCounts, generated.operationCounts);
+        fanoutMessages += generated.changes.length * consumers.length;
+        if (tx % 10 === 0) {
+          sampleMemory();
+        }
+
+        if (
+          reconnect === undefined &&
+          tx > this.#config.reconnectLagTx + 2 &&
+          performance.now() - start >= this.#config.durationMs / 2
+        ) {
+          const catchupTx = Math.max(2, tx - this.#config.reconnectLagTx);
+          reconnectCatchupFrom = watermarkFor(catchupTx);
+          reconnectStartedAtTx = tx;
+          reconnectStartAbsoluteMs = performance.now();
+          reconnectStartedAtMs = reconnectStartAbsoluteMs - start;
+          reconnectJoinWatermark = generated.watermark;
+          const reconnectConfig = ConsumerFactory.configForApplySlot(
+            this.#config.consumer,
+            consumers.length,
+          );
+          reconnect = await this.#consumers.create(
+            `reconnect-${scenario.name}`,
+            reconnectCatchupFrom,
+            reconnectConfig.ackDelayMs,
+            reconnectConfig,
+            false,
+          );
+          consumers.push(reconnect);
+          storer.catchup(reconnect.sub, 'serving');
+          forwarder.add(reconnect.sub);
+        }
+
+        if (
+          reconnect !== undefined &&
+          reconnectJoinWatermark !== null &&
+          reconnectStartAbsoluteMs !== null &&
+          reconnectCaughtUpToJoinMs === null &&
+          reconnect.sub.acked >= reconnectJoinWatermark
+        ) {
+          reconnectCaughtUpToJoinMs =
+            performance.now() - reconnectStartAbsoluteMs;
+          reconnectCaughtUpToJoinDuringLoad = true;
+        }
+
+        nextDue += 1000 / scenario.targetTxPerSec;
+        const waitMs = nextDue - performance.now();
+        if (waitMs > 0) {
+          await sleep(waitMs);
+        }
+      }
+      loadPhaseMs = performance.now() - start;
+
+      const beforeDrain = performance.now();
+      await storer.allProcessed();
+      const storerDrainMs = performance.now() - beforeDrain;
+
+      if (reconnect !== undefined && latestGeneratedWatermark !== null) {
+        const finalCatchupStart = performance.now();
+        if (reconnect.sub.acked < latestGeneratedWatermark) {
+          await waitForConsumerWatermark(
+            reconnect,
+            latestGeneratedWatermark,
+            this.#config.reconnectFinalCatchupTimeoutMs,
+          );
+        }
+        reconnectFinalCatchupWaitMs = performance.now() - finalCatchupStart;
+        if (
+          reconnectStartAbsoluteMs !== null &&
+          reconnect.sub.acked >= latestGeneratedWatermark
+        ) {
+          reconnectCaughtUpToFinalMs =
+            performance.now() - reconnectStartAbsoluteMs;
+        }
+        if (
+          reconnectJoinWatermark !== null &&
+          reconnectStartAbsoluteMs !== null &&
+          reconnectCaughtUpToJoinMs === null &&
+          reconnect.sub.acked >= reconnectJoinWatermark
+        ) {
+          reconnectCaughtUpToJoinMs =
+            performance.now() - reconnectStartAbsoluteMs;
+        }
+      }
+
+      if (this.#config.settleMs > 0) {
+        await sleep(this.#config.settleMs);
+      }
+      const elapsedMs = performance.now() - start;
+      const memoryEnd = sampleMemory();
+      const cpu = process.cpuUsage(cpuStart);
+      const stats = consumers.map(consumer => consumer.stats());
+      const websocketMessages = sum(stats.map(s => s.transportMessages));
+      const websocketBytes = sum(stats.map(s => s.transportBytes));
+      const websocketAcks = sum(stats.map(s => s.transportAcks));
+      const websocketAckBytes = sum(stats.map(s => s.transportAckBytes));
+      const maxAckLagMessages = Math.max(
+        0,
+        ...stats.map(s => s.maxAckLagMessages),
+      );
+      const samples = sum(stats.map(s => s.samples));
+      const avgAckLagMessages =
+        samples === 0
+          ? 0
+          : sum(stats.map(s => s.totalAckLagMessages)) / samples;
+      const avgSubscriberParseMs =
+        samples === 0 ? 0 : sum(stats.map(s => s.totalParseMs)) / samples;
+      const avgSubscriberApplyMs =
+        samples === 0 ? 0 : sum(stats.map(s => s.totalApplyMs)) / samples;
+      const txApplySamples = sum(stats.map(s => s.txApplySamples));
+      const avgSubscriberTxApplyMs =
+        txApplySamples === 0
+          ? 0
+          : sum(stats.map(s => s.totalTxApplyMs)) / txApplySamples;
+      const maxSubscriberTxApplyMs = Math.max(
+        0,
+        ...stats.map(s => s.maxTxApplyMs),
+      );
+      const avgSubscriberClientCpuMs =
+        samples === 0 ? 0 : sum(stats.map(s => s.totalClientCpuMs)) / samples;
+      const reconnectStats = reconnect?.stats();
+      const syncWorkerStats = syncWorkers?.stats() ?? {
+        count: 0,
+        reads: 0,
+        totalReadMs: 0,
+        maxReadMs: 0,
+        errors: 0,
+      };
+      const avgSyncWorkerReadMs =
+        syncWorkerStats.reads === 0
+          ? 0
+          : syncWorkerStats.totalReadMs / syncWorkerStats.reads;
+
+      summary = {
+        name: scenario.name,
+        rowsPerTx: scenario.rowsPerTx,
+        payload: scenario.payload.size,
+        payloadBytes: scenario.payload.bytes,
+        workload: workloadName(scenario.workload),
+        operationCounts: {...operationCounts},
+        targetTxPerSec: scenario.targetTxPerSec,
+        durationMs: this.#config.durationMs,
+        tx,
+        rows,
+        storerBytes,
+        loadPhaseMs,
+        elapsedMs,
+        storerDrainMs,
+        writeLoopTxPerSec: tx / (loadPhaseMs / 1000),
+        writeLoopRowsPerSec: rows / (loadPhaseMs / 1000),
+        ingestTxPerSec: tx / (elapsedMs / 1000),
+        ingestRowsPerSec: rows / (elapsedMs / 1000),
+        fanoutMessages,
+        fanoutMessagesPerSec: fanoutMessages / (elapsedMs / 1000),
+        websocketMessages,
+        websocketMessagesPerSec: websocketMessages / (elapsedMs / 1000),
+        websocketBytes,
+        websocketBytesPerSec: websocketBytes / (elapsedMs / 1000),
+        websocketAcks,
+        websocketAckBytes,
+        processCpuUserMs: cpu.user / 1000,
+        processCpuSystemMs: cpu.system / 1000,
+        processCpuTotalMs: (cpu.user + cpu.system) / 1000,
+        processCpuUtilization: (cpu.user + cpu.system) / 1000 / elapsedMs,
+        startHeapUsedBytes: memoryStart.heapUsed,
+        maxHeapUsedBytes,
+        endHeapUsedBytes: memoryEnd.heapUsed,
+        startRssBytes: memoryStart.rss,
+        maxRssBytes,
+        endRssBytes: memoryEnd.rss,
+        p50TxLatencyMs: percentile(latencies, 50),
+        p95TxLatencyMs: percentile(latencies, 95),
+        p99TxLatencyMs: percentile(latencies, 99),
+        subscriberCount: this.#config.consumer.count,
+        reconnectCatchup: reconnect !== undefined,
+        reconnectCatchupFrom,
+        reconnectMessages: reconnectStats?.processed ?? 0,
+        reconnectLagTx: this.#config.reconnectLagTx,
+        reconnectStartedAtTx,
+        reconnectStartedAtMs,
+        reconnectJoinWatermark,
+        reconnectCaughtUpToJoinMs,
+        reconnectCaughtUpToJoinDuringLoad,
+        reconnectFinalWatermark: latestGeneratedWatermark,
+        reconnectCaughtUpToFinalMs,
+        reconnectFinalCatchupWaitMs,
+        reconnectFinalAckedWatermark: reconnectStats?.ackedWatermark ?? null,
+        reconnectEndLagTx:
+          reconnectStats === undefined || latestGeneratedWatermark === null
+            ? null
+            : watermarkLagTx(
+                reconnectStats.ackedWatermark,
+                latestGeneratedWatermark,
+              ),
+        reconnectMaxAckLagMessages: reconnectStats?.maxAckLagMessages ?? null,
+        subscriberAckDelayMs: this.#config.consumer.ackDelayMs,
+        subscriberApplyMode: this.#config.consumer.applyMode,
+        subscriberApplyMessages: this.#config.consumer.applyMessages,
+        subscriberApplyLimit: this.#config.consumer.applyLimit,
+        subscriberTransportMode: this.#config.consumer.transportMode,
+        subscriberTransportAckMode: this.#config.consumer.transportAckMode,
+        subscriberTransportBatchMessages:
+          this.#config.consumer.transportBatchMessages,
+        subscriberProtocolMode: this.#config.consumer.protocolMode,
+        subscriberSynchronous: this.#config.consumer.synchronous,
+        subscriberWalAutocheckpoint: this.#config.consumer.walAutocheckpoint,
+        subscriberClientCpuMicros: this.#config.consumer.clientCpuMicros,
+        syncWorkerCount: syncWorkerStats.count,
+        syncWorkerReadDelayMs: this.#config.syncWorkerReadDelayMs,
+        syncWorkerReads: syncWorkerStats.reads,
+        syncWorkerReadsPerSec: syncWorkerStats.reads / (elapsedMs / 1000),
+        avgSyncWorkerReadMs,
+        maxSyncWorkerReadMs: syncWorkerStats.maxReadMs,
+        syncWorkerErrors: syncWorkerStats.errors,
+        avgSubscriberParseMs,
+        avgSubscriberApplyMs,
+        avgSubscriberTxApplyMs,
+        maxSubscriberTxApplyMs,
+        avgSubscriberClientCpuMs,
+        slowSubscriberAckDelayMs: this.#config.consumer.slowAckDelayMs,
+        slowSubscriberEvery: this.#config.consumer.slowEvery,
+        sourceApply: this.#config.sourceApply,
+        forwardFlushBytesThreshold: this.#config.flushBytesThreshold,
+        maxAckLagMessages,
+        avgAckLagMessages,
+      };
+    } finally {
+      await syncWorkers?.stop();
+      for (const consumer of consumers) {
+        consumer.stop();
+      }
+      await Promise.all(consumers.map(consumer => consumer.done));
+      await storer.stop();
+      await storerDone;
+      replica?.close();
+    }
+    if (fatalErrors.length > 0) {
+      throw fatalErrors[0];
+    }
+    if (summary === undefined) {
+      throw new Error(`Scenario ${scenario.name} did not complete`);
+    }
+    return summary;
+  }
+
+  async #resetChangeDB() {
+    await this.#changeDB`DROP SCHEMA IF EXISTS ${this.#changeDB(
+      cdcSchema(this.#shard),
+    )} CASCADE`;
+    await this.#changeDB.begin(tx => setupCDCTables(this.#lc, tx, this.#shard));
+    await ensureReplicationConfig(
+      this.#lc,
+      this.#changeDB,
+      {
+        replicaVersion: this.#replicaVersion,
+        publications: [],
+        watermark: this.#replicaVersion,
+      },
+      this.#shard,
+      true,
+    );
+  }
+}
+
+async function waitForConsumerWatermark(
+  consumer: LoadConsumer,
+  targetWatermark: string,
+  timeoutMs: number,
+) {
+  const deadline = performance.now() + timeoutMs;
+  while (consumer.sub.acked < targetWatermark && performance.now() < deadline) {
+    await sleep(5);
+  }
+}
+
+function watermarkLagTx(ackedWatermark: string, finalWatermark: string) {
+  return Math.max(
+    0,
+    Number.parseInt(finalWatermark, 36) - Number.parseInt(ackedWatermark, 36),
+  );
+}
+
+export function formatOperationCounts(counts: {
+  readonly insert: number;
+  readonly update: number;
+  readonly delete: number;
+}) {
+  return `i=${counts.insert} u=${counts.update} d=${counts.delete}`;
+}
+
+export function formatReconnectSummary(result: ScenarioSummary) {
+  if (!result.reconnectCatchup) {
+    return '';
+  }
+  return (
+    ` | catchup join ${formatOptionalMs(result.reconnectCaughtUpToJoinMs)}` +
+    ` final ${formatOptionalMs(result.reconnectCaughtUpToFinalMs)}` +
+    ` end lag ${result.reconnectEndLagTx ?? 'n/a'} tx`
+  );
+}
+
+function formatOptionalMs(ms: number | null) {
+  return ms === null ? 'n/a' : `${ms.toFixed(1)} ms`;
+}

--- a/packages/zero-cache/bench/rm-vs-load/scenarios.test.ts
+++ b/packages/zero-cache/bench/rm-vs-load/scenarios.test.ts
@@ -1,0 +1,64 @@
+import {expect, test} from 'vitest';
+import {EnvReader} from './config.ts';
+import {describeScenarios, loadScenarios} from './scenarios.ts';
+
+test('loads the smoke scenario by default', () => {
+  const scenarios = loadScenarios({full: false, env: new EnvReader({})});
+
+  expect(scenarios.map(scenario => scenario.name)).toEqual(['steady-small']);
+  expect(scenarios[0].targetTxPerSec).toBe(500);
+  expect(describeScenarios(scenarios)).toBe('steady-small=1x96 B insert-only');
+});
+
+test('loads full scenarios with env backed targets and mixed weights', () => {
+  const scenarios = loadScenarios({
+    full: true,
+    env: new EnvReader({
+      ZERO_RM_VS_MEDIUM_WIDE_TARGET_TPS: '4321',
+      ZERO_RM_VS_SHARED_SYNC_TARGET_TPS: '2345',
+      ZERO_RM_VS_SYNC_WORKERS: '6',
+      ZERO_RM_VS_MIXED_INSERT_WEIGHT: '5',
+      ZERO_RM_VS_MIXED_UPDATE_WEIGHT: '3',
+      ZERO_RM_VS_MIXED_DELETE_WEIGHT: '2',
+    }),
+  });
+
+  const mediumWide = scenarios.find(
+    scenario => scenario.name === 'medium-wide-batch-pressure',
+  );
+  const mixed = scenarios.find(
+    scenario => scenario.name === 'mixed-hot-row-churn',
+  );
+  const shared = scenarios.find(
+    scenario => scenario.name === 'shared-replica-sync-workers',
+  );
+
+  expect(mediumWide?.targetTxPerSec).toBe(4321);
+  expect(shared?.targetTxPerSec).toBe(2345);
+  expect(shared?.syncWorkerCount).toBe(6);
+  expect(mixed?.workload).toEqual({
+    kind: 'mixed-row-churn',
+    insertWeight: 5,
+    updateWeight: 3,
+    deleteWeight: 2,
+  });
+});
+
+test('filters scenarios by exact name and reports valid choices', () => {
+  const scenarios = loadScenarios({
+    full: true,
+    env: new EnvReader({
+      ZERO_RM_VS_SCENARIO: 'mixed-hot-row-churn',
+    }),
+  });
+
+  expect(scenarios.map(scenario => scenario.name)).toEqual([
+    'mixed-hot-row-churn',
+  ]);
+  expect(() =>
+    loadScenarios({
+      full: true,
+      env: new EnvReader({ZERO_RM_VS_SCENARIO: 'missing'}),
+    }),
+  ).toThrow(/Unknown ZERO_RM_VS_SCENARIO=missing/);
+});

--- a/packages/zero-cache/bench/rm-vs-load/scenarios.ts
+++ b/packages/zero-cache/bench/rm-vs-load/scenarios.ts
@@ -1,0 +1,130 @@
+import {EnvReader} from './config.ts';
+import {
+  loadPayloadProfiles,
+  smokePayloadProfiles,
+  type PayloadProfile,
+} from './fixtures.ts';
+import {formatBytes} from './perf-utils.ts';
+import type {Scenario} from './types.ts';
+import {workloadName} from './workloads.ts';
+
+export type ScenarioCatalogOptions = {
+  readonly full: boolean;
+  readonly env?: EnvReader | undefined;
+};
+
+export function loadScenarios({
+  full,
+  env = new EnvReader(),
+}: ScenarioCatalogOptions): Scenario[] {
+  return filterScenarios(full ? fullScenarios(env) : smokeScenarios(env), env);
+}
+
+export function describeScenarios(scenarios: readonly Scenario[]): string {
+  return scenarios
+    .map(
+      s =>
+        `${s.name}=${s.rowsPerTx}x${formatBytes(s.payload.bytes)} ` +
+        workloadName(s.workload) +
+        (s.syncWorkerCount === undefined
+          ? ''
+          : ` sync-workers=${s.syncWorkerCount}`),
+    )
+    .join(', ');
+}
+
+function smokeScenarios(env: EnvReader): Scenario[] {
+  const small = profile('small', smokePayloadProfiles);
+  return [
+    {
+      name: 'steady-small',
+      rowsPerTx: 1,
+      payload: small,
+      targetTxPerSec: env.int('ZERO_RM_VS_TARGET_TPS', 500),
+      workload: {kind: 'insert-only'},
+    },
+  ];
+}
+
+function fullScenarios(env: EnvReader): Scenario[] {
+  const small = profile('small', loadPayloadProfiles);
+  const medium = profile('medium', loadPayloadProfiles);
+  const large = profile('large', loadPayloadProfiles);
+  return [
+    {
+      name: 'single-row-flood',
+      rowsPerTx: 1,
+      payload: small,
+      targetTxPerSec: env.int('ZERO_RM_VS_SMALL_TARGET_TPS', 1_200),
+      workload: {kind: 'insert-only'},
+    },
+    {
+      name: 'medium-batch-pressure',
+      rowsPerTx: 10,
+      payload: medium,
+      targetTxPerSec: env.int('ZERO_RM_VS_MEDIUM_TARGET_TPS', 400),
+      workload: {kind: 'insert-only'},
+    },
+    {
+      name: 'medium-wide-batch-pressure',
+      rowsPerTx: 20,
+      payload: medium,
+      targetTxPerSec: env.int('ZERO_RM_VS_MEDIUM_WIDE_TARGET_TPS', 1_000),
+      workload: {kind: 'insert-only'},
+    },
+    {
+      name: 'shared-replica-sync-workers',
+      rowsPerTx: 20,
+      payload: medium,
+      targetTxPerSec: env.int('ZERO_RM_VS_SHARED_SYNC_TARGET_TPS', 1_000),
+      syncWorkerCount: env.int('ZERO_RM_VS_SYNC_WORKERS', 8),
+      workload: {kind: 'insert-only'},
+    },
+    {
+      name: 'mixed-hot-row-churn',
+      rowsPerTx: 20,
+      payload: medium,
+      targetTxPerSec: env.int('ZERO_RM_VS_MIXED_TARGET_TPS', 4_000),
+      workload: {
+        kind: 'mixed-row-churn',
+        insertWeight: env.int('ZERO_RM_VS_MIXED_INSERT_WEIGHT', 4),
+        updateWeight: env.int('ZERO_RM_VS_MIXED_UPDATE_WEIGHT', 4),
+        deleteWeight: env.int('ZERO_RM_VS_MIXED_DELETE_WEIGHT', 2),
+      },
+    },
+    {
+      name: 'large-row-burst',
+      rowsPerTx: 50,
+      payload: large,
+      targetTxPerSec: env.int('ZERO_RM_VS_LARGE_TARGET_TPS', 80),
+      workload: {kind: 'insert-only'},
+    },
+  ];
+}
+
+function profile(
+  size: PayloadProfile['size'],
+  profiles: readonly PayloadProfile[],
+): PayloadProfile {
+  const payload = profiles.find(profile => profile.size === size);
+  if (payload === undefined) {
+    throw new Error(`Missing ${size} payload profile`);
+  }
+  return payload;
+}
+
+function filterScenarios(scenarios: Scenario[], env: EnvReader): Scenario[] {
+  const filter = env.string('ZERO_RM_VS_SCENARIO');
+  if (filter === undefined || filter === '') {
+    return scenarios;
+  }
+  const selected = scenarios.filter(scenario => scenario.name === filter);
+  if (selected.length === 0) {
+    throw new Error(
+      `Unknown ZERO_RM_VS_SCENARIO=${filter}; choices: ${scenarios
+        .map(scenario => scenario.name)
+        .join(', ')}`,
+    );
+  }
+  return selected;
+}

--- a/packages/zero-cache/bench/rm-vs-load/sync-worker-reader.ts
+++ b/packages/zero-cache/bench/rm-vs-load/sync-worker-reader.ts
@@ -1,0 +1,94 @@
+import {performance} from 'node:perf_hooks';
+import {parentPort, workerData} from 'node:worker_threads';
+import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
+import {Database} from '../../../zqlite/src/db.ts';
+import {sleep} from './perf-utils.ts';
+import type {SyncWorkerData, SyncWorkerStats} from './types.ts';
+
+if (parentPort === null) {
+  throw new Error('sync-worker-reader must run inside a worker_thread');
+}
+
+const workerPort = parentPort;
+const config = workerData as SyncWorkerData;
+const lc = createSilentLogContext();
+let active = true;
+let reads = 0;
+let totalReadMs = 0;
+let maxReadMs = 0;
+let errors = 0;
+
+workerPort.on('message', msg => {
+  if (typeof msg === 'object' && msg !== null && 'type' in msg) {
+    switch (msg.type) {
+      case 'stop':
+        active = false;
+        break;
+      case 'stats':
+        postStats();
+        break;
+    }
+  }
+});
+
+try {
+  await run();
+  workerPort.postMessage({type: 'done', stats: stats()});
+  workerPort.close();
+} catch (e) {
+  const error = e instanceof Error ? e : new Error(String(e));
+  workerPort.postMessage({
+    type: 'error',
+    error: {message: error.message, stack: error.stack},
+  });
+  workerPort.close();
+}
+
+async function run() {
+  const replica = new Database(lc, config.sqlitePath);
+  try {
+    replica.pragma('query_only = ON');
+    replica.pragma('busy_timeout = 30000');
+    const read = replica.prepare(
+      'SELECT count(*) AS count, max(tx) AS maxTx FROM "bench_rows"',
+    );
+    const interval = setInterval(postStats, 25);
+    interval.unref();
+    workerPort.postMessage({type: 'ready'});
+
+    try {
+      while (active) {
+        const start = performance.now();
+        try {
+          read.get<{count: number; maxTx: number | null}>();
+        } catch {
+          errors++;
+        }
+        const elapsed = performance.now() - start;
+        reads++;
+        totalReadMs += elapsed;
+        maxReadMs = Math.max(maxReadMs, elapsed);
+        if (config.readDelayMs > 0) {
+          await sleep(config.readDelayMs);
+        }
+      }
+    } finally {
+      clearInterval(interval);
+    }
+  } finally {
+    replica.close();
+  }
+}
+
+function postStats() {
+  workerPort.postMessage({type: 'stats', stats: stats()});
+}
+
+function stats(): SyncWorkerStats {
+  return {
+    reads,
+    totalReadMs,
+    maxReadMs,
+    errors,
+  };
+}

--- a/packages/zero-cache/bench/rm-vs-load/sync-workers.ts
+++ b/packages/zero-cache/bench/rm-vs-load/sync-workers.ts
@@ -1,0 +1,149 @@
+import {Worker} from 'node:worker_threads';
+import type {SyncWorkerData, SyncWorkerStats} from './types.ts';
+
+export type SyncWorkerGroupStats = SyncWorkerStats & {
+  readonly count: number;
+};
+
+export type SharedReplicaSyncWorkersOptions = {
+  readonly count: number;
+  readonly sqlitePath: string;
+  readonly readDelayMs: number;
+  readonly workerUrl?: URL | undefined;
+};
+
+export class SharedReplicaSyncWorkers {
+  readonly #workers: SyncWorkerHandle[];
+
+  private constructor(workers: SyncWorkerHandle[]) {
+    this.#workers = workers;
+  }
+
+  static async start({
+    count,
+    sqlitePath,
+    readDelayMs,
+    workerUrl = new URL('./sync-worker-reader.ts', import.meta.url),
+  }: SharedReplicaSyncWorkersOptions): Promise<SharedReplicaSyncWorkers> {
+    const workers = Array.from(
+      {length: count},
+      (_, index) =>
+        new SyncWorkerHandle(workerUrl, {
+          id: `sync-worker-${index}`,
+          sqlitePath,
+          readDelayMs,
+        }),
+    );
+    await Promise.all(workers.map(worker => worker.ready));
+    return new SharedReplicaSyncWorkers(workers);
+  }
+
+  stats(): SyncWorkerGroupStats {
+    const workerStats = this.#workers.map(worker => worker.stats());
+    return {
+      count: this.#workers.length,
+      reads: sum(workerStats.map(stats => stats.reads)),
+      totalReadMs: sum(workerStats.map(stats => stats.totalReadMs)),
+      maxReadMs: Math.max(0, ...workerStats.map(stats => stats.maxReadMs)),
+      errors: sum(workerStats.map(stats => stats.errors)),
+    };
+  }
+
+  async stop(): Promise<void> {
+    await Promise.all(this.#workers.map(worker => worker.stop()));
+  }
+}
+
+class SyncWorkerHandle {
+  readonly #worker: Worker;
+  readonly ready: Promise<void>;
+  readonly #done: Promise<void>;
+  #stats = emptyStats();
+  #stopped = false;
+
+  constructor(workerUrl: URL, data: SyncWorkerData) {
+    this.#worker = new Worker(workerUrl, {workerData: data});
+
+    let resolveReady!: () => void;
+    let rejectReady!: (err: Error) => void;
+    this.ready = new Promise<void>((resolve, reject) => {
+      resolveReady = resolve;
+      rejectReady = reject;
+    });
+
+    let resolveDone!: () => void;
+    let rejectDone!: (err: Error) => void;
+    this.#done = new Promise<void>((resolve, reject) => {
+      resolveDone = resolve;
+      rejectDone = reject;
+    });
+    void this.#done.catch(() => {});
+
+    const fail = (err: Error) => {
+      rejectReady(err);
+      rejectDone(err);
+    };
+
+    this.#worker.on('message', msg => {
+      if (typeof msg !== 'object' || msg === null || !('type' in msg)) {
+        return;
+      }
+      switch (msg.type) {
+        case 'ready':
+          resolveReady();
+          break;
+        case 'stats':
+          this.#stats = msg.stats as SyncWorkerStats;
+          break;
+        case 'done':
+          this.#stats = msg.stats as SyncWorkerStats;
+          resolveDone();
+          break;
+        case 'error': {
+          const error = msg.error as {message?: unknown; stack?: unknown};
+          const message =
+            typeof error.message === 'string'
+              ? error.message
+              : 'sync worker reader error';
+          const err = new Error(message);
+          if (typeof error.stack === 'string') {
+            err.stack = error.stack;
+          }
+          fail(err);
+          break;
+        }
+      }
+    });
+    this.#worker.on('error', fail);
+    this.#worker.on('exit', code => {
+      if (!this.#stopped && code !== 0) {
+        fail(new Error(`sync worker reader exited with code ${code}`));
+      }
+    });
+  }
+
+  stats(): SyncWorkerStats {
+    this.#worker.postMessage({type: 'stats'});
+    return this.#stats;
+  }
+
+  async stop(): Promise<void> {
+    this.#stopped = true;
+    this.#worker.postMessage({type: 'stop'});
+    await this.#done.catch(() => {});
+    await this.#worker.terminate();
+  }
+}
+
+function emptyStats(): SyncWorkerStats {
+  return {
+    reads: 0,
+    totalReadMs: 0,
+    maxReadMs: 0,
+    errors: 0,
+  };
+}
+
+function sum(values: readonly number[]): number {
+  return values.reduce((total, value) => total + value, 0);
+}

--- a/packages/zero-cache/bench/rm-vs-load/types.ts
+++ b/packages/zero-cache/bench/rm-vs-load/types.ts
@@ -1,0 +1,212 @@
+import type {Subscriber} from '../../src/services/change-streamer/subscriber.ts';
+import type {OperationCounts, PayloadProfile} from './fixtures.ts';
+
+export type Scenario = {
+  readonly name: string;
+  readonly rowsPerTx: number;
+  readonly payload: PayloadProfile;
+  readonly targetTxPerSec: number;
+  readonly syncWorkerCount?: number | undefined;
+  readonly workload: ScenarioWorkload;
+};
+
+export type ScenarioWorkload =
+  | {readonly kind: 'insert-only'}
+  | {
+      readonly kind: 'mixed-row-churn';
+      readonly insertWeight: number;
+      readonly updateWeight: number;
+      readonly deleteWeight: number;
+    };
+
+export type ConsumerConfig = {
+  readonly count: number;
+  readonly ackDelayMs: number;
+  readonly runtime: ConsumerRuntime;
+  readonly applyMode: ConsumerApplyMode;
+  readonly applyMessages: boolean;
+  readonly applyLimit: number | undefined;
+  readonly transportMode: ConsumerTransportMode;
+  readonly transportAckMode: ConsumerTransportAckMode;
+  readonly transportBatchMessages: number;
+  readonly protocolMode: ConsumerProtocolMode;
+  readonly synchronous: 'OFF' | 'NORMAL' | 'FULL' | undefined;
+  readonly walAutocheckpoint: number | undefined;
+  readonly clientCpuMicros: number;
+  readonly slowAckDelayMs: number;
+  readonly slowEvery: number;
+};
+
+export type ConsumerRuntime = 'inline' | 'worker';
+
+export type ConsumerApplyMode = 'none' | 'direct' | 'worker-message';
+
+export type ConsumerTransportMode = 'in-process' | 'websocket';
+export type ConsumerTransportAckMode = 'per-message';
+export type ConsumerProtocolMode = 'v6';
+
+export type BenchmarkConfig = {
+  readonly mode: 'smoke' | 'full';
+  readonly full: boolean;
+  readonly durationMs: number;
+  readonly settleMs: number;
+  readonly flushBytesThreshold: number;
+  readonly reconnectLagTx: number;
+  readonly reconnectFinalCatchupTimeoutMs: number;
+  readonly sourceApply: boolean;
+  readonly pgImage: string;
+  readonly outputPath: string | undefined;
+  readonly syncWorkerReadDelayMs: number;
+  readonly consumer: ConsumerConfig;
+};
+
+export type ScenarioSummary = {
+  readonly name: string;
+  readonly rowsPerTx: number;
+  readonly payload: string;
+  readonly payloadBytes: number;
+  readonly workload: string;
+  readonly operationCounts: OperationCounts;
+  readonly targetTxPerSec: number;
+  readonly durationMs: number;
+  readonly tx: number;
+  readonly rows: number;
+  readonly storerBytes: number;
+  readonly loadPhaseMs: number;
+  readonly elapsedMs: number;
+  readonly storerDrainMs: number;
+  readonly writeLoopTxPerSec: number;
+  readonly writeLoopRowsPerSec: number;
+  readonly ingestTxPerSec: number;
+  readonly ingestRowsPerSec: number;
+  readonly fanoutMessages: number;
+  readonly fanoutMessagesPerSec: number;
+  readonly websocketMessages: number;
+  readonly websocketMessagesPerSec: number;
+  readonly websocketBytes: number;
+  readonly websocketBytesPerSec: number;
+  readonly websocketAcks: number;
+  readonly websocketAckBytes: number;
+  readonly processCpuUserMs: number;
+  readonly processCpuSystemMs: number;
+  readonly processCpuTotalMs: number;
+  readonly processCpuUtilization: number;
+  readonly startHeapUsedBytes: number;
+  readonly maxHeapUsedBytes: number;
+  readonly endHeapUsedBytes: number;
+  readonly startRssBytes: number;
+  readonly maxRssBytes: number;
+  readonly endRssBytes: number;
+  readonly p50TxLatencyMs: number;
+  readonly p95TxLatencyMs: number;
+  readonly p99TxLatencyMs: number;
+  readonly subscriberCount: number;
+  readonly reconnectCatchup: boolean;
+  readonly reconnectCatchupFrom: string | null;
+  readonly reconnectMessages: number;
+  readonly reconnectLagTx: number;
+  readonly reconnectStartedAtTx: number | null;
+  readonly reconnectStartedAtMs: number | null;
+  readonly reconnectJoinWatermark: string | null;
+  readonly reconnectCaughtUpToJoinMs: number | null;
+  readonly reconnectCaughtUpToJoinDuringLoad: boolean;
+  readonly reconnectFinalWatermark: string | null;
+  readonly reconnectCaughtUpToFinalMs: number | null;
+  readonly reconnectFinalCatchupWaitMs: number | null;
+  readonly reconnectFinalAckedWatermark: string | null;
+  readonly reconnectEndLagTx: number | null;
+  readonly reconnectMaxAckLagMessages: number | null;
+  readonly subscriberAckDelayMs: number;
+  readonly subscriberApplyMode: ConsumerApplyMode;
+  readonly subscriberApplyMessages: boolean;
+  readonly subscriberApplyLimit: number | undefined;
+  readonly subscriberTransportMode: ConsumerTransportMode;
+  readonly subscriberTransportAckMode: ConsumerTransportAckMode;
+  readonly subscriberTransportBatchMessages: number;
+  readonly subscriberProtocolMode: ConsumerProtocolMode;
+  readonly subscriberSynchronous: 'OFF' | 'NORMAL' | 'FULL' | undefined;
+  readonly subscriberWalAutocheckpoint: number | undefined;
+  readonly subscriberClientCpuMicros: number;
+  readonly syncWorkerCount: number;
+  readonly syncWorkerReadDelayMs: number;
+  readonly syncWorkerReads: number;
+  readonly syncWorkerReadsPerSec: number;
+  readonly avgSyncWorkerReadMs: number;
+  readonly maxSyncWorkerReadMs: number;
+  readonly syncWorkerErrors: number;
+  readonly avgSubscriberParseMs: number;
+  readonly avgSubscriberApplyMs: number;
+  readonly avgSubscriberTxApplyMs: number;
+  readonly maxSubscriberTxApplyMs: number;
+  readonly avgSubscriberClientCpuMs: number;
+  readonly slowSubscriberAckDelayMs: number;
+  readonly slowSubscriberEvery: number;
+  readonly sourceApply: boolean;
+  readonly forwardFlushBytesThreshold: number;
+  readonly maxAckLagMessages: number;
+  readonly avgAckLagMessages: number;
+};
+
+export type Summary = {
+  readonly name: 'zero-cache-rm-vs-load';
+  readonly mode: 'smoke' | 'full';
+  readonly generatedAt: string;
+  readonly rmCount: 1;
+  readonly viewSyncerCount: number;
+  readonly scenarios: readonly ScenarioSummary[];
+};
+
+export type LoadConsumerStats = {
+  readonly processed: number;
+  readonly ackedWatermark: string;
+  readonly watermark: string;
+  readonly pending: number;
+  readonly transportMessages: number;
+  readonly transportBytes: number;
+  readonly transportAcks: number;
+  readonly transportAckBytes: number;
+  readonly maxAckLagMessages: number;
+  readonly totalAckLagMessages: number;
+  readonly totalParseMs: number;
+  readonly totalApplyMs: number;
+  readonly totalTxApplyMs: number;
+  readonly maxTxApplyMs: number;
+  readonly txApplySamples: number;
+  readonly totalClientCpuMs: number;
+  readonly samples: number;
+};
+
+export type ConsumerWorkerData = {
+  readonly id: string;
+  readonly url: string;
+  readonly sqlitePath: string | undefined;
+  readonly replicaVersion: string;
+  readonly protocolMode: ConsumerProtocolMode;
+  readonly transportAckMode: ConsumerTransportAckMode;
+  readonly applyMode: ConsumerApplyMode;
+  readonly synchronous: 'OFF' | 'NORMAL' | 'FULL' | undefined;
+  readonly walAutocheckpoint: number | undefined;
+  readonly clientCpuMicros: number;
+  readonly ackDelayMs: number;
+};
+
+export type SyncWorkerData = {
+  readonly id: string;
+  readonly sqlitePath: string;
+  readonly readDelayMs: number;
+};
+
+export type SyncWorkerStats = {
+  readonly reads: number;
+  readonly totalReadMs: number;
+  readonly maxReadMs: number;
+  readonly errors: number;
+};
+
+export type LoadConsumer = {
+  readonly sub: Subscriber;
+  readonly sqlitePath: string | undefined;
+  readonly stop: () => void;
+  readonly done: Promise<void>;
+  readonly stats: () => LoadConsumerStats;
+};

--- a/packages/zero-cache/bench/rm-vs-load/workloads.test.ts
+++ b/packages/zero-cache/bench/rm-vs-load/workloads.test.ts
@@ -1,0 +1,84 @@
+import {expect, test} from 'vitest';
+import {smokePayloadProfiles} from './fixtures.ts';
+import type {Scenario} from './types.ts';
+import {createTransactionGenerator, workloadName} from './workloads.ts';
+
+const smallPayload = smokePayloadProfiles[0];
+
+test('insert only workload generates one transaction envelope with row inserts', () => {
+  const scenario: Scenario = {
+    name: 'insert-test',
+    rowsPerTx: 3,
+    payload: smallPayload,
+    targetTxPerSec: 100,
+    workload: {kind: 'insert-only'},
+  };
+
+  const tx = createTransactionGenerator(scenario).next(7);
+
+  expect(tx.watermark).toBe('000000000007');
+  expect(tx.rows).toBe(3);
+  expect(tx.operationCounts).toEqual({insert: 3, update: 0, delete: 0});
+  expect(tx.changes.map(change => change[0])).toEqual([
+    'begin',
+    'data',
+    'data',
+    'data',
+    'commit',
+  ]);
+});
+
+test('mixed row churn follows the configured operation cadence', () => {
+  const scenario: Scenario = {
+    name: 'mixed-test',
+    rowsPerTx: 10,
+    payload: smallPayload,
+    targetTxPerSec: 100,
+    workload: {
+      kind: 'mixed-row-churn',
+      insertWeight: 4,
+      updateWeight: 4,
+      deleteWeight: 2,
+    },
+  };
+  const generator = createTransactionGenerator(scenario);
+
+  const first = generator.next(1);
+  const second = generator.next(2);
+
+  expect(first.operationCounts).toEqual({insert: 4, update: 4, delete: 2});
+  expect(second.operationCounts).toEqual({insert: 4, update: 4, delete: 2});
+  expect(first.changes.at(0)?.[0]).toBe('begin');
+  expect(first.changes.at(-1)?.[0]).toBe('commit');
+});
+
+test('mixed row churn inserts until an update or delete has an active row', () => {
+  const scenario: Scenario = {
+    name: 'delete-heavy',
+    rowsPerTx: 4,
+    payload: smallPayload,
+    targetTxPerSec: 100,
+    workload: {
+      kind: 'mixed-row-churn',
+      insertWeight: 0,
+      updateWeight: 0,
+      deleteWeight: 1,
+    },
+  };
+
+  const tx = createTransactionGenerator(scenario).next(1);
+
+  expect(tx.operationCounts).toEqual({insert: 2, update: 0, delete: 2});
+});
+
+test('workload names are stable for benchmark summaries', () => {
+  expect(workloadName({kind: 'insert-only'})).toBe('insert-only');
+  expect(
+    workloadName({
+      kind: 'mixed-row-churn',
+      insertWeight: 4,
+      updateWeight: 4,
+      deleteWeight: 2,
+    }),
+  ).toBe('mixed-row-churn 4i/4u/2d');
+});

--- a/packages/zero-cache/bench/rm-vs-load/workloads.ts
+++ b/packages/zero-cache/bench/rm-vs-load/workloads.ts
@@ -1,0 +1,152 @@
+import {assert} from '../../../shared/src/asserts.ts';
+import {
+  emptyOperationCounts,
+  makeDelete,
+  makeInsert,
+  makeTransaction,
+  makeUpdate,
+  watermarkFor,
+  type GeneratedTransaction,
+  type OperationCounts,
+} from './fixtures.ts';
+import type {Scenario, ScenarioWorkload} from './types.ts';
+
+export type TransactionGenerator = {
+  next(tx: number): GeneratedTransaction;
+};
+
+type MixedRowChurnWorkload = Extract<
+  ScenarioWorkload,
+  {readonly kind: 'mixed-row-churn'}
+>;
+
+export function createTransactionGenerator(
+  scenario: Scenario,
+): TransactionGenerator {
+  switch (scenario.workload.kind) {
+    case 'insert-only':
+      return {
+        next: tx => makeTransaction(tx, scenario.rowsPerTx, scenario.payload),
+      };
+    case 'mixed-row-churn':
+      return new MixedRowChurnGenerator(scenario);
+  }
+}
+
+export function workloadName(workload: ScenarioWorkload): string {
+  switch (workload.kind) {
+    case 'insert-only':
+      return 'insert-only';
+    case 'mixed-row-churn':
+      return (
+        `mixed-row-churn ` +
+        `${workload.insertWeight}i/` +
+        `${workload.updateWeight}u/` +
+        `${workload.deleteWeight}d`
+      );
+  }
+}
+
+export function addOperationCounts(
+  total: OperationCounts,
+  next: OperationCounts,
+) {
+  total.insert += next.insert;
+  total.update += next.update;
+  total.delete += next.delete;
+}
+
+class MixedRowChurnGenerator implements TransactionGenerator {
+  readonly #scenario: Scenario;
+  readonly #workload: MixedRowChurnWorkload;
+  readonly #period: number;
+  readonly #activeIDs: string[] = [];
+  #nextID = 0;
+  #opIndex = 0;
+
+  constructor(scenario: Scenario) {
+    assert(
+      scenario.workload.kind === 'mixed-row-churn',
+      'expected mixed-row-churn workload',
+    );
+    this.#scenario = scenario;
+    this.#workload = scenario.workload;
+    this.#period =
+      this.#workload.insertWeight +
+      this.#workload.updateWeight +
+      this.#workload.deleteWeight;
+    assert(this.#period > 0, 'mixed workload weights must be positive');
+  }
+
+  next(tx: number): GeneratedTransaction {
+    const watermark = watermarkFor(tx);
+    const changes: GeneratedTransaction['changes'] = [
+      ['begin', {tag: 'begin'}, {commitWatermark: watermark}],
+    ];
+    const operationCounts = emptyOperationCounts();
+
+    for (let seq = 0; seq < this.#scenario.rowsPerTx; seq++) {
+      const requestedOp = this.#nextRequestedOperation();
+      const op = this.#activeIDs.length === 0 ? 'insert' : requestedOp;
+
+      switch (op) {
+        case 'insert': {
+          const id = `m-${(this.#nextID++).toString(36)}`;
+          this.#activeIDs.push(id);
+          operationCounts.insert++;
+          changes.push([
+            'data',
+            makeInsert(tx, seq, this.#scenario.payload.bytes, id),
+          ]);
+          break;
+        }
+        case 'update': {
+          const id = this.#activeIDs[this.#pickIndex(tx, seq)];
+          assert(id !== undefined, 'expected active row for update');
+          operationCounts.update++;
+          changes.push([
+            'data',
+            makeUpdate(id, tx, seq, this.#scenario.payload.bytes),
+          ]);
+          break;
+        }
+        case 'delete': {
+          const index = this.#pickIndex(tx, seq);
+          const id = this.#activeIDs[index];
+          assert(id !== undefined, 'expected active row for delete');
+          const last = this.#activeIDs.pop();
+          if (last !== undefined && index < this.#activeIDs.length) {
+            this.#activeIDs[index] = last;
+          }
+          operationCounts.delete++;
+          changes.push(['data', makeDelete(id)]);
+          break;
+        }
+      }
+    }
+
+    changes.push(['commit', {tag: 'commit'}, {watermark}]);
+    return {
+      watermark,
+      changes,
+      rows: this.#scenario.rowsPerTx,
+      operationCounts,
+    };
+  }
+
+  #nextRequestedOperation(): keyof OperationCounts {
+    const {insertWeight, updateWeight} = this.#workload;
+    const slot = this.#opIndex++ % this.#period;
+    if (slot < insertWeight) {
+      return 'insert';
+    }
+    if (slot < insertWeight + updateWeight) {
+      return 'update';
+    }
+    return 'delete';
+  }
+
+  #pickIndex(tx: number, seq: number): number {
+    return (tx * this.#scenario.rowsPerTx + seq) % this.#activeIDs.length;
+  }
+}

--- a/packages/zero-cache/package.json
+++ b/packages/zero-cache/package.json
@@ -28,6 +28,8 @@
     "start": "node ./src/server/runner/main.ts",
     "benchdb": "node ./bench/bench.ts",
     "double": "node ./bench/double.ts",
+    "perf:rm-vs-load": "node ./bench/rm-vs-load/index.ts",
+    "perf:rm-vs-load:e2e": "node ./bench/rm-vs-load/e2e.ts",
     "wal_bench": "node ./bench/wal-bench.ts",
     "wal2_bench": "node ./bench/wal2-bench.ts",
     "fmt": "oxfmt .",

--- a/packages/zero-cache/vitest.config.ts
+++ b/packages/zero-cache/vitest.config.ts
@@ -37,7 +37,10 @@ export function configForNoPg(url: string) {
   return mergeConfig(config, {
     test: {
       name: `${name}/no-pg`,
-      include: ['src/**/*.test.?(c|m)[jt]s?(x)'],
+      include: [
+        'src/**/*.test.?(c|m)[jt]s?(x)',
+        'bench/**/*.test.?(c|m)[jt]s?(x)',
+      ],
       exclude: ['src/**/*.pg.test.?(c|m)[jt]s?(x)'],
       browser: {enabled: false},
       silent: 'passed-only',


### PR DESCRIPTION
**BLUF:** this PR gives the rest of the stack a benchmark that matches the deployment shape we actually care about. Its first output is a reproducible baseline for the old serving apply path: **247.0 tx/s**, **4,939.9 rows/s**, **2.561 ms avg VS transaction apply**, and **0 sync worker read errors** with eight readers sharing the serving SQLite file.

The production shape to keep in mind is:

```text
RM machine                                  VS machine
upstream changes
  -> storer/changeLog
  -> websocket v6 stream  ----------------> serving replicator
                                               |
                                               v
                                          serving SQLite file
                                               ^
                                               |
                                      8 sync workers read here
```

The benchmark harness in #6070 models this as `shared-replica-sync-workers`: one VS-side stream consumer, one serving replica applier, eight reader workers on the same SQLite file, v6 websocket frames, per-message ACKs, and reconnect catchup during load. The point is to avoid measuring an easier but less useful shape where each sync worker gets treated like an independent SQLite writer.

This benchmark is worth adding because the real bottleneck can move between the RM and the VS. A fast RM does not help if the VS serving replica cannot apply and publish fresh versions. A fast VS does not help if the RM storer or fanout path cannot keep the stream moving. The harness keeps those parts in one run so we can see which change moved the actual RM to VS path.

The code is intentionally contained under `bench/rm-vs-load`. [`packages/zero-cache/bench/rm-vs-load/scenarios.ts`](https://github.com/Karavil/mono/blob/capy/rm-vs-load-benchmark/packages/zero-cache/bench/rm-vs-load/scenarios.ts) defines the scenario, [`packages/zero-cache/bench/rm-vs-load/runner.ts`](https://github.com/Karavil/mono/blob/capy/rm-vs-load-benchmark/packages/zero-cache/bench/rm-vs-load/runner.ts) wires together the RM, storer, forwarder, stream consumer, reconnect consumer, and readers, and [`packages/zero-cache/bench/rm-vs-load/sync-workers.ts`](https://github.com/Karavil/mono/blob/capy/rm-vs-load-benchmark/packages/zero-cache/bench/rm-vs-load/sync-workers.ts) starts the shared SQLite reader workers.

```ts
{
  name: 'shared-replica-sync-workers',
  rowsPerTx: 20,
  syncWorkerCount: env.int('ZERO_RM_VS_SYNC_WORKERS', 8),
  workload: {kind: 'insert-only'},
}
```

Baseline output:

| metric | old worker-message path |
| --- | ---: |
| load tx/s | 247.0 |
| load rows/s | 4,939.9 |
| avg VS tx apply | 2.561 ms |
| storer drain | 4,193.2 ms |
| reconnect catchup to final | 11,761.0 ms |
| sync worker reads/s | 258.4 |
| sync worker avg read | 29.597 ms |
| sync worker max read | 196.267 ms |
| sync worker errors | 0 |

Validation:

```text
pnpm exec vitest --project='*no-pg*' run bench/rm-vs-load/config.test.ts bench/rm-vs-load/scenarios.test.ts bench/rm-vs-load/workloads.test.ts
pnpm --filter zero-cache run lint
pnpm --filter @rocicorp/zero-events run build
pnpm --filter zero-cache run check-types
```

Stack context: #6070 adds the benchmark, #6071 reduces RM storer cost, #6072 reduces VS apply cost, #6073 reduces thread-worker handoff cost, #6074 removes the serving-mode thread hop, #6075 improves RM fanout flow control, and #6076 removes subscription queue shifting.
