### PR TITLE
fix(react native): support op-sqlite v17

### DIFF
--- a/packages/replicache/src/kv/op-sqlite/store.test.node.ts
+++ b/packages/replicache/src/kv/op-sqlite/store.test.node.ts
@@ -29,34 +29,26 @@ vi.mock('@op-engineering/op-sqlite', () => {
       // Create a new database connection - SQLite handles file locking and concurrency
       const db = sqlite3(filename);
 
+      // Mimic op-sqlite `>=17` executeRaw shape: `{rawRows, ...}`. See `RawResult`.
+      const exec = (sql: string, params: string[] = []) => {
+        const stmt = db.prepare(sql);
+        let rawRows: unknown[][] = [];
+        if (/^\s*select/i.test(sql)) {
+          const result = stmt.all(...params);
+          rawRows = Array.isArray(result)
+            ? result.map(row => Object.values(row as Record<string, unknown>))
+            : [];
+        } else {
+          stmt.run(...params);
+        }
+        return {rowsAffected: 0, insertId: 0, rawRows, columnNames: []};
+      };
+
       return {
         // oxlint-disable-next-line require-await
-        executeRaw: async (sql: string, params: string[] = []) => {
-          const stmt = db.prepare(sql);
-          const isSelectQuery = /^\s*select/i.test(sql);
-          if (isSelectQuery) {
-            const result = stmt.all(...params);
-            // Convert to raw format (array of arrays)
-            return Array.isArray(result)
-              ? result.map(row => Object.values(row as Record<string, unknown>))
-              : [];
-          }
-          stmt.run(...params);
-          return [];
-        },
-        executeRawSync: (sql: string, params: string[] = []) => {
-          const stmt = db.prepare(sql);
-          const isSelectQuery = /^\s*select/i.test(sql);
-          if (isSelectQuery) {
-            const result = stmt.all(...params);
-            // Convert to raw format (array of arrays)
-            return Array.isArray(result)
-              ? result.map(row => Object.values(row as Record<string, unknown>))
-              : [];
-          }
-          stmt.run(...params);
-          return [];
-        },
+        executeRaw: async (sql: string, params: string[] = []) =>
+          exec(sql, params),
+        executeRawSync: exec,
         close: () => {
           // SQLite handles this properly, just close the connection
           db.close();

--- a/packages/replicache/src/kv/op-sqlite/store.ts
+++ b/packages/replicache/src/kv/op-sqlite/store.ts
@@ -5,7 +5,7 @@ import type {
 } from '../sqlite-store.ts';
 import {dropStore, SQLiteStore} from '../sqlite-store.ts';
 import type {StoreProvider} from '../store.ts';
-import {open, type DB} from './types.ts';
+import {open, rawResultRows, type DB} from './types.ts';
 
 export type OpSQLiteStoreOptions = SQLiteStoreOptions & {
   // OpSQLite-specific options
@@ -57,8 +57,8 @@ class OpSQLitePreparedStatement implements PreparedStatement {
     await this.#db.executeRaw(this.#sql, params);
   }
 
-  all(params: string[]): Promise<unknown[][]> {
-    return this.#db.executeRaw(this.#sql, params);
+  async all(params: string[]): Promise<unknown[][]> {
+    return rawResultRows(await this.#db.executeRaw(this.#sql, params));
   }
 }
 

--- a/packages/replicache/src/kv/op-sqlite/types.ts
+++ b/packages/replicache/src/kv/op-sqlite/types.ts
@@ -3,13 +3,35 @@
 
 import {open as openDB} from '@op-engineering/op-sqlite';
 
+/**
+ * Result of `executeRaw`/`executeRawSync`. op-sqlite changed this shape in
+ * v17.0.0 (commit `4cd58b8`): `<=16` returned a bare array of row arrays, `>=17`
+ * returns `{rowsAffected, insertId, rawRows, columnNames}` with rows under
+ * `rawRows`. The peer range is `>=15`, so both shapes must be handled.
+ */
+export type RawResult =
+  | unknown[][]
+  | {
+      rawRows?: unknown[][];
+      columnNames?: unknown[];
+      rowsAffected?: number;
+      insertId?: number;
+    };
+
+/** Extracts the row arrays from either {@link RawResult} shape. */
+export function rawResultRows(result: RawResult): unknown[][] {
+  return (
+    Array.isArray(result) ? result : (result.rawRows ?? [])
+  ) as unknown[][];
+}
+
 // Minimal type definitions for @op-engineering/op-sqlite
 // These types are used as fallback since imports have module resolution issues
 export interface DB {
   close: () => void;
   delete: (location?: string) => void;
-  executeRaw: (query: string, params?: string[]) => Promise<string[][]>;
-  executeRawSync: (query: string, params?: string[]) => string[][];
+  executeRaw: (query: string, params?: string[]) => Promise<RawResult>;
+  executeRawSync: (query: string, params?: string[]) => RawResult;
 }
 
 export type OpenFunction = (params: {


### PR DESCRIPTION
op-sqlite v17.0.0 changed `executeRaw`/`executeRawSync` to resolve to `{rowsAffected, insertId, rawRows, columnNames}` instead of a bare array of row arrays. The op-sqlite KV adapter forwarded that result directly, so the get/has batching in `SQLiteStore` (`new Map(rows)`, `rows.map`) iterated a plain object and threw "iterator method is not callable", crashing reads at startup. Add a `RawResult` type and `rawResultRows()` helper that handle both the <=16 (bare array) and >=17 ({rawRows}) shapes, and use it in `OpSQLitePreparedStatement.all()`. Update the test mock to emit the v17 shape so the regression stays covered.