### PR TITLE
refactor(release): split build and Docker Hub publish into separate jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,16 +25,23 @@ concurrency:
   cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
 jobs:
-  release:
-    name: Release
+  # Build job: runs all the heavy, untrusted code (pnpm install, the workspace
+  # build, and the Dockerfile build, which execute dependency lifecycle scripts).
+  # It deliberately does NOT have the long-lived Docker Hub credential. It uses
+  # only ephemeral, run-scoped credentials: OIDC for npm provenance + cosign, and
+  # GITHUB_TOKEN for the git tag push and the GHCR image push. The image is staged
+  # to GHCR; the publish job promotes it to Docker Hub.
+  build:
+    name: Build & stage to GHCR
     if: github.event_name == 'workflow_dispatch' || (github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release-canary'))
     runs-on: ubuntu-latest
     environment: Release
+    outputs:
+      version: ${{ steps.release.outputs.version }}
     permissions:
       contents: write # Required to push release tags.
-      id-token: write # Required for cosign keyless signing.
-      packages: write # Required to push images to GHCR (ghcr.io).
-      pull-requests: write # Required to comment on canary release PRs.
+      id-token: write # Required for npm provenance and cosign keyless signing.
+      packages: write # Required to push the image to GHCR (ghcr.io).
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         # zizmor: ignore[artipacked] release.ts needs checkout credentials to push release tags.
@@ -57,16 +64,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - name: Login to GHCR
         # Authenticate with the ephemeral, run-scoped GITHUB_TOKEN rather than a
         # stored PAT. The packages:write permission above grants it push access
-        # to ghcr.io/${{ github.repository_owner }}/*.
+        # to ghcr.io/${{ github.repository_owner }}/*. The long-lived Docker Hub
+        # token is intentionally not present in this job.
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
@@ -105,21 +107,61 @@ jobs:
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
-      - name: Sign Docker images
+      - name: Sign GHCR image
         if: ${{ inputs.dry_run != true }}
         env:
           VERSION: ${{ steps.release.outputs.version }}
         # Keyless signing via the OIDC identity token (id-token: write above).
-        run: |
-          cosign sign --yes rocicorp/zero:$VERSION
-          cosign sign --yes ghcr.io/rocicorp/zero:$VERSION
+        run: cosign sign --yes ghcr.io/rocicorp/zero:$VERSION
+
+  # Publish job: the ONLY job that holds the long-lived Docker Hub credential. It
+  # runs minimal, trusted code — it promotes the already-built GHCR image to
+  # Docker Hub (copying the manifest + SBOM/provenance attestations verbatim) and
+  # signs it. No checkout, no install, no build.
+  publish:
+    name: Promote to Docker Hub
+    needs: build
+    if: github.event_name == 'workflow_dispatch' || (github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release-canary'))
+    runs-on: ubuntu-latest
+    environment: Release
+    permissions:
+      id-token: write # Required for cosign keyless signing.
+      packages: read # Required to pull the staged image from GHCR.
+      pull-requests: write # Required to comment on canary release PRs.
+    env:
+      VERSION: ${{ needs.build.outputs.version }}
+    steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GHCR
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Promote GHCR image to Docker Hub
+        if: ${{ inputs.dry_run != true }}
+        # Copies the multi-arch manifest and its SBOM/provenance attestations from
+        # GHCR to Docker Hub without rebuilding.
+        run: docker buildx imagetools create -t rocicorp/zero:$VERSION ghcr.io/rocicorp/zero:$VERSION
+
+      - name: Sign Docker Hub image
+        if: ${{ inputs.dry_run != true }}
+        run: cosign sign --yes rocicorp/zero:$VERSION
 
       - name: Comment on PR
         if: github.event_name == 'pull_request'
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          VERSION: ${{ steps.release.outputs.version }}
         run: |
           {
             printf '## Canary Release Published\n\n'

--- a/packages/zero/tool/release.ts
+++ b/packages/zero/tool/release.ts
@@ -174,7 +174,7 @@ async function main() {
       }
     }
     console.log(
-      `* ${dryRun ? 'Would create' : 'Created'} Docker images rocicorp/zero:${result.version} and ghcr.io/rocicorp/zero:${result.version}.`,
+      `* ${dryRun ? 'Would create' : 'Created'} Docker image ghcr.io/rocicorp/zero:${result.version} (promote to Docker Hub happens in the publish job).`,
     );
     console.log(``);
     console.log(``);
@@ -690,7 +690,7 @@ function pushNpm(isCanary: boolean, dryRun: boolean) {
 async function pushDocker(version: string, dryRun: boolean) {
   if (dryRun) {
     console.log(
-      `[DRY RUN] Would run: docker buildx build --platform linux/amd64,linux/arm64 --build-arg=ZERO_VERSION=${version} -t rocicorp/zero:${version} -t ghcr.io/rocicorp/zero:${version} --sbom=true --provenance=mode=max --push .`,
+      `[DRY RUN] Would run: docker buildx build --platform linux/amd64,linux/arm64 --build-arg=ZERO_VERSION=${version} -t ghcr.io/rocicorp/zero:${version} --sbom=true --provenance=mode=max --push .`,
     );
     return;
   }
@@ -715,13 +715,16 @@ async function pushDocker(version: string, dryRun: boolean) {
   const dockerBuildAttempts = 3;
   for (let i = 0; i < dockerBuildAttempts; i++) {
     try {
-      // A single build pushed to both registries. The multiple -t flags share
-      // one build, so the SBOM and provenance attestations apply to both.
+      // Build and push to GHCR only. The release pipeline keeps the long-lived
+      // Docker Hub credential out of this build (which runs untrusted dependency
+      // and Dockerfile code) and instead promotes this GHCR image to Docker Hub
+      // in a separate, minimal publish job via `docker buildx imagetools create`.
+      // SBOM and provenance attestations are produced here and copied verbatim
+      // during that promotion.
       execute(
         `docker buildx build \\
     --platform linux/amd64,linux/arm64 \\
     --build-arg=ZERO_VERSION=${version} \\
-    -t rocicorp/zero:${version} \\
     -t ghcr.io/rocicorp/zero:${version} \\
     --sbom=true \\
     --provenance=mode=max \\


### PR DESCRIPTION
Follow-up to #6161 (GHCR publishing), now rebased onto `main` — this PR contains **only** the build/publish job split.

## Goal

Reduce the blast radius of the **long-lived `DOCKERHUB_TOKEN`** by isolating it to a minimal publish job. It's the only stored, long-lived secret in the release workflow — npm publish (OIDC trusted publishing), the git tag push (`GITHUB_TOKEN`), the GHCR push (`GITHUB_TOKEN`), and cosign (OIDC keyless) all use ephemeral, run-scoped credentials already.

## How

Split the single `release` job into two:

- **`build` — "Build & stage to GHCR"** (`contents: write`, `id-token: write`, `packages: write`; **no `DOCKERHUB_TOKEN`**). Runs all the heavy, untrusted code: `pnpm install`, the workspace build, and the Dockerfile build (which execute dependency lifecycle scripts). Builds, npm-publishes, git-tags, and pushes the image to **GHCR only**. Signs the GHCR image.
- **`publish` — "Promote to Docker Hub"** (`needs: build`; **only `DOCKERHUB_TOKEN`** + `id-token` for signing + `packages: read`). Runs no checkout/install/build. Promotes the staged GHCR image to Docker Hub via `docker buildx imagetools create` (copying the multi-arch manifest + SBOM/provenance attestations verbatim), signs the Docker Hub image, and comments on the PR.

`release.ts`'s `pushDocker` now pushes to GHCR only; Docker Hub publishing becomes the promote step. The two jobs are chained via `needs:` and run automatically in one workflow run — the split is purely for credential isolation, not an extra manual step.

This keeps the sensitive Docker Hub credential away from all the dependency/Dockerfile code execution — it only ever touches a job running `imagetools` + `cosign`. No build-from-tarball / Dockerfile changes were needed because the Docker build still pulls from npm after npm publish, all within the build job.

## Heads-up for branch protection

The required status check names change from `Release` to `Build & stage to GHCR` and `Promote to Docker Hub`. If branch protection requires the old `Release` check, it'll need updating.

> [!NOTE]
> Not validated end-to-end (no Actions run available in the authoring environment). The `dry_run` workflow_dispatch input is the safest way to smoke-test before a real release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)