### PR TITLE
ci(zero): make npm promotion manual

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -46,36 +46,10 @@ jobs:
           WORKFLOW_REF_NAME: ${{ github.ref_name }}
         run: node --experimental-strip-types --no-warnings scripts/src/promote-validate.ts
 
-  promote-npm:
-    name: Promote npm latest
-    runs-on: ubuntu-latest
-    needs: validate
-    environment:
-      name: zero-promote-npm
-    permissions:
-      contents: read
-    env:
-      VERSION: ${{ needs.validate.outputs.version }}
-      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-    steps:
-      - name: Set up pnpm
-        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
-        with:
-          version: 11.5.3
-
-      - name: Set up Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: 24.x
-          registry-url: 'https://registry.npmjs.org'
-
-      - name: Move npm latest dist-tag
-        run: pnpm dist-tag add "@rocicorp/zero@$VERSION" latest
-
   promote-docker:
     name: Promote Docker latest
     runs-on: ubuntu-latest
-    needs: [validate, promote-npm]
+    needs: validate
     environment:
       name: zero-promote-docker
     permissions:
@@ -116,7 +90,7 @@ jobs:
   promote-git:
     name: Promote git latest tag
     runs-on: ubuntu-latest
-    needs: [validate, promote-npm, promote-docker]
+    needs: [validate, promote-docker]
     permissions:
       contents: write # Required to move the git latest tag.
     env:
@@ -133,3 +107,16 @@ jobs:
         run: |
           git tag --force latest "zero/v$VERSION"
           git push --force origin refs/tags/latest:refs/tags/latest
+
+      - name: Summarize manual npm promotion
+        run: |
+          {
+            printf '## Manual npm promotion\n\n'
+            printf 'Docker and git `latest` have been promoted for `%s`.\n\n' "$VERSION"
+            printf 'Run these commands locally to promote npm:\n\n'
+            printf '```sh\n'
+            printf 'pnpm dist-tag add "@rocicorp/zero@%s" latest\n' "$VERSION"
+            printf 'pnpm dist-tag rm "@rocicorp/zero" staging\n'
+            printf 'pnpm dist-tag ls "@rocicorp/zero"\n'
+            printf '```\n'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/packages/zero/README.md
+++ b/packages/zero/README.md
@@ -48,7 +48,7 @@ gh workflow run release.yml --ref main -f mode=canary -f release_branch=maint/ze
 gh workflow run release.yml --ref main -f mode=stable -f release_branch=main
 ```
 
-Stable releases use npm staged publishing. After `pnpm stage approve`, promote the approved version with the [Promote Zero Release workflow](https://github.com/rocicorp/mono/actions/workflows/promote.yml):
+Stable releases use npm staged publishing. After `pnpm stage approve`, promote the Docker and git `latest` tags with the [Promote Zero Release workflow](https://github.com/rocicorp/mono/actions/workflows/promote.yml). After the workflow succeeds, run the npm commands from its GitHub step summary to move the npm `latest` dist-tag and remove the npm `staging` dist-tag.
 
 ```bash
 gh workflow run promote.yml -f version=<VERSION>


### PR DESCRIPTION


- Remove npm dist-tag promotion from the Zero promote workflow so CI no longer depends on `NPM_TOKEN`.
- Keep Docker `latest` promotion/signing and git `latest` tag promotion in CI.
- Add a `$GITHUB_STEP_SUMMARY` section with concrete local npm commands to move `latest`, remove `staging`, and verify tags.
- Update Zero release docs to describe the manual npm follow-up.
