### PR TITLE
chore(zero-cache): backupWithv5 flag and supporting infra

### DIFF
--- a/packages/zero-cache/src/config/normalize.ts
+++ b/packages/zero-cache/src/config/normalize.ts
@@ -42,6 +42,10 @@ export function assertNormalized(
   assert(config.changeStreamer.port, 'missing --change-streamer-port');
   assert(config.changeStreamer.address, 'missing --change-streamer-address');
   assert(config.litestream.port, 'missing --litestream-port');
+  assert(
+    !config.litestream.backupUsingV5 || config.litestream.restoreUsingV5,
+    '--litestream-backup-using-v5 requires --litestream-restore-using-v5',
+  );
   assert(config.change.db, 'missing --change-db');
   assert(config.cvr.db, 'missing --cvr-db');
   assertNotUndefined(config.numSyncWorkers, 'missing --num-sync-workers');

--- a/packages/zero-cache/src/config/zero-config.test.ts
+++ b/packages/zero-cache/src/config/zero-config.test.ts
@@ -520,6 +520,12 @@ test('zero-cache --help', () => {
        ZERO_LITESTREAM_RESTORE_USING_V5 env                                                                                                                                                        
                                                                         Restores the backup using the ZERO_LITESTREAM_EXECUTABLE_V5 if specified.                                                  
                                                                                                                                                                                                    
+     --litestream-backup-using-v5 boolean                               default: false                                                                                                             
+       ZERO_LITESTREAM_BACKUP_USING_V5 env                                                                                                                                                         
+                                                                        Backs up the replica using Litestream v0.5.x and monitors cleanup                                                          
+                                                                        watermarks by reading the backup through the Litestream SQLite VFS.                                                        
+                                                                        This requires ZERO_LITESTREAM_RESTORE_USING_V5.                                                                            
+                                                                                                                                                                                                   
      --litestream-config-path string                                    default: "./src/services/litestream/config.yml"                                                                            
        ZERO_LITESTREAM_CONFIG_PATH env                                                                                                                                                             
                                                                         Path to the litestream yaml config file. zero-cache will run this with its                                                 

--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -797,6 +797,15 @@ export const zeroOptions = {
       ],
     },
 
+    backupUsingV5: {
+      type: v.boolean().default(false),
+      desc: [
+        `Backs up the replica using Litestream v0.5.x and monitors cleanup`,
+        `watermarks by reading the backup through the Litestream SQLite VFS.`,
+        `This requires {bold ZERO_LITESTREAM_RESTORE_USING_V5}.`,
+      ],
+    },
+
     configPath: {
       type: v.string().default('./src/services/litestream/config.yml'),
       desc: [

--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -219,6 +219,7 @@ export default async function runWorker(
     //
     // Consider: Also account for permanent volumes?
     initialCleanupDelayMs: Date.now() - workerStartTime,
+    env,
   });
   const monitor =
     backupMonitor ?? new ReplicaMonitor(lc, replica.file, changeStreamer);

--- a/packages/zero-cache/src/services/change-streamer/backup-cleanup-monitor-factory.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/backup-cleanup-monitor-factory.test.ts
@@ -5,6 +5,7 @@ import {Subscription} from '../../types/subscription.ts';
 import {createBackupCleanupMonitor} from './backup-cleanup-monitor-factory.ts';
 import type {ChangeStreamerService} from './change-streamer.ts';
 import {Litestream3BackupMonitor} from './litestream3-backup-monitor.ts';
+import {VfsBackupMonitor} from './vfs-backup-monitor.ts';
 
 const changeStreamer = {
   id: 'change-streamer',
@@ -26,6 +27,10 @@ function configWithLitestream(
     litestream: {
       backupURL: undefined,
       port: 9090,
+      backupUsingV5: false,
+      restoreUsingV5: false,
+      vfsProbeIntervalMs: 30_000,
+      vfsProbeTimeoutMs: 30_000,
       ...litestream,
     },
   } as unknown as NormalizedZeroConfig;
@@ -56,6 +61,27 @@ describe('createBackupCleanupMonitor', () => {
 
     expect(monitor).toBeInstanceOf(Litestream3BackupMonitor);
     expect(monitor?.id).toBe('backup-monitor');
+    await monitor?.stop();
+  });
+
+  test('creates the v5 backup monitor when v5 backup is enabled', async () => {
+    const monitor = createBackupCleanupMonitor({
+      lc: createSilentLogContext(),
+      config: configWithLitestream({
+        backupURL: 's3://bucket/prefix',
+        backupUsingV5: true,
+        restoreUsingV5: true,
+      }),
+      replicaFile: '/tmp/replica.db',
+      changeStreamer,
+      initialCleanupDelayMs: 0,
+      vfsBackupWatermarkSource: {
+        readWatermark: vi.fn(),
+      },
+    });
+
+    expect(monitor).toBeInstanceOf(VfsBackupMonitor);
+    expect(monitor?.id).toBe('vfs-backup-monitor');
     await monitor?.stop();
   });
 });

--- a/packages/zero-cache/src/services/change-streamer/backup-cleanup-monitor-factory.ts
+++ b/packages/zero-cache/src/services/change-streamer/backup-cleanup-monitor-factory.ts
@@ -1,12 +1,19 @@
 import type {LogContext} from '@rocicorp/logger';
 import type {NormalizedZeroConfig} from '../../config/normalize.ts';
+import {BACKUP_WATERMARK_READER_URL} from '../../server/worker-urls.ts';
+import {forkChildWorker} from '../../types/processes.ts';
 import {getLastBackupTime} from '../litestream/commands.ts';
+import {VfsBackupWatermarkWorkerSource} from '../litestream/vfs-watermark-worker-source.ts';
 import type {BackupMonitor} from './backup-monitor.ts';
 import type {ChangeStreamerService} from './change-streamer.ts';
 import {
   Litestream3BackupMonitor,
   type BackupStateVerifier,
 } from './litestream3-backup-monitor.ts';
+import {
+  VfsBackupMonitor,
+  type VfsBackupWatermarkSource,
+} from './vfs-backup-monitor.ts';
 
 export type BackupCleanupMonitorFactoryOptions = {
   lc: LogContext;
@@ -15,6 +22,8 @@ export type BackupCleanupMonitorFactoryOptions = {
   changeStreamer: ChangeStreamerService;
   initialCleanupDelayMs: number;
   verifyBackupState?: BackupStateVerifier | undefined;
+  vfsBackupWatermarkSource?: VfsBackupWatermarkSource | undefined;
+  env?: NodeJS.ProcessEnv | undefined;
 };
 
 export function createBackupCleanupMonitor({
@@ -24,10 +33,29 @@ export function createBackupCleanupMonitor({
   changeStreamer,
   initialCleanupDelayMs,
   verifyBackupState,
+  vfsBackupWatermarkSource,
+  env,
 }: BackupCleanupMonitorFactoryOptions): BackupMonitor | null {
   const {backupURL, port: metricsPort} = config.litestream;
   if (!backupURL) {
     return null;
+  }
+
+  if (config.litestream.backupUsingV5) {
+    return new VfsBackupMonitor(
+      lc,
+      backupURL,
+      changeStreamer,
+      initialCleanupDelayMs,
+      config.litestream.vfsProbeIntervalMs,
+      vfsBackupWatermarkSource ??
+        new VfsBackupWatermarkWorkerSource(
+          lc,
+          () =>
+            forkChildWorker(BACKUP_WATERMARK_READER_URL, env ?? process.env),
+          config.litestream.vfsProbeTimeoutMs,
+        ),
+    );
   }
 
   return new Litestream3BackupMonitor(

--- a/packages/zero-cache/src/services/change-streamer/vfs-backup-monitor.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/vfs-backup-monitor.test.ts
@@ -1,0 +1,158 @@
+import {resolver} from '@rocicorp/resolver';
+import {beforeEach, describe, expect, test, vi} from 'vitest';
+import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
+import type {Subscription} from '../../types/subscription.ts';
+import type {VfsBackupWatermark} from '../litestream/vfs-watermark-reader.ts';
+import type {ChangeStreamerService} from './change-streamer.ts';
+import type {SnapshotMessage} from './snapshot.ts';
+import {
+  VfsBackupMonitor,
+  type VfsBackupWatermarkSource,
+} from './vfs-backup-monitor.ts';
+
+describe('change-streamer/vfs-backup-monitor', () => {
+  const scheduled: string[] = [];
+  const changeStreamer = {
+    scheduleCleanup: (watermark: string) => scheduled.push(watermark),
+    getChangeLogState: () =>
+      Promise.resolve({
+        replicaVersion: '123',
+        minWatermark: '1ab',
+      }),
+  } as unknown as ChangeStreamerService;
+
+  let readWatermark: ReturnType<
+    typeof vi.fn<() => Promise<VfsBackupWatermark>>
+  >;
+  let closeSource: ReturnType<typeof vi.fn<() => void>>;
+  let source: VfsBackupWatermarkSource;
+  let monitor: VfsBackupMonitor;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    scheduled.splice(0);
+    readWatermark = vi.fn<() => Promise<VfsBackupWatermark>>();
+    closeSource = vi.fn<() => void>();
+    source = {
+      readWatermark,
+      close: closeSource,
+    };
+    monitor = new VfsBackupMonitor(
+      createSilentLogContext(),
+      's3://foo/bar',
+      changeStreamer,
+      100_000,
+      30_000,
+      source,
+    );
+
+    return () => {
+      void monitor.stop();
+      vi.useRealTimers();
+    };
+  });
+
+  function getFirstMessage(
+    sub: Subscription<SnapshotMessage>,
+  ): Promise<SnapshotMessage> {
+    const {promise, resolve} = resolver<SnapshotMessage>();
+    void (async function () {
+      for await (const msg of sub) {
+        resolve(msg);
+      }
+    })();
+    return promise;
+  }
+
+  function backupWatermark(
+    watermark: string,
+    observedAtMs: number,
+  ): VfsBackupWatermark {
+    return {
+      watermark,
+      writeTimeMs: observedAtMs - 1000,
+      txid: `000000000000000${watermark}`,
+      lagSeconds: 1,
+      observedAtMs,
+    };
+  }
+
+  test('schedules cleanup from the VFS-visible watermark after the cleanup delay', async () => {
+    const time = Date.UTC(2025, 3, 24);
+    vi.setSystemTime(time);
+    readWatermark.mockResolvedValue(backupWatermark('04', time));
+
+    await monitor.checkWatermarkAndScheduleCleanup();
+    expect(scheduled).toEqual([]);
+
+    vi.setSystemTime(time + 99_999);
+    await monitor.checkWatermarkAndScheduleCleanup();
+    expect(scheduled).toEqual([]);
+
+    vi.setSystemTime(time + 100_000);
+    await monitor.checkWatermarkAndScheduleCleanup();
+    expect(scheduled).toEqual(['04']);
+
+    await monitor.stop();
+    expect(closeSource).toHaveBeenCalledTimes(1);
+  });
+
+  test('blocks cleanup when the VFS probe fails', async () => {
+    const time = Date.UTC(2025, 3, 24);
+    vi.setSystemTime(time);
+    readWatermark
+      .mockResolvedValueOnce(backupWatermark('04', time))
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce(backupWatermark('04', time));
+
+    await monitor.checkWatermarkAndScheduleCleanup();
+
+    vi.setSystemTime(time + 100_000);
+    await monitor.checkWatermarkAndScheduleCleanup();
+    expect(scheduled).toEqual([]);
+
+    await monitor.checkWatermarkAndScheduleCleanup();
+    expect(scheduled).toEqual(['04']);
+  });
+
+  test('does not schedule a cached watermark newer than the current VFS read', async () => {
+    const time = Date.UTC(2025, 3, 24);
+    vi.setSystemTime(time);
+    readWatermark
+      .mockResolvedValueOnce(backupWatermark('05', time))
+      .mockResolvedValueOnce(backupWatermark('04', time));
+
+    await monitor.checkWatermarkAndScheduleCleanup();
+
+    vi.setSystemTime(time + 100_000);
+    await monitor.checkWatermarkAndScheduleCleanup();
+    expect(scheduled).toEqual(['04']);
+  });
+
+  test('pauses cleanup during snapshot reservation', async () => {
+    const time = Date.UTC(2025, 3, 24);
+    vi.setSystemTime(time);
+    readWatermark.mockResolvedValue(backupWatermark('04', time));
+
+    await monitor.checkWatermarkAndScheduleCleanup();
+
+    const sub = monitor.startSnapshotReservation('foo-bar');
+    expect(await getFirstMessage(sub)).toEqual([
+      'status',
+      {
+        tag: 'status',
+        backupURL: 's3://foo/bar',
+        replicaVersion: '123',
+        minWatermark: '1ab',
+      },
+    ]);
+
+    vi.setSystemTime(time + 100_000);
+    await monitor.checkWatermarkAndScheduleCleanup();
+    expect(scheduled).toEqual([]);
+
+    monitor.endReservation('foo-bar');
+    await monitor.checkWatermarkAndScheduleCleanup();
+    expect(scheduled).toEqual(['04']);
+  });
+});

--- a/packages/zero-cache/src/services/change-streamer/vfs-backup-monitor.ts
+++ b/packages/zero-cache/src/services/change-streamer/vfs-backup-monitor.ts
@@ -1,0 +1,245 @@
+import type {LogContext} from '@rocicorp/logger';
+import {promiseVoid} from '../../../../shared/src/resolved-promises.ts';
+import {
+  getOrCreateCounter,
+  getOrCreateGauge,
+} from '../../observability/metrics.ts';
+import {Subscription} from '../../types/subscription.ts';
+import type {VfsBackupWatermark} from '../litestream/vfs-watermark-reader.ts';
+import {RunningState} from '../running-state.ts';
+import type {BackupMonitor} from './backup-monitor.ts';
+import type {ChangeStreamerService} from './change-streamer.ts';
+import type {SnapshotMessage} from './snapshot.ts';
+
+const MIN_CLEANUP_DELAY_MS = 30_000;
+
+type Reservation = {
+  start: Date;
+  sub: Subscription<SnapshotMessage>;
+};
+
+export interface VfsBackupWatermarkSource {
+  readWatermark(): Promise<VfsBackupWatermark>;
+  close?(): void;
+}
+
+/**
+ * Monitors a Litestream v0.5.x backup by reading Zero's replication state from
+ * the backup itself through the Litestream SQLite VFS.
+ */
+export class VfsBackupMonitor implements BackupMonitor {
+  readonly id = 'vfs-backup-monitor';
+  readonly #lc: LogContext;
+  readonly #backupURL: string;
+  readonly #changeStreamer: ChangeStreamerService;
+  readonly #source: VfsBackupWatermarkSource;
+  readonly #probeIntervalMs: number;
+  readonly #state = new RunningState(this.id);
+
+  readonly #reservations = new Map<string, Reservation>();
+  readonly #watermarks = new Map<string, VfsBackupWatermark>();
+
+  readonly #purgesBlocked = getOrCreateCounter('replica', 'purge_blocked', {
+    description:
+      'Number of change-log purges blocked because the actual backup ' +
+      'watermark could not be read through the Litestream VFS.',
+  });
+
+  #lastWatermark: string = '';
+  #latestBackupWatermark: VfsBackupWatermark | undefined;
+  #cleanupDelayMs: number;
+  #checkWatermarkTimer: NodeJS.Timeout | undefined;
+
+  constructor(
+    lc: LogContext,
+    backupURL: string,
+    changeStreamer: ChangeStreamerService,
+    initialCleanupDelayMs: number,
+    probeIntervalMs: number,
+    source: VfsBackupWatermarkSource,
+  ) {
+    this.#lc = lc.withContext('component', this.id);
+    this.#backupURL = backupURL;
+    this.#changeStreamer = changeStreamer;
+    this.#source = source;
+    this.#probeIntervalMs = probeIntervalMs;
+    this.#cleanupDelayMs = Math.max(
+      initialCleanupDelayMs,
+      MIN_CLEANUP_DELAY_MS,
+    );
+  }
+
+  run(): Promise<void> {
+    this.#lc.info?.(
+      `monitoring v5 backups at ${this.#backupURL} with ` +
+        `${this.#cleanupDelayMs} ms cleanup delay`,
+    );
+    this.#checkWatermarkTimer = setInterval(
+      this.checkWatermarkAndScheduleCleanup,
+      this.#probeIntervalMs,
+    );
+    this.#initBackupLagMetric();
+    return this.#state.stopped();
+  }
+
+  startSnapshotReservation(taskID: string): Subscription<SnapshotMessage> {
+    this.#lc.info?.(`pausing change-log cleanup while ${taskID} snapshots`);
+    this.#reservations.get(taskID)?.sub.cancel();
+
+    const sub = Subscription.create<SnapshotMessage>({
+      cleanup: () => this.endReservation(taskID, false),
+    });
+    this.#reservations.set(taskID, {start: new Date(), sub});
+
+    void this.#changeStreamer
+      .getChangeLogState()
+      .then(changeLogState => {
+        sub.push([
+          'status',
+          {tag: 'status', backupURL: this.#backupURL, ...changeLogState},
+        ]);
+      })
+      .catch(e => {
+        this.#lc.warn?.(`failing snapshot reservation`, e);
+        sub.fail(e);
+      });
+    return sub;
+  }
+
+  endReservation(taskID: string, updateCleanupDelay = true): void {
+    const res = this.#reservations.get(taskID);
+    if (res === undefined) {
+      return;
+    }
+    this.#reservations.delete(taskID);
+    const {start, sub} = res;
+    sub.cancel();
+
+    if (updateCleanupDelay) {
+      const duration = Date.now() - start.getTime();
+      this.#lc.info?.(`snapshot initialized by ${taskID} in ${duration} ms`);
+      if (duration > this.#cleanupDelayMs) {
+        this.#cleanupDelayMs = duration;
+        this.#lc.info?.(`increased cleanup delay to ${duration} ms`);
+      }
+    }
+  }
+
+  // Exported for testing
+  readonly checkWatermarkAndScheduleCleanup = async () => {
+    try {
+      await this.#checkWatermark();
+    } catch (e) {
+      this.#purgesBlocked.add(1, {reason: 'vfs-probe-failed'});
+      this.#lc.warn?.(
+        `unable to read backup watermark through Litestream VFS. ` +
+          `skipping change-log cleanup`,
+        e,
+      );
+      return;
+    }
+
+    this.#scheduleCleanup();
+  };
+
+  async #checkWatermark(): Promise<void> {
+    const watermark = await this.#source.readWatermark();
+    this.#latestBackupWatermark = watermark;
+    if (
+      watermark.watermark > this.#lastWatermark &&
+      !this.#watermarks.has(watermark.watermark)
+    ) {
+      this.#lc.info?.(
+        `observed backup watermark=${watermark.watermark} through ` +
+          `Litestream VFS at ${new Date(watermark.observedAtMs).toISOString()}`,
+        {
+          writeTimeMs: watermark.writeTimeMs,
+          txid: watermark.txid,
+          lagSeconds: watermark.lagSeconds,
+        },
+      );
+      this.#watermarks.set(watermark.watermark, watermark);
+    }
+  }
+
+  #scheduleCleanup(): void {
+    if (this.#reservations.size > 0) {
+      this.#lc.info?.(
+        `watermark cleanup paused for snapshot(s): ${[...this.#reservations.keys()]}`,
+      );
+      return;
+    }
+
+    const latestConfirmedWatermark = this.#latestBackupWatermark?.watermark;
+    if (latestConfirmedWatermark === undefined) {
+      return;
+    }
+
+    const maxWatermark = this.#maxWatermarkUpTo(
+      Date.now() - this.#cleanupDelayMs,
+      latestConfirmedWatermark,
+    );
+    if (maxWatermark.length === 0) {
+      return;
+    }
+
+    this.#changeStreamer.scheduleCleanup(maxWatermark);
+    for (const watermark of this.#watermarks.keys()) {
+      if (watermark <= maxWatermark) {
+        this.#watermarks.delete(watermark);
+      }
+    }
+    this.#lastWatermark = maxWatermark;
+  }
+
+  #maxWatermarkUpTo(cutoff: number, latestConfirmedWatermark: string): string {
+    let max = '';
+    for (const [watermark, backupWatermark] of this.#watermarks) {
+      if (
+        watermark <= latestConfirmedWatermark &&
+        backupWatermark.observedAtMs <= cutoff &&
+        watermark > max
+      ) {
+        max = watermark;
+      }
+    }
+    return max;
+  }
+
+  stop(): Promise<void> {
+    clearInterval(this.#checkWatermarkTimer);
+    for (const {sub} of this.#reservations.values()) {
+      sub.cancel();
+    }
+    this.#source.close?.();
+    this.#state.stop(this.#lc);
+    return promiseVoid;
+  }
+
+  #initBackupLagMetric(): void {
+    getOrCreateGauge('replica', 'backup_lag', {
+      description:
+        'Latency from when a change is written to the replica ' +
+        'to when it is backed up to litestream.',
+      unit: 'millisecond',
+    }).addCallback(o => {
+      const latestBackupWatermark = this.#latestBackupWatermark;
+      if (latestBackupWatermark?.writeTimeMs === undefined) {
+        this.#lc.warn?.(
+          `no backed up watermarks. unable to report replica.backup_lag`,
+        );
+        return;
+      }
+      if (latestBackupWatermark.writeTimeMs === null) {
+        return;
+      }
+      o.observe(
+        Math.max(
+          0,
+          latestBackupWatermark.observedAtMs -
+            latestBackupWatermark.writeTimeMs,
+        ),
+      );
+    });
+  }
+}

--- a/packages/zero-cache/src/services/litestream/vfs-watermark-worker-source.ts
+++ b/packages/zero-cache/src/services/litestream/vfs-watermark-worker-source.ts
@@ -1,0 +1,118 @@
+import type {LogContext} from '@rocicorp/logger';
+import type {Worker} from '../../types/processes.ts';
+import type {VfsBackupWatermark} from './vfs-watermark-reader.ts';
+import {
+  BackupWatermarkTimeoutError,
+  requestVfsBackupWatermark,
+} from './vfs-watermark-worker.ts';
+
+export type VfsBackupWatermarkWorkerFactory = () => Worker;
+
+export class VfsBackupWatermarkWorkerSource {
+  readonly #lc: LogContext;
+  readonly #workerFactory: VfsBackupWatermarkWorkerFactory;
+  readonly #timeoutMs: number;
+
+  #worker: Worker | undefined;
+  #ready: Promise<Worker> | undefined;
+
+  constructor(
+    lc: LogContext,
+    workerFactory: VfsBackupWatermarkWorkerFactory,
+    timeoutMs: number,
+  ) {
+    this.#lc = lc.withContext(
+      'component',
+      'vfs-backup-watermark-worker-source',
+    );
+    this.#workerFactory = workerFactory;
+    this.#timeoutMs = timeoutMs;
+  }
+
+  async readWatermark(): Promise<VfsBackupWatermark> {
+    const worker = await this.#getWorker();
+    try {
+      return await requestVfsBackupWatermark(worker, this.#timeoutMs, {
+        killOnTimeout: true,
+      });
+    } catch (e) {
+      if (e instanceof BackupWatermarkTimeoutError) {
+        this.#clearWorker(worker);
+      }
+      throw e;
+    }
+  }
+
+  close(): void {
+    this.#worker?.kill('SIGTERM');
+    this.#worker = undefined;
+    this.#ready = undefined;
+  }
+
+  #getWorker(): Promise<Worker> {
+    if (this.#ready) {
+      return this.#ready;
+    }
+
+    const worker = this.#workerFactory();
+    this.#worker = worker;
+    this.#ready = new Promise((resolve, reject) => {
+      const cleanup = () => {
+        worker.off('message', onMessage);
+        worker.off('error', onError);
+        worker.off('close', onClose);
+      };
+      const fail = (e: unknown) => {
+        cleanup();
+        this.#clearWorker(worker);
+        reject(e);
+      };
+      const onMessage = (data: unknown) => {
+        if (!isReadyMessage(data)) {
+          return;
+        }
+        cleanup();
+        resolve(worker);
+      };
+      const onError = (e: unknown) => fail(e);
+      const onClose = (code: unknown, signal: unknown) =>
+        fail(
+          new Error(
+            `backup watermark reader worker exited before ready ` +
+              `(code=${String(code)}, signal=${String(signal)})`,
+          ),
+        );
+
+      worker.on('message', onMessage);
+      worker.once('error', onError);
+      worker.once('close', onClose);
+    });
+
+    worker.once('close', () => this.#clearWorker(worker));
+    worker.once('error', e => {
+      this.#lc.warn?.(`backup watermark reader worker failed`, e);
+      this.#clearWorker(worker);
+    });
+
+    return this.#ready;
+  }
+
+  #clearWorker(worker: Worker): void {
+    if (this.#worker === worker) {
+      this.#worker = undefined;
+      this.#ready = undefined;
+    }
+  }
+}
+
+function isReadyMessage(data: unknown): boolean {
+  return (
+    Array.isArray(data) &&
+    data.length === 2 &&
+    data[0] === 'ready' &&
+    typeof data[1] === 'object' &&
+    data[1] !== null &&
+    'ready' in data[1] &&
+    data[1].ready === true
+  );
+}

--- a/packages/zero-cache/src/services/litestream/vfs-watermark-worker.test.ts
+++ b/packages/zero-cache/src/services/litestream/vfs-watermark-worker.test.ts
@@ -2,6 +2,7 @@ import EventEmitter from 'node:events';
 import {describe, expect, test, vi} from 'vitest';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
 import {inProcChannel, type Worker} from '../../types/processes.ts';
+import {VfsBackupWatermarkWorkerSource} from './vfs-watermark-worker-source.ts';
 import {
   requestVfsBackupWatermark,
   VfsBackupWatermarkWorkerService,
@@ -114,5 +115,69 @@ describe('litestream/vfs-watermark-worker', () => {
     ).rejects.toThrow('timed out waiting 1 ms for backup watermark response');
 
     expect(worker.kill).toHaveBeenCalledWith('SIGKILL');
+  });
+
+  test('worker source waits for ready and reads watermark', async () => {
+    const [parent, child] = inProcChannel();
+    const source: BackupWatermarkSource = {
+      readWatermark: vi.fn(() => ({
+        watermark: '04',
+        writeTimeMs: 123,
+        txid: '0000000000000004',
+        lagSeconds: 2,
+        observedAtMs: 1000,
+      })),
+      close: vi.fn(),
+    };
+    const workerFactory = vi.fn(() => parent);
+    const workerSource = new VfsBackupWatermarkWorkerSource(
+      lc,
+      workerFactory,
+      100,
+    );
+
+    const read = workerSource.readWatermark();
+    const svc = new VfsBackupWatermarkWorkerService(lc, child, source, 30_000);
+    const run = svc.run();
+
+    await expect(read).resolves.toEqual({
+      watermark: '04',
+      writeTimeMs: 123,
+      txid: '0000000000000004',
+      lagSeconds: 2,
+      observedAtMs: 1000,
+    });
+    expect(workerFactory).toHaveBeenCalledTimes(1);
+    expect(source.readWatermark).toHaveBeenCalledTimes(1);
+
+    workerSource.close();
+    await svc.stop();
+    await run;
+  });
+
+  test('worker source recreates worker after timeout', async () => {
+    const workers: Worker[] = [];
+    const workerFactory = vi.fn(() => {
+      const worker = Object.assign(new EventEmitter(), {
+        send: vi.fn(() => true),
+        kill: vi.fn(),
+      }) as unknown as Worker;
+      workers.push(worker);
+      queueMicrotask(() => worker.emit('message', ['ready', {ready: true}]));
+      return worker;
+    });
+    const source = new VfsBackupWatermarkWorkerSource(lc, workerFactory, 1);
+
+    await expect(source.readWatermark()).rejects.toThrow(
+      'timed out waiting 1 ms for backup watermark response',
+    );
+    expect(workers[0].kill).toHaveBeenCalledWith('SIGKILL');
+
+    await expect(source.readWatermark()).rejects.toThrow(
+      'timed out waiting 1 ms for backup watermark response',
+    );
+    expect(workerFactory).toHaveBeenCalledTimes(2);
+
+    source.close();
   });
 });

--- a/packages/zero-cache/src/services/litestream/vfs-watermark-worker.ts
+++ b/packages/zero-cache/src/services/litestream/vfs-watermark-worker.ts
@@ -36,6 +36,8 @@ export type BackupWatermarkSourceFactory = () => BackupWatermarkSource;
 
 let nextRequestID = 0;
 
+export class BackupWatermarkTimeoutError extends Error {}
+
 export function requestVfsBackupWatermark(
   worker: Worker,
   timeoutMs: number,
@@ -52,7 +54,7 @@ export function requestVfsBackupWatermark(
         worker.kill(options.killSignal ?? 'SIGKILL');
       }
       reject(
-        new Error(
+        new BackupWatermarkTimeoutError(
           `timed out waiting ${timeoutMs} ms for backup watermark response`,
         ),
       );

--- a/packages/zero-cache/src/types/processes.ts
+++ b/packages/zero-cache/src/types/processes.ts
@@ -164,7 +164,7 @@ export function childWorker(
   env?: NodeJS.ProcessEnv,
   ...args: string[]
 ): Worker {
-  args.push(...process.argv.slice(2));
+  args = workerArgs(args);
 
   if (singleProcessMode()) {
     const [parent, child] = inProcChannel();
@@ -182,6 +182,26 @@ export function childWorker(
       .catch(err => child.emit('error', err));
     return child;
   }
+  return forkChildWorkerWithArgs(moduleUrl, env, args);
+}
+
+export function forkChildWorker(
+  moduleUrl: URL,
+  env?: NodeJS.ProcessEnv,
+  ...args: string[]
+): Worker {
+  return forkChildWorkerWithArgs(moduleUrl, env, workerArgs(args));
+}
+
+function workerArgs(args: string[]): string[] {
+  return [...args, ...process.argv.slice(2)];
+}
+
+function forkChildWorkerWithArgs(
+  moduleUrl: URL,
+  env: NodeJS.ProcessEnv | undefined,
+  args: string[],
+): Worker {
   const child = fork(moduleUrl, args, {
     // For production / non-windows, set `detached` to `true` so that SIGINT is
     // not automatically propagated and graceful shutdown happens as intended.


### PR DESCRIPTION
## Summary

  Adds Litestream v0.5 backup cleanup support to zero-
  cache.

  When `litestream.backupUsingV5` is enabled, the change-
  streamer now uses a VFS-backed backup monitor that reads
  the actual backed-up Zero watermark from the Litestream
  backup and schedules change-log cleanup from that
  verified watermark. Legacy Litestream v3 cleanup
  continues to use `Litestream3BackupMonitor`.

  ## Design

  ```mermaid
flowchart TD
    CS["server/change-streamer.ts"] --> F["createBackupCleanupMonitor"]
    F -->|"backupUsingV5=false"| V3["Litestream3BackupMonitor"]
    F -->|"backupUsingV5=true"| V5["VfsBackupMonitor"]

    V5 --> S["VfsBackupWatermarkWorkerSource"]
    S -->|"forks"| W["backup-watermark-reader child"]
    W --> WS["VfsBackupWatermarkWorkerService"]
    WS --> R["VfsBackupWatermarkReader"]
    R -->|"Litestream SQLite VFS"| B[("Litestream v5 backup")]

    V5 -->|"safe watermark"| CL["changeStreamer.scheduleCleanup"]
    V3 -->|"safe watermark"| CL
```

## Component Roles

- `VfsBackupWatermarkWorkerSource`: parent-side adapter used by `VfsBackupMonitor`; owns the child worker lifecycle,
waits for readiness, sends watermark requests, and recreates the child after timeout/failure.
- `backup-watermark-reader child`: isolated Node child process that hosts Litestream VFS reads so native/VFS hangs can
be killed without blocking the change-streamer.
- `VfsBackupWatermarkWorkerService`: IPC service running inside the child; receives watermark requests from the parent
and returns either a `VfsBackupWatermark` or a serialized error.
- `VfsBackupWatermarkReader`: low-level reader that loads the Litestream SQLite VFS extension, opens the backup read-
only, and reads Zero’s backed-up replication watermark.