### PR TITLE
chore(devcontainer): upgrade agents feature to v3

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -29,8 +29,8 @@ bind to on a machine without a checkout, which is exactly the failure mode
 this avoids. (Consequence: the source lives in the volume and is edited
 through VS Code, not browsable on the host filesystem. On macOS this is also
 substantially faster than a bind mount.) Git identity inside the container
-comes from the `gh` login the `agents` feature persists, not a mounted
-`~/.gitconfig`.
+comes from the Dev Containers tooling's Git credential forwarding (it shares
+the host's Git config and credentials), not a mounted `~/.gitconfig`.
 
 ## Profiles
 

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -9,9 +9,7 @@
       "version": "3.0.0",
       "resolved": "ghcr.io/rocicorp/devcontainer-features/agents@sha256:cb7bb04455faaab8fa55e5d57656be969f0f59657fee8a3320e61badb025a5a3",
       "integrity": "sha256:cb7bb04455faaab8fa55e5d57656be969f0f59657fee8a3320e61badb025a5a3",
-      "dependsOn": [
-        "ghcr.io/anthropics/devcontainer-features/claude-code:1"
-      ]
+      "dependsOn": ["ghcr.io/anthropics/devcontainer-features/claude-code:1"]
     },
     "ghcr.io/rocicorp/devcontainer-features/pnpm:1": {
       "version": "1.0.0",

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -5,18 +5,12 @@
       "resolved": "ghcr.io/anthropics/devcontainer-features/claude-code@sha256:cfc2e7d3e9fd3b9b01f8d5cb158508a884c8c0ede2e23ed10f32dea5d4ffe69a",
       "integrity": "sha256:cfc2e7d3e9fd3b9b01f8d5cb158508a884c8c0ede2e23ed10f32dea5d4ffe69a"
     },
-    "ghcr.io/devcontainers/features/github-cli:1": {
-      "version": "1.1.0",
-      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
-      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
-    },
-    "ghcr.io/rocicorp/devcontainer-features/agents:2": {
-      "version": "2.0.0",
-      "resolved": "ghcr.io/rocicorp/devcontainer-features/agents@sha256:172905cd57fbc946323644a52d5829415c77ff8c6f217594720966efcba11db6",
-      "integrity": "sha256:172905cd57fbc946323644a52d5829415c77ff8c6f217594720966efcba11db6",
+    "ghcr.io/rocicorp/devcontainer-features/agents:3": {
+      "version": "3.0.0",
+      "resolved": "ghcr.io/rocicorp/devcontainer-features/agents@sha256:cb7bb04455faaab8fa55e5d57656be969f0f59657fee8a3320e61badb025a5a3",
+      "integrity": "sha256:cb7bb04455faaab8fa55e5d57656be969f0f59657fee8a3320e61badb025a5a3",
       "dependsOn": [
-        "ghcr.io/anthropics/devcontainer-features/claude-code:1",
-        "ghcr.io/devcontainers/features/github-cli:1"
+        "ghcr.io/anthropics/devcontainer-features/claude-code:1"
       ]
     },
     "ghcr.io/rocicorp/devcontainer-features/pnpm:1": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,20 +14,14 @@
   "remoteUser": "node",
   "features": {
     // Shared rocicorp features (https://github.com/rocicorp/devcontainer-features):
-    //  - agents: Codex (pinned) + Claude Code + gh. Persists the Claude login
-    //    across rebuilds (CLAUDE_CONFIG_DIR). gh auth is NOT persisted — it uses
-    //    GITHUB_TOKEN forwarded from the host (resolved there via 1Password).
+    //  - agents: Codex (pinned) + Claude Code. Persists the Claude login
+    //    across rebuilds (CLAUDE_CONFIG_DIR). v3 dropped the bundled GitHub CLI
+    //    (gh) and 1Password CLI (op); add github-cli explicitly if you need gh.
     //  - pnpm: corepack-managed pnpm; removes npm/npx to enforce pnpm.
-    "ghcr.io/rocicorp/devcontainer-features/agents:2": {
+    "ghcr.io/rocicorp/devcontainer-features/agents:3": {
       "codexVersion": "0.139.0"
     },
     "ghcr.io/rocicorp/devcontainer-features/pnpm:1": {}
-  },
-  // gh reads GITHUB_TOKEN directly. Resolve it on your HOST (1Password app /
-  // Touch ID) and forward it in — nothing is stored in the container or repo.
-  // Host setup: see https://github.com/rocicorp/devcontainer-features#gh-auth-via-1password-no-host-side-credentials
-  "remoteEnv": {
-    "GITHUB_TOKEN": "${localEnv:GITHUB_TOKEN}"
   },
   "postCreateCommand": "pnpm install",
   "customizations": {

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -38,7 +38,7 @@ services:
     # "Clone Repository in Container Volume" mounts at /workspaces. Adding a
     # `..:/workspaces/mono` host bind here would break that flow (there is no
     # host checkout to bind) and is unnecessary — git identity comes from the
-    # gh login the `agents` feature persists, not a mounted ~/.gitconfig.
+    # Dev Containers tooling's Git credential forwarding, not a mounted ~/.gitconfig.
     environment:
       # Points the zero-cache pg tests at the sibling services below instead
       # of testcontainers (which would need a Docker daemon).

--- a/.devcontainer/zbugs/devcontainer-lock.json
+++ b/.devcontainer/zbugs/devcontainer-lock.json
@@ -9,9 +9,7 @@
       "version": "3.0.0",
       "resolved": "ghcr.io/rocicorp/devcontainer-features/agents@sha256:cb7bb04455faaab8fa55e5d57656be969f0f59657fee8a3320e61badb025a5a3",
       "integrity": "sha256:cb7bb04455faaab8fa55e5d57656be969f0f59657fee8a3320e61badb025a5a3",
-      "dependsOn": [
-        "ghcr.io/anthropics/devcontainer-features/claude-code:1"
-      ]
+      "dependsOn": ["ghcr.io/anthropics/devcontainer-features/claude-code:1"]
     },
     "ghcr.io/rocicorp/devcontainer-features/pnpm:1": {
       "version": "1.0.0",

--- a/.devcontainer/zbugs/devcontainer-lock.json
+++ b/.devcontainer/zbugs/devcontainer-lock.json
@@ -5,18 +5,12 @@
       "resolved": "ghcr.io/anthropics/devcontainer-features/claude-code@sha256:cfc2e7d3e9fd3b9b01f8d5cb158508a884c8c0ede2e23ed10f32dea5d4ffe69a",
       "integrity": "sha256:cfc2e7d3e9fd3b9b01f8d5cb158508a884c8c0ede2e23ed10f32dea5d4ffe69a"
     },
-    "ghcr.io/devcontainers/features/github-cli:1": {
-      "version": "1.1.0",
-      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
-      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
-    },
-    "ghcr.io/rocicorp/devcontainer-features/agents:1": {
-      "version": "1.2.0",
-      "resolved": "ghcr.io/rocicorp/devcontainer-features/agents@sha256:b5161d2a6698717cb6cf804f47e682ceb07beac7aa425b4d33f7a92d9902dd84",
-      "integrity": "sha256:b5161d2a6698717cb6cf804f47e682ceb07beac7aa425b4d33f7a92d9902dd84",
+    "ghcr.io/rocicorp/devcontainer-features/agents:3": {
+      "version": "3.0.0",
+      "resolved": "ghcr.io/rocicorp/devcontainer-features/agents@sha256:cb7bb04455faaab8fa55e5d57656be969f0f59657fee8a3320e61badb025a5a3",
+      "integrity": "sha256:cb7bb04455faaab8fa55e5d57656be969f0f59657fee8a3320e61badb025a5a3",
       "dependsOn": [
-        "ghcr.io/anthropics/devcontainer-features/claude-code:1",
-        "ghcr.io/devcontainers/features/github-cli:1"
+        "ghcr.io/anthropics/devcontainer-features/claude-code:1"
       ]
     },
     "ghcr.io/rocicorp/devcontainer-features/pnpm:1": {

--- a/.devcontainer/zbugs/devcontainer.json
+++ b/.devcontainer/zbugs/devcontainer.json
@@ -18,13 +18,10 @@
   "remoteUser": "node",
   "features": {
     // Keep in sync with ../devcontainer.json.
-    "ghcr.io/rocicorp/devcontainer-features/agents:2": {
+    "ghcr.io/rocicorp/devcontainer-features/agents:3": {
       "codexVersion": "0.139.0"
     },
     "ghcr.io/rocicorp/devcontainer-features/pnpm:1": {}
-  },
-  "remoteEnv": {
-    "GITHUB_TOKEN": "${localEnv:GITHUB_TOKEN}"
   },
   "postCreateCommand": "pnpm install",
   "customizations": {


### PR DESCRIPTION
## What

Upgrades `ghcr.io/rocicorp/devcontainer-features/agents` to **v3** across all dev container configs.

`agents` v3.0.0 is a **breaking** release: it drops the bundled GitHub CLI (`gh`) and 1Password CLI (`op`), so the container no longer injects a GitHub token (or 1Password credentials) at shell start. See the [migration note](https://github.com/rocicorp/devcontainer-features#agents).

## Changes

**Pin bump (`:2` → `:3`)** in both dev container configs (`codexVersion` left unchanged; the other rocicorp pins `pnpm:1`/`docker:1` are untouched):
- `.devcontainer/devcontainer.json`
- `.devcontainer/zbugs/devcontainer.json`

**Removed now-dead wiring** that only existed to feed the old bundled `gh`:
- The `GITHUB_TOKEN` `remoteEnv` passthrough (`"${localEnv:GITHUB_TOKEN}"`) in **both** configs.
- The accompanying comments about `gh`/`GITHUB_TOKEN`/1Password.
- Refreshed the two doc comments that described git auth via the bundled `gh` (`.devcontainer/README.md`, `.devcontainer/docker-compose.yml`) — git identity in the Clone-in-Volume flow comes from the Dev Containers tooling's git credential forwarding, not the dropped `gh`.

**Lockfiles regenerated** for agents `3.0.0` (`.devcontainer/devcontainer-lock.json`, `.devcontainer/zbugs/devcontainer-lock.json`):
- `agents` → `3.0.0`, new digest `sha256:cb7bb044…25a5a3`.
- `github-cli` removed from the dependency closure — agents v3's manifest `dependsOn` is now just `claude-code:1` (confirmed against the published manifest). `claude-code:1` and `pnpm:1` pins are unchanged.
- The CLI (`@devcontainers/cli upgrade`) can't run here because this environment's egress policy blocks the ghcr.io blob host, so the locks were updated by resolving the v3 manifest digest directly from the registry and validating the method against the known `agents:2` digest.

## Risk: risk-free

Nothing in the repo uses `gh` or `op` **inside the container** — `postCreateCommand` is just `pnpm install`, and there are no lifecycle/script/in-container-CI usages. The `gh` calls in `.github/workflows/*` run on GitHub-hosted runners, not in the dev container, so they're unaffected.

Because of that, **`github-cli` was not re-added**. If someone later needs `gh` in the container, add the official feature explicitly:

```jsonc
"ghcr.io/devcontainers/features/github-cli:1": {}
```

(There's a reminder to this effect in the `devcontainer.json` comment.)

## Dependabot

No change needed. `.github/dependabot.yml` already has a `devcontainers` entry at `directory: "/"`, and the dependabot `devcontainers` file-fetcher recurses into `.devcontainer/` subfolders — so it already covers **both** `.devcontainer/devcontainer.json` and `.devcontainer/zbugs/devcontainer.json`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V7Y4QXQYTd44wh3ytjbvyY)_