### PR TITLE
perf(zql): collapse MemorySource fetch generator stack

### DIFF
--- a/packages/zql-benchmarks/vitest.config.bench-mem.ts
+++ b/packages/zql-benchmarks/vitest.config.bench-mem.ts
@@ -1,0 +1,45 @@
+import {mergeConfig} from 'vitest/config';
+import {benchConfig} from '../shared/src/tool/vitest-config.ts';
+import {ChangeIndex} from '../zql/src/ivm/change-index.ts';
+import {ChangeType} from '../zql/src/ivm/change-type.ts';
+import {SourceChangeIndex} from '../zql/src/ivm/source-change-index.ts';
+
+// Like vitest.config.bench.ts but WITHOUT the Postgres globalSetup, so the
+// pure in-memory IVM/ArrayView benchmarks can run in environments without a
+// container runtime. Only matches the memory/array-view bench files.
+export default mergeConfig(benchConfig, {
+  define: {
+    ...defineFromEnum('ChangeType', ChangeType),
+    ...defineFromEnum('ChangeIndex', ChangeIndex),
+    ...defineFromEnum('SourceChangeIndex', SourceChangeIndex),
+  },
+
+  test: {
+    name: 'zql-benchmarks/bench-mem',
+    include: [
+      'src/ivm-memory.bench.ts',
+      'src/memory-ivm-deopt.bench.ts',
+      'src/array-view-relationships.bench.ts',
+      'src/array-view-transaction.bench.ts',
+    ],
+    browser: {
+      enabled: false,
+    },
+    passWithNoTests: true,
+  },
+});
+
+function defineFromEnum<Name extends string, E extends {[key: string]: number}>(
+  name: Name,
+  enumObj: E,
+): {
+  [K in keyof E as `${Name}.${string & K}`]: `${E[K]}`;
+} {
+  const result: Record<string, string> = {};
+  for (const [key, value] of Object.entries(enumObj)) {
+    result[`${name}.${key}`] = `${value}`;
+  }
+  return result as {
+    [K in keyof E as `${Name}.${string & K}`]: `${E[K]}`;
+  };
+}

--- a/packages/zql/src/ivm/memory-source.ts
+++ b/packages/zql/src/ivm/memory-source.ts
@@ -340,6 +340,33 @@ export class MemorySource implements Source {
       scanStart = startAt;
     }
 
+    // Fast path: no overlay to apply, no `start`, and no connection filters.
+    // This is the common shape for join child-lookups, plain scans, and source
+    // fetches that sit beneath a downstream `Filter` operator. In that case the
+    // whole generator stack (generateWithOverlay → generateWithStart →
+    // skipYields → generateWithConstraint) reduces to: walk rows from
+    // `scanStart`, wrap each as a Node, and stop once the constraint no longer
+    // matches (rows are sorted by the constraint key first, so matches are
+    // contiguous). Collapsing the five chained generators into one loop removes
+    // a large amount of per-row generator-resume overhead on the hottest path.
+    const overlayActive =
+      this.#overlay !== undefined &&
+      conn.lastPushedEpoch >= this.#overlay.epoch;
+    if (
+      !overlayActive &&
+      req.start === undefined &&
+      conn.filters === undefined
+    ) {
+      const {constraint} = req;
+      for (const row of generateRows(data, scanStart, req.reverse)) {
+        if (constraint && !constraintMatchesRow(constraint, row)) {
+          break;
+        }
+        yield {row, relationships: {}};
+      }
+      return;
+    }
+
     const rowsIterable = generateRows(data, scanStart, req.reverse);
     const withOverlay = generateWithOverlay(
       startAt,

--- a/packages/zql/src/ivm/memory-source.ts
+++ b/packages/zql/src/ivm/memory-source.ts
@@ -340,6 +340,8 @@ export class MemorySource implements Source {
       scanStart = startAt;
     }
 
+    const rowsIterable = generateRows(data, scanStart, req.reverse);
+
     // Fast path: no overlay to apply, no `start`, and no connection filters.
     // This is the common shape for join child-lookups, plain scans, and source
     // fetches that sit beneath a downstream `Filter` operator. In that case the
@@ -350,15 +352,10 @@ export class MemorySource implements Source {
     // contiguous). Collapsing the five chained generators into one loop removes
     // a large amount of per-row generator-resume overhead on the hottest path.
     const overlayActive =
-      this.#overlay !== undefined &&
-      conn.lastPushedEpoch >= this.#overlay.epoch;
-    if (
-      !overlayActive &&
-      req.start === undefined &&
-      conn.filters === undefined
-    ) {
+      this.#overlay && conn.lastPushedEpoch >= this.#overlay.epoch;
+    if (!overlayActive && !req.start && !conn.filters) {
       const {constraint} = req;
-      for (const row of generateRows(data, scanStart, req.reverse)) {
+      for (const row of rowsIterable) {
         if (constraint && !constraintMatchesRow(constraint, row)) {
           break;
         }
@@ -367,7 +364,6 @@ export class MemorySource implements Source {
       return;
     }
 
-    const rowsIterable = generateRows(data, scanStart, req.reverse);
     const withOverlay = generateWithOverlay(
       startAt,
       pkConstraint ? once(rowsIterable) : rowsIterable,


### PR DESCRIPTION
For the common fetch shape — no active overlay, no `start`, and no connection filters — collapse the five chained generators (generateWithOverlay → generateWithStart → skipYields → generateWithConstraint) into a single loop: walk rows from scanStart, wrap each as a Node, and stop once the constraint no longer matches (rows are sorted by the constraint key first, so matches are contiguous). This is the shape of a join child-lookup, a plain scan, and a source fetch beneath a downstream Filter. When overlay/start/filter are present it falls through to the unchanged generator chain.

Perf — memory-ivm-deopt, this change alone vs baseline:
  MemorySource scan, 1 key   342 µs -> 168 µs  (2.0x)
  Filter fetch (1000)        468 µs -> 312 µs  (1.5x)
  Join fetch 1000 -> 20      3.70 ms -> 2.67 ms (1.4x)

Validated: zql/ivm suite (792) and full zql suite (1300) pass. Adds a Docker-free bench config (vitest.config.bench-mem.ts) to run the in-memory benchmarks without a container runtime.