### PR TITLE
fix(zero-cache): filter rows to client schema

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/client-handler.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/client-handler.test.ts
@@ -2,6 +2,7 @@ import {resolver} from '@rocicorp/resolver';
 import {beforeEach, describe, expect, test} from 'vitest';
 import type {JSONObject} from '../../../../shared/src/bigint-json.ts';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
+import type {ClientSchema} from '../../../../zero-protocol/src/client-schema.ts';
 import type {Downstream} from '../../../../zero-protocol/src/down.ts';
 import type {
   PokeEndMessage,
@@ -20,6 +21,58 @@ import {
 const APP_ID = 'zapp';
 const SHARD_NUM = 6;
 const SHARD = {appID: APP_ID, shardNum: SHARD_NUM};
+const CLIENT_SCHEMA = {
+  tables: {
+    issues: {
+      columns: {
+        id: {type: 'string'},
+        name: {type: 'string'},
+      },
+      primaryKey: ['id'],
+    },
+  },
+} satisfies ClientSchema;
+const CLIENT_SCHEMA_WITH_BIG = {
+  tables: {
+    issues: {
+      columns: {
+        id: {type: 'string'},
+        name: {type: 'string'},
+        big: {type: 'number'},
+      },
+      primaryKey: ['id'],
+    },
+  },
+} satisfies ClientSchema;
+const CLIENT_SCHEMA_WITH_NUMERIC_ID = {
+  tables: {
+    issues: {
+      columns: {
+        id: {type: 'number'},
+        name: {type: 'string'},
+      },
+      primaryKey: ['id'],
+    },
+  },
+} satisfies ClientSchema;
+const NON_PUBLIC_CLIENT_SCHEMA = {
+  tables: {
+    'issues': {
+      columns: {
+        id: {type: 'string'},
+        name: {type: 'string'},
+      },
+      primaryKey: ['id'],
+    },
+    'private.issues': {
+      columns: {
+        id: {type: 'string'},
+        alias: {type: 'string'},
+      },
+      primaryKey: ['id'],
+    },
+  },
+} satisfies ClientSchema;
 
 describe('view-syncer/client-handler', () => {
   const lc = createSilentLogContext();
@@ -166,7 +219,7 @@ describe('view-syncer/client-handler', () => {
       ),
     ];
 
-    let pokers = startPoke(handlers, poke1Version);
+    let pokers = startPoke(handlers, poke1Version, CLIENT_SCHEMA);
     await pokers.addPatch({
       toVersion: {stateVersion: '11z', configVersion: 1},
       patch: {
@@ -271,7 +324,7 @@ describe('view-syncer/client-handler', () => {
     await pokers.end(poke1Version);
 
     // Now send another (empty) poke with everyone at the same baseCookie.
-    pokers = startPoke(handlers, poke2Version);
+    pokers = startPoke(handlers, poke2Version, CLIENT_SCHEMA);
     await pokers.end(poke2Version);
 
     const results = await Promise.all(subscriptions.map(sub => sub.close()));
@@ -304,12 +357,12 @@ describe('view-syncer/client-handler', () => {
             {
               op: 'put',
               tableName: 'issues',
-              value: {id: 'bar', name: 'hello', num: 123},
+              value: {id: 'bar', name: 'hello'},
             },
             {
               op: 'put',
               tableName: 'issues',
-              value: {id: 'boo', name: 'world', num: 123456},
+              value: {id: 'boo', name: 'world'},
             },
           ],
         },
@@ -349,13 +402,13 @@ describe('view-syncer/client-handler', () => {
             {
               op: 'put',
               tableName: 'issues',
-              value: {id: 'bar', name: 'hello', num: 123},
+              value: {id: 'bar', name: 'hello'},
             },
             {op: 'del', tableName: 'issues', id: {id: 'foo'}},
             {
               op: 'put',
               tableName: 'issues',
-              value: {id: 'boo', name: 'world', num: 123456},
+              value: {id: 'boo', name: 'world'},
             },
           ],
         },
@@ -369,6 +422,509 @@ describe('view-syncer/client-handler', () => {
       ] satisfies PokeStartMessage,
       ['pokeEnd', {pokeID: '123', cookie: '123'}] satisfies PokeEndMessage,
     ]);
+  });
+
+  test('row patches are projected to the client schema', async () => {
+    const {subscription, close} = createSubscription();
+
+    const handler = new ClientHandler(
+      lc,
+      'g1',
+      'id1',
+      'ws1',
+      SHARD,
+      '121',
+      subscription,
+    );
+    const poker = handler.startPoke({stateVersion: '123'}, CLIENT_SCHEMA);
+    await poker.addPatch({
+      toVersion: {stateVersion: '123'},
+      patch: {
+        type: 'row',
+        op: 'put',
+        id: {schema: 'public', table: 'issues', rowKey: {id: 'bar'}},
+        contents: {
+          id: 'bar',
+          name: 'hello',
+          private: 'secret',
+          unsafePrivate: 983712341234123412348n,
+        },
+      },
+    });
+    await poker.addPatch({
+      toVersion: {stateVersion: '123'},
+      patch: {
+        type: 'row',
+        op: 'del',
+        id: {
+          schema: 'public',
+          table: 'issues',
+          rowKey: {id: 'foo', private: 'secret'},
+        },
+      },
+    });
+    await poker.addPatch({
+      toVersion: {stateVersion: '123'},
+      patch: {
+        type: 'row',
+        op: 'put',
+        id: {schema: 'public', table: 'hidden', rowKey: {id: 'secret'}},
+        contents: {
+          id: 'secret',
+          private: 'not sent',
+        },
+      },
+    });
+    await poker.end({stateVersion: '123'});
+
+    const {received, err} = await close();
+
+    expect(received).toEqual([
+      [
+        'pokeStart',
+        {
+          baseCookie: '121',
+          pokeID: '123',
+        },
+      ] satisfies PokeStartMessage,
+      [
+        'pokePart',
+        {
+          pokeID: '123',
+          rowsPatch: [
+            {
+              op: 'put',
+              tableName: 'issues',
+              value: {id: 'bar', name: 'hello'},
+            },
+            {
+              op: 'del',
+              tableName: 'issues',
+              id: {id: 'foo'},
+            },
+          ],
+        },
+      ] satisfies PokePartMessage,
+      [
+        'pokeEnd',
+        {
+          cookie: '123',
+          pokeID: '123',
+        },
+      ] satisfies PokeEndMessage,
+    ]);
+    expect(err).toBeUndefined();
+  });
+
+  test('safe bigint primary key deletes are converted', async () => {
+    const {subscription, close} = createSubscription();
+
+    const handler = new ClientHandler(
+      lc,
+      'g1',
+      'id1',
+      'ws1',
+      SHARD,
+      '121',
+      subscription,
+    );
+    const poker = handler.startPoke(
+      {stateVersion: '123'},
+      CLIENT_SCHEMA_WITH_NUMERIC_ID,
+    );
+    await poker.addPatch({
+      toVersion: {stateVersion: '123'},
+      patch: {
+        type: 'row',
+        op: 'del',
+        id: {
+          schema: 'public',
+          table: 'issues',
+          rowKey: {id: 123n},
+        },
+      },
+    });
+    await poker.end({stateVersion: '123'});
+
+    const {received, err} = await close();
+
+    expect(received).toEqual([
+      [
+        'pokeStart',
+        {
+          baseCookie: '121',
+          pokeID: '123',
+        },
+      ] satisfies PokeStartMessage,
+      [
+        'pokePart',
+        {
+          pokeID: '123',
+          rowsPatch: [
+            {
+              op: 'del',
+              tableName: 'issues',
+              id: {id: 123},
+            },
+          ],
+        },
+      ] satisfies PokePartMessage,
+      [
+        'pokeEnd',
+        {
+          cookie: '123',
+          pokeID: '123',
+        },
+      ] satisfies PokeEndMessage,
+    ]);
+    expect(err).toBeUndefined();
+  });
+
+  test('row projection preserves __proto__ primary key column', async () => {
+    const schemaWithProtoPrimaryKey = {
+      tables: {
+        issues: {
+          columns: Object.fromEntries([
+            ['__proto__', {type: 'string' as const}],
+            ['name', {type: 'string' as const}],
+          ]),
+          primaryKey: ['__proto__'],
+        },
+      },
+    } satisfies ClientSchema;
+    const {subscription, close} = createSubscription();
+
+    const handler = new ClientHandler(
+      lc,
+      'g1',
+      'id1',
+      'ws1',
+      SHARD,
+      '121',
+      subscription,
+    );
+    const poker = handler.startPoke(
+      {stateVersion: '123'},
+      schemaWithProtoPrimaryKey,
+    );
+    await poker.addPatch({
+      toVersion: {stateVersion: '123'},
+      patch: {
+        type: 'row',
+        op: 'put',
+        id: {
+          schema: 'public',
+          table: 'issues',
+          rowKey: Object.fromEntries([['__proto__', 'p1']]),
+        },
+        contents: Object.fromEntries([
+          ['__proto__', 'p1'],
+          ['name', 'hello'],
+          ['private', 'secret'],
+        ]),
+      },
+    });
+    await poker.addPatch({
+      toVersion: {stateVersion: '123'},
+      patch: {
+        type: 'row',
+        op: 'del',
+        id: {
+          schema: 'public',
+          table: 'issues',
+          rowKey: Object.fromEntries([
+            ['__proto__', 'p2'],
+            ['private', 'secret'],
+          ]),
+        },
+      },
+    });
+    await poker.end({stateVersion: '123'});
+
+    const {received, err} = await close();
+
+    expect(received).toEqual([
+      [
+        'pokeStart',
+        {
+          baseCookie: '121',
+          pokeID: '123',
+        },
+      ] satisfies PokeStartMessage,
+      [
+        'pokePart',
+        {
+          pokeID: '123',
+          rowsPatch: [
+            {
+              op: 'put',
+              tableName: 'issues',
+              value: Object.fromEntries([
+                ['__proto__', 'p1'],
+                ['name', 'hello'],
+              ]),
+            },
+            {
+              op: 'del',
+              tableName: 'issues',
+              id: Object.fromEntries([['__proto__', 'p2']]),
+            },
+          ],
+        },
+      ] satisfies PokePartMessage,
+      [
+        'pokeEnd',
+        {
+          cookie: '123',
+          pokeID: '123',
+        },
+      ] satisfies PokeEndMessage,
+    ]);
+    expect(err).toBeUndefined();
+  });
+
+  test('app row patches without client schema fail', async () => {
+    const {subscription, close} = createSubscription();
+
+    const handler = new ClientHandler(
+      lc,
+      'g1',
+      'id1',
+      'ws1',
+      SHARD,
+      '121',
+      subscription,
+    );
+    const poker = handler.startPoke({stateVersion: '123'});
+    await poker.addPatch({
+      toVersion: {stateVersion: '123'},
+      patch: {
+        type: 'row',
+        op: 'put',
+        id: {schema: 'public', table: 'issues', rowKey: {id: 'bar'}},
+        contents: {
+          id: 'bar',
+          name: 'hello',
+          private: 'secret',
+          unsafePrivate: 983712341234123412348n,
+        },
+      },
+    });
+
+    const {received, err} = await close();
+
+    expect(received).toEqual([
+      [
+        'pokeStart',
+        {
+          baseCookie: '121',
+          pokeID: '123',
+        },
+      ] satisfies PokeStartMessage,
+    ]);
+    expect(String(err)).toContain(
+      'Cannot send app row patch without clientSchema',
+    );
+  });
+
+  test('app row patches for inherited object table names are skipped', async () => {
+    const {subscription, close} = createSubscription();
+
+    const handler = new ClientHandler(
+      lc,
+      'g1',
+      'id1',
+      'ws1',
+      SHARD,
+      '121',
+      subscription,
+    );
+    const poker = handler.startPoke({stateVersion: '123'}, CLIENT_SCHEMA);
+    await poker.addPatch({
+      toVersion: {stateVersion: '123'},
+      patch: {
+        type: 'row',
+        op: 'put',
+        id: {schema: 'public', table: 'toString', rowKey: {id: 'x'}},
+        contents: {
+          id: 'x',
+          private: 'not sent',
+        },
+      },
+    });
+    await poker.end({stateVersion: '123'});
+
+    const {received, err} = await close();
+
+    expect(received).toEqual([
+      [
+        'pokeStart',
+        {
+          baseCookie: '121',
+          pokeID: '123',
+        },
+      ] satisfies PokeStartMessage,
+      [
+        'pokePart',
+        {
+          pokeID: '123',
+        },
+      ] satisfies PokePartMessage,
+      [
+        'pokeEnd',
+        {
+          cookie: '123',
+          pokeID: '123',
+        },
+      ] satisfies PokeEndMessage,
+    ]);
+    expect(err).toBeUndefined();
+  });
+
+  test('internal row patches bypass client schema projection', async () => {
+    const {subscription, close} = createSubscription();
+
+    const handler = new ClientHandler(
+      lc,
+      'g1',
+      'id1',
+      'ws1',
+      SHARD,
+      '121',
+      subscription,
+    );
+    const poker = handler.startPoke({stateVersion: '123'}, CLIENT_SCHEMA);
+    await poker.addPatch({
+      toVersion: {stateVersion: '123'},
+      patch: {
+        type: 'row',
+        op: 'put',
+        id: {
+          schema: '',
+          table: 'zapp_6.clients',
+          rowKey: {clientID: 'foo'},
+        },
+        contents: {
+          clientGroupID: 'g1',
+          clientID: 'foo',
+          lastMutationID: 124n,
+          userID: 'ignored',
+        },
+      },
+    });
+    await poker.end({stateVersion: '123'});
+
+    const {received, err} = await close();
+
+    expect(received).toEqual([
+      [
+        'pokeStart',
+        {
+          baseCookie: '121',
+          pokeID: '123',
+        },
+      ] satisfies PokeStartMessage,
+      [
+        'pokePart',
+        {
+          pokeID: '123',
+          lastMutationIDChanges: {foo: 124},
+        },
+      ] satisfies PokePartMessage,
+      [
+        'pokeEnd',
+        {
+          cookie: '123',
+          pokeID: '123',
+        },
+      ] satisfies PokeEndMessage,
+    ]);
+    expect(err).toBeUndefined();
+  });
+
+  test('row patches project by canonical server table key', async () => {
+    const {subscription, close} = createSubscription();
+
+    const handler = new ClientHandler(
+      lc,
+      'g1',
+      'id1',
+      'ws1',
+      SHARD,
+      '121',
+      subscription,
+    );
+    const poker = handler.startPoke(
+      {stateVersion: '123'},
+      NON_PUBLIC_CLIENT_SCHEMA,
+    );
+    await poker.addPatch({
+      toVersion: {stateVersion: '123'},
+      patch: {
+        type: 'row',
+        op: 'put',
+        id: {schema: '', table: 'issues', rowKey: {id: 'public'}},
+        contents: {
+          id: 'public',
+          name: 'hello',
+          alias: 'wrong table',
+          private: 'secret',
+        },
+      },
+    });
+    await poker.addPatch({
+      toVersion: {stateVersion: '123'},
+      patch: {
+        type: 'row',
+        op: 'put',
+        id: {schema: 'private', table: 'issues', rowKey: {id: 'private'}},
+        contents: {
+          id: 'private',
+          name: 'wrong table',
+          alias: 'hidden namespace',
+          private: 'secret',
+        },
+      },
+    });
+    await poker.end({stateVersion: '123'});
+
+    const {received, err} = await close();
+
+    expect(received).toEqual([
+      [
+        'pokeStart',
+        {
+          baseCookie: '121',
+          pokeID: '123',
+        },
+      ] satisfies PokeStartMessage,
+      [
+        'pokePart',
+        {
+          pokeID: '123',
+          rowsPatch: [
+            {
+              op: 'put',
+              tableName: 'issues',
+              value: {id: 'public', name: 'hello'},
+            },
+            {
+              op: 'put',
+              tableName: 'private.issues',
+              value: {id: 'private', alias: 'hidden namespace'},
+            },
+          ],
+        },
+      ] satisfies PokePartMessage,
+      [
+        'pokeEnd',
+        {
+          cookie: '123',
+          pokeID: '123',
+        },
+      ] satisfies PokeEndMessage,
+    ]);
+    expect(err).toBeUndefined();
   });
 
   describe('mutation results', () => {
@@ -576,33 +1132,89 @@ describe('view-syncer/client-handler', () => {
       `);
       expect(err).toBeUndefined();
     });
+
+    test('unsafe mutation result delete id fails instead of rounding', async () => {
+      await poker.addPatch({
+        toVersion: {stateVersion: '123'},
+        patch: {
+          type: 'row',
+          op: 'del',
+          id: {
+            schema: '',
+            table: 'zapp_6.mutations',
+            rowKey: {
+              clientGroupID: 'g1',
+              clientID: 'boo',
+              mutationID: 9007199254740993n,
+            },
+          },
+        },
+      });
+
+      const {received, err} = await closer();
+      expect(received).toMatchInlineSnapshot(`
+        [
+          [
+            "pokeStart",
+            {
+              "baseCookie": "121",
+              "pokeID": "123",
+            },
+          ],
+        ]
+      `);
+      expect(String(err)).toMatch(
+        /Error: Value of "mutationID" exceeds safe Number range \(\d+\)/,
+      );
+    });
   });
 
   test('error on unsafe integer', async () => {
-    for (const patch of [
+    for (const {patch, clientSchema} of [
       {
-        type: 'row',
-        op: 'put',
-        id: {schema: 'public', table: 'issues', rowKey: {id: 'boo'}},
-        contents: {id: 'boo', name: 'world', big: 12345231234123414n},
-      },
-      {
-        type: 'row',
-        op: 'put',
-        id: {schema: 'public', table: 'issues', rowKey: {id: 'boo'}},
-        contents: {id: 'boo', name: 'world', big: 983712341234123412348n},
-      },
-      {
-        type: 'row',
-        op: 'put',
-        id: {schema: '', table: 'zapp_6.clients', rowKey: {clientID: 'boo'}},
-        contents: {
-          clientGroupID: 'g1',
-          clientID: 'boo',
-          lastMutationID: 98371234123423412341238n,
+        clientSchema: CLIENT_SCHEMA_WITH_BIG,
+        patch: {
+          type: 'row',
+          op: 'put',
+          id: {schema: 'public', table: 'issues', rowKey: {id: 'boo'}},
+          contents: {id: 'boo', name: 'world', big: 12345231234123414n},
         },
       },
-    ] satisfies Patch[]) {
+      {
+        clientSchema: CLIENT_SCHEMA_WITH_BIG,
+        patch: {
+          type: 'row',
+          op: 'put',
+          id: {schema: 'public', table: 'issues', rowKey: {id: 'boo'}},
+          contents: {id: 'boo', name: 'world', big: 983712341234123412348n},
+        },
+      },
+      {
+        clientSchema: CLIENT_SCHEMA_WITH_NUMERIC_ID,
+        patch: {
+          type: 'row',
+          op: 'del',
+          id: {
+            schema: 'public',
+            table: 'issues',
+            rowKey: {id: 983712341234123412348n},
+          },
+        },
+      },
+      {
+        clientSchema: undefined,
+        patch: {
+          type: 'row',
+          op: 'put',
+          id: {schema: '', table: 'zapp_6.clients', rowKey: {clientID: 'boo'}},
+          contents: {
+            clientGroupID: 'g1',
+            clientID: 'boo',
+            lastMutationID: 98371234123423412341238n,
+          },
+        },
+      },
+    ] satisfies {patch: Patch; clientSchema?: ClientSchema | undefined}[]) {
       const {subscription, close} = createSubscription();
 
       const handler = new ClientHandler(
@@ -614,7 +1226,7 @@ describe('view-syncer/client-handler', () => {
         '121',
         subscription,
       );
-      const poker = handler.startPoke({stateVersion: '123'});
+      const poker = handler.startPoke({stateVersion: '123'}, clientSchema);
 
       await poker.addPatch({toVersion: {stateVersion: '123'}, patch});
       const {err} = await close();

--- a/packages/zero-cache/src/services/view-syncer/client-handler.ts
+++ b/packages/zero-cache/src/services/view-syncer/client-handler.ts
@@ -8,6 +8,7 @@ import {
 import {promiseVoid} from '../../../../shared/src/resolved-promises.ts';
 import * as v from '../../../../shared/src/valita.ts';
 import type {Writable} from '../../../../shared/src/writable.ts';
+import type {ClientSchema} from '../../../../zero-protocol/src/client-schema.ts';
 import type {ErroredQuery} from '../../../../zero-protocol/src/custom-queries.ts';
 import {rowSchema} from '../../../../zero-protocol/src/data.ts';
 import type {DeleteClientsBody} from '../../../../zero-protocol/src/delete-clients.ts';
@@ -85,8 +86,9 @@ const NOOP: PokeHandler = {
 export function startPoke(
   clients: ClientHandler[],
   tentativeVersion: CVRVersion,
+  clientSchema?: ClientSchema | null,
 ): PokeHandler {
-  const pokers = clients.map(c => c.startPoke(tentativeVersion));
+  const pokers = clients.map(c => c.startPoke(tentativeVersion, clientSchema));
 
   // Promise.allSettled() ensures that a failed (e.g. disconnected) client
   // does not prevent other clients from receiving the pokes. However, the
@@ -181,7 +183,10 @@ export class ClientHandler {
     this.#downstream.cancel();
   }
 
-  startPoke(tentativeVersion: CVRVersion): PokeHandler {
+  startPoke(
+    tentativeVersion: CVRVersion,
+    clientSchema?: ClientSchema | null,
+  ): PokeHandler {
     const pokeID = versionToCookie(tentativeVersion);
     const lc = this.#lc.withContext('pokeID', pokeID);
 
@@ -258,26 +263,28 @@ export class ClientHandler {
                 },
               });
             } else {
-              const {clientID, mutationID} = patch.id.rowKey;
-              assert(
-                typeof clientID === 'string',
-                'client id must be a string',
+              const {clientID, mutationID} = v.parse(
+                ensureSafeJSON(patch.id.rowKey),
+                mutationDeleteRowKeySchema,
+                'passthrough',
               );
-              const id = Number(mutationID);
               assert(
-                !Number.isNaN(id) && Number.isFinite(id) && id >= 0,
-                'mutation id must be a finite number',
+                Number.isSafeInteger(mutationID) && mutationID >= 0,
+                'mutation id must be a non-negative safe integer',
               );
               patches.push({
                 op: 'del',
                 id: {
                   clientID,
-                  id,
+                  id: mutationID,
                 },
               });
             }
           } else {
-            (body.rowsPatch ??= []).push(makeRowPatch(patch));
+            const rowPatch = makeRowPatch(patch, clientSchema);
+            if (rowPatch) {
+              (body.rowsPatch ??= []).push(rowPatch);
+            }
           }
           break;
         default:
@@ -399,30 +406,94 @@ const mutationRowSchema = v.object({
   result: mutationResultSchema,
 });
 
-function makeRowPatch(patch: RowPatch): RowPatchOp {
+const mutationDeleteRowKeySchema = v.object({
+  clientID: v.string(),
+  mutationID: v.number(),
+});
+
+function makeRowPatch(
+  patch: RowPatch,
+  clientSchema: ClientSchema | null | undefined,
+): RowPatchOp | undefined {
   const {
     op,
-    id: {table: tableName, rowKey: id},
+    id: {rowKey: id},
   } = patch;
+  const tableName = tableNameForClientSchema(patch.id);
+
+  if (!clientSchema) {
+    throw new Error('Cannot send app row patch without clientSchema');
+  }
+
+  const tableSchema = Object.hasOwn(clientSchema.tables, tableName)
+    ? clientSchema.tables[tableName]
+    : undefined;
+  if (!tableSchema) {
+    return undefined;
+  }
 
   switch (op) {
     case 'put':
       return {
         op: 'put',
         tableName,
-        value: v.parse(ensureSafeJSON(patch.contents), rowSchema),
+        value: v.parse(
+          ensureSafeJSON(
+            tableSchema
+              ? projectRow(tableSchema, patch.contents)
+              : patch.contents,
+          ),
+          rowSchema,
+        ),
       };
 
     case 'del':
       return {
         op,
         tableName,
-        id: v.parse(id, primaryKeyValueRecordSchema),
+        id: v.parse(
+          ensureSafeJSON(projectPrimaryKey(tableSchema.primaryKey, id)),
+          primaryKeyValueRecordSchema,
+        ),
       };
 
     default:
       unreachable(op);
   }
+}
+
+function tableNameForClientSchema(id: RowID): string {
+  return id.schema === '' || id.schema === 'public'
+    ? id.table
+    : `${id.schema}.${id.table}`;
+}
+
+function projectRow(
+  tableSchema: ClientSchema['tables'][string],
+  row: JSONObject,
+): JSONObject {
+  return projectColumns(
+    [...Object.keys(tableSchema.columns), ...tableSchema.primaryKey],
+    row,
+  );
+}
+
+function projectPrimaryKey(
+  primaryKey: readonly string[],
+  row: JSONObject,
+): JSONObject {
+  return projectColumns(primaryKey, row);
+}
+
+function projectColumns(
+  columns: readonly string[],
+  row: JSONObject,
+): JSONObject {
+  return Object.fromEntries(
+    columns
+      .filter(column => Object.hasOwn(row, column))
+      .map(column => [column, row[column]]),
+  ) as JSONObject;
 }
 
 /**

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -1058,6 +1058,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
           const pokers = startPoke(
             this.#getClients(cvr.version),
             newCVR.version,
+            newCVR.clientSchema,
           );
           for (const patch of patches) {
             await pokers.addPatch(patch);
@@ -1972,7 +1973,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
       );
 
       const clients = this.#getClients();
-      const pokers = startPoke(clients, newVersion);
+      const pokers = startPoke(clients, newVersion, cvr.clientSchema);
       for (const patch of queryPatches) {
         // Bump patches' toVersion to the post-drift-bump version so that
         // pokers don't see them as belonging to a stale cookie.
@@ -2107,7 +2108,8 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     return startAsyncSpan(tracer, 'vs.#catchupClients', async span => {
       current ??= cvr.version;
       const clients = this.#getClients();
-      const pokers = usePokers ?? startPoke(clients, cvr.version);
+      const pokers =
+        usePokers ?? startPoke(clients, cvr.version, cvr.clientSchema);
       span.setAttribute('numClients', clients.length);
 
       const catchupFrom = clients
@@ -2303,6 +2305,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
       const pokers = startPoke(
         this.#getClients(cvr.version),
         updater.updatedVersion(),
+        cvr.clientSchema,
       );
       lc.debug?.(`applying ${numChanges} to advance to ${version}`);
 

--- a/packages/zero-client/src/client/zero-poke-handler.test.ts
+++ b/packages/zero-client/src/client/zero-poke-handler.test.ts
@@ -10,10 +10,12 @@ import {
   test,
   vi,
 } from 'vitest';
+import {mergeUpdate} from '../../../replicache/src/sync/patch.ts';
 import type {MutationPatch} from '../../../zero-protocol/src/mutations-patch.ts';
 import {createSchema} from '../../../zero-schema/src/builder/schema-builder.ts';
 import {string, table} from '../../../zero-schema/src/builder/table-builder.ts';
 import {serverToClient} from '../../../zero-schema/src/name-mapper.ts';
+import type {Schema} from '../../../zero-types/src/schema.ts';
 import {MutationTracker} from './mutation-tracker.ts';
 import {PokeHandler, mergePokes} from './zero-poke-handler.ts';
 
@@ -88,7 +90,7 @@ describe('poke handler', () => {
           value: {
             ['issue_id']: 'issue1',
             title: 'foo1',
-            description: 'columns not in client schema pass through',
+            private: 'columns not in client schema are projected out',
           },
         },
       ],
@@ -140,7 +142,6 @@ describe('poke handler', () => {
             value: {
               id: 'issue1',
               title: 'foo1',
-              description: 'columns not in client schema pass through',
             },
           },
           {
@@ -1658,6 +1659,603 @@ describe('poke handler', () => {
           },
         ],
       },
+    });
+  });
+
+  test('mergePokes projects row patches to the client schema', () => {
+    const result = mergePokes(
+      [
+        {
+          pokeStart: {
+            pokeID: 'poke1',
+            baseCookie: '1',
+          },
+          parts: [
+            {
+              pokeID: 'poke1',
+              rowsPatch: [
+                {
+                  op: 'put',
+                  tableName: 'issues',
+                  value: {
+                    ['issue_id']: 'issue1',
+                    title: 'foo1',
+                    private: 'secret',
+                  },
+                },
+                {
+                  op: 'del',
+                  tableName: 'issues',
+                  id: {['issue_id']: 'issue2', private: 'secret'},
+                },
+                {
+                  op: 'update',
+                  tableName: 'issues',
+                  id: {['issue_id']: 'issue3', private: 'secret'},
+                  merge: {
+                    ['issue_id']: 'issue3',
+                    title: 'baz1',
+                    private: 'secret',
+                  },
+                  constrain: ['issue_id', 'title', 'private'],
+                },
+              ],
+            },
+          ],
+          pokeEnd: {
+            pokeID: 'poke1',
+            cookie: '2',
+          },
+        },
+      ],
+      schema,
+      serverToClient(schema.tables),
+    );
+
+    expect(result).toEqual({
+      baseCookie: '1',
+      pullResponse: {
+        cookie: '2',
+        lastMutationIDChanges: {},
+        patch: [
+          {
+            op: 'put',
+            key: 'e/issue/issue1',
+            value: {id: 'issue1', title: 'foo1'},
+          },
+          {
+            op: 'del',
+            key: 'e/issue/issue2',
+          },
+          {
+            op: 'update',
+            key: 'e/issue/issue3',
+            merge: {id: 'issue3', title: 'baz1'},
+            constrain: ['id', 'title'],
+          },
+        ],
+      },
+    });
+  });
+
+  test('mergePokes projects server columns before name mapping', () => {
+    const result = mergePokes(
+      [
+        {
+          pokeStart: {
+            pokeID: 'poke1',
+            baseCookie: '1',
+          },
+          parts: [
+            {
+              pokeID: 'poke1',
+              rowsPatch: [
+                {
+                  op: 'put',
+                  tableName: 'issues',
+                  value: {
+                    ['issue_id']: 'issue1',
+                    id: 'hidden physical column',
+                    title: 'foo1',
+                  },
+                },
+                {
+                  op: 'del',
+                  tableName: 'issues',
+                  id: {
+                    ['issue_id']: 'issue2',
+                    id: 'hidden physical column',
+                  },
+                },
+                {
+                  op: 'update',
+                  tableName: 'issues',
+                  id: {
+                    ['issue_id']: 'issue3',
+                    id: 'hidden physical column',
+                  },
+                  merge: {
+                    ['issue_id']: 'issue3',
+                    id: 'hidden physical column',
+                    title: 'baz1',
+                  },
+                  constrain: ['issue_id', 'id', 'title'],
+                },
+              ],
+            },
+          ],
+          pokeEnd: {
+            pokeID: 'poke1',
+            cookie: '2',
+          },
+        },
+      ],
+      schema,
+      serverToClient(schema.tables),
+    );
+
+    expect(result).toEqual({
+      baseCookie: '1',
+      pullResponse: {
+        cookie: '2',
+        lastMutationIDChanges: {},
+        patch: [
+          {
+            op: 'put',
+            key: 'e/issue/issue1',
+            value: {id: 'issue1', title: 'foo1'},
+          },
+          {
+            op: 'del',
+            key: 'e/issue/issue2',
+          },
+          {
+            op: 'update',
+            key: 'e/issue/issue3',
+            merge: {id: 'issue3', title: 'baz1'},
+            constrain: ['id', 'title'],
+          },
+        ],
+      },
+    });
+  });
+
+  test('mergePokes preserves mapped __proto__ primary key column', () => {
+    const schemaWithProtoPrimaryKey = {
+      tables: {
+        issue: {
+          name: 'issue',
+          serverName: 'issues',
+          columns: Object.fromEntries([
+            ['__proto__', {type: 'string' as const, serverName: 'proto_id'}],
+            ['title', {type: 'string' as const}],
+          ]),
+          primaryKey: ['__proto__'],
+        },
+      },
+      relationships: {
+        issue: {},
+      },
+    } satisfies Schema;
+    const result = mergePokes(
+      [
+        {
+          pokeStart: {
+            pokeID: 'poke1',
+            baseCookie: '1',
+          },
+          parts: [
+            {
+              pokeID: 'poke1',
+              rowsPatch: [
+                {
+                  op: 'put',
+                  tableName: 'issues',
+                  value: Object.fromEntries([
+                    ['proto_id', 'p1'],
+                    ['title', 'hello'],
+                    ['private', 'secret'],
+                  ]),
+                },
+                {
+                  op: 'del',
+                  tableName: 'issues',
+                  id: Object.fromEntries([
+                    ['proto_id', 'p2'],
+                    ['private', 'secret'],
+                  ]),
+                },
+              ],
+            },
+          ],
+          pokeEnd: {
+            pokeID: 'poke1',
+            cookie: '2',
+          },
+        },
+      ],
+      schemaWithProtoPrimaryKey,
+      serverToClient(schemaWithProtoPrimaryKey.tables),
+    );
+
+    expect(result).toEqual({
+      baseCookie: '1',
+      pullResponse: {
+        cookie: '2',
+        lastMutationIDChanges: {},
+        patch: [
+          {
+            op: 'put',
+            key: 'e/issue/p1',
+            value: Object.fromEntries([
+              ['__proto__', 'p1'],
+              ['title', 'hello'],
+            ]),
+          },
+          {
+            op: 'del',
+            key: 'e/issue/p2',
+          },
+        ],
+      },
+    });
+  });
+
+  test('mergePokes keeps primary key constraints outside columns', () => {
+    const schemaWithPrimaryKeyOnly = {
+      tables: {
+        legacyIssue: {
+          name: 'legacyIssue',
+          serverName: 'legacy_issues',
+          columns: {
+            title: {type: 'string'},
+          },
+          primaryKey: ['id'],
+        },
+      },
+      relationships: {
+        legacyIssue: {},
+      },
+    } satisfies Schema;
+
+    const result = mergePokes(
+      [
+        {
+          pokeStart: {
+            pokeID: 'poke1',
+            baseCookie: '1',
+          },
+          parts: [
+            {
+              pokeID: 'poke1',
+              rowsPatch: [
+                {
+                  op: 'update',
+                  tableName: 'legacy_issues',
+                  id: {id: 'issue1'},
+                  merge: {
+                    private: 'secret',
+                  },
+                  constrain: ['id', 'private'],
+                },
+              ],
+            },
+          ],
+          pokeEnd: {
+            pokeID: 'poke1',
+            cookie: '2',
+          },
+        },
+      ],
+      schemaWithPrimaryKeyOnly,
+      serverToClient(schemaWithPrimaryKeyOnly.tables),
+    );
+
+    expect(result).toEqual({
+      baseCookie: '1',
+      pullResponse: {
+        cookie: '2',
+        lastMutationIDChanges: {},
+        patch: [
+          {
+            op: 'update',
+            key: 'e/legacyIssue/issue1',
+            merge: {},
+            constrain: ['id', 'title'],
+          },
+        ],
+      },
+    });
+  });
+
+  test('mergePokes constrains hidden-only updates to visible columns', () => {
+    const result = mergePokes(
+      [
+        {
+          pokeStart: {
+            pokeID: 'poke1',
+            baseCookie: '1',
+          },
+          parts: [
+            {
+              pokeID: 'poke1',
+              rowsPatch: [
+                {
+                  op: 'update',
+                  tableName: 'issues',
+                  id: {['issue_id']: 'issue1'},
+                  merge: {
+                    private: 'secret',
+                  },
+                  constrain: ['private'],
+                },
+              ],
+            },
+          ],
+          pokeEnd: {
+            pokeID: 'poke1',
+            cookie: '2',
+          },
+        },
+      ],
+      schema,
+      serverToClient(schema.tables),
+    );
+
+    expect(result).toEqual({
+      baseCookie: '1',
+      pullResponse: {
+        cookie: '2',
+        lastMutationIDChanges: {},
+        patch: [
+          {
+            op: 'update',
+            key: 'e/issue/issue1',
+            merge: {},
+            constrain: ['id', 'title'],
+          },
+        ],
+      },
+    });
+  });
+
+  test('mergePokes preserves visible fields when hidden constrain includes primary key', () => {
+    const result = mergePokes(
+      [
+        {
+          pokeStart: {
+            pokeID: 'poke1',
+            baseCookie: '1',
+          },
+          parts: [
+            {
+              pokeID: 'poke1',
+              rowsPatch: [
+                {
+                  op: 'update',
+                  tableName: 'issues',
+                  id: {['issue_id']: 'issue1'},
+                  merge: {
+                    ['issue_id']: 'issue1',
+                    private: 'new-secret',
+                  },
+                  constrain: ['issue_id', 'private'],
+                },
+              ],
+            },
+          ],
+          pokeEnd: {
+            pokeID: 'poke1',
+            cookie: '2',
+          },
+        },
+      ],
+      schema,
+      serverToClient(schema.tables),
+    );
+
+    if (!result || !('patch' in result.pullResponse)) {
+      throw new Error('Expected patch response');
+    }
+    const update = result.pullResponse.patch[0];
+    expect(update).toEqual({
+      op: 'update',
+      key: 'e/issue/issue1',
+      merge: {id: 'issue1'},
+      constrain: ['id', 'title'],
+    });
+    if (update?.op !== 'update') {
+      throw new Error('Expected update patch');
+    }
+    expect(
+      mergeUpdate(update, {
+        id: 'issue1',
+        title: 'old-title',
+        private: 'old-secret',
+      }),
+    ).toEqual({
+      id: 'issue1',
+      title: 'old-title',
+    });
+  });
+
+  test('mergePokes preserves primary keys for visible constrained updates', () => {
+    const result = mergePokes(
+      [
+        {
+          pokeStart: {
+            pokeID: 'poke1',
+            baseCookie: '1',
+          },
+          parts: [
+            {
+              pokeID: 'poke1',
+              rowsPatch: [
+                {
+                  op: 'update',
+                  tableName: 'issues',
+                  id: {['issue_id']: 'issue1'},
+                  merge: {
+                    title: 'new',
+                  },
+                  constrain: ['title'],
+                },
+              ],
+            },
+          ],
+          pokeEnd: {
+            pokeID: 'poke1',
+            cookie: '2',
+          },
+        },
+      ],
+      schema,
+      serverToClient(schema.tables),
+    );
+
+    if (!result || !('patch' in result.pullResponse)) {
+      throw new Error('Expected patch response');
+    }
+    const update = result.pullResponse.patch[0];
+    expect(update).toEqual({
+      op: 'update',
+      key: 'e/issue/issue1',
+      merge: {title: 'new'},
+      constrain: ['id', 'title'],
+    });
+    if (update?.op !== 'update') {
+      throw new Error('Expected update patch');
+    }
+    expect(
+      mergeUpdate(update, {
+        id: 'issue1',
+        title: 'old',
+        private: 'old-secret',
+      }),
+    ).toEqual({
+      id: 'issue1',
+      title: 'new',
+    });
+  });
+
+  test('mergePokes constrains updates with missing constrain to visible columns', () => {
+    const result = mergePokes(
+      [
+        {
+          pokeStart: {
+            pokeID: 'poke1',
+            baseCookie: '1',
+          },
+          parts: [
+            {
+              pokeID: 'poke1',
+              rowsPatch: [
+                {
+                  op: 'update',
+                  tableName: 'issues',
+                  id: {['issue_id']: 'issue1'},
+                  merge: {
+                    ['issue_id']: 'issue1',
+                    title: 'new',
+                    private: 'secret',
+                  },
+                },
+              ],
+            },
+          ],
+          pokeEnd: {
+            pokeID: 'poke1',
+            cookie: '2',
+          },
+        },
+      ],
+      schema,
+      serverToClient(schema.tables),
+    );
+
+    if (!result || !('patch' in result.pullResponse)) {
+      throw new Error('Expected patch response');
+    }
+    const update = result.pullResponse.patch[0];
+    expect(update).toEqual({
+      op: 'update',
+      key: 'e/issue/issue1',
+      merge: {id: 'issue1', title: 'new'},
+      constrain: ['id', 'title'],
+    });
+    if (update?.op !== 'update') {
+      throw new Error('Expected update patch');
+    }
+    expect(
+      mergeUpdate(update, {
+        id: 'issue1',
+        title: 'old',
+        private: 'old-secret',
+      }),
+    ).toEqual({
+      id: 'issue1',
+      title: 'new',
+    });
+  });
+
+  test('mergePokes constrains updates with empty constrain to visible columns', () => {
+    const result = mergePokes(
+      [
+        {
+          pokeStart: {
+            pokeID: 'poke1',
+            baseCookie: '1',
+          },
+          parts: [
+            {
+              pokeID: 'poke1',
+              rowsPatch: [
+                {
+                  op: 'update',
+                  tableName: 'issues',
+                  id: {['issue_id']: 'issue1'},
+                  merge: {
+                    ['issue_id']: 'issue1',
+                    title: 'new',
+                    private: 'secret',
+                  },
+                  constrain: [],
+                },
+              ],
+            },
+          ],
+          pokeEnd: {
+            pokeID: 'poke1',
+            cookie: '2',
+          },
+        },
+      ],
+      schema,
+      serverToClient(schema.tables),
+    );
+
+    if (!result || !('patch' in result.pullResponse)) {
+      throw new Error('Expected patch response');
+    }
+    const update = result.pullResponse.patch[0];
+    expect(update).toEqual({
+      op: 'update',
+      key: 'e/issue/issue1',
+      merge: {id: 'issue1', title: 'new'},
+      constrain: ['id', 'title'],
+    });
+    if (update?.op !== 'update') {
+      throw new Error('Expected update patch');
+    }
+    expect(
+      mergeUpdate(update, {
+        id: 'issue1',
+        title: 'old',
+        private: 'old-secret',
+      }),
+    ).toEqual({
+      id: 'issue1',
+      title: 'new',
     });
   });
 

--- a/packages/zero-client/src/client/zero-poke-handler.ts
+++ b/packages/zero-client/src/client/zero-poke-handler.ts
@@ -7,6 +7,7 @@ import type {
 import type {PatchOperation} from '../../../replicache/src/patch-operation.ts';
 import type {ClientID} from '../../../replicache/src/sync/ids.ts';
 import {unreachable} from '../../../shared/src/asserts.ts';
+import type {Row} from '../../../zero-protocol/src/data.ts';
 import type {MutationPatch} from '../../../zero-protocol/src/mutations-patch.ts';
 import type {
   PokeEndBody,
@@ -365,39 +366,123 @@ function rowsPatchOpToReplicachePatchOp(
     return undefined;
   }
   switch (op.op) {
-    case 'del':
+    case 'del': {
+      const tableSchema = schema.tables[tableName];
+      const delID = serverToClient.row(
+        op.tableName,
+        projectServerPrimaryKey(tableSchema, op.id),
+      );
       return {
         op: 'del',
-        key: toPrimaryKeyString(
-          tableName,
-          schema.tables[tableName].primaryKey,
-          serverToClient.row(op.tableName, op.id),
-        ),
+        key: toPrimaryKeyString(tableName, tableSchema.primaryKey, delID),
       };
-    case 'put':
+    }
+    case 'put': {
+      const tableSchema = schema.tables[tableName];
+      const value = serverToClient.row(
+        op.tableName,
+        projectServerRow(tableSchema, op.value),
+      );
       return {
         op: 'put',
-        key: toPrimaryKeyString(
-          tableName,
-          schema.tables[tableName].primaryKey,
-          serverToClient.row(op.tableName, op.value),
-        ),
-        value: serverToClient.row(op.tableName, op.value),
+        key: toPrimaryKeyString(tableName, tableSchema.primaryKey, value),
+        value,
       };
-    case 'update':
+    }
+    case 'update': {
+      const tableSchema = schema.tables[tableName];
+      const id = serverToClient.row(
+        op.tableName,
+        projectServerPrimaryKey(tableSchema, op.id),
+      );
+      const merge = op.merge
+        ? serverToClient.row(
+            op.tableName,
+            projectServerRow(tableSchema, op.merge),
+          )
+        : undefined;
       return {
         op: 'update',
-        key: toPrimaryKeyString(
-          tableName,
-          schema.tables[tableName].primaryKey,
-          serverToClient.row(op.tableName, op.id),
+        key: toPrimaryKeyString(tableName, tableSchema.primaryKey, id),
+        merge,
+        constrain: serverToClient.columns(
+          op.tableName,
+          projectServerColumns(tableSchema, op.constrain),
         ),
-        merge: op.merge
-          ? serverToClient.row(op.tableName, op.merge)
-          : undefined,
-        constrain: serverToClient.columns(op.tableName, op.constrain),
       };
+    }
     default:
       unreachable(op);
   }
+}
+
+function projectServerRow(
+  tableSchema: Schema['tables'][string],
+  row: Row,
+): Row {
+  return projectServerKeys(serverColumnNames(tableSchema), row);
+}
+
+function projectServerPrimaryKey(
+  tableSchema: Schema['tables'][string],
+  row: Row,
+): Row {
+  return projectServerKeys(serverPrimaryKeyNames(tableSchema), row);
+}
+
+function projectServerKeys(columns: readonly string[], row: Row): Row {
+  return Object.fromEntries(
+    columns
+      .filter(column => Object.hasOwn(row, column))
+      .map(column => [column, row[column]]),
+  ) as Row;
+}
+
+function projectServerColumns(
+  tableSchema: Schema['tables'][string],
+  cols: readonly string[] | undefined,
+): readonly string[] {
+  const visibleColumns = serverColumnNames(tableSchema);
+  if (!cols || cols.length === 0) {
+    return visibleColumns;
+  }
+  const columnSet = new Set(visibleColumns);
+  const projected = cols.filter(col => columnSet.has(col));
+  if (projected.length === cols.length) {
+    return withServerPrimaryKeyColumns(tableSchema, projected);
+  }
+  // Replicache treats an empty constrain list as unconstrained. If any changed
+  // column was hidden by the client schema, constrain to the visible row shape
+  // so old hidden fields are not retained locally without dropping unchanged
+  // visible fields.
+  return visibleColumns;
+}
+
+function withServerPrimaryKeyColumns(
+  tableSchema: Schema['tables'][string],
+  cols: readonly string[],
+): readonly string[] {
+  return [...new Set([...serverPrimaryKeyNames(tableSchema), ...cols])];
+}
+
+function serverColumnNames(tableSchema: Schema['tables'][string]): string[] {
+  const names = new Set<string>();
+  for (const columnName of serverPrimaryKeyNames(tableSchema)) {
+    names.add(columnName);
+  }
+  for (const [columnName, column] of Object.entries(tableSchema.columns)) {
+    names.add(column.serverName ?? columnName);
+  }
+  return [...names];
+}
+
+function serverPrimaryKeyNames(
+  tableSchema: Schema['tables'][string],
+): readonly string[] {
+  return tableSchema.primaryKey.map(columnName => {
+    const column = Object.hasOwn(tableSchema.columns, columnName)
+      ? tableSchema.columns[columnName]
+      : undefined;
+    return column?.serverName ?? columnName;
+  });
 }

--- a/packages/zero-client/src/client/zero-poke-handler.ts
+++ b/packages/zero-client/src/client/zero-poke-handler.ts
@@ -433,12 +433,16 @@ function projectWireKeys(columns: readonly string[], row: Row): Row {
   const projected: Record<string, Row[string]> = {};
   for (const column of columns) {
     if (Object.hasOwn(row, column)) {
-      Object.defineProperty(projected, column, {
-        value: row[column],
-        enumerable: true,
-        configurable: true,
-        writable: true,
-      });
+      if (column === '__proto__') {
+        Object.defineProperty(projected, column, {
+          value: row[column],
+          enumerable: true,
+          configurable: true,
+          writable: true,
+        });
+      } else {
+        projected[column] = row[column];
+      }
     }
   }
   return projected;

--- a/packages/zero-client/src/client/zero-poke-handler.ts
+++ b/packages/zero-client/src/client/zero-poke-handler.ts
@@ -365,12 +365,14 @@ function rowsPatchOpToReplicachePatchOp(
   if (!tableName) {
     return undefined;
   }
+  // Row patches are wire data: table and column names are server names until
+  // they are mapped to the client schema shape for Replicache storage.
   switch (op.op) {
     case 'del': {
       const tableSchema = schema.tables[tableName];
       const delID = serverToClient.row(
         op.tableName,
-        projectServerPrimaryKey(tableSchema, op.id),
+        projectWirePrimaryKey(tableSchema, op.id),
       );
       return {
         op: 'del',
@@ -381,7 +383,7 @@ function rowsPatchOpToReplicachePatchOp(
       const tableSchema = schema.tables[tableName];
       const value = serverToClient.row(
         op.tableName,
-        projectServerRow(tableSchema, op.value),
+        projectWireRow(tableSchema, op.value),
       );
       return {
         op: 'put',
@@ -393,12 +395,12 @@ function rowsPatchOpToReplicachePatchOp(
       const tableSchema = schema.tables[tableName];
       const id = serverToClient.row(
         op.tableName,
-        projectServerPrimaryKey(tableSchema, op.id),
+        projectWirePrimaryKey(tableSchema, op.id),
       );
       const merge = op.merge
         ? serverToClient.row(
             op.tableName,
-            projectServerRow(tableSchema, op.merge),
+            projectWireRow(tableSchema, op.merge),
           )
         : undefined;
       return {
@@ -407,7 +409,7 @@ function rowsPatchOpToReplicachePatchOp(
         merge,
         constrain: serverToClient.columns(
           op.tableName,
-          projectServerColumns(tableSchema, op.constrain),
+          projectWireColumns(tableSchema, op.constrain),
         ),
       };
     }
@@ -416,40 +418,44 @@ function rowsPatchOpToReplicachePatchOp(
   }
 }
 
-function projectServerRow(
+function projectWireRow(tableSchema: Schema['tables'][string], row: Row): Row {
+  return projectWireKeys(wireColumnNames(tableSchema), row);
+}
+
+function projectWirePrimaryKey(
   tableSchema: Schema['tables'][string],
   row: Row,
 ): Row {
-  return projectServerKeys(serverColumnNames(tableSchema), row);
+  return projectWireKeys(wirePrimaryKeyNames(tableSchema), row);
 }
 
-function projectServerPrimaryKey(
-  tableSchema: Schema['tables'][string],
-  row: Row,
-): Row {
-  return projectServerKeys(serverPrimaryKeyNames(tableSchema), row);
+function projectWireKeys(columns: readonly string[], row: Row): Row {
+  const projected: Record<string, Row[string]> = {};
+  for (const column of columns) {
+    if (Object.hasOwn(row, column)) {
+      Object.defineProperty(projected, column, {
+        value: row[column],
+        enumerable: true,
+        configurable: true,
+        writable: true,
+      });
+    }
+  }
+  return projected;
 }
 
-function projectServerKeys(columns: readonly string[], row: Row): Row {
-  return Object.fromEntries(
-    columns
-      .filter(column => Object.hasOwn(row, column))
-      .map(column => [column, row[column]]),
-  ) as Row;
-}
-
-function projectServerColumns(
+function projectWireColumns(
   tableSchema: Schema['tables'][string],
   cols: readonly string[] | undefined,
 ): readonly string[] {
-  const visibleColumns = serverColumnNames(tableSchema);
+  const visibleColumns = wireColumnNames(tableSchema);
   if (!cols || cols.length === 0) {
     return visibleColumns;
   }
   const columnSet = new Set(visibleColumns);
   const projected = cols.filter(col => columnSet.has(col));
   if (projected.length === cols.length) {
-    return withServerPrimaryKeyColumns(tableSchema, projected);
+    return withWirePrimaryKeyColumns(tableSchema, projected);
   }
   // Replicache treats an empty constrain list as unconstrained. If any changed
   // column was hidden by the client schema, constrain to the visible row shape
@@ -458,16 +464,16 @@ function projectServerColumns(
   return visibleColumns;
 }
 
-function withServerPrimaryKeyColumns(
+function withWirePrimaryKeyColumns(
   tableSchema: Schema['tables'][string],
   cols: readonly string[],
 ): readonly string[] {
-  return [...new Set([...serverPrimaryKeyNames(tableSchema), ...cols])];
+  return [...new Set([...wirePrimaryKeyNames(tableSchema), ...cols])];
 }
 
-function serverColumnNames(tableSchema: Schema['tables'][string]): string[] {
+function wireColumnNames(tableSchema: Schema['tables'][string]): string[] {
   const names = new Set<string>();
-  for (const columnName of serverPrimaryKeyNames(tableSchema)) {
+  for (const columnName of wirePrimaryKeyNames(tableSchema)) {
     names.add(columnName);
   }
   for (const [columnName, column] of Object.entries(tableSchema.columns)) {
@@ -476,7 +482,7 @@ function serverColumnNames(tableSchema: Schema['tables'][string]): string[] {
   return [...names];
 }
 
-function serverPrimaryKeyNames(
+function wirePrimaryKeyNames(
   tableSchema: Schema['tables'][string],
 ): readonly string[] {
   return tableSchema.primaryKey.map(columnName => {

--- a/packages/zero-schema/src/name-mapper.ts
+++ b/packages/zero-schema/src/name-mapper.ts
@@ -23,7 +23,7 @@ function createMapperFrom(
     Object.entries(tables).map(
       ([tableName, {serverName: serverTableName, columns}]) => {
         let allColumnsSame = true;
-        const names: Record<string, string> = {};
+        const names: Record<string, string> = Object.create(null);
         for (const [name, {serverName}] of Object.entries(columns)) {
           if (serverName && serverName !== name) {
             allColumnsSame = false;

--- a/packages/zero-types/src/name-mapper.ts
+++ b/packages/zero-types/src/name-mapper.ts
@@ -1,4 +1,5 @@
 import type {JSONValue, ReadonlyJSONValue} from '../../shared/src/json.ts';
+import {mapEntries} from '../../shared/src/objects.ts';
 
 // Value type from zero-protocol (JSONValue/ReadonlyJSONValue | undefined)
 // Defined here to avoid circular dependency with zero-protocol
@@ -59,13 +60,19 @@ export class NameMapper {
     if (allColumnsSame) {
       return row;
     }
+    if (Object.values(columns).includes('__proto__')) {
+      return Object.fromEntries(
+        Object.entries(row).map(([col, value]) => [
+          Object.hasOwn(columns, col) ? columns[col] : col,
+          value,
+        ]),
+      ) as Record<string, V>;
+    }
     // Note: columns with unknown names simply pass through.
-    return Object.fromEntries(
-      Object.entries(row).map(([col, value]) => [
-        Object.hasOwn(columns, col) ? columns[col] : col,
-        value,
-      ]),
-    ) as Record<string, V>;
+    return mapEntries(row, (col, value) => [
+      Object.hasOwn(columns, col) ? columns[col] : col,
+      value,
+    ]);
   }
 
   columns<Columns extends readonly string[] | undefined>(

--- a/packages/zero-types/src/name-mapper.ts
+++ b/packages/zero-types/src/name-mapper.ts
@@ -60,7 +60,10 @@ export class NameMapper {
     if (allColumnsSame) {
       return row;
     }
-    if (Object.values(columns).includes('__proto__')) {
+    if (
+      Object.hasOwn(row, '__proto__') ||
+      Object.values(columns).includes('__proto__')
+    ) {
       return Object.fromEntries(
         Object.entries(row).map(([col, value]) => [
           Object.hasOwn(columns, col) ? columns[col] : col,

--- a/packages/zero-types/src/name-mapper.ts
+++ b/packages/zero-types/src/name-mapper.ts
@@ -38,7 +38,8 @@ export class NameMapper {
   }
 
   columnName(table: string, src: string, ctx?: JSONValue): string {
-    const dst = this.#getTable(table, ctx).columns[src];
+    const columns = this.#getTable(table, ctx).columns;
+    const dst = Object.hasOwn(columns, src) ? columns[src] : undefined;
     if (!dst) {
       throw new Error(
         `unknown column "${src}" of "${table}" table ${
@@ -58,12 +59,13 @@ export class NameMapper {
     if (allColumnsSame) {
       return row;
     }
-    const clientRow: Record<string, V> = {};
-    for (const col in row) {
-      // Note: columns with unknown names simply pass through.
-      clientRow[columns[col] ?? col] = row[col];
-    }
-    return clientRow;
+    // Note: columns with unknown names simply pass through.
+    return Object.fromEntries(
+      Object.entries(row).map(([col, value]) => [
+        Object.hasOwn(columns, col) ? columns[col] : col,
+        value,
+      ]),
+    ) as Record<string, V>;
   }
 
   columns<Columns extends readonly string[] | undefined>(
@@ -76,6 +78,8 @@ export class NameMapper {
     // Note: Columns not defined in the schema simply pass through.
     return cols === undefined || allColumnsSame
       ? cols
-      : (cols.map(col => columns[col] ?? col) as unknown as Columns);
+      : (cols.map(col =>
+          Object.hasOwn(columns, col) ? columns[col] : col,
+        ) as unknown as Columns);
   }
 }


### PR DESCRIPTION
## Summary

This changes row patch serialization so zero-cache projects row payloads to the configured client schema before sending `pokePart.rowsPatch` to clients.

The cache still keeps the full replica row available for IVM, predicates, permissions, ordering, joins, and catchup computation. The projection only happens at the final server to client poke boundary.

I also added a defensive zero-client projection when merging incoming pokes. That protects newer clients during rolling upgrades if they receive full row payloads from an older cache.

## Security note

This is not a malicious-client security boundary. zero-cache still validates a client schema against the replicated Zero table specs, so a column that is replicated and supported by Zero can still be requested by a client that declares it.

Apps should continue to keep sensitive columns out of the replicated/public Zero surface, for example by excluding them from the publication or syncing a sanitized table/view.

This change should be read as honoring the accepted client schema at the poke/storage boundary for honest clients, plus reducing network bytes and client storage. It prevents columns omitted from that accepted client schema from being sent or stored, but it does not replace reducing the set of columns Zero can replicate in the first place.

## Compatibility

For new cache versions, omitted client schema columns are not sent over the wire. Tables absent from the client schema are omitted from row patches.

For new client versions talking to older caches, unknown columns are dropped before Replicache patch values are produced.

Primary key fields are retained in projected put payloads even if a malformed schema leaves them out of `columns`.

## Testing

* `pnpm --filter zero-cache run test:no-pg -- src/services/view-syncer/client-handler.test.ts`
* `pnpm --filter zero-client exec vitest run --browser.enabled=false src/client/zero-poke-handler.test.ts`
* `pnpm --filter zero-cache run check-types`
* `pnpm --filter zero-client run check-types`
* `pnpm --filter zero-cache run lint`
* `pnpm --filter zero-client run lint`
* `pnpm --filter zero-cache run check-format`
* `pnpm --filter zero-client run check-format`
