### PR TITLE
chore(zero-cache): cap the subscriber queue during catchup

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/forwarder.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/forwarder.test.ts
@@ -7,6 +7,10 @@ import {createSubscriber} from './test-utils.ts';
 
 const json = BigIntJSON.stringify;
 
+function nextEventLoopTurn() {
+  return new Promise<void>(resolve => setImmediate(resolve));
+}
+
 describe('change-streamer/forwarder', () => {
   const messages = new ReplicationMessages({issues: 'id'});
 
@@ -29,11 +33,11 @@ describe('change-streamer/forwarder', () => {
         released = true;
       });
 
-    await Promise.resolve();
+    await nextEventLoopTurn();
     expect(released).toBe(false);
 
     const drained = sub.setCaughtUp();
-    await Promise.resolve();
+    await nextEventLoopTurn();
 
     // Status initialization plus the forwarded change are now queued
     // downstream, but the forwarder should still be waiting on consumption.

--- a/packages/zero-cache/src/services/change-streamer/forwarder.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/forwarder.test.ts
@@ -10,6 +10,42 @@ const json = BigIntJSON.stringify;
 describe('change-streamer/forwarder', () => {
   const messages = new ReplicationMessages({issues: 'id'});
 
+  test('flow control waits on catching-up subscriber backlog', async () => {
+    const forwarder = new Forwarder(createSilentLogContext());
+    const [sub, _, receiver] = createSubscriber('00', false, {
+      backlogHighWaterBytes: 1,
+    });
+
+    forwarder.add(sub);
+
+    let released = false;
+    const forwarded = forwarder
+      .forwardWithFlowControl([
+        '11',
+        'begin',
+        json(['begin', messages.begin(), {commitWatermark: '12'}]),
+      ])
+      .then(() => {
+        released = true;
+      });
+
+    await Promise.resolve();
+    expect(released).toBe(false);
+
+    const drained = sub.setCaughtUp();
+    await Promise.resolve();
+
+    // Status initialization plus the forwarded change are now queued
+    // downstream, but the forwarder should still be waiting on consumption.
+    expect(receiver.queued).toBe(2);
+    expect(released).toBe(false);
+
+    receiver.cancel();
+    await forwarded;
+    await drained;
+    expect(released).toBe(true);
+  });
+
   test('in transaction queueing', () => {
     const forwarder = new Forwarder(createSilentLogContext());
 

--- a/packages/zero-cache/src/services/change-streamer/storer.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.ts
@@ -756,9 +756,11 @@ export class Storer implements Service {
               `change DB to catch up`,
           );
         }
-        // Flushes the backlog of messages buffered during catchup and
-        // allows the subscription to forward subsequent messages immediately.
-        sub.setCaughtUp();
+        // Start draining messages buffered during catchup. The returned promise
+        // is intentionally not awaited here: while the drain is in progress,
+        // new sends keep appending to the subscriber backlog and inherit its
+        // byte-based backpressure.
+        void sub.setCaughtUp();
       });
     } catch (err) {
       this.#lc.error?.(`error while catching up subscriber ${sub.id}`, err);

--- a/packages/zero-cache/src/services/change-streamer/subscriber.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/subscriber.test.ts
@@ -312,6 +312,45 @@ describe('change-streamer/subscriber', () => {
     await drained;
   });
 
+  test('post-catchup live sends accumulate without downstream consumption', async () => {
+    const [sub, _, receiver] = createSubscriber('00', true);
+
+    let completed = 0;
+    const sends: Promise<void>[] = [];
+    const count = 1000;
+
+    for (let i = 0; i < count; i++) {
+      const watermark = String(i + 1).padStart(4, '0');
+      sends.push(
+        sub
+          .send([
+            watermark,
+            'begin',
+            json(['begin', messages.begin(), {commitWatermark: watermark}]),
+          ])
+          .then(() => {
+            completed++;
+          }),
+      );
+    }
+
+    await Promise.resolve();
+
+    // Status initialization plus every live send is retained because nothing
+    // is consuming the downstream Subscription.
+    expect(receiver.queued).toBe(count + 1);
+    expect(sub.getStats()).toMatchObject({
+      pending: count + 1,
+      backlog: 0,
+      backlogBytes: 0,
+    });
+    expect(completed).toBe(0);
+
+    receiver.cancel();
+    await Promise.all(sends);
+    expect(completed).toBe(count);
+  });
+
   test('acks, pending, processed, stats', async () => {
     const [sub, _, receiver] = createSubscriber('00');
 

--- a/packages/zero-cache/src/services/change-streamer/subscriber.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/subscriber.test.ts
@@ -42,7 +42,7 @@ describe('change-streamer/subscriber', () => {
       json(['commit', messages.commit(), {watermark: '02'}]),
     ]);
 
-    sub.setCaughtUp();
+    void sub.setCaughtUp();
 
     // Send some messages after catchup.
     void sub.send([
@@ -160,7 +160,7 @@ describe('change-streamer/subscriber', () => {
       'commit',
       json(['commit', messages.commit(), {watermark: '02'}]),
     ]);
-    sub.setCaughtUp();
+    void sub.setCaughtUp();
 
     // Still lower than the watermark ...
     void sub.send([
@@ -229,6 +229,89 @@ describe('change-streamer/subscriber', () => {
     `);
   });
 
+  test('backlog applies backpressure until drained', async () => {
+    const [sub, _, receiver] = createSubscriber('00', false, {
+      backlogHighWaterBytes: 1,
+    });
+
+    let released = false;
+    const blocked = sub
+      .send([
+        '11',
+        'begin',
+        json(['begin', messages.begin(), {commitWatermark: '12'}]),
+      ])
+      .then(() => {
+        released = true;
+      });
+
+    await Promise.resolve();
+    expect(released).toBe(false);
+
+    const drained = sub.setCaughtUp();
+    await Promise.resolve();
+    expect(released).toBe(false);
+
+    receiver.cancel();
+    await blocked;
+    await drained;
+    expect(released).toBe(true);
+  });
+
+  test('close releases backlog backpressure', async () => {
+    const [sub] = createSubscriber('00', false, {
+      backlogHighWaterBytes: 1,
+    });
+
+    let released = false;
+    const blocked = sub
+      .send([
+        '11',
+        'begin',
+        json(['begin', messages.begin(), {commitWatermark: '12'}]),
+      ])
+      .then(() => {
+        released = true;
+      });
+
+    await Promise.resolve();
+    expect(released).toBe(false);
+
+    sub.close();
+    await blocked;
+    expect(released).toBe(true);
+  });
+
+  test('setCaughtUp drains backlog with bounded in-flight sends', async () => {
+    const [sub, _, receiver] = createSubscriber('00', false, {
+      backlogHighWaterBytes: 1,
+    });
+
+    void sub.send([
+      '11',
+      'begin',
+      json(['begin', messages.begin(), {commitWatermark: '12'}]),
+    ]);
+    void sub.send([
+      '12',
+      'commit',
+      json(['commit', messages.commit(), {watermark: '12'}]),
+    ]);
+    void sub.send([
+      '21',
+      'begin',
+      json(['begin', messages.begin(), {commitWatermark: '22'}]),
+    ]);
+
+    const drained = sub.setCaughtUp();
+
+    // Status initialization plus the first backlog entry. The remaining
+    // backlog stays buffered until the receiver consumes this window.
+    expect(receiver.queued).toBe(2);
+    receiver.cancel();
+    await drained;
+  });
+
   test('acks, pending, processed, stats', async () => {
     const [sub, _, receiver] = createSubscriber('00');
 
@@ -256,7 +339,7 @@ describe('change-streamer/subscriber', () => {
       json(['commit', messages.commit(), {watermark: '02'}]),
     ]);
 
-    sub.setCaughtUp();
+    void sub.setCaughtUp();
 
     // Send some messages after catchup.
     void sub.send([
@@ -280,7 +363,11 @@ describe('change-streamer/subscriber', () => {
 
     let processed = 0;
     let pending = 8;
-    expect(sub.getStats()).toEqual({processRate: 0, pending: 8});
+    const initialStats = sub.getStats();
+    expect(initialStats.processRate).toBe(0);
+    expect(initialStats.pending).toBe(8);
+    expect(initialStats.backlog).toBe(0);
+    expect(initialStats.backlogBytes).toBeGreaterThan(0);
     expect(sub.numPending).toBe(pending);
 
     let txNum = 0;

--- a/packages/zero-cache/src/services/change-streamer/subscriber.ts
+++ b/packages/zero-cache/src/services/change-streamer/subscriber.ts
@@ -4,6 +4,7 @@ import {BigIntJSON} from '../../../../shared/src/bigint-json.ts';
 import type {Enum} from '../../../../shared/src/enum.ts';
 import {must} from '../../../../shared/src/must.ts';
 import {promiseVoid} from '../../../../shared/src/resolved-promises.ts';
+import {RingBuffer} from '../../../../shared/src/ring-buffer.ts';
 import {max} from '../../types/lexi-version.ts';
 import type {Subscription} from '../../types/subscription.ts';
 import type {ChangeTag, WatermarkedChange} from './change-streamer-service.ts';
@@ -14,7 +15,6 @@ type ErrorType = Enum<typeof ErrorType>;
 
 const DEFAULT_BACKLOG_HIGH_WATER_BYTES = 16 * 1024 * 1024;
 const DEFAULT_BACKLOG_LOW_WATER_RATIO = 0.8;
-const BACKLOG_COMPACT_THRESHOLD = 1024;
 
 export type SubscriberOptions = {
   backlogHighWaterBytes?: number | undefined;
@@ -35,17 +35,14 @@ export class Subscriber {
   readonly #latestStatus: () => Status;
   #watermark: string;
   #acked: string;
-  #backlog: WatermarkedChange[] | null;
+  #backlog: RingBuffer<WatermarkedChange> | null;
   // While catchup is running, live changes are buffered here instead of being
-  // pushed downstream. The start cursor lets drainBacklog consume that array
-  // without shifting every entry, which matters when a subscriber is far behind.
-  #backlogStart = 0;
+  // pushed downstream. RingBuffer lets drainBacklog consume that backlog without
+  // shifting an array, which matters when a subscriber is far behind.
   #backlogBytes = 0;
   #backlogInFlightBytes = 0;
   #backlogDrain: Promise<void> | null = null;
-  readonly #backlogHighWaterBytes: number;
-  readonly #backlogLowWaterBytes: number;
-  readonly #backlogWaiters: Resolver<void>[] = [];
+  readonly #backlogBackpressure: ByteBackpressureGate;
 
   constructor(
     protocolVersion: number,
@@ -61,19 +58,11 @@ export class Subscriber {
     this.#latestStatus = latestStatus;
     this.#watermark = watermark;
     this.#acked = watermark;
-    this.#backlog = [];
-    this.#backlogHighWaterBytes = Math.max(
-      1,
+    this.#backlog = new RingBuffer();
+    this.#backlogBackpressure = new ByteBackpressureGate(
       options.backlogHighWaterBytes ?? DEFAULT_BACKLOG_HIGH_WATER_BYTES,
+      options.backlogLowWaterRatio ?? DEFAULT_BACKLOG_LOW_WATER_RATIO,
     );
-    const lowWaterRatio = Math.min(
-      1,
-      Math.max(
-        0,
-        options.backlogLowWaterRatio ?? DEFAULT_BACKLOG_LOW_WATER_RATIO,
-      ),
-    );
-    this.#backlogLowWaterBytes = this.#backlogHighWaterBytes * lowWaterRatio;
   }
 
   get watermark() {
@@ -134,9 +123,10 @@ export class Subscriber {
       return this.#backlogDrain ?? promiseVoid;
     }
     if (!this.#backlogDrain) {
-      // Keep #backlog non-null until the drain finishes. That preserves ordering
-      // for sends that race with setCaughtUp(): they append to the same backlog
-      // instead of bypassing older buffered changes.
+      // Keep #backlog non-null while queued entries are being handed to
+      // downstream. That preserves ordering for sends that race with
+      // setCaughtUp(): they append to the same backlog instead of bypassing
+      // older buffered changes.
       this.#backlogDrain = this.#drainBacklog();
       void this.#backlogDrain.catch(e => this.fail(e));
     }
@@ -261,9 +251,8 @@ export class Subscriber {
     // Closing the subscriber must also release producers that are blocked on
     // backlog capacity; there is no future drain that could wake them.
     this.#backlog = null;
-    this.#backlogStart = 0;
     this.#backlogBytes = 0;
-    this.#releaseBacklogWaiters();
+    this.#backlogBackpressure.releaseAll();
 
     if (error) {
       // Wait for the ACK of the error message before closing the connection.
@@ -276,7 +265,7 @@ export class Subscriber {
   }
 
   get #backlogCount() {
-    return this.#backlog ? this.#backlog.length - this.#backlogStart : 0;
+    return this.#backlog?.size ?? 0;
   }
 
   get #bufferedBacklogBytes() {
@@ -293,49 +282,7 @@ export class Subscriber {
   }
 
   #maybeWaitForBacklogSpace(): Promise<void> {
-    if (this.#bufferedBacklogBytes < this.#backlogHighWaterBytes) {
-      return promiseVoid;
-    }
-    // One waiter represents one send() call that has already appended its
-    // change. The producer is released when the backlog falls back below the low
-    // water mark or the subscriber closes.
-    const r = resolver<void>();
-    this.#backlogWaiters.push(r);
-    return r.promise;
-  }
-
-  #releaseBacklogWaiters() {
-    const waiters = this.#backlogWaiters.splice(0);
-    for (const waiter of waiters) {
-      waiter.resolve();
-    }
-  }
-
-  #maybeReleaseBacklogWaiters() {
-    if (
-      this.#backlogWaiters.length === 0 ||
-      this.#bufferedBacklogBytes > this.#backlogLowWaterBytes
-    ) {
-      return;
-    }
-
-    // Use a low water mark so waiting producers are released in batches instead
-    // of waking one at a time around the high water boundary.
-    this.#releaseBacklogWaiters();
-  }
-
-  #compactBacklog() {
-    const backlog = this.#backlog;
-    if (
-      backlog &&
-      this.#backlogStart > BACKLOG_COMPACT_THRESHOLD &&
-      this.#backlogStart * 2 > backlog.length
-    ) {
-      // The drain advances #backlogStart instead of shifting. Compact once the
-      // consumed prefix is large enough to otherwise keep memory alive.
-      backlog.splice(0, this.#backlogStart);
-      this.#backlogStart = 0;
-    }
+    return this.#backlogBackpressure.waitForSpace(this.#bufferedBacklogBytes);
   }
 
   async #drainBacklog() {
@@ -344,34 +291,36 @@ export class Subscriber {
 
     try {
       for (;;) {
-        const backlog = this.#backlog;
-        const change = backlog?.[this.#backlogStart];
+        const change = this.#backlog?.shift();
         if (!change) {
           this.#backlog = null;
-          this.#backlogStart = 0;
           this.#backlogBytes = 0;
-          this.#maybeReleaseBacklogWaiters();
+          this.#backlogBackpressure.releaseIfUnderLowWater(
+            this.#bufferedBacklogBytes,
+          );
           break;
         }
 
-        this.#backlogStart++;
         const bytes = change[2].length;
         this.#backlogBytes -= bytes;
         this.#backlogInFlightBytes += bytes;
-        this.#compactBacklog();
-        this.#maybeReleaseBacklogWaiters();
+        this.#backlogBackpressure.releaseIfUnderLowWater(
+          this.#bufferedBacklogBytes,
+        );
 
         // Send backlog entries in order, but keep only a bounded byte window in
         // flight. This avoids replacing one unbounded buffer with another inside
         // the downstream Subscription during catchup completion.
         const promise = this.#sendChange(change).finally(() => {
           this.#backlogInFlightBytes -= bytes;
-          this.#maybeReleaseBacklogWaiters();
+          this.#backlogBackpressure.releaseIfUnderLowWater(
+            this.#bufferedBacklogBytes,
+          );
         });
         inFlight.push({promise, bytes});
         inFlightBytes += bytes;
 
-        while (inFlightBytes >= this.#backlogHighWaterBytes) {
+        while (inFlightBytes >= this.#backlogBackpressure.highWaterBytes) {
           const next = must(inFlight.shift());
           await next.promise;
           inFlightBytes -= next.bytes;
@@ -383,7 +332,51 @@ export class Subscriber {
       }
     } finally {
       this.#backlogDrain = null;
-      this.#maybeReleaseBacklogWaiters();
+      this.#backlogBackpressure.releaseIfUnderLowWater(
+        this.#bufferedBacklogBytes,
+      );
+    }
+  }
+}
+
+class ByteBackpressureGate {
+  readonly highWaterBytes: number;
+  readonly #lowWaterBytes: number;
+  readonly #waiters: Resolver<void>[] = [];
+
+  constructor(highWaterBytes: number, lowWaterRatio: number) {
+    this.highWaterBytes = Math.max(1, highWaterBytes);
+    this.#lowWaterBytes =
+      this.highWaterBytes * Math.min(1, Math.max(0, lowWaterRatio));
+  }
+
+  waitForSpace(bufferedBytes: number): Promise<void> {
+    if (bufferedBytes < this.highWaterBytes) {
+      return promiseVoid;
+    }
+
+    // One waiter represents one send() call that has already appended its
+    // change. The producer is released when the backlog falls back below the low
+    // water mark or the subscriber closes.
+    const r = resolver<void>();
+    this.#waiters.push(r);
+    return r.promise;
+  }
+
+  releaseIfUnderLowWater(bufferedBytes: number) {
+    if (this.#waiters.length === 0 || bufferedBytes > this.#lowWaterBytes) {
+      return;
+    }
+
+    // Use a low water mark so waiting producers are released in batches instead
+    // of waking one at a time around the high water boundary.
+    this.releaseAll();
+  }
+
+  releaseAll() {
+    const waiters = this.#waiters.splice(0);
+    for (const waiter of waiters) {
+      waiter.resolve();
     }
   }
 }

--- a/packages/zero-cache/src/services/change-streamer/subscriber.ts
+++ b/packages/zero-cache/src/services/change-streamer/subscriber.ts
@@ -1,7 +1,9 @@
+import {resolver, type Resolver} from '@rocicorp/resolver';
 import {assert} from '../../../../shared/src/asserts.ts';
 import {BigIntJSON} from '../../../../shared/src/bigint-json.ts';
 import type {Enum} from '../../../../shared/src/enum.ts';
 import {must} from '../../../../shared/src/must.ts';
+import {promiseVoid} from '../../../../shared/src/resolved-promises.ts';
 import {max} from '../../types/lexi-version.ts';
 import type {Subscription} from '../../types/subscription.ts';
 import type {ChangeTag, WatermarkedChange} from './change-streamer-service.ts';
@@ -9,6 +11,15 @@ import {type Downstream, type Status} from './change-streamer.ts';
 import * as ErrorType from './error-type-enum.ts';
 
 type ErrorType = Enum<typeof ErrorType>;
+
+const DEFAULT_BACKLOG_HIGH_WATER_BYTES = 16 * 1024 * 1024;
+const DEFAULT_BACKLOG_LOW_WATER_RATIO = 0.8;
+const BACKLOG_COMPACT_THRESHOLD = 1024;
+
+export type SubscriberOptions = {
+  backlogHighWaterBytes?: number | undefined;
+  backlogLowWaterRatio?: number | undefined;
+};
 
 /**
  * Encapsulates a subscriber to changes. All subscribers start in a
@@ -25,6 +36,16 @@ export class Subscriber {
   #watermark: string;
   #acked: string;
   #backlog: WatermarkedChange[] | null;
+  // While catchup is running, live changes are buffered here instead of being
+  // pushed downstream. The start cursor lets drainBacklog consume that array
+  // without shifting every entry, which matters when a subscriber is far behind.
+  #backlogStart = 0;
+  #backlogBytes = 0;
+  #backlogInFlightBytes = 0;
+  #backlogDrain: Promise<void> | null = null;
+  readonly #backlogHighWaterBytes: number;
+  readonly #backlogLowWaterBytes: number;
+  readonly #backlogWaiters: Resolver<void>[] = [];
 
   constructor(
     protocolVersion: number,
@@ -32,6 +53,7 @@ export class Subscriber {
     watermark: string,
     downstream: Subscription<string>,
     latestStatus: () => Status,
+    options: SubscriberOptions = {},
   ) {
     this.#protocolVersion = protocolVersion;
     this.id = id;
@@ -40,6 +62,18 @@ export class Subscriber {
     this.#watermark = watermark;
     this.#acked = watermark;
     this.#backlog = [];
+    this.#backlogHighWaterBytes = Math.max(
+      1,
+      options.backlogHighWaterBytes ?? DEFAULT_BACKLOG_HIGH_WATER_BYTES,
+    );
+    const lowWaterRatio = Math.min(
+      1,
+      Math.max(
+        0,
+        options.backlogLowWaterRatio ?? DEFAULT_BACKLOG_LOW_WATER_RATIO,
+      ),
+    );
+    this.#backlogLowWaterBytes = this.#backlogHighWaterBytes * lowWaterRatio;
   }
 
   get watermark() {
@@ -50,15 +84,19 @@ export class Subscriber {
     return this.#acked;
   }
 
-  async send(change: WatermarkedChange) {
+  send(change: WatermarkedChange): Promise<void> {
     const [watermark] = change;
     if (watermark > this.#watermark) {
       if (this.#backlog) {
-        this.#backlog.push(change);
-      } else {
-        await this.#sendChange(change);
+        // During catchup, buffer live changes behind the durable catchup stream.
+        // The returned promise applies backpressure if the buffered bytes cross
+        // the high water mark.
+        this.#pushBacklog(change);
+        return this.#maybeWaitForBacklogSpace();
       }
+      return this.#sendChange(change);
     }
+    return promiseVoid;
   }
 
   #initialized = false;
@@ -90,20 +128,19 @@ export class Subscriber {
    * Marks the Subscribe as "caught up" and flushes any backlog of
    * entries that were received during the catchup.
    */
-  setCaughtUp() {
+  setCaughtUp(): Promise<void> {
     this.#initialize();
-    assert(
-      this.#backlog,
-      'setCaughtUp() called but subscriber is not in catchup mode',
-    );
-    // Note that this method must be asynchronous in order for send() to
-    // interpret the #backlog variable correctly. This is the only place
-    // where I/O flow control is not heeded. However, it will be awaited
-    // by the next caller to send().
-    for (const change of this.#backlog) {
-      void this.#sendChange(change);
+    if (!this.#backlog) {
+      return this.#backlogDrain ?? promiseVoid;
     }
-    this.#backlog = null;
+    if (!this.#backlogDrain) {
+      // Keep #backlog non-null until the drain finishes. That preserves ordering
+      // for sends that race with setCaughtUp(): they append to the same backlog
+      // instead of bypassing older buffered changes.
+      this.#backlogDrain = this.#drainBacklog();
+      void this.#backlogDrain.catch(e => this.fail(e));
+    }
+    return this.#backlogDrain;
   }
 
   async #sendChange(change: WatermarkedChange) {
@@ -156,7 +193,7 @@ export class Subscriber {
    * The number of downstream messages that have yet to be acked.
    */
   get numPending() {
-    return this.#pending;
+    return this.#pending + this.#backlogCount;
   }
 
   /**
@@ -179,17 +216,32 @@ export class Subscriber {
     return this;
   }
 
-  getStats(): {processRate: number; pending: number} {
-    const pending = this.#pending;
+  getStats(): {
+    processRate: number;
+    pending: number;
+    backlog: number;
+    backlogBytes: number;
+  } {
+    const pending = this.numPending;
     if (this.#samples.length < 2) {
-      return {processRate: 0, pending};
+      return {
+        processRate: 0,
+        pending,
+        backlog: this.#backlogCount,
+        backlogBytes: this.#bufferedBacklogBytes,
+      };
     }
     const from = this.#samples[0];
     const to = must(this.#samples.at(-1));
     const processed = to.processed - from.processed;
     const seconds = (to.timestamp - from.timestamp) / 1000;
     const processRate = seconds === 0 ? 0 : processed / seconds;
-    return {processRate, pending};
+    return {
+      processRate,
+      pending,
+      backlog: this.#backlogCount,
+      backlogBytes: this.#bufferedBacklogBytes,
+    };
   }
 
   supportsMessage(tag: ChangeTag) {
@@ -206,6 +258,13 @@ export class Subscriber {
   }
 
   close(error?: ErrorType, message?: string) {
+    // Closing the subscriber must also release producers that are blocked on
+    // backlog capacity; there is no future drain that could wake them.
+    this.#backlog = null;
+    this.#backlogStart = 0;
+    this.#backlogBytes = 0;
+    this.#releaseBacklogWaiters();
+
     if (error) {
       // Wait for the ACK of the error message before closing the connection.
       void this.#sendDownstream(['error', {type: error, message}]).finally(() =>
@@ -213,6 +272,118 @@ export class Subscriber {
       );
     } else {
       this.#downstream.cancel();
+    }
+  }
+
+  get #backlogCount() {
+    return this.#backlog ? this.#backlog.length - this.#backlogStart : 0;
+  }
+
+  get #bufferedBacklogBytes() {
+    // Include entries already handed to downstream but not yet consumed. Without
+    // this, setCaughtUp() could move bytes out of #backlog faster than the
+    // downstream Subscription can process them and release producers too early.
+    return this.#backlogBytes + this.#backlogInFlightBytes;
+  }
+
+  #pushBacklog(change: WatermarkedChange) {
+    assert(this.#backlog, 'cannot push to backlog after catchup completed');
+    this.#backlog.push(change);
+    this.#backlogBytes += change[2].length;
+  }
+
+  #maybeWaitForBacklogSpace(): Promise<void> {
+    if (this.#bufferedBacklogBytes < this.#backlogHighWaterBytes) {
+      return promiseVoid;
+    }
+    // One waiter represents one send() call that has already appended its
+    // change. The producer is released when the backlog falls back below the low
+    // water mark or the subscriber closes.
+    const r = resolver<void>();
+    this.#backlogWaiters.push(r);
+    return r.promise;
+  }
+
+  #releaseBacklogWaiters() {
+    const waiters = this.#backlogWaiters.splice(0);
+    for (const waiter of waiters) {
+      waiter.resolve();
+    }
+  }
+
+  #maybeReleaseBacklogWaiters() {
+    if (
+      this.#backlogWaiters.length === 0 ||
+      this.#bufferedBacklogBytes > this.#backlogLowWaterBytes
+    ) {
+      return;
+    }
+
+    // Use a low water mark so waiting producers are released in batches instead
+    // of waking one at a time around the high water boundary.
+    this.#releaseBacklogWaiters();
+  }
+
+  #compactBacklog() {
+    const backlog = this.#backlog;
+    if (
+      backlog &&
+      this.#backlogStart > BACKLOG_COMPACT_THRESHOLD &&
+      this.#backlogStart * 2 > backlog.length
+    ) {
+      // The drain advances #backlogStart instead of shifting. Compact once the
+      // consumed prefix is large enough to otherwise keep memory alive.
+      backlog.splice(0, this.#backlogStart);
+      this.#backlogStart = 0;
+    }
+  }
+
+  async #drainBacklog() {
+    const inFlight: {promise: Promise<void>; bytes: number}[] = [];
+    let inFlightBytes = 0;
+
+    try {
+      for (;;) {
+        const backlog = this.#backlog;
+        const change = backlog?.[this.#backlogStart];
+        if (!change) {
+          this.#backlog = null;
+          this.#backlogStart = 0;
+          this.#backlogBytes = 0;
+          this.#maybeReleaseBacklogWaiters();
+          break;
+        }
+
+        this.#backlogStart++;
+        const bytes = change[2].length;
+        this.#backlogBytes -= bytes;
+        this.#backlogInFlightBytes += bytes;
+        this.#compactBacklog();
+        this.#maybeReleaseBacklogWaiters();
+
+        // Send backlog entries in order, but keep only a bounded byte window in
+        // flight. This avoids replacing one unbounded buffer with another inside
+        // the downstream Subscription during catchup completion.
+        const promise = this.#sendChange(change).finally(() => {
+          this.#backlogInFlightBytes -= bytes;
+          this.#maybeReleaseBacklogWaiters();
+        });
+        inFlight.push({promise, bytes});
+        inFlightBytes += bytes;
+
+        while (inFlightBytes >= this.#backlogHighWaterBytes) {
+          const next = must(inFlight.shift());
+          await next.promise;
+          inFlightBytes -= next.bytes;
+        }
+      }
+
+      for (const {promise} of inFlight) {
+        await promise;
+      }
+    } finally {
+      this.#backlogDrain = null;
+      this.#maybeReleaseBacklogWaiters();
     }
   }
 }

--- a/packages/zero-cache/src/services/change-streamer/test-utils.ts
+++ b/packages/zero-cache/src/services/change-streamer/test-utils.ts
@@ -1,12 +1,13 @@
 import {Subscription} from '../../types/subscription.ts';
 import {PROTOCOL_VERSION, type Downstream} from './change-streamer.ts';
-import {Subscriber} from './subscriber.ts';
+import {Subscriber, type SubscriberOptions} from './subscriber.ts';
 
 let nextID = 1;
 
 export function createSubscriber(
   watermark = '00',
   caughtUp = false,
+  options: SubscriberOptions = {},
 ): [Subscriber, Downstream[], Subscription<string>] {
   const id = '' + nextID++;
   const received: Downstream[] = [];
@@ -19,9 +20,10 @@ export function createSubscriber(
     watermark,
     sub,
     () => ({tag: 'status'}),
+    options,
   );
   if (caughtUp) {
-    subscriber.setCaughtUp();
+    void subscriber.setCaughtUp();
   }
 
   return [subscriber, received, sub];


### PR DESCRIPTION
active, post-catchup subscribers that was already the expectation.

The chain was:

```
 forwardWithFlowControl() -> Broadcast -> Subscriber.send() -> #sendChange() -> Subscription.push().result
```

  That push().result resolves when the downstream message is consumed, coalesced, or canceled. So forwardWithFlowControl() was designed to occasionally stop
  the replication loop until subscribers had actually made progress.

  The bug was that catchup subscribers bypassed that contract.

  Before this change, if #backlog was non-null, Subscriber.send() just did:

  this.#backlog.push(change);

  and returned immediately. So from Broadcast’s perspective, that subscriber had “completed” the send even though the change was only sitting in an unbounded
  in-memory backlog. Then setCaughtUp() dumped the backlog into downstream with void #sendChange(...), also not waiting on the downstream subscription.

  So the original expectation was valid, but only for the non-catchup path. Catchup created a blind spot:

  - active/live subscriber: send() supplied backpressure
  - catching-up subscriber: send() acknowledged enqueue into local backlog, not downstream progress
  - catchup completion: backlog flush ignored flow control and could move the memory pressure into the downstream queue

  This PR makes catchup participate in the same basic backpressure story: while catching up, send() can block on backlog capacity, and once catchup completes,
  draining into downstream is bounded instead of firehosing the whole backlog.