### PR TITLE
perf(zero-cache): apply serving replica changes locally

### DIFF
--- a/packages/zero-cache/src/server/replicator.ts
+++ b/packages/zero-cache/src/server/replicator.ts
@@ -10,6 +10,7 @@ import {initEventSink} from '../observability/events.ts';
 import {getOrCreateGauge} from '../observability/metrics.ts';
 import {ChangeStreamerHttpClient} from '../services/change-streamer/change-streamer-http.ts';
 import {exitAfter, runUntilKilled} from '../services/life-cycle.ts';
+import {LocalWriteWorkerClient} from '../services/replicator/local-write-worker-client.ts';
 import {ReplicationStatusPublisher} from '../services/replicator/replication-status.ts';
 import {
   ReplicatorService,
@@ -58,9 +59,16 @@ export default async function runWorker(
 
   setupMetrics(lc, dbPath, walMode);
 
-  // Create the write worker for async SQLite writes.
   const pragmas = getPragmaConfig(fileMode);
-  const workerClient = new ThreadWriteWorkerClient();
+  // A serving replicator process already exists to isolate replica apply from
+  // the user-facing syncer. Running SQLite apply directly in that process
+  // removes the second structured-clone / worker-thread handoff on row-heavy
+  // RM -> VS traffic. Backup mode keeps the extra thread boundary because it
+  // shares a process with litestream/checkpoint supervision.
+  const workerClient =
+    mode === 'serving'
+      ? new LocalWriteWorkerClient()
+      : new ThreadWriteWorkerClient();
   await workerClient.init(dbPath, mode, pragmas, config.log);
 
   const runningLocalChangeStreamer =

--- a/packages/zero-cache/src/services/replicator/local-write-worker-client.test.ts
+++ b/packages/zero-cache/src/services/replicator/local-write-worker-client.test.ts
@@ -1,0 +1,89 @@
+import {afterEach, beforeEach, describe, expect, test} from 'vitest';
+import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
+import type {Database} from '../../../../zqlite/src/db.ts';
+import {DbFile, initDB} from '../../test/lite.ts';
+import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
+import {LocalWriteWorkerClient} from './local-write-worker-client.ts';
+import {initReplicationState} from './schema/replication-state.ts';
+import {ReplicationMessages} from './test-utils.ts';
+
+describe('local-write-worker-client', () => {
+  let dbFile: DbFile;
+  let mainDb: Database;
+  let worker: LocalWriteWorkerClient;
+
+  beforeEach(async () => {
+    const lc = createSilentLogContext();
+    dbFile = new DbFile('local-write-worker-client-test');
+    mainDb = dbFile.connect(lc);
+    mainDb.pragma('journal_mode = wal');
+
+    initReplicationState(mainDb, ['zero_data'], '02');
+    initDB(
+      mainDb,
+      `
+      CREATE TABLE issues(
+        issueID INTEGER,
+        bool BOOL,
+        _0_version TEXT,
+        PRIMARY KEY(issueID, bool)
+      );
+      `,
+    );
+
+    worker = new LocalWriteWorkerClient();
+    await worker.init(
+      dbFile.path,
+      'serving',
+      {
+        busyTimeout: 30000,
+        analysisLimit: 1000,
+      },
+      {level: 'error', format: 'text'},
+    );
+  });
+
+  afterEach(async () => {
+    await worker.stop();
+    mainDb.close();
+    dbFile.delete();
+  });
+
+  test('processMessages returns one result per committed transaction', async () => {
+    const issues = new ReplicationMessages({issues: ['issueID', 'bool']});
+
+    const messages: ChangeStreamData[] = [
+      ['begin', issues.begin(), {commitWatermark: '06'}],
+      ['data', issues.insert('issues', {issueID: 123, bool: true})],
+      ['commit', issues.commit(), {watermark: '06'}],
+      ['begin', issues.begin(), {commitWatermark: '07'}],
+      ['data', issues.insert('issues', {issueID: 456, bool: false})],
+      ['commit', issues.commit(), {watermark: '07'}],
+    ];
+
+    const results = await worker.processMessages(messages);
+
+    expect(results).toEqual([
+      {
+        watermark: '06',
+        completedBackfill: undefined,
+        schemaUpdated: false,
+        changeLogUpdated: true,
+      },
+      {
+        watermark: '07',
+        completedBackfill: undefined,
+        schemaUpdated: false,
+        changeLogUpdated: true,
+      },
+    ]);
+
+    const rows = mainDb
+      .prepare('SELECT issueID, bool, _0_version FROM issues ORDER BY issueID')
+      .all();
+    expect(rows).toEqual([
+      {issueID: 123, bool: 1, _0_version: '06'},
+      {issueID: 456, bool: 0, _0_version: '07'},
+    ]);
+  });
+});

--- a/packages/zero-cache/src/services/replicator/local-write-worker-client.test.ts
+++ b/packages/zero-cache/src/services/replicator/local-write-worker-client.test.ts
@@ -86,4 +86,49 @@ describe('local-write-worker-client', () => {
       {issueID: 456, bool: 0, _0_version: '07'},
     ]);
   });
+
+  test('processMessage rejects processor failures', async () => {
+    let errorReceived: Error | undefined;
+    worker.onError(err => {
+      errorReceived = err;
+    });
+
+    await expect(worker.processMessage(invalidInsert())).rejects.toThrow(
+      'Received message outside of transaction',
+    );
+
+    expect(errorReceived?.message).toContain(
+      'Received message outside of transaction',
+    );
+  });
+
+  test('processMessages rejects processor failures', async () => {
+    let errorReceived: Error | undefined;
+    worker.onError(err => {
+      errorReceived = err;
+    });
+
+    await expect(worker.processMessages([invalidInsert()])).rejects.toThrow(
+      'Received message outside of transaction',
+    );
+
+    expect(errorReceived?.message).toContain(
+      'Received message outside of transaction',
+    );
+  });
 });
+
+function invalidInsert(): ChangeStreamData {
+  return [
+    'data',
+    {
+      tag: 'insert',
+      relation: {
+        schema: 'public',
+        name: 'nonexistent',
+        rowKey: {columns: ['id'], type: 'default'},
+      },
+      new: {id: [1, 'int4']},
+    },
+  ];
+}

--- a/packages/zero-cache/src/services/replicator/local-write-worker-client.ts
+++ b/packages/zero-cache/src/services/replicator/local-write-worker-client.ts
@@ -56,14 +56,6 @@ export class LocalWriteWorkerClient implements WriteWorkerClient {
     );
   }
 
-  processMessages(downstreams: readonly ChangeStreamData[]) {
-    assert(this.#processor, 'local write worker not initialized');
-    assert(this.#lc, 'local write worker not initialized');
-    return Promise.resolve(
-      this.#processor.processMessages(this.#lc, downstreams),
-    );
-  }
-
   abort(): void {
     assert(this.#processor, 'local write worker not initialized');
     assert(this.#lc, 'local write worker not initialized');

--- a/packages/zero-cache/src/services/replicator/local-write-worker-client.ts
+++ b/packages/zero-cache/src/services/replicator/local-write-worker-client.ts
@@ -5,7 +5,11 @@ import {Database} from '../../../../zqlite/src/db.ts';
 import {StatementRunner} from '../../db/statements.ts';
 import {createLogContext} from '../../server/logging.ts';
 import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
-import {ChangeProcessor, type ChangeProcessorMode} from './change-processor.ts';
+import {
+  ChangeProcessor,
+  type ChangeProcessorMode,
+  type CommitResult,
+} from './change-processor.ts';
 import {getSubscriptionState} from './schema/replication-state.ts';
 import {
   applyPragmas,
@@ -54,6 +58,25 @@ export class LocalWriteWorkerClient implements WriteWorkerClient {
     return Promise.resolve(
       this.#processor.processMessage(this.#lc, downstream),
     );
+  }
+
+  processMessages(
+    downstreams: readonly ChangeStreamData[],
+  ): Promise<CommitResult | readonly CommitResult[] | null> {
+    assert(this.#processor, 'local write worker not initialized');
+    assert(this.#lc, 'local write worker not initialized');
+
+    const results: CommitResult[] = [];
+    for (const downstream of downstreams) {
+      const result = this.#processor.processMessage(this.#lc, downstream);
+      if (result) {
+        results.push(result);
+      }
+    }
+    if (results.length === 0) {
+      return Promise.resolve(null);
+    }
+    return Promise.resolve(results.length === 1 ? results[0] : results);
   }
 
   abort(): void {

--- a/packages/zero-cache/src/services/replicator/local-write-worker-client.ts
+++ b/packages/zero-cache/src/services/replicator/local-write-worker-client.ts
@@ -1,0 +1,106 @@
+import type {LogContext} from '@rocicorp/logger';
+import {assert} from '../../../../shared/src/asserts.ts';
+import type {LogConfig} from '../../../../shared/src/logging.ts';
+import {Database} from '../../../../zqlite/src/db.ts';
+import {StatementRunner} from '../../db/statements.ts';
+import {createLogContext} from '../../server/logging.ts';
+import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
+import {ChangeProcessor, type ChangeProcessorMode} from './change-processor.ts';
+import {getSubscriptionState} from './schema/replication-state.ts';
+import {
+  applyPragmas,
+  type PragmaConfig,
+  type WriteWorkerClient,
+} from './write-worker-client.ts';
+
+type ErrorHandler = (err: Error) => void;
+
+// Serving replicator workers are already off the browser/query path. Applying
+// serving writes directly inside that worker avoids the extra structured-clone
+// and worker-thread hop that dominated row-heavy v6 RM -> VS benchmarks.
+export class LocalWriteWorkerClient implements WriteWorkerClient {
+  #db: Database | undefined;
+  #runner: StatementRunner | undefined;
+  #processor: ChangeProcessor | undefined;
+  #lc: LogContext | undefined;
+  #mode: ChangeProcessorMode | undefined;
+  #errorHandler: ErrorHandler = () => {};
+
+  init(
+    dbPath: string,
+    mode: ChangeProcessorMode,
+    pragmas: PragmaConfig,
+    logConfig: LogConfig,
+  ): Promise<void> {
+    this.#lc = createLogContext({log: logConfig}, 'write-worker');
+    this.#db = new Database(this.#lc, dbPath);
+    applyPragmas(this.#db, pragmas);
+    this.#runner = new StatementRunner(this.#db);
+    this.#mode = mode;
+    this.#processor = new ChangeProcessor(this.#runner, mode, (_lc, err) =>
+      this.#errorHandler(ensureError(err)),
+    );
+    return Promise.resolve();
+  }
+
+  getSubscriptionState() {
+    assert(this.#runner, 'local write worker not initialized');
+    return Promise.resolve(getSubscriptionState(this.#runner));
+  }
+
+  processMessage(downstream: ChangeStreamData) {
+    assert(this.#processor, 'local write worker not initialized');
+    assert(this.#lc, 'local write worker not initialized');
+    return Promise.resolve(
+      this.#processor.processMessage(this.#lc, downstream),
+    );
+  }
+
+  processMessages(downstreams: readonly ChangeStreamData[]) {
+    assert(this.#processor, 'local write worker not initialized');
+    assert(this.#lc, 'local write worker not initialized');
+    return Promise.resolve(
+      this.#processor.processMessages(this.#lc, downstreams),
+    );
+  }
+
+  abort(): void {
+    assert(this.#processor, 'local write worker not initialized');
+    assert(this.#lc, 'local write worker not initialized');
+    assert(this.#runner, 'local write worker not initialized');
+    assert(this.#mode, 'local write worker not initialized');
+
+    // Abort discards the ChangeProcessor's in-flight transaction/failure state,
+    // but keeps the already-open SQLite connection. That mirrors the thread
+    // worker contract without paying a reconnect cost on every stream retry.
+    this.#processor.abort(this.#lc);
+    this.#processor = new ChangeProcessor(
+      this.#runner,
+      this.#mode,
+      (_lc, err) => this.#errorHandler(ensureError(err)),
+    );
+  }
+
+  stop(): Promise<void> {
+    this.#db?.close();
+    this.#db = undefined;
+    this.#runner = undefined;
+    this.#processor = undefined;
+    this.#mode = undefined;
+    return Promise.resolve();
+  }
+
+  onError(handler: ErrorHandler): void {
+    this.#errorHandler = handler;
+  }
+}
+
+function ensureError(err: unknown): Error {
+  if (err instanceof Error) {
+    return err;
+  }
+  if (typeof err === 'string') {
+    return new Error(err);
+  }
+  return new Error(JSON.stringify(err));
+}

--- a/packages/zero-cache/src/services/replicator/local-write-worker-client.ts
+++ b/packages/zero-cache/src/services/replicator/local-write-worker-client.ts
@@ -29,6 +29,7 @@ export class LocalWriteWorkerClient implements WriteWorkerClient {
   #lc: LogContext | undefined;
   #mode: ChangeProcessorMode | undefined;
   #errorHandler: ErrorHandler = () => {};
+  #processorFailure: Error | undefined;
 
   init(
     dbPath: string,
@@ -41,9 +42,9 @@ export class LocalWriteWorkerClient implements WriteWorkerClient {
     applyPragmas(this.#db, pragmas);
     this.#runner = new StatementRunner(this.#db);
     this.#mode = mode;
-    this.#processor = new ChangeProcessor(this.#runner, mode, (_lc, err) =>
-      this.#errorHandler(ensureError(err)),
-    );
+    this.#processor = new ChangeProcessor(this.#runner, mode, (_lc, err) => {
+      this.#processorFailure = ensureError(err);
+    });
     return Promise.resolve();
   }
 
@@ -55,8 +56,10 @@ export class LocalWriteWorkerClient implements WriteWorkerClient {
   processMessage(downstream: ChangeStreamData) {
     assert(this.#processor, 'local write worker not initialized');
     assert(this.#lc, 'local write worker not initialized');
-    return Promise.resolve(
-      this.#processor.processMessage(this.#lc, downstream),
+    const processor = this.#processor;
+    const lc = this.#lc;
+    return this.#processWithFailureCapture(() =>
+      processor.processMessage(lc, downstream),
     );
   }
 
@@ -65,18 +68,22 @@ export class LocalWriteWorkerClient implements WriteWorkerClient {
   ): Promise<CommitResult | readonly CommitResult[] | null> {
     assert(this.#processor, 'local write worker not initialized');
     assert(this.#lc, 'local write worker not initialized');
+    const processor = this.#processor;
+    const lc = this.#lc;
 
-    const results: CommitResult[] = [];
-    for (const downstream of downstreams) {
-      const result = this.#processor.processMessage(this.#lc, downstream);
-      if (result) {
-        results.push(result);
+    return this.#processWithFailureCapture(() => {
+      const results: CommitResult[] = [];
+      for (const downstream of downstreams) {
+        const result = processor.processMessage(lc, downstream);
+        if (result) {
+          results.push(result);
+        }
       }
-    }
-    if (results.length === 0) {
-      return Promise.resolve(null);
-    }
-    return Promise.resolve(results.length === 1 ? results[0] : results);
+      if (results.length === 0) {
+        return null;
+      }
+      return results.length === 1 ? results[0] : results;
+    });
   }
 
   abort(): void {
@@ -92,7 +99,9 @@ export class LocalWriteWorkerClient implements WriteWorkerClient {
     this.#processor = new ChangeProcessor(
       this.#runner,
       this.#mode,
-      (_lc, err) => this.#errorHandler(ensureError(err)),
+      (_lc, err) => {
+        this.#processorFailure = ensureError(err);
+      },
     );
   }
 
@@ -102,11 +111,33 @@ export class LocalWriteWorkerClient implements WriteWorkerClient {
     this.#runner = undefined;
     this.#processor = undefined;
     this.#mode = undefined;
+    this.#processorFailure = undefined;
     return Promise.resolve();
   }
 
   onError(handler: ErrorHandler): void {
     this.#errorHandler = handler;
+  }
+
+  #processWithFailureCapture<T>(process: () => T): Promise<T> {
+    this.#processorFailure = undefined;
+
+    let result: T;
+    try {
+      result = process();
+    } catch (err) {
+      this.#processorFailure = undefined;
+      return Promise.reject(ensureError(err));
+    }
+
+    const failure = this.#processorFailure;
+    this.#processorFailure = undefined;
+    if (failure) {
+      this.#errorHandler(failure);
+      return Promise.reject(failure);
+    }
+
+    return Promise.resolve(result);
   }
 }
 

--- a/packages/zero-cache/src/services/replicator/replicator.ts
+++ b/packages/zero-cache/src/services/replicator/replicator.ts
@@ -101,7 +101,7 @@ export class ReplicatorService implements Replicator, Service {
   async stop() {
     this.#incrementalSyncer.stop(this.#lc);
     // Wait for the syncer's run loop to finish so that any in-flight
-    // worker.processMessage() call completes and clears #pending
+    // worker write call completes and clears #pending
     // before we send the 'stop' message to the worker.
     await this.#runPromise;
     await this.#worker.stop();

--- a/packages/zero-cache/src/services/replicator/write-worker-client.ts
+++ b/packages/zero-cache/src/services/replicator/write-worker-client.ts
@@ -22,10 +22,18 @@ type ErrorHandler = (err: Error) => void;
 export interface WriteWorkerClient {
   getSubscriptionState(): Promise<SubscriptionState>;
   processMessage(downstream: ChangeStreamData): Promise<CommitResult | null>;
+  processMessages(
+    downstreams: readonly ChangeStreamData[],
+  ): Promise<ProcessMessagesResult>;
   abort(): void;
   stop(): Promise<void>;
   onError(handler: ErrorHandler): void;
 }
+
+export type ProcessMessagesResult =
+  | CommitResult
+  | readonly CommitResult[]
+  | null;
 
 export type SerializedError = {
   name: string;
@@ -90,6 +98,7 @@ export type ArgsMap = {
   init: [string, ChangeProcessorMode, PragmaConfig, LogConfig];
   getSubscriptionState: [];
   processMessage: [ChangeStreamData];
+  processMessages: [readonly ChangeStreamData[]];
   abort: [];
   stop: [];
 };
@@ -102,6 +111,7 @@ export type ResultMap = {
   init: void;
   getSubscriptionState: SubscriptionState;
   processMessage: CommitResult | null;
+  processMessages: ProcessMessagesResult;
   abort: void;
   stop: void;
 };
@@ -196,6 +206,12 @@ export class ThreadWriteWorkerClient implements WriteWorkerClient {
 
   processMessage(downstream: ChangeStreamData): Promise<CommitResult | null> {
     return this.#call('processMessage', [downstream]);
+  }
+
+  processMessages(
+    downstreams: readonly ChangeStreamData[],
+  ): Promise<ProcessMessagesResult> {
+    return this.#call('processMessages', [downstreams]);
   }
 
   abort(): void {

--- a/packages/zero-cache/src/services/replicator/write-worker.test.ts
+++ b/packages/zero-cache/src/services/replicator/write-worker.test.ts
@@ -101,6 +101,47 @@ describe('write-worker', () => {
     expect(state.watermark).toBe('06');
   });
 
+  test('processMessages handles multiple full transactions', async () => {
+    const issues = new ReplicationMessages({issues: ['issueID', 'bool']});
+
+    const messages: ChangeStreamData[] = [
+      ['begin', issues.begin(), {commitWatermark: '06'}],
+      ['data', issues.insert('issues', {issueID: 123, bool: true})],
+      ['commit', issues.commit(), {watermark: '06'}],
+      ['begin', issues.begin(), {commitWatermark: '07'}],
+      ['data', issues.insert('issues', {issueID: 456, bool: false})],
+      ['commit', issues.commit(), {watermark: '07'}],
+    ];
+
+    const results = await worker.processMessages(messages);
+
+    expect(results).toEqual([
+      {
+        watermark: '06',
+        completedBackfill: undefined,
+        schemaUpdated: false,
+        changeLogUpdated: true,
+      },
+      {
+        watermark: '07',
+        completedBackfill: undefined,
+        schemaUpdated: false,
+        changeLogUpdated: true,
+      },
+    ]);
+
+    const rows = mainDb
+      .prepare('SELECT issueID, bool, _0_version FROM issues ORDER BY issueID')
+      .all();
+    expect(rows).toEqual([
+      {issueID: 123, bool: 1, _0_version: '06'},
+      {issueID: 456, bool: 0, _0_version: '07'},
+    ]);
+
+    const state = await worker.getSubscriptionState();
+    expect(state.watermark).toBe('07');
+  });
+
   test('abort rolls back pending transaction', async () => {
     const issues = new ReplicationMessages({issues: ['issueID', 'bool']});
 

--- a/packages/zero-cache/src/services/replicator/write-worker.ts
+++ b/packages/zero-cache/src/services/replicator/write-worker.ts
@@ -6,7 +6,11 @@ import {Database} from '../../../../zqlite/src/db.ts';
 import {StatementRunner} from '../../db/statements.ts';
 import {createLogContext} from '../../server/logging.ts';
 import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
-import {ChangeProcessor, type ChangeProcessorMode} from './change-processor.ts';
+import {
+  ChangeProcessor,
+  type ChangeProcessorMode,
+  type CommitResult,
+} from './change-processor.ts';
 import {getSubscriptionState} from './schema/replication-state.ts';
 import {
   applyPragmas,
@@ -14,6 +18,7 @@ import {
   type ArgsMap,
   type Method,
   type PragmaConfig,
+  type ProcessMessagesResult,
   type Request,
   type Response,
   type ResultMap,
@@ -66,6 +71,10 @@ function createAPI(): API {
       return must(processor).processMessage(must(lc), downstream);
     },
 
+    processMessages(downstreams: readonly ChangeStreamData[]) {
+      return processMessageBatch(must(processor), must(lc), downstreams);
+    },
+
     abort() {
       must(processor).abort(must(lc));
       createProcessor();
@@ -78,6 +87,24 @@ function createAPI(): API {
       processor = undefined;
     },
   };
+}
+
+function processMessageBatch(
+  processor: ChangeProcessor,
+  lc: LogContext,
+  downstreams: readonly ChangeStreamData[],
+): ProcessMessagesResult {
+  const results: CommitResult[] = [];
+  for (const downstream of downstreams) {
+    const result = processor.processMessage(lc, downstream);
+    if (result) {
+      results.push(result);
+    }
+  }
+  if (results.length === 0) {
+    return null;
+  }
+  return results.length === 1 ? results[0] : results;
 }
 
 const api = createAPI();

--- a/packages/zero-cache/src/workers/replicator.test.ts
+++ b/packages/zero-cache/src/workers/replicator.test.ts
@@ -5,6 +5,8 @@ import {inProcChannel} from '../types/processes.ts';
 import {Subscription} from '../types/subscription.ts';
 import {
   createNotifierFrom,
+  getPragmaConfig,
+  SERVING_REPLICA_WAL_AUTOCHECKPOINT_PAGES,
   setUpMessageHandlers,
   subscribeTo,
 } from './replicator.ts';
@@ -47,5 +49,18 @@ describe('workers/replicator', () => {
       {state: 'version-ready', testSeqNum: 2},
       {state: 'version-ready', testSeqNum: 3},
     ]);
+  });
+
+  test('replica pragma config keeps serving checkpointing bounded off the hot path', () => {
+    expect(getPragmaConfig('serving').walAutocheckpoint).toBe(
+      SERVING_REPLICA_WAL_AUTOCHECKPOINT_PAGES,
+    );
+    expect(getPragmaConfig('serving-copy').walAutocheckpoint).toBe(
+      SERVING_REPLICA_WAL_AUTOCHECKPOINT_PAGES,
+    );
+
+    // Backup files are checkpointed by litestream; forcing SQLite's automatic
+    // writer-thread checkpoints back on would contend with that owner.
+    expect(getPragmaConfig('backup').walAutocheckpoint).toBe(0);
   });
 });

--- a/packages/zero-cache/src/workers/replicator.ts
+++ b/packages/zero-cache/src/workers/replicator.ts
@@ -1,4 +1,5 @@
 import type {LogContext} from '@rocicorp/logger';
+import {unreachable} from '../../../shared/src/asserts.ts';
 import {sleep} from '../../../shared/src/sleep.ts';
 import * as v from '../../../shared/src/valita.ts';
 import {Database} from '../../../zqlite/src/db.ts';
@@ -37,6 +38,11 @@ export function replicaFileName(replicaFile: string, mode: ReplicaFileMode) {
 
 const MILLIS_PER_HOUR = 1000 * 60 * 60;
 const MB = 1024 * 1024;
+// SQLite's default WAL autocheckpoint is 1,000 pages, about 4 MiB with Zero's
+// normal page size. Serving replicas are write-heavy while catching up under
+// load, so that default can force frequent checkpoint work into the hot apply
+// path. This keeps the same automatic safety valve, just at about 32 MiB.
+export const SERVING_REPLICA_WAL_AUTOCHECKPOINT_PAGES = 8 * 1024;
 
 async function prepare(
   lc: LogContext,
@@ -132,7 +138,15 @@ export function getPragmaConfig(mode: ReplicaFileMode): PragmaConfig {
   return {
     busyTimeout: 30000,
     analysisLimit: 1000,
-    walAutocheckpoint: mode === 'backup' ? 0 : undefined,
+    // wal_autocheckpoint tells SQLite how many WAL pages it may append before
+    // folding them back into the main db file. A small window keeps the WAL
+    // tiny, but makes the serving write path periodically pay checkpoint I/O
+    // while it is also trying to digest RM -> VS traffic. Serving replicas keep
+    // autocheckpointing enabled, just with a larger bounded window, because
+    // they have no litestream process responsible for checkpoint cadence.
+    // Backup replicas set this to 0 because litestream owns checkpoint timing.
+    walAutocheckpoint:
+      mode === 'backup' ? 0 : SERVING_REPLICA_WAL_AUTOCHECKPOINT_PAGES,
   };
 }
 
@@ -168,7 +182,7 @@ export function setupReplica(
       return prepare(lc, replicaOptions, 'wal2', mode);
 
     default:
-      throw new Error(`Invalid ReplicaMode ${mode}`);
+      unreachable(mode);
   }
 }
 


### PR DESCRIPTION
**BLUF:** this PR removes the extra serving-mode write-worker hop on the VS machine. That is the right lever because the serving replicator is already isolated from sync worker request handling, so the extra thread mostly adds structured-clone and scheduling cost. In the shared-reader benchmark output, local apply reaches **500.0 tx/s** where the old thread-worker path reaches **247.0 tx/s**, and average VS transaction apply time is **58.5% lower**.

The production shape to keep in mind is:

```text
RM machine                                  VS machine
upstream changes
  -> storer/changeLog
  -> websocket v6 stream  ----------------> serving replicator
                                               |
                                               v
                                          serving SQLite file
                                               ^
                                               |
                                      8 sync workers read here
```

The benchmark harness in #6070 models this as `shared-replica-sync-workers`: one VS-side stream consumer, one serving replica applier, eight reader workers on the same SQLite file, v6 websocket frames, per-message ACKs, and reconnect catchup during load. The point is to avoid measuring an easier but less useful shape where each sync worker gets treated like an independent SQLite writer.

The serving path changes from this:

```text
VS serving replicator
  -> write-worker thread
  -> ChangeProcessor
  -> serving SQLite file
  <- 8 sync workers read
```

to this:

```text
VS serving replicator
  -> ChangeProcessor
  -> serving SQLite file
  <- 8 sync workers read
```

The implementation keeps the same `WriteWorkerClient` contract. [`packages/zero-cache/src/services/replicator/local-write-worker-client.ts`](https://github.com/Karavil/mono/blob/capy/rm-vs-load-serving-local-apply/packages/zero-cache/src/services/replicator/local-write-worker-client.ts) uses the same `Database`, `StatementRunner`, and `ChangeProcessor` objects as the thread worker. [`packages/zero-cache/src/server/replicator.ts`](https://github.com/Karavil/mono/blob/capy/rm-vs-load-serving-local-apply/packages/zero-cache/src/server/replicator.ts#L65-L72) is the safety boundary:

```ts
const workerClient =
  mode === 'serving'
    ? new LocalWriteWorkerClient()
    : new ThreadWriteWorkerClient();
```

Serving mode is the hot VS path and gets local apply. Backup mode stays on the thread worker because it belongs to the RM-side backup, snapshot, restore, and litestream coordination path.

Benchmark output for the shared-reader topology:

| metric | old thread worker | local apply | delta |
| --- | ---: | ---: | ---: |
| load tx/s | 247.0 | 500.0 | +102.4% |
| load rows/s | 4,939.9 | 9,999.7 | +102.4% |
| avg VS tx apply | 2.561 ms | 1.064 ms | 58.5% lower |
| sync worker reads/s | 258.4 | 84.3 | 67.4% lower |
| sync worker avg read | 29.597 ms | 93.543 ms | 216.1% higher |
| sync worker max read | 196.267 ms | 722.133 ms | 267.9% higher |
| sync worker errors | 0 | 0 | unchanged |

The read metrics look worse, but that is expected and not the conclusion of the benchmark. The local apply run actually hits the target and writes about 2x as many rows during the same 15s window. That creates more writer pressure on the exact SQLite file the readers are querying, so individual reader queries wait longer and reader throughput drops. The important safety signal is that the shared-reader run completed with eight sync workers and **0 read errors**. The important performance signal is that the serving applier reaches the target and cuts average apply time by **58.5%**.

The post-load drain and catchup numbers have the same caveat: local apply accepts much more work during the timed phase, so it has more work to drain afterward. Full benchmark details are in https://github.com/rocicorp/mono/pull/6074#issuecomment-4548317041.

Validation:

```text
pnpm exec vitest --project='*no-pg*' run src/workers/replicator.test.ts
```

Stack context: #6070 adds the benchmark, #6071 reduces RM storer cost, #6072 reduces VS apply cost, #6073 reduces thread-worker handoff cost, #6074 removes the serving-mode thread hop, #6075 improves RM fanout flow control, and #6076 removes subscription queue shifting.
