### PR TITLE
bench: report pg throughput in payload MB

### DIFF
--- a/packages/shared/src/bench.ts
+++ b/packages/shared/src/bench.ts
@@ -30,6 +30,7 @@ const defaultMeasureOptions: MeasureOptions = {
 };
 
 type BenchResult = {name: string; stats: Stats};
+type ThroughputSample = {elapsedMs: number; operations: number};
 const resultsStack: (BenchResult[] | undefined)[] = [];
 let currentResults: BenchResult[] | undefined;
 
@@ -68,6 +69,15 @@ function statsFromSamples(samples: readonly number[]): Stats {
     p99: percentile(sorted, 0.99),
     samples: sorted,
   };
+}
+
+function statsFromThroughputSamples(samples: readonly ThroughputSample[]) {
+  if (samples.some(({operations}) => operations <= 0)) {
+    throw new Error('Cannot record throughput without operations');
+  }
+  return statsFromSamples(
+    samples.map(({elapsedMs, operations}) => (elapsedMs * 1e6) / operations),
+  );
 }
 
 function benchResultToJson(name: string, stats: Stats) {
@@ -188,14 +198,20 @@ export function createManualBenchmarkRecorder() {
       elapsedMsSamples: readonly number[],
       operations: number,
     ) {
-      if (operations <= 0) {
-        throw new Error('Cannot record throughput without operations');
-      }
       results.push({
         name,
-        stats: statsFromSamples(
-          elapsedMsSamples.map(ms => (ms * 1e6) / operations),
+        stats: statsFromThroughputSamples(
+          elapsedMsSamples.map(elapsedMs => ({elapsedMs, operations})),
         ),
+      });
+    },
+    recordThroughputSamples(
+      name: string,
+      samples: readonly ThroughputSample[],
+    ) {
+      results.push({
+        name,
+        stats: statsFromThroughputSamples(samples),
       });
     },
   };

--- a/packages/zero-cache/src/db/initial-sync.bench.pg.ts
+++ b/packages/zero-cache/src/db/initial-sync.bench.pg.ts
@@ -10,6 +10,7 @@ import {getConnectionURI, type PgTest, test} from '../test/db.ts';
 import {DbFile} from '../test/lite.ts';
 import {
   BENCHMARK_FIXTURE_PUBLICATION,
+  benchmarkFixturePayloadMB,
   benchmarkFixtureReplicaRowCount,
   setupBenchmarkFixture,
 } from '../test/pg-bench.ts';
@@ -47,10 +48,11 @@ afterEach(async () => {
 
 describe('zero-cache/initial-sync throughput', () => {
   test(
-    'generated fixture rows/sec',
+    'generated fixture payload MB/sec',
     {timeout: TEST_TIMEOUT_MS},
     async ({testDBs}: PgTest) => {
       const samples: number[] = [];
+      const fixturePayloadMB = benchmarkFixturePayloadMB(1, FIXTURE_ROWS);
 
       for (let rep = 0; rep < WARMUP_REPS + REPS; rep++) {
         const upstream = await testDBs.create(`initial_sync_bench_${rep}`);
@@ -93,9 +95,9 @@ describe('zero-cache/initial-sync throughput', () => {
       }
 
       benchmarkRecorder.recordThroughput(
-        'zero-cache/initial-sync generated fixture rows',
+        'zero-cache/initial-sync generated fixture payload MB',
         samples,
-        FIXTURE_ROWS,
+        fixturePayloadMB,
       );
     },
   );

--- a/packages/zero-cache/src/services/change-streamer/storer.bench.pg.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.bench.pg.ts
@@ -7,6 +7,7 @@ import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.
 import {type PgTest, test} from '../../test/db.ts';
 import {
   BENCHMARK_FIXTURE_TABLE_KEYS,
+  benchmarkFixturePayloadMB,
   makeBenchmarkFixtureRows,
   type BenchmarkFixtureRow,
 } from '../../test/pg-bench.ts';
@@ -126,15 +127,16 @@ async function changeLogRowCount(db: PostgresDB): Promise<number> {
 
 describe('change-streamer/storer throughput', () => {
   test(
-    'single transaction changes/sec',
+    'single transaction payload MB/sec',
     {timeout: TEST_TIMEOUT_MS},
     async ({testDBs}: PgTest) => {
-      const samples: number[] = [];
+      const samples: {elapsedMs: number; operations: number}[] = [];
 
       for (let rep = 0; rep < WARMUP_REPS + REPS; rep++) {
         const watermark = versionToLexi(1000 + rep);
+        const startID = rep * SINGLE_TRANSACTION_CHANGES + 1;
         const rows = makeBenchmarkFixtureRows(
-          rep * SINGLE_TRANSACTION_CHANGES + 1,
+          startID,
           SINGLE_TRANSACTION_CHANGES,
         );
         const {db, storer} = await makeStorer(testDBs, `bench_single_${rep}`);
@@ -147,32 +149,35 @@ describe('change-streamer/storer throughput', () => {
         const changeLogRows = (await changeLogRowCount(db)) - seed;
         expect(changeLogRows).toBe(SINGLE_TRANSACTION_CHANGES + 2);
         if (rep >= WARMUP_REPS) {
-          samples.push(elapsed);
+          samples.push({
+            elapsedMs: elapsed,
+            operations: benchmarkFixturePayloadMB(
+              startID,
+              SINGLE_TRANSACTION_CHANGES,
+            ),
+          });
         }
         await runCleanup();
       }
 
-      benchmarkRecorder.recordThroughput(
-        'change-streamer/storer single transaction changes',
+      benchmarkRecorder.recordThroughputSamples(
+        'change-streamer/storer single transaction payload MB',
         samples,
-        SINGLE_TRANSACTION_CHANGES,
       );
     },
   );
 
   test(
-    'sustained stream changes/sec and commits/sec',
+    'sustained stream payload MB/sec',
     {timeout: TEST_TIMEOUT_MS},
     async ({testDBs}: PgTest) => {
-      const samples: number[] = [];
+      const samples: {elapsedMs: number; operations: number}[] = [];
       const totalChanges =
         SUSTAINED_TRANSACTIONS * SUSTAINED_CHANGES_PER_TRANSACTION;
 
       for (let rep = 0; rep < WARMUP_REPS + REPS; rep++) {
-        const rows = makeBenchmarkFixtureRows(
-          rep * totalChanges + 1,
-          totalChanges,
-        );
+        const startID = rep * totalChanges + 1;
+        const rows = makeBenchmarkFixtureRows(startID, totalChanges);
         const transactions = Array.from(
           {length: SUSTAINED_TRANSACTIONS},
           (_, i) =>
@@ -202,20 +207,17 @@ describe('change-streamer/storer throughput', () => {
           SUSTAINED_TRANSACTIONS * (SUSTAINED_CHANGES_PER_TRANSACTION + 2),
         );
         if (rep >= WARMUP_REPS) {
-          samples.push(elapsed);
+          samples.push({
+            elapsedMs: elapsed,
+            operations: benchmarkFixturePayloadMB(startID, totalChanges),
+          });
         }
         await runCleanup();
       }
 
-      benchmarkRecorder.recordThroughput(
-        'change-streamer/storer sustained stream changes',
+      benchmarkRecorder.recordThroughputSamples(
+        'change-streamer/storer sustained stream payload MB',
         samples,
-        totalChanges,
-      );
-      benchmarkRecorder.recordThroughput(
-        'change-streamer/storer sustained stream commits',
-        samples,
-        SUSTAINED_TRANSACTIONS,
       );
     },
   );

--- a/packages/zero-cache/src/services/replicator/replication-throughput.bench.pg.ts
+++ b/packages/zero-cache/src/services/replicator/replication-throughput.bench.pg.ts
@@ -10,6 +10,7 @@ import {getConnectionURI, type PgTest, test} from '../../test/db.ts';
 import {DbFile} from '../../test/lite.ts';
 import {
   BENCHMARK_FIXTURE_PUBLICATION,
+  benchmarkFixturePayloadMB,
   benchmarkFixtureReplicaRowCount,
   insertBenchmarkFixtureRowBatches,
   insertBenchmarkFixtureRows,
@@ -186,11 +187,11 @@ async function startReplicationPipeline(testDBs: PgTest['testDBs']) {
 
 describe('replicator/logical replication throughput', () => {
   test(
-    'end-to-end rows/sec',
+    'end-to-end payload MB/sec',
     {timeout: TEST_TIMEOUT_MS},
     async ({testDBs}: PgTest) => {
       const {upstream, replicaPath} = await startReplicationPipeline(testDBs);
-      const samples: number[] = [];
+      const samples: {elapsedMs: number; operations: number}[] = [];
 
       expect(replicaRowCount(replicaPath)).toBe(0);
 
@@ -229,13 +230,15 @@ describe('replicator/logical replication throughput', () => {
         expect(await waitForReplicaRows(replicaPath, expectedRows)).toBe(
           expectedRows,
         );
-        samples.push(performance.now() - start);
+        samples.push({
+          elapsedMs: performance.now() - start,
+          operations: benchmarkFixturePayloadMB(startID, MEASURED_ROWS),
+        });
       }
 
-      benchmarkRecorder.recordThroughput(
-        'replicator/logical replication end-to-end rows',
+      benchmarkRecorder.recordThroughputSamples(
+        'replicator/logical replication end-to-end payload MB',
         samples,
-        MEASURED_ROWS,
       );
     },
   );

--- a/packages/zero-cache/src/test/pg-bench.ts
+++ b/packages/zero-cache/src/test/pg-bench.ts
@@ -17,6 +17,7 @@ export const BENCHMARK_FIXTURE_TABLE_KEYS = {
   bench_wide: 'id',
   bench_composite: ['account_id', 'seq'],
 } satisfies Record<string, string | string[]>;
+export const BENCHMARK_FIXTURE_BYTES_PER_MB = 1_000_000;
 
 export type BenchmarkFixtureTable = (typeof BENCHMARK_FIXTURE_TABLES)[number];
 
@@ -75,11 +76,50 @@ type RowBatch = {
 // Creates deterministic variable-size ASCII text. Lengths are approximately
 // uniform across the inclusive byte range for each payload column.
 function makePayload(id: number, minBytes: number, maxBytes: number) {
-  const range = maxBytes - minBytes + 1;
-  const length = minBytes + ((id * 9973) % range);
+  const length = payloadLength(id, minBytes, maxBytes);
   const seed = Math.imul(id, 2654435761) >>> 0;
   const chunk = `${id.toString(36)}:${seed.toString(36)}:abcdefghijklmnopqrstuvwxyz0123456789:`;
   return chunk.repeat(Math.ceil(length / chunk.length)).slice(0, length);
+}
+
+function payloadLength(id: number, minBytes: number, maxBytes: number) {
+  const range = maxBytes - minBytes + 1;
+  return minBytes + ((id * 9973) % range);
+}
+
+function benchmarkFixtureRowPayloadBytes(id: number) {
+  const kind = id % 10;
+
+  if (kind < 5) {
+    return payloadLength(id, 256, 2048);
+  }
+  if (kind < 7) {
+    return (
+      `wide row ${id}`.length +
+      payloadLength(id, 2048, 8192) +
+      payloadLength(id + 17, 512, 2048)
+    );
+  }
+  if (kind < 9) {
+    return payloadLength(id, 128, 1024);
+  }
+  return `lookup-${id % 10_000}`.length;
+}
+
+export function benchmarkFixturePayloadBytes(startID: number, count: number) {
+  let total = 0;
+  for (let i = 0; i < count; i++) {
+    total += benchmarkFixtureRowPayloadBytes(startID + i);
+  }
+  return total;
+}
+
+// Decimal MB of generated text payload, not logical-replication or WAL bytes.
+export function benchmarkFixturePayloadMB(startID: number, count: number) {
+  return (
+    benchmarkFixturePayloadBytes(startID, count) /
+    BENCHMARK_FIXTURE_BYTES_PER_MB
+  );
 }
 
 // The fixture uses id % 10 so every benchmark run gets the same table mix:


### PR DESCRIPTION
## Summary

Changes all PG benchmark throughput rows to report generated payload MB/s instead of rows/sec or changes/sec.

This makes the replication benchmarks easier to interpret for payload-heavy fixture data, where rows/sec can obscure how much data is actually moving.

## Details

Adds fixture payload-size helpers in `pg-bench.ts`:

- `benchmarkFixturePayloadBytes(startID, count)`
- `benchmarkFixturePayloadMB(startID, count)`

The payload metric is decimal MB of generated text payload.

Adds `recordThroughputSamples()` to the manual benchmark recorder so each sample can use its own operation count. This matters because generated payload size can vary slightly by ID range.

Updated PG benchmark outputs:

| Benchmark | New metric |
| --- | --- |
| Initial sync | `zero-cache/initial-sync generated fixture payload MB` |
| Storer single transaction | `change-streamer/storer single transaction payload MB` |
| Storer sustained stream | `change-streamer/storer sustained stream payload MB` |
| E2E replication | `replicator/logical replication end-to-end payload MB` |

Removed the storer `commits/sec` output so the PG suite consistently reports payload MB throughput.

Sample medians from the verification run:

| Benchmark | Median |
| --- | ---: |
| E2E replication | `19.35 MB/s` |
| Storer single transaction | `78.68 MB/s` |
| Storer sustained stream | `74.12 MB/s` |
| Initial sync | `335.67 MB/s` |
