### PR TITLE
chore(zero-cache): simple covering algo + log impact

### DIFF
--- a/packages/zero-cache/src/config/zero-config.test.ts
+++ b/packages/zero-cache/src/config/zero-config.test.ts
@@ -248,6 +248,15 @@ test('zero-cache --help', () => {
                                                                                                                                                                                                    
                                                                         You can disable the planner if it is picking bad strategies.                                                               
                                                                                                                                                                                                    
+     --enable-query-covering boolean                                    default: true                                                                                                              
+       ZERO_ENABLE_QUERY_COVERING env                                                                                                                                                              
+                                                                        Enable shadow-mode query covering detection during query hydration.                                                        
+                                                                                                                                                                                                   
+                                                                        When enabled, view-syncers compare newly hydrated queries against running                                                  
+                                                                        queries with the same root table and log aggregate coverage stats.                                                         
+                                                                                                                                                                                                   
+                                                                        You can disable this if covering detection adds too much CPU overhead.                                                     
+                                                                                                                                                                                                   
      --yield-threshold-ms number                                        default: 10                                                                                                                
        ZERO_YIELD_THRESHOLD_MS env                                                                                                                                                                 
                                                                         The maximum amount of time in milliseconds that a sync worker will                                                         
@@ -773,6 +782,17 @@ test.each([['isok'], ['has_underscores'], ['1'], ['123']])(
     expect(config.app.id).toBe(appID);
   },
 );
+
+test('--enable-query-covering can be disabled', () => {
+  const {config} = parseOptionsAdvanced(zeroOptions, {
+    argv: ['--enable-query-covering', 'false'],
+    envNamePrefix: 'ZERO_',
+    allowUnknown: false,
+    allowPartial: true,
+  });
+
+  expect(config.enableQueryCovering).toBe(false);
+});
 
 test('--shard-id disallowed', () => {
   const logger = {info: vi.fn()};

--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -488,6 +488,18 @@ export const zeroOptions = {
     ],
   },
 
+  enableQueryCovering: {
+    type: v.boolean().default(true),
+    desc: [
+      `Enable shadow-mode query covering detection during query hydration.`,
+      ``,
+      `When enabled, view-syncers compare newly hydrated queries against running`,
+      `queries with the same root table and log aggregate coverage stats.`,
+      ``,
+      `You can disable this if covering detection adds too much CPU overhead.`,
+    ],
+  },
+
   yieldThresholdMs: {
     type: v.number().default(10),
     desc: [

--- a/packages/zero-cache/src/services/view-syncer/query-covering.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/query-covering.test.ts
@@ -4,7 +4,11 @@ import type {
   Condition,
   CorrelatedSubquery,
 } from '../../../../zero-protocol/src/ast.ts';
-import {findCoveringQuery, isQueryCoveredBy} from './query-covering.ts';
+import {
+  findCoveringQuery,
+  isQueryCoveredBy,
+  QueryCoveringIndex,
+} from './query-covering.ts';
 
 const allIssues: AST = {
   table: 'issues',
@@ -181,6 +185,23 @@ test('not exists coverage reverses subquery implication', () => {
   expect(isQueryCoveredBy(noHelloComments, noComments)).toBe(false);
 });
 
+test('correlated subquery flip does not affect coverage semantics', () => {
+  const unflipped: AST = where({
+    type: 'correlatedSubquery',
+    op: 'EXISTS',
+    related: commentsRelated(allComments),
+  });
+  const flipped: AST = where({
+    type: 'correlatedSubquery',
+    op: 'EXISTS',
+    flip: true,
+    related: commentsRelated(allComments),
+  });
+
+  expect(isQueryCoveredBy(unflipped, flipped)).toBe(true);
+  expect(isQueryCoveredBy(flipped, unflipped)).toBe(true);
+});
+
 test('findCoveringQuery returns the first active covering query', () => {
   const running = new Map([
     [
@@ -207,4 +228,60 @@ test('findCoveringQuery returns the first active covering query', () => {
       queryName: 'allIssues',
     },
   );
+});
+
+test('QueryCoveringIndex only considers matching root queries', () => {
+  const index = new QueryCoveringIndex(
+    new Map([
+      [
+        'query-1',
+        {
+          transformedAst: allComments,
+          transformationHash: 'hash-1',
+        },
+      ],
+    ]),
+  );
+
+  expect(index.findCoveringQuery('query-2', where(eq('id', '123')))).toBe(
+    undefined,
+  );
+});
+
+test('QueryCoveringIndex can be updated during a hydration batch', () => {
+  const index = new QueryCoveringIndex();
+
+  expect(index.findCoveringQuery('query-2', where(eq('id', '123')))).toBe(
+    undefined,
+  );
+
+  index.add('query-1', {
+    transformedAst: allIssues,
+    transformationHash: 'hash-1',
+  });
+
+  expect(index.findCoveringQuery('query-2', where(eq('id', '123')))).toEqual({
+    queryID: 'query-1',
+    transformationHash: 'hash-1',
+  });
+});
+
+test('QueryCoveringIndex replaces a query when its root changes', () => {
+  const index = new QueryCoveringIndex();
+  index.add('query-1', {
+    transformedAst: allIssues,
+    transformationHash: 'issues-hash',
+  });
+  index.add('query-1', {
+    transformedAst: allComments,
+    transformationHash: 'comments-hash',
+  });
+
+  expect(index.findCoveringQuery('query-2', where(eq('id', '123')))).toBe(
+    undefined,
+  );
+  expect(index.findCoveringQuery('query-2', allComments)).toEqual({
+    queryID: 'query-1',
+    transformationHash: 'comments-hash',
+  });
 });

--- a/packages/zero-cache/src/services/view-syncer/query-covering.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/query-covering.test.ts
@@ -1,0 +1,210 @@
+import {expect, test} from 'vitest';
+import type {
+  AST,
+  Condition,
+  CorrelatedSubquery,
+} from '../../../../zero-protocol/src/ast.ts';
+import {findCoveringQuery, isQueryCoveredBy} from './query-covering.ts';
+
+const allIssues: AST = {
+  table: 'issues',
+  orderBy: [['id', 'asc']],
+};
+
+const allComments: AST = {
+  table: 'comments',
+  orderBy: [['id', 'asc']],
+};
+
+function where(condition: Condition): AST {
+  return {
+    ...allIssues,
+    where: condition,
+  };
+}
+
+function eq(column: string, value: string | number): Condition {
+  return {
+    type: 'simple',
+    left: {type: 'column', name: column},
+    op: '=',
+    right: {type: 'literal', value},
+  };
+}
+
+function gt(column: string, value: number): Condition {
+  return {
+    type: 'simple',
+    left: {type: 'column', name: column},
+    op: '>',
+    right: {type: 'literal', value},
+  };
+}
+
+function and(...conditions: Condition[]): Condition {
+  return {
+    type: 'and',
+    conditions,
+  };
+}
+
+function or(...conditions: Condition[]): Condition {
+  return {
+    type: 'or',
+    conditions,
+  };
+}
+
+function commentsRelated(subquery: AST): CorrelatedSubquery {
+  return {
+    system: 'client',
+    correlation: {
+      parentField: ['id'],
+      childField: ['issueID'],
+    },
+    subquery: {
+      ...subquery,
+      alias: 'comments',
+    },
+  };
+}
+
+test('same query covers itself', () => {
+  expect(isQueryCoveredBy(where(eq('id', '123')), where(eq('id', '123')))).toBe(
+    true,
+  );
+});
+
+test('unfiltered query covers filtered query on the same table', () => {
+  expect(isQueryCoveredBy(where(eq('id', '123')), allIssues)).toBe(true);
+});
+
+test('filter conjunction is covered by a subset of its filters', () => {
+  const covered = where(and(eq('status', 'open'), eq('owner', 'alice')));
+  const covering = where(eq('status', 'open'));
+
+  expect(isQueryCoveredBy(covered, covering)).toBe(true);
+  expect(isQueryCoveredBy(covering, covered)).toBe(false);
+});
+
+test('simple equality and range implication are recognized', () => {
+  expect(
+    isQueryCoveredBy(
+      where(eq('id', '1')),
+      where({
+        type: 'simple',
+        left: {type: 'column', name: 'id'},
+        op: 'IN',
+        right: {type: 'literal', value: ['1', '2']},
+      }),
+    ),
+  ).toBe(true);
+
+  expect(
+    isQueryCoveredBy(where(gt('priority', 5)), where(gt('priority', 3))),
+  ).toBe(true);
+});
+
+test('or coverage is conservative but detects disjunct coverage', () => {
+  const bug = eq('type', 'bug');
+  const feature = eq('type', 'feature');
+
+  expect(isQueryCoveredBy(where(bug), where(or(bug, feature)))).toBe(true);
+  expect(isQueryCoveredBy(where(or(bug, feature)), where(bug))).toBe(false);
+});
+
+test('unlimited covering query covers limited and paged covered query', () => {
+  const covered: AST = {
+    ...where(eq('status', 'open')),
+    limit: 10,
+    start: {
+      row: {id: 'abc'},
+      exclusive: true,
+    },
+  };
+
+  expect(isQueryCoveredBy(covered, allIssues)).toBe(true);
+});
+
+test('limited covering query must have equivalent input and a large enough limit', () => {
+  const covered: AST = {
+    ...where(eq('status', 'open')),
+    limit: 10,
+  };
+  const sameInputLargerLimit: AST = {
+    ...where(eq('status', 'open')),
+    limit: 20,
+  };
+  const broaderInputSameLimit: AST = {
+    ...allIssues,
+    limit: 10,
+  };
+
+  expect(isQueryCoveredBy(covered, sameInputLargerLimit)).toBe(true);
+  expect(isQueryCoveredBy(covered, broaderInputSameLimit)).toBe(false);
+});
+
+test('related query coverage is recursive', () => {
+  const commentsWithText: AST = {
+    ...allComments,
+    where: eq('text', 'hello'),
+  };
+  const covered: AST = {
+    ...where(eq('status', 'open')),
+    related: [commentsRelated(commentsWithText)],
+  };
+  const covering: AST = {
+    ...allIssues,
+    related: [commentsRelated(allComments)],
+  };
+
+  expect(isQueryCoveredBy(covered, covering)).toBe(true);
+  expect(isQueryCoveredBy(covered, allIssues)).toBe(false);
+});
+
+test('not exists coverage reverses subquery implication', () => {
+  const noComments: AST = where({
+    type: 'correlatedSubquery',
+    op: 'NOT EXISTS',
+    related: commentsRelated(allComments),
+  });
+  const noHelloComments: AST = where({
+    type: 'correlatedSubquery',
+    op: 'NOT EXISTS',
+    related: commentsRelated({
+      ...allComments,
+      where: eq('text', 'hello'),
+    }),
+  });
+
+  expect(isQueryCoveredBy(noComments, noHelloComments)).toBe(true);
+  expect(isQueryCoveredBy(noHelloComments, noComments)).toBe(false);
+});
+
+test('findCoveringQuery returns the first active covering query', () => {
+  const running = new Map([
+    [
+      'query-1',
+      {
+        transformedAst: allComments,
+        transformationHash: 'hash-1',
+      },
+    ],
+    [
+      'query-2',
+      {
+        transformedAst: allIssues,
+        transformationHash: 'hash-2',
+        queryName: 'allIssues',
+      },
+    ],
+  ]);
+
+  expect(findCoveringQuery('query-3', where(eq('id', '123')), running)).toEqual(
+    {
+      queryID: 'query-2',
+      transformationHash: 'hash-2',
+      queryName: 'allIssues',
+    },
+  );
+});

--- a/packages/zero-cache/src/services/view-syncer/query-covering.ts
+++ b/packages/zero-cache/src/services/view-syncer/query-covering.ts
@@ -1,0 +1,377 @@
+import {
+  deepEqual,
+  type ReadonlyJSONValue,
+} from '../../../../shared/src/json.ts';
+import {
+  normalizeAST,
+  type AST,
+  type Condition,
+  type CorrelatedSubquery,
+  type CorrelatedSubqueryCondition,
+  type LiteralValue,
+  type SimpleCondition,
+} from '../../../../zero-protocol/src/ast.ts';
+
+export type RunningQuery = {
+  readonly transformedAst: AST;
+  readonly transformationHash: string;
+  readonly queryName?: string | undefined;
+};
+
+export type CoveringQuery = {
+  readonly queryID: string;
+  readonly transformationHash: string;
+  readonly queryName?: string | undefined;
+};
+
+type NormalizedAST = Required<AST>;
+type NonNullScalarLiteralValue = string | number | boolean;
+
+/**
+ * Returns true when every row that can be produced by `covered` is also
+ * produced by `covering`.
+ *
+ * This is intentionally conservative: unsupported cases return false rather
+ * than guessing. It is used for shadow logging only.
+ */
+export function isQueryCoveredBy(covered: AST, covering: AST): boolean {
+  return astCoveredBy(normalizeAST(covered), normalizeAST(covering));
+}
+
+export function findCoveringQuery(
+  coveredQueryID: string,
+  coveredAst: AST,
+  runningQueries: ReadonlyMap<string, RunningQuery>,
+): CoveringQuery | undefined {
+  for (const [queryID, query] of runningQueries) {
+    if (queryID === coveredQueryID) {
+      continue;
+    }
+    if (isQueryCoveredBy(coveredAst, query.transformedAst)) {
+      return {
+        queryID,
+        transformationHash: query.transformationHash,
+        ...(query.queryName !== undefined && {queryName: query.queryName}),
+      };
+    }
+  }
+  return undefined;
+}
+
+function astCoveredBy(
+  covered: NormalizedAST,
+  covering: NormalizedAST,
+): boolean {
+  return (
+    covered.schema === covering.schema &&
+    covered.table === covering.table &&
+    covered.alias === covering.alias &&
+    conditionImplies(covered.where, covering.where) &&
+    relatedCoveredBy(covered.related, covering.related) &&
+    boundsCoveredBy(covered, covering)
+  );
+}
+
+function boundsCoveredBy(
+  covered: NormalizedAST,
+  covering: NormalizedAST,
+): boolean {
+  if (covering.limit === undefined) {
+    if (covering.start === undefined) {
+      return true;
+    }
+    return (
+      jsonEqual(covered.start, covering.start) &&
+      jsonEqual(covered.orderBy, covering.orderBy)
+    );
+  }
+
+  if (covered.limit === undefined || covering.limit < covered.limit) {
+    return false;
+  }
+
+  // A limited broader query does not necessarily contain a limited narrower
+  // query. The ordered input to the limit must be equivalent.
+  return (
+    conditionEquivalent(covered.where, covering.where) &&
+    jsonEqual(covered.start, covering.start) &&
+    jsonEqual(covered.orderBy, covering.orderBy)
+  );
+}
+
+function relatedCoveredBy(
+  covered: readonly CorrelatedSubquery[] | undefined,
+  covering: readonly CorrelatedSubquery[] | undefined,
+): boolean {
+  if (covered === undefined || covered.length === 0) {
+    return true;
+  }
+  if (covering === undefined) {
+    return false;
+  }
+  return covered.every(coveredRelated =>
+    covering.some(
+      coveringRelated =>
+        sameRelatedEdge(coveredRelated, coveringRelated) &&
+        astCoveredBy(
+          coveredRelated.subquery as NormalizedAST,
+          coveringRelated.subquery as NormalizedAST,
+        ),
+    ),
+  );
+}
+
+function conditionEquivalent(
+  a: Condition | undefined,
+  b: Condition | undefined,
+): boolean {
+  return conditionImplies(a, b) && conditionImplies(b, a);
+}
+
+function conditionImplies(
+  covered: Condition | undefined,
+  covering: Condition | undefined,
+): boolean {
+  if (covering === undefined) {
+    return true;
+  }
+  if (covered === undefined) {
+    return false;
+  }
+  if (jsonEqual(covered, covering)) {
+    return true;
+  }
+
+  if (covered.type === 'or') {
+    return covered.conditions.every(c => conditionImplies(c, covering));
+  }
+  if (covering.type === 'or') {
+    return covering.conditions.some(c => conditionImplies(covered, c));
+  }
+  if (covering.type === 'and') {
+    return covering.conditions.every(c => conditionImplies(covered, c));
+  }
+  if (covered.type === 'and') {
+    return covered.conditions.some(c => conditionImplies(c, covering));
+  }
+  if (covered.type === 'simple' && covering.type === 'simple') {
+    return simpleConditionImplies(covered, covering);
+  }
+  if (
+    covered.type === 'correlatedSubquery' &&
+    covering.type === 'correlatedSubquery'
+  ) {
+    return correlatedConditionImplies(covered, covering);
+  }
+  return false;
+}
+
+function correlatedConditionImplies(
+  covered: CorrelatedSubqueryCondition,
+  covering: CorrelatedSubqueryCondition,
+): boolean {
+  if (
+    covered.op !== covering.op ||
+    covered.flip !== covering.flip ||
+    covered.scalar !== covering.scalar ||
+    !sameRelatedEdge(covered.related, covering.related)
+  ) {
+    return false;
+  }
+
+  if (covered.op === 'EXISTS') {
+    return astCoveredBy(
+      covered.related.subquery as NormalizedAST,
+      covering.related.subquery as NormalizedAST,
+    );
+  }
+
+  return astCoveredBy(
+    covering.related.subquery as NormalizedAST,
+    covered.related.subquery as NormalizedAST,
+  );
+}
+
+function sameRelatedEdge(
+  a: CorrelatedSubquery,
+  b: CorrelatedSubquery,
+): boolean {
+  return (
+    jsonEqual(a.correlation, b.correlation) &&
+    a.hidden === b.hidden &&
+    a.system === b.system &&
+    a.subquery.alias === b.subquery.alias
+  );
+}
+
+function simpleConditionImplies(
+  covered: SimpleCondition,
+  covering: SimpleCondition,
+): boolean {
+  const coveredParts = columnLiteralParts(covered);
+  const coveringParts = columnLiteralParts(covering);
+  if (!coveredParts || !coveringParts) {
+    return false;
+  }
+  if (coveredParts.column !== coveringParts.column) {
+    return false;
+  }
+
+  const {op: coveredOp, value: coveredValue} = coveredParts;
+  const {op: coveringOp, value: coveringValue} = coveringParts;
+
+  if (isEqualityOp(coveredOp) && isNonNullScalarLiteralValue(coveredValue)) {
+    return equalityImplies(coveredValue, coveringOp, coveringValue);
+  }
+
+  if (
+    coveredOp === 'IN' &&
+    coveringOp === 'IN' &&
+    Array.isArray(coveredValue) &&
+    Array.isArray(coveringValue)
+  ) {
+    return coveredValue.every(v => literalArrayIncludes(coveringValue, v));
+  }
+
+  if (isNumericOrderOp(coveredOp) && isNumericOrderOp(coveringOp)) {
+    return orderConditionImplies(
+      coveredOp,
+      coveredValue,
+      coveringOp,
+      coveringValue,
+    );
+  }
+
+  return false;
+}
+
+function equalityImplies(
+  value: NonNullScalarLiteralValue,
+  coveringOp: SimpleCondition['op'],
+  coveringValue: LiteralValue,
+): boolean {
+  switch (coveringOp) {
+    case '=':
+    case 'IS':
+      return jsonEqual(value, coveringValue);
+    case '!=':
+    case 'IS NOT':
+      return !jsonEqual(value, coveringValue);
+    case 'IN':
+      return (
+        Array.isArray(coveringValue) &&
+        literalArrayIncludes(coveringValue, value)
+      );
+    case '<':
+      return (
+        typeof value === 'number' &&
+        typeof coveringValue === 'number' &&
+        value < coveringValue
+      );
+    case '<=':
+      return (
+        typeof value === 'number' &&
+        typeof coveringValue === 'number' &&
+        value <= coveringValue
+      );
+    case '>':
+      return (
+        typeof value === 'number' &&
+        typeof coveringValue === 'number' &&
+        value > coveringValue
+      );
+    case '>=':
+      return (
+        typeof value === 'number' &&
+        typeof coveringValue === 'number' &&
+        value >= coveringValue
+      );
+    case 'NOT IN':
+    case 'LIKE':
+    case 'NOT LIKE':
+    case 'ILIKE':
+    case 'NOT ILIKE':
+      return false;
+  }
+}
+
+function orderConditionImplies(
+  coveredOp: '<' | '>' | '<=' | '>=',
+  coveredValue: LiteralValue,
+  coveringOp: '<' | '>' | '<=' | '>=',
+  coveringValue: LiteralValue,
+): boolean {
+  if (typeof coveredValue !== 'number' || typeof coveringValue !== 'number') {
+    return false;
+  }
+
+  switch (coveredOp) {
+    case '>':
+      return (
+        (coveringOp === '>' && coveredValue >= coveringValue) ||
+        (coveringOp === '>=' && coveredValue >= coveringValue)
+      );
+    case '>=':
+      return (
+        (coveringOp === '>' && coveredValue > coveringValue) ||
+        (coveringOp === '>=' && coveredValue >= coveringValue)
+      );
+    case '<':
+      return (
+        (coveringOp === '<' && coveredValue <= coveringValue) ||
+        (coveringOp === '<=' && coveredValue <= coveringValue)
+      );
+    case '<=':
+      return (
+        (coveringOp === '<' && coveredValue < coveringValue) ||
+        (coveringOp === '<=' && coveredValue <= coveringValue)
+      );
+  }
+}
+
+function columnLiteralParts(condition: SimpleCondition):
+  | {
+      readonly column: string;
+      readonly op: SimpleCondition['op'];
+      readonly value: LiteralValue;
+    }
+  | undefined {
+  if (condition.left.type !== 'column' || condition.right.type !== 'literal') {
+    return undefined;
+  }
+  return {
+    column: condition.left.name,
+    op: condition.op,
+    value: condition.right.value,
+  };
+}
+
+function isEqualityOp(op: SimpleCondition['op']): op is '=' | 'IS' {
+  return op === '=' || op === 'IS';
+}
+
+function isNumericOrderOp(
+  op: SimpleCondition['op'],
+): op is '<' | '>' | '<=' | '>=' {
+  return op === '<' || op === '>' || op === '<=' || op === '>=';
+}
+
+function isNonNullScalarLiteralValue(
+  value: LiteralValue,
+): value is NonNullScalarLiteralValue {
+  return value !== null && !Array.isArray(value);
+}
+
+function literalArrayIncludes(
+  values: ReadonlyArray<string | number | boolean>,
+  value: string | number | boolean | null,
+): boolean {
+  return values.some(v => jsonEqual(v, value));
+}
+
+function jsonEqual(a: unknown, b: unknown): boolean {
+  return deepEqual(
+    a as ReadonlyJSONValue | undefined,
+    b as ReadonlyJSONValue | undefined,
+  );
+}

--- a/packages/zero-cache/src/services/view-syncer/query-covering.ts
+++ b/packages/zero-cache/src/services/view-syncer/query-covering.ts
@@ -26,6 +26,9 @@ export type CoveringQuery = {
 
 type NormalizedAST = Required<AST>;
 type NonNullScalarLiteralValue = string | number | boolean;
+type IndexedRunningQuery = RunningQuery & {
+  readonly normalizedAst: NormalizedAST;
+};
 
 /**
  * Returns true when every row that can be produced by `covered` is also
@@ -43,19 +46,84 @@ export function findCoveringQuery(
   coveredAst: AST,
   runningQueries: ReadonlyMap<string, RunningQuery>,
 ): CoveringQuery | undefined {
-  for (const [queryID, query] of runningQueries) {
-    if (queryID === coveredQueryID) {
-      continue;
-    }
-    if (isQueryCoveredBy(coveredAst, query.transformedAst)) {
-      return {
-        queryID,
-        transformationHash: query.transformationHash,
-        ...(query.queryName !== undefined && {queryName: query.queryName}),
-      };
+  return new QueryCoveringIndex(runningQueries).findCoveringQuery(
+    coveredQueryID,
+    coveredAst,
+  );
+}
+
+export class QueryCoveringIndex {
+  readonly #byRoot = new Map<string, Map<string, IndexedRunningQuery>>();
+  readonly #queryIDToRoot = new Map<string, string>();
+
+  constructor(runningQueries?: ReadonlyMap<string, RunningQuery>) {
+    if (runningQueries) {
+      for (const [queryID, query] of runningQueries) {
+        this.add(queryID, query);
+      }
     }
   }
-  return undefined;
+
+  add(queryID: string, query: RunningQuery): void {
+    this.remove(queryID);
+
+    const normalizedAst = normalizeAST(query.transformedAst);
+    const root = rootKey(normalizedAst);
+    let queries = this.#byRoot.get(root);
+    if (!queries) {
+      queries = new Map();
+      this.#byRoot.set(root, queries);
+    }
+    queries.set(queryID, {...query, normalizedAst});
+    this.#queryIDToRoot.set(queryID, root);
+  }
+
+  remove(queryID: string): void {
+    const root = this.#queryIDToRoot.get(queryID);
+    if (root === undefined) {
+      return;
+    }
+
+    this.#queryIDToRoot.delete(queryID);
+    const queries = this.#byRoot.get(root);
+    if (!queries) {
+      return;
+    }
+
+    queries.delete(queryID);
+    if (queries.size === 0) {
+      this.#byRoot.delete(root);
+    }
+  }
+
+  findCoveringQuery(
+    coveredQueryID: string,
+    coveredAst: AST,
+  ): CoveringQuery | undefined {
+    const normalizedCoveredAst = normalizeAST(coveredAst);
+    const queries = this.#byRoot.get(rootKey(normalizedCoveredAst));
+    if (!queries) {
+      return undefined;
+    }
+
+    for (const [queryID, query] of queries) {
+      if (queryID === coveredQueryID) {
+        continue;
+      }
+      if (astCoveredBy(normalizedCoveredAst, query.normalizedAst)) {
+        return {
+          queryID,
+          transformationHash: query.transformationHash,
+          ...(query.queryName !== undefined && {queryName: query.queryName}),
+        };
+      }
+    }
+    return undefined;
+  }
+}
+
+function rootKey(ast: NormalizedAST): string {
+  return JSON.stringify([ast.schema, ast.table, ast.alias]);
 }
 
 function astCoveredBy(
@@ -172,7 +240,6 @@ function correlatedConditionImplies(
 ): boolean {
   if (
     covered.op !== covering.op ||
-    covered.flip !== covering.flip ||
     covered.scalar !== covering.scalar ||
     !sameRelatedEdge(covered.related, covering.related)
   ) {

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -90,7 +90,7 @@ import type {DrainCoordinator} from './drain-coordinator.ts';
 import {handleInspect} from './inspect-handler.ts';
 import type {PipelineDriver} from './pipeline-driver.ts';
 import {type RowChange} from './pipeline-driver.ts';
-import {findCoveringQuery} from './query-covering.ts';
+import {QueryCoveringIndex} from './query-covering.ts';
 import {parseSignature} from './row-set-signature.ts';
 import {
   cmpVersions,
@@ -1508,6 +1508,9 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     );
 
     const driftedQueryIDs = new Set<string>();
+    const queryCoveringIndex = new QueryCoveringIndex(
+      this.#pipelines.queries(),
+    );
     let totalHydratedQueries = 0;
     let coveredHydratedQueries = 0;
     let firstCoveredQuery: QueryCoverageShadowHit | undefined;
@@ -1520,6 +1523,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
       const query = cvr.queries[queryID];
       const queryName = query.type === 'custom' ? query.name : undefined;
       const covered = this.#findQueryCoverageShadowHit(
+        queryCoveringIndex,
         queryID,
         transformationHash,
         transformedAst,
@@ -1565,6 +1569,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
       this.#inspectorDelegate.addQuery(transformationHash, transformedAst);
       lc.debug?.(`hydrated ${count} rows for ${queryID} (${elapsed} ms)`);
 
+      let drifted = false;
       // Drift detection: compare the just-computed candidate signature against
       // the signature stored in the CVR. They should match for a deterministic
       // query at the same db state. A mismatch indicates a query containing
@@ -1592,7 +1597,16 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
           this.#rowSetSignatureDrifts.add(1);
           this.#pipelines.removeQuery(queryID);
           driftedQueryIDs.add(queryID);
+          drifted = true;
         }
+      }
+
+      if (!drifted) {
+        queryCoveringIndex.add(queryID, {
+          transformedAst,
+          transformationHash,
+          ...(queryName !== undefined && {queryName}),
+        });
       }
     }
 
@@ -1693,12 +1707,13 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
   }
 
   #findQueryCoverageShadowHit(
+    queryCoveringIndex: QueryCoveringIndex,
     queryID: string,
     transformationHash: string,
     ast: AST,
     queryName?: string | undefined,
   ): QueryCoverageShadowHit | undefined {
-    const covering = findCoveringQuery(queryID, ast, this.#pipelines.queries());
+    const covering = queryCoveringIndex.findCoveringQuery(queryID, ast);
     if (!covering) {
       return undefined;
     }
@@ -2128,6 +2143,9 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
       const pipelines = this.#pipelines;
       const hydrations = this.#hydrations;
       const hydrationTime = this.#hydrationTime;
+      const queryCoveringIndex = new QueryCoveringIndex(
+        this.#pipelines.queries(),
+      );
       let totalHydratedQueries = 0;
       let coveredHydratedQueries = 0;
       let firstCoveredQuery: QueryCoverageShadowHit | undefined;
@@ -2150,6 +2168,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
           queryLC.debug?.(`adding pipeline for query`, q.ast);
 
           const covered = self.#findQueryCoverageShadowHit(
+            queryCoveringIndex,
             q.id,
             q.transformationHash,
             q.ast,
@@ -2172,6 +2191,11 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
 
           self.#addQueryMaterializationServerMetric(q.id, elapsed);
           self.#inspectorDelegate.addQuery(q.id, q.ast);
+          queryCoveringIndex.add(q.id, {
+            transformedAst: q.ast,
+            transformationHash: q.transformationHash,
+            ...(q.name !== undefined && {queryName: q.name}),
+          });
 
           if (elapsed > slowHydrateThreshold) {
             queryLC.warn?.('Slow query materialization', elapsed, q.ast);

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -90,6 +90,7 @@ import type {DrainCoordinator} from './drain-coordinator.ts';
 import {handleInspect} from './inspect-handler.ts';
 import type {PipelineDriver} from './pipeline-driver.ts';
 import {type RowChange} from './pipeline-driver.ts';
+import {findCoveringQuery} from './query-covering.ts';
 import {parseSignature} from './row-set-signature.ts';
 import {
   cmpVersions,
@@ -1516,6 +1517,13 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
           if (queryName !== undefined) {
             span.setAttribute('queryName', queryName);
           }
+          this.#logCoveredQueryShadow(
+            lc,
+            queryID,
+            transformationHash,
+            transformedAst,
+            queryName,
+          );
           for (const change of this.#pipelines.addQuery(
             transformationHash,
             queryID,
@@ -1655,6 +1663,37 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
       'query-materialization-server',
       elapsed,
       queryID,
+    );
+  }
+
+  #logCoveredQueryShadow(
+    lc: LogContext,
+    queryID: string,
+    transformationHash: string,
+    ast: AST,
+    queryName?: string | undefined,
+  ) {
+    const covering = findCoveringQuery(queryID, ast, this.#pipelines.queries());
+    if (!covering) {
+      return;
+    }
+
+    let coverageLC = lc
+      .withContext('coveredQueryHash', queryID)
+      .withContext('coveredTransformationHash', transformationHash)
+      .withContext('coveringQueryHash', covering.queryID)
+      .withContext('coveringTransformationHash', covering.transformationHash);
+    if (queryName !== undefined) {
+      coverageLC = coverageLC.withContext('coveredQueryName', queryName);
+    }
+    if (covering.queryName !== undefined) {
+      coverageLC = coverageLC.withContext(
+        'coveringQueryName',
+        covering.queryName,
+      );
+    }
+    coverageLC.info?.(
+      'query coverage shadow: newly hydrated query is covered by a running query',
     );
   }
 
@@ -2030,6 +2069,13 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
           }
           queryLC.debug?.(`adding pipeline for query`, q.ast);
 
+          self.#logCoveredQueryShadow(
+            queryLC,
+            q.id,
+            q.transformationHash,
+            q.ast,
+            q.name,
+          );
           yield* pipelines.addQuery(
             q.transformationHash,
             q.id,

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -116,6 +116,17 @@ import {
 
 const PROTOCOL_VERSION_ATTR = 'protocol.version';
 
+type QueryCoverageHydrationPath = 'add' | 'hydrate-unchanged';
+
+type QueryCoverageShadowHit = {
+  readonly coveredQueryHash: string;
+  readonly coveredTransformationHash: string;
+  readonly coveredQueryName?: string | undefined;
+  readonly coveringQueryHash: string;
+  readonly coveringTransformationHash: string;
+  readonly coveringQueryName?: string | undefined;
+};
+
 export interface ViewSyncer {
   initConnection(
     selector: ConnectionSelector,
@@ -1497,6 +1508,9 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     );
 
     const driftedQueryIDs = new Set<string>();
+    let totalHydratedQueries = 0;
+    let coveredHydratedQueries = 0;
+    let firstCoveredQuery: QueryCoverageShadowHit | undefined;
 
     for (const {
       id: queryID,
@@ -1505,6 +1519,17 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     } of transformedQueries) {
       const query = cvr.queries[queryID];
       const queryName = query.type === 'custom' ? query.name : undefined;
+      const covered = this.#findQueryCoverageShadowHit(
+        queryID,
+        transformationHash,
+        transformedAst,
+        queryName,
+      );
+      totalHydratedQueries++;
+      if (covered) {
+        coveredHydratedQueries++;
+        firstCoveredQuery ??= covered;
+      }
       const timer = new TimeSliceTimer(lc);
       let count = 0;
       await startAsyncSpan(
@@ -1517,13 +1542,6 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
           if (queryName !== undefined) {
             span.setAttribute('queryName', queryName);
           }
-          this.#logCoveredQueryShadow(
-            lc,
-            queryID,
-            transformationHash,
-            transformedAst,
-            queryName,
-          );
           for (const change of this.#pipelines.addQuery(
             transformationHash,
             queryID,
@@ -1577,6 +1595,14 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
         }
       }
     }
+
+    this.#logQueryCoverageShadowSummary(
+      lc,
+      'hydrate-unchanged',
+      totalHydratedQueries,
+      coveredHydratedQueries,
+      firstCoveredQuery,
+    );
 
     return driftedQueryIDs;
   }
@@ -1666,35 +1692,86 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     );
   }
 
-  #logCoveredQueryShadow(
-    lc: LogContext,
+  #findQueryCoverageShadowHit(
     queryID: string,
     transformationHash: string,
     ast: AST,
     queryName?: string | undefined,
-  ) {
+  ): QueryCoverageShadowHit | undefined {
     const covering = findCoveringQuery(queryID, ast, this.#pipelines.queries());
     if (!covering) {
+      return undefined;
+    }
+
+    return {
+      coveredQueryHash: queryID,
+      coveredTransformationHash: transformationHash,
+      ...(queryName !== undefined && {coveredQueryName: queryName}),
+      coveringQueryHash: covering.queryID,
+      coveringTransformationHash: covering.transformationHash,
+      ...(covering.queryName !== undefined && {
+        coveringQueryName: covering.queryName,
+      }),
+    };
+  }
+
+  #logQueryCoverageShadowSummary(
+    lc: LogContext,
+    hydrationPath: QueryCoverageHydrationPath,
+    totalHydratedQueries: number,
+    coveredHydratedQueries: number,
+    firstCoveredQuery: QueryCoverageShadowHit | undefined,
+  ) {
+    if (totalHydratedQueries === 0) {
       return;
     }
 
     let coverageLC = lc
-      .withContext('coveredQueryHash', queryID)
-      .withContext('coveredTransformationHash', transformationHash)
-      .withContext('coveringQueryHash', covering.queryID)
-      .withContext('coveringTransformationHash', covering.transformationHash);
-    if (queryName !== undefined) {
-      coverageLC = coverageLC.withContext('coveredQueryName', queryName);
-    }
-    if (covering.queryName !== undefined) {
-      coverageLC = coverageLC.withContext(
-        'coveringQueryName',
-        covering.queryName,
+      .withContext('appID', this.#shard.appID)
+      .withContext('shardNum', this.#shard.shardNum)
+      .withContext('clientGroupID', this.id)
+      .withContext('queryCoverageMode', 'shadow')
+      .withContext('hydrationPath', hydrationPath)
+      .withContext('totalHydratedQueries', totalHydratedQueries)
+      .withContext('coveredHydratedQueries', coveredHydratedQueries)
+      .withContext(
+        'uncoveredHydratedQueries',
+        totalHydratedQueries - coveredHydratedQueries,
       );
+
+    if (firstCoveredQuery) {
+      coverageLC = coverageLC
+        .withContext(
+          'firstCoveredQueryHash',
+          firstCoveredQuery.coveredQueryHash,
+        )
+        .withContext(
+          'firstCoveredTransformationHash',
+          firstCoveredQuery.coveredTransformationHash,
+        )
+        .withContext(
+          'firstCoveringQueryHash',
+          firstCoveredQuery.coveringQueryHash,
+        )
+        .withContext(
+          'firstCoveringTransformationHash',
+          firstCoveredQuery.coveringTransformationHash,
+        );
+      if (firstCoveredQuery.coveredQueryName !== undefined) {
+        coverageLC = coverageLC.withContext(
+          'firstCoveredQueryName',
+          firstCoveredQuery.coveredQueryName,
+        );
+      }
+      if (firstCoveredQuery.coveringQueryName !== undefined) {
+        coverageLC = coverageLC.withContext(
+          'firstCoveringQueryName',
+          firstCoveredQuery.coveringQueryName,
+        );
+      }
     }
-    coverageLC.info?.(
-      'query coverage shadow: newly hydrated query is covered by a running query',
-    );
+
+    coverageLC.info?.('query coverage shadow summary');
   }
 
   /**
@@ -2051,6 +2128,9 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
       const pipelines = this.#pipelines;
       const hydrations = this.#hydrations;
       const hydrationTime = this.#hydrationTime;
+      let totalHydratedQueries = 0;
+      let coveredHydratedQueries = 0;
+      let firstCoveredQuery: QueryCoverageShadowHit | undefined;
       // oxlint-disable-next-line @typescript-eslint/no-this-alias
       const self = this;
 
@@ -2069,13 +2149,17 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
           }
           queryLC.debug?.(`adding pipeline for query`, q.ast);
 
-          self.#logCoveredQueryShadow(
-            queryLC,
+          const covered = self.#findQueryCoverageShadowHit(
             q.id,
             q.transformationHash,
             q.ast,
             q.name,
           );
+          totalHydratedQueries++;
+          if (covered) {
+            coveredHydratedQueries++;
+            firstCoveredQuery ??= covered;
+          }
           yield* pipelines.addQuery(
             q.transformationHash,
             q.id,
@@ -2109,6 +2193,13 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
         generateRowChanges(this.#slowHydrateThreshold),
         updater,
         pokers,
+      );
+      this.#logQueryCoverageShadowSummary(
+        lc,
+        'add',
+        totalHydratedQueries,
+        coveredHydratedQueries,
+        firstCoveredQuery,
       );
 
       await startAsyncSpan(

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -1508,9 +1508,9 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     );
 
     const driftedQueryIDs = new Set<string>();
-    const queryCoveringIndex = new QueryCoveringIndex(
-      this.#pipelines.queries(),
-    );
+    const queryCoveringIndex = this.#config.enableQueryCovering
+      ? new QueryCoveringIndex(this.#pipelines.queries())
+      : undefined;
     let totalHydratedQueries = 0;
     let coveredHydratedQueries = 0;
     let firstCoveredQuery: QueryCoverageShadowHit | undefined;
@@ -1522,13 +1522,15 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     } of transformedQueries) {
       const query = cvr.queries[queryID];
       const queryName = query.type === 'custom' ? query.name : undefined;
-      const covered = this.#findQueryCoverageShadowHit(
-        queryCoveringIndex,
-        queryID,
-        transformationHash,
-        transformedAst,
-        queryName,
-      );
+      const covered = queryCoveringIndex
+        ? this.#findQueryCoverageShadowHit(
+            queryCoveringIndex,
+            queryID,
+            transformationHash,
+            transformedAst,
+            queryName,
+          )
+        : undefined;
       totalHydratedQueries++;
       if (covered) {
         coveredHydratedQueries++;
@@ -1601,7 +1603,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
         }
       }
 
-      if (!drifted) {
+      if (!drifted && queryCoveringIndex) {
         queryCoveringIndex.add(queryID, {
           transformedAst,
           transformationHash,
@@ -1737,7 +1739,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     coveredHydratedQueries: number,
     firstCoveredQuery: QueryCoverageShadowHit | undefined,
   ) {
-    if (totalHydratedQueries === 0) {
+    if (!this.#config.enableQueryCovering || totalHydratedQueries === 0) {
       return;
     }
 
@@ -2143,9 +2145,9 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
       const pipelines = this.#pipelines;
       const hydrations = this.#hydrations;
       const hydrationTime = this.#hydrationTime;
-      const queryCoveringIndex = new QueryCoveringIndex(
-        this.#pipelines.queries(),
-      );
+      const queryCoveringIndex = this.#config.enableQueryCovering
+        ? new QueryCoveringIndex(this.#pipelines.queries())
+        : undefined;
       let totalHydratedQueries = 0;
       let coveredHydratedQueries = 0;
       let firstCoveredQuery: QueryCoverageShadowHit | undefined;
@@ -2167,13 +2169,15 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
           }
           queryLC.debug?.(`adding pipeline for query`, q.ast);
 
-          const covered = self.#findQueryCoverageShadowHit(
-            queryCoveringIndex,
-            q.id,
-            q.transformationHash,
-            q.ast,
-            q.name,
-          );
+          const covered = queryCoveringIndex
+            ? self.#findQueryCoverageShadowHit(
+                queryCoveringIndex,
+                q.id,
+                q.transformationHash,
+                q.ast,
+                q.name,
+              )
+            : undefined;
           totalHydratedQueries++;
           if (covered) {
             coveredHydratedQueries++;
@@ -2191,7 +2195,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
 
           self.#addQueryMaterializationServerMetric(q.id, elapsed);
           self.#inspectorDelegate.addQuery(q.id, q.ast);
-          queryCoveringIndex.add(q.id, {
+          queryCoveringIndex?.add(q.id, {
             transformedAst: q.ast,
             transformationHash: q.transformationHash,
             ...(q.name !== undefined && {queryName: q.name}),


### PR DESCRIPTION
 # Query Covering Shadow Mode

  “Covering” detects when all results of one query are already contained in another running query.

  If query **B** covers query **A**, then every row A can return is also returned by B. In the current implementation this is used only for shadow logging; it
  does not change hydration behavior.

  ## Runtime Shape

  For each hydration batch, view-syncer builds an index of currently running queries keyed by normalized root:

  ```ts
  (schema, table, alias)

  For each newly hydrated query, we only compare against running queries with the same root. After each successful hydration in the batch, the new query is
  added to the index so later queries in the same batch can be covered by earlier ones.

  The summary log is:

  query coverage shadow summary

  with scalar context fields:

  queryCoverageMode = shadow
  hydrationPath = add | hydrate-unchanged
  totalHydratedQueries
  coveredHydratedQueries
  uncoveredHydratedQueries
  appID
  shardNum
  clientGroupID

  If there is at least one hit, the log also includes one representative covered/covering query hash pair.

  ## Conservative By Design

  The algorithm only returns covered when it can prove coverage from AST shape. Unsupported or ambiguous cases return false.

  It does not read rows, query SQLite, or inspect client state. It only compares transformed ASTs.

  ## Covered Examples

  ### Unfiltered Query Covers Filtered Query

  A: issues.where('id', '1')
  B: issues

  B covers A because B returns all issues.

  ### Equality Covered By IN

  A: issues.where('id', '1')
  B: issues.where('id', 'IN', ['1', '2', '3'])

  ### Stronger Conjunction Covered By Weaker Filter

  A: issues.where('status', 'open').where('owner', 'alice')
  B: issues.where('status', 'open')

  A’s result is a subset of B’s result.

  ### Numeric Range Implication

  A: issues.where('priority', '>', 5)
  B: issues.where('priority', '>', 3)

  Also similar cases like:

  A: issues.where('priority', '<', 5)
  B: issues.where('priority', '<=', 5)

  ### OR Coverage

  A: issues.where('type', 'bug')

  B: issues.where(({or}) =>
    or(
      q => q.where('type', 'bug'),
      q => q.where('type', 'feature'),
    ),
  )

  A is covered by one branch of B.

  For an OR query to be covered, every branch must be covered:

  A: issues.where(({or}) =>
    or(
      q => q.where('id', '1'),
      q => q.where('id', '2'),
    ),
  )

  B: issues.where('id', 'IN', ['1', '2', '3'])

  ## Limits And Starts

  Unlimited queries cover limited queries:

  A: issues.where('status', 'open').limit(10)
  B: issues.where('status', 'open')

  Same-basis windows are covered when the covering limit is larger:

  A: issues.where('status', 'open').start(cursor).limit(10)
  B: issues.where('status', 'open').start(cursor).limit(20)

  Same-basis means:

  same root
  same where semantics
  same orderBy
  same start
  B.limit >= A.limit

  A broader limited query does not necessarily cover a narrower limited query:

  A: issues.where('status', 'open').limit(10)
  B: issues.limit(100)

  This is not treated as covered because B’s limit may be consumed by rows that A would filter out.

  The algorithm also does not reason about relative cursor positions:

  A: issues.where('status', 'open').start(cursor10).limit(10)
  B: issues.where('status', 'open').start(cursor0).limit(100)

  This may be covered semantically, but is not detected today.

  ## Related Queries

  Related query coverage is recursive.

  A: issues
    .where('status', 'open')
    .related('comments', q => q.where('text', 'hello'))

  B: issues
    .related('comments', q => q)

  B covers A because:

  - B covers the root issue set.
  - B’s related comments query covers A’s narrower related comments query.

  Relationship edges must match by:

  correlation
  hidden
  system
  subquery alias

  ## EXISTS

  A: issues.whereExists('comments', q => q.where('text', 'hello'))
  B: issues.whereExists('comments', q => q)

  B covers A because any issue with a matching “hello” comment also has some comment.

  ## NOT EXISTS

  For NOT EXISTS, implication reverses inside the subquery.

  A: issues.whereNotExists('comments', q => q)
  B: issues.whereNotExists('comments', q => q.where('text', 'hello'))

  A is covered by B because if an issue has no comments at all, then it also has no comments whose text is hello.

  ## Flip

  flip does not affect semantic coverage.

  A flipped correlated subquery condition and an unflipped equivalent condition can cover each other.

  ## Not Detected Today

  These may be semantically valid in some cases, but the current algorithm intentionally does not infer them.

  ### Singleton IN As Equality

  A: issues.where('id', 'IN', ['1'])
  B: issues.where('id', '1')

  ### LIKE / ILIKE / NOT IN Reasoning

  A: issues.where('title', 'hello')
  B: issues.where('title', 'LIKE', 'h%')

  ### Cross-Root Coverage

  A: comments.where('id', '1')
  B: issues.related('comments', q => q)

  Different root table queries are not compared.

  ### Relative Window Coverage

  A: issues.start(cursor10).limit(10)
  B: issues.start(cursor0).limit(100)

  The algorithm only handles exact same start.

  ## Athena Metric

  Covered hydration percent can be computed from the summary logs:

  SELECT
    SUM(CAST(context.coveredHydratedQueries AS bigint)) AS covered,
    SUM(CAST(context.totalHydratedQueries AS bigint)) AS total,
    100.0 * SUM(CAST(context.coveredHydratedQueries AS double))
      / NULLIF(SUM(CAST(context.totalHydratedQueries AS double)), 0) AS covered_pct
  FROM logs
  WHERE message = 'query coverage shadow summary'
    AND context.queryCoverageMode = 'shadow';