### PR TITLE
chore(zero-cache): log qid and name on failure

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
@@ -1,7 +1,7 @@
-import type {LogContext} from '@rocicorp/logger';
+import {LogContext} from '@rocicorp/logger';
 import {afterEach, beforeEach, describe, expect, test} from 'vitest';
 import {testLogConfig} from '../../../../otel/src/test-log-config.ts';
-import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
+import {TestLogSink} from '../../../../shared/src/logging-test-utils.ts';
 import type {AST} from '../../../../zero-protocol/src/ast.ts';
 import {createSchema} from '../../../../zero-schema/src/builder/schema-builder.ts';
 import {
@@ -47,11 +47,13 @@ describe('view-syncer/pipeline-driver', () => {
   let dbFile: DbFile;
   let db: DB;
   let lc: LogContext;
+  let logSink: TestLogSink;
   let pipelines: PipelineDriver;
   let replicator: FakeReplicator;
 
   beforeEach(() => {
-    lc = createSilentLogContext();
+    logSink = new TestLogSink();
+    lc = new LogContext('error', undefined, logSink);
     dbFile = new DbFile('pipelines_test');
     dbFile.connect(lc).pragma('journal_mode = wal2');
 
@@ -663,6 +665,32 @@ describe('view-syncer/pipeline-driver', () => {
         },
       ]
     `);
+  });
+
+  test('logs query identity when query hydration fails', () => {
+    pipelines.init(clientSchema);
+
+    expect(() => [
+      ...pipelines.addQuery(
+        'hash1',
+        'queryID1',
+        {table: 'doesNotExist'},
+        startTimer(),
+        'myQuery',
+      ),
+    ]).toThrowError(/doesNotExist/);
+
+    const failureLog = logSink.messages.find(
+      ([level, context, args]) =>
+        level === 'error' &&
+        context?.queryHash === 'queryID1' &&
+        args[0] === 'query hydration failed',
+    );
+    expect(failureLog?.[1]).toMatchObject({
+      queryHash: 'queryID1',
+      queryName: 'myQuery',
+      transformationHash: 'hash1',
+    });
   });
 
   test('insert', () => {

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
@@ -421,7 +421,7 @@ export class PipelineDriver {
     queryID: string,
     query: AST,
     timer: Timer,
-    queryName: string | undefined = undefined,
+    queryName?: string,
   ): Iterable<RowChange | 'yield'> {
     return this.#trackRowSetSignatures(
       this.#addQueryImpl(transformationHash, queryID, query, timer, queryName),
@@ -433,7 +433,7 @@ export class PipelineDriver {
     queryID: string,
     query: AST,
     timer: Timer,
-    queryName: string | undefined = undefined,
+    queryName?: string,
   ): Iterable<RowChange | 'yield'> {
     assert(
       this.initialized(),
@@ -455,7 +455,6 @@ export class PipelineDriver {
     this.#hydrateContext = {
       timer,
     };
-    const queryInfo = {queryHash: queryID, transformationHash, queryName};
     try {
       const {
         ast: resolvedQuery,
@@ -473,7 +472,13 @@ export class PipelineDriver {
           createStorage: () => this.#createStorage(),
           decorateSourceInput: (input: SourceInput, _queryID: string): Input =>
             new MeasurePushOperator(
-              new QueryFailureLoggingOperator(this.#lc, input, queryInfo),
+              new QueryFailureLoggingOperator(
+                this.#lc,
+                input,
+                queryID,
+                transformationHash,
+                queryName,
+              ),
               queryID,
               this.#inspectorDelegate,
               'query-update-server',
@@ -589,7 +594,12 @@ export class PipelineDriver {
         companions: liveCompanions,
       });
     } catch (e) {
-      logQueryFailure(this.#lc, queryInfo, 'query hydration failed', e);
+      logQueryFailure(
+        this.#lc,
+        {queryHash: queryID, transformationHash, queryName},
+        'query hydration failed',
+        e,
+      );
       throw e;
     } finally {
       this.#hydrateContext = null;
@@ -925,9 +935,7 @@ class Streamer {
   constructor(
     primaryKeys: Map<string, PrimaryKey>,
     tableSpecs: Map<string, LiteAndZqlSpec>,
-    logQueryFailure:
-      | ((queryID: string, error: unknown) => void)
-      | undefined = undefined,
+    logQueryFailure?: (queryID: string, error: unknown) => void,
   ) {
     this.#primaryKeys = primaryKeys;
     this.#tableSpecs = tableSpecs;
@@ -1060,13 +1068,23 @@ class Streamer {
 class QueryFailureLoggingOperator implements Input, Output {
   readonly #lc: LogContext;
   readonly #input: Input;
-  readonly #queryInfo: QueryLogInfo;
+  readonly #queryHash: string;
+  readonly #transformationHash: string;
+  readonly #queryName: string | undefined;
   #output: Output = throwOutput;
 
-  constructor(lc: LogContext, input: Input, queryInfo: QueryLogInfo) {
+  constructor(
+    lc: LogContext,
+    input: Input,
+    queryHash: string,
+    transformationHash: string,
+    queryName?: string,
+  ) {
     this.#lc = lc;
     this.#input = input;
-    this.#queryInfo = queryInfo;
+    this.#queryHash = queryHash;
+    this.#transformationHash = transformationHash;
+    this.#queryName = queryName;
     input.setOutput(this);
   }
 
@@ -1090,7 +1108,16 @@ class QueryFailureLoggingOperator implements Input, Output {
     try {
       yield* this.#output.push(change, this);
     } catch (e) {
-      logQueryFailure(this.#lc, this.#queryInfo, 'query pipeline failed', e);
+      logQueryFailure(
+        this.#lc,
+        {
+          queryHash: this.#queryHash,
+          transformationHash: this.#transformationHash,
+          queryName: this.#queryName,
+        },
+        'query pipeline failed',
+        e,
+      );
       throw e;
     }
   }

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
@@ -17,7 +17,10 @@ import type {Change} from '../../../../zql/src/ivm/change.ts';
 import type {Node} from '../../../../zql/src/ivm/data.ts';
 import {
   skipYields,
+  throwOutput,
+  type FetchRequest,
   type Input,
+  type Output,
   type Storage,
 } from '../../../../zql/src/ivm/operator.ts';
 import type {SourceSchema} from '../../../../zql/src/ivm/schema.ts';
@@ -89,12 +92,20 @@ type Pipeline = {
   readonly hydrationTimeMs: number;
   readonly transformedAst: AST;
   readonly transformationHash: string;
+  readonly queryName?: string | undefined;
   readonly companions: readonly CompanionPipeline[];
 };
 
 type QueryInfo = {
   readonly transformedAst: AST;
   readonly transformationHash: string;
+  readonly queryName?: string | undefined;
+};
+
+type QueryLogInfo = {
+  readonly queryHash: string;
+  readonly transformationHash: string;
+  readonly queryName?: string | undefined;
 };
 
 type AdvanceContext = {
@@ -410,9 +421,10 @@ export class PipelineDriver {
     queryID: string,
     query: AST,
     timer: Timer,
+    queryName: string | undefined = undefined,
   ): Iterable<RowChange | 'yield'> {
     return this.#trackRowSetSignatures(
-      this.#addQueryImpl(transformationHash, queryID, query, timer),
+      this.#addQueryImpl(transformationHash, queryID, query, timer, queryName),
     );
   }
 
@@ -421,6 +433,7 @@ export class PipelineDriver {
     queryID: string,
     query: AST,
     timer: Timer,
+    queryName: string | undefined = undefined,
   ): Iterable<RowChange | 'yield'> {
     assert(
       this.initialized(),
@@ -442,6 +455,7 @@ export class PipelineDriver {
     this.#hydrateContext = {
       timer,
     };
+    const queryInfo = {queryHash: queryID, transformationHash, queryName};
     try {
       const {
         ast: resolvedQuery,
@@ -459,7 +473,7 @@ export class PipelineDriver {
           createStorage: () => this.#createStorage(),
           decorateSourceInput: (input: SourceInput, _queryID: string): Input =>
             new MeasurePushOperator(
-              input,
+              new QueryFailureLoggingOperator(this.#lc, input, queryInfo),
               queryID,
               this.#inspectorDelegate,
               'query-update-server',
@@ -571,8 +585,12 @@ export class PipelineDriver {
         hydrationTimeMs,
         transformedAst: resolvedQuery,
         transformationHash,
+        ...(queryName !== undefined && {queryName}),
         companions: liveCompanions,
       });
+    } catch (e) {
+      logQueryFailure(this.#lc, queryInfo, 'query hydration failed', e);
+      throw e;
     } finally {
       this.#hydrateContext = null;
     }
@@ -869,7 +887,12 @@ export class PipelineDriver {
 
   #startAccumulating() {
     assert(this.#streamer === null, 'Streamer already started');
-    this.#streamer = new Streamer(must(this.#primaryKeys), this.#tableSpecs);
+    this.#streamer = new Streamer(
+      must(this.#primaryKeys),
+      this.#tableSpecs,
+      (queryID, error) =>
+        this.#logQueryFailure(queryID, 'query pipeline failed', error),
+    );
   }
 
   #stopAccumulating(): Streamer {
@@ -878,18 +901,37 @@ export class PipelineDriver {
     this.#streamer = null;
     return streamer;
   }
+
+  #logQueryFailure(queryID: string, message: string, error: unknown): void {
+    const pipeline = this.#pipelines.get(queryID);
+    const queryInfo = pipeline
+      ? {
+          queryHash: queryID,
+          transformationHash: pipeline.transformationHash,
+          queryName: pipeline.queryName,
+        }
+      : undefined;
+    logQueryFailure(this.#lc, queryInfo, message, error);
+  }
 }
 
 class Streamer {
   readonly #primaryKeys: Map<string, PrimaryKey>;
   readonly #tableSpecs: Map<string, LiteAndZqlSpec>;
+  readonly #logQueryFailure:
+    | ((queryID: string, error: unknown) => void)
+    | undefined;
 
   constructor(
     primaryKeys: Map<string, PrimaryKey>,
     tableSpecs: Map<string, LiteAndZqlSpec>,
+    logQueryFailure:
+      | ((queryID: string, error: unknown) => void)
+      | undefined = undefined,
   ) {
     this.#primaryKeys = primaryKeys;
     this.#tableSpecs = tableSpecs;
+    this.#logQueryFailure = logQueryFailure;
   }
 
   readonly #changes: [
@@ -909,7 +951,12 @@ class Streamer {
 
   *stream(): Iterable<RowChange | 'yield'> {
     for (const [queryID, schema, changes] of this.#changes) {
-      yield* this.#streamChanges(queryID, schema, changes);
+      try {
+        yield* this.#streamChanges(queryID, schema, changes);
+      } catch (e) {
+        this.#logQueryFailure?.(queryID, e);
+        throw e;
+      }
     }
   }
 
@@ -1008,6 +1055,66 @@ class Streamer {
       }
     }
   }
+}
+
+class QueryFailureLoggingOperator implements Input, Output {
+  readonly #lc: LogContext;
+  readonly #input: Input;
+  readonly #queryInfo: QueryLogInfo;
+  #output: Output = throwOutput;
+
+  constructor(lc: LogContext, input: Input, queryInfo: QueryLogInfo) {
+    this.#lc = lc;
+    this.#input = input;
+    this.#queryInfo = queryInfo;
+    input.setOutput(this);
+  }
+
+  setOutput(output: Output): void {
+    this.#output = output;
+  }
+
+  getSchema(): SourceSchema {
+    return this.#input.getSchema();
+  }
+
+  destroy(): void {
+    this.#input.destroy();
+  }
+
+  fetch(req: FetchRequest): Iterable<Node | 'yield'> {
+    return this.#input.fetch(req);
+  }
+
+  *push(change: Change): Iterable<'yield'> {
+    try {
+      yield* this.#output.push(change, this);
+    } catch (e) {
+      logQueryFailure(this.#lc, this.#queryInfo, 'query pipeline failed', e);
+      throw e;
+    }
+  }
+}
+
+function logQueryFailure(
+  lc: LogContext,
+  queryInfo: QueryLogInfo | undefined,
+  message: string,
+  error: unknown,
+): void {
+  if (error instanceof ResetPipelinesSignal) {
+    return;
+  }
+  let queryLC = lc;
+  if (queryInfo) {
+    queryLC = queryLC
+      .withContext('queryHash', queryInfo.queryHash)
+      .withContext('transformationHash', queryInfo.transformationHash);
+    if (queryInfo.queryName !== undefined) {
+      queryLC = queryLC.withContext('queryName', queryInfo.queryName);
+    }
+  }
+  queryLC.error?.(message, error);
 }
 
 function* toAdds(nodes: Iterable<Node | 'yield'>): Iterable<Change | 'yield'> {

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -1490,6 +1490,8 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
       transformationHash,
       transformedAst,
     } of transformedQueries) {
+      const query = cvr.queries[queryID];
+      const queryName = query.type === 'custom' ? query.name : undefined;
       const timer = new TimeSliceTimer(lc);
       let count = 0;
       await startAsyncSpan(
@@ -1499,11 +1501,15 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
           span.setAttribute('queryHash', queryID);
           span.setAttribute('transformationHash', transformationHash);
           span.setAttribute('table', transformedAst.table);
+          if (queryName !== undefined) {
+            span.setAttribute('queryName', queryName);
+          }
           for (const change of this.#pipelines.addQuery(
             transformationHash,
             queryID,
             transformedAst,
             await timer.start(),
+            queryName,
           )) {
             if (change === 'yield') {
               await timer.yieldProcess('yield in hydrateUnchangedQueries');
@@ -2003,16 +2009,21 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
 
       function* generateRowChanges(slowHydrateThreshold: number) {
         for (const q of addQueries) {
-          lc = lc
+          let queryLC = lc
             .withContext('hash', q.id)
+            .withContext('queryHash', q.id)
             .withContext('transformationHash', q.transformationHash);
-          lc.debug?.(`adding pipeline for query`, q.ast);
+          if (q.name !== undefined) {
+            queryLC = queryLC.withContext('queryName', q.name);
+          }
+          queryLC.debug?.(`adding pipeline for query`, q.ast);
 
           yield* pipelines.addQuery(
             q.transformationHash,
             q.id,
             q.ast,
             timer.startWithoutYielding(),
+            q.name,
           );
           const elapsed = timer.stop();
           totalProcessTime += elapsed;
@@ -2021,7 +2032,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
           self.#inspectorDelegate.addQuery(q.id, q.ast);
 
           if (elapsed > slowHydrateThreshold) {
-            lc.warn?.('Slow query materialization', elapsed, q.ast);
+            queryLC.warn?.('Slow query materialization', elapsed, q.ast);
           }
           manualSpan(tracer, 'vs.addAndConsumeQuery', elapsed, {
             hash: q.id,


### PR DESCRIPTION
For incidents where a query fails, this will let us know _which_ query so we can ask the customer and debug.