### PR TITLE
fix(zero-cache): don't self-terminate the view-syncer while the initial backup is still uploading

### DIFF
--- a/packages/zero-cache/src/services/litestream/commands.ts
+++ b/packages/zero-cache/src/services/litestream/commands.ts
@@ -19,9 +19,6 @@ import type {
 } from '../change-streamer/snapshot.ts';
 import {getSubscriptionState} from '../replicator/schema/replication-state.ts';
 
-// Retry for up to 3 minutes (60 times with 3 second delay).
-// Beyond that, let the container runner restart the task.
-const MAX_RETRIES = 60;
 const RETRY_INTERVAL_MS = 3000;
 
 type ReplicaConstraints = {
@@ -48,26 +45,41 @@ export async function restoreReplica(
   config: ZeroConfig,
   replicaConstraints: ReplicaConstraints | null,
 ) {
-  for (let i = 0; i < MAX_RETRIES; i++) {
+  // View-syncers (no replicaConstraints) wait indefinitely for the
+  // replication-manager to publish a restorable backup. On a fresh stack the
+  // first backup is not durable until the initial sync completes and litestream
+  // uploads the initial snapshot, which can take many minutes for a large
+  // replica. The platform's startup probe budget (which scales with replica
+  // size) is the backstop, so restoreReplica must not impose its own shorter
+  // cap and self-terminate while the backup is still being produced.
+  //
+  // `consecutiveErrors` distinguishes a transient restore *error* (e.g. the
+  // `replicate` process compacting a snapshot mid-restore) — which is retried
+  // once — from a "backup not found" result, which is expected while waiting.
+  let consecutiveErrors = 0;
+  for (;;) {
     try {
       if (await tryRestore(lc, config, replicaConstraints)) {
         return;
       }
+      consecutiveErrors = 0;
     } catch (e) {
-      if (i === 0) {
+      if (++consecutiveErrors <= 1) {
         // A restore will fail if the `replicate` process creates a new
         // snapshot (and compacts old files) at the same time. Snapshots are
         // infrequent (e.g. once every 12 hours), and the scenario is
         // recoverable with a retry.
-        lc.warn?.(`initial restore attempt failed. retrying once`, e);
+        lc.warn?.(`restore attempt failed. retrying once`, e);
         continue;
       }
       // If it fails again on the retry, though, bail.
       throw e;
     }
     if (replicaConstraints) {
-      // This can happen if the litestream URL is purposefully changed to
-      // force a resync.
+      // The replication-manager restores against explicit constraints, so a
+      // missing backup is fatal (e.g. the litestream URL was purposefully
+      // changed to force a resync). Only the view-syncer (no constraints)
+      // waits for a backup to appear.
       throw new BackupNotFoundException(config.litestream.backupURL);
     }
     lc.info?.(
@@ -75,7 +87,6 @@ export async function restoreReplica(
     );
     await sleep(RETRY_INTERVAL_MS);
   }
-  throw new Error(`max attempts exceeded restoring replica`);
 }
 
 function getLitestream(


### PR DESCRIPTION
## Problem (INC-783)

On a cold start of a fresh stack, both view-syncer pods exited with code 255
~1am, throwing:

```
Error: max attempts exceeded restoring replica
```

Root cause: the replication-manager's **first** litestream backup is not
durable until (a) the initial Postgres→replica sync completes and (b) the
initial snapshot finishes its multipart upload to S3 — a snapshot is not
listable/restorable until `CompleteMultipartUpload`. For this stack's first
~31GB replica that took ~4 minutes. Meanwhile `restoreReplica` on the
view-syncer gave up after a fixed `MAX_RETRIES (60) × RETRY_INTERVAL_MS (3s)
= 180s`, ~30s *before* the backup became restorable, throwing and exiting 255
on every pod. The stack self-healed only because the container runner
restarted the task (by which point the backup existed).

## Why the cap is in the wrong place

The view-syncer (the **consumer**) cannot evaluate whether the
replication-manager (the **producer**) is still making progress on the
initial backup — S3 gives no incremental signal while a multipart snapshot
uploads. So a fixed consumer-side deadline is fundamentally racing the
producer.

The platform already enforces the real backstop: the Kubernetes startup probe
grants a storage-scaled allowance (~1 hour per 50GB) before the pod is killed.
The app should not impose its own *shorter* deadline and self-terminate while
the backup is legitimately still being produced.

## Change

`packages/zero-cache/src/services/litestream/commands.ts`:

- Remove `MAX_RETRIES` and the `max attempts exceeded restoring replica`
  throw on the **view-syncer** path (`replicaConstraints == null`): it now
  waits (logging `replica not found. retrying…` every 3s) for the
  replication-manager to publish a restorable backup. The startup-probe budget
  is the backstop.
- The **replication-manager** path (`replicaConstraints != null`) is
  unchanged in behavior: a missing backup is still fatal immediately via
  `BackupNotFoundException` (e.g. the litestream URL was changed to force a
  resync).
- Transient restore errors (e.g. the `replicate` process compacting a snapshot
  mid-restore) still retry **once** then throw — now tracked via a
  `consecutiveErrors` counter instead of the `i === 0` first-iteration check,
  so a transient error after a long wait is still retried.

## Follow-up (separate PR)

A producer-side fix is also planned: have `BackupMonitor.startSnapshotReservation`
withhold the `status` snapshot signal until a restorable backup actually
exists, and put the give-up deadline on the replication-manager (which *can*
observe its own progress). This PR is the minimal, safe consumer-side fix for
INC-783.
