### PR TITLE
fix(zqlite): Postgres-correct LIKE/ILIKE on the SQLite replica

### DIFF
--- a/packages/analyze-query/src/run-ast.test.ts
+++ b/packages/analyze-query/src/run-ast.test.ts
@@ -101,7 +101,7 @@ test('runAst always returns vendedRowCounts regardless of vendedRows option', as
       "afterPermissions": undefined,
       "dbScansByQuery": {},
       "elapsed": 13,
-      "end": 1017,
+      "end": 1019,
       "readRowCount": 2,
       "readRowCountsByQuery": {
         "users": {
@@ -110,7 +110,7 @@ test('runAst always returns vendedRowCounts regardless of vendedRows option', as
       },
       "readRows": undefined,
       "sqlitePlans": {},
-      "start": 1004,
+      "start": 1006,
       "syncedRowCount": 0,
       "syncedRows": undefined,
       "warnings": [],
@@ -138,7 +138,7 @@ test('runAst always returns vendedRowCounts regardless of vendedRows option', as
       "afterPermissions": undefined,
       "dbScansByQuery": {},
       "elapsed": 13,
-      "end": 1031,
+      "end": 1033,
       "readRowCount": 2,
       "readRowCountsByQuery": {
         "users": {
@@ -160,7 +160,7 @@ test('runAst always returns vendedRowCounts regardless of vendedRows option', as
         },
       },
       "sqlitePlans": {},
-      "start": 1018,
+      "start": 1020,
       "syncedRowCount": 0,
       "syncedRows": undefined,
       "warnings": [],
@@ -188,7 +188,7 @@ test('runAst always returns vendedRowCounts regardless of vendedRows option', as
       "afterPermissions": undefined,
       "dbScansByQuery": {},
       "elapsed": 13,
-      "end": 1045,
+      "end": 1047,
       "readRowCount": 2,
       "readRowCountsByQuery": {
         "users": {
@@ -197,7 +197,7 @@ test('runAst always returns vendedRowCounts regardless of vendedRows option', as
       },
       "readRows": undefined,
       "sqlitePlans": {},
-      "start": 1032,
+      "start": 1034,
       "syncedRowCount": 0,
       "syncedRows": undefined,
       "warnings": [],
@@ -236,12 +236,12 @@ test('runAst returns empty object for vendedRowCounts when no debug tracking', a
       "afterPermissions": undefined,
       "dbScansByQuery": {},
       "elapsed": 13,
-      "end": 1017,
+      "end": 1019,
       "readRowCount": 0,
       "readRowCountsByQuery": {},
       "readRows": undefined,
       "sqlitePlans": {},
-      "start": 1004,
+      "start": 1006,
       "syncedRowCount": 0,
       "syncedRows": undefined,
       "warnings": [],
@@ -280,7 +280,7 @@ test('runAst basic structure and functionality', async () => {
       "afterPermissions": undefined,
       "dbScansByQuery": {},
       "elapsed": 13,
-      "end": 1017,
+      "end": 1019,
       "readRowCount": 2,
       "readRowCountsByQuery": {
         "users": {
@@ -289,7 +289,7 @@ test('runAst basic structure and functionality', async () => {
       },
       "readRows": undefined,
       "sqlitePlans": {},
-      "start": 1004,
+      "start": 1006,
       "syncedRowCount": 0,
       "syncedRows": undefined,
       "warnings": [],

--- a/packages/zqlite/src/db.test.ts
+++ b/packages/zqlite/src/db.test.ts
@@ -30,6 +30,13 @@ test('slow queries are logged', () => {
   }
 
   expect(sink.messages).toEqual([
+    // case_sensitive_like pragma, set in the Database constructor.
+    [
+      'warn',
+      {class: 'Database', path: ':memory:', method: 'pragma'},
+      ['Slow SQLite query', 0],
+    ],
+    // page_size pragma, also read in the constructor.
     [
       'warn',
       {class: 'Database', path: ':memory:', method: 'pragma'},

--- a/packages/zqlite/src/db.ts
+++ b/packages/zqlite/src/db.ts
@@ -42,7 +42,7 @@ export class Database implements Disposable {
       // insensitive ILIKE is handled in query-builder.ts by lower()-ing both
       // operands (using the Unicode-aware lower() that @rocicorp/zero-sqlite3
       // provides via ICU).
-      this.#db.pragma('case_sensitive_like = ON');
+      this.pragma('case_sensitive_like = ON');
 
       const [{page_size: pageSize}] = this.pragma<{page_size: number}>(
         'page_size',

--- a/packages/zqlite/src/db.ts
+++ b/packages/zqlite/src/db.ts
@@ -36,6 +36,14 @@ export class Database implements Disposable {
       this.#db = new SQLite3Database(path, options);
       this.#threshold = slowQueryThreshold;
 
+      // Match Postgres LIKE/ILIKE semantics. Postgres LIKE is case-sensitive,
+      // but SQLite's LIKE operator is case-insensitive by default; enable
+      // case-sensitive LIKE so the bare operator matches Postgres. Case-
+      // insensitive ILIKE is handled in query-builder.ts by lower()-ing both
+      // operands (using the Unicode-aware lower() that @rocicorp/zero-sqlite3
+      // provides via ICU).
+      this.#db.pragma('case_sensitive_like = ON');
+
       const [{page_size: pageSize}] = this.pragma<{page_size: number}>(
         'page_size',
       );

--- a/packages/zqlite/src/query-builder.test.ts
+++ b/packages/zqlite/src/query-builder.test.ts
@@ -3,7 +3,12 @@ import {createSilentLogContext} from '../../shared/src/logging-test-utils.ts';
 import type {SchemaValue} from '../../zero-schema/src/table-schema.ts';
 import {Database} from './db.ts';
 import {format} from './internal/sql.ts';
-import {buildSelectQuery, multiConstraintToSQL} from './query-builder.ts';
+import {
+  buildSelectQuery,
+  filtersToSQL,
+  multiConstraintToSQL,
+  type NoSubqueryCondition,
+} from './query-builder.ts';
 
 test('non-nullable cursor columns use range and equality operators without IS NULL guards', () => {
   const columns = {
@@ -257,4 +262,43 @@ test('multiConstraints compound row-value IN uses index (EXPLAIN QUERY PLAN)', (
     .map(r => r.detail)
     .join('\n');
   expect(plan).toMatch(/SEARCH pairs USING/);
+});
+
+function likeSQL(
+  op: 'LIKE' | 'NOT LIKE' | 'ILIKE' | 'NOT ILIKE',
+  pattern: string,
+) {
+  return format(
+    filtersToSQL({
+      type: 'simple',
+      left: {type: 'column', name: 'name'},
+      op,
+      right: {type: 'literal', value: pattern},
+    } as NoSubqueryCondition),
+  );
+}
+
+test('LIKE is case-sensitive and uses an explicit backslash escape', () => {
+  const {text, values} = likeSQL('LIKE', 'a%');
+  // Bare LIKE operator; case-sensitivity comes from PRAGMA case_sensitive_like.
+  expect(text).toBe(`"name" LIKE ? ESCAPE '\\'`);
+  expect(values).toEqual(['a%']);
+});
+
+test('NOT LIKE keeps the operator and the backslash escape', () => {
+  const {text, values} = likeSQL('NOT LIKE', 'a%');
+  expect(text).toBe(`"name" NOT LIKE ? ESCAPE '\\'`);
+  expect(values).toEqual(['a%']);
+});
+
+test('ILIKE lowers both operands for Unicode case-insensitive matching', () => {
+  const {text, values} = likeSQL('ILIKE', 'A%');
+  expect(text).toBe(`lower("name") LIKE lower(?) ESCAPE '\\'`);
+  expect(values).toEqual(['A%']);
+});
+
+test('NOT ILIKE lowers both operands and negates', () => {
+  const {text, values} = likeSQL('NOT ILIKE', 'A%');
+  expect(text).toBe(`lower("name") NOT LIKE lower(?) ESCAPE '\\'`);
+  expect(values).toEqual(['A%']);
 });

--- a/packages/zqlite/src/query-builder.ts
+++ b/packages/zqlite/src/query-builder.ts
@@ -209,15 +209,44 @@ function simpleConditionToSQL(filter: SimpleCondition): SQLQuery {
         );
     }
   }
+  if (
+    op === 'LIKE' ||
+    op === 'NOT LIKE' ||
+    op === 'ILIKE' ||
+    op === 'NOT ILIKE'
+  ) {
+    return likeConditionToSQL(filter);
+  }
+
   return sql`${valuePositionToSQL(filter.left)} ${sql.__dangerous__rawValue(
-    // SQLite's LIKE operator is case-insensitive by default, so we
-    // convert ILIKE to LIKE and NOT ILIKE to NOT LIKE.
-    filter.op === 'ILIKE'
-      ? 'LIKE'
-      : filter.op === 'NOT ILIKE'
-        ? 'NOT LIKE'
-        : filter.op,
+    filter.op,
   )} ${valuePositionToSQL(filter.right)}`;
+}
+
+function likeConditionToSQL(filter: SimpleCondition): SQLQuery {
+  const {op} = filter;
+  // Mirror Postgres pattern-matching semantics:
+  //  * LIKE is case-sensitive. The replica connection runs with
+  //    `PRAGMA case_sensitive_like = ON` (see db.ts), so the bare LIKE
+  //    operator is case-sensitive.
+  //  * ILIKE is case-insensitive. We lower() both operands using the
+  //    Unicode-aware lower() that @rocicorp/zero-sqlite3 provides via ICU,
+  //    mirroring the toLowerCase() used by the in-memory IVM matcher
+  //    (see zql/src/builder/like.ts).
+  //  * Backslash is the default escape character in Postgres and in the IVM
+  //    matcher, but SQLite has no default, so we specify `ESCAPE '\'`
+  //    explicitly. The SQL literal '\' is a single backslash (SQLite does not
+  //    process backslash escapes inside string literals).
+  const caseInsensitive = op === 'ILIKE' || op === 'NOT ILIKE';
+  const negated = op === 'NOT LIKE' || op === 'NOT ILIKE';
+  const likeOp = sql.__dangerous__rawValue(negated ? 'NOT LIKE' : 'LIKE');
+
+  const left = valuePositionToSQL(filter.left);
+  const right = valuePositionToSQL(filter.right);
+  if (caseInsensitive) {
+    return sql`lower(${left}) ${likeOp} lower(${right}) ESCAPE '\\'`;
+  }
+  return sql`${left} ${likeOp} ${right} ESCAPE '\\'`;
 }
 
 function valuePositionToSQL(value: ValuePosition): SQLQuery {


### PR DESCRIPTION
## Problem

The SQLite replica (`zqlite`) diverged from Postgres on `LIKE`/`ILIKE`, so query results could differ between the server-side replica, Postgres, and the in-memory IVM matcher:

- **Postgres `LIKE` is case-sensitive**, but SQLite's `LIKE` operator is case-*insensitive* by default → plain `LIKE` matched too much.
- **`ILIKE` was rewritten to `LIKE`**, which only case-folds **ASCII** → non-English `ILIKE` was effectively case-sensitive (e.g. `Ä`/`ä`, Cyrillic, Greek didn't match).
- **No `ESCAPE` was emitted**, but Postgres and the in-memory IVM matcher (`zql/src/builder/like.ts`) both treat backslash as the default escape character.

## Fix

Mirror the in-memory IVM matcher so all three backends (Postgres, IVM, SQLite replica) agree:

- Enable `PRAGMA case_sensitive_like = ON` on every connection (`db.ts`) so the bare `LIKE` operator is case-sensitive — matching Postgres `LIKE`.
- Compile `ILIKE`/`NOT ILIKE` as `lower(a) LIKE lower(b)`, using the Unicode-aware `lower()` that `@rocicorp/zero-sqlite3` provides via ICU — matching the `toLowerCase()` the IVM matcher uses.
- Emit an explicit `ESCAPE '\'` for all `LIKE`/`ILIKE` operators.

The generated SQL now looks like:

| Op | SQL |
|----|-----|
| `LIKE` | `"name" LIKE ? ESCAPE '\'` |
| `NOT LIKE` | `"name" NOT LIKE ? ESCAPE '\'` |
| `ILIKE` | `lower("name") LIKE lower(?) ESCAPE '\'` |
| `NOT ILIKE` | `lower("name") NOT LIKE lower(?) ESCAPE '\'` |

## Dependency note

Full Unicode case-insensitivity for `ILIKE` requires the **ICU-enabled build of `@rocicorp/zero-sqlite3`** (see companion PR rocicorp/zero-sqlite3#31, which compiles SQLite with `SQLITE_ENABLE_ICU`). Until that release is picked up:

- `LIKE` case-sensitivity and `ESCAPE '\'` take effect **immediately** (core SQLite).
- `ILIKE` remains ASCII-folded via `lower()` — i.e. **no regression** vs. today, and it upgrades to full Unicode automatically once the ICU build lands.

## Safety of the global pragma

`case_sensitive_like = ON` is connection-scoped. The only internal SQLite `LIKE`s are the lowercase introspection patterns in `lite-tables.ts` (`'sqlite_%'`, `'_zero.%'`), which match lowercase identifiers and stay correct under case-sensitivity. All other internal `LIKE` usage is in Postgres queries, which the pragma doesn't affect.

## Tests

- New unit tests in `query-builder.test.ts` pin the generated SQL for all four operators.
- Existing `table-source.test.ts` / `query.test.ts` / `db.test.ts` pass (45 tests).
- `tsc` and `oxfmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)