### PR TITLE
chore(zero-cache): drain info

### DIFF
--- a/packages/zero-cache/src/server/main.ts
+++ b/packages/zero-cache/src/server/main.ts
@@ -58,7 +58,7 @@ export default async function runWorker(
   lc = createLogContext(config, 'dispatcher');
   initEventSink(lc, config);
 
-  const processes = new ProcessManager(lc, parent);
+  const processes = new ProcessManager(lc, parent, env);
 
   const {numSyncWorkers: numSyncers} = config;
   if (config.enableCrudMutations && config.upstream.maxConns < numSyncers) {

--- a/packages/zero-cache/src/server/runner/run-worker.ts
+++ b/packages/zero-cache/src/server/runner/run-worker.ts
@@ -47,7 +47,7 @@ export async function runWorker(
 
   const defaultTaskID = await getTaskID(lc);
   const config = normalizeZeroConfig(lc, cfg, env, defaultTaskID);
-  const processes = new ProcessManager(lc, parent ?? process);
+  const processes = new ProcessManager(lc, parent ?? process, env);
 
   const {port, keepaliveTimeoutMs, lazyStartup} = config;
   const serverVersion = getServerVersion(config);

--- a/packages/zero-cache/src/services/life-cycle.test.ts
+++ b/packages/zero-cache/src/services/life-cycle.test.ts
@@ -1,10 +1,15 @@
 import EventEmitter from 'node:events';
+import {LogContext} from '@rocicorp/logger';
 import {resolver} from '@rocicorp/resolver';
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
-import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
+import {
+  createSilentLogContext,
+  TestLogSink,
+} from '../../../shared/src/logging-test-utils.ts';
 import {promiseVoid} from '../../../shared/src/resolved-promises.ts';
 import {
   exitAfter,
+  EXPECTED_GRACEFUL_SHUTDOWN_REASON_ENV,
   INTENTIONAL_SHUTDOWN_ERROR_CODE,
   ProcessManager,
   runUntilKilled,
@@ -275,5 +280,32 @@ describe('exitAfter', () => {
     ).rejects.toMatchObject({code: 0});
 
     expect(exit).toHaveBeenCalledWith(0);
+  });
+});
+
+describe('drain logging', () => {
+  test('logs expected graceful shutdown reason', () => {
+    process.env['SINGLE_PROCESS'] = '1';
+
+    const sink = new TestLogSink();
+    const proc = new EventEmitter();
+    new ProcessManager(new LogContext('info', undefined, sink), proc, {
+      [EXPECTED_GRACEFUL_SHUTDOWN_REASON_ENV]:
+        'cloudzero-interruptible-deployment',
+    });
+
+    proc.emit('SIGTERM');
+
+    expect(sink.messages).toContainEqual([
+      'info',
+      {component: 'process-manager'},
+      [
+        'initiating drain (SIGTERM)',
+        {
+          intentionalDrain: true,
+          drainReason: 'cloudzero-interruptible-deployment',
+        },
+      ],
+    ]);
   });
 });

--- a/packages/zero-cache/src/services/life-cycle.ts
+++ b/packages/zero-cache/src/services/life-cycle.ts
@@ -29,6 +29,8 @@ export type WorkerType = 'user-facing' | 'supporting';
 
 export const GRACEFUL_SHUTDOWN = ['SIGTERM', 'SIGINT'] as const;
 export const FORCEFUL_SHUTDOWN = ['SIGQUIT', 'SIGABRT'] as const;
+export const EXPECTED_GRACEFUL_SHUTDOWN_REASON_ENV =
+  'ZERO_EXPECTED_GRACEFUL_SHUTDOWN_REASON';
 
 type GracefulShutdownSignal = (typeof GRACEFUL_SHUTDOWN)[number];
 
@@ -51,14 +53,21 @@ export class ProcessManager {
   readonly #userFacing = new Set<Subprocess>();
   readonly #all = new Set<Subprocess>();
   readonly #exitImpl: (code: number) => never;
+  readonly #expectedGracefulShutdownReason: string | undefined;
   readonly #start = Date.now();
   readonly #ready: Promise<void>[] = [];
 
   #runningState = new RunningState('process-manager');
   #drainStart = 0;
 
-  constructor(lc: LogContext, proc: EventEmitter) {
+  constructor(
+    lc: LogContext,
+    proc: EventEmitter,
+    env: NodeJS.ProcessEnv = process.env,
+  ) {
     this.#lc = lc.withContext('component', 'process-manager');
+    this.#expectedGracefulShutdownReason =
+      getExpectedGracefulShutdownReason(env);
 
     // Propagate `SIGTERM` and `SIGINT` to all user-facing workers,
     // initiating a graceful shutdown. The parent process will
@@ -116,13 +125,25 @@ export class ProcessManager {
       this.#lc.info?.(`exiting on ${signal}`);
       this.#exit(0);
     }
-    this.#lc.info?.(`initiating drain (${signal})`);
+    this.#logInitiatingDrain(signal);
     this.#drainStart = Date.now();
     if (this.#userFacing.size) {
       this.#kill(this.#userFacing, signal);
     } else {
       this.#kill(this.#all, signal);
     }
+  }
+
+  #logInitiatingDrain(signal: GracefulShutdownSignal) {
+    if (this.#expectedGracefulShutdownReason) {
+      this.#lc.info?.(`initiating drain (${signal})`, {
+        intentionalDrain: true,
+        drainReason: this.#expectedGracefulShutdownReason,
+      });
+      return;
+    }
+
+    this.#lc.info?.(`initiating drain (${signal})`);
   }
 
   addSubprocess(proc: Subprocess, type: WorkerType, name: string) {
@@ -258,6 +279,11 @@ export class ProcessManager {
       }
     }
   }
+}
+
+function getExpectedGracefulShutdownReason(env: NodeJS.ProcessEnv) {
+  const reason = env[EXPECTED_GRACEFUL_SHUTDOWN_REASON_ENV]?.trim();
+  return reason === '' ? undefined : reason;
 }
 
 /**


### PR DESCRIPTION
So we can tell in the logs if the drain and shutdown was expected. cloudzero sets the env when initiating the drain.