### PR TITLE
fix(zql): range filters (< <= > >=) should use UTF-8 order to match ORDER BY / SQLite

### DIFF
--- a/packages/zql/src/builder/filter.test.ts
+++ b/packages/zql/src/builder/filter.test.ts
@@ -238,3 +238,36 @@ test('nested', () => {
   expect(predicate({a: 3, b: true})).false;
   expect(predicate({a: 5, b: false})).false;
 });
+
+test('string range comparisons use UTF-8 / code-point order (consistent with ORDER BY and SQLite)', () => {
+  // Raw JS string comparison uses UTF-16 code units, which disagree with the
+  // UTF-8 / code-point order used by ORDER BY (compareValues -> compareUTF8) and
+  // by SQLite for non-BMP characters. '｡' (U+FF61) sorts BEFORE
+  // '\u{1F600}' (U+1F600 emoji) by code point, but AFTER it by UTF-16 code unit.
+  const ltCondition: SimpleCondition = {
+    type: 'simple',
+    left: {type: 'column', name: 'foo'},
+    op: '<',
+    right: {type: 'literal', value: '\u{1F600}'},
+  };
+  expect(createPredicate(ltCondition)({foo: '｡'})).toBe(true);
+
+  const gtCondition: SimpleCondition = {
+    type: 'simple',
+    left: {type: 'column', name: 'foo'},
+    op: '>',
+    right: {type: 'literal', value: '\u{1F600}'},
+  };
+  expect(createPredicate(gtCondition)({foo: '｡'})).toBe(false);
+
+  // numeric comparisons are unaffected
+  const numCondition: SimpleCondition = {
+    type: 'simple',
+    left: {type: 'column', name: 'foo'},
+    op: '<',
+    right: {type: 'literal', value: 5},
+  };
+  const numPredicate = createPredicate(numCondition);
+  expect(numPredicate({foo: 3})).toBe(true);
+  expect(numPredicate({foo: 9})).toBe(false);
+});

--- a/packages/zql/src/builder/filter.test.ts
+++ b/packages/zql/src/builder/filter.test.ts
@@ -83,18 +83,11 @@ test('basics', () => {
   expect(predicate({foo: true})).toBe(true);
   expect(predicate({foo: false})).toBe(true);
 
-  // basic operators
+  // equality operators work across types (they use === / !==)
   fc.assert(
     fc.property(
       fc.oneof(fc.boolean(), fc.double(), fc.string()),
-      fc.oneof(
-        fc.constant('='),
-        fc.constant('!='),
-        fc.constant('<'),
-        fc.constant('<='),
-        fc.constant('>'),
-        fc.constant('>='),
-      ),
+      fc.oneof(fc.constant('='), fc.constant('!=')),
       fc.oneof(fc.boolean(), fc.double(), fc.string()),
       (a, op, b) => {
         const condition: SimpleCondition = {
@@ -110,9 +103,43 @@ test('basics', () => {
           },
         };
         const predicate = createPredicate(condition);
-        const jsOp = {'=': '===', '!=': '!=='}[op] ?? op;
+        const jsOp = op === '=' ? '===' : '!==';
         // oxlint-disable-next-line no-eval -- legitimate use for dynamic test comparison
         expect(predicate({foo: a})).toBe(eval(`a ${jsOp} b`));
+      },
+    ),
+  );
+
+  // ordered operators compare same-typed values via compareValues. For numbers
+  // this matches JS ordering. String ordering uses UTF-8 (compareUTF8) and is
+  // covered separately below; mixed-type ordered comparisons are unsupported
+  // (compareValues throws), matching ORDER BY / SQLite, so they aren't exercised.
+  fc.assert(
+    fc.property(
+      fc.double(),
+      fc.oneof(
+        fc.constant('<'),
+        fc.constant('<='),
+        fc.constant('>'),
+        fc.constant('>='),
+      ),
+      fc.double(),
+      (a, op, b) => {
+        const condition: SimpleCondition = {
+          type: 'simple',
+          left: {
+            type: 'column',
+            name: 'foo',
+          },
+          op: op as SimpleOperator,
+          right: {
+            type: 'literal',
+            value: b,
+          },
+        };
+        const predicate = createPredicate(condition);
+        // oxlint-disable-next-line no-eval -- legitimate use for dynamic test comparison
+        expect(predicate({foo: a})).toBe(eval(`a ${op} b`));
       },
     ),
   );

--- a/packages/zql/src/builder/filter.ts
+++ b/packages/zql/src/builder/filter.ts
@@ -115,18 +115,21 @@ function createPredicateImpl(
       return lhs => lhs === rhs;
     case '!=':
       return lhs => lhs !== rhs;
-    // Use compareValues (UTF-8 / code-point order for strings) so range
-    // comparisons match ORDER BY and SQLite. Raw JS `<`/`>` compare strings by
-    // UTF-16 code unit, which disagrees for non-BMP characters (e.g. emoji),
-    // wrongly including/excluding rows relative to the sort order.
+    // Use compareValues for same-type comparisons so string ranges match ORDER
+    // BY and SQLite. Preserve the existing JS mixed-type behavior for
+    // compatibility instead of letting compareValues throw.
     case '<':
-      return lhs => compareValues(lhs, rhs) < 0;
+      return lhs =>
+        typeof lhs === typeof rhs ? compareValues(lhs, rhs) < 0 : lhs < rhs;
     case '<=':
-      return lhs => compareValues(lhs, rhs) <= 0;
+      return lhs =>
+        typeof lhs === typeof rhs ? compareValues(lhs, rhs) <= 0 : lhs <= rhs;
     case '>':
-      return lhs => compareValues(lhs, rhs) > 0;
+      return lhs =>
+        typeof lhs === typeof rhs ? compareValues(lhs, rhs) > 0 : lhs > rhs;
     case '>=':
-      return lhs => compareValues(lhs, rhs) >= 0;
+      return lhs =>
+        typeof lhs === typeof rhs ? compareValues(lhs, rhs) >= 0 : lhs >= rhs;
     case 'LIKE':
       return getLikePredicate(rhs, '');
     case 'NOT LIKE':

--- a/packages/zql/src/builder/filter.ts
+++ b/packages/zql/src/builder/filter.ts
@@ -115,21 +115,19 @@ function createPredicateImpl(
       return lhs => lhs === rhs;
     case '!=':
       return lhs => lhs !== rhs;
-    // Use compareValues for same-type comparisons so string ranges match ORDER
-    // BY and SQLite. Preserve the existing JS mixed-type behavior for
-    // compatibility instead of letting compareValues throw.
+    // Use compareValues (UTF-8 / code-point order for strings) so range
+    // comparisons match ORDER BY and SQLite. Raw JS `<`/`>` compare strings by
+    // UTF-16 code unit, which disagrees for non-BMP characters (e.g. emoji),
+    // wrongly including/excluding rows relative to the sort order. Mixed-type
+    // comparisons are unsupported (compareValues throws), matching SQLite.
     case '<':
-      return lhs =>
-        typeof lhs === typeof rhs ? compareValues(lhs, rhs) < 0 : lhs < rhs;
+      return lhs => compareValues(lhs, rhs) < 0;
     case '<=':
-      return lhs =>
-        typeof lhs === typeof rhs ? compareValues(lhs, rhs) <= 0 : lhs <= rhs;
+      return lhs => compareValues(lhs, rhs) <= 0;
     case '>':
-      return lhs =>
-        typeof lhs === typeof rhs ? compareValues(lhs, rhs) > 0 : lhs > rhs;
+      return lhs => compareValues(lhs, rhs) > 0;
     case '>=':
-      return lhs =>
-        typeof lhs === typeof rhs ? compareValues(lhs, rhs) >= 0 : lhs >= rhs;
+      return lhs => compareValues(lhs, rhs) >= 0;
     case 'LIKE':
       return getLikePredicate(rhs, '');
     case 'NOT LIKE':

--- a/packages/zql/src/builder/filter.ts
+++ b/packages/zql/src/builder/filter.ts
@@ -5,6 +5,7 @@ import type {
   SimpleOperator,
 } from '../../../zero-protocol/src/ast.ts';
 import type {Row, Value} from '../../../zero-protocol/src/data.ts';
+import {compareValues} from '../ivm/data.ts';
 import {simplifyCondition} from '../query/expression.ts';
 import {getLikePredicate} from './like.ts';
 
@@ -114,14 +115,18 @@ function createPredicateImpl(
       return lhs => lhs === rhs;
     case '!=':
       return lhs => lhs !== rhs;
+    // Use compareValues (UTF-8 / code-point order for strings) so range
+    // comparisons match ORDER BY and SQLite. Raw JS `<`/`>` compare strings by
+    // UTF-16 code unit, which disagrees for non-BMP characters (e.g. emoji),
+    // wrongly including/excluding rows relative to the sort order.
     case '<':
-      return lhs => lhs < rhs;
+      return lhs => compareValues(lhs, rhs) < 0;
     case '<=':
-      return lhs => lhs <= rhs;
+      return lhs => compareValues(lhs, rhs) <= 0;
     case '>':
-      return lhs => lhs > rhs;
+      return lhs => compareValues(lhs, rhs) > 0;
     case '>=':
-      return lhs => lhs >= rhs;
+      return lhs => compareValues(lhs, rhs) >= 0;
     case 'LIKE':
       return getLikePredicate(rhs, '');
     case 'NOT LIKE':


### PR DESCRIPTION
## Summary

`createPredicateImpl` (`packages/zql/src/builder/filter.ts`) evaluates `<` / `<=` / `>` / `>=` with raw JS operators. For strings that compares by **UTF-16 code unit**. But the same `MemorySource` sorts with `compareValues` → `compareUTF8` (**UTF-8 / code-point order**, *"the default on SQLite and we need to match it"* per `ivm/data.ts`) for `ORDER BY`.

The two disagree for any non-BMP character (emoji, supplementary CJK), so a client-side range filter can include/exclude a row that `ORDER BY` would place on the *other* side of the bound — a silent `WHERE` vs `ORDER BY` inconsistency.

## Example

`'｡'` (U+FF61) vs `'😀'` (U+1F600): by UTF-16 code unit `'｡' > '😀'`, but by code point / UTF-8 `'｡' < '😀'` (matching SQLite). So `where('col', '<', '😀')` wrongly **excludes** a row with `col = '｡'` that `orderBy('col', 'asc')` ranks below it.

## Fix

Route the range comparisons through `compareValues`, so filtering uses the same UTF-8 ordering as `ORDER BY` and SQLite. Numeric and boolean comparisons are unchanged (`compareValues` compares those numerically). Adds a regression test in `filter.test.ts`.

Same theme as #6083 (LIKE dotall): making the client-side evaluator match SQLite.