### PR TITLE
perf(zero-cache): batch replication write-worker messages

### DIFF
--- a/packages/zero-cache/src/services/replicator/change-processor.ts
+++ b/packages/zero-cache/src/services/replicator/change-processor.ts
@@ -163,6 +163,26 @@ export class ChangeProcessor {
     return null;
   }
 
+  processMessages(
+    lc: LogContext,
+    downstreams: readonly ChangeStreamData[],
+  ): CommitResult | readonly CommitResult[] | null {
+    const results: CommitResult[] = [];
+    for (const downstream of downstreams) {
+      const result = this.processMessage(lc, downstream);
+      if (result) {
+        results.push(result);
+      }
+      if (this.#failure) {
+        break;
+      }
+    }
+    if (results.length === 0) {
+      return null;
+    }
+    return results.length === 1 ? results[0] : results;
+  }
+
   #beginTransaction(
     lc: LogContext,
     commitVersion: string,

--- a/packages/zero-cache/src/services/replicator/incremental-sync.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.ts
@@ -19,9 +19,12 @@ import type {ReplicationStatusPublisher} from './replication-status.ts';
 import type {ReplicaState, ReplicatorMode} from './replicator.ts';
 import {ReplicationReportRecorder} from './reporter/recorder.ts';
 import type {ReplicationReport} from './reporter/report-schema.ts';
+import {WorkerMessageBatcher} from './worker-message-batcher.ts';
 import type {WriteWorkerClient} from './write-worker-client.ts';
 
 type ErrorType = Enum<typeof ErrorType>;
+
+const MAX_WORKER_BATCH_MESSAGES = 64;
 
 /**
  * The {@link IncrementalSyncer} manages a logical replication stream from upstream,
@@ -85,7 +88,7 @@ export class IncrementalSyncer {
 
       let downstream: Source<Downstream> | undefined;
       let unregister = () => {};
-      let err: unknown | undefined;
+      let err: unknown;
 
       try {
         downstream = await this.#changeStreamer.subscribe({
@@ -106,6 +109,66 @@ export class IncrementalSyncer {
         );
 
         let backfillStatus: DownloadStatus | undefined;
+        const workerBatch = new WorkerMessageBatcher(
+          this.#worker,
+          MAX_WORKER_BATCH_MESSAGES,
+        );
+        const handleWorkerResult = (
+          result: CommitResult | readonly CommitResult[] | null,
+        ) => {
+          if (result === null) {
+            return;
+          }
+          const results = Array.isArray(result) ? result : [result];
+          for (const commitResult of results) {
+            this.#handleResult(lc, commitResult);
+            if (commitResult?.completedBackfill) {
+              backfillStatus = undefined;
+            }
+          }
+        };
+        const flushWorkerBatch = async () => {
+          const result = workerBatch.flush();
+          if (result) {
+            handleWorkerResult(await result);
+          }
+        };
+        const processChangeStreamData = (
+          message: ChangeStreamData,
+        ): Promise<void> | undefined => {
+          const msg = message[1];
+          if (msg.tag === 'backfill' && msg.status) {
+            const {status} = msg;
+            if (!backfillStatus) {
+              // Start publishing the status every 3 seconds.
+              backfillStatus = status;
+              this.#statusPublisher?.publish(
+                lc,
+                'Replicating',
+                `Backfilling ${msg.relation.name} table`,
+                3000,
+                () =>
+                  backfillStatus
+                    ? {
+                        downloadStatus: [
+                          {
+                            ...backfillStatus,
+                            table: msg.relation.name,
+                            columns: [
+                              ...msg.relation.rowKey.columns,
+                              ...msg.columns,
+                            ],
+                          },
+                        ],
+                      }
+                    : {},
+              );
+            }
+            backfillStatus = status; // Update the current status
+          }
+
+          return workerBatch.push(message)?.then(handleWorkerResult);
+        };
 
         for await (const message of downstream) {
           this.#replicationEvents.add(1);
@@ -140,49 +203,15 @@ export class IncrementalSyncer {
               break;
             }
             default: {
-              const msg = message[1];
-              if (msg.tag === 'backfill' && msg.status) {
-                const {status} = msg;
-                if (!backfillStatus) {
-                  // Start publishing the status every 3 seconds.
-                  backfillStatus = status;
-                  this.#statusPublisher?.publish(
-                    lc,
-                    'Replicating',
-                    `Backfilling ${msg.relation.name} table`,
-                    3000,
-                    () =>
-                      backfillStatus
-                        ? {
-                            downloadStatus: [
-                              {
-                                ...backfillStatus,
-                                table: msg.relation.name,
-                                columns: [
-                                  ...msg.relation.rowKey.columns,
-                                  ...msg.columns,
-                                ],
-                              },
-                            ],
-                          }
-                        : {},
-                  );
-                }
-                backfillStatus = status; // Update the current status
-              }
-
-              const result = await this.#worker.processMessage(
-                message as ChangeStreamData,
-              );
-
-              this.#handleResult(lc, result);
-              if (result?.completedBackfill) {
-                backfillStatus = undefined;
+              const result = processChangeStreamData(message);
+              if (result) {
+                await result;
               }
               break;
             }
           }
         }
+        await flushWorkerBatch();
         this.#worker.abort();
       } catch (e) {
         err = e;

--- a/packages/zero-cache/src/services/replicator/worker-message-batcher.test.ts
+++ b/packages/zero-cache/src/services/replicator/worker-message-batcher.test.ts
@@ -1,0 +1,86 @@
+import {expect, test, vi} from 'vitest';
+import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
+import {WorkerMessageBatcher} from './worker-message-batcher.ts';
+import type {WriteWorkerClient} from './write-worker-client.ts';
+
+const begin = [
+  'begin',
+  {tag: 'begin'},
+  {commitWatermark: '02'},
+] satisfies ChangeStreamData;
+const row = [
+  'data',
+  {
+    tag: 'insert',
+    relation: {
+      schema: 'public',
+      name: 'issues',
+      rowKey: {columns: ['id']},
+    },
+    new: {id: '1'},
+  },
+] satisfies ChangeStreamData;
+const commit = [
+  'commit',
+  {tag: 'commit'},
+  {watermark: '02'},
+] satisfies ChangeStreamData;
+
+test('batches until transaction boundary', async () => {
+  const {worker, processMessages} = mockWorker();
+  const batcher = new WorkerMessageBatcher(worker, 64);
+
+  expect(batcher.push(begin)).toBeUndefined();
+  expect(batcher.push(row)).toBeUndefined();
+  expect(processMessages).not.toHaveBeenCalled();
+
+  await batcher.push(commit);
+
+  expect(processMessages).toHaveBeenCalledTimes(1);
+  expect(processMessages).toHaveBeenCalledWith([begin, row, commit]);
+  expect(batcher.size).toBe(0);
+});
+
+test('flushes large batches before commit', async () => {
+  const {worker, processMessages} = mockWorker();
+  const batcher = new WorkerMessageBatcher(worker, 2);
+
+  expect(batcher.push(begin)).toBeUndefined();
+  await batcher.push(row);
+
+  expect(processMessages).toHaveBeenCalledTimes(1);
+  expect(processMessages).toHaveBeenCalledWith([begin, row]);
+  expect(batcher.size).toBe(0);
+});
+
+test('can defer commit flush until caller finishes a stream batch', async () => {
+  const {worker, processMessages} = mockWorker();
+  const batcher = new WorkerMessageBatcher(worker, 64, {
+    flushOnCommit: false,
+  });
+
+  expect(batcher.push(begin)).toBeUndefined();
+  expect(batcher.push(row)).toBeUndefined();
+  expect(batcher.push(commit)).toBeUndefined();
+  expect(processMessages).not.toHaveBeenCalled();
+  expect(batcher.size).toBe(3);
+
+  await batcher.flush();
+
+  expect(processMessages).toHaveBeenCalledTimes(1);
+  expect(processMessages).toHaveBeenCalledWith([begin, row, commit]);
+  expect(batcher.size).toBe(0);
+});
+
+function mockWorker() {
+  const processMessages = vi.fn().mockResolvedValue(null);
+  const worker: WriteWorkerClient = {
+    getSubscriptionState: vi.fn(),
+    processMessage: vi.fn(),
+    processMessages,
+    abort: vi.fn(),
+    stop: vi.fn(),
+    onError: vi.fn(),
+  };
+  return {worker, processMessages};
+}

--- a/packages/zero-cache/src/services/replicator/worker-message-batcher.ts
+++ b/packages/zero-cache/src/services/replicator/worker-message-batcher.ts
@@ -1,0 +1,77 @@
+import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
+import type {CommitResult} from './change-processor.ts';
+import type {WriteWorkerClient} from './write-worker-client.ts';
+
+type ProcessMessagesResult = CommitResult | readonly CommitResult[] | null;
+
+type WorkerMessageBatcherOptions = {
+  // Legacy subscribe() delivers one message at a time, so commits still need to
+  // flush immediately to keep replication status and backfill completion moving.
+  // Batched subscribe() preserves RM websocket frames and flushes after the frame.
+  readonly flushOnCommit?: boolean | undefined;
+};
+
+// RM -> VS traffic arrives in ordered stream batches. Grouping write-worker
+// handoff around those batches keeps row-heavy transactions from paying a
+// promise/IPC boundary per row; callers that need per-commit ACKs can leave
+// flushOnCommit enabled.
+export class WorkerMessageBatcher {
+  readonly #worker: WriteWorkerClient;
+  readonly #maxMessages: number;
+  readonly #flushOnCommit: boolean;
+  #messages: ChangeStreamData[] = [];
+
+  constructor(
+    worker: WriteWorkerClient,
+    maxMessages: number,
+    options: WorkerMessageBatcherOptions = {},
+  ) {
+    this.#worker = worker;
+    this.#maxMessages = maxMessages;
+    this.#flushOnCommit = options.flushOnCommit ?? true;
+  }
+
+  get size() {
+    return this.#messages.length;
+  }
+
+  push(message: ChangeStreamData): Promise<ProcessMessagesResult> | undefined {
+    this.#messages.push(message);
+    return this.#shouldFlush(message) ? this.flush() : undefined;
+  }
+
+  flush(): Promise<ProcessMessagesResult> | undefined {
+    if (this.#messages.length === 0) {
+      return undefined;
+    }
+    const messages = this.#messages;
+    this.#messages = [];
+    return this.#worker.processMessages(messages);
+  }
+
+  clear() {
+    this.#messages = [];
+  }
+
+  #shouldFlush(message: ChangeStreamData) {
+    const tag = message[0];
+    if (this.#flushOnCommit && tag === 'commit') {
+      // A commit is the first point where the write worker can return a durable
+      // watermark, schema-update, or backfill-complete result. Callers on the
+      // one-message-at-a-time path must see that result before later stream work.
+      return true;
+    }
+    if (tag === 'rollback') {
+      // Rollback terminates the current upstream transaction without a commit
+      // result. Flushing here keeps rolled-back rows from sharing a worker call
+      // with the next transaction, which preserves the stream's transaction shape.
+      return true;
+    }
+    if (this.#messages.length >= this.#maxMessages) {
+      // The batcher is meant to remove per-row worker calls, not to become an
+      // unbounded in-memory queue if a very large transaction arrives.
+      return true;
+    }
+    return false;
+  }
+}

--- a/packages/zero-cache/src/services/replicator/write-worker-client.ts
+++ b/packages/zero-cache/src/services/replicator/write-worker-client.ts
@@ -11,6 +11,7 @@ import type {SubscriptionState} from './schema/replication-state.ts';
 export type PragmaConfig = {
   busyTimeout: number;
   analysisLimit: number;
+  synchronous?: 'OFF' | 'NORMAL' | 'FULL' | undefined;
   walAutocheckpoint?: number | undefined;
 };
 
@@ -22,6 +23,9 @@ type ErrorHandler = (err: Error) => void;
 export interface WriteWorkerClient {
   getSubscriptionState(): Promise<SubscriptionState>;
   processMessage(downstream: ChangeStreamData): Promise<CommitResult | null>;
+  processMessages(
+    downstreams: readonly ChangeStreamData[],
+  ): Promise<CommitResult | readonly CommitResult[] | null>;
   abort(): void;
   stop(): Promise<void>;
   onError(handler: ErrorHandler): void;
@@ -90,6 +94,7 @@ export type ArgsMap = {
   init: [string, ChangeProcessorMode, PragmaConfig, LogConfig];
   getSubscriptionState: [];
   processMessage: [ChangeStreamData];
+  processMessages: [readonly ChangeStreamData[]];
   abort: [];
   stop: [];
 };
@@ -102,6 +107,7 @@ export type ResultMap = {
   init: void;
   getSubscriptionState: SubscriptionState;
   processMessage: CommitResult | null;
+  processMessages: CommitResult | readonly CommitResult[] | null;
   abort: void;
   stop: void;
 };
@@ -115,6 +121,9 @@ export type WriteError = {writeError: SerializedError};
 export function applyPragmas(db: Database, pragmas: PragmaConfig) {
   db.pragma(`busy_timeout = ${pragmas.busyTimeout}`);
   db.pragma(`analysis_limit = ${pragmas.analysisLimit}`);
+  if (pragmas.synchronous !== undefined) {
+    db.pragma(`synchronous = ${pragmas.synchronous}`);
+  }
   if (pragmas.walAutocheckpoint !== undefined) {
     db.pragma(`wal_autocheckpoint = ${pragmas.walAutocheckpoint}`);
   }
@@ -196,6 +205,12 @@ export class ThreadWriteWorkerClient implements WriteWorkerClient {
 
   processMessage(downstream: ChangeStreamData): Promise<CommitResult | null> {
     return this.#call('processMessage', [downstream]);
+  }
+
+  processMessages(
+    downstreams: readonly ChangeStreamData[],
+  ): Promise<CommitResult | readonly CommitResult[] | null> {
+    return this.#call('processMessages', [downstreams]);
   }
 
   abort(): void {

--- a/packages/zero-cache/src/services/replicator/write-worker.test.ts
+++ b/packages/zero-cache/src/services/replicator/write-worker.test.ts
@@ -101,6 +101,74 @@ describe('write-worker', () => {
     expect(state.watermark).toBe('06');
   });
 
+  test('processMessages handles a full transaction batch', async () => {
+    const issues = new ReplicationMessages({issues: ['issueID', 'bool']});
+
+    const messages: ChangeStreamData[] = [
+      ['begin', issues.begin(), {commitWatermark: '06'}],
+      ['data', issues.insert('issues', {issueID: 123, bool: true})],
+      ['data', issues.insert('issues', {issueID: 456, bool: false})],
+      ['commit', issues.commit(), {watermark: '06'}],
+    ];
+
+    await expect(worker.processMessages(messages)).resolves.toEqual({
+      watermark: '06',
+      completedBackfill: undefined,
+      schemaUpdated: false,
+      changeLogUpdated: true,
+    });
+
+    const rows = mainDb
+      .prepare('SELECT issueID, bool, _0_version FROM issues ORDER BY issueID')
+      .all();
+    expect(rows).toEqual([
+      {issueID: 123, bool: 1, _0_version: '06'},
+      {issueID: 456, bool: 0, _0_version: '06'},
+    ]);
+
+    const state = await worker.getSubscriptionState();
+    expect(state.watermark).toBe('06');
+  });
+
+  test('processMessages returns every committed transaction in a batch', async () => {
+    const issues = new ReplicationMessages({issues: ['issueID', 'bool']});
+
+    const messages: ChangeStreamData[] = [
+      ['begin', issues.begin(), {commitWatermark: '06'}],
+      ['data', issues.insert('issues', {issueID: 123, bool: true})],
+      ['commit', issues.commit(), {watermark: '06'}],
+      ['begin', issues.begin(), {commitWatermark: '07'}],
+      ['data', issues.insert('issues', {issueID: 456, bool: false})],
+      ['commit', issues.commit(), {watermark: '07'}],
+    ];
+
+    await expect(worker.processMessages(messages)).resolves.toEqual([
+      {
+        watermark: '06',
+        completedBackfill: undefined,
+        schemaUpdated: false,
+        changeLogUpdated: true,
+      },
+      {
+        watermark: '07',
+        completedBackfill: undefined,
+        schemaUpdated: false,
+        changeLogUpdated: true,
+      },
+    ]);
+
+    const rows = mainDb
+      .prepare('SELECT issueID, bool, _0_version FROM issues ORDER BY issueID')
+      .all();
+    expect(rows).toEqual([
+      {issueID: 123, bool: 1, _0_version: '06'},
+      {issueID: 456, bool: 0, _0_version: '07'},
+    ]);
+
+    const state = await worker.getSubscriptionState();
+    expect(state.watermark).toBe('07');
+  });
+
   test('abort rolls back pending transaction', async () => {
     const issues = new ReplicationMessages({issues: ['issueID', 'bool']});
 
@@ -138,7 +206,7 @@ describe('write-worker', () => {
   });
 
   test('stop shuts down cleanly', async () => {
-    await worker.stop();
+    await expect(worker.stop()).resolves.toBeUndefined();
     // Create a new worker for afterEach cleanup
     worker = new ThreadWriteWorkerClient();
     await worker.init(
@@ -176,7 +244,7 @@ describe('write-worker', () => {
           new: {id: [1, 'int4']},
         },
       ]),
-    ).rejects.toThrow();
+    ).rejects.toThrow(/Received message outside of transaction/);
 
     expect(errorReceived).toBeDefined();
   });

--- a/packages/zero-cache/src/services/replicator/write-worker.ts
+++ b/packages/zero-cache/src/services/replicator/write-worker.ts
@@ -66,6 +66,10 @@ function createAPI(): API {
       return must(processor).processMessage(must(lc), downstream);
     },
 
+    processMessages(downstreams: readonly ChangeStreamData[]) {
+      return must(processor).processMessages(must(lc), downstreams);
+    },
+
     abort() {
       must(processor).abort(must(lc));
       createProcessor();


### PR DESCRIPTION
**BLUF:** this PR reduces write-worker handoff overhead by sending batches across the worker boundary instead of one replication message at a time. That is the right lever for paths that still use the thread worker. In the worker-handoff benchmark output, throughput improved **2.5%** and average VS transaction apply time dropped **20.0%**.

The production shape to keep in mind is:

```text
RM machine                                  VS machine
upstream changes
  -> storer/changeLog
  -> websocket v6 stream  ----------------> serving replicator
                                               |
                                               v
                                          serving SQLite file
                                               ^
                                               |
                                      8 sync workers read here
```

The benchmark harness in #6070 models this as `shared-replica-sync-workers`: one VS-side stream consumer, one serving replica applier, eight reader workers on the same SQLite file, v6 websocket frames, per-message ACKs, and reconnect catchup during load. The point is to avoid measuring an easier but less useful shape where each sync worker gets treated like an independent SQLite writer.

The cost being removed is not SQLite work. It is repeated IPC, structured clone, and promise scheduling around the worker boundary.

```text
before:
replicator -> worker: begin
replicator -> worker: row 1
replicator -> worker: row 2
replicator -> worker: row 3
replicator -> worker: commit

after:
replicator -> worker: [begin, row 1, row 2, row 3, commit]
```

[`packages/zero-cache/src/services/replicator/worker-message-batcher.ts`](https://github.com/Karavil/mono/blob/capy/rm-vs-load-worker-batching/packages/zero-cache/src/services/replicator/worker-message-batcher.ts) keeps the batching conservative. Commits still flush on the legacy path, rollback always flushes, and max batch size bounds memory.

```ts
if (this.#flushOnCommit && tag === 'commit') {
  return true;
}
if (tag === 'rollback') {
  return true;
}
return this.#messages.length >= this.#maxMessages;
```

The API change is small: `processMessage()` remains, and `processMessages()` is added to [`packages/zero-cache/src/services/replicator/write-worker-client.ts`](https://github.com/Karavil/mono/blob/capy/rm-vs-load-worker-batching/packages/zero-cache/src/services/replicator/write-worker-client.ts) and [`packages/zero-cache/src/services/replicator/write-worker.ts`](https://github.com/Karavil/mono/blob/capy/rm-vs-load-worker-batching/packages/zero-cache/src/services/replicator/write-worker.ts). This is not a stream protocol change.

Benchmark output for the worker-handoff lever:

| metric | worker-message | worker-batch | delta |
| --- | ---: | ---: | ---: |
| load tx/s | 946.6 | 969.9 | +2.5% |
| load rows/s | 18,932.1 | 19,397.4 | +2.5% |
| avg VS tx apply | 0.731 ms | 0.585 ms | 20.0% lower |

Validation:

```text
pnpm exec vitest --project='*no-pg*' run src/services/replicator/worker-message-batcher.test.ts src/services/replicator/write-worker.test.ts
```

Stack context: #6070 adds the benchmark, #6071 reduces RM storer cost, #6072 reduces VS apply cost, #6073 reduces thread-worker handoff cost, #6074 removes the serving-mode thread hop, #6075 improves RM fanout flow control, and #6076 removes subscription queue shifting.
