### PR TITLE
bump zero-sqlite3 to 1.1.2

### DIFF
--- a/packages/replicache/package.json
+++ b/packages/replicache/package.json
@@ -80,7 +80,7 @@
   },
   "devDependencies": {
     "@op-engineering/op-sqlite": ">=15",
-    "@rocicorp/zero-sqlite3": "^1.1.1",
+    "@rocicorp/zero-sqlite3": "^1.1.2",
     "@types/command-line-args": "^5.2.3",
     "@types/command-line-usage": "^5.0.4",
     "@vitest/runner": "^4.1.6",
@@ -100,7 +100,7 @@
   },
   "peerDependencies": {
     "@op-engineering/op-sqlite": ">=15",
-    "@rocicorp/zero-sqlite3": "^1.1.1",
+    "@rocicorp/zero-sqlite3": "^1.1.2",
     "expo-sqlite": ">=15"
   },
   "peerDependenciesMeta": {

--- a/packages/zero-cache/package.json
+++ b/packages/zero-cache/package.json
@@ -54,7 +54,7 @@
     "@rocicorp/lock": "^1.0.4",
     "@rocicorp/logger": "^5.4.0",
     "@rocicorp/resolver": "^1.0.2",
-    "@rocicorp/zero-sqlite3": "^1.1.1",
+    "@rocicorp/zero-sqlite3": "^1.1.2",
     "@types/basic-auth": "^1.1.8",
     "basic-auth": "^2.0.1",
     "cloudevents": "^10.0.0",

--- a/packages/zero/package.json
+++ b/packages/zero/package.json
@@ -141,7 +141,7 @@
     "@rocicorp/lock": "^1.0.4",
     "@rocicorp/logger": "^5.4.0",
     "@rocicorp/resolver": "^1.0.2",
-    "@rocicorp/zero-sqlite3": "^1.1.1",
+    "@rocicorp/zero-sqlite3": "^1.1.2",
     "@standard-schema/spec": "^1.0.0",
     "@types/basic-auth": "^1.1.8",
     "@types/ws": "^8.5.12",

--- a/packages/zqlite/package.json
+++ b/packages/zqlite/package.json
@@ -24,7 +24,7 @@
     "@databases/sql": "^3.3.0",
     "@opentelemetry/api": "^1.9.0",
     "@rocicorp/logger": "^5.4.0",
-    "@rocicorp/zero-sqlite3": "^1.1.1",
+    "@rocicorp/zero-sqlite3": "^1.1.2",
     "zql": "workspace:*"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -482,8 +482,8 @@ importers:
         specifier: '>=15'
         version: 15.2.14(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       '@rocicorp/zero-sqlite3':
-        specifier: ^1.1.1
-        version: 1.1.1
+        specifier: ^1.1.2
+        version: 1.1.2
       '@types/command-line-args':
         specifier: ^5.2.3
         version: 5.2.3
@@ -852,8 +852,8 @@ importers:
         specifier: ^1.0.2
         version: 1.0.2
       '@rocicorp/zero-sqlite3':
-        specifier: ^1.1.1
-        version: 1.1.1
+        specifier: ^1.1.2
+        version: 1.1.2
       '@standard-schema/spec':
         specifier: ^1.0.0
         version: 1.1.0
@@ -1075,8 +1075,8 @@ importers:
         specifier: ^1.0.2
         version: 1.0.2
       '@rocicorp/zero-sqlite3':
-        specifier: ^1.1.1
-        version: 1.1.1
+        specifier: ^1.1.2
+        version: 1.1.2
       '@types/basic-auth':
         specifier: ^1.1.8
         version: 1.1.8
@@ -1699,8 +1699,8 @@ importers:
         specifier: ^5.4.0
         version: 5.4.0
       '@rocicorp/zero-sqlite3':
-        specifier: ^1.1.1
-        version: 1.1.1
+        specifier: ^1.1.2
+        version: 1.1.2
       zql:
         specifier: workspace:*
         version: link:../zql
@@ -5608,8 +5608,8 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     deprecated: Use Promise.withResolvers instead
 
-  '@rocicorp/zero-sqlite3@1.1.1':
-    resolution: {integrity: sha512-BZ9FkXADOOalBbvfPmSq3QD193O5QQz/zqs9xXsAjWx/lL0VyYfT4zNrSEZqMpyv/7vH7DhPEDvbIzV6bvl7TQ==}
+  '@rocicorp/zero-sqlite3@1.1.2':
+    resolution: {integrity: sha512-bpxeS/JXENp8Wgo68wHsiMJjy41zePI0tCX0va/T4wAlUGfQ+gy4/Fr0TTfWWwHgDkVkAiQn5nb2EdN9xdOQWQ==}
     engines: {bun: '>=1.1.0', node: 22.x || 24.x}
     hasBin: true
 
@@ -18506,7 +18506,7 @@ snapshots:
 
   '@rocicorp/resolver@1.0.2': {}
 
-  '@rocicorp/zero-sqlite3@1.1.1':
+  '@rocicorp/zero-sqlite3@1.1.2':
     dependencies:
       bindings: 1.5.0
       prebuild-install: 7.1.3


### PR DESCRIPTION
## Summary

Bumps all workspace references to `@rocicorp/zero-sqlite3` from `^1.1.1` to `^1.1.2` and refreshes `pnpm-lock.yaml` so installs resolve the patched native package.

## Why

`@rocicorp/zero-sqlite3@1.1.1` can fail for users installing/building Zero with newer Node versions because it may fall back to a source build with an incomplete tarball. The `1.1.2` patch includes the upstream fix, preventing future users from hitting that install failure.

## Validation

- `pnpm why @rocicorp/zero-sqlite3` resolves a single version: `1.1.2`
- `pnpm run format`
- `pnpm run lint` on Node `24.11.1`
- `pnpm run check-types` on Node `24.11.1`
