### PR TITLE
Support forwarding request headers

### DIFF
--- a/packages/shared/src/build-nested-object-path.ts
+++ b/packages/shared/src/build-nested-object-path.ts
@@ -39,7 +39,7 @@ export function buildNestedObjectPath<
   let current = target as Record<string, unknown>;
   for (let i = 0; i < parts.length - 1; i++) {
     const part = parts[i];
-    let next = current[part];
+    let next = Object.hasOwn(current, part) ? current[part] : undefined;
     if (next === undefined) {
       next = {};
       safeSet(current, part, next);

--- a/packages/shared/src/build-nested-object-path.ts
+++ b/packages/shared/src/build-nested-object-path.ts
@@ -1,4 +1,5 @@
 import type {DeepMerge} from './deep-merge.ts';
+import {safeSet} from './objects.ts';
 
 /**
  * Helper function to build nested object structure from a dot-separated key path.
@@ -41,12 +42,12 @@ export function buildNestedObjectPath<
     let next = current[part];
     if (next === undefined) {
       next = {};
-      current[part] = next;
+      safeSet(current, part, next);
     }
     current = next as Record<string, unknown>;
   }
   // oxlint-disable-next-line typescript/no-non-null-assertion
-  current[parts.at(-1)!] = value;
+  safeSet(current, parts.at(-1)!, value);
   return target as DeepMerge<T, BuildNested<Path, Separator, Value>>;
 }
 

--- a/packages/shared/src/deep-clone.ts
+++ b/packages/shared/src/deep-clone.ts
@@ -1,5 +1,6 @@
 import {hasOwn} from './has-own.ts';
 import type {JSONValue, ReadonlyJSONValue} from './json.ts';
+import {safeSet} from './objects.ts';
 
 export function deepClone(value: ReadonlyJSONValue): JSONValue {
   const seen: Array<ReadonlyJSONValue> = [];
@@ -36,7 +37,7 @@ export function internalDeepClone(
         if (hasOwn(value, k)) {
           const v = (value as Record<string, ReadonlyJSONValue>)[k];
           if (v !== undefined) {
-            obj[k] = internalDeepClone(v, seen);
+            safeSet(obj, k, internalDeepClone(v, seen));
           }
         }
       }

--- a/packages/shared/src/deep-merge.ts
+++ b/packages/shared/src/deep-merge.ts
@@ -1,3 +1,5 @@
+import {safeAssign, safeSet} from './objects.ts';
+
 // Force TypeScript to evaluate/flatten a type
 type Simplify<T> = {[K in keyof T]: T[K]} & {};
 
@@ -60,28 +62,22 @@ export function deepMerge<
   const result: Record<string, unknown> = {};
 
   // Copy all keys from a
-  for (const key of Object.keys(a)) {
-    result[key] = a[key];
-  }
+  safeAssign(result, a);
 
   // Merge/override with keys from b
   for (const key of Object.keys(b)) {
     const aVal = a[key];
     const bVal = b[key];
 
-    if (key in a && !isLeaf(aVal) && !isLeaf(bVal)) {
-      result[key] = deepMerge<
-        Record<string, unknown>,
-        Record<string, unknown>,
-        Leaf
-      >(
-        aVal as Record<string, unknown>,
-        bVal as Record<string, unknown>,
-        isLeaf,
-      );
-    } else {
-      result[key] = bVal;
-    }
+    const merged =
+      key in a && !isLeaf(aVal) && !isLeaf(bVal)
+        ? deepMerge<Record<string, unknown>, Record<string, unknown>, Leaf>(
+            aVal as Record<string, unknown>,
+            bVal as Record<string, unknown>,
+            isLeaf,
+          )
+        : bVal;
+    safeSet(result, key, merged);
   }
 
   return result as DeepMerge<A, B, Leaf>;

--- a/packages/shared/src/deep-merge.ts
+++ b/packages/shared/src/deep-merge.ts
@@ -1,4 +1,4 @@
-import {safeAssign, safeSet} from './objects.ts';
+import {safeSet} from './objects.ts';
 
 // Force TypeScript to evaluate/flatten a type
 type Simplify<T> = {[K in keyof T]: T[K]} & {};
@@ -62,7 +62,9 @@ export function deepMerge<
   const result: Record<string, unknown> = {};
 
   // Copy all keys from a
-  safeAssign(result, a);
+  for (const key of Object.keys(a)) {
+    safeSet(result, key, a[key]);
+  }
 
   // Merge/override with keys from b
   for (const key of Object.keys(b)) {

--- a/packages/shared/src/objects.test.ts
+++ b/packages/shared/src/objects.test.ts
@@ -1,5 +1,11 @@
 import {expect, test} from 'vitest';
-import {mapAllEntries, mapEntries, mapValues} from './objects.ts';
+import {
+  mapAllEntries,
+  mapEntries,
+  mapValues,
+  safeAssign,
+  safeSet,
+} from './objects.ts';
 
 // Use JSON.stringify in expectations to preserve / verify key order.
 const stringify = (o: unknown) => JSON.stringify(o, null, 2);
@@ -65,4 +71,113 @@ test('mapAllEntries', () => {
       "bar": "baz"
     }"
   `);
+});
+
+test('safeAssign copies own enumerable string props and returns target', () => {
+  const target = {a: 1};
+  const result = safeAssign(target, {b: 2, c: 3});
+  // Mutates and returns the same target reference.
+  expect(result).toBe(target);
+  expect(result).toEqual({a: 1, b: 2, c: 3});
+});
+
+test('safeAssign overwrites existing keys', () => {
+  expect(safeAssign({a: 1, b: 2}, {b: 3})).toEqual({a: 1, b: 3});
+});
+
+test('safeAssign applies sources left-to-right, last write wins', () => {
+  expect(safeAssign({}, {a: 1}, {a: 2, b: 3})).toEqual({a: 2, b: 3});
+});
+
+test('safeAssign only copies own enumerable props, not inherited ones', () => {
+  const source = Object.create({inherited: 'nope'});
+  source.own = 'yep';
+  expect(safeAssign({}, source)).toEqual({own: 'yep'});
+});
+
+test('safeAssign copies symbol keys (like Object.assign)', () => {
+  const sym = Symbol('s');
+  const result = safeAssign({}, {[sym]: 1, a: 2});
+  expect(result[sym]).toBe(1);
+  expect(result.a).toBe(2);
+});
+
+test('safeAssign skips non-enumerable own props (like Object.assign)', () => {
+  const sym = Symbol('s');
+  const source = {};
+  Object.defineProperty(source, 'hidden', {value: 1, enumerable: false});
+  Object.defineProperty(source, sym, {value: 2, enumerable: false});
+  Object.defineProperty(source, 'visible', {value: 3, enumerable: true});
+
+  const result = safeAssign({}, source) as Record<PropertyKey, unknown>;
+  expect(result).toEqual({visible: 3});
+  expect(result.hidden).toBeUndefined();
+  expect(result[sym]).toBeUndefined();
+});
+
+test('safeAssign creates writable/enumerable/configurable data props', () => {
+  const result = safeAssign({}, {a: 1});
+  expect(Object.getOwnPropertyDescriptor(result, 'a')).toEqual({
+    value: 1,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  });
+});
+
+test('safeAssign with a __proto__ source key sets an own property, not the prototype', () => {
+  // An object literal `{__proto__: ...}` sets the prototype, so use JSON.parse
+  // to get a source whose OWN enumerable key is literally "__proto__".
+  const malicious = JSON.parse('{"__proto__": {"polluted": true}}');
+  expect(Object.keys(malicious)).toEqual(['__proto__']);
+
+  const target: Record<string, unknown> = {};
+  safeAssign(target, malicious);
+
+  // The key is set as a normal own property...
+  expect(Object.hasOwn(target, '__proto__')).toBe(true);
+  expect(Object.keys(target)).toEqual(['__proto__']);
+  // ...and the prototype is left untouched (the object is not reparented).
+  expect(Object.getPrototypeOf(target)).toBe(Object.prototype);
+  // Global Object.prototype is never polluted.
+  expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+});
+
+test('safeSet sets a property and returns the target', () => {
+  const target: Record<string, unknown> = {a: 1};
+  const result = safeSet(target, 'b', 2);
+  expect(result).toBe(target);
+  expect(result).toEqual({a: 1, b: 2});
+});
+
+test('safeSet overwrites an existing key', () => {
+  expect(safeSet({a: 1}, 'a', 2)).toEqual({a: 2});
+});
+
+test('safeSet supports symbol keys', () => {
+  const sym = Symbol('s');
+  const result = safeSet({}, sym, 1) as Record<PropertyKey, unknown>;
+  expect(result[sym]).toBe(1);
+});
+
+test('safeSet creates a writable/enumerable/configurable data prop', () => {
+  expect(Object.getOwnPropertyDescriptor(safeSet({}, 'a', 1), 'a')).toEqual({
+    value: 1,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  });
+});
+
+test('safeSet with a __proto__ key sets an own property, not the prototype', () => {
+  const target: Record<string, unknown> = {};
+  const proto = {polluted: true};
+  safeSet(target, '__proto__', proto);
+
+  // Set as a normal own property, not as the prototype.
+  expect(Object.hasOwn(target, '__proto__')).toBe(true);
+  expect(target['__proto__']).toBe(proto);
+  expect(Object.getPrototypeOf(target)).toBe(Object.prototype);
+  // Global Object.prototype is never polluted.
+  expect(({} as Record<string, unknown>).polluted).toBeUndefined();
 });

--- a/packages/shared/src/objects.test.ts
+++ b/packages/shared/src/objects.test.ts
@@ -136,6 +136,12 @@ test('safeAssign with a __proto__ source key sets an own property, not the proto
 
   // The key is set as a normal own property...
   expect(Object.hasOwn(target, '__proto__')).toBe(true);
+  expect(Object.getOwnPropertyDescriptor(target, '__proto__')).toEqual({
+    value: malicious.__proto__,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  });
   expect(Object.keys(target)).toEqual(['__proto__']);
   // ...and the prototype is left untouched (the object is not reparented).
   expect(Object.getPrototypeOf(target)).toBe(Object.prototype);

--- a/packages/shared/src/objects.ts
+++ b/packages/shared/src/objects.ts
@@ -36,11 +36,11 @@ export function safeSet<T extends object>(
  * symbol-keyed).
  */
 export function safeAssign<T extends object, U>(target: T, source: U): T & U;
-export function safeAssign<T extends object, U, V>(
-  target: T,
-  source1: U,
-  source2: V,
-): T & U & V;
+export function safeAssign<
+  T extends object,
+  U extends object,
+  V extends object,
+>(target: T, source1: U, source2: V): T & U & V;
 export function safeAssign<T extends object>(
   target: T,
   ...sources: object[]

--- a/packages/shared/src/objects.ts
+++ b/packages/shared/src/objects.ts
@@ -1,3 +1,61 @@
+/**
+ * Sets a single property on `target`, guarding against prototype pollution: a
+ * `__proto__` key sets a literal own property (via `Object.defineProperty`)
+ * instead of invoking the inherited setter that would mutate the target's
+ * prototype. `__proto__` is the only key with this hazard (e.g. `constructor`
+ * assigns a normal own property) and a symbol key can never trigger it, so
+ * every other key is assigned directly.
+ *
+ * Use this instead of `target[key] = value` when `key` may come from untrusted
+ * data. See {@link safeAssign} to copy an entire source object.
+ */
+export function safeSet<T extends object>(
+  target: T,
+  key: PropertyKey,
+  value: unknown,
+): T {
+  if (key === '__proto__') {
+    Object.defineProperty(target, key, {
+      value,
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
+  } else {
+    (target as Record<PropertyKey, unknown>)[key] = value;
+  }
+  return target;
+}
+
+/**
+ * Behaves like {@link Object.assign}, but guards against prototype pollution by
+ * setting each property via {@link safeSet}, so a `__proto__` source key sets a
+ * literal own property instead of mutating the target's prototype.
+ *
+ * Like `Object.assign`, this copies own enumerable properties (both string- and
+ * symbol-keyed).
+ */
+export function safeAssign<T extends object, U>(target: T, source: U): T & U;
+export function safeAssign<T extends object, U, V>(
+  target: T,
+  source1: U,
+  source2: V,
+): T & U & V;
+export function safeAssign<T extends object>(
+  target: T,
+  ...sources: object[]
+): T;
+export function safeAssign(target: object, ...sources: object[]): object {
+  for (const source of sources) {
+    for (const key of Reflect.ownKeys(source)) {
+      if (Object.prototype.propertyIsEnumerable.call(source, key)) {
+        safeSet(target, key, (source as Record<PropertyKey, unknown>)[key]);
+      }
+    }
+  }
+  return target;
+}
+
 export function mapValues<T extends Record<string, unknown>, U>(
   input: T,
   mapper: (value: T[keyof T]) => U,
@@ -19,7 +77,7 @@ export function mapEntries<T, U>(
   // https://gist.github.com/arv/1b4e113724f6a14e2d4742bcc760d1fa
   for (const entry of Object.entries(input)) {
     const mapped = mapper(entry[0], entry[1]);
-    output[mapped[0]] = mapped[1];
+    safeSet(output, mapped[0], mapped[1]);
   }
   return output;
 }
@@ -32,7 +90,7 @@ export function mapAllEntries<T, U>(
   // https://github.com/rocicorp/mono/pull/3927#issuecomment-2706059475
   const output: Record<string, U> = {};
   for (const mapped of mapper(Object.entries(input))) {
-    output[mapped[0]] = mapped[1];
+    safeSet(output, mapped[0], mapped[1]);
   }
   return output;
 }

--- a/packages/zero-cache/src/config/zero-config.test.ts
+++ b/packages/zero-cache/src/config/zero-config.test.ts
@@ -113,6 +113,16 @@ test('zero-cache --help', () => {
                                                                         If not specified, no client-provided headers are forwarded (secure by default).                                            
                                                                         Example: ZERO_MUTATE_ALLOWED_CLIENT_HEADERS=x-request-id,x-correlation-id                                                  
                                                                                                                                                                                                    
+     --mutate-allowed-request-headers string[]                          optional                                                                                                                   
+       ZERO_MUTATE_ALLOWED_REQUEST_HEADERS env                                                                                                                                                     
+                                                                        A list of header names to forward from the incoming HTTP request to the push URL.                                          
+                                                                        Unlike allowed-client-headers (which forwards headers set by the client), these are taken                                  
+                                                                        from the HTTP request that established the connection (e.g. headers injected by a proxy or load balancer).                 
+                                                                        If a listed header is present on the request, its value is forwarded upstream under the same header name.                  
+                                                                        Header names are case-insensitive.                                                                                         
+                                                                        If not specified, no request headers are forwarded (secure by default).                                                    
+                                                                        Example: ZERO_MUTATE_ALLOWED_REQUEST_HEADERS=x-forwarded-for,cf-ray                                                        
+                                                                                                                                                                                                   
      --query-url string[]                                               optional                                                                                                                   
        ZERO_QUERY_URL env                                                                                                                                                                          
                                                                         The URL of the API server to which zero-cache will send synced queries.                                                    
@@ -172,6 +182,16 @@ test('zero-cache --help', () => {
                                                                         Header names are case-insensitive.                                                                                         
                                                                         If not specified, no client-provided headers are forwarded (secure by default).                                            
                                                                         Example: ZERO_QUERY_ALLOWED_CLIENT_HEADERS=x-request-id,x-correlation-id                                                   
+                                                                                                                                                                                                   
+     --query-allowed-request-headers string[]                           optional                                                                                                                   
+       ZERO_QUERY_ALLOWED_REQUEST_HEADERS env                                                                                                                                                      
+                                                                        A list of header names to forward from the incoming HTTP request to the query URL.                                         
+                                                                        Unlike allowed-client-headers (which forwards headers set by the client), these are taken                                  
+                                                                        from the HTTP request that established the connection (e.g. headers injected by a proxy or load balancer).                 
+                                                                        If a listed header is present on the request, its value is forwarded upstream under the same header name.                  
+                                                                        Header names are case-insensitive.                                                                                         
+                                                                        If not specified, no request headers are forwarded (secure by default).                                                    
+                                                                        Example: ZERO_QUERY_ALLOWED_REQUEST_HEADERS=x-forwarded-for,cf-ray                                                         
                                                                                                                                                                                                    
      --enable-crud-mutations boolean                                    default: true                                                                                                              
        ZERO_ENABLE_CRUD_MUTATIONS env                                                                                                                                                              

--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -301,6 +301,25 @@ const makeMutatorQueryOptions = (
         }
       : {}),
   },
+  allowedRequestHeaders: {
+    type: v.array(v.string()).optional(),
+    desc: [
+      `A list of header names to forward from the incoming HTTP request to the ${suffix === 'push mutations' ? 'push' : 'query'} URL.`,
+      `Unlike {bold allowed-client-headers} (which forwards headers set by the client), these are taken`,
+      `from the HTTP request that established the connection (e.g. headers injected by a proxy or load balancer).`,
+      `If a listed header is present on the request, its value is forwarded upstream under the same header name.`,
+      `Header names are case-insensitive.`,
+      `If not specified, no request headers are forwarded (secure by default).`,
+      `Example: ZERO_${replacement ? replacement.toUpperCase() : suffix === 'push mutations' ? 'MUTATE' : 'QUERY'}_ALLOWED_REQUEST_HEADERS=x-forwarded-for,cf-ray`,
+    ],
+    ...(replacement
+      ? {
+          deprecated: [
+            makeDeprecationMessage(`${replacement}-allowed-request-headers`),
+          ],
+        }
+      : {}),
+  },
 });
 
 const mutateOptions = makeMutatorQueryOptions(undefined, 'push mutations');

--- a/packages/zero-cache/src/custom-queries/transform-query.test.ts
+++ b/packages/zero-cache/src/custom-queries/transform-query.test.ts
@@ -661,6 +661,53 @@ describe('CustomQueryTransformer', () => {
     expect(mockFetchFromAPIServer).toHaveBeenCalledTimes(2);
   });
 
+  test('should differentiate cache key by forwarded request headers', async () => {
+    const mockSuccessResponse = () =>
+      transformedMessage([mockQueryResponses[0]]);
+
+    mockFetchFromAPIServer.mockResolvedValue(mockSuccessResponse());
+
+    const allowedRequestHeaders = ['x-forwarded-for'];
+    const transformer = makeTransformer();
+    // Cache with one set of forwarded request headers
+    await transformer.transform(
+      {
+        ...headerOptions,
+        allowedRequestHeaders,
+        requestHeaders: {'x-forwarded-for': '203.0.113.1'},
+      },
+      [mockQueries[0]],
+      undefined,
+    );
+    expect(mockFetchFromAPIServer).toHaveBeenCalledTimes(1);
+
+    // Different request header value - should fetch again
+    mockFetchFromAPIServer.mockResolvedValue(mockSuccessResponse());
+    await transformer.transform(
+      {
+        ...headerOptions,
+        allowedRequestHeaders,
+        requestHeaders: {'x-forwarded-for': '203.0.113.2'},
+      },
+      [mockQueries[0]],
+      undefined,
+    );
+    expect(mockFetchFromAPIServer).toHaveBeenCalledTimes(2);
+
+    // Original request headers again - should use cache
+    mockFetchFromAPIServer.mockResolvedValue(mockSuccessResponse());
+    await transformer.transform(
+      {
+        ...headerOptions,
+        allowedRequestHeaders,
+        requestHeaders: {'x-forwarded-for': '203.0.113.1'},
+      },
+      [mockQueries[0]],
+      undefined,
+    );
+    expect(mockFetchFromAPIServer).toHaveBeenCalledTimes(2);
+  });
+
   test('should use custom URL when userQueryURL is provided', async () => {
     const customUrl = 'https://custom-api.example.com/transform';
 

--- a/packages/zero-cache/src/custom-queries/transform-query.ts
+++ b/packages/zero-cache/src/custom-queries/transform-query.ts
@@ -258,7 +258,30 @@ function getCacheKey(ctx: ConnectionContext, queryID: string) {
     userID: ctx.user,
     url: ctx.queryContext.url,
     customHeaders: normalizedForwardedHeaders(ctx.queryContext.headerOptions),
+    requestHeaders: normalizedRequestHeaders(ctx.queryContext.headerOptions),
   });
+}
+
+function normalizedRequestHeaders(headerOptions: HeaderOptions) {
+  const {allowedRequestHeaders, requestHeaders} = headerOptions;
+  if (
+    !requestHeaders ||
+    !allowedRequestHeaders ||
+    allowedRequestHeaders.length === 0
+  ) {
+    return undefined;
+  }
+
+  const allowedHeaders = new Set(
+    allowedRequestHeaders.map(header => header.toLowerCase()),
+  );
+  const forwardedHeaders = sortedEntries(requestHeaders).filter(([header]) =>
+    allowedHeaders.has(header.toLowerCase()),
+  );
+
+  return forwardedHeaders.length === 0
+    ? undefined
+    : JSON.stringify(forwardedHeaders);
 }
 
 function normalizedForwardedHeaders(headerOptions: HeaderOptions) {

--- a/packages/zero-cache/src/custom-queries/transform-query.ts
+++ b/packages/zero-cache/src/custom-queries/transform-query.ts
@@ -26,7 +26,6 @@ import {fetchFromAPIServer} from '../custom/fetch.ts';
 import type {
   ConnectionContext,
   ConnectionValidation,
-  HeaderOptions,
 } from '../services/view-syncer/connection-context-manager.ts';
 import type {CustomQueryRecord} from '../services/view-syncer/schema/types.ts';
 import type {ShardID} from '../types/shards.ts';
@@ -257,48 +256,28 @@ function getCacheKey(ctx: ConnectionContext, queryID: string) {
     origin: ctx.queryContext.headerOptions.origin,
     userID: ctx.user,
     url: ctx.queryContext.url,
-    customHeaders: normalizedForwardedHeaders(ctx.queryContext.headerOptions),
-    requestHeaders: normalizedRequestHeaders(ctx.queryContext.headerOptions),
+    customHeaders: normalizedHeaders(
+      ctx.queryContext.headerOptions.customHeaders,
+      ctx.queryContext.headerOptions.allowedClientHeaders,
+    ),
+    requestHeaders: normalizedHeaders(
+      ctx.queryContext.headerOptions.requestHeaders,
+      ctx.queryContext.headerOptions.allowedRequestHeaders,
+    ),
   });
 }
 
-function normalizedRequestHeaders(headerOptions: HeaderOptions) {
-  const {allowedRequestHeaders, requestHeaders} = headerOptions;
-  if (
-    !requestHeaders ||
-    !allowedRequestHeaders ||
-    allowedRequestHeaders.length === 0
-  ) {
+function normalizedHeaders(
+  headers: Readonly<Record<string, string>> | undefined,
+  allowedHeaders: readonly string[] | undefined,
+) {
+  if (!headers || !allowedHeaders || allowedHeaders.length === 0) {
     return undefined;
   }
 
-  const allowedHeaders = new Set(
-    allowedRequestHeaders.map(header => header.toLowerCase()),
-  );
-  const forwardedHeaders = sortedEntries(requestHeaders).filter(([header]) =>
-    allowedHeaders.has(header.toLowerCase()),
-  );
-
-  return forwardedHeaders.length === 0
-    ? undefined
-    : JSON.stringify(forwardedHeaders);
-}
-
-function normalizedForwardedHeaders(headerOptions: HeaderOptions) {
-  const {allowedClientHeaders, customHeaders} = headerOptions;
-  if (
-    !customHeaders ||
-    !allowedClientHeaders ||
-    allowedClientHeaders.length === 0
-  ) {
-    return undefined;
-  }
-
-  const allowedHeaders = new Set(
-    allowedClientHeaders.map(header => header.toLowerCase()),
-  );
-  const forwardedHeaders = sortedEntries(customHeaders).filter(([header]) =>
-    allowedHeaders.has(header.toLowerCase()),
+  const allowed = new Set(allowedHeaders.map(header => header.toLowerCase()));
+  const forwardedHeaders = sortedEntries(headers).filter(([header]) =>
+    allowed.has(header.toLowerCase()),
   );
 
   return forwardedHeaders.length === 0

--- a/packages/zero-cache/src/custom/fetch.test.ts
+++ b/packages/zero-cache/src/custom/fetch.test.ts
@@ -340,6 +340,49 @@ describe('fetchFromAPIServer', () => {
     });
   });
 
+  test('only forwards request headers in allowedRequestHeaders list', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({success: true}), {status: 200}),
+    );
+
+    await fetchWithContext(validator, 'push', {
+      headerOptions: {
+        requestHeaders: {
+          'x-forwarded-for': '203.0.113.1',
+          'cf-ray': 'abc123',
+          'x-not-allowed': 'secret',
+        },
+        allowedRequestHeaders: ['x-forwarded-for', 'cf-ray'],
+      },
+    });
+
+    const init = mockFetch.mock.calls[0]![1];
+    expect(init?.headers).toEqual({
+      'Content-Type': 'application/json',
+      'x-forwarded-for': '203.0.113.1',
+      'cf-ray': 'abc123',
+    });
+  });
+
+  test('drops request headers when allowedRequestHeaders is not set', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({success: true}), {status: 200}),
+    );
+
+    await fetchWithContext(validator, 'push', {
+      headerOptions: {
+        requestHeaders: {
+          'x-forwarded-for': '203.0.113.1',
+        },
+      },
+    });
+
+    const init = mockFetch.mock.calls[0]![1];
+    expect(init?.headers).toEqual({
+      'Content-Type': 'application/json',
+    });
+  });
+
   test('rejects URLs that are not allowed by configuration for push', async () => {
     await expect(
       fetchFromAPIServer(

--- a/packages/zero-cache/src/custom/fetch.ts
+++ b/packages/zero-cache/src/custom/fetch.ts
@@ -5,6 +5,7 @@ import {assert, unreachable} from '../../../shared/src/asserts.ts';
 import {getErrorMessage} from '../../../shared/src/error.ts';
 import type {ReadonlyJSONValue} from '../../../shared/src/json.ts';
 import {must} from '../../../shared/src/must.ts';
+import {safeAssign, safeSet} from '../../../shared/src/objects.ts';
 import {randInt} from '../../../shared/src/rand.ts';
 import {sleep} from '../../../shared/src/sleep.ts';
 import {type Type} from '../../../shared/src/valita.ts';
@@ -57,7 +58,7 @@ function filterCustomHeaders(
   const filtered: Record<string, string> = {};
   for (const [key, value] of Object.entries(headers)) {
     if (allowed.has(key.toLowerCase())) {
-      filtered[key] = value;
+      safeSet(filtered, key, value);
     }
   }
   return filtered;
@@ -139,7 +140,7 @@ export async function fetchFromAPIServer<TValidator extends Type>(
   if (headerOptions.apiKey) {
     headers['X-Api-Key'] = headerOptions.apiKey;
   }
-  Object.assign(
+  safeAssign(
     headers,
     filterCustomHeaders(
       headerOptions.customHeaders,
@@ -147,7 +148,7 @@ export async function fetchFromAPIServer<TValidator extends Type>(
     ),
   );
   // Forward allowlisted headers from the incoming HTTP request.
-  Object.assign(
+  safeAssign(
     headers,
     filterCustomHeaders(
       headerOptions.requestHeaders,

--- a/packages/zero-cache/src/custom/fetch.ts
+++ b/packages/zero-cache/src/custom/fetch.ts
@@ -146,6 +146,14 @@ export async function fetchFromAPIServer<TValidator extends Type>(
       headerOptions.allowedClientHeaders,
     ),
   );
+  // Forward allowlisted headers from the incoming HTTP request.
+  Object.assign(
+    headers,
+    filterCustomHeaders(
+      headerOptions.requestHeaders,
+      headerOptions.allowedRequestHeaders,
+    ),
+  );
   if (ctx.auth?.raw) {
     headers['Authorization'] = `Bearer ${ctx.auth.raw}`;
   }

--- a/packages/zero-cache/src/observability/events.ts
+++ b/packages/zero-cache/src/observability/events.ts
@@ -6,6 +6,7 @@ import {nanoid} from 'nanoid';
 import {stringify} from '../../../shared/src/bigint-json.ts';
 import {isJSONValue, type JSONObject} from '../../../shared/src/json.ts';
 import {must} from '../../../shared/src/must.ts';
+import {safeSet} from '../../../shared/src/objects.ts';
 import {promiseVoid} from '../../../shared/src/resolved-promises.ts';
 import {sleep} from '../../../shared/src/sleep.ts';
 import * as v from '../../../shared/src/valita.ts';
@@ -151,7 +152,7 @@ export function makeErrorDetails(e: unknown): JSONObject {
   // Include any enumerable properties (e.g. of Error subtypes).
   for (const [field, value] of Object.entries(err)) {
     if (isJSONValue(value, [])) {
-      errorDetails[field] = value;
+      safeSet(errorDetails, field, value);
     }
   }
   return errorDetails;

--- a/packages/zero-cache/src/server/syncer.ts
+++ b/packages/zero-cache/src/server/syncer.ts
@@ -62,6 +62,7 @@ function getCustomQueryConfig(
     url: queryConfig.url,
     apiKey: queryConfig.apiKey,
     allowedClientHeaders: queryConfig.allowedClientHeaders,
+    allowedRequestHeaders: queryConfig.allowedRequestHeaders,
     forwardCookies: queryConfig.forwardCookies ?? false,
   };
 }

--- a/packages/zero-cache/src/services/change-source/pg/initial-sync.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync.test.ts
@@ -1,6 +1,7 @@
 import type postgres from 'postgres';
 import {describe, expect, test, vi} from 'vitest';
 import {createSilentLogContext} from '../../../../../shared/src/logging-test-utils.ts';
+import {safeAssign} from '../../../../../shared/src/objects.ts';
 import type {PublishedTableSpec} from '../../../db/specs.ts';
 import type {PostgresDB} from '../../../types/pg.ts';
 import {
@@ -97,7 +98,7 @@ describe('getInitialDownloadState', () => {
 
   test('skipTotals=true returns zeros without touching the DB', async () => {
     let called = false;
-    const sql = Object.assign(
+    const sql = safeAssign(
       () => {
         called = true;
         throw new Error('sql should not be called when skipTotals=true');
@@ -129,7 +130,7 @@ describe('getInitialDownloadState', () => {
   test('skipTotals=false uses pg_class estimates', async () => {
     // The tagged template sql`...` is called as a function with
     // (strings, ...values) when used as a template tag.
-    const sql = Object.assign(
+    const sql = safeAssign(
       (strings: TemplateStringsArray, ..._values: unknown[]) => {
         const query = strings.join('$1');
         if (query.includes('pg_class')) {

--- a/packages/zero-cache/src/services/life-cycle.test.ts
+++ b/packages/zero-cache/src/services/life-cycle.test.ts
@@ -2,6 +2,7 @@ import EventEmitter from 'node:events';
 import {resolver} from '@rocicorp/resolver';
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
+import {safeAssign} from '../../../shared/src/objects.ts';
 import {promiseVoid} from '../../../shared/src/resolved-promises.ts';
 import {
   exitAfter,
@@ -265,7 +266,7 @@ describe('shutdown', () => {
 describe('exitAfter', () => {
   test('exits 0 for configuration errors', async () => {
     const exit = vi.spyOn(process, 'exit').mockImplementation(code => {
-      throw Object.assign(new Error('process.exit'), {code});
+      throw safeAssign(new Error('process.exit'), {code});
     });
 
     await expect(

--- a/packages/zero-cache/src/services/mutagen/pusher.test.ts
+++ b/packages/zero-cache/src/services/mutagen/pusher.test.ts
@@ -40,6 +40,7 @@ type TestConnectionOptions = {
   userID?: string | undefined;
   userPushURL?: string | undefined;
   userPushHeaders?: Record<string, string> | undefined;
+  requestHeaders?: Record<string, string> | undefined;
 };
 
 const contextManagers = new WeakMap<
@@ -52,6 +53,7 @@ function newPusherService(pushConfig: {
   apiKey?: string | undefined;
   forwardCookies: boolean;
   allowedClientHeaders?: string[] | undefined;
+  allowedRequestHeaders?: string[] | undefined;
 }): PusherService {
   const connContextManager = new ConnectionContextManagerImpl(
     lc,
@@ -61,12 +63,14 @@ function newPusherService(pushConfig: {
       url: undefined,
       apiKey: undefined,
       allowedClientHeaders: undefined,
+      allowedRequestHeaders: undefined,
       forwardCookies: false,
     },
     {
       url: pushConfig.url,
       apiKey: pushConfig.apiKey,
       allowedClientHeaders: pushConfig.allowedClientHeaders,
+      allowedRequestHeaders: pushConfig.allowedRequestHeaders,
       forwardCookies: pushConfig.forwardCookies,
     },
   );
@@ -113,6 +117,7 @@ function registerConnection(
       initConnectionMsg: undefined,
       httpCookie: options.httpCookie,
       origin: options.origin,
+      requestHeaders: options.requestHeaders,
     },
     makeAuth(options.auth),
   );
@@ -548,6 +553,80 @@ describe('pusher service', () => {
       userPushHeaders: {
         'x-vercel-automation-bypass-secret': 'my-secret',
         'x-custom-header': 'custom-value',
+      },
+    });
+
+    pusher.enqueuePush(selector, makePush(1));
+
+    await pusher.stop();
+
+    expect(fetch.mock.calls[0][1]?.headers).toEqual({
+      'Content-Type': 'application/json',
+      'X-Api-Key': 'api-key',
+      'Authorization': 'Bearer jwt',
+    });
+
+    fetch.mockReset();
+  });
+
+  test('the service forwards request headers in allowedRequestHeaders', async () => {
+    const fetch = (global.fetch = vi.fn());
+    fetch.mockResolvedValue({
+      ok: true,
+    });
+
+    const pusher = newPusherService({
+      url: ['http://example.com'],
+      apiKey: 'api-key',
+      forwardCookies: false,
+      allowedRequestHeaders: ['x-forwarded-for', 'cf-ray'],
+    });
+    void pusher.run();
+    const {selector} = openConnection(pusher, {
+      clientID,
+      wsID,
+      auth: 'jwt',
+      requestHeaders: {
+        'x-forwarded-for': '203.0.113.1',
+        'cf-ray': 'abc123',
+        'x-not-allowed': 'secret',
+      },
+    });
+
+    pusher.enqueuePush(selector, makePush(1));
+
+    await pusher.stop();
+
+    expect(fetch.mock.calls[0][1]?.headers).toEqual({
+      'Content-Type': 'application/json',
+      'X-Api-Key': 'api-key',
+      'x-forwarded-for': '203.0.113.1',
+      'cf-ray': 'abc123',
+      'Authorization': 'Bearer jwt',
+    });
+
+    fetch.mockReset();
+  });
+
+  test('the service drops request headers not in allowedRequestHeaders', async () => {
+    const fetch = (global.fetch = vi.fn());
+    fetch.mockResolvedValue({
+      ok: true,
+    });
+
+    const pusher = newPusherService({
+      url: ['http://example.com'],
+      apiKey: 'api-key',
+      forwardCookies: false,
+      // allowedRequestHeaders not set - secure by default
+    });
+    void pusher.run();
+    const {selector} = openConnection(pusher, {
+      clientID,
+      wsID,
+      auth: 'jwt',
+      requestHeaders: {
+        'x-forwarded-for': '203.0.113.1',
       },
     });
 

--- a/packages/zero-cache/src/services/replicator/write-worker-client.ts
+++ b/packages/zero-cache/src/services/replicator/write-worker-client.ts
@@ -2,6 +2,7 @@ import {Worker} from 'node:worker_threads';
 import {resolver, type Resolver} from '@rocicorp/resolver';
 import {assert} from '../../../../shared/src/asserts.ts';
 import type {LogConfig} from '../../../../shared/src/logging.ts';
+import {safeAssign} from '../../../../shared/src/objects.ts';
 import type {Database} from '../../../../zqlite/src/db.ts';
 import {WRITE_WORKER_URL} from '../../server/worker-urls.ts';
 import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
@@ -80,7 +81,7 @@ export function deserializeError(serialized: SerializedError): Error {
         : deserializeError(serialized.cause);
   }
   if (serialized.details) {
-    Object.assign(err, serialized.details);
+    safeAssign(err, serialized.details);
   }
   return err;
 }

--- a/packages/zero-cache/src/services/view-syncer/connection-context-manager.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/connection-context-manager.test.ts
@@ -625,6 +625,88 @@ describe('ConnectionContextManager', () => {
     );
   });
 
+  test('stores incoming request headers and the allowlist for filtering at fetch time', () => {
+    const manager = new ConnectionContextManagerImpl(
+      lc,
+      undefined,
+      undefined,
+      {
+        url: ['https://default.example/query'],
+        apiKey: 'query-api-key',
+        allowedRequestHeaders: ['x-forwarded-for'],
+        forwardCookies: false,
+      },
+      {
+        url: ['https://default.example/push'],
+        apiKey: 'push-api-key',
+        allowedRequestHeaders: ['cf-ray'],
+        forwardCookies: false,
+      },
+    );
+
+    const requestHeaders = {
+      'x-forwarded-for': '203.0.113.1',
+      'cf-ray': 'abc123',
+      'x-not-allowed': 'secret',
+    };
+    const connection = manager.registerConnection(
+      selector('c1', 'ws1'),
+      {
+        ...makeConnectParams('c1', 'ws1'),
+        requestHeaders,
+      },
+      {type: 'opaque', raw: 'token-1'},
+    );
+
+    // The full set of request headers is carried through; the allowlist is
+    // applied later in fetchFromAPIServer.
+    expect(connection.queryContext.headerOptions.requestHeaders).toEqual(
+      requestHeaders,
+    );
+    expect(connection.queryContext.headerOptions.allowedRequestHeaders).toEqual(
+      ['x-forwarded-for'],
+    );
+    expect(connection.mutateContext.headerOptions.requestHeaders).toEqual(
+      requestHeaders,
+    );
+    expect(
+      connection.mutateContext.headerOptions.allowedRequestHeaders,
+    ).toEqual(['cf-ray']);
+  });
+
+  test('leaves allowedRequestHeaders undefined when not configured', () => {
+    const manager = new ConnectionContextManagerImpl(
+      lc,
+      undefined,
+      undefined,
+      {
+        url: ['https://default.example/query'],
+        forwardCookies: false,
+        // allowedRequestHeaders not set - secure by default
+      },
+      {
+        url: ['https://default.example/push'],
+        forwardCookies: false,
+      },
+    );
+
+    const connection = manager.registerConnection(
+      selector('c1', 'ws1'),
+      {
+        ...makeConnectParams('c1', 'ws1'),
+        requestHeaders: {'x-forwarded-for': '203.0.113.1'},
+      },
+      {type: 'opaque', raw: 'token-1'},
+    );
+
+    expect(
+      connection.queryContext.headerOptions.allowedRequestHeaders,
+    ).toBeUndefined();
+    expect(
+      connection.mutateContext.headerOptions.allowedRequestHeaders,
+    ).toBeUndefined();
+  });
+
   test('ignores stale revision-scoped validation and failure updates', () => {
     const manager = new ConnectionContextManagerImpl(lc);
     const registered = register(manager, 'c1', 'ws1');

--- a/packages/zero-cache/src/services/view-syncer/connection-context-manager.ts
+++ b/packages/zero-cache/src/services/view-syncer/connection-context-manager.ts
@@ -43,8 +43,12 @@ type FetchConfig = ZeroConfig['query'];
 
 export type HeaderOptions = {
   readonly apiKey?: string | undefined;
+  /** Headers provided in the client options */
   readonly customHeaders?: Readonly<Record<string, string>> | undefined;
   readonly allowedClientHeaders?: readonly string[] | undefined;
+  /** Headers from the incoming HTTP request */
+  readonly requestHeaders?: Readonly<Record<string, string>> | undefined;
+  readonly allowedRequestHeaders?: readonly string[] | undefined;
   readonly cookie?: string | undefined;
   readonly origin?: string | undefined;
 };
@@ -242,6 +246,10 @@ export class ConnectionContextManagerImpl implements ConnectionContextManager {
           apiKey: config?.apiKey,
           allowedClientHeaders: cloneAllowedClientHeaders(
             config?.allowedClientHeaders,
+          ),
+          requestHeaders: cloneCustomHeaders(connectParams.requestHeaders),
+          allowedRequestHeaders: cloneAllowedClientHeaders(
+            config?.allowedRequestHeaders,
           ),
           cookie: config?.forwardCookies ? connectParams.httpCookie : undefined,
         },

--- a/packages/zero-cache/src/services/view-syncer/cvr-store.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr-store.ts
@@ -11,6 +11,7 @@ import {
   deepEqual,
   type ReadonlyJSONValue,
 } from '../../../../shared/src/json.ts';
+import {safeAssign} from '../../../../shared/src/objects.ts';
 import {sleep} from '../../../../shared/src/sleep.ts';
 import * as v from '../../../../shared/src/valita.ts';
 import {astSchema} from '../../../../zero-protocol/src/ast.ts';
@@ -764,7 +765,7 @@ export class CVRStore {
       const existing = this.#pendingQueryUpdates.get(queryHash);
       if (existing) {
         // Merge partial into full update
-        Object.assign(existing, partial);
+        safeAssign(existing, partial);
       } else {
         // Track partial-only updates to batch separately
         partialOnly.set(queryHash, partial);

--- a/packages/zero-cache/src/types/pg.test.ts
+++ b/packages/zero-cache/src/types/pg.test.ts
@@ -1,5 +1,6 @@
 import postgres from 'postgres';
 import {describe, expect, test} from 'vitest';
+import {safeAssign} from '../../../shared/src/objects.ts';
 import {
   isPostgresConfigError,
   millisecondsToPostgresTime,
@@ -9,7 +10,7 @@ import {
 } from './pg.ts';
 
 function postgresError(code: string) {
-  return Object.assign(new postgres.PostgresError('test error'), {
+  return safeAssign(new postgres.PostgresError('test error'), {
     code,
     severity: 'ERROR',
     severity_local: 'ERROR',
@@ -17,7 +18,7 @@ function postgresError(code: string) {
 }
 
 function connectionError(code: string) {
-  return Object.assign(new Error(`connection failed: ${code}`), {code});
+  return safeAssign(new Error(`connection failed: ${code}`), {code});
 }
 
 describe('isPostgresConfigError', () => {

--- a/packages/zero-cache/src/types/processes.ts
+++ b/packages/zero-cache/src/types/processes.ts
@@ -7,6 +7,7 @@ import {
 import EventEmitter from 'node:events';
 import {platform} from 'node:os';
 import {pid} from 'node:process';
+import {safeAssign} from '../../../shared/src/objects.ts';
 
 /**
  * Central registry of message type names, which are used to identify
@@ -226,10 +227,10 @@ export function inProcChannel(): [Worker, Worker] {
 
   return [
     wrap(
-      Object.assign(worker1, {send: sendTo(worker2), kill: kill(worker2), pid}),
+      safeAssign(worker1, {send: sendTo(worker2), kill: kill(worker2), pid}),
     ),
     wrap(
-      Object.assign(worker2, {send: sendTo(worker1), kill: kill(worker1), pid}),
+      safeAssign(worker2, {send: sendTo(worker1), kill: kill(worker1), pid}),
     ),
   ];
 }

--- a/packages/zero-cache/src/workers/connect-params.ts
+++ b/packages/zero-cache/src/workers/connect-params.ts
@@ -21,7 +21,26 @@ export type ConnectParams = {
   readonly initConnectionMsg: InitConnectionMessage | undefined;
   readonly httpCookie: string | undefined;
   readonly origin: string | undefined;
+  readonly requestHeaders?: Readonly<Record<string, string>> | undefined;
 };
+
+/**
+ * Normalizes Node's {@link IncomingHttpHeaders} (whose values are
+ * `string | string[] | undefined`) into a plain `Record<string, string>`,
+ * joining array values with `, ` and dropping `undefined` values.
+ */
+function normalizeHeaders(
+  headers: IncomingHttpHeaders,
+): Record<string, string> {
+  const normalized: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    if (value === undefined) {
+      continue;
+    }
+    normalized[key] = Array.isArray(value) ? value.join(', ') : value;
+  }
+  return normalized;
+}
 
 export function getConnectParams(
   protocolVersion: number,
@@ -68,6 +87,7 @@ export function getConnectParams(
         userID,
         httpCookie: headers.cookie,
         origin: headers.origin,
+        requestHeaders: normalizeHeaders(headers),
       },
       error: null,
     };

--- a/packages/zero-cache/src/workers/connect-params.ts
+++ b/packages/zero-cache/src/workers/connect-params.ts
@@ -1,5 +1,6 @@
 import type {IncomingHttpHeaders} from 'node:http2';
 import {must} from '../../../shared/src/must.ts';
+import {safeSet} from '../../../shared/src/objects.ts';
 import {
   decodeSecProtocols,
   type InitConnectionMessage,
@@ -37,7 +38,7 @@ function normalizeHeaders(
     if (value === undefined) {
       continue;
     }
-    normalized[key] = Array.isArray(value) ? value.join(', ') : value;
+    safeSet(normalized, key, Array.isArray(value) ? value.join(', ') : value);
   }
   return normalized;
 }

--- a/packages/zero-cache/src/workers/connection.test.ts
+++ b/packages/zero-cache/src/workers/connection.test.ts
@@ -5,6 +5,7 @@ import {
   createSilentLogContext,
   TestLogSink,
 } from '../../../shared/src/logging-test-utils.ts';
+import {safeAssign} from '../../../shared/src/objects.ts';
 import type {Downstream} from '../../../zero-protocol/src/down.ts';
 import {ErrorKind} from '../../../zero-protocol/src/error-kind.ts';
 import {ErrorOrigin} from '../../../zero-protocol/src/error-origin.ts';
@@ -97,7 +98,7 @@ describe('sendError', () => {
   });
 
   test('socket write errno errors are logged as warnings', () => {
-    const err = Object.assign(new Error('write EPIPE'), {
+    const err = safeAssign(new Error('write EPIPE'), {
       errno: -32,
       code: 'EPIPE',
     });
@@ -115,7 +116,7 @@ describe('sendError', () => {
   });
 
   test('ECANCELED error code is logged as warning', () => {
-    const err = Object.assign(new Error('write ECANCELED'), {
+    const err = safeAssign(new Error('write ECANCELED'), {
       code: 'ECANCELED',
     });
     sendError(
@@ -192,7 +193,7 @@ describe('sendError', () => {
   });
 
   test('ECONNRESET error code is logged as warning', () => {
-    const err = Object.assign(new Error('read ECONNRESET'), {
+    const err = safeAssign(new Error('read ECONNRESET'), {
       code: 'ECONNRESET',
     });
     sendError(

--- a/packages/zero-server/src/custom.ts
+++ b/packages/zero-server/src/custom.ts
@@ -1,5 +1,5 @@
 import {assert} from '../../shared/src/asserts.ts';
-import {mapValues} from '../../shared/src/objects.ts';
+import {mapValues, safeSet} from '../../shared/src/objects.ts';
 import {recordProxy} from '../../shared/src/record-proxy.ts';
 import {
   formatPgInternalConvert,
@@ -300,7 +300,7 @@ function removeUndefined<T extends Record<string, unknown>>(value: T): T {
   const valueWithoutUndefined: Record<string, unknown> = {};
   for (const [key, val] of Object.entries(value)) {
     if (val !== undefined) {
-      valueWithoutUndefined[key] = val;
+      safeSet(valueWithoutUndefined, key, val);
     }
   }
   return valueWithoutUndefined as T;

--- a/packages/zql/src/ivm/view-apply-change.ts
+++ b/packages/zql/src/ivm/view-apply-change.ts
@@ -5,6 +5,7 @@ import {
   unreachable,
 } from '../../../shared/src/asserts.ts';
 import {must} from '../../../shared/src/must.ts';
+import {safeAssign} from '../../../shared/src/objects.ts';
 import type {Writable} from '../../../shared/src/writable.ts';
 import type {Row} from '../../../zero-protocol/src/data.ts';
 import {type Comparator, type Node} from './data.ts';
@@ -588,7 +589,7 @@ function applyEdit<M extends Mutate>(
   const canMutate = mutate || owns(existing);
   const newEntry: MutableMetaEntry =
     canMutate && schema.compareRows(change.oldNode.row, change.node.row) === 0
-      ? Object.assign(existing, change.node.row)
+      ? safeAssign(existing, change.node.row)
       : track({...existing, ...change.node.row});
 
   if (withIDs) {

--- a/packages/zql/src/query/create-builder.ts
+++ b/packages/zql/src/query/create-builder.ts
@@ -1,3 +1,4 @@
+import {safeAssign} from '../../../shared/src/objects.ts';
 import {recordProxy} from '../../../shared/src/record-proxy.ts';
 import type {Schema} from '../../../zero-types/src/schema.ts';
 import type {QueryDelegate} from './query-delegate.ts';
@@ -37,7 +38,7 @@ function createBuilderWithQueryFactory<S extends Schema>(
   // undefined instead of inherited Object.prototype methods (e.g., toString).
   // This fixes React 19 dev mode compatibility where accessing $$typeof should
   // return undefined rather than throwing.
-  const target = Object.assign(Object.create(null), schema.tables) as Record<
+  const target = safeAssign(Object.create(null), schema.tables) as Record<
     string,
     unknown
   >;


### PR DESCRIPTION
This adds 2 new options
- `mutate-allowed-request-headers`
- `query-allowed-request-headers`

which are an allow list of headers to forward from the incoming request upstream.

We need to record the IP address of the caller, which arrives on an `x-forwarded-for` header. We can't provide this in the client as it needs to come from the load balancer server side. I think allowing any header to be forwarded is a useful feature but open to other suggestions :)

Also I spotted a lot of `Object.assign`, including when checking headers, and replaced them with a safe version that can't pollute the prototype. Similar issue in places where we're setting a property directly on an object. If the property is `__proto__` and the object isn't one with a null prototype that could cause an issue. Let me know if you'd like this breaking out into a separate PR. Didn't for now because the headers logic also uses it.

Found a related bug here in the bug tracker: https://bugs.rocicorp.dev/p/zero/issue/3928

Discord: https://discord.com/channels/830183651022471199/1514221426268438689