### PR TITLE
zqlite: adopt @rocicorp/zero-sqlite3 1.1.1 (Unicode ILIKE, self-contained)

### DIFF
--- a/packages/replicache/package.json
+++ b/packages/replicache/package.json
@@ -80,7 +80,7 @@
   },
   "devDependencies": {
     "@op-engineering/op-sqlite": ">=15",
-    "@rocicorp/zero-sqlite3": "^1.0.18",
+    "@rocicorp/zero-sqlite3": "^1.1.0",
     "@types/command-line-args": "^5.2.3",
     "@types/command-line-usage": "^5.0.4",
     "@vitest/runner": "^4.1.6",
@@ -100,7 +100,7 @@
   },
   "peerDependencies": {
     "@op-engineering/op-sqlite": ">=15",
-    "@rocicorp/zero-sqlite3": "^1.0.18",
+    "@rocicorp/zero-sqlite3": "^1.1.0",
     "expo-sqlite": ">=15"
   },
   "peerDependenciesMeta": {

--- a/packages/replicache/package.json
+++ b/packages/replicache/package.json
@@ -80,7 +80,7 @@
   },
   "devDependencies": {
     "@op-engineering/op-sqlite": ">=15",
-    "@rocicorp/zero-sqlite3": "^1.1.0",
+    "@rocicorp/zero-sqlite3": "^1.1.1",
     "@types/command-line-args": "^5.2.3",
     "@types/command-line-usage": "^5.0.4",
     "@vitest/runner": "^4.1.6",
@@ -100,7 +100,7 @@
   },
   "peerDependencies": {
     "@op-engineering/op-sqlite": ">=15",
-    "@rocicorp/zero-sqlite3": "^1.1.0",
+    "@rocicorp/zero-sqlite3": "^1.1.1",
     "expo-sqlite": ">=15"
   },
   "peerDependenciesMeta": {

--- a/packages/zero-cache/package.json
+++ b/packages/zero-cache/package.json
@@ -54,7 +54,7 @@
     "@rocicorp/lock": "^1.0.4",
     "@rocicorp/logger": "^5.4.0",
     "@rocicorp/resolver": "^1.0.2",
-    "@rocicorp/zero-sqlite3": "^1.1.0",
+    "@rocicorp/zero-sqlite3": "^1.1.1",
     "@types/basic-auth": "^1.1.8",
     "basic-auth": "^2.0.1",
     "cloudevents": "^10.0.0",

--- a/packages/zero-cache/package.json
+++ b/packages/zero-cache/package.json
@@ -54,7 +54,7 @@
     "@rocicorp/lock": "^1.0.4",
     "@rocicorp/logger": "^5.4.0",
     "@rocicorp/resolver": "^1.0.2",
-    "@rocicorp/zero-sqlite3": "^1.0.18",
+    "@rocicorp/zero-sqlite3": "^1.1.0",
     "@types/basic-auth": "^1.1.8",
     "basic-auth": "^2.0.1",
     "cloudevents": "^10.0.0",

--- a/packages/zero/Dockerfile
+++ b/packages/zero/Dockerfile
@@ -26,6 +26,11 @@ RUN test -n "$ZERO_VERSION"
 
 RUN apk add --update curl
 RUN apk add --no-cache readline readline-dev
+# @rocicorp/zero-sqlite3 >= 1.1.0 dynamically links ICU on Linux (musl static
+# ICU is not -fPIC), so the runtime image must provide libicu or the native
+# module fails to load. icu-libs matches the ICU major the prebuilt binary was
+# built against (Alpine 3.x ships ICU 76).
+RUN apk add --no-cache icu-libs
 
 # Install pnpm via corepack (bundled with Node). Matches the monorepo's
 # packageManager field. pnpm's build-script allowlist (v10+) blocks lifecycle

--- a/packages/zero/Dockerfile
+++ b/packages/zero/Dockerfile
@@ -26,11 +26,6 @@ RUN test -n "$ZERO_VERSION"
 
 RUN apk add --update curl
 RUN apk add --no-cache readline readline-dev
-# @rocicorp/zero-sqlite3 >= 1.1.0 dynamically links ICU on Linux (musl static
-# ICU is not -fPIC), so the runtime image must provide libicu or the native
-# module fails to load. icu-libs matches the ICU major the prebuilt binary was
-# built against (Alpine 3.x ships ICU 76).
-RUN apk add --no-cache icu-libs
 
 # Install pnpm via corepack (bundled with Node). Matches the monorepo's
 # packageManager field. pnpm's build-script allowlist (v10+) blocks lifecycle

--- a/packages/zero/package.json
+++ b/packages/zero/package.json
@@ -141,7 +141,7 @@
     "@rocicorp/lock": "^1.0.4",
     "@rocicorp/logger": "^5.4.0",
     "@rocicorp/resolver": "^1.0.2",
-    "@rocicorp/zero-sqlite3": "^1.0.18",
+    "@rocicorp/zero-sqlite3": "^1.1.0",
     "@standard-schema/spec": "^1.0.0",
     "@types/basic-auth": "^1.1.8",
     "@types/ws": "^8.5.12",

--- a/packages/zero/package.json
+++ b/packages/zero/package.json
@@ -141,7 +141,7 @@
     "@rocicorp/lock": "^1.0.4",
     "@rocicorp/logger": "^5.4.0",
     "@rocicorp/resolver": "^1.0.2",
-    "@rocicorp/zero-sqlite3": "^1.1.0",
+    "@rocicorp/zero-sqlite3": "^1.1.1",
     "@standard-schema/spec": "^1.0.0",
     "@types/basic-auth": "^1.1.8",
     "@types/ws": "^8.5.12",

--- a/packages/zqlite/package.json
+++ b/packages/zqlite/package.json
@@ -24,7 +24,7 @@
     "@databases/sql": "^3.3.0",
     "@opentelemetry/api": "^1.9.0",
     "@rocicorp/logger": "^5.4.0",
-    "@rocicorp/zero-sqlite3": "^1.0.18",
+    "@rocicorp/zero-sqlite3": "^1.1.0",
     "zql": "workspace:*"
   },
   "devDependencies": {

--- a/packages/zqlite/package.json
+++ b/packages/zqlite/package.json
@@ -24,7 +24,7 @@
     "@databases/sql": "^3.3.0",
     "@opentelemetry/api": "^1.9.0",
     "@rocicorp/logger": "^5.4.0",
-    "@rocicorp/zero-sqlite3": "^1.1.0",
+    "@rocicorp/zero-sqlite3": "^1.1.1",
     "zql": "workspace:*"
   },
   "devDependencies": {

--- a/packages/zqlite/src/ilike-parity.test.ts
+++ b/packages/zqlite/src/ilike-parity.test.ts
@@ -1,4 +1,4 @@
-import {expect, test} from 'vitest';
+import {beforeAll, test} from 'vitest';
 import {createSilentLogContext} from '../../shared/src/logging-test-utils.ts';
 import {getLikePredicate} from '../../zql/src/builder/like.ts';
 import {Database} from './db.ts';
@@ -62,16 +62,16 @@ const cases: ReadonlyArray<readonly [pattern: string, input: string]> = [
   ['straße', 'STRASSE'],
 ];
 
-test('client-side ILIKE and zqlite ILIKE agree (Unicode, wildcards, escapes)', () => {
-  const db = new Database(createSilentLogContext(), ':memory:');
-  for (const [pattern, input] of cases) {
+let db: Database;
+beforeAll(() => {
+  db = new Database(createSilentLogContext(), ':memory:');
+});
+
+test.for(cases)(
+  'client-side and zqlite ILIKE agree: %j vs %j',
+  ([pattern, input], {expect}) => {
     const ivm = ivmIlike(pattern, input);
     const sqlite = zqliteIlike(db, pattern, input);
-    expect(
-      sqlite,
-      `mismatch for pattern=${JSON.stringify(pattern)} input=${JSON.stringify(
-        input,
-      )}: ivm=${ivm} sqlite=${sqlite}`,
-    ).toBe(ivm);
-  }
-});
+    expect(sqlite, `ivm=${ivm} sqlite=${sqlite}`).toBe(ivm);
+  },
+);

--- a/packages/zqlite/src/ilike-parity.test.ts
+++ b/packages/zqlite/src/ilike-parity.test.ts
@@ -1,0 +1,77 @@
+import {expect, test} from 'vitest';
+import {createSilentLogContext} from '../../shared/src/logging-test-utils.ts';
+import {getLikePredicate} from '../../zql/src/builder/like.ts';
+import {Database} from './db.ts';
+import {format} from './internal/sql.ts';
+import {filtersToSQL, type NoSubqueryCondition} from './query-builder.ts';
+
+// Zero evaluates the same query two ways that must agree: the client-side IVM
+// matcher (getLikePredicate, JS String.toLowerCase) and the zqlite replica
+// (compiled to `lower(col) LIKE lower(pattern)`, backed by @rocicorp/zero-sqlite3's
+// ICU lower()). This test pins that they produce identical ILIKE results across
+// Unicode case-folding, wildcards, escapes and newlines.
+
+function ivmIlike(pattern: string, input: string): boolean {
+  return getLikePredicate(pattern, 'i')(input) as boolean;
+}
+
+function zqliteIlike(db: Database, pattern: string, input: string): boolean {
+  // Use the real compiler output so we test the actual zqlite ILIKE SQL.
+  const {text, values} = format(
+    filtersToSQL({
+      type: 'simple',
+      left: {type: 'column', name: 'name'},
+      op: 'ILIKE',
+      right: {type: 'literal', value: pattern},
+    } as NoSubqueryCondition),
+  );
+  const row = db
+    .prepare(`SELECT (${text}) AS m FROM (SELECT ? AS name)`)
+    .get<{m: number}>(...values, input);
+  return !!row.m;
+}
+
+const cases: ReadonlyArray<readonly [pattern: string, input: string]> = [
+  // Unicode case-insensitive equality (umlauts / accents / Cyrillic / Greek).
+  ['müller', 'MÜLLER'],
+  ['MÜLLER', 'müller'],
+  ['café', 'CAFÉ'],
+  ['привет', 'ПРИВЕТ'],
+  ['σιγμα', 'ΣΙΓΜΑ'],
+  ['müller', 'schmidt'], // no match
+  ['å', 'Ä'], // distinct letters, no match
+
+  // Wildcards over Unicode input.
+  ['m%r', 'MÜLLER'],
+  ['m_ller', 'müller'], // _ matches the single char ü
+  ['%Ü%', 'müller'], // wildcard + case-insensitive fold
+  ['x%', 'MÜLLER'], // no match
+
+  // % and _ span newlines, matching SQLite LIKE.
+  ['a%b', 'a\nb'],
+  ['a_b', 'a\nb'],
+
+  // Backslash escapes: \% and \_ are literal.
+  [String.raw`100\%`, '100%'],
+  [String.raw`100\%`, '100x'], // no match (literal %)
+  [String.raw`a\_b`, 'a_b'],
+  [String.raw`a\_b`, 'axb'], // no match (literal _)
+
+  // ß is the case where folding (ß->ss) and lowering differ. BOTH backends
+  // lower() rather than fold, so neither matches "ss" — and they still agree.
+  ['straße', 'STRASSE'],
+];
+
+test('client-side ILIKE and zqlite ILIKE agree (Unicode, wildcards, escapes)', () => {
+  const db = new Database(createSilentLogContext(), ':memory:');
+  for (const [pattern, input] of cases) {
+    const ivm = ivmIlike(pattern, input);
+    const sqlite = zqliteIlike(db, pattern, input);
+    expect(
+      sqlite,
+      `mismatch for pattern=${JSON.stringify(pattern)} input=${JSON.stringify(
+        input,
+      )}: ivm=${ivm} sqlite=${sqlite}`,
+    ).toBe(ivm);
+  }
+});

--- a/packages/zqlite/src/query-builder.test.ts
+++ b/packages/zqlite/src/query-builder.test.ts
@@ -302,3 +302,29 @@ test('NOT ILIKE lowers both operands and negates', () => {
   expect(text).toBe(`lower("name") NOT LIKE lower(?) ESCAPE '\\'`);
   expect(values).toEqual(['A%']);
 });
+
+test('ILIKE matches case-insensitively across Unicode (needs ICU lower())', () => {
+  const lc = createSilentLogContext();
+  const db = new Database(lc, ':memory:');
+  db.exec(
+    `CREATE TABLE t (name TEXT);
+     INSERT INTO t VALUES ('MÜLLER'), ('Schmidt');`,
+  );
+
+  // Run the exact SQL the compiler emits for ILIKE.
+  const {text, values} = likeSQL('ILIKE', 'müller');
+  const rows = db
+    .prepare(`SELECT name FROM t WHERE ${text}`)
+    .all<{name: string}>(...values)
+    .map(r => r.name);
+
+  // ILIKE compiles to `lower(col) LIKE lower(pattern)`, so matching 'MÜLLER'
+  // against 'müller' depends on lower() folding Ü -> ü. Only the Unicode-aware
+  // lower() from @rocicorp/zero-sqlite3's ICU build (>= 1.1.0) does that; an
+  // ASCII-only lower() leaves Ü untouched and this returns no rows.
+  //
+  // (Note: ß is deliberately NOT a good example here — case *folding* maps ß to
+  // "ss", but lower() does not, so 'STRASSE' ILIKE 'straße' would not match even
+  // with ICU. Umlauts/accents/Cyrillic are the clean cases.)
+  expect(rows).toEqual(['MÜLLER']);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -482,8 +482,8 @@ importers:
         specifier: '>=15'
         version: 15.2.14(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       '@rocicorp/zero-sqlite3':
-        specifier: ^1.0.18
-        version: 1.0.18
+        specifier: ^1.1.0
+        version: 1.1.0
       '@types/command-line-args':
         specifier: ^5.2.3
         version: 5.2.3
@@ -852,8 +852,8 @@ importers:
         specifier: ^1.0.2
         version: 1.0.2
       '@rocicorp/zero-sqlite3':
-        specifier: ^1.0.18
-        version: 1.0.18
+        specifier: ^1.1.0
+        version: 1.1.0
       '@standard-schema/spec':
         specifier: ^1.0.0
         version: 1.1.0
@@ -1075,8 +1075,8 @@ importers:
         specifier: ^1.0.2
         version: 1.0.2
       '@rocicorp/zero-sqlite3':
-        specifier: ^1.0.18
-        version: 1.0.18
+        specifier: ^1.1.0
+        version: 1.1.0
       '@types/basic-auth':
         specifier: ^1.1.8
         version: 1.1.8
@@ -1699,8 +1699,8 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0
       '@rocicorp/zero-sqlite3':
-        specifier: ^1.0.18
-        version: 1.0.18
+        specifier: ^1.1.0
+        version: 1.1.0
       zql:
         specifier: workspace:*
         version: link:../zql
@@ -5608,8 +5608,8 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     deprecated: Use Promise.withResolvers instead
 
-  '@rocicorp/zero-sqlite3@1.0.18':
-    resolution: {integrity: sha512-JwHcCijxKj94NDij5UDCJsGHo/D8z4j5De/5zphQ+NctQ4TWr9Zx7L+Q1JBfie4ewVS82Ingu+QKbIwWvdNFXg==}
+  '@rocicorp/zero-sqlite3@1.1.0':
+    resolution: {integrity: sha512-54XwOGJiNx1FS9hedeHZG5ZslCN6vHsVqOJXYeYKYBs1DS0llSfHyeSQrfdaSbDzySeHVMFWbrDhV2tUsNyTEg==}
     engines: {bun: '>=1.1.0', node: 20.x || 22.x || 23.x || 24.x || 25.x}
     hasBin: true
 
@@ -18506,7 +18506,7 @@ snapshots:
 
   '@rocicorp/resolver@1.0.2': {}
 
-  '@rocicorp/zero-sqlite3@1.0.18':
+  '@rocicorp/zero-sqlite3@1.1.0':
     dependencies:
       bindings: 1.5.0
       prebuild-install: 7.1.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -482,8 +482,8 @@ importers:
         specifier: '>=15'
         version: 15.2.14(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       '@rocicorp/zero-sqlite3':
-        specifier: ^1.1.0
-        version: 1.1.0
+        specifier: ^1.1.1
+        version: 1.1.1
       '@types/command-line-args':
         specifier: ^5.2.3
         version: 5.2.3
@@ -852,8 +852,8 @@ importers:
         specifier: ^1.0.2
         version: 1.0.2
       '@rocicorp/zero-sqlite3':
-        specifier: ^1.1.0
-        version: 1.1.0
+        specifier: ^1.1.1
+        version: 1.1.1
       '@standard-schema/spec':
         specifier: ^1.0.0
         version: 1.1.0
@@ -1075,8 +1075,8 @@ importers:
         specifier: ^1.0.2
         version: 1.0.2
       '@rocicorp/zero-sqlite3':
-        specifier: ^1.1.0
-        version: 1.1.0
+        specifier: ^1.1.1
+        version: 1.1.1
       '@types/basic-auth':
         specifier: ^1.1.8
         version: 1.1.8
@@ -1699,8 +1699,8 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0
       '@rocicorp/zero-sqlite3':
-        specifier: ^1.1.0
-        version: 1.1.0
+        specifier: ^1.1.1
+        version: 1.1.1
       zql:
         specifier: workspace:*
         version: link:../zql
@@ -5608,9 +5608,9 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     deprecated: Use Promise.withResolvers instead
 
-  '@rocicorp/zero-sqlite3@1.1.0':
-    resolution: {integrity: sha512-54XwOGJiNx1FS9hedeHZG5ZslCN6vHsVqOJXYeYKYBs1DS0llSfHyeSQrfdaSbDzySeHVMFWbrDhV2tUsNyTEg==}
-    engines: {bun: '>=1.1.0', node: 20.x || 22.x || 23.x || 24.x || 25.x}
+  '@rocicorp/zero-sqlite3@1.1.1':
+    resolution: {integrity: sha512-BZ9FkXADOOalBbvfPmSq3QD193O5QQz/zqs9xXsAjWx/lL0VyYfT4zNrSEZqMpyv/7vH7DhPEDvbIzV6bvl7TQ==}
+    engines: {bun: '>=1.1.0', node: 22.x || 24.x}
     hasBin: true
 
   '@rocicorp/zero-virtual@0.1.4':
@@ -18506,7 +18506,7 @@ snapshots:
 
   '@rocicorp/resolver@1.0.2': {}
 
-  '@rocicorp/zero-sqlite3@1.1.0':
+  '@rocicorp/zero-sqlite3@1.1.1':
     dependencies:
       bindings: 1.5.0
       prebuild-install: 7.1.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,8 +23,7 @@ minimumReleaseAgeExclude:
   - ajv@8.18.0
   - '@hono/node-server@1.19.13'
   - postcss@8.5.10
-  - '@rocicorp/zero-sqlite3@1.1.0'
-  - '@rocicorp/zero-sqlite3@1.1.1'
+  - '@rocicorp/zero-sqlite3'
 overrides:
   '@hono/node-server@<1.19.13': ^1.19.13
   '@types/node': '^22.10.5'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,6 +23,7 @@ minimumReleaseAgeExclude:
   - ajv@8.18.0
   - '@hono/node-server@1.19.13'
   - postcss@8.5.10
+  - '@rocicorp/zero-sqlite3@1.1.0'
 overrides:
   '@hono/node-server@<1.19.13': ^1.19.13
   '@types/node': '^22.10.5'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,6 +24,7 @@ minimumReleaseAgeExclude:
   - '@hono/node-server@1.19.13'
   - postcss@8.5.10
   - '@rocicorp/zero-sqlite3@1.1.0'
+  - '@rocicorp/zero-sqlite3@1.1.1'
 overrides:
   '@hono/node-server@<1.19.13': ^1.19.13
   '@types/node': '^22.10.5'


### PR DESCRIPTION
Fixes https://bugs.rocicorp.dev/p/zero/issue/3043

## What

Bump `@rocicorp/zero-sqlite3` to **1.1.1**, which ships Unicode-aware `lower()`/`upper()` built from an embedded case-mapping table (generated from Node's `String.prototype.toLowerCase`/`toUpperCase`, including the Greek final-sigma rule). zqlite compiles `ILIKE` to `lower(col) LIKE lower(pattern)`, so this is what makes `ILIKE` genuinely case-insensitive beyond ASCII — e.g. `'MÜLLER' ILIKE 'müller'` now matches.

The production wiring for this (`PRAGMA case_sensitive_like = ON`, the `lower(...) LIKE lower(...)` compilation in `query-builder.ts`) already landed separately. This PR is the dependency bump plus the tests that lock the behavior in.

## Why 1.1.1 and not the ICU build

Earlier attempts linked SQLite's ICU extension. That turned out to be unshippable across Linux distros — distro static ICU archives aren't `-fPIC`, dynamic ICU couples the binary to a specific `libicu` soname (glibc/musl/version skew), QEMU arm64 crashed, and ICU pulls in ~28 MB of data. **1.1.1 drops ICU entirely** in favor of a self-contained Unicode table, so the prebuilt binaries are portable with **no extra runtime dependency** (no `apk add icu-libs`, no soname caveat) on every platform including Windows and Alpine.

## Changes

- **Bump the floor** `^1.0.18 → ^1.1.1` (`zqlite`, `zero-cache`, `zero`, `replicache`) + lockfile.
- **New behavioral test** in `query-builder.test.ts`: runs the actual compiled `ILIKE` SQL against a Unicode row (`'MÜLLER' ILIKE 'müller'`). Fails on an ASCII-only `lower()`, passes with the Unicode `lower()` in 1.1.1.
- **New `ilike-parity.test.ts`** (using `test.for`): asserts the client-side IVM `ILIKE` matcher and the zqlite SQL `ILIKE` agree on the same inputs, so the two sides of the query engine stay in sync.
- **`pnpm-workspace.yaml`:** exclude `@rocicorp/zero-sqlite3` from `minimumReleaseAge` by package name. The version-pinned form (`@rocicorp/zero-sqlite3@1.1.1`) is not honored by pnpm's frozen-lockfile supply-chain check, so a freshly published bump otherwise trips `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION` in CI. Name-only matches and avoids per-version churn for our own first-party package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)