### PR TITLE
perf(zero-cache): batch v6 websocket change frames

### DIFF
--- a/packages/shared/src/head-indexed-queue.test.ts
+++ b/packages/shared/src/head-indexed-queue.test.ts
@@ -1,0 +1,55 @@
+import {describe, expect, test} from 'vitest';
+import {HeadIndexedQueue} from './head-indexed-queue.ts';
+
+describe('HeadIndexedQueue', () => {
+  test('keeps FIFO order across many shifts without exposing compacted slots', () => {
+    const queue = new HeadIndexedQueue<number>();
+    for (let i = 0; i < 2050; i++) {
+      queue.push(i);
+    }
+
+    for (let i = 0; i < 1500; i++) {
+      expect(queue.shift()).toBe(i);
+    }
+    queue.push(2050);
+
+    expect(queue.size).toBe(551);
+    expect(queue.peek()).toBe(1500);
+    expect(queue.last()).toBe(2050);
+    expect(queue.toArray()).toEqual(
+      Array.from({length: 551}, (_, i) => i + 1500),
+    );
+  });
+
+  test('delete and replace operations skip holes left in the active window', () => {
+    const queue = new HeadIndexedQueue<string>();
+    queue.push('a');
+    queue.push('b');
+    queue.push('c');
+    queue.push('d');
+
+    expect(queue.deleteFirst('a')).toBe(true);
+    expect(queue.deleteMatching(value => value === 'c')).toBe(1);
+    queue.replaceLast('D');
+
+    expect(queue.size).toBe(2);
+    expect(queue.peek()).toBe('b');
+    expect(queue.last()).toBe('D');
+    expect(queue.toArray()).toEqual(['b', 'D']);
+    expect(queue.shift()).toBe('b');
+    expect(queue.shift()).toBe('D');
+    expect(queue.shift()).toBeUndefined();
+  });
+
+  test('stores undefined values without confusing them with deleted slots', () => {
+    const queue = new HeadIndexedQueue<string | undefined>();
+    queue.push(undefined);
+    queue.push('next');
+
+    expect(queue.size).toBe(2);
+    expect(queue.shift()).toBeUndefined();
+    expect(queue.size).toBe(1);
+    expect(queue.shift()).toBe('next');
+    expect(queue.size).toBe(0);
+  });
+});

--- a/packages/shared/src/head-indexed-queue.ts
+++ b/packages/shared/src/head-indexed-queue.ts
@@ -1,0 +1,143 @@
+// High-volume RM -> VS streams should not make every FIFO dequeue move the
+// rest of the array. Keep the head-index/compaction bookkeeping in one small
+// type so hot queues can stay O(1) without spreading that machinery through
+// the caller.
+export class HeadIndexedQueue<T> {
+  // `undefined` is a valid queue value for some callers, so deleted slots use a
+  // private sentinel instead of overloading undefined.
+  readonly #entries: (T | EmptySlot)[] = [];
+  // #head is the first slot worth scanning; #count is the number of live values
+  // after holes from deletes/shifts. Keeping both lets shift() stay O(1) while
+  // deleteMatching() can remove arbitrary pending entries.
+  #head = 0;
+  #count = 0;
+
+  get size(): number {
+    return this.#count;
+  }
+
+  push(value: T): void {
+    this.#entries.push(value);
+    this.#count++;
+  }
+
+  peek(): T | undefined {
+    if (this.#count === 0) {
+      return undefined;
+    }
+    for (let i = this.#head; i < this.#entries.length; i++) {
+      const value = this.#entries[i];
+      if (value !== EMPTY_SLOT) {
+        return value;
+      }
+    }
+    return undefined;
+  }
+
+  shift(): T | undefined {
+    if (this.#count === 0) {
+      this.clear();
+      return undefined;
+    }
+
+    while (this.#head < this.#entries.length) {
+      const value = this.#entries[this.#head];
+      // Clear the reference before returning so long-lived streams do not keep
+      // consumed payloads alive until the next compaction.
+      this.#entries[this.#head] = EMPTY_SLOT;
+      this.#head++;
+      if (value !== EMPTY_SLOT) {
+        this.#count--;
+        this.#maybeCompact();
+        return value;
+      }
+    }
+
+    this.clear();
+    return undefined;
+  }
+
+  last(): T | undefined {
+    if (this.#count === 0) {
+      return undefined;
+    }
+    for (let i = this.#entries.length - 1; i >= this.#head; i--) {
+      const value = this.#entries[i];
+      if (value !== EMPTY_SLOT) {
+        return value;
+      }
+    }
+    return undefined;
+  }
+
+  replaceLast(value: T): void {
+    for (let i = this.#entries.length - 1; i >= this.#head; i--) {
+      if (this.#entries[i] !== EMPTY_SLOT) {
+        this.#entries[i] = value;
+        return;
+      }
+    }
+    this.push(value);
+  }
+
+  deleteFirst(value: T): boolean {
+    for (let i = this.#head; i < this.#entries.length; i++) {
+      if (this.#entries[i] === value) {
+        this.#entries[i] = EMPTY_SLOT;
+        this.#count--;
+        this.#maybeCompact();
+        return true;
+      }
+    }
+    return false;
+  }
+
+  deleteMatching(predicate: (value: T) => boolean): number {
+    let deleted = 0;
+    // Scan backward so several deletions can create holes without changing the
+    // indexes of entries that have not been inspected yet.
+    for (let i = this.#entries.length - 1; i >= this.#head; i--) {
+      const value = this.#entries[i];
+      if (value !== EMPTY_SLOT && predicate(value)) {
+        this.#entries[i] = EMPTY_SLOT;
+        this.#count--;
+        deleted++;
+      }
+    }
+    this.#maybeCompact();
+    return deleted;
+  }
+
+  toArray(): T[] {
+    const values: T[] = [];
+    for (let i = this.#head; i < this.#entries.length; i++) {
+      const value = this.#entries[i];
+      if (value !== EMPTY_SLOT) {
+        values.push(value);
+      }
+    }
+    return values;
+  }
+
+  clear(): void {
+    this.#entries.length = 0;
+    this.#head = 0;
+    this.#count = 0;
+  }
+
+  #maybeCompact(): void {
+    if (this.#count === 0) {
+      // Empty queues should release the whole backing array immediately; this is
+      // the common state after a stream drains.
+      this.clear();
+    } else if (this.#head > 1024 && this.#head * 2 > this.#entries.length) {
+      // Compaction copies the live suffix, so wait until the dead prefix is both
+      // large and at least half the array.
+      this.#entries.splice(0, this.#head);
+      this.#head = 0;
+    }
+  }
+}
+
+const EMPTY_SLOT = Symbol('empty-slot');
+type EmptySlot = typeof EMPTY_SLOT;

--- a/packages/zero-cache/src/config/zero-config.test.ts
+++ b/packages/zero-cache/src/config/zero-config.test.ts
@@ -406,11 +406,11 @@ test('zero-cache --help', () => {
                                                                         rather, it protects the system when the upstream throughput exceeds the downstream                                         
                                                                         throughput.                                                                                                                
                                                                                                                                                                                                    
-     --change-streamer-flow-control-consensus-padding-seconds number    default: 1                                                                                                                 
+     --change-streamer-flow-control-consensus-padding-seconds number    default: 0.1                                                                                                               
        ZERO_CHANGE_STREAMER_FLOW_CONTROL_CONSENSUS_PADDING_SECONDS env                                                                                                                             
-                                                                        During periodic flow control checks (every 64kb), the amount of time to wait after the                                     
-                                                                        majority of subscribers have acked, after which replication will continue even if                                          
-                                                                        some subscribers have yet to ack. (Note that this is not a timeout for the entire send,                                    
+                                                                        During flow control flushes, the amount of time to wait after the majority of                                              
+                                                                        subscribers have acked, after which replication will continue even if some subscribers                                     
+                                                                        have yet to ack. (Note that this is not a timeout for the entire send,                                                     
                                                                         but a timeout that starts after the majority of receivers have acked.)                                                     
                                                                                                                                                                                                    
                                                                         This allows a bounded amount of time for backlogged subscribers to catch up on each flush                                  

--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -651,11 +651,11 @@ export const zeroOptions = {
     },
 
     flowControlConsensusPaddingSeconds: {
-      type: v.number().default(1),
+      type: v.number().default(0.1),
       desc: [
-        `During periodic flow control checks (every 64kb), the amount of time to wait after the`,
-        `majority of subscribers have acked, after which replication will continue even if`,
-        `some subscribers have yet to ack. (Note that this is not a timeout for the {italic entire} send,`,
+        `During flow control flushes, the amount of time to wait after the majority of`,
+        `subscribers have acked, after which replication will continue even if some subscribers`,
+        `have yet to ack. (Note that this is not a timeout for the {italic entire} send,`,
         `but a timeout that starts {italic after} the majority of receivers have acked.)`,
         ``,
         `This allows a bounded amount of time for backlogged subscribers to catch up on each flush`,

--- a/packages/zero-cache/src/server/replicator.ts
+++ b/packages/zero-cache/src/server/replicator.ts
@@ -10,6 +10,7 @@ import {initEventSink} from '../observability/events.ts';
 import {getOrCreateGauge} from '../observability/metrics.ts';
 import {ChangeStreamerHttpClient} from '../services/change-streamer/change-streamer-http.ts';
 import {exitAfter, runUntilKilled} from '../services/life-cycle.ts';
+import {LocalWriteWorkerClient} from '../services/replicator/local-write-worker-client.ts';
 import {ReplicationStatusPublisher} from '../services/replicator/replication-status.ts';
 import {
   ReplicatorService,
@@ -58,9 +59,16 @@ export default async function runWorker(
 
   setupMetrics(lc, dbPath, walMode);
 
-  // Create the write worker for async SQLite writes.
   const pragmas = getPragmaConfig(fileMode);
-  const workerClient = new ThreadWriteWorkerClient();
+  // A serving replicator process already exists to isolate replica apply from
+  // the user-facing syncer. Running SQLite apply directly in that process
+  // removes the second structured-clone / worker-thread handoff on row-heavy
+  // RM -> VS traffic. Backup mode keeps the extra thread boundary because it
+  // shares a process with litestream/checkpoint supervision.
+  const workerClient =
+    mode === 'serving'
+      ? new LocalWriteWorkerClient()
+      : new ThreadWriteWorkerClient();
   await workerClient.init(dbPath, mode, pragmas, config.log);
 
   const runningLocalChangeStreamer =

--- a/packages/zero-cache/src/services/change-streamer/broadcast.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/broadcast.test.ts
@@ -2,6 +2,7 @@ import {afterEach, describe, expect, test, vi} from 'vitest';
 import {BigIntJSON} from '../../../../shared/src/bigint-json.ts';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
 import {sleep} from '../../../../shared/src/sleep.ts';
+import type {StringifiedStreamPayload} from '../../types/streams.ts';
 import type {Subscription} from '../../types/subscription.ts';
 import {ReplicationMessages} from '../replicator/test-utils.ts';
 import {Broadcast} from './broadcast.ts';
@@ -24,7 +25,9 @@ describe('change-streamer/broadcast', () => {
     vi.restoreAllMocks();
   });
 
-  async function consumeOne(downstream: Subscription<string>) {
+  async function consumeOne(
+    downstream: Subscription<StringifiedStreamPayload>,
+  ) {
     const pipeline = downstream.pipeline;
     if (pipeline === undefined) {
       throw new Error('Expected pipelined subscription');
@@ -43,7 +46,7 @@ describe('change-streamer/broadcast', () => {
 
   async function makeSubscribers(count: number) {
     const subscribers: Subscriber[] = [];
-    const downstreams: Subscription<string>[] = [];
+    const downstreams: Subscription<StringifiedStreamPayload>[] = [];
     for (let i = 0; i < count; i++) {
       const [subscriber, , downstream] = createSubscriber('00', true);
       subscribers.push(subscriber);
@@ -54,7 +57,9 @@ describe('change-streamer/broadcast', () => {
     return {subscribers, downstreams};
   }
 
-  async function consumeChange(downstream: Subscription<string>) {
+  async function consumeChange(
+    downstream: Subscription<StringifiedStreamPayload>,
+  ) {
     await consumeOne(downstream);
     await flushCompletions();
   }

--- a/packages/zero-cache/src/services/change-streamer/broadcast.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/broadcast.test.ts
@@ -1,9 +1,11 @@
-import {describe, expect, test} from 'vitest';
+import {afterEach, describe, expect, test, vi} from 'vitest';
 import {BigIntJSON} from '../../../../shared/src/bigint-json.ts';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
 import {sleep} from '../../../../shared/src/sleep.ts';
+import type {Subscription} from '../../types/subscription.ts';
 import {ReplicationMessages} from '../replicator/test-utils.ts';
 import {Broadcast} from './broadcast.ts';
+import type {Subscriber} from './subscriber.ts';
 import {createSubscriber} from './test-utils.ts';
 
 const json = BigIntJSON.stringify;
@@ -11,6 +13,58 @@ const json = BigIntJSON.stringify;
 describe('change-streamer/broadcast', () => {
   const messages = new ReplicationMessages({issues: 'id'});
   const lc = createSilentLogContext();
+  const change: [string, 'begin', string] = [
+    '11',
+    'begin',
+    json(['begin', messages.begin(), {commitWatermark: '13'}]),
+  ];
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  async function consumeOne(downstream: Subscription<string>) {
+    const pipeline = downstream.pipeline;
+    if (pipeline === undefined) {
+      throw new Error('Expected pipelined subscription');
+    }
+    const next = await pipeline[Symbol.asyncIterator]().next();
+    if (next.done) {
+      throw new Error('Expected subscription message');
+    }
+    next.value.consumed();
+  }
+
+  async function flushCompletions() {
+    await Promise.resolve();
+    await Promise.resolve();
+  }
+
+  async function makeSubscribers(count: number) {
+    const subscribers: Subscriber[] = [];
+    const downstreams: Subscription<string>[] = [];
+    for (let i = 0; i < count; i++) {
+      const [subscriber, , downstream] = createSubscriber('00', true);
+      subscribers.push(subscriber);
+      downstreams.push(downstream);
+    }
+    await Promise.all(downstreams.map(consumeOne));
+    await flushCompletions();
+    return {subscribers, downstreams};
+  }
+
+  async function consumeChange(downstream: Subscription<string>) {
+    await consumeOne(downstream);
+    await flushCompletions();
+  }
+
+  async function closeAll(subscribers: readonly Subscriber[]) {
+    for (const sub of subscribers) {
+      sub.close();
+    }
+    await flushCompletions();
+  }
 
   test('without tracking', () => {
     const [sub1, stream1] = createSubscriber('00', true);
@@ -74,6 +128,102 @@ describe('change-streamer/broadcast', () => {
         ['begin', {tag: 'begin'}, {commitWatermark: '13'}],
       ]);
     }
+  });
+
+  test('flow control releases after majority plus padding', async () => {
+    vi.useFakeTimers();
+    const {subscribers, downstreams} = await makeSubscribers(4);
+    const broadcast = new Broadcast(subscribers, change, {
+      lc,
+      flowControlConsensusPaddingMs: 50,
+    });
+
+    await consumeChange(downstreams[0]);
+    await consumeChange(downstreams[1]);
+    await vi.advanceTimersByTimeAsync(100);
+    expect(broadcast.isDone).toBe(false);
+
+    await consumeChange(downstreams[2]);
+    await vi.advanceTimersByTimeAsync(49);
+    expect(broadcast.isDone).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await broadcast.done;
+    expect(broadcast.isDone).toBe(true);
+
+    await closeAll(subscribers);
+  });
+
+  test('flow control timer resets after post-majority progress', async () => {
+    vi.useFakeTimers();
+    const {subscribers, downstreams} = await makeSubscribers(5);
+    const broadcast = new Broadcast(subscribers, change, {
+      lc,
+      flowControlConsensusPaddingMs: 50,
+    });
+
+    await consumeChange(downstreams[0]);
+    await consumeChange(downstreams[1]);
+    await consumeChange(downstreams[2]);
+    await vi.advanceTimersByTimeAsync(30);
+    await consumeChange(downstreams[3]);
+
+    await vi.advanceTimersByTimeAsync(49);
+    expect(broadcast.isDone).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await broadcast.done;
+    expect(broadcast.isDone).toBe(true);
+
+    await closeAll(subscribers);
+  });
+
+  test('flow control timer is cleared when all subscribers complete', async () => {
+    vi.useFakeTimers();
+    const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout');
+    const {subscribers, downstreams} = await makeSubscribers(4);
+    const broadcast = new Broadcast(subscribers, change, {
+      lc,
+      flowControlConsensusPaddingMs: 50,
+    });
+
+    await consumeChange(downstreams[0]);
+    await consumeChange(downstreams[1]);
+    await consumeChange(downstreams[2]);
+    expect(broadcast.isDone).toBe(false);
+
+    await consumeChange(downstreams[3]);
+    await broadcast.done;
+    expect(broadcast.isDone).toBe(true);
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(50);
+    expect(broadcast.isDone).toBe(true);
+    await closeAll(subscribers);
+  });
+
+  test('negative flow control padding disables early release', async () => {
+    vi.useFakeTimers();
+    const {subscribers, downstreams} = await makeSubscribers(4);
+    const broadcast = new Broadcast(subscribers, change, {
+      lc,
+      flowControlConsensusPaddingMs: -1,
+    });
+
+    await consumeChange(downstreams[0]);
+    await consumeChange(downstreams[1]);
+    await consumeChange(downstreams[2]);
+    expect(broadcast.checkProgress(lc, -1, performance.now() + 1000)).toBe(
+      false,
+    );
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(broadcast.isDone).toBe(false);
+
+    await consumeChange(downstreams[3]);
+    await broadcast.done;
+    expect(broadcast.isDone).toBe(true);
+
+    await closeAll(subscribers);
   });
 
   test('checkProgress', async () => {

--- a/packages/zero-cache/src/services/change-streamer/broadcast.ts
+++ b/packages/zero-cache/src/services/change-streamer/broadcast.ts
@@ -3,6 +3,8 @@ import {resolver} from '@rocicorp/resolver';
 import type {WatermarkedChange} from './change-streamer-service.ts';
 import type {Subscriber} from './subscriber.ts';
 
+type BroadcastChange = WatermarkedChange | readonly WatermarkedChange[];
+
 /**
  * Initiates and tracks the progress of a change broadcasted to
  * a set of subscribers.
@@ -10,9 +12,9 @@ import type {Subscriber} from './subscriber.ts';
  * Creating a `Broadcast` automatically initiates the send.
  *
  * By default, {@link Broadcast.done} resolves when all subscribers
- * have acked the change. However, {@link Broadcast.checkProgress()}
- * can be called to resolve the broadcast earlier based on the flow
- * control policy.
+ * have acked the change. When flow control options are supplied,
+ * {@link Broadcast.done} resolves after majority consensus plus the
+ * configured padding.
  */
 export class Broadcast {
   /**
@@ -21,17 +23,24 @@ export class Broadcast {
    */
   static withoutTracking(
     subscribers: Iterable<Subscriber>,
-    change: WatermarkedChange,
+    change: BroadcastChange,
   ) {
+    const changes = normalizeChanges(change);
     for (const sub of subscribers) {
-      void sub.send(change);
+      void sub.sendBatch(changes);
     }
   }
 
+  // Subscribers still gating this broadcast. A subscriber leaves this set when
+  // its downstream stream has consumed the batch.
   readonly #pending: Set<Subscriber>;
+  // Completion samples are retained for flow-control logs; they explain which
+  // subscribers were fast enough to form the majority.
   readonly #completed: Completed[];
   readonly #done = resolver();
+  readonly #flowControl: FlowControlOptions | undefined;
   #isDone = false;
+  #flowControlTimer: ReturnType<typeof setTimeout> | undefined;
 
   readonly #watermark: string;
   readonly #majority: number;
@@ -43,22 +52,35 @@ export class Broadcast {
    * Broadcasts the `change` to the `subscribers` and tracks their
    * completion.
    */
-  constructor(subscribers: Iterable<Subscriber>, change: WatermarkedChange) {
+  constructor(
+    subscribers: Iterable<Subscriber>,
+    change: BroadcastChange,
+    flowControl?: FlowControlOptions,
+  ) {
+    const changes = normalizeChanges(change);
     this.#pending = new Set(subscribers);
     this.#completed = [];
-    this.#watermark = change[0];
+    this.#flowControl = flowControl;
+    // The last change in the broadcast is the highest commit/order watermark
+    // represented by this batch, so it is the useful label for diagnostics.
+    this.#watermark = changes.at(-1)?.[0] ?? 'none';
+    // "More than half" keeps one slow or broken minority from stalling the RM,
+    // while a one-subscriber topology still waits for that subscriber.
     this.#majority = Math.floor(this.#pending.size / 2) + 1;
 
     for (const sub of this.#pending) {
-      const changes = sub.numPending + 1; // add one for this `change`
+      // Log the work visible to the subscriber at send time: its existing
+      // downstream backlog plus this broadcast's new logical messages.
+      const numChanges = sub.numPending + changes.length;
       void sub
-        .send(change)
+        .sendBatch(changes)
         .catch(() => {})
-        .finally(() => this.#markCompleted(sub, changes));
+        .finally(() => this.#markCompleted(sub, numChanges));
     }
 
-    // set done if there are no subscribers (mainly for tests)
     if (this.#pending.size === 0) {
+      // With no subscribers, there is nobody to apply flow control to; let the
+      // upstream continue immediately.
       this.#setDone();
     }
   }
@@ -69,12 +91,71 @@ export class Broadcast {
     this.#pending.delete(sub);
     if (this.#pending.size === 0) {
       this.#setDone();
+    } else {
+      this.#resetConsensusTimer();
     }
   }
 
-  #setDone() {
+  #setDone(): boolean {
+    if (this.#isDone) {
+      return false;
+    }
     this.#isDone = true;
+    this.#clearConsensusTimer();
     this.#done.resolve();
+    return true;
+  }
+
+  #resetConsensusTimer() {
+    if (
+      this.#isDone ||
+      this.#flowControl === undefined ||
+      !(this.#flowControl.flowControlConsensusPaddingMs >= 0) ||
+      this.#completed.length < this.#majority
+    ) {
+      // Timer starts only after majority completion and only when early release
+      // is enabled. Before that, releasing would let the RM outrun the VS fleet.
+      return;
+    }
+    this.#clearConsensusTimer();
+    this.#flowControlTimer = setTimeout(
+      this.#releaseAfterConsensusPadding,
+      this.#flowControl.flowControlConsensusPaddingMs,
+    );
+  }
+
+  readonly #releaseAfterConsensusPadding = () => {
+    this.#flowControlTimer = undefined;
+    const flowControl = this.#flowControl;
+    if (
+      this.#isDone ||
+      flowControl === undefined ||
+      this.#pending.size === 0 ||
+      this.#completed.length < this.#majority
+    ) {
+      // The callback can race with normal completion or option changes; in
+      // those cases there is either nothing left to release or no consensus yet.
+      return;
+    }
+    const now = performance.now();
+    if (
+      now - this.#latestCompleted <
+      flowControl.flowControlConsensusPaddingMs
+    ) {
+      this.#resetConsensusTimer();
+      return;
+    }
+    this.#logWithState(
+      flowControl.lc,
+      `continuing with ${this.#pending.size} subscriber(s) still pending`,
+      now - this.#start,
+    );
+    this.#setDone();
+  };
+
+  #clearConsensusTimer() {
+    clearTimeout(this.#flowControlTimer);
+    this.#flowControlTimer = undefined;
   }
 
   get isDone(): boolean {
@@ -159,8 +240,14 @@ export class Broadcast {
     flowControlConsensusPaddingMs: number,
     now: number,
   ) {
+    if (this.#isDone) {
+      return true;
+    }
     if (this.#pending.size === 0) {
       return true;
+    }
+    if (!(flowControlConsensusPaddingMs >= 0)) {
+      return false;
     }
     const elapsed = now - this.#start;
     if (this.#completed.length < this.#majority) {
@@ -206,6 +293,18 @@ export class Broadcast {
   }
 }
 
+function normalizeChanges(
+  change: BroadcastChange,
+): readonly WatermarkedChange[] {
+  return isWatermarkedChange(change) ? [change] : change;
+}
+
+function isWatermarkedChange(
+  change: BroadcastChange,
+): change is WatermarkedChange {
+  return typeof change[0] === 'string';
+}
+
 /** Tracks the completed result of a single subscriber. */
 type Completed = {
   sub: Subscriber;
@@ -213,4 +312,9 @@ type Completed = {
   changes: number;
   /** The elapsed milliseconds. */
   elapsed: number;
+};
+
+export type FlowControlOptions = {
+  readonly lc: LogContext;
+  readonly flowControlConsensusPaddingMs: number;
 };

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-http.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-http.pg.test.ts
@@ -65,8 +65,7 @@ describe('change-streamer/http', () => {
     const {promise, resolve: cleanup} = resolver<Downstream[]>();
     connectionClosed = promise;
     downstream = Subscription.create({
-      cleanup: msgs =>
-        cleanup(msgs.map(m => BigIntJSON.parse(m) as Downstream)),
+      cleanup: msgs => cleanup(msgs.flatMap(parseDownstreamPayload)),
     });
     snapshotStream = Subscription.create();
     subscribeFn = vi.fn();
@@ -143,6 +142,10 @@ describe('change-streamer/http', () => {
       }
     }
     return drained;
+  }
+
+  function parseDownstreamPayload(msg: string): Downstream[] {
+    return [BigIntJSON.parse(msg) as Downstream];
   }
 
   test('health checks and keepalives', async () => {

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-http.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-http.ts
@@ -10,9 +10,11 @@ import {type Worker} from '../../types/processes.ts';
 import {type ShardID} from '../../types/shards.ts';
 import {
   streamIn,
+  streamInBatches,
   streamOut,
   streamOutStringified,
   type Source,
+  type StreamInPayload,
 } from '../../types/streams.ts';
 import {URLParams} from '../../types/url-params.ts';
 import {installWebSocketReceiver} from '../../types/websocket-handoff.ts';
@@ -35,6 +37,7 @@ const MIN_SUPPORTED_PROTOCOL_VERSION = 1;
 const SNAPSHOT_PATH_PATTERN = '/replication/:version/snapshot';
 const CHANGES_PATH_PATTERN = '/replication/:version/changes';
 const PATH_REGEX = /\/replication\/v(?<version>\d+)\/(changes|snapshot)$/;
+const STREAM_BATCH_MESSAGES = 256;
 
 const SNAPSHOT_PATH = `/replication/v${PROTOCOL_VERSION}/snapshot`;
 const CHANGES_PATH = `/replication/v${PROTOCOL_VERSION}/changes`;
@@ -101,13 +104,6 @@ export class ChangeStreamerHttpServer extends HttpService {
         return this.#reserveSnapshot(ws, msg);
       case 'changes':
         return this.#subscribe(ws, msg);
-      default:
-        closeWithError(
-          this._lc,
-          ws,
-          `invalid action "${action}" received in handoff`,
-        );
-        return;
     }
   };
 
@@ -143,7 +139,20 @@ export class ChangeStreamerHttpServer extends HttpService {
         // end the reservation to safely resume scheduling cleanup.
         this.#backupMonitor.endReservation(ctx.taskID);
       }
-      void streamOutStringified(this._lc, downstream, ws);
+      const url = new URL(
+        req.url ?? '',
+        req.headers.origin ?? 'http://localhost',
+      );
+      // Serving replicas request streamBatch=1 so the RM can preserve a
+      // websocket batch boundary instead of forcing the VS to rediscover
+      // batching after parse/ACK. Older clients omit the flag and keep the
+      // original one-message stream shape.
+      const streamBatchRequested = url.searchParams.get('streamBatch') === '1';
+      void streamOutStringified(this._lc, downstream, ws, {
+        batch: streamBatchRequested
+          ? {maxMessages: STREAM_BATCH_MESSAGES}
+          : undefined,
+      });
     } catch (err) {
       closeWithError(this._lc, ws, err, PROTOCOL_ERROR);
     }
@@ -233,12 +242,25 @@ export class ChangeStreamerHttpClient implements ChangeStreamer {
   }
 
   async subscribe(ctx: SubscriberContext): Promise<Source<Downstream>> {
+    const ws = await this.#openChangesWebSocket(ctx);
+    return streamIn(this.#lc, ws, downstreamSchema);
+  }
+
+  async subscribeBatched(
+    ctx: SubscriberContext,
+  ): Promise<Source<StreamInPayload<Downstream>>> {
+    const ws = await this.#openChangesWebSocket(ctx);
+    // Keep websocket batches visible to the incremental syncer so it can hand a
+    // whole received frame to the write worker before ACKing the frame messages.
+    return streamInBatches(this.#lc, ws, downstreamSchema);
+  }
+
+  async #openChangesWebSocket(ctx: SubscriberContext) {
     const uri = await this.#resolveChangeStreamer(CHANGES_PATH);
 
     const params = getParams(ctx);
-    const ws = new WebSocket(uri + `?${params.toString()}`);
-
-    return streamIn(this.#lc, ws, downstreamSchema);
+    params.set('streamBatch', '1');
+    return new WebSocket(uri + `?${params.toString()}`);
   }
 }
 

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
@@ -13,7 +13,7 @@ import {Database} from '../../../../zqlite/src/db.ts';
 import {StatementRunner} from '../../db/statements.ts';
 import {expectTables, test, type PgTest} from '../../test/db.ts';
 import type {PostgresDB} from '../../types/pg.ts';
-import type {Source} from '../../types/streams.ts';
+import type {Source, StringifiedStreamPayload} from '../../types/streams.ts';
 import {Subscription, type Result} from '../../types/subscription.ts';
 import type {ChangeSource} from '../change-source/change-source.ts';
 import {type ChangeStreamMessage} from '../change-source/protocol/current/downstream.ts';
@@ -110,11 +110,16 @@ describe('change-streamer/service', () => {
     };
   });
 
-  function drainToQueue(sub: Source<string>): Queue<Downstream> {
+  function drainToQueue(
+    sub: Source<StringifiedStreamPayload>,
+  ): Queue<Downstream> {
     const queue = new Queue<Downstream>();
     void (async () => {
-      for await (const msg of sub) {
-        queue.enqueue(BigIntJSON.parse(msg) as Downstream);
+      for await (const payload of sub) {
+        const entries = typeof payload === 'string' ? [payload] : payload;
+        for (const msg of entries) {
+          queue.enqueue(BigIntJSON.parse(msg) as Downstream);
+        }
       }
     })();
     return queue;
@@ -891,18 +896,20 @@ describe('change-streamer/service', () => {
     expect(setTimeoutFn).toHaveBeenCalledTimes(3);
 
     drainToQueue(sub1);
-    for await (const json of sub2) {
-      const msg: Downstream = BigIntJSON.parse(json) as Downstream;
+    const sub2Queue = drainToQueue(sub2);
+    for (;;) {
+      const msg = await sub2Queue.dequeue();
       if (msg[0] === 'commit' && msg[2].watermark === '08') {
-        // Now that sub2 has consumed past '06',
-        // a purge should successfully clear records before '06'
-        await (setTimeoutFn.mock.calls[2][0]() as unknown as Promise<void>);
-        expect(
-          await sql`SELECT watermark FROM "zoro_3/cdc"."changeLog"`.values(),
-        ).toEqual([['06'], ['07'], ['08']]);
         break;
       }
     }
+    // Now that sub2 has consumed past '06',
+    // a purge should successfully clear records before '06'
+    await (setTimeoutFn.mock.calls[2][0]() as unknown as Promise<void>);
+    expect(
+      await sql`SELECT watermark FROM "zoro_3/cdc"."changeLog"`.values(),
+    ).toEqual([['06'], ['07'], ['08']]);
+
     // replicationState is unaffected
     await expectTables(sql, {
       ['zoro_3/cdc.replicationState']: [

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -1,4 +1,3 @@
-import {getDefaultHighWaterMark} from 'node:stream';
 import type {LogContext} from '@rocicorp/logger';
 import {resolver} from '@rocicorp/resolver';
 import {unreachable} from '../../../../shared/src/asserts.ts';
@@ -57,6 +56,13 @@ import {Subscriber} from './subscriber.ts';
 export type TuningOptions = StorerOptions & {
   flowControlConsensusPaddingSeconds: number;
 };
+
+// This is the RM-side byte window for forwarded, already-stringified changes
+// waiting on serving-replica flow control. Node's default 16 KiB stream window
+// made the RM pause before a row-heavy transaction could fill the VS write
+// pipeline. 2 MiB is still a bounded queue, but large enough for the applier to
+// batch useful work instead of oscillating between RM sends and VS ACKs.
+export const FORWARDER_FLOW_CONTROL_BYTES_THRESHOLD = 2 * 1024 * 1024;
 
 /**
  * Performs initialization and schema migrations to initialize a ChangeStreamerImpl.
@@ -366,10 +372,6 @@ class ChangeStreamerImpl implements ChangeStreamerService {
     await this.#storer.assumeOwnership(this.#purgeLock);
     this.#purgeLock = null;
 
-    // The threshold in (estimated number of) bytes to send() on subscriber
-    // websockets before `await`-ing the I/O buffers to be ready for more.
-    const flushBytesThreshold = getDefaultHighWaterMark(false);
-
     while (this.#state.shouldRun()) {
       let err: unknown;
       let watermark: string | null = null;
@@ -443,8 +445,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
           const json = this.#storer.store(watermark, change);
           const entry: WatermarkedChange = [watermark, change[1].tag, json];
           unflushedBytes += json.length;
-          if (unflushedBytes < flushBytesThreshold) {
-            // pipeline changes until flushBytesThreshold
+          if (unflushedBytes < FORWARDER_FLOW_CONTROL_BYTES_THRESHOLD) {
             this.#forwarder.forward(entry);
           } else {
             // Wait for messages to clear socket buffers to ensure that they

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -11,7 +11,7 @@ import {
 } from '../../types/lexi-version.ts';
 import type {PostgresDB} from '../../types/pg.ts';
 import type {ShardID} from '../../types/shards.ts';
-import type {Source} from '../../types/streams.ts';
+import type {Source, StringifiedStreamPayload} from '../../types/streams.ts';
 import {Subscription} from '../../types/subscription.ts';
 import type {
   ChangeSource,
@@ -523,12 +523,12 @@ class ChangeStreamerImpl implements ChangeStreamerService {
     }
   }
 
-  subscribe(ctx: SubscriberContext): Promise<Source<string>> {
+  subscribe(ctx: SubscriberContext): Promise<Source<StringifiedStreamPayload>> {
     const {protocolVersion, id, mode, replicaVersion, watermark} = ctx;
     if (mode === 'serving') {
       this.#serving.resolve();
     }
-    const downstream = Subscription.create<string>({
+    const downstream = Subscription.create<StringifiedStreamPayload>({
       cleanup: () => this.#forwarder.remove(subscriber),
     });
     const subscriber = new Subscriber(

--- a/packages/zero-cache/src/services/change-streamer/change-streamer.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer.ts
@@ -1,6 +1,10 @@
 import type {Enum} from '../../../../shared/src/enum.ts';
 import * as v from '../../../../shared/src/valita.ts';
-import type {Source} from '../../types/streams.ts';
+import type {
+  Source,
+  StreamInPayload,
+  StringifiedStreamPayload,
+} from '../../types/streams.ts';
 import {changeStreamDataSchema} from '../change-source/protocol/current/downstream.ts';
 import type {ReplicatorMode} from '../replicator/replicator.ts';
 import {changeSourceTimingsSchema} from '../replicator/reporter/report-schema.ts';
@@ -75,7 +79,6 @@ export interface ChangeStreamer {
 //   - Adds support for `backfill` messages
 // v6: v1.0.1  (backwards compatible, no version change)
 //   - Adds lag reporting to status messages
-
 export const PROTOCOL_VERSION = 6;
 
 export type SubscriberContext = {
@@ -168,19 +171,6 @@ export const downstreamSchema = v.union(
 
 export type Error = v.Infer<typeof errorSchema>;
 
-export function errorTypeToReadableName(val: ErrorType) {
-  switch (val) {
-    case ErrorType.WrongReplicaVersion:
-      return 'WrongReplicaVersion';
-    case ErrorType.WatermarkTooOld:
-      return 'WatermarkTooOld';
-    case ErrorType.Unknown:
-      return 'Unknown';
-    default:
-      return 'Unknown';
-  }
-}
-
 /**
  * A stream of transactions, each starting with a {@link Begin} message,
  * containing one or more {@link Data} messages, and ending with a
@@ -194,13 +184,40 @@ export function errorTypeToReadableName(val: ErrorType) {
  */
 export type Downstream = v.Infer<typeof downstreamSchema>;
 
+export interface BatchedChangeStreamer extends ChangeStreamer {
+  subscribeBatched(
+    ctx: SubscriberContext,
+  ): Promise<Source<StreamInPayload<Downstream>>>;
+}
+
+export function hasBatchedSubscribe(
+  changeStreamer: ChangeStreamer,
+): changeStreamer is BatchedChangeStreamer {
+  return 'subscribeBatched' in changeStreamer;
+}
+
+export function errorTypeToReadableName(val: ErrorType) {
+  switch (val) {
+    case ErrorType.WrongReplicaVersion:
+      return 'WrongReplicaVersion';
+    case ErrorType.WatermarkTooOld:
+      return 'WatermarkTooOld';
+    case ErrorType.Unknown:
+      return 'Unknown';
+    default:
+      return 'Unknown';
+  }
+}
+
 export interface ChangeStreamerService
   extends Omit<ChangeStreamer, 'subscribe'>, Service {
   /**
    * The server-side interface overrides `subscribe()` to return a stream
-   * of already-stringified {@link Downstream} payloads.
+   * of already-stringified {@link Downstream} payloads. A payload can contain
+   * several ordered messages so the stream layer can flatten them into the
+   * normal wire format without adding one producer queue entry per message.
    */
-  subscribe(ctx: SubscriberContext): Promise<Source<string>>;
+  subscribe(ctx: SubscriberContext): Promise<Source<StringifiedStreamPayload>>;
 
   /**
    * Notifies the change streamer of a watermark that has been backed up,

--- a/packages/zero-cache/src/services/change-streamer/forwarder.ts
+++ b/packages/zero-cache/src/services/change-streamer/forwarder.ts
@@ -9,19 +9,29 @@ export type ProgressMonitorOptions = {
   flowControlConsensusPaddingSeconds: number;
 };
 
+const FORWARD_BATCH_SIZE = 64;
+
 export class Forwarder {
   readonly #lc: LogContext;
   readonly #progressMonitorOptions: ProgressMonitorOptions;
+  // Active subscribers receive new changes immediately. Queued subscribers
+  // connected in the middle of a transaction and must wait for catchup handoff
+  // so they do not see the tail of a transaction without its beginning.
   readonly #active = new Set<Subscriber>();
   readonly #queued = new Set<Subscriber>();
   #inTransaction = false;
+  // Batch the data-heavy middle of a transaction before fanning it out to
+  // every view-syncer. Transaction boundaries still flush immediately so
+  // subscriber handoff and catchup keep the same observable ordering.
+  #pending: WatermarkedChange[] = [];
 
   #currentBroadcast: Broadcast | undefined;
   #progressMonitor: NodeJS.Timeout | undefined;
+  #pendingFlush: NodeJS.Timeout | undefined;
 
   constructor(
     lc: LogContext,
-    opts: ProgressMonitorOptions = {flowControlConsensusPaddingSeconds: 1},
+    opts: ProgressMonitorOptions = {flowControlConsensusPaddingSeconds: 0.1},
   ) {
     this.#lc = lc.withContext('component', 'progress-monitor');
     this.#progressMonitorOptions = opts;
@@ -39,8 +49,9 @@ export class Forwarder {
     }
 
     const {flowControlConsensusPaddingSeconds} = this.#progressMonitorOptions;
-    // A negative number disables early flow control release.
     if (flowControlConsensusPaddingSeconds >= 0) {
+      // Non-negative padding enables majority-based early release. Negative
+      // padding is the escape hatch for "wait for every subscriber" debugging.
       this.#currentBroadcast?.checkProgress(
         this.#lc,
         flowControlConsensusPaddingSeconds * 1000,
@@ -51,6 +62,7 @@ export class Forwarder {
 
   stopProgressMonitor() {
     clearInterval(this.#progressMonitor);
+    this.#clearPendingFlush();
   }
 
   /**
@@ -82,11 +94,25 @@ export class Forwarder {
    * occasionally to avoid memory blowup.
    */
   forward(entry: WatermarkedChange) {
-    Broadcast.withoutTracking(this.#active.values(), entry);
+    this.#pending.push(entry);
+    const batchFull = this.#pending.length >= FORWARD_BATCH_SIZE;
+    const transactionBoundary =
+      entry[1] === 'begin' || entry[1] === 'commit' || entry[1] === 'rollback';
+    if (batchFull || transactionBoundary) {
+      // Full batches bound queued JSON and event-loop delay. Transaction
+      // boundaries flush immediately so subscriber handoff, catchup, and
+      // rollback/commit visibility stay aligned with the Storer.
+      this.#flushPendingWithoutTracking();
+    } else {
+      // A quiet transaction may never hit the size threshold, so schedule a
+      // zero-delay flush to avoid waiting for unrelated future traffic.
+      this.#schedulePendingFlush();
+    }
     this.#updateActiveSubscribers(entry[1]);
   }
 
   sendStatus(status: Status) {
+    this.#flushPendingWithoutTracking();
     for (const sub of this.#active.values()) {
       sub.sendStatus(status);
     }
@@ -97,7 +123,18 @@ export class Forwarder {
    * Promise that resolves when replication should continue.
    */
   async forwardWithFlowControl(entry: WatermarkedChange) {
-    const broadcast = new Broadcast(this.#active.values(), entry);
+    const {flowControlConsensusPaddingSeconds} = this.#progressMonitorOptions;
+    const flowControlConsensusPaddingMs =
+      flowControlConsensusPaddingSeconds * 1000;
+    this.#pending.push(entry);
+    this.#clearPendingFlush();
+    const broadcast = new Broadcast(
+      this.#active.values(),
+      this.#drainPending(),
+      flowControlConsensusPaddingMs >= 0
+        ? {lc: this.#lc, flowControlConsensusPaddingMs}
+        : undefined,
+    );
     this.#updateActiveSubscribers(entry[1]);
 
     // set for progress tracking
@@ -110,6 +147,38 @@ export class Forwarder {
     if (this.#currentBroadcast === broadcast) {
       this.#currentBroadcast = undefined;
     }
+  }
+
+  #flushPendingWithoutTracking() {
+    this.#clearPendingFlush();
+    const pending = this.#drainPending();
+    if (pending.length > 0) {
+      Broadcast.withoutTracking(this.#active.values(), pending);
+    }
+  }
+
+  #schedulePendingFlush() {
+    if (this.#pendingFlush === undefined) {
+      this.#pendingFlush = setTimeout(
+        () => this.#flushPendingWithoutTracking(),
+        0,
+      );
+    }
+  }
+
+  #clearPendingFlush() {
+    if (this.#pendingFlush !== undefined) {
+      clearTimeout(this.#pendingFlush);
+      this.#pendingFlush = undefined;
+    }
+  }
+
+  #drainPending(): WatermarkedChange[] {
+    // Transfer ownership of the backing array instead of copying it; this is on
+    // the fanout hot path and the next forward() can append to a fresh array.
+    const pending = this.#pending;
+    this.#pending = [];
+    return pending;
   }
 
   #updateActiveSubscribers(tag: ChangeTag) {

--- a/packages/zero-cache/src/services/change-streamer/storer.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.pg.test.ts
@@ -7,6 +7,7 @@ import {Queue} from '../../../../shared/src/queue.ts';
 import {sleep} from '../../../../shared/src/sleep.ts';
 import {type PgTest, test} from '../../test/db.ts';
 import type {PostgresDB} from '../../types/pg.ts';
+import type {StringifiedStreamPayload} from '../../types/streams.ts';
 import type {Subscription} from '../../types/subscription.ts';
 import {
   type ChangeStreamData,
@@ -93,13 +94,19 @@ describe('change-streamer/storer', () => {
 
   const messages = new ReplicationMessages({issues: 'id'});
 
-  async function drain(sub: Subscription<string>, untilWatermark?: string) {
+  async function drain(
+    sub: Subscription<StringifiedStreamPayload>,
+    untilWatermark?: string,
+  ) {
     const msgs: Downstream[] = [];
-    for await (const json of sub) {
-      const msg: Downstream = JSON.parse(json);
-      msgs.push(msg);
-      if (msg[0] === 'commit' && msg[2].watermark === untilWatermark) {
-        return msgs;
+    for await (const payload of sub) {
+      const entries = typeof payload === 'string' ? [payload] : payload;
+      for (const json of entries) {
+        const msg: Downstream = JSON.parse(json);
+        msgs.push(msg);
+        if (msg[0] === 'commit' && msg[2].watermark === untilWatermark) {
+          return msgs;
+        }
       }
     }
     return msgs;

--- a/packages/zero-cache/src/services/change-streamer/storer.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.pg.test.ts
@@ -79,9 +79,9 @@ describe('change-streamer/storer', () => {
     fatalErrors = new Queue();
 
     return async () => {
-      await testDBs.drop(db);
       void storer?.stop();
       await done;
+      await testDBs.drop(db);
     };
   });
 
@@ -99,7 +99,7 @@ describe('change-streamer/storer', () => {
       const msg: Downstream = JSON.parse(json);
       msgs.push(msg);
       if (msg[0] === 'commit' && msg[2].watermark === untilWatermark) {
-        break;
+        return msgs;
       }
     }
     return msgs;
@@ -127,6 +127,142 @@ describe('change-streamer/storer', () => {
       expect(
         await db`SELECT "ownerAddress" FROM "xero_5/cdc"."replicationState" WHERE owner = 'task-id'`,
       ).toEqual([{ownerAddress: 'change-streamer:12345'}]);
+    });
+
+    test('stores large transactions in batched changeLog inserts without reordering', async () => {
+      storer.store('08', ['begin', messages.begin(), {commitWatermark: '08'}]);
+      for (let i = 0; i < 250; i++) {
+        storer.store('08', [
+          'data',
+          messages.insert('issues', {id: `batched-${i}`}),
+        ]);
+      }
+      storer.store('08', ['commit', messages.commit(), {watermark: '08'}]);
+
+      await storer.allProcessed();
+      await expectConsumed('08');
+
+      const rows = await db<{pos: bigint; tag: string}[]>`
+        SELECT pos, change->>'tag' as tag
+          FROM "xero_5/cdc"."changeLog"
+         WHERE watermark = '08'
+         ORDER BY pos`;
+      expect(rows).toHaveLength(252);
+      expect(rows.at(0)).toEqual({pos: 0n, tag: 'begin'});
+      expect(rows.at(-1)).toEqual({pos: 251n, tag: 'commit'});
+      expect(rows.map(row => Number(row.pos))).toEqual(
+        Array.from({length: 252}, (_, i) => i),
+      );
+    });
+
+    test('rollback only discards the current transaction from a group', async () => {
+      storer.store('08', ['begin', messages.begin(), {commitWatermark: '08'}]);
+      storer.store('08', ['commit', messages.commit(), {watermark: '08'}]);
+
+      storer.store('09', ['begin', messages.begin(), {commitWatermark: '09'}]);
+      storer.store('09', [
+        'data',
+        messages.insert('issues', {id: 'rolled-back'}),
+      ]);
+      storer.store('09', ['rollback', messages.rollback()]);
+
+      await storer.allProcessed();
+      await expectConsumed('08');
+
+      expect(
+        await db`
+          SELECT watermark, pos, change->>'tag' as tag
+            FROM "xero_5/cdc"."changeLog"
+           WHERE watermark >= '08'
+           ORDER BY watermark, pos`,
+      ).toEqual([
+        {watermark: '08', pos: 0n, tag: 'begin'},
+        {watermark: '08', pos: 1n, tag: 'commit'},
+      ]);
+      expect(
+        await db`SELECT "lastWatermark" FROM "xero_5/cdc"."replicationState"`,
+      ).toEqual([{lastWatermark: '08'}]);
+    });
+
+    test('status during an open transaction waits for grouped commit', async () => {
+      storer.store('07', ['begin', messages.begin(), {commitWatermark: '08'}]);
+      storer.store('07', [
+        'data',
+        messages.insert('issues', {id: 'mid-status'}),
+      ]);
+      storer.status(['status', {ack: true}, {watermark: '07'}]);
+      storer.store('08', ['commit', messages.commit(), {watermark: '08'}]);
+
+      await storer.allProcessed();
+      await expectConsumed('07', '08');
+
+      expect(
+        await db<{lastWatermark: string}[]>`
+          SELECT "lastWatermark" FROM "xero_5/cdc"."replicationState"`,
+      ).toEqual([{lastWatermark: '08'}]);
+      expect(
+        await db`
+          SELECT watermark, pos, precommit, change->>'tag' as tag
+            FROM "xero_5/cdc"."changeLog"
+           WHERE watermark >= '07'
+           ORDER BY watermark, pos`,
+      ).toEqual([
+        {watermark: '07', pos: 0n, precommit: null, tag: 'begin'},
+        {watermark: '07', pos: 1n, precommit: null, tag: 'insert'},
+        {watermark: '08', pos: 2n, precommit: '07', tag: 'commit'},
+      ]);
+
+      const [sub, _0, stream] = createSubscriber('06');
+      storer.catchup(sub, 'serving');
+
+      expect(await drain(stream, '08')).toMatchInlineSnapshot(`
+        [
+          [
+            "status",
+            {
+              "tag": "status",
+            },
+          ],
+          [
+            "begin",
+            {
+              "tag": "begin",
+            },
+            {
+              "commitWatermark": "07",
+            },
+          ],
+          [
+            "data",
+            {
+              "new": {
+                "id": "mid-status",
+              },
+              "relation": {
+                "name": "issues",
+                "rowKey": {
+                  "columns": [
+                    "id",
+                  ],
+                  "type": "default",
+                },
+                "schema": "public",
+                "tag": "relation",
+              },
+              "tag": "insert",
+            },
+          ],
+          [
+            "commit",
+            {
+              "tag": "commit",
+            },
+            {
+              "watermark": "08",
+            },
+          ],
+        ]
+      `);
     });
 
     test('purge', async () => {
@@ -922,6 +1058,7 @@ describe('change-streamer/storer', () => {
 
       // Now send commit.
       storer.store('08', ['commit', messages.commit(), {watermark: '08'}]);
+      await storer.allProcessed();
 
       // Now an ownership change should succeed.
       expect(
@@ -947,6 +1084,7 @@ describe('change-streamer/storer', () => {
       storer.store('0a', ['data', messages.insert('issues', {id: 'bar'})]);
       storer.store('0a', ['commit', messages.commit(), {watermark: '0a'}]);
 
+      await storer.allProcessed();
       await expectConsumed('0a');
 
       expect(

--- a/packages/zero-cache/src/services/change-streamer/storer.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.ts
@@ -61,21 +61,63 @@ type QueueEntry =
   | ['subscriber', SubscriberAndMode]
   | DownstreamStatusMessage
   | ['abort']
+  | ['flush-idle-group']
   | 'stop';
 
 type PendingTransaction = {
-  pool: TransactionPool;
+  group: PendingGroup;
   preCommitWatermark: string;
   pos: number;
-  startingReplicationState: Promise<ReplicationOwner>;
+  pendingChangeLogEntries: ChangeLogInsert[];
+  hasSchemaChange: boolean;
+  // skipAck lets internal/replayed commits become durable without advancing the
+  // upstream replication slot.
   ack: boolean;
+};
+
+type PendingGroup = {
+  pool: TransactionPool;
+  startingReplicationState: Promise<ReplicationOwner>;
+  upstreamAcks: (
+    | {type: 'commit'; commit: Commit; ack: boolean}
+    | {type: 'status'; status: UpstreamStatusMessage}
+  )[];
+  txCount: number;
+  lastWatermark: string | null;
 };
 
 type ReplicationOwner = {
   owner: string | null;
 };
 
+/**
+ * A row in the RM's durable catchup journal.
+ *
+ * Connected VSs get changes live from the Forwarder. A new or lagging VS reads
+ * this log from its last commit watermark and replays rows in `(watermark, pos)`
+ * order:
+ *
+ *   begin/data/data -> stored at precommit watermark
+ *   commit          -> stored at commit watermark and makes that point resumable
+ *
+ * The `precommit` link on the commit row lets catchup include the whole
+ * transaction while still exposing only commit watermarks as subscriber progress.
+ */
+type ChangeLogInsert = {
+  watermark: string;
+  precommit: string | null;
+  pos: number;
+  change: string;
+};
+
 const backfillRequestsSchema = v.array(backfillRequestSchema);
+const CHANGE_LOG_INSERT_BATCH_SIZE = 100;
+// Group up to this many upstream transactions per changeDB commit to remove
+// per-transaction commit/fsync overhead. The group remains a visibility
+// boundary: catchup, status, schema changes, rollback, ready checks, and full
+// groups flush before later work proceeds.
+const CHANGE_LOG_TX_GROUP_SIZE = 32;
+const CURRENT_TX_SAVEPOINT = 'zero_storer_current_tx';
 
 export type TuningOptions = {
   backPressureLimitHeapProportion: number;
@@ -337,9 +379,11 @@ export class Storer implements Service {
   #maybeReleaseBackPressure() {
     if (
       this.#readyForMore !== null &&
-      // Wait for at least 20% of the threshold to free up.
       this.#approximateQueuedBytes < this.#backPressureThresholdBytes * 0.8
     ) {
+      // Keep hysteresis between "pause upstream" and "resume upstream". Without
+      // the 20% margin, a busy RM can bounce around the threshold and spend extra
+      // time scheduling backpressure transitions.
       this.#lc.info?.(
         `releasing back pressure with ${this.#queue.size()} queued changes (~${(this.#approximateQueuedBytes / 1024 ** 2).toFixed(2)} MB)`,
       );
@@ -412,21 +456,119 @@ export class Storer implements Service {
 
   async #processQueue() {
     let tx: PendingTransaction | null = null;
+    let group: PendingGroup | null = null;
     let msg: QueueEntry | false;
 
     const catchupQueue: SubscriberAndMode[] = [];
+    const startGroup = (watermark: string): PendingGroup => {
+      const {promise, resolve, reject} = resolver<ReplicationOwner>();
+      void promise.catch(() => {}); // handle rejections before the await
+      const pool = new TransactionPool(
+        this.#lc.withContext('watermark', watermark),
+        {
+          mode: Mode.READ_COMMITTED,
+          statementResponseTimeout: this.#statementTimeoutMs,
+        },
+      );
+      pool.run(this.#db);
+      // Check ownership once per group instead of once per upstream commit.
+      // The grouped transaction keeps pending rows private until flushGroup()
+      // commits, so ownership loss still prevents ACK release.
+      //
+      //   replicationState FOR UPDATE
+      //           |
+      //           v
+      //   tx1 savepoint -> tx2 savepoint -> ... -> update lastWatermark
+      void pool.process(tx => {
+        tx<ReplicationOwner[]> /*sql*/ `
+          SELECT "owner" FROM ${this.#cdc('replicationState')} FOR UPDATE`.then(
+          ([result]) => resolve(result),
+          reject,
+        );
+        return [];
+      });
+      return {
+        pool,
+        startingReplicationState: promise,
+        upstreamAcks: [],
+        txCount: 0,
+        lastWatermark: null,
+      };
+    };
+
+    const flushGroup = async () => {
+      if (group === null) {
+        return;
+      }
+      const flushing = group;
+      group = null;
+      // ACKs are intentionally released only after the grouped changeDB
+      // transaction is durable. Reordering this sequence can acknowledge
+      // upstream commits that would be lost after a crash.
+      //
+      //   1. verify owner
+      //   2. publish lastWatermark in the same DB transaction
+      //   3. commit changeLog rows
+      //   4. ACK upstream commits
+      //   5. run catchup against the committed snapshot
+      const {owner} = await flushing.startingReplicationState;
+      if (owner !== this.#taskID) {
+        flushing.pool.fail(
+          new AbortError(`changeLog ownership has been assumed by ${owner}`),
+        );
+      } else if (flushing.lastWatermark !== null) {
+        const lastWatermark = flushing.lastWatermark;
+        void flushing.pool.process(tx => [
+          tx`
+            UPDATE ${this.#cdc('replicationState')} SET ${tx({lastWatermark})}`,
+        ]);
+        flushing.pool.setDone();
+      } else {
+        flushing.pool.setDone();
+      }
+
+      await flushing.pool.done();
+      for (const pendingAck of flushing.upstreamAcks) {
+        switch (pendingAck.type) {
+          case 'commit':
+            if (pendingAck.ack) {
+              this.#onConsumed(pendingAck.commit);
+            }
+            break;
+          case 'status':
+            this.#onConsumed(pendingAck.status);
+            break;
+        }
+      }
+
+      await this.#startCatchup(catchupQueue.splice(0));
+    };
+
+    const dequeueEntry = () =>
+      group !== null && tx === null
+        ? this.#queue.dequeue(['flush-idle-group'], 0)
+        : this.#queue.dequeue();
+
     try {
-      while ((msg = await this.#queue.dequeue()) !== 'stop') {
+      while ((msg = await dequeueEntry()) !== 'stop') {
         const [msgType] = msg;
         switch (msgType) {
+          case 'flush-idle-group':
+            // Grouping optimizes bursts, but an idle upstream must not leave
+            // durable commits unacked until an unrelated status/subscriber
+            // event arrives. Flushing here bounds ACK latency while preserving
+            // grouping whenever the storer already has queued work.
+            await flushGroup();
+            continue;
           case 'ready': {
             const signalReady = msg[1];
+            await flushGroup();
             signalReady();
             continue;
           }
           case 'subscriber': {
             const subscriber = msg[1];
-            if (tx) {
+            if (tx || group) {
               catchupQueue.push(subscriber); // Wait for the current tx to complete.
             } else {
               await this.#startCatchup([subscriber]); // Catch up immediately.
@@ -434,12 +576,18 @@ export class Storer implements Service {
             continue;
           }
           case 'status':
+            if (tx !== null) {
+              tx.group.upstreamAcks.push({type: 'status', status: msg});
+              continue;
+            }
+            await flushGroup();
             this.#onConsumed(msg);
             continue;
           case 'abort': {
-            if (tx) {
-              tx.pool.abort();
-              await tx.pool.done();
+            if (group) {
+              group.pool.abort();
+              await group.pool.done();
+              group = null;
               tx = null;
             }
             continue;
@@ -452,38 +600,35 @@ export class Storer implements Service {
 
         if (tag === 'begin') {
           assert(!tx, 'received BEGIN in the middle of a transaction');
-          const {promise, resolve, reject} = resolver<ReplicationOwner>();
-          void promise.catch(() => {}); // handle rejections before the await
+          group ??= startGroup(watermark);
           tx = {
-            pool: new TransactionPool(
-              this.#lc.withContext('watermark', watermark),
-              {
-                mode: Mode.READ_COMMITTED,
-                statementResponseTimeout: this.#statementTimeoutMs,
-              },
-            ),
+            group,
             preCommitWatermark: watermark,
             pos: 0,
-            startingReplicationState: promise,
+            pendingChangeLogEntries: [],
+            hasSchemaChange: false,
             ack: !change.skipAck,
           };
-          tx.pool.run(this.#db);
-          // Acquire a lock on the replicationState row to detect and/or prevent
-          // a concurrent ownership change.
-          void tx.pool.process(tx => {
-            tx<ReplicationOwner[]> /*sql*/ `
-          SELECT "owner" FROM ${this.#cdc('replicationState')} FOR UPDATE`.then(
-              ([result]) => resolve(result),
-              reject,
-            );
-            return [];
-          });
+          // Savepoints keep upstream rollbacks scoped to the current
+          // transaction while still allowing multiple upstream transactions to
+          // share one changeDB commit. ACKs and catchup wait for the group
+          // commit so subscribers never observe uncommitted group contents.
+          //
+          //   group tx
+          //     SAVEPOINT current upstream tx
+          //       buffered INSERT changeLog rows...
+          //     RELEASE SAVEPOINT
+          //     ...repeat up to CHANGE_LOG_TX_GROUP_SIZE...
+          //   UPDATE replicationState(lastWatermark) + COMMIT group tx
+          void tx.group.pool.process(sql => [
+            sql.unsafe(`SAVEPOINT ${CURRENT_TX_SAVEPOINT}`),
+          ]);
         } else {
           assert(tx, () => `received change outside of transaction: ${json}`);
           tx.pos++;
         }
 
-        const entry = {
+        const entry: ChangeLogInsert = {
           watermark: tag === 'commit' ? watermark : tx.preCommitWatermark,
           precommit: tag === 'commit' ? tx.preCommitWatermark : null,
           pos: tx.pos,
@@ -492,15 +637,26 @@ export class Storer implements Service {
           change: extractChangeSubstring(json, tag),
         };
 
-        const processed = tx.pool.process(sql => [
-          sql`INSERT INTO ${this.#cdc('changeLog')} ${sql(entry)}`,
-          ...(change !== null && isSchemaChange(change)
-            ? this.#trackBackfillMetadata(sql, change)
-            : []),
-        ]);
+        let processed = promiseVoid;
+        if (change !== null && isSchemaChange(change)) {
+          tx.hasSchemaChange = true;
+          await this.#flushChangeLogEntries(tx);
+          processed = tx.group.pool.process(sql => [
+            sql`INSERT INTO ${this.#cdc('changeLog')} ${sql(entry)}`,
+            ...this.#trackBackfillMetadata(sql, change),
+          ]);
+        } else {
+          tx.pendingChangeLogEntries.push(entry);
+          if (
+            tag === 'commit' ||
+            tx.pendingChangeLogEntries.length >= CHANGE_LOG_INSERT_BATCH_SIZE
+          ) {
+            processed = this.#flushChangeLogEntries(tx);
+          }
+        }
 
         if (tx.pos % 100 === 0) {
-          // Backpressure is exerted on commit when awaiting tx.pool.done().
+          // Backpressure is exerted when the group is flushed.
           // However, backpressure checks need to be regularly done for
           // very large transactions in order to avoid memory blowup.
           await processed;
@@ -508,45 +664,47 @@ export class Storer implements Service {
         this.#maybeReleaseBackPressure();
 
         if (tag === 'commit') {
-          const {owner} = await tx.startingReplicationState;
-          if (owner !== this.#taskID) {
-            // Ownership change reflected in the replicationState read in 'begin'.
-            tx.pool.fail(
-              new AbortError(
-                `changeLog ownership has been assumed by ${owner}`,
-              ),
-            );
-          } else {
-            // Update the replication state.
-            const lastWatermark = watermark;
-            void tx.pool.process(tx => [
-              tx`
-            UPDATE ${this.#cdc('replicationState')} SET ${tx({lastWatermark})}`,
-            ]);
-            tx.pool.setDone();
-          }
-
-          await tx.pool.done();
-
-          // ACK the LSN to the upstream Postgres.
-          if (tx.ack) {
-            this.#onConsumed(['commit', change, {watermark}]);
-          }
+          assert(change?.tag === 'commit', 'commit change should be retained');
+          void tx.group.pool.process(sql => [
+            sql.unsafe(`RELEASE SAVEPOINT ${CURRENT_TX_SAVEPOINT}`),
+          ]);
+          tx.group.lastWatermark = watermark;
+          tx.group.upstreamAcks.push({
+            type: 'commit',
+            commit: ['commit', change, {watermark}],
+            ack: tx.ack,
+          });
+          tx.group.txCount++;
+          // Schema changes publish metadata side effects that must become
+          // visible with the commit that introduced them.
+          const hasSchemaSideEffects = tx.hasSchemaChange;
+          // Subscribers waiting for catchup need a committed snapshot to read;
+          // holding the group open would make new VSs wait behind unrelated
+          // future transactions.
+          const catchupWaiting = catchupQueue.length > 0;
+          // Transaction grouping removes per-commit round trips, but this cap
+          // bounds uncommitted changeDB work and ACK latency under sustained load.
+          const groupFull = tx.group.txCount >= CHANGE_LOG_TX_GROUP_SIZE;
+          const shouldFlushGroup =
+            hasSchemaSideEffects || catchupWaiting || groupFull;
           tx = null;
-
-          // Before beginning the next transaction, open a READONLY snapshot to
-          // concurrently catchup any queued subscribers.
-          await this.#startCatchup(catchupQueue.splice(0));
+          if (shouldFlushGroup) {
+            await flushGroup();
+          }
         } else if (tag === 'rollback') {
-          // Aborted transactions are not stored in the changeLog. Abort the current tx
-          // and process catchup of subscribers that were waiting for it to end.
-          tx.pool.abort();
-          await tx.pool.done();
+          // Aborted transactions are not stored in the changeLog. Roll back
+          // only the current upstream transaction, preserving previous
+          // committed transactions in the group.
+          tx.pendingChangeLogEntries = [];
+          await tx.group.pool.process(sql => [
+            sql.unsafe(`ROLLBACK TO SAVEPOINT ${CURRENT_TX_SAVEPOINT}`),
+            sql.unsafe(`RELEASE SAVEPOINT ${CURRENT_TX_SAVEPOINT}`),
+          ]);
           tx = null;
-
-          await this.#startCatchup(catchupQueue.splice(0));
+          await flushGroup();
         }
       }
+      await flushGroup();
     } catch (e) {
       catchupQueue.forEach(({subscriber}) => subscriber.fail(e));
       throw e;
@@ -587,6 +745,23 @@ export class Storer implements Service {
     ).finally(() => reader.setDone());
   }
 
+  #flushChangeLogEntries(tx: PendingTransaction): Promise<void> {
+    if (tx.pendingChangeLogEntries.length === 0) {
+      return promiseVoid;
+    }
+    const entries = tx.pendingChangeLogEntries;
+    tx.pendingChangeLogEntries = [];
+    // Data changes are just replay-journal rows for future catchup, so they can
+    // be written as one multi-row INSERT without changing what any VS observes.
+    //
+    // Schema changes are different: they also update metadata tables. Flush
+    // pending data rows before those metadata writes so a catchup reader sees
+    // the same story the live stream saw.
+    return tx.group.pool.process(sql => [
+      sql`INSERT INTO ${this.#cdc('changeLog')} ${sql(entries)}`,
+    ]);
+  }
+
   async #catchup(
     {subscriber: sub, mode}: SubscriberAndMode,
     lastWatermark: string,
@@ -622,13 +797,14 @@ export class Storer implements Service {
             );
           }
 
+          const catchupChanges: WatermarkedChange[] = [];
           for (const entry of entries) {
             if (entry.watermark === sub.watermark) {
               // This should be the first entry.
               // Catchup starts from *after* the watermark.
               watermarkFound = true;
             } else if (watermarkFound) {
-              lastBatchConsumed = sub.catchup(toDownstream(entry));
+              catchupChanges.push(toDownstream(entry));
               count++;
             } else if (mode === 'backup') {
               throw new AutoResetSignal(
@@ -644,6 +820,9 @@ export class Storer implements Service {
               );
               return;
             }
+          }
+          if (catchupChanges.length > 0) {
+            lastBatchConsumed = sub.catchupBatch(catchupChanges);
           }
         }
         if (watermarkFound) {

--- a/packages/zero-cache/src/services/change-streamer/subscriber.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/subscriber.test.ts
@@ -1,8 +1,13 @@
 import {describe, expect, test} from 'vitest';
+import type {StringifiedStreamPayload} from '../../types/streams.ts';
 import {ReplicationMessages} from '../replicator/test-utils.ts';
 import {createSubscriber} from './test-utils.ts';
 
 const json = JSON.stringify;
+
+function expandPayload(payload: StringifiedStreamPayload): readonly string[] {
+  return typeof payload === 'string' ? [payload] : payload;
+}
 
 describe('change-streamer/subscriber', () => {
   const messages = new ReplicationMessages({issues: 'id'});
@@ -284,29 +289,35 @@ describe('change-streamer/subscriber', () => {
     expect(sub.numPending).toBe(pending);
 
     let txNum = 0;
-    for await (const json of receiver) {
-      const msg = JSON.parse(json);
-      expect(sub.numProcessed).toBe(processed++);
-      expect(sub.numPending).toBe(pending--);
-
-      if (msg[0] === 'begin') {
-        txNum++;
+    for await (const payload of receiver) {
+      const beforeProcessed = processed;
+      const beforePending = pending;
+      const messages = expandPayload(payload);
+      for (const json of messages) {
+        const msg = JSON.parse(json);
+        if (msg[0] === 'begin') {
+          txNum++;
+        }
+        switch (txNum) {
+          case 1:
+            expect(sub.acked).toBe('00');
+            break;
+          case 2:
+            expect(sub.acked).toBe('02');
+            break;
+          case 3:
+            expect(sub.acked).toBe('12');
+            break;
+          case 4:
+            expect(sub.acked).toBe('22');
+            sub.close();
+            break;
+        }
       }
-      switch (txNum) {
-        case 1:
-          expect(sub.acked).toBe('00');
-          break;
-        case 2:
-          expect(sub.acked).toBe('02');
-          break;
-        case 3:
-          expect(sub.acked).toBe('12');
-          break;
-        case 4:
-          expect(sub.acked).toBe('22');
-          sub.close();
-          break;
-      }
+      expect(sub.numProcessed).toBe(beforeProcessed);
+      expect(sub.numPending).toBe(beforePending);
+      processed += messages.length;
+      pending -= messages.length;
     }
     expect(sub.numProcessed).toBe(8);
     expect(

--- a/packages/zero-cache/src/services/change-streamer/subscriber.ts
+++ b/packages/zero-cache/src/services/change-streamer/subscriber.ts
@@ -86,6 +86,14 @@ export class Subscriber {
     await this.#sendChange(change);
   }
 
+  /** catchupBatch() is called on ChangeEntries loaded from the store. */
+  async catchupBatch(changes: readonly WatermarkedChange[]) {
+    this.#initialize();
+    for (const change of changes) {
+      await this.#sendChange(change);
+    }
+  }
+
   /**
    * Marks the Subscribe as "caught up" and flushes any backlog of
    * entries that were received during the catchup.

--- a/packages/zero-cache/src/services/change-streamer/subscriber.ts
+++ b/packages/zero-cache/src/services/change-streamer/subscriber.ts
@@ -3,6 +3,7 @@ import {BigIntJSON} from '../../../../shared/src/bigint-json.ts';
 import type {Enum} from '../../../../shared/src/enum.ts';
 import {must} from '../../../../shared/src/must.ts';
 import {max} from '../../types/lexi-version.ts';
+import type {StringifiedStreamPayload} from '../../types/streams.ts';
 import type {Subscription} from '../../types/subscription.ts';
 import type {ChangeTag, WatermarkedChange} from './change-streamer-service.ts';
 import {type Downstream, type Status} from './change-streamer.ts';
@@ -20,17 +21,22 @@ type ErrorType = Enum<typeof ErrorType>;
 export class Subscriber {
   readonly #protocolVersion: number;
   readonly id: string;
-  readonly #downstream: Subscription<string>;
+  readonly #downstream: Subscription<StringifiedStreamPayload>;
   readonly #latestStatus: () => Status;
+  // #watermark is the latest commit sent to this subscriber. #acked lags until
+  // the downstream stream confirms that the commit frame was consumed.
   #watermark: string;
   #acked: string;
+  // Non-null while catchup is reading historical changeLog rows. Live forwarded
+  // changes are buffered here so the subscriber sees "historical, then live" in
+  // one ordered stream.
   #backlog: WatermarkedChange[] | null;
 
   constructor(
     protocolVersion: number,
     id: string,
     watermark: string,
-    downstream: Subscription<string>,
+    downstream: Subscription<StringifiedStreamPayload>,
     latestStatus: () => Status,
   ) {
     this.#protocolVersion = protocolVersion;
@@ -54,15 +60,19 @@ export class Subscriber {
     const [watermark] = change;
     if (watermark > this.#watermark) {
       if (this.#backlog) {
+        // Catchup has not finished; keep live traffic behind the historical
+        // replay so the subscriber never sees a gap.
         this.#backlog.push(change);
       } else {
-        await this.#sendChange(change);
+        await this.#sendChanges([change]);
       }
     }
   }
 
   async sendBatch(changes: readonly WatermarkedChange[]) {
     if (this.#backlog) {
+      // Entries at or before the subscriber watermark were already represented
+      // in its replica and must not be replayed during catchup handoff.
       for (const change of changes) {
         if (change[0] > this.#watermark) {
           this.#backlog.push(change);
@@ -70,7 +80,7 @@ export class Subscriber {
       }
       return;
     }
-    await Promise.all(changes.map(change => this.#sendChange(change)));
+    await this.#sendChanges(changes);
   }
 
   #initialized = false;
@@ -88,6 +98,8 @@ export class Subscriber {
 
   sendStatus(status: Status) {
     if (this.#protocolVersion >= 2 && this.#initialized) {
+      // Older protocol versions do not know status messages. Before initialize,
+      // the subscriber's requested watermark has not been validated yet.
       void this.#sendDownstream(['status', status]);
     }
   }
@@ -95,15 +107,13 @@ export class Subscriber {
   /** catchup() is called on ChangeEntries loaded from the store. */
   async catchup(change: WatermarkedChange) {
     this.#initialize();
-    await this.#sendChange(change);
+    await this.#sendChanges([change]);
   }
 
   /** catchupBatch() is called on ChangeEntries loaded from the store. */
   async catchupBatch(changes: readonly WatermarkedChange[]) {
     this.#initialize();
-    for (const change of changes) {
-      await this.#sendChange(change);
-    }
+    await this.#sendChanges(changes);
   }
 
   /**
@@ -120,26 +130,55 @@ export class Subscriber {
     // interpret the #backlog variable correctly. This is the only place
     // where I/O flow control is not heeded. However, it will be awaited
     // by the next caller to send().
-    for (const change of this.#backlog) {
-      void this.#sendChange(change);
+    const backlog = this.#backlog;
+    for (let i = 0; i < backlog.length; i += 64) {
+      // Send fixed-size ranges from the existing array instead of slice()ing.
+      // Catchup handoff can hold thousands of live entries under load, and the
+      // range form avoids duplicating those references during the flush.
+      void this.#sendChanges(backlog, i, i + 64);
     }
     this.#backlog = null;
   }
 
-  async #sendChange(change: WatermarkedChange) {
-    const [watermark, tag, json] = change;
-    if (watermark <= this.watermark) {
+  async #sendChanges(
+    changes: readonly WatermarkedChange[],
+    start = 0,
+    end = changes.length,
+  ) {
+    const json: string[] = [];
+    let commitWatermark: string | undefined;
+    for (let i = start; i < end && i < changes.length; i++) {
+      const change = changes[i];
+      const [watermark, tag, payload] = change;
+      if (watermark <= this.watermark) {
+        // Catchup queries include the row at the requested watermark to prove
+        // continuity. The subscriber only needs changes after that point.
+        continue;
+      }
+      if (!this.supportsMessage(tag)) {
+        // Protocol-version filtering happens before JSON write so old serving
+        // replicas can continue catching up through newer metadata events.
+        continue;
+      }
+      if (tag === 'commit') {
+        // Only commit messages advance the public replication position; data
+        // messages carry an internal ordering watermark but are not resumable.
+        this.#watermark = watermark;
+        commitWatermark = watermark;
+      }
+      json.push(payload);
+    }
+    if (json.length === 0) {
+      // Nothing survived the watermark/protocol filters, so there is no commit
+      // ACK to wait for and no downstream flow-control work to track.
       return;
     }
-    if (!this.supportsMessage(tag)) {
-      return;
-    }
-    if (tag === 'commit') {
-      this.#watermark = watermark;
-    }
-    const result = await this.#sendStringifiedDownstream(json);
-    if (tag === 'commit' && result === 'consumed') {
-      this.#acked = max(this.#acked, watermark);
+    const payload = json.length === 1 ? json[0] : json;
+    const result = await this.#sendStringifiedDownstream(payload, json.length);
+    if (commitWatermark !== undefined && result === 'consumed') {
+      // Purge logic uses acked watermarks, so advance only after the downstream
+      // stream confirms that the commit frame was consumed.
+      this.#acked = max(this.#acked, commitWatermark);
     }
   }
 
@@ -147,14 +186,19 @@ export class Subscriber {
     return this.#sendStringifiedDownstream(BigIntJSON.stringify(downstream));
   }
 
-  async #sendStringifiedDownstream(json: string) {
-    this.#pending++;
-    const {result} = this.#downstream.push(json);
+  async #sendStringifiedDownstream(
+    payload: StringifiedStreamPayload,
+    messageCount = typeof payload === 'string' ? 1 : payload.length,
+  ) {
+    // pending/processed track logical downstream messages, not websocket frames;
+    // a stringified array still represents several change-stream messages.
+    this.#pending += messageCount;
+    const {result} = this.#downstream.push(payload);
     try {
       return await result;
     } finally {
-      this.#pending--;
-      this.#processed++;
+      this.#pending -= messageCount;
+      this.#processed += messageCount;
     }
   }
 
@@ -215,7 +259,8 @@ export class Subscriber {
   supportsMessage(tag: ChangeTag) {
     switch (tag) {
       case 'update-table-metadata':
-        // update-table-row-key is only understood by subscribers >= protocol v5
+        // Protocol v5 introduced relation row-key/table-metadata updates.
+        // Earlier replicas must skip this message instead of failing catchup.
         return this.#protocolVersion >= 5;
     }
     return true;

--- a/packages/zero-cache/src/services/change-streamer/subscriber.ts
+++ b/packages/zero-cache/src/services/change-streamer/subscriber.ts
@@ -61,6 +61,18 @@ export class Subscriber {
     }
   }
 
+  async sendBatch(changes: readonly WatermarkedChange[]) {
+    if (this.#backlog) {
+      for (const change of changes) {
+        if (change[0] > this.#watermark) {
+          this.#backlog.push(change);
+        }
+      }
+      return;
+    }
+    await Promise.all(changes.map(change => this.#sendChange(change)));
+  }
+
   #initialized = false;
 
   /**

--- a/packages/zero-cache/src/services/change-streamer/test-utils.ts
+++ b/packages/zero-cache/src/services/change-streamer/test-utils.ts
@@ -1,3 +1,4 @@
+import type {StringifiedStreamPayload} from '../../types/streams.ts';
 import {Subscription} from '../../types/subscription.ts';
 import {PROTOCOL_VERSION, type Downstream} from './change-streamer.ts';
 import {Subscriber} from './subscriber.ts';
@@ -7,14 +8,15 @@ let nextID = 1;
 export function createSubscriber(
   watermark = '00',
   caughtUp = false,
-): [Subscriber, Downstream[], Subscription<string>] {
+  protocolVersion = PROTOCOL_VERSION,
+): [Subscriber, Downstream[], Subscription<StringifiedStreamPayload>] {
   const id = '' + nextID++;
   const received: Downstream[] = [];
-  const sub = Subscription.create<string>({
-    cleanup: unconsumed => received.push(...unconsumed.map(m => JSON.parse(m))),
+  const sub = Subscription.create<StringifiedStreamPayload>({
+    cleanup: unconsumed => received.push(...unconsumed.flatMap(parsePayload)),
   });
   const subscriber = new Subscriber(
-    PROTOCOL_VERSION,
+    protocolVersion,
     id,
     watermark,
     sub,
@@ -25,4 +27,10 @@ export function createSubscriber(
   }
 
   return [subscriber, received, sub];
+}
+
+function parsePayload(payload: StringifiedStreamPayload): Downstream[] {
+  return (typeof payload === 'string' ? [payload] : payload).map(
+    m => JSON.parse(m) as Downstream,
+  );
 }

--- a/packages/zero-cache/src/services/replicator/change-processor.bench.ts
+++ b/packages/zero-cache/src/services/replicator/change-processor.bench.ts
@@ -1,0 +1,136 @@
+import {bench, describe, use} from '../../../../shared/src/bench.ts';
+import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
+import {Database} from '../../../../zqlite/src/db.ts';
+import {StatementRunner} from '../../db/statements.ts';
+import type {DataOrSchemaChange} from '../change-source/protocol/current/data.ts';
+import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
+import {ChangeProcessor} from './change-processor.ts';
+import {initReplicationState} from './schema/replication-state.ts';
+import {ReplicationMessages} from './test-utils.ts';
+
+const ROWS = 1_000;
+const lc = createSilentLogContext();
+const messages = new ReplicationMessages({foo: ['id', 'shard']});
+
+describe('change-processor DML apply', () => {
+  const stableInsertChanges = transaction(
+    '10',
+    Array.from({length: ROWS}, (_, i) =>
+      messages.insert('foo', {
+        id: i,
+        shard: i % 10,
+        alpha: i * 2,
+        beta: i * 3,
+      }),
+    ),
+  );
+  const stableInsertUncached = setupBenchmark(false);
+  const stableInsertCached = setupBenchmark(true);
+
+  bench(
+    '1k stable-shape inserts (uncached plans)',
+    () => {
+      use(apply(stableInsertUncached, stableInsertChanges));
+    },
+    {min_cpu_time: 5e8, min_samples: 20},
+  );
+
+  bench(
+    '1k stable-shape inserts (cached plans)',
+    () => {
+      use(apply(stableInsertCached, stableInsertChanges));
+    },
+    {min_cpu_time: 5e8, min_samples: 20},
+  );
+
+  const mixedDmlChanges = transaction('20', [
+    ...Array.from({length: ROWS}, (_, i) =>
+      messages.insert('foo', {
+        id: i,
+        shard: i % 10,
+        alpha: i * 2,
+        beta: i * 3,
+      }),
+    ),
+    ...Array.from({length: ROWS}, (_, i) =>
+      i % 2 === 0
+        ? messages.update('foo', {
+            id: i,
+            shard: i % 10,
+            alpha: i * 5,
+            beta: i * 7,
+          })
+        : messages.update('foo', {
+            beta: i * 7,
+            shard: i % 10,
+            id: i,
+            alpha: i * 5,
+          }),
+    ),
+    ...Array.from({length: ROWS}, (_, i) =>
+      i % 2 === 0
+        ? messages.delete('foo', {id: i, shard: i % 10})
+        : messages.delete('foo', {shard: i % 10, id: i}),
+    ),
+  ]);
+  const mixedDmlUncached = setupBenchmark(false);
+  const mixedDmlCached = setupBenchmark(true);
+
+  bench(
+    '1k inserts + updates + deletes (uncached plans)',
+    () => {
+      use(apply(mixedDmlUncached, mixedDmlChanges));
+    },
+    {min_cpu_time: 5e8, min_samples: 20},
+  );
+
+  bench(
+    '1k inserts + updates + deletes (cached plans)',
+    () => {
+      use(apply(mixedDmlCached, mixedDmlChanges));
+    },
+    {min_cpu_time: 5e8, min_samples: 20},
+  );
+});
+
+function setupBenchmark(cacheDmlSqlPlans: boolean) {
+  const replica = new Database(lc, ':memory:');
+  initReplicationState(replica, ['zero_data'], '02');
+  replica.exec(`
+    CREATE TABLE foo(
+      id INTEGER,
+      shard INTEGER,
+      alpha INTEGER,
+      beta INTEGER,
+      _0_version TEXT,
+      PRIMARY KEY(id, shard)
+    );
+  `);
+  return new ChangeProcessor(
+    new StatementRunner(replica),
+    'backup',
+    (_, err) => {
+      throw err;
+    },
+    {cacheDmlSqlPlans},
+  );
+}
+
+function transaction(
+  watermark: string,
+  dataMessages: DataOrSchemaChange[],
+): ChangeStreamData[] {
+  return [
+    ['begin', messages.begin(), {commitWatermark: watermark}],
+    ...dataMessages.map(msg => ['data', msg] as ChangeStreamData),
+    ['commit', messages.commit(), {watermark}],
+  ];
+}
+
+function apply(processor: ChangeProcessor, changes: ChangeStreamData[]) {
+  let result = null;
+  for (const change of changes) {
+    result = processor.processMessage(lc, change);
+  }
+  return result;
+}

--- a/packages/zero-cache/src/services/replicator/change-processor.test.ts
+++ b/packages/zero-cache/src/services/replicator/change-processor.test.ts
@@ -3639,6 +3639,98 @@ describe('replicator/change-processor', () => {
       }
     });
   }
+
+  test('DML plan cache binds repeated shapes by column name', () => {
+    initDB(
+      servingReplica,
+      `
+      CREATE TABLE foo(
+        id INTEGER,
+        shard INTEGER,
+        alpha INTEGER,
+        beta INTEGER,
+        _0_version TEXT,
+        PRIMARY KEY(id, shard)
+      );
+      `,
+    );
+
+    const foo = new ReplicationMessages({foo: ['id', 'shard']});
+    for (const change of [
+      ['begin', foo.begin(), {commitWatermark: '07'}],
+      ['data', foo.insert('foo', {id: 1, shard: 10, alpha: 100, beta: 200})],
+      ['data', foo.insert('foo', {beta: 400, shard: 20, id: 2, alpha: 300})],
+      ['data', foo.update('foo', {id: 1, shard: 10, alpha: 101, beta: 201})],
+      ['data', foo.update('foo', {beta: 401, shard: 20, id: 2, alpha: 301})],
+      ['data', foo.delete('foo', {shard: 20, id: 2})],
+      ['commit', foo.commit(), {watermark: '07'}],
+    ] satisfies ChangeStreamData[]) {
+      servingProcessor.processMessage(lc, change);
+    }
+
+    expectTables(
+      servingReplica,
+      {
+        foo: [
+          {
+            id: 1n,
+            shard: 10n,
+            alpha: 101n,
+            beta: 201n,
+            ['_0_version']: '07',
+          },
+        ],
+      },
+      'bigint',
+    );
+  });
+
+  test('processMessages applies a stream batch and returns each commit', () => {
+    initDB(
+      servingReplica,
+      `
+      CREATE TABLE foo(
+        id INTEGER PRIMARY KEY,
+        _0_version TEXT
+      );
+      `,
+    );
+
+    const foo = new ReplicationMessages({foo: 'id'});
+    const result = servingProcessor.processMessages(lc, [
+      ['begin', foo.begin(), {commitWatermark: '07'}],
+      ['data', foo.insert('foo', {id: 1})],
+      ['commit', foo.commit(), {watermark: '07'}],
+      ['begin', foo.begin(), {commitWatermark: '0a'}],
+      ['data', foo.insert('foo', {id: 2})],
+      ['commit', foo.commit(), {watermark: '0a'}],
+    ]);
+
+    expect(result).toEqual([
+      {
+        watermark: '07',
+        completedBackfill: undefined,
+        schemaUpdated: false,
+        changeLogUpdated: true,
+      },
+      {
+        watermark: '0a',
+        completedBackfill: undefined,
+        schemaUpdated: false,
+        changeLogUpdated: true,
+      },
+    ]);
+    expectTables(
+      servingReplica,
+      {
+        foo: [
+          {id: 1n, ['_0_version']: '07'},
+          {id: 2n, ['_0_version']: '0a'},
+        ],
+      },
+      'bigint',
+    );
+  });
 });
 
 describe('replicator/change-processor-errors', () => {
@@ -3789,6 +3881,11 @@ describe('replicator/change-processor-errors', () => {
     processor.processMessage(lc, [
       'data',
       messages.insert('auto_rollback', {id: 123}),
+    ]);
+    processor.processMessage(lc, [
+      'commit',
+      messages.commit(),
+      {watermark: '0e'},
     ]);
 
     expect(failures).toHaveLength(1);

--- a/packages/zero-cache/src/services/replicator/change-processor.ts
+++ b/packages/zero-cache/src/services/replicator/change-processor.ts
@@ -5,6 +5,7 @@ import {assert, unreachable} from '../../../../shared/src/asserts.ts';
 import {stringify} from '../../../../shared/src/bigint-json.ts';
 import {must} from '../../../../shared/src/must.ts';
 import type {DownloadStatus} from '../../../../zero-events/src/status.ts';
+import type {Statement} from '../../../../zqlite/src/db.ts';
 import {
   createLiteIndexStatement,
   createLiteTableStatement,
@@ -32,6 +33,7 @@ import {
   type LiteValueType,
 } from '../../types/lite.ts';
 import {liteTableName} from '../../types/names.ts';
+import {normalizedKeyOrder} from '../../types/row-key.ts';
 import {id} from '../../types/sql.ts';
 import type {
   BackfillCompleted,
@@ -56,7 +58,12 @@ import type {
 } from '../change-source/protocol/current/data.ts';
 import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
 import type {ReplicatorMode} from './replicator.ts';
-import {ChangeLog, DEL_OP, SET_OP} from './schema/change-log.ts';
+import {
+  type BatchRowOp,
+  ChangeLog,
+  DEL_OP,
+  SET_OP,
+} from './schema/change-log.ts';
 import {ColumnMetadataStore} from './schema/column-metadata.ts';
 import {
   ZERO_VERSION_COLUMN_NAME,
@@ -72,6 +79,382 @@ export type CommitResult = {
   schemaUpdated: boolean;
   changeLogUpdated: boolean;
 };
+
+type ChangeProcessorOptions = {
+  readonly cacheDmlSqlPlans?: boolean;
+};
+
+type UpsertPlan = {
+  // The row's present columns define the prepared INSERT shape; partial
+  // backfill/update rows must not reuse a statement for a different shape.
+  readonly rowColumns: readonly string[];
+  readonly sql: string;
+  statement: Statement | undefined;
+  // Multi-row INSERT SQL has one placeholder group per row, so the row count is
+  // part of the prepared-statement shape.
+  readonly batchStatements: Map<number, Statement>;
+};
+
+type UpdatePlan = {
+  readonly rowColumns: readonly string[];
+  readonly keyColumns: readonly string[];
+  readonly sql: string;
+};
+
+type DeletePlan = {
+  readonly keyColumns: readonly string[];
+  readonly sql: string;
+};
+
+type PendingInsertBatch = {
+  readonly table: string;
+  // All rows in a batch share a table and upsert plan so SQLite sees one
+  // multi-row INSERT with a fixed column list and placeholder layout.
+  readonly plan: UpsertPlan;
+  // Bound by SQLite's parameter limit; the version column is included in the
+  // per-row binding count.
+  readonly maxRows: number;
+  readonly rows: LiteRow[];
+  readonly logEntries: BatchRowOp[];
+  // A duplicate row key in the same multi-row INSERT would make "last write
+  // wins" depend on SQLite conflict behavior instead of stream order, so it
+  // forces a batch boundary.
+  readonly rowKeys: Set<string>;
+};
+
+// Consecutive same-shape inserts are the common catch-up/load-test burst:
+// one upstream transaction can carry many rows, and each row used to cross
+// JS/SQLite separately. Batching only this narrow shape keeps ordering and
+// rollback behavior easy to reason about while reducing native calls.
+const MAX_BATCH_BINDINGS = 900;
+
+class DmlSqlPlanCache {
+  readonly #enabled: boolean;
+  // Full maps retain prepared SQL by table/column/key shape across transactions.
+  readonly #upsertPlans = new Map<string, UpsertPlan>();
+  readonly #updatePlans = new Map<string, UpdatePlan>();
+  readonly #deletePlans = new Map<string, DeletePlan>();
+  // Logical replication usually emits long runs for the same table and shape.
+  // The one-entry per-table fast path avoids rebuilding a shape key for every
+  // row when the previous plan is still valid.
+  readonly #lastUpsertPlan = new Map<string, UpsertPlan>();
+  readonly #lastUpdatePlan = new Map<string, UpdatePlan>();
+  readonly #lastDeletePlan = new Map<string, DeletePlan>();
+
+  constructor(enabled: boolean) {
+    this.#enabled = enabled;
+  }
+
+  clear() {
+    this.#upsertPlans.clear();
+    this.#updatePlans.clear();
+    this.#deletePlans.clear();
+    this.#lastUpsertPlan.clear();
+    this.#lastUpdatePlan.clear();
+    this.#lastDeletePlan.clear();
+  }
+
+  getUpsertPlan(table: string, row: LiteRow, numCols: number): UpsertPlan {
+    if (!this.#enabled) {
+      return createUpsertPlan(table, columnsForRow(row, numCols));
+    }
+
+    const last = this.#lastUpsertPlan.get(table);
+    if (last && rowHasColumns(row, numCols, last.rowColumns)) {
+      // Reuse is safe only when the row still has every column the prepared
+      // INSERT binds. Otherwise values would be bound to the wrong column list.
+      return last;
+    }
+
+    const rowColumns = columnsForRow(row, numCols);
+    const cacheKey = shapeKey(table, rowColumns);
+    let plan = this.#upsertPlans.get(cacheKey);
+    if (!plan) {
+      plan = createUpsertPlan(table, rowColumns);
+      this.#upsertPlans.set(cacheKey, plan);
+    }
+    this.#lastUpsertPlan.set(table, plan);
+    return plan;
+  }
+
+  getUpdatePlan(
+    table: string,
+    row: LiteRow,
+    numCols: number,
+    keyColumns: readonly string[],
+  ): UpdatePlan {
+    if (!this.#enabled) {
+      return createUpdatePlan(table, columnsForRow(row, numCols), keyColumns);
+    }
+
+    const last = this.#lastUpdatePlan.get(table);
+    if (
+      last &&
+      rowHasColumns(row, numCols, last.rowColumns) &&
+      sameColumns(keyColumns, last.keyColumns)
+    ) {
+      // UPDATE reuse also depends on the key column order because those
+      // placeholders are bound after the SET values.
+      return last;
+    }
+
+    const rowColumns = columnsForRow(row, numCols);
+    const cacheKey = shapeKey(table, rowColumns, keyColumns);
+    let plan = this.#updatePlans.get(cacheKey);
+    if (!plan) {
+      plan = createUpdatePlan(table, rowColumns, keyColumns);
+      this.#updatePlans.set(cacheKey, plan);
+    }
+    this.#lastUpdatePlan.set(table, plan);
+    return plan;
+  }
+
+  getDeletePlan(table: string, keyColumns: readonly string[]): DeletePlan {
+    if (!this.#enabled) {
+      return createDeletePlan(table, keyColumns);
+    }
+
+    const last = this.#lastDeletePlan.get(table);
+    if (last && sameColumns(keyColumns, last.keyColumns)) {
+      // DELETE statements bind only the key columns, so key order is the whole
+      // statement shape.
+      return last;
+    }
+
+    const cacheKey = shapeKey(table, keyColumns);
+    let plan = this.#deletePlans.get(cacheKey);
+    if (!plan) {
+      plan = createDeletePlan(table, keyColumns);
+      this.#deletePlans.set(cacheKey, plan);
+    }
+    this.#lastDeletePlan.set(table, plan);
+    return plan;
+  }
+}
+
+function createUpsertPlan(
+  table: string,
+  rowColumns: readonly string[],
+): UpsertPlan {
+  const insertColumns = [...rowColumns, ZERO_VERSION_COLUMN_NAME];
+  const columnsSQL = insertColumns.map(c => id(c)).join(',');
+  return {
+    rowColumns,
+    sql: /*sql*/ `
+      INSERT OR REPLACE INTO ${id(table)} (${columnsSQL})
+        VALUES (${placeholders(insertColumns.length)})
+      `,
+    statement: undefined,
+    batchStatements: new Map(),
+  };
+}
+
+function createBatchUpsertSql(
+  table: string,
+  rowColumns: readonly string[],
+  rows: number,
+): string {
+  const insertColumns = [...rowColumns, ZERO_VERSION_COLUMN_NAME];
+  const columnsSQL = insertColumns.map(c => id(c)).join(',');
+  return /*sql*/ `
+    INSERT OR REPLACE INTO ${id(table)} (${columnsSQL})
+      VALUES ${Array.from({length: rows})
+        .map(() => `(${placeholders(insertColumns.length)})`)
+        .join(',')}
+    `;
+}
+
+function upsertStatement(
+  db: StatementRunner,
+  table: string,
+  plan: UpsertPlan,
+  rows: number,
+): Statement {
+  if (rows === 1) {
+    return (plan.statement ??= db.db.prepare(plan.sql));
+  }
+
+  let stmt = plan.batchStatements.get(rows);
+  if (!stmt) {
+    // Multi-row SQL changes with the row count because the placeholder list
+    // changes, so cache by rows inside the shared plan.
+    stmt = db.db.prepare(createBatchUpsertSql(table, plan.rowColumns, rows));
+    plan.batchStatements.set(rows, stmt);
+  }
+  return stmt;
+}
+
+function createUpdatePlan(
+  table: string,
+  rowColumns: readonly string[],
+  keyColumns: readonly string[],
+): UpdatePlan {
+  const setExprs = [...rowColumns, ZERO_VERSION_COLUMN_NAME].map(
+    col => `${id(col)}=?`,
+  );
+  const conds = keyColumns.map(col => `${id(col)}=?`);
+  return {
+    rowColumns,
+    keyColumns,
+    sql: /*sql*/ `
+      UPDATE ${id(table)}
+        SET ${setExprs.join(',')}
+        WHERE ${conds.join(' AND ')}
+      `,
+  };
+}
+
+function createDeletePlan(
+  table: string,
+  keyColumns: readonly string[],
+): DeletePlan {
+  const conds = keyColumns.map(col => `${id(col)}=?`);
+  return {
+    keyColumns,
+    sql: `DELETE FROM ${id(table)} WHERE ${conds.join(' AND ')}`,
+  };
+}
+
+function columnsForRow(row: LiteRow, numCols: number): string[] {
+  const columns: string[] = [];
+  columns.length = numCols;
+  let i = 0;
+  for (const col in row) {
+    columns[i++] = col;
+  }
+  assert(i === numCols, `Expected ${numCols} columns, got ${i}`);
+  return columns;
+}
+
+function rowHasColumns(
+  row: LiteRow,
+  numCols: number,
+  columns: readonly string[],
+) {
+  // The row object can be reused from parsed change-source payloads; this check
+  // proves the cached statement's column list still matches without allocating a
+  // new column array for the common same-shape row.
+  if (numCols !== columns.length) {
+    return false;
+  }
+  for (const col of columns) {
+    if (!Object.hasOwn(row, col)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function sameColumns(left: readonly string[], right: readonly string[]) {
+  if (left.length !== right.length) {
+    return false;
+  }
+  for (let i = 0; i < left.length; i++) {
+    if (left[i] !== right[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function shapeKey(
+  table: string,
+  columns: readonly string[],
+  extraColumns?: readonly string[],
+) {
+  let key = columnKeyPart(table) + columnListKeyPart(columns);
+  if (extraColumns) {
+    key += columnListKeyPart(extraColumns);
+  }
+  return key;
+}
+
+function columnListKeyPart(columns: readonly string[]) {
+  // Length prefixes keep shapes unambiguous without allocating nested arrays;
+  // ["ab", "c"] and ["a", "bc"] must not collide.
+  let key = `#${columns.length}`;
+  for (const col of columns) {
+    key += columnKeyPart(col);
+  }
+  return key;
+}
+
+function columnKeyPart(col: string) {
+  return `${col.length}:${col}`;
+}
+
+function placeholders(length: number) {
+  return Array.from({length}).fill('?').join(',');
+}
+
+function upsertValues(
+  row: LiteRow,
+  columns: readonly string[],
+  version: LexiVersion,
+) {
+  const values: (LiteValueType | LexiVersion)[] = [];
+  values.length = columns.length + 1;
+  for (let i = 0; i < columns.length; i++) {
+    values[i] = row[columns[i]];
+  }
+  values[columns.length] = version;
+  return values;
+}
+
+function updateValues(
+  row: LiteRow,
+  rowColumns: readonly string[],
+  key: LiteRowKey,
+  keyColumns: readonly string[],
+  version: LexiVersion,
+) {
+  const values: (LiteValueType | LexiVersion)[] = [];
+  values.length = rowColumns.length + keyColumns.length + 1;
+  let pos = 0;
+  for (const col of rowColumns) {
+    values[pos++] = row[col];
+  }
+  values[pos++] = version;
+  for (const col of keyColumns) {
+    values[pos++] = key[col];
+  }
+  return values;
+}
+
+function keyValues(key: LiteRowKey, keyColumns: readonly string[]) {
+  const values: LiteValueType[] = [];
+  values.length = keyColumns.length;
+  for (let i = 0; i < keyColumns.length; i++) {
+    values[i] = key[keyColumns[i]];
+  }
+  return values;
+}
+
+function rowKeyString(key: LiteRowKey) {
+  // Most replicated tables use a single-column key. Build that canonical JSON
+  // directly to avoid allocating a normalized copy on every row; composite keys
+  // still use normalizedKeyOrder() so column order remains stable.
+  let singleColumn: string | undefined;
+  let singleValue: LiteValueType = null;
+  for (const col in key) {
+    if (singleColumn !== undefined) {
+      return stringify(normalizedKeyOrder(key));
+    }
+    singleColumn = col;
+    singleValue = key[col];
+  }
+  if (singleColumn !== undefined) {
+    return `{${JSON.stringify(singleColumn)}:${valueKeyString(singleValue)}}`;
+  }
+  return stringify(normalizedKeyOrder(key));
+}
+
+function valueKeyString(value: LiteValueType) {
+  if (typeof value === 'string') {
+    return JSON.stringify(value);
+  }
+  return stringify(value);
+}
 
 /**
  * The ChangeProcessor partitions the stream of messages into transactions
@@ -95,6 +478,7 @@ export class ChangeProcessor {
   // and reloads them after a schema change. It is cached here to avoid
   // reading them from the DB on every transaction.
   readonly #tableSpecs = new Map<string, LiteTableSpecWithReplicationStatus>();
+  readonly #dmlSqlPlans: DmlSqlPlanCache;
 
   #currentTx: TransactionProcessor | null = null;
 
@@ -104,12 +488,14 @@ export class ChangeProcessor {
     db: StatementRunner,
     mode: ChangeProcessorMode,
     failService: (lc: LogContext, err: unknown) => void,
+    {cacheDmlSqlPlans = true}: ChangeProcessorOptions = {},
   ) {
     this.#db = db;
     this.#changeLog = new ChangeLog(db.db);
     this.#tableMetadata = new TableMetadataTracker(db.db);
     this.#mode = mode;
     this.#failService = failService;
+    this.#dmlSqlPlans = new DmlSqlPlanCache(cacheDmlSqlPlans);
   }
 
   #fail(lc: LogContext, err: unknown) {
@@ -156,11 +542,49 @@ export class ChangeProcessor {
           : type === 'commit'
             ? downstream[2].watermark
             : undefined;
+      // Begin carries the future commit watermark used as this transaction's
+      // row version. Commit carries the durable replication watermark to persist.
+      // Data messages intentionally carry neither; they are ordered by the open tx.
       return this.#processMessage(lc, message, watermark);
     } catch (e) {
       this.#fail(lc, e);
     }
     return null;
+  }
+
+  processMessages(
+    lc: LogContext,
+    downstreams: readonly ChangeStreamData[],
+  ): CommitResult | readonly CommitResult[] | null {
+    if (this.#failure) {
+      return null;
+    }
+
+    // RM -> VS streams are row-heavy, so the common path should pay the public
+    // failure/try wrapper once per stream batch rather than once per row.
+    const results: CommitResult[] = [];
+    try {
+      for (const downstream of downstreams) {
+        const [type, message] = downstream;
+        const watermark =
+          type === 'begin'
+            ? downstream[2].commitWatermark
+            : type === 'commit'
+              ? downstream[2].watermark
+              : undefined;
+        const result = this.#processMessage(lc, message, watermark);
+        if (result) {
+          results.push(result);
+        }
+      }
+    } catch (e) {
+      this.#fail(lc, e);
+    }
+
+    if (results.length === 0) {
+      return null;
+    }
+    return results.length === 1 ? results[0] : results;
   }
 
   #beginTransaction(
@@ -186,6 +610,7 @@ export class ChangeProcessor {
           this.#changeLog,
           this.#tableMetadata,
           this.#tableSpecs,
+          this.#dmlSqlPlans,
           commitVersion,
           jsonFormat,
         );
@@ -231,11 +656,11 @@ export class ChangeProcessor {
     }
 
     if (msg.tag === 'commit') {
+      assert(watermark, 'watermark is required for commit messages');
+      const result = tx.processCommit(msg, watermark);
       // Undef this.#currentTx to allow the assembly of the next transaction.
       this.#currentTx = null;
-
-      assert(watermark, 'watermark is required for commit messages');
-      return tx.processCommit(msg, watermark);
+      return result;
     }
 
     if (msg.tag === 'rollback') {
@@ -244,50 +669,67 @@ export class ChangeProcessor {
       return null;
     }
 
+    // Insert batches are deliberately narrow: consecutive INSERTs with the same
+    // table/shape. Every other mutation flushes first so change-log positions,
+    // metadata side effects, and rollback behavior remain in stream order.
     switch (msg.tag) {
       case 'insert':
         tx.processInsert(msg);
         break;
       case 'update':
+        tx.flushPendingInserts();
         tx.processUpdate(msg);
         break;
       case 'delete':
+        tx.flushPendingInserts();
         tx.processDelete(msg);
         break;
       case 'truncate':
+        tx.flushPendingInserts();
         tx.processTruncate(msg);
         break;
       case 'create-table':
+        tx.flushPendingInserts();
         tx.processCreateTable(msg);
         break;
       case 'rename-table':
+        tx.flushPendingInserts();
         tx.processRenameTable(msg);
         break;
       case 'update-table-metadata':
+        tx.flushPendingInserts();
         tx.processTableMetadata(msg);
         break;
       case 'add-column':
+        tx.flushPendingInserts();
         tx.processAddColumn(msg);
         break;
       case 'update-column':
+        tx.flushPendingInserts();
         tx.processUpdateColumn(msg);
         break;
       case 'drop-column':
+        tx.flushPendingInserts();
         tx.processDropColumn(msg);
         break;
       case 'drop-table':
+        tx.flushPendingInserts();
         tx.processDropTable(msg);
         break;
       case 'create-index':
+        tx.flushPendingInserts();
         tx.processCreateIndex(msg);
         break;
       case 'drop-index':
+        tx.flushPendingInserts();
         tx.processDropIndex(msg);
         break;
       case 'backfill':
+        tx.flushPendingInserts();
         tx.processBackfill(msg);
         break;
       case 'backfill-completed':
+        tx.flushPendingInserts();
         tx.processBackfillCompleted(msg);
         break;
       default:
@@ -328,12 +770,14 @@ class TransactionProcessor {
   readonly #changeLog: ChangeLog;
   readonly #tableMetadata: TableMetadataTracker;
   readonly #tableSpecs: Map<string, LiteTableSpecWithReplicationStatus>;
+  readonly #dmlSqlPlans: DmlSqlPlanCache;
   readonly #jsonFormat: JSONFormat;
   readonly #columnMetadata: ColumnMetadataStore;
 
   #pos = 0;
   #schemaChanged = false;
   #numChangeLogEntries = 0;
+  #pendingInsertBatch: PendingInsertBatch | undefined;
 
   constructor(
     lc: LogContext,
@@ -342,6 +786,7 @@ class TransactionProcessor {
     changeLog: ChangeLog,
     tableMetadata: TableMetadataTracker,
     tableSpecs: Map<string, LiteTableSpecWithReplicationStatus>,
+    dmlSqlPlans: DmlSqlPlanCache,
     commitVersion: LexiVersion,
     jsonFormat: JSONFormat,
   ) {
@@ -380,6 +825,7 @@ class TransactionProcessor {
     this.#changeLog = changeLog;
     this.#tableMetadata = tableMetadata;
     this.#tableSpecs = tableSpecs;
+    this.#dmlSqlPlans = dmlSqlPlans;
     // The column_metadata table is guaranteed to exist since the
     // replica-schema.ts migration to v8.
     this.#columnMetadata = must(ColumnMetadataStore.getInstance(db.db));
@@ -391,6 +837,7 @@ class TransactionProcessor {
 
   #reloadTableSpecs() {
     this.#tableSpecs.clear();
+    this.#dmlSqlPlans.clear();
     // zqlSpecs include the primary key derived from unique indexes
     const zqlSpecs = computeZqlSpecs(this.#lc, this.#db.db, {
       includeBackfillingColumns: true,
@@ -412,10 +859,7 @@ class TransactionProcessor {
     return must(this.#tableSpecs.get(name), `Unknown table ${name}`);
   }
 
-  #getKey(
-    {row, numCols}: {row: LiteRow; numCols: number},
-    {relation}: {relation: MessageRelation},
-  ): LiteRowKey {
+  #getKeyColumns({relation}: {relation: MessageRelation}) {
     const keyColumns =
       relation.rowKey.type !== 'full'
         ? relation.rowKey.columns // already a suitable key
@@ -425,6 +869,14 @@ class TransactionProcessor {
         `Cannot replicate table "${relation.name}" without a PRIMARY KEY or UNIQUE INDEX`,
       );
     }
+    return keyColumns;
+  }
+
+  #getKey(
+    {row, numCols}: {row: LiteRow; numCols: number},
+    {relation}: {relation: MessageRelation},
+    keyColumns = this.#getKeyColumns({relation}),
+  ): LiteRowKey {
     // For the common case (replica identity default), the row is already the
     // key for deletes and updates, in which case a new object can be avoided.
     if (numCols === keyColumns.length) {
@@ -442,11 +894,6 @@ class TransactionProcessor {
     const tableSpec = this.#tableSpec(table);
     const newRow = liteRow(insert.new, tableSpec, this.#jsonFormat);
 
-    this.#upsert(table, {
-      ...newRow.row,
-      [ZERO_VERSION_COLUMN_NAME]: this.#version,
-    });
-
     if (insert.relation.rowKey.columns.length === 0) {
       // INSERTs can be replicated for rows without a PRIMARY KEY or a
       // UNIQUE INDEX. These are written to the replica but not recorded
@@ -455,21 +902,109 @@ class TransactionProcessor {
       // (Once the table schema has been corrected to include a key, the
       //  associated schema change will reset pipelines and data can be
       //  loaded via hydration.)
+      this.#queueInsert(table, newRow, undefined, undefined);
       return;
     }
     const key = this.#getKey(newRow, insert);
-    this.#logSetOp(table, key, getBackfilledColumns(newRow.row, tableSpec));
+    const backfilledColumns = getBackfilledColumns(newRow.row, tableSpec);
+    if (backfilledColumns !== undefined) {
+      // Backfill markers merge with column metadata in the change log, so this
+      // row takes the single-row path instead of the plain SET-op batch.
+      this.#flushPendingInserts();
+      this.#upsert(table, newRow);
+      this.#logSetOp(table, key, backfilledColumns);
+      return;
+    }
+    this.#queueInsert(table, newRow, key, rowKeyString(key));
   }
 
-  #upsert(table: string, row: LiteRow) {
-    const columns = Object.keys(row).map(c => id(c));
-    this.#db.run(
-      `
-      INSERT OR REPLACE INTO ${id(table)} (${columns.join(',')})
-        VALUES (${Array.from({length: columns.length}).fill('?').join(',')})
-      `,
-      Object.values(row),
+  #upsert(table: string, {row, numCols}: {row: LiteRow; numCols: number}) {
+    const plan = this.#dmlSqlPlans.getUpsertPlan(table, row, numCols);
+    this.#db.run(plan.sql, upsertValues(row, plan.rowColumns, this.#version));
+  }
+
+  #queueInsert(
+    table: string,
+    newRow: {row: LiteRow; numCols: number},
+    key: LiteRowKey | undefined,
+    rowKey: string | undefined,
+  ) {
+    const plan = this.#dmlSqlPlans.getUpsertPlan(
+      table,
+      newRow.row,
+      newRow.numCols,
     );
+    const maxRows = Math.max(
+      1,
+      Math.floor(MAX_BATCH_BINDINGS / (plan.rowColumns.length + 1)),
+    );
+    const batch = this.#pendingInsertBatch;
+    if (batch) {
+      const tableChanged = batch.table !== table;
+      const shapeChanged = batch.plan.sql !== plan.sql;
+      const batchFull = batch.rows.length >= batch.maxRows;
+      const duplicateRowInBatch =
+        rowKey !== undefined && batch.rowKeys.has(rowKey);
+      if (tableChanged || shapeChanged || batchFull || duplicateRowInBatch) {
+        // A multi-row INSERT has one target table and one column shape. It also
+        // must not contain the same row key twice, because stream order should
+        // decide repeated writes to a row, not SQLite conflict resolution inside
+        // one statement.
+        this.#flushPendingInserts();
+      }
+    }
+
+    const current =
+      this.#pendingInsertBatch ??
+      (this.#pendingInsertBatch = {
+        table,
+        plan,
+        maxRows,
+        rows: [],
+        logEntries: [],
+        rowKeys: new Set(),
+      });
+
+    if (rowKey !== undefined) {
+      current.rowKeys.add(rowKey);
+    }
+    const logEntry =
+      this.#mode === 'serving' && key !== undefined && rowKey !== undefined
+        ? {
+            pos: this.#pos++,
+            table,
+            rowKey,
+          }
+        : undefined;
+    if (logEntry) {
+      this.#numChangeLogEntries++;
+      current.logEntries.push(logEntry);
+    }
+    current.rows.push(newRow.row);
+  }
+
+  #flushPendingInserts() {
+    const batch = this.#pendingInsertBatch;
+    if (!batch) {
+      return;
+    }
+    this.#pendingInsertBatch = undefined;
+
+    const values = [];
+    const rowValueCount = batch.plan.rowColumns.length + 1;
+    values.length = batch.rows.length * rowValueCount;
+    let i = 0;
+    for (const row of batch.rows) {
+      for (const col of batch.plan.rowColumns) {
+        values[i++] = row[col];
+      }
+      values[i++] = this.#version;
+    }
+
+    upsertStatement(this.#db, batch.table, batch.plan, batch.rows.length).run(
+      values,
+    );
+    this.#changeLog.logSetOps(this.#version, batch.logEntries);
   }
 
   // Updates by default are applied as UPDATE commands to support partial
@@ -488,16 +1023,17 @@ class TransactionProcessor {
     const table = liteTableName(update.relation);
     const tableSpec = this.#tableSpec(table);
     const newRow = liteRow(update.new, tableSpec, this.#jsonFormat);
-    const row = {...newRow.row, [ZERO_VERSION_COLUMN_NAME]: this.#version};
+    const keyColumns = this.#getKeyColumns(update);
 
     // update.key is set with the old values if the key has changed.
     const oldKey = update.key
       ? this.#getKey(
           liteRow(update.key, this.#tableSpec(table), this.#jsonFormat),
           update,
+          keyColumns,
         )
       : null;
-    const newKey = this.#getKey(newRow, update);
+    const newKey = this.#getKey(newRow, update, keyColumns);
 
     if (oldKey) {
       this.#logDeleteOp(table, oldKey, tableSpec.backfilling);
@@ -505,43 +1041,52 @@ class TransactionProcessor {
     this.#logSetOp(table, newKey, getBackfilledColumns(newRow.row, tableSpec));
 
     const currKey = oldKey ?? newKey;
-    const conds = Object.keys(currKey).map(col => `${id(col)}=?`);
-    const setExprs = Object.keys(row).map(col => `${id(col)}=?`);
+    const plan = this.#dmlSqlPlans.getUpdatePlan(
+      table,
+      newRow.row,
+      newRow.numCols,
+      keyColumns,
+    );
 
     const {changes} = this.#db.run(
-      `
-      UPDATE ${id(table)}
-        SET ${setExprs.join(',')}
-        WHERE ${conds.join(' AND ')}
-      `,
-      [...Object.values(row), ...Object.values(currKey)],
+      plan.sql,
+      updateValues(
+        newRow.row,
+        plan.rowColumns,
+        currKey,
+        plan.keyColumns,
+        this.#version,
+      ),
     );
 
     // If the UPDATE did not affect any rows, perform an UPSERT of the
     // new row for resumptive replication.
     if (changes === 0) {
-      this.#upsert(table, row);
+      this.#upsert(table, newRow);
     }
   }
 
   processDelete(del: MessageDelete) {
     const table = liteTableName(del.relation);
     const tableSpec = this.#tableSpec(table);
+    const keyColumns = this.#getKeyColumns(del);
     const rowKey = this.#getKey(
       liteRow(del.key, tableSpec, this.#jsonFormat),
       del,
+      keyColumns,
     );
 
-    this.#delete(table, rowKey);
+    this.#delete(table, rowKey, keyColumns);
     this.#logDeleteOp(table, rowKey, tableSpec.backfilling);
   }
 
-  #delete(table: string, rowKey: LiteRowKey) {
-    const conds = Object.keys(rowKey).map(col => `${id(col)}=?`);
-    this.#db.run(
-      `DELETE FROM ${id(table)} WHERE ${conds.join(' AND ')}`,
-      Object.values(rowKey),
-    );
+  #delete(table: string, rowKey: LiteRowKey, keyColumns: readonly string[]) {
+    const plan = this.#dmlSqlPlans.getDeletePlan(table, keyColumns);
+    this.#db.run(plan.sql, keyValues(rowKey, plan.keyColumns));
+  }
+
+  flushPendingInserts() {
+    this.#flushPendingInserts();
   }
 
   processTruncate(truncate: MessageTruncate) {
@@ -892,6 +1437,7 @@ class TransactionProcessor {
         }: ${stringify(commit)}`,
       );
     }
+    this.#flushPendingInserts();
     updateReplicationWatermark(this.#db, watermark);
 
     if (this.#schemaChanged) {

--- a/packages/zero-cache/src/services/replicator/incremental-sync.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.ts
@@ -19,9 +19,12 @@ import type {ReplicationStatusPublisher} from './replication-status.ts';
 import type {ReplicaState, ReplicatorMode} from './replicator.ts';
 import {ReplicationReportRecorder} from './reporter/recorder.ts';
 import type {ReplicationReport} from './reporter/report-schema.ts';
+import {WorkerMessageBatcher} from './worker-message-batcher.ts';
 import type {WriteWorkerClient} from './write-worker-client.ts';
 
 type ErrorType = Enum<typeof ErrorType>;
+
+const MAX_WORKER_BATCH_MESSAGES = 64;
 
 /**
  * The {@link IncrementalSyncer} manages a logical replication stream from upstream,
@@ -85,7 +88,7 @@ export class IncrementalSyncer {
 
       let downstream: Source<Downstream> | undefined;
       let unregister = () => {};
-      let err: unknown | undefined;
+      let err: unknown;
 
       try {
         downstream = await this.#changeStreamer.subscribe({
@@ -106,6 +109,66 @@ export class IncrementalSyncer {
         );
 
         let backfillStatus: DownloadStatus | undefined;
+        const workerBatch = new WorkerMessageBatcher(
+          this.#worker,
+          MAX_WORKER_BATCH_MESSAGES,
+        );
+        const handleWorkerResult = (
+          result: CommitResult | readonly CommitResult[] | null,
+        ) => {
+          if (result === null) {
+            return;
+          }
+          const results = Array.isArray(result) ? result : [result];
+          for (const commitResult of results) {
+            this.#handleResult(lc, commitResult);
+            if (commitResult?.completedBackfill) {
+              backfillStatus = undefined;
+            }
+          }
+        };
+        const flushWorkerBatch = async () => {
+          const result = workerBatch.flush();
+          if (result) {
+            handleWorkerResult(await result);
+          }
+        };
+        const processChangeStreamData = (
+          message: ChangeStreamData,
+        ): Promise<void> | undefined => {
+          const msg = message[1];
+          if (msg.tag === 'backfill' && msg.status) {
+            const {status} = msg;
+            if (!backfillStatus) {
+              // Start publishing the status every 3 seconds.
+              backfillStatus = status;
+              this.#statusPublisher?.publish(
+                lc,
+                'Replicating',
+                `Backfilling ${msg.relation.name} table`,
+                3000,
+                () =>
+                  backfillStatus
+                    ? {
+                        downloadStatus: [
+                          {
+                            ...backfillStatus,
+                            table: msg.relation.name,
+                            columns: [
+                              ...msg.relation.rowKey.columns,
+                              ...msg.columns,
+                            ],
+                          },
+                        ],
+                      }
+                    : {},
+              );
+            }
+            backfillStatus = status; // Update the current status
+          }
+
+          return workerBatch.push(message)?.then(handleWorkerResult);
+        };
 
         for await (const message of downstream) {
           this.#replicationEvents.add(1);
@@ -140,49 +203,15 @@ export class IncrementalSyncer {
               break;
             }
             default: {
-              const msg = message[1];
-              if (msg.tag === 'backfill' && msg.status) {
-                const {status} = msg;
-                if (!backfillStatus) {
-                  // Start publishing the status every 3 seconds.
-                  backfillStatus = status;
-                  this.#statusPublisher?.publish(
-                    lc,
-                    'Replicating',
-                    `Backfilling ${msg.relation.name} table`,
-                    3000,
-                    () =>
-                      backfillStatus
-                        ? {
-                            downloadStatus: [
-                              {
-                                ...backfillStatus,
-                                table: msg.relation.name,
-                                columns: [
-                                  ...msg.relation.rowKey.columns,
-                                  ...msg.columns,
-                                ],
-                              },
-                            ],
-                          }
-                        : {},
-                  );
-                }
-                backfillStatus = status; // Update the current status
-              }
-
-              const result = await this.#worker.processMessage(
-                message as ChangeStreamData,
-              );
-
-              this.#handleResult(lc, result);
-              if (result?.completedBackfill) {
-                backfillStatus = undefined;
+              const result = processChangeStreamData(message);
+              if (result) {
+                await result;
               }
               break;
             }
           }
         }
+        await flushWorkerBatch();
         this.#worker.abort();
       } catch (e) {
         err = e;

--- a/packages/zero-cache/src/services/replicator/incremental-sync.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.ts
@@ -2,11 +2,16 @@ import type {LogContext} from '@rocicorp/logger';
 import {AbortError} from '../../../../shared/src/abort-error.ts';
 import type {Enum} from '../../../../shared/src/enum.ts';
 import {getOrCreateCounter} from '../../observability/metrics.ts';
-import type {Source} from '../../types/streams.ts';
+import {
+  isStreamBatch,
+  type Source,
+  type StreamInPayload,
+} from '../../types/streams.ts';
 import type {DownloadStatus} from '../change-source/protocol/current.ts';
 import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
 import {
   errorTypeToReadableName,
+  hasBatchedSubscribe,
   PROTOCOL_VERSION,
   type ChangeStreamer,
   type Downstream,
@@ -24,6 +29,11 @@ import type {WriteWorkerClient} from './write-worker-client.ts';
 
 type ErrorType = Enum<typeof ErrorType>;
 
+// Batch replication messages before crossing into the write worker so
+// data-heavy transactions do not pay one IPC round trip per row. The
+// rm-vs-load benchmark covers the 1 RM / 16 VS case this is meant to protect;
+// the cap keeps unusually large upstream transactions from sitting in the
+// syncer heap while the worker is idle.
 const MAX_WORKER_BATCH_MESSAGES = 64;
 
 /**
@@ -86,12 +96,12 @@ export class IncrementalSyncer {
       const {replicaVersion, watermark} =
         await this.#worker.getSubscriptionState();
 
-      let downstream: Source<Downstream> | undefined;
+      let downstream: Source<StreamInPayload<Downstream>> | undefined;
       let unregister = () => {};
       let err: unknown;
 
       try {
-        downstream = await this.#changeStreamer.subscribe({
+        const ctx = {
           protocolVersion: PROTOCOL_VERSION,
           taskID: this.#taskID,
           id: this.#id,
@@ -99,7 +109,15 @@ export class IncrementalSyncer {
           watermark,
           replicaVersion,
           initial: watermark === initialWatermark,
-        });
+        };
+        // Batched subscribe preserves the RM websocket frame boundary. That is
+        // the unit that actually arrived together on the VS, so using it as the
+        // worker-flush boundary gives SQLite enough contiguous work to batch
+        // without changing the replication protocol or commit semantics.
+        const useBatchedSubscribe = hasBatchedSubscribe(this.#changeStreamer);
+        downstream = useBatchedSubscribe
+          ? await this.#changeStreamer.subscribeBatched(ctx)
+          : await this.#changeStreamer.subscribe(ctx);
         this.#state.resetBackoff();
         unregister = this.#state.cancelOnStop(downstream);
         this.#statusPublisher?.publish(
@@ -112,6 +130,10 @@ export class IncrementalSyncer {
         const workerBatch = new WorkerMessageBatcher(
           this.#worker,
           MAX_WORKER_BATCH_MESSAGES,
+          // Legacy subscribe() has no outer stream batch to flush at, so commits
+          // remain the visibility boundary. Batched subscribe() flushes after the
+          // transport batch, which keeps row-heavy transactions together.
+          {flushOnCommit: !useBatchedSubscribe},
         );
         const handleWorkerResult = (
           result: CommitResult | readonly CommitResult[] | null,
@@ -169,8 +191,7 @@ export class IncrementalSyncer {
 
           return workerBatch.push(message)?.then(handleWorkerResult);
         };
-
-        for await (const message of downstream) {
+        const processChangeStreamerMessage = async (message: Downstream) => {
           this.#replicationEvents.add(1);
           switch (message[0]) {
             case 'status': {
@@ -208,6 +229,26 @@ export class IncrementalSyncer {
                 await result;
               }
               break;
+            }
+          }
+        };
+
+        for await (const payload of downstream) {
+          if (isStreamBatch(payload)) {
+            // This is the production fast path for RM -> VS traffic: apply the
+            // whole received websocket batch, then ACK/flush once after all of
+            // its messages have crossed into the write worker.
+            for (const message of payload.messages) {
+              await processChangeStreamerMessage(message);
+            }
+            await flushWorkerBatch();
+          } else {
+            await processChangeStreamerMessage(payload);
+            if (useBatchedSubscribe) {
+              // Batched streams can still emit single messages. Flush them here
+              // so status/error/small frames do not sit behind a future batch
+              // that may never arrive.
+              await flushWorkerBatch();
             }
           }
         }

--- a/packages/zero-cache/src/services/replicator/local-write-worker-client.ts
+++ b/packages/zero-cache/src/services/replicator/local-write-worker-client.ts
@@ -1,0 +1,106 @@
+import type {LogContext} from '@rocicorp/logger';
+import {assert} from '../../../../shared/src/asserts.ts';
+import type {LogConfig} from '../../../../shared/src/logging.ts';
+import {Database} from '../../../../zqlite/src/db.ts';
+import {StatementRunner} from '../../db/statements.ts';
+import {createLogContext} from '../../server/logging.ts';
+import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
+import {ChangeProcessor, type ChangeProcessorMode} from './change-processor.ts';
+import {getSubscriptionState} from './schema/replication-state.ts';
+import {
+  applyPragmas,
+  type PragmaConfig,
+  type WriteWorkerClient,
+} from './write-worker-client.ts';
+
+type ErrorHandler = (err: Error) => void;
+
+// Serving replicator workers are already off the browser/query path. Applying
+// serving writes directly inside that worker avoids the extra structured-clone
+// and worker-thread hop that dominated row-heavy v6 RM -> VS benchmarks.
+export class LocalWriteWorkerClient implements WriteWorkerClient {
+  #db: Database | undefined;
+  #runner: StatementRunner | undefined;
+  #processor: ChangeProcessor | undefined;
+  #lc: LogContext | undefined;
+  #mode: ChangeProcessorMode | undefined;
+  #errorHandler: ErrorHandler = () => {};
+
+  init(
+    dbPath: string,
+    mode: ChangeProcessorMode,
+    pragmas: PragmaConfig,
+    logConfig: LogConfig,
+  ): Promise<void> {
+    this.#lc = createLogContext({log: logConfig}, 'write-worker');
+    this.#db = new Database(this.#lc, dbPath);
+    applyPragmas(this.#db, pragmas);
+    this.#runner = new StatementRunner(this.#db);
+    this.#mode = mode;
+    this.#processor = new ChangeProcessor(this.#runner, mode, (_lc, err) =>
+      this.#errorHandler(ensureError(err)),
+    );
+    return Promise.resolve();
+  }
+
+  getSubscriptionState() {
+    assert(this.#runner, 'local write worker not initialized');
+    return Promise.resolve(getSubscriptionState(this.#runner));
+  }
+
+  processMessage(downstream: ChangeStreamData) {
+    assert(this.#processor, 'local write worker not initialized');
+    assert(this.#lc, 'local write worker not initialized');
+    return Promise.resolve(
+      this.#processor.processMessage(this.#lc, downstream),
+    );
+  }
+
+  processMessages(downstreams: readonly ChangeStreamData[]) {
+    assert(this.#processor, 'local write worker not initialized');
+    assert(this.#lc, 'local write worker not initialized');
+    return Promise.resolve(
+      this.#processor.processMessages(this.#lc, downstreams),
+    );
+  }
+
+  abort(): void {
+    assert(this.#processor, 'local write worker not initialized');
+    assert(this.#lc, 'local write worker not initialized');
+    assert(this.#runner, 'local write worker not initialized');
+    assert(this.#mode, 'local write worker not initialized');
+
+    // Abort discards the ChangeProcessor's in-flight transaction/failure state,
+    // but keeps the already-open SQLite connection. That mirrors the thread
+    // worker contract without paying a reconnect cost on every stream retry.
+    this.#processor.abort(this.#lc);
+    this.#processor = new ChangeProcessor(
+      this.#runner,
+      this.#mode,
+      (_lc, err) => this.#errorHandler(ensureError(err)),
+    );
+  }
+
+  stop(): Promise<void> {
+    this.#db?.close();
+    this.#db = undefined;
+    this.#runner = undefined;
+    this.#processor = undefined;
+    this.#mode = undefined;
+    return Promise.resolve();
+  }
+
+  onError(handler: ErrorHandler): void {
+    this.#errorHandler = handler;
+  }
+}
+
+function ensureError(err: unknown): Error {
+  if (err instanceof Error) {
+    return err;
+  }
+  if (typeof err === 'string') {
+    return new Error(err);
+  }
+  return new Error(JSON.stringify(err));
+}

--- a/packages/zero-cache/src/services/replicator/replicator.ts
+++ b/packages/zero-cache/src/services/replicator/replicator.ts
@@ -101,7 +101,7 @@ export class ReplicatorService implements Replicator, Service {
   async stop() {
     this.#incrementalSyncer.stop(this.#lc);
     // Wait for the syncer's run loop to finish so that any in-flight
-    // worker.processMessage() call completes and clears #pending
+    // worker write call completes and clears #pending
     // before we send the 'stop' message to the worker.
     await this.#runPromise;
     await this.#worker.stop();

--- a/packages/zero-cache/src/services/replicator/schema/change-log.ts
+++ b/packages/zero-cache/src/services/replicator/schema/change-log.ts
@@ -10,25 +10,23 @@ import type {LiteRowKey} from '../../../types/lite.ts';
 import {normalizedKeyOrder} from '../../../types/row-key.ts';
 
 /**
- * The Change Log tracks the last operation (set or delete) for each row in the
- * data base, ordered by state version; in other words, a cross-table
- * index of row changes ordered by version. This facilitates a minimal "diff"
- * of row changes needed to advance a pipeline from one state version to another.
+ * The local Change Log is the view-syncer's "what became dirty?" index. It is
+ * not an audit log and it does not store row contents. When a pipeline advances
+ * from one state version to another, it needs to know which row keys to re-read;
+ * the before/after row values still come from SQLite snapshots.
  *
- * The Change Log stores identifiers only, i.e. it does not store contents.
- * A database snapshot at the previous version can be used to query a row's
- * old contents, if any, and the current snapshot can be used to query a row's
- * new contents. (In the common case, the new contents will have just been applied
- * and thus has a high likelihood of being in the SQLite cache.)
+ *   replicated row -> SQLite table has the value
+ *                  -> _zero.changeLog2 marks that row key dirty at a version
+ *
+ * Because only the latest operation for a row matters to the next diff,
+ * `_zero.changeLog2` is unique by `(table, rowKey)`.
  *
  * There are two table-wide operations:
  * - `t` corresponds to the postgres `TRUNCATE` operation
  * - `r` represents any schema (i.e. column) change
  *
- * For both operations, the corresponding row changes are not explicitly included
- * in the change log. The consumer has the option of simulating them be reading
- * from pre- and post- snapshots, or resetting their state entirely with the current
- * snapshot.
+ * For both operations, individual row changes are not expanded into the log.
+ * Consumers either compare pre/post snapshots or reset to the current snapshot.
  *
  * To achieve the desired ordering semantics when processing tables that have been
  * truncated, reset, and modified, the "rowKey" is set to `null` for resets and
@@ -119,23 +117,32 @@ const rawChangeLogEntrySchema = v.object({
 
 export type RawChangeLogEntry = v.Infer<typeof rawChangeLogEntrySchema>;
 
+export type BatchRowOp = {
+  readonly pos: number;
+  readonly table: string;
+  readonly rowKey: string;
+};
+
 export class ChangeLog {
+  readonly #db: Database;
   readonly #logRowOpStmt: Statement;
   readonly #logRowOpWithBackfillStmt: Statement;
   readonly #logTableWideOpStmt;
   readonly #getRowOpStmt: Statement;
+  readonly #logSetOpsStmts = new Map<number, Statement>();
 
   constructor(db: Database) {
+    this.#db = db;
     this.#logRowOpStmt = db.prepare(/*sql*/ `
       INSERT OR REPLACE INTO "_zero.changeLog2" 
         (stateVersion, pos, "table", rowKey, op)
-        VALUES (@version, @pos, @table, JSON(@rowKey), @op)
+        VALUES (@version, @pos, @table, @rowKey, @op)
     `);
 
     this.#logRowOpWithBackfillStmt = db.prepare(/*sql*/ `
       INSERT INTO "_zero.changeLog2" 
         (stateVersion, pos, "table", rowKey, op, backfillingColumnVersions)
-        VALUES (@version, @pos, @table, JSON(@rowKey), @op, 
+        VALUES (@version, @pos, @table, @rowKey, @op,
                 JSON(@backfillingColumnVersions))
         ON CONFLICT ("table", rowKey) DO UPDATE 
                    SET stateVersion = excluded.stateVersion,
@@ -160,7 +167,7 @@ export class ChangeLog {
 
     // oxlint-disable-next-line zero/no-select-star -- Local SQLite replica query; not run through pg prepared statements.
     this.#getRowOpStmt = db.prepare(/*sql*/ `
-      SELECT * FROM "_zero.changeLog2" WHERE "table" = ? AND "rowKey" = JSON(?)
+      SELECT * FROM "_zero.changeLog2" WHERE "table" = ? AND "rowKey" = ?
     `);
   }
 
@@ -183,6 +190,42 @@ export class ChangeLog {
     backfilled: string[] | undefined,
   ): string {
     return this.#logRowOp(version, pos, table, row, SET_OP, backfilled);
+  }
+
+  logSetOps(version: LexiVersion, entries: readonly BatchRowOp[]) {
+    if (entries.length === 0) {
+      return;
+    }
+    if (entries.length === 1) {
+      const {pos, table, rowKey} = entries[0];
+      this.#logRowOpStmt.run({version, pos, table, rowKey, op: SET_OP});
+      return;
+    }
+
+    let stmt = this.#logSetOpsStmts.get(entries.length);
+    if (!stmt) {
+      // Each dirty row contributes one VALUES tuple, so the batch length changes
+      // the SQL shape. Cache by length to keep repeated row-heavy batches cheap.
+      stmt = this.#db.prepare(/*sql*/ `
+        INSERT OR REPLACE INTO "_zero.changeLog2"
+          (stateVersion, pos, "table", rowKey, op)
+          VALUES ${Array.from({length: entries.length})
+            .map(() => `(?, ?, ?, ?, '${SET_OP}')`)
+            .join(',')}
+      `);
+      this.#logSetOpsStmts.set(entries.length, stmt);
+    }
+
+    const values = [];
+    values.length = entries.length * 4;
+    let i = 0;
+    for (const {pos, table, rowKey} of entries) {
+      values[i++] = version;
+      values[i++] = pos;
+      values[i++] = table;
+      values[i++] = rowKey;
+    }
+    stmt.run(values);
   }
 
   logDeleteOp(

--- a/packages/zero-cache/src/services/replicator/worker-message-batcher.test.ts
+++ b/packages/zero-cache/src/services/replicator/worker-message-batcher.test.ts
@@ -1,0 +1,86 @@
+import {expect, test, vi} from 'vitest';
+import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
+import {WorkerMessageBatcher} from './worker-message-batcher.ts';
+import type {WriteWorkerClient} from './write-worker-client.ts';
+
+const begin = [
+  'begin',
+  {tag: 'begin'},
+  {commitWatermark: '02'},
+] satisfies ChangeStreamData;
+const row = [
+  'data',
+  {
+    tag: 'insert',
+    relation: {
+      schema: 'public',
+      name: 'issues',
+      rowKey: {columns: ['id']},
+    },
+    new: {id: '1'},
+  },
+] satisfies ChangeStreamData;
+const commit = [
+  'commit',
+  {tag: 'commit'},
+  {watermark: '02'},
+] satisfies ChangeStreamData;
+
+test('batches until transaction boundary', async () => {
+  const {worker, processMessages} = mockWorker();
+  const batcher = new WorkerMessageBatcher(worker, 64);
+
+  expect(batcher.push(begin)).toBeUndefined();
+  expect(batcher.push(row)).toBeUndefined();
+  expect(processMessages).not.toHaveBeenCalled();
+
+  await batcher.push(commit);
+
+  expect(processMessages).toHaveBeenCalledTimes(1);
+  expect(processMessages).toHaveBeenCalledWith([begin, row, commit]);
+  expect(batcher.size).toBe(0);
+});
+
+test('flushes large batches before commit', async () => {
+  const {worker, processMessages} = mockWorker();
+  const batcher = new WorkerMessageBatcher(worker, 2);
+
+  expect(batcher.push(begin)).toBeUndefined();
+  await batcher.push(row);
+
+  expect(processMessages).toHaveBeenCalledTimes(1);
+  expect(processMessages).toHaveBeenCalledWith([begin, row]);
+  expect(batcher.size).toBe(0);
+});
+
+test('can defer commit flush until caller finishes a stream batch', async () => {
+  const {worker, processMessages} = mockWorker();
+  const batcher = new WorkerMessageBatcher(worker, 64, {
+    flushOnCommit: false,
+  });
+
+  expect(batcher.push(begin)).toBeUndefined();
+  expect(batcher.push(row)).toBeUndefined();
+  expect(batcher.push(commit)).toBeUndefined();
+  expect(processMessages).not.toHaveBeenCalled();
+  expect(batcher.size).toBe(3);
+
+  await batcher.flush();
+
+  expect(processMessages).toHaveBeenCalledTimes(1);
+  expect(processMessages).toHaveBeenCalledWith([begin, row, commit]);
+  expect(batcher.size).toBe(0);
+});
+
+function mockWorker() {
+  const processMessages = vi.fn().mockResolvedValue(null);
+  const worker: WriteWorkerClient = {
+    getSubscriptionState: vi.fn(),
+    processMessage: vi.fn(),
+    processMessages,
+    abort: vi.fn(),
+    stop: vi.fn(),
+    onError: vi.fn(),
+  };
+  return {worker, processMessages};
+}

--- a/packages/zero-cache/src/services/replicator/worker-message-batcher.ts
+++ b/packages/zero-cache/src/services/replicator/worker-message-batcher.ts
@@ -1,0 +1,77 @@
+import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
+import type {CommitResult} from './change-processor.ts';
+import type {WriteWorkerClient} from './write-worker-client.ts';
+
+type ProcessMessagesResult = CommitResult | readonly CommitResult[] | null;
+
+type WorkerMessageBatcherOptions = {
+  // Legacy subscribe() delivers one message at a time, so commits still need to
+  // flush immediately to keep replication status and backfill completion moving.
+  // Batched subscribe() preserves RM websocket frames and flushes after the frame.
+  readonly flushOnCommit?: boolean | undefined;
+};
+
+// RM -> VS traffic arrives in ordered stream batches. Grouping write-worker
+// handoff around those batches keeps row-heavy transactions from paying a
+// promise/IPC boundary per row; callers that need per-commit ACKs can leave
+// flushOnCommit enabled.
+export class WorkerMessageBatcher {
+  readonly #worker: WriteWorkerClient;
+  readonly #maxMessages: number;
+  readonly #flushOnCommit: boolean;
+  #messages: ChangeStreamData[] = [];
+
+  constructor(
+    worker: WriteWorkerClient,
+    maxMessages: number,
+    options: WorkerMessageBatcherOptions = {},
+  ) {
+    this.#worker = worker;
+    this.#maxMessages = maxMessages;
+    this.#flushOnCommit = options.flushOnCommit ?? true;
+  }
+
+  get size() {
+    return this.#messages.length;
+  }
+
+  push(message: ChangeStreamData): Promise<ProcessMessagesResult> | undefined {
+    this.#messages.push(message);
+    return this.#shouldFlush(message) ? this.flush() : undefined;
+  }
+
+  flush(): Promise<ProcessMessagesResult> | undefined {
+    if (this.#messages.length === 0) {
+      return undefined;
+    }
+    const messages = this.#messages;
+    this.#messages = [];
+    return this.#worker.processMessages(messages);
+  }
+
+  clear() {
+    this.#messages = [];
+  }
+
+  #shouldFlush(message: ChangeStreamData) {
+    const tag = message[0];
+    if (this.#flushOnCommit && tag === 'commit') {
+      // A commit is the first point where the write worker can return a durable
+      // watermark, schema-update, or backfill-complete result. Callers on the
+      // one-message-at-a-time path must see that result before later stream work.
+      return true;
+    }
+    if (tag === 'rollback') {
+      // Rollback terminates the current upstream transaction without a commit
+      // result. Flushing here keeps rolled-back rows from sharing a worker call
+      // with the next transaction, which preserves the stream's transaction shape.
+      return true;
+    }
+    if (this.#messages.length >= this.#maxMessages) {
+      // The batcher is meant to remove per-row worker calls, not to become an
+      // unbounded in-memory queue if a very large transaction arrives.
+      return true;
+    }
+    return false;
+  }
+}

--- a/packages/zero-cache/src/services/replicator/write-worker-client.ts
+++ b/packages/zero-cache/src/services/replicator/write-worker-client.ts
@@ -11,6 +11,7 @@ import type {SubscriptionState} from './schema/replication-state.ts';
 export type PragmaConfig = {
   busyTimeout: number;
   analysisLimit: number;
+  synchronous?: 'OFF' | 'NORMAL' | 'FULL' | undefined;
   walAutocheckpoint?: number | undefined;
 };
 
@@ -22,6 +23,9 @@ type ErrorHandler = (err: Error) => void;
 export interface WriteWorkerClient {
   getSubscriptionState(): Promise<SubscriptionState>;
   processMessage(downstream: ChangeStreamData): Promise<CommitResult | null>;
+  processMessages(
+    downstreams: readonly ChangeStreamData[],
+  ): Promise<CommitResult | readonly CommitResult[] | null>;
   abort(): void;
   stop(): Promise<void>;
   onError(handler: ErrorHandler): void;
@@ -32,6 +36,7 @@ export type ArgsMap = {
   init: [string, ChangeProcessorMode, PragmaConfig, LogConfig];
   getSubscriptionState: [];
   processMessage: [ChangeStreamData];
+  processMessages: [readonly ChangeStreamData[]];
   abort: [];
   stop: [];
 };
@@ -44,6 +49,7 @@ export type ResultMap = {
   init: void;
   getSubscriptionState: SubscriptionState;
   processMessage: CommitResult | null;
+  processMessages: CommitResult | readonly CommitResult[] | null;
   abort: void;
   stop: void;
 };
@@ -57,6 +63,9 @@ export type WriteError = {writeError: Error};
 export function applyPragmas(db: Database, pragmas: PragmaConfig) {
   db.pragma(`busy_timeout = ${pragmas.busyTimeout}`);
   db.pragma(`analysis_limit = ${pragmas.analysisLimit}`);
+  if (pragmas.synchronous !== undefined) {
+    db.pragma(`synchronous = ${pragmas.synchronous}`);
+  }
   if (pragmas.walAutocheckpoint !== undefined) {
     db.pragma(`wal_autocheckpoint = ${pragmas.walAutocheckpoint}`);
   }
@@ -89,9 +98,7 @@ export class ThreadWriteWorkerClient implements WriteWorkerClient {
       if (!r) return; // stale abort response
       this.#pending = null;
       if (msg.error !== undefined) {
-        r.reject(
-          msg.error instanceof Error ? msg.error : new Error(String(msg.error)),
-        );
+        r.reject(ensureError(msg.error));
       } else {
         r.resolve(msg.result);
       }
@@ -145,6 +152,12 @@ export class ThreadWriteWorkerClient implements WriteWorkerClient {
     return this.#call('processMessage', [downstream]);
   }
 
+  processMessages(
+    downstreams: readonly ChangeStreamData[],
+  ): Promise<CommitResult | readonly CommitResult[] | null> {
+    return this.#call('processMessages', [downstreams]);
+  }
+
   abort(): void {
     if (!this.#terminated) {
       this.#worker.postMessage({method: 'abort', args: []} satisfies Request);
@@ -161,4 +174,14 @@ export class ThreadWriteWorkerClient implements WriteWorkerClient {
   onError(handler: ErrorHandler): void {
     this.#errorHandler = handler;
   }
+}
+
+function ensureError(err: unknown): Error {
+  if (err instanceof Error) {
+    return err;
+  }
+  if (typeof err === 'string') {
+    return new Error(err);
+  }
+  return new Error(JSON.stringify(err));
 }

--- a/packages/zero-cache/src/services/replicator/write-worker.test.ts
+++ b/packages/zero-cache/src/services/replicator/write-worker.test.ts
@@ -97,6 +97,74 @@ describe('write-worker', () => {
     expect(state.watermark).toBe('06');
   });
 
+  test('processMessages handles a full transaction batch', async () => {
+    const issues = new ReplicationMessages({issues: ['issueID', 'bool']});
+
+    const messages: ChangeStreamData[] = [
+      ['begin', issues.begin(), {commitWatermark: '06'}],
+      ['data', issues.insert('issues', {issueID: 123, bool: true})],
+      ['data', issues.insert('issues', {issueID: 456, bool: false})],
+      ['commit', issues.commit(), {watermark: '06'}],
+    ];
+
+    await expect(worker.processMessages(messages)).resolves.toEqual({
+      watermark: '06',
+      completedBackfill: undefined,
+      schemaUpdated: false,
+      changeLogUpdated: true,
+    });
+
+    const rows = mainDb
+      .prepare('SELECT issueID, bool, _0_version FROM issues ORDER BY issueID')
+      .all();
+    expect(rows).toEqual([
+      {issueID: 123, bool: 1, _0_version: '06'},
+      {issueID: 456, bool: 0, _0_version: '06'},
+    ]);
+
+    const state = await worker.getSubscriptionState();
+    expect(state.watermark).toBe('06');
+  });
+
+  test('processMessages returns every committed transaction in a batch', async () => {
+    const issues = new ReplicationMessages({issues: ['issueID', 'bool']});
+
+    const messages: ChangeStreamData[] = [
+      ['begin', issues.begin(), {commitWatermark: '06'}],
+      ['data', issues.insert('issues', {issueID: 123, bool: true})],
+      ['commit', issues.commit(), {watermark: '06'}],
+      ['begin', issues.begin(), {commitWatermark: '07'}],
+      ['data', issues.insert('issues', {issueID: 456, bool: false})],
+      ['commit', issues.commit(), {watermark: '07'}],
+    ];
+
+    await expect(worker.processMessages(messages)).resolves.toEqual([
+      {
+        watermark: '06',
+        completedBackfill: undefined,
+        schemaUpdated: false,
+        changeLogUpdated: true,
+      },
+      {
+        watermark: '07',
+        completedBackfill: undefined,
+        schemaUpdated: false,
+        changeLogUpdated: true,
+      },
+    ]);
+
+    const rows = mainDb
+      .prepare('SELECT issueID, bool, _0_version FROM issues ORDER BY issueID')
+      .all();
+    expect(rows).toEqual([
+      {issueID: 123, bool: 1, _0_version: '06'},
+      {issueID: 456, bool: 0, _0_version: '07'},
+    ]);
+
+    const state = await worker.getSubscriptionState();
+    expect(state.watermark).toBe('07');
+  });
+
   test('abort rolls back pending transaction', async () => {
     const issues = new ReplicationMessages({issues: ['issueID', 'bool']});
 
@@ -134,7 +202,7 @@ describe('write-worker', () => {
   });
 
   test('stop shuts down cleanly', async () => {
-    await worker.stop();
+    await expect(worker.stop()).resolves.toBeUndefined();
     // Create a new worker for afterEach cleanup
     worker = new ThreadWriteWorkerClient();
     await worker.init(
@@ -172,7 +240,7 @@ describe('write-worker', () => {
           new: {id: [1, 'int4']},
         },
       ]),
-    ).rejects.toThrow();
+    ).rejects.toThrow(/Received message outside of transaction/);
 
     expect(errorReceived).toBeDefined();
   });

--- a/packages/zero-cache/src/services/replicator/write-worker.ts
+++ b/packages/zero-cache/src/services/replicator/write-worker.ts
@@ -65,6 +65,10 @@ function createAPI(): API {
       return must(processor).processMessage(must(lc), downstream);
     },
 
+    processMessages(downstreams: readonly ChangeStreamData[]) {
+      return must(processor).processMessages(must(lc), downstreams);
+    },
+
     abort() {
       must(processor).abort(must(lc));
       createProcessor();

--- a/packages/zero-cache/src/types/lite.test.ts
+++ b/packages/zero-cache/src/types/lite.test.ts
@@ -204,6 +204,9 @@ describe('types/lite', () => {
     ['bytea', Buffer.from('hello world'), Buffer.from('hello world')],
     ['json', {custom: {json: 'object'}}, '{"custom":{"json":"object"}}'],
     ['jsonb', [1, 2], '[1,2]'],
+    ['JSON|NOT_NULL', {upper: true}, '{"upper":true}'],
+    ['JSONB|NOT_NULL', true, 'true'],
+    ['jsonpath', true, 1],
     ['json', ['two', 'three'], '["two","three"]'],
     ['json', [null, null], '[null,null]'],
     [
@@ -213,6 +216,8 @@ describe('types/lite', () => {
     ],
     ['float[]', [123.456, 987.654], '[123.456,987.654]'],
     ['bool[]', [true, false], '[true,false]'],
+    ['int|TEXT_ARRAY', [1, 2], '[1,2]'],
+    ['varchar[]|NOT_NULL', ['a', 'b'], '["a","b"]'],
     [
       'json',
       [{custom: {json: 'object'}}, {another: {json: 'object'}}],

--- a/packages/zero-cache/src/types/lite.ts
+++ b/packages/zero-cache/src/types/lite.ts
@@ -78,8 +78,7 @@ export function liteValue(
   if (val instanceof Uint8Array || val === null) {
     return val;
   }
-  const valueType = liteTypeToZqlValueType(pgType);
-  if (valueType === 'json') {
+  if (shouldStoreAsJson(pgType)) {
     if (jsonFormat === JSON_STRINGIFIED && typeof val === 'string') {
       // JSON and JSONB values are already strings if the JSON was not parsed.
       return val;
@@ -87,9 +86,47 @@ export function liteValue(
     // Non-JSON/JSONB values will always appear as objects / arrays.
     return stringify(val);
   }
+  if (typeof val === 'boolean') {
+    return val ? 1 : 0;
+  }
+  if (
+    typeof val === 'string' ||
+    typeof val === 'number' ||
+    typeof val === 'bigint'
+  ) {
+    return val;
+  }
   const obj = toLiteValue(val);
   return obj && typeof obj === 'object' ? stringify(obj) : obj;
 }
+
+function shouldStoreAsJson(liteTypeString: string) {
+  // Row-heavy serving apply calls liteValue for every column. Most columns are
+  // scalar non-JSON, so the first-character check lets them skip delimiter
+  // parsing and lowercasing. The slower array-marker checks stay last because
+  // array columns are uncommon but still stored as JSON text in SQLite.
+  const first = liteTypeString.charCodeAt(0);
+  if (first === JSON_TYPE_PREFIX_LOWER || first === JSON_TYPE_PREFIX_UPPER) {
+    // Lite type strings append Zero attributes after "|"; only the upstream
+    // type before that delimiter decides whether json/jsonb is stored as text.
+    const delim = liteTypeString.indexOf('|');
+    const upstream =
+      delim > 0 ? liteTypeString.substring(0, delim) : liteTypeString;
+    const lower = upstream.toLowerCase();
+    if (lower === 'json' || lower === 'jsonb') {
+      return true;
+    }
+  }
+  return (
+    liteTypeString.includes(TEXT_ARRAY_ATTRIBUTE) ||
+    liteTypeString.includes('[]')
+  );
+}
+
+// Named constants keep the branch above readable without putting string
+// allocation or toLowerCase() on the common scalar path.
+const JSON_TYPE_PREFIX_LOWER = 'j'.charCodeAt(0);
+const JSON_TYPE_PREFIX_UPPER = 'J'.charCodeAt(0);
 
 function toLiteValue(val: JSONValue): Exclude<JSONValue, boolean> {
   switch (typeof val) {

--- a/packages/zero-cache/src/types/streams.test.ts
+++ b/packages/zero-cache/src/types/streams.test.ts
@@ -6,6 +6,7 @@ import Fastify, {type FastifyInstance} from 'fastify';
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import WebSocket from 'ws';
 import {unreachable} from '../../../shared/src/asserts.ts';
+import type {JSONValue} from '../../../shared/src/bigint-json.ts';
 import {
   createSilentLogContext,
   TestLogSink,
@@ -17,10 +18,13 @@ import * as v from '../../../shared/src/valita.ts';
 import {
   stream,
   streamIn,
+  streamInBatches,
   streamOut,
   streamOutStringified,
+  type StreamInPayload,
   type Sink,
   type Source,
+  type StringifiedStreamPayload,
 } from './streams.ts';
 import {Subscription, type Result} from './subscription.ts';
 
@@ -215,10 +219,12 @@ describe('streams with internal acks', () => {
 
   let server: FastifyInstance;
   let producer: Subscription<Message>;
-  let stringifiedProducer: Subscription<string>;
+  let stringifiedProducer: Subscription<StringifiedStreamPayload>;
   let consumed: Queue<Message>;
   let cleanedUp: Promise<Message[]>;
   let cleanup: (m: Message[]) => void;
+  let ackMessages: number[];
+  let streamBatchMessages: number;
   let port: number;
 
   let ws: WebSocket;
@@ -231,6 +237,8 @@ describe('streams with internal acks', () => {
     cleanup = resolve;
 
     consumed = new Queue();
+    ackMessages = [];
+    streamBatchMessages = 1;
     producer = Subscription.create({
       consumed: m => consumed.enqueue(m),
       cleanup: resolve,
@@ -240,8 +248,23 @@ describe('streams with internal acks', () => {
     server = Fastify();
     await server.register(websocket);
     server.get('/', {websocket: true}, ws => {
-      void streamOut(lc, producer, ws);
-      void streamOutStringified(lc, stringifiedProducer, ws);
+      ws.on('message', data => {
+        const text = data.toString();
+        if (!text.startsWith('{"ack":')) {
+          return;
+        }
+        const {ack} = JSON.parse(text) as {ack?: unknown};
+        if (typeof ack === 'number') {
+          ackMessages.push(ack);
+        }
+      });
+      const batchOptions =
+        streamBatchMessages > 1
+          ? {maxMessages: streamBatchMessages}
+          : undefined;
+      const streamOptions = {batch: batchOptions};
+      void streamOut(lc, producer, ws, streamOptions);
+      void streamOutStringified(lc, stringifiedProducer, ws, streamOptions);
     });
 
     // Run the server for real instead of using `injectWS()`, as that has a
@@ -265,6 +288,16 @@ describe('streams with internal acks', () => {
         ws,
         messageSchema,
       )) as Subscription<Message>,
+    };
+  }
+
+  async function startBatchReceiver() {
+    ws = new WebSocket(`http://localhost:${port}/`);
+    return {
+      ws,
+      consumer: (await streamInBatches(lc, ws, messageSchema)) as Subscription<
+        StreamInPayload<Message>
+      >,
     };
   }
 
@@ -346,6 +379,147 @@ describe('streams with internal acks', () => {
       'consumed',
       'consumed',
     ]);
+  });
+
+  test('pipelined stream uses per-message acks', async () => {
+    const messageCount = 96;
+    const results: Promise<Result>[] = [];
+    for (let i = 0; i < messageCount; i++) {
+      results.push(producer.push({from: i, to: i + 1, str: `msg-${i}`}).result);
+    }
+
+    const {consumer} = await startReceiver();
+    await vi.waitFor(() => expect(consumer.queued).toBe(messageCount));
+
+    const entries = await drainPipeline(messageCount, consumer);
+    for (const {consumed} of entries) {
+      consumed();
+    }
+
+    expect(await Promise.all(results)).toEqual(
+      Array<Result>(messageCount).fill('consumed'),
+    );
+    expect(ackMessages).toEqual(
+      Array.from({length: messageCount}, (_, i) => i + 1),
+    );
+    consumer.cancel();
+    expect(await cleanedUp).toEqual([]);
+  });
+
+  test('pipelined outbound stream batches queued messages', async () => {
+    streamBatchMessages = 4;
+    const messageCount = 10;
+    for (let i = 0; i < messageCount; i++) {
+      producer.push({from: i, to: i + 1, str: `msg-${i}`});
+    }
+
+    const {consumer} = await startReceiver();
+    await vi.waitFor(() => expect(consumer.queued).toBe(messageCount));
+
+    const received: Message[] = [];
+    for await (const msg of consumer) {
+      received.push(msg);
+      if (received.length === messageCount) {
+        break;
+      }
+    }
+
+    expect(received).toEqual(
+      Array.from({length: messageCount}, (_, i) => ({
+        from: i,
+        to: i + 1,
+        str: `msg-${i}`,
+      })),
+    );
+    expect(await cleanedUp).toEqual([]);
+  });
+
+  test('pipelined outbound stream uses batch frames', async () => {
+    streamBatchMessages = 4;
+    const received: JSONValue[] = [];
+    const messageCount = 10;
+
+    ws = new WebSocket(`http://localhost:${port}/`);
+    ws.on('message', data =>
+      received.push(JSON.parse(data.toString()) as JSONValue),
+    );
+
+    for (let i = 0; i < messageCount; i++) {
+      producer.push({from: i, to: i + 1, str: `msg-${i}`});
+    }
+
+    await vi.waitFor(() => expect(received).toHaveLength(3));
+    expect(received).toMatchObject([
+      {batch: [{id: 1}, {id: 2}, {id: 3}, {id: 4}]},
+      {batch: [{id: 5}, {id: 6}, {id: 7}, {id: 8}]},
+      {batch: [{id: 9}, {id: 10}]},
+    ]);
+    ws.close();
+  });
+
+  test('streamInBatches preserves received batch frames', async () => {
+    streamBatchMessages = 4;
+    const messageCount = 6;
+    for (let i = 0; i < messageCount; i++) {
+      producer.push({from: i, to: i + 1, str: `msg-${i}`});
+    }
+
+    const {consumer} = await startBatchReceiver();
+
+    const received: StreamInPayload<Message>[] = [];
+    for await (const payload of consumer) {
+      received.push(payload);
+      if (
+        received.reduce(
+          (sum, payload) =>
+            sum + ('messages' in payload ? payload.messages.length : 1),
+          0,
+        ) === messageCount
+      ) {
+        break;
+      }
+    }
+
+    expect(received).toEqual([
+      {
+        tag: 'stream-batch',
+        messages: [
+          {from: 0, to: 1, str: 'msg-0'},
+          {from: 1, to: 2, str: 'msg-1'},
+          {from: 2, to: 3, str: 'msg-2'},
+          {from: 3, to: 4, str: 'msg-3'},
+        ],
+      },
+      {
+        tag: 'stream-batch',
+        messages: [
+          {from: 4, to: 5, str: 'msg-4'},
+          {from: 5, to: 6, str: 'msg-5'},
+        ],
+      },
+    ]);
+    await vi.waitFor(() => expect(ackMessages).toEqual([1, 2, 3, 4, 5, 6]));
+    expect(await cleanedUp).toEqual([]);
+  });
+
+  test('pipelined unexpected ack closes connection', async () => {
+    const received: JSONValue[] = [];
+    const closed = resolver<void>();
+    const results: Promise<Result>[] = [];
+
+    ws = new WebSocket(`http://localhost:${port}/`);
+    ws.on('message', data =>
+      received.push(JSON.parse(data.toString()) as JSONValue),
+    );
+    ws.on('close', () => closed.resolve());
+
+    results.push(producer.push({from: 0, to: 1, str: 'foo'}).result);
+    results.push(producer.push({from: 1, to: 2, str: 'bar'}).result);
+
+    await vi.waitFor(() => expect(received).toHaveLength(2));
+    ws.send(JSON.stringify({ack: 2}));
+    await closed.promise;
+    expect(await Promise.all(results)).toEqual(['unconsumed', 'unconsumed']);
   });
 
   test('pipelined (unconsumed)', async () => {
@@ -462,6 +636,28 @@ describe('streams with internal acks', () => {
     return drained;
   }
 
+  async function drainPipeline(
+    num: number,
+    consumer: Source<Message>,
+  ): Promise<{value: Message; consumed: () => void}[]> {
+    const {pipeline} = consumer;
+    expect(pipeline).not.toBeUndefined();
+    if (!pipeline) {
+      unreachable();
+    }
+    const iterator = pipeline[Symbol.asyncIterator]();
+    const drained: {value: Message; consumed: () => void}[] = [];
+    for (let i = 0; i < num; i++) {
+      const result = await iterator.next();
+      expect(result.done).not.toBe(true);
+      if (result.done) {
+        unreachable();
+      }
+      drained.push(result.value);
+    }
+    return drained;
+  }
+
   test('passthrough', async () => {
     producer.push({from: 1, to: 2, str: 'foo', extra: 'bar'} as Message);
 
@@ -478,6 +674,24 @@ describe('streams with internal acks', () => {
     expect(await drain(1, consumer)).toEqual([
       {from: 1, to: 2, str: 'foo', extra: 'bar'},
     ]);
+  });
+
+  test('stringified source flattens internal message batches', async () => {
+    const results = [
+      stringifiedProducer.push('{"from":1,"to":2,"str":"one"}').result,
+      stringifiedProducer.push([
+        '{"from":2,"to":3,"str":"two"}',
+        '{"from":3,"to":4,"str":"three"}',
+      ]).result,
+    ];
+
+    const {consumer} = await startReceiver();
+    expect(await drain(3, consumer)).toEqual([
+      {from: 1, to: 2, str: 'one'},
+      {from: 2, to: 3, str: 'two'},
+      {from: 3, to: 4, str: 'three'},
+    ]);
+    expect(await Promise.all(results)).toEqual(['consumed', 'consumed']);
   });
 
   test('bigints', async () => {

--- a/packages/zero-cache/src/types/streams.ts
+++ b/packages/zero-cache/src/types/streams.ts
@@ -16,6 +16,7 @@ import {
 } from 'ws';
 import {assert} from '../../../shared/src/asserts.ts';
 import {BigIntJSON, type JSONValue} from '../../../shared/src/bigint-json.ts';
+import {HeadIndexedQueue} from '../../../shared/src/head-indexed-queue.ts';
 import {Queue} from '../../../shared/src/queue.ts';
 import * as v from '../../../shared/src/valita.ts';
 import {Subscription, type Options} from './subscription.ts';
@@ -56,6 +57,24 @@ export type Source<T> = AsyncIterable<T> & {
 export type Sink<T> = {
   push(message: T): void;
 };
+
+export type StreamBatch<T> = {
+  readonly tag: 'stream-batch';
+  readonly messages: readonly T[];
+};
+
+export type StreamInPayload<T> = T | StreamBatch<T>;
+
+export function isStreamBatch<T>(
+  payload: StreamInPayload<T>,
+): payload is StreamBatch<T> {
+  return (
+    typeof payload === 'object' &&
+    payload !== null &&
+    !Array.isArray(payload) &&
+    (payload as {readonly tag?: unknown}).tag === 'stream-batch'
+  );
+}
 
 /**
  * Back-pressure-aware transformation of a WebSocket into
@@ -155,7 +174,7 @@ type PipeOptions<T> = {
 export function pipe<T>({source, sink, parse, bufferMessages}: PipeOptions<T>) {
   bufferMessages ??= 0;
   assert(bufferMessages >= 0, 'bufferMessages must be non-negative');
-  const pending: Promise<unknown>[] = [];
+  const pending = new HeadIndexedQueue<Promise<unknown>>();
 
   pipeline(
     source,
@@ -181,12 +200,14 @@ export function pipe<T>({source, sink, parse, bufferMessages}: PipeOptions<T>) {
         pending.push(result);
         void result.then(() => pending.shift());
 
-        if (pending.length <= bufferMessages) {
+        if (pending.size <= bufferMessages) {
           // immediately allow more messages
           callback();
         } else {
           // wait for the oldest result in the pending queue
-          pending[0].then(
+          const oldest = pending.peek();
+          assert(oldest !== undefined, 'pending result expected');
+          oldest.then(
             () => callback(),
             err => callback(ensureError(err)),
           );
@@ -212,9 +233,22 @@ function ensureError(err: unknown) {
   return err instanceof Error ? err : new Error(String(err));
 }
 
-const ackSchema = v.object({ack: v.number()});
+type Ack = {ack: number};
 
-type Ack = v.Infer<typeof ackSchema>;
+function parseAck(data: unknown): Ack {
+  if (typeof data !== 'string') {
+    throw new Error('Expected string message');
+  }
+  const ack = JSON.parse(data) as {ack?: unknown};
+  if (
+    typeof ack.ack !== 'number' ||
+    !Number.isSafeInteger(ack.ack) ||
+    ack.ack < 0
+  ) {
+    throw new Error(`Invalid ack ${String(ack.ack)}`);
+  }
+  return {ack: ack.ack};
+}
 
 type Streamed<T> = {
   /** Application-level message. */
@@ -224,12 +258,22 @@ type Streamed<T> = {
   id: number;
 };
 
+export type StringifiedStreamPayload = string | readonly string[];
+
 export function streamOut<T extends JSONValue>(
   lc: LogContext,
   source: Source<T>,
   sink: WebSocket,
+  options: StreamOutOptions = {},
 ): Promise<void> {
-  return streamOutInternal(lc, source, sink, BigIntJSON.stringify);
+  return streamOutInternal<T, T>(
+    lc,
+    source,
+    sink,
+    BigIntJSON.stringify,
+    payload => [payload],
+    options,
+  );
 }
 
 /**
@@ -237,29 +281,39 @@ export function streamOut<T extends JSONValue>(
  */
 export function streamOutStringified(
   lc: LogContext,
-  source: Source<string>,
+  source: Source<StringifiedStreamPayload>,
   sink: WebSocket,
+  options: StreamOutOptions = {},
 ): Promise<void> {
-  return streamOutInternal(lc, source, sink, json => json);
+  return streamOutInternal<StringifiedStreamPayload, string>(
+    lc,
+    source,
+    sink,
+    json => json,
+    payload => (typeof payload === 'string' ? [payload] : payload),
+    options,
+  );
 }
 
-async function streamOutInternal<T extends JSONValue>(
+type StreamOutOptions = {
+  batch?: {maxMessages?: number | undefined} | undefined;
+};
+
+async function streamOutInternal<TPayload, TMessage extends JSONValue>(
   lc: LogContext,
-  source: Source<T>,
+  source: Source<TPayload>,
   sink: WebSocket,
-  stringify: (payload: T) => string,
+  stringify: (payload: TMessage) => string,
+  expandPayload: (payload: TPayload) => readonly TMessage[],
+  options: StreamOutOptions,
 ): Promise<void> {
   sendPingsForLiveness(lc, sink, PING_INTERVAL_MS);
 
   const closer = WebSocketCloser.forSource(lc, sink, source);
-
   const acks = new Queue<Ack>();
   sink.addEventListener('message', ({data}) => {
     try {
-      if (typeof data !== 'string') {
-        throw new Error('Expected string message');
-      }
-      acks.enqueue(v.parse(JSON.parse(data), ackSchema));
+      acks.enqueue(parseAck(data));
     } catch (e) {
       lc.error?.(`error parsing ack`, e);
       closer.close(e);
@@ -270,35 +324,91 @@ async function streamOutInternal<T extends JSONValue>(
     let nextID = 0;
     const {pipeline} = source;
     if (pipeline) {
+      const iterator = pipeline[Symbol.asyncIterator]();
+      const maxBatchMessages = Math.max(1, options.batch?.maxMessages ?? 1);
+
       lc.debug?.(`started pipelined outbound stream`);
-      for await (const {value: msg, consumed} of pipeline) {
-        const id = ++nextID;
-        const data = `{"id":${id},"msg":${stringify(msg)}}`;
+      for (;;) {
+        const next = await iterator.next();
+        if (next.done) {
+          break;
+        }
+        const batch = [next.value];
+        while (
+          batch.length < maxBatchMessages &&
+          source instanceof Subscription &&
+          source.queued > 0
+        ) {
+          // Only drain work that is already queued. Waiting for future messages
+          // just to fill a websocket frame would add latency to quiet streams
+          // and status/error delivery.
+          const queued = await iterator.next();
+          if (queued.done) {
+            break;
+          }
+          batch.push(queued.value);
+        }
+        const outbound = [];
+        for (const {value, consumed} of batch) {
+          const messages = expandPayload(value);
+          if (messages.length === 0) {
+            consumed();
+            continue;
+          }
+          let remaining = messages.length;
+          const consumeOne = () => {
+            remaining--;
+            if (remaining === 0) {
+              // A single source payload can expand to several websocket IDs.
+              // The source is consumed only after all IDs are ACKed.
+              consumed();
+            }
+          };
+          for (const msg of messages) {
+            const id = ++nextID;
+            outbound.push({id, msg});
+            void (async () => {
+              const {ack} = await acks.dequeue();
+              // lc.debug?.(`received ack`, ack);
+              if (ack !== id) {
+                throw new Error(`Unexpected ack for ${id}: ${ack}`);
+              }
+              consumeOne();
+            })().catch(e => {
+              lc.error?.(`error handling ack`, e);
+              closer.close(e);
+            });
+          }
+        }
+        if (outbound.length === 0) {
+          continue;
+        }
+        const data = stringifyOutboundBatch(outbound, stringify);
         // Enable for debugging. Otherwise too verbose.
         // lc.debug?.(`pipelining`, data);
         sink.send(data);
-
-        void (async () => {
-          const {ack} = await acks.dequeue();
-          // lc.debug?.(`received ack`, ack);
-          if (ack !== id) {
-            throw new Error(`Unexpected ack for ${id}: ${ack}`);
-          }
-          consumed();
-        })();
       }
     } else {
       lc.debug?.(`started synchronous outbound stream`);
-      for await (const msg of source) {
-        const id = ++nextID;
-        const data = `{"id":${id},"msg":${stringify(msg)}}`;
+      for await (const payload of source) {
+        const messages = expandPayload(payload);
+        if (messages.length === 0) {
+          continue;
+        }
+        const outbound = messages.map(msg => ({
+          id: ++nextID,
+          msg,
+        }));
+        const data = stringifyOutboundBatch(outbound, stringify);
         // Enable for debugging. Otherwise too verbose.
         // lc.debug?.(`sending`, data);
         sink.send(data);
 
-        const {ack} = await acks.dequeue();
-        if (ack !== id) {
-          throw new Error(`Unexpected ack for ${id}: ${ack}`);
+        for (const {id} of outbound) {
+          const {ack} = await acks.dequeue();
+          if (ack !== id) {
+            throw new Error(`Unexpected ack for ${id}: ${ack}`);
+          }
         }
       }
     }
@@ -308,11 +418,50 @@ async function streamOutInternal<T extends JSONValue>(
   }
 }
 
-export async function streamIn<T extends JSONValue>(
+function stringifyOutboundBatch<T extends JSONValue>(
+  batch: readonly {readonly id: number; readonly msg: T}[],
+  stringify: (payload: T) => string,
+) {
+  if (batch.length === 1) {
+    const [{id, msg}] = batch;
+    return `{"id":${id},"msg":${stringify(msg)}}`;
+  }
+  // RM -> VS catchup emits large websocket batches. Building the frame in one
+  // loop avoids the extra strings and array that `map().join()` creates in the
+  // hottest fanout path.
+  let data = '{"batch":[';
+  for (let i = 0; i < batch.length; i++) {
+    if (i > 0) {
+      data += ',';
+    }
+    const {id, msg} = batch[i];
+    data += `{"id":${id},"msg":${stringify(msg)}}`;
+  }
+  return `${data}]}`;
+}
+
+export function streamIn<T extends JSONValue>(
   lc: LogContext,
   source: WebSocket,
   schema: v.Type<T>,
 ): Promise<Source<T>> {
+  return streamInInternal(lc, source, schema, false) as Promise<Source<T>>;
+}
+
+export function streamInBatches<T extends JSONValue>(
+  lc: LogContext,
+  source: WebSocket,
+  schema: v.Type<T>,
+): Promise<Source<StreamInPayload<T>>> {
+  return streamInInternal(lc, source, schema, true);
+}
+
+async function streamInInternal<T extends JSONValue>(
+  lc: LogContext,
+  source: WebSocket,
+  schema: v.Type<T>,
+  preserveBatches: boolean,
+): Promise<Source<StreamInPayload<T>>> {
   expectPingsForLiveness(lc, source, PING_INTERVAL_MS);
 
   const streamedSchema = v.object({
@@ -320,28 +469,53 @@ export async function streamIn<T extends JSONValue>(
     id: v.number(),
   });
 
-  const sink: Subscription<T, Streamed<T>> = new Subscription<T, Streamed<T>>(
+  const sink: Subscription<
+    StreamInPayload<T>,
+    Streamed<T> | readonly Streamed<T>[]
+  > = new Subscription(
     {
-      consumed: ({id}) => source.send(JSON.stringify({ack: id} satisfies Ack)),
+      consumed: streamOrBatch => {
+        if (isStreamedBatch(streamOrBatch)) {
+          for (const {id} of streamOrBatch) {
+            source.send(JSON.stringify({ack: id} satisfies Ack));
+          }
+        } else {
+          source.send(JSON.stringify({ack: streamOrBatch.id} satisfies Ack));
+        }
+      },
       cleanup: () => closer.close(),
     },
-    ({msg}) => msg,
+    streamOrBatch =>
+      isStreamedBatch(streamOrBatch)
+        ? {
+            tag: 'stream-batch',
+            messages: streamOrBatch.map(({msg}) => msg),
+          }
+        : streamOrBatch.msg,
   );
 
   const closer = WebSocketCloser.forSink(lc, source, sink, handleMessage);
 
   function handleMessage(event: MessageEvent) {
-    const data = event.data.toString();
+    const data = webSocketMessageDataToString(event.data);
     if (!sink.active) {
       lc.warn?.('dropping ws message received after close', data);
       return;
     }
     try {
       const value = BigIntJSON.parse(data);
-      const msg = v.parse(value, streamedSchema, 'passthrough');
-      // Enable for debugging. Otherwise too verbose.
-      // lc.debug?.(`received`, data);
-      sink.push(msg);
+      const messages = parseStreamedMessages(value, streamedSchema);
+      if (preserveBatches && messages.length > 1) {
+        // The RM already grouped these messages into one websocket frame. Keep
+        // that boundary visible so the VS can batch one write-worker apply.
+        sink.push(messages);
+        return;
+      }
+      for (const msg of messages) {
+        // Enable for debugging. Otherwise too verbose.
+        // lc.debug?.(`received`, data);
+        sink.push(msg);
+      }
     } catch (e) {
       closer.close(e);
     }
@@ -349,6 +523,51 @@ export async function streamIn<T extends JSONValue>(
 
   await closer.connected;
   return sink;
+}
+
+function webSocketMessageDataToString(data: MessageEvent['data']): string {
+  if (typeof data === 'string') {
+    return data;
+  }
+  if (Buffer.isBuffer(data)) {
+    return data.toString();
+  }
+  if (data instanceof ArrayBuffer) {
+    return Buffer.from(data).toString();
+  }
+  return Buffer.concat(data).toString();
+}
+
+function isStreamedBatch<T>(
+  streamOrBatch: Streamed<T> | readonly Streamed<T>[],
+): streamOrBatch is readonly Streamed<T>[] {
+  return Array.isArray(streamOrBatch);
+}
+
+function parseStreamedMessages<T extends JSONValue>(
+  value: JSONValue,
+  streamedSchema: v.Type<Streamed<T>>,
+): Streamed<T>[] {
+  if (
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.hasOwn(value, 'batch')
+  ) {
+    // A batch frame is a transport optimization only. Validate each child
+    // message against the normal streamed schema before handing it to callers.
+    const batch = (value as {readonly batch?: unknown}).batch;
+    if (!Array.isArray(batch)) {
+      throw new Error('Invalid stream batch');
+    }
+    const messages: Streamed<T>[] = [];
+    messages.length = batch.length;
+    for (let i = 0; i < batch.length; i++) {
+      messages[i] = v.parse(batch[i], streamedSchema, 'passthrough');
+    }
+    return messages;
+  }
+  return [v.parse(value, streamedSchema, 'passthrough')];
 }
 
 class WebSocketCloser {
@@ -368,10 +587,10 @@ class WebSocketCloser {
     return new WebSocketCloser(lc, ws, () => stream.cancel());
   }
 
-  static forSink<T>(
+  static forSink<T, M>(
     lc: LogContext,
     ws: WebSocket,
-    stream: Subscription<T, Streamed<T>>,
+    stream: Subscription<T, M>,
     messageHandler: (e: MessageEvent) => void | undefined,
   ) {
     // If the websocket is closed, call end() to allow the downstream Sink

--- a/packages/zero-cache/src/types/subscription.test.ts
+++ b/packages/zero-cache/src/types/subscription.test.ts
@@ -628,4 +628,79 @@ describe('types/subscription', () => {
     });
     expect(subWithCoalesceAndPipeline.pipeline).not.toBeUndefined();
   });
+
+  test('pipeline cancel cleanup ignores already dequeued head entries', async () => {
+    const consumed: number[] = [];
+    const cleanup = vi.fn();
+    const results: Promise<Result>[] = [];
+
+    const subscription = Subscription.create<number>({
+      cleanup,
+      consumed: m => consumed.push(m),
+    });
+    for (let i = 0; i < 1500; i++) {
+      results.push(subscription.push(i).result);
+    }
+
+    assert(
+      subscription.pipeline,
+      'Expected subscription pipeline to be defined',
+    );
+    const iterator = subscription.pipeline[Symbol.asyncIterator]();
+
+    for (let i = 0; i < 1200; i++) {
+      const next = await iterator.next();
+      assert(!next.done, 'Expected next subscription entry');
+      expect(next.value.value).toBe(i);
+      next.value.consumed();
+      expect(await results[i]).toBe('consumed');
+    }
+
+    const current = await iterator.next();
+    assert(!current.done, 'Expected current subscription entry');
+    expect(current.value.value).toBe(1200);
+    expect(subscription.queued).toBe(299);
+
+    subscription.cancel();
+    expect(await iterator.next()).toEqual({value: undefined, done: true});
+
+    for (let i = 1200; i < 1500; i++) {
+      expect(await results[i]).toBe('unconsumed');
+    }
+    expect(consumed).toEqual(Array.from({length: 1200}, (_, i) => i));
+    expect(cleanup).toBeCalledTimes(1);
+    expect(cleanup.mock.calls[0][0]).toEqual(
+      Array.from({length: 300}, (_, i) => i + 1200),
+    );
+  });
+
+  test('end drains queued messages after head advances', async () => {
+    const consumed: number[] = [];
+    const cleanup = vi.fn();
+    const results: Promise<Result>[] = [];
+
+    const subscription = Subscription.create<number>({
+      cleanup,
+      consumed: m => consumed.push(m),
+    });
+    for (let i = 0; i < 1500; i++) {
+      results.push(subscription.push(i).result);
+    }
+
+    const received: number[] = [];
+    for await (const m of subscription) {
+      received.push(m);
+      if (m === 1199) {
+        subscription.end();
+      }
+    }
+
+    expect(received).toEqual(Array.from({length: 1500}, (_, i) => i));
+    expect(consumed).toEqual(received);
+    expect(cleanup).toBeCalledTimes(1);
+    expect(cleanup.mock.calls[0][0]).toEqual([]);
+    for (const result of results) {
+      expect(await result).toBe('consumed');
+    }
+  });
 });

--- a/packages/zero-cache/src/types/subscription.ts
+++ b/packages/zero-cache/src/types/subscription.ts
@@ -1,5 +1,6 @@
 import {resolver, type Resolver} from '@rocicorp/resolver';
 import {assert} from '../../../shared/src/asserts.ts';
+import {HeadIndexedQueue} from '../../../shared/src/head-indexed-queue.ts';
 import type {Sink, Source} from './streams.ts';
 
 /**
@@ -74,10 +75,8 @@ export class Subscription<T, M = T> implements Source<T>, Sink<M> {
     return new Subscription(options, publish);
   }
 
-  // Consumers waiting to consume messages (i.e. an async iteration awaiting the next message).
-  readonly #consumers: Resolver<Entry<M> | null>[] = [];
-  // Messages waiting to be dequeued.
-  readonly #messages: (Entry<M> | 'terminus')[] = [];
+  readonly #consumers = new HeadIndexedQueue<Resolver<Entry<M> | null>>();
+  readonly #messages = new HeadIndexedQueue<Entry<M> | Terminus>();
   // Messages dequeued but not yet consumed.
   readonly #consuming = new Set<Entry<M>>();
   readonly #pipelineEnabled: boolean;
@@ -156,16 +155,15 @@ export class Subscription<T, M = T> implements Source<T>, Sink<M> {
       consumer.resolve(entry);
     } else if (
       this.#coalesce &&
-      this.#messages.length &&
-      this.#messages.at(-1) !== 'terminus'
+      this.#messages.size > 0 &&
+      this.#messages.last() !== TERMINUS
     ) {
-      // oxlint-disable-next-line typescript/no-non-null-assertion
-      const prev = this.#messages.at(-1)!;
-      assert(prev !== 'terminus', 'prev should not be terminus after check');
-      this.#messages[this.#messages.length - 1] = {
+      const prev = this.#messages.last();
+      assert(prev !== undefined && prev !== TERMINUS, 'expected an entry');
+      this.#messages.replaceLast({
         value: this.#coalesce(entry, prev),
         resolve,
-      };
+      });
     } else {
       this.#messages.push(entry);
     }
@@ -179,7 +177,7 @@ export class Subscription<T, M = T> implements Source<T>, Sink<M> {
 
   /** The number of messages waiting to be dequeued. */
   get queued(): number {
-    return this.#messages.length;
+    return this.#messages.size;
   }
 
   /** The number of messages dequeued but not yet "consumed" */
@@ -202,10 +200,10 @@ export class Subscription<T, M = T> implements Source<T>, Sink<M> {
   end() {
     if (this.#sentinel) {
       // already terminated
-    } else if (this.#messages.length === 0) {
+    } else if (this.#messages.size === 0) {
       this.cancel();
     } else {
-      this.#messages.push('terminus');
+      this.#messages.push(TERMINUS);
     }
   }
 
@@ -230,20 +228,23 @@ export class Subscription<T, M = T> implements Source<T>, Sink<M> {
   #terminate(sentinel: 'canceled' | Error) {
     if (!this.#sentinel) {
       this.#sentinel = sentinel;
+      const pendingMessages = this.#messages.toArray().filter(isEntry);
       this.#cleanup(
-        [...this.#consuming, ...this.#messages.filter(m => m !== 'terminus')],
+        [...this.#consuming, ...pendingMessages],
         sentinel instanceof Error ? sentinel : undefined,
       );
-      this.#messages.splice(0);
+      this.#messages.clear();
 
       for (
         let consumer = this.#consumers.shift();
-        consumer;
+        consumer !== undefined;
         consumer = this.#consumers.shift()
       ) {
-        sentinel === 'canceled'
-          ? consumer.resolve(null)
-          : consumer.reject(sentinel);
+        if (sentinel === 'canceled') {
+          consumer.resolve(null);
+        } else {
+          consumer.reject(sentinel);
+        }
       }
     }
   }
@@ -258,7 +259,7 @@ export class Subscription<T, M = T> implements Source<T>, Sink<M> {
     return {
       next: async () => {
         const entry = this.#messages.shift();
-        if (entry === 'terminus') {
+        if (entry === TERMINUS) {
           this.cancel();
           return {value: undefined, done: true};
         }
@@ -393,3 +394,10 @@ type Entry<M> = {
   readonly value: M;
   readonly resolve: (r: Result) => void;
 };
+
+const TERMINUS = Symbol('terminus');
+type Terminus = typeof TERMINUS;
+
+function isEntry<M>(entry: Entry<M> | Terminus): entry is Entry<M> {
+  return entry !== TERMINUS;
+}

--- a/packages/zero-cache/src/workers/replicator.test.ts
+++ b/packages/zero-cache/src/workers/replicator.test.ts
@@ -5,6 +5,8 @@ import {inProcChannel} from '../types/processes.ts';
 import {Subscription} from '../types/subscription.ts';
 import {
   createNotifierFrom,
+  getPragmaConfig,
+  SERVING_REPLICA_WAL_AUTOCHECKPOINT_PAGES,
   setUpMessageHandlers,
   subscribeTo,
 } from './replicator.ts';
@@ -47,5 +49,18 @@ describe('workers/replicator', () => {
       {state: 'version-ready', testSeqNum: 2},
       {state: 'version-ready', testSeqNum: 3},
     ]);
+  });
+
+  test('replica pragma config keeps serving checkpointing bounded off the hot path', () => {
+    expect(getPragmaConfig('serving').walAutocheckpoint).toBe(
+      SERVING_REPLICA_WAL_AUTOCHECKPOINT_PAGES,
+    );
+    expect(getPragmaConfig('serving-copy').walAutocheckpoint).toBe(
+      SERVING_REPLICA_WAL_AUTOCHECKPOINT_PAGES,
+    );
+
+    // Backup files are checkpointed by litestream; forcing SQLite's automatic
+    // writer-thread checkpoints back on would contend with that owner.
+    expect(getPragmaConfig('backup').walAutocheckpoint).toBe(0);
   });
 });

--- a/packages/zero-cache/src/workers/replicator.ts
+++ b/packages/zero-cache/src/workers/replicator.ts
@@ -1,4 +1,5 @@
 import type {LogContext} from '@rocicorp/logger';
+import {unreachable} from '../../../shared/src/asserts.ts';
 import {sleep} from '../../../shared/src/sleep.ts';
 import * as v from '../../../shared/src/valita.ts';
 import {Database} from '../../../zqlite/src/db.ts';
@@ -37,6 +38,11 @@ export function replicaFileName(replicaFile: string, mode: ReplicaFileMode) {
 
 const MILLIS_PER_HOUR = 1000 * 60 * 60;
 const MB = 1024 * 1024;
+// SQLite's default WAL autocheckpoint is 1,000 pages, about 4 MiB with Zero's
+// normal page size. Serving replicas are write-heavy while catching up under
+// load, so that default can force frequent checkpoint work into the hot apply
+// path. This keeps the same automatic safety valve, just at about 32 MiB.
+export const SERVING_REPLICA_WAL_AUTOCHECKPOINT_PAGES = 8 * 1024;
 
 async function prepare(
   lc: LogContext,
@@ -132,7 +138,15 @@ export function getPragmaConfig(mode: ReplicaFileMode): PragmaConfig {
   return {
     busyTimeout: 30000,
     analysisLimit: 1000,
-    walAutocheckpoint: mode === 'backup' ? 0 : undefined,
+    // wal_autocheckpoint tells SQLite how many WAL pages it may append before
+    // folding them back into the main db file. A small window keeps the WAL
+    // tiny, but makes the serving write path periodically pay checkpoint I/O
+    // while it is also trying to digest RM -> VS traffic. Serving replicas keep
+    // autocheckpointing enabled, just with a larger bounded window, because
+    // they have no litestream process responsible for checkpoint cadence.
+    // Backup replicas set this to 0 because litestream owns checkpoint timing.
+    walAutocheckpoint:
+      mode === 'backup' ? 0 : SERVING_REPLICA_WAL_AUTOCHECKPOINT_PAGES,
   };
 }
 
@@ -168,7 +182,7 @@ export function setupReplica(
       return prepare(lc, replicaOptions, 'wal2', mode);
 
     default:
-      throw new Error(`Invalid ReplicaMode ${mode}`);
+      unreachable(mode);
   }
 }
 


### PR DESCRIPTION
## summary

Preserves the v6 `Downstream` payload shape while allowing websocket batch frames and `subscribeBatched()`. Incremental sync flushes the worker batch after a received websocket frame.

ACK semantics stay per-message in this PR.

## delta vs previous PR

Previous PR: hot queue helpers.

Scenario: `medium-wide-batch-pressure`, 15s, 1 RM stream consumer, websocket transport, v6 protocol.

| metric | before | after | delta |
| --- | ---: | ---: | ---: |
| tx/s | 1,652.3 | 2,099.4 | +27.1% |
| rows/s | 33,046.2 | 41,987.6 | +27.1% |
| fanout msg/s | 51,531.8 | 68,585.4 | +33.1% |
| websocket messages | 807,248 | 557 | 99.9% lower |
| websocket ACKs | 807,248 | 1,046,498 | higher because ACKs are still per-message |
| reconnect catchup to join | 1,658.3 ms | 275.1 ms | 83.4% lower |

## why this is safe

The child messages remain normal v6 `Downstream` payloads. The batch frame is a transport envelope only. Old clients that do not request batch frames keep the one-message stream shape.

## validation

```text
pnpm exec vitest --project='*no-pg*' run src/types/streams.test.ts src/services/change-streamer/subscriber.test.ts src/services/replicator/worker-message-batcher.test.ts
pnpm exec vitest --project='*15*' run src/services/change-streamer/change-streamer-http.pg.test.ts src/services/change-streamer/change-streamer-service.pg.test.ts src/services/change-streamer/storer.pg.test.ts
pnpm run check-types
```

## related perf workstream PRs

Benchmarked with the harness from #6070. This implementation PR intentionally does not include the benchmark harness files.

1. #6070: benchmark harness
2. #6071: storer batching
3. #6072: change processor batching
4. #6073: write-worker batching
5. #6074: serving local apply
6. #6075: RM fanout flow control
7. #6076: hot queue helpers
8. #6077: v6 websocket batch frames
9. #6078: cumulative ACK negotiation
