### PR TITLE
chore(zero-cache): add the ability to change backup monitors

### DIFF
--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -10,11 +10,10 @@ import {initEventSink, publishCriticalEvent} from '../observability/events.ts';
 import {upgradeReplica} from '../services/change-source/common/replica-schema.ts';
 import {initializeCustomChangeSource} from '../services/change-source/custom/change-source.ts';
 import {initializePostgresChangeSource} from '../services/change-source/pg/change-source.ts';
-import type {BackupMonitor} from '../services/change-streamer/backup-monitor.ts';
+import {createBackupCleanupMonitor} from '../services/change-streamer/backup-cleanup-monitor-factory.ts';
 import {ChangeStreamerHttpServer} from '../services/change-streamer/change-streamer-http.ts';
 import {initializeStreamer} from '../services/change-streamer/change-streamer-service.ts';
 import type {ChangeStreamerService} from '../services/change-streamer/change-streamer.ts';
-import {Litestream3BackupMonitor} from '../services/change-streamer/litestream3-backup-monitor.ts';
 import {ReplicaMonitor} from '../services/change-streamer/replica-monitor.ts';
 import {initChangeStreamerSchema} from '../services/change-streamer/schema/init.ts';
 import {AutoResetSignal} from '../services/change-streamer/schema/tables.ts';
@@ -22,7 +21,6 @@ import {PurgeLocker} from '../services/change-streamer/storer.ts';
 import {exitAfter, runUntilKilled} from '../services/life-cycle.ts';
 import {
   BackupNotFoundException,
-  getLastBackupTime,
   restoreReplica,
 } from '../services/litestream/commands.ts';
 import {
@@ -63,7 +61,6 @@ export default async function runWorker(
     change,
     replica,
     initialSync,
-    litestream,
     keepaliveTimeoutMs,
   } = config;
 
@@ -209,29 +206,20 @@ export default async function runWorker(
   // upgrade logic redundantly since it is idempotent.
   await upgradeReplica(lc, 'change-streamer-init', replica.file);
 
-  const {backupURL, port: metricsPort} = litestream;
-  let backupMonitor: BackupMonitor | null = null;
-  if (backupURL) {
-    backupMonitor = new Litestream3BackupMonitor(
-      lc,
-      replica.file,
-      backupURL,
-      `http://localhost:${metricsPort}/metrics`,
-      changeStreamer,
-      // The time between when the zero-cache was started to when the
-      // change-streamer is ready to start serves as the initial delay for
-      // watermark cleanup (as it either includes a similar replica
-      // restoration/preparation step, or an initial-sync, which
-      // generally takes longer).
-      //
-      // Consider: Also account for permanent volumes?
-      Date.now() - workerStartTime,
-      // Verifies litestream's claimed backup progress against the actual
-      // backup state in the replica destination before advancing the
-      // change-log cleanup watermark.
-      () => getLastBackupTime(lc, config),
-    );
-  }
+  const backupMonitor = createBackupCleanupMonitor({
+    lc,
+    config,
+    replicaFile: replica.file,
+    changeStreamer,
+    // The time between when the zero-cache was started to when the
+    // change-streamer is ready to start serves as the initial delay for
+    // watermark cleanup (as it either includes a similar replica
+    // restoration/preparation step, or an initial-sync, which
+    // generally takes longer).
+    //
+    // Consider: Also account for permanent volumes?
+    initialCleanupDelayMs: Date.now() - workerStartTime,
+  });
   const monitor =
     backupMonitor ?? new ReplicaMonitor(lc, replica.file, changeStreamer);
 

--- a/packages/zero-cache/src/services/change-streamer/backup-cleanup-monitor-factory.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/backup-cleanup-monitor-factory.test.ts
@@ -1,0 +1,61 @@
+import {describe, expect, test, vi} from 'vitest';
+import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
+import type {NormalizedZeroConfig} from '../../config/normalize.ts';
+import {Subscription} from '../../types/subscription.ts';
+import {createBackupCleanupMonitor} from './backup-cleanup-monitor-factory.ts';
+import type {ChangeStreamerService} from './change-streamer.ts';
+import {Litestream3BackupMonitor} from './litestream3-backup-monitor.ts';
+
+const changeStreamer = {
+  id: 'change-streamer',
+  run: () => Promise.resolve(),
+  stop: () => Promise.resolve(),
+  subscribe: () => Promise.resolve(Subscription.create<string>()),
+  scheduleCleanup: vi.fn(),
+  getChangeLogState: () =>
+    Promise.resolve({
+      replicaVersion: 'replica-version',
+      minWatermark: 'min-watermark',
+    }),
+} satisfies ChangeStreamerService;
+
+function configWithLitestream(
+  litestream: Partial<NormalizedZeroConfig['litestream']>,
+): NormalizedZeroConfig {
+  return {
+    litestream: {
+      backupURL: undefined,
+      port: 9090,
+      ...litestream,
+    },
+  } as unknown as NormalizedZeroConfig;
+}
+
+describe('createBackupCleanupMonitor', () => {
+  test('returns null when backup is not configured', () => {
+    const monitor = createBackupCleanupMonitor({
+      lc: createSilentLogContext(),
+      config: configWithLitestream({backupURL: undefined}),
+      replicaFile: '/tmp/replica.db',
+      changeStreamer,
+      initialCleanupDelayMs: 0,
+    });
+
+    expect(monitor).toBeNull();
+  });
+
+  test('creates the v3 backup monitor when backup is configured', async () => {
+    const monitor = createBackupCleanupMonitor({
+      lc: createSilentLogContext(),
+      config: configWithLitestream({backupURL: 's3://bucket/prefix'}),
+      replicaFile: '/tmp/replica.db',
+      changeStreamer,
+      initialCleanupDelayMs: 0,
+      verifyBackupState: vi.fn().mockResolvedValue(new Date()),
+    });
+
+    expect(monitor).toBeInstanceOf(Litestream3BackupMonitor);
+    expect(monitor?.id).toBe('backup-monitor');
+    await monitor?.stop();
+  });
+});

--- a/packages/zero-cache/src/services/change-streamer/backup-cleanup-monitor-factory.ts
+++ b/packages/zero-cache/src/services/change-streamer/backup-cleanup-monitor-factory.ts
@@ -1,0 +1,42 @@
+import type {LogContext} from '@rocicorp/logger';
+import type {NormalizedZeroConfig} from '../../config/normalize.ts';
+import {getLastBackupTime} from '../litestream/commands.ts';
+import type {BackupMonitor} from './backup-monitor.ts';
+import type {ChangeStreamerService} from './change-streamer.ts';
+import {
+  Litestream3BackupMonitor,
+  type BackupStateVerifier,
+} from './litestream3-backup-monitor.ts';
+
+export type BackupCleanupMonitorFactoryOptions = {
+  lc: LogContext;
+  config: NormalizedZeroConfig;
+  replicaFile: string;
+  changeStreamer: ChangeStreamerService;
+  initialCleanupDelayMs: number;
+  verifyBackupState?: BackupStateVerifier | undefined;
+};
+
+export function createBackupCleanupMonitor({
+  lc,
+  config,
+  replicaFile,
+  changeStreamer,
+  initialCleanupDelayMs,
+  verifyBackupState,
+}: BackupCleanupMonitorFactoryOptions): BackupMonitor | null {
+  const {backupURL, port: metricsPort} = config.litestream;
+  if (!backupURL) {
+    return null;
+  }
+
+  return new Litestream3BackupMonitor(
+    lc,
+    replicaFile,
+    backupURL,
+    `http://localhost:${metricsPort}/metrics`,
+    changeStreamer,
+    initialCleanupDelayMs,
+    verifyBackupState ?? (() => getLastBackupTime(lc, config)),
+  );
+}


### PR DESCRIPTION
Adds a factory. Currently it just returns the existing backup monitor. Later it will return litestream 5.