### PR TITLE
chore: extra safety before swapping to litestreamv5

### DIFF
--- a/packages/zero-cache/src/config/normalize.test.ts
+++ b/packages/zero-cache/src/config/normalize.test.ts
@@ -1,0 +1,99 @@
+import {describe, expect, test} from 'vitest';
+import {assertNormalized} from './normalize.ts';
+import type {ZeroConfig} from './zero-config.ts';
+
+function configWith(litestream: Partial<ZeroConfig['litestream']>): ZeroConfig {
+  return {
+    taskID: 'task-id',
+    numSyncWorkers: 1,
+    adminPassword: 'admin',
+    changeStreamer: {port: 4849, address: 'localhost'},
+    change: {db: 'postgres:///change'},
+    cvr: {db: 'postgres:///cvr'},
+    litestream: {
+      port: 9090,
+      backupUsingV5: false,
+      restoreUsingV5: false,
+      executable: undefined,
+      executableV5: undefined,
+      ...litestream,
+    },
+  } as unknown as ZeroConfig;
+}
+
+describe('config/normalize litestream v5 gating', () => {
+  test('backupUsingV5 requires restoreUsingV5', () => {
+    expect(() =>
+      assertNormalized(
+        configWith({
+          backupUsingV5: true,
+          restoreUsingV5: false,
+          executable: '/bin/litestream-v5',
+          executableV5: '/bin/litestream-v5',
+        }),
+      ),
+    ).toThrow(
+      '--litestream-backup-using-v5 requires --litestream-restore-using-v5',
+    );
+  });
+
+  test('backupUsingV5 requires the executable flipped to the v5 binary', () => {
+    expect(() =>
+      assertNormalized(
+        configWith({
+          backupUsingV5: true,
+          restoreUsingV5: true,
+          executable: '/bin/litestream-v3',
+          executableV5: '/bin/litestream-v5',
+        }),
+      ),
+    ).toThrow(
+      '--litestream-backup-using-v5 requires --litestream-executable to be ' +
+        'flipped to the v5 binary',
+    );
+  });
+
+  test('backupUsingV5 requires executableV5 to actually be configured', () => {
+    // Guards against `undefined === undefined` slipping past the equality check
+    // when neither executable is set.
+    expect(() =>
+      assertNormalized(
+        configWith({
+          backupUsingV5: true,
+          restoreUsingV5: true,
+          executable: undefined,
+          executableV5: undefined,
+        }),
+      ),
+    ).toThrow('--litestream-executable must equal');
+  });
+
+  test('allows backupUsingV5 when executable === executableV5', () => {
+    expect(() =>
+      assertNormalized(
+        configWith({
+          backupUsingV5: true,
+          restoreUsingV5: true,
+          executable: '/bin/litestream-v5',
+          executableV5: '/bin/litestream-v5',
+        }),
+      ),
+    ).not.toThrow();
+  });
+
+  test('does not gate the executable during the restore-only transition', () => {
+    // The restore-forward-compat step runs a v3 executable with only
+    // restoreUsingV5 enabled (so every replica can restore both WAL and LTX
+    // before any backup is flipped). That must remain valid.
+    expect(() =>
+      assertNormalized(
+        configWith({
+          backupUsingV5: false,
+          restoreUsingV5: true,
+          executable: '/bin/litestream-v3',
+          executableV5: '/bin/litestream-v5',
+        }),
+      ),
+    ).not.toThrow();
+  });
+});

--- a/packages/zero-cache/src/config/normalize.ts
+++ b/packages/zero-cache/src/config/normalize.ts
@@ -46,6 +46,20 @@ export function assertNormalized(
     !config.litestream.backupUsingV5 || config.litestream.restoreUsingV5,
     '--litestream-backup-using-v5 requires --litestream-restore-using-v5',
   );
+  // The `litestream replicate` process always runs --litestream-executable, so
+  // enabling v5 backups (which write the LTX format read by the VFS monitor)
+  // requires --litestream-executable itself to have been flipped to the v5
+  // binary. Restoring is verified separately via --litestream-restore-using-v5,
+  // which is the prerequisite step that must roll out *before* the executable
+  // is flipped (so every replica can restore both WAL and LTX formats).
+  assert(
+    !config.litestream.backupUsingV5 ||
+      (config.litestream.executableV5 !== undefined &&
+        config.litestream.executable === config.litestream.executableV5),
+    '--litestream-backup-using-v5 requires --litestream-executable to be ' +
+      'flipped to the v5 binary (--litestream-executable must equal ' +
+      '--litestream-executable-v5)',
+  );
   assert(config.change.db, 'missing --change-db');
   assert(config.cvr.db, 'missing --cvr-db');
   assertNotUndefined(config.numSyncWorkers, 'missing --num-sync-workers');

--- a/packages/zero-cache/src/server/backup-watermark-reader.ts
+++ b/packages/zero-cache/src/server/backup-watermark-reader.ts
@@ -9,6 +9,7 @@ import {
 import {VfsBackupWatermarkWorkerService} from '../services/litestream/vfs-watermark-worker.ts';
 import {
   parentWorker,
+  shouldStartWorker,
   singleProcessMode,
   type Worker,
 } from '../types/processes.ts';
@@ -54,7 +55,12 @@ export default async function runWorker(
   );
 }
 
-if (!singleProcessMode()) {
+// Unlike the other workers, the backup watermark reader is *always* run as its
+// own OS process — forked on demand by the `VfsBackupMonitor` (via
+// `forkChildWorker`), or launched directly as a standalone debug tool — so that
+// the native Litestream VFS extension and its process-global `LITESTREAM_*` env
+// stay isolated from the rest of zero-cache. See `shouldStartWorker`.
+if (shouldStartWorker(parentWorker, singleProcessMode())) {
   void exitAfter(lc, () =>
     runWorker(parentWorker, process.env, ...process.argv.slice(2)),
   );

--- a/packages/zero-cache/src/types/processes.test.ts
+++ b/packages/zero-cache/src/types/processes.test.ts
@@ -1,6 +1,6 @@
 import type {SendHandle} from 'child_process';
 import {describe, expect, test, vi} from 'vitest';
-import {inProcChannel} from './processes.ts';
+import {inProcChannel, shouldStartWorker, type Worker} from './processes.ts';
 
 describe('types/processes', () => {
   test('in-proc channel', () => {
@@ -88,5 +88,31 @@ describe('types/processes', () => {
       [{foo: 'bar'}, 'sendHandle'],
       [{foo: 'baz'}, undefined],
     ]);
+  });
+
+  describe('shouldStartWorker', () => {
+    const parent = {} as unknown as Worker;
+
+    // A forked child always starts, even when it inherited SINGLE_PROCESS from
+    // its parent — this is the case that previously hung re-forking the backup
+    // watermark reader.
+    test('forked child starts even in single-process mode', () => {
+      expect(shouldStartWorker(parent, true)).toBe(true);
+    });
+
+    test('forked child starts in multi-process mode', () => {
+      expect(shouldStartWorker(parent, false)).toBe(true);
+    });
+
+    // Standalone direct launch (no parent): start only outside single-process
+    // mode, otherwise childWorker invokes runWorker in-process and we must not
+    // self-start.
+    test('standalone launch starts in multi-process mode', () => {
+      expect(shouldStartWorker(null, false)).toBe(true);
+    });
+
+    test('standalone launch does not start in single-process mode', () => {
+      expect(shouldStartWorker(null, true)).toBe(false);
+    });
   });
 });

--- a/packages/zero-cache/src/types/processes.ts
+++ b/packages/zero-cache/src/types/processes.ts
@@ -156,6 +156,34 @@ export function setSingleProcessMode(enabled: boolean = true): void {
 }
 
 /**
+ * Determines whether a module loaded as a worker process entry point should
+ * start its worker.
+ *
+ * Most workers are launched via {@link childWorker}, which in single-process
+ * mode runs them in-process (no real fork) by invoking their exported
+ * `runWorker` directly; those entry points must therefore *not* self-start in
+ * single-process mode, or they would run twice.
+ *
+ * A worker launched via {@link forkChildWorker}, however, is *always* a real
+ * forked OS process — even in single-process mode — and it inherits the
+ * parent's `SINGLE_PROCESS` env. So {@link singleProcessMode} alone would
+ * wrongly suppress its startup, leaving the parent to spin re-forking a child
+ * that immediately exits. Such a forked child has a non-null
+ * {@link parentWorker} (`process.send` is defined), which is the signal to
+ * start regardless. A standalone direct launch (no parent, not single-process)
+ * also starts.
+ *
+ * @param parent The entry point's {@link parentWorker} (non-null iff forked).
+ * @param isSingleProcessMode The result of {@link singleProcessMode}.
+ */
+export function shouldStartWorker(
+  parent: Worker | null,
+  isSingleProcessMode: boolean,
+): boolean {
+  return parent !== null || !isSingleProcessMode;
+}
+
+/**
  *
  * @param modulePath Path to the module file, relative to zero-cache/src/, or an absolute file:// URL
  */


### PR DESCRIPTION
Checks if the litestream v5 executable is set before trying to use a v5 backup monitor.