### PR TITLE
fix(zero-server): support drizzle rc prepareQuery

### DIFF
--- a/packages/zero-server/src/adapters/drizzle.ts
+++ b/packages/zero-server/src/adapters/drizzle.ts
@@ -1,9 +1,3 @@
-import type {
-  PgDatabase,
-  PgQueryResultHKT,
-  PgTransaction,
-} from 'drizzle-orm/pg-core';
-import type {ExtractTablesWithRelations} from 'drizzle-orm/relations';
 import type {AST} from '../../../zero-protocol/src/ast.ts';
 import type {Format} from '../../../zero-types/src/format.ts';
 import type {Schema} from '../../../zero-types/src/schema.ts';
@@ -19,38 +13,75 @@ import {ZQLDatabase} from '../zql-database.ts';
 
 export type {ZQLDatabase};
 
+type DrizzleQuery = {sql: string; params: unknown[]};
+type DrizzlePreparedQuery = {execute(): Promise<unknown>};
+
+type DrizzlePrepareQueryV0 = (
+  query: DrizzleQuery,
+  fields: undefined,
+  name: undefined,
+  isResponseInArrayMode: false,
+) => DrizzlePreparedQuery;
+
+type DrizzlePrepareQueryV1 = (
+  query: DrizzleQuery,
+  mode: 'objects',
+  name: undefined,
+  mapper: undefined,
+) => DrizzlePreparedQuery;
+
+type DrizzleSession = {
+  prepareQuery: {length: number};
+};
+
+type DrizzleTransactionLike = {
+  _: {session: DrizzleSession};
+};
+
+type DrizzleQueryResult<TResult> = PromiseLike<TResult> & {
+  execute(): Promise<TResult>;
+};
+
+type DrizzleInferSelect<TTable> = TTable extends {$inferSelect: infer TSelect}
+  ? TSelect
+  : Record<string, unknown>;
+
+type DrizzleTransactionFromSchema<TSchema> = DrizzleTransactionLike & {
+  query: {
+    [TTable in keyof TSchema]: {
+      findFirst(
+        args?: unknown,
+      ): DrizzleQueryResult<DrizzleInferSelect<TSchema[TTable]> | undefined>;
+    };
+  };
+};
+
 export type DrizzleDatabase<
-  TQueryResult extends PgQueryResultHKT = PgQueryResultHKT,
-  TSchema extends Record<string, unknown> = Record<string, unknown>,
-> = PgDatabase<TQueryResult, TSchema>;
+  TTransaction extends DrizzleTransactionLike = DrizzleTransactionLike,
+> = {
+  transaction<T>(
+    transaction: (tx: TTransaction) => Promise<T>,
+    config?: never,
+  ): Promise<T>;
+};
 
 /**
  * Helper type for the wrapped transaction used by drizzle-orm.
  *
  * @remarks Use with `ServerTransaction` as `ServerTransaction<Schema, DrizzleTransaction<typeof drizzleDb>>`.
  */
-export type DrizzleTransaction<
-  TDbOrSchema extends DrizzleDatabase | Record<string, unknown>,
-  TSchema extends Record<string, unknown> = TDbOrSchema extends PgDatabase<
-    PgQueryResultHKT,
-    infer TInferredSchema
-  >
-    ? TInferredSchema
-    : TDbOrSchema,
-> = PgTransaction<
-  PgQueryResultHKT,
-  TSchema,
-  ExtractTablesWithRelations<TSchema>
->;
+export type DrizzleTransaction<TDbOrSchema = Record<string, unknown>> =
+  TDbOrSchema extends DrizzleDatabase<infer TTransaction>
+    ? TTransaction
+    : DrizzleTransactionFromSchema<TDbOrSchema>;
 
 export class DrizzleConnection<
-  TDrizzle extends DrizzleDatabase,
-  TTransaction extends DrizzleTransaction<TDrizzle> =
-    DrizzleTransaction<TDrizzle>,
+  TDrizzle,
+  TTransaction extends DrizzleTransactionLike = DrizzleTransaction<TDrizzle>,
 > implements DBConnection<TTransaction> {
-  readonly #drizzle: TDrizzle;
+  readonly #drizzle: DrizzleDatabase<TTransaction>;
 
-  constructor(drizzle: TDrizzle) {
+  constructor(drizzle: TDrizzle & DrizzleDatabase<TTransaction>) {
     this.#drizzle = drizzle;
   }
 
@@ -68,7 +99,7 @@ export class DrizzleConnection<
 }
 
 class DrizzleInternalTransaction<
-  TTransaction extends DrizzleTransaction<DrizzleDatabase>,
+  TTransaction extends DrizzleTransactionLike,
 > implements DBTransaction<TTransaction> {
   readonly wrappedTransaction: TTransaction;
 
@@ -92,12 +123,22 @@ class DrizzleInternalTransaction<
   }
 
   async query(sql: string, params: unknown[]): Promise<Iterable<Row>> {
-    const prepared = this.wrappedTransaction._.session.prepareQuery(
-      {sql, params},
-      undefined,
-      undefined,
-      false,
-    );
+    const {session} = this.wrappedTransaction._;
+    const query = {sql, params};
+    const prepared =
+      session.prepareQuery.length < 7
+        ? (session.prepareQuery as DrizzlePrepareQueryV1)(
+            query,
+            'objects',
+            undefined,
+            undefined,
+          )
+        : (session.prepareQuery as DrizzlePrepareQueryV0)(
+            query,
+            undefined,
+            undefined,
+            false,
+          );
     const result = await prepared.execute();
     return toIterableRows(result);
   }
@@ -176,13 +217,14 @@ export function toIterableRows(result: unknown): Iterable<Row> {
  */
 export function zeroDrizzle<
   TSchema extends Schema,
-  TDrizzle extends DrizzleDatabase,
+  TDrizzle,
+  TTransaction extends DrizzleTransactionLike = DrizzleTransaction<TDrizzle>,
 >(
   schema: TSchema,
-  client: TDrizzle,
-): ZQLDatabase<TSchema, DrizzleTransaction<TDrizzle>> {
+  client: TDrizzle & DrizzleDatabase<TTransaction>,
+): ZQLDatabase<TSchema, TTransaction> {
   return new ZQLDatabase(
-    new DrizzleConnection<TDrizzle, DrizzleTransaction<TDrizzle>>(client),
+    new DrizzleConnection<TDrizzle, TTransaction>(client),
     schema,
   );
 }


### PR DESCRIPTION
Closes #6148.

## Summary

Updates the Zero Drizzle adapter to support both `drizzle-orm@0.45.x` and the `drizzle-orm@1.0.0-rc` `prepareQuery` signature.

Drizzle changed `PgSession.prepareQuery` from the old positional form:

```ts
prepareQuery(query, fields, name, isResponseInArrayMode)
```

to the RC form:

```ts
prepareQuery(query, mode, name, mapper)
```

Zero was still calling the old form. With Drizzle RC, that leaves `mode` unset and causes raw query results to come back in array mode instead of object mode.

## Changes

- Removes direct internal Drizzle type imports from the adapter.
- Adds small local structural types for the Drizzle database/session/transaction shape Zero needs.
- Detects the `prepareQuery` signature with `session.prepareQuery.length`.
- Uses the old call form for `<1`.
- Uses the RC call form with `'objects'` mode for `>=1.0.0-rc`.

## Verification

Tested against the repo's current `drizzle-orm@0.45.2`:

```sh
pnpm --filter zero-server run format
pnpm --filter zero-server run lint
pnpm --filter zero-server run check-types
pnpm --filter zero-server run test:pg17 -- src/adapters/adapters.pg.test.ts
```

Also temporarily verified against `drizzle-orm@1.0.0-rc.3` with a workspace override and a temporary runtime smoke test covering:

- `drizzle-orm/node-postgres`
- `drizzle-orm/postgres-js`
- RC constructor form: `drizzle({client})`
- `zeroDrizzle(...).run(...)`
- `tx.dbTransaction.query(...)`
- object-row results from the new `prepareQuery(query, 'objects', ...)` path

The temporary override and smoke test were removed afterward; no dependency-file changes are included.

## Attribution

Based on the original work by @typedrat in #6148.
