### PR TITLE
feat(zero-cache): forward incoming request headers to API

### DIFF
--- a/packages/zero-cache/src/config/zero-config.test.ts
+++ b/packages/zero-cache/src/config/zero-config.test.ts
@@ -110,8 +110,18 @@ test('zero-cache --help', () => {
                                                                         A list of header names that clients are allowed to set via custom headers.                                                 
                                                                         If specified, only headers in this list will be forwarded to the push URL.                                                 
                                                                         Header names are case-insensitive.                                                                                         
-                                                                        If not specified, no client-provided headers are forwarded (secure by default).                                            
+                                                                        If not specified, no client-provided headers are forwarded.                                                                
                                                                         Example: ZERO_MUTATE_ALLOWED_CLIENT_HEADERS=x-request-id,x-correlation-id                                                  
+                                                                                                                                                                                                   
+     --mutate-allowed-request-headers string[]                          optional                                                                                                                   
+       ZERO_MUTATE_ALLOWED_REQUEST_HEADERS env                                                                                                                                                     
+                                                                        A list of header names to forward from the incoming HTTP request to the push URL.                                          
+                                                                        Unlike allowed-client-headers (which forwards headers set by the client), these are taken                                  
+                                                                        from the HTTP request that established the connection (e.g. headers injected by a proxy or load balancer).                 
+                                                                        If a listed header is present on the request, its value is forwarded upstream under the same header name.                  
+                                                                        Header names are case-insensitive.                                                                                         
+                                                                        If not specified, no request headers are forwarded.                                                                        
+                                                                        Example: ZERO_MUTATE_ALLOWED_REQUEST_HEADERS=x-forwarded-for,cf-ray                                                        
                                                                                                                                                                                                    
      --query-url string[]                                               optional                                                                                                                   
        ZERO_QUERY_URL env                                                                                                                                                                          
@@ -170,8 +180,18 @@ test('zero-cache --help', () => {
                                                                         A list of header names that clients are allowed to set via custom headers.                                                 
                                                                         If specified, only headers in this list will be forwarded to the query URL.                                                
                                                                         Header names are case-insensitive.                                                                                         
-                                                                        If not specified, no client-provided headers are forwarded (secure by default).                                            
+                                                                        If not specified, no client-provided headers are forwarded.                                                                
                                                                         Example: ZERO_QUERY_ALLOWED_CLIENT_HEADERS=x-request-id,x-correlation-id                                                   
+                                                                                                                                                                                                   
+     --query-allowed-request-headers string[]                           optional                                                                                                                   
+       ZERO_QUERY_ALLOWED_REQUEST_HEADERS env                                                                                                                                                      
+                                                                        A list of header names to forward from the incoming HTTP request to the query URL.                                         
+                                                                        Unlike allowed-client-headers (which forwards headers set by the client), these are taken                                  
+                                                                        from the HTTP request that established the connection (e.g. headers injected by a proxy or load balancer).                 
+                                                                        If a listed header is present on the request, its value is forwarded upstream under the same header name.                  
+                                                                        Header names are case-insensitive.                                                                                         
+                                                                        If not specified, no request headers are forwarded.                                                                        
+                                                                        Example: ZERO_QUERY_ALLOWED_REQUEST_HEADERS=x-forwarded-for,cf-ray                                                         
                                                                                                                                                                                                    
      --enable-crud-mutations boolean                                    default: true                                                                                                              
        ZERO_ENABLE_CRUD_MUTATIONS env                                                                                                                                                              

--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -290,13 +290,32 @@ const makeMutatorQueryOptions = (
       `A list of header names that clients are allowed to set via custom headers.`,
       `If specified, only headers in this list will be forwarded to the ${suffix === 'push mutations' ? 'push' : 'query'} URL.`,
       `Header names are case-insensitive.`,
-      `If not specified, no client-provided headers are forwarded (secure by default).`,
+      `If not specified, no client-provided headers are forwarded.`,
       `Example: ZERO_${replacement ? replacement.toUpperCase() : suffix === 'push mutations' ? 'MUTATE' : 'QUERY'}_ALLOWED_CLIENT_HEADERS=x-request-id,x-correlation-id`,
     ],
     ...(replacement
       ? {
           deprecated: [
             makeDeprecationMessage(`${replacement}-allowed-client-headers`),
+          ],
+        }
+      : {}),
+  },
+  allowedRequestHeaders: {
+    type: v.array(v.string()).optional(),
+    desc: [
+      `A list of header names to forward from the incoming HTTP request to the ${suffix === 'push mutations' ? 'push' : 'query'} URL.`,
+      `Unlike {bold allowed-client-headers} (which forwards headers set by the client), these are taken`,
+      `from the HTTP request that established the connection (e.g. headers injected by a proxy or load balancer).`,
+      `If a listed header is present on the request, its value is forwarded upstream under the same header name.`,
+      `Header names are case-insensitive.`,
+      `If not specified, no request headers are forwarded.`,
+      `Example: ZERO_${replacement ? replacement.toUpperCase() : suffix === 'push mutations' ? 'MUTATE' : 'QUERY'}_ALLOWED_REQUEST_HEADERS=x-forwarded-for,cf-ray`,
+    ],
+    ...(replacement
+      ? {
+          deprecated: [
+            makeDeprecationMessage(`${replacement}-allowed-request-headers`),
           ],
         }
       : {}),

--- a/packages/zero-cache/src/custom-queries/transform-query.test.ts
+++ b/packages/zero-cache/src/custom-queries/transform-query.test.ts
@@ -87,7 +87,6 @@ describe('CustomQueryTransformer', () => {
         allowedUrlPatterns: [],
         headerOptions: {
           apiKey: undefined,
-          allowedClientHeaders: undefined,
           customHeaders: undefined,
           cookie: undefined,
           origin: undefined,
@@ -658,6 +657,49 @@ describe('CustomQueryTransformer', () => {
     // Call again with original header options - should use cache
     mockFetchFromAPIServer.mockResolvedValue(mockSuccessResponse());
     await transformer.transform(headerOptions, [mockQueries[0]], undefined);
+    expect(mockFetchFromAPIServer).toHaveBeenCalledTimes(2);
+  });
+
+  test('should differentiate cache key by forwarded request headers', async () => {
+    const mockSuccessResponse = () =>
+      transformedMessage([mockQueryResponses[0]]);
+
+    mockFetchFromAPIServer.mockResolvedValue(mockSuccessResponse());
+
+    const transformer = makeTransformer();
+    // Cache with one set of forwarded request headers
+    await transformer.transform(
+      {
+        ...headerOptions,
+        requestHeaders: {'x-forwarded-for': '203.0.113.1'},
+      },
+      [mockQueries[0]],
+      undefined,
+    );
+    expect(mockFetchFromAPIServer).toHaveBeenCalledTimes(1);
+
+    // Different request header value - should fetch again
+    mockFetchFromAPIServer.mockResolvedValue(mockSuccessResponse());
+    await transformer.transform(
+      {
+        ...headerOptions,
+        requestHeaders: {'x-forwarded-for': '203.0.113.2'},
+      },
+      [mockQueries[0]],
+      undefined,
+    );
+    expect(mockFetchFromAPIServer).toHaveBeenCalledTimes(2);
+
+    // Original request headers again - should use cache
+    mockFetchFromAPIServer.mockResolvedValue(mockSuccessResponse());
+    await transformer.transform(
+      {
+        ...headerOptions,
+        requestHeaders: {'x-forwarded-for': '203.0.113.1'},
+      },
+      [mockQueries[0]],
+      undefined,
+    );
     expect(mockFetchFromAPIServer).toHaveBeenCalledTimes(2);
   });
 

--- a/packages/zero-cache/src/custom-queries/transform-query.ts
+++ b/packages/zero-cache/src/custom-queries/transform-query.ts
@@ -26,7 +26,6 @@ import {fetchFromAPIServer} from '../custom/fetch.ts';
 import type {
   ConnectionContext,
   ConnectionValidation,
-  HeaderOptions,
 } from '../services/view-syncer/connection-context-manager.ts';
 import type {CustomQueryRecord} from '../services/view-syncer/schema/types.ts';
 import type {ShardID} from '../types/shards.ts';
@@ -257,26 +256,23 @@ function getCacheKey(ctx: ConnectionContext, queryID: string) {
     origin: ctx.queryContext.headerOptions.origin,
     userID: ctx.user,
     url: ctx.queryContext.url,
-    customHeaders: normalizedForwardedHeaders(ctx.queryContext.headerOptions),
+    customHeaders: normalizedHeaders(
+      ctx.queryContext.headerOptions.customHeaders,
+    ),
+    requestHeaders: normalizedHeaders(
+      ctx.queryContext.headerOptions.requestHeaders,
+    ),
   });
 }
 
-function normalizedForwardedHeaders(headerOptions: HeaderOptions) {
-  const {allowedClientHeaders, customHeaders} = headerOptions;
-  if (
-    !customHeaders ||
-    !allowedClientHeaders ||
-    allowedClientHeaders.length === 0
-  ) {
+function normalizedHeaders(
+  headers: Readonly<Record<string, string>> | undefined,
+) {
+  if (!headers) {
     return undefined;
   }
 
-  const allowedHeaders = new Set(
-    allowedClientHeaders.map(header => header.toLowerCase()),
-  );
-  const forwardedHeaders = sortedEntries(customHeaders).filter(([header]) =>
-    allowedHeaders.has(header.toLowerCase()),
-  );
+  const forwardedHeaders = sortedEntries(headers);
 
   return forwardedHeaders.length === 0
     ? undefined

--- a/packages/zero-cache/src/custom/fetch.test.ts
+++ b/packages/zero-cache/src/custom/fetch.test.ts
@@ -201,7 +201,7 @@ describe('fetchFromAPIServer', () => {
     expect(init?.headers).toEqual({'Content-Type': 'application/json'});
   });
 
-  test('includes customHeaders in request when allowed', async () => {
+  test('includes forwarded headers in request', async () => {
     mockFetch.mockResolvedValueOnce(
       new Response(JSON.stringify({success: true}), {status: 200}),
     );
@@ -212,10 +212,9 @@ describe('fetchFromAPIServer', () => {
           'x-vercel-automation-bypass-secret': 'my-secret',
           'x-custom-header': 'custom-value',
         },
-        allowedClientHeaders: [
-          'x-vercel-automation-bypass-secret',
-          'x-custom-header',
-        ],
+        requestHeaders: {
+          'x-forwarded-for': '203.0.113.1',
+        },
       },
     });
 
@@ -224,6 +223,7 @@ describe('fetchFromAPIServer', () => {
       'Content-Type': 'application/json',
       'x-vercel-automation-bypass-secret': 'my-secret',
       'x-custom-header': 'custom-value',
+      'x-forwarded-for': '203.0.113.1',
     });
   });
 
@@ -238,7 +238,6 @@ describe('fetchFromAPIServer', () => {
         customHeaders: {
           'x-vercel-automation-bypass-secret': 'my-secret',
         },
-        allowedClientHeaders: ['x-vercel-automation-bypass-secret'],
       },
       auth: 'jwt-token',
     });
@@ -249,94 +248,6 @@ describe('fetchFromAPIServer', () => {
       'X-Api-Key': 'api-key',
       'x-vercel-automation-bypass-secret': 'my-secret',
       'Authorization': 'Bearer jwt-token',
-    });
-  });
-
-  test('filters out all client headers when allowedClientHeaders is not set', async () => {
-    mockFetch.mockResolvedValueOnce(
-      new Response(JSON.stringify({success: true}), {status: 200}),
-    );
-
-    await fetchWithContext(validator, 'push', {
-      headerOptions: {
-        customHeaders: {
-          'x-request-id': '123',
-          'x-custom': 'value',
-        },
-      },
-    });
-
-    const init = mockFetch.mock.calls[0]![1];
-    expect(init?.headers).toEqual({
-      'Content-Type': 'application/json',
-    });
-  });
-
-  test('filters out all client headers when allowedClientHeaders is empty', async () => {
-    mockFetch.mockResolvedValueOnce(
-      new Response(JSON.stringify({success: true}), {status: 200}),
-    );
-
-    await fetchWithContext(validator, 'push', {
-      headerOptions: {
-        customHeaders: {
-          'x-request-id': '123',
-          'x-custom': 'value',
-        },
-        allowedClientHeaders: [],
-      },
-    });
-
-    const init = mockFetch.mock.calls[0]![1];
-    expect(init?.headers).toEqual({
-      'Content-Type': 'application/json',
-    });
-  });
-
-  test('only forwards headers in allowedClientHeaders list', async () => {
-    mockFetch.mockResolvedValueOnce(
-      new Response(JSON.stringify({success: true}), {status: 200}),
-    );
-
-    await fetchWithContext(validator, 'push', {
-      headerOptions: {
-        customHeaders: {
-          'x-request-id': '123',
-          'x-forbidden': 'bad',
-          'X-Correlation-ID': 'abc',
-        },
-        allowedClientHeaders: ['x-request-id', 'x-correlation-id'],
-      },
-    });
-
-    const init = mockFetch.mock.calls[0]![1];
-    expect(init?.headers).toEqual({
-      'Content-Type': 'application/json',
-      'x-request-id': '123',
-      'X-Correlation-ID': 'abc',
-    });
-  });
-
-  test('header filtering is case-insensitive', async () => {
-    mockFetch.mockResolvedValueOnce(
-      new Response(JSON.stringify({success: true}), {status: 200}),
-    );
-
-    await fetchWithContext(validator, 'push', {
-      headerOptions: {
-        customHeaders: {
-          'X-REQUEST-ID': 'uppercase',
-          'x-custom-header': 'lowercase',
-        },
-        allowedClientHeaders: ['x-request-id', 'X-CUSTOM-HEADER'],
-      },
-    });
-
-    const init = mockFetch.mock.calls[0]![1];
-    expect(init?.headers).toEqual({
-      'Content-Type': 'application/json',
-      'X-REQUEST-ID': 'uppercase',
-      'x-custom-header': 'lowercase',
     });
   });
 

--- a/packages/zero-cache/src/custom/fetch.ts
+++ b/packages/zero-cache/src/custom/fetch.ts
@@ -37,32 +37,6 @@ export function compileUrlPattern(pattern: string): URLPattern {
   }
 }
 
-/**
- * Filters custom headers based on the allowed headers list.
- * If no allowedHeaders list is specified, no custom headers are forwarded (secure by default).
- * Header names are compared case-insensitively.
- */
-function filterCustomHeaders(
-  headers: Readonly<Record<string, string>> | undefined,
-  allowedHeaders: readonly string[] | undefined,
-): Record<string, string> {
-  if (!headers) {
-    return {};
-  }
-  if (!allowedHeaders || allowedHeaders.length === 0) {
-    return {};
-  }
-
-  const allowed = new Set(allowedHeaders.map(h => h.toLowerCase()));
-  const filtered: Record<string, string> = {};
-  for (const [key, value] of Object.entries(headers)) {
-    if (allowed.has(key.toLowerCase())) {
-      filtered[key] = value;
-    }
-  }
-  return filtered;
-}
-
 export const getBodyPreview = async (
   res: Response,
   lc: LogContext,
@@ -141,10 +115,8 @@ export async function fetchFromAPIServer<TValidator extends Type>(
   }
   Object.assign(
     headers,
-    filterCustomHeaders(
-      headerOptions.customHeaders,
-      headerOptions.allowedClientHeaders,
-    ),
+    headerOptions.customHeaders,
+    headerOptions.requestHeaders,
   );
   if (ctx.auth?.raw) {
     headers['Authorization'] = `Bearer ${ctx.auth.raw}`;

--- a/packages/zero-cache/src/server/syncer.ts
+++ b/packages/zero-cache/src/server/syncer.ts
@@ -62,6 +62,7 @@ function getCustomQueryConfig(
     url: queryConfig.url,
     apiKey: queryConfig.apiKey,
     allowedClientHeaders: queryConfig.allowedClientHeaders,
+    allowedRequestHeaders: queryConfig.allowedRequestHeaders,
     forwardCookies: queryConfig.forwardCookies ?? false,
   };
 }

--- a/packages/zero-cache/src/services/mutagen/pusher.test.ts
+++ b/packages/zero-cache/src/services/mutagen/pusher.test.ts
@@ -40,6 +40,7 @@ type TestConnectionOptions = {
   userID?: string | undefined;
   userPushURL?: string | undefined;
   userPushHeaders?: Record<string, string> | undefined;
+  requestHeaders?: Record<string, string> | undefined;
 };
 
 const contextManagers = new WeakMap<
@@ -52,6 +53,7 @@ function newPusherService(pushConfig: {
   apiKey?: string | undefined;
   forwardCookies: boolean;
   allowedClientHeaders?: string[] | undefined;
+  allowedRequestHeaders?: string[] | undefined;
 }): PusherService {
   const connContextManager = new ConnectionContextManagerImpl(
     lc,
@@ -61,12 +63,14 @@ function newPusherService(pushConfig: {
       url: undefined,
       apiKey: undefined,
       allowedClientHeaders: undefined,
+      allowedRequestHeaders: undefined,
       forwardCookies: false,
     },
     {
       url: pushConfig.url,
       apiKey: pushConfig.apiKey,
       allowedClientHeaders: pushConfig.allowedClientHeaders,
+      allowedRequestHeaders: pushConfig.allowedRequestHeaders,
       forwardCookies: pushConfig.forwardCookies,
     },
   );
@@ -113,6 +117,7 @@ function registerConnection(
       initConnectionMsg: undefined,
       httpCookie: options.httpCookie,
       origin: options.origin,
+      requestHeaders: options.requestHeaders,
     },
     makeAuth(options.auth),
   );
@@ -180,7 +185,6 @@ function makeEntry(
           cookie: options.httpCookie,
           origin: options.origin,
           apiKey: undefined,
-          allowedClientHeaders: undefined,
         },
       },
       mutateContext: {
@@ -191,7 +195,6 @@ function makeEntry(
           cookie: options.httpCookie,
           origin: options.origin,
           apiKey: undefined,
-          allowedClientHeaders: undefined,
         },
       },
     } satisfies ConnectionContext,
@@ -538,7 +541,7 @@ describe('pusher service', () => {
       url: ['http://example.com'],
       apiKey: 'api-key',
       forwardCookies: false,
-      // allowedClientHeaders not set - secure by default
+      // allowedClientHeaders not set.
     });
     void pusher.run();
     const {selector} = openConnection(pusher, {
@@ -558,6 +561,45 @@ describe('pusher service', () => {
     expect(fetch.mock.calls[0][1]?.headers).toEqual({
       'Content-Type': 'application/json',
       'X-Api-Key': 'api-key',
+      'Authorization': 'Bearer jwt',
+    });
+
+    fetch.mockReset();
+  });
+
+  test('the service forwards only allowed request headers', async () => {
+    const fetch = (global.fetch = vi.fn());
+    fetch.mockResolvedValue({
+      ok: true,
+    });
+
+    const pusher = newPusherService({
+      url: ['http://example.com'],
+      apiKey: 'api-key',
+      forwardCookies: false,
+      allowedRequestHeaders: ['x-forwarded-for', 'cf-ray'],
+    });
+    void pusher.run();
+    const {selector} = openConnection(pusher, {
+      clientID,
+      wsID,
+      auth: 'jwt',
+      requestHeaders: {
+        'x-forwarded-for': '203.0.113.1',
+        'cf-ray': 'abc123',
+        'x-not-allowed': 'secret',
+      },
+    });
+
+    pusher.enqueuePush(selector, makePush(1));
+
+    await pusher.stop();
+
+    expect(fetch.mock.calls[0][1]?.headers).toEqual({
+      'Content-Type': 'application/json',
+      'X-Api-Key': 'api-key',
+      'x-forwarded-for': '203.0.113.1',
+      'cf-ray': 'abc123',
       'Authorization': 'Bearer jwt',
     });
 

--- a/packages/zero-cache/src/services/view-syncer/connection-context-manager.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/connection-context-manager.test.ts
@@ -114,7 +114,13 @@ function validate(
 
 describe('ConnectionContextManager', () => {
   test('registers provisional connections, applies init metadata, and replaces prior sockets for a client', () => {
-    const manager = new ConnectionContextManagerImpl(lc);
+    const manager = new ConnectionContextManagerImpl(
+      lc,
+      undefined,
+      undefined,
+      {allowedClientHeaders: ['foo'], forwardCookies: false},
+      {allowedClientHeaders: ['baz'], forwardCookies: false},
+    );
 
     expect(register(manager, 'c1', 'ws1')).toMatchObject({
       clientID: 'c1',
@@ -322,7 +328,7 @@ describe('ConnectionContextManager', () => {
       lc,
       5,
       10,
-      undefined,
+      {allowedClientHeaders: ['foo'], forwardCookies: false},
       undefined,
       undefined,
       () => 1_000,
@@ -603,7 +609,6 @@ describe('ConnectionContextManager', () => {
           headerOptions: expect.objectContaining({
             apiKey: 'query-api-key',
             customHeaders: {'x-query-header': 'query-value'},
-            allowedClientHeaders: ['x-query-header'],
             cookie: 'cookie-ws1',
             origin: 'origin-ws1',
           }),
@@ -616,13 +621,115 @@ describe('ConnectionContextManager', () => {
           headerOptions: expect.objectContaining({
             apiKey: 'push-api-key',
             customHeaders: {'x-push-header': 'push-value'},
-            allowedClientHeaders: ['x-push-header'],
             cookie: undefined,
             origin: 'origin-ws1',
           }),
         }),
       }),
     );
+  });
+
+  test('stores only allowlisted forwarded headers on the fetch context', () => {
+    const manager = new ConnectionContextManagerImpl(
+      lc,
+      undefined,
+      undefined,
+      {
+        url: ['https://default.example/query'],
+        apiKey: 'query-api-key',
+        allowedClientHeaders: ['x-query-header'],
+        allowedRequestHeaders: ['x-forwarded-for'],
+        forwardCookies: false,
+      },
+      {
+        url: ['https://default.example/push'],
+        apiKey: 'push-api-key',
+        allowedClientHeaders: ['x-push-header'],
+        allowedRequestHeaders: ['cf-ray'],
+        forwardCookies: false,
+      },
+    );
+
+    const requestHeaders = {
+      'x-forwarded-for': '203.0.113.1',
+      'cf-ray': 'abc123',
+      'x-not-allowed': 'secret',
+    };
+    manager.registerConnection(
+      selector('c1', 'ws1'),
+      {
+        ...makeConnectParams('c1', 'ws1'),
+        requestHeaders,
+      },
+      {type: 'opaque', raw: 'token-1'},
+    );
+    const connection = manager.initConnection(selector('c1', 'ws1'), {
+      desiredQueriesPatch: [],
+      userQueryHeaders: {
+        'X-Query-Header': 'query-value',
+        'x-not-allowed': 'secret',
+      },
+      userPushHeaders: {
+        'X-Push-Header': 'push-value',
+        'x-not-allowed-2': 'secret-2',
+      },
+    });
+
+    expect(connection.queryContext.headerOptions.customHeaders).toEqual({
+      'X-Query-Header': 'query-value',
+    });
+    expect(connection.queryContext.headerOptions.requestHeaders).toEqual({
+      'x-forwarded-for': '203.0.113.1',
+    });
+    expect(connection.mutateContext.headerOptions.customHeaders).toEqual({
+      'X-Push-Header': 'push-value',
+    });
+    expect(connection.mutateContext.headerOptions.requestHeaders).toEqual({
+      'cf-ray': 'abc123',
+    });
+  });
+
+  test('drops forwarded headers when no allowlist is configured', () => {
+    const manager = new ConnectionContextManagerImpl(
+      lc,
+      undefined,
+      undefined,
+      {
+        url: ['https://default.example/query'],
+        forwardCookies: false,
+      },
+      {
+        url: ['https://default.example/push'],
+        forwardCookies: false,
+      },
+    );
+
+    const connection = manager.registerConnection(
+      selector('c1', 'ws1'),
+      {
+        ...makeConnectParams('c1', 'ws1'),
+        requestHeaders: {'x-forwarded-for': '203.0.113.1'},
+      },
+      {type: 'opaque', raw: 'token-1'},
+    );
+    const initialized = manager.initConnection(selector('c1', 'ws1'), {
+      desiredQueriesPatch: [],
+      userQueryHeaders: {'x-query-header': 'query-value'},
+      userPushHeaders: {'x-push-header': 'push-value'},
+    });
+
+    expect(
+      connection.queryContext.headerOptions.requestHeaders,
+    ).toBeUndefined();
+    expect(
+      connection.mutateContext.headerOptions.requestHeaders,
+    ).toBeUndefined();
+    expect(
+      initialized.queryContext.headerOptions.customHeaders,
+    ).toBeUndefined();
+    expect(
+      initialized.mutateContext.headerOptions.customHeaders,
+    ).toBeUndefined();
   });
 
   test('ignores stale revision-scoped validation and failure updates', () => {

--- a/packages/zero-cache/src/services/view-syncer/connection-context-manager.ts
+++ b/packages/zero-cache/src/services/view-syncer/connection-context-manager.ts
@@ -43,8 +43,10 @@ type FetchConfig = ZeroConfig['query'];
 
 export type HeaderOptions = {
   readonly apiKey?: string | undefined;
+  /** Allowlisted headers provided in the client options. */
   readonly customHeaders?: Readonly<Record<string, string>> | undefined;
-  readonly allowedClientHeaders?: readonly string[] | undefined;
+  /** Allowlisted headers from the incoming HTTP request. */
+  readonly requestHeaders?: Readonly<Record<string, string>> | undefined;
   readonly cookie?: string | undefined;
   readonly origin?: string | undefined;
 };
@@ -238,11 +240,12 @@ export class ConnectionContextManagerImpl implements ConnectionContextManager {
         allowedUrlPatterns: config?.url?.map(compileUrlPattern),
         headerOptions: {
           customHeaders: undefined,
+          requestHeaders: filterHeaders(
+            connectParams.requestHeaders,
+            config?.allowedRequestHeaders,
+          ),
           origin: connectParams.origin,
           apiKey: config?.apiKey,
-          allowedClientHeaders: cloneAllowedClientHeaders(
-            config?.allowedClientHeaders,
-          ),
           cookie: config?.forwardCookies ? connectParams.httpCookie : undefined,
         },
       };
@@ -300,7 +303,10 @@ export class ConnectionContextManagerImpl implements ConnectionContextManager {
         ...queryContext,
         headerOptions: {
           ...queryContext.headerOptions,
-          customHeaders: cloneCustomHeaders(body.userQueryHeaders),
+          customHeaders: filterHeaders(
+            body.userQueryHeaders,
+            this.#queryConfig?.allowedClientHeaders,
+          ),
         },
       };
     }
@@ -315,7 +321,10 @@ export class ConnectionContextManagerImpl implements ConnectionContextManager {
         ...mutateContext,
         headerOptions: {
           ...mutateContext.headerOptions,
-          customHeaders: cloneCustomHeaders(body.userPushHeaders),
+          customHeaders: filterHeaders(
+            body.userPushHeaders,
+            this.#pushConfig?.allowedClientHeaders,
+          ),
         },
       };
     }
@@ -863,12 +872,21 @@ function sameConnectionSelector(
   return a?.clientID === b?.clientID && a?.wsID === b?.wsID;
 }
 
-function cloneCustomHeaders(
+function filterHeaders(
   headers: Readonly<Record<string, string>> | undefined,
+  allowedHeaders: readonly string[] | undefined,
 ) {
-  return headers ? {...headers} : undefined;
-}
+  if (!headers || !allowedHeaders || allowedHeaders.length === 0) {
+    return undefined;
+  }
 
-function cloneAllowedClientHeaders(headers: readonly string[] | undefined) {
-  return headers ? [...headers] : undefined;
+  const allowed = new Set(allowedHeaders.map(header => header.toLowerCase()));
+  let filtered: Record<string, string> | undefined;
+  for (const [key, value] of Object.entries(headers)) {
+    if (allowed.has(key.toLowerCase())) {
+      filtered ??= {};
+      filtered[key] = value;
+    }
+  }
+  return filtered;
 }

--- a/packages/zero-cache/src/services/view-syncer/view-syncer-inspect.pg.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer-inspect.pg.test.ts
@@ -529,11 +529,11 @@ describe('view-syncer/service', () => {
           URLPattern {},
         ],
         "headerOptions": {
-          "allowedClientHeaders": undefined,
           "apiKey": undefined,
           "cookie": undefined,
           "customHeaders": undefined,
           "origin": undefined,
+          "requestHeaders": undefined,
         },
         "url": "http://my-pull-endpoint.dev/api/zero/pull",
       }

--- a/packages/zero-cache/src/services/view-syncer/view-syncer-test-util.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer-test-util.ts
@@ -788,6 +788,7 @@ export async function setup(
       url: query.url,
       apiKey: query.apiKey,
       allowedClientHeaders: query.allowedClientHeaders,
+      allowedRequestHeaders: query.allowedRequestHeaders,
       forwardCookies: query.forwardCookies,
     },
     {
@@ -796,6 +797,9 @@ export async function setup(
       allowedClientHeaders:
         config.push?.allowedClientHeaders ??
         config.mutate?.allowedClientHeaders,
+      allowedRequestHeaders:
+        config.push?.allowedRequestHeaders ??
+        config.mutate?.allowedRequestHeaders,
       forwardCookies:
         config.push?.forwardCookies ?? config.mutate?.forwardCookies ?? false,
     },
@@ -968,6 +972,7 @@ export function restartViewSyncer(params: {
       url: query.url,
       apiKey: query.apiKey,
       allowedClientHeaders: query.allowedClientHeaders,
+      allowedRequestHeaders: query.allowedRequestHeaders,
       forwardCookies: query.forwardCookies,
     },
     {
@@ -976,6 +981,9 @@ export function restartViewSyncer(params: {
       allowedClientHeaders:
         config.push?.allowedClientHeaders ??
         config.mutate?.allowedClientHeaders,
+      allowedRequestHeaders:
+        config.push?.allowedRequestHeaders ??
+        config.mutate?.allowedRequestHeaders,
       forwardCookies:
         config.push?.forwardCookies ?? config.mutate?.forwardCookies ?? false,
     },

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg.test.ts
@@ -1294,11 +1294,11 @@ describe('view-syncer/service', () => {
             "mutateContext": {
               "allowedUrlPatterns": undefined,
               "headerOptions": {
-                "allowedClientHeaders": undefined,
                 "apiKey": undefined,
                 "cookie": undefined,
                 "customHeaders": undefined,
                 "origin": undefined,
+                "requestHeaders": undefined,
               },
               "url": undefined,
             },
@@ -1309,11 +1309,11 @@ describe('view-syncer/service', () => {
                 URLPattern {},
               ],
               "headerOptions": {
-                "allowedClientHeaders": undefined,
                 "apiKey": undefined,
                 "cookie": undefined,
                 "customHeaders": undefined,
                 "origin": undefined,
+                "requestHeaders": undefined,
               },
               "url": "http://my-pull-endpoint.dev/api/zero/pull",
             },
@@ -1584,11 +1584,11 @@ describe('view-syncer/service', () => {
             "mutateContext": {
               "allowedUrlPatterns": undefined,
               "headerOptions": {
-                "allowedClientHeaders": undefined,
                 "apiKey": undefined,
                 "cookie": undefined,
                 "customHeaders": undefined,
                 "origin": undefined,
+                "requestHeaders": undefined,
               },
               "url": undefined,
             },
@@ -1599,11 +1599,11 @@ describe('view-syncer/service', () => {
                 URLPattern {},
               ],
               "headerOptions": {
-                "allowedClientHeaders": undefined,
                 "apiKey": undefined,
                 "cookie": undefined,
                 "customHeaders": undefined,
                 "origin": undefined,
+                "requestHeaders": undefined,
               },
               "url": "http://my-pull-endpoint.dev/api/zero/pull",
             },
@@ -2262,11 +2262,11 @@ describe('view-syncer/service', () => {
             "mutateContext": {
               "allowedUrlPatterns": undefined,
               "headerOptions": {
-                "allowedClientHeaders": undefined,
                 "apiKey": undefined,
                 "cookie": undefined,
                 "customHeaders": undefined,
                 "origin": undefined,
+                "requestHeaders": undefined,
               },
               "url": undefined,
             },
@@ -2277,11 +2277,11 @@ describe('view-syncer/service', () => {
                 URLPattern {},
               ],
               "headerOptions": {
-                "allowedClientHeaders": undefined,
                 "apiKey": undefined,
                 "cookie": undefined,
                 "customHeaders": undefined,
                 "origin": undefined,
+                "requestHeaders": undefined,
               },
               "url": "http://my-pull-endpoint.dev/api/zero/pull",
             },
@@ -2481,11 +2481,11 @@ describe('view-syncer/service', () => {
             "mutateContext": {
               "allowedUrlPatterns": undefined,
               "headerOptions": {
-                "allowedClientHeaders": undefined,
                 "apiKey": undefined,
                 "cookie": undefined,
                 "customHeaders": undefined,
                 "origin": undefined,
+                "requestHeaders": undefined,
               },
               "url": undefined,
             },
@@ -2496,11 +2496,11 @@ describe('view-syncer/service', () => {
                 URLPattern {},
               ],
               "headerOptions": {
-                "allowedClientHeaders": undefined,
                 "apiKey": undefined,
                 "cookie": undefined,
                 "customHeaders": undefined,
                 "origin": undefined,
+                "requestHeaders": undefined,
               },
               "url": "http://my-pull-endpoint.dev/api/zero/pull",
             },

--- a/packages/zero-cache/src/workers/connect-params.ts
+++ b/packages/zero-cache/src/workers/connect-params.ts
@@ -1,4 +1,4 @@
-import type {IncomingHttpHeaders} from 'node:http2';
+import type {IncomingHttpHeaders} from 'node:http';
 import {must} from '../../../shared/src/must.ts';
 import {
   decodeSecProtocols,
@@ -21,7 +21,26 @@ export type ConnectParams = {
   readonly initConnectionMsg: InitConnectionMessage | undefined;
   readonly httpCookie: string | undefined;
   readonly origin: string | undefined;
+  readonly requestHeaders?: Readonly<Record<string, string>> | undefined;
 };
+
+/**
+ * Normalizes Node's {@link IncomingHttpHeaders} (whose values are
+ * `string | string[] | undefined`) into a plain `Record<string, string>`,
+ * joining array values with `, ` and dropping `undefined` values.
+ */
+function normalizeHeaders(
+  headers: IncomingHttpHeaders,
+): Record<string, string> {
+  const normalized: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    if (value === undefined) {
+      continue;
+    }
+    normalized[key] = Array.isArray(value) ? value.join(', ') : value;
+  }
+  return normalized;
+}
 
 export function getConnectParams(
   protocolVersion: number,
@@ -68,6 +87,7 @@ export function getConnectParams(
         userID,
         httpCookie: headers.cookie,
         origin: headers.origin,
+        requestHeaders: normalizeHeaders(headers),
       },
       error: null,
     };


### PR DESCRIPTION
This adds 2 new options
- `mutate-allowed-request-headers`
- `query-allowed-request-headers`

which are an allow list of headers to forward from the incoming request upstream.

We need to record the IP address of the caller, which arrives on an `x-forwarded-for` header. We can't provide this in the client as it needs to come from the load balancer server side. I think allowing any header to be forwarded is a useful feature but open to other suggestions :)

Found a related bug here in the bug tracker: https://bugs.rocicorp.dev/p/zero/issue/3928

Discord: https://discord.com/channels/830183651022471199/1514221426268438689

Extracted from https://github.com/rocicorp/mono/pull/6109