### PR TITLE
fix(zero): preserve __proto__ as user data

### DIFF
--- a/packages/shared/src/objects.test.ts
+++ b/packages/shared/src/objects.test.ts
@@ -1,8 +1,24 @@
 import {expect, test} from 'vitest';
-import {mapAllEntries, mapEntries, mapValues} from './objects.ts';
+import {
+  assignProperty,
+  mapAllEntries,
+  mapEntries,
+  mapValues,
+} from './objects.ts';
 
 // Use JSON.stringify in expectations to preserve / verify key order.
 const stringify = (o: unknown) => JSON.stringify(o, null, 2);
+
+const inputWithProtoKey = <T>(value: T): Record<string, T> => {
+  const input: Record<string, T> = {};
+  Object.defineProperty(input, '__proto__', {
+    value,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  });
+  return input;
+};
 
 test('mapValues', () => {
   const obj = {
@@ -21,6 +37,15 @@ test('mapValues', () => {
   `);
 });
 
+test('mapValues safely maps __proto__ as an own property', () => {
+  const mapped = mapValues(inputWithProtoKey('bar'), v => v.toUpperCase());
+
+  expect(Object.getPrototypeOf(mapped)).toBe(Object.prototype);
+  expect(Object.hasOwn(mapped, '__proto__')).toBe(true);
+  expect(mapped.__proto__).toBe('BAR');
+  expect(Object.keys(mapped)).toEqual(['__proto__']);
+});
+
 test('mapEntries', () => {
   const obj = {
     boo: 'doo',
@@ -35,6 +60,15 @@ test('mapEntries', () => {
       "baz": "bar"
     }"
   `);
+});
+
+test('mapEntries safely maps __proto__ as an own property', () => {
+  const mapped = mapEntries({foo: 'bar'}, () => ['__proto__', 'baz']);
+
+  expect(Object.getPrototypeOf(mapped)).toBe(Object.prototype);
+  expect(Object.hasOwn(mapped, '__proto__')).toBe(true);
+  expect(mapped.__proto__).toBe('baz');
+  expect(Object.keys(mapped)).toEqual(['__proto__']);
 });
 
 test('mapAllEntries', () => {
@@ -65,4 +99,23 @@ test('mapAllEntries', () => {
       "bar": "baz"
     }"
   `);
+});
+
+test('mapAllEntries safely maps __proto__ as an own property', () => {
+  const mapped = mapAllEntries({foo: 'bar'}, () => [['__proto__', 'baz']]);
+
+  expect(Object.getPrototypeOf(mapped)).toBe(Object.prototype);
+  expect(Object.hasOwn(mapped, '__proto__')).toBe(true);
+  expect(mapped.__proto__).toBe('baz');
+  expect(Object.keys(mapped)).toEqual(['__proto__']);
+});
+
+test('assignProperty safely assigns __proto__ as an own property', () => {
+  const target: Record<string, string> = {};
+
+  assignProperty(target, '__proto__', 'bar');
+
+  expect(Object.getPrototypeOf(target)).toBe(Object.prototype);
+  expect(Object.hasOwn(target, '__proto__')).toBe(true);
+  expect(target.__proto__).toBe('bar');
 });

--- a/packages/shared/src/objects.ts
+++ b/packages/shared/src/objects.ts
@@ -7,7 +7,6 @@ export function mapValues<T extends Record<string, unknown>, U>(
   };
 }
 
-
 export function defineOwnDataProperty<T>(
   object: object,
   key: string,
@@ -25,8 +24,8 @@ export function mapEntries<T, U>(
   input: Record<string, T>,
   mapper: (key: string, val: T) => [key: string, val: U],
 ): Record<string, U> {
-  // Direct assignment is faster than Object.fromEntries()
-  // https://github.com/rocicorp/mono/pull/3927#issuecomment-2706059475
+  // Defining output properties in place is faster than Object.fromEntries()
+  // and safely creates own data properties for keys like "__proto__".
   const output: Record<string, U> = {};
 
   // In chrome Object.entries is faster than for-in (13x) or Object.keys (15x)

--- a/packages/shared/src/objects.ts
+++ b/packages/shared/src/objects.ts
@@ -1,39 +1,55 @@
 export function mapValues<T extends Record<string, unknown>, U>(
   input: T,
-  mapper: (value: T[keyof T]) => U,
+  mapper: (value: T[keyof T], key: keyof T & string) => U,
 ): {[K in keyof T]: U} {
-  return mapEntries(input, (k, v) => [k, mapper(v as T[keyof T])]) as {
-    [K in keyof T]: U;
-  };
+  const output = {} as {[K in keyof T]: U};
+
+  for (const entry of Object.entries(input) as [
+    keyof T & string,
+    T[keyof T],
+  ][]) {
+    assignProperty(output, entry[0], mapper(entry[1], entry[0]));
+  }
+
+  return output;
 }
 
-export function defineOwnDataProperty<T>(
-  object: object,
-  key: string,
+/**
+ * Safe function of `[[Set]]`/assign that prevents invoking the legacy
+ * `__proto__` setter. This is used to avoid prototype pollution attacks.
+ */
+export function assignProperty<K extends string | number | symbol, T>(
+  object: Record<K, T>,
+  key: K,
   value: T,
 ): void {
-  Object.defineProperty(object, key, {
-    value,
-    writable: true,
-    enumerable: true,
-    configurable: true,
-  });
+  if (key === '__proto__') {
+    // Shadow the `__proto__` property on the object to prevent prototype
+    // pollution.
+    Object.defineProperty(object, key, {
+      value,
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
+    // fall through to the normal assignment to ensure that potentional Proxy
+    // traps are invoked.
+  }
+
+  object[key] = value;
 }
 
 export function mapEntries<T, U>(
   input: Record<string, T>,
   mapper: (key: string, val: T) => [key: string, val: U],
 ): Record<string, U> {
-  // Defining output properties in place is faster than Object.fromEntries()
-  // and safely creates own data properties for keys like "__proto__".
   const output: Record<string, U> = {};
 
-  // In chrome Object.entries is faster than for-in (13x) or Object.keys (15x)
-  // https://gist.github.com/arv/1b4e113724f6a14e2d4742bcc760d1fa
   for (const entry of Object.entries(input)) {
     const mapped = mapper(entry[0], entry[1]);
-    defineOwnDataProperty(output, mapped[0], mapped[1]);
+    assignProperty(output, mapped[0], mapped[1]);
   }
+
   return output;
 }
 
@@ -41,11 +57,11 @@ export function mapAllEntries<T, U>(
   input: Record<string, T>,
   mapper: (entries: [key: string, val: T][]) => [key: string, val: U][],
 ): Record<string, U> {
-  // Direct assignment is faster than Object.fromEntries()
-  // https://github.com/rocicorp/mono/pull/3927#issuecomment-2706059475
   const output: Record<string, U> = {};
-  for (const mapped of mapper(Object.entries(input))) {
-    defineOwnDataProperty(output, mapped[0], mapped[1]);
+
+  for (const [key, val] of mapper(Object.entries(input))) {
+    assignProperty(output, key, val);
   }
+
   return output;
 }

--- a/packages/shared/src/objects.ts
+++ b/packages/shared/src/objects.ts
@@ -7,6 +7,20 @@ export function mapValues<T extends Record<string, unknown>, U>(
   };
 }
 
+
+export function defineOwnDataProperty<T>(
+  object: object,
+  key: string,
+  value: T,
+): void {
+  Object.defineProperty(object, key, {
+    value,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  });
+}
+
 export function mapEntries<T, U>(
   input: Record<string, T>,
   mapper: (key: string, val: T) => [key: string, val: U],
@@ -19,7 +33,7 @@ export function mapEntries<T, U>(
   // https://gist.github.com/arv/1b4e113724f6a14e2d4742bcc760d1fa
   for (const entry of Object.entries(input)) {
     const mapped = mapper(entry[0], entry[1]);
-    output[mapped[0]] = mapped[1];
+    defineOwnDataProperty(output, mapped[0], mapped[1]);
   }
   return output;
 }
@@ -32,7 +46,7 @@ export function mapAllEntries<T, U>(
   // https://github.com/rocicorp/mono/pull/3927#issuecomment-2706059475
   const output: Record<string, U> = {};
   for (const mapped of mapper(Object.entries(input))) {
-    output[mapped[0]] = mapped[1];
+    defineOwnDataProperty(output, mapped[0], mapped[1]);
   }
   return output;
 }

--- a/packages/zero-client/src/client/crud.ts
+++ b/packages/zero-client/src/client/crud.ts
@@ -1,4 +1,4 @@
-import {defineOwnDataProperty} from '../../../shared/src/objects.ts';
+import {assignProperty, mapValues} from '../../../shared/src/objects.ts';
 import {promiseVoid} from '../../../shared/src/resolved-promises.ts';
 import type {MaybePromise} from '../../../shared/src/types.ts';
 import {
@@ -61,11 +61,9 @@ export function makeCRUDMutateBatch<const S extends Schema>(
 
   const mutateBatch = async <R>(body: (m: DBMutator<S>) => R): Promise<R> => {
     const ops: CRUDOp[] = [];
-    const m = {} as Record<string, unknown>;
-    for (const name of Object.keys(schema.tables)) {
-      defineOwnDataProperty(m, name, makeBatchCRUDMutate(name, schema, ops));
-    }
-
+    const m = mapValues(schema.tables, (_, name) =>
+      makeBatchCRUDMutate(name, schema, ops),
+    );
     const rv = await body(m as DBMutator<S>);
     await zeroCRUD({ops});
     return rv;
@@ -81,8 +79,8 @@ export function addTableCRUDProperties<TSchema extends Schema>(
 ): void {
   const {[CRUD_MUTATION_NAME]: zeroCRUD} = repMutate;
   for (const [name, tableSchema] of Object.entries(schema.tables)) {
-    defineOwnDataProperty(
-      mutate,
+    assignProperty(
+      mutate as Record<string, unknown>,
       name,
       makeEntityCRUDMutate(name, tableSchema.primaryKey, zeroCRUD),
     );

--- a/packages/zero-client/src/client/crud.ts
+++ b/packages/zero-client/src/client/crud.ts
@@ -1,3 +1,4 @@
+import {defineOwnDataProperty} from '../../../shared/src/objects.ts';
 import {promiseVoid} from '../../../shared/src/resolved-promises.ts';
 import type {MaybePromise} from '../../../shared/src/types.ts';
 import {
@@ -62,7 +63,7 @@ export function makeCRUDMutateBatch<const S extends Schema>(
     const ops: CRUDOp[] = [];
     const m = {} as Record<string, unknown>;
     for (const name of Object.keys(schema.tables)) {
-      m[name] = makeBatchCRUDMutate(name, schema, ops);
+      defineOwnDataProperty(m, name, makeBatchCRUDMutate(name, schema, ops));
     }
 
     const rv = await body(m as DBMutator<S>);
@@ -80,10 +81,10 @@ export function addTableCRUDProperties<TSchema extends Schema>(
 ): void {
   const {[CRUD_MUTATION_NAME]: zeroCRUD} = repMutate;
   for (const [name, tableSchema] of Object.entries(schema.tables)) {
-    (mutate as Record<string, unknown>)[name] = makeEntityCRUDMutate(
+    defineOwnDataProperty(
+      mutate,
       name,
-      tableSchema.primaryKey,
-      zeroCRUD,
+      makeEntityCRUDMutate(name, tableSchema.primaryKey, zeroCRUD),
     );
   }
 }

--- a/packages/zero-client/src/client/zero-mutate.test.ts
+++ b/packages/zero-client/src/client/zero-mutate.test.ts
@@ -179,6 +179,44 @@ describe('mutate', () => {
     // Runtime test: CRUD methods should work
     await z.mutate.issues.insert({id: '1', title: 'test'});
   });
+
+  test('legacy mutators preserve __proto__ table names', async () => {
+    const protoName = '__proto__' as const;
+    const schema = createSchema({
+      tables: [
+        table(protoName)
+          .columns({
+            id: string(),
+          })
+          .primaryKey('id'),
+      ],
+      enableLegacyMutators: true,
+    });
+
+    const z = zeroForTest({schema});
+    const mutate = z.mutate as unknown as Record<
+      string,
+      {insert(value: {id: string}): Promise<void>}
+    >;
+
+    expect(Object.getPrototypeOf(z.mutate)).toBe(Function.prototype);
+    expect(Object.hasOwn(z.mutate, protoName)).toBe(true);
+    expect(Object.getOwnPropertyDescriptor(z.mutate, protoName)?.value).toBe(
+      mutate[protoName],
+    );
+    expect(typeof mutate[protoName].insert).toBe('function');
+    await mutate[protoName].insert({id: '1'});
+
+    await z.mutateBatch?.(async m => {
+      const batchMutate = m as unknown as Record<
+        string,
+        {insert(value: {id: string}): Promise<void>}
+      >;
+      expect(Object.getPrototypeOf(m)).toBe(Object.prototype);
+      expect(Object.hasOwn(m, protoName)).toBe(true);
+      await batchMutate[protoName].insert({id: '2'});
+    });
+  });
 });
 
 describe('both legacy flags undefined (default behavior)', () => {

--- a/packages/zero-schema/src/builder/relationship-builder.ts
+++ b/packages/zero-schema/src/builder/relationship-builder.ts
@@ -1,4 +1,5 @@
 /* oxlint-disable @typescript-eslint/no-explicit-any */
+import {mapValues} from '../../../shared/src/objects.ts';
 import type {Relationship, TableSchema} from '../table-schema.ts';
 import type {TableBuilderWithColumns} from './table-builder.ts';
 
@@ -130,11 +131,14 @@ export function relationships<
     one: OneConnector<TSource>;
   }) => TRelationships,
 ): {name: TSource['name']; relationships: TRelationships} {
-  const relationships = cb({many, one} as any);
+  const relationships = mapValues(
+    cb({many, one} as any),
+    relationship => relationship,
+  );
 
   return {
     name: table.schema.name,
-    relationships,
+    relationships: relationships as TRelationships,
   };
 }
 

--- a/packages/zero-schema/src/builder/schema-builder.test.ts
+++ b/packages/zero-schema/src/builder/schema-builder.test.ts
@@ -593,6 +593,60 @@ test('schema with conflicting table names', () => {
   );
 });
 
+test('schema preserves __proto__ table, column, and relationship names', () => {
+  const protoName = '__proto__' as const;
+  const source = table(protoName)
+    .columns({
+      id: string(),
+      [protoName]: string(),
+    })
+    .primaryKey('id');
+  const relationshipSource = table('relationshipSource')
+    .columns({id: string()})
+    .primaryKey('id');
+  const dest = table('dest').columns({id: string()}).primaryKey('id');
+  const sourceRelationships = relationships(relationshipSource, ({one}) => ({
+    [protoName]: one({
+      sourceField: ['id'],
+      destField: ['id'],
+      destSchema: dest,
+    }),
+  }));
+
+  const schema = createSchema({
+    tables: [source, relationshipSource, dest],
+    relationships: [sourceRelationships],
+  });
+
+  expect(Object.getPrototypeOf(schema.tables)).toBe(Object.prototype);
+  expect(Object.hasOwn(schema.tables, protoName)).toBe(true);
+  expect(schema.tables[protoName].name).toBe(protoName);
+  expect(Object.getPrototypeOf(schema.tables[protoName].columns)).toBe(
+    Object.prototype,
+  );
+  expect(Object.hasOwn(schema.tables[protoName].columns, protoName)).toBe(true);
+  expect(Object.getPrototypeOf(schema.relationships)).toBe(Object.prototype);
+  expect(Object.getPrototypeOf(schema.relationships.relationshipSource)).toBe(
+    Object.prototype,
+  );
+  expect(
+    Object.hasOwn(schema.relationships.relationshipSource, protoName),
+  ).toBe(true);
+  expect(schema.relationships.relationshipSource[protoName][0].destSchema).toBe(
+    'dest',
+  );
+
+  const {clientSchema} = clientSchemaFrom(schema);
+  expect(Object.getPrototypeOf(clientSchema.tables)).toBe(Object.prototype);
+  expect(Object.hasOwn(clientSchema.tables, protoName)).toBe(true);
+  expect(Object.getPrototypeOf(clientSchema.tables[protoName].columns)).toBe(
+    Object.prototype,
+  );
+  expect(Object.hasOwn(clientSchema.tables[protoName].columns, protoName)).toBe(
+    true,
+  );
+});
+
 // Use JSON.stringify in expectations to preserve / verify key order.
 const stringify = (o: unknown) => JSON.stringify(o, null, 2);
 

--- a/packages/zero-schema/src/builder/schema-builder.ts
+++ b/packages/zero-schema/src/builder/schema-builder.ts
@@ -1,9 +1,6 @@
 /* oxlint-disable @typescript-eslint/no-explicit-any */
 import {h64} from '../../../shared/src/hash.ts';
-import {
-  defineOwnDataProperty,
-  mapEntries,
-} from '../../../shared/src/objects.ts';
+import {assignProperty, mapEntries} from '../../../shared/src/objects.ts';
 import {
   normalizeClientSchema,
   type ClientSchema,
@@ -67,7 +64,7 @@ export function createSchema<
         `Table "${table.schema.name}" is defined more than once in the schema`,
       );
     }
-    defineOwnDataProperty(retTables, table.schema.name, table.build());
+    assignProperty(retTables, table.schema.name, table.build());
   });
   options.relationships?.forEach(relationships => {
     if (Object.hasOwn(retRelationships, relationships.name)) {
@@ -75,7 +72,7 @@ export function createSchema<
         `Relationships for table "${relationships.name}" are defined more than once in the schema`,
       );
     }
-    defineOwnDataProperty(
+    assignProperty(
       retRelationships,
       relationships.name,
       relationships.relationships,

--- a/packages/zero-schema/src/builder/schema-builder.ts
+++ b/packages/zero-schema/src/builder/schema-builder.ts
@@ -1,6 +1,9 @@
 /* oxlint-disable @typescript-eslint/no-explicit-any */
 import {h64} from '../../../shared/src/hash.ts';
-import {mapEntries} from '../../../shared/src/objects.ts';
+import {
+  defineOwnDataProperty,
+  mapEntries,
+} from '../../../shared/src/objects.ts';
 import {
   normalizeClientSchema,
   type ClientSchema,
@@ -64,15 +67,19 @@ export function createSchema<
         `Table "${table.schema.name}" is defined more than once in the schema`,
       );
     }
-    retTables[table.schema.name] = table.build();
+    defineOwnDataProperty(retTables, table.schema.name, table.build());
   });
   options.relationships?.forEach(relationships => {
-    if (retRelationships[relationships.name]) {
+    if (Object.hasOwn(retRelationships, relationships.name)) {
       throw new Error(
         `Relationships for table "${relationships.name}" are defined more than once in the schema`,
       );
     }
-    retRelationships[relationships.name] = relationships.relationships;
+    defineOwnDataProperty(
+      retRelationships,
+      relationships.name,
+      relationships.relationships,
+    );
     checkRelationship(
       relationships.relationships,
       relationships.name,
@@ -96,18 +103,18 @@ function checkRelationship(
   // TS should be able to check this for us but something is preventing it from happening.
   Object.entries(relationships).forEach(([name, rel]) => {
     let source = tables[tableName];
-    if (source.columns[name] !== undefined) {
+    if (Object.hasOwn(source.columns, name)) {
       throw new Error(
         `Relationship "${tableName}"."${name}" cannot have the same name as the column "${name}" on the the table "${source.name}"`,
       );
     }
     rel.forEach(connection => {
-      if (!tables[connection.destSchema]) {
+      if (!Object.hasOwn(tables, connection.destSchema)) {
         throw new Error(
           `For relationship "${tableName}"."${name}", destination table "${connection.destSchema}" is missing in the schema`,
         );
       }
-      if (!source.columns[connection.sourceField[0]]) {
+      if (!Object.hasOwn(source.columns, connection.sourceField[0])) {
         throw new Error(
           `For relationship "${tableName}"."${name}", the source field "${connection.sourceField[0]}" is missing in the table schema "${source.name}"`,
         );

--- a/packages/zero-schema/src/builder/table-builder.ts
+++ b/packages/zero-schema/src/builder/table-builder.ts
@@ -1,4 +1,5 @@
 import type {ReadonlyJSONValue} from '../../../shared/src/json.ts';
+import {mapValues} from '../../../shared/src/objects.ts';
 import type {PrimaryKey} from '../../../zero-protocol/src/primary-key.ts';
 import type {SchemaValue, TableSchema} from '../table-schema.ts';
 
@@ -84,9 +85,7 @@ export class TableBuilder<TShape extends TableSchema> {
     columns: {[K in keyof TColumns]: TColumns[K]['schema']};
     primaryKey: TShape['primaryKey'];
   }> {
-    const columnSchemas = Object.fromEntries(
-      Object.entries(columns).map(([k, v]) => [k, v.schema]),
-    ) as {[K in keyof TColumns]: TColumns[K]['schema']};
+    const columnSchemas = mapValues(columns, column => column.schema);
     return new TableBuilderWithColumns({
       ...this.#schema,
       columns: columnSchemas,

--- a/packages/zql/src/ivm/view-apply-change.test.ts
+++ b/packages/zql/src/ivm/view-apply-change.test.ts
@@ -804,7 +804,7 @@ describe('applyChange', () => {
 
       const row = at(root, '', 0) as Entry & {__proto__: unknown};
       expect(row['__proto__']).toEqual([3, 'four', {deep: false}]);
-      expect(Object.getPrototypeOf(row)).toBeNull();
+      expect(Object.getPrototypeOf(row)).toBe(Object.prototype);
     });
 
     test('relationship named __proto__ is preserved and does not affect prototype', () => {
@@ -908,7 +908,7 @@ describe('applyChange', () => {
       expect(at(parent, '__proto__', 0)).toEqual(
         expect.objectContaining({id: 'c1', parentId: '1'}),
       );
-      expect(Object.getPrototypeOf(parent)).toBeNull();
+      expect(Object.getPrototypeOf(parent)).toBe(Object.prototype);
     });
 
     test('singular: true', () => {

--- a/packages/zql/src/ivm/view-apply-change.test.ts
+++ b/packages/zql/src/ivm/view-apply-change.test.ts
@@ -741,6 +741,176 @@ describe('applyChange', () => {
       ).toThrowError(new Error('node does not exist'));
     });
 
+    test('column named __proto__ with JSON array is preserved on Object.assign edit path', () => {
+      const columns: SourceSchema['columns'] = {
+        id: {type: 'string'},
+      };
+      Object.defineProperty(columns, '__proto__', {
+        value: {type: 'json'},
+        enumerable: true,
+      });
+
+      const schema = {
+        tableName: 'event',
+        columns,
+        primaryKey: ['id'],
+        sort: [['id', 'asc']],
+        system: 'client',
+        relationships: {},
+        isHidden: false,
+        compareRows: makeComparator([['id', 'asc']]),
+      } as const;
+      let root: Entry = {'': []};
+      const format = {
+        singular: false,
+        relationships: {},
+      };
+
+      const parseRow = (json: string) => JSON.parse(json) as {id: string};
+
+      root = applyChange(
+        root,
+        {
+          type: 'add',
+          node: {
+            row: parseRow('{"id":"1","__proto__":[1,"two",{"deep":true}]}'),
+            relationships: {},
+          },
+        },
+        schema,
+        '',
+        format,
+        WITH_IDS,
+        NO_MUTATE,
+      );
+
+      root = applyChange(
+        root,
+        {
+          type: 'edit',
+          oldNode: {
+            row: parseRow('{"id":"1","__proto__":[1,"two",{"deep":true}]}'),
+          },
+          node: {
+            row: parseRow('{"id":"1","__proto__":[3,"four",{"deep":false}]}'),
+          },
+        },
+        schema,
+        '',
+        format,
+        WITH_IDS,
+        MUTATE,
+      );
+
+      const row = at(root, '', 0) as Entry & {__proto__: unknown};
+      expect(row['__proto__']).toEqual([3, 'four', {deep: false}]);
+      expect(Object.getPrototypeOf(row)).toBeNull();
+    });
+
+    test('relationship named __proto__ is preserved and does not affect prototype', () => {
+      const childSchema: SourceSchema = {
+        tableName: 'child',
+        columns: {
+          id: {type: 'string'},
+          parentId: {type: 'string'},
+        },
+        primaryKey: ['id'],
+        sort: [['id', 'asc']],
+        system: 'client',
+        relationships: {},
+        isHidden: false,
+        compareRows: makeComparator([['id', 'asc']]),
+      };
+
+      const relationships: SourceSchema['relationships'] = {};
+      Object.defineProperty(relationships, '__proto__', {
+        value: childSchema,
+        enumerable: true,
+      });
+
+      const formatRelationships: Format['relationships'] = {};
+      Object.defineProperty(formatRelationships, '__proto__', {
+        value: {singular: false, relationships: {}},
+        enumerable: true,
+      });
+
+      const schema: SourceSchema = {
+        tableName: 'event',
+        columns: {
+          id: {type: 'string'},
+          name: {type: 'string'},
+        },
+        primaryKey: ['id'],
+        sort: [['id', 'asc']],
+        system: 'client',
+        relationships,
+        isHidden: false,
+        compareRows: makeComparator([['id', 'asc']]),
+      };
+
+      const format: Format = {
+        singular: false,
+        relationships: formatRelationships,
+      };
+
+      const makeProtoRelationships = <T>(value: T): Record<string, T> => {
+        const result: Record<string, T> = {};
+        Object.defineProperty(result, '__proto__', {
+          value,
+          enumerable: true,
+        });
+        return result;
+      };
+
+      let root: Entry = {'': []};
+
+      root = applyChange(
+        root,
+        {
+          type: 'add',
+          node: {
+            row: {id: '1', name: 'Aaron'},
+            relationships: makeProtoRelationships(() => []),
+          },
+        },
+        schema,
+        '',
+        format,
+        WITH_IDS,
+        NO_MUTATE,
+      );
+
+      root = applyChange(
+        root,
+        {
+          type: 'child',
+          node: {row: {id: '1', name: 'Aaron'}},
+          child: {
+            relationshipName: '__proto__',
+            change: {
+              type: 'add',
+              node: {
+                row: {id: 'c1', parentId: '1'},
+                relationships: {},
+              },
+            },
+          },
+        },
+        schema,
+        '',
+        format,
+        WITH_IDS,
+        NO_MUTATE,
+      );
+
+      const parent = at(root, '', 0);
+      expect(entries(parent, '__proto__')).toHaveLength(1);
+      expect(at(parent, '__proto__', 0)).toEqual(
+        expect.objectContaining({id: 'c1', parentId: '1'}),
+      );
+      expect(Object.getPrototypeOf(parent)).toBeNull();
+    });
+
     test('singular: true', () => {
       const schema = {
         tableName: 'event',

--- a/packages/zql/src/ivm/view-apply-change.ts
+++ b/packages/zql/src/ivm/view-apply-change.ts
@@ -5,6 +5,7 @@ import {
   unreachable,
 } from '../../../shared/src/asserts.ts';
 import {must} from '../../../shared/src/must.ts';
+import {defineOwnDataProperty} from '../../../shared/src/objects.ts';
 import type {Writable} from '../../../shared/src/writable.ts';
 import type {Row} from '../../../zero-protocol/src/data.ts';
 import {type Comparator, type Node} from './data.ts';
@@ -15,8 +16,6 @@ import type {Entry, Format} from './view.ts';
 export const refCountSymbol = Symbol('rc');
 export const idSymbol = Symbol('id');
 
-// ReadonlyMetaEntry has a `null` `[[Prototype]]` so that the legacy `__proto__`
-// setter is not invoked when `__proto__` is `[[Set]]`. 
 type ReadonlyMetaEntry = Entry & {
   readonly [refCountSymbol]: number;
   readonly [idSymbol]?: string | undefined;
@@ -838,15 +837,13 @@ function makeNewMetaEntry(
   // This creates a new MetaEntry from a Row. We never mutate Rows.
   if (withIDs) {
     return track({
-      __proto__: null,
       ...row,
       [refCountSymbol]: rc,
       [idSymbol]: makeID(row, schema),
     });
   }
   return track({
-    __proto__: null,
-    ...row,
+     ...row,
     [refCountSymbol]: rc,
   });
 }
@@ -883,7 +880,6 @@ function setRefCount<M extends Mutate>(
     return entry;
   }
   return track({
-    __proto__: null,
     ...entry,
     [refCountSymbol]: count,
   });
@@ -913,12 +909,17 @@ function setProperty<
   value: V,
 ): MutableMetaEntry & {[P in K]: V} {
   if (mutate || owns(parentEntry)) {
+    // Avoid triggering legacy __proto__ setter on parentEntry.
+    // We still want to set the property, so SolidJS's Proxy set trap is invoked
+    // below.
+    if (key === '__proto__' && !Object.hasOwn(parentEntry, '__proto__')) {
+      defineOwnDataProperty(parentEntry, '__proto__', null);
+    }
     (parentEntry as {[P in K]: V})[key] = value;
     return parentEntry as MutableMetaEntry & {[P in K]: V};
   }
   return track({
-    __proto__: null,
-    ...parentEntry,
+      ...parentEntry,
     [key]: value,
   }) as MutableMetaEntry & {[P in K]: V};
 }

--- a/packages/zql/src/ivm/view-apply-change.ts
+++ b/packages/zql/src/ivm/view-apply-change.ts
@@ -15,6 +15,8 @@ import type {Entry, Format} from './view.ts';
 export const refCountSymbol = Symbol('rc');
 export const idSymbol = Symbol('id');
 
+// ReadonlyMetaEntry has a `null` `[[Prototype]]` so that the legacy `__proto__`
+// setter is not invoked when `__proto__` is `[[Set]]`. 
 type ReadonlyMetaEntry = Entry & {
   readonly [refCountSymbol]: number;
   readonly [idSymbol]?: string | undefined;
@@ -836,12 +838,17 @@ function makeNewMetaEntry(
   // This creates a new MetaEntry from a Row. We never mutate Rows.
   if (withIDs) {
     return track({
+      __proto__: null,
       ...row,
       [refCountSymbol]: rc,
       [idSymbol]: makeID(row, schema),
     });
   }
-  return track({...row, [refCountSymbol]: rc});
+  return track({
+    __proto__: null,
+    ...row,
+    [refCountSymbol]: rc,
+  });
 }
 
 function makeID(row: Row, schema: SourceSchema) {
@@ -875,7 +882,11 @@ function setRefCount<M extends Mutate>(
     (entry as MutableMetaEntry)[refCountSymbol] = count;
     return entry;
   }
-  return track({...entry, [refCountSymbol]: count});
+  return track({
+    __proto__: null,
+    ...entry,
+    [refCountSymbol]: count,
+  });
 }
 
 function arrayWith<M extends Mutate, T>(
@@ -905,7 +916,11 @@ function setProperty<
     (parentEntry as {[P in K]: V})[key] = value;
     return parentEntry as MutableMetaEntry & {[P in K]: V};
   }
-  return track({...parentEntry, [key]: value});
+  return track({
+    __proto__: null,
+    ...parentEntry,
+    [key]: value,
+  }) as MutableMetaEntry & {[P in K]: V};
 }
 
 const setRelation: <M extends Mutate>(

--- a/packages/zql/src/ivm/view-apply-change.ts
+++ b/packages/zql/src/ivm/view-apply-change.ts
@@ -5,7 +5,7 @@ import {
   unreachable,
 } from '../../../shared/src/asserts.ts';
 import {must} from '../../../shared/src/must.ts';
-import {defineOwnDataProperty} from '../../../shared/src/objects.ts';
+import {assignProperty} from '../../../shared/src/objects.ts';
 import type {Writable} from '../../../shared/src/writable.ts';
 import type {Row} from '../../../zero-protocol/src/data.ts';
 import {type Comparator, type Node} from './data.ts';
@@ -909,13 +909,7 @@ function setProperty<
   value: V,
 ): MutableMetaEntry & {[P in K]: V} {
   if (mutate || owns(parentEntry)) {
-    // Avoid triggering legacy __proto__ setter on parentEntry.
-    // We still want to set the property, so SolidJS's Proxy set trap is invoked
-    // below.
-    if (key === '__proto__' && !Object.hasOwn(parentEntry, '__proto__')) {
-      defineOwnDataProperty(parentEntry, '__proto__', null);
-    }
-    (parentEntry as {[P in K]: V})[key] = value;
+    assignProperty(parentEntry as {[P in K]: V}, key, value);
     return parentEntry as MutableMetaEntry & {[P in K]: V};
   }
   return track({

--- a/packages/zql/src/ivm/view-apply-change.ts
+++ b/packages/zql/src/ivm/view-apply-change.ts
@@ -843,7 +843,7 @@ function makeNewMetaEntry(
     });
   }
   return track({
-     ...row,
+    ...row,
     [refCountSymbol]: rc,
   });
 }
@@ -919,7 +919,7 @@ function setProperty<
     return parentEntry as MutableMetaEntry & {[P in K]: V};
   }
   return track({
-      ...parentEntry,
+    ...parentEntry,
     [key]: value,
   }) as MutableMetaEntry & {[P in K]: V};
 }

--- a/packages/zql/src/mutate/crud.ts
+++ b/packages/zql/src/mutate/crud.ts
@@ -1,5 +1,5 @@
 import type {Expand} from '../../../shared/src/expand.ts';
-import {mapValues} from '../../../shared/src/objects.ts';
+import {assignProperty, mapValues} from '../../../shared/src/objects.ts';
 import {recordProxy} from '../../../shared/src/record-proxy.ts';
 import type {SchemaValueToTSType} from '../../../zero-types/src/schema-value.ts';
 import type {Schema, TableSchema} from '../../../zero-types/src/schema.ts';
@@ -146,7 +146,13 @@ export function makeCRUDMutate<
   // Only add table properties when enableLegacyMutators is true
   if (addSchemaCRUD) {
     // Add table names as keys so the proxy can discover them
-    mapValues(schema.tables, () => undefined);
+    for (const tableName of Object.keys(schema.tables)) {
+      assignProperty(
+        mutate as unknown as Record<string, undefined>,
+        tableName,
+        undefined,
+      );
+    }
 
     // Wrap in proxy that lazily creates and caches table CRUD objects
     return recordProxy(

--- a/packages/zql/src/mutate/crud.ts
+++ b/packages/zql/src/mutate/crud.ts
@@ -1,4 +1,5 @@
 import type {Expand} from '../../../shared/src/expand.ts';
+import {defineOwnDataProperty} from '../../../shared/src/objects.ts';
 import {recordProxy} from '../../../shared/src/record-proxy.ts';
 import type {SchemaValueToTSType} from '../../../zero-types/src/schema-value.ts';
 import type {Schema, TableSchema} from '../../../zero-types/src/schema.ts';
@@ -146,7 +147,7 @@ export function makeCRUDMutate<
   if (addSchemaCRUD) {
     // Add table names as keys so the proxy can discover them
     for (const tableName of Object.keys(schema.tables)) {
-      (mutate as unknown as Record<string, undefined>)[tableName] = undefined;
+      defineOwnDataProperty(mutate, tableName, undefined);
     }
 
     // Wrap in proxy that lazily creates and caches table CRUD objects
@@ -165,7 +166,7 @@ export function makeTransactionMutate<TSchema extends Schema>(
 ): TransactionMutate<TSchema> {
   const target: Record<string, undefined> = {};
   for (const tableName of Object.keys(schema.tables)) {
-    target[tableName] = undefined;
+    defineOwnDataProperty(target, tableName, undefined);
   }
 
   return recordProxy(target, (_value, tableName) =>

--- a/packages/zql/src/mutate/crud.ts
+++ b/packages/zql/src/mutate/crud.ts
@@ -1,5 +1,5 @@
 import type {Expand} from '../../../shared/src/expand.ts';
-import {defineOwnDataProperty} from '../../../shared/src/objects.ts';
+import {mapValues} from '../../../shared/src/objects.ts';
 import {recordProxy} from '../../../shared/src/record-proxy.ts';
 import type {SchemaValueToTSType} from '../../../zero-types/src/schema-value.ts';
 import type {Schema, TableSchema} from '../../../zero-types/src/schema.ts';
@@ -146,9 +146,7 @@ export function makeCRUDMutate<
   // Only add table properties when enableLegacyMutators is true
   if (addSchemaCRUD) {
     // Add table names as keys so the proxy can discover them
-    for (const tableName of Object.keys(schema.tables)) {
-      defineOwnDataProperty(mutate, tableName, undefined);
-    }
+    mapValues(schema.tables, () => undefined);
 
     // Wrap in proxy that lazily creates and caches table CRUD objects
     return recordProxy(
@@ -164,10 +162,7 @@ export function makeTransactionMutate<TSchema extends Schema>(
   schema: TSchema,
   executor: CRUDExecutor,
 ): TransactionMutate<TSchema> {
-  const target: Record<string, undefined> = {};
-  for (const tableName of Object.keys(schema.tables)) {
-    defineOwnDataProperty(target, tableName, undefined);
-  }
+  const target = mapValues(schema.tables, () => undefined);
 
   return recordProxy(target, (_value, tableName) =>
     makeTableCRUD(tableName, executor),


### PR DESCRIPTION
Define schema and mutator records with own data properties so `__proto__` table, column, and relationship names are not routed through the legacy prototype setter.

Use null-prototype ZQL meta entries so rows and relationships named `__proto__` survive view updates without changing the entry prototype.

Based on #6145 by @tjenkinson