### PR TITLE
feat(zql): fail loudly when PG and Zero disagree

### DIFF
--- a/packages/zql-integration-tests/src/chinook/chinook-fuzz-backbone.pg.test.ts
+++ b/packages/zql-integration-tests/src/chinook/chinook-fuzz-backbone.pg.test.ts
@@ -31,6 +31,7 @@ import {
   checkL0Hydrate,
   checkL1,
   checkPushWalk,
+  checkStartPushRefetch,
   checkYield,
   panicIfFailed,
 } from './fuzz/driver.ts';
@@ -131,6 +132,22 @@ test(
     console.log(
       `Decorated push backbone (top-N, D≤1): ${report.total} cases, ${report.failures.length} failures`,
     );
+    panicIfFailed(report, 12);
+  },
+  TIMEOUT_MS,
+);
+
+test(
+  'Start push/refetch — top-N edit pushes match fresh refetch over mini',
+  async () => {
+    // `start` cannot ride the PG-oracle fuzzer lanes because z2s ignores it. This lane is
+    // the direct incremental-vs-refetch property: hydrate a keyed top-N query with a null
+    // cursor, run normal source edit pushes, and compare each live IVM view to a fresh run.
+    const report = await checkStartPushRefetch(harness.transact, data, 1);
+    console.log(
+      `Start push/refetch backbone: ${report.total} cases, ${report.failures.length} failures`,
+    );
+    expect(report.total).toBeGreaterThan(0);
     panicIfFailed(report, 12);
   },
   TIMEOUT_MS,

--- a/packages/zql-integration-tests/src/chinook/fuzz/axes.ts
+++ b/packages/zql-integration-tests/src/chinook/fuzz/axes.ts
@@ -23,7 +23,8 @@
  * (mono ZQL has no projection — the AST returns all columns) and the `start` (keyset
  * paging) axis (z2s does not compile `start`, so the Postgres oracle silently ignores
  * it — it cannot validate paging, and every `start` case would diverge spuriously).
- * Re-add `start` here if z2s gains keyset support.
+ * `start` push/refetch consistency is checked separately by the driver; re-add it here
+ * only if z2s gains keyset support.
  */
 
 import {must} from '../../../../shared/src/must.ts';

--- a/packages/zql-integration-tests/src/chinook/fuzz/cover.ts
+++ b/packages/zql-integration-tests/src/chinook/fuzz/cover.ts
@@ -2,7 +2,7 @@
  * **L1 — a t-wise covering array of decorations** (ported from rusty-ivm
  * `rindle-fuzz/src/cover.rs`, design §2 L1).
  *
- * The decorations (`filter / exists / order / limit / start`) form a combinatorial
+ * The decorations (`filter / exists / order / limit`) form a combinatorial
  * space we do **not** cross-product (that explodes). Instead {@link greedyCover} builds
  * a *t-wise covering array*: a small set of assignments such that every combination of
  * `t` `(axis, value)` pairs appears in at least one row (`t = 2`, pairwise, by default).

--- a/packages/zql-integration-tests/src/chinook/fuzz/driver.ts
+++ b/packages/zql-integration-tests/src/chinook/fuzz/driver.ts
@@ -35,6 +35,7 @@ import type {AnyQuery} from '../../../../zql/src/query/query.ts';
 import {mapResultToClientNames} from '../../../../zqlite/src/test/source-factory.ts';
 import {type Delegates, runAndCompare} from '../../helpers/runner.ts';
 import {schema} from '../schema.ts';
+import {pkOf, tables} from './axes.ts';
 import type {CostModel} from './cost.ts';
 import {
   applyLimit,
@@ -50,7 +51,7 @@ import {Coverage} from './coverage.ts';
 import {flipAssignments, flippableExistsCount, setFlips} from './flip.ts';
 import type {Data} from './literals.ts';
 import {mutate} from './mutate.ts';
-import {type Mutation, pushForSkeleton} from './push.ts';
+import {fourPhase, type Mutation, pushForSkeleton} from './push.ts';
 import type {Regression} from './regressions.ts';
 import {rng} from './rng.ts';
 import {
@@ -478,6 +479,59 @@ async function pushWalk(
   }
 }
 
+function nullPkStartTopN(table: string): AnyQuery {
+  const pk0 = must(pkOf(table)[0]);
+  return wrapAst({
+    table,
+    orderBy: [[pk0, 'asc']],
+    start: {
+      row: {[pk0]: null},
+      exclusive: true,
+    },
+    limit: 5,
+  });
+}
+
+async function pushRefetchWalk(
+  delegates: Delegates,
+  query: AnyQuery,
+  mutations: readonly Mutation[],
+): Promise<void> {
+  const table = asQueryInternals(query).ast.table;
+  const memView = delegates.memory.materialize(query);
+  const sqliteView = delegates.sqlite.materialize(query);
+  const serverTx = await makeServerTransaction(
+    delegates.pg.transaction,
+    'test-client',
+    0,
+    schema,
+  );
+  const compare = async () => {
+    expect(
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+      mapResultToClientNames(sqliteView.data, schema, table as any),
+    ).toEqualPg(
+      mapResultToClientNames(
+        await delegates.sqlite.run(query),
+        schema,
+        // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+        table as any,
+      ),
+    );
+    expect(memView.data).toEqualPg(await delegates.memory.run(query));
+  };
+  try {
+    await compare();
+    for (const m of mutations) {
+      await applyMutation(serverTx, delegates, m);
+      await compare();
+    }
+  } finally {
+    memView.destroy();
+    sqliteView.destroy();
+  }
+}
+
 /**
  * **Push sweep:** lower each skeleton, generate its four-phase push history (root +
  * deepest leaf), and check per-step push parity inside a rolled-back transaction. `n`
@@ -503,6 +557,37 @@ export async function checkPushWalk(
     );
     if (msg) {
       failures.push([`push|${label(s)}`, msg]);
+    }
+  }
+  return {total, failures};
+}
+
+/**
+ * **Start push/refetch sweep:** `start` is deliberately excluded from the PG-oracle axes
+ * because z2s currently ignores it. This lane checks the property directly instead:
+ * materialize a top-N query with a null PK cursor, drive normal source edit pushes, and
+ * compare each live IVM view to a fresh run of the same delegate after every step.
+ */
+export async function checkStartPushRefetch(
+  transact: Transact,
+  data: Data,
+  n: number,
+  rootTables: readonly string[] = tables(),
+): Promise<Report> {
+  const failures: Array<[string, string]> = [];
+  let total = 0;
+  for (const table of rootTables) {
+    const mutations = fourPhase(data, table, n).filter(m => m.kind === 'edit');
+    if (mutations.length === 0) {
+      continue;
+    }
+    total += 1;
+    const query = nullPkStartTopN(table);
+    const msg = await capture(() =>
+      transact(d => pushRefetchWalk(d, query, mutations)),
+    );
+    if (msg) {
+      failures.push([`start-refetch|${table}`, msg]);
     }
   }
   return {total, failures};

--- a/packages/zql/src/ivm/take.ts
+++ b/packages/zql/src/ivm/take.ts
@@ -445,7 +445,17 @@ export class Take implements Operator {
       return;
     }
 
-    assert(takeState.bound, 'Bound should be set');
+    if (takeState.bound === undefined) {
+      this.#setTakeState(
+        takeStateKey,
+        takeState.size + 1,
+        change[ChangeIndex.NODE].row,
+        maxBound,
+      );
+      yield* this.#output.push(makeAddChange(change[ChangeIndex.NODE]), this);
+      return;
+    }
+
     const {compareRows} = this.getSchema();
     const oldCmp = compareRows(
       change[ChangeIndex.OLD_NODE].row,

--- a/packages/zql/src/ivm/take.ts
+++ b/packages/zql/src/ivm/take.ts
@@ -446,13 +446,10 @@ export class Take implements Operator {
     }
 
     if (takeState.bound === undefined) {
-      this.#setTakeState(
-        takeStateKey,
-        takeState.size + 1,
-        change[ChangeIndex.NODE].row,
-        maxBound,
-      );
-      yield* this.#output.push(makeAddChange(change[ChangeIndex.NODE]), this);
+      // This should be unreachable for a self-consistent input: an edit can
+      // only be forwarded if the old row was visible, and fetching that row
+      // should have hydrated a bound. If fetch and push disagree, fail closed
+      // rather than fabricating a row that a fresh fetch would not return.
       return;
     }
 

--- a/packages/zql/src/query/test/query-gen.test.ts
+++ b/packages/zql/src/query/test/query-gen.test.ts
@@ -1,7 +1,8 @@
 import {en, Faker, generateMersenne53Randomizer} from '@faker-js/faker';
 import {describe, expect, test} from 'vitest';
+import type {Schema} from '../../../../zero-types/src/schema.ts';
 import {asQueryInternals} from '../query-internals.ts';
-import {generateQuery} from './query-gen.ts';
+import {generateQuery, type Dataset} from './query-gen.ts';
 import {generateSchema} from './schema-gen.ts';
 
 describe('random generation', () => {
@@ -30,6 +31,57 @@ describe('random generation', () => {
     ).not.toThrow();
   });
 });
+
+test('generates partial or nullish start cursors when data is available', () => {
+  const schema = {
+    tables: {
+      issue: {
+        name: 'issue',
+        columns: {
+          id: {type: 'string'},
+          owner: {type: 'string'},
+          created: {type: 'number'},
+        },
+        primaryKey: ['id'],
+      },
+    },
+    relationships: {
+      issue: {},
+    },
+  } as const satisfies Schema;
+  const data: Dataset = {
+    issue: [
+      {id: 'a', owner: 'alice', created: 1},
+      {id: 'b', owner: 'z', created: 2},
+    ],
+  };
+
+  for (let seed = 0; seed < 2_000; seed++) {
+    const randomizer = generateMersenne53Randomizer(seed);
+    const rng = () => randomizer.next();
+    const faker = new Faker({locale: en, randomizer});
+    const q = generateQuery(schema, data, rng, faker);
+    const {orderBy, start} = asQueryInternals(q).ast;
+    if (!orderBy || !start) {
+      continue;
+    }
+
+    if (
+      orderBy.some(
+        ([field]) =>
+          !(field in start.row) ||
+          start.row[field] === null ||
+          start.row[field] === undefined,
+      )
+    ) {
+      expect(start).toBeDefined();
+      return;
+    }
+  }
+
+  throw new Error('Expected a generated query with a nullish start cursor');
+});
+
 test('stable generation', () => {
   const randomizer = generateMersenne53Randomizer(42);
   const rng = () => randomizer.next();

--- a/packages/zql/src/query/test/query-gen.ts
+++ b/packages/zql/src/query/test/query-gen.ts
@@ -75,11 +75,10 @@ function augmentQuery(
     // - limit
     // - order by
     // makes no sense.
-    // TODO: fuzzer does not fuzz start!
     return addWhere(addExists(query));
   }
 
-  return addLimit(addOrderBy(addWhere(addExists(addRelated(query)))));
+  return addLimit(addStart(addOrderBy(addWhere(addExists(addRelated(query))))));
 
   function addLimit(query: AnyQuery) {
     if (rng() < 0.2) {
@@ -130,6 +129,55 @@ function augmentQuery(
       throw e;
     }
 
+    return query;
+  }
+
+  function addStart(query: AnyQuery) {
+    const {ast} = asQueryInternals(query);
+    if (!ast.orderBy || ast.orderBy.length === 0) {
+      return query;
+    }
+
+    const tableName = ast.table;
+    const table = schema.tables[tableName];
+    const tableData = data[tableName];
+    if (!tableData || tableData.length === 0 || rng() < 0.8) {
+      return query;
+    }
+
+    const sourceRow = rng() < 0.7 ? selectRandom(rng, tableData) : undefined;
+    const row: Record<string, Row[string]> = {};
+
+    for (const [columnName] of ast.orderBy) {
+      const column = table.columns[columnName];
+      if (!column || column.type === 'json') {
+        continue;
+      }
+
+      // Generate partial and invalid cursors too. At runtime start rows are
+      // just data; missing/undefined fields compare as null in IVM, while SQL
+      // start compilation may use schema nullability for seek optimizations.
+      if (rng() < 0.15) {
+        continue;
+      }
+      if (rng() < 0.15) {
+        row[columnName] = undefined;
+      } else if (rng() < 0.15) {
+        row[columnName] = null;
+      } else if (sourceRow && rng() < 0.8) {
+        row[columnName] = sourceRow[columnName];
+      } else {
+        row[columnName] = randomValueForType(
+          rng,
+          faker,
+          column.type,
+          column.optional,
+        ) as Row[string];
+      }
+    }
+
+    query = query.start(row, {inclusive: rng() < 0.5});
+    generations.push(query);
     return query;
   }
 

--- a/packages/zqlite/src/table-source.test.ts
+++ b/packages/zqlite/src/table-source.test.ts
@@ -4,11 +4,14 @@ import {assert} from '../../shared/src/asserts.ts';
 import type {JSONValue} from '../../shared/src/json.ts';
 import {createSilentLogContext} from '../../shared/src/logging-test-utils.ts';
 import {must} from '../../shared/src/must.ts';
+import type {AST} from '../../zero-protocol/src/ast.ts';
 import type {Row, Value} from '../../zero-protocol/src/data.ts';
+import {buildPipeline} from '../../zql/src/builder/builder.ts';
 import {
   Debug,
   type DebugDelegate,
 } from '../../zql/src/builder/debug-delegate.ts';
+import {TestBuilderDelegate} from '../../zql/src/builder/test-builder-delegate.ts';
 import {Catch} from '../../zql/src/ivm/catch.ts';
 import {
   makeAddChange,
@@ -571,6 +574,75 @@ test('pushing values does the correct writes and outputs', () => {
       );
     }).toThrow('Row not found');
   }
+});
+
+test('edit after a null start cursor can reach take with an empty window', () => {
+  const db = new Database(createSilentLogContext(), ':memory:');
+  db.exec(`
+    CREATE TABLE t (
+      id TEXT PRIMARY KEY,
+      owner TEXT,
+      text TEXT
+    );
+    INSERT INTO t (id, owner, text) VALUES
+      ('a', NULL, 'a'),
+      ('b', 'z', 'b');
+  `);
+
+  const source = new TableSource(
+    lc,
+    testLogConfig,
+    db,
+    't',
+    {
+      id: {type: 'string'},
+      owner: {type: 'string'},
+      text: {type: 'string'},
+    },
+    ['id'],
+  );
+  const ast: AST = {
+    table: 't',
+    orderBy: [
+      ['owner', 'asc'],
+      ['id', 'asc'],
+    ],
+    start: {
+      row: {id: 'a', owner: null},
+      exclusive: true,
+    },
+    limit: 5,
+  };
+  const pipeline = buildPipeline(
+    ast,
+    new TestBuilderDelegate({t: source}),
+    'query-id',
+  );
+  const out = new Catch(pipeline);
+
+  // The Zero schema says `owner` is non-nullable, but the actual cursor row
+  // has NULL. SQLite hydrates nothing from the start constraint, while Skip's
+  // comparator still forwards later non-null rows during push.
+  expect(out.fetch({})).toEqual([]);
+
+  consume(
+    source.push(
+      makeSourceChangeEdit(
+        {id: 'b', owner: 'z', text: 'bb'},
+        {id: 'b', owner: 'z', text: 'b'},
+      ),
+    ),
+  );
+
+  expect(out.pushes).toEqual([
+    {
+      type: 'add',
+      node: {
+        row: {id: 'b', owner: 'z', text: 'bb'},
+        relationships: {},
+      },
+    },
+  ]);
 });
 
 test('getByKey', () => {

--- a/packages/zqlite/src/table-source.test.ts
+++ b/packages/zqlite/src/table-source.test.ts
@@ -576,7 +576,7 @@ test('pushing values does the correct writes and outputs', () => {
   }
 });
 
-test('edit after a null start cursor can reach take with an empty window', () => {
+test('edit after a null start cursor fails closed when take has an empty window', () => {
   const db = new Database(createSilentLogContext(), ':memory:');
   db.exec(`
     CREATE TABLE t (
@@ -634,15 +634,8 @@ test('edit after a null start cursor can reach take with an empty window', () =>
     ),
   );
 
-  expect(out.pushes).toEqual([
-    {
-      type: 'add',
-      node: {
-        row: {id: 'b', owner: 'z', text: 'bb'},
-        relationships: {},
-      },
-    },
-  ]);
+  expect(out.pushes).toEqual([]);
+  expect(out.fetch({})).toEqual([]);
 });
 
 test('getByKey', () => {


### PR DESCRIPTION
Some users still get "take bound" errors. 

- https://github.com/rocicorp/mono/pull/6122 attempts to address it

That fix would allow the push to flow but cause `push` and `fetch` to no longer agree.

The root of the problem is that PG and Zero disagree on the shape of the data. E.g., Zero says "this field cannot be null" but there is null data in it. In that case the `start` comparator returns the wrong data because it created comparison operations assuming the inability of `null` to be present.