### PR TITLE
chore: detect malformed sqlite sooner

### DIFF
--- a/packages/zero-cache/src/db/migration-lite.test.ts
+++ b/packages/zero-cache/src/db/migration-lite.test.ts
@@ -1,3 +1,4 @@
+import {closeSync, openSync, writeSync} from 'node:fs';
 import type {LogContext} from '@rocicorp/logger';
 import {afterEach, beforeEach, describe, expect, test} from 'vitest';
 import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
@@ -367,5 +368,58 @@ describe('db/migration-lite', () => {
 
     expect(err).toBeDefined();
     c.verify(err);
+  });
+
+  test('runs quick_check for existing databases', async () => {
+    const lc = createSilentLogContext();
+    const db = dbFile.connect(lc);
+    getVersionHistory(db);
+    db.prepare(
+      `
+      INSERT INTO "_zero.versionHistory" (dataVersion, schemaVersion, minSafeVersion)
+      VALUES (1, 1, 1)
+    `,
+    ).run();
+
+    db.exec(`CREATE TABLE "Payload" (id INTEGER PRIMARY KEY, value BLOB)`);
+    const insert = db.prepare(
+      `INSERT INTO "Payload" (value) VALUES (randomblob(2000))`,
+    );
+    db.transaction(() => {
+      for (let i = 0; i < 200; i++) {
+        insert.run();
+      }
+    });
+
+    const [{page_size: pageSize}] = db.pragma<{page_size: number}>('page_size');
+    const {pageno} = db
+      .prepare(
+        `
+      SELECT pageno FROM dbstat
+      WHERE name = 'Payload' AND pagetype = 'leaf'
+      ORDER BY pageno LIMIT 1 OFFSET 5
+    `,
+      )
+      .get<{pageno: number}>();
+    db.close();
+
+    const fd = openSync(dbFile.path, 'r+');
+    try {
+      writeSync(fd, Buffer.alloc(100, 0xff), 0, 100, (pageno - 1) * pageSize);
+    } finally {
+      closeSync(fd);
+    }
+
+    await expect(
+      runSchemaMigrations(
+        lc,
+        debugName,
+        dbFile.path,
+        {
+          migrateSchema: () => Promise.reject('not expected to run'),
+        },
+        {1: {}},
+      ),
+    ).rejects.toThrow(/database disk image is malformed|quick_check failed/);
   });
 });

--- a/packages/zero-cache/src/db/migration-lite.ts
+++ b/packages/zero-cache/src/db/migration-lite.ts
@@ -102,6 +102,7 @@ export async function runSchemaMigrations(
       }
       return versions;
     });
+    const initialDataVersion = versions.dataVersion;
 
     if (versions.dataVersion < codeVersion) {
       db.unsafeMode(true); // Enables journal_mode = OFF
@@ -145,6 +146,10 @@ export async function runSchemaMigrations(
 
       db.exec('ANALYZE main');
       log.info?.('ANALYZE completed');
+
+      if (initialDataVersion > 0) {
+        assertDatabaseIntegrity(log, debugName, db);
+      }
     } else {
       // Run optimize whenever opening an sqlite db file as recommended in
       // https://www.sqlite.org/pragma.html#pragma_optimize
@@ -154,9 +159,7 @@ export async function runSchemaMigrations(
       // similarly detected in the change-streamer, facilitating an eventual
       // recovery by resyncing the replica anew.
       db.pragma('optimize = 0x10002');
-
-      // TODO: Investigate running `integrity_check` or `quick_check` as well,
-      // provided that they are not inordinately expensive on large databases.
+      assertDatabaseIntegrity(log, debugName, db);
     }
 
     db.pragma('synchronous = NORMAL');
@@ -179,6 +182,37 @@ export async function runSchemaMigrations(
     db.close();
     void log.flush(); // Flush the logs but do not block server progress on it.
   }
+}
+
+export class DatabaseIntegrityError extends Error {
+  readonly name = 'DatabaseIntegrityError';
+  readonly issues: readonly string[];
+
+  constructor(debugName: string, issues: readonly string[]) {
+    super(`SQLite quick_check failed for ${debugName}: ${issues.join('; ')}`);
+    this.issues = issues;
+  }
+}
+
+export function assertDatabaseIntegrity(
+  log: LogContext,
+  debugName: string,
+  db: Db,
+) {
+  const start = Date.now();
+  const rows = db.pragma<{quick_check: string}>('quick_check');
+  const issues =
+    rows.length === 0
+      ? ['PRAGMA quick_check returned no rows']
+      : rows.map(row => row.quick_check).filter(issue => issue !== 'ok');
+
+  if (issues.length > 0) {
+    throw new DatabaseIntegrityError(debugName, issues);
+  }
+
+  log.info?.(
+    `quick_check completed for ${debugName} (${Date.now() - start} ms)`,
+  );
 }
 
 function sorted(

--- a/packages/zero-cache/src/services/change-source/common/replica-schema.test.ts
+++ b/packages/zero-cache/src/services/change-source/common/replica-schema.test.ts
@@ -1,3 +1,4 @@
+import {closeSync, openSync, writeSync} from 'node:fs';
 import {beforeEach, describe, expect, test} from 'vitest';
 import {createSilentLogContext} from '../../../../../shared/src/logging-test-utils.ts';
 import {promiseVoid} from '../../../../../shared/src/resolved-promises.ts';
@@ -6,6 +7,7 @@ import {
   expectMatchingObjectsInTables,
   initDB as initLiteDB,
 } from '../../../test/lite.ts';
+import {AutoResetSignal} from '../../change-streamer/schema/tables.ts';
 import {initReplicationState} from '../../replicator/schema/replication-state.ts';
 import {CREATE_TABLE_METADATA_TABLE} from '../../replicator/schema/table-metadata.ts';
 import {
@@ -14,6 +16,7 @@ import {
   CREATE_V9_TABLE_METADATA_TABLE,
   CURRENT_SCHEMA_VERSION,
   initReplica,
+  upgradeReplica,
 } from './replica-schema.ts';
 
 export const CURRENT_SCHEMA_VERSIONS = {
@@ -486,4 +489,52 @@ describe('replica-schema-migrations', () => {
       });
     });
   }
+
+  test('upgradeReplica resets when quick_check detects corruption', async () => {
+    const replica = replicaFile.connect(lc);
+    replica.exec(CREATE_VERSION_HISTORY);
+    replica
+      .prepare(
+        `
+        INSERT INTO "_zero.versionHistory" (dataVersion, schemaVersion, minSafeVersion)
+        VALUES (?, ?, 1)
+      `,
+      )
+      .run(CURRENT_SCHEMA_VERSION, CURRENT_SCHEMA_VERSION);
+
+    replica.exec(`CREATE TABLE "Payload" (id INTEGER PRIMARY KEY, value BLOB)`);
+    const insert = replica.prepare(
+      `INSERT INTO "Payload" (value) VALUES (randomblob(2000))`,
+    );
+    replica.transaction(() => {
+      for (let i = 0; i < 200; i++) {
+        insert.run();
+      }
+    });
+
+    const [{page_size: pageSize}] = replica.pragma<{page_size: number}>(
+      'page_size',
+    );
+    const {pageno} = replica
+      .prepare(
+        `
+        SELECT pageno FROM dbstat
+        WHERE name = 'Payload' AND pagetype = 'leaf'
+        ORDER BY pageno LIMIT 1 OFFSET 5
+      `,
+      )
+      .get<{pageno: number}>();
+    replica.close();
+
+    const fd = openSync(replicaFile.path, 'r+');
+    try {
+      writeSync(fd, Buffer.alloc(100, 0xff), 0, 100, (pageno - 1) * pageSize);
+    } finally {
+      closeSync(fd);
+    }
+
+    await expect(upgradeReplica(lc, 'test', replicaFile.path)).rejects.toThrow(
+      AutoResetSignal,
+    );
+  });
 });

--- a/packages/zero-cache/src/services/change-source/common/replica-schema.ts
+++ b/packages/zero-cache/src/services/change-source/common/replica-schema.ts
@@ -3,6 +3,7 @@ import {SqliteError} from '@rocicorp/zero-sqlite3';
 import type {Database} from '../../../../../zqlite/src/db.ts';
 import {listTables} from '../../../db/lite-tables.ts';
 import {
+  DatabaseIntegrityError,
   runSchemaMigrations,
   type IncrementalMigrationMap,
   type Migration,
@@ -34,10 +35,7 @@ export async function initReplica(
       schemaVersionMigrationMap,
     );
   } catch (e) {
-    if (e instanceof SqliteError && e.code === 'SQLITE_CORRUPT') {
-      throw new AutoResetSignal(e.message);
-    }
-    throw e;
+    throwAutoResetForCorruption(e);
   }
 }
 
@@ -46,20 +44,37 @@ export async function upgradeReplica(
   debugName: string,
   dbPath: string,
 ) {
-  await runSchemaMigrations(
-    log,
-    debugName,
-    dbPath,
-    // setupMigration should never be invoked
-    {
-      migrateSchema: () => {
-        throw new Error(
-          'This should only be called for already synced replicas',
-        );
+  try {
+    await runSchemaMigrations(
+      log,
+      debugName,
+      dbPath,
+      // setupMigration should never be invoked
+      {
+        migrateSchema: () => {
+          throw new Error(
+            'This should only be called for already synced replicas',
+          );
+        },
       },
-    },
-    schemaVersionMigrationMap,
-  );
+      schemaVersionMigrationMap,
+    );
+  } catch (e) {
+    throwAutoResetForCorruption(e);
+  }
+}
+
+function throwAutoResetForCorruption(e: unknown): never {
+  if (
+    e instanceof DatabaseIntegrityError ||
+    (e instanceof SqliteError && e.code === 'SQLITE_CORRUPT')
+  ) {
+    throw new AutoResetSignal(
+      `replica database failed integrity check: ${String(e)}`,
+      {cause: e},
+    );
+  }
+  throw e;
 }
 
 export const CREATE_V6_COLUMN_METADATA_TABLE = /*sql*/ `

--- a/packages/zero-cache/src/services/litestream/commands.ts
+++ b/packages/zero-cache/src/services/litestream/commands.ts
@@ -9,6 +9,7 @@ import {Database} from '../../../../zqlite/src/db.ts';
 import {assertNormalized} from '../../config/normalize.ts';
 import type {ZeroConfig} from '../../config/zero-config.ts';
 import {deleteLiteDB} from '../../db/delete-lite-db.ts';
+import {assertDatabaseIntegrity} from '../../db/migration-lite.ts';
 import {StatementRunner} from '../../db/statements.ts';
 import {getShardConfig} from '../../types/shards.ts';
 import type {Source} from '../../types/streams.ts';
@@ -207,8 +208,10 @@ function replicaIsValid(
   replica: string,
   constraints: ReplicaConstraints,
 ) {
-  const db = new Database(lc, replica);
+  let db: Database | undefined;
   try {
+    db = new Database(lc, replica);
+    assertDatabaseIntegrity(lc, 'restored replica', db);
     const {replicaVersion, watermark} = getSubscriptionState(
       new StatementRunner(db),
     );
@@ -234,7 +237,7 @@ function replicaIsValid(
     lc.error?.('Error while validating restored replica', e);
     return false;
   } finally {
-    db.close();
+    db?.close();
   }
 }
 

--- a/packages/zero-cache/src/workers/replicator.ts
+++ b/packages/zero-cache/src/workers/replicator.ts
@@ -44,58 +44,60 @@ async function prepare(
   walMode: WalMode,
   mode: ReplicaFileMode,
 ): Promise<{file: string; walMode: WalMode}> {
-  const replica = new Database(lc, file);
-
   // Perform any upgrades to the replica in case the backup is an
   // earlier version.
   await upgradeReplica(lc, `${mode}-replica`, file);
 
-  // Start by folding any (e.g. restored) WAL(2) files into the main db.
-  await setJournalMode(lc, replica, 'delete');
+  const replica = new Database(lc, file);
+  try {
+    // Start by folding any (e.g. restored) WAL(2) files into the main db.
+    await setJournalMode(lc, replica, 'delete');
 
-  const [{page_size: pageSize}] = replica.pragma<{page_size: number}>(
-    'page_size',
-  );
-  const [{page_count: pageCount}] = replica.pragma<{page_count: number}>(
-    'page_count',
-  );
-  const [{freelist_count: freelistCount}] = replica.pragma<{
-    freelist_count: number;
-  }>('freelist_count');
+    const [{page_size: pageSize}] = replica.pragma<{page_size: number}>(
+      'page_size',
+    );
+    const [{page_count: pageCount}] = replica.pragma<{page_count: number}>(
+      'page_count',
+    );
+    const [{freelist_count: freelistCount}] = replica.pragma<{
+      freelist_count: number;
+    }>('freelist_count');
 
-  const dbSize = ((pageCount * pageSize) / MB).toFixed(2);
-  const freelistSize = ((freelistCount * pageSize) / MB).toFixed(2);
+    const dbSize = ((pageCount * pageSize) / MB).toFixed(2);
+    const freelistSize = ((freelistCount * pageSize) / MB).toFixed(2);
 
-  // TODO: Consider adding a freelist size or ratio based vacuum trigger.
-  lc.info?.(`Size of db ${file}: ${dbSize} MB (${freelistSize} MB freeable)`);
+    // TODO: Consider adding a freelist size or ratio based vacuum trigger.
+    lc.info?.(`Size of db ${file}: ${dbSize} MB (${freelistSize} MB freeable)`);
 
-  // Check for the VACUUM threshold.
-  const events = getAscendingEvents(replica);
-  lc.debug?.(`Runtime events for db ${file}`, {events});
-  if (vacuumIntervalHours !== undefined) {
-    const millisSinceLastEvent =
-      Date.now() - (events.at(-1)?.timestamp.getTime() ?? 0);
-    if (millisSinceLastEvent / MILLIS_PER_HOUR > vacuumIntervalHours) {
-      lc.info?.(`Performing maintenance cleanup on ${file}`);
-      const t0 = performance.now();
-      replica.unsafeMode(true);
-      replica.pragma('journal_mode = OFF');
-      replica.exec('VACUUM');
-      recordEvent(replica, 'vacuum');
-      replica.unsafeMode(false);
-      const t1 = performance.now();
-      lc.info?.(`VACUUM completed (${t1 - t0} ms)`);
+    // Check for the VACUUM threshold.
+    const events = getAscendingEvents(replica);
+    lc.debug?.(`Runtime events for db ${file}`, {events});
+    if (vacuumIntervalHours !== undefined) {
+      const millisSinceLastEvent =
+        Date.now() - (events.at(-1)?.timestamp.getTime() ?? 0);
+      if (millisSinceLastEvent / MILLIS_PER_HOUR > vacuumIntervalHours) {
+        lc.info?.(`Performing maintenance cleanup on ${file}`);
+        const t0 = performance.now();
+        replica.unsafeMode(true);
+        replica.pragma('journal_mode = OFF');
+        replica.exec('VACUUM');
+        recordEvent(replica, 'vacuum');
+        replica.unsafeMode(false);
+        const t1 = performance.now();
+        lc.info?.(`VACUUM completed (${t1 - t0} ms)`);
+      }
     }
+
+    await setJournalMode(lc, replica, walMode);
+
+    const pragmas = getPragmaConfig(mode);
+    applyPragmas(replica, pragmas);
+
+    replica.pragma('optimize = 0x10002');
+    lc.info?.(`optimized ${file}`);
+  } finally {
+    replica.close();
   }
-
-  await setJournalMode(lc, replica, walMode);
-
-  const pragmas = getPragmaConfig(mode);
-  applyPragmas(replica, pragmas);
-
-  replica.pragma('optimize = 0x10002');
-  lc.info?.(`optimized ${file}`);
-  replica.close();
   return {file, walMode};
 }
 


### PR DESCRIPTION
Detect malformed SQLite replica files earlier by running
  `PRAGMA quick_check` when restoring/opening existing
  replicas, and convert detected corruption into the
  existing restore/autoreset recovery paths.

  ## Changes

  - Adds `assertDatabaseIntegrity()` /
  `DatabaseIntegrityError` around SQLite `quick_check`.
  - Runs `quick_check` for existing DBs during schema
  migration/open.
  - Validates litestream-restored replicas before accepting
  them; failed validation deletes the local replica and
  retries restore.
  - Maps `quick_check` failures to `AutoResetSignal` during
  replica init/upgrade.
  - Ensures replicator preparation upgrades/checks the
  replica before opening the maintenance connection, and
  closes it reliably.
  - Adds regression tests that corrupt SQLite payload pages
  directly and verify the corruption is detected.