### PR TITLE
feat: add encryptRow/decryptRow hooks for end-to-end row encryption

### DIFF
--- a/packages/zero-client/src/client/options.ts
+++ b/packages/zero-client/src/client/options.ts
@@ -1,6 +1,7 @@
 import type {LogLevel, LogSink} from '@rocicorp/logger';
 import type {StoreProvider} from '../../../replicache/src/kv/store.ts';
 import * as v from '../../../shared/src/valita.ts';
+import type {Row} from '../../../zero-protocol/src/data.ts';
 import type {
   BaseDefaultContext,
   BaseDefaultSchema,
@@ -10,6 +11,13 @@ import type {
 import type {AnyMutatorRegistry} from '../../../zql/src/mutate/mutator-registry.ts';
 import type {CustomMutatorDefs} from './custom.ts';
 import {UpdateNeededReasonType} from './update-needed-reason-type.ts';
+
+/**
+ * Async hook applied to each server row before it is written to the local
+ * store, e.g. to decrypt end-to-end encrypted columns. The returned row is
+ * stored in place of the original.
+ */
+export type DecryptRow = (tableName: string, row: Row) => Row | Promise<Row>;
 
 /**
  * Configuration for {@linkcode Zero}.
@@ -299,6 +307,12 @@ export type ZeroOptions<
    * allowing a custom implementation of the underlying storage layer.
    */
   kvStore?: 'mem' | 'idb' | StoreProvider | undefined;
+
+  /**
+   * Async hook to decrypt each server row before it is written to the local
+   * store. Applied in {@linkcode PokeHandler} to `put` and `update` ops.
+   */
+  decryptRow?: DecryptRow | undefined;
 
   /**
    * The maximum number of bytes to allow in a single header.

--- a/packages/zero-client/src/client/zero-poke-handler.test.ts
+++ b/packages/zero-client/src/client/zero-poke-handler.test.ts
@@ -1293,13 +1293,13 @@ describe('poke handler', () => {
     expect(lastMutationIDChangeForSelf2).toBeUndefined();
   });
 
-  test('mergePokes with empty array returns undefined', () => {
-    const merged = mergePokes([], schema, serverToClient(schema.tables));
+  test('mergePokes with empty array returns undefined', async () => {
+    const merged = await mergePokes([], schema, serverToClient(schema.tables));
     expect(merged).toBeUndefined();
   });
 
-  test('mergePokes with all optionals defined', () => {
-    const result = mergePokes(
+  test('mergePokes with all optionals defined', async () => {
+    const result = await mergePokes(
       [
         {
           pokeStart: {
@@ -1474,8 +1474,8 @@ describe('poke handler', () => {
     });
   });
 
-  test('mergePokes sparse', () => {
-    const result = mergePokes(
+  test('mergePokes sparse', async () => {
+    const result = await mergePokes(
       [
         {
           pokeStart: {
@@ -1599,8 +1599,8 @@ describe('poke handler', () => {
     });
   });
 
-  test('mergePokes skips rows for tables not in client schema', () => {
-    const result = mergePokes(
+  test('mergePokes skips rows for tables not in client schema', async () => {
+    const result = await mergePokes(
       [
         {
           pokeStart: {
@@ -1661,8 +1661,8 @@ describe('poke handler', () => {
     });
   });
 
-  test('mergePokes skips del and update ops for tables not in client schema', () => {
-    const result = mergePokes(
+  test('mergePokes skips del and update ops for tables not in client schema', async () => {
+    const result = await mergePokes(
       [
         {
           pokeStart: {
@@ -1720,8 +1720,8 @@ describe('poke handler', () => {
     });
   });
 
-  test('mergePokes throws error on cookie gaps', () => {
-    expect(() => {
+  test('mergePokes throws error on cookie gaps', async () => {
+    await expect(
       mergePokes(
         [
           {
@@ -1759,8 +1759,8 @@ describe('poke handler', () => {
         ],
         schema,
         serverToClient(schema.tables),
-      );
-    }).toThrow();
+      ),
+    ).rejects.toThrow();
   });
 });
 

--- a/packages/zero-client/src/client/zero-poke-handler.ts
+++ b/packages/zero-client/src/client/zero-poke-handler.ts
@@ -27,6 +27,7 @@ import {
   toPrimaryKeyString,
 } from './keys.ts';
 import type {MutationTracker} from './mutation-tracker.ts';
+import type {DecryptRow} from './options.ts';
 
 type PokeAccumulator = {
   readonly pokeStart: PokeStartBody;
@@ -58,6 +59,7 @@ export class PokeHandler {
   readonly #schema: Schema;
   readonly #serverToClient: NameMapper;
   readonly #mutationTracker: MutationTracker;
+  readonly #decryptRow: DecryptRow | undefined;
 
   constructor(
     replicachePoke: (poke: PokeInternal) => Promise<void>,
@@ -66,6 +68,7 @@ export class PokeHandler {
     schema: Schema,
     lc: LogContext,
     mutationTracker: MutationTracker,
+    decryptRow?: DecryptRow,
   ) {
     this.#replicachePoke = replicachePoke;
     this.#onPokeError = onPokeError;
@@ -74,6 +77,7 @@ export class PokeHandler {
     this.#serverToClient = serverToClient(schema.tables);
     this.#lc = lc.withContext('PokeHandler');
     this.#mutationTracker = mutationTracker;
+    this.#decryptRow = decryptRow;
   }
 
   handlePokeStart(pokeStart: PokeStartBody) {
@@ -164,10 +168,11 @@ export class PokeHandler {
       lc.debug?.('got poke lock at', now);
       lc.debug?.('merging', this.#pokeBuffer.length);
       try {
-        const merged = mergePokes(
+        const merged = await mergePokes(
           this.#pokeBuffer,
           this.#schema,
           this.#serverToClient,
+          this.#decryptRow,
         );
         this.#pokeBuffer.length = 0;
         if (merged === undefined) {
@@ -211,13 +216,15 @@ export class PokeHandler {
   }
 }
 
-export function mergePokes(
+export async function mergePokes(
   pokeBuffer: PokeAccumulator[],
   schema: Schema,
   serverToClient: NameMapper,
-):
+  decryptRow?: DecryptRow,
+): Promise<
   | (PokeInternal & {mutationResults?: MutationPatch[] | undefined})
-  | undefined {
+  | undefined
+> {
   if (pokeBuffer.length === 0) {
     return undefined;
   }
@@ -273,10 +280,11 @@ export function mergePokes(
       }
       if (pokePart.rowsPatch) {
         for (const p of pokePart.rowsPatch) {
-          const patchOp = rowsPatchOpToReplicachePatchOp(
+          const patchOp = await rowsPatchOpToReplicachePatchOp(
             p,
             schema,
             serverToClient,
+            decryptRow,
           );
           if (patchOp) {
             mergedPatch.push(patchOp);
@@ -349,11 +357,12 @@ export function mutationPatchOpToReplicachePatchOp(
   }
 }
 
-function rowsPatchOpToReplicachePatchOp(
+async function rowsPatchOpToReplicachePatchOp(
   op: RowPatchOp,
   schema: Schema,
   serverToClient: NameMapper,
-): PatchOperationInternal | undefined {
+  decryptRow?: DecryptRow,
+): Promise<PatchOperationInternal | undefined> {
   if (op.op === 'clear') {
     return op;
   }
@@ -374,17 +383,22 @@ function rowsPatchOpToReplicachePatchOp(
           serverToClient.row(op.tableName, op.id),
         ),
       };
-    case 'put':
+    case 'put': {
+      const value = serverToClient.row(op.tableName, op.value);
       return {
         op: 'put',
         key: toPrimaryKeyString(
           tableName,
           schema.tables[tableName].primaryKey,
-          serverToClient.row(op.tableName, op.value),
+          value,
         ),
-        value: serverToClient.row(op.tableName, op.value),
+        value: decryptRow ? await decryptRow(tableName, value) : value,
       };
-    case 'update':
+    }
+    case 'update': {
+      const merge = op.merge
+        ? serverToClient.row(op.tableName, op.merge)
+        : undefined;
       return {
         op: 'update',
         key: toPrimaryKeyString(
@@ -392,11 +406,13 @@ function rowsPatchOpToReplicachePatchOp(
           schema.tables[tableName].primaryKey,
           serverToClient.row(op.tableName, op.id),
         ),
-        merge: op.merge
-          ? serverToClient.row(op.tableName, op.merge)
-          : undefined,
+        merge:
+          merge && decryptRow
+            ? ((await decryptRow(tableName, merge)) as typeof merge)
+            : merge,
         constrain: serverToClient.columns(op.tableName, op.constrain),
       };
+    }
     default:
       unreachable(op);
   }

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -819,6 +819,7 @@ export class Zero<
       schema,
       this.#lc,
       this.#mutationTracker,
+      options.decryptRow,
     );
 
     this.#visibilityWatcher = getDocumentVisibilityWatcher(

--- a/packages/zero-server/src/adapters/drizzle.ts
+++ b/packages/zero-server/src/adapters/drizzle.ts
@@ -8,10 +8,18 @@ import type {
   Row,
 } from '../../../zql/src/mutate/custom.ts';
 import type {HumanReadable} from '../../../zql/src/query/query.ts';
+import type {RowCrypto} from '../custom.ts';
 import {executePostgresQuery} from '../pg-query-executor.ts';
 import {ZQLDatabase} from '../zql-database.ts';
 
 export type {ZQLDatabase};
+export type {RowCrypto};
+
+/** Server-side encryption hooks applied to every Zero transaction read/write. */
+export interface ZeroServerCryptoOptions {
+  encryptRow?: RowCrypto | undefined;
+  decryptRow?: RowCrypto | undefined;
+}
 
 type DrizzleQuery = {sql: string; params: unknown[]};
 type DrizzlePreparedQuery = {execute(): Promise<unknown>};
@@ -80,18 +88,25 @@ export class DrizzleConnection<
   TTransaction extends DrizzleTransactionLike = DrizzleTransaction<TDrizzle>,
 > implements DBConnection<TTransaction> {
   readonly #drizzle: DrizzleDatabase<TTransaction>;
+  readonly #decryptRow: RowCrypto | undefined;
 
-  constructor(drizzle: TDrizzle & DrizzleDatabase<TTransaction>) {
+  constructor(
+    drizzle: TDrizzle & DrizzleDatabase<TTransaction>,
+    decryptRow?: RowCrypto,
+  ) {
     this.#drizzle = drizzle;
+    this.#decryptRow = decryptRow;
   }
 
   transaction<T>(
     fn: (tx: DBTransaction<TTransaction>) => Promise<T>,
   ): Promise<T> {
+    const decryptRow = this.#decryptRow;
     return this.#drizzle.transaction(drizzleTx =>
       fn(
         new DrizzleInternalTransaction(
           drizzleTx,
+          decryptRow,
         ) as DBTransaction<TTransaction>,
       ),
     );
@@ -102,9 +117,11 @@ class DrizzleInternalTransaction<
   TTransaction extends DrizzleTransactionLike,
 > implements DBTransaction<TTransaction> {
   readonly wrappedTransaction: TTransaction;
+  readonly #decryptRow: RowCrypto | undefined;
 
-  constructor(drizzleTx: TTransaction) {
+  constructor(drizzleTx: TTransaction, decryptRow?: RowCrypto) {
     this.wrappedTransaction = drizzleTx;
+    this.#decryptRow = decryptRow;
   }
 
   runQuery<TReturn>(
@@ -113,13 +130,21 @@ class DrizzleInternalTransaction<
     schema: Schema,
     serverSchema: ServerSchema,
   ): Promise<HumanReadable<TReturn>> {
-    return executePostgresQuery<TReturn>(
+    const result = executePostgresQuery<TReturn>(
       this,
       ast,
       format,
       schema,
       serverSchema,
     );
+    const decryptRow = this.#decryptRow;
+    if (!decryptRow) {
+      return result;
+    }
+    const decrypted = result.then(rows =>
+      decryptZqlResult(rows, ast, decryptRow),
+    );
+    return decrypted as Promise<HumanReadable<TReturn>>;
   }
 
   async query(sql: string, params: unknown[]): Promise<Iterable<Row>> {
@@ -178,6 +203,40 @@ export function toIterableRows(result: unknown): Iterable<Row> {
 }
 
 /**
+ * Recursively decrypt a ZQL query result, walking `related` subqueries so
+ * nested rows are decrypted with their own table name before the parent row.
+ */
+async function decryptZqlResult(
+  value: unknown,
+  ast: AST,
+  decryptRow: RowCrypto,
+): Promise<unknown> {
+  if (value === null || value === undefined) {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return Promise.all(
+      value.map(row => decryptZqlResult(row, ast, decryptRow)),
+    );
+  }
+  const row = value as Record<string, unknown>;
+  for (const relationship of ast.related ?? []) {
+    const {alias} = relationship.subquery;
+    // oxlint-disable-next-line eqeqeq
+    if (alias == null || row[alias] == null) {
+      continue;
+    }
+    const hiddenChild = relationship.subquery.related?.[0];
+    const childAst =
+      relationship.hidden && hiddenChild
+        ? hiddenChild.subquery
+        : relationship.subquery;
+    row[alias] = await decryptZqlResult(row[alias], childAst, decryptRow);
+  }
+  return decryptRow(ast.table, row as Row);
+}
+
+/**
  * Wrap a `drizzle-orm` database for Zero ZQL.
  *
  * Provides ZQL querying plus access to the underlying drizzle transaction.
@@ -222,9 +281,11 @@ export function zeroDrizzle<
 >(
   schema: TSchema,
   client: TDrizzle & DrizzleDatabase<TTransaction>,
+  options?: ZeroServerCryptoOptions,
 ): ZQLDatabase<TSchema, TTransaction> {
   return new ZQLDatabase(
-    new DrizzleConnection<TDrizzle, TTransaction>(client),
+    new DrizzleConnection<TDrizzle, TTransaction>(client, options?.decryptRow),
     schema,
+    options?.encryptRow,
   );
 }

--- a/packages/zero-server/src/custom.ts
+++ b/packages/zero-server/src/custom.ts
@@ -25,6 +25,7 @@ import {
 import type {
   DBTransaction,
   MutateCRUD,
+  Row,
   ServerTransaction,
 } from '../../zql/src/mutate/custom.ts';
 import {createRunnableBuilder} from '../../zql/src/query/create-builder.ts';
@@ -172,6 +173,12 @@ type WithHiddenTxAndSchema = {
 };
 
 /**
+ * Per-row column transform applied inside every Zero transaction:
+ * `encryptRow` before a write, `decryptRow` after a read.
+ */
+export type RowCrypto = (tableName: string, row: Row) => Row | Promise<Row>;
+
+/**
  * Factory for creating MutateCRUD instances efficiently.
  *
  * Pre-creates the SQL-generating TableCRUD methods once from the schema,
@@ -184,10 +191,12 @@ type WithHiddenTxAndSchema = {
 export class CRUDMutatorFactory<S extends Schema> {
   readonly #schema: S;
   readonly #tableCRUDs: Record<string, TableCRUD<TableSchema>>;
+  readonly #encryptRow: RowCrypto | undefined;
   #serverSchema: ServerSchema | undefined;
 
-  constructor(schema: S) {
+  constructor(schema: S, encryptRow?: RowCrypto) {
     this.#schema = schema;
+    this.#encryptRow = encryptRow;
     // Pre-create TableCRUD methods for each table once
     this.#tableCRUDs = {};
     for (const tableSchema of Object.values(schema.tables)) {
@@ -222,9 +231,16 @@ export class CRUDMutatorFactory<S extends Schema> {
     const boundCRUDs = recordProxy(this.#tableCRUDs, tableCRUD =>
       mapValues(tableCRUD, method => method.bind(txHolder)),
     ) as unknown as SchemaCRUD<S>;
+    const encryptRow = this.#encryptRow;
 
     return (table: string, kind: CRUDKind, args: unknown) => {
       const tableCRUD = boundCRUDs[table as keyof S['tables']];
+      if (encryptRow && kind !== 'delete') {
+        return Promise.resolve(encryptRow(table, args as Row)).then(
+          // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+          encrypted => (tableCRUD as any)[kind](encrypted),
+        );
+      }
       // oxlint-disable-next-line @typescript-eslint/no-explicit-any
       return (tableCRUD as any)[kind](args);
     };

--- a/packages/zero-server/src/zql-database.ts
+++ b/packages/zero-server/src/zql-database.ts
@@ -8,7 +8,11 @@ import type {
   Query,
   RunOptions,
 } from '../../zql/src/query/query.ts';
-import {CRUDMutatorFactory, type TransactionImpl} from './custom.ts';
+import {
+  CRUDMutatorFactory,
+  type RowCrypto,
+  type TransactionImpl,
+} from './custom.ts';
 import type {
   Database,
   TransactionProviderHooks,
@@ -29,9 +33,13 @@ export class ZQLDatabase<
   readonly connection: DBConnection<TWrappedTransaction>;
   readonly #crudFactory: CRUDMutatorFactory<TSchema>;
 
-  constructor(connection: DBConnection<TWrappedTransaction>, schema: TSchema) {
+  constructor(
+    connection: DBConnection<TWrappedTransaction>,
+    schema: TSchema,
+    encryptRow?: RowCrypto,
+  ) {
     this.connection = connection;
-    this.#crudFactory = new CRUDMutatorFactory(schema);
+    this.#crudFactory = new CRUDMutatorFactory(schema, encryptRow);
   }
 
   transaction<R>(


### PR DESCRIPTION
## Summary

Adds optional, **inert-by-default** row-encryption hooks to Zero so an application can encrypt designated columns at rest and on the sync wire. zero-cache continues to replicate and fan out rows byte-for-byte — it never sees plaintext or holds a key. There are three seams, and when the corresponding hook is unset the existing behavior is completely unchanged.

### Client — decrypt on sync read

`new Zero({ decryptRow })` (`packages/zero-client/src/client/options.ts`, `zero.ts`). `PokeHandler` applies `decryptRow` to `put` values and `update` merges as rows are converted to Replicache patches, just before they land in the local store. `del`/`clear` are untouched.

```ts
const z = new Zero({
  ...opts,
  decryptRow: (tableName, row) => decryptColumns(tableName, row),
});
```

### Server — encrypt on write, decrypt on read

`zeroDrizzle(schema, db, { encryptRow, decryptRow })` (`packages/zero-server/src/adapters/drizzle.ts`).

- **Write**: `encryptRow` runs in the `CRUDMutatorFactory` executor on `insert`/`upsert`/`update`. `delete` is skipped — its args are a bare primary key and must not be transformed.
- **Read**: `decryptRow` runs in `DrizzleInternalTransaction.runQuery`, walking `related` subqueries recursively so nested rows are decrypted under their own table name before the parent.

```ts
const zql = zeroDrizzle(schema, drizzleDb, {
  encryptRow: (tableName, row) => encryptColumns(tableName, row),
  decryptRow: (tableName, row) => decryptColumns(tableName, row),
});
```

`RowCrypto` (`(tableName: string, row: Row) => Row | Promise<Row>`) and `ZeroServerCryptoOptions` are exported from `@rocicorp/zero/server/adapters/drizzle`; `DecryptRow` is exported from the client options.

## Notable change

`mergePokes` and `rowsPatchOpToReplicachePatchOp` become `async` to await the (possibly async) decrypt hook. All new parameters are optional, so existing call sites are unaffected; the `mergePokes` unit tests are updated to `await` and the cookie-gap test now asserts via `.rejects.toThrow()`.

## Why

We run these exact transforms in production today via a `patch-package` patch over the published `@rocicorp/zero` bundle. Upstreaming the hooks removes a brittle patch that silently re-points at compiled output on every release. The design is intentionally minimal: hooks are opt-in, the encrypt/decrypt boundary is the application's responsibility, and Zero stays key-agnostic.

## Validation — please read

This change was **ported from our production patch** (against the v1.6.2 compiled output) onto current `main` by hand. It has **not** been run through this repo's `oxfmt` / `oxlint --type-aware` / `tsc` / test toolchain locally, so I've opened it as a **draft** and am relying on CI to confirm formatting, types, and tests. Happy to adjust naming, types, doc comments, or split client/server into separate PRs — whatever fits the project's conventions.
