### PR TITLE
Log SQLite index creation during initial sync

### DIFF
--- a/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
@@ -277,7 +277,7 @@ export async function initialSync(
         5000,
       );
       const indexStart = performance.now();
-      createLiteIndices(tx, indexes);
+      createLiteIndices(lc, tx, indexes);
       const index = performance.now() - indexStart;
       lc.info?.(`Created indexes (${index.toFixed(3)} ms)`);
 
@@ -567,9 +567,16 @@ function createLiteTables(
   }
 }
 
-function createLiteIndices(tx: Database, indices: IndexSpec[]) {
-  for (const index of indices) {
-    tx.exec(createLiteIndexStatement(mapPostgresToLiteIndex(index)));
+function createLiteIndices(lc: LogContext, tx: Database, indices: IndexSpec[]) {
+  for (const [i, index] of indices.entries()) {
+    const stmt = createLiteIndexStatement(mapPostgresToLiteIndex(index));
+    lc.info?.(`Creating index ${i + 1}/${indices.length}: ${stmt}`);
+    const start = performance.now();
+    tx.exec(stmt);
+    lc.info?.(
+      `Created index ${i + 1}/${indices.length} ` +
+        `(${(performance.now() - start).toFixed(3)} ms): ${stmt}`,
+    );
   }
 }
 


### PR DESCRIPTION
## What changed

Adds info-level logging around each SQLite index created during Zero initial sync. Each log includes the index position, total count, exact SQLite CREATE INDEX statement after PG-to-Lite mapping, and per-index elapsed time.

## Why

Initial sync index creation is rare but can be slow and currently only has aggregate logging. Per-index logs make it easier to identify the exact mirrored index responsible for long readiness delays.

## Validation

- npm --workspace packages/zero-cache run format
- npm --workspace packages/zero-cache run lint
- npm --workspace packages/zero-cache run check-types