### PR TITLE
test(zero-cache): cover subscriber-ahead-of-changeDB catchup; clarify warning

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/storer.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.pg.test.ts
@@ -1117,6 +1117,48 @@ describe('change-streamer/storer', () => {
       );
     });
 
+    // A subscriber can legitimately be ahead of the latest durable watermark
+    // ('06' here); see Storer.#catchup for why. It must NOT trigger a reset or
+    // a WatermarkTooOld error — the subscriber is marked caught up and resumes
+    // from forwarded changes. Regression test for INC-783 / the 2026-06-17
+    // Margins incident ("subscriber at watermark X is ahead of latest
+    // watermark").
+    test.for(['backup', 'serving'] as const)(
+      'subscriber ahead of latest durable watermark (%s)',
+      async mode => {
+        const [sub, _, stream] = createSubscriber('09');
+
+        // "Live" changes forwarded ahead of the durable store, buffered until
+        // catchup completes.
+        void sub.send([
+          '10',
+          'begin',
+          json(['begin', messages.begin(), {commitWatermark: '11'}]),
+        ]);
+        void sub.send([
+          '11',
+          'commit',
+          json(['commit', messages.commit(), {watermark: '11'}]),
+        ]);
+
+        // Catchup starts immediately (no tx in progress). The subscriber is
+        // ahead of '06', so no catchup changes are sent; the buffered '11'
+        // transaction is flushed once it is marked caught up.
+        storer.catchup(sub, mode);
+
+        expect(await drain(stream, '11')).toEqual([
+          ['status', {tag: 'status'}],
+          ['begin', {tag: 'begin'}, {commitWatermark: '11'}],
+          ['commit', {tag: 'commit'}, {watermark: '11'}],
+        ]);
+
+        // Critically, no AutoResetSignal / fatal error was raised, and (for
+        // 'serving') the subscriber was not closed with WatermarkTooOld.
+        await storer.allProcessed();
+        expect(fatalErrors.size()).toBe(0);
+      },
+    );
+
     test('queued if transaction in progress', async () => {
       const [sub1, _0, stream1] = createSubscriber('03');
       const [sub2, _1, stream2] = createSubscriber('06');

--- a/packages/zero-cache/src/services/change-streamer/storer.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.ts
@@ -664,8 +664,20 @@ export class Storer implements Service {
             } ms)`,
           );
         } else {
+          // The subscriber is ahead of the latest durable changeLog entry
+          // (lastWatermark). This can legitimately happen: changes are
+          // forwarded to subscribers (the backup replica and view-syncers)
+          // concurrently with — and can outrun — the durable store, so a
+          // replica may briefly lead the change DB after the storer falls
+          // behind or the change-streamer restarts. No catchup is possible or
+          // needed; once the change DB catches back up, forwarding resumes and
+          // the subscriber dedups any watermarks it already has. Unlike the
+          // AutoResetSignal / WatermarkTooOld cases above, this is not a gap in
+          // replication history, so the subscriber is simply marked caught up.
           this.#lc.warn?.(
-            `subscriber at watermark ${sub.watermark} is ahead of latest watermark`,
+            `subscriber ${sub.id} at watermark ${sub.watermark} is ahead of ` +
+              `the latest durable watermark ${lastWatermark}; waiting for the ` +
+              `change DB to catch up`,
           );
         }
         // Flushes the backlog of messages buffered during catchup and


### PR DESCRIPTION
## Summary

The change-streamer forwards changes to subscribers concurrently with — and able to outrun — the durable store (`change-streamer-service.ts` calls `storer.store(...)` then `forwarder.forward(...)` without awaiting the change-DB commit). As a result a backup replica or view-syncer can legitimately reconnect at a watermark **ahead** of the change DB's `lastWatermark`.

In `Storer.#catchup`, when `sub.watermark > lastWatermark` the catchup query returns zero rows, so the subscriber is just marked caught up. This is correct and self-healing (once the change DB catches back up, forwarding resumes and `Subscriber.#sendChange` dedups any watermarks the subscriber already has) — but it was **untested**, and the warning was terse.

This surfaced in the 2026-06-17 Margins incident (INC-783) as repeated `subscriber at watermark X is ahead of latest watermark` logs.

## Changes

- **Regression tests** (`storer.pg.test.ts`, `backup` + `serving` modes): assert that a subscriber ahead of `lastWatermark` is marked caught up **without** an `AutoResetSignal` or `WatermarkTooOld` error, and resumes from forwarded changes.
- **Clearer warning** (`storer.ts`): include the subscriber id and `lastWatermark`, and document why the condition is benign and self-healing — distinct from the `AutoResetSignal` / `WatermarkTooOld` gap cases above it.

Behavior is unchanged. This hardens and documents the invariant that #6123 (preserve changelog boundary) relies on.

## Testing

`packages/zero-cache` — full `storer.pg` suite green (24 passed), plus `oxfmt`, `oxlint` (0 errors), and `tsc`.


---
_Generated by [Claude Code](https://claude.ai/code/session_017EAwdCYGhS65csLx3dpWHH)_