### PR TITLE
fix(zero-cache): verify actual backup state before purging change-log

### DIFF
--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -21,6 +21,7 @@ import {PurgeLocker} from '../services/change-streamer/storer.ts';
 import {exitAfter, runUntilKilled} from '../services/life-cycle.ts';
 import {
   BackupNotFoundException,
+  getLastBackupTime,
   restoreReplica,
 } from '../services/litestream/commands.ts';
 import {
@@ -223,6 +224,10 @@ export default async function runWorker(
         //
         // Consider: Also account for permanent volumes?
         Date.now() - workerStartTime,
+        // Verifies litestream's claimed backup progress against the actual
+        // backup state in the replica destination before advancing the
+        // change-log cleanup watermark.
+        () => getLastBackupTime(lc, config),
       )
     : new ReplicaMonitor(lc, replica.file, changeStreamer);
 

--- a/packages/zero-cache/src/services/change-streamer/backup-monitor.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/backup-monitor.test.ts
@@ -5,7 +5,7 @@ import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.
 import {DbFile} from '../../test/lite.ts';
 import type {Subscription} from '../../types/subscription.ts';
 import {initReplicationState} from '../replicator/schema/replication-state.ts';
-import {BackupMonitor} from './backup-monitor.ts';
+import {BackupMonitor, WEDGED_SHUTDOWN_GRACE_MS} from './backup-monitor.ts';
 import type {ChangeStreamerService} from './change-streamer.ts';
 import type {SnapshotMessage} from './snapshot.ts';
 
@@ -445,5 +445,79 @@ litestream_replica_validation_total{db="/tmp/zbugs-sync-replica.db",name="file",
 
     // Since the fetch was aborted, no watermarks were processed.
     expect(scheduled).toEqual([]);
+  });
+
+  test('shuts down when the backup stays wedged past the grace period', async () => {
+    const time = Date.UTC(2025, 3, 24);
+    vi.setSystemTime(time);
+
+    // Litestream keeps claiming a fresh backup, but the last object actually
+    // uploaded is frozen 10 minutes in the past: the backup is wedged.
+    setMetricsResponse('618p0bw8', (time / 1000).toPrecision(9));
+    lastActualBackupTime = () => Promise.resolve(new Date(time - 10 * 60_000));
+
+    const runResult = monitor.run();
+    let rejection: unknown;
+    void runResult.catch(e => (rejection = e));
+
+    // First eligible check: the staleness clock starts, no shutdown yet.
+    vi.setSystemTime(time + 100_000);
+    await monitor.checkWatermarksAndScheduleCleanup();
+    await Promise.resolve();
+    expect(scheduled).toEqual([]);
+    expect(rejection).toBeUndefined();
+
+    // Still stale, but just shy of the grace period: still no shutdown.
+    vi.setSystemTime(time + 100_000 + WEDGED_SHUTDOWN_GRACE_MS - 1);
+    await monitor.checkWatermarksAndScheduleCleanup();
+    await Promise.resolve();
+    expect(rejection).toBeUndefined();
+
+    // The backup has now been continuously stale for the full grace period,
+    // so the process shuts down by rejecting the `run()` promise.
+    vi.setSystemTime(time + 100_000 + WEDGED_SHUTDOWN_GRACE_MS);
+    await monitor.checkWatermarksAndScheduleCleanup();
+    await expect(runResult).rejects.toThrow(/wedged/);
+    expect(scheduled).toEqual([]);
+  });
+
+  test('resets the staleness clock when the backup recovers', async () => {
+    const time = Date.UTC(2025, 3, 24);
+    vi.setSystemTime(time);
+
+    setMetricsResponse('618p0bw8', (time / 1000).toPrecision(9));
+    lastActualBackupTime = () => Promise.resolve(new Date(time - 10 * 60_000));
+
+    const runResult = monitor.run();
+    let rejection: unknown;
+    void runResult.catch(e => (rejection = e));
+
+    // Stale right up until the last moment before the grace period elapses.
+    vi.setSystemTime(time + 100_000);
+    await monitor.checkWatermarksAndScheduleCleanup();
+    vi.setSystemTime(time + 100_000 + WEDGED_SHUTDOWN_GRACE_MS - 1);
+    await monitor.checkWatermarksAndScheduleCleanup();
+    await Promise.resolve();
+    expect(rejection).toBeUndefined();
+    expect(scheduled).toEqual([]);
+
+    // The backup recovers before the grace period elapses: the purge proceeds
+    // and the staleness clock is reset.
+    lastActualBackupTime = () => Promise.resolve(new Date(time));
+    await monitor.checkWatermarksAndScheduleCleanup();
+    expect(scheduled).toEqual(['618p0bw8']);
+
+    // A subsequent wedge must endure a *fresh* full grace period. Even though
+    // the total time spent stale now far exceeds the grace period, it was not
+    // continuous, so the process keeps running.
+    setMetricsResponse('618p0bw9', ((time + 100_000) / 1000).toPrecision(9));
+    lastActualBackupTime = () => Promise.resolve(new Date(time));
+    vi.setSystemTime(time + 100_000 + WEDGED_SHUTDOWN_GRACE_MS + 100_000);
+    await monitor.checkWatermarksAndScheduleCleanup();
+    await Promise.resolve();
+    expect(rejection).toBeUndefined();
+    expect(scheduled).toEqual(['618p0bw8']);
+
+    await monitor.stop();
   });
 });

--- a/packages/zero-cache/src/services/change-streamer/backup-monitor.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/backup-monitor.test.ts
@@ -23,6 +23,11 @@ describe('change-streamer/backup-monitor', () => {
   let monitor: BackupMonitor;
   let replica: DbFile;
 
+  // Mocks the verification of the actual backup state (i.e. the
+  // `getLastBackupTime()` litestream CLI invocation in production).
+  let lastActualBackupTime: () => Promise<Date>;
+  const verifyBackupState = vi.fn(() => lastActualBackupTime());
+
   function setMetricsResponse(watermark: string, timestamp: string) {
     // Sample response from prometheus metrics handler
     metricsResponse = `# HELP litestream_db_size The current size of the real DB
@@ -54,6 +59,11 @@ litestream_replica_validation_total{db="/tmp/zbugs-sync-replica.db",name="file",
     vi.useFakeTimers();
     scheduled.splice(0);
 
+    // By default, verification confirms whatever litestream claims
+    // (i.e. the last actual upload happened "now").
+    verifyBackupState.mockClear();
+    lastActualBackupTime = () => Promise.resolve(new Date());
+
     monitor = new BackupMonitor(
       lc,
       replica.path,
@@ -61,6 +71,7 @@ litestream_replica_validation_total{db="/tmp/zbugs-sync-replica.db",name="file",
       'http://localhost:4850/metrics',
       changeStreamer as unknown as ChangeStreamerService,
       100_000, // 100 seconds
+      verifyBackupState,
     );
 
     nock('http://localhost:4850')
@@ -131,6 +142,129 @@ litestream_replica_validation_total{db="/tmp/zbugs-sync-replica.db",name="file",
     vi.setSystemTime(time + 110_000);
     await monitor.checkWatermarksAndScheduleCleanup();
     expect(scheduled).toEqual(['618p0bw8']);
+  });
+
+  test('blocks purge when actual backup is older than claimed', async () => {
+    const time = Date.UTC(2025, 3, 24);
+    vi.setSystemTime(time);
+    const nowSeconds = (Date.now() / 1000).toPrecision(9);
+    setMetricsResponse('618p0bw8', nowSeconds);
+
+    // Litestream claims the watermark was backed up "now", but the last
+    // object actually uploaded to the backup destination is 10 minutes old.
+    lastActualBackupTime = () => Promise.resolve(new Date(time - 10 * 60_000));
+
+    await monitor.checkWatermarksAndScheduleCleanup();
+    expect(scheduled).toEqual([]);
+    expect(verifyBackupState).toHaveBeenCalledTimes(0);
+
+    // The cleanup delay has passed, but the purge must be blocked because
+    // the claimed backup time is not corroborated by an actual upload.
+    vi.setSystemTime(time + 100_000);
+    await monitor.checkWatermarksAndScheduleCleanup();
+    expect(scheduled).toEqual([]);
+    expect(verifyBackupState).toHaveBeenCalledTimes(1);
+
+    vi.setSystemTime(time + 160_000);
+    await monitor.checkWatermarksAndScheduleCleanup();
+    expect(scheduled).toEqual([]);
+    expect(verifyBackupState).toHaveBeenCalledTimes(2);
+
+    // Once the backup destination reflects an upload at (or after) the
+    // claimed backup time, the purge proceeds.
+    lastActualBackupTime = () => Promise.resolve(new Date(time));
+    await monitor.checkWatermarksAndScheduleCleanup();
+    expect(scheduled).toEqual(['618p0bw8']);
+  });
+
+  test('purges only up to the verified backup state', async () => {
+    const time = Date.UTC(2025, 3, 24);
+    vi.setSystemTime(time);
+
+    // The last object actually uploaded to the backup destination was
+    // at `time`, regardless of what litestream metrics claim.
+    lastActualBackupTime = () => Promise.resolve(new Date(time));
+
+    const t1 = (Date.now() / 1000).toPrecision(9);
+    setMetricsResponse('618ocqq8', t1);
+    await monitor.checkWatermarksAndScheduleCleanup();
+    expect(scheduled).toEqual([]);
+
+    // The first watermark (claimed at `time`) becomes eligible and is
+    // confirmed by the actual backup state.
+    vi.setSystemTime(time + 10 * 60_000);
+    const t2 = (Date.now() / 1000).toPrecision(9);
+    setMetricsResponse('618p0bw8', t2);
+    await monitor.checkWatermarksAndScheduleCleanup();
+    expect(scheduled).toEqual(['618ocqq8']);
+
+    // Both watermarks have passed the cleanup delay, but the second one
+    // (claimed at time + 10 min) is not corroborated by the actual backup
+    // state (last actual upload at `time`), so it must not be purged.
+    vi.setSystemTime(time + 20 * 60_000);
+    await monitor.checkWatermarksAndScheduleCleanup();
+    expect(scheduled).toEqual(['618ocqq8']);
+
+    // Once the actual backup state catches up, the second one is purged.
+    lastActualBackupTime = () => Promise.resolve(new Date(time + 10 * 60_000));
+    await monitor.checkWatermarksAndScheduleCleanup();
+    expect(scheduled).toEqual(['618ocqq8', '618p0bw8']);
+  });
+
+  test('blocks purge when backup verification fails', async () => {
+    const time = Date.UTC(2025, 3, 24);
+    vi.setSystemTime(time);
+    const nowSeconds = (Date.now() / 1000).toPrecision(9);
+    setMetricsResponse('618p0bw8', nowSeconds);
+
+    lastActualBackupTime = () =>
+      Promise.reject(new Error('cannot list backup'));
+
+    await monitor.checkWatermarksAndScheduleCleanup();
+    expect(scheduled).toEqual([]);
+
+    // Verification fails, so the purge is conservatively skipped.
+    vi.setSystemTime(time + 100_000);
+    await monitor.checkWatermarksAndScheduleCleanup();
+    expect(scheduled).toEqual([]);
+    expect(verifyBackupState).toHaveBeenCalledTimes(1);
+
+    // When verification recovers (and confirms the claim), the purge
+    // proceeds.
+    lastActualBackupTime = () => Promise.resolve(new Date());
+    await monitor.checkWatermarksAndScheduleCleanup();
+    expect(scheduled).toEqual(['618p0bw8']);
+  });
+
+  test('skips verification confirmed by cached backup state', async () => {
+    const time = Date.UTC(2025, 3, 24);
+    vi.setSystemTime(time);
+
+    const t1 = (Date.now() / 1000).toPrecision(9);
+    setMetricsResponse('618ocqq8', t1);
+    await monitor.checkWatermarksAndScheduleCleanup();
+
+    vi.setSystemTime(time + 10_000);
+    const t2 = (Date.now() / 1000).toPrecision(9);
+    setMetricsResponse('618p0bw8', t2);
+    await monitor.checkWatermarksAndScheduleCleanup();
+
+    // The first purge verifies against the backup destination, which
+    // reports a last actual upload time that also covers the second
+    // watermark (within the clock-skew slack).
+    lastActualBackupTime = () => Promise.resolve(new Date(time + 10_000));
+    vi.setSystemTime(time + 100_000);
+    await monitor.checkWatermarksAndScheduleCleanup();
+    expect(scheduled).toEqual(['618ocqq8']);
+    expect(verifyBackupState).toHaveBeenCalledTimes(1);
+
+    // The second watermark's claimed backup time is already confirmed by
+    // the cached verification result, so the backup destination is not
+    // consulted again.
+    vi.setSystemTime(time + 110_000);
+    await monitor.checkWatermarksAndScheduleCleanup();
+    expect(scheduled).toEqual(['618ocqq8', '618p0bw8']);
+    expect(verifyBackupState).toHaveBeenCalledTimes(1);
   });
 
   test('only keeps one reservation per id', async () => {

--- a/packages/zero-cache/src/services/change-streamer/backup-monitor.ts
+++ b/packages/zero-cache/src/services/change-streamer/backup-monitor.ts
@@ -1,4 +1,5 @@
 import type {LogContext} from '@rocicorp/logger';
+import {resolver} from '@rocicorp/resolver';
 import parsePrometheusTextFormat from 'parse-prometheus-text-format';
 import {must} from '../../../../shared/src/must.ts';
 import {promiseVoid} from '../../../../shared/src/resolved-promises.ts';
@@ -8,7 +9,7 @@ import {
   getOrCreateGauge,
 } from '../../observability/metrics.ts';
 import {Subscription} from '../../types/subscription.ts';
-import {RunningState} from '../running-state.ts';
+import {RunningState, UnrecoverableError} from '../running-state.ts';
 import type {Service} from '../service.ts';
 import type {ChangeStreamerService} from './change-streamer.ts';
 import type {SnapshotMessage} from './snapshot.ts';
@@ -21,6 +22,29 @@ const MIN_CLEANUP_DELAY_MS = 30_000;
  * and the timestamps reported by the backup destination (e.g. S3).
  */
 export const BACKUP_VERIFICATION_SLACK_MS = 60_000;
+
+/**
+ * How long the actual backup state may remain *continuously* behind the
+ * backup progress claimed by litestream metrics before the backup is
+ * considered genuinely wedged and the process is shut down.
+ *
+ * A wedged backup is dangerous: litestream believes it is making durable
+ * progress when it is not, which can silently corrupt the backup (the WAL
+ * format only makes *some* such gaps detectable). Once that is confirmed to
+ * be the persistent state, continuing to run is worse than crashing, so the
+ * process exits loudly (non-zero, with a logged error) and the wedged backup
+ * destination becomes the priority to investigate.
+ *
+ * The change-log is conservatively *not* purged for the entire time the
+ * backup is stale, so the only cost of a generous grace period is unbounded
+ * change-log growth. We therefore err well on the side of slack: the backup
+ * must stay stuck across many {@link CHECK_INTERVAL_MS} checks before we tear
+ * the server down, so that a transient hiccup (a slow or briefly unreachable
+ * destination, or litestream restarting) does not trigger a shutdown. The
+ * staleness clock is reset the moment a purge is confirmed against a real
+ * upload.
+ */
+export const WEDGED_SHUTDOWN_GRACE_MS = 15 * 60_000; // 15 minutes
 
 /**
  * Returns the time of the most recent object actually uploaded to the
@@ -72,7 +96,10 @@ type Reservation = {
  * reflect what litestream *believes* has been backed up (which has been
  * observed to diverge from reality when uploads silently fail), the cleanup
  * watermark is only advanced after verifying it against the actual backup
- * state in the replica destination via a {@link BackupStateVerifier}.
+ * state in the replica destination via a {@link BackupStateVerifier}. If the
+ * actual backup state stays behind the claimed progress for longer than
+ * {@link WEDGED_SHUTDOWN_GRACE_MS}, the backup is treated as wedged and the
+ * process is shut down rather than risk corrupting the backup.
  */
 export class BackupMonitor implements Service {
   readonly id = 'backup-monitor';
@@ -92,12 +119,23 @@ export class BackupMonitor implements Service {
       'Number of change-log purges blocked because the actual backup state ' +
       '(as listed from the replica destination) could not be verified, or ' +
       'is older than the backup progress claimed by litestream metrics. ' +
-      'A steadily increasing value indicates a wedged or failing backup.',
+      'A steadily increasing value indicates a wedged or failing backup. ' +
+      'The "backup-wedged" reason is emitted once just before the process ' +
+      'shuts itself down due to a persistently stale backup.',
   });
+
+  // Rejected when the backup is determined to be genuinely wedged, which
+  // surfaces as a rejection of the `run()` promise and shuts the process down.
+  readonly #fatal = resolver<void>();
 
   #lastWatermark: string = '';
   #latestBackupTime: Date | null = null;
   #lastVerifiedUploadTime: Date | null = null;
+  // Epoch ms at which the actual backup state was first observed to be
+  // continuously behind the watermark litestream claims to have backed up,
+  // or `null` while the backup is keeping up. Reset whenever a purge is
+  // confirmed against a real upload.
+  #backupStaleSince: number | null = null;
   #cleanupDelayMs: number;
   #checkMetricsTimer: NodeJS.Timeout | undefined;
 
@@ -136,7 +174,8 @@ export class BackupMonitor implements Service {
       CHECK_INTERVAL_MS,
     );
     this.#initBackupLagMetric();
-    return this.#state.stopped();
+    // Resolves on a normal stop; rejects if the backup is found to be wedged.
+    return Promise.race([this.#state.stopped(), this.#fatal.promise]);
   }
 
   startSnapshotReservation(taskID: string): Subscription<SnapshotMessage> {
@@ -309,16 +348,27 @@ export class BackupMonitor implements Service {
     );
     if (verifiedWatermark.length === 0) {
       this.#purgesBlocked.add(1, {reason: 'backup-stale'});
+      const now = Date.now();
+      if (this.#backupStaleSince === null) {
+        this.#backupStaleSince = now;
+      }
+      const staleForMs = now - this.#backupStaleSince;
       this.#lc.warn?.(
         `blocked change-log cleanup up to watermark ${maxWatermark}: ` +
           `litestream claims it was backed up at ` +
           `${claimedTime.toISOString()}, but the last object actually ` +
           `uploaded to ${this.#backupURL} was at ` +
           `${lastUpload.toISOString()}. ` +
-          `The backup may be wedged.`,
+          `The backup has been stale for ${staleForMs} ms.`,
       );
+      if (staleForMs >= WEDGED_SHUTDOWN_GRACE_MS) {
+        this.#shutDownOnWedgedBackup(staleForMs, claimedTime, lastUpload);
+      }
       return;
     }
+    // The cleanup watermark advanced past a real upload, so the backup is
+    // keeping up: clear the staleness clock.
+    this.#backupStaleSince = null;
     this.#changeStreamer.scheduleCleanup(verifiedWatermark);
     for (const watermark of this.#watermarks.keys()) {
       if (watermark <= verifiedWatermark) {
@@ -326,6 +376,33 @@ export class BackupMonitor implements Service {
       }
     }
     this.#lastWatermark = verifiedWatermark;
+  }
+
+  /**
+   * Called when the backup has been continuously stale for longer than
+   * {@link WEDGED_SHUTDOWN_GRACE_MS}. Continuing to run risks corrupting the
+   * backup, so the process is shut down by rejecting the {@link run()}
+   * promise. The exit is non-zero and logged at ERROR for alerting; on
+   * restart the monitor re-verifies, so a still-wedged backup keeps the
+   * process down until the destination is fixed.
+   */
+  #shutDownOnWedgedBackup(
+    staleForMs: number,
+    claimedTime: Date,
+    lastUpload: Date,
+  ) {
+    this.#purgesBlocked.add(1, {reason: 'backup-wedged'});
+    const err = new UnrecoverableError(
+      `backup at ${this.#backupURL} is wedged: litestream claims a backup ` +
+        `at ${claimedTime.toISOString()}, but the last object actually ` +
+        `uploaded was at ${lastUpload.toISOString()}, and the backup has ` +
+        `not advanced for ${staleForMs} ms (grace period ` +
+        `${WEDGED_SHUTDOWN_GRACE_MS} ms). Shutting down to avoid corrupting ` +
+        `the backup; investigate the backup destination.`,
+    );
+    this.#lc.error?.(err.message);
+    clearInterval(this.#checkMetricsTimer);
+    this.#fatal.reject(err);
   }
 
   /**

--- a/packages/zero-cache/src/services/change-streamer/backup-monitor.ts
+++ b/packages/zero-cache/src/services/change-streamer/backup-monitor.ts
@@ -1,8 +1,12 @@
 import type {LogContext} from '@rocicorp/logger';
 import parsePrometheusTextFormat from 'parse-prometheus-text-format';
+import {must} from '../../../../shared/src/must.ts';
 import {promiseVoid} from '../../../../shared/src/resolved-promises.ts';
 import {Database} from '../../../../zqlite/src/db.ts';
-import {getOrCreateGauge} from '../../observability/metrics.ts';
+import {
+  getOrCreateCounter,
+  getOrCreateGauge,
+} from '../../observability/metrics.ts';
 import {Subscription} from '../../types/subscription.ts';
 import {RunningState} from '../running-state.ts';
 import type {Service} from '../service.ts';
@@ -11,6 +15,22 @@ import type {SnapshotMessage} from './snapshot.ts';
 
 export const CHECK_INTERVAL_MS = 60_000;
 const MIN_CLEANUP_DELAY_MS = 30_000;
+
+/**
+ * Allowance for clock skew between the machine reporting litestream metrics
+ * and the timestamps reported by the backup destination (e.g. S3).
+ */
+export const BACKUP_VERIFICATION_SLACK_MS = 60_000;
+
+/**
+ * Returns the time of the most recent object actually uploaded to the
+ * backup replica destination (e.g. as determined by listing the snapshots
+ * and WAL segments in S3). Rejects if the backup state cannot be determined.
+ *
+ * See `getLastBackupTime()` in `../litestream/commands.ts` for the
+ * production implementation.
+ */
+export type BackupStateVerifier = () => Promise<Date>;
 
 type Reservation = {
   start: Date;
@@ -47,6 +67,12 @@ type Reservation = {
  * Note that the reservation request is the primary mechanism by which
  * premature change log cleanup is prevented. The cleanup delay interval is
  * a secondary safeguard.
+ *
+ * Additionally, because the watermarks reported by litestream metrics
+ * reflect what litestream *believes* has been backed up (which has been
+ * observed to diverge from reality when uploads silently fail), the cleanup
+ * watermark is only advanced after verifying it against the actual backup
+ * state in the replica destination via a {@link BackupStateVerifier}.
  */
 export class BackupMonitor implements Service {
   readonly id = 'backup-monitor';
@@ -60,8 +86,18 @@ export class BackupMonitor implements Service {
   readonly #reservations = new Map<string, Reservation>();
   readonly #watermarks = new Map<string, Date>();
 
+  readonly #verifyBackupState: BackupStateVerifier;
+  readonly #purgesBlocked = getOrCreateCounter('replica', 'purge_blocked', {
+    description:
+      'Number of change-log purges blocked because the actual backup state ' +
+      '(as listed from the replica destination) could not be verified, or ' +
+      'is older than the backup progress claimed by litestream metrics. ' +
+      'A steadily increasing value indicates a wedged or failing backup.',
+  });
+
   #lastWatermark: string = '';
   #latestBackupTime: Date | null = null;
+  #lastVerifiedUploadTime: Date | null = null;
   #cleanupDelayMs: number;
   #checkMetricsTimer: NodeJS.Timeout | undefined;
 
@@ -72,12 +108,14 @@ export class BackupMonitor implements Service {
     metricsEndpoint: string,
     changeStreamer: ChangeStreamerService,
     initialCleanupDelayMs: number,
+    verifyBackupState: BackupStateVerifier,
   ) {
     this.#lc = lc.withContext('component', this.id);
     this.#replicaFile = replicaFile;
     this.#backupURL = backupURL;
     this.#metricsEndpoint = metricsEndpoint;
     this.#changeStreamer = changeStreamer;
+    this.#verifyBackupState = verifyBackupState;
     this.#cleanupDelayMs = Math.max(
       initialCleanupDelayMs,
       MIN_CLEANUP_DELAY_MS, // purely for peace of mind
@@ -157,7 +195,7 @@ export class BackupMonitor implements Service {
       this.#lc.warn?.(`unable to fetch metrics at ${this.#metricsEndpoint}`, e);
     }
     try {
-      this.#scheduleCleanup();
+      await this.#scheduleCleanup();
     } catch (e) {
       this.#lc.warn?.(`error scheduling cleanup`, e);
     }
@@ -223,7 +261,7 @@ export class BackupMonitor implements Service {
     return this.#latestBackupTime;
   }
 
-  #scheduleCleanup() {
+  async #scheduleCleanup() {
     if (this.#reservations.size > 0) {
       this.#lc.info?.(
         `watermark cleanup paused for snapshot(s): ${[...this.#reservations.keys()]}`,
@@ -231,24 +269,93 @@ export class BackupMonitor implements Service {
       return;
     }
     const latestCleanupTime = Date.now() - this.#cleanupDelayMs;
-    let maxWatermark = '';
-    for (const [watermark, backupTime] of this.#watermarks.entries()) {
-      if (
-        backupTime.getTime() <= latestCleanupTime &&
-        watermark > maxWatermark
-      ) {
-        maxWatermark = watermark;
+    const maxWatermark = this.#maxWatermarkUpTo(latestCleanupTime);
+    if (maxWatermark.length === 0) {
+      return;
+    }
+    // Purge guard: the watermarks (and their backup times) come from
+    // litestream metrics, which are exported when litestream *believes*
+    // an upload succeeded, and have been observed to advance even when
+    // nothing was actually written to the backup destination. Purging the
+    // change-log based on a falsely advancing watermark permanently breaks
+    // the ability to restore + catch up. Before advancing the cleanup
+    // watermark, verify it against the actual backup state: a claimed
+    // backup time is only trusted if an object was actually uploaded to
+    // the replica destination at (or after) that time, modulo clock skew.
+    const claimedTime = must(this.#watermarks.get(maxWatermark));
+    if (!this.#confirmedDurable(claimedTime)) {
+      try {
+        this.#lastVerifiedUploadTime = await this.#verifyBackupState();
+      } catch (e) {
+        this.#purgesBlocked.add(1, {reason: 'verification-failed'});
+        // Skipping the purge is safe: the change-log just grows.
+        this.#lc.warn?.(
+          `unable to verify backup state. skipping change-log cleanup ` +
+            `up to watermark ${maxWatermark} ` +
+            `(claimed backup time ${claimedTime.toISOString()})`,
+          e,
+        );
+        return;
       }
     }
-    if (maxWatermark.length) {
-      this.#changeStreamer.scheduleCleanup(maxWatermark);
-      for (const watermark of this.#watermarks.keys()) {
-        if (watermark <= maxWatermark) {
-          this.#watermarks.delete(watermark);
-        }
-      }
-      this.#lastWatermark = maxWatermark;
+    // Watermarks whose backup time isn't yet confirmed durable remain in the
+    // map and are re-evaluated at the next check.
+    const lastUpload = must(this.#lastVerifiedUploadTime);
+    const verifiedWatermark = this.#maxWatermarkUpTo(
+      Math.min(
+        latestCleanupTime,
+        lastUpload.getTime() + BACKUP_VERIFICATION_SLACK_MS,
+      ),
+    );
+    if (verifiedWatermark.length === 0) {
+      this.#purgesBlocked.add(1, {reason: 'backup-stale'});
+      this.#lc.warn?.(
+        `blocked change-log cleanup up to watermark ${maxWatermark}: ` +
+          `litestream claims it was backed up at ` +
+          `${claimedTime.toISOString()}, but the last object actually ` +
+          `uploaded to ${this.#backupURL} was at ` +
+          `${lastUpload.toISOString()}. ` +
+          `The backup may be wedged.`,
+      );
+      return;
     }
+    this.#changeStreamer.scheduleCleanup(verifiedWatermark);
+    for (const watermark of this.#watermarks.keys()) {
+      if (watermark <= verifiedWatermark) {
+        this.#watermarks.delete(watermark);
+      }
+    }
+    this.#lastWatermark = verifiedWatermark;
+  }
+
+  /**
+   * Returns the newest watermark whose backup time is at or before `cutoff`
+   * (epoch ms), or `''` if there is none.
+   */
+  #maxWatermarkUpTo(cutoff: number): string {
+    let max = '';
+    for (const [watermark, backupTime] of this.#watermarks) {
+      if (backupTime.getTime() <= cutoff && watermark > max) {
+        max = watermark;
+      }
+    }
+    return max;
+  }
+
+  /**
+   * Returns `true` if the actual backup state, as last verified against the
+   * backup destination, confirms that data claimed to be backed up at
+   * `claimedTime` is durable (i.e. an object was actually uploaded at or
+   * after `claimedTime`, allowing {@link BACKUP_VERIFICATION_SLACK_MS} of
+   * clock skew).
+   */
+  #confirmedDurable(claimedTime: Date): boolean {
+    const lastUpload = this.#lastVerifiedUploadTime;
+    return (
+      lastUpload !== null &&
+      claimedTime.getTime() <=
+        lastUpload.getTime() + BACKUP_VERIFICATION_SLACK_MS
+    );
   }
 
   stop(): Promise<void> {

--- a/packages/zero-cache/src/services/litestream/commands.test.ts
+++ b/packages/zero-cache/src/services/litestream/commands.test.ts
@@ -1,0 +1,160 @@
+import {mkdtempSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {LogContext} from '@rocicorp/logger';
+import {afterEach, describe, expect, test, vi} from 'vitest';
+import {
+  createSilentLogContext,
+  TestLogSink,
+} from '../../../../shared/src/logging-test-utils.ts';
+import type {ZeroConfig} from '../../config/zero-config.ts';
+import {getLastBackupTime, parseBackupCreatedTimes} from './commands.ts';
+
+describe('litestream/commands parseBackupCreatedTimes', () => {
+  const lc = createSilentLogContext();
+
+  test('parses the created column from snapshot output', () => {
+    const output =
+      `replica  generation        index  size     created\n` +
+      `s3       1862f44967b3863f  0      4546445  2026-06-10T01:11:32Z\n`;
+    expect(parseBackupCreatedTimes(lc, 'snapshots', output)).toEqual([
+      new Date('2026-06-10T01:11:32Z'),
+    ]);
+  });
+
+  test('parses the created column (last) from wal output with extra columns', () => {
+    const output =
+      `replica  generation        index  offset  size  created\n` +
+      `s3       1862f44967b3863f  0      0       100   2026-06-10T01:11:32Z\n` +
+      `s3       1862f44967b3863f  1      4096    200   2026-06-10T01:12:00Z\n`;
+    expect(parseBackupCreatedTimes(lc, 'wal', output)).toEqual([
+      new Date('2026-06-10T01:11:32Z'),
+      new Date('2026-06-10T01:12:00Z'),
+    ]);
+  });
+
+  test('skips the header, blank lines, and short lines', () => {
+    const output =
+      `\n` +
+      `replica  generation        index  size     created\n` +
+      `\n` +
+      `   \n` +
+      `s3       1862f44967b3863f  0      4546445  2026-06-10T01:11:32Z\n`;
+    expect(parseBackupCreatedTimes(lc, 'snapshots', output)).toEqual([
+      new Date('2026-06-10T01:11:32Z'),
+    ]);
+  });
+
+  test('returns empty for empty or header-only output', () => {
+    expect(parseBackupCreatedTimes(lc, 'snapshots', '')).toEqual([]);
+    expect(
+      parseBackupCreatedTimes(
+        lc,
+        'snapshots',
+        `replica  generation  index  size  created\n`,
+      ),
+    ).toEqual([]);
+  });
+
+  test('warns and skips lines with an unparseable created time', () => {
+    const sink = new TestLogSink();
+    const lc = new LogContext('debug', undefined, sink);
+    const output =
+      `replica  generation        index  size     created\n` +
+      `s3       1862f44967b3863f  0      4546445  not-a-date\n` +
+      `s3       1862f44967b3863f  1      4546445  2026-06-10T01:12:00Z\n`;
+    expect(parseBackupCreatedTimes(lc, 'snapshots', output)).toEqual([
+      new Date('2026-06-10T01:12:00Z'),
+    ]);
+    expect(
+      sink.messages.some(
+        ([level, , args]) =>
+          level === 'warn' &&
+          String(args[0]).includes('unexpected line in litestream snapshots'),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe('litestream/commands getLastBackupTime', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // Writes a fake `litestream` executable that emits `sh` (a POSIX shell
+  // snippet that can branch on `$1`, the snapshots|wal subcommand) and
+  // returns the config pointing at it.
+  function configWithFakeLitestream(sh: string): ZeroConfig {
+    const dir = mkdtempSync(join(tmpdir(), 'litestream-test-'));
+    const executable = join(dir, 'fake-litestream');
+    writeFileSync(executable, `#!/bin/sh\n${sh}\n`, {mode: 0o755});
+    return {
+      port: 4848,
+      log: {format: 'text'},
+      replica: {file: join(dir, 'replica.db')},
+      litestream: {
+        executable,
+        backupURL: 's3://fake-bucket/backup',
+        configPath: './src/services/litestream/config.yml',
+        logLevel: 'warn',
+        restoreUsingV5: false,
+        checkpointThresholdMB: 40,
+        incrementalBackupIntervalMinutes: 15,
+        snapshotBackupIntervalHours: 12,
+        multipartConcurrency: 48,
+        multipartSize: 16 * 1024 * 1024,
+        restoreParallelism: 48,
+      },
+    } as unknown as ZeroConfig;
+  }
+
+  const lc = createSilentLogContext();
+
+  test('returns the most recent created time across snapshots and wal', async () => {
+    const config = configWithFakeLitestream(
+      `if [ "$1" = "snapshots" ]; then\n` +
+        `  echo "replica generation index size created"\n` +
+        `  echo "s3 gen 0 100 2025-04-24T00:00:00Z"\n` +
+        `else\n` +
+        `  echo "replica generation index offset size created"\n` +
+        `  echo "s3 gen 1 0 100 2025-04-24T00:05:00Z"\n` +
+        `  echo "s3 gen 2 0 100 2025-04-24T00:10:00Z"\n` +
+        `fi`,
+    );
+    expect(await getLastBackupTime(lc, config)).toEqual(
+      new Date('2025-04-24T00:10:00Z'),
+    );
+  });
+
+  test('rejects when nothing is listed at the destination', async () => {
+    const config = configWithFakeLitestream(`exit 0`);
+    await expect(getLastBackupTime(lc, config)).rejects.toThrow(
+      /no snapshots or WAL segments listed/,
+    );
+  });
+
+  test('rejects when the litestream process exits non-zero', async () => {
+    const config = configWithFakeLitestream(`exit 1`);
+    await expect(getLastBackupTime(lc, config)).rejects.toThrow(
+      /litestream (snapshots|wal) exited with code 1/,
+    );
+  });
+
+  test('rejects (and kills the process) when listing times out', async () => {
+    vi.useFakeTimers();
+    const config = configWithFakeLitestream(`sleep 30`);
+    const result = getLastBackupTime(lc, config);
+    // Surface the rejection synchronously so the unhandled-rejection guard
+    // does not fire before we await it below.
+    const settled = result.then(
+      v => ({ok: true as const, v}),
+      e => ({ok: false as const, e}),
+    );
+    await vi.advanceTimersByTimeAsync(30_000);
+    const outcome = await settled;
+    expect(outcome.ok).toBe(false);
+    expect(String(outcome.ok === false && outcome.e)).toMatch(
+      /timed out listing backup state/,
+    );
+  });
+});

--- a/packages/zero-cache/src/services/litestream/commands.ts
+++ b/packages/zero-cache/src/services/litestream/commands.ts
@@ -251,6 +251,131 @@ export function startReplicaBackupProcess(
   });
 }
 
+// Listing the backup state requires a few S3 LIST requests, which should
+// normally complete well within this timeout.
+const LIST_BACKUP_TIMEOUT_MS = 30_000;
+
+const wsRe = /\s+/;
+
+/**
+ * Returns the time of the most recent object (snapshot or WAL segment)
+ * actually uploaded to the backup replica destination, as listed by the
+ * bundled litestream CLI (`litestream snapshots` / `litestream wal`).
+ *
+ * This queries the replica destination (e.g. S3) directly, and thus serves
+ * as a source of truth for backup durability. This is in contrast to the
+ * `litestream_replica_progress` metric, which is exported when litestream
+ * *believes* an upload has succeeded, and has been observed to advance even
+ * when nothing is actually written to the destination.
+ *
+ * Rejects if the backup state cannot be determined (spawn error, non-zero
+ * exit, timeout, or empty/unparseable listing).
+ */
+export async function getLastBackupTime(
+  lc: LogContext,
+  config: ZeroConfig,
+): Promise<Date> {
+  const [snapshots, wal] = await Promise.all([
+    listBackupCreatedTimes(lc, config, 'snapshots'),
+    listBackupCreatedTimes(lc, config, 'wal'),
+  ]);
+  const times = [...snapshots, ...wal];
+  if (times.length === 0) {
+    // Note: the litestream CLI exits with code 0 and logs listing errors
+    // (e.g. S3 failures) to stderr, so an empty listing cannot be
+    // distinguished from a failed one. Since a valid backup always contains
+    // at least one snapshot, an empty listing is treated as a failure.
+    throw new Error(
+      `no snapshots or WAL segments listed at ${config.litestream.backupURL}`,
+    );
+  }
+  return new Date(Math.max(...times.map(time => time.getTime())));
+}
+
+/**
+ * Runs `litestream <snapshots|wal> <replica-file>` with the same config /
+ * environment used by the `litestream replicate` process (so that the
+ * backupURL, endpoint, region, and credentials are identical), and parses
+ * the `created` column (RFC3339) of the tab-formatted output, e.g.:
+ *
+ * ```
+ * replica  generation        index  size     created
+ * s3       1862f44967b3863f  0      4546445  2026-06-10T01:11:32Z
+ * ```
+ */
+async function listBackupCreatedTimes(
+  lc: LogContext,
+  config: ZeroConfig,
+  command: 'snapshots' | 'wal',
+): Promise<Date[]> {
+  const {litestream, env} = getLitestream('replicate', config);
+  const proc = spawn(litestream, [command, config.replica.file], {
+    env,
+    stdio: ['ignore', 'pipe', 'inherit'],
+    windowsHide: true,
+  });
+  const {promise, resolve, reject} = resolver<string>();
+  let stdout = '';
+  proc.stdout.setEncoding('utf-8');
+  proc.stdout.on('data', chunk => (stdout += chunk));
+  proc.on('error', reject);
+  proc.on('close', (code, signal) => {
+    if (signal) {
+      reject(new Error(`litestream ${command} killed with ${signal}`));
+    } else if (code !== 0) {
+      reject(new Error(`litestream ${command} exited with code ${code}`));
+    } else {
+      resolve(stdout);
+    }
+  });
+  const timeout = setTimeout(() => {
+    reject(new Error(`timed out listing backup state (litestream ${command})`));
+    proc.kill('SIGKILL');
+  }, LIST_BACKUP_TIMEOUT_MS);
+
+  let output: string;
+  try {
+    output = await promise;
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  return parseBackupCreatedTimes(lc, command, output);
+}
+
+/**
+ * Parses the `created` column (the last, RFC3339-formatted column) from the
+ * tab-formatted output of `litestream snapshots` / `litestream wal`. The
+ * header row and any unparseable lines are skipped.
+ *
+ * Exported for testing.
+ */
+export function parseBackupCreatedTimes(
+  lc: LogContext,
+  command: 'snapshots' | 'wal',
+  output: string,
+): Date[] {
+  const times: Date[] = [];
+  for (const line of output.split('\n')) {
+    const cols = line.trim().split(wsRe);
+    const created = cols.at(-1);
+    if (
+      cols.length < 2 ||
+      created === undefined ||
+      created === 'created' /* header row */
+    ) {
+      continue;
+    }
+    const time = new Date(created);
+    if (Number.isNaN(time.getTime())) {
+      lc.warn?.(`unexpected line in litestream ${command} output: ${line}`);
+      continue;
+    }
+    times.push(time);
+  }
+  return times;
+}
+
 function reserveAndGetSnapshotStatus(
   lc: LogContext,
   config: ZeroConfig,


### PR DESCRIPTION
The BackupMonitor previously trusted the litestream_replica_progress
metric as proof that a watermark was durably backed up before purging
the change-log up to it. During the 2026-06-10 incident (INC-684), a
wedged litestream replicate process kept advancing that metric without
writing anything to S3; the change-log was purged past the real backup,
leaving view-syncers unable to restore (watermark < minWatermark) and
crash-looping until manual intervention.

The cleanup watermark is now only advanced after verifying the claimed
backup time against the actual backup state, by listing snapshots and
WAL segments at the backup destination via the bundled litestream CLI.
If verification fails or the destination is stale, the purge is
conservatively skipped, a rate-limited warning is logged, and a new
replica.purge_blocked counter is incremented for alerting.

Addresses the TODO in backup-monitor.ts about verifying backups
directly rather than trusting litestream metrics.
