### PR TITLE
Add SQLite dialect support to compiler and SQL formatting

### DIFF
--- a/packages/z2s/src/compiler.output.test.ts
+++ b/packages/z2s/src/compiler.output.test.ts
@@ -13,6 +13,7 @@ import type {ServerSchema} from '../../zero-types/src/server-schema.ts';
 import {
   any,
   compile,
+  compileSQLite,
   distinctFrom,
   limit,
   makeCorrelator,
@@ -22,7 +23,7 @@ import {
   simple,
   type Spec,
 } from './compiler.ts';
-import {formatPgInternalConvert} from './sql.ts';
+import {formatPgInternalConvert, formatSqliteInternalConvert} from './sql.ts';
 
 // Tests the output of basic primitives.
 // Top-level things like `SELECT` are tested by actually executing the SQL as inspecting
@@ -1477,4 +1478,131 @@ test('compound primary key ORDER BY preserves user-defined column order', () => 
   expect(result.text).not.toContain(
     'ORDER BY "connected_calls_0"."callId" ASC NULLS FIRST, "connected_calls_0"."connectionId" ASC NULLS FIRST, "connected_calls_0"."userId" ASC NULLS FIRST',
   );
+});
+
+test('compileSQLite emits full SQL for a basic query', () => {
+  const result = formatSqliteInternalConvert(
+    compileSQLite(serverSchema, schema, {
+      table: 'issue',
+      where: {
+        type: 'simple',
+        left: {type: 'column', name: 'ownerId'},
+        op: 'IN',
+        right: {type: 'literal', value: ['u1', 'u2']},
+      },
+      orderBy: [['title', 'asc']],
+      limit: 2,
+    }),
+  );
+
+  expect(result).toMatchInlineSnapshot(`
+    {
+      "text": "SELECT\n      COALESCE(json_group_array(json_object(?, \"zql_root\".\"id\", ?, \"zql_root\".\"title\", ?, \"zql_root\".\"description\", ?, \"zql_root\".\"closed\", ?, \"zql_root\".\"ownerId\", ?, \"zql_root\".\"created\")), '[]') AS \"zql_result\"\n      FROM (SELECT \"issue_0\".\"id\" as \"id\",\"issue_0\".\"title\" as \"title\",\"issue_0\".\"description\" as \"description\",\"issue_0\".\"closed\" as \"closed\",\"issue_0\".\"ownerId\" as \"ownerId\",\"issue_0\".\"created\" as \"created\"\n      FROM \"issue\" AS \"issue_0\"\n      WHERE \"issue_0\".\"ownerId\"  IN (\n      SELECT value FROM json_each(?)\n      )\n\n      ORDER BY \"issue_0\".\"title\" ASC , \"issue_0\".\"id\" ASC\n      LIMIT ?) \"zql_root\"",
+      "values": [
+        "id",
+        "title",
+        "description",
+        "closed",
+        "ownerId",
+        "created",
+        "[\\\"u1\\\",\\\"u2\\\"]",
+        2,
+      ],
+    }
+  `);
+});
+
+test('compileSQLite emits full SQL for a related query', () => {
+  const result = formatSqliteInternalConvert(
+    compileSQLite(serverSchema, schema, {
+      table: 'issue',
+      where: {
+        type: 'simple',
+        left: {type: 'column', name: 'title'},
+        op: 'ILIKE',
+        right: {type: 'literal', value: '%bug%'},
+      },
+      orderBy: [['created', 'desc']],
+      related: [
+        {
+          system: 'client',
+          correlation: {
+            parentField: ['id'],
+            childField: ['issueId'],
+          },
+          subquery: {
+            table: 'issueLabel',
+            alias: 'labels',
+          },
+        },
+      ],
+    }),
+  );
+
+  expect(result).toMatchInlineSnapshot(`
+    {
+      "text": "SELECT\n      COALESCE(json_group_array(json_object(?, json(\"zql_root\".\"labels\"), ?, \"zql_root\".\"id\", ?, \"zql_root\".\"title\", ?, \"zql_root\".\"description\", ?, \"zql_root\".\"closed\", ?, \"zql_root\".\"ownerId\", ?, \"zql_root\".\"created\")), '[]') AS \"zql_result\"\n      FROM (SELECT (\n      SELECT COALESCE(json_group_array(json_object(?, \"inner_labels\".\"issueId\", ?, \"inner_labels\".\"labelId\")), '[]') FROM (SELECT \"issueLabel_1\".\"issue_id\" as \"issueId\",\"issueLabel_1\".\"label_id\" as \"labelId\"\n      FROM \"issue_label\" AS \"issueLabel_1\"\n      WHERE \"issue_0\".\"id\" = \"issueLabel_1\".\"issue_id\"\n\n\n      ) \"inner_labels\"\n      ) as \"labels\",\"issue_0\".\"id\" as \"id\",\"issue_0\".\"title\" as \"title\",\"issue_0\".\"description\" as \"description\",\"issue_0\".\"closed\" as \"closed\",\"issue_0\".\"ownerId\" as \"ownerId\",\"issue_0\".\"created\" as \"created\"\n      FROM \"issue\" AS \"issue_0\"\n      WHERE LOWER(\"issue_0\".\"title\") LIKE LOWER(?)\n\n      ORDER BY \"issue_0\".\"created\" DESC , \"issue_0\".\"id\" ASC\n      ) \"zql_root\"",
+      "values": [
+        "labels",
+        "id",
+        "title",
+        "description",
+        "closed",
+        "ownerId",
+        "created",
+        "issueId",
+        "labelId",
+        "%bug%",
+      ],
+    }
+  `);
+});
+
+test('compileSQLite emits full SQL for a singular scalar subquery', () => {
+  const result = formatSqliteInternalConvert(
+    compileSQLite(
+      serverSchema,
+      schema,
+      {
+        table: 'issue',
+        where: {
+          type: 'correlatedSubquery',
+          op: 'NOT EXISTS',
+          scalar: true,
+          related: {
+            system: 'client',
+            correlation: {
+              parentField: ['ownerId'],
+              childField: ['id'],
+            },
+            subquery: {
+              table: 'user',
+              where: {
+                type: 'simple',
+                left: {type: 'column', name: 'name'},
+                op: '=',
+                right: {type: 'literal', value: 'Alice'},
+              },
+            },
+          },
+        },
+      },
+      {singular: true, relationships: {}},
+    ),
+  );
+
+  expect(result).toMatchInlineSnapshot(`
+    {
+      "text": "SELECT\n      json_object(?, \"zql_root\".\"id\", ?, \"zql_root\".\"title\", ?, \"zql_root\".\"description\", ?, \"zql_root\".\"closed\", ?, \"zql_root\".\"ownerId\", ?, \"zql_root\".\"created\") AS \"zql_result\"\n      FROM (SELECT \"issue_0\".\"id\" as \"id\",\"issue_0\".\"title\" as \"title\",\"issue_0\".\"description\" as \"description\",\"issue_0\".\"closed\" as \"closed\",\"issue_0\".\"ownerId\" as \"ownerId\",\"issue_0\".\"created\" as \"created\"\n      FROM \"issue\" AS \"issue_0\"\n      WHERE \"issue_0\".\"ownerId\" IS NOT (SELECT \"user_1\".\"id\" FROM \"user\" AS \"user_1\" WHERE \"user_1\".\"name\" = ? ORDER BY \"user_1\".\"id\" ASC  LIMIT 1)\n\n      ORDER BY \"issue_0\".\"id\" ASC\n      LIMIT 1) \"zql_root\"",
+      "values": [
+        "id",
+        "title",
+        "description",
+        "closed",
+        "ownerId",
+        "created",
+        "Alice",
+      ],
+    }
+  `);
 });

--- a/packages/z2s/src/compiler.ts
+++ b/packages/z2s/src/compiler.ts
@@ -45,6 +45,8 @@ type QualifiedColumn = {
   zql: string;
 };
 
+type Dialect = 'pg' | 'sqlite';
+
 type ServerSpec = {
   schema: ServerSchema;
   // maps zql names to server names
@@ -55,6 +57,7 @@ export type Spec = {
   server: ServerSpec;
   zql: Schema['tables'];
   aliasCount: number;
+  dialect?: Dialect | undefined;
 };
 
 const ZQL_RESULT_KEY = 'zql_result';
@@ -63,11 +66,21 @@ const ZQL_RESULT_KEY_IDENT = sql.ident(ZQL_RESULT_KEY);
 const ZQL_RESULT_TABLE_KEY = 'zql_root';
 const ZQL_RESULT_TABLE_IDENT = sql.ident(ZQL_RESULT_TABLE_KEY);
 
+export function compileSQLite(
+  serverSchema: ServerSchema,
+  zqlSchema: Schema,
+  ast: AST,
+  format?: Format,
+): SQLQuery {
+  return compile(serverSchema, zqlSchema, ast, format, 'sqlite');
+}
+
 export function compile(
   serverSchema: ServerSchema,
   zqlSchema: Schema,
   ast: AST,
   format?: Format,
+  dialect: Dialect = 'pg',
 ): SQLQuery {
   ast = completeOrdering(
     ast,
@@ -80,9 +93,11 @@ export function compile(
       mapper: clientToServer(zqlSchema.tables),
     },
     zql: zqlSchema.tables,
+    dialect,
   };
+  const rootKeys = resultKeys(spec, ast);
   return sql`SELECT 
-    ${toJSON(ZQL_RESULT_TABLE_KEY, format?.singular)}::text AS ${ZQL_RESULT_KEY_IDENT}
+    ${toJSON(spec, ZQL_RESULT_TABLE_KEY, rootKeys, format?.singular)} AS ${ZQL_RESULT_KEY_IDENT}
     FROM (${select(spec, ast, format)}) ${ZQL_RESULT_TABLE_IDENT}`;
 }
 
@@ -101,7 +116,7 @@ function select(
   for (const column of Object.keys(tableSchema.columns)) {
     if (!usedAliases.has(column)) {
       selectionSet.push(
-        selectIdent(spec.server, {
+        selectIdent(spec, {
           table,
           zql: column,
         }),
@@ -168,11 +183,11 @@ export function orderBy(
           sql`${colIdent(spec.server, {
             table,
             zql: col,
-          })} ASC NULLS FIRST`
+          })} ASC ${nulls(spec, 'FIRST')}`
         : sql`${colIdent(spec.server, {
             table,
             zql: col,
-          })} DESC NULLS LAST`,
+          })} DESC ${nulls(spec, 'LAST')}`,
     ),
     ', ',
   )}`;
@@ -219,7 +234,7 @@ function relationshipSubquery(
     const tableSchema = spec.zql[nestedAst.table];
     for (const column of Object.keys(tableSchema.columns)) {
       selectionSet.push(
-        selectIdent(spec.server, {
+        selectIdent(spec, {
           table: lastTable,
           zql: column,
         }),
@@ -227,7 +242,7 @@ function relationshipSubquery(
     }
 
     return sql`(
-        SELECT ${toJSON(innerAlias, format?.singular)} FROM (SELECT ${sql.join(
+        SELECT ${toJSON(spec, innerAlias, resultKeys(spec, nestedAst), format?.singular)} FROM (SELECT ${sql.join(
           selectionSet,
           ',',
         )} FROM ${join} WHERE (${makeCorrelator(
@@ -249,7 +264,7 @@ function relationshipSubquery(
   }
 
   return sql`(
-      SELECT ${toJSON(innerAlias, format?.singular)} FROM (${select(
+      SELECT ${toJSON(spec, innerAlias, resultKeys(spec, relationship.subquery), format?.singular)} FROM (${select(
         spec,
         relationship.subquery,
         format,
@@ -403,19 +418,7 @@ export function simple(
     case 'LIKE':
     case 'NOT ILIKE':
     case 'NOT LIKE':
-      return sql`${valueComparison(
-        spec,
-        condition.left,
-        table,
-        condition.right,
-        false,
-      )} ${sql.__dangerous__rawValue(condition.op)} ${valueComparison(
-        spec,
-        condition.right,
-        table,
-        condition.left,
-        false,
-      )}`;
+      return comparison(spec, condition, table);
     case 'NOT IN':
     case 'IN':
       return any(spec, condition, table);
@@ -430,9 +433,26 @@ export function any(
   condition: SimpleCondition,
   table: Table,
 ): SQLQuery {
+  if (dialect(spec) === 'sqlite') {
+    return sql`${valueComparison(
+      spec,
+      condition.left,
+      table,
+      condition.right,
+      false,
+    )} ${condition.op === 'NOT IN' ? sql`NOT` : sql``} IN (
+      SELECT value FROM json_each(${valueComparison(
+        spec,
+        condition.right,
+        table,
+        condition.left,
+        true,
+      )})
+    )`;
+  }
   return sql`${condition.op === 'NOT IN' ? sql`NOT` : sql``}
     (
-      ${valueComparison(spec, condition.left, table, condition.right, false)} = ANY 
+      ${valueComparison(spec, condition.left, table, condition.right, false)} = ANY
       (${valueComparison(spec, condition.right, table, condition.left, true)})
     )`;
 }
@@ -613,17 +633,97 @@ export function pullTablesForJunction(
   ];
 }
 
-function toJSON(table: string, singular = false): SQLQuery {
-  return sql`${
-    singular ? sql`` : sql`COALESCE(json_agg`
-  }(row_to_json(${sql.ident(table)}))${singular ? sql`` : sql`, '[]'::json)`}`;
+function toJSON(
+  spec: Spec,
+  table: string,
+  keys: ResultKey[],
+  singular = false,
+): SQLQuery {
+  if (dialect(spec) === 'pg') {
+    if (singular) {
+      return sql`row_to_json(${sql.ident(table)})::text`;
+    }
+    return sql`COALESCE(json_agg(row_to_json(${sql.ident(table)})), '[]'::json)::text`;
+  }
+
+  const object = sql`json_object(${sql.join(
+    keys.flatMap(key => [
+      sql`${key.name}`,
+      key.json
+        ? sql`json(${sql.ident(table, key.name)})`
+        : sql.ident(table, key.name),
+    ]),
+    ', ',
+  )})`;
+  return singular ? object : sql`COALESCE(json_group_array(${object}), '[]')`;
 }
 
-function selectIdent(server: ServerSpec, column: QualifiedColumn): SQLQuery {
+type ResultKey = {name: string; json: boolean};
+
+function resultKeys(spec: Spec, ast: AST): ResultKey[] {
+  const relationshipKeys: ResultKey[] = (ast.related ?? []).map(r => ({
+    name: must(r.subquery.alias),
+    json: true,
+  }));
+  const usedAliases = new Set(relationshipKeys.map(k => k.name));
+  const columnKeys: ResultKey[] = Object.keys(spec.zql[ast.table].columns)
+    .filter(name => !usedAliases.has(name))
+    .map(name => ({name, json: false}));
+  return [...relationshipKeys, ...columnKeys];
+}
+
+function dialect(spec: Spec): Dialect {
+  return spec.dialect ?? 'pg';
+}
+
+function nulls(spec: Spec, which: 'FIRST' | 'LAST'): SQLQuery {
+  return dialect(spec) === 'sqlite'
+    ? sql``
+    : sql.__dangerous__rawValue(`NULLS ${which}`);
+}
+
+function comparison(
+  spec: Spec,
+  condition: SimpleCondition,
+  table: Table,
+): SQLQuery {
+  const left = valueComparison(
+    spec,
+    condition.left,
+    table,
+    condition.right,
+    false,
+  );
+  const right = valueComparison(
+    spec,
+    condition.right,
+    table,
+    condition.left,
+    false,
+  );
+  switch (condition.op) {
+    case 'ILIKE':
+      return dialect(spec) === 'sqlite'
+        ? sql`LOWER(${left}) LIKE LOWER(${right})`
+        : sql`${left} ILIKE ${right}`;
+    case 'NOT ILIKE':
+      return dialect(spec) === 'sqlite'
+        ? sql`LOWER(${left}) NOT LIKE LOWER(${right})`
+        : sql`${left} NOT ILIKE ${right}`;
+    default:
+      return sql`${left} ${sql.__dangerous__rawValue(condition.op)} ${right}`;
+  }
+}
+
+function selectIdent(spec: Spec, column: QualifiedColumn): SQLQuery {
+  const {server} = spec;
   const serverColumnSchema =
     server.schema[server.mapper.tableName(column.table.zql)][
       server.mapper.columnName(column.table.zql, column.zql)
     ];
+  if (dialect(spec) === 'sqlite') {
+    return sql`${colIdent(server, column)} as ${sql.ident(column.zql)}`;
+  }
   const serverType = serverColumnSchema.type;
   if (!serverColumnSchema.isEnum) {
     let needsNormalization = false;

--- a/packages/z2s/src/sql.ts
+++ b/packages/z2s/src/sql.ts
@@ -25,7 +25,12 @@ export function formatPgInternalConvert(sql: SQLQuery) {
 }
 
 export function formatSqlite(sql: SQLQuery) {
-  const format = new ReusingFormat(escapeSQLiteIdentifier);
+  const format = new ReusingFormat(escapeSQLiteIdentifier, '?');
+  return sql.format((items: readonly SQLItem[]) => formatFn(items, format));
+}
+
+export function formatSqliteInternalConvert(sql: SQLQuery) {
+  const format = new SQLiteConvertFormat(escapeSQLiteIdentifier);
   return sql.format((items: readonly SQLItem[]) => formatFn(items, format));
 }
 
@@ -101,11 +106,20 @@ class ReusingFormat implements FormatConfig {
   readonly #seen: Map<unknown, number> = new Map();
   readonly escapeIdentifier: (str: string) => string;
 
-  constructor(escapeIdentifier: (str: string) => string) {
+  readonly #placeholder: '?' | 'numbered';
+
+  constructor(
+    escapeIdentifier: (str: string) => string,
+    placeholder: '?' | 'numbered' = 'numbered',
+  ) {
     this.escapeIdentifier = escapeIdentifier;
+    this.#placeholder = placeholder;
   }
 
   formatValue = (value: unknown) => {
+    if (this.#placeholder === '?' && this.#seen.has(value)) {
+      return {placeholder: '?', value};
+    }
     if (this.#seen.has(value)) {
       return {
         placeholder: `$${this.#seen.get(value)}`,
@@ -113,7 +127,29 @@ class ReusingFormat implements FormatConfig {
       };
     }
     this.#seen.set(value, this.#seen.size + 1);
-    return {placeholder: `$${this.#seen.size}`, value};
+    return {
+      placeholder: this.#placeholder === '?' ? '?' : `$${this.#seen.size}`,
+      value,
+    };
+  };
+}
+
+class SQLiteConvertFormat implements FormatConfig {
+  readonly escapeIdentifier: (str: string) => string;
+
+  constructor(escapeIdentifier: (str: string) => string) {
+    this.escapeIdentifier = escapeIdentifier;
+  }
+
+  formatValue = (value: unknown) => {
+    assert(
+      isSqlConvert(value),
+      'SQLiteConvertFormat can only take SqlConvertArgs.',
+    );
+    return {
+      placeholder: '?',
+      value: stringify(value),
+    };
   };
 }
 

--- a/packages/zql-integration-tests/src/compiler-sqlite.pg.test.ts
+++ b/packages/zql-integration-tests/src/compiler-sqlite.pg.test.ts
@@ -1,0 +1,230 @@
+import {afterAll, beforeAll, expect, test} from 'vitest';
+import type {JSONValue} from '../../shared/src/json.ts';
+import {compileSQLite, extractZqlResult} from '../../z2s/src/compiler.ts';
+import {formatSqliteInternalConvert} from '../../z2s/src/sql.ts';
+import {testDBs} from '../../zero-cache/src/test/db.ts';
+import type {PostgresDB} from '../../zero-cache/src/types/pg.ts';
+import type {Row} from '../../zero-protocol/src/data.ts';
+import {relationships} from '../../zero-schema/src/builder/relationship-builder.ts';
+import {createSchema} from '../../zero-schema/src/builder/schema-builder.ts';
+import {string, table} from '../../zero-schema/src/builder/table-builder.ts';
+import type {ServerSchema} from '../../zero-types/src/server-schema.ts';
+import {MemorySource} from '../../zql/src/ivm/memory-source.ts';
+import {consume} from '../../zql/src/ivm/stream.ts';
+import {makeSourceChangeAdd} from '../../zql/src/ivm/source.ts';
+import {newQuery} from '../../zql/src/query/query-impl.ts';
+import {asQueryInternals} from '../../zql/src/query/query-internals.ts';
+import type {AnyQuery} from '../../zql/src/query/query.ts';
+import {QueryDelegateImpl as TestMemoryQueryDelegate} from '../../zql/src/query/test/query-delegate.ts';
+import type {Database} from '../../zqlite/src/db.ts';
+import {fillPgAndSync} from './helpers/setup.ts';
+import './helpers/comparePg.ts';
+
+const DB_NAME = 'compiler-sqlite-oracle';
+
+const project = table('project')
+  .columns({
+    id: string(),
+    name: string(),
+  })
+  .primaryKey('id');
+
+const task = table('task')
+  .columns({
+    id: string(),
+    projectId: string().from('project_id'),
+    assigneeId: string().from('assignee_id'),
+    title: string(),
+  })
+  .primaryKey('id');
+
+const assignee = table('assignee')
+  .columns({
+    id: string(),
+    name: string(),
+  })
+  .primaryKey('id');
+
+const projectRelationships = relationships(project, ({many}) => ({
+  tasks: many({
+    sourceField: ['id'],
+    destField: ['projectId'],
+    destSchema: task,
+  }),
+}));
+
+const taskRelationships = relationships(task, ({one}) => ({
+  project: one({
+    sourceField: ['projectId'],
+    destField: ['id'],
+    destSchema: project,
+  }),
+  assignee: one({
+    sourceField: ['assigneeId'],
+    destField: ['id'],
+    destSchema: assignee,
+  }),
+}));
+
+const assigneeRelationships = relationships(assignee, ({many}) => ({
+  tasks: many({
+    sourceField: ['id'],
+    destField: ['assigneeId'],
+    destSchema: task,
+  }),
+}));
+
+const schema = createSchema({
+  tables: [project, task, assignee],
+  relationships: [
+    projectRelationships,
+    taskRelationships,
+    assigneeRelationships,
+  ],
+});
+
+const createTableSQL = /*sql*/ `
+CREATE TABLE "project" (
+  "id" TEXT PRIMARY KEY,
+  "name" TEXT NOT NULL
+);
+
+CREATE TABLE "task" (
+  "id" TEXT PRIMARY KEY,
+  "project_id" TEXT NOT NULL,
+  "assignee_id" TEXT NOT NULL,
+  "title" TEXT NOT NULL
+);
+
+CREATE TABLE "assignee" (
+  "id" TEXT PRIMARY KEY,
+  "name" TEXT NOT NULL
+);
+`;
+
+const serverSchema: ServerSchema = {
+  project: {
+    id: {type: 'text', isEnum: false, isArray: false},
+    name: {type: 'text', isEnum: false, isArray: false},
+  },
+  task: {
+    id: {type: 'text', isEnum: false, isArray: false},
+    project_id: {type: 'text', isEnum: false, isArray: false},
+    assignee_id: {type: 'text', isEnum: false, isArray: false},
+    title: {type: 'text', isEnum: false, isArray: false},
+  },
+  assignee: {
+    id: {type: 'text', isEnum: false, isArray: false},
+    name: {type: 'text', isEnum: false, isArray: false},
+  },
+};
+
+const testData: Record<string, Row[]> = {
+  project: [
+    {id: 'project1', name: 'Zero'},
+    {id: 'project2', name: 'Replicache'},
+  ],
+  task: [
+    {
+      id: 'task1',
+      projectId: 'project1',
+      assigneeId: 'user1',
+      title: 'Write SQLite compiler',
+    },
+    {
+      id: 'task2',
+      projectId: 'project1',
+      assigneeId: 'user2',
+      title: 'Add oracle tests',
+    },
+    {
+      id: 'task3',
+      projectId: 'project2',
+      assigneeId: 'user2',
+      title: 'Review SQL snapshots',
+    },
+  ],
+  assignee: [
+    {id: 'user1', name: 'Alice'},
+    {id: 'user2', name: 'Bob'},
+  ],
+};
+
+let pg: PostgresDB;
+let sqlite: Database;
+let memoryDelegate: TestMemoryQueryDelegate;
+
+beforeAll(async () => {
+  const setup = await fillPgAndSync(schema, createTableSQL, testData, DB_NAME);
+  pg = setup.pg;
+  sqlite = setup.sqlite;
+
+  const sources: Record<string, MemorySource> = Object.fromEntries(
+    Object.entries(schema.tables).map(([key, tableSchema]) => [
+      key,
+      new MemorySource(
+        tableSchema.name,
+        tableSchema.columns,
+        tableSchema.primaryKey,
+      ),
+    ]),
+  );
+  memoryDelegate = new TestMemoryQueryDelegate({sources});
+
+  for (const [table, rows] of Object.entries(testData)) {
+    for (const row of rows) {
+      consume(sources[table].push(makeSourceChangeAdd(row)));
+    }
+  }
+});
+
+afterAll(async () => {
+  sqlite.close();
+  await testDBs.drop(pg);
+});
+
+test('basic query matches ZQL', async () => {
+  await expectSQLiteCompilerToMatchZql(
+    newQuery(schema, 'task')
+      .where('assigneeId', 'IN', ['user1', 'user2'])
+      .where('title', 'LIKE', '%SQL%')
+      .orderBy('title', 'asc'),
+  );
+});
+
+test('many relationship query matches ZQL', async () => {
+  await expectSQLiteCompilerToMatchZql(
+    newQuery(schema, 'project')
+      .where('id', 'project1')
+      .related('tasks', q => q.orderBy('title', 'asc')),
+  );
+});
+
+test('one relationship query matches ZQL', async () => {
+  await expectSQLiteCompilerToMatchZql(
+    newQuery(schema, 'task')
+      .related('project')
+      .related('assignee')
+      .where('id', 'task1'),
+  );
+});
+
+async function expectSQLiteCompilerToMatchZql(query: AnyQuery) {
+  const queryInternals = asQueryInternals(query);
+  const sqlQuery = formatSqliteInternalConvert(
+    compileSQLite(
+      serverSchema,
+      schema,
+      queryInternals.ast,
+      queryInternals.format,
+    ),
+  );
+  const sqliteResult = extractZqlResult(
+    sqlite
+      .prepare(sqlQuery.text)
+      .all(...(sqlQuery.values as JSONValue[])),
+  );
+  const zqlResult = await memoryDelegate.run(query);
+
+  expect(sqliteResult).toEqualPg(zqlResult);
+}

--- a/packages/zql-integration-tests/src/compiler-sqlite.test.ts
+++ b/packages/zql-integration-tests/src/compiler-sqlite.test.ts
@@ -1,9 +1,8 @@
 import {afterAll, beforeAll, expect, test} from 'vitest';
 import type {JSONValue} from '../../shared/src/json.ts';
+import {createSilentLogContext} from '../../shared/src/logging-test-utils.ts';
 import {compileSQLite, extractZqlResult} from '../../z2s/src/compiler.ts';
 import {formatSqliteInternalConvert} from '../../z2s/src/sql.ts';
-import {testDBs} from '../../zero-cache/src/test/db.ts';
-import type {PostgresDB} from '../../zero-cache/src/types/pg.ts';
 import type {Row} from '../../zero-protocol/src/data.ts';
 import {relationships} from '../../zero-schema/src/builder/relationship-builder.ts';
 import {createSchema} from '../../zero-schema/src/builder/schema-builder.ts';
@@ -16,11 +15,9 @@ import {newQuery} from '../../zql/src/query/query-impl.ts';
 import {asQueryInternals} from '../../zql/src/query/query-internals.ts';
 import type {AnyQuery} from '../../zql/src/query/query.ts';
 import {QueryDelegateImpl as TestMemoryQueryDelegate} from '../../zql/src/query/test/query-delegate.ts';
-import type {Database} from '../../zqlite/src/db.ts';
-import {fillPgAndSync} from './helpers/setup.ts';
+import {Database} from '../../zqlite/src/db.ts';
 import './helpers/comparePg.ts';
 
-const DB_NAME = 'compiler-sqlite-oracle';
 
 const project = table('project')
   .columns({
@@ -150,14 +147,13 @@ const testData: Record<string, Row[]> = {
   ],
 };
 
-let pg: PostgresDB;
 let sqlite: Database;
 let memoryDelegate: TestMemoryQueryDelegate;
 
-beforeAll(async () => {
-  const setup = await fillPgAndSync(schema, createTableSQL, testData, DB_NAME);
-  pg = setup.pg;
-  sqlite = setup.sqlite;
+beforeAll(() => {
+  sqlite = new Database(createSilentLogContext(), ':memory:');
+  sqlite.exec(createTableSQL);
+  seedSQLite();
 
   const sources: Record<string, MemorySource> = Object.fromEntries(
     Object.entries(schema.tables).map(([key, tableSchema]) => [
@@ -178,9 +174,31 @@ beforeAll(async () => {
   }
 });
 
-afterAll(async () => {
+function seedSQLite() {
+  const insertProject = sqlite.prepare(
+    'INSERT INTO "project" ("id", "name") VALUES (?, ?)',
+  );
+  for (const row of testData.project) {
+    insertProject.run(row.id, row.name);
+  }
+
+  const insertTask = sqlite.prepare(
+    'INSERT INTO "task" ("id", "project_id", "assignee_id", "title") VALUES (?, ?, ?, ?)',
+  );
+  for (const row of testData.task) {
+    insertTask.run(row.id, row.projectId, row.assigneeId, row.title);
+  }
+
+  const insertAssignee = sqlite.prepare(
+    'INSERT INTO "assignee" ("id", "name") VALUES (?, ?)',
+  );
+  for (const row of testData.assignee) {
+    insertAssignee.run(row.id, row.name);
+  }
+}
+
+afterAll(() => {
   sqlite.close();
-  await testDBs.drop(pg);
 });
 
 test('basic query matches ZQL', async () => {


### PR DESCRIPTION
I want to beef up the fuzzer. Fuzzing against SQLite will reduce the footprint of all these tests.

----

### Motivation

- Enable emitting SQLite-compatible SQL from the existing compiler and reuse existing PG logic where possible.
- Provide internal formatting for SQLite so tests can compare concrete SQL text/params like the PG path.

### Description

- Added a `Dialect` field to `Spec` and a `compileSQLite` wrapper that calls `compile(..., 'sqlite')` to produce SQLite SQL.
- Implemented dialect-specific behavior throughout the compiler: `toJSON` now emits `json_object`/`json_group_array` for SQLite and `row_to_json`/`json_agg` for Postgres, `any` uses `json_each` for `IN` lists on SQLite, and `comparison` maps `ILIKE`/`NOT ILIKE` to `LOWER(...) LIKE LOWER(...)` for SQLite.
- Adjusted ordering/nulls handling with `nulls` helper to omit `NULLS FIRST/LAST` for SQLite and made `selectIdent` and other value conversion helpers dialect-aware.
- Added `resultKeys` to compute JSON output keys and updated call sites to pass `spec` and keys into `toJSON`.
- Extended SQL formatting utilities in `sql.ts` with `formatSqliteInternalConvert`, a `SQLiteConvertFormat` class, and updated `ReusingFormat` to support positional `?` placeholders for SQLite internal conversion.
- Tests updated to import `compileSQLite` and `formatSqliteInternalConvert` and three new SQLite integration-style output tests were added.

### Testing

- Ran the `vitest` suite for the modified package and the updated `packages/z2s/src/compiler.output.test.ts` tests executed successfully.
- Added tests: `compileSQLite emits full SQL for a basic query`, `compileSQLite emits full SQL for a related query`, and `compileSQLite emits full SQL for a singular scalar subquery`, and all three passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a318f4ad6748324944f22b193386f44)