### PR TITLE
chore: e2e throughput measurements

### DIFF
--- a/ZERO_THROUGHPUT_DESIGN.md
+++ b/ZERO_THROUGHPUT_DESIGN.md
@@ -1,0 +1,296 @@
+# Zero E2E Throughput Benchmark Design
+
+## Purpose
+
+We need a repeatable benchmark that answers how much write throughput Zero can
+sustain before connected clients fall behind.
+
+The benchmark should measure the full path:
+
+1. PostgreSQL accepts committed writes.
+2. The replicator observes and applies WAL changes.
+3. The view-syncer evaluates standing queries and produces diffs.
+4. Synthetic clients receive and apply query results over the Zero protocol.
+
+The primary output is the maximum sustainable PostgreSQL write rate for a given
+application profile, user count, and standing-query mix.
+
+## Questions
+
+- At a fixed user count and query mix, what writes/sec can Zero sustain while
+  keeping client-visible lag bounded?
+- Which stage becomes the bottleneck: PostgreSQL, replication, view syncing,
+  network fanout, or client-side apply?
+- How do throughput and lag change as we vary:
+  - concurrent users
+  - standing queries per user
+  - rows matched per query
+  - write batch size
+  - payload size
+  - hot-set updates versus append-only inserts
+  - simple table queries versus multi-table relationship queries
+
+## Non-Goals
+
+- This is not a correctness replacement for existing integration tests.
+- This is not initially a broad database benchmark. PostgreSQL is the source of
+  writes, but the benchmark exists to characterize Zero E2E behavior.
+- This is not initially a browser rendering benchmark. Synthetic clients should
+  speak the protocol directly unless a browser client becomes necessary for a
+  specific measurement.
+
+## Location
+
+The benchmark app should live at:
+
+```text
+apps/zero-throughput
+```
+
+It should be runnable locally and in CI-like environments, with configuration
+for workload profile, scale, duration, and output path.
+
+## High-Level Harness
+
+The harness owns process lifecycle and measurement collection:
+
+1. Start PostgreSQL.
+2. Apply benchmark schema and seed data.
+3. Start the Zero replicator.
+4. Start the Zero view-syncer.
+5. Start synthetic protocol clients.
+6. Register standing queries for each synthetic user.
+7. Start a controlled PostgreSQL write generator.
+8. Increase or hold write rate according to the selected run mode.
+9. Collect stage metrics, client observations, and final summaries.
+10. Stop all processes and write a machine-readable result file.
+
+If replicator and view-syncer cannot initially be launched as independent
+processes, the first implementation can launch the existing zero-cache process
+and still record stage metrics where available. The benchmark should preserve
+the conceptual split so we can separate the processes later.
+
+## Workload Model
+
+Each benchmark run chooses one application profile. A profile defines schema,
+seed data, standing queries, write operations, and scale parameters.
+
+Initial profiles:
+
+| Profile           | Shape                                                 | Purpose                                        |
+| ----------------- | ----------------------------------------------------- | ---------------------------------------------- |
+| `feed-append`     | Append-only rows with many users watching recent rows | Measures high-fanout insert throughput         |
+| `feed-update-hot` | Updates over a small hot working set                  | Measures invalidation and repeated diff cost   |
+| `issue-list`      | Users subscribe to filtered issue lists               | Models zbugs-style list views                  |
+| `dashboard`       | Each user registers several narrow standing queries   | Measures many-query-per-user overhead          |
+| `relational`      | Multi-table data with relationship queries            | Measures query planning and IVM cost for joins |
+
+Scale dimensions:
+
+- `users`: number of concurrent synthetic clients.
+- `queriesPerUser`: number of standing queries each client registers.
+- `rowsPerQuery`: approximate result-set size per standing query.
+- `writeRate`: target committed writes per second.
+- `batchSize`: rows written per PostgreSQL transaction.
+- `payloadBytes`: size of user payload per row.
+- `hotSetSize`: number of rows updated when using hot-set profiles.
+- `duration`: measured run duration after warmup.
+- `warmup`: time allowed for clients to connect and reach initial sync.
+
+## Benchmark Schema Signals
+
+Rows used for lag calculation should include both a monotonic sequence and a
+server-side timestamp.
+
+Example columns:
+
+```sql
+id text primary key,
+profile text not null,
+shard int not null,
+bucket int not null,
+seq bigint not null,
+payload jsonb not null,
+written_at timestamptz not null default clock_timestamp(),
+updated_at timestamptz not null default clock_timestamp()
+```
+
+Use `seq` as the primary catch-up signal. It gives an unambiguous ordering for
+written data and lets clients report the maximum sequence observed for each
+query.
+
+Use `written_at` as the wall-clock latency signal. It should be generated by
+PostgreSQL, not the write-generator process. If we later expose WAL commit
+timestamps or LSN timestamps cheaply, those should be preferred for stage-level
+latency because `clock_timestamp()` records statement execution time rather than
+commit visibility.
+
+## Lag and Throughput Calculation
+
+For each run, record:
+
+- highest committed `seq`
+- highest observed `seq` per client query
+- client receive time for observed rows
+- write commit rate
+- diff receive rate
+- diff byte rate
+
+Primary lag signals:
+
+- `seqLag = highestCommittedSeq - minObservedSeqAcrossRequiredQueries`
+- `timeLag = clientReceivedAt - written_at`
+- `lagSlope = changeInSeqLag / time`
+
+A write rate is sustainable for a profile when:
+
+- all required clients remain connected
+- initial sync completes before the measured window
+- p95 and p99 client-visible lag stay under the configured SLO
+- `seqLag` remains bounded during the measured window
+- `lagSlope` is approximately zero or negative after warmup
+
+The benchmark should report the highest sustainable writes/sec for each profile
+and user count under a declared SLO, for example:
+
+```text
+p99 client-visible lag < 2s for 10 minutes, with no positive lag slope
+```
+
+## Stage Metrics
+
+E2E numbers are necessary but not sufficient. The harness should collect enough
+stage metrics to identify the bottleneck.
+
+PostgreSQL:
+
+- committed transactions/sec
+- committed rows/sec
+- transaction latency p50/p95/p99
+- WAL bytes/sec
+- replication slot lag, confirmed flush LSN, and restart LSN
+- CPU, memory, and disk IO
+
+Replicator:
+
+- WAL records/sec
+- rows applied/sec
+- source LSN and applied LSN
+- apply queue depth
+- apply latency
+- CPU and RSS
+
+View-syncer:
+
+- changed rows received/sec
+- queries invalidated/sec
+- queries evaluated/sec
+- diffs produced/sec
+- diff rows/sec
+- diff bytes/sec
+- query evaluation latency
+- output queue depth
+- CPU and RSS
+
+Synthetic clients:
+
+- connected clients
+- registered queries
+- initial sync latency
+- diffs received/sec
+- diff bytes/sec
+- max observed `seq` per query
+- receive-to-apply latency
+- protocol errors and reconnects
+- CPU and RSS
+
+## Run Modes
+
+### Fixed Rate
+
+Run a profile at a specified write rate for a specified duration. This is useful
+for regression testing and comparing commits.
+
+### Sweep
+
+Run the same profile across a list of write rates and user counts. This is
+useful for producing throughput curves.
+
+### Search
+
+Use a bounded search to find the maximum sustainable write rate for a selected
+profile and user count. This is useful for headline capacity numbers.
+
+## Output
+
+Each run should write a JSON result file and a concise human-readable summary.
+
+The JSON should include:
+
+- git commit
+- profile name
+- benchmark configuration
+- process versions and command lines
+- environment details
+- time-series metric samples
+- final p50/p95/p99 latency summaries
+- maximum lag and lag slope
+- pass/fail against the configured SLO
+
+The summary should include:
+
+- profile and scale
+- target write rate and achieved write rate
+- p95 and p99 client-visible lag
+- max `seqLag`
+- lag slope
+- likely bottleneck stage when detectable
+- links or paths to detailed output
+
+## Implementation Phases
+
+### Phase 1: Minimal E2E Harness
+
+- Create `apps/zero-throughput`.
+- Define a single append-only profile.
+- Start PostgreSQL, Zero, and one synthetic client.
+- Register one standing query.
+- Generate writes at a fixed rate.
+- Report committed `seq`, observed `seq`, and E2E lag.
+
+### Phase 2: Scale and Profiles
+
+- Add concurrent synthetic clients.
+- Add configurable users, queries per user, write rate, batch size, and duration.
+- Add the `feed-update-hot`, `issue-list`, and `dashboard` profiles.
+- Write JSON result files.
+
+### Phase 3: Stage Metrics
+
+- Collect PostgreSQL replication metrics.
+- Add replicator and view-syncer queue, latency, and throughput metrics.
+- Add client diff byte and apply metrics.
+- Emit time-series samples.
+
+### Phase 4: Capacity Search
+
+- Add write-rate sweep mode.
+- Add bounded search mode for maximum sustainable writes/sec.
+- Add pass/fail SLO configuration.
+- Produce comparison summaries across profiles and user counts.
+
+### Phase 5: CI and Regression Tracking
+
+- Add a small fixed-rate smoke benchmark suitable for CI.
+- Add a longer opt-in benchmark for release or nightly runs.
+- Store historical result artifacts for comparison.
+
+## Open Decisions
+
+- Whether to launch replicator and view-syncer as separate processes from the
+  start or begin with the current zero-cache process boundary.
+- Whether synthetic clients should use the production Zero client, a lower-level
+  protocol client, or both.
+- Which SLO should be the default headline number.
+- Which metrics already exist versus which need to be added to Zero internals.
+- Whether to run PostgreSQL through Docker, an existing local instance, or both.

--- a/ZERO_THROUGHPUT_DESIGN.md
+++ b/ZERO_THROUGHPUT_DESIGN.md
@@ -77,13 +77,15 @@ seed data, standing queries, write operations, and scale parameters.
 
 Initial profiles:
 
-| Profile           | Shape                                                 | Purpose                                        |
-| ----------------- | ----------------------------------------------------- | ---------------------------------------------- |
-| `feed-append`     | Append-only rows with many users watching recent rows | Measures high-fanout insert throughput         |
-| `feed-update-hot` | Updates over a small hot working set                  | Measures invalidation and repeated diff cost   |
-| `issue-list`      | Users subscribe to filtered issue lists               | Models zbugs-style list views                  |
-| `dashboard`       | Each user registers several narrow standing queries   | Measures many-query-per-user overhead          |
-| `relational`      | Multi-table data with relationship queries            | Measures query planning and IVM cost for joins |
+| Profile           | Shape                                                             | Purpose                                             |
+| ----------------- | ----------------------------------------------------------------- | --------------------------------------------------- |
+| `feed-append`     | Append-only rows with many users watching recent rows             | Measures high-fanout insert throughput              |
+| `email`           | Inbox threads, message lists, unread thread/message relationships | Models email-client list/detail query fanout        |
+| `forum`           | Category, thread, post, and author relationship queries           | Models forum-style hierarchical discussion activity |
+| `relational`      | Org/account/contact/activity relationship queries                 | Measures query planning and IVM cost for joins      |
+| `feed-update-hot` | Updates over a small hot working set                              | Measures invalidation and repeated diff cost        |
+| `issue-list`      | Users subscribe to filtered issue lists                           | Models zbugs-style list views                       |
+| `dashboard`       | Each user registers several narrow standing queries               | Measures many-query-per-user overhead               |
 
 Scale dimensions:
 

--- a/apps/zero-throughput/.gitignore
+++ b/apps/zero-throughput/.gitignore
@@ -1,0 +1,1 @@
+results/

--- a/apps/zero-throughput/README.md
+++ b/apps/zero-throughput/README.md
@@ -1,0 +1,42 @@
+# zero-throughput
+
+Phase 1 E2E throughput harness for Zero.
+
+The default run:
+
+1. Starts a dedicated PostgreSQL 16 Docker container on port `6436`.
+2. Resets the benchmark table and Zero metadata for app id `zero_throughput`.
+3. Deploys allow-read permissions for the benchmark table.
+4. Starts `zero-cache` on port `4848`.
+5. Starts synthetic Zero clients with live `feed-append` queries.
+6. Writes append-only rows to PostgreSQL at a fixed target rate.
+7. Writes a JSON result file and prints a short summary.
+
+```bash
+pnpm --filter zero-throughput start
+```
+
+Useful overrides:
+
+```bash
+pnpm --filter zero-throughput start -- \
+  --users 10 \
+  --queries-per-user 1 \
+  --rows-per-query 100 \
+  --write-rate 500 \
+  --batch-size 10 \
+  --duration-ms 60000 \
+  --output results/feed-append-10u-500rps.json
+```
+
+Use an already-running PostgreSQL or Zero:
+
+```bash
+ZERO_THROUGHPUT_PG_START=false \
+ZERO_THROUGHPUT_PG_URL=postgresql://user:password@127.0.0.1:6436/postgres \
+ZERO_THROUGHPUT_ZERO_START=false \
+ZERO_THROUGHPUT_CACHE_URL=http://127.0.0.1:4848 \
+pnpm --filter zero-throughput start
+```
+
+Run `pnpm --filter zero-throughput start -- --help` for all options.

--- a/apps/zero-throughput/README.md
+++ b/apps/zero-throughput/README.md
@@ -65,6 +65,27 @@ pnpm --filter zero-throughput start -- \
   --output results/relational-10u-250rps.json
 ```
 
+Analyze the exact profile query shapes against a running zero-cache:
+
+```bash
+pnpm --filter zero-throughput run analyze -- \
+  --zero-cache-url=http://127.0.0.1:4848 \
+  --profile relational \
+  --query-index 2 \
+  --rows-per-query 50 \
+  --join-plans
+```
+
+Useful profile query diagnostics:
+
+```bash
+pnpm --filter zero-throughput run analyze -- --list-profile-queries
+pnpm --filter zero-throughput run analyze -- \
+  --profile-query relational:activity-list \
+  --rows-per-query 50 \
+  --print-ast
+```
+
 To stream zero-cache logs directly in the terminal:
 
 ```bash

--- a/apps/zero-throughput/README.md
+++ b/apps/zero-throughput/README.md
@@ -16,6 +16,11 @@ The default run:
 pnpm --filter zero-throughput start
 ```
 
+By default, the JSON result is written to `apps/zero-throughput/results/latest.json`
+and zero-cache logs are written to `apps/zero-throughput/results/logs/`. The
+summary is printed after child services are stopped so it is the final benchmark
+output in the terminal.
+
 Useful overrides:
 
 ```bash
@@ -27,6 +32,12 @@ pnpm --filter zero-throughput start -- \
   --batch-size 10 \
   --duration-ms 60000 \
   --output results/feed-append-10u-500rps.json
+```
+
+To stream zero-cache logs directly in the terminal:
+
+```bash
+pnpm --filter zero-throughput start -- --process-log-mode inherit
 ```
 
 Use an already-running PostgreSQL or Zero:

--- a/apps/zero-throughput/README.md
+++ b/apps/zero-throughput/README.md
@@ -67,6 +67,33 @@ pnpm --filter zero-throughput start -- \
   --output results/relational-10u-250rps.json
 ```
 
+Run the recommended parameter sweep. The default sweep covers
+`relational,email,forum`, users `50,100,200,400`, rows per query `50`, sync
+workers `1,2,4`, and binary-searches the sustainable write rate from 1 to 100
+logical writes/s for each point. This keeps the first sweep focused on
+read-heavy fanout, profile complexity, and syncer concurrency without exploding
+the run count.
+
+```bash
+pnpm --filter zero-throughput run sweep -- --dry-run
+pnpm --filter zero-throughput run sweep -- \
+  --output-dir results/sweeps/read-heavy
+```
+
+To also sweep query window size, add `--rows-per-query 25,50,100`.
+
+Sweep output includes:
+
+- `manifest.json` with the exact matrix and git SHA
+- `attempts.jsonl` with every benchmark attempt
+- `points.jsonl` with one binary-search result per matrix point
+- `summary.csv` with the best sustainable write rate per point
+- `runs/` containing the normal per-run benchmark JSON outputs
+- `logs/` containing zero-cache and query-plan logs for each benchmark run
+
+Use `--limit 1` for a smoke run, `--pg-start false` when PostgreSQL is already
+running, and `--verbose-child-logs` to stream each benchmark's full output.
+
 Analyze the exact profile query shapes against a running zero-cache:
 
 ```bash

--- a/apps/zero-throughput/README.md
+++ b/apps/zero-throughput/README.md
@@ -8,8 +8,8 @@ The default run:
 2. Resets the benchmark table and Zero metadata for app id `zero_throughput`.
 3. Deploys allow-read permissions for the benchmark table.
 4. Starts `zero-cache` on port `4848`.
-5. Starts synthetic Zero clients with live `feed-append` queries.
-6. Writes append-only rows to PostgreSQL at a fixed target rate.
+5. Starts synthetic Zero clients with live queries for the selected profile.
+6. Writes profile-shaped rows to PostgreSQL at a fixed target rate.
 7. Writes a JSON result file and prints a short summary.
 
 ```bash
@@ -25,6 +25,7 @@ Useful overrides:
 
 ```bash
 pnpm --filter zero-throughput start -- \
+  --profile feed-append \
   --users 10 \
   --queries-per-user 1 \
   --rows-per-query 100 \
@@ -32,6 +33,36 @@ pnpm --filter zero-throughput start -- \
   --batch-size 10 \
   --duration-ms 60000 \
   --output results/feed-append-10u-500rps.json
+```
+
+Profiles:
+
+| Profile       | Query shape                                                       | Write shape                                   |
+| ------------- | ----------------------------------------------------------------- | --------------------------------------------- |
+| `feed-append` | Recent append-only events                                         | Insert one event row                          |
+| `email`       | Inbox threads, message lists, and unread thread queries           | Insert message and update parent thread       |
+| `forum`       | Category/thread/post queries with author and thread relationships | Insert post and update parent thread/category |
+| `relational`  | Org/account/activity queries with nested account/contact joins    | Insert activity and update parent account/org |
+
+`queriesPerUser` cycles through the distinct query shapes for each profile, so
+setting `--queries-per-user 3` registers the full current mix for `email`,
+`forum`, and `relational`.
+
+`writeRate` is measured in logical writes per second. A logical write maps to
+one monotonic `seq`; non-feed profiles may touch additional parent rows so their
+list and relationship queries observe that `seq`.
+
+Example profile run:
+
+```bash
+pnpm --filter zero-throughput start -- \
+  --profile relational \
+  --users 10 \
+  --queries-per-user 3 \
+  --rows-per-query 50 \
+  --write-rate 250 \
+  --duration-ms 60000 \
+  --output results/relational-10u-250rps.json
 ```
 
 To stream zero-cache logs directly in the terminal:

--- a/apps/zero-throughput/README.md
+++ b/apps/zero-throughput/README.md
@@ -8,9 +8,10 @@ The default run:
 2. Resets the benchmark table and Zero metadata for app id `zero_throughput`.
 3. Deploys allow-read permissions for the benchmark table.
 4. Starts `zero-cache` on port `4848`.
-5. Starts synthetic Zero clients with live queries for the selected profile.
-6. Writes profile-shaped rows to PostgreSQL at a fixed target rate.
-7. Writes a JSON result file and prints a short summary.
+5. Runs analyze-query for each distinct live query shape in the selected profile.
+6. Starts synthetic Zero clients with live queries for the selected profile.
+7. Writes profile-shaped rows to PostgreSQL at a fixed target rate.
+8. Writes a JSON result file and prints a short summary.
 
 ```bash
 pnpm --filter zero-throughput start
@@ -18,8 +19,9 @@ pnpm --filter zero-throughput start
 
 By default, the JSON result is written to `apps/zero-throughput/results/latest.json`
 and zero-cache logs are written to `apps/zero-throughput/results/logs/`. The
-summary is printed after child services are stopped so it is the final benchmark
-output in the terminal.
+query plan analysis is written to the same logs directory as
+`<runID>-query-plans.log`. The summary is printed after child services are
+stopped so it is the final benchmark output in the terminal.
 
 Useful overrides:
 
@@ -85,6 +87,9 @@ pnpm --filter zero-throughput run analyze -- \
   --rows-per-query 50 \
   --print-ast
 ```
+
+`--print-ast` prints the server-mapped AST, so it can be passed directly to
+the underlying analyze-query `--ast` option.
 
 To stream zero-cache logs directly in the terminal:
 

--- a/apps/zero-throughput/docker/docker-compose.yml
+++ b/apps/zero-throughput/docker/docker-compose.yml
@@ -1,0 +1,30 @@
+services:
+  postgres:
+    image: postgres:16.2-alpine
+    shm_size: 1g
+    user: postgres
+    restart: always
+    ports:
+      - 6436:5432
+    environment:
+      POSTGRES_USER: user
+      POSTGRES_DB: postgres
+      POSTGRES_PASSWORD: password
+    command: |
+      postgres
+      -c wal_level=logical
+      -c max_wal_senders=10
+      -c max_replication_slots=10
+      -c hot_standby=on
+      -c hot_standby_feedback=on
+    healthcheck:
+      test: 'pg_isready -U user --dbname=postgres'
+      interval: 2s
+      timeout: 5s
+      retries: 30
+    volumes:
+      - zero_throughput_pgdata:/var/lib/postgresql/data
+
+volumes:
+  zero_throughput_pgdata:
+    driver: local

--- a/apps/zero-throughput/package.json
+++ b/apps/zero-throughput/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "node src/main.ts",
     "analyze": "node src/analyze.ts",
+    "sweep": "node src/sweep.ts",
     "go": "node src/main.ts",
     "db-up": "cd docker && docker compose up",
     "db-down": "cd docker && docker compose down",

--- a/apps/zero-throughput/package.json
+++ b/apps/zero-throughput/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "zero-throughput",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "node src/main.ts",
+    "go": "node src/main.ts",
+    "db-up": "cd docker && docker compose up",
+    "db-down": "cd docker && docker compose down",
+    "check-types": "tsc",
+    "format": "oxfmt .",
+    "check-format": "oxfmt --check .",
+    "lint": "oxlint --quiet --config ../../oxlint.config.ts .",
+    "fmt": "oxfmt .",
+    "check-fmt": "oxfmt --check ."
+  },
+  "dependencies": {
+    "@dotenvx/dotenvx": "^1.39.0",
+    "@rocicorp/zero": "workspace:*",
+    "postgres": "3.4.7",
+    "ws": "^8.18.1"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.5",
+    "@types/ws": "^8.5.12",
+    "oxfmt": "^0.45.0",
+    "shared": "workspace:*",
+    "typescript": "~6.0.2"
+  },
+  "packageManager": "pnpm@11.5.3"
+}

--- a/apps/zero-throughput/package.json
+++ b/apps/zero-throughput/package.json
@@ -28,7 +28,10 @@
     "@types/ws": "^8.5.12",
     "oxfmt": "^0.45.0",
     "shared": "workspace:*",
-    "typescript": "~6.0.2"
+    "typescript": "~6.0.2",
+    "zero-protocol": "workspace:*",
+    "zero-schema": "workspace:*",
+    "zql": "workspace:*"
   },
   "packageManager": "pnpm@11.5.3"
 }

--- a/apps/zero-throughput/package.json
+++ b/apps/zero-throughput/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "start": "node src/main.ts",
+    "analyze": "node src/analyze.ts",
     "go": "node src/main.ts",
     "db-up": "cd docker && docker compose up",
     "db-down": "cd docker && docker compose down",

--- a/apps/zero-throughput/src/analyze.ts
+++ b/apps/zero-throughput/src/analyze.ts
@@ -1,3 +1,5 @@
+import {mapAST, type AST} from '../../../packages/zero-protocol/src/ast.ts';
+import {clientToServer} from '../../../packages/zero-schema/src/name-mapper.ts';
 import {runAnalyzeCLI} from '../../../packages/zero/src/analyze.ts';
 import {createBuilder} from '../../../packages/zql/src/query/create-builder.ts';
 import type {BenchmarkProfile} from './config.ts';
@@ -51,7 +53,7 @@ if (config.help) {
     queryIndex,
     config.rowsPerQuery,
   );
-  const ast = queryAST(query);
+  const ast = mapAST(queryAST(query), clientToServer(schema.tables));
   if (config.printAst) {
     stdout(`${JSON.stringify(ast)}\n`);
   } else {
@@ -146,11 +148,11 @@ function parseArgs(argv: readonly string[]): AnalyzeConfig {
   };
 }
 
-function queryAST(query: unknown): unknown {
+function queryAST(query: unknown): AST {
   if (query === null || typeof query !== 'object' || !('ast' in query)) {
     throw new Error('Profile query did not expose an AST');
   }
-  return (query as {readonly ast: unknown}).ast;
+  return (query as {readonly ast: AST}).ast;
 }
 
 function parseOption(arg: string): {

--- a/apps/zero-throughput/src/analyze.ts
+++ b/apps/zero-throughput/src/analyze.ts
@@ -1,0 +1,296 @@
+import {runAnalyzeCLI} from '../../../packages/zero/src/analyze.ts';
+import {createBuilder} from '../../../packages/zql/src/query/create-builder.ts';
+import type {BenchmarkProfile} from './config.ts';
+import {
+  buildProfileQuery,
+  findProfileQuery,
+  PROFILE_QUERY_NAMES,
+} from './profile-queries.ts';
+import {schema} from './schema.ts';
+
+const DEFAULT_PROFILE = 'relational' satisfies BenchmarkProfile;
+const DEFAULT_QUERY_INDEX = 0;
+const DEFAULT_ROWS_PER_QUERY = 100;
+const PROFILES = new Set<BenchmarkProfile>([
+  'feed-append',
+  'email',
+  'forum',
+  'relational',
+]);
+
+type AnalyzeConfig = {
+  readonly passThroughArgs: readonly string[];
+  readonly profile: BenchmarkProfile | undefined;
+  readonly profileQueryName: string | undefined;
+  readonly queryIndex: number;
+  readonly rowsPerQuery: number;
+  readonly printAst: boolean;
+  readonly listProfileQueries: boolean;
+  readonly help: boolean;
+  readonly usesProfileOptions: boolean;
+};
+
+const config = parseArgs(process.argv.slice(2));
+
+if (config.help) {
+  printUsage();
+} else if (config.listProfileQueries) {
+  printProfileQueries();
+} else if (hasAnalyzeQuerySelector(config.passThroughArgs)) {
+  if (config.usesProfileOptions || config.printAst) {
+    throw new Error(
+      'Use either profile query options or --ast/--query/--query-name, not both.',
+    );
+  }
+  await runAnalyzeCLI({schema, argv: config.passThroughArgs});
+} else {
+  const {profile, queryIndex} = resolveProfileQuery(config);
+  const {name, query} = buildProfileQuery(
+    createBuilder(schema),
+    profile,
+    queryIndex,
+    config.rowsPerQuery,
+  );
+  const ast = queryAST(query);
+  if (config.printAst) {
+    stdout(`${JSON.stringify(ast)}\n`);
+  } else {
+    stderr(`Analyzing ${name} with rowsPerQuery=${config.rowsPerQuery}\n`);
+    await runAnalyzeCLI({
+      schema,
+      argv: [...config.passThroughArgs, `--ast=${JSON.stringify(ast)}`],
+    });
+  }
+}
+
+function parseArgs(argv: readonly string[]): AnalyzeConfig {
+  const passThroughArgs: string[] = [];
+  let profile: BenchmarkProfile | undefined;
+  let profileQueryName: string | undefined;
+  let queryIndex = DEFAULT_QUERY_INDEX;
+  let rowsPerQuery = DEFAULT_ROWS_PER_QUERY;
+  let printAst = false;
+  let listProfileQueries = false;
+  let help = false;
+  let usesProfileOptions = false;
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    const option = parseOption(arg);
+    switch (option.name) {
+      case '--help':
+      case '-h':
+        help = true;
+        break;
+
+      case '--profile':
+        profile = parseProfile(readOptionValue(argv, option, i));
+        i += option.value === undefined ? 1 : 0;
+        usesProfileOptions = true;
+        break;
+
+      case '--profile-query':
+      case '--profileQuery':
+        profileQueryName = readOptionValue(argv, option, i);
+        i += option.value === undefined ? 1 : 0;
+        usesProfileOptions = true;
+        break;
+
+      case '--query-index':
+      case '--queryIndex':
+        queryIndex = parseNonNegativeInteger(
+          option.name,
+          readOptionValue(argv, option, i),
+        );
+        i += option.value === undefined ? 1 : 0;
+        usesProfileOptions = true;
+        break;
+
+      case '--rows-per-query':
+      case '--rowsPerQuery':
+        rowsPerQuery = parsePositiveInteger(
+          option.name,
+          readOptionValue(argv, option, i),
+        );
+        i += option.value === undefined ? 1 : 0;
+        usesProfileOptions = true;
+        break;
+
+      case '--print-ast':
+      case '--printAst':
+        printAst = parseBooleanOption(option.value, true);
+        usesProfileOptions = true;
+        break;
+
+      case '--list-profile-queries':
+      case '--listProfileQueries':
+        listProfileQueries = parseBooleanOption(option.value, true);
+        usesProfileOptions = true;
+        break;
+
+      default:
+        passThroughArgs.push(arg);
+    }
+  }
+
+  return {
+    passThroughArgs,
+    profile,
+    profileQueryName,
+    queryIndex,
+    rowsPerQuery,
+    printAst,
+    listProfileQueries,
+    help,
+    usesProfileOptions,
+  };
+}
+
+function queryAST(query: unknown): unknown {
+  if (query === null || typeof query !== 'object' || !('ast' in query)) {
+    throw new Error('Profile query did not expose an AST');
+  }
+  return (query as {readonly ast: unknown}).ast;
+}
+
+function parseOption(arg: string): {
+  readonly name: string;
+  readonly value: string | undefined;
+} {
+  const equals = arg.indexOf('=');
+  if (equals === -1) {
+    return {name: arg, value: undefined};
+  }
+  return {name: arg.slice(0, equals), value: arg.slice(equals + 1)};
+}
+
+function readOptionValue(
+  argv: readonly string[],
+  option: {readonly name: string; readonly value: string | undefined},
+  index: number,
+): string {
+  if (option.value !== undefined) {
+    return option.value;
+  }
+  const value = argv[index + 1];
+  if (value === undefined || value.startsWith('--')) {
+    throw new Error(`${option.name} requires a value`);
+  }
+  return value;
+}
+
+function parseProfile(value: string): BenchmarkProfile {
+  if (PROFILES.has(value as BenchmarkProfile)) {
+    return value as BenchmarkProfile;
+  }
+  throw new Error(
+    `Invalid profile "${value}". Expected one of: ${[...PROFILES].join(', ')}`,
+  );
+}
+
+function parsePositiveInteger(name: string, value: string): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function parseNonNegativeInteger(name: string, value: string): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`${name} must be a non-negative integer`);
+  }
+  return parsed;
+}
+
+function parseBooleanOption(
+  value: string | undefined,
+  defaultValue: boolean,
+): boolean {
+  if (value === undefined) {
+    return defaultValue;
+  }
+  switch (value) {
+    case 'true':
+      return true;
+    case 'false':
+      return false;
+    default:
+      throw new Error(`Expected boolean value, got "${value}"`);
+  }
+}
+
+function hasAnalyzeQuerySelector(argv: readonly string[]): boolean {
+  return argv.some(
+    arg =>
+      arg === '--ast' ||
+      arg.startsWith('--ast=') ||
+      arg === '--query' ||
+      arg.startsWith('--query=') ||
+      arg === '--query-name' ||
+      arg.startsWith('--query-name=') ||
+      arg === '--queryName' ||
+      arg.startsWith('--queryName='),
+  );
+}
+
+function resolveProfileQuery(config: AnalyzeConfig): {
+  readonly profile: BenchmarkProfile;
+  readonly queryIndex: number;
+} {
+  if (config.profileQueryName !== undefined) {
+    const found = findProfileQuery(config.profileQueryName);
+    if (found === undefined) {
+      throw new Error(`Unknown profile query "${config.profileQueryName}"`);
+    }
+    if (config.profile !== undefined && found.profile !== config.profile) {
+      throw new Error(
+        `Profile query ${config.profileQueryName} belongs to ${found.profile}, not ${config.profile}`,
+      );
+    }
+    return found;
+  }
+  return {
+    profile: config.profile ?? DEFAULT_PROFILE,
+    queryIndex: config.queryIndex,
+  };
+}
+
+function printUsage(): void {
+  stdout(`Usage:
+  pnpm --filter zero-throughput run analyze -- --zero-cache-url=http://127.0.0.1:4848 [options]
+
+Profile query options:
+  --profile relational --query-index 2 --rows-per-query 50
+  --profile-query relational:activity-list
+  --print-ast
+  --list-profile-queries
+
+Any other flags are passed through to analyze-query, such as --join-plans,
+--output-vended-rows, --output-synced-rows, --admin-password, or --user-id.
+
+Defaults:
+  --profile ${DEFAULT_PROFILE}
+  --query-index ${DEFAULT_QUERY_INDEX}
+  --rows-per-query ${DEFAULT_ROWS_PER_QUERY}
+`);
+  printProfileQueries();
+}
+
+function printProfileQueries(): void {
+  for (const [profile, names] of Object.entries(PROFILE_QUERY_NAMES)) {
+    stdout(`${profile}:\n`);
+    for (const [index, name] of names.entries()) {
+      stdout(`  ${index}: ${name}\n`);
+    }
+  }
+}
+
+function stdout(message: string): void {
+  process.stdout.write(message);
+}
+
+function stderr(message: string): void {
+  process.stderr.write(message);
+}

--- a/apps/zero-throughput/src/client.ts
+++ b/apps/zero-throughput/src/client.ts
@@ -1,7 +1,7 @@
 import {Zero, type ConnectionState, type ResultType} from '@rocicorp/zero';
 import WebSocket from 'ws';
 import type {BenchmarkConfig} from './config.ts';
-import {FORUM_CATEGORY_ID, REL_ORG_ID, SHARED_OWNER_ID} from './profiles.ts';
+import {buildProfileQuery} from './profile-queries.ts';
 import {schema} from './schema.ts';
 import {nowMs, withTimeout} from './util.ts';
 
@@ -69,165 +69,14 @@ export class SyntheticClient {
   }
 
   #registerProfileQuery(config: BenchmarkConfig, queryIndex: number): void {
-    switch (config.profile) {
-      case 'feed-append': {
-        const query = this.#zero.query.event
-          .where('bucket', 0)
-          .orderBy('seq', 'desc')
-          .limit(config.rowsPerQuery);
-        const view = this.#zero.materialize(query);
-        this.#registerView('feed:recent-events', queryIndex, view);
-        return;
-      }
-      case 'email': {
-        this.#registerEmailQuery(config, queryIndex);
-        return;
-      }
-      case 'forum': {
-        this.#registerForumQuery(config, queryIndex);
-        return;
-      }
-      case 'relational': {
-        this.#registerRelationalQuery(config, queryIndex);
-        return;
-      }
-    }
-  }
-
-  #registerEmailQuery(config: BenchmarkConfig, queryIndex: number): void {
-    switch (queryIndex % 3) {
-      case 0: {
-        const query = this.#zero.query.emailThread
-          .where('ownerID', SHARED_OWNER_ID)
-          .where('mailbox', 'inbox')
-          .related('messages', q => q.orderBy('seq', 'desc').limit(5))
-          .orderBy('seq', 'desc')
-          .limit(config.rowsPerQuery);
-        const view = this.#zero.materialize(query);
-        this.#registerView('email:thread-list-with-messages', queryIndex, view);
-        return;
-      }
-      case 1: {
-        const query = this.#zero.query.emailMessage
-          .where('ownerID', SHARED_OWNER_ID)
-          .where('mailbox', 'inbox')
-          .related('thread')
-          .orderBy('seq', 'desc')
-          .limit(config.rowsPerQuery);
-        const view = this.#zero.materialize(query);
-        this.#registerView('email:message-list-with-thread', queryIndex, view);
-        return;
-      }
-      case 2: {
-        const query = this.#zero.query.emailThread
-          .where('ownerID', SHARED_OWNER_ID)
-          .where('mailbox', 'inbox')
-          .related('messages', q =>
-            q.where('unread', true).orderBy('seq', 'desc').limit(10),
-          )
-          .orderBy('seq', 'desc')
-          .limit(config.rowsPerQuery);
-        const view = this.#zero.materialize(query);
-        this.#registerView('email:unread-thread-list', queryIndex, view);
-        return;
-      }
-    }
-  }
-
-  #registerForumQuery(config: BenchmarkConfig, queryIndex: number): void {
-    switch (queryIndex % 3) {
-      case 0: {
-        const query = this.#zero.query.forumCategory
-          .where('id', FORUM_CATEGORY_ID)
-          .related('threads', q =>
-            q
-              .orderBy('seq', 'desc')
-              .limit(config.rowsPerQuery)
-              .related('author')
-              .related('posts', p =>
-                p.orderBy('seq', 'desc').limit(3).related('author'),
-              ),
-          );
-        const view = this.#zero.materialize(query);
-        this.#registerView('forum:category-thread-tree', queryIndex, view);
-        return;
-      }
-      case 1: {
-        const query = this.#zero.query.forumThread
-          .where('categoryID', FORUM_CATEGORY_ID)
-          .related('category')
-          .related('author')
-          .related('posts', q =>
-            q.orderBy('seq', 'desc').limit(5).related('author'),
-          )
-          .orderBy('seq', 'desc')
-          .limit(config.rowsPerQuery);
-        const view = this.#zero.materialize(query);
-        this.#registerView('forum:thread-list-with-posts', queryIndex, view);
-        return;
-      }
-      case 2: {
-        const query = this.#zero.query.forumPost
-          .where('categoryID', FORUM_CATEGORY_ID)
-          .related('thread', q => q.related('author').related('category'))
-          .related('author')
-          .orderBy('seq', 'desc')
-          .limit(config.rowsPerQuery);
-        const view = this.#zero.materialize(query);
-        this.#registerView('forum:post-list-with-thread', queryIndex, view);
-        return;
-      }
-    }
-  }
-
-  #registerRelationalQuery(config: BenchmarkConfig, queryIndex: number): void {
-    switch (queryIndex % 3) {
-      case 0: {
-        const query = this.#zero.query.relOrg
-          .where('id', REL_ORG_ID)
-          .related('accounts', q =>
-            q
-              .orderBy('seq', 'desc')
-              .limit(config.rowsPerQuery)
-              .related('contacts')
-              .related('activities', a =>
-                a.orderBy('seq', 'desc').limit(5).related('contact'),
-              ),
-          )
-          .related('activities', q =>
-            q.orderBy('seq', 'desc').limit(config.rowsPerQuery),
-          );
-        const view = this.#zero.materialize(query);
-        this.#registerView('relational:org-account-tree', queryIndex, view);
-        return;
-      }
-      case 1: {
-        const query = this.#zero.query.relAccount
-          .where('orgID', REL_ORG_ID)
-          .related('org')
-          .related('contacts')
-          .related('activities', q =>
-            q.orderBy('seq', 'desc').limit(5).related('contact'),
-          )
-          .orderBy('seq', 'desc')
-          .limit(config.rowsPerQuery);
-        const view = this.#zero.materialize(query);
-        this.#registerView('relational:account-list', queryIndex, view);
-        return;
-      }
-      case 2: {
-        const query = this.#zero.query.relActivity
-          .where('orgID', REL_ORG_ID)
-          .related('org')
-          .related('account', q => q.related('contacts'))
-          .related('contact')
-          .orderBy('seq', 'desc')
-          .limit(config.rowsPerQuery);
-        const view = this.#zero.materialize(query);
-        this.#registerView('relational:activity-list', queryIndex, view);
-        return;
-      }
-    }
+    const {name, query} = buildProfileQuery(
+      this.#zero.query,
+      config.profile,
+      queryIndex,
+      config.rowsPerQuery,
+    );
+    const view = this.#zero.materialize(query);
+    this.#registerView(name, queryIndex, view);
   }
 
   #registerView(

--- a/apps/zero-throughput/src/client.ts
+++ b/apps/zero-throughput/src/client.ts
@@ -1,0 +1,206 @@
+import {Zero, type ConnectionState, type ResultType} from '@rocicorp/zero';
+import WebSocket from 'ws';
+import type {BenchmarkConfig} from './config.ts';
+import {schema, type ThroughputEvent} from './schema.ts';
+import {nowMs, withTimeout} from './util.ts';
+
+export type ClientQueryStats = {
+  readonly clientID: string;
+  readonly queryIndex: number;
+  readonly initialSyncMs: number | undefined;
+  readonly updates: number;
+  readonly observedSeq: number;
+  readonly observedRows: number;
+  readonly latencySamplesMs: readonly number[];
+  readonly lastResultType: ResultType;
+};
+
+export type ClientStats = {
+  readonly userID: string;
+  readonly connected: boolean;
+  readonly connectionState: ConnectionState;
+  readonly queries: readonly ClientQueryStats[];
+};
+
+export class SyntheticClient {
+  readonly userID: string;
+  readonly #zero: Zero<typeof schema>;
+  readonly #queryStates: QueryState[] = [];
+  readonly #createdAtMs = nowMs();
+  #connectionState: ConnectionState;
+  #unsubscribeConnection: (() => void) | undefined;
+
+  constructor(userID: string, config: BenchmarkConfig) {
+    this.userID = userID;
+    installWebSocketPolyfill();
+    this.#zero = new Zero({
+      schema,
+      cacheURL: config.cacheURL,
+      userID,
+      storageKey: config.runID,
+      kvStore: 'mem',
+      logLevel: 'error',
+      queryChangeThrottleMs: 0,
+    });
+    this.#connectionState = this.#zero.connection.state.current;
+    this.#unsubscribeConnection = this.#zero.connection.state.subscribe(
+      state => {
+        this.#connectionState = state;
+      },
+    );
+
+    for (let i = 0; i < config.queriesPerUser; i++) {
+      const eventQuery = this.#zero.query.event;
+      if (eventQuery === undefined) {
+        throw new Error('Zero query builder did not expose event table');
+      }
+      const query = eventQuery
+        .where('bucket', 0)
+        .orderBy('seq', 'desc')
+        .limit(config.rowsPerQuery);
+      const state = new QueryState(this.userID, i, this.#createdAtMs);
+      const view = this.#zero.materialize(query);
+      const unsubscribe = view.addListener((rows, resultType) => {
+        state.observe(rows as readonly ThroughputEvent[], resultType);
+      });
+      state.setCleanup(() => {
+        unsubscribe();
+        view.destroy();
+      });
+      this.#queryStates.push(state);
+    }
+  }
+
+  async waitForInitialSync(timeoutMs: number): Promise<void> {
+    await withTimeout(
+      Promise.all(this.#queryStates.map(state => state.initialSync)),
+      timeoutMs,
+      `${this.userID} did not complete initial sync within ${timeoutMs}ms`,
+    );
+  }
+
+  stats(): ClientStats {
+    return {
+      userID: this.userID,
+      connected: this.#connectionState.name === 'connected',
+      connectionState: this.#connectionState,
+      queries: this.#queryStates.map(state => state.stats()),
+    };
+  }
+
+  minObservedSeq(): number {
+    return Math.min(...this.#queryStates.map(state => state.observedSeq));
+  }
+
+  latencySamplesMs(): number[] {
+    return this.#queryStates.flatMap(state => state.latencySamplesMs);
+  }
+
+  async close(): Promise<void> {
+    this.#unsubscribeConnection?.();
+    this.#unsubscribeConnection = undefined;
+    for (const state of this.#queryStates) {
+      state.cleanup();
+    }
+    await this.#zero.close();
+  }
+}
+
+export async function startSyntheticClients(
+  config: BenchmarkConfig,
+): Promise<SyntheticClient[]> {
+  const clients: SyntheticClient[] = [];
+  for (let i = 0; i < config.users; i++) {
+    clients.push(new SyntheticClient(`throughput-user-${i}`, config));
+  }
+  await Promise.all(
+    clients.map(client => client.waitForInitialSync(config.warmupMs)),
+  );
+  return clients;
+}
+
+class QueryState {
+  readonly #clientID: string;
+  readonly #queryIndex: number;
+  readonly #createdAtMs: number;
+  readonly #initialSyncPromise: Promise<void>;
+  #resolveInitialSync: () => void = () => undefined;
+  #cleanup: (() => void) | undefined;
+  #initialSyncMs: number | undefined;
+  #updates = 0;
+  #observedSeq = 0;
+  #observedRows = 0;
+  #lastResultType: ResultType = 'unknown';
+  readonly #latencySamplesMs: number[] = [];
+
+  constructor(clientID: string, queryIndex: number, createdAtMs: number) {
+    this.#clientID = clientID;
+    this.#queryIndex = queryIndex;
+    this.#createdAtMs = createdAtMs;
+    this.#initialSyncPromise = new Promise(resolve => {
+      this.#resolveInitialSync = resolve;
+    });
+  }
+
+  get initialSync(): Promise<void> {
+    return this.#initialSyncPromise;
+  }
+
+  get observedSeq(): number {
+    return this.#observedSeq;
+  }
+
+  get latencySamplesMs(): readonly number[] {
+    return this.#latencySamplesMs;
+  }
+
+  setCleanup(cleanup: () => void): void {
+    this.#cleanup = cleanup;
+  }
+
+  cleanup(): void {
+    this.#cleanup?.();
+    this.#cleanup = undefined;
+  }
+
+  observe(rows: readonly ThroughputEvent[], resultType: ResultType): void {
+    this.#updates++;
+    this.#lastResultType = resultType;
+    if (resultType === 'complete' && this.#initialSyncMs === undefined) {
+      this.#initialSyncMs = nowMs() - this.#createdAtMs;
+      this.#resolveInitialSync();
+    }
+
+    const receivedAtMs = nowMs();
+    let maxSeq = this.#observedSeq;
+    for (const row of rows) {
+      if (row.seq > this.#observedSeq) {
+        this.#latencySamplesMs.push(Math.max(0, receivedAtMs - row.writtenAt));
+      }
+      maxSeq = Math.max(maxSeq, row.seq);
+    }
+    this.#observedSeq = maxSeq;
+    this.#observedRows += rows.length;
+  }
+
+  stats(): ClientQueryStats {
+    return {
+      clientID: this.#clientID,
+      queryIndex: this.#queryIndex,
+      initialSyncMs: this.#initialSyncMs,
+      updates: this.#updates,
+      observedSeq: this.#observedSeq,
+      observedRows: this.#observedRows,
+      latencySamplesMs: this.#latencySamplesMs,
+      lastResultType: this.#lastResultType,
+    };
+  }
+}
+
+function installWebSocketPolyfill(): void {
+  const globalWithWebSocket = globalThis as typeof globalThis & {
+    WebSocket?: typeof globalThis.WebSocket | undefined;
+  };
+  globalWithWebSocket.WebSocket ??=
+    WebSocket as unknown as typeof globalThis.WebSocket;
+}

--- a/apps/zero-throughput/src/client.ts
+++ b/apps/zero-throughput/src/client.ts
@@ -1,3 +1,4 @@
+import {performance} from 'node:perf_hooks';
 import {Zero, type ConnectionState, type ResultType} from '@rocicorp/zero';
 import WebSocket from 'ws';
 import type {BenchmarkConfig} from './config.ts';
@@ -13,6 +14,10 @@ export type ClientQueryStats = {
   readonly updates: number;
   readonly observedSeq: number;
   readonly observedRows: number;
+  readonly observeTotalMs: number;
+  readonly observeMaxMs: number;
+  readonly collectSignalsTotalMs: number;
+  readonly collectSignalsMaxMs: number;
   readonly latencySamplesMs: readonly number[];
   readonly lastResultType: ResultType;
 };
@@ -160,6 +165,10 @@ class QueryState {
   #updates = 0;
   #observedSeq = 0;
   #observedRows = 0;
+  #observeTotalMs = 0;
+  #observeMaxMs = 0;
+  #collectSignalsTotalMs = 0;
+  #collectSignalsMaxMs = 0;
   #lastResultType: ResultType = 'unknown';
   readonly #latencySamplesMs: number[] = [];
 
@@ -200,6 +209,7 @@ class QueryState {
   }
 
   observe(rows: readonly unknown[], resultType: ResultType): void {
+    const observeStartedAtMs = performance.now();
     this.#updates++;
     this.#lastResultType = resultType;
     if (resultType === 'complete' && this.#initialSyncMs === undefined) {
@@ -211,7 +221,15 @@ class QueryState {
     const previousObservedSeq = this.#observedSeq;
     let maxSeq = this.#observedSeq;
     const newWrittenAtBySeq = new Map<number, number>();
-    for (const signal of collectSignals(rows)) {
+    const collectStartedAtMs = performance.now();
+    const signals = collectSignals(rows);
+    const collectElapsedMs = performance.now() - collectStartedAtMs;
+    this.#collectSignalsTotalMs += collectElapsedMs;
+    this.#collectSignalsMaxMs = Math.max(
+      this.#collectSignalsMaxMs,
+      collectElapsedMs,
+    );
+    for (const signal of signals) {
       if (signal.seq > previousObservedSeq) {
         const writtenAt = newWrittenAtBySeq.get(signal.seq);
         if (writtenAt === undefined || signal.writtenAt < writtenAt) {
@@ -225,6 +243,9 @@ class QueryState {
     }
     this.#observedSeq = maxSeq;
     this.#observedRows += rows.length;
+    const observeElapsedMs = performance.now() - observeStartedAtMs;
+    this.#observeTotalMs += observeElapsedMs;
+    this.#observeMaxMs = Math.max(this.#observeMaxMs, observeElapsedMs);
   }
 
   stats(): ClientQueryStats {
@@ -236,6 +257,10 @@ class QueryState {
       updates: this.#updates,
       observedSeq: this.#observedSeq,
       observedRows: this.#observedRows,
+      observeTotalMs: this.#observeTotalMs,
+      observeMaxMs: this.#observeMaxMs,
+      collectSignalsTotalMs: this.#collectSignalsTotalMs,
+      collectSignalsMaxMs: this.#collectSignalsMaxMs,
       latencySamplesMs: this.#latencySamplesMs,
       lastResultType: this.#lastResultType,
     };

--- a/apps/zero-throughput/src/client.ts
+++ b/apps/zero-throughput/src/client.ts
@@ -1,12 +1,14 @@
 import {Zero, type ConnectionState, type ResultType} from '@rocicorp/zero';
 import WebSocket from 'ws';
 import type {BenchmarkConfig} from './config.ts';
-import {schema, type ThroughputEvent} from './schema.ts';
+import {FORUM_CATEGORY_ID, REL_ORG_ID, SHARED_OWNER_ID} from './profiles.ts';
+import {schema} from './schema.ts';
 import {nowMs, withTimeout} from './util.ts';
 
 export type ClientQueryStats = {
   readonly clientID: string;
   readonly queryIndex: number;
+  readonly queryName: string;
   readonly initialSyncMs: number | undefined;
   readonly updates: number;
   readonly observedSeq: number;
@@ -20,6 +22,18 @@ export type ClientStats = {
   readonly connected: boolean;
   readonly connectionState: ConnectionState;
   readonly queries: readonly ClientQueryStats[];
+};
+
+type MaterializedView = {
+  addListener(
+    listener: (rows: readonly unknown[], resultType: ResultType) => void,
+  ): () => void;
+  destroy(): void;
+};
+
+type Signal = {
+  readonly seq: number;
+  readonly writtenAt: number;
 };
 
 export class SyntheticClient {
@@ -50,25 +64,191 @@ export class SyntheticClient {
     );
 
     for (let i = 0; i < config.queriesPerUser; i++) {
-      const eventQuery = this.#zero.query.event;
-      if (eventQuery === undefined) {
-        throw new Error('Zero query builder did not expose event table');
-      }
-      const query = eventQuery
-        .where('bucket', 0)
-        .orderBy('seq', 'desc')
-        .limit(config.rowsPerQuery);
-      const state = new QueryState(this.userID, i, this.#createdAtMs);
-      const view = this.#zero.materialize(query);
-      const unsubscribe = view.addListener((rows, resultType) => {
-        state.observe(rows as readonly ThroughputEvent[], resultType);
-      });
-      state.setCleanup(() => {
-        unsubscribe();
-        view.destroy();
-      });
-      this.#queryStates.push(state);
+      this.#registerProfileQuery(config, i);
     }
+  }
+
+  #registerProfileQuery(config: BenchmarkConfig, queryIndex: number): void {
+    switch (config.profile) {
+      case 'feed-append': {
+        const query = this.#zero.query.event
+          .where('bucket', 0)
+          .orderBy('seq', 'desc')
+          .limit(config.rowsPerQuery);
+        const view = this.#zero.materialize(query);
+        this.#registerView('feed:recent-events', queryIndex, view);
+        return;
+      }
+      case 'email': {
+        this.#registerEmailQuery(config, queryIndex);
+        return;
+      }
+      case 'forum': {
+        this.#registerForumQuery(config, queryIndex);
+        return;
+      }
+      case 'relational': {
+        this.#registerRelationalQuery(config, queryIndex);
+        return;
+      }
+    }
+  }
+
+  #registerEmailQuery(config: BenchmarkConfig, queryIndex: number): void {
+    switch (queryIndex % 3) {
+      case 0: {
+        const query = this.#zero.query.emailThread
+          .where('ownerID', SHARED_OWNER_ID)
+          .where('mailbox', 'inbox')
+          .related('messages', q => q.orderBy('seq', 'desc').limit(5))
+          .orderBy('seq', 'desc')
+          .limit(config.rowsPerQuery);
+        const view = this.#zero.materialize(query);
+        this.#registerView('email:thread-list-with-messages', queryIndex, view);
+        return;
+      }
+      case 1: {
+        const query = this.#zero.query.emailMessage
+          .where('ownerID', SHARED_OWNER_ID)
+          .where('mailbox', 'inbox')
+          .related('thread')
+          .orderBy('seq', 'desc')
+          .limit(config.rowsPerQuery);
+        const view = this.#zero.materialize(query);
+        this.#registerView('email:message-list-with-thread', queryIndex, view);
+        return;
+      }
+      case 2: {
+        const query = this.#zero.query.emailThread
+          .where('ownerID', SHARED_OWNER_ID)
+          .where('mailbox', 'inbox')
+          .related('messages', q =>
+            q.where('unread', true).orderBy('seq', 'desc').limit(10),
+          )
+          .orderBy('seq', 'desc')
+          .limit(config.rowsPerQuery);
+        const view = this.#zero.materialize(query);
+        this.#registerView('email:unread-thread-list', queryIndex, view);
+        return;
+      }
+    }
+  }
+
+  #registerForumQuery(config: BenchmarkConfig, queryIndex: number): void {
+    switch (queryIndex % 3) {
+      case 0: {
+        const query = this.#zero.query.forumCategory
+          .where('id', FORUM_CATEGORY_ID)
+          .related('threads', q =>
+            q
+              .orderBy('seq', 'desc')
+              .limit(config.rowsPerQuery)
+              .related('author')
+              .related('posts', p =>
+                p.orderBy('seq', 'desc').limit(3).related('author'),
+              ),
+          );
+        const view = this.#zero.materialize(query);
+        this.#registerView('forum:category-thread-tree', queryIndex, view);
+        return;
+      }
+      case 1: {
+        const query = this.#zero.query.forumThread
+          .where('categoryID', FORUM_CATEGORY_ID)
+          .related('category')
+          .related('author')
+          .related('posts', q =>
+            q.orderBy('seq', 'desc').limit(5).related('author'),
+          )
+          .orderBy('seq', 'desc')
+          .limit(config.rowsPerQuery);
+        const view = this.#zero.materialize(query);
+        this.#registerView('forum:thread-list-with-posts', queryIndex, view);
+        return;
+      }
+      case 2: {
+        const query = this.#zero.query.forumPost
+          .where('categoryID', FORUM_CATEGORY_ID)
+          .related('thread', q => q.related('author').related('category'))
+          .related('author')
+          .orderBy('seq', 'desc')
+          .limit(config.rowsPerQuery);
+        const view = this.#zero.materialize(query);
+        this.#registerView('forum:post-list-with-thread', queryIndex, view);
+        return;
+      }
+    }
+  }
+
+  #registerRelationalQuery(config: BenchmarkConfig, queryIndex: number): void {
+    switch (queryIndex % 3) {
+      case 0: {
+        const query = this.#zero.query.relOrg
+          .where('id', REL_ORG_ID)
+          .related('accounts', q =>
+            q
+              .orderBy('seq', 'desc')
+              .limit(config.rowsPerQuery)
+              .related('contacts')
+              .related('activities', a =>
+                a.orderBy('seq', 'desc').limit(5).related('contact'),
+              ),
+          )
+          .related('activities', q =>
+            q.orderBy('seq', 'desc').limit(config.rowsPerQuery),
+          );
+        const view = this.#zero.materialize(query);
+        this.#registerView('relational:org-account-tree', queryIndex, view);
+        return;
+      }
+      case 1: {
+        const query = this.#zero.query.relAccount
+          .where('orgID', REL_ORG_ID)
+          .related('org')
+          .related('contacts')
+          .related('activities', q =>
+            q.orderBy('seq', 'desc').limit(5).related('contact'),
+          )
+          .orderBy('seq', 'desc')
+          .limit(config.rowsPerQuery);
+        const view = this.#zero.materialize(query);
+        this.#registerView('relational:account-list', queryIndex, view);
+        return;
+      }
+      case 2: {
+        const query = this.#zero.query.relActivity
+          .where('orgID', REL_ORG_ID)
+          .related('org')
+          .related('account', q => q.related('contacts'))
+          .related('contact')
+          .orderBy('seq', 'desc')
+          .limit(config.rowsPerQuery);
+        const view = this.#zero.materialize(query);
+        this.#registerView('relational:activity-list', queryIndex, view);
+        return;
+      }
+    }
+  }
+
+  #registerView(
+    queryName: string,
+    queryIndex: number,
+    view: MaterializedView,
+  ): void {
+    const state = new QueryState(
+      this.userID,
+      queryIndex,
+      queryName,
+      this.#createdAtMs,
+    );
+    const unsubscribe = view.addListener((rows, resultType) => {
+      state.observe(rows, resultType);
+    });
+    state.setCleanup(() => {
+      unsubscribe();
+      view.destroy();
+    });
+    this.#queryStates.push(state);
   }
 
   async waitForInitialSync(timeoutMs: number): Promise<void> {
@@ -122,6 +302,7 @@ export async function startSyntheticClients(
 class QueryState {
   readonly #clientID: string;
   readonly #queryIndex: number;
+  readonly #queryName: string;
   readonly #createdAtMs: number;
   readonly #initialSyncPromise: Promise<void>;
   #resolveInitialSync: () => void = () => undefined;
@@ -133,9 +314,15 @@ class QueryState {
   #lastResultType: ResultType = 'unknown';
   readonly #latencySamplesMs: number[] = [];
 
-  constructor(clientID: string, queryIndex: number, createdAtMs: number) {
+  constructor(
+    clientID: string,
+    queryIndex: number,
+    queryName: string,
+    createdAtMs: number,
+  ) {
     this.#clientID = clientID;
     this.#queryIndex = queryIndex;
+    this.#queryName = queryName;
     this.#createdAtMs = createdAtMs;
     this.#initialSyncPromise = new Promise(resolve => {
       this.#resolveInitialSync = resolve;
@@ -163,7 +350,7 @@ class QueryState {
     this.#cleanup = undefined;
   }
 
-  observe(rows: readonly ThroughputEvent[], resultType: ResultType): void {
+  observe(rows: readonly unknown[], resultType: ResultType): void {
     this.#updates++;
     this.#lastResultType = resultType;
     if (resultType === 'complete' && this.#initialSyncMs === undefined) {
@@ -172,12 +359,20 @@ class QueryState {
     }
 
     const receivedAtMs = nowMs();
+    const previousObservedSeq = this.#observedSeq;
     let maxSeq = this.#observedSeq;
-    for (const row of rows) {
-      if (row.seq > this.#observedSeq) {
-        this.#latencySamplesMs.push(Math.max(0, receivedAtMs - row.writtenAt));
+    const newWrittenAtBySeq = new Map<number, number>();
+    for (const signal of collectSignals(rows)) {
+      if (signal.seq > previousObservedSeq) {
+        const writtenAt = newWrittenAtBySeq.get(signal.seq);
+        if (writtenAt === undefined || signal.writtenAt < writtenAt) {
+          newWrittenAtBySeq.set(signal.seq, signal.writtenAt);
+        }
       }
-      maxSeq = Math.max(maxSeq, row.seq);
+      maxSeq = Math.max(maxSeq, signal.seq);
+    }
+    for (const writtenAt of newWrittenAtBySeq.values()) {
+      this.#latencySamplesMs.push(Math.max(0, receivedAtMs - writtenAt));
     }
     this.#observedSeq = maxSeq;
     this.#observedRows += rows.length;
@@ -187,6 +382,7 @@ class QueryState {
     return {
       clientID: this.#clientID,
       queryIndex: this.#queryIndex,
+      queryName: this.#queryName,
       initialSyncMs: this.#initialSyncMs,
       updates: this.#updates,
       observedSeq: this.#observedSeq,
@@ -194,6 +390,51 @@ class QueryState {
       latencySamplesMs: this.#latencySamplesMs,
       lastResultType: this.#lastResultType,
     };
+  }
+}
+
+function collectSignals(value: unknown): Signal[] {
+  const signals: Signal[] = [];
+  collectSignalsInto(value, signals, new Set());
+  return signals;
+}
+
+function collectSignalsInto(
+  value: unknown,
+  signals: Signal[],
+  seen: Set<object>,
+): void {
+  if (value === null || value === undefined) {
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectSignalsInto(item, signals, seen);
+    }
+    return;
+  }
+  if (typeof value !== 'object') {
+    return;
+  }
+  if (seen.has(value)) {
+    return;
+  }
+  seen.add(value);
+
+  const record = value as Record<string, unknown>;
+  const seq = record.seq;
+  const writtenAt = record.writtenAt;
+  if (
+    typeof seq === 'number' &&
+    Number.isFinite(seq) &&
+    typeof writtenAt === 'number' &&
+    Number.isFinite(writtenAt)
+  ) {
+    signals.push({seq, writtenAt});
+  }
+
+  for (const child of Object.values(record)) {
+    collectSignalsInto(child, signals, seen);
   }
 }
 

--- a/apps/zero-throughput/src/config.ts
+++ b/apps/zero-throughput/src/config.ts
@@ -1,0 +1,157 @@
+import '../../../packages/shared/src/dotenv.ts';
+
+import {fileURLToPath} from 'node:url';
+import {parseOptions} from '../../../packages/shared/src/options.ts';
+import * as v from '../../../packages/shared/src/valita.ts';
+
+export const appRoot = fileURLToPath(new URL('..', import.meta.url));
+export const repoRoot = fileURLToPath(new URL('../../..', import.meta.url));
+
+const DEFAULT_PG_URL = 'postgresql://user:password@127.0.0.1:6436/postgres';
+const APP_ID_PATTERN = /^[a-z0-9_]+$/;
+
+const options = {
+  profile: v.literalUnion('feed-append').default('feed-append'),
+
+  users: v.number().default(1),
+  queriesPerUser: v.number().default(1),
+  rowsPerQuery: v.number().default(100),
+  writeRate: v.number().default(100),
+  batchSize: v.number().default(1),
+  payloadBytes: v.number().default(256),
+  durationMs: v.number().default(30_000),
+  warmupMs: v.number().default(10_000),
+  settleMs: v.number().default(5_000),
+  sampleIntervalMs: v.number().default(1_000),
+  sloP99LagMs: v.number().default(2_000),
+  output: v.string().default('results/latest.json'),
+  reset: v.boolean().default(true),
+  cacheURL: v.string().optional(),
+
+  pg: {
+    url: v.string().default(DEFAULT_PG_URL),
+    start: v.boolean().default(true),
+    stopAfterRun: v.boolean().default(true),
+    readyTimeoutMs: v.number().default(60_000),
+  },
+
+  zero: {
+    start: v.boolean().default(true),
+    port: v.number().default(4_848),
+    readyTimeoutMs: v.number().default(120_000),
+    appID: v.string().default('zero_throughput'),
+    replicaFile: v.string().default('/tmp/zero-throughput-replica.db'),
+    logLevel: v.literalUnion('debug', 'info', 'warn', 'error').default('info'),
+    numSyncWorkers: v.number().default(1),
+    upstreamMaxConns: v.number().default(10),
+    cvrMaxConns: v.number().default(10),
+    changeMaxConns: v.number().default(5),
+  },
+};
+
+export type BenchmarkProfile = 'feed-append';
+
+export type BenchmarkConfig = {
+  readonly runID: string;
+  readonly profile: BenchmarkProfile;
+  readonly users: number;
+  readonly queriesPerUser: number;
+  readonly rowsPerQuery: number;
+  readonly writeRate: number;
+  readonly batchSize: number;
+  readonly payloadBytes: number;
+  readonly durationMs: number;
+  readonly warmupMs: number;
+  readonly settleMs: number;
+  readonly sampleIntervalMs: number;
+  readonly sloP99LagMs: number;
+  readonly outputPath: string;
+  readonly reset: boolean;
+  readonly cacheURL: string;
+  readonly pg: {
+    readonly url: string;
+    readonly start: boolean;
+    readonly stopAfterRun: boolean;
+    readonly readyTimeoutMs: number;
+  };
+  readonly zero: {
+    readonly start: boolean;
+    readonly port: number;
+    readonly readyTimeoutMs: number;
+    readonly appID: string;
+    readonly replicaFile: string;
+    readonly logLevel: 'debug' | 'info' | 'warn' | 'error';
+    readonly numSyncWorkers: number;
+    readonly upstreamMaxConns: number;
+    readonly cvrMaxConns: number;
+    readonly changeMaxConns: number;
+  };
+};
+
+export function loadConfig(): BenchmarkConfig {
+  const argv = process.argv.slice(2);
+  const parsed = parseOptions(options, {
+    argv: argv[0] === '--' ? argv.slice(1) : argv,
+    envNamePrefix: 'ZERO_THROUGHPUT_',
+  });
+  assertPositiveInteger('users', parsed.users);
+  assertPositiveInteger('queriesPerUser', parsed.queriesPerUser);
+  assertPositiveInteger('rowsPerQuery', parsed.rowsPerQuery);
+  assertPositiveNumber('writeRate', parsed.writeRate);
+  assertPositiveInteger('batchSize', parsed.batchSize);
+  assertNonNegativeInteger('payloadBytes', parsed.payloadBytes);
+  assertPositiveInteger('durationMs', parsed.durationMs);
+  assertNonNegativeInteger('warmupMs', parsed.warmupMs);
+  assertNonNegativeInteger('settleMs', parsed.settleMs);
+  assertPositiveInteger('sampleIntervalMs', parsed.sampleIntervalMs);
+  assertPositiveInteger('sloP99LagMs', parsed.sloP99LagMs);
+  assertValidAppID(parsed.zero.appID);
+
+  return {
+    runID: new Date().toISOString().replace(/[:.]/g, '-'),
+    profile: parsed.profile,
+    users: parsed.users,
+    queriesPerUser: parsed.queriesPerUser,
+    rowsPerQuery: parsed.rowsPerQuery,
+    writeRate: parsed.writeRate,
+    batchSize: parsed.batchSize,
+    payloadBytes: parsed.payloadBytes,
+    durationMs: parsed.durationMs,
+    warmupMs: parsed.warmupMs,
+    settleMs: parsed.settleMs,
+    sampleIntervalMs: parsed.sampleIntervalMs,
+    sloP99LagMs: parsed.sloP99LagMs,
+    outputPath: parsed.output,
+    reset: parsed.reset,
+    cacheURL: parsed.cacheURL ?? `http://127.0.0.1:${parsed.zero.port}`,
+    pg: parsed.pg,
+    zero: parsed.zero,
+  };
+}
+
+function assertPositiveNumber(name: string, value: number): void {
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(`${name} must be a positive number`);
+  }
+}
+
+function assertPositiveInteger(name: string, value: number): void {
+  assertPositiveNumber(name, value);
+  if (!Number.isInteger(value)) {
+    throw new Error(`${name} must be an integer`);
+  }
+}
+
+function assertNonNegativeInteger(name: string, value: number): void {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`${name} must be a non-negative integer`);
+  }
+}
+
+function assertValidAppID(appID: string): void {
+  if (!APP_ID_PATTERN.test(appID)) {
+    throw new Error(
+      'zero.appID must contain only lowercase letters, digits, and underscores',
+    );
+  }
+}

--- a/apps/zero-throughput/src/config.ts
+++ b/apps/zero-throughput/src/config.ts
@@ -12,7 +12,9 @@ const DEFAULT_PG_URL = 'postgresql://user:password@127.0.0.1:6436/postgres';
 const APP_ID_PATTERN = /^[a-z0-9_]+$/;
 
 const options = {
-  profile: v.literalUnion('feed-append').default('feed-append'),
+  profile: v
+    .literalUnion('feed-append', 'email', 'forum', 'relational')
+    .default('feed-append'),
 
   users: v.number().default(1),
   queriesPerUser: v.number().default(1),
@@ -53,7 +55,7 @@ const options = {
   },
 };
 
-export type BenchmarkProfile = 'feed-append';
+export type BenchmarkProfile = 'feed-append' | 'email' | 'forum' | 'relational';
 
 export type BenchmarkConfig = {
   readonly runID: string;

--- a/apps/zero-throughput/src/config.ts
+++ b/apps/zero-throughput/src/config.ts
@@ -1,5 +1,6 @@
 import '../../../packages/shared/src/dotenv.ts';
 
+import {isAbsolute, join} from 'node:path';
 import {fileURLToPath} from 'node:url';
 import {parseOptions} from '../../../packages/shared/src/options.ts';
 import * as v from '../../../packages/shared/src/valita.ts';
@@ -23,8 +24,11 @@ const options = {
   warmupMs: v.number().default(10_000),
   settleMs: v.number().default(5_000),
   sampleIntervalMs: v.number().default(1_000),
+  progressIntervalMs: v.number().default(5_000),
   sloP99LagMs: v.number().default(2_000),
   output: v.string().default('results/latest.json'),
+  logsDir: v.string().default('results/logs'),
+  processLogMode: v.literalUnion('file', 'inherit', 'ignore').default('file'),
   reset: v.boolean().default(true),
   cacheURL: v.string().optional(),
 
@@ -64,8 +68,11 @@ export type BenchmarkConfig = {
   readonly warmupMs: number;
   readonly settleMs: number;
   readonly sampleIntervalMs: number;
+  readonly progressIntervalMs: number;
   readonly sloP99LagMs: number;
   readonly outputPath: string;
+  readonly logsDir: string;
+  readonly processLogMode: 'file' | 'inherit' | 'ignore';
   readonly reset: boolean;
   readonly cacheURL: string;
   readonly pg: {
@@ -104,6 +111,7 @@ export function loadConfig(): BenchmarkConfig {
   assertNonNegativeInteger('warmupMs', parsed.warmupMs);
   assertNonNegativeInteger('settleMs', parsed.settleMs);
   assertPositiveInteger('sampleIntervalMs', parsed.sampleIntervalMs);
+  assertNonNegativeInteger('progressIntervalMs', parsed.progressIntervalMs);
   assertPositiveInteger('sloP99LagMs', parsed.sloP99LagMs);
   assertValidAppID(parsed.zero.appID);
 
@@ -120,13 +128,20 @@ export function loadConfig(): BenchmarkConfig {
     warmupMs: parsed.warmupMs,
     settleMs: parsed.settleMs,
     sampleIntervalMs: parsed.sampleIntervalMs,
+    progressIntervalMs: parsed.progressIntervalMs,
     sloP99LagMs: parsed.sloP99LagMs,
     outputPath: parsed.output,
+    logsDir: parsed.logsDir,
+    processLogMode: parsed.processLogMode,
     reset: parsed.reset,
     cacheURL: parsed.cacheURL ?? `http://127.0.0.1:${parsed.zero.port}`,
     pg: parsed.pg,
     zero: parsed.zero,
   };
+}
+
+export function appPath(path: string): string {
+  return isAbsolute(path) ? path : join(appRoot, path);
 }
 
 function assertPositiveNumber(name: string, value: number): void {

--- a/apps/zero-throughput/src/db.ts
+++ b/apps/zero-throughput/src/db.ts
@@ -1,5 +1,16 @@
 import postgres from 'postgres';
 import type {BenchmarkConfig} from './config.ts';
+import {
+  EMAIL_THREAD_COUNT,
+  FORUM_CATEGORY_ID,
+  FORUM_CATEGORY_SLUG,
+  FORUM_THREAD_COUNT,
+  FORUM_USER_COUNT,
+  REL_ACCOUNT_COUNT,
+  REL_CONTACTS_PER_ACCOUNT,
+  REL_ORG_ID,
+  SHARED_OWNER_ID,
+} from './profiles.ts';
 import {sleep} from './util.ts';
 
 export type BenchmarkDB = postgres.Sql;
@@ -53,6 +64,17 @@ export async function resetBenchmarkDatabase(
   }
 
   await sql`DROP TABLE IF EXISTS zero_throughput_event CASCADE`;
+  await sql`DROP TABLE IF EXISTS zero_throughput_email_message CASCADE`;
+  await sql`DROP TABLE IF EXISTS zero_throughput_email_thread CASCADE`;
+  await sql`DROP TABLE IF EXISTS zero_throughput_forum_post CASCADE`;
+  await sql`DROP TABLE IF EXISTS zero_throughput_forum_thread CASCADE`;
+  await sql`DROP TABLE IF EXISTS zero_throughput_forum_category CASCADE`;
+  await sql`DROP TABLE IF EXISTS zero_throughput_forum_user CASCADE`;
+  await sql`DROP TABLE IF EXISTS zero_throughput_rel_activity CASCADE`;
+  await sql`DROP TABLE IF EXISTS zero_throughput_rel_contact CASCADE`;
+  await sql`DROP TABLE IF EXISTS zero_throughput_rel_account CASCADE`;
+  await sql`DROP TABLE IF EXISTS zero_throughput_rel_org CASCADE`;
+
   await sql`
     CREATE TABLE zero_throughput_event (
       id text PRIMARY KEY,
@@ -73,4 +95,235 @@ export async function resetBenchmarkDatabase(
     CREATE INDEX zero_throughput_event_bucket_seq_idx
     ON zero_throughput_event (bucket, seq DESC)
   `;
+
+  await sql`
+    CREATE TABLE zero_throughput_email_thread (
+      id text PRIMARY KEY,
+      owner_id text NOT NULL,
+      mailbox text NOT NULL,
+      subject text NOT NULL,
+      participant_count integer NOT NULL,
+      seq bigint NOT NULL,
+      written_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+      updated_at timestamptz NOT NULL DEFAULT clock_timestamp()
+    )
+  `;
+  await sql`
+    CREATE INDEX zero_throughput_email_thread_owner_mailbox_seq_idx
+    ON zero_throughput_email_thread (owner_id, mailbox, seq DESC)
+  `;
+  await sql`
+    CREATE TABLE zero_throughput_email_message (
+      id text PRIMARY KEY,
+      thread_id text NOT NULL,
+      owner_id text NOT NULL,
+      mailbox text NOT NULL,
+      sender_id text NOT NULL,
+      unread boolean NOT NULL,
+      body text NOT NULL,
+      seq bigint NOT NULL,
+      written_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+      updated_at timestamptz NOT NULL DEFAULT clock_timestamp()
+    )
+  `;
+  await sql`
+    CREATE INDEX zero_throughput_email_message_owner_mailbox_seq_idx
+    ON zero_throughput_email_message (owner_id, mailbox, seq DESC)
+  `;
+  await sql`
+    CREATE INDEX zero_throughput_email_message_thread_seq_idx
+    ON zero_throughput_email_message (thread_id, seq DESC)
+  `;
+
+  await sql`
+    CREATE TABLE zero_throughput_forum_user (
+      id text PRIMARY KEY,
+      name text NOT NULL
+    )
+  `;
+  await sql`
+    CREATE TABLE zero_throughput_forum_category (
+      id text PRIMARY KEY,
+      slug text NOT NULL,
+      title text NOT NULL,
+      seq bigint NOT NULL,
+      written_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+      updated_at timestamptz NOT NULL DEFAULT clock_timestamp()
+    )
+  `;
+  await sql`
+    CREATE UNIQUE INDEX zero_throughput_forum_category_slug_idx
+    ON zero_throughput_forum_category (slug)
+  `;
+  await sql`
+    CREATE TABLE zero_throughput_forum_thread (
+      id text PRIMARY KEY,
+      category_id text NOT NULL,
+      author_id text NOT NULL,
+      title text NOT NULL,
+      pinned boolean NOT NULL,
+      seq bigint NOT NULL,
+      written_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+      updated_at timestamptz NOT NULL DEFAULT clock_timestamp()
+    )
+  `;
+  await sql`
+    CREATE INDEX zero_throughput_forum_thread_category_seq_idx
+    ON zero_throughput_forum_thread (category_id, seq DESC)
+  `;
+  await sql`
+    CREATE TABLE zero_throughput_forum_post (
+      id text PRIMARY KEY,
+      thread_id text NOT NULL,
+      category_id text NOT NULL,
+      author_id text NOT NULL,
+      body text NOT NULL,
+      seq bigint NOT NULL,
+      written_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+      updated_at timestamptz NOT NULL DEFAULT clock_timestamp()
+    )
+  `;
+  await sql`
+    CREATE INDEX zero_throughput_forum_post_category_seq_idx
+    ON zero_throughput_forum_post (category_id, seq DESC)
+  `;
+  await sql`
+    CREATE INDEX zero_throughput_forum_post_thread_seq_idx
+    ON zero_throughput_forum_post (thread_id, seq DESC)
+  `;
+
+  await sql`
+    CREATE TABLE zero_throughput_rel_org (
+      id text PRIMARY KEY,
+      name text NOT NULL,
+      region text NOT NULL,
+      seq bigint NOT NULL,
+      written_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+      updated_at timestamptz NOT NULL DEFAULT clock_timestamp()
+    )
+  `;
+  await sql`
+    CREATE TABLE zero_throughput_rel_account (
+      id text PRIMARY KEY,
+      org_id text NOT NULL,
+      owner_id text NOT NULL,
+      name text NOT NULL,
+      status text NOT NULL,
+      seq bigint NOT NULL,
+      written_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+      updated_at timestamptz NOT NULL DEFAULT clock_timestamp()
+    )
+  `;
+  await sql`
+    CREATE INDEX zero_throughput_rel_account_org_seq_idx
+    ON zero_throughput_rel_account (org_id, seq DESC)
+  `;
+  await sql`
+    CREATE TABLE zero_throughput_rel_contact (
+      id text PRIMARY KEY,
+      account_id text NOT NULL,
+      name text NOT NULL,
+      role text NOT NULL,
+      seq bigint NOT NULL,
+      written_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+      updated_at timestamptz NOT NULL DEFAULT clock_timestamp()
+    )
+  `;
+  await sql`
+    CREATE INDEX zero_throughput_rel_contact_account_idx
+    ON zero_throughput_rel_contact (account_id)
+  `;
+  await sql`
+    CREATE TABLE zero_throughput_rel_activity (
+      id text PRIMARY KEY,
+      org_id text NOT NULL,
+      account_id text NOT NULL,
+      contact_id text NOT NULL,
+      kind text NOT NULL,
+      body text NOT NULL,
+      seq bigint NOT NULL,
+      written_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+      updated_at timestamptz NOT NULL DEFAULT clock_timestamp()
+    )
+  `;
+  await sql`
+    CREATE INDEX zero_throughput_rel_activity_org_seq_idx
+    ON zero_throughput_rel_activity (org_id, seq DESC)
+  `;
+  await sql`
+    CREATE INDEX zero_throughput_rel_activity_account_seq_idx
+    ON zero_throughput_rel_activity (account_id, seq DESC)
+  `;
+  await sql`
+    CREATE INDEX zero_throughput_rel_activity_contact_seq_idx
+    ON zero_throughput_rel_activity (contact_id, seq DESC)
+  `;
+
+  await seedEmail(sql);
+  await seedForum(sql);
+  await seedRelational(sql);
+}
+
+async function seedEmail(sql: BenchmarkDB): Promise<void> {
+  const threads = Array.from({length: EMAIL_THREAD_COUNT}, (_, index) => ({
+    id: `email-thread-${index}`,
+    owner_id: SHARED_OWNER_ID,
+    mailbox: 'inbox',
+    subject: `Throughput thread ${index}`,
+    participant_count: 3,
+    seq: 0,
+  }));
+  await sql`INSERT INTO zero_throughput_email_thread ${sql(threads)}`;
+}
+
+async function seedForum(sql: BenchmarkDB): Promise<void> {
+  const users = Array.from({length: FORUM_USER_COUNT}, (_, index) => ({
+    id: `forum-user-${index}`,
+    name: `Forum User ${index}`,
+  }));
+  await sql`INSERT INTO zero_throughput_forum_user ${sql(users)}`;
+  await sql`
+    INSERT INTO zero_throughput_forum_category
+      (id, slug, title, seq)
+    VALUES
+      (${FORUM_CATEGORY_ID}, ${FORUM_CATEGORY_SLUG}, 'General', 0)
+  `;
+  const threads = Array.from({length: FORUM_THREAD_COUNT}, (_, index) => ({
+    id: `forum-thread-${index}`,
+    category_id: FORUM_CATEGORY_ID,
+    author_id: `forum-user-${index % FORUM_USER_COUNT}`,
+    title: `Throughput discussion ${index}`,
+    pinned: index === 0,
+    seq: 0,
+  }));
+  await sql`INSERT INTO zero_throughput_forum_thread ${sql(threads)}`;
+}
+
+async function seedRelational(sql: BenchmarkDB): Promise<void> {
+  await sql`
+    INSERT INTO zero_throughput_rel_org
+      (id, name, region, seq)
+    VALUES
+      (${REL_ORG_ID}, 'Throughput Org', 'na', 0)
+  `;
+  const accounts = Array.from({length: REL_ACCOUNT_COUNT}, (_, index) => ({
+    id: `rel-account-${index}`,
+    org_id: REL_ORG_ID,
+    owner_id: `owner-${index % 8}`,
+    name: `Account ${index}`,
+    status: index % 3 === 0 ? 'risk' : 'active',
+    seq: 0,
+  }));
+  await sql`INSERT INTO zero_throughput_rel_account ${sql(accounts)}`;
+
+  const contacts = accounts.flatMap(account =>
+    Array.from({length: REL_CONTACTS_PER_ACCOUNT}, (_, index) => ({
+      id: `${account.id}-contact-${index}`,
+      account_id: account.id,
+      name: `Contact ${index} at ${account.name}`,
+      role: index === 0 ? 'buyer' : 'stakeholder',
+      seq: 0,
+    })),
+  );
+  await sql`INSERT INTO zero_throughput_rel_contact ${sql(contacts)}`;
 }

--- a/apps/zero-throughput/src/db.ts
+++ b/apps/zero-throughput/src/db.ts
@@ -93,7 +93,7 @@ export async function resetBenchmarkDatabase(
   `;
   await sql`
     CREATE INDEX zero_throughput_event_bucket_seq_idx
-    ON zero_throughput_event (bucket, seq DESC)
+    ON zero_throughput_event (bucket, seq DESC, id ASC)
   `;
 
   await sql`
@@ -110,7 +110,7 @@ export async function resetBenchmarkDatabase(
   `;
   await sql`
     CREATE INDEX zero_throughput_email_thread_owner_mailbox_seq_idx
-    ON zero_throughput_email_thread (owner_id, mailbox, seq DESC)
+    ON zero_throughput_email_thread (owner_id, mailbox, seq DESC, id ASC)
   `;
   await sql`
     CREATE TABLE zero_throughput_email_message (
@@ -128,11 +128,11 @@ export async function resetBenchmarkDatabase(
   `;
   await sql`
     CREATE INDEX zero_throughput_email_message_owner_mailbox_seq_idx
-    ON zero_throughput_email_message (owner_id, mailbox, seq DESC)
+    ON zero_throughput_email_message (owner_id, mailbox, seq DESC, id ASC)
   `;
   await sql`
     CREATE INDEX zero_throughput_email_message_thread_seq_idx
-    ON zero_throughput_email_message (thread_id, seq DESC)
+    ON zero_throughput_email_message (thread_id, seq DESC, id ASC)
   `;
 
   await sql`
@@ -169,7 +169,7 @@ export async function resetBenchmarkDatabase(
   `;
   await sql`
     CREATE INDEX zero_throughput_forum_thread_category_seq_idx
-    ON zero_throughput_forum_thread (category_id, seq DESC)
+    ON zero_throughput_forum_thread (category_id, seq DESC, id ASC)
   `;
   await sql`
     CREATE TABLE zero_throughput_forum_post (
@@ -185,11 +185,11 @@ export async function resetBenchmarkDatabase(
   `;
   await sql`
     CREATE INDEX zero_throughput_forum_post_category_seq_idx
-    ON zero_throughput_forum_post (category_id, seq DESC)
+    ON zero_throughput_forum_post (category_id, seq DESC, id ASC)
   `;
   await sql`
     CREATE INDEX zero_throughput_forum_post_thread_seq_idx
-    ON zero_throughput_forum_post (thread_id, seq DESC)
+    ON zero_throughput_forum_post (thread_id, seq DESC, id ASC)
   `;
 
   await sql`
@@ -216,7 +216,7 @@ export async function resetBenchmarkDatabase(
   `;
   await sql`
     CREATE INDEX zero_throughput_rel_account_org_seq_idx
-    ON zero_throughput_rel_account (org_id, seq DESC)
+    ON zero_throughput_rel_account (org_id, seq DESC, id ASC)
   `;
   await sql`
     CREATE TABLE zero_throughput_rel_contact (
@@ -231,7 +231,7 @@ export async function resetBenchmarkDatabase(
   `;
   await sql`
     CREATE INDEX zero_throughput_rel_contact_account_idx
-    ON zero_throughput_rel_contact (account_id)
+    ON zero_throughput_rel_contact (account_id, id ASC)
   `;
   await sql`
     CREATE TABLE zero_throughput_rel_activity (
@@ -248,15 +248,15 @@ export async function resetBenchmarkDatabase(
   `;
   await sql`
     CREATE INDEX zero_throughput_rel_activity_org_seq_idx
-    ON zero_throughput_rel_activity (org_id, seq DESC)
+    ON zero_throughput_rel_activity (org_id, seq DESC, id ASC)
   `;
   await sql`
     CREATE INDEX zero_throughput_rel_activity_account_seq_idx
-    ON zero_throughput_rel_activity (account_id, seq DESC)
+    ON zero_throughput_rel_activity (account_id, seq DESC, id ASC)
   `;
   await sql`
     CREATE INDEX zero_throughput_rel_activity_contact_seq_idx
-    ON zero_throughput_rel_activity (contact_id, seq DESC)
+    ON zero_throughput_rel_activity (contact_id, seq DESC, id ASC)
   `;
 
   await seedEmail(sql);

--- a/apps/zero-throughput/src/db.ts
+++ b/apps/zero-throughput/src/db.ts
@@ -1,0 +1,74 @@
+import postgres from 'postgres';
+import type {BenchmarkConfig} from './config.ts';
+import {sleep} from './util.ts';
+
+export type BenchmarkDB = postgres.Sql;
+
+export function connectBenchmarkDB(url: string): BenchmarkDB {
+  return postgres(url, {
+    idle_timeout: 0,
+    connect_timeout: 30,
+    max_lifetime: null,
+  });
+}
+
+export async function waitForPostgres(
+  url: string,
+  timeoutMs: number,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown;
+  while (Date.now() < deadline) {
+    const sql = postgres(url, {
+      max: 1,
+      idle_timeout: 1,
+      connect_timeout: 5,
+    });
+    try {
+      await sql`SELECT 1`;
+      await sql.end();
+      return;
+    } catch (error) {
+      lastError = error;
+      await sql.end().catch(() => undefined);
+      await sleep(500);
+    }
+  }
+  throw new Error(
+    `Timed out waiting for PostgreSQL after ${timeoutMs}ms: ${String(lastError)}`,
+  );
+}
+
+export async function resetBenchmarkDatabase(
+  sql: BenchmarkDB,
+  config: BenchmarkConfig,
+): Promise<void> {
+  const appID = config.zero.appID;
+  const schemas = [appID, `${appID}_0`, `${appID}_0/cvr`, `${appID}_0/cdc`];
+
+  for (const schema of schemas) {
+    await sql`DROP SCHEMA IF EXISTS ${sql(schema)} CASCADE`;
+  }
+
+  await sql`DROP TABLE IF EXISTS zero_throughput_event CASCADE`;
+  await sql`
+    CREATE TABLE zero_throughput_event (
+      id text PRIMARY KEY,
+      profile text NOT NULL,
+      shard integer NOT NULL,
+      bucket integer NOT NULL,
+      seq bigint NOT NULL,
+      payload jsonb NOT NULL,
+      written_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+      updated_at timestamptz NOT NULL DEFAULT clock_timestamp()
+    )
+  `;
+  await sql`
+    CREATE UNIQUE INDEX zero_throughput_event_seq_idx
+    ON zero_throughput_event (seq)
+  `;
+  await sql`
+    CREATE INDEX zero_throughput_event_bucket_seq_idx
+    ON zero_throughput_event (bucket, seq DESC)
+  `;
+}

--- a/apps/zero-throughput/src/db.ts
+++ b/apps/zero-throughput/src/db.ts
@@ -9,6 +9,7 @@ export function connectBenchmarkDB(url: string): BenchmarkDB {
     idle_timeout: 0,
     connect_timeout: 30,
     max_lifetime: null,
+    onnotice: () => undefined,
   });
 }
 
@@ -23,6 +24,7 @@ export async function waitForPostgres(
       max: 1,
       idle_timeout: 1,
       connect_timeout: 5,
+      onnotice: () => undefined,
     });
     try {
       await sql`SELECT 1`;

--- a/apps/zero-throughput/src/env.d.ts
+++ b/apps/zero-throughput/src/env.d.ts
@@ -1,0 +1,3 @@
+interface ImportMeta {
+  readonly env?: {readonly VITEST?: string | boolean};
+}

--- a/apps/zero-throughput/src/main.ts
+++ b/apps/zero-throughput/src/main.ts
@@ -1,3 +1,4 @@
+import {inspect} from 'node:util';
 import {startSyntheticClients, type SyntheticClient} from './client.ts';
 import {loadConfig} from './config.ts';
 import {
@@ -17,12 +18,14 @@ import {
 } from './processes.ts';
 import {
   buildResult,
+  resultOutputPath,
   sampleMetrics,
   writeResult,
+  type BenchmarkResult,
   type MetricSample,
 } from './results.ts';
-import {log, warn, sleep} from './util.ts';
-import {FixedRateWriter} from './writer.ts';
+import {formatDuration, log, warn, sleep} from './util.ts';
+import {FixedRateWriter, type WriterStats} from './writer.ts';
 
 async function main(): Promise<void> {
   const config = loadConfig();
@@ -30,6 +33,9 @@ async function main(): Promise<void> {
   const processes: ProcessCommand[] = [];
   let zeroCache: ManagedProcess | undefined;
   let clients: SyntheticClient[] = [];
+  let result: BenchmarkResult | undefined;
+  let outputPath: string | undefined;
+  let error: unknown;
 
   const onSigint = () => {
     warn('Interrupted. Cleaning up benchmark processes...');
@@ -39,6 +45,7 @@ async function main(): Promise<void> {
 
   try {
     log(`zero-throughput ${config.profile} run ${config.runID}`);
+    log(`Results will be written to ${resultOutputPath(config)}`);
 
     if (config.pg.start) {
       log('Starting PostgreSQL...');
@@ -67,6 +74,9 @@ async function main(): Promise<void> {
       zeroCache = startZeroCache(config);
       processes.push(zeroCache);
       cleanup.push(() => zeroCache?.stop() ?? Promise.resolve());
+      if (zeroCache.logPath !== undefined) {
+        log(`zero-cache logs: ${zeroCache.logPath}`);
+      }
     }
 
     log('Waiting for zero-cache...');
@@ -82,20 +92,34 @@ async function main(): Promise<void> {
       await Promise.all(clients.map(client => client.close()));
     });
 
-    log('Initial sync complete. Starting fixed-rate writer...');
+    log(
+      `Initial sync complete. Writing for ${formatDuration(config.durationMs)} at ${config.writeRate} rows/s...`,
+    );
     const writer = new FixedRateWriter(sql, config);
     const samples: MetricSample[] = [];
     const sampleStartedAtMs = Date.now();
-    const sampler = setInterval(() => {
-      samples.push(
-        sampleMetrics(sampleStartedAtMs, writer.highestCommittedSeq, clients),
+    let nextProgressAtMs = sampleStartedAtMs + config.progressIntervalMs;
+    const recordSample = () => {
+      const sample = sampleMetrics(
+        sampleStartedAtMs,
+        writer.highestCommittedSeq,
+        clients,
       );
-    }, config.sampleIntervalMs);
+      samples.push(sample);
+      if (config.progressIntervalMs > 0 && Date.now() >= nextProgressAtMs) {
+        printProgress(sample, config.durationMs, config.users);
+        nextProgressAtMs = Date.now() + config.progressIntervalMs;
+      }
+    };
+    const sampler = setInterval(recordSample, config.sampleIntervalMs);
 
-    const writerStats = await writer.run(config.durationMs);
-    samples.push(
-      sampleMetrics(sampleStartedAtMs, writer.highestCommittedSeq, clients),
-    );
+    let writerStats: WriterStats;
+    try {
+      writerStats = await writer.run(config.durationMs);
+      recordSample();
+    } finally {
+      clearInterval(sampler);
+    }
 
     if (config.settleMs > 0) {
       log(`Waiting ${config.settleMs}ms for final client observations...`);
@@ -104,21 +128,28 @@ async function main(): Promise<void> {
         sampleMetrics(sampleStartedAtMs, writer.highestCommittedSeq, clients),
       );
     }
-    clearInterval(sampler);
 
-    const result = buildResult({
+    result = buildResult({
       config,
       processes,
       writerStats,
       samples,
       clients,
     });
-    const outputPath = await writeResult(config, result);
-
-    printSummary(result.summary, outputPath);
+    outputPath = await writeResult(config, result);
+  } catch (caught) {
+    error = caught;
   } finally {
     process.off('SIGINT', onSigint);
     await cleanup.run();
+  }
+
+  if (result !== undefined && outputPath !== undefined) {
+    printSummary(result.summary, outputPath);
+  }
+  if (error !== undefined) {
+    warn(`Benchmark failed before writing results: ${formatError(error)}`);
+    throw error;
   }
 }
 
@@ -162,6 +193,26 @@ function printSummary(
     log(`failure reasons: ${summary.failureReasons.join('; ')}`);
   }
   log(`details: ${outputPath}`);
+}
+
+function printProgress(
+  sample: MetricSample,
+  durationMs: number,
+  expectedClients: number,
+): void {
+  log(
+    `Progress: ${formatDuration(Math.min(sample.elapsedMs, durationMs))} / ${formatDuration(durationMs)}, committed=${sample.committedSeq}, seqLag=${sample.seqLag}, connected=${sample.connectedClients}/${expectedClients}`,
+  );
+}
+
+function formatError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.stack ?? error.message;
+  }
+  if (typeof error === 'string') {
+    return error;
+  }
+  return inspect(error);
 }
 
 await main();

--- a/apps/zero-throughput/src/main.ts
+++ b/apps/zero-throughput/src/main.ts
@@ -93,7 +93,7 @@ async function main(): Promise<void> {
     });
 
     log(
-      `Initial sync complete. Writing for ${formatDuration(config.durationMs)} at ${config.writeRate} rows/s...`,
+      `Initial sync complete. Writing for ${formatDuration(config.durationMs)} at ${config.writeRate} logical writes/s...`,
     );
     const writer = new FixedRateWriter(sql, config);
     const samples: MetricSample[] = [];
@@ -183,8 +183,12 @@ function printSummary(
 ): void {
   log('');
   log(`Result: ${summary.pass ? 'PASS' : 'FAIL'}`);
-  log(`Target write rate: ${summary.targetWriteRate.toFixed(2)} rows/s`);
-  log(`Achieved write rate: ${summary.achievedWriteRate.toFixed(2)} rows/s`);
+  log(
+    `Target write rate: ${summary.targetWriteRate.toFixed(2)} logical writes/s`,
+  );
+  log(
+    `Achieved write rate: ${summary.achievedWriteRate.toFixed(2)} logical writes/s`,
+  );
   log(`p95 client-visible lag: ${summary.p95ClientVisibleLagMs.toFixed(2)}ms`);
   log(`p99 client-visible lag: ${summary.p99ClientVisibleLagMs.toFixed(2)}ms`);
   log(`max seq lag: ${summary.maxSeqLag}`);

--- a/apps/zero-throughput/src/main.ts
+++ b/apps/zero-throughput/src/main.ts
@@ -1,0 +1,167 @@
+import {startSyntheticClients, type SyntheticClient} from './client.ts';
+import {loadConfig} from './config.ts';
+import {
+  connectBenchmarkDB,
+  resetBenchmarkDatabase,
+  waitForPostgres,
+} from './db.ts';
+import {
+  deployPermissions,
+  removeReplicaFiles,
+  startPostgres,
+  startZeroCache,
+  stopPostgres,
+  waitForZeroCache,
+  type ManagedProcess,
+  type ProcessCommand,
+} from './processes.ts';
+import {
+  buildResult,
+  sampleMetrics,
+  writeResult,
+  type MetricSample,
+} from './results.ts';
+import {log, warn, sleep} from './util.ts';
+import {FixedRateWriter} from './writer.ts';
+
+async function main(): Promise<void> {
+  const config = loadConfig();
+  const cleanup = new CleanupStack();
+  const processes: ProcessCommand[] = [];
+  let zeroCache: ManagedProcess | undefined;
+  let clients: SyntheticClient[] = [];
+
+  const onSigint = () => {
+    warn('Interrupted. Cleaning up benchmark processes...');
+    void cleanup.run().finally(() => process.exit(130));
+  };
+  process.once('SIGINT', onSigint);
+
+  try {
+    log(`zero-throughput ${config.profile} run ${config.runID}`);
+
+    if (config.pg.start) {
+      log('Starting PostgreSQL...');
+      processes.push(await startPostgres());
+      if (config.pg.stopAfterRun) {
+        cleanup.push(() => stopPostgres());
+      }
+    }
+
+    log('Waiting for PostgreSQL...');
+    await waitForPostgres(config.pg.url, config.pg.readyTimeoutMs);
+    const sql = connectBenchmarkDB(config.pg.url);
+    cleanup.push(() => sql.end());
+
+    if (config.reset) {
+      log('Resetting benchmark database...');
+      await resetBenchmarkDatabase(sql, config);
+      await removeReplicaFiles(config.zero.replicaFile);
+    }
+
+    log('Deploying benchmark permissions...');
+    processes.push(await deployPermissions(config));
+
+    if (config.zero.start) {
+      log('Starting zero-cache...');
+      zeroCache = startZeroCache(config);
+      processes.push(zeroCache);
+      cleanup.push(() => zeroCache?.stop() ?? Promise.resolve());
+    }
+
+    log('Waiting for zero-cache...');
+    await waitForZeroCache(
+      config.cacheURL,
+      config.zero.readyTimeoutMs,
+      zeroCache,
+    );
+
+    log(`Starting ${config.users} synthetic clients...`);
+    clients = await startSyntheticClients(config);
+    cleanup.push(async () => {
+      await Promise.all(clients.map(client => client.close()));
+    });
+
+    log('Initial sync complete. Starting fixed-rate writer...');
+    const writer = new FixedRateWriter(sql, config);
+    const samples: MetricSample[] = [];
+    const sampleStartedAtMs = Date.now();
+    const sampler = setInterval(() => {
+      samples.push(
+        sampleMetrics(sampleStartedAtMs, writer.highestCommittedSeq, clients),
+      );
+    }, config.sampleIntervalMs);
+
+    const writerStats = await writer.run(config.durationMs);
+    samples.push(
+      sampleMetrics(sampleStartedAtMs, writer.highestCommittedSeq, clients),
+    );
+
+    if (config.settleMs > 0) {
+      log(`Waiting ${config.settleMs}ms for final client observations...`);
+      await sleep(config.settleMs);
+      samples.push(
+        sampleMetrics(sampleStartedAtMs, writer.highestCommittedSeq, clients),
+      );
+    }
+    clearInterval(sampler);
+
+    const result = buildResult({
+      config,
+      processes,
+      writerStats,
+      samples,
+      clients,
+    });
+    const outputPath = await writeResult(config, result);
+
+    printSummary(result.summary, outputPath);
+  } finally {
+    process.off('SIGINT', onSigint);
+    await cleanup.run();
+  }
+}
+
+class CleanupStack {
+  readonly #callbacks: (() => Promise<void>)[] = [];
+  #running = false;
+
+  push(callback: () => Promise<void>): void {
+    this.#callbacks.push(callback);
+  }
+
+  async run(): Promise<void> {
+    if (this.#running) {
+      return;
+    }
+    this.#running = true;
+    const callbacks = this.#callbacks.splice(0).reverse();
+    for (const callback of callbacks) {
+      try {
+        await callback();
+      } catch (error) {
+        warn(`Cleanup failed: ${String(error)}`);
+      }
+    }
+  }
+}
+
+function printSummary(
+  summary: ReturnType<typeof buildResult>['summary'],
+  outputPath: string,
+): void {
+  log('');
+  log(`Result: ${summary.pass ? 'PASS' : 'FAIL'}`);
+  log(`Target write rate: ${summary.targetWriteRate.toFixed(2)} rows/s`);
+  log(`Achieved write rate: ${summary.achievedWriteRate.toFixed(2)} rows/s`);
+  log(`p95 client-visible lag: ${summary.p95ClientVisibleLagMs.toFixed(2)}ms`);
+  log(`p99 client-visible lag: ${summary.p99ClientVisibleLagMs.toFixed(2)}ms`);
+  log(`max seq lag: ${summary.maxSeqLag}`);
+  log(`lag slope: ${summary.lagSlopeSeqPerSec.toFixed(2)} seq/s`);
+  if (summary.failureReasons.length > 0) {
+    log(`failure reasons: ${summary.failureReasons.join('; ')}`);
+  }
+  log(`details: ${outputPath}`);
+}
+
+await main();

--- a/apps/zero-throughput/src/main.ts
+++ b/apps/zero-throughput/src/main.ts
@@ -7,7 +7,9 @@ import {
   waitForPostgres,
 } from './db.ts';
 import {
+  analyzeProfileQueries,
   deployPermissions,
+  queryPlanAnalysisLogPath,
   removeReplicaFiles,
   startPostgres,
   startZeroCache,
@@ -85,6 +87,11 @@ async function main(): Promise<void> {
       config.zero.readyTimeoutMs,
       zeroCache,
     );
+
+    log('Analyzing profile query plans...');
+    log(`query-plan logs: ${queryPlanAnalysisLogPath(config)}`);
+    const queryPlanAnalysis = await analyzeProfileQueries(config);
+    processes.push(queryPlanAnalysis);
 
     log(`Starting ${config.users} synthetic clients...`);
     clients = await startSyntheticClients(config);

--- a/apps/zero-throughput/src/permissions.ts
+++ b/apps/zero-throughput/src/permissions.ts
@@ -9,4 +9,54 @@ export const permissions = await definePermissions(schema, () => ({
       select: ANYONE_CAN,
     },
   },
+  emailThread: {
+    row: {
+      select: ANYONE_CAN,
+    },
+  },
+  emailMessage: {
+    row: {
+      select: ANYONE_CAN,
+    },
+  },
+  forumUser: {
+    row: {
+      select: ANYONE_CAN,
+    },
+  },
+  forumCategory: {
+    row: {
+      select: ANYONE_CAN,
+    },
+  },
+  forumThread: {
+    row: {
+      select: ANYONE_CAN,
+    },
+  },
+  forumPost: {
+    row: {
+      select: ANYONE_CAN,
+    },
+  },
+  relOrg: {
+    row: {
+      select: ANYONE_CAN,
+    },
+  },
+  relAccount: {
+    row: {
+      select: ANYONE_CAN,
+    },
+  },
+  relContact: {
+    row: {
+      select: ANYONE_CAN,
+    },
+  },
+  relActivity: {
+    row: {
+      select: ANYONE_CAN,
+    },
+  },
 }));

--- a/apps/zero-throughput/src/permissions.ts
+++ b/apps/zero-throughput/src/permissions.ts
@@ -1,0 +1,12 @@
+import {ANYONE_CAN, definePermissions} from '@rocicorp/zero';
+import {schema} from './schema.ts';
+
+export {schema};
+
+export const permissions = await definePermissions(schema, () => ({
+  event: {
+    row: {
+      select: ANYONE_CAN,
+    },
+  },
+}));

--- a/apps/zero-throughput/src/processes.ts
+++ b/apps/zero-throughput/src/processes.ts
@@ -1,10 +1,15 @@
 import {spawn, type ChildProcess} from 'node:child_process';
+import {once} from 'node:events';
 import {createWriteStream, mkdirSync, type WriteStream} from 'node:fs';
 import {rm} from 'node:fs/promises';
 import {join} from 'node:path';
 import {fileURLToPath} from 'node:url';
 import type {BenchmarkConfig} from './config.ts';
 import {appPath, appRoot, repoRoot} from './config.ts';
+import {
+  profileQueryIndexesForRun,
+  profileQueryName,
+} from './profile-queries.ts';
 import {sleep} from './util.ts';
 
 export type ProcessCommand = {
@@ -60,6 +65,89 @@ export async function startPostgres(): Promise<ProcessCommand> {
 
 export async function stopPostgres(): Promise<void> {
   await runCommand('docker', ['compose', 'down'], join(appRoot, 'docker'));
+}
+
+export async function analyzeProfileQueries(
+  config: BenchmarkConfig,
+): Promise<ProcessCommand> {
+  const analyzeMain = fileURLToPath(new URL('analyze.ts', import.meta.url));
+  const logPath = queryPlanAnalysisLogPath(config);
+  const logStream = createWriteStream(logPath, {flags: 'w'});
+  const indexes = profileQueryIndexesForRun(
+    config.profile,
+    config.queriesPerUser,
+  );
+  const command = [
+    process.execPath,
+    analyzeMain,
+    '--zero-cache-url',
+    config.cacheURL,
+    '--profile',
+    config.profile,
+    '--rows-per-query',
+    String(config.rowsPerQuery),
+    '--join-plans',
+  ];
+
+  try {
+    await writeLog(
+      logStream,
+      [
+        `zero-throughput query plan analysis`,
+        `runID: ${config.runID}`,
+        `profile: ${config.profile}`,
+        `queriesPerUser: ${config.queriesPerUser}`,
+        `rowsPerQuery: ${config.rowsPerQuery}`,
+        `cacheURL: ${config.cacheURL}`,
+        `distinctQueries: ${indexes.length}`,
+        '',
+      ].join('\n'),
+    );
+
+    for (const queryIndex of indexes) {
+      const queryName = profileQueryName(config.profile, queryIndex);
+      const args = [
+        '--zero-cache-url',
+        config.cacheURL,
+        '--profile',
+        config.profile,
+        '--query-index',
+        String(queryIndex),
+        '--rows-per-query',
+        String(config.rowsPerQuery),
+        '--join-plans',
+      ];
+      await writeLog(
+        logStream,
+        [
+          `\n================================================================================`,
+          `query: ${queryName}`,
+          `queryIndex: ${queryIndex}`,
+          `command: ${process.execPath} ${[analyzeMain, ...args].join(' ')}`,
+          `================================================================================\n`,
+        ].join('\n'),
+      );
+      await runCommandToLog(
+        process.execPath,
+        [analyzeMain, ...args],
+        repoRoot,
+        logStream,
+      );
+    }
+  } finally {
+    await closeLog(logStream);
+  }
+
+  return {
+    name: 'zero-analyze-profile-queries',
+    command,
+    cwd: repoRoot,
+    logPath,
+  };
+}
+
+export function queryPlanAnalysisLogPath(config: BenchmarkConfig): string {
+  return join(processLogsDir(config), `${config.runID}-query-plans.log`);
 }
 
 export async function removeReplicaFiles(replicaFile: string): Promise<void> {
@@ -185,6 +273,45 @@ async function runCommand(
       }
     });
   });
+}
+
+async function runCommandToLog(
+  command: string,
+  args: readonly string[],
+  cwd: string,
+  logStream: WriteStream,
+): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    child.stdout?.on('data', chunk => {
+      logStream.write(chunk);
+    });
+    child.stderr?.on('data', chunk => {
+      logStream.write(chunk);
+    });
+    child.once('error', reject);
+    child.once('exit', code => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`${command} ${args.join(' ')} exited with ${code}`));
+      }
+    });
+  });
+}
+
+async function writeLog(stream: WriteStream, text: string): Promise<void> {
+  if (!stream.write(text)) {
+    await once(stream, 'drain');
+  }
+}
+
+async function closeLog(stream: WriteStream): Promise<void> {
+  stream.end();
+  await once(stream, 'finish');
 }
 
 function processLogsDir(config: BenchmarkConfig): string {

--- a/apps/zero-throughput/src/processes.ts
+++ b/apps/zero-throughput/src/processes.ts
@@ -1,0 +1,191 @@
+import {spawn, type ChildProcess} from 'node:child_process';
+import {rm} from 'node:fs/promises';
+import {join} from 'node:path';
+import {fileURLToPath} from 'node:url';
+import type {BenchmarkConfig} from './config.ts';
+import {appRoot, repoRoot} from './config.ts';
+import {sleep} from './util.ts';
+
+export type ProcessCommand = {
+  readonly name: string;
+  readonly command: readonly string[];
+  readonly cwd: string;
+};
+
+export type ManagedProcess = ProcessCommand & {
+  readonly child: ChildProcess;
+  stop(): Promise<void>;
+};
+
+export async function deployPermissions(
+  config: BenchmarkConfig,
+): Promise<ProcessCommand> {
+  const deployPermissionsMain = fileURLToPath(
+    new URL(
+      '../../../packages/zero-cache/src/scripts/deploy-permissions.ts',
+      import.meta.url,
+    ),
+  );
+  const schemaPath = join(appRoot, 'src/permissions.ts');
+  const command = [
+    process.execPath,
+    deployPermissionsMain,
+    '--schema-path',
+    schemaPath,
+    '--upstream-db',
+    config.pg.url,
+    '--app-id',
+    config.zero.appID,
+    '--force',
+  ];
+  await runCommand(command[0], command.slice(1), repoRoot);
+  return {
+    name: 'zero-deploy-permissions',
+    command,
+    cwd: repoRoot,
+  };
+}
+
+export async function startPostgres(): Promise<ProcessCommand> {
+  const cwd = join(appRoot, 'docker');
+  await runCommand('docker', ['compose', 'up', '-d', 'postgres'], cwd);
+  return {
+    name: 'postgres',
+    command: ['docker', 'compose', 'up', '-d', 'postgres'],
+    cwd,
+  };
+}
+
+export async function stopPostgres(): Promise<void> {
+  await runCommand('docker', ['compose', 'down'], join(appRoot, 'docker'));
+}
+
+export async function removeReplicaFiles(replicaFile: string): Promise<void> {
+  await Promise.all(
+    [replicaFile, `${replicaFile}-shm`, `${replicaFile}-wal`].map(file =>
+      rm(file, {force: true}),
+    ),
+  );
+}
+
+export function startZeroCache(config: BenchmarkConfig): ManagedProcess {
+  const zeroCacheMain = fileURLToPath(
+    new URL(
+      '../../../packages/zero-cache/src/server/runner/main.ts',
+      import.meta.url,
+    ),
+  );
+  const command = [process.execPath, '--trace-warnings', zeroCacheMain];
+  const env = zeroCacheEnv(config);
+  const child = spawn(command[0], command.slice(1), {
+    cwd: repoRoot,
+    env,
+    stdio: 'inherit',
+  });
+
+  return {
+    name: 'zero-cache',
+    command,
+    cwd: repoRoot,
+    child,
+    stop: () => stopChild(child, 'SIGQUIT'),
+  };
+}
+
+export async function waitForZeroCache(
+  cacheURL: string,
+  timeoutMs: number,
+  process: ManagedProcess | undefined,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let exited = false;
+  let lastError: unknown;
+  const onExit = () => {
+    exited = true;
+  };
+  process?.child.once('exit', onExit);
+  try {
+    while (Date.now() < deadline) {
+      if (exited) {
+        throw new Error('zero-cache exited before becoming ready');
+      }
+      try {
+        const response = await fetch(new URL('/statz', cacheURL));
+        if (response.ok || response.status === 401 || response.status === 403) {
+          return;
+        }
+        lastError = new Error(`HTTP ${response.status}`);
+      } catch (error) {
+        lastError = error;
+      }
+      await sleep(500);
+    }
+  } finally {
+    process?.child.off('exit', onExit);
+  }
+  throw new Error(
+    `Timed out waiting for zero-cache after ${timeoutMs}ms: ${String(lastError)}`,
+  );
+}
+
+function zeroCacheEnv(config: BenchmarkConfig): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    NODE_ENV: 'development',
+    DO_NOT_TRACK: '1',
+    ZERO_ENABLE_TELEMETRY: 'false',
+    ZERO_UPSTREAM_DB: config.pg.url,
+    ZERO_CVR_DB: config.pg.url,
+    ZERO_CHANGE_DB: config.pg.url,
+    ZERO_REPLICA_FILE: config.zero.replicaFile,
+    ZERO_APP_ID: config.zero.appID,
+    ZERO_TASK_ID: `zero-throughput-${config.runID}`,
+    ZERO_PORT: String(config.zero.port),
+    ZERO_NUM_SYNC_WORKERS: String(config.zero.numSyncWorkers),
+    ZERO_UPSTREAM_MAX_CONNS: String(config.zero.upstreamMaxConns),
+    ZERO_CVR_MAX_CONNS: String(config.zero.cvrMaxConns),
+    ZERO_CHANGE_MAX_CONNS: String(config.zero.changeMaxConns),
+    ZERO_CHANGE_STREAMER_STARTUP_DELAY_MS: '0',
+    ZERO_REPLICATION_LAG_REPORT_INTERVAL_MS: '1000',
+    ZERO_LOG_LEVEL: config.zero.logLevel,
+    ZERO_LOG_FORMAT: 'text',
+  };
+}
+
+async function runCommand(
+  command: string,
+  args: readonly string[],
+  cwd: string,
+): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(command, args, {cwd, stdio: 'inherit'});
+    child.once('error', reject);
+    child.once('exit', code => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`${command} ${args.join(' ')} exited with ${code}`));
+      }
+    });
+  });
+}
+
+async function stopChild(
+  child: ChildProcess,
+  signal: NodeJS.Signals,
+): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return;
+  }
+  const exited = new Promise<void>(resolve =>
+    child.once('exit', () => resolve()),
+  );
+  child.kill(signal);
+  const timeout = sleep(5_000).then(() => {
+    if (child.exitCode === null && child.signalCode === null) {
+      child.kill('SIGKILL');
+    }
+  });
+  await Promise.race([exited, timeout]);
+  await exited;
+}

--- a/apps/zero-throughput/src/processes.ts
+++ b/apps/zero-throughput/src/processes.ts
@@ -1,15 +1,17 @@
 import {spawn, type ChildProcess} from 'node:child_process';
+import {createWriteStream, mkdirSync, type WriteStream} from 'node:fs';
 import {rm} from 'node:fs/promises';
 import {join} from 'node:path';
 import {fileURLToPath} from 'node:url';
 import type {BenchmarkConfig} from './config.ts';
-import {appRoot, repoRoot} from './config.ts';
+import {appPath, appRoot, repoRoot} from './config.ts';
 import {sleep} from './util.ts';
 
 export type ProcessCommand = {
   readonly name: string;
   readonly command: readonly string[];
   readonly cwd: string;
+  readonly logPath?: string | undefined;
 };
 
 export type ManagedProcess = ProcessCommand & {
@@ -77,16 +79,31 @@ export function startZeroCache(config: BenchmarkConfig): ManagedProcess {
   );
   const command = [process.execPath, '--trace-warnings', zeroCacheMain];
   const env = zeroCacheEnv(config);
+  const logPath =
+    config.processLogMode === 'file'
+      ? join(processLogsDir(config), `${config.runID}-zero-cache.log`)
+      : undefined;
+  const logStream =
+    logPath === undefined ? undefined : createWriteStream(logPath);
   const child = spawn(command[0], command.slice(1), {
     cwd: repoRoot,
     env,
-    stdio: 'inherit',
+    stdio:
+      config.processLogMode === 'inherit'
+        ? 'inherit'
+        : [
+            'ignore',
+            config.processLogMode === 'file' ? 'pipe' : 'ignore',
+            config.processLogMode === 'file' ? 'pipe' : 'ignore',
+          ],
   });
+  pipeProcessLogs(child, logStream);
 
   return {
     name: 'zero-cache',
     command,
     cwd: repoRoot,
+    logPath,
     child,
     stop: () => stopChild(child, 'SIGQUIT'),
   };
@@ -168,6 +185,24 @@ async function runCommand(
       }
     });
   });
+}
+
+function processLogsDir(config: BenchmarkConfig): string {
+  const logsDir = appPath(config.logsDir);
+  mkdirSync(logsDir, {recursive: true});
+  return logsDir;
+}
+
+function pipeProcessLogs(
+  child: ChildProcess,
+  logStream: WriteStream | undefined,
+): void {
+  if (logStream === undefined) {
+    return;
+  }
+  child.stdout?.pipe(logStream, {end: false});
+  child.stderr?.pipe(logStream, {end: false});
+  child.once('close', () => logStream.end());
 }
 
 async function stopChild(

--- a/apps/zero-throughput/src/profile-queries.ts
+++ b/apps/zero-throughput/src/profile-queries.ts
@@ -1,0 +1,240 @@
+import type {Query, SchemaQuery} from '@rocicorp/zero';
+import type {BenchmarkProfile} from './config.ts';
+import {FORUM_CATEGORY_ID, REL_ORG_ID, SHARED_OWNER_ID} from './profiles.ts';
+import type {schema} from './schema.ts';
+
+type ThroughputSchema = typeof schema;
+type ThroughputTable = keyof ThroughputSchema['tables'] & string;
+export type ThroughputQuery = Query<ThroughputTable, ThroughputSchema, object>;
+
+export type BuiltProfileQuery = {
+  readonly name: string;
+  readonly query: ThroughputQuery;
+};
+
+export const PROFILE_QUERY_NAMES = {
+  'feed-append': ['feed:recent-events'],
+  'email': [
+    'email:thread-list-with-messages',
+    'email:message-list-with-thread',
+    'email:unread-thread-list',
+  ],
+  'forum': [
+    'forum:category-thread-tree',
+    'forum:thread-list-with-posts',
+    'forum:post-list-with-thread',
+  ],
+  'relational': [
+    'relational:org-account-tree',
+    'relational:account-list',
+    'relational:activity-list',
+  ],
+} as const satisfies Record<BenchmarkProfile, readonly string[]>;
+
+export function buildProfileQuery(
+  builder: SchemaQuery<ThroughputSchema>,
+  profile: BenchmarkProfile,
+  queryIndex: number,
+  rowsPerQuery: number,
+): BuiltProfileQuery {
+  switch (profile) {
+    case 'feed-append':
+      return {
+        name: profileQueryName(profile, queryIndex),
+        query: builder.event
+          .where('bucket', 0)
+          .orderBy('seq', 'desc')
+          .limit(rowsPerQuery) as ThroughputQuery,
+      };
+
+    case 'email':
+      return buildEmailQuery(builder, queryIndex, rowsPerQuery);
+
+    case 'forum':
+      return buildForumQuery(builder, queryIndex, rowsPerQuery);
+
+    case 'relational':
+      return buildRelationalQuery(builder, queryIndex, rowsPerQuery);
+  }
+}
+
+export function profileQueryName(
+  profile: BenchmarkProfile,
+  queryIndex: number,
+): string {
+  const names = PROFILE_QUERY_NAMES[profile];
+  return names[normalizeProfileQueryIndex(profile, queryIndex)];
+}
+
+export function normalizeProfileQueryIndex(
+  profile: BenchmarkProfile,
+  queryIndex: number,
+): number {
+  const names = PROFILE_QUERY_NAMES[profile];
+  return ((queryIndex % names.length) + names.length) % names.length;
+}
+
+export function findProfileQuery(
+  name: string,
+):
+  | {readonly profile: BenchmarkProfile; readonly queryIndex: number}
+  | undefined {
+  for (const [profile, names] of Object.entries(PROFILE_QUERY_NAMES)) {
+    const queryIndex = (names as readonly string[]).indexOf(name);
+    if (queryIndex !== -1) {
+      return {profile: profile as BenchmarkProfile, queryIndex};
+    }
+  }
+  return undefined;
+}
+
+function buildEmailQuery(
+  builder: SchemaQuery<ThroughputSchema>,
+  queryIndex: number,
+  rowsPerQuery: number,
+): BuiltProfileQuery {
+  const name = profileQueryName('email', queryIndex);
+  switch (normalizeProfileQueryIndex('email', queryIndex)) {
+    case 0:
+      return {
+        name,
+        query: builder.emailThread
+          .where('ownerID', SHARED_OWNER_ID)
+          .where('mailbox', 'inbox')
+          .related('messages', q => q.orderBy('seq', 'desc').limit(5))
+          .orderBy('seq', 'desc')
+          .limit(rowsPerQuery) as ThroughputQuery,
+      };
+
+    case 1:
+      return {
+        name,
+        query: builder.emailMessage
+          .where('ownerID', SHARED_OWNER_ID)
+          .where('mailbox', 'inbox')
+          .related('thread')
+          .orderBy('seq', 'desc')
+          .limit(rowsPerQuery) as ThroughputQuery,
+      };
+
+    case 2:
+      return {
+        name,
+        query: builder.emailThread
+          .where('ownerID', SHARED_OWNER_ID)
+          .where('mailbox', 'inbox')
+          .related('messages', q =>
+            q.where('unread', true).orderBy('seq', 'desc').limit(10),
+          )
+          .orderBy('seq', 'desc')
+          .limit(rowsPerQuery) as ThroughputQuery,
+      };
+  }
+  throw new Error(`Invalid email query index: ${queryIndex}`);
+}
+
+function buildForumQuery(
+  builder: SchemaQuery<ThroughputSchema>,
+  queryIndex: number,
+  rowsPerQuery: number,
+): BuiltProfileQuery {
+  const name = profileQueryName('forum', queryIndex);
+  switch (normalizeProfileQueryIndex('forum', queryIndex)) {
+    case 0:
+      return {
+        name,
+        query: builder.forumCategory
+          .where('id', FORUM_CATEGORY_ID)
+          .related('threads', q =>
+            q
+              .orderBy('seq', 'desc')
+              .limit(rowsPerQuery)
+              .related('author')
+              .related('posts', p =>
+                p.orderBy('seq', 'desc').limit(3).related('author'),
+              ),
+          ) as ThroughputQuery,
+      };
+
+    case 1:
+      return {
+        name,
+        query: builder.forumThread
+          .where('categoryID', FORUM_CATEGORY_ID)
+          .related('category')
+          .related('author')
+          .related('posts', q =>
+            q.orderBy('seq', 'desc').limit(5).related('author'),
+          )
+          .orderBy('seq', 'desc')
+          .limit(rowsPerQuery) as ThroughputQuery,
+      };
+
+    case 2:
+      return {
+        name,
+        query: builder.forumPost
+          .where('categoryID', FORUM_CATEGORY_ID)
+          .related('thread', q => q.related('author').related('category'))
+          .related('author')
+          .orderBy('seq', 'desc')
+          .limit(rowsPerQuery) as ThroughputQuery,
+      };
+  }
+  throw new Error(`Invalid forum query index: ${queryIndex}`);
+}
+
+function buildRelationalQuery(
+  builder: SchemaQuery<ThroughputSchema>,
+  queryIndex: number,
+  rowsPerQuery: number,
+): BuiltProfileQuery {
+  const name = profileQueryName('relational', queryIndex);
+  switch (normalizeProfileQueryIndex('relational', queryIndex)) {
+    case 0:
+      return {
+        name,
+        query: builder.relOrg
+          .where('id', REL_ORG_ID)
+          .related('accounts', q =>
+            q
+              .orderBy('seq', 'desc')
+              .limit(rowsPerQuery)
+              .related('contacts')
+              .related('activities', a =>
+                a.orderBy('seq', 'desc').limit(5).related('contact'),
+              ),
+          )
+          .related('activities', q =>
+            q.orderBy('seq', 'desc').limit(rowsPerQuery),
+          ) as ThroughputQuery,
+      };
+
+    case 1:
+      return {
+        name,
+        query: builder.relAccount
+          .where('orgID', REL_ORG_ID)
+          .related('org')
+          .related('contacts')
+          .related('activities', q =>
+            q.orderBy('seq', 'desc').limit(5).related('contact'),
+          )
+          .orderBy('seq', 'desc')
+          .limit(rowsPerQuery) as ThroughputQuery,
+      };
+
+    case 2:
+      return {
+        name,
+        query: builder.relActivity
+          .where('orgID', REL_ORG_ID)
+          .related('org')
+          .related('account', q => q.related('contacts'))
+          .related('contact')
+          .orderBy('seq', 'desc')
+          .limit(rowsPerQuery) as ThroughputQuery,
+      };
+  }
+  throw new Error(`Invalid relational query index: ${queryIndex}`);
+}

--- a/apps/zero-throughput/src/profile-queries.ts
+++ b/apps/zero-throughput/src/profile-queries.ts
@@ -74,6 +74,23 @@ export function normalizeProfileQueryIndex(
   return ((queryIndex % names.length) + names.length) % names.length;
 }
 
+export function profileQueryIndexesForRun(
+  profile: BenchmarkProfile,
+  queriesPerUser: number,
+): readonly number[] {
+  const indexes: number[] = [];
+  const seen = new Set<string>();
+  for (let queryIndex = 0; queryIndex < queriesPerUser; queryIndex++) {
+    const normalized = normalizeProfileQueryIndex(profile, queryIndex);
+    const name = profileQueryName(profile, normalized);
+    if (!seen.has(name)) {
+      indexes.push(normalized);
+      seen.add(name);
+    }
+  }
+  return indexes;
+}
+
 export function findProfileQuery(
   name: string,
 ):

--- a/apps/zero-throughput/src/profiles.ts
+++ b/apps/zero-throughput/src/profiles.ts
@@ -1,0 +1,12 @@
+export const SHARED_OWNER_ID = 'throughput-shared-owner';
+
+export const EMAIL_THREAD_COUNT = 128;
+
+export const FORUM_CATEGORY_ID = 'forum-category-general';
+export const FORUM_CATEGORY_SLUG = 'general';
+export const FORUM_THREAD_COUNT = 128;
+export const FORUM_USER_COUNT = 24;
+
+export const REL_ORG_ID = 'rel-org-0';
+export const REL_ACCOUNT_COUNT = 64;
+export const REL_CONTACTS_PER_ACCOUNT = 4;

--- a/apps/zero-throughput/src/results.ts
+++ b/apps/zero-throughput/src/results.ts
@@ -1,0 +1,212 @@
+import {execFileSync} from 'node:child_process';
+import {mkdir, writeFile} from 'node:fs/promises';
+import {dirname, isAbsolute, join} from 'node:path';
+import type {ClientStats, SyntheticClient} from './client.ts';
+import type {BenchmarkConfig} from './config.ts';
+import {appRoot} from './config.ts';
+import type {ProcessCommand} from './processes.ts';
+import {average, max, percentile} from './util.ts';
+import type {WriterStats} from './writer.ts';
+
+export type MetricSample = {
+  readonly elapsedMs: number;
+  readonly committedSeq: number;
+  readonly minObservedSeq: number;
+  readonly seqLag: number;
+  readonly connectedClients: number;
+};
+
+export type BenchmarkResult = {
+  readonly gitCommit: string | undefined;
+  readonly profile: string;
+  readonly config: BenchmarkConfig;
+  readonly processes: readonly ProcessCommand[];
+  readonly environment: {
+    readonly node: string;
+    readonly platform: string;
+    readonly arch: string;
+  };
+  readonly samples: readonly MetricSample[];
+  readonly clients: readonly ClientStats[];
+  readonly summary: {
+    readonly targetWriteRate: number;
+    readonly achievedWriteRate: number;
+    readonly committedRows: number;
+    readonly committedTransactions: number;
+    readonly highestCommittedSeq: number;
+    readonly minObservedSeq: number;
+    readonly maxSeqLag: number;
+    readonly lagSlopeSeqPerSec: number;
+    readonly p50ClientVisibleLagMs: number;
+    readonly p95ClientVisibleLagMs: number;
+    readonly p99ClientVisibleLagMs: number;
+    readonly maxClientVisibleLagMs: number;
+    readonly txLatencyP50Ms: number;
+    readonly txLatencyP95Ms: number;
+    readonly txLatencyP99Ms: number;
+    readonly txLatencyAverageMs: number;
+    readonly pass: boolean;
+    readonly failureReasons: readonly string[];
+  };
+};
+
+export function sampleMetrics(
+  startedAtMs: number,
+  committedSeq: number,
+  clients: readonly SyntheticClient[],
+): MetricSample {
+  const observedSeqs = clients.map(client => client.minObservedSeq());
+  const minObservedSeq =
+    observedSeqs.length === 0 ? 0 : Math.min(...observedSeqs);
+  return {
+    elapsedMs: Date.now() - startedAtMs,
+    committedSeq,
+    minObservedSeq,
+    seqLag: Math.max(0, committedSeq - minObservedSeq),
+    connectedClients: clients.filter(client => client.stats().connected).length,
+  };
+}
+
+export function buildResult(args: {
+  readonly config: BenchmarkConfig;
+  readonly processes: readonly ProcessCommand[];
+  readonly writerStats: WriterStats;
+  readonly samples: readonly MetricSample[];
+  readonly clients: readonly SyntheticClient[];
+}): BenchmarkResult {
+  const clientStats = args.clients.map(client => client.stats());
+  const latencySamples = args.clients.flatMap(client =>
+    client.latencySamplesMs(),
+  );
+  const minObservedSeq =
+    args.clients.length === 0
+      ? 0
+      : Math.min(...args.clients.map(client => client.minObservedSeq()));
+  const maxSeqLag = max(args.samples.map(sample => sample.seqLag));
+  const measuredSeconds =
+    (args.writerStats.finishedAtMs - args.writerStats.startedAtMs) / 1000;
+  const failureReasons = failureReasonsFor({
+    config: args.config,
+    clientStats,
+    p99ClientVisibleLagMs: percentile(latencySamples, 99),
+    maxSeqLag,
+    lagSlopeSeqPerSec: lagSlope(args.samples),
+  });
+
+  return {
+    gitCommit: gitCommit(),
+    profile: args.config.profile,
+    config: args.config,
+    processes: args.processes,
+    environment: {
+      node: process.version,
+      platform: process.platform,
+      arch: process.arch,
+    },
+    samples: args.samples,
+    clients: clientStats,
+    summary: {
+      targetWriteRate: args.config.writeRate,
+      achievedWriteRate:
+        measuredSeconds === 0
+          ? 0
+          : args.writerStats.committedRows / measuredSeconds,
+      committedRows: args.writerStats.committedRows,
+      committedTransactions: args.writerStats.committedTransactions,
+      highestCommittedSeq: args.writerStats.highestCommittedSeq,
+      minObservedSeq,
+      maxSeqLag,
+      lagSlopeSeqPerSec: lagSlope(args.samples),
+      p50ClientVisibleLagMs: percentile(latencySamples, 50),
+      p95ClientVisibleLagMs: percentile(latencySamples, 95),
+      p99ClientVisibleLagMs: percentile(latencySamples, 99),
+      maxClientVisibleLagMs: max(latencySamples),
+      txLatencyP50Ms: percentile(args.writerStats.transactionLatencyMs, 50),
+      txLatencyP95Ms: percentile(args.writerStats.transactionLatencyMs, 95),
+      txLatencyP99Ms: percentile(args.writerStats.transactionLatencyMs, 99),
+      txLatencyAverageMs: average(args.writerStats.transactionLatencyMs),
+      pass: failureReasons.length === 0,
+      failureReasons,
+    },
+  };
+}
+
+export async function writeResult(
+  config: BenchmarkConfig,
+  result: BenchmarkResult,
+): Promise<string> {
+  const outputPath = isAbsolute(config.outputPath)
+    ? config.outputPath
+    : join(appRoot, config.outputPath);
+  await mkdir(dirname(outputPath), {recursive: true});
+  await writeFile(outputPath, `${JSON.stringify(result, null, 2)}\n`);
+  return outputPath;
+}
+
+function failureReasonsFor(args: {
+  readonly config: BenchmarkConfig;
+  readonly clientStats: readonly ClientStats[];
+  readonly p99ClientVisibleLagMs: number;
+  readonly maxSeqLag: number;
+  readonly lagSlopeSeqPerSec: number;
+}): string[] {
+  const reasons: string[] = [];
+  const disconnected = args.clientStats.filter(client => !client.connected);
+  if (disconnected.length > 0) {
+    reasons.push(`${disconnected.length} clients were disconnected at the end`);
+  }
+  if (
+    args.clientStats.some(client =>
+      client.queries.some(query => query.initialSyncMs === undefined),
+    )
+  ) {
+    reasons.push('at least one query did not complete initial sync');
+  }
+  if (args.p99ClientVisibleLagMs > args.config.sloP99LagMs) {
+    reasons.push(
+      `p99 client-visible lag ${args.p99ClientVisibleLagMs}ms exceeded SLO ${args.config.sloP99LagMs}ms`,
+    );
+  }
+  const allowedSeqLag = Math.ceil(
+    args.config.writeRate * (args.config.sloP99LagMs / 1000),
+  );
+  if (args.maxSeqLag > allowedSeqLag) {
+    reasons.push(
+      `max seq lag ${args.maxSeqLag} exceeded SLO-equivalent ${allowedSeqLag}`,
+    );
+  }
+  if (args.lagSlopeSeqPerSec > args.config.writeRate * 0.05) {
+    reasons.push(
+      `lag slope ${args.lagSlopeSeqPerSec.toFixed(2)} seq/s was positive`,
+    );
+  }
+  return reasons;
+}
+
+function lagSlope(samples: readonly MetricSample[]): number {
+  if (samples.length < 2) {
+    return 0;
+  }
+  const first = samples.at(0);
+  const last = samples.at(-1);
+  if (first === undefined || last === undefined) {
+    return 0;
+  }
+  const elapsedSeconds = (last.elapsedMs - first.elapsedMs) / 1000;
+  if (elapsedSeconds <= 0) {
+    return 0;
+  }
+  return (last.seqLag - first.seqLag) / elapsedSeconds;
+}
+
+function gitCommit(): string | undefined {
+  try {
+    return execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd: appRoot,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return undefined;
+  }
+}

--- a/apps/zero-throughput/src/results.ts
+++ b/apps/zero-throughput/src/results.ts
@@ -1,9 +1,9 @@
 import {execFileSync} from 'node:child_process';
 import {mkdir, writeFile} from 'node:fs/promises';
-import {dirname, isAbsolute, join} from 'node:path';
+import {dirname} from 'node:path';
 import type {ClientStats, SyntheticClient} from './client.ts';
 import type {BenchmarkConfig} from './config.ts';
-import {appRoot} from './config.ts';
+import {appPath, appRoot} from './config.ts';
 import type {ProcessCommand} from './processes.ts';
 import {average, max, percentile} from './util.ts';
 import type {WriterStats} from './writer.ts';
@@ -135,12 +135,14 @@ export async function writeResult(
   config: BenchmarkConfig,
   result: BenchmarkResult,
 ): Promise<string> {
-  const outputPath = isAbsolute(config.outputPath)
-    ? config.outputPath
-    : join(appRoot, config.outputPath);
+  const outputPath = resultOutputPath(config);
   await mkdir(dirname(outputPath), {recursive: true});
   await writeFile(outputPath, `${JSON.stringify(result, null, 2)}\n`);
   return outputPath;
+}
+
+export function resultOutputPath(config: BenchmarkConfig): string {
+  return appPath(config.outputPath);
 }
 
 function failureReasonsFor(args: {

--- a/apps/zero-throughput/src/schema.ts
+++ b/apps/zero-throughput/src/schema.ts
@@ -1,0 +1,29 @@
+import {
+  createSchema,
+  json,
+  number,
+  string,
+  table,
+  type Row,
+} from '@rocicorp/zero';
+
+export const eventTable = table('event')
+  .from('zero_throughput_event')
+  .columns({
+    id: string(),
+    profile: string(),
+    shard: number(),
+    bucket: number(),
+    seq: number(),
+    payload: json(),
+    writtenAt: number().from('written_at'),
+    updatedAt: number().from('updated_at'),
+  })
+  .primaryKey('id');
+
+export const schema = createSchema({
+  tables: [eventTable],
+  enableLegacyQueries: true,
+});
+
+export type ThroughputEvent = Row<typeof eventTable.schema>;

--- a/apps/zero-throughput/src/schema.ts
+++ b/apps/zero-throughput/src/schema.ts
@@ -1,10 +1,11 @@
 import {
+  boolean,
   createSchema,
   json,
   number,
+  relationships,
   string,
   table,
-  type Row,
 } from '@rocicorp/zero';
 
 export const eventTable = table('event')
@@ -21,9 +22,301 @@ export const eventTable = table('event')
   })
   .primaryKey('id');
 
+export const emailThreadTable = table('emailThread')
+  .from('zero_throughput_email_thread')
+  .columns({
+    id: string(),
+    ownerID: string().from('owner_id'),
+    mailbox: string(),
+    subject: string(),
+    participantCount: number().from('participant_count'),
+    seq: number(),
+    writtenAt: number().from('written_at'),
+    updatedAt: number().from('updated_at'),
+  })
+  .primaryKey('id');
+
+export const emailMessageTable = table('emailMessage')
+  .from('zero_throughput_email_message')
+  .columns({
+    id: string(),
+    threadID: string().from('thread_id'),
+    ownerID: string().from('owner_id'),
+    mailbox: string(),
+    senderID: string().from('sender_id'),
+    unread: boolean(),
+    body: string(),
+    seq: number(),
+    writtenAt: number().from('written_at'),
+    updatedAt: number().from('updated_at'),
+  })
+  .primaryKey('id');
+
+export const forumUserTable = table('forumUser')
+  .from('zero_throughput_forum_user')
+  .columns({
+    id: string(),
+    name: string(),
+  })
+  .primaryKey('id');
+
+export const forumCategoryTable = table('forumCategory')
+  .from('zero_throughput_forum_category')
+  .columns({
+    id: string(),
+    slug: string(),
+    title: string(),
+    seq: number(),
+    writtenAt: number().from('written_at'),
+    updatedAt: number().from('updated_at'),
+  })
+  .primaryKey('id');
+
+export const forumThreadTable = table('forumThread')
+  .from('zero_throughput_forum_thread')
+  .columns({
+    id: string(),
+    categoryID: string().from('category_id'),
+    authorID: string().from('author_id'),
+    title: string(),
+    pinned: boolean(),
+    seq: number(),
+    writtenAt: number().from('written_at'),
+    updatedAt: number().from('updated_at'),
+  })
+  .primaryKey('id');
+
+export const forumPostTable = table('forumPost')
+  .from('zero_throughput_forum_post')
+  .columns({
+    id: string(),
+    threadID: string().from('thread_id'),
+    categoryID: string().from('category_id'),
+    authorID: string().from('author_id'),
+    body: string(),
+    seq: number(),
+    writtenAt: number().from('written_at'),
+    updatedAt: number().from('updated_at'),
+  })
+  .primaryKey('id');
+
+export const relOrgTable = table('relOrg')
+  .from('zero_throughput_rel_org')
+  .columns({
+    id: string(),
+    name: string(),
+    region: string(),
+    seq: number(),
+    writtenAt: number().from('written_at'),
+    updatedAt: number().from('updated_at'),
+  })
+  .primaryKey('id');
+
+export const relAccountTable = table('relAccount')
+  .from('zero_throughput_rel_account')
+  .columns({
+    id: string(),
+    orgID: string().from('org_id'),
+    ownerID: string().from('owner_id'),
+    name: string(),
+    status: string(),
+    seq: number(),
+    writtenAt: number().from('written_at'),
+    updatedAt: number().from('updated_at'),
+  })
+  .primaryKey('id');
+
+export const relContactTable = table('relContact')
+  .from('zero_throughput_rel_contact')
+  .columns({
+    id: string(),
+    accountID: string().from('account_id'),
+    name: string(),
+    role: string(),
+    seq: number(),
+    writtenAt: number().from('written_at'),
+    updatedAt: number().from('updated_at'),
+  })
+  .primaryKey('id');
+
+export const relActivityTable = table('relActivity')
+  .from('zero_throughput_rel_activity')
+  .columns({
+    id: string(),
+    orgID: string().from('org_id'),
+    accountID: string().from('account_id'),
+    contactID: string().from('contact_id'),
+    kind: string(),
+    body: string(),
+    seq: number(),
+    writtenAt: number().from('written_at'),
+    updatedAt: number().from('updated_at'),
+  })
+  .primaryKey('id');
+
+const emailThreadRelationships = relationships(emailThreadTable, ({many}) => ({
+  messages: many({
+    sourceField: ['id'],
+    destField: ['threadID'],
+    destSchema: emailMessageTable,
+  }),
+}));
+
+const emailMessageRelationships = relationships(emailMessageTable, ({one}) => ({
+  thread: one({
+    sourceField: ['threadID'],
+    destField: ['id'],
+    destSchema: emailThreadTable,
+  }),
+}));
+
+const forumCategoryRelationships = relationships(
+  forumCategoryTable,
+  ({many}) => ({
+    threads: many({
+      sourceField: ['id'],
+      destField: ['categoryID'],
+      destSchema: forumThreadTable,
+    }),
+    posts: many({
+      sourceField: ['id'],
+      destField: ['categoryID'],
+      destSchema: forumPostTable,
+    }),
+  }),
+);
+
+const forumThreadRelationships = relationships(
+  forumThreadTable,
+  ({many, one}) => ({
+    category: one({
+      sourceField: ['categoryID'],
+      destField: ['id'],
+      destSchema: forumCategoryTable,
+    }),
+    author: one({
+      sourceField: ['authorID'],
+      destField: ['id'],
+      destSchema: forumUserTable,
+    }),
+    posts: many({
+      sourceField: ['id'],
+      destField: ['threadID'],
+      destSchema: forumPostTable,
+    }),
+  }),
+);
+
+const forumPostRelationships = relationships(forumPostTable, ({one}) => ({
+  category: one({
+    sourceField: ['categoryID'],
+    destField: ['id'],
+    destSchema: forumCategoryTable,
+  }),
+  thread: one({
+    sourceField: ['threadID'],
+    destField: ['id'],
+    destSchema: forumThreadTable,
+  }),
+  author: one({
+    sourceField: ['authorID'],
+    destField: ['id'],
+    destSchema: forumUserTable,
+  }),
+}));
+
+const relOrgRelationships = relationships(relOrgTable, ({many}) => ({
+  accounts: many({
+    sourceField: ['id'],
+    destField: ['orgID'],
+    destSchema: relAccountTable,
+  }),
+  activities: many({
+    sourceField: ['id'],
+    destField: ['orgID'],
+    destSchema: relActivityTable,
+  }),
+}));
+
+const relAccountRelationships = relationships(
+  relAccountTable,
+  ({many, one}) => ({
+    org: one({
+      sourceField: ['orgID'],
+      destField: ['id'],
+      destSchema: relOrgTable,
+    }),
+    contacts: many({
+      sourceField: ['id'],
+      destField: ['accountID'],
+      destSchema: relContactTable,
+    }),
+    activities: many({
+      sourceField: ['id'],
+      destField: ['accountID'],
+      destSchema: relActivityTable,
+    }),
+  }),
+);
+
+const relContactRelationships = relationships(
+  relContactTable,
+  ({many, one}) => ({
+    account: one({
+      sourceField: ['accountID'],
+      destField: ['id'],
+      destSchema: relAccountTable,
+    }),
+    activities: many({
+      sourceField: ['id'],
+      destField: ['contactID'],
+      destSchema: relActivityTable,
+    }),
+  }),
+);
+
+const relActivityRelationships = relationships(relActivityTable, ({one}) => ({
+  org: one({
+    sourceField: ['orgID'],
+    destField: ['id'],
+    destSchema: relOrgTable,
+  }),
+  account: one({
+    sourceField: ['accountID'],
+    destField: ['id'],
+    destSchema: relAccountTable,
+  }),
+  contact: one({
+    sourceField: ['contactID'],
+    destField: ['id'],
+    destSchema: relContactTable,
+  }),
+}));
+
 export const schema = createSchema({
-  tables: [eventTable],
+  tables: [
+    eventTable,
+    emailThreadTable,
+    emailMessageTable,
+    forumUserTable,
+    forumCategoryTable,
+    forumThreadTable,
+    forumPostTable,
+    relOrgTable,
+    relAccountTable,
+    relContactTable,
+    relActivityTable,
+  ],
+  relationships: [
+    emailThreadRelationships,
+    emailMessageRelationships,
+    forumCategoryRelationships,
+    forumThreadRelationships,
+    forumPostRelationships,
+    relOrgRelationships,
+    relAccountRelationships,
+    relContactRelationships,
+    relActivityRelationships,
+  ],
   enableLegacyQueries: true,
 });
-
-export type ThroughputEvent = Row<typeof eventTable.schema>;

--- a/apps/zero-throughput/src/sweep.ts
+++ b/apps/zero-throughput/src/sweep.ts
@@ -1,0 +1,983 @@
+import {execFileSync, spawn} from 'node:child_process';
+import {once} from 'node:events';
+import {createWriteStream, type WriteStream} from 'node:fs';
+import {access, appendFile, mkdir, readFile, writeFile} from 'node:fs/promises';
+import {dirname, join} from 'node:path';
+import {fileURLToPath} from 'node:url';
+import type {BenchmarkProfile} from './config.ts';
+import {appPath, appRoot, repoRoot} from './config.ts';
+import {startPostgres, stopPostgres} from './processes.ts';
+import type {BenchmarkResult} from './results.ts';
+import {formatDuration} from './util.ts';
+
+const DEFAULT_PROFILES = ['relational', 'email', 'forum'] as const;
+const DEFAULT_USERS = [50, 100, 200, 400] as const;
+const DEFAULT_ROWS_PER_QUERY = [50] as const;
+const DEFAULT_SYNC_WORKERS = [1, 2, 4] as const;
+const DEFAULT_WRITE_RATE_MAX = 100;
+const DEFAULT_SEARCH_STEPS = 7;
+const CSV_ESCAPE_PATTERN = /[",\n]/;
+const PROFILE_VALUES = new Set<BenchmarkProfile>([
+  'feed-append',
+  'email',
+  'forum',
+  'relational',
+]);
+
+type SweepConfig = {
+  readonly runID: string;
+  readonly profiles: readonly BenchmarkProfile[];
+  readonly users: readonly number[];
+  readonly rowsPerQuery: readonly number[];
+  readonly syncWorkers: readonly number[];
+  readonly queriesPerUser: number;
+  readonly durationMs: number;
+  readonly warmupMs: number;
+  readonly settleMs: number;
+  readonly sampleIntervalMs: number;
+  readonly progressIntervalMs: number;
+  readonly sloP99LagMs: number;
+  readonly batchSize: number;
+  readonly payloadBytes: number;
+  readonly writeRateMin: number;
+  readonly writeRateMax: number;
+  readonly searchSteps: number;
+  readonly repetitions: number;
+  readonly outputDir: string;
+  readonly zeroPort: number;
+  readonly pgStart: boolean;
+  readonly pgURL: string | undefined;
+  readonly resume: boolean;
+  readonly continueOnError: boolean;
+  readonly dryRun: boolean;
+  readonly limit: number | undefined;
+  readonly verboseChildLogs: boolean;
+};
+
+type SweepPoint = {
+  readonly profile: BenchmarkProfile;
+  readonly users: number;
+  readonly queriesPerUser: number;
+  readonly rowsPerQuery: number;
+  readonly zeroNumSyncWorkers: number;
+};
+
+type AttemptStatus = 'pass' | 'fail' | 'error';
+
+type SweepAttempt = {
+  readonly point: SweepPoint;
+  readonly writeRate: number;
+  readonly repetition: number;
+  readonly outputPath: string;
+  readonly logPath: string;
+  readonly reused: boolean;
+  readonly status: AttemptStatus;
+  readonly exitCode: number | undefined;
+  readonly error: string | undefined;
+  readonly summary: BenchmarkResult['summary'] | undefined;
+};
+
+type PointResult = {
+  readonly point: SweepPoint;
+  readonly bestWriteRate: number | undefined;
+  readonly lowerBoundWriteRate: number;
+  readonly upperBoundWriteRate: number;
+  readonly attempts: readonly SweepAttempt[];
+  readonly bestAttempt: SweepAttempt | undefined;
+};
+
+const argv = process.argv.slice(2);
+const config = parseArgs(argv[0] === '--' ? argv.slice(1) : argv);
+
+if (config.dryRun) {
+  printDryRun(config);
+} else {
+  await runSweep(config);
+}
+
+async function runSweep(config: SweepConfig): Promise<void> {
+  const outputDir = appPath(config.outputDir);
+  const runsDir = join(outputDir, 'runs');
+  const childLogsDir = join(outputDir, 'child-logs');
+  const attemptsPath = join(outputDir, 'attempts.jsonl');
+  const pointsPath = join(outputDir, 'points.jsonl');
+  const summaryPath = join(outputDir, 'summary.csv');
+  const manifestPath = join(outputDir, 'manifest.json');
+  const points = sweepPoints(config);
+  const results: PointResult[] = [];
+  let postgresStarted = false;
+
+  await mkdir(runsDir, {recursive: true});
+  await mkdir(childLogsDir, {recursive: true});
+  await writeFile(
+    manifestPath,
+    `${JSON.stringify(
+      {
+        runID: config.runID,
+        startedAt: new Date().toISOString(),
+        gitCommit: gitCommit(),
+        config,
+        points,
+        maxBenchmarkRuns:
+          points.length * config.searchSteps * config.repetitions,
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  await writeFile(attemptsPath, '');
+  await writeFile(pointsPath, '');
+  await writeFile(summaryPath, `${csvHeader()}\n`);
+
+  const onSigint = () => {
+    stderr('\nInterrupted. Cleaning up sweep PostgreSQL if needed...\n');
+    void (async () => {
+      if (postgresStarted) {
+        await stopPostgres();
+      }
+      process.exit(130);
+    })();
+  };
+  process.once('SIGINT', onSigint);
+
+  try {
+    stdout(`zero-throughput sweep ${config.runID}\n`);
+    stdout(`output: ${outputDir}\n`);
+    stdout(
+      `points: ${points.length}, max benchmark runs: ${
+        points.length * config.searchSteps * config.repetitions
+      }\n`,
+    );
+
+    if (config.pgStart) {
+      stdout('Starting sweep PostgreSQL...\n');
+      await startPostgres();
+      postgresStarted = true;
+    }
+
+    for (const [index, point] of points.entries()) {
+      stdout(
+        `\n[${index + 1}/${points.length}] ${pointLabel(point)} ` +
+          `searching ${config.writeRateMin}-${config.writeRateMax} writes/s\n`,
+      );
+      const result = await runPointSearch({
+        config,
+        point,
+        runsDir,
+        childLogsDir,
+        attemptsPath,
+      });
+      results.push(result);
+      await appendFile(pointsPath, `${JSON.stringify(result)}\n`);
+      await appendFile(summaryPath, `${csvRow(result)}\n`);
+      stdout(
+        `best sustainable write rate: ${
+          result.bestWriteRate === undefined ? 'none' : result.bestWriteRate
+        } logical writes/s\n`,
+      );
+    }
+
+    await writeFile(
+      join(outputDir, 'sweep.json'),
+      `${JSON.stringify(
+        {
+          runID: config.runID,
+          finishedAt: new Date().toISOString(),
+          config,
+          results,
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    stdout(`\nsummary: ${summaryPath}\n`);
+    stdout(`attempts: ${attemptsPath}\n`);
+  } finally {
+    process.off('SIGINT', onSigint);
+    if (postgresStarted) {
+      stdout('Stopping sweep PostgreSQL...\n');
+      await stopPostgres();
+    }
+  }
+}
+
+async function runPointSearch(args: {
+  readonly config: SweepConfig;
+  readonly point: SweepPoint;
+  readonly runsDir: string;
+  readonly childLogsDir: string;
+  readonly attemptsPath: string;
+}): Promise<PointResult> {
+  let low = args.config.writeRateMin;
+  let high = args.config.writeRateMax;
+  let bestWriteRate: number | undefined;
+  let bestAttempt: SweepAttempt | undefined;
+  const attempts: SweepAttempt[] = [];
+
+  for (let step = 0; step < args.config.searchSteps && low <= high; step++) {
+    const writeRate = Math.floor((low + high) / 2);
+    const rateAttempts: SweepAttempt[] = [];
+    let ratePassed = true;
+
+    stdout(`  step ${step + 1}: ${writeRate} logical writes/s\n`);
+    for (
+      let repetition = 0;
+      repetition < args.config.repetitions;
+      repetition++
+    ) {
+      const attempt = await runAttempt({
+        config: args.config,
+        point: args.point,
+        writeRate,
+        repetition,
+        runsDir: args.runsDir,
+        childLogsDir: args.childLogsDir,
+      });
+      attempts.push(attempt);
+      rateAttempts.push(attempt);
+      await appendFile(args.attemptsPath, `${JSON.stringify(attempt)}\n`);
+
+      if (attempt.status === 'error' && !args.config.continueOnError) {
+        throw new Error(
+          `Benchmark attempt failed for ${pointLabel(args.point)} at ${writeRate} writes/s. See ${attempt.logPath}`,
+        );
+      }
+      if (attempt.status !== 'pass') {
+        ratePassed = false;
+        break;
+      }
+    }
+
+    if (ratePassed) {
+      bestWriteRate = writeRate;
+      bestAttempt = rateAttempts.at(-1);
+      low = writeRate + 1;
+    } else {
+      high = writeRate - 1;
+    }
+  }
+
+  return {
+    point: args.point,
+    bestWriteRate,
+    lowerBoundWriteRate: low,
+    upperBoundWriteRate: high,
+    attempts,
+    bestAttempt,
+  };
+}
+
+async function runAttempt(args: {
+  readonly config: SweepConfig;
+  readonly point: SweepPoint;
+  readonly writeRate: number;
+  readonly repetition: number;
+  readonly runsDir: string;
+  readonly childLogsDir: string;
+}): Promise<SweepAttempt> {
+  const outputPath = join(
+    args.runsDir,
+    `${pointID(args.point)}-rate${args.writeRate}-rep${args.repetition + 1}.json`,
+  );
+  const logPath = join(
+    args.childLogsDir,
+    `${pointID(args.point)}-rate${args.writeRate}-rep${args.repetition + 1}.log`,
+  );
+
+  if (args.config.resume && (await fileExists(outputPath))) {
+    const result = await readBenchmarkResult(outputPath);
+    return attemptFromResult({
+      point: args.point,
+      writeRate: args.writeRate,
+      repetition: args.repetition,
+      outputPath,
+      logPath,
+      reused: true,
+      result,
+    });
+  }
+
+  const command = benchmarkCommand(args.config, args.point, args.writeRate, {
+    outputPath,
+    logsDir: join(args.config.outputDir, 'logs'),
+  });
+  const exitCode = await runCommandToLog({
+    command: command[0],
+    args: command.slice(1),
+    cwd: repoRoot,
+    logPath,
+    verbose: args.config.verboseChildLogs,
+  });
+
+  if (!(await fileExists(outputPath))) {
+    return {
+      point: args.point,
+      writeRate: args.writeRate,
+      repetition: args.repetition,
+      outputPath,
+      logPath,
+      reused: false,
+      status: 'error',
+      exitCode,
+      error: `Benchmark exited ${exitCode} without writing ${outputPath}`,
+      summary: undefined,
+    };
+  }
+
+  const result = await readBenchmarkResult(outputPath);
+  return attemptFromResult({
+    point: args.point,
+    writeRate: args.writeRate,
+    repetition: args.repetition,
+    outputPath,
+    logPath,
+    reused: false,
+    result,
+    exitCode,
+  });
+}
+
+function attemptFromResult(args: {
+  readonly point: SweepPoint;
+  readonly writeRate: number;
+  readonly repetition: number;
+  readonly outputPath: string;
+  readonly logPath: string;
+  readonly reused: boolean;
+  readonly result: BenchmarkResult;
+  readonly exitCode?: number | undefined;
+}): SweepAttempt {
+  const pass = args.result.summary.pass;
+  return {
+    point: args.point,
+    writeRate: args.writeRate,
+    repetition: args.repetition,
+    outputPath: args.outputPath,
+    logPath: args.logPath,
+    reused: args.reused,
+    status: pass ? 'pass' : 'fail',
+    exitCode: args.exitCode,
+    error: undefined,
+    summary: args.result.summary,
+  };
+}
+
+function benchmarkCommand(
+  config: SweepConfig,
+  point: SweepPoint,
+  writeRate: number,
+  paths: {readonly outputPath: string; readonly logsDir: string},
+): readonly string[] {
+  const main = fileURLToPath(new URL('main.ts', import.meta.url));
+  const command = [
+    process.execPath,
+    main,
+    '--profile',
+    point.profile,
+    '--users',
+    String(point.users),
+    '--queries-per-user',
+    String(point.queriesPerUser),
+    '--rows-per-query',
+    String(point.rowsPerQuery),
+    '--write-rate',
+    String(writeRate),
+    '--duration-ms',
+    String(config.durationMs),
+    '--warmup-ms',
+    String(config.warmupMs),
+    '--settle-ms',
+    String(config.settleMs),
+    '--sample-interval-ms',
+    String(config.sampleIntervalMs),
+    '--progress-interval-ms',
+    String(config.progressIntervalMs),
+    '--slo-p99lag-ms',
+    String(config.sloP99LagMs),
+    '--batch-size',
+    String(config.batchSize),
+    '--payload-bytes',
+    String(config.payloadBytes),
+    '--zero-num-sync-workers',
+    String(point.zeroNumSyncWorkers),
+    '--zero-port',
+    String(config.zeroPort),
+    '--pg-start',
+    'false',
+    '--pg-stop-after-run',
+    'false',
+    '--output',
+    paths.outputPath,
+    '--logs-dir',
+    paths.logsDir,
+  ];
+  if (config.pgURL !== undefined) {
+    command.push('--pg-url', config.pgURL);
+  }
+  return command;
+}
+
+async function runCommandToLog(args: {
+  readonly command: string;
+  readonly args: readonly string[];
+  readonly cwd: string;
+  readonly logPath: string;
+  readonly verbose: boolean;
+}): Promise<number> {
+  await mkdir(dirname(args.logPath), {recursive: true});
+  const log = createWriteStream(args.logPath, {flags: 'w'});
+  await writeLog(log, `$ ${args.command} ${args.args.join(' ')}\n`);
+  try {
+    return await new Promise<number>((resolve, reject) => {
+      const child = spawn(args.command, args.args, {
+        cwd: args.cwd,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      child.stdout?.on('data', chunk => {
+        log.write(chunk);
+        if (args.verbose) {
+          process.stdout.write(chunk);
+        }
+      });
+      child.stderr?.on('data', chunk => {
+        log.write(chunk);
+        if (args.verbose) {
+          process.stderr.write(chunk);
+        }
+      });
+      child.once('error', reject);
+      child.once('exit', code => {
+        resolve(code ?? 1);
+      });
+    });
+  } finally {
+    await closeLog(log);
+  }
+}
+
+function sweepPoints(config: SweepConfig): readonly SweepPoint[] {
+  const points: SweepPoint[] = [];
+  for (const profile of config.profiles) {
+    for (const users of config.users) {
+      for (const rowsPerQuery of config.rowsPerQuery) {
+        for (const zeroNumSyncWorkers of config.syncWorkers) {
+          points.push({
+            profile,
+            users,
+            queriesPerUser: config.queriesPerUser,
+            rowsPerQuery,
+            zeroNumSyncWorkers,
+          });
+          if (config.limit !== undefined && points.length >= config.limit) {
+            return points;
+          }
+        }
+      }
+    }
+  }
+  return points;
+}
+
+function parseArgs(argv: readonly string[]): SweepConfig {
+  const runID = new Date().toISOString().replace(/[:.]/g, '-');
+  let profiles: readonly BenchmarkProfile[] = DEFAULT_PROFILES;
+  let users: readonly number[] = DEFAULT_USERS;
+  let rowsPerQuery: readonly number[] = DEFAULT_ROWS_PER_QUERY;
+  let syncWorkers: readonly number[] = DEFAULT_SYNC_WORKERS;
+  let queriesPerUser = 3;
+  let durationMs = 300_000;
+  let warmupMs = 30_000;
+  let settleMs = 5_000;
+  let sampleIntervalMs = 1_000;
+  let progressIntervalMs = 5_000;
+  let sloP99LagMs = 2_000;
+  let batchSize = 1;
+  let payloadBytes = 256;
+  let writeRateMin = 1;
+  let writeRateMax = DEFAULT_WRITE_RATE_MAX;
+  let searchSteps = DEFAULT_SEARCH_STEPS;
+  let repetitions = 1;
+  let outputDir = join('results', 'sweeps', runID);
+  let zeroPort = 4_848;
+  let pgStart = true;
+  let pgURL: string | undefined;
+  let resume = true;
+  let continueOnError = false;
+  let dryRun = false;
+  let limit: number | undefined;
+  let verboseChildLogs = false;
+  let help = false;
+
+  for (let i = 0; i < argv.length; i++) {
+    const option = parseOption(argv[i]);
+    switch (option.name) {
+      case '--help':
+      case '-h':
+        help = true;
+        break;
+      case '--profiles':
+        profiles = parseProfiles(readOptionValue(argv, option, i));
+        i += option.value === undefined ? 1 : 0;
+        break;
+      case '--users':
+        users = parsePositiveIntegerList(
+          option.name,
+          readOptionValue(argv, option, i),
+        );
+        i += option.value === undefined ? 1 : 0;
+        break;
+      case '--rows-per-query':
+        rowsPerQuery = parsePositiveIntegerList(
+          option.name,
+          readOptionValue(argv, option, i),
+        );
+        i += option.value === undefined ? 1 : 0;
+        break;
+      case '--sync-workers':
+      case '--zero-num-sync-workers':
+        syncWorkers = parsePositiveIntegerList(
+          option.name,
+          readOptionValue(argv, option, i),
+        );
+        i += option.value === undefined ? 1 : 0;
+        break;
+      case '--queries-per-user':
+        queriesPerUser = parsePositiveInteger(
+          option.name,
+          readOptionValue(argv, option, i),
+        );
+        i += option.value === undefined ? 1 : 0;
+        break;
+      case '--duration-ms':
+        durationMs = parsePositiveInteger(
+          option.name,
+          readOptionValue(argv, option, i),
+        );
+        i += option.value === undefined ? 1 : 0;
+        break;
+      case '--warmup-ms':
+        warmupMs = parseNonNegativeInteger(
+          option.name,
+          readOptionValue(argv, option, i),
+        );
+        i += option.value === undefined ? 1 : 0;
+        break;
+      case '--settle-ms':
+        settleMs = parseNonNegativeInteger(
+          option.name,
+          readOptionValue(argv, option, i),
+        );
+        i += option.value === undefined ? 1 : 0;
+        break;
+      case '--sample-interval-ms':
+        sampleIntervalMs = parsePositiveInteger(
+          option.name,
+          readOptionValue(argv, option, i),
+        );
+        i += option.value === undefined ? 1 : 0;
+        break;
+      case '--progress-interval-ms':
+        progressIntervalMs = parseNonNegativeInteger(
+          option.name,
+          readOptionValue(argv, option, i),
+        );
+        i += option.value === undefined ? 1 : 0;
+        break;
+      case '--slo-p99-lag-ms':
+      case '--slo-p99lag-ms':
+        sloP99LagMs = parsePositiveInteger(
+          option.name,
+          readOptionValue(argv, option, i),
+        );
+        i += option.value === undefined ? 1 : 0;
+        break;
+      case '--batch-size':
+        batchSize = parsePositiveInteger(
+          option.name,
+          readOptionValue(argv, option, i),
+        );
+        i += option.value === undefined ? 1 : 0;
+        break;
+      case '--payload-bytes':
+        payloadBytes = parseNonNegativeInteger(
+          option.name,
+          readOptionValue(argv, option, i),
+        );
+        i += option.value === undefined ? 1 : 0;
+        break;
+      case '--write-rate-min':
+        writeRateMin = parsePositiveInteger(
+          option.name,
+          readOptionValue(argv, option, i),
+        );
+        i += option.value === undefined ? 1 : 0;
+        break;
+      case '--write-rate-max':
+        writeRateMax = parsePositiveInteger(
+          option.name,
+          readOptionValue(argv, option, i),
+        );
+        i += option.value === undefined ? 1 : 0;
+        break;
+      case '--search-steps':
+        searchSteps = parsePositiveInteger(
+          option.name,
+          readOptionValue(argv, option, i),
+        );
+        i += option.value === undefined ? 1 : 0;
+        break;
+      case '--repetitions':
+        repetitions = parsePositiveInteger(
+          option.name,
+          readOptionValue(argv, option, i),
+        );
+        i += option.value === undefined ? 1 : 0;
+        break;
+      case '--output-dir':
+        outputDir = readOptionValue(argv, option, i);
+        i += option.value === undefined ? 1 : 0;
+        break;
+      case '--zero-port':
+        zeroPort = parsePositiveInteger(
+          option.name,
+          readOptionValue(argv, option, i),
+        );
+        i += option.value === undefined ? 1 : 0;
+        break;
+      case '--pg-start': {
+        const parsed = readBooleanOption(argv, option, i, true);
+        pgStart = parsed.value;
+        i += parsed.consumed;
+        break;
+      }
+      case '--pg-url':
+        pgURL = readOptionValue(argv, option, i);
+        i += option.value === undefined ? 1 : 0;
+        break;
+      case '--resume': {
+        const parsed = readBooleanOption(argv, option, i, true);
+        resume = parsed.value;
+        i += parsed.consumed;
+        break;
+      }
+      case '--continue-on-error': {
+        const parsed = readBooleanOption(argv, option, i, true);
+        continueOnError = parsed.value;
+        i += parsed.consumed;
+        break;
+      }
+      case '--dry-run': {
+        const parsed = readBooleanOption(argv, option, i, true);
+        dryRun = parsed.value;
+        i += parsed.consumed;
+        break;
+      }
+      case '--limit':
+        limit = parsePositiveInteger(
+          option.name,
+          readOptionValue(argv, option, i),
+        );
+        i += option.value === undefined ? 1 : 0;
+        break;
+      case '--verbose-child-logs': {
+        const parsed = readBooleanOption(argv, option, i, true);
+        verboseChildLogs = parsed.value;
+        i += parsed.consumed;
+        break;
+      }
+      default:
+        throw new Error(`Unknown sweep option ${option.name}`);
+    }
+  }
+
+  if (help) {
+    printUsage();
+    process.exit(0);
+  }
+  if (writeRateMin > writeRateMax) {
+    throw new Error('--write-rate-min must be <= --write-rate-max');
+  }
+
+  return {
+    runID,
+    profiles,
+    users,
+    rowsPerQuery,
+    syncWorkers,
+    queriesPerUser,
+    durationMs,
+    warmupMs,
+    settleMs,
+    sampleIntervalMs,
+    progressIntervalMs,
+    sloP99LagMs,
+    batchSize,
+    payloadBytes,
+    writeRateMin,
+    writeRateMax,
+    searchSteps,
+    repetitions,
+    outputDir,
+    zeroPort,
+    pgStart,
+    pgURL,
+    resume,
+    continueOnError,
+    dryRun,
+    limit,
+    verboseChildLogs,
+  };
+}
+
+function parseOption(arg: string): {
+  readonly name: string;
+  readonly value: string | undefined;
+} {
+  const equals = arg.indexOf('=');
+  if (equals === -1) {
+    return {name: arg, value: undefined};
+  }
+  return {name: arg.slice(0, equals), value: arg.slice(equals + 1)};
+}
+
+function readOptionValue(
+  argv: readonly string[],
+  option: {readonly name: string; readonly value: string | undefined},
+  index: number,
+): string {
+  if (option.value !== undefined) {
+    return option.value;
+  }
+  const value = argv[index + 1];
+  if (value === undefined || value.startsWith('--')) {
+    throw new Error(`${option.name} requires a value`);
+  }
+  return value;
+}
+
+function readBooleanOption(
+  argv: readonly string[],
+  option: {readonly name: string; readonly value: string | undefined},
+  index: number,
+  defaultValue: boolean,
+): {readonly value: boolean; readonly consumed: number} {
+  if (option.value !== undefined) {
+    return {value: parseBoolean(option.value), consumed: 0};
+  }
+  const value = argv[index + 1];
+  if (value === 'true' || value === 'false') {
+    return {value: parseBoolean(value), consumed: 1};
+  }
+  return {value: defaultValue, consumed: 0};
+}
+
+function parseProfiles(value: string): readonly BenchmarkProfile[] {
+  const profiles = value.split(',').map(part => {
+    const trimmed = part.trim();
+    if (!PROFILE_VALUES.has(trimmed as BenchmarkProfile)) {
+      throw new Error(`Invalid profile "${trimmed}"`);
+    }
+    return trimmed as BenchmarkProfile;
+  });
+  if (profiles.length === 0) {
+    throw new Error('--profiles must not be empty');
+  }
+  return profiles;
+}
+
+function parsePositiveIntegerList(
+  name: string,
+  value: string,
+): readonly number[] {
+  const values = value
+    .split(',')
+    .map(part => parsePositiveInteger(name, part.trim()));
+  if (values.length === 0) {
+    throw new Error(`${name} must not be empty`);
+  }
+  return values;
+}
+
+function parsePositiveInteger(name: string, value: string): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function parseNonNegativeInteger(name: string, value: string): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`${name} must be a non-negative integer`);
+  }
+  return parsed;
+}
+
+function parseBoolean(value: string): boolean {
+  switch (value) {
+    case 'true':
+      return true;
+    case 'false':
+      return false;
+    default:
+      throw new Error(`Expected boolean value, got "${value}"`);
+  }
+}
+
+function printDryRun(config: SweepConfig): void {
+  const points = sweepPoints(config);
+  stdout(`zero-throughput recommended sweep dry run\n`);
+  stdout(`points: ${points.length}\n`);
+  stdout(
+    `max benchmark runs: ${points.length * config.searchSteps * config.repetitions}\n`,
+  );
+  stdout(`duration per benchmark: ${formatDuration(config.durationMs)}\n`);
+  stdout(
+    `write-rate search: ${config.writeRateMin}-${config.writeRateMax} logical writes/s, ${config.searchSteps} steps\n\n`,
+  );
+  for (const point of points) {
+    stdout(`${pointLabel(point)}\n`);
+  }
+}
+
+function printUsage(): void {
+  stdout(`Usage:
+  pnpm --filter zero-throughput run sweep -- [options]
+
+Default matrix:
+  --profiles relational,email,forum
+  --users 50,100,200,400
+  --rows-per-query 50
+  --sync-workers 1,2,4
+  --queries-per-user 3
+  --duration-ms 300000
+
+Write-rate search:
+  --write-rate-min 1
+  --write-rate-max 100
+  --search-steps 7
+
+Useful:
+  --dry-run
+  --limit 1
+  --output-dir results/sweeps/my-run
+  --pg-start false
+  --verbose-child-logs
+`);
+}
+
+async function readBenchmarkResult(path: string): Promise<BenchmarkResult> {
+  const parsed = JSON.parse(await readFile(path, 'utf8')) as unknown;
+  if (
+    parsed === null ||
+    typeof parsed !== 'object' ||
+    !('summary' in parsed) ||
+    parsed.summary === null ||
+    typeof parsed.summary !== 'object' ||
+    !('pass' in parsed.summary) ||
+    typeof parsed.summary.pass !== 'boolean'
+  ) {
+    throw new Error(`${path} is not a benchmark result`);
+  }
+  return parsed as BenchmarkResult;
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function writeLog(stream: WriteStream, text: string): Promise<void> {
+  if (!stream.write(text)) {
+    await once(stream, 'drain');
+  }
+}
+
+async function closeLog(stream: WriteStream): Promise<void> {
+  stream.end();
+  await once(stream, 'finish');
+}
+
+function csvHeader(): string {
+  return [
+    'profile',
+    'users',
+    'queriesPerUser',
+    'rowsPerQuery',
+    'zeroNumSyncWorkers',
+    'bestWriteRate',
+    'attemptedWriteRates',
+    'bestP99ClientVisibleLagMs',
+    'bestMaxSeqLag',
+    'bestLagSlopeSeqPerSec',
+    'bestOutputPath',
+    'bestFailureReasons',
+  ].join(',');
+}
+
+function csvRow(result: PointResult): string {
+  const best = result.bestAttempt;
+  return [
+    result.point.profile,
+    result.point.users,
+    result.point.queriesPerUser,
+    result.point.rowsPerQuery,
+    result.point.zeroNumSyncWorkers,
+    result.bestWriteRate ?? '',
+    result.attempts.map(attempt => attempt.writeRate).join('|'),
+    best?.summary?.p99ClientVisibleLagMs ?? '',
+    best?.summary?.maxSeqLag ?? '',
+    best?.summary?.lagSlopeSeqPerSec ?? '',
+    best?.outputPath ?? '',
+    best?.summary?.failureReasons.join('|') ?? '',
+  ]
+    .map(csvCell)
+    .join(',');
+}
+
+function csvCell(value: unknown): string {
+  const text = String(value);
+  if (CSV_ESCAPE_PATTERN.test(text)) {
+    return `"${text.replaceAll('"', '""')}"`;
+  }
+  return text;
+}
+
+function pointID(point: SweepPoint): string {
+  return [
+    point.profile,
+    `${point.users}u`,
+    `${point.queriesPerUser}q`,
+    `${point.rowsPerQuery}rows`,
+    `${point.zeroNumSyncWorkers}sync`,
+  ].join('-');
+}
+
+function pointLabel(point: SweepPoint): string {
+  return `${point.profile} users=${point.users} queriesPerUser=${point.queriesPerUser} rowsPerQuery=${point.rowsPerQuery} syncWorkers=${point.zeroNumSyncWorkers}`;
+}
+
+function gitCommit(): string | undefined {
+  try {
+    return execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd: appRoot,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return undefined;
+  }
+}
+
+function stdout(message: string): void {
+  process.stdout.write(message);
+}
+
+function stderr(message: string): void {
+  process.stderr.write(message);
+}

--- a/apps/zero-throughput/src/util.ts
+++ b/apps/zero-throughput/src/util.ts
@@ -37,7 +37,11 @@ export function average(values: readonly number[]): number {
 }
 
 export function max(values: readonly number[]): number {
-  return values.length === 0 ? 0 : Math.max(...values);
+  let result = 0;
+  for (const value of values) {
+    result = Math.max(result, value);
+  }
+  return result;
 }
 
 export function formatDuration(ms: number): string {

--- a/apps/zero-throughput/src/util.ts
+++ b/apps/zero-throughput/src/util.ts
@@ -1,0 +1,59 @@
+export function log(message = ''): void {
+  process.stdout.write(`${message}\n`);
+}
+
+export function warn(message = ''): void {
+  process.stderr.write(`${message}\n`);
+}
+
+export function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+export function nowMs(): number {
+  return Date.now();
+}
+
+export function percentile(
+  values: readonly number[],
+  percentileValue: number,
+): number {
+  if (values.length === 0) {
+    return 0;
+  }
+  const sorted = values.toSorted((a, b) => a - b);
+  const index = Math.min(
+    sorted.length - 1,
+    Math.max(0, Math.ceil((percentileValue / 100) * sorted.length) - 1),
+  );
+  return sorted[index];
+}
+
+export function average(values: readonly number[]): number {
+  if (values.length === 0) {
+    return 0;
+  }
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+export function max(values: readonly number[]): number {
+  return values.length === 0 ? 0 : Math.max(...values);
+}
+
+export async function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  message: string,
+): Promise<T> {
+  let timeout: NodeJS.Timeout | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeout = setTimeout(() => reject(new Error(message)), ms);
+  });
+  try {
+    return await Promise.race([promise, timeoutPromise]);
+  } finally {
+    if (timeout !== undefined) {
+      clearTimeout(timeout);
+    }
+  }
+}

--- a/apps/zero-throughput/src/util.ts
+++ b/apps/zero-throughput/src/util.ts
@@ -40,6 +40,19 @@ export function max(values: readonly number[]): number {
   return values.length === 0 ? 0 : Math.max(...values);
 }
 
+export function formatDuration(ms: number): string {
+  if (ms < 1000) {
+    return `${ms}ms`;
+  }
+  const seconds = ms / 1000;
+  if (seconds < 60) {
+    return `${seconds.toFixed(seconds % 1 === 0 ? 0 : 1)}s`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = Math.round(seconds % 60);
+  return `${minutes}m ${remainingSeconds}s`;
+}
+
 export async function withTimeout<T>(
   promise: Promise<T>,
   ms: number,

--- a/apps/zero-throughput/src/writer.ts
+++ b/apps/zero-throughput/src/writer.ts
@@ -1,5 +1,16 @@
+import type postgres from 'postgres';
 import type {BenchmarkConfig} from './config.ts';
 import type {BenchmarkDB} from './db.ts';
+import {
+  EMAIL_THREAD_COUNT,
+  FORUM_CATEGORY_ID,
+  FORUM_THREAD_COUNT,
+  FORUM_USER_COUNT,
+  REL_ACCOUNT_COUNT,
+  REL_CONTACTS_PER_ACCOUNT,
+  REL_ORG_ID,
+  SHARED_OWNER_ID,
+} from './profiles.ts';
 import {nowMs, sleep} from './util.ts';
 
 export type WriterStats = {
@@ -11,25 +22,18 @@ export type WriterStats = {
   readonly transactionLatencyMs: readonly number[];
 };
 
-type InsertRow = {
-  readonly id: string;
-  readonly profile: string;
-  readonly shard: number;
-  readonly bucket: number;
-  readonly seq: number;
-  readonly payload: {readonly data: string};
-};
+type WriteSQL = BenchmarkDB | postgres.TransactionSql;
 
 export class FixedRateWriter {
   readonly #sql: BenchmarkDB;
   readonly #config: BenchmarkConfig;
-  readonly #payload: {readonly data: string};
+  readonly #payload: string;
   #highestCommittedSeq = 0;
 
   constructor(sql: BenchmarkDB, config: BenchmarkConfig) {
     this.#sql = sql;
     this.#config = config;
-    this.#payload = {data: 'x'.repeat(config.payloadBytes)};
+    this.#payload = 'x'.repeat(config.payloadBytes);
   }
 
   get highestCommittedSeq(): number {
@@ -53,25 +57,19 @@ export class FixedRateWriter {
       }
       nextStart += intervalMs;
 
-      const rows: InsertRow[] = [];
-      for (let i = 0; i < this.#config.batchSize; i++) {
-        const seq = nextSeq++;
-        rows.push({
-          id: `${this.#config.runID}-${seq}`,
-          profile: this.#config.profile,
-          shard: 0,
-          bucket: 0,
-          seq,
-          payload: this.#payload,
-        });
-      }
+      const seqs = Array.from(
+        {length: this.#config.batchSize},
+        () => nextSeq++,
+      );
 
       const txStart = nowMs();
       await this.#sql.begin(async tx => {
-        await tx`INSERT INTO zero_throughput_event ${tx(rows)}`;
+        for (const seq of seqs) {
+          await this.#writeOne(tx, seq);
+        }
       });
       transactionLatencyMs.push(nowMs() - txStart);
-      committedRows += rows.length;
+      committedRows += seqs.length;
       committedTransactions++;
       this.#highestCommittedSeq = nextSeq - 1;
     }
@@ -84,5 +82,140 @@ export class FixedRateWriter {
       highestCommittedSeq: this.#highestCommittedSeq,
       transactionLatencyMs,
     };
+  }
+
+  async #writeOne(sql: WriteSQL, seq: number): Promise<void> {
+    switch (this.#config.profile) {
+      case 'feed-append': {
+        await this.#writeFeedAppend(sql, seq);
+        return;
+      }
+      case 'email': {
+        await this.#writeEmail(sql, seq);
+        return;
+      }
+      case 'forum': {
+        await this.#writeForum(sql, seq);
+        return;
+      }
+      case 'relational': {
+        await this.#writeRelational(sql, seq);
+        return;
+      }
+    }
+  }
+
+  async #writeFeedAppend(sql: WriteSQL, seq: number): Promise<void> {
+    await sql`
+      INSERT INTO zero_throughput_event
+        (id, profile, shard, bucket, seq, payload)
+      VALUES
+        (
+          ${`${this.#config.runID}-${seq}`},
+          ${this.#config.profile},
+          0,
+          0,
+          ${seq},
+          ${sql.json({data: this.#payload})}
+        )
+    `;
+  }
+
+  async #writeEmail(sql: WriteSQL, seq: number): Promise<void> {
+    const threadID = `email-thread-${seq % EMAIL_THREAD_COUNT}`;
+    await sql`
+      INSERT INTO zero_throughput_email_message
+        (id, thread_id, owner_id, mailbox, sender_id, unread, body, seq)
+      VALUES
+        (
+          ${`${this.#config.runID}-email-message-${seq}`},
+          ${threadID},
+          ${SHARED_OWNER_ID},
+          'inbox',
+          ${`sender-${seq % 16}`},
+          true,
+          ${this.#payload},
+          ${seq}
+        )
+    `;
+    await sql`
+      UPDATE zero_throughput_email_thread
+      SET
+        seq = ${seq},
+        written_at = clock_timestamp(),
+        updated_at = clock_timestamp()
+      WHERE id = ${threadID}
+    `;
+  }
+
+  async #writeForum(sql: WriteSQL, seq: number): Promise<void> {
+    const threadID = `forum-thread-${seq % FORUM_THREAD_COUNT}`;
+    const authorID = `forum-user-${seq % FORUM_USER_COUNT}`;
+    await sql`
+      INSERT INTO zero_throughput_forum_post
+        (id, thread_id, category_id, author_id, body, seq)
+      VALUES
+        (
+          ${`${this.#config.runID}-forum-post-${seq}`},
+          ${threadID},
+          ${FORUM_CATEGORY_ID},
+          ${authorID},
+          ${this.#payload},
+          ${seq}
+        )
+    `;
+    await sql`
+      UPDATE zero_throughput_forum_thread
+      SET
+        seq = ${seq},
+        written_at = clock_timestamp(),
+        updated_at = clock_timestamp()
+      WHERE id = ${threadID}
+    `;
+    await sql`
+      UPDATE zero_throughput_forum_category
+      SET
+        seq = ${seq},
+        written_at = clock_timestamp(),
+        updated_at = clock_timestamp()
+      WHERE id = ${FORUM_CATEGORY_ID}
+    `;
+  }
+
+  async #writeRelational(sql: WriteSQL, seq: number): Promise<void> {
+    const accountIndex = seq % REL_ACCOUNT_COUNT;
+    const contactIndex = seq % REL_CONTACTS_PER_ACCOUNT;
+    const accountID = `rel-account-${accountIndex}`;
+    const contactID = `${accountID}-contact-${contactIndex}`;
+    await sql`
+      INSERT INTO zero_throughput_rel_activity
+        (id, org_id, account_id, contact_id, kind, body, seq)
+      VALUES
+        (
+          ${`${this.#config.runID}-rel-activity-${seq}`},
+          ${REL_ORG_ID},
+          ${accountID},
+          ${contactID},
+          ${seq % 5 === 0 ? 'meeting' : 'note'},
+          ${this.#payload},
+          ${seq}
+        )
+    `;
+    await sql`
+      UPDATE zero_throughput_rel_account
+      SET
+        seq = ${seq},
+        written_at = clock_timestamp(),
+        updated_at = clock_timestamp()
+      WHERE id = ${accountID}
+    `;
+    await sql`
+      UPDATE zero_throughput_rel_org
+      SET
+        seq = ${seq},
+        written_at = clock_timestamp(),
+        updated_at = clock_timestamp()
+      WHERE id = ${REL_ORG_ID}
+    `;
   }
 }

--- a/apps/zero-throughput/src/writer.ts
+++ b/apps/zero-throughput/src/writer.ts
@@ -1,0 +1,88 @@
+import type {BenchmarkConfig} from './config.ts';
+import type {BenchmarkDB} from './db.ts';
+import {nowMs, sleep} from './util.ts';
+
+export type WriterStats = {
+  readonly startedAtMs: number;
+  readonly finishedAtMs: number;
+  readonly committedRows: number;
+  readonly committedTransactions: number;
+  readonly highestCommittedSeq: number;
+  readonly transactionLatencyMs: readonly number[];
+};
+
+type InsertRow = {
+  readonly id: string;
+  readonly profile: string;
+  readonly shard: number;
+  readonly bucket: number;
+  readonly seq: number;
+  readonly payload: {readonly data: string};
+};
+
+export class FixedRateWriter {
+  readonly #sql: BenchmarkDB;
+  readonly #config: BenchmarkConfig;
+  readonly #payload: {readonly data: string};
+  #highestCommittedSeq = 0;
+
+  constructor(sql: BenchmarkDB, config: BenchmarkConfig) {
+    this.#sql = sql;
+    this.#config = config;
+    this.#payload = {data: 'x'.repeat(config.payloadBytes)};
+  }
+
+  get highestCommittedSeq(): number {
+    return this.#highestCommittedSeq;
+  }
+
+  async run(durationMs: number): Promise<WriterStats> {
+    const startedAtMs = nowMs();
+    const deadline = startedAtMs + durationMs;
+    const transactionLatencyMs: number[] = [];
+    let committedRows = 0;
+    let committedTransactions = 0;
+    let nextSeq = 1;
+    let nextStart = startedAtMs;
+    const intervalMs = (this.#config.batchSize / this.#config.writeRate) * 1000;
+
+    while (nowMs() < deadline) {
+      const delayMs = nextStart - nowMs();
+      if (delayMs > 0) {
+        await sleep(delayMs);
+      }
+      nextStart += intervalMs;
+
+      const rows: InsertRow[] = [];
+      for (let i = 0; i < this.#config.batchSize; i++) {
+        const seq = nextSeq++;
+        rows.push({
+          id: `${this.#config.runID}-${seq}`,
+          profile: this.#config.profile,
+          shard: 0,
+          bucket: 0,
+          seq,
+          payload: this.#payload,
+        });
+      }
+
+      const txStart = nowMs();
+      await this.#sql.begin(async tx => {
+        await tx`INSERT INTO zero_throughput_event ${tx(rows)}`;
+      });
+      transactionLatencyMs.push(nowMs() - txStart);
+      committedRows += rows.length;
+      committedTransactions++;
+      this.#highestCommittedSeq = nextSeq - 1;
+    }
+
+    return {
+      startedAtMs,
+      finishedAtMs: nowMs(),
+      committedRows,
+      committedTransactions,
+      highestCommittedSeq: this.#highestCommittedSeq,
+      transactionLatencyMs,
+    };
+  }
+}

--- a/apps/zero-throughput/tsconfig.json
+++ b/apps/zero-throughput/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "declaration": false,
+    "declarationMap": false,
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/apps/zero-throughput/tsconfig.json
+++ b/apps/zero-throughput/tsconfig.json
@@ -3,6 +3,9 @@
   "compilerOptions": {
     "declaration": false,
     "declarationMap": false,
+    "paths": {
+      "@rocicorp/zero": ["../../packages/zero/src/zero.ts"]
+    },
     "types": ["node"]
   },
   "include": ["src"]

--- a/packages/zero-cache/src/server/anonymous-otel-start.ts
+++ b/packages/zero-cache/src/server/anonymous-otel-start.ts
@@ -12,12 +12,12 @@ import {
   PeriodicExportingMetricReader,
 } from '@opentelemetry/sdk-metrics';
 import type {LogContext} from '@rocicorp/logger';
-import {h64} from '../../../shared/src/hash.js';
+import {h64} from '../../../shared/src/hash.ts';
 import {
   getServerVersion,
   getZeroConfig,
   type ZeroConfig,
-} from '../config/zero-config.js';
+} from '../config/zero-config.ts';
 import {setupOtelDiagnosticLogger} from './otel-diag-logger.ts';
 
 export type ActiveUsers = {

--- a/packages/zero-cache/src/services/change-source/pg/replication-slots.ts
+++ b/packages/zero-cache/src/services/change-source/pg/replication-slots.ts
@@ -4,16 +4,16 @@ import {
 } from '@drdgvhbh/postgres-error-codes';
 import type {LogContext} from '@rocicorp/logger';
 import type postgres from 'postgres';
-import {runTx} from '../../../db/run-transaction';
-import {isPostgresError, type PostgresDB} from '../../../types/pg';
-import {upstreamSchema, type ShardID} from '../../../types/shards';
-import {orTimeout} from '../../../types/timeout';
-import {toStateVersionString} from './lsn';
+import {runTx} from '../../../db/run-transaction.ts';
+import {isPostgresError, type PostgresDB} from '../../../types/pg.ts';
+import {upstreamSchema, type ShardID} from '../../../types/shards.ts';
+import {orTimeout} from '../../../types/timeout.ts';
+import {toStateVersionString} from './lsn.ts';
 import {
   createReplica,
   replicationSlotExpression,
   replicationSlotPrefix,
-} from './schema/shard';
+} from './schema/shard.ts';
 
 // Record returned by `CREATE_REPLICATION_SLOT`
 export type ReplicationSlot = {

--- a/packages/zql-benchmarks/package.json
+++ b/packages/zql-benchmarks/package.json
@@ -14,6 +14,7 @@
     "test": "vitest run --silent=false --disable-console-intercept",
     "test:watch": "vitest watch",
     "bench": "vitest run --config vitest.config.bench.ts",
+    "bench:mem": "vitest run --config vitest.config.bench-mem.ts",
     "bench:deopt": "vitest run --config vitest.config.bench.ts --execArgv=--trace-deopt",
     "bench:bmf": "BENCH_OUTPUT_FORMAT=json pnpm run bench 2>&1 | node ../shared/src/tool/mitata-json-to-bmf.ts",
     "bench:bmf:silent": "pnpm run bench:bmf --silent",

--- a/packages/zql-benchmarks/src/zero-throughput-relational.bench.ts
+++ b/packages/zql-benchmarks/src/zero-throughput-relational.bench.ts
@@ -1,0 +1,655 @@
+/**
+ * Isolated zqlite push benchmark for the zero-throughput relational profile.
+ *
+ * This mirrors the E2E relational profile shape without zero-cache, CVR flush,
+ * WebSockets, or client groups:
+ *
+ *   - 100 users
+ *   - 3 standing query shapes per user
+ *   - 50 rows per top-level query window
+ *   - one logical write = add relActivity + edit relAccount + edit relOrg
+ *
+ * Run with:
+ *   pnpm --filter zql-benchmarks run bench:mem zero-throughput-relational
+ */
+
+import {bench, describe, use} from '../../shared/src/bench.ts';
+import {createSilentLogContext} from '../../shared/src/logging-test-utils.ts';
+import type {Row} from '../../zero-protocol/src/data.ts';
+import {relationships} from '../../zero-schema/src/builder/relationship-builder.ts';
+import {createSchema} from '../../zero-schema/src/builder/schema-builder.ts';
+import {
+  number,
+  string,
+  table,
+} from '../../zero-schema/src/builder/table-builder.ts';
+import {MemorySource} from '../../zql/src/ivm/memory-source.ts';
+import {
+  makeSourceChangeAdd,
+  makeSourceChangeEdit,
+  type Source,
+} from '../../zql/src/ivm/source.ts';
+import {consume} from '../../zql/src/ivm/stream.ts';
+import {createBuilder} from '../../zql/src/query/create-builder.ts';
+import type {Query} from '../../zql/src/query/query.ts';
+import {QueryDelegateImpl as MemoryQueryDelegate} from '../../zql/src/query/test/query-delegate.ts';
+import {Database} from '../../zqlite/src/db.ts';
+import {QueryDelegateImpl as ZqliteQueryDelegate} from '../../zqlite/src/query-delegate.ts';
+
+const USERS = 100;
+const QUERIES_PER_USER = 3;
+const ROWS_PER_QUERY = 50;
+const QUERY_INSTANCES = USERS * QUERIES_PER_USER;
+
+const REL_ORG_ID = 'rel-org-0';
+const REL_ACCOUNT_COUNT = 64;
+const REL_CONTACTS_PER_ACCOUNT = 4;
+const INITIAL_ACTIVITY_COUNT = 512;
+const PAYLOAD = 'x'.repeat(256);
+
+const relOrg = table('relOrg')
+  .columns({
+    id: string(),
+    name: string(),
+    region: string(),
+    seq: number(),
+    writtenAt: number(),
+    updatedAt: number(),
+  })
+  .primaryKey('id');
+
+const relAccount = table('relAccount')
+  .columns({
+    id: string(),
+    orgID: string(),
+    ownerID: string(),
+    name: string(),
+    status: string(),
+    seq: number(),
+    writtenAt: number(),
+    updatedAt: number(),
+  })
+  .primaryKey('id');
+
+const relContact = table('relContact')
+  .columns({
+    id: string(),
+    accountID: string(),
+    name: string(),
+    role: string(),
+    seq: number(),
+    writtenAt: number(),
+    updatedAt: number(),
+  })
+  .primaryKey('id');
+
+const relActivity = table('relActivity')
+  .columns({
+    id: string(),
+    orgID: string(),
+    accountID: string(),
+    contactID: string(),
+    kind: string(),
+    body: string(),
+    seq: number(),
+    writtenAt: number(),
+    updatedAt: number(),
+  })
+  .primaryKey('id');
+
+const relOrgRelationships = relationships(relOrg, ({many}) => ({
+  accounts: many({
+    sourceField: ['id'],
+    destField: ['orgID'],
+    destSchema: relAccount,
+  }),
+  activities: many({
+    sourceField: ['id'],
+    destField: ['orgID'],
+    destSchema: relActivity,
+  }),
+}));
+
+const relAccountRelationships = relationships(relAccount, ({many, one}) => ({
+  org: one({
+    sourceField: ['orgID'],
+    destField: ['id'],
+    destSchema: relOrg,
+  }),
+  contacts: many({
+    sourceField: ['id'],
+    destField: ['accountID'],
+    destSchema: relContact,
+  }),
+  activities: many({
+    sourceField: ['id'],
+    destField: ['accountID'],
+    destSchema: relActivity,
+  }),
+}));
+
+const relContactRelationships = relationships(relContact, ({many, one}) => ({
+  account: one({
+    sourceField: ['accountID'],
+    destField: ['id'],
+    destSchema: relAccount,
+  }),
+  activities: many({
+    sourceField: ['id'],
+    destField: ['contactID'],
+    destSchema: relActivity,
+  }),
+}));
+
+const relActivityRelationships = relationships(relActivity, ({one}) => ({
+  org: one({
+    sourceField: ['orgID'],
+    destField: ['id'],
+    destSchema: relOrg,
+  }),
+  account: one({
+    sourceField: ['accountID'],
+    destField: ['id'],
+    destSchema: relAccount,
+  }),
+  contact: one({
+    sourceField: ['contactID'],
+    destField: ['id'],
+    destSchema: relContact,
+  }),
+}));
+
+const schema = createSchema({
+  tables: [relOrg, relAccount, relContact, relActivity],
+  relationships: [
+    relOrgRelationships,
+    relAccountRelationships,
+    relContactRelationships,
+    relActivityRelationships,
+  ],
+  enableLegacyMutators: false,
+  enableLegacyQueries: false,
+});
+
+const builder = createBuilder(schema);
+
+type TableName = keyof typeof schema.tables;
+type RelationalQuery = Query<TableName, typeof schema>;
+type MutableRow = Record<string, string | number>;
+type FlushableView = {
+  readonly data: unknown;
+  destroy(): void;
+  flush(): void;
+};
+
+type SourceSet = {
+  readonly relActivity: Source;
+  readonly relAccount: Source;
+  readonly relOrg: Source;
+};
+
+type BenchState = {
+  org: MutableRow;
+  readonly views: readonly FlushableView[];
+  readonly accounts: MutableRow[];
+  readonly sources: SourceSet;
+  readonly close: () => void;
+  nextSeq: number;
+};
+
+type SeedData = {
+  readonly org: MutableRow;
+  readonly accounts: MutableRow[];
+  readonly contacts: readonly Row[];
+  readonly activities: readonly Row[];
+  readonly nextSeq: number;
+};
+
+function buildRelationalQuery(queryIndex: number): RelationalQuery {
+  switch (queryIndex % QUERIES_PER_USER) {
+    case 0:
+      return builder.relOrg
+        .where('id', REL_ORG_ID)
+        .related('accounts', q =>
+          q
+            .orderBy('seq', 'desc')
+            .limit(ROWS_PER_QUERY)
+            .related('contacts')
+            .related('activities', a =>
+              a.orderBy('seq', 'desc').limit(5).related('contact'),
+            ),
+        )
+        .related('activities', q =>
+          q.orderBy('seq', 'desc').limit(ROWS_PER_QUERY),
+        );
+
+    case 1:
+      return builder.relAccount
+        .where('orgID', REL_ORG_ID)
+        .related('org')
+        .related('contacts')
+        .related('activities', q =>
+          q.orderBy('seq', 'desc').limit(5).related('contact'),
+        )
+        .orderBy('seq', 'desc')
+        .limit(ROWS_PER_QUERY);
+
+    case 2:
+      return builder.relActivity
+        .where('orgID', REL_ORG_ID)
+        .related('org')
+        .related('account', q => q.related('contacts'))
+        .related('contact')
+        .orderBy('seq', 'desc')
+        .limit(ROWS_PER_QUERY);
+  }
+  throw new Error(`Invalid relational query index: ${queryIndex}`);
+}
+
+function createDB(): Database {
+  const db = new Database(createSilentLogContext(), ':memory:');
+  db.unsafeMode(true);
+  db.pragma('journal_mode = OFF');
+  db.pragma('synchronous = OFF');
+  db.pragma('foreign_keys = OFF');
+  db.exec(`
+    CREATE TABLE relOrg (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      region TEXT NOT NULL,
+      seq REAL NOT NULL,
+      writtenAt REAL NOT NULL,
+      updatedAt REAL NOT NULL
+    );
+
+    CREATE TABLE relAccount (
+      id TEXT PRIMARY KEY,
+      orgID TEXT NOT NULL,
+      ownerID TEXT NOT NULL,
+      name TEXT NOT NULL,
+      status TEXT NOT NULL,
+      seq REAL NOT NULL,
+      writtenAt REAL NOT NULL,
+      updatedAt REAL NOT NULL
+    );
+    CREATE INDEX relAccount_org_seq_idx
+      ON relAccount (orgID, seq DESC, id ASC);
+
+    CREATE TABLE relContact (
+      id TEXT PRIMARY KEY,
+      accountID TEXT NOT NULL,
+      name TEXT NOT NULL,
+      role TEXT NOT NULL,
+      seq REAL NOT NULL,
+      writtenAt REAL NOT NULL,
+      updatedAt REAL NOT NULL
+    );
+    CREATE INDEX relContact_account_idx
+      ON relContact (accountID, id ASC);
+
+    CREATE TABLE relActivity (
+      id TEXT PRIMARY KEY,
+      orgID TEXT NOT NULL,
+      accountID TEXT NOT NULL,
+      contactID TEXT NOT NULL,
+      kind TEXT NOT NULL,
+      body TEXT NOT NULL,
+      seq REAL NOT NULL,
+      writtenAt REAL NOT NULL,
+      updatedAt REAL NOT NULL
+    );
+    CREATE INDEX relActivity_org_seq_idx
+      ON relActivity (orgID, seq DESC, id ASC);
+    CREATE INDEX relActivity_account_seq_idx
+      ON relActivity (accountID, seq DESC, id ASC);
+    CREATE INDEX relActivity_contact_seq_idx
+      ON relActivity (contactID, seq DESC, id ASC);
+  `);
+  return db;
+}
+
+function makeSeedData(): SeedData {
+  const org: MutableRow = {
+    id: REL_ORG_ID,
+    name: 'Throughput Org',
+    region: 'na',
+    seq: 0,
+    writtenAt: 0,
+    updatedAt: 0,
+  };
+  const accounts: MutableRow[] = Array.from(
+    {length: REL_ACCOUNT_COUNT},
+    (_, index) => ({
+      id: `rel-account-${index}`,
+      orgID: REL_ORG_ID,
+      ownerID: `owner-${index % 8}`,
+      name: `Account ${index}`,
+      status: index % 3 === 0 ? 'risk' : 'active',
+      seq: 0,
+      writtenAt: 0,
+      updatedAt: 0,
+    }),
+  );
+  const contacts: Row[] = accounts.flatMap(account =>
+    Array.from({length: REL_CONTACTS_PER_ACCOUNT}, (_, index) => ({
+      id: `${account.id}-contact-${index}`,
+      accountID: account.id,
+      name: `Contact ${index} at ${account.name}`,
+      role: index === 0 ? 'buyer' : 'stakeholder',
+      seq: 0,
+      writtenAt: 0,
+      updatedAt: 0,
+    })),
+  );
+  const activities: Row[] = [];
+
+  for (let seq = 1; seq <= INITIAL_ACTIVITY_COUNT; seq++) {
+    const accountIndex = seq % REL_ACCOUNT_COUNT;
+    const account = accounts[accountIndex];
+    account.seq = seq;
+    account.writtenAt = seq;
+    account.updatedAt = seq;
+    org.seq = seq;
+    org.writtenAt = seq;
+    org.updatedAt = seq;
+    activities.push(makeActivityRow(seq));
+  }
+
+  return {
+    org,
+    accounts,
+    contacts,
+    activities,
+    nextSeq: INITIAL_ACTIVITY_COUNT + 1,
+  };
+}
+
+function seedDB(db: Database, seed: SeedData): void {
+  const insertOrg = db.prepare(`
+    INSERT INTO relOrg
+      (id, name, region, seq, writtenAt, updatedAt)
+    VALUES (?, ?, ?, ?, ?, ?)
+  `);
+  const insertAccount = db.prepare(`
+    INSERT INTO relAccount
+      (id, orgID, ownerID, name, status, seq, writtenAt, updatedAt)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+  const insertContact = db.prepare(`
+    INSERT INTO relContact
+      (id, accountID, name, role, seq, writtenAt, updatedAt)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+  `);
+  const insertActivity = db.prepare(`
+    INSERT INTO relActivity
+      (id, orgID, accountID, contactID, kind, body, seq, writtenAt, updatedAt)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+
+  db.transaction(() => {
+    insertOrg.run(
+      seed.org.id,
+      seed.org.name,
+      seed.org.region,
+      seed.org.seq,
+      seed.org.writtenAt,
+      seed.org.updatedAt,
+    );
+    for (const account of seed.accounts) {
+      insertAccount.run(
+        account.id,
+        account.orgID,
+        account.ownerID,
+        account.name,
+        account.status,
+        account.seq,
+        account.writtenAt,
+        account.updatedAt,
+      );
+    }
+    for (const contact of seed.contacts) {
+      insertContact.run(
+        contact.id,
+        contact.accountID,
+        contact.name,
+        contact.role,
+        contact.seq,
+        contact.writtenAt,
+        contact.updatedAt,
+      );
+    }
+    for (const activity of seed.activities) {
+      insertActivity.run(
+        activity.id,
+        activity.orgID,
+        activity.accountID,
+        activity.contactID,
+        activity.kind,
+        activity.body,
+        activity.seq,
+        activity.writtenAt,
+        activity.updatedAt,
+      );
+    }
+  });
+}
+
+function setupZqlite(): BenchState {
+  const db = createDB();
+  const seed = makeSeedData();
+  seedDB(db, seed);
+  const delegate = new ZqliteQueryDelegate(
+    createSilentLogContext(),
+    db,
+    schema,
+    {
+      format: 'text',
+      level: 'error',
+      ivmSampling: 0,
+      slowHydrateThreshold: 0,
+      slowRowThreshold: 0,
+    },
+  );
+  const queries = Array.from({length: QUERIES_PER_USER}, (_, queryIndex) =>
+    buildRelationalQuery(queryIndex),
+  );
+  const views: FlushableView[] = [];
+  for (let user = 0; user < USERS; user++) {
+    for (const query of queries) {
+      views.push(delegate.materialize(query) as unknown as FlushableView);
+    }
+  }
+  use(views.length);
+  return {
+    org: seed.org,
+    views,
+    accounts: seed.accounts,
+    sources: {
+      relActivity: delegate.getSource('relActivity'),
+      relAccount: delegate.getSource('relAccount'),
+      relOrg: delegate.getSource('relOrg'),
+    },
+    close: () => db.close(),
+    nextSeq: seed.nextSeq,
+  };
+}
+
+function setupMemory(): BenchState {
+  const seed = makeSeedData();
+  const sources = Object.fromEntries(
+    Object.entries(schema.tables).map(([name, tableSchema]) => [
+      name,
+      new MemorySource(
+        tableSchema.name,
+        tableSchema.columns,
+        tableSchema.primaryKey,
+      ),
+    ]),
+  ) as Record<TableName, MemorySource>;
+
+  addToMemorySource(sources.relOrg, seed.org);
+  for (const account of seed.accounts) {
+    addToMemorySource(sources.relAccount, account);
+  }
+  for (const contact of seed.contacts) {
+    addToMemorySource(sources.relContact, contact);
+  }
+  for (const activity of seed.activities) {
+    addToMemorySource(sources.relActivity, activity);
+  }
+
+  const delegate = new MemoryQueryDelegate({sources});
+  const queries = Array.from({length: QUERIES_PER_USER}, (_, queryIndex) =>
+    buildRelationalQuery(queryIndex),
+  );
+  const views: FlushableView[] = [];
+  for (let user = 0; user < USERS; user++) {
+    for (const query of queries) {
+      views.push(delegate.materialize(query) as unknown as FlushableView);
+    }
+  }
+  use(views.length);
+  return {
+    org: seed.org,
+    views,
+    accounts: seed.accounts,
+    sources: {
+      relActivity: sources.relActivity,
+      relAccount: sources.relAccount,
+      relOrg: sources.relOrg,
+    },
+    close: () => {},
+    nextSeq: seed.nextSeq,
+  };
+}
+
+function addToMemorySource(source: MemorySource, row: Row): void {
+  consume(source.push(makeSourceChangeAdd({...row})));
+}
+
+function teardown(state: BenchState): void {
+  for (const view of state.views) {
+    view.destroy();
+  }
+  state.close();
+}
+
+function pushLogicalWrite(state: BenchState): void {
+  const seq = state.nextSeq++;
+  const accountIndex = seq % REL_ACCOUNT_COUNT;
+
+  consume(
+    state.sources.relActivity.push(makeSourceChangeAdd(makeActivityRow(seq))),
+  );
+
+  const oldAccount = state.accounts[accountIndex];
+  const newAccount = {
+    ...oldAccount,
+    seq,
+    writtenAt: seq,
+    updatedAt: seq,
+  };
+  consume(
+    state.sources.relAccount.push(makeSourceChangeEdit(newAccount, oldAccount)),
+  );
+  state.accounts[accountIndex] = newAccount;
+
+  const oldOrg = state.org;
+  const newOrg = {
+    ...oldOrg,
+    seq,
+    writtenAt: seq,
+    updatedAt: seq,
+  };
+  consume(state.sources.relOrg.push(makeSourceChangeEdit(newOrg, oldOrg)));
+  state.org = newOrg;
+}
+
+function flushViews(state: BenchState): void {
+  for (const view of state.views) {
+    view.flush();
+  }
+}
+
+function makeActivityRow(seq: number): Row {
+  const accountIndex = seq % REL_ACCOUNT_COUNT;
+  const contactIndex = seq % REL_CONTACTS_PER_ACCOUNT;
+  const accountID = `rel-account-${accountIndex}`;
+  return {
+    id: `bench-rel-activity-${seq}`,
+    orgID: REL_ORG_ID,
+    accountID,
+    contactID: `${accountID}-contact-${contactIndex}`,
+    kind: seq % 5 === 0 ? 'meeting' : 'note',
+    body: PAYLOAD,
+    seq,
+    writtenAt: seq,
+    updatedAt: seq,
+  };
+}
+
+const pushOptions = {
+  max_samples: 1_000,
+};
+
+describe('zero-throughput relational zqlite push', () => {
+  bench(
+    `${QUERY_INSTANCES} queries: logical write push only`,
+    function* () {
+      const state = setupZqlite();
+
+      yield () => {
+        pushLogicalWrite(state);
+      };
+
+      teardown(state);
+    },
+    pushOptions,
+  );
+
+  bench(
+    `${QUERY_INSTANCES} queries: logical write push + flush views`,
+    function* () {
+      const state = setupZqlite();
+
+      yield () => {
+        pushLogicalWrite(state);
+        flushViews(state);
+      };
+
+      teardown(state);
+    },
+    pushOptions,
+  );
+});
+
+describe('zero-throughput relational memory push', () => {
+  bench(
+    `${QUERY_INSTANCES} queries: logical write push only`,
+    function* () {
+      const state = setupMemory();
+
+      yield () => {
+        pushLogicalWrite(state);
+      };
+
+      teardown(state);
+    },
+    pushOptions,
+  );
+
+  bench(
+    `${QUERY_INSTANCES} queries: logical write push + flush views`,
+    function* () {
+      const state = setupMemory();
+
+      yield () => {
+        pushLogicalWrite(state);
+        flushViews(state);
+      };
+
+      teardown(state);
+    },
+    pushOptions,
+  );
+});

--- a/packages/zql-benchmarks/vitest.config.bench-mem.ts
+++ b/packages/zql-benchmarks/vitest.config.bench-mem.ts
@@ -22,6 +22,7 @@ export default mergeConfig(benchConfig, {
       'src/array-view-relationships.bench.ts',
       'src/array-view-transaction.bench.ts',
       'src/debug-row-vended.bench.ts',
+      'src/zero-throughput-relational.bench.ts',
     ],
     browser: {
       enabled: false,

--- a/packages/zql/package.json
+++ b/packages/zql/package.json
@@ -25,6 +25,7 @@
     "@standard-schema/spec": "^1.0.0",
     "fast-check": "^3.18.0",
     "nanoid": "^5.1.2",
+    "otel": "workspace:*",
     "oxfmt": "^0.45.0",
     "shared": "workspace:*",
     "typescript": "~6.0.2",

--- a/packages/zql/tool/bench-ivm-inmem.ts
+++ b/packages/zql/tool/bench-ivm-inmem.ts
@@ -1,0 +1,388 @@
+import {testLogConfig} from '../../../packages/otel/src/test-log-config.ts';
+/**
+ * In-memory head-to-head bench (Zero ZQL side) vs Jazz and Rindle.
+ *
+ * A faithful mirror of `crates/jazz-tools/examples/bench_ivm_inmem.rs` (Jazz) and
+ * `<rindle>/examples/bench_ivm_inmem.rs` (Rindle): the same three workloads, the
+ * same `bench_min` timing harness (~200 ms warmup, min ns/op over 6 rounds x 8
+ * samples), and the same machine-line + human-line output format — so the three
+ * runs are directly comparable.
+ *
+ * Measures, for three workloads over a sweep of N rows:
+ *   - hydration:   fork the populated source (O(1) COW), build a fresh pipeline +
+ *                  ArrayView, hydrate to the first full result (rebuilds the
+ *                  secondary sort index — exactly the work a first subscription pays)
+ *   - maintenance: apply one source push (Add) that enters the result, propagate to
+ *                  the view + flush, then undo it (untimed) to keep N stable
+ *   - retained:    heapUsed retained by the materialized view + its secondary index
+ *                  after hydration (gc-forced delta; primary data shared/excluded)
+ *
+ * Leaf: the in-memory `MemorySource` (COW B+tree), same structure Rindle's
+ * `MemorySource` ports. Full JS (no native), which is the point of the comparison.
+ *
+ * Run:   node --experimental-transform-types --expose-gc tool/bench-ivm-inmem.ts
+ * Knobs: ZQL_BENCH_SCALES=1000,10000,100000
+ */
+import {createSilentLogContext} from '../../../packages/shared/src/logging-test-utils.ts';
+import type {AST} from '../../../packages/zero-protocol/src/ast.ts';
+import type {Row} from '../../../packages/zero-protocol/src/data.ts';
+import {buildPipeline} from '../src/builder/builder.ts';
+import {TestBuilderDelegate} from '../src/builder/test-builder-delegate.ts';
+import {ArrayView} from '../src/ivm/array-view.ts';
+import {MemorySource} from '../src/ivm/memory-source.ts';
+import {
+  makeSourceChangeAdd,
+  makeSourceChangeRemove,
+} from '../src/ivm/source.ts';
+import {consume} from '../src/ivm/stream.ts';
+import type {Format} from '../src/ivm/view.ts';
+
+const lc = createSilentLogContext();
+
+// ---------------------------------------------------------------------------
+// Timing harness: ~200ms warmup, then min ns/op over 6 rounds x 8 samples.
+// The closure is self-contained: it does its own untimed state-reset and
+// returns only the measured nanoseconds. Mirror of the Rust `bench_min`.
+// ---------------------------------------------------------------------------
+function benchMin(op: () => number): number {
+  const warmEnd = Number(process.hrtime.bigint()) + 200_000_000; // 200ms
+  while (Number(process.hrtime.bigint()) < warmEnd) {
+    op();
+  }
+  let best = Infinity;
+  for (let round = 0; round < 6; round++) {
+    let rb = Infinity;
+    for (let s = 0; s < 8; s++) {
+      const v = op();
+      if (v < rb) rb = v;
+    }
+    if (rb < best) best = rb;
+  }
+  return best;
+}
+
+// A black-box sink so V8 can't optimize away the work we're measuring.
+let sink = 0;
+function blackBox(x: number) {
+  sink ^= x;
+}
+
+// heapUsed after forcing GC. Two passes to settle finalizers.
+function memAfterGc(): number {
+  const gc = (globalThis as {gc?: () => void}).gc;
+  if (gc) {
+    gc();
+    gc();
+  }
+  return process.memoryUsage().heapUsed;
+}
+
+// ---------------------------------------------------------------------------
+// A pre-populated source template. Every build forks it (O(1) COW share of the
+// primary btree); the query's sort builds any secondary index lazily during
+// hydration — exactly the work a first subscription pays.
+// ---------------------------------------------------------------------------
+type Src = {
+  name: string;
+  columns: Record<string, {type: 'number' | 'string'}>;
+  pk: [string, ...string[]];
+  tmpl: MemorySource;
+};
+
+function makeSrc(
+  name: string,
+  columns: Record<string, {type: 'number' | 'string'}>,
+  pk: [string, ...string[]],
+  rows: Row[],
+): Src {
+  const tmpl = new MemorySource(name, columns, pk);
+  for (const r of rows) {
+    consume(tmpl.push(makeSourceChangeAdd(r)));
+  }
+  return {name, columns, pk, tmpl};
+}
+
+type Built = {
+  view: ArrayView<readonly unknown[]>;
+  sources: Record<string, MemorySource>;
+};
+
+// Fork each source into fresh leaves, build the pipeline, materialize + hydrate
+// the ArrayView (its constructor hydrates).
+function build(srcs: Src[], ast: AST, format: Format): Built {
+  const sources: Record<string, MemorySource> = {};
+  for (const s of srcs) {
+    sources[s.name] = s.tmpl.fork();
+  }
+  const delegate = new TestBuilderDelegate(sources);
+  const input = buildPipeline(ast, delegate, 'q');
+  const view = new ArrayView(input, format, true, () => {}) as ArrayView<
+    readonly unknown[]
+  >;
+  return {view, sources};
+}
+
+function rowCount(b: Built): number {
+  return (b.view.data as readonly unknown[]).length;
+}
+
+// Retained heap per materialized view + its secondary index. heapUsed deltas are
+// noisy for small allocations, so build K independent live views, hold them all,
+// measure the total delta, and divide. This amplifies the signal well above GC
+// jitter. Rows are shared (COW fork) so, like the Rust side, only the view +
+// lazily-built secondary index are counted, not the primary data.
+function retainedPerView(
+  srcs: Src[],
+  ast: AST,
+  format: Format,
+  n: number,
+): number {
+  const k = n <= 1000 ? 40 : n <= 10000 ? 12 : 4;
+  const base = memAfterGc();
+  const held: Built[] = [];
+  for (let i = 0; i < k; i++) {
+    const b = build(srcs, ast, format);
+    if (rowCount(b) === 0) throw new Error('hydration empty (retained)');
+    held.push(b);
+  }
+  const total = Math.max(0, memAfterGc() - base);
+  blackBox(held.length);
+  return total / k;
+}
+
+function report(
+  workload: string,
+  n: number,
+  hydNs: number,
+  maintNs: number,
+  memBytes: number,
+) {
+  console.log(`zql|${workload}|N=${n}|hydration_ns|${Math.round(hydNs)}`);
+  console.log(`zql|${workload}|N=${n}|maintenance_ns|${Math.round(maintNs)}`);
+  console.log(`zql|${workload}|N=${n}|retained_bytes|${Math.round(memBytes)}`);
+  const pad = (s: string, w: number) => s.padStart(w);
+  process.stderr.write(
+    `[zql] ${workload.padEnd(15)} N=${pad(String(n), 7)}  ` +
+      `hydration=${pad((hydNs / 1000).toFixed(1), 10)}us  ` +
+      `maintenance=${pad((maintNs / 1000).toFixed(2), 9)}us  ` +
+      `retained=${pad(String(Math.round(memBytes)), 10)} B\n`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Workload 1: top-k. item(score) order_by score desc limit 50.
+// ---------------------------------------------------------------------------
+function workloadTopk(n: number) {
+  const rows: Row[] = [];
+  for (let i = 0; i < n; i++) rows.push({id: i, score: i, body: 'x'});
+  const srcs = [
+    makeSrc(
+      'item',
+      {id: {type: 'number'}, score: {type: 'number'}, body: {type: 'string'}},
+      ['id'],
+      rows,
+    ),
+  ];
+  const ast: AST = {table: 'item', orderBy: [['score', 'desc']], limit: 50};
+  const format: Format = {singular: false, relationships: {}};
+
+  const retained = retainedPerView(srcs, ast, format, n);
+  const held = build(srcs, ast, format);
+  if (rowCount(held) === 0) throw new Error('topk hydration empty');
+
+  // maintenance: push a new max (enters the top-50 window), then undo (untimed).
+  const item = held.sources.item;
+  let next = n + 1;
+  const maint = benchMin(() => {
+    const row = {id: next, score: next, body: 'm'};
+    const t = process.hrtime.bigint();
+    consume(item.push(makeSourceChangeAdd(row)));
+    held.view.flush();
+    const ns = Number(process.hrtime.bigint() - t);
+    const top = (held.view.data as {score: number}[])[0];
+    if (top.score !== next) throw new Error('topk: new max not at top');
+    consume(item.push(makeSourceChangeRemove(row)));
+    held.view.flush();
+    next++;
+    return ns;
+  });
+
+  // hydration: fork + build + hydrate to first full result each op.
+  const hyd = benchMin(() => {
+    const t = process.hrtime.bigint();
+    const b = build(srcs, ast, format);
+    const r = rowCount(b);
+    const ns = Number(process.hrtime.bigint() - t);
+    if (r === 0) throw new Error('topk hydration empty');
+    blackBox(r);
+    return ns;
+  });
+
+  report('topk', n, hyd, maint, retained);
+}
+
+// ---------------------------------------------------------------------------
+// Workload 2: filtered top-k.
+// item(kind,score) where kind=1 order_by score desc limit 50.
+// ---------------------------------------------------------------------------
+function workloadFilteredTopk(n: number) {
+  const rows: Row[] = [];
+  for (let i = 0; i < n; i++)
+    rows.push({id: i, kind: i % 2, score: i, body: 'x'});
+  const srcs = [
+    makeSrc(
+      'item',
+      {
+        id: {type: 'number'},
+        kind: {type: 'number'},
+        score: {type: 'number'},
+        body: {type: 'string'},
+      },
+      ['id'],
+      rows,
+    ),
+  ];
+  const ast: AST = {
+    table: 'item',
+    where: {
+      type: 'simple',
+      left: {type: 'column', name: 'kind'},
+      op: '=',
+      right: {type: 'literal', value: 1},
+    },
+    orderBy: [['score', 'desc']],
+    limit: 50,
+  };
+  const format: Format = {singular: false, relationships: {}};
+
+  const retained = retainedPerView(srcs, ast, format, n);
+  const held = build(srcs, ast, format);
+  if (rowCount(held) === 0) throw new Error('filtered_topk hydration empty');
+
+  const item = held.sources.item;
+  let next = n + 1;
+  const maint = benchMin(() => {
+    const row = {id: next, kind: 1, score: next, body: 'm'};
+    const t = process.hrtime.bigint();
+    consume(item.push(makeSourceChangeAdd(row)));
+    held.view.flush();
+    const ns = Number(process.hrtime.bigint() - t);
+    const top = (held.view.data as {score: number}[])[0];
+    if (top.score !== next)
+      throw new Error('filtered_topk: new max not at top');
+    consume(item.push(makeSourceChangeRemove(row)));
+    held.view.flush();
+    next++;
+    return ns;
+  });
+
+  const hyd = benchMin(() => {
+    const t = process.hrtime.bigint();
+    const b = build(srcs, ast, format);
+    const r = rowCount(b);
+    const ns = Number(process.hrtime.bigint() - t);
+    if (r === 0) throw new Error('filtered_topk hydration empty');
+    blackBox(r);
+    return ns;
+  });
+
+  report('filtered_topk', n, hyd, maint, retained);
+}
+
+// ---------------------------------------------------------------------------
+// Workload 3: 1:many join. n children joined to ~n/5 parents (child -> parent).
+// Top level is the child; each child materializes its one parent. No limit.
+// ---------------------------------------------------------------------------
+function workloadJoin(n: number) {
+  const numParents = Math.max(1, Math.floor(n / 5));
+  const parentRows: Row[] = [];
+  for (let i = 0; i < numParents; i++) parentRows.push({id: i, name: `p${i}`});
+  const childRows: Row[] = [];
+  for (let i = 0; i < n; i++)
+    childRows.push({id: i, parent_id: i % numParents, body: 'c'});
+
+  const srcs = [
+    makeSrc(
+      'child',
+      {
+        id: {type: 'number'},
+        parent_id: {type: 'number'},
+        body: {type: 'string'},
+      },
+      ['id'],
+      childRows,
+    ),
+    makeSrc(
+      'parent',
+      {id: {type: 'number'}, name: {type: 'string'}},
+      ['id'],
+      parentRows,
+    ),
+  ];
+
+  // child { parent: parent where parent.id == child.parent_id } — full 1:many
+  // join, every child materialized with its parent (no limit).
+  const ast: AST = {
+    table: 'child',
+    related: [
+      {
+        correlation: {parentField: ['parent_id'], childField: ['id']},
+        subquery: {table: 'parent', alias: 'parent'},
+      },
+    ],
+  };
+  const format: Format = {
+    singular: false,
+    relationships: {parent: {singular: false, relationships: {}}},
+  };
+
+  const retained = retainedPerView(srcs, ast, format, n);
+  const held = build(srcs, ast, format);
+  const baseline = rowCount(held);
+  if (baseline === 0) throw new Error('join hydration empty');
+
+  const child = held.sources.child;
+  let next = n + 1;
+  const maint = benchMin(() => {
+    const row = {id: next, parent_id: 0, body: 'm'};
+    const t = process.hrtime.bigint();
+    consume(child.push(makeSourceChangeAdd(row)));
+    held.view.flush();
+    const ns = Number(process.hrtime.bigint() - t);
+    if (rowCount(held) !== baseline + 1)
+      throw new Error('join: child not added');
+    consume(child.push(makeSourceChangeRemove(row)));
+    held.view.flush();
+    next++;
+    return ns;
+  });
+
+  const hyd = benchMin(() => {
+    const t = process.hrtime.bigint();
+    const b = build(srcs, ast, format);
+    const r = rowCount(b);
+    const ns = Number(process.hrtime.bigint() - t);
+    if (r === 0) throw new Error('join hydration empty');
+    blackBox(r);
+    return ns;
+  });
+
+  report('join', n, hyd, maint, retained);
+}
+
+function main() {
+  const scales = (process.env.ZQL_BENCH_SCALES ?? '1000,10000,100000')
+    .split(',')
+    .map(s => Number(s.trim()))
+    .filter(x => Number.isFinite(x) && x > 0);
+
+  process.stderr.write('== Zero ZQL in-memory IVM bench (MemorySource) ==\n');
+  for (const n of scales) {
+    workloadTopk(n);
+    workloadFilteredTopk(n);
+    workloadJoin(n);
+  }
+  blackBox(sink);
+}
+
+main();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -282,6 +282,37 @@ importers:
         specifier: ^4.1.6
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0))
 
+  apps/zero-throughput:
+    dependencies:
+      '@dotenvx/dotenvx':
+        specifier: ^1.39.0
+        version: 1.66.0
+      '@rocicorp/zero':
+        specifier: workspace:*
+        version: link:../../packages/zero
+      postgres:
+        specifier: 3.4.7
+        version: 3.4.7
+      ws:
+        specifier: ^8.18.1
+        version: 8.20.1
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.5
+        version: 22.19.19
+      '@types/ws':
+        specifier: ^8.5.12
+        version: 8.18.1
+      oxfmt:
+        specifier: ^0.45.0
+        version: 0.45.0
+      shared:
+        specifier: workspace:*
+        version: link:../../packages/shared
+      typescript:
+        specifier: ~6.0.2
+        version: 6.0.3
+
   apps/zql-viz:
     dependencies:
       '@monaco-editor/react':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -292,7 +292,7 @@ importers:
         version: link:../../packages/zero
       postgres:
         specifier: 3.4.7
-        version: 3.4.7
+        version: 3.4.7(patch_hash=2bd119d361250d5ee010b23af4c98504e9c6861b692d2e2ae23b9a9e5de4dbce)
       ws:
         specifier: ^8.18.1
         version: 8.20.1
@@ -312,6 +312,15 @@ importers:
       typescript:
         specifier: ~6.0.2
         version: 6.0.3
+      zero-protocol:
+        specifier: workspace:*
+        version: link:../../packages/zero-protocol
+      zero-schema:
+        specifier: workspace:*
+        version: link:../../packages/zero-schema
+      zql:
+        specifier: workspace:*
+        version: link:../../packages/zql
 
   apps/zql-viz:
     dependencies:
@@ -1597,6 +1606,9 @@ importers:
       nanoid:
         specifier: ^5.1.2
         version: 5.1.11
+      otel:
+        specifier: workspace:*
+        version: link:../otel
       oxfmt:
         specifier: ^0.45.0
         version: 0.45.0


### PR DESCRIPTION
Measure full E2E throughput from PG -> ReplicationManager -> ViewSyncer -> Client


```
pnpm --filter zero-throughput start -- \
    --profile relational \
    --users 100 \
    --queries-per-user 3 \
    --rows-per-query 50 \
    --write-rate 25 \
    --duration-ms 60000 \
    --zero-num-sync-workers 1 \
    --output results/relational-100u-3q-25wps-1syncer.json
```



Note that the "WPS" here are writes that impact every query being viewed. Not writes that are un-observed by queries. We should measure the latter too.

## Param Sweep

<img width="508" height="344" alt="Screenshot 2026-06-30 at 10 21 20 PM" src="https://github.com/user-attachments/assets/27c0c299-8559-484e-81f6-f5979df1dc2c" />

