### PR TITLE
fix(zero-cache): fix logging of catchup wait time

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/storer.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.ts
@@ -703,7 +703,7 @@ export class Storer implements Service {
           await lastBatchConsumed;
           const elapsed = performance.now() - start;
           if (lastBatchConsumed) {
-            (elapsed > 100 ? this.#lc.info : this.#lc.debug)?.(
+            this.#lc[elapsed > 100 ? 'info' : 'debug']?.(
               `waited ${elapsed.toFixed(3)} ms for ${sub.id} to consume last batch of catchup entries`,
             );
           }

--- a/tools/load-generator/src/main.ts
+++ b/tools/load-generator/src/main.ts
@@ -114,7 +114,7 @@ async function run() {
         total++;
         inFlight--;
       })
-      .catch(lc.error);
+      .catch(e => lc.error?.(e));
     if (running) {
       setTimeout(sendQueries, 1000 / qps);
     } else {


### PR DESCRIPTION
The method is not bound to the logger, so we need to call it as a method and not as an extracted function. This was causing the logging to fail and throw an error.