### PR TITLE
chore(devcontainer): v0 of devcontainer for mono

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,27 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/typescript-node
+{
+  "name": "CloudZero App (Node 24)",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:24@sha256:5be6833735e290e26232abe2d65197942057fb5091f103c128ca454e2043c1d9",
+  "remoteUser": "node",
+  "customizations": {
+    "vscode": {
+      "extensions": ["oxc.oxc-vscode@1.57.0"],
+      "settings": {
+        "editor.formatOnSave": true,
+
+        "editor.defaultFormatter": "oxc.oxc-vscode",
+
+        "oxc.enable": true,
+        "oxc.enable.oxfmt": true,
+
+        "oxc.path.oxfmt": "./node_modules/.bin/oxfmt",
+
+        "extensions.autoUpdate": false,
+        "extensions.autoCheckUpdates": false
+      }
+    }
+  },
+  "postCreateCommand": ".devcontainer/post-create.sh",
+  "postStartCommand": ".devcontainer/post-start.sh"
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Do toolchain setup outside the mounted repo/workspace.
+cd "$HOME"
+
+sudo corepack enable pnpm
+
+# Configure pnpm to use the correct store directory
+pnpm config set store-dir "$HOME/.local/share/pnpm/store"
+
+# Remove npm and npx symlinks to force pnpm usage
+sudo rm -rf \
+  /usr/local/bin/npm \
+  /usr/local/bin/npx \
+  /usr/local/lib/node_modules/npm

--- a/.devcontainer/post-start.sh
+++ b/.devcontainer/post-start.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! git config --get user.name >/dev/null; then
+  echo "WARN: git user.name is not configured."
+fi
+
+if ! git config --get user.email >/dev/null; then
+  echo "WARN: git user.email is not configured."
+fi
+
+if ! ssh-add -L >/dev/null 2>&1; then
+  echo "WARN: SSH agent has no visible keys. Commit signing through 1Password/SSH agent may not work."
+fi


### PR DESCRIPTION
- Does not address how to run `apps/zbugs/docker/docker-compose.yml` for local dev.  This might be how we want to address that https://app.notion.com/p/replicache/Devcontainer-Docker-Compose-Sibling-Services-37c3bed8954580ee90f4c9dc68008c85
- Would be great to figure out how to share with cloudzero and other repos.

