### PR TITLE
chore: add Docker to the dev container for zero-cache pg tests

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -5,6 +5,11 @@
       "resolved": "ghcr.io/anthropics/devcontainer-features/claude-code@sha256:cfc2e7d3e9fd3b9b01f8d5cb158508a884c8c0ede2e23ed10f32dea5d4ffe69a",
       "integrity": "sha256:cfc2e7d3e9fd3b9b01f8d5cb158508a884c8c0ede2e23ed10f32dea5d4ffe69a"
     },
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      "version": "2.17.0",
+      "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:25b9f05705ffba7dbe503230ac76081419306f8c8bc88e0ce78c4ecd99a0c78c",
+      "integrity": "sha256:25b9f05705ffba7dbe503230ac76081419306f8c8bc88e0ce78c4ecd99a0c78c"
+    },
     "ghcr.io/devcontainers/features/github-cli:1": {
       "version": "1.1.0",
       "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
@@ -17,6 +22,14 @@
       "dependsOn": [
         "ghcr.io/anthropics/devcontainer-features/claude-code:1",
         "ghcr.io/devcontainers/features/github-cli:1"
+      ]
+    },
+    "ghcr.io/rocicorp/devcontainer-features/docker:1": {
+      "version": "1.0.0",
+      "resolved": "ghcr.io/rocicorp/devcontainer-features/docker@sha256:36fcab27b6c8727d3ac8df3818a213ea73339f17fa655090de81a83fa1907e64",
+      "integrity": "sha256:36fcab27b6c8727d3ac8df3818a213ea73339f17fa655090de81a83fa1907e64",
+      "dependsOn": [
+        "ghcr.io/devcontainers/features/docker-in-docker:2"
       ]
     },
     "ghcr.io/rocicorp/devcontainer-features/pnpm:1": {

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -28,9 +28,7 @@
       "version": "1.0.0",
       "resolved": "ghcr.io/rocicorp/devcontainer-features/docker@sha256:36fcab27b6c8727d3ac8df3818a213ea73339f17fa655090de81a83fa1907e64",
       "integrity": "sha256:36fcab27b6c8727d3ac8df3818a213ea73339f17fa655090de81a83fa1907e64",
-      "dependsOn": [
-        "ghcr.io/devcontainers/features/docker-in-docker:2"
-      ]
+      "dependsOn": ["ghcr.io/devcontainers/features/docker-in-docker:2"]
     },
     "ghcr.io/rocicorp/devcontainer-features/pnpm:1": {
       "version": "1.0.0",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,8 +12,10 @@
     //  - agents: Codex (pinned) + Claude Code + gh; persists the Claude/gh logins
     //    across rebuilds and sets CLAUDE_CONFIG_DIR.
     //  - pnpm: corepack-managed pnpm; removes npm/npx to enforce pnpm.
+    //  - docker: Docker-in-Docker daemon so testcontainers (zero-cache pg tests) work.
     "ghcr.io/rocicorp/devcontainer-features/agents:1": {},
-    "ghcr.io/rocicorp/devcontainer-features/pnpm:1": {}
+    "ghcr.io/rocicorp/devcontainer-features/pnpm:1": {},
+    "ghcr.io/rocicorp/devcontainer-features/docker:1": {}
   },
   "customizations": {
     "vscode": {


### PR DESCRIPTION
## What

Adds the rocicorp `docker` dev container feature (Docker-in-Docker) to `.devcontainer/devcontainer.json` and pins it (+ its `docker-in-docker` dependency) in `devcontainer-lock.json`.

## Why

`pnpm test` in `packages/zero-cache` fails inside the dev container:

```
Error: Could not find a working container runtime strategy
 ❯ PostgreSqlContainer.start .../@testcontainers/postgresql/...
 ❯ Object.setup test/pg-container-setup.ts:5:23
```

The pg test suite (`test/pg-container-setup.ts`) starts Postgres via testcontainers, which needs a Docker daemon. The dev container shipped none (no `docker` binary, no socket).

## Dependency

Uses `ghcr.io/rocicorp/devcontainer-features/docker:1`, added in rocicorp/devcontainer-features#4 (merged + published to ghcr, public).

## After merge

Rebuild the dev container ("Dev Containers: Rebuild Container"). Docker-in-Docker starts a daemon in the container; `pnpm --filter zero-cache test` then runs the pg suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)