### PR TITLE
chore: update @rocicorp/logger to version 6.1.0

### DIFF
--- a/packages/analyze-query/package.json
+++ b/packages/analyze-query/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@dotenvx/dotenvx": "^1.39.0",
-    "@rocicorp/logger": "^6.0.0",
+    "@rocicorp/logger": "^6.1.0",
     "ws": "^8.18.1"
   },
   "devDependencies": {

--- a/packages/datadog/package.json
+++ b/packages/datadog/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@rocicorp/lock": "^1.0.4",
-    "@rocicorp/logger": "^6.0.0",
+    "@rocicorp/logger": "^6.1.0",
     "@rocicorp/resolver": "^1.0.2",
     "@vitest/runner": "^4.1.6",
     "oxfmt": "^0.45.0",

--- a/packages/otel/package.json
+++ b/packages/otel/package.json
@@ -17,7 +17,7 @@
     "@opentelemetry/core": "^2.0.0",
     "@opentelemetry/sdk-metrics": "^2.7.1",
     "@opentelemetry/sdk-trace-node": "^2.7.1",
-    "@rocicorp/logger": "^6.0.0"
+    "@rocicorp/logger": "^6.1.0"
   },
   "devDependencies": {
     "oxfmt": "^0.45.0",

--- a/packages/replicache/package.json
+++ b/packages/replicache/package.json
@@ -75,7 +75,7 @@
   "dependencies": {
     "@badrap/valita": "0.3.11",
     "@rocicorp/lock": "^1.0.4",
-    "@rocicorp/logger": "^6.0.0",
+    "@rocicorp/logger": "^6.1.0",
     "@rocicorp/resolver": "^1.0.2"
   },
   "devDependencies": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@badrap/valita": "0.3.11",
     "@dotenvx/dotenvx": "^1.39.0",
-    "@rocicorp/logger": "^6.0.0",
+    "@rocicorp/logger": "^6.1.0",
     "@rocicorp/resolver": "^1.0.2",
     "chalk-template": "^1.1.0",
     "command-line-args": "^6.0.1",

--- a/packages/zero-cache/package.json
+++ b/packages/zero-cache/package.json
@@ -52,7 +52,7 @@
     "@opentelemetry/semantic-conventions": "^1.41.1",
     "@postgresql-typed/oids": "^0.2.0",
     "@rocicorp/lock": "^1.0.4",
-    "@rocicorp/logger": "^6.0.0",
+    "@rocicorp/logger": "^6.1.0",
     "@rocicorp/resolver": "^1.0.2",
     "@rocicorp/zero-sqlite3": "^1.1.2",
     "@types/basic-auth": "^1.1.8",

--- a/packages/zero-client/package.json
+++ b/packages/zero-client/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@rocicorp/lock": "^1.0.4",
-    "@rocicorp/logger": "^6.0.0",
+    "@rocicorp/logger": "^6.1.0",
     "@rocicorp/resolver": "^1.0.2"
   },
   "devDependencies": {

--- a/packages/zero-pg/package.json
+++ b/packages/zero-pg/package.json
@@ -16,7 +16,7 @@
     "check-fmt": "oxfmt --check ."
   },
   "dependencies": {
-    "@rocicorp/logger": "^6.0.0"
+    "@rocicorp/logger": "^6.1.0"
   },
   "devDependencies": {
     "@vitest/runner": "^4.1.6",

--- a/packages/zero-server/package.json
+++ b/packages/zero-server/package.json
@@ -19,7 +19,7 @@
     "check-fmt": "oxfmt --check ."
   },
   "dependencies": {
-    "@rocicorp/logger": "^6.0.0"
+    "@rocicorp/logger": "^6.1.0"
   },
   "devDependencies": {
     "@prisma/adapter-pg": "^7.7.0",

--- a/packages/zero/package.json
+++ b/packages/zero/package.json
@@ -139,7 +139,7 @@
     "@opentelemetry/semantic-conventions": "^1.41.1",
     "@postgresql-typed/oids": "^0.2.0",
     "@rocicorp/lock": "^1.0.4",
-    "@rocicorp/logger": "^6.0.0",
+    "@rocicorp/logger": "^6.1.0",
     "@rocicorp/resolver": "^1.0.2",
     "@rocicorp/zero-sqlite3": "^1.1.2",
     "@standard-schema/spec": "^1.0.0",

--- a/packages/zql-integration-tests/package.json
+++ b/packages/zql-integration-tests/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@faker-js/faker": "^9.6.0",
-    "@rocicorp/logger": "^6.0.0",
+    "@rocicorp/logger": "^6.1.0",
     "@types/pg": "^8.20.0",
     "@types/tmp": "^0.2.6",
     "ast-to-zql": "workspace:*",

--- a/packages/zql/package.json
+++ b/packages/zql/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@faker-js/faker": "^9.6.0",
-    "@rocicorp/logger": "^6.0.0",
+    "@rocicorp/logger": "^6.1.0",
     "@standard-schema/spec": "^1.0.0",
     "fast-check": "^3.18.0",
     "nanoid": "^5.1.2",

--- a/packages/zqlite-zql-test/package.json
+++ b/packages/zqlite-zql-test/package.json
@@ -19,7 +19,7 @@
     "zqlite": "workspace:*"
   },
   "devDependencies": {
-    "@rocicorp/logger": "^6.0.0",
+    "@rocicorp/logger": "^6.1.0",
     "@vitest/runner": "^4.1.6",
     "oxfmt": "^0.45.0",
     "shared": "workspace:*",

--- a/packages/zqlite/package.json
+++ b/packages/zqlite/package.json
@@ -23,12 +23,12 @@
     "@databases/escape-identifier": "^1.0.3",
     "@databases/sql": "^3.3.0",
     "@opentelemetry/api": "^1.9.0",
-    "@rocicorp/logger": "^6.0.0",
+    "@rocicorp/logger": "^6.1.0",
     "@rocicorp/zero-sqlite3": "^1.1.2",
     "zql": "workspace:*"
   },
   "devDependencies": {
-    "@rocicorp/logger": "^6.0.0",
+    "@rocicorp/logger": "^6.1.0",
     "fast-check": "^3.18.0",
     "nanoid": "^5.1.2",
     "otel": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -334,8 +334,8 @@ importers:
         specifier: ^1.39.0
         version: 1.66.0
       '@rocicorp/logger':
-        specifier: ^6.0.0
-        version: 6.0.0
+        specifier: ^6.1.0
+        version: 6.1.0
       ws:
         specifier: ^8.18.1
         version: 8.20.1
@@ -414,8 +414,8 @@ importers:
         specifier: ^1.0.4
         version: 1.0.4
       '@rocicorp/logger':
-        specifier: ^6.0.0
-        version: 6.0.0
+        specifier: ^6.1.0
+        version: 6.1.0
       '@rocicorp/resolver':
         specifier: ^1.0.2
         version: 1.0.2
@@ -450,8 +450,8 @@ importers:
         specifier: ^2.7.1
         version: 2.7.1(@opentelemetry/api@1.9.1)
       '@rocicorp/logger':
-        specifier: ^6.0.0
-        version: 6.0.0
+        specifier: ^6.1.0
+        version: 6.1.0
     devDependencies:
       oxfmt:
         specifier: ^0.45.0
@@ -472,8 +472,8 @@ importers:
         specifier: ^1.0.4
         version: 1.0.4
       '@rocicorp/logger':
-        specifier: ^6.0.0
-        version: 6.0.0
+        specifier: ^6.1.0
+        version: 6.1.0
       '@rocicorp/resolver':
         specifier: ^1.0.2
         version: 1.0.2
@@ -655,8 +655,8 @@ importers:
         specifier: ^1.39.0
         version: 1.66.0
       '@rocicorp/logger':
-        specifier: ^6.0.0
-        version: 6.0.0
+        specifier: ^6.1.0
+        version: 6.1.0
       '@rocicorp/resolver':
         specifier: ^1.0.2
         version: 1.0.2
@@ -846,8 +846,8 @@ importers:
         specifier: ^1.0.4
         version: 1.0.4
       '@rocicorp/logger':
-        specifier: ^6.0.0
-        version: 6.0.0
+        specifier: ^6.1.0
+        version: 6.1.0
       '@rocicorp/resolver':
         specifier: ^1.0.2
         version: 1.0.2
@@ -1069,8 +1069,8 @@ importers:
         specifier: ^1.0.4
         version: 1.0.4
       '@rocicorp/logger':
-        specifier: ^6.0.0
-        version: 6.0.0
+        specifier: ^6.1.0
+        version: 6.1.0
       '@rocicorp/resolver':
         specifier: ^1.0.2
         version: 1.0.2
@@ -1202,8 +1202,8 @@ importers:
         specifier: ^1.0.4
         version: 1.0.4
       '@rocicorp/logger':
-        specifier: ^6.0.0
-        version: 6.0.0
+        specifier: ^6.1.0
+        version: 6.1.0
       '@rocicorp/resolver':
         specifier: ^1.0.2
         version: 1.0.2
@@ -1309,8 +1309,8 @@ importers:
   packages/zero-pg:
     dependencies:
       '@rocicorp/logger':
-        specifier: ^6.0.0
-        version: 6.0.0
+        specifier: ^6.1.0
+        version: 6.1.0
     devDependencies:
       '@vitest/runner':
         specifier: ^4.1.6
@@ -1433,8 +1433,8 @@ importers:
   packages/zero-server:
     dependencies:
       '@rocicorp/logger':
-        specifier: ^6.0.0
-        version: 6.0.0
+        specifier: ^6.1.0
+        version: 6.1.0
     devDependencies:
       '@prisma/adapter-pg':
         specifier: ^7.7.0
@@ -1552,8 +1552,8 @@ importers:
         specifier: ^9.6.0
         version: 9.9.0
       '@rocicorp/logger':
-        specifier: ^6.0.0
-        version: 6.0.0
+        specifier: ^6.1.0
+        version: 6.1.0
       '@standard-schema/spec':
         specifier: ^1.0.0
         version: 1.1.0
@@ -1633,8 +1633,8 @@ importers:
         specifier: ^9.6.0
         version: 9.9.0
       '@rocicorp/logger':
-        specifier: ^6.0.0
-        version: 6.0.0
+        specifier: ^6.1.0
+        version: 6.1.0
       '@types/pg':
         specifier: ^8.20.0
         version: 8.20.0
@@ -1699,8 +1699,8 @@ importers:
         specifier: ^1.9.0
         version: 1.9.1
       '@rocicorp/logger':
-        specifier: ^6.0.0
-        version: 6.0.0
+        specifier: ^6.1.0
+        version: 6.1.0
       '@rocicorp/zero-sqlite3':
         specifier: ^1.1.2
         version: 1.1.2
@@ -1746,8 +1746,8 @@ importers:
         version: link:../zqlite
     devDependencies:
       '@rocicorp/logger':
-        specifier: ^6.0.0
-        version: 6.0.0
+        specifier: ^6.1.0
+        version: 6.1.0
       '@vitest/runner':
         specifier: ^4.1.6
         version: 4.1.6
@@ -1786,8 +1786,8 @@ importers:
         specifier: ^1.39.0
         version: 1.66.0
       '@rocicorp/logger':
-        specifier: ^6.0.0
-        version: 6.0.0
+        specifier: ^6.1.0
+        version: 6.1.0
       nanoid:
         specifier: ^5.1.2
         version: 5.1.11
@@ -1814,8 +1814,8 @@ importers:
         specifier: ^1.39.0
         version: 1.66.0
       '@rocicorp/logger':
-        specifier: ^6.0.0
-        version: 6.0.0
+        specifier: ^6.1.0
+        version: 6.1.0
       nanoid:
         specifier: ^5.1.2
         version: 5.1.11
@@ -1839,8 +1839,8 @@ importers:
   tools/process-tracker:
     dependencies:
       '@rocicorp/logger':
-        specifier: ^6.0.0
-        version: 6.0.0
+        specifier: ^6.1.0
+        version: 6.1.0
       find-process:
         specifier: ^1.4.10
         version: 1.4.11
@@ -1864,8 +1864,8 @@ importers:
         specifier: ^1.0.4
         version: 1.0.4
       '@rocicorp/logger':
-        specifier: ^6.0.0
-        version: 6.0.0
+        specifier: ^6.1.0
+        version: 6.1.0
       ws:
         specifier: ^8.18.1
         version: 8.20.1
@@ -5606,8 +5606,8 @@ packages:
   '@rocicorp/logger@5.5.0':
     resolution: {integrity: sha512-lBn0Y4FPKB/IOhcz+r3f9/Ig//LLjWiaQ66Z9tJ54uFib8juzBSXeuxZd/oRnvBt+Lu4epDmLsO1Pnl4mdkSFQ==}
 
-  '@rocicorp/logger@6.0.0':
-    resolution: {integrity: sha512-JbduzH6tP5soFnr/d4BV2Hto1RlGhoGmHo4wlMn5KK8oUWisTiK/M1lZkBiEO3kKyTQcsefykwJNOs6XHaOPWA==}
+  '@rocicorp/logger@6.1.0':
+    resolution: {integrity: sha512-4jOOwem9veRxl7uH15PsmT48PRd3OzM7n3umkO8WCMt8M929MJml4kfeqAcga8feZAfUb/+DRjsvl4ySgPWqYQ==}
 
   '@rocicorp/resolver@1.0.2':
     resolution: {integrity: sha512-TfjMTQp9cNNqNtHFfa+XHEGdA7NnmDRu+ZJH4YF3dso0Xk/b9DMhg/sl+b6CR4ThFZArXXDsG1j8Mwl34wcOZQ==}
@@ -18510,7 +18510,7 @@ snapshots:
 
   '@rocicorp/logger@5.5.0': {}
 
-  '@rocicorp/logger@6.0.0': {}
+  '@rocicorp/logger@6.1.0': {}
 
   '@rocicorp/resolver@1.0.2': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,7 +24,8 @@ minimumReleaseAgeExclude:
   - '@hono/node-server@1.19.13'
   - postcss@8.5.10
   - '@rocicorp/zero-sqlite3'
-  - '@rocicorp/logger@5.5.0 || 6.0.0'
+  - '@rocicorp/logger@6.1.0'
+
 overrides:
   '@hono/node-server@<1.19.13': ^1.19.13
   '@types/node': '^22.10.5'

--- a/tools/client-simulator/package.json
+++ b/tools/client-simulator/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@dotenvx/dotenvx": "^1.39.0",
-    "@rocicorp/logger": "^6.0.0",
+    "@rocicorp/logger": "^6.1.0",
     "nanoid": "^5.1.2",
     "ws": "^8.18.1"
   },

--- a/tools/load-generator/package.json
+++ b/tools/load-generator/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@dotenvx/dotenvx": "^1.39.0",
-    "@rocicorp/logger": "^6.0.0",
+    "@rocicorp/logger": "^6.1.0",
     "nanoid": "^5.1.2",
     "pg-format": "npm:pg-format-fix@^1.0.5",
     "postgres": "3.4.7"

--- a/tools/process-tracker/package.json
+++ b/tools/process-tracker/package.json
@@ -13,7 +13,7 @@
     "check-fmt": "oxfmt --check ."
   },
   "dependencies": {
-    "@rocicorp/logger": "^6.0.0",
+    "@rocicorp/logger": "^6.1.0",
     "find-process": "^1.4.10",
     "pidusage": "^4.0.0"
   },

--- a/tools/sqlite-io-yield-simulator/package.json
+++ b/tools/sqlite-io-yield-simulator/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@rocicorp/lock": "^1.0.4",
-    "@rocicorp/logger": "^6.0.0",
+    "@rocicorp/logger": "^6.1.0",
     "ws": "^8.18.1",
     "zqlite": "workspace:*"
   },


### PR DESCRIPTION
This is to get the type checking of non bound methods