### PR TITLE
Add `--join-plans` option to analyze CLI

### DIFF
--- a/packages/analyze-query/src/analyze-cli.ts
+++ b/packages/analyze-query/src/analyze-cli.ts
@@ -13,6 +13,7 @@ import {Zero} from '../../zero-client/src/client/zero.ts';
 import type {AnalyzeQueryResult} from '../../zero-protocol/src/analyze-query-result.ts';
 import type {AST} from '../../zero-protocol/src/ast.ts';
 import type {Schema} from '../../zero-types/src/schema.ts';
+import {formatPlannerEvents} from '../../zql/src/planner/planner-debug.ts';
 import {createBuilder} from '../../zql/src/query/create-builder.ts';
 import type {AnyQuery} from '../../zql/src/query/query.ts';
 import type {SchemaQuery} from '../../zql/src/query/schema-query.ts';
@@ -106,6 +107,10 @@ const options = {
   outputSyncedRows: {
     type: v.boolean().default(false),
     desc: ['Include the rows that would be synced to the client.'],
+  },
+  joinPlans: {
+    type: v.boolean().default(false),
+    desc: ['Include join planner diagnostics.'],
   },
   log: {
     ...logOptions,
@@ -220,6 +225,7 @@ export async function runAnalyzeCLI(opts: AnalyzeCLIOptions): Promise<void> {
     const rpcOptions = {
       vendedRows: config.outputVendedRows,
       syncedRows: config.outputSyncedRows,
+      joinPlans: config.joinPlans,
     };
 
     if (plan.kind === 'ast') {
@@ -412,6 +418,11 @@ function renderResult(
     for (const w of result.warnings) {
       colorConsole.log(styleText('yellow', w));
     }
+  }
+
+  if (result.joinPlans && result.joinPlans.length > 0) {
+    colorConsole.log(styleText(['blue', 'bold'], '\n=== Join Plans: ===\n'));
+    colorConsole.log(formatPlannerEvents(result.joinPlans));
   }
 }
 


### PR DESCRIPTION
## Summary

Adds a `--join-plans` option to the project-specific remote analyze CLI powered by `runAnalyzeCLI`. The option is passed through to the inspector `analyze-query` RPC as `joinPlans`, and when the server returns planner diagnostics the CLI renders them with the existing `formatPlannerEvents()` formatter.

## Why

The inspector API already supports `analyze({joinPlans: true})`, but `analyze-cli.ts` had no equivalent flag. This made the supported CLI unable to request or display join planner diagnostics.

## Validation

- `pnpm --filter analyze-query run format`
- `pnpm --filter analyze-query run lint` (0 errors; existing warnings remain)
- `pnpm --filter analyze-query run check-types`
- zbugs smoke test against local Postgres, zero-cache, and API server:
  - `scripts/analyze.ts ... --join-plans` printed `=== Join Plans: ===`, two planner attempts, and `Best plan: Attempt 1`
  - the same AST without `--join-plans` produced no Join Plans section