### PR TITLE
fix(zql): LIKE/ILIKE should use dotall (s), not multiline (m), to match SQLite

### DIFF
--- a/packages/zql/src/builder/like-test-cases.ts
+++ b/packages/zql/src/builder/like-test-cases.ts
@@ -76,7 +76,34 @@ export const cases: {
       ['fo', false],
       ['afoo', false],
       ['afoob', false],
-      ['fooa\nbar', true],
+      // 'fooa\nbar' is 8 chars; `foo_` matches exactly 4. Must be false (SQLite
+      // returns 0). The previous `true` came from the buggy `m`/multiline flag
+      // matching the interior line "fooa".
+      ['fooa\nbar', false],
+    ],
+  },
+  {
+    // `%` and `_` must match newline characters (dotall), and the pattern must
+    // match the whole string. A `m`/multiline flag would wrongly match a single
+    // interior line. All verified against SQLite.
+    pattern: 'a%b',
+    flags: '',
+    inputs: [
+      ['a\nb', true],
+      ['axb', true],
+      ['ab', true],
+      ['z\nab', false],
+      ['a\nbz', false],
+    ],
+  },
+  {
+    pattern: 'a_b',
+    flags: '',
+    inputs: [
+      ['a\nb', true],
+      ['axb', true],
+      ['ab', false],
+      ['a\nbc', false],
     ],
   },
   {

--- a/packages/zql/src/builder/like.ts
+++ b/packages/zql/src/builder/like.ts
@@ -69,5 +69,10 @@ function patternToRegExp(source: string, flags: '' | 'i' = ''): RegExp {
         break;
     }
   }
-  return new RegExp(pattern + '$', flags + 'm');
+  // Use the `s` (dotall) flag so `.` (from `_`) and `.*` (from `%`) match
+  // newlines, and keep `^`/`$` anchored to the whole string. The `m` (multiline)
+  // flag was wrong on both counts: it let `^`/`$` match interior line boundaries
+  // (false positives, e.g. 'fooa\nbar' LIKE 'foo_') while the wildcards still
+  // skipped newlines (false negatives, e.g. 'a\nb' NOT LIKE 'a%b').
+  return new RegExp(pattern + '$', flags + 's');
 }


### PR DESCRIPTION
## Summary

`getLikePredicate` (`packages/zql/src/builder/like.ts`) compiles a SQL
`LIKE`/`ILIKE` pattern to a `RegExp` with the `m` (multiline) flag. ZQL evaluates
these predicates client-side (`MemorySource`), so this silently returns the
**wrong rows**, and it's wrong in *two* directions:

1. **False negatives** — `%` (→ `.*`) and `_` (→ `.`) don't match newlines without
   the dotall flag:
   ```
   'a\nb' LIKE 'a%b'  -> false   (SQLite: true)
   'a\nb' LIKE 'a_b'  -> false   (SQLite: true)
   ```
2. **False positives** — the `m` flag lets `^`/`$` match interior line boundaries,
   so a pattern matches a single line of a multi-line value:
   ```
   'fooa\nbar' LIKE 'foo_' -> true   (SQLite: false)
   'z\nabc'    LIKE 'a%'   -> true   (SQLite: false)
   ```

Both verified against real `sqlite3` (the comments in `data.ts` note ZQL matches
SQLite/UTF-8 semantics).

## Fix

Use the `s` (dotall) flag instead of `m`. Then `.`/`.*` match newlines, and `^`/`$`
stay anchored to the whole string (JS `$` without `m` is end-of-string, so no
trailing-newline match). With `s`, all cases match SQLite.

## Tests

- Corrected one case in `like-test-cases.ts` that encoded the buggy behaviour:
  `'fooa\nbar' LIKE 'foo_'` is **false** in SQLite, not `true`.
- Added newline regression cases (`a%b`, `a_b`), including false-positive guards
  (`'z\nab' LIKE 'a%b'` → false).

Opened as a draft pending a CI run of the zql suite.
