### PR TITLE
fix(analyze-query): allow anonymous analyze cli

### DIFF
--- a/packages/analyze-query/src/analyze-cli.ts
+++ b/packages/analyze-query/src/analyze-cli.ts
@@ -67,7 +67,7 @@ const options = {
     type: v.string().optional(),
     desc: [
       'Optional userID to report to zero-cache.',
-      'Has no functional effect on analysis; defaults to "analyze-cli".',
+      'Omit for anonymous analysis.',
     ],
   },
   ast: {
@@ -207,7 +207,7 @@ export async function runAnalyzeCLI(opts: AnalyzeCLIOptions): Promise<void> {
     schema: opts.schema,
     server: config.zeroCacheURL,
     auth: config.authToken,
-    userID: config.userId ?? 'analyze-cli',
+    userID: config.userId,
     kvStore: 'mem',
     logLevel: config.log.level,
     logSink: stderrLogSink,


### PR DESCRIPTION
## What changed

- Stop defaulting omitted `--user-id` to `"analyze-cli"` in `analyze-query` CLI.
- Update the CLI help text to make omitted `--user-id` mean anonymous analysis.

## Why

Anonymous analyze calls against zbugs were being sent with a synthetic client `userID`, which made zero-cache reject the connection when the validated server user was anonymous/null.

## Validation

- `pnpm --filter analyze-query run format`
- `pnpm --filter analyze-query run lint`
- `pnpm --filter analyze-query run check-types`
- Checked that no tests or snapshots validate the previous default-`"analyze-cli"` behavior.
