### PR TITLE
fix(zqlite): make take start fetches seekable

### DIFF
--- a/packages/zqlite/src/query-builder.test.ts
+++ b/packages/zqlite/src/query-builder.test.ts
@@ -36,8 +36,9 @@ test('non-nullable cursor columns use range and equality operators without IS NU
     ),
   ).toMatchInlineSnapshot(`
     {
-      "text": "SELECT "id","name" FROM "issues" WHERE (("id" > ?) OR ("id" = ? AND "name" < ?)) ORDER BY "id" asc, "name" desc",
+      "text": "SELECT "id","name" FROM "issues" WHERE ("id" >= ? AND (("id" > ?) OR ("id" = ? AND "name" < ?))) ORDER BY "id" asc, "name" desc",
       "values": [
+        "issue-1",
         "issue-1",
         "issue-1",
         "z",
@@ -199,16 +200,62 @@ test('multiConstraints + constraint + start + reverse compose into a single WHER
     ),
   ).toMatchInlineSnapshot(`
     {
-      "text": "SELECT "id","org","rank" FROM "issues" WHERE "org" = ? AND "id" IN (?,?,?) AND (("rank" < ?)) ORDER BY "rank" desc",
+      "text": "SELECT "id","org","rank" FROM "issues" WHERE "org" = ? AND "id" IN (?,?,?) AND ("rank" <= ? AND (("rank" < ?))) ORDER BY "rank" desc",
       "values": [
         "acme",
         "i1",
         "i2",
         "i3",
         100,
+        100,
       ],
     }
   `);
+});
+
+test('start constraint adds a sargable leading-column bound', () => {
+  const columns = {
+    workspaceID: {type: 'string'},
+    a: {type: 'number'},
+    b: {type: 'number'},
+    c: {type: 'number'},
+  } as const satisfies Record<string, SchemaValue>;
+  const lc = createSilentLogContext();
+  const db = new Database(lc, ':memory:');
+  db.exec(`
+    CREATE TABLE activity (
+      workspaceID TEXT NOT NULL,
+      a INTEGER NOT NULL,
+      b INTEGER NOT NULL,
+      c INTEGER NOT NULL
+    );
+    CREATE INDEX activity_sort ON activity(workspaceID, a DESC, b ASC, c ASC);
+  `);
+
+  const {text, values} = format(
+    buildSelectQuery(
+      'activity',
+      columns,
+      {workspaceID: 'w1'},
+      undefined,
+      [
+        ['a', 'desc'],
+        ['b', 'asc'],
+        ['c', 'asc'],
+      ],
+      true,
+      {row: {a: 500, b: 123, c: 99}, basis: 'after'},
+    ),
+  );
+  const plan = db
+    .prepare(`EXPLAIN QUERY PLAN ${text} LIMIT 2`)
+    .all<{detail: string}>(...values)
+    .map(r => r.detail)
+    .join('\n');
+
+  expect(text).toContain(`"workspaceID" = ? AND ("a" >= ? AND (("a" > ?)`);
+  expect(plan).toMatch(/SEARCH activity USING (COVERING )?INDEX/);
+  expect(plan).toMatch(/workspaceID=\? AND a>\?/);
 });
 
 test('multiConstraintToSQL asserts on empty multiConstraint', () => {

--- a/packages/zqlite/src/query-builder.ts
+++ b/packages/zqlite/src/query-builder.ts
@@ -322,6 +322,22 @@ function nullableAwareRangeComparison(
     : sql`(${sql.ident(field)} IS NULL OR ${comparison})`;
 }
 
+function sargableLeadingStartBound(
+  field: string,
+  value: unknown,
+  operator: '>' | '<',
+  columnType: SchemaValue,
+): SQLQuery | undefined {
+  if (columnType.optional === true) {
+    return undefined;
+  }
+
+  const inclusiveOperator = operator === '>' ? '>=' : '<=';
+  return sql`${sql.ident(field)} ${sql.__dangerous__rawValue(
+    inclusiveOperator,
+  )} ${value}`;
+}
+
 /**
  * The ordering could be complex such as:
  * `ORDER BY a ASC, b DESC, c ASC`
@@ -346,6 +362,7 @@ function gatherStartConstraints(
 ): SQLQuery {
   const constraints: SQLQuery[] = [];
   const {row: from, basis} = start;
+  let leadingBound: SQLQuery | undefined;
 
   for (let i = 0; i < order.length; i++) {
     const group: SQLQuery[] = [];
@@ -356,6 +373,14 @@ function gatherStartConstraints(
         const constraintValue = toSQLiteType(from[iField], columnType.type);
         const operator =
           iDirection === 'asc' ? (reverse ? '<' : '>') : reverse ? '>' : '<';
+        if (i === 0) {
+          leadingBound = sargableLeadingStartBound(
+            iField,
+            constraintValue,
+            operator,
+            columnType,
+          );
+        }
         group.push(
           nullableAwareRangeComparison(
             iField,
@@ -387,5 +412,8 @@ function gatherStartConstraints(
     );
   }
 
-  return sql`(${sql.join(constraints, sql` OR `)})`;
+  const lexicographicStart = sql`(${sql.join(constraints, sql` OR `)})`;
+  return leadingBound === undefined
+    ? lexicographicStart
+    : sql`(${leadingBound} AND ${lexicographicStart})`;
 }


### PR DESCRIPTION
Take window maintenance fetches around its current boundary after adds, removes, and bound-moving edits. For ordered SQLite sources, that boundary is represented as a Start cursor and gatherStartConstraints lowers it into a lexicographic OR-of-ANDs predicate.

For a partitioned sort like workspaceID, a DESC, b ASC, c ASC, the old predicate was correct but planner-hostile: workspaceID = ? AND (a < ? OR (a = ? AND b > ?) OR (a = ? AND b = ? AND c > ?)). SQLite can choose to seek only to workspaceID=? and then walk the partition in order while filtering the OR. LIMIT 2 does not help when the boundary is near the far end of a large partition.

Add a redundant inclusive leading-column bound, such as a <= ? or a >= ?, before the disjunction when the leading sort column is non-nullable. Every OR branch already entails that bound, so it removes no rows, but it gives SQLite a simple index range to seek. Skip nullable leading columns because the NULL-aware lowering needs IS NULL semantics and a bare range bound is not sound there.

Add regression coverage for the emitted SQL and the SQLite EXPLAIN QUERY PLAN shape.