### PR TITLE
fix(ci): restrict release workflow refs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,6 @@ on:
         options:
           - canary
           - stable
-      ref:
-        description: Branch, tag, or commit SHA to build the release from
-        required: true
-        type: string
       dry_run:
         description: Build but skip git push, npm publish, and Docker push
         required: false
@@ -80,7 +76,7 @@ jobs:
         id: release
         env:
           MODE: ${{ github.event_name == 'workflow_dispatch' && inputs.mode || 'canary' }}
-          REF: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.event.pull_request.base.ref }}
+          REF: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || github.event.pull_request.base.ref }}
           DRY_RUN: ${{ inputs.dry_run == true && '--dry-run' || '' }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary

- Remove the manual `workflow_dispatch` `ref` input from the Release workflow.
- For manual releases, pass the workflow-selected `github.ref_name` to `release.ts`.
- Keep release privilege gating in the GitHub `Release` environment.

## Why

A free-form `workflow_dispatch` ref let any user who could dispatch the workflow choose what code the privileged release job built. That path was risky because the release job has `contents: write`, `id-token: write`, `pull-requests: write`, Docker Hub credentials, npm trusted publishing/OIDC capability, and cosign signing. Once a caller-selected ref reached the release flow, package lifecycle scripts during `pnpm install` or release code from that ref could run in that credentialed context and potentially exfiltrate credentials or publish malicious npm/Docker artifacts. The later ref syntax validation did not establish trust in the ref.

This change removes arbitrary ref selection from workflow inputs. Manual releases now use the ref selected by the workflow dispatch UI, and the `Release` environment enforces approval and allowed ref policy before environment secrets are available.
