### PR TITLE
feat(release): also publish Docker image to GHCR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,7 @@ jobs:
     permissions:
       contents: write # Required to push release tags.
       id-token: write # Required for cosign keyless signing.
+      packages: write # Required to push images to GHCR (ghcr.io).
       pull-requests: write # Required to comment on canary release PRs.
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -61,6 +62,16 @@ jobs:
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GHCR
+        # Authenticate with the ephemeral, run-scoped GITHUB_TOKEN rather than a
+        # stored PAT. The packages:write permission above grants it push access
+        # to ghcr.io/${{ github.repository_owner }}/*.
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure git identity
         run: |
@@ -94,11 +105,14 @@ jobs:
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
-      - name: Sign Docker image
+      - name: Sign Docker images
         if: ${{ inputs.dry_run != true }}
         env:
           VERSION: ${{ steps.release.outputs.version }}
-        run: cosign sign --yes rocicorp/zero:$VERSION
+        # Keyless signing via the OIDC identity token (id-token: write above).
+        run: |
+          cosign sign --yes rocicorp/zero:$VERSION
+          cosign sign --yes ghcr.io/rocicorp/zero:$VERSION
 
       - name: Comment on PR
         if: github.event_name == 'pull_request'
@@ -113,6 +127,7 @@ jobs:
             printf '```\n'
             printf 'npm install @rocicorp/zero@%s\n' "$VERSION"
             printf '```\n\n'
-            printf '**Docker:** `%s`\n' "rocicorp/zero:$VERSION"
+            printf '**Docker Hub:** `%s`\n' "rocicorp/zero:$VERSION"
+            printf '**GHCR:** `%s`\n' "ghcr.io/rocicorp/zero:$VERSION"
           } > release-comment.md
           gh pr comment "$PR_NUMBER" --body-file release-comment.md

--- a/packages/zero/tool/make-latest.js
+++ b/packages/zero/tool/make-latest.js
@@ -29,6 +29,9 @@ execute(
 execute(
   `docker buildx imagetools create -t rocicorp/zero:latest rocicorp/zero:${version}`,
 );
+execute(
+  `docker buildx imagetools create -t ghcr.io/rocicorp/zero:latest ghcr.io/rocicorp/zero:${version}`,
+);
 execute(`pnpm dist-tag add @rocicorp/zero@${version} latest`);
 
 const localLatest = execute('git rev-parse latest', {stdio: 'pipe'});
@@ -52,6 +55,16 @@ retry(() => {
 });
 
 retry(() => {
+  const ghcrVersionDigest = dockerDigest(`ghcr.io/rocicorp/zero:${version}`);
+  const ghcrLatestDigest = dockerDigest('ghcr.io/rocicorp/zero:latest');
+  if (ghcrVersionDigest !== ghcrLatestDigest) {
+    throw new Error(
+      `Failed to update GHCR latest tag: ${ghcrLatestDigest} !== ${ghcrVersionDigest}`,
+    );
+  }
+});
+
+retry(() => {
   const npmLatest = execute('pnpm view @rocicorp/zero dist-tags.latest', {
     stdio: 'pipe',
   });
@@ -68,6 +81,7 @@ console.log(`🎉 Success!`);
 console.log(``);
 console.log(`* Added 'latest' tag to @rocicorp/zero@${version} on npm.`);
 console.log(`* Added 'latest' tag to rocicorp/zero:${version} on dockerhub.`);
+console.log(`* Added 'latest' tag to ghcr.io/rocicorp/zero:${version} on GHCR.`);
 console.log(`* Added 'latest' git tag pointing to ${gitTag}.`);
 console.log(``);
 console.log(``);

--- a/packages/zero/tool/make-latest.js
+++ b/packages/zero/tool/make-latest.js
@@ -81,7 +81,9 @@ console.log(`🎉 Success!`);
 console.log(``);
 console.log(`* Added 'latest' tag to @rocicorp/zero@${version} on npm.`);
 console.log(`* Added 'latest' tag to rocicorp/zero:${version} on dockerhub.`);
-console.log(`* Added 'latest' tag to ghcr.io/rocicorp/zero:${version} on GHCR.`);
+console.log(
+  `* Added 'latest' tag to ghcr.io/rocicorp/zero:${version} on GHCR.`,
+);
 console.log(`* Added 'latest' git tag pointing to ${gitTag}.`);
 console.log(``);
 console.log(``);

--- a/packages/zero/tool/release.ts
+++ b/packages/zero/tool/release.ts
@@ -174,7 +174,7 @@ async function main() {
       }
     }
     console.log(
-      `* ${dryRun ? 'Would create' : 'Created'} Docker image rocicorp/zero:${result.version}.`,
+      `* ${dryRun ? 'Would create' : 'Created'} Docker images rocicorp/zero:${result.version} and ghcr.io/rocicorp/zero:${result.version}.`,
     );
     console.log(``);
     console.log(``);
@@ -690,7 +690,7 @@ function pushNpm(isCanary: boolean, dryRun: boolean) {
 async function pushDocker(version: string, dryRun: boolean) {
   if (dryRun) {
     console.log(
-      `[DRY RUN] Would run: docker buildx build --platform linux/amd64,linux/arm64 --build-arg=ZERO_VERSION=${version} -t rocicorp/zero:${version} --sbom=true --provenance=mode=max --push .`,
+      `[DRY RUN] Would run: docker buildx build --platform linux/amd64,linux/arm64 --build-arg=ZERO_VERSION=${version} -t rocicorp/zero:${version} -t ghcr.io/rocicorp/zero:${version} --sbom=true --provenance=mode=max --push .`,
     );
     return;
   }
@@ -715,11 +715,14 @@ async function pushDocker(version: string, dryRun: boolean) {
   const dockerBuildAttempts = 3;
   for (let i = 0; i < dockerBuildAttempts; i++) {
     try {
+      // A single build pushed to both registries. The multiple -t flags share
+      // one build, so the SBOM and provenance attestations apply to both.
       execute(
         `docker buildx build \\
     --platform linux/amd64,linux/arm64 \\
     --build-arg=ZERO_VERSION=${version} \\
     -t rocicorp/zero:${version} \\
+    -t ghcr.io/rocicorp/zero:${version} \\
     --sbom=true \\
     --provenance=mode=max \\
     --push .`,


### PR DESCRIPTION
Publish the zero Docker image to ghcr.io/rocicorp/zero alongside the existing Docker Hub image. A single buildx build pushes both tags, so SBOM and provenance attestations apply to both registries.

Authenticate to GHCR with the ephemeral, run-scoped GITHUB_TOKEN (packages: write) instead of a stored PAT, and extend cosign keyless signing (OIDC) to the GHCR image. make-latest.js retags and verifies the `latest` digest on GHCR as well.


