### PR TITLE
fix(zero-react, zero-solid): include full result format in view cache key

### DIFF
--- a/packages/zero-react/src/use-query.test.tsx
+++ b/packages/zero-react/src/use-query.test.tsx
@@ -10,6 +10,7 @@ import {
   vi,
   type Mock,
 } from 'vitest';
+import type {Format} from '../../zero-types/src/format.ts';
 import {newQuery} from '../../zql/src/query/query-impl.ts';
 import {queryInternalsTag, type QueryImpl} from './bindings.ts';
 import {
@@ -41,6 +42,20 @@ function newMockQuery(query: string, singular = false): Query<string, Schema> {
       return query;
     },
     format: {singular},
+  } as unknown as QueryImpl<string, Schema>;
+  return ret;
+}
+
+function newMockQueryWithFormat(
+  query: string,
+  format: Format,
+): Query<string, Schema> {
+  const ret = {
+    [queryInternalsTag]: true,
+    hash() {
+      return query;
+    },
+    format,
   } as unknown as QueryImpl<string, Schema>;
   return ret;
 }
@@ -365,6 +380,70 @@ describe('ViewStore', () => {
       const view2 = viewStore.getView(
         zero2,
         newMockQuery('query1', true),
+        true,
+        'forever',
+      );
+
+      expect(view1).toBe(view2);
+      expect(getAllViewsSizeForTesting(viewStore)).toBe(1);
+    });
+
+    test('queries that differ only in a nested relationship singular flag create different views', () => {
+      // `related('owner', q => q.one())` and `related('owner', q => q.limit(1))`
+      // produce the same AST (and therefore the same query hash) and the same
+      // top-level `format.singular`. They differ only in the *nested*
+      // `format.relationships.owner.singular`, so the cache key must fold the
+      // whole format, not just the top-level singular flag.
+      const viewStore = new ViewStore();
+      const zero = newMockZero('client1');
+
+      const oneFormat: Format = {
+        singular: false,
+        relationships: {owner: {singular: true, relationships: {}}},
+      };
+      const limitFormat: Format = {
+        singular: false,
+        relationships: {owner: {singular: false, relationships: {}}},
+      };
+
+      const view1 = viewStore.getView(
+        zero,
+        newMockQueryWithFormat('query1', oneFormat),
+        true,
+        'forever',
+      );
+      const view2 = viewStore.getView(
+        zero,
+        newMockQueryWithFormat('query1', limitFormat),
+        true,
+        'forever',
+      );
+
+      expect(view1).not.toBe(view2);
+      expect(getAllViewsSizeForTesting(viewStore)).toBe(2);
+    });
+
+    test('duplicate queries with matching nested formats share a view', () => {
+      const viewStore = new ViewStore();
+      const zero = newMockZero('client1');
+
+      const format: Format = {
+        singular: false,
+        relationships: {owner: {singular: true, relationships: {}}},
+      };
+
+      const view1 = viewStore.getView(
+        zero,
+        newMockQueryWithFormat('query1', format),
+        true,
+        'forever',
+      );
+      const view2 = viewStore.getView(
+        zero,
+        newMockQueryWithFormat('query1', {
+          singular: false,
+          relationships: {owner: {singular: true, relationships: {}}},
+        }),
         true,
         'forever',
       );

--- a/packages/zero-react/src/use-query.tsx
+++ b/packages/zero-react/src/use-query.tsx
@@ -448,7 +448,7 @@ export class ViewStore {
       };
     }
 
-    const hash = qi.hash() + (qi.format.singular ? 't' : 'f') + zero.clientID;
+    const hash = qi.hash() + JSON.stringify(qi.format) + zero.clientID;
     let existing = this.#views.get(hash);
     if (!existing) {
       existing = new ViewWrapper(q, zero, ttl, view => {

--- a/packages/zero-solid/src/use-query.test.tsx
+++ b/packages/zero-solid/src/use-query.test.tsx
@@ -961,6 +961,76 @@ test('useQuery plural and singular with same hash create different views', () =>
   expect(materializeSpy.mock.calls[1][0]).toBe(singularQuery);
 });
 
+test('useQuery nested one() and limit(1) with same hash create different views', () => {
+  const issue = table('issue').columns({id: string()}).primaryKey('id');
+  const comment = table('comment')
+    .columns({id: string(), issueID: string()})
+    .primaryKey('id');
+  const schema = createSchema({
+    tables: [issue, comment],
+    relationships: [
+      relationships(issue, connect => ({
+        comments: connect.many({
+          sourceField: ['id'],
+          destField: ['issueID'],
+          destSchema: comment,
+        }),
+      })),
+    ],
+  });
+  const issueSource = new MemorySource(
+    schema.tables.issue.name,
+    schema.tables.issue.columns,
+    schema.tables.issue.primaryKey,
+  );
+  const commentSource = new MemorySource(
+    schema.tables.comment.name,
+    schema.tables.comment.columns,
+    schema.tables.comment.primaryKey,
+  );
+  consume(issueSource.push(makeSourceChangeAdd({id: 'i1'})));
+  consume(commentSource.push(makeSourceChangeAdd({id: 'c1', issueID: 'i1'})));
+  const queryDelegate = new QueryDelegateImpl({
+    sources: {issue: issueSource, comment: commentSource},
+  });
+  const issueQuery = newQuery(schema, 'issue');
+
+  // one() and limit(1) on a *nested* relationship produce the same AST hash
+  // because the singular flag lives only in the format, not the AST. The view
+  // hash must therefore fold the whole format (including nested relationships),
+  // not just the top-level singular flag.
+  const pluralRel = issueQuery
+    .where('id', 'i1')
+    .related('comments', q => q.limit(1));
+  const singularRel = issueQuery
+    .where('id', 'i1')
+    .related('comments', q => q.one());
+  expect(asQueryInternals(pluralRel).hash()).toBe(
+    asQueryInternals(singularRel).hash(),
+  );
+
+  type AnyQuery = typeof pluralRel | typeof singularRel;
+  const [querySignal, setQuery] = createSignal<AnyQuery>(pluralRel);
+
+  const zero = newMockZero('useQuery-nested-one-limit', queryDelegate);
+  const materializeSpy = vi.spyOn(queryDelegate, 'materialize');
+  useQueryWithZeroProvider(zero, querySignal as () => typeof pluralRel);
+
+  expect(materializeSpy).toHaveBeenCalledTimes(1);
+  expect(materializeSpy.mock.calls[0][0]).toBe(pluralRel);
+
+  const view0 = materializeSpy.mock.results[0].value;
+  const destroy0Spy = vi.spyOn(view0, 'destroy');
+
+  // Switch to the singular relationship — the view hash must change even though
+  // the underlying AST hash is identical.
+  setQuery(singularRel as unknown as AnyQuery);
+
+  expect(destroy0Spy).toHaveBeenCalledTimes(1);
+  expect(materializeSpy).toHaveBeenCalledTimes(2);
+  expect(materializeSpy.mock.calls[1][0]).toBe(singularRel);
+});
+
 test('useQuery same query for different clientIDs creates different views', () => {
   const {tableQuery, queryDelegate} = setupTestEnvironment();
   const query = tableQuery.where('a', 1);

--- a/packages/zero-solid/src/use-query.ts
+++ b/packages/zero-solid/src/use-query.ts
@@ -150,7 +150,7 @@ export function useQuery<
   });
 
   const hash = createMemo(
-    () => qi()?.hash() + (qi()?.format.singular ? 't' : 'f') + zero().clientID,
+    () => qi()?.hash() + JSON.stringify(qi()?.format ?? null) + zero().clientID,
   );
   const ttl = createMemo(() => normalize(options)?.ttl ?? DEFAULT_TTL_MS);
 


### PR DESCRIPTION
Summary

.one() sets limit: 1 in the AST and singular: true in the format; .limit(1) sets only limit: 1. The two therefore produce an identical AST hash and are distinguishable only by their format. The ViewStore cache key folded only the top-level format.singular flag, so any one() vs limit(1) difference inside a nested relationship collided onto a single shared ViewWrapper. Whichever query materialized first won, and the other got the wrong shape for that relationship ([row] instead of row, or vice-versa).

This is the same class of bug as #6065 / #6037, one level down — the AST can't disambiguate it because CorrelatedSubquery has no cardinality field; one() just stores singular: true in format.relationships[...] ===
false: z.query.issue.where('id', '=', id).related('owner', q =>

```
// Same parent, identical AST hash, identical top-level format.singular === false:
z.query.issue.where('id', '=', id).related('owner', q => q.one());    // owner.singular = true
z.query.issue.where('id', '=', id).related('owner', q => q.limit(1)); // owner.singular = false
// Previous key: hash + 'f' + clientID  →  collision
```

Fix

Fold the whole format into the view cache key instead of just the top-level singular flag. JSON.stringify recurses through format.relationships natively, so nested cardinality differences now produce distinct keys.