### PR TITLE
bench: add planner hydration predicate indexes

### DIFF
--- a/packages/zql-benchmarks/src/planner-hydration.bench.ts
+++ b/packages/zql-benchmarks/src/planner-hydration.bench.ts
@@ -29,7 +29,10 @@ const {dbs, delegates, queries} = await bootstrap({
   pgContent,
 });
 
-// Run ANALYZE to populate SQLite statistics for cost model
+dbs.sqlite.exec('CREATE INDEX IF NOT EXISTS idx_album_title ON album(title)');
+dbs.sqlite.exec('CREATE INDEX IF NOT EXISTS idx_genre_name ON genre(name)');
+
+// Run ANALYZE after index creation to populate SQLite statistics for cost model.
 dbs.sqlite.exec('ANALYZE;');
 
 const tables: {[key: string]: TableSchema} = schema.tables;


### PR DESCRIPTION
## Summary

Adds the Chinook predicate indexes used by the planner hydration benchmark before running `ANALYZE`:

- `album(title)`
- `genre(name)`

This makes the benchmark measure planner/execution behavior for the intended indexed schema rather than an under-indexed edge case.

## Context

While comparing Zero 1.7 vs 1.6 benchmark results, the largest reported regression was:

`planner-hydration.bench.ts > track.exists(album).exists(genre) with filters > planned`

It appeared to regress from ~103 us in 1.6 to ~3.88 ms in 1.7.

Further investigation showed the benchmark fixture had relationship indexes like `track(album_id)` and `track(genre_id)`, but was missing predicate indexes for the filtered related tables. In particular, the query filters on `album.title = "Big Ones"` and `genre.name = "Rock"`, but the SQLite benchmark DB did not have `album(title)` or `genre(name)` indexes before `ANALYZE`.

Because `"Big Ones"` is highly selective and `"Rock"` matches many tracks, missing stats/indexes could cause the planner to pick the worse `genre`-flipped plan.

## Fix

Create the relevant indexes before `ANALYZE` in `planner-hydration.bench.ts` so SQLite statistics include them:

```ts
dbs.sqlite.exec('CREATE INDEX IF NOT EXISTS idx_album_title ON album(title)');
dbs.sqlite.exec('CREATE INDEX IF NOT EXISTS idx_genre_name ON genre(name)');

dbs.sqlite.exec('ANALYZE;');
```
