### PR TITLE
chore(replicache): remove stale .vscode eslint/prettier config

### DIFF
--- a/packages/replicache/.vscode/extensions.json
+++ b/packages/replicache/.vscode/extensions.json
@@ -1,3 +1,0 @@
-{
-  "recommendations": ["dbaeumer.vscode-eslint", "esbenp.prettier-vscode"]
-}

--- a/packages/replicache/.vscode/settings.json
+++ b/packages/replicache/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-  "editor.tabSize": 2,
-  "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": "explicit"
-  },
-  "typescript.tsdk": "node_modules/typescript/lib"
-}


### PR DESCRIPTION
The monorepo standardized on oxlint/oxfmt (oxc.oxc-vscode); replicache's .vscode recommended dbaeumer.vscode-eslint + esbenp.prettier-vscode and set source.fixAll.eslint, which auto-installed unused extensions on checkout.