### PR TITLE
perf(zero-cache): copy largest tables first during initial sync

### DIFF
--- a/packages/zero-cache/src/services/change-source/pg/initial-sync.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync.test.ts
@@ -91,14 +91,16 @@ describe('sortDownloadsForInitialCopy', () => {
     const small = {status: {table: 'small', totalBytes: 10}};
     const large = {status: {table: 'large', totalBytes: 1000}};
     const medium = {status: {table: 'medium', totalBytes: 100}};
-    const downloads = [small, large, medium];
+    const unknown = {status: {table: 'unknown', totalBytes: undefined}};
+    const downloads = [small, unknown, large, medium];
 
     expect(sortDownloadsForInitialCopy(downloads)).toEqual([
       large,
       medium,
       small,
+      unknown,
     ]);
-    expect(downloads).toEqual([small, large, medium]);
+    expect(downloads).toEqual([small, unknown, large, medium]);
   });
 });
 

--- a/packages/zero-cache/src/services/change-source/pg/initial-sync.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync.test.ts
@@ -6,6 +6,7 @@ import type {PostgresDB} from '../../../types/pg.ts';
 import {
   getInitialDownloadState,
   makeDownloadStatements,
+  sortDownloadsForInitialCopy,
 } from './initial-sync.ts';
 import {createReplicationSlot} from './replication-slots.ts';
 
@@ -82,6 +83,22 @@ describe('makeDownloadStatements', () => {
     expect(stmts.select).toMatch(
       /FROM "public"\."t" TABLESAMPLE BERNOULLI\(50\) WHERE a > 10/,
     );
+  });
+});
+
+describe('sortDownloadsForInitialCopy', () => {
+  test('orders table copies by estimated bytes descending', () => {
+    const small = {status: {table: 'small', totalBytes: 10}};
+    const large = {status: {table: 'large', totalBytes: 1000}};
+    const medium = {status: {table: 'medium', totalBytes: 100}};
+    const downloads = [small, large, medium];
+
+    expect(sortDownloadsForInitialCopy(downloads)).toEqual([
+      large,
+      medium,
+      small,
+    ]);
+    expect(downloads).toEqual([small, large, medium]);
   });
 });
 

--- a/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
@@ -777,10 +777,10 @@ type DownloadState = {
 };
 
 export function sortDownloadsForInitialCopy<
-  T extends {status: {totalBytes: number}},
+  T extends {status: {totalBytes?: number | undefined}},
 >(downloads: readonly T[]): T[] {
   return downloads.toSorted(
-    (a, b) => b.status.totalBytes - a.status.totalBytes,
+    (a, b) => (b.status.totalBytes ?? 0) - (a.status.totalBytes ?? 0),
   );
 }
 

--- a/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
@@ -244,7 +244,7 @@ export async function initialSync(
 
       void copyProfiler?.start();
       const rowCounts = await Promise.all(
-        downloads.map(table =>
+        sortDownloadsForInitialCopy(downloads).map(table =>
           copiers.processReadTask((db, lc) =>
             copy(
               lc,
@@ -775,6 +775,14 @@ type DownloadState = {
   spec: PublishedTableSpec;
   status: DownloadStatus;
 };
+
+export function sortDownloadsForInitialCopy<
+  T extends {status: {totalBytes: number}},
+>(downloads: readonly T[]): T[] {
+  return downloads.toSorted(
+    (a, b) => b.status.totalBytes - a.status.totalBytes,
+  );
+}
 
 // Exported for testing.
 export async function getInitialDownloadState(


### PR DESCRIPTION
Sort initial-sync table copy work by estimated `totalBytes` descending.

## Why

After a logical replication slot invalidation, Zero may need to rebuild the replica with a full initial sync. For large datasets, the copy phase can dominate recovery time.

Initial sync currently submits table copy tasks in publication order. That can leave the largest tables until later, causing worker tail time when smaller table copies finish and one expensive table remains.

Submitting larger estimated tables first is a small, safe scheduling improvement that should reduce tail latency without changing replica contents or sync semantics.