### PR TITLE
perf(zql): reduce Catch.expandNode allocation

### DIFF
--- a/packages/zql/src/ivm/catch.ts
+++ b/packages/zql/src/ivm/catch.ts
@@ -128,11 +128,6 @@ export function expandNode(node: Node | 'yield'): CaughtNode {
     : {
         row: node.row,
         relationships: mapValues(node.relationships, getChildren => {
-          // Manual push instead of Array.from(getChildren(), expandNode): both
-          // walk the same iterator, but Array.from's iterable+mapFn builtin
-          // carries per-element overhead (index tracking, generic mapFn call)
-          // that an inlined for-of + push avoids (~1.4x on the relationship-
-          // heavy memory-ivm-deopt Join hydration benchmark).
           const children: CaughtNode[] = [];
           for (const child of getChildren()) {
             children.push(expandNode(child));

--- a/packages/zql/src/ivm/catch.ts
+++ b/packages/zql/src/ivm/catch.ts
@@ -1,4 +1,5 @@
 import {unreachable} from '../../../shared/src/asserts.ts';
+import {mapValues} from '../../../shared/src/objects.ts';
 import {emptyArray} from '../../../shared/src/sentinels.ts';
 import type {Row} from '../../../zero-protocol/src/data.ts';
 import {ChangeIndex} from './change-index.ts';
@@ -126,11 +127,17 @@ export function expandNode(node: Node | 'yield'): CaughtNode {
     ? node
     : {
         row: node.row,
-        relationships: Object.fromEntries(
-          Object.entries(node.relationships).map(([k, v]) => [
-            k,
-            Array.from(v(), expandNode),
-          ]),
-        ),
+        relationships: mapValues(node.relationships, getChildren => {
+          // Manual push instead of Array.from(getChildren(), expandNode): both
+          // walk the same iterator, but Array.from's iterable+mapFn builtin
+          // carries per-element overhead (index tracking, generic mapFn call)
+          // that an inlined for-of + push avoids (~1.4x on the relationship-
+          // heavy memory-ivm-deopt Join hydration benchmark).
+          const children: CaughtNode[] = [];
+          for (const child of getChildren()) {
+            children.push(expandNode(child));
+          }
+          return children;
+        }),
       };
 }


### PR DESCRIPTION
Catch is a test/benchmark helper — the standard way tests and benchmarks drain
an Input — and is not used by production code. Its expandNode rebuilt the
relationships object via Object.entries(...).map() -> Object.fromEntries() and
Array.from(stream, fn); a direct loop produces the identical CaughtNode with
fewer intermediates. The point of this change is to cut the benchmark's
consumption overhead, which inflates and adds variance to the in-memory IVM
benchmarks — it is not a production perf win.

Two changes:
  - Build relationships with mapValues instead of
    Object.entries().map() -> Object.fromEntries(). (Object.entries-vs-for-in
    was negligible on its own, but mapValues is cleaner and kept.)
  - Expand children with a for-of + push instead of Array.from(getChildren(),
    expandNode). Both walk the same iterator, but Array.from's iterable+mapFn
    builtin carries per-element overhead (index tracking, generic mapFn call)
    that the inlined loop avoids — ~1.4x on the memory-ivm-deopt Join hydration.

Perf — memory-ivm-deopt, this change alone vs baseline:
  Join fetch 1000 -> 20      3.70 ms -> 2.62 ms
  MemorySource scan, 1 key   342 µs -> 299 µs

Validated: zql/ivm suite (792) and full zql suite (1300) pass.