### PR TITLE
fix(zero-cache): support text-represented PG scalar types

### DIFF
--- a/packages/z2s/src/sql.pg.test.ts
+++ b/packages/z2s/src/sql.pg.test.ts
@@ -267,6 +267,48 @@ describe('SQL builder with PostgreSQL', () => {
       expect(result).toEqual([{value}]);
     },
   );
+
+  test('text-represented scalar types insert and compare by native type', async () => {
+    await using pg = await testDBs.create(`${DB_NAME}_text_represented`);
+    await pg.unsafe(`
+      CREATE EXTENSION IF NOT EXISTS isn;
+      CREATE TABLE text_represented_scalars (
+        isbn ISBN13 PRIMARY KEY,
+        ip INET NOT NULL,
+        mac MACADDR NOT NULL
+      );
+    `);
+
+    const row = {
+      isbn: '9780306406157',
+      ip: '192.168.0.1/24',
+      mac: '08:00:2b:01:02:03',
+    };
+
+    const insertStmt = formatPgInternalConvert(sql`
+      INSERT INTO text_represented_scalars (isbn, ip, mac)
+      VALUES (
+        ${sqlConvertArg('isbn13', row.isbn)},
+        ${sqlConvertArg('inet', row.ip)},
+        ${sqlConvertArg('macaddr', row.mac)}
+      )
+    `);
+    await pg.unsafe(insertStmt.text, insertStmt.values as JSONValue[]);
+
+    const selectStmt = formatPgInternalConvert(sql`
+      SELECT isbn::text AS isbn, ip::text AS ip, mac::text AS mac
+      FROM text_represented_scalars
+      WHERE isbn = ${sqlConvertArg('isbn13', row.isbn, singularComparison)}
+        AND ip = ${sqlConvertArg('inet', row.ip, singularComparison)}
+        AND mac = ${sqlConvertArg('macaddr', row.mac, singularComparison)}
+    `);
+    const result = await pg.unsafe(
+      selectStmt.text,
+      selectStmt.values as JSONValue[],
+    );
+
+    expect(result).toEqual([{...row, isbn: '978-0-306-40615-7'}]);
+  });
 });
 
 const pluralComparison = {

--- a/packages/z2s/src/sql.test.ts
+++ b/packages/z2s/src/sql.test.ts
@@ -171,6 +171,30 @@ describe('string arg packing', () => {
       `);
     });
 
+    test('text-represented scalar type', () => {
+      expect(
+        formatPgInternalConvert(
+          sql`SELECT * FROM "foo" WHERE "isbn" = ${sqlConvertColumnArg(
+            {
+              isArray: false,
+              isEnum: false,
+              type: 'isbn13',
+            },
+            '9780306406157',
+            false,
+            true,
+          )}`,
+        ),
+      ).toMatchInlineSnapshot(`
+        {
+          "text": "SELECT * FROM "foo" WHERE "isbn" = $1::text::isbn13",
+          "values": [
+            "9780306406157",
+          ],
+        }
+      `);
+    });
+
     test('boolean type', () => {
       expect(
         formatPgInternalConvert(
@@ -584,6 +608,26 @@ describe('string arg packing', () => {
           "text": "INSERT INTO "foo" VALUES ($1::text::text)",
           "values": [
             "two",
+          ],
+        }
+      `);
+    });
+
+    test('insert text-represented scalar type', () => {
+      expect(
+        formatPgInternalConvert(
+          sql`INSERT INTO "foo" VALUES (${sqlConvertColumnArg(
+            {isArray: false, isEnum: false, type: 'macaddr'},
+            '08:00:2b:01:02:03',
+            false,
+            false,
+          )})`,
+        ),
+      ).toMatchInlineSnapshot(`
+        {
+          "text": "INSERT INTO "foo" VALUES ($1::text::macaddr)",
+          "values": [
+            "08:00:2b:01:02:03",
           ],
         }
       `);

--- a/packages/z2s/src/sql.ts
+++ b/packages/z2s/src/sql.ts
@@ -6,8 +6,10 @@ import type {FormatConfig, SQLItem, SQLQuery} from '@databases/sql';
 import sql, {SQLItemType} from '@databases/sql';
 import {assert, unreachable} from '../../shared/src/asserts.ts';
 import {
+  isPgNativeStringType,
   isPgNumberType,
   isPgStringType,
+  isPgTextRepresentedType,
 } from '../../zero-cache/src/types/pg-data-type.ts';
 import type {LiteralValue} from '../../zero-protocol/src/ast.ts';
 import type {ServerColumnSchema} from '../../zero-types/src/server-schema.ts';
@@ -230,7 +232,7 @@ function formatCommonToSingularAndPlural(
   if (arg.isEnum) {
     return `${valuePlaceholder}::text::"${arg.type}"`;
   }
-  if (isPgStringType(arg.type)) {
+  if (isPgNativeStringType(arg.type)) {
     // For comparison cast to the general `text` type, not the
     // specific column type (i.e. `arg.type`), because we don't want to
     // force the value being compared to the size/max-size of the column
@@ -238,6 +240,9 @@ function formatCommonToSingularAndPlural(
     return arg.isComparison
       ? `${valuePlaceholder}::text`
       : `${valuePlaceholder}::text::${arg.type}`;
+  }
+  if (isPgTextRepresentedType(arg.type)) {
+    return `${valuePlaceholder}::text::${arg.type}`;
   }
   if (isPgNumberType(arg.type)) {
     // For comparison cast to `double precision` which uses IEEE 754 (the same

--- a/packages/zero-cache/src/db/lite-tables.test.ts
+++ b/packages/zero-cache/src/db/lite-tables.test.ts
@@ -511,10 +511,10 @@ describe('computeZqlSpec', () => {
     `);
   });
 
-  test('unsupported columns (MACADDR8) are excluded', () => {
+  test('unsupported columns (BYTEA) are excluded', () => {
     expect(
       t(`
-    CREATE TABLE foo(a INT, b "TEXT|NOT_NULL", c MACADDR8, d BYTEA);
+    CREATE TABLE foo(a INT, b "TEXT|NOT_NULL", c BYTEA);
     CREATE UNIQUE INDEX foo_pkey ON foo(b ASC);
     `),
     ).toMatchInlineSnapshot(`
@@ -581,10 +581,26 @@ describe('computeZqlSpec', () => {
     expect(spec.zqlSpec.time_tz).toEqual({type: 'number'});
   });
 
-  test('indexes with unsupported columns (MACADDR8) are excluded', () => {
+  test('text-represented scalar columns can be used as primary keys', () => {
+    const spec = must(
+      t(`
+    CREATE TABLE foo(id "MACADDR8|NOT_NULL", ip INET, book ISBN13);
+    CREATE UNIQUE INDEX foo_pkey ON foo(id ASC);
+    `)[0],
+    );
+
+    expect(spec.tableSpec.primaryKey).toEqual(['id']);
+    expect(spec.zqlSpec).toEqual({
+      id: {type: 'string'},
+      ip: {type: 'string'},
+      book: {type: 'string'},
+    });
+  });
+
+  test('indexes with unsupported columns (BYTEA) are excluded', () => {
     expect(
       t(`
-    CREATE TABLE foo(a "INT|NOT_NULL", b "TEXT|NOT_NULL", c "MACADDR8|NOT_NULL", d "TEXT|NOT_NULL");
+    CREATE TABLE foo(a "INT|NOT_NULL", b "TEXT|NOT_NULL", c "BYTEA|NOT_NULL", d "TEXT|NOT_NULL");
     CREATE UNIQUE INDEX foo_pkey ON foo(a ASC, c DESC);
     CREATE UNIQUE INDEX foo_other_key ON foo(b ASC, d ASC, a DESC);
     `),

--- a/packages/zero-cache/src/integration/integration.pg.test.ts
+++ b/packages/zero-cache/src/integration/integration.pg.test.ts
@@ -55,14 +55,24 @@ const nopk = table('nopk')
   })
   .primaryKey('id');
 
+const book = table('book')
+  .columns({
+    id: string(),
+    ip: string(),
+    mac: string(),
+    title: string(),
+  })
+  .primaryKey('id');
+
 const schema = createSchema({
-  tables: [foo, bar, nopk],
+  tables: [foo, bar, nopk, book],
 });
 
 const permissions = await definePermissions(schema, () => ({
   'foo': ANYONE_CAN_DO_ANYTHING,
   'boo.far': ANYONE_CAN_DO_ANYTHING,
   'nopk': ANYONE_CAN_DO_ANYTHING,
+  'book': ANYONE_CAN_DO_ANYTHING,
 }));
 
 // Note: The NULL unicode character \u0000 is specifically used to verify
@@ -70,6 +80,8 @@ const permissions = await definePermissions(schema, () => ({
 //       JSONB storage of row contents would not be able to handle it.
 function initialPGSetup(replicaIdentity = 'DEFAULT') {
   return `
+      CREATE EXTENSION IF NOT EXISTS isn;
+
       CREATE TABLE foo(
         id TEXT PRIMARY KEY, 
         far_id TEXT,
@@ -97,7 +109,21 @@ function initialPGSetup(replicaIdentity = 'DEFAULT') {
       CREATE TABLE nopk(id TEXT NOT NULL, val TEXT);
       INSERT INTO nopk(id, val) VALUES ('foo', 'bar');
 
-      CREATE PUBLICATION zero_all FOR TABLE foo, TABLE boo.far, TABLE nopk;
+      CREATE TABLE book(
+        id ISBN13 PRIMARY KEY,
+        ip INET,
+        mac MACADDR,
+        title TEXT
+      );
+      ALTER TABLE book REPLICA IDENTITY ${replicaIdentity};
+      INSERT INTO book(id, ip, mac, title)
+        VALUES (
+          '9780306406157'::isbn13,
+          '192.168.0.1/24'::inet,
+          '08:00:2b:01:02:03'::macaddr,
+          'Zero book');
+
+      CREATE PUBLICATION zero_all FOR TABLE foo, TABLE boo.far, TABLE nopk, TABLE book;
 
       CREATE SCHEMA "123";
 
@@ -500,6 +526,11 @@ describe('integration', {timeout: 30000}, () => {
     ],
   };
 
+  const BOOK_QUERY: AST = {
+    table: 'book',
+    orderBy: [['id', 'asc']],
+  };
+
   // One or two zero-caches (i.e. multi-node)
   type Envs = [NodeJS.ProcessEnv] | [NodeJS.ProcessEnv, NodeJS.ProcessEnv];
 
@@ -548,6 +579,98 @@ describe('integration', {timeout: 30000}, () => {
 
   const WATERMARK_REGEX = /[0-9a-z]{4,}/;
   const BACKFILL_WATERMARK_REGEX = /[0-9a-z]{4,}\.[0-9a-z]{2,}/;
+
+  test('syncs text-represented scalar columns from Postgres', async () => {
+    await upDB.unsafe(initialPGSetup());
+    await startZero([env]);
+
+    const downstream = new Queue<unknown>();
+    const ws = new WebSocket(
+      `ws://localhost:${port}/zero/sync/v${PROTOCOL_VERSION}/connect` +
+        `?clientGroupID=abc&clientID=def&wsid=123&schemaVersion=1&baseCookie=&ts=123456789&lmid=1`,
+      encodeURIComponent(btoa('{}')),
+    );
+    ws.on('message', data =>
+      downstream.enqueue(JSON.parse(data.toString('utf-8'))),
+    );
+    ws.on('open', () =>
+      ws.send(
+        JSON.stringify([
+          'initConnection',
+          {
+            desiredQueriesPatch: [
+              {op: 'put', hash: 'book-query-hash', ast: BOOK_QUERY},
+            ],
+            clientSchema: {
+              tables: {
+                book: {
+                  primaryKey: ['id'],
+                  columns: {
+                    id: {type: 'string'},
+                    ip: {type: 'string'},
+                    mac: {type: 'string'},
+                    title: {type: 'string'},
+                  },
+                },
+              },
+            },
+          },
+        ] satisfies InitConnectionMessage),
+      ),
+    );
+
+    expect(await downstream.dequeue()).toMatchObject([
+      'connected',
+      {wsid: '123'},
+    ]);
+    expect(await downstream.dequeue()).toMatchObject([
+      'pokeStart',
+      {pokeID: '00:01'},
+    ]);
+    expect(await downstream.dequeue()).toMatchObject([
+      'pokePart',
+      {
+        pokeID: '00:01',
+        desiredQueriesPatches: {
+          def: [{op: 'put', hash: 'book-query-hash'}],
+        },
+      },
+    ]);
+    expect(await downstream.dequeue()).toMatchObject([
+      'pokeEnd',
+      {pokeID: '00:01'},
+    ]);
+
+    const contentPokeStart = (await downstream.dequeue()) as PokeStartMessage;
+    expect(contentPokeStart).toMatchObject([
+      'pokeStart',
+      {pokeID: /[0-9a-z]{2,}/},
+    ]);
+    const contentPokeID = contentPokeStart[1].pokeID;
+    expect(await downstream.dequeue()).toMatchObject([
+      'pokePart',
+      {
+        pokeID: contentPokeID,
+        gotQueriesPatch: [{op: 'put', hash: 'book-query-hash'}],
+        rowsPatch: [
+          {
+            op: 'put',
+            tableName: 'book',
+            value: {
+              id: '978-0-306-40615-7',
+              ip: '192.168.0.1/24',
+              mac: '08:00:2b:01:02:03',
+              title: 'Zero book',
+            },
+          },
+        ],
+      },
+    ]);
+    expect(await downstream.dequeue()).toMatchObject([
+      'pokeEnd',
+      {pokeID: contentPokeID},
+    ]);
+  });
 
   test.for([
     ['single-node', 'pg', () => [env], undefined],

--- a/packages/zero-cache/src/services/view-syncer/client-schema.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/client-schema.test.ts
@@ -55,6 +55,12 @@ describe('client schemas', () => {
       CREATE INDEX not_unique ON nopk (id ASC);
       CREATE UNIQUE INDEX nullable ON nopk (d ASC);
 
+      CREATE TABLE unsupported_pk(
+        id BYTEA PRIMARY KEY,
+        val TEXT,
+        _0_version TEXT
+      );
+
       -- Not the full internal tables. Just declared here to confirm that
       -- they do not show up in the error messages.
       CREATE TABLE "zero.permissions" (lock bool PRIMARY KEY);
@@ -309,6 +315,29 @@ describe('client schemas', () => {
       ),
     ).toThrowErrorMatchingInlineSnapshot(
       `[ProtocolError: The "nopk" table is missing a primary key or non-null unique index and thus cannot be synced to the client]`,
+    );
+  });
+
+  test('table with unsupported primary key column', () => {
+    expect(() =>
+      checkClientSchema(
+        SHARD_ID,
+        {
+          tables: {
+            unsupported_pk: {
+              columns: {
+                id: {type: 'string'},
+                val: {type: 'string'},
+              },
+              primaryKey: ['id'],
+            },
+          },
+        },
+        tableSpecs,
+        fullTables,
+      ),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[ProtocolError: The "unsupported_pk" table's primary key contains unsupported columns: "id" (BYTEA). These columns must use Zero-supported data types to sync the table to the client.]`,
     );
   });
 

--- a/packages/zero-cache/src/services/view-syncer/client-schema.ts
+++ b/packages/zero-cache/src/services/view-syncer/client-schema.ts
@@ -9,6 +9,7 @@ import type {ClientSchema} from '../../../../zero-protocol/src/client-schema.ts'
 import {ErrorOrigin} from '../../../../zero-protocol/src/error-origin.ts';
 import {ProtocolError} from '../../../../zero-protocol/src/error.ts';
 import type {LiteAndZqlSpec, LiteTableSpec} from '../../db/specs.ts';
+import {liteTypeToZqlValueType} from '../../types/lite.ts';
 import {appSchema, upstreamSchema, type ShardID} from '../../types/shards.ts';
 import {ZERO_VERSION_COLUMN_NAME} from '../replicator/schema/constants.ts';
 
@@ -32,6 +33,23 @@ export function checkClientSchema(
   const missingTables = difference(clientTables, tableSpecs);
   for (const missing of toSorted(missingTables)) {
     if (fullTables.has(missing)) {
+      const fullTable = must(fullTables.get(missing));
+      const unsupportedPrimaryKeyColumns = (fullTable.primaryKey ?? []).filter(
+        col => !liteTypeToZqlValueType(fullTable.columns[col]?.dataType ?? ''),
+      );
+      if (unsupportedPrimaryKeyColumns.length) {
+        errors.push(
+          `The "${missing}" table's primary key contains unsupported columns: ` +
+            unsupportedPrimaryKeyColumns
+              .map(
+                col =>
+                  `"${col}" (${fullTable.columns[col]?.dataType ?? 'unknown'})`,
+              )
+              .join(', ') +
+            `. These columns must use Zero-supported data types to sync the table to the client.`,
+        );
+        continue;
+      }
       errors.push(
         `The "${missing}" table is missing a primary key or non-null ` +
           `unique index and thus cannot be synced to the client`,

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
@@ -83,7 +83,7 @@ describe('view-syncer/pipeline-driver', () => {
       CREATE TABLE issues (
         id TEXT PRIMARY KEY,
         closed BOOL,
-        ignored INET,
+        ignored BYTEA,
         _0_version TEXT NOT NULL
       );
       CREATE TABLE comments (

--- a/packages/zero-cache/src/types/lite.test.ts
+++ b/packages/zero-cache/src/types/lite.test.ts
@@ -236,6 +236,8 @@ describe('types/lite', () => {
 describe('dataTypeToZqlValueType', () => {
   test.each([
     ['int', 'number'],
+    ['isbn13', 'string'],
+    ['macaddr8', 'string'],
     ['text', 'string'],
     ['float', 'number'],
     ['bool', 'boolean'],

--- a/packages/zero-cache/src/types/pg-data-type.test.ts
+++ b/packages/zero-cache/src/types/pg-data-type.test.ts
@@ -1,10 +1,14 @@
 import {describe, expect, test} from 'vitest';
 import {
   dataTypeToZqlValueType,
+  isPgNativeStringType,
   isPgNumberType,
   isPgStringType,
+  isPgTextRepresentedType,
+  pgToZqlNativeStringTypeMap,
   pgToZqlNumericTypeMap,
   pgToZqlStringTypeMap,
+  pgToZqlTextRepresentedTypeMap,
 } from './pg-data-type.ts';
 
 describe('pg-data-type helpers', () => {
@@ -24,8 +28,26 @@ describe('pg-data-type helpers', () => {
     },
   );
 
+  test.each(Object.keys(pgToZqlNativeStringTypeMap))(
+    'identifies native string type %s',
+    pgType => {
+      expect(isPgNativeStringType(pgType)).toBe(true);
+      expect(isPgTextRepresentedType(pgType)).toBe(false);
+    },
+  );
+
+  test.each(Object.keys(pgToZqlTextRepresentedTypeMap))(
+    'identifies text-represented type %s',
+    pgType => {
+      expect(isPgTextRepresentedType(pgType)).toBe(true);
+      expect(isPgNativeStringType(pgType)).toBe(false);
+    },
+  );
+
   test('isPgStringType and isPgNumberType are case insensitive', () => {
     expect(isPgStringType('TEXT')).toBe(true);
+    expect(isPgNativeStringType('TEXT')).toBe(true);
+    expect(isPgTextRepresentedType('ISBN13')).toBe(true);
     expect(isPgNumberType('INTEGER')).toBe(true);
   });
 });
@@ -62,7 +84,20 @@ describe('dataTypeToZqlValueType', () => {
     ['bpchar', 'string'],
     ['character', 'string'],
     ['character varying', 'string'],
+    ['cidr', 'string'],
+    ['ean13', 'string'],
+    ['inet', 'string'],
+    ['isbn', 'string'],
+    ['isbn13', 'string'],
+    ['ismn', 'string'],
+    ['ismn13', 'string'],
+    ['issn', 'string'],
+    ['issn13', 'string'],
+    ['macaddr', 'string'],
+    ['macaddr8', 'string'],
+    ['pg_lsn', 'string'],
     ['text', 'string'],
+    ['upc', 'string'],
     ['uuid', 'string'],
     ['varchar', 'string'],
     ['bool', 'boolean'],

--- a/packages/zero-cache/src/types/pg-data-type.ts
+++ b/packages/zero-cache/src/types/pg-data-type.ts
@@ -27,13 +27,45 @@ export function isPgNumberType(pgType: string): boolean {
   return Object.hasOwn(pgToZqlNumericTypeMap, formatTypeForLookup(pgType));
 }
 
-export const pgToZqlStringTypeMap = Object.freeze({
+export const pgToZqlNativeStringTypeMap = Object.freeze({
   'bpchar': 'string',
   'character': 'string',
   'character varying': 'string',
   'text': 'string',
-  'uuid': 'string',
   'varchar': 'string',
+});
+
+export function isPgNativeStringType(pgType: string): boolean {
+  return Object.hasOwn(pgToZqlNativeStringTypeMap, formatTypeForLookup(pgType));
+}
+
+export const pgToZqlTextRepresentedTypeMap = Object.freeze({
+  cidr: 'string',
+  ean13: 'string',
+  inet: 'string',
+  isbn: 'string',
+  isbn13: 'string',
+  ismn: 'string',
+  ismn13: 'string',
+  issn: 'string',
+  issn13: 'string',
+  macaddr: 'string',
+  macaddr8: 'string',
+  pg_lsn: 'string',
+  upc: 'string',
+  uuid: 'string',
+});
+
+export function isPgTextRepresentedType(pgType: string): boolean {
+  return Object.hasOwn(
+    pgToZqlTextRepresentedTypeMap,
+    formatTypeForLookup(pgType),
+  );
+}
+
+export const pgToZqlStringTypeMap = Object.freeze({
+  ...pgToZqlNativeStringTypeMap,
+  ...pgToZqlTextRepresentedTypeMap,
 });
 
 export function isPgStringType(pgType: string): boolean {

--- a/packages/zero-server/src/custom.pg.test.ts
+++ b/packages/zero-server/src/custom.pg.test.ts
@@ -68,6 +68,17 @@ describe('makeSchemaCRUD', () => {
     type: 'user' as const,
   };
 
+  const textRepresentedScalarRow = {
+    id: '9780306406157',
+    ip: '192.168.0.1/24',
+    mac: '08:00:2b:01:02:03',
+    title: 'initial',
+  };
+  const textRepresentedScalarCanonicalRow = {
+    ...textRepresentedScalarRow,
+    id: '978-0-306-40615-7',
+  };
+
   test('insert', async () => {
     await pg.begin(async tx => {
       const transaction = new Transaction(tx);
@@ -179,6 +190,48 @@ describe('makeSchemaCRUD', () => {
 
       await crud.arrayCases.upsert({id: '1', tags: null});
       await checkDb(tx, 'arrayCases', [{id: '1', tags: null}]);
+    });
+  });
+
+  test('insert/update/upsert/delete with text-represented scalar columns', async () => {
+    await pg.begin(async tx => {
+      const transaction = new Transaction(tx);
+      const crud = crudProvider(
+        transaction,
+        await getServerSchema(transaction, schema),
+      );
+
+      await crud.textRepresentedScalars.insert(textRepresentedScalarRow);
+      await checkDb(tx, 'textRepresentedScalars', [
+        textRepresentedScalarCanonicalRow,
+      ]);
+
+      const updatedRow = {
+        ...textRepresentedScalarRow,
+        ip: '192.168.0.2/24',
+        mac: '08:00:2b:01:02:04',
+        title: 'updated',
+      };
+      await crud.textRepresentedScalars.update(updatedRow);
+      await checkDb(tx, 'textRepresentedScalars', [
+        {...updatedRow, id: textRepresentedScalarCanonicalRow.id},
+      ]);
+
+      const upsertedRow = {
+        ...textRepresentedScalarRow,
+        ip: '192.168.0.3/24',
+        mac: '08:00:2b:01:02:05',
+        title: 'upserted',
+      };
+      await crud.textRepresentedScalars.upsert(upsertedRow);
+      await checkDb(tx, 'textRepresentedScalars', [
+        {...upsertedRow, id: textRepresentedScalarCanonicalRow.id},
+      ]);
+
+      await crud.textRepresentedScalars.delete({
+        id: textRepresentedScalarRow.id,
+      });
+      await checkDb(tx, 'textRepresentedScalars', []);
     });
   });
 

--- a/packages/zero-server/src/schema.test.ts
+++ b/packages/zero-server/src/schema.test.ts
@@ -18,12 +18,84 @@ import type {
   ServerColumnSchema,
   ServerSchema,
 } from '../../zero-types/src/server-schema.ts';
+import type {DBTransaction} from '../../zql/src/mutate/custom.ts';
 import {
   checkSchemasAreCompatible,
+  getServerSchema,
   type SchemaIncompatibilityError,
 } from './schema.ts';
 
 describe('checkSchemasAreCompatible', () => {
+  test('getServerSchema maps known text-represented user-defined types', async () => {
+    const schema = createSchema({
+      tables: [
+        table('book')
+          .columns({
+            id: string(),
+            ip: string(),
+            mac: string(),
+          })
+          .primaryKey('id'),
+      ],
+      relationships: [],
+    });
+
+    const mockTx: DBTransaction<unknown> = {
+      wrappedTransaction: null,
+      query: () =>
+        Promise.resolve([
+          {
+            schema: 'public',
+            table: 'book',
+            column: 'id',
+            dataType: 'USER-DEFINED',
+            length: null,
+            precision: null,
+            scale: null,
+            typtype: 'b',
+            typename: 'isbn13',
+            elemTyptype: null,
+            elemTypname: null,
+          },
+          {
+            schema: 'public',
+            table: 'book',
+            column: 'ip',
+            dataType: 'inet',
+            length: null,
+            precision: null,
+            scale: null,
+            typtype: 'b',
+            typename: 'inet',
+            elemTyptype: null,
+            elemTypname: null,
+          },
+          {
+            schema: 'public',
+            table: 'book',
+            column: 'mac',
+            dataType: 'macaddr',
+            length: null,
+            precision: null,
+            scale: null,
+            typtype: 'b',
+            typename: 'macaddr',
+            elemTyptype: null,
+            elemTypname: null,
+          },
+        ]),
+      runQuery: () => Promise.reject(new Error('not implemented')),
+    };
+
+    expect(await getServerSchema(mockTx, schema)).toEqual({
+      book: {
+        id: {type: 'isbn13', isEnum: false, isArray: false},
+        ip: {type: 'inet', isEnum: false, isArray: false},
+        mac: {type: 'macaddr', isEnum: false, isArray: false},
+      },
+    });
+  });
+
   test('should return empty array when schemas are compatible', () => {
     const schema = createSchema({
       tables: [

--- a/packages/zero-server/src/schema.ts
+++ b/packages/zero-server/src/schema.ts
@@ -106,6 +106,11 @@ export async function getServerSchema<S extends Schema>(
       );
     } else if (isEnum) {
       type = row.typename;
+    } else if (
+      type === 'user-defined' &&
+      dataTypeToZqlValueType(row.typename, false, false) !== undefined
+    ) {
+      type = row.typename;
     }
     if (
       (type === 'bpchar' ||

--- a/packages/zero-server/src/test/schema.ts
+++ b/packages/zero-server/src/test/schema.ts
@@ -92,13 +92,23 @@ export const schema = createSchema({
         c: boolean().optional(),
       })
       .primaryKey('id'),
+    table('textRepresentedScalars')
+      .columns({
+        id: string(),
+        ip: string(),
+        mac: string(),
+        title: string(),
+      })
+      .primaryKey('id'),
   ],
   relationships: [],
   enableLegacyMutators: true,
   enableLegacyQueries: true,
 });
 
-export const schemaSql = `CREATE TABLE basic (
+export const schemaSql = `CREATE EXTENSION IF NOT EXISTS isn;
+
+CREATE TABLE basic (
   id TEXT PRIMARY KEY,
   a INTEGER,
   b TEXT,
@@ -179,6 +189,13 @@ CREATE TABLE alternate_schema.basic (
   a INTEGER,
   b TEXT,
   C BOOLEAN
+);
+
+CREATE TABLE "textRepresentedScalars" (
+  "id" ISBN13 PRIMARY KEY,
+  "ip" INET NOT NULL,
+  "mac" MACADDR NOT NULL,
+  "title" TEXT NOT NULL
 );
 `;
 


### PR DESCRIPTION
## Summary

- Map identifier/address-like Postgres scalar types to Zero `string`
- Support the `isn` extension family (`isbn13`, `ean13`, etc.) as string columns
- Allow these supported string-like types to participate in Zero primary key selection
- Improve schema rejection diagnostics when an upstream primary key uses unsupported column types

## Notes

This intentionally does not stringify arbitrary unknown Postgres types. The new support is an explicit allowlist for types whose textual representation is the natural client representation.

`name` is excluded for now because PG reports metadata that currently collides with Zero's array-type detection path.

## Testing

- `pnpm --filter zero-cache test src/types/pg-data-type.test.ts src/types/lite.test.ts src/db/lite-tables.test.ts src/services/view-syncer/client-schema.test.ts`
- `pnpm --filter zero-cache format`
- `pnpm --filter zero-cache lint`
- `pnpm --filter zero-cache check-types`