### PR TITLE
fix(zero-server): schema-qualify casts to non-public Postgres types

### DIFF
--- a/packages/z2s/src/sql.test.ts
+++ b/packages/z2s/src/sql.test.ts
@@ -980,3 +980,152 @@ describe('string arg packing', () => {
     });
   });
 });
+
+describe('schema-qualified user-defined types', () => {
+  test('enum in a non-public schema is schema-qualified', () => {
+    expect(
+      formatPgInternalConvert(
+        sql`INSERT INTO "app"."doc_review_item" ("kind") VALUES (${sqlConvertColumnArg(
+          {
+            isArray: false,
+            isEnum: true,
+            type: 'doc_review_item_kind',
+            typeSchema: 'app',
+          },
+          'edge_case',
+          false,
+          false,
+        )})`,
+      ),
+    ).toMatchInlineSnapshot(`
+      {
+        "text": "INSERT INTO "app"."doc_review_item" ("kind") VALUES ($1::text::"app"."doc_review_item_kind")",
+        "values": [
+          "edge_case",
+        ],
+      }
+    `);
+  });
+
+  test('enum[] in a non-public schema is schema-qualified', () => {
+    expect(
+      formatPgInternalConvert(
+        sql`INSERT INTO "app"."doc_review_item" ("kinds") VALUES (${sqlConvertColumnArg(
+          {
+            isArray: true,
+            isEnum: true,
+            type: 'doc_review_item_kind',
+            typeSchema: 'app',
+          },
+          ['edge_case', 'normal'],
+          false,
+          false,
+        )})`,
+      ),
+    ).toMatchInlineSnapshot(`
+      {
+        "text": "INSERT INTO "app"."doc_review_item" ("kinds") VALUES (ARRAY(
+                SELECT value::text::"app"."doc_review_item_kind" FROM jsonb_array_elements_text($1::text::jsonb)
+              ))",
+        "values": [
+          "["edge_case","normal"]",
+        ],
+      }
+    `);
+  });
+
+  test('enum in public schema stays unqualified (back-compat)', () => {
+    expect(
+      formatPgInternalConvert(
+        sql`INSERT INTO "foo" VALUES (${sqlConvertColumnArg(
+          {
+            isArray: false,
+            isEnum: true,
+            type: 'some_enum',
+            typeSchema: 'public',
+          },
+          'ENUM_KEY',
+          false,
+          false,
+        )})`,
+      ),
+    ).toMatchInlineSnapshot(`
+      {
+        "text": "INSERT INTO "foo" VALUES ($1::text::"some_enum")",
+        "values": [
+          "ENUM_KEY",
+        ],
+      }
+    `);
+  });
+
+  test('builtin types in pg_catalog stay unqualified', () => {
+    expect(
+      formatPgInternalConvert(
+        sql`INSERT INTO "foo" VALUES (${sqlConvertColumnArg(
+          {
+            isArray: false,
+            isEnum: false,
+            type: 'numeric',
+            typeSchema: 'pg_catalog',
+          },
+          1,
+          false,
+          false,
+        )})`,
+      ),
+    ).toMatchInlineSnapshot(`
+      {
+        "text": "INSERT INTO "foo" VALUES ($1::text::numeric)",
+        "values": [
+          "1",
+        ],
+      }
+    `);
+  });
+
+  test('text-represented type in a non-public schema is schema-qualified', () => {
+    // e.g. the `isn` extension installed into a non-public schema.
+    expect(
+      formatPgInternalConvert(
+        sql`INSERT INTO "foo" VALUES (${sqlConvertColumnArg(
+          {
+            isArray: false,
+            isEnum: false,
+            type: 'isbn13',
+            typeSchema: 'app',
+          },
+          '9780306406157',
+          false,
+          false,
+        )})`,
+      ),
+    ).toMatchInlineSnapshot(`
+      {
+        "text": "INSERT INTO "foo" VALUES ($1::text::"app"."isbn13")",
+        "values": [
+          "9780306406157",
+        ],
+      }
+    `);
+  });
+
+  test('identifiers are safely escaped, not string-concatenated', () => {
+    // A schema/type name containing a double quote must be escaped (the quote
+    // doubled), never blindly wrapped in quotes which would break the cast.
+    const {text} = formatPgInternalConvert(
+      sql`SELECT ${sqlConvertColumnArg(
+        {
+          isArray: false,
+          isEnum: true,
+          type: 'we"ird',
+          typeSchema: 'sch"ema',
+        },
+        'x',
+        false,
+        false,
+      )}`,
+    );
+    expect(text).toBe(`SELECT $1::text::"sch""ema"."we""ird"`);
+  });
+});

--- a/packages/z2s/src/sql.test.ts
+++ b/packages/z2s/src/sql.test.ts
@@ -1110,6 +1110,56 @@ describe('schema-qualified user-defined types', () => {
     `);
   });
 
+  test('enum whose name matches a builtin type is schema-qualified', () => {
+    expect(
+      formatPgInternalConvert(
+        sql`INSERT INTO "foo" VALUES (${sqlConvertColumnArg(
+          {
+            isArray: false,
+            isEnum: true,
+            type: 'uuid',
+            typeSchema: 'app',
+          },
+          'internal',
+          false,
+          false,
+        )})`,
+      ),
+    ).toMatchInlineSnapshot(`
+      {
+        "text": "INSERT INTO "foo" VALUES ($1::text::"app"."uuid")",
+        "values": [
+          "internal",
+        ],
+      }
+    `);
+  });
+
+  test('non-enum type whose name matches a builtin type is schema-qualified', () => {
+    expect(
+      formatPgInternalConvert(
+        sql`INSERT INTO "foo" VALUES (${sqlConvertColumnArg(
+          {
+            isArray: false,
+            isEnum: false,
+            type: 'numeric',
+            typeSchema: 'app',
+          },
+          1,
+          false,
+          false,
+        )})`,
+      ),
+    ).toMatchInlineSnapshot(`
+      {
+        "text": "INSERT INTO "foo" VALUES ($1::text::"app"."numeric")",
+        "values": [
+          "1",
+        ],
+      }
+    `);
+  });
+
   test('identifiers are safely escaped, not string-concatenated', () => {
     // A schema/type name containing a double quote must be escaped (the quote
     // doubled), never blindly wrapped in quotes which would break the cast.

--- a/packages/z2s/src/sql.ts
+++ b/packages/z2s/src/sql.ts
@@ -246,37 +246,49 @@ function formatCommonToSingularAndPlural(
   // being bool/json/numeric/whatever and the bindings try to coerce
   // the inputs to those types.
   const valuePlaceholder = arg.plural ? 'value' : `$${index}`;
-  let atTimeZone = ` AT TIME ZONE 'UTC'`;
-  switch (arg.type) {
-    case 'timestamptz':
-    // @ts-expect-error Fallthrough intended
-    case 'timestamp with time zone':
-      atTimeZone = '';
-    // fallthrough
-
-    case 'date':
-    case 'timestamp':
-    case 'timestamp without time zone':
-      return `to_timestamp(${valuePlaceholder}::text::numeric / 1000.0)${atTimeZone}`;
-
-    case 'timetz':
-    // @ts-expect-error Fallthrough intended
-    case 'time with time zone':
-      atTimeZone = '';
-    // fallthrough
-
-    case 'time':
-    case 'time without time zone':
-      return `(${valuePlaceholder}::text::int * interval'1ms')::time${atTimeZone}`;
-
-    // uuid: cast to native uuid type for proper comparison and index usage
-    case 'uuid':
-      return `${valuePlaceholder}::text::uuid`;
-  }
   if (arg.isEnum) {
     return `${valuePlaceholder}::text::${typeCastTarget(arg, escapeIdentifier, true)}`;
   }
-  if (isPgNativeStringType(arg.type)) {
+
+  // Type names are only unique within a Postgres namespace. Only apply
+  // built-in conversion semantics when the catalog confirms that this is a
+  // pg_catalog type, or when legacy callers do not provide a namespace. A
+  // user-defined type can legally have a built-in name such as `uuid` or
+  // `numeric`; those values must be cast to the schema-qualified custom type.
+  const usesBuiltinTypeSemantics =
+    arg.typeSchema === undefined ||
+    arg.typeSchema === '' ||
+    arg.typeSchema === 'pg_catalog';
+  let atTimeZone = ` AT TIME ZONE 'UTC'`;
+  if (usesBuiltinTypeSemantics) {
+    switch (arg.type) {
+      case 'timestamptz':
+      // @ts-expect-error Fallthrough intended
+      case 'timestamp with time zone':
+        atTimeZone = '';
+      // fallthrough
+
+      case 'date':
+      case 'timestamp':
+      case 'timestamp without time zone':
+        return `to_timestamp(${valuePlaceholder}::text::numeric / 1000.0)${atTimeZone}`;
+
+      case 'timetz':
+      // @ts-expect-error Fallthrough intended
+      case 'time with time zone':
+        atTimeZone = '';
+      // fallthrough
+
+      case 'time':
+      case 'time without time zone':
+        return `(${valuePlaceholder}::text::int * interval'1ms')::time${atTimeZone}`;
+
+      // uuid: cast to native uuid type for proper comparison and index usage
+      case 'uuid':
+        return `${valuePlaceholder}::text::uuid`;
+    }
+  }
+  if (usesBuiltinTypeSemantics && isPgNativeStringType(arg.type)) {
     // For comparison cast to the general `text` type, not the
     // specific column type (i.e. `arg.type`), because we don't want to
     // force the value being compared to the size/max-size of the column
@@ -288,7 +300,7 @@ function formatCommonToSingularAndPlural(
   if (isPgTextRepresentedType(arg.type)) {
     return `${valuePlaceholder}::text::${typeCastTarget(arg, escapeIdentifier, false)}`;
   }
-  if (isPgNumberType(arg.type)) {
+  if (usesBuiltinTypeSemantics && isPgNumberType(arg.type)) {
     // For comparison cast to `double precision` which uses IEEE 754 (the same
     // representation as JavaScript numbers which will accurately
     // represent any number value from zql) not the specific column type

--- a/packages/z2s/src/sql.ts
+++ b/packages/z2s/src/sql.ts
@@ -37,6 +37,9 @@ export type PluralLiteralType = Exclude<LiteralType, 'null'>;
 type ColumnSqlConvertArg = {
   [sqlConvert]: 'column';
   type: string;
+  // The Postgres namespace `type` lives in, when known. Used to schema-qualify
+  // casts to user-defined types (enums, domains, ...) outside of `public`.
+  typeSchema: string | undefined;
   value: unknown;
   plural: boolean;
   isEnum: boolean;
@@ -90,6 +93,7 @@ export function sqlConvertColumnArg(
   return sql.value({
     [sqlConvert]: 'column',
     type: serverColumnSchema.type,
+    typeSchema: serverColumnSchema.typeSchema,
     isEnum: serverColumnSchema.isEnum,
     value,
     plural: plural || serverColumnSchema.isArray,
@@ -150,7 +154,11 @@ class SQLConvertFormat implements FormatConfig {
     const byType = this.#seen.get(value.value);
     if (byType?.has(value.type)) {
       return {
-        placeholder: createPlaceholder(byType.get(value.type)!, value),
+        placeholder: createPlaceholder(
+          byType.get(value.type)!,
+          value,
+          this.escapeIdentifier,
+        ),
         value: PREVIOUSLY_SEEN_VALUE,
       };
     }
@@ -161,13 +169,48 @@ class SQLConvertFormat implements FormatConfig {
       this.#seen.set(value.value, new Map([[value.type, this.#size]]));
     }
     return {
-      placeholder: createPlaceholder(this.#size, value),
+      placeholder: createPlaceholder(this.#size, value, this.escapeIdentifier),
       value: stringify(value),
     };
   };
 }
 
-function createPlaceholder(index: number, arg: SqlConvertArg) {
+/**
+ * Renders the cast-target type reference for a (potentially user-defined) type.
+ *
+ * A type that lives in a non-public, non-catalog schema is schema-qualified
+ * using properly-escaped identifiers (e.g. `"app"."some_enum"`) so that it
+ * resolves regardless of the connection's `search_path`. Built-in types
+ * (`pg_catalog`) and types in `public` are left as-is so generated SQL stays
+ * byte-compatible with prior output.
+ *
+ * `quoteName` controls whether the unqualified type name is escaped/quoted:
+ * enums have always been emitted quoted (e.g. `::"some_enum"`); other types
+ * (e.g. `::isbn13`) are emitted bare. Schema-qualified output is always
+ * escaped on both segments regardless of `quoteName`.
+ */
+function typeCastTarget(
+  arg: ColumnSqlConvertArg,
+  escapeIdentifier: (str: string) => string,
+  quoteName: boolean,
+): string {
+  const {typeSchema} = arg;
+  if (
+    typeSchema !== undefined &&
+    typeSchema !== '' &&
+    typeSchema !== 'public' &&
+    typeSchema !== 'pg_catalog'
+  ) {
+    return `${escapeIdentifier(typeSchema)}.${escapeIdentifier(arg.type)}`;
+  }
+  return quoteName ? escapeIdentifier(arg.type) : arg.type;
+}
+
+function createPlaceholder(
+  index: number,
+  arg: SqlConvertArg,
+  escapeIdentifier: (str: string) => string,
+) {
   if (arg.type === 'null') {
     assert(arg.value === null, "Args of type 'null' must have value null");
     assert(!arg.plural, "Args of type 'null' must not be plural");
@@ -187,13 +230,14 @@ function createPlaceholder(index: number, arg: SqlConvertArg) {
     return `$${index}::text::${pgTypeForLiteralType(arg.type)}`;
   }
 
-  const common = formatCommonToSingularAndPlural(index, arg);
+  const common = formatCommonToSingularAndPlural(index, arg, escapeIdentifier);
   return arg.plural ? formatPlural(index, common) : common;
 }
 
 function formatCommonToSingularAndPlural(
   index: number,
   arg: ColumnSqlConvertArg,
+  escapeIdentifier: (str: string) => string,
 ) {
   // Ok, so what is with all the `::text` casts
   // before the final cast?
@@ -230,7 +274,7 @@ function formatCommonToSingularAndPlural(
       return `${valuePlaceholder}::text::uuid`;
   }
   if (arg.isEnum) {
-    return `${valuePlaceholder}::text::"${arg.type}"`;
+    return `${valuePlaceholder}::text::${typeCastTarget(arg, escapeIdentifier, true)}`;
   }
   if (isPgNativeStringType(arg.type)) {
     // For comparison cast to the general `text` type, not the
@@ -242,7 +286,7 @@ function formatCommonToSingularAndPlural(
       : `${valuePlaceholder}::text::${arg.type}`;
   }
   if (isPgTextRepresentedType(arg.type)) {
-    return `${valuePlaceholder}::text::${arg.type}`;
+    return `${valuePlaceholder}::text::${typeCastTarget(arg, escapeIdentifier, false)}`;
   }
   if (isPgNumberType(arg.type)) {
     // For comparison cast to `double precision` which uses IEEE 754 (the same
@@ -254,7 +298,7 @@ function formatCommonToSingularAndPlural(
       ? `${valuePlaceholder}::text::double precision`
       : `${valuePlaceholder}::text::${arg.type}`;
   }
-  return `${valuePlaceholder}::text::${arg.type}`;
+  return `${valuePlaceholder}::text::${typeCastTarget(arg, escapeIdentifier, false)}`;
 }
 
 function formatPlural(index: number, select: string) {

--- a/packages/zero-server/src/custom.pg.test.ts
+++ b/packages/zero-server/src/custom.pg.test.ts
@@ -193,6 +193,114 @@ describe('makeSchemaCRUD', () => {
     });
   });
 
+  // Regression test for schema-qualification of casts to user-defined types
+  // that live in a non-public Postgres schema. The `docReviewItem` table maps
+  // to `app.doc_review_item` and has enum columns (and an enum array column)
+  // whose enum types also live in the `app` schema, plus a domain-backed
+  // column. Previously the generated casts looked like `$1::text::"enum_name"`,
+  // which Postgres resolves through search_path and therefore fails with
+  // `type "enum_name" does not exist` under the default search_path. These
+  // CRUD paths must succeed WITHOUT touching search_path.
+  test('insert/update/upsert/delete with non-public-schema enum, enum[] and domain columns', async () => {
+    await pg.begin(async tx => {
+      // Sanity check: the non-public schema must NOT be on the search_path, so
+      // that an unqualified enum cast would genuinely fail. This guards the
+      // regression from being masked by a permissive search_path.
+      const [{search_path: searchPath}] = await tx`SHOW search_path`;
+      expect(searchPath).not.toContain('app');
+
+      const transaction = new Transaction(tx);
+      const crud = crudProvider(
+        transaction,
+        await getServerSchema(transaction, schema),
+      );
+
+      // postgres.js has no parser registered for the *custom* enum array type
+      // OID, so reading `kinds` directly yields a raw array literal string.
+      // Cast it to text[] so it round-trips back into a JS array. (This is a
+      // client read-back detail and unrelated to the write paths under test.)
+      const checkDocReview = async (expected: unknown[]) => {
+        const rows = await tx`
+          SELECT id, kind::text, state::text, kinds::text[] AS kinds, priority
+          FROM app.doc_review_item ORDER BY id`;
+        expect(rows).toEqual(expected);
+      };
+
+      const row = {
+        id: '1',
+        kind: 'edge_case' as const,
+        state: 'active' as const,
+        kinds: ['edge_case', 'normal'] as ('edge_case' | 'normal')[],
+        priority: 5,
+      };
+      await crud.docReviewItem.insert(row);
+      await checkDocReview([row]);
+
+      await crud.docReviewItem.update({
+        id: '1',
+        kind: 'normal',
+        state: 'archived',
+        kinds: ['normal'],
+        priority: 7,
+      });
+      await checkDocReview([
+        {
+          id: '1',
+          kind: 'normal',
+          state: 'archived',
+          kinds: ['normal'],
+          priority: 7,
+        },
+      ]);
+
+      await crud.docReviewItem.upsert({
+        id: '1',
+        kind: 'edge_case',
+        state: 'active',
+        kinds: null,
+        priority: null,
+      });
+      await checkDocReview([
+        {
+          id: '1',
+          kind: 'edge_case',
+          state: 'active',
+          kinds: null,
+          priority: null,
+        },
+      ]);
+
+      // upsert a brand new row to exercise the INSERT path of ON CONFLICT
+      await crud.docReviewItem.upsert({
+        id: '2',
+        kind: 'normal',
+        state: 'archived',
+        kinds: ['edge_case'],
+        priority: 0,
+      });
+      await checkDocReview([
+        {
+          id: '1',
+          kind: 'edge_case',
+          state: 'active',
+          kinds: null,
+          priority: null,
+        },
+        {
+          id: '2',
+          kind: 'normal',
+          state: 'archived',
+          kinds: ['edge_case'],
+          priority: 0,
+        },
+      ]);
+
+      await crud.docReviewItem.delete({id: '1'});
+      await crud.docReviewItem.delete({id: '2'});
+      await checkDocReview([]);
+    });
+  });
+
   test('insert/update/upsert/delete with text-represented scalar columns', async () => {
     await pg.begin(async tx => {
       const transaction = new Transaction(tx);

--- a/packages/zero-server/src/schema.ts
+++ b/packages/zero-server/src/schema.ts
@@ -20,8 +20,10 @@ type ServerSchemaRow = {
   scale: string | null;
   typtype: PostgresTypeClass;
   typename: string;
+  typenamespace: string;
   elemTyptype: PostgresTypeClass | null;
   elemTypname: string | null;
+  elemTypenamespace: string | null;
 };
 
 export async function getServerSchema<S extends Schema>(
@@ -67,16 +69,24 @@ export async function getServerSchema<S extends Schema>(
           c.numeric_scale AS scale,
           t.typtype::text AS typtype,
           t.typname::text AS typename,
+          n.nspname::text AS "typenamespace",
           CASE WHEN t.typelem <> 0 THEN et.typtype::text ELSE NULL END AS "elemTyptype",
-          CASE WHEN t.typelem <> 0 THEN et.typname::text ELSE NULL END AS "elemTypname"
+          CASE WHEN t.typelem <> 0 THEN et.typname::text ELSE NULL END AS "elemTypname",
+          CASE WHEN t.typelem <> 0 THEN en.nspname::text ELSE NULL END AS "elemTypenamespace"
       FROM
           information_schema.columns c
+      -- Join the column's type using BOTH the type name and the namespace it
+      -- lives in. Matching on name alone (the previous behavior) is ambiguous
+      -- when the same type name exists in more than one schema and could pick
+      -- the wrong type (and thus the wrong namespace) entirely.
       JOIN
-          pg_catalog.pg_type t ON c.udt_name = t.typname
+          pg_catalog.pg_namespace n ON n.nspname = c.udt_schema
+      JOIN
+          pg_catalog.pg_type t ON t.typname = c.udt_name AND t.typnamespace = n.oid
       LEFT JOIN
           pg_catalog.pg_type et ON t.typelem = et.oid
-      JOIN
-          pg_catalog.pg_namespace n ON t.typnamespace = n.oid
+      LEFT JOIN
+          pg_catalog.pg_namespace en ON et.typnamespace = en.oid
       WHERE
           (c.table_schema, c.table_name) IN (${inClause})
     `;
@@ -128,10 +138,17 @@ export async function getServerSchema<S extends Schema>(
     ) {
       type = `${type}(${row.precision}, ${row.scale})`;
     }
+    // The namespace that backs `type`. For arrays `type` holds the element
+    // type name, so we record the element type's namespace; otherwise the
+    // column type's own namespace. This lets the SQL generator schema-qualify
+    // casts to user-defined types (enums, ...) that live outside `public`.
+    const typeSchema =
+      (isArray ? row.elemTypenamespace : row.typenamespace) ?? undefined;
     tableSchema[row.column] = {
       type,
       isEnum,
       isArray,
+      typeSchema,
     };
   }
 

--- a/packages/zero-server/src/test/schema.ts
+++ b/packages/zero-server/src/test/schema.ts
@@ -8,6 +8,9 @@ import {
   table,
 } from '../../../zero-schema/src/builder/table-builder.ts';
 
+type DocReviewKind = 'edge_case' | 'normal';
+type DocReviewState = 'active' | 'archived';
+
 const jsonCols = {
   str: json<string>(),
   num: json<number>(),
@@ -98,6 +101,20 @@ export const schema = createSchema({
         ip: string(),
         mac: string(),
         title: string(),
+      })
+      .primaryKey('id'),
+    // A table in a non-public Postgres schema whose enum columns (and enum
+    // array column) use enum types that also live in that non-public schema.
+    // The `priority` column is backed by a domain in the non-public schema to
+    // exercise domain-backed columns. See `docReviewSchemaSql`.
+    table('docReviewItem')
+      .from('app.doc_review_item')
+      .columns({
+        id: string(),
+        kind: enumeration<DocReviewKind>(),
+        state: enumeration<DocReviewState>(),
+        kinds: json<DocReviewKind[]>().optional(),
+        priority: number().optional(),
       })
       .primaryKey('id'),
   ],
@@ -196,6 +213,28 @@ CREATE TABLE "textRepresentedScalars" (
   "ip" INET NOT NULL,
   "mac" MACADDR NOT NULL,
   "title" TEXT NOT NULL
+);
+
+-- A table living in a non-public schema, whose enum (and enum array) columns
+-- reference enum types declared in that same non-public schema, plus a column
+-- backed by a domain declared in that schema. Generated CRUD SQL must
+-- schema-qualify the enum casts (e.g. "app"."doc_review_item_kind") so that
+-- they resolve under the default search_path ("$user", public).
+CREATE SCHEMA app;
+
+CREATE TYPE app.doc_review_item_kind AS ENUM ('edge_case', 'normal');
+CREATE TYPE app.doc_review_item_state AS ENUM ('active', 'archived');
+-- A domain in the non-public schema. Postgres' information_schema reports
+-- domain columns as their underlying base type, so Zero treats them as the
+-- base type and never needs to reference the domain name in a cast.
+CREATE DOMAIN app.priority AS INTEGER CHECK (VALUE >= 0);
+
+CREATE TABLE app.doc_review_item (
+  id TEXT PRIMARY KEY,
+  kind app.doc_review_item_kind NOT NULL,
+  state app.doc_review_item_state NOT NULL,
+  kinds app.doc_review_item_kind[],
+  priority app.priority
 );
 `;
 

--- a/packages/zero-types/src/server-schema.ts
+++ b/packages/zero-types/src/server-schema.ts
@@ -6,6 +6,21 @@ export type ServerColumnSchema = {
   type: string;
   isEnum: boolean;
   isArray: boolean;
+  /**
+   * The Postgres schema (namespace) that the column's underlying type lives in.
+   *
+   * For array columns this is the namespace of the *element* type, since that
+   * is the type name recorded in {@link ServerColumnSchema.type}.
+   *
+   * This is needed so that generated SQL can schema-qualify casts to
+   * user-defined types (enums, domains, ...) that live outside of `public`.
+   * Built-in types in `pg_catalog` and types in `public` are left unqualified
+   * so generated SQL stays compatible with the default `search_path`.
+   *
+   * Left `undefined` when the namespace is unknown (e.g. legacy callers that
+   * construct a `ServerColumnSchema` by hand).
+   */
+  typeSchema?: string | undefined;
 };
 
 export type ServerSchema = {


### PR DESCRIPTION
Server-side CRUD/query SQL cast values to their Postgres column type (e.g. `$1::text::"some_enum"`). For enum and other user-defined types the generated cast used only the bare type name, which Postgres resolves through `search_path`. A table in a non-public schema whose enum columns use enum types in that same schema therefore failed with `type "..." does not exist` under the default search_path.

Root cause: `getServerSchema` joined `pg_namespace` but never recorded the type's namespace, so `ServerColumnSchema` kept only `typname`; the SQL generator then rendered the cast as a single bare/quoted identifier.

Fix:
- Record the type's namespace (element type's namespace for arrays) as `ServerColumnSchema.typeSchema`, collected from the catalog. Also match the type by name AND `udt_schema` so same-named types in different schemas no longer resolve ambiguously.
- When generating casts, schema-qualify user-defined types that live outside `public`/`pg_catalog` (e.g. `$1::text::"app"."some_enum"`), using `escapePostgresIdentifier` for both segments. Public and built-in types stay byte-compatible with prior output.