### PR TITLE
feat(zero-cache): calculate how far behind a view syncer is on serving clients

### DIFF
--- a/packages/zero-cache/src/services/replicator/incremental-sync.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.ts
@@ -77,7 +77,12 @@ export class IncrementalSyncer {
       await this.#worker.getSubscriptionState();
 
     // Notify any waiting subscribers that the replica is ready to be read.
-    void this.#notifier.notifySubscribers();
+    // This initial notification intentionally omits replicaReadyTimeMs because
+    // it represents already-current state, not newly-unserved work.
+    void this.#notifier.notifySubscribers({
+      state: 'version-ready',
+      watermark: initialWatermark,
+    });
 
     while (this.#state.shouldRun()) {
       const {replicaVersion, watermark} =
@@ -215,7 +220,11 @@ export class IncrementalSyncer {
       this.#statusPublisher?.publish(lc, 'Replicating', 'Schema updated');
     }
     if (result.watermark && result.changeLogUpdated) {
-      void this.#notifier.notifySubscribers({state: 'version-ready'});
+      void this.#notifier.notifySubscribers({
+        state: 'version-ready',
+        watermark: result.watermark,
+        replicaReadyTimeMs: Date.now(),
+      });
     }
   }
 

--- a/packages/zero-cache/src/services/replicator/notifier.test.ts
+++ b/packages/zero-cache/src/services/replicator/notifier.test.ts
@@ -54,4 +54,31 @@ describe('replicator/notifier', () => {
     await expectSingleMessage(sub2, {state: 'version-ready', testSeqNum: 456});
     expect(await Promise.all(results2)).toEqual(['consumed']);
   });
+
+  test('coalesced notifications keep earliest replica ready time', async () => {
+    const notifier = new Notifier();
+    const sub = notifier.subscribe();
+
+    void notifier.notifySubscribers({
+      state: 'version-ready',
+      watermark: '02',
+      replicaReadyTimeMs: 200,
+    });
+    void notifier.notifySubscribers({
+      state: 'version-ready',
+      watermark: '03',
+      replicaReadyTimeMs: 300,
+    });
+
+    await expectSingleMessage(sub, {
+      state: 'version-ready',
+      watermark: '03',
+      replicaReadyTimeMs: 200,
+    });
+    expect(notifier.latestState).toEqual({
+      state: 'version-ready',
+      watermark: '03',
+      replicaReadyTimeMs: 300,
+    });
+  });
 });

--- a/packages/zero-cache/src/services/replicator/notifier.ts
+++ b/packages/zero-cache/src/services/replicator/notifier.ts
@@ -32,10 +32,22 @@ export class Notifier implements ReplicaStateNotifier {
   readonly #eventEmitter = new EventEmitter();
   #lastStateReceived: ReplicaState | undefined;
 
+  get latestState(): ReplicaState | undefined {
+    return this.#lastStateReceived;
+  }
+
   #newSubscription() {
     const notify = (state: ReplicaState) => subscription.push(state);
     const subscription = Subscription.create<ReplicaState>({
-      coalesce: curr => curr,
+      coalesce: (curr, prev) => ({
+        ...curr,
+        replicaReadyTimeMs:
+          curr.replicaReadyTimeMs === undefined
+            ? prev.replicaReadyTimeMs
+            : prev.replicaReadyTimeMs === undefined
+              ? curr.replicaReadyTimeMs
+              : Math.min(curr.replicaReadyTimeMs, prev.replicaReadyTimeMs),
+      }),
       cleanup: () => this.#eventEmitter.off('version', notify),
     });
     return {notify, subscription};

--- a/packages/zero-cache/src/services/replicator/replicator.ts
+++ b/packages/zero-cache/src/services/replicator/replicator.ts
@@ -10,10 +10,20 @@ import type {WriteWorkerClient} from './write-worker-client.ts';
 /** See {@link ReplicaStateNotifier.subscribe()}. */
 export type ReplicaState = {
   readonly state: 'version-ready';
+  /**
+   * The replica watermark that became ready. Omitted for the initial
+   * "current state is ready" notification, which should not count as newly
+   * unserved work for a freshly-started ViewSyncer.
+   */
+  readonly watermark?: string | undefined;
+  /**
+   * Millisecond epoch when `watermark` became ready to read from the replica.
+   */
+  readonly replicaReadyTimeMs?: number | undefined;
 
   // Used in tests to verify behavior when additional information
   // is ferried in the future. Not set in production.
-  readonly testSeqNum?: number;
+  readonly testSeqNum?: number | undefined;
 };
 
 export interface ReplicaStateNotifier {

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -143,6 +143,8 @@ export interface ViewSyncer {
 
   readonly queryCount: number;
   readonly rowCount: number;
+  readonly createdAtMs: number;
+  readonly servedVersion: string | null;
 }
 
 export type SyncContext = ConnectionSelector & {
@@ -196,6 +198,7 @@ type CustomQueryTransformMode = 'all' | 'missing';
 
 export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
   readonly id: string;
+  readonly createdAtMs = Date.now();
   // Centralized connection/group auth bookkeeping plus maintenance policy.
   // Network validation still happens in ViewSyncerService.
   readonly connContextManager: ConnectionContextManager;
@@ -254,6 +257,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
 
   #cvr: CVRSnapshot | undefined;
   #pipelinesSynced = false;
+  #servedVersion: string | null = null;
 
   #expiredQueriesTimer: ReturnType<SetTimeout> | 0 = 0;
   #authMaintenanceTimer: ReturnType<SetTimeout> | 0 = 0;
@@ -593,6 +597,14 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
 
   get rowCount(): number {
     return this.#cvrStore.rowCount;
+  }
+
+  get servedVersion(): string | null {
+    return this.#servedVersion;
+  }
+
+  #markVersionServed(version: CVRVersion) {
+    this.#servedVersion = version.stateVersion;
   }
 
   #keepAliveUntil: number = 0;
@@ -2081,6 +2093,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
       await startAsyncSpan(tracer, 'vs.#syncQueryPipelineSet.pokeEnd', () =>
         pokers.end(finalVersion),
       );
+      this.#markVersionServed(finalVersion);
 
       const wallTime = performance.now() - start;
       lc.info?.(
@@ -2185,6 +2198,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
 
       if (!usePokers) {
         await pokers.end(cvr.version);
+        this.#markVersionServed(cvr.version);
       }
     });
   }
@@ -2341,6 +2355,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
       await startAsyncSpan(tracer, 'vs.#advancePipelines.pokeEnd', () =>
         pokers.end(finalVersion),
       );
+      this.#markVersionServed(finalVersion);
 
       const wallTime = performance.now() - start;
       const totalProcessTime = timer.totalElapsed();

--- a/packages/zero-cache/src/workers/replicator.ts
+++ b/packages/zero-cache/src/workers/replicator.ts
@@ -222,11 +222,16 @@ export function handleSubscriptionsFrom(
  * This does not send the initial subscription message. Use {@link subscribeTo}
  * to initiate the subscription.
  */
-export function createNotifierFrom(_lc: LogContext, source: Worker): Notifier {
+export function createNotifierFrom(
+  _lc: LogContext,
+  source: Worker,
+  onNotify?: (state: ReplicaState) => void,
+): Notifier {
   const notifier = new Notifier();
-  source.onMessageType<Notification>('notify', msg =>
-    notifier.notifySubscribers(msg),
-  );
+  source.onMessageType<Notification>('notify', msg => {
+    onNotify?.(msg);
+    void notifier.notifySubscribers(msg);
+  });
   return notifier;
 }
 

--- a/packages/zero-cache/src/workers/syncer-ws-message-handler.test.ts
+++ b/packages/zero-cache/src/workers/syncer-ws-message-handler.test.ts
@@ -49,6 +49,10 @@ function createMockViewSyncer(
     deleteClients: vi.fn().mockResolvedValue([]),
     initConnection: vi.fn(),
     inspect: vi.fn().mockResolvedValue(undefined),
+    queryCount: 0,
+    rowCount: 0,
+    createdAtMs: Date.now(),
+    servedVersion: null,
   } as unknown as MockViewSyncer;
 }
 

--- a/packages/zero-cache/src/workers/syncer.test.ts
+++ b/packages/zero-cache/src/workers/syncer.test.ts
@@ -58,6 +58,7 @@ import type {ViewSyncer} from '../services/view-syncer/view-syncer.ts';
 import type {WebSocketReceiver} from '../types/websocket-handoff.ts';
 import {
   computeMaxServingLagMs,
+  computeServingLagStatsMs,
   MAX_REPLICA_READY_STATES,
   Syncer,
 } from './syncer.ts';
@@ -284,6 +285,54 @@ describe('computeMaxServingLagMs', () => {
 
     expect(states).toHaveLength(MAX_REPLICA_READY_STATES);
     expect(states[0]).toEqual({watermark: '00001', replicaReadyTimeMs: 1});
+  });
+});
+
+describe('computeServingLagStatsMs', () => {
+  test('returns distribution across active view syncers including zero-lag groups', () => {
+    const states = [
+      {watermark: '02', replicaReadyTimeMs: 100},
+      {watermark: '03', replicaReadyTimeMs: 150},
+      {watermark: '04', replicaReadyTimeMs: 200},
+      {watermark: '05', replicaReadyTimeMs: 250},
+    ];
+
+    expect(
+      computeServingLagStatsMs(300, states, [
+        {createdAtMs: 0, servedVersion: '05'},
+        {createdAtMs: 0, servedVersion: '03'},
+        {createdAtMs: 0, servedVersion: '04'},
+        {createdAtMs: 225, servedVersion: null},
+      ]),
+    ).toEqual({
+      activeClientGroups: 4,
+      laggingClientGroups: 3,
+      minMs: 0,
+      p50Ms: 50,
+      p75Ms: 50,
+      p99Ms: 100,
+      maxMs: 100,
+    });
+
+    expect(states).toEqual([
+      {watermark: '04', replicaReadyTimeMs: 200},
+      {watermark: '05', replicaReadyTimeMs: 250},
+    ]);
+  });
+
+  test('returns zero stats with no active view syncers', () => {
+    const states = [{watermark: '02', replicaReadyTimeMs: 100}];
+
+    expect(computeServingLagStatsMs(300, states, [])).toEqual({
+      activeClientGroups: 0,
+      laggingClientGroups: 0,
+      minMs: 0,
+      p50Ms: 0,
+      p75Ms: 0,
+      p99Ms: 0,
+      maxMs: 0,
+    });
+    expect(states).toEqual([]);
   });
 });
 

--- a/packages/zero-cache/src/workers/syncer.test.ts
+++ b/packages/zero-cache/src/workers/syncer.test.ts
@@ -246,6 +246,27 @@ describe('computeMaxServingLagMs', () => {
     expect(states).toEqual([{watermark: '03', replicaReadyTimeMs: 150}]);
   });
 
+  test('uses the later of creation time and served version as the first unserved state', () => {
+    const states = [
+      {watermark: '02', replicaReadyTimeMs: 100},
+      {watermark: '03', replicaReadyTimeMs: 150},
+      {watermark: '04', replicaReadyTimeMs: 200},
+      {watermark: '05', replicaReadyTimeMs: 250},
+    ];
+
+    expect(
+      computeMaxServingLagMs(300, states, [
+        {createdAtMs: 175, servedVersion: '02'},
+        {createdAtMs: 0, servedVersion: '04'},
+      ]),
+    ).toBe(100);
+
+    expect(states).toEqual([
+      {watermark: '04', replicaReadyTimeMs: 200},
+      {watermark: '05', replicaReadyTimeMs: 250},
+    ]);
+  });
+
   test('bounds retained states even when a client group is behind', () => {
     const states = Array.from(
       {length: MAX_REPLICA_READY_STATES + 1},

--- a/packages/zero-cache/src/workers/syncer.test.ts
+++ b/packages/zero-cache/src/workers/syncer.test.ts
@@ -56,7 +56,11 @@ import type {ConnectionContextManager} from '../services/view-syncer/connection-
 import {ConnectionContextManagerImpl} from '../services/view-syncer/connection-context-manager.ts';
 import type {ViewSyncer} from '../services/view-syncer/view-syncer.ts';
 import type {WebSocketReceiver} from '../types/websocket-handoff.ts';
-import {Syncer} from './syncer.ts';
+import {
+  computeMaxServingLagMs,
+  MAX_REPLICA_READY_STATES,
+  Syncer,
+} from './syncer.ts';
 
 const lc = createSilentLogContext();
 const tempDir = await fs.mkdtemp(
@@ -112,6 +116,8 @@ function makeFactories(
           keepalive: () => true,
           queryCount: 0,
           rowCount: 0,
+          createdAtMs: Date.now(),
+          servedVersion: null,
           stop() {
             stopped.resolve();
             return stopped.promise;
@@ -197,6 +203,68 @@ const baseParams = {
   wsID: '1',
   protocolVersion: 30,
 };
+
+describe('computeMaxServingLagMs', () => {
+  test('returns zero with no active view syncers', () => {
+    const states = [{watermark: '02', replicaReadyTimeMs: 100}];
+    expect(computeMaxServingLagMs(200, states, [])).toBe(0);
+    expect(states).toEqual([]);
+  });
+
+  test('uses oldest unserved replica-ready state across active view syncers', () => {
+    const states = [
+      {watermark: '02', replicaReadyTimeMs: 100},
+      {watermark: '03', replicaReadyTimeMs: 150},
+      {watermark: '04', replicaReadyTimeMs: 175},
+    ];
+
+    expect(
+      computeMaxServingLagMs(300, states, [
+        {createdAtMs: 0, servedVersion: '03'},
+        {createdAtMs: 0, servedVersion: '02'},
+      ]),
+    ).toBe(150);
+
+    expect(states).toEqual([
+      {watermark: '03', replicaReadyTimeMs: 150},
+      {watermark: '04', replicaReadyTimeMs: 175},
+    ]);
+  });
+
+  test('ignores replica states from before a view syncer was created', () => {
+    const states = [
+      {watermark: '02', replicaReadyTimeMs: 100},
+      {watermark: '03', replicaReadyTimeMs: 150},
+    ];
+
+    expect(
+      computeMaxServingLagMs(300, states, [
+        {createdAtMs: 125, servedVersion: null},
+      ]),
+    ).toBe(150);
+
+    expect(states).toEqual([{watermark: '03', replicaReadyTimeMs: 150}]);
+  });
+
+  test('bounds retained states even when a client group is behind', () => {
+    const states = Array.from(
+      {length: MAX_REPLICA_READY_STATES + 1},
+      (_, i) => ({
+        watermark: String(i).padStart(5, '0'),
+        replicaReadyTimeMs: i,
+      }),
+    );
+
+    expect(
+      computeMaxServingLagMs(20_000, states, [
+        {createdAtMs: 0, servedVersion: null},
+      ]),
+    ).toBe(20_000);
+
+    expect(states).toHaveLength(MAX_REPLICA_READY_STATES);
+    expect(states[0]).toEqual({watermark: '00001', replicaReadyTimeMs: 1});
+  });
+});
 
 function makeParams(clientID: number, params: any = {}) {
   return {

--- a/packages/zero-cache/src/workers/syncer.ts
+++ b/packages/zero-cache/src/workers/syncer.ts
@@ -43,6 +43,72 @@ export type SyncerWorkerData = {
   replicatorPort: MessagePort;
 };
 
+export type ReplicaReadyState = {
+  readonly watermark: string;
+  readonly replicaReadyTimeMs: number;
+};
+
+export type ServingLagViewSyncer = Pick<
+  ViewSyncer,
+  'createdAtMs' | 'servedVersion'
+>;
+
+export const MAX_REPLICA_READY_STATES = 10_000;
+
+function boundReplicaReadyStates(
+  replicaReadyStates: ReplicaReadyState[],
+): void {
+  if (replicaReadyStates.length > MAX_REPLICA_READY_STATES) {
+    replicaReadyStates.splice(
+      0,
+      replicaReadyStates.length - MAX_REPLICA_READY_STATES,
+    );
+  }
+}
+
+function pruneReplicaReadyStates(
+  replicaReadyStates: ReplicaReadyState[],
+  firstNeededIndex: number,
+): void {
+  if (firstNeededIndex > 0) {
+    replicaReadyStates.splice(0, firstNeededIndex);
+  }
+
+  boundReplicaReadyStates(replicaReadyStates);
+}
+
+export function computeMaxServingLagMs(
+  now: number,
+  replicaReadyStates: ReplicaReadyState[],
+  viewSyncers: Iterable<ServingLagViewSyncer>,
+): number {
+  let maxLagMs = 0;
+  let firstNeededIndex = replicaReadyStates.length;
+
+  for (const viewSyncer of viewSyncers) {
+    const firstUnservedIndex = replicaReadyStates.findIndex(
+      ({replicaReadyTimeMs, watermark}) =>
+        replicaReadyTimeMs >= viewSyncer.createdAtMs &&
+        (viewSyncer.servedVersion === null ||
+          viewSyncer.servedVersion < watermark),
+    );
+
+    if (firstUnservedIndex === -1) {
+      continue;
+    }
+
+    firstNeededIndex = Math.min(firstNeededIndex, firstUnservedIndex);
+    maxLagMs = Math.max(
+      maxLagMs,
+      now - replicaReadyStates[firstUnservedIndex].replicaReadyTimeMs,
+    );
+  }
+
+  pruneReplicaReadyStates(replicaReadyStates, firstNeededIndex);
+
+  return Math.max(0, maxLagMs);
+}
+
 function getWebSocketServerOptions(config: ZeroConfig): ServerOptions {
   const options: ServerOptions = {
     noServer: true,
@@ -89,6 +155,7 @@ export class Syncer implements SingletonService {
   readonly #stopped = resolver();
   readonly #config: ZeroConfig;
   readonly #validateLegacyJWT: ValidateLegacyJWT | undefined;
+  readonly #replicaReadyStates: ReplicaReadyState[] = [];
 
   constructor(
     lc: LogContext,
@@ -112,7 +179,9 @@ export class Syncer implements SingletonService {
     this.#validateLegacyJWT = validateLegacyJWT;
     // Relays notifications from the parent thread subscription
     // to ViewSyncers within this thread.
-    const notifier = createNotifierFrom(lc, parent);
+    const notifier = createNotifierFrom(lc, parent, state =>
+      this.#recordReplicaReadyState(state),
+    );
     subscribeTo(lc, parent);
 
     this.#lc = lc;
@@ -176,6 +245,44 @@ export class Syncer implements SingletonService {
       }
       result.observe(total);
     });
+
+    getOrCreateGauge('sync', 'serving-lag', {
+      description:
+        'Maximum time active ViewSyncer client groups have had unserved ' +
+        'replica changes. A change is served after IVM advancement, CVR flush, ' +
+        'and pokeEnd.',
+      unit: 'millisecond',
+    }).addCallback(result => {
+      result.observe(
+        computeMaxServingLagMs(
+          Date.now(),
+          this.#replicaReadyStates,
+          this.#viewSyncers.getServices(),
+        ),
+      );
+    });
+  }
+
+  #recordReplicaReadyState(state: ReplicaState): void {
+    if (
+      state.watermark === undefined ||
+      state.replicaReadyTimeMs === undefined
+    ) {
+      return;
+    }
+    const last = this.#replicaReadyStates.at(-1);
+    if (last && last.watermark >= state.watermark) {
+      return;
+    }
+    this.#replicaReadyStates.push({
+      watermark: state.watermark,
+      replicaReadyTimeMs: state.replicaReadyTimeMs,
+    });
+    if (this.#viewSyncers.size === 0) {
+      this.#replicaReadyStates.length = 0;
+      return;
+    }
+    boundReplicaReadyStates(this.#replicaReadyStates);
   }
 
   readonly #createConnection = async (ws: WebSocket, params: ConnectParams) => {

--- a/packages/zero-cache/src/workers/syncer.ts
+++ b/packages/zero-cache/src/workers/syncer.ts
@@ -77,6 +77,62 @@ function pruneReplicaReadyStates(
   boundReplicaReadyStates(replicaReadyStates);
 }
 
+function lowerBoundReplicaReadyTimeMs(
+  replicaReadyStates: readonly ReplicaReadyState[],
+  replicaReadyTimeMs: number,
+): number {
+  let low = 0;
+  let high = replicaReadyStates.length;
+  while (low < high) {
+    const mid = low + Math.floor((high - low) / 2);
+    if (replicaReadyStates[mid].replicaReadyTimeMs < replicaReadyTimeMs) {
+      low = mid + 1;
+    } else {
+      high = mid;
+    }
+  }
+  return low;
+}
+
+function upperBoundWatermark(
+  replicaReadyStates: readonly ReplicaReadyState[],
+  watermark: string,
+): number {
+  let low = 0;
+  let high = replicaReadyStates.length;
+  while (low < high) {
+    const mid = low + Math.floor((high - low) / 2);
+    if (replicaReadyStates[mid].watermark <= watermark) {
+      low = mid + 1;
+    } else {
+      high = mid;
+    }
+  }
+  return low;
+}
+
+function findFirstUnservedIndex(
+  replicaReadyStates: readonly ReplicaReadyState[],
+  viewSyncer: ServingLagViewSyncer,
+): number {
+  const firstReadyAfterCreation = lowerBoundReplicaReadyTimeMs(
+    replicaReadyStates,
+    viewSyncer.createdAtMs,
+  );
+  const firstAfterServedVersion =
+    viewSyncer.servedVersion === null
+      ? 0
+      : upperBoundWatermark(replicaReadyStates, viewSyncer.servedVersion);
+
+  const firstUnservedIndex = Math.max(
+    firstReadyAfterCreation,
+    firstAfterServedVersion,
+  );
+  return firstUnservedIndex < replicaReadyStates.length
+    ? firstUnservedIndex
+    : -1;
+}
+
 export function computeMaxServingLagMs(
   now: number,
   replicaReadyStates: ReplicaReadyState[],
@@ -86,13 +142,10 @@ export function computeMaxServingLagMs(
   let firstNeededIndex = replicaReadyStates.length;
 
   for (const viewSyncer of viewSyncers) {
-    const firstUnservedIndex = replicaReadyStates.findIndex(
-      ({replicaReadyTimeMs, watermark}) =>
-        replicaReadyTimeMs >= viewSyncer.createdAtMs &&
-        (viewSyncer.servedVersion === null ||
-          viewSyncer.servedVersion < watermark),
+    const firstUnservedIndex = findFirstUnservedIndex(
+      replicaReadyStates,
+      viewSyncer,
     );
-
     if (firstUnservedIndex === -1) {
       continue;
     }

--- a/packages/zero-cache/src/workers/syncer.ts
+++ b/packages/zero-cache/src/workers/syncer.ts
@@ -53,6 +53,16 @@ export type ServingLagViewSyncer = Pick<
   'createdAtMs' | 'servedVersion'
 >;
 
+export type ServingLagStats = {
+  readonly activeClientGroups: number;
+  readonly laggingClientGroups: number;
+  readonly minMs: number;
+  readonly p50Ms: number;
+  readonly p75Ms: number;
+  readonly p99Ms: number;
+  readonly maxMs: number;
+};
+
 export const MAX_REPLICA_READY_STATES = 10_000;
 
 function boundReplicaReadyStates(
@@ -133,12 +143,27 @@ function findFirstUnservedIndex(
     : -1;
 }
 
-export function computeMaxServingLagMs(
+function percentileNearestRank(
+  sortedValues: readonly number[],
+  percentile: number,
+): number {
+  if (sortedValues.length === 0) {
+    return 0;
+  }
+  const index = Math.min(
+    sortedValues.length - 1,
+    Math.max(0, Math.ceil((percentile / 100) * sortedValues.length) - 1),
+  );
+  return sortedValues[index];
+}
+
+export function computeServingLagStatsMs(
   now: number,
   replicaReadyStates: ReplicaReadyState[],
   viewSyncers: Iterable<ServingLagViewSyncer>,
-): number {
-  let maxLagMs = 0;
+): ServingLagStats {
+  const lags: number[] = [];
+  let laggingClientGroups = 0;
   let firstNeededIndex = replicaReadyStates.length;
 
   for (const viewSyncer of viewSyncers) {
@@ -147,19 +172,41 @@ export function computeMaxServingLagMs(
       viewSyncer,
     );
     if (firstUnservedIndex === -1) {
+      lags.push(0);
       continue;
     }
 
     firstNeededIndex = Math.min(firstNeededIndex, firstUnservedIndex);
-    maxLagMs = Math.max(
-      maxLagMs,
+    const lagMs = Math.max(
+      0,
       now - replicaReadyStates[firstUnservedIndex].replicaReadyTimeMs,
     );
+    lags.push(lagMs);
+    if (lagMs > 0) {
+      laggingClientGroups++;
+    }
   }
 
   pruneReplicaReadyStates(replicaReadyStates, firstNeededIndex);
 
-  return Math.max(0, maxLagMs);
+  lags.sort((a, b) => a - b);
+  return {
+    activeClientGroups: lags.length,
+    laggingClientGroups,
+    minMs: lags[0] ?? 0,
+    p50Ms: percentileNearestRank(lags, 50),
+    p75Ms: percentileNearestRank(lags, 75),
+    p99Ms: percentileNearestRank(lags, 99),
+    maxMs: lags.at(-1) ?? 0,
+  };
+}
+
+export function computeMaxServingLagMs(
+  now: number,
+  replicaReadyStates: ReplicaReadyState[],
+  viewSyncers: Iterable<ServingLagViewSyncer>,
+): number {
+  return computeServingLagStatsMs(now, replicaReadyStates, viewSyncers).maxMs;
 }
 
 function getWebSocketServerOptions(config: ZeroConfig): ServerOptions {
@@ -209,6 +256,8 @@ export class Syncer implements SingletonService {
   readonly #config: ZeroConfig;
   readonly #validateLegacyJWT: ValidateLegacyJWT | undefined;
   readonly #replicaReadyStates: ReplicaReadyState[] = [];
+  #servingLagStatsCache: ServingLagStats | undefined;
+  #servingLagStatsCacheClearQueued = false;
 
   constructor(
     lc: LogContext,
@@ -306,14 +355,52 @@ export class Syncer implements SingletonService {
         'and pokeEnd.',
       unit: 'millisecond',
     }).addCallback(result => {
-      result.observe(
-        computeMaxServingLagMs(
-          Date.now(),
-          this.#replicaReadyStates,
-          this.#viewSyncers.getServices(),
-        ),
-      );
+      result.observe(this.#computeServingLagStats().maxMs);
     });
+
+    getOrCreateGauge('sync', 'serving-lag-stats', {
+      description:
+        'Distribution of time active ViewSyncer client groups have had ' +
+        'unserved replica changes. A change is served after IVM advancement, ' +
+        'CVR flush, and pokeEnd.',
+      unit: 'millisecond',
+    }).addCallback(result => {
+      const stats = this.#computeServingLagStats();
+      result.observe(stats.minMs, {stat: 'min'});
+      result.observe(stats.p50Ms, {stat: 'p50'});
+      result.observe(stats.p75Ms, {stat: 'p75'});
+      result.observe(stats.p99Ms, {stat: 'p99'});
+      result.observe(stats.maxMs, {stat: 'max'});
+    });
+
+    getOrCreateGauge(
+      'sync',
+      'serving-lagging-client-groups',
+      'Number of active client groups with unserved replica changes',
+    ).addCallback(result => {
+      result.observe(this.#computeServingLagStats().laggingClientGroups);
+    });
+  }
+
+  #computeServingLagStats(): ServingLagStats {
+    if (this.#servingLagStatsCache) {
+      return this.#servingLagStatsCache;
+    }
+
+    const stats = computeServingLagStatsMs(
+      Date.now(),
+      this.#replicaReadyStates,
+      this.#viewSyncers.getServices(),
+    );
+    this.#servingLagStatsCache = stats;
+    if (!this.#servingLagStatsCacheClearQueued) {
+      this.#servingLagStatsCacheClearQueued = true;
+      queueMicrotask(() => {
+        this.#servingLagStatsCache = undefined;
+        this.#servingLagStatsCacheClearQueued = false;
+      });
+    }
+    return stats;
   }
 
   #recordReplicaReadyState(state: ReplicaState): void {


### PR DESCRIPTION
## E2E: Serving Lag Tracking

  ### What We Want To Measure

  For each active client group, we want to know:

  > How long has there been replica data ready locally that this ViewSyncer has not finished serving to clients yet?

  That time is `sync.serving-lag`.

  ---

  ## The Pieces

  ### Replica Ready State

  When the local replica finishes applying a change, we record:

  ```ts
  {
    watermark: '04',
    replicaReadyTimeMs: 123456789,
  }

  Think of watermark as “version number” and replicaReadyTimeMs as “when that version became readable.”

  ### ViewSyncer State

  Each active ViewSyncer exposes:

  {
    createdAtMs,
    servedVersion,
  }

  - createdAtMs: ignore replica changes that were already ready before this ViewSyncer existed.
  - servedVersion: the latest watermark this ViewSyncer has fully served through pokeEnd.

  ———

  ## Flow

  1. Replication applies a change
      - IncrementalSyncer processes upstream changes into the local SQLite replica.
      - When a new watermark is ready, it sends:

```js
  {
    state: 'version-ready',
    watermark,
    replicaReadyTimeMs: Date.now(),
  }
```

  2. Notifier forwards the message
      - The replicator notifier sends this to subscribers.
      - If notifications coalesce, it keeps the newest watermark but preserves the earliest ready time so lag is not
        underreported.

  3. Syncer records ready states
      - Syncer receives the notification.
      - If it has both watermark and replicaReadyTimeMs, it appends it to #replicaReadyStates.
      - If there are no active ViewSyncers, it clears the list immediately.
      - Otherwise it caps the list at 10_000 entries.

  4. ViewSyncers serve changes
      - ViewSyncers advance pipelines, flush CVRs, and send pokeEnd.
      - Only after pokeEnd completes do they update servedVersion.

  5. OTel gauge computes lag
      - When metrics collection runs, the sync.serving-lag gauge calls computeMaxServingLagMs.

  ———

  ## Computation

  For each active ViewSyncer:

  1. Find the first replica-ready state after createdAtMs.
  2. Find the first replica-ready state with watermark > servedVersion.
  3. Use the later of those two positions.
  4. Lag is:

  now - replicaReadyTimeMs

  The metric reports the max lag across all active ViewSyncers.