### PR TITLE
fix(zero): repair release Docker image build

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -109,6 +109,44 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm run check-types
 
+  zero-docker:
+    name: Build Zero Docker Image
+    runs-on: ubuntu-latest
+    needs: [syncpack, verify-deps]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          version: 11.5.3
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24.x
+          cache: 'pnpm'
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter @rocicorp/zero run build
+      - name: Pack Zero
+        id: pack
+        working-directory: packages/zero
+        run: |
+          node <<'EOF'
+          const {execFileSync} = require('node:child_process');
+          const {appendFileSync} = require('node:fs');
+
+          const output = execFileSync(
+            'npm',
+            ['pack', '--pack-destination', 'pkgs', '--json'],
+            {encoding: 'utf8'},
+          );
+          const [{filename}] = JSON.parse(output);
+          appendFileSync(process.env.GITHUB_OUTPUT, `filename=${filename}\n`);
+          EOF
+      - name: Build Docker Image
+        working-directory: packages/zero
+        run: docker buildx build --platform linux/amd64 --build-arg=ZERO_VERSION="${{ steps.pack.outputs.filename }}" --progress=plain .
+
   test:
     name: Test (Shard ${{ matrix.shard }}/3)
     runs-on: ubuntu-latest

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -145,7 +145,9 @@ jobs:
           EOF
       - name: Build Docker Image
         working-directory: packages/zero
-        run: docker buildx build --platform linux/amd64 --build-arg=ZERO_VERSION="${{ steps.pack.outputs.filename }}" --progress=plain .
+        env:
+          ZERO_TARBALL: ${{ steps.pack.outputs.filename }}
+        run: docker buildx build --platform linux/amd64 --build-arg=ZERO_VERSION="$ZERO_TARBALL" --progress=plain .
 
   test:
     name: Test (Shard ${{ matrix.shard }}/3)

--- a/packages/zero/Dockerfile
+++ b/packages/zero/Dockerfile
@@ -31,7 +31,7 @@ RUN apk add --no-cache readline readline-dev
 # packageManager field. pnpm's build-script allowlist (v10+) blocks lifecycle
 # scripts from transitive deps unless explicitly opted in, shrinking the
 # postinstall supply-chain surface to packages we name below.
-RUN corepack enable && corepack prepare pnpm@11 --activate
+RUN corepack enable && corepack prepare pnpm@11.5.3 --activate
 
 RUN mkdir -p /opt/app
 WORKDIR /opt/app
@@ -48,11 +48,13 @@ EOF
 # binary in its tarball (see its package.json `files`) — its `install` script
 # runs prebuild-install to fetch one, so it must be allowed. esbuild is pulled
 # in transitively via tsx and downloads a platform binary in postinstall; keep
-# it allowlisted unless runtime testing confirms tsx is never invoked.
+# it allowlisted unless runtime testing confirms tsx is never invoked. protobufjs
+# is pulled in by OpenTelemetry's gRPC exporters and runs a postinstall script.
 RUN cat > pnpm-workspace.yaml <<'EOF'
 allowBuilds:
   '@rocicorp/zero-sqlite3': true
   esbuild: true
+  protobufjs: true
 EOF
 
 COPY pkgs/ /tmp/pkgs/

--- a/packages/zero/tool/release.ts
+++ b/packages/zero/tool/release.ts
@@ -712,7 +712,8 @@ async function pushDocker(version: string, dryRun: boolean) {
     throw e;
   }
 
-  for (let i = 0; i < 3; i++) {
+  const dockerBuildAttempts = 3;
+  for (let i = 0; i < dockerBuildAttempts; i++) {
     try {
       execute(
         `docker buildx build \\
@@ -724,15 +725,14 @@ async function pushDocker(version: string, dryRun: boolean) {
     --push .`,
         {cwd: basePath('packages', 'zero')},
       );
+      return;
     } catch (e) {
-      if (i < 3) {
-        console.error(`Error building docker image, retrying in 10 seconds...`);
-        await new Promise(resolve => setTimeout(resolve, 10_000));
-        continue;
+      if (i === dockerBuildAttempts - 1) {
+        throw e;
       }
-      throw e;
+      console.error(`Error building docker image, retrying in 10 seconds...`);
+      await new Promise(resolve => setTimeout(resolve, 10_000));
     }
-    break;
   }
 }
 


### PR DESCRIPTION
## Summary

- Add `protobufjs` to the Zero Docker image pnpm `allowBuilds` config because it is pulled in transitively by OpenTelemetry gRPC exporters and runs a postinstall script.
- Pin the Dockerfile pnpm version to the repo package manager version, `11.5.3`.
- Fix the Docker publish retry loop so the final failed attempt throws instead of reporting release success.
- Add a simple JS CI job that packs the local Zero package and verifies the Docker image builds on `linux/amd64` without pushing.

## What Happened

The `zero/v1.7.0-canary.2` release pushed the git tag and published npm, then the Docker build failed during `pnpm add @rocicorp/zero@1.7.0-canary.2` with `ERR_PNPM_IGNORED_BUILDS` for `protobufjs@7.6.4`. The Dockerfile creates a minimal pnpm workspace config and did not include the root repo allowlist entry for `protobufjs`.

The release script then retried Docker three times, but the retry condition used `i < 3` inside a `for (let i = 0; i < 3; i++)` loop, so the final failure was also swallowed after sleeping. The script printed success even though no image was pushed, and the later `cosign sign rocicorp/zero:1.7.0-canary.2` step failed with `MANIFEST_UNKNOWN` because the tag did not exist in Docker Hub.