### PR TITLE
fix(z2s): z2s did not compile `start` | queryBuilder incorrectly handled `null` start fields

### DIFF
--- a/packages/z2s/src/compiler.output.test.ts
+++ b/packages/z2s/src/compiler.output.test.ts
@@ -20,6 +20,7 @@ import {
   orderBy,
   pullTablesForJunction,
   simple,
+  start,
   type Spec,
 } from './compiler.ts';
 import {formatPgInternalConvert} from './sql.ts';
@@ -326,6 +327,86 @@ test('orderBy', () => {
   ).toMatchInlineSnapshot(`
     {
       "text": "",
+      "values": [],
+    }
+  `);
+});
+
+test('start', () => {
+  expect(
+    formatPgInternalConvert(
+      start(
+        spec,
+        {
+          row: {ownerId: 'alice', id: 'issue-1'},
+          exclusive: true,
+        },
+        [
+          ['ownerId', 'asc'],
+          ['id', 'asc'],
+        ],
+        {
+          zql: 'issue',
+          alias: 'issue',
+        },
+      ),
+    ),
+  ).toMatchInlineSnapshot(`
+    {
+      "text": "(("issue"."ownerId" > $1::text) OR ("issue"."ownerId" IS NOT DISTINCT FROM $1::text AND "issue"."id" > $2::text))",
+      "values": [
+        "alice",
+        "issue-1",
+      ],
+    }
+  `);
+
+  expect(
+    formatPgInternalConvert(
+      start(
+        spec,
+        {
+          row: {created: 100, id: 'issue-1'},
+          exclusive: false,
+        },
+        [
+          ['created', 'desc'],
+          ['id', 'asc'],
+        ],
+        {
+          zql: 'issue',
+          alias: 'issue',
+        },
+      ),
+    ),
+  ).toMatchInlineSnapshot(`
+    {
+      "text": "((("issue"."created" IS NULL OR "issue"."created" < to_timestamp($1::text::numeric / 1000.0) AT TIME ZONE 'UTC')) OR ("issue"."created" IS NOT DISTINCT FROM to_timestamp($1::text::numeric / 1000.0) AT TIME ZONE 'UTC' AND "issue"."id" > $2::text) OR ("issue"."created" IS NOT DISTINCT FROM to_timestamp($1::text::numeric / 1000.0) AT TIME ZONE 'UTC' AND "issue"."id" IS NOT DISTINCT FROM $2::text))",
+      "values": [
+        "100",
+        "issue-1",
+      ],
+    }
+  `);
+
+  expect(
+    formatPgInternalConvert(
+      start(
+        spec,
+        {
+          row: {id: null},
+          exclusive: true,
+        },
+        [['id', 'asc']],
+        {
+          zql: 'issue',
+          alias: 'issue',
+        },
+      ),
+    ),
+  ).toMatchInlineSnapshot(`
+    {
+      "text": "(("issue"."id" IS NOT NULL))",
       "values": [],
     }
   `);

--- a/packages/z2s/src/compiler.pg.test.ts
+++ b/packages/z2s/src/compiler.pg.test.ts
@@ -46,7 +46,15 @@ const temporalsTable = table('temporalsTable')
   })
   .primaryKey('id');
 
-const schema = createSchema({tables: [timesTable, temporalsTable]});
+const issueTable = table('issue')
+  .columns({
+    id: string(),
+    owner: string().optional(),
+    rank: number(),
+  })
+  .primaryKey('id');
+
+const schema = createSchema({tables: [timesTable, temporalsTable, issueTable]});
 
 const serverSchema: ServerSchema = {
   times: {
@@ -79,6 +87,11 @@ const serverSchema: ServerSchema = {
       isArray: true,
       isEnum: false,
     },
+  },
+  issue: {
+    id: {type: 'text', isArray: false, isEnum: false},
+    owner: {type: 'text', isArray: false, isEnum: false},
+    rank: {type: 'double precision', isArray: false, isEnum: false},
   },
 };
 
@@ -125,6 +138,19 @@ describe('compiler with PostgreSQL', () => {
       );
 
       INSERT INTO temporals (id) VALUES ('row1');
+
+      CREATE TABLE issue (
+        id TEXT PRIMARY KEY,
+        owner TEXT,
+        rank DOUBLE PRECISION NOT NULL
+      );
+
+      INSERT INTO issue (id, owner, rank) VALUES
+        ('a', NULL, 1),
+        ('e', NULL, 2),
+        ('b', 'alice', 1),
+        ('c', 'bob', 1),
+        ('d', 'bob', 2);
     `);
   });
 
@@ -191,6 +217,54 @@ describe('compiler with PostgreSQL', () => {
         nullableTimestampArray: null,
         nullableTimestamptzArray: null,
       },
+    ]);
+  });
+
+  test('compiled start paginates from a null cursor', async () => {
+    const sqlQuery = formatPgInternalConvert(
+      compile(serverSchema, schema, {
+        table: 'issue',
+        orderBy: [['owner', 'asc']],
+        start: {
+          row: {owner: null, id: 'a'},
+          exclusive: true,
+        },
+      }),
+    );
+
+    const compiled = extractZqlResult(
+      await pg.unsafe(sqlQuery.text, sqlQuery.values as JSONValue[]),
+    );
+
+    expect(compiled).toEqual([
+      {id: 'e', owner: null, rank: 2},
+      {id: 'b', owner: 'alice', rank: 1},
+      {id: 'c', owner: 'bob', rank: 1},
+      {id: 'd', owner: 'bob', rank: 2},
+    ]);
+  });
+
+  test('compiled start paginates descending orderings', async () => {
+    const sqlQuery = formatPgInternalConvert(
+      compile(serverSchema, schema, {
+        table: 'issue',
+        orderBy: [['rank', 'desc']],
+        start: {
+          row: {rank: 2, id: 'd'},
+          exclusive: true,
+        },
+      }),
+    );
+
+    const compiled = extractZqlResult(
+      await pg.unsafe(sqlQuery.text, sqlQuery.values as JSONValue[]),
+    );
+
+    expect(compiled).toEqual([
+      {id: 'e', owner: null, rank: 2},
+      {id: 'a', owner: null, rank: 1},
+      {id: 'b', owner: 'alice', rank: 1},
+      {id: 'c', owner: 'bob', rank: 1},
     ]);
   });
 });

--- a/packages/z2s/src/compiler.ts
+++ b/packages/z2s/src/compiler.ts
@@ -10,6 +10,7 @@ import {type JSONValue} from '../../shared/src/json.ts';
 import {must} from '../../shared/src/must.ts';
 import type {
   AST,
+  Bound,
   Condition,
   CorrelatedSubquery,
   CorrelatedSubqueryCondition,
@@ -110,7 +111,7 @@ function select(
   }
 
   let appliedWhere = false;
-  function maybeWhere(test: unknown | undefined) {
+  function maybeWhere(test: unknown) {
     if (!test) {
       return sql``;
     }
@@ -122,7 +123,12 @@ function select(
 
   return sql`SELECT ${sql.join(selectionSet, ',')}
     FROM ${fromIdent(spec.server, table)}
-    ${maybeWhere(ast.where)} ${where(spec, ast.where, table)}
+    ${maybeWhere(ast.where)} ${where(spec, ast.where, table)}${
+      ast.start
+        ? sql`
+    ${maybeWhere(ast.start)} ${start(spec, ast.start, ast.orderBy, table)}`
+        : sql``
+    }
     ${maybeWhere(correlate)} ${correlate ? correlate(table) : sql``}
     ${orderBy(spec, ast.orderBy, table)}
     ${limit(ast.limit, format?.singular)}`;
@@ -176,6 +182,57 @@ export function orderBy(
     ),
     ', ',
   )}`;
+}
+
+export function start(
+  spec: Spec,
+  bound: Bound | undefined,
+  orderBy: Ordering | undefined,
+  table: Table,
+): SQLQuery {
+  if (!bound) {
+    return sql``;
+  }
+  assert(
+    orderBy !== undefined && orderBy.length > 0,
+    'start requires ordering',
+  );
+
+  const constraints: SQLQuery[] = [];
+  for (let i = 0; i < orderBy.length; i++) {
+    const group: SQLQuery[] = [];
+    const [iField, iDirection] = orderBy[i];
+    for (let j = 0; j <= i; j++) {
+      const [field] = orderBy[j];
+      if (j === i) {
+        group.push(
+          startRangeComparison(
+            spec,
+            table,
+            iField,
+            bound.row[iField] ?? null,
+            iDirection === 'asc' ? '>' : '<',
+          ),
+        );
+      } else {
+        group.push(startEquality(spec, table, field, bound.row[field] ?? null));
+      }
+    }
+    constraints.push(sql`(${sql.join(group, ' AND ')})`);
+  }
+
+  if (!bound.exclusive) {
+    constraints.push(
+      sql`(${sql.join(
+        orderBy.map(([field]) =>
+          startEquality(spec, table, field, bound.row[field] ?? null),
+        ),
+        ' AND ',
+      )})`,
+    );
+  }
+
+  return sql`(${sql.join(constraints, ' OR ')})`;
 }
 
 function related(
@@ -240,6 +297,15 @@ function relationshipSubquery(
         )(participatingTables[0].table)}) ${
           nestedAst.where
             ? sql`AND ${where(spec, nestedAst.where, lastTable)}`
+            : sql``
+        }${
+          nestedAst.start
+            ? sql` AND ${start(
+                spec,
+                nestedAst.start,
+                nestedAst.orderBy,
+                lastTable,
+              )}`
             : sql``
         } ${orderBy(spec, nestedAst.orderBy, lastTable)} ${limit(
           last(participatingTables)?.limit,
@@ -356,12 +422,21 @@ function scalarSubquery(
     condition.op === 'EXISTS' ? '=' : 'IS NOT',
   );
 
-  const subqueryWhere = subqueryAST.where
-    ? sql`WHERE ${where(spec, subqueryAST.where, subqueryTable)}`
-    : sql``;
+  const subqueryConditions = subqueryAST.where
+    ? [where(spec, subqueryAST.where, subqueryTable)]
+    : [];
+  if (subqueryAST.start) {
+    subqueryConditions.push(
+      start(spec, subqueryAST.start, subqueryAST.orderBy, subqueryTable),
+    );
+  }
   const subqueryOrderBy = orderBy(spec, subqueryAST.orderBy, subqueryTable);
 
-  return sql`${parentCol} ${op} (SELECT ${childCol} FROM ${fromIdent(spec.server, subqueryTable)} ${subqueryWhere} ${subqueryOrderBy} LIMIT 1)`;
+  return sql`${parentCol} ${op} (SELECT ${childCol} FROM ${fromIdent(spec.server, subqueryTable)} ${
+    subqueryConditions.length > 0
+      ? sql`WHERE ${sql.join(subqueryConditions, ' AND ')}`
+      : sql``
+  } ${subqueryOrderBy} LIMIT 1)`;
 }
 
 export function makeCorrelator(
@@ -445,6 +520,49 @@ export function distinctFrom(
   return sql`${valueComparison(spec, condition.left, table, condition.right, false)} ${
     condition.op === 'IS' ? sql`IS NOT DISTINCT FROM` : sql`IS DISTINCT FROM`
   } ${valueComparison(spec, condition.right, table, condition.left, false)}`;
+}
+
+function startEquality(
+  spec: Spec,
+  table: Table,
+  field: string,
+  value: unknown,
+): SQLQuery {
+  return sql`${colIdent(spec.server, {
+    table,
+    zql: field,
+  })} IS NOT DISTINCT FROM ${startValue(spec, table, field, value)}`;
+}
+
+function startRangeComparison(
+  spec: Spec,
+  table: Table,
+  field: string,
+  value: unknown,
+  operator: '>' | '<',
+): SQLQuery {
+  const column = colIdent(spec.server, {table, zql: field});
+  if (value === null) {
+    return operator === '>' ? sql`${column} IS NOT NULL` : sql`FALSE`;
+  }
+  const typedValue = startValue(spec, table, field, value);
+  return operator === '>'
+    ? sql`${column} > ${typedValue}`
+    : sql`(${column} IS NULL OR ${column} < ${typedValue})`;
+}
+
+function startValue(
+  spec: Spec,
+  table: Table,
+  field: string,
+  value: unknown,
+): SQLQuery {
+  return sqlConvertColumnArg(
+    getServerColumn(spec.server, table, field),
+    value,
+    false,
+    true,
+  );
 }
 
 function valueComparison(

--- a/packages/zql-integration-tests/src/chinook/chinook-fuzz-backbone.pg.test.ts
+++ b/packages/zql-integration-tests/src/chinook/chinook-fuzz-backbone.pg.test.ts
@@ -10,7 +10,7 @@
  * - **L0** — every bounded-exhaustive skeleton (depth ≤ 2) hydrates identically through
  *   the IVM memory + sqlite views and the Postgres oracle (z2s).
  * - **L1** — the pairwise covering array of decorations (filter × exists × order ×
- *   limit), lowered onto every decoratable root and onto nested child collections,
+ *   limit × start), lowered onto every decoratable root and onto nested child collections,
  *   hydrates identically — and the realized assignments reach **100% pairwise** coverage
  *   (the design's headline backbone gate).
  * - **Push** — every single-level (depth ≤ 1) skeleton, driven through the four-phase
@@ -69,7 +69,7 @@ test(
 test(
   'L1 — pairwise covering array: 100% coverage + hydrate-equal over mini',
   async () => {
-    const {report, coverage} = await checkL1(harness.delegates);
+    const {report, coverage} = await checkL1(harness.delegates, data);
     console.log(
       `L1 backbone: ${report.total} cases, ${coverage.summary()}, ${report.failures.length} failures`,
     );

--- a/packages/zql-integration-tests/src/chinook/chinook-fuzz-scale.pg.test.ts
+++ b/packages/zql-integration-tests/src/chinook/chinook-fuzz-scale.pg.test.ts
@@ -21,6 +21,7 @@
 import {expect, test} from 'vitest';
 import '../helpers/comparePg.ts';
 import {bootstrap} from '../helpers/runner.ts';
+import {pkOf} from './fuzz/axes.ts';
 import {CostModel} from './fuzz/cost.ts';
 import {
   checkSwarm,
@@ -28,12 +29,15 @@ import {
   checkYieldTail,
   panicIfFailed,
 } from './fuzz/driver.ts';
+import {Data} from './fuzz/literals.ts';
+import {miniData} from './fuzz/mini.ts';
 import {getChinook} from './get-deps.ts';
 import {schema} from './schema.ts';
 
 const RUN = !!process.env.CHINOOK_SCALE;
 const SEED = 0x00c0ffee;
 const TIMEOUT_MS = 600_000;
+const startData = new Data(miniData, pkOf);
 
 /**
  * Approximate full-chinook table sizes (client names) for the static cost gate. Exact
@@ -92,7 +96,7 @@ test.skipIf(!RUN)(
   'scale swarm — masked-random over full chinook',
   async () => {
     // oxlint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const report = await checkSwarm(harness!.delegates, SEED, 24, 6);
+    const report = await checkSwarm(harness!.delegates, startData, SEED, 24, 6);
     console.log(
       `chinook swarm: ${report.total} cases, ${report.failures.length} failures`,
     );

--- a/packages/zql-integration-tests/src/chinook/chinook-fuzz-sweep.pg.test.ts
+++ b/packages/zql-integration-tests/src/chinook/chinook-fuzz-sweep.pg.test.ts
@@ -25,6 +25,7 @@
 import {expect, test} from 'vitest';
 import '../helpers/comparePg.ts';
 import {bootstrap} from '../helpers/runner.ts';
+import {pkOf} from './fuzz/axes.ts';
 import {CostModel} from './fuzz/cost.ts';
 import {
   checkMutate,
@@ -32,6 +33,7 @@ import {
   checkTail,
   panicIfFailed,
 } from './fuzz/driver.ts';
+import {Data} from './fuzz/literals.ts';
 import {miniData, miniPgContent} from './fuzz/mini.ts';
 import {enumerate} from './fuzz/skeleton.ts';
 import {schema} from './schema.ts';
@@ -40,6 +42,7 @@ const TIMEOUT_MS = 120_000;
 
 /** The repro key (design §9). Override-able for replay if a regression is found. */
 const SEED = 0x00c0ffee;
+const data = new Data(miniData, pkOf);
 
 const harness = await bootstrap({
   suiteName: 'chinook_fuzz_sweep',
@@ -52,7 +55,7 @@ console.log(`══ chinook-fuzz sweep ══  seed = ${SEED}`);
 test(
   'L2 swarm — masked-random queries hydrate-equal over mini',
   async () => {
-    const report = await checkSwarm(harness.delegates, SEED, 16, 4);
+    const report = await checkSwarm(harness.delegates, data, SEED, 16, 4);
     console.log(
       `swarm: ${report.total} cases, ${report.failures.length} failures`,
     );

--- a/packages/zql-integration-tests/src/chinook/fuzz/axes.ts
+++ b/packages/zql-integration-tests/src/chinook/fuzz/axes.ts
@@ -14,16 +14,13 @@
  *    generalized to all 11 tables). These are the one hand-authored piece; they are
  *    pinned against the schema by `axes.test.ts`.
  * 3. The formal **decoration axes** ({@link AXES}) the t-wise covering array (L1)
- *    covers and `coverage.ts` measures: `filter × exists × order × limit`. Each axis
- *    value is self-contained, so the covering array needs no inter-axis constraint
+ *    covers and `coverage.ts` measures: `filter × exists × order × limit × start`. Each
+ *    axis value is self-contained, so the covering array needs no inter-axis constraint
  *    solver — the only realizability gate is per-table (a text filter needs a text
  *    column; an EXISTS needs an outgoing relationship).
  *
  * **Known-inert axes dropped vs the Rust port** (design §8): the Rust `select` axis
- * (mono ZQL has no projection — the AST returns all columns) and the `start` (keyset
- * paging) axis (z2s does not compile `start`, so the Postgres oracle silently ignores
- * it — it cannot validate paging, and every `start` case would diverge spuriously).
- * Re-add `start` here if z2s gains keyset support.
+ * (mono ZQL has no projection — the AST returns all columns).
  */
 
 import {must} from '../../../../shared/src/must.ts';
@@ -314,6 +311,14 @@ export type OrderVal = (typeof ORDER_VALS)[number];
 export const LIMIT_VALS = ['none', 'small', 'large'] as const;
 export type LimitVal = (typeof LIMIT_VALS)[number];
 
+export const START_VALS = [
+  'none',
+  'mid_exclusive',
+  'mid_inclusive',
+  'null_exclusive',
+] as const;
+export type StartVal = (typeof START_VALS)[number];
+
 /** One formal axis: a name + its ordered value-token domain. */
 export type AxisSpec = {
   readonly name: string;
@@ -330,6 +335,7 @@ export const AXES: readonly AxisSpec[] = [
   {name: 'exists', values: EXISTS_VALS},
   {name: 'order', values: ORDER_VALS},
   {name: 'limit', values: LIMIT_VALS},
+  {name: 'start', values: START_VALS},
 ];
 
 export const N_AXES = AXES.length;

--- a/packages/zql-integration-tests/src/chinook/fuzz/cover.ts
+++ b/packages/zql-integration-tests/src/chinook/fuzz/cover.ts
@@ -15,6 +15,7 @@
  */
 
 import type {Condition} from '../../../../zero-protocol/src/ast.ts';
+import {asQueryInternals} from '../../../../zql/src/query/query-internals.ts';
 import type {AnyQuery} from '../../../../zql/src/query/query.ts';
 import {newStaticQuery} from '../../../../zql/src/query/static-query.ts';
 import {schema} from '../schema.ts';
@@ -34,9 +35,11 @@ import {
   type Rel,
   relsOf,
   rolesOf,
+  START_VALS,
+  type StartVal,
 } from './axes.ts';
 import {axisCombinations} from './coverage.ts';
-import {filterCondition, simple} from './literals.ts';
+import {type Data, filterCondition, simple} from './literals.ts';
 
 // ── the greedy covering-array builder ─────────────────────────────────────────────────
 
@@ -202,6 +205,34 @@ export function applyLimit(q: AnyQuery, lv: LimitVal): AnyQuery {
   }
 }
 
+/** Apply the `start` axis using a data-driven cursor row. */
+export function applyStart(
+  q: AnyQuery,
+  table: string,
+  sv: StartVal,
+  data: Data,
+): AnyQuery | null {
+  switch (sv) {
+    case 'none':
+      return q;
+    case 'mid_exclusive': {
+      const row = data.startRow(table, asQueryInternals(q).ast.orderBy);
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+      return row ? (q as any).start(row) : null;
+    }
+    case 'mid_inclusive': {
+      const row = data.startRow(table, asQueryInternals(q).ast.orderBy);
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+      return row ? (q as any).start(row, {inclusive: true}) : null;
+    }
+    case 'null_exclusive': {
+      const row = data.nullStartRow(table, asQueryInternals(q).ast.orderBy);
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+      return row ? (q as any).start(row) : null;
+    }
+  }
+}
+
 /**
  * Build the EXISTS/NOT-EXISTS `where` condition for an {@link ExistsVal} on `table`:
  * gate on `rel`, at the requested boolean position. The AND/OR positions pair the gate
@@ -271,11 +302,13 @@ function applyDecorations(
   q: AnyQuery,
   table: string,
   a: readonly number[],
+  data: Data,
 ): AnyQuery | null {
   const fv = FILTER_VALS[a[axisIndex('filter')]] as FilterVal;
   const ev = EXISTS_VALS[a[axisIndex('exists')]] as ExistsVal;
   const ov = ORDER_VALS[a[axisIndex('order')]] as OrderVal;
   const lv = LIMIT_VALS[a[axisIndex('limit')]] as LimitVal;
+  const sv = START_VALS[a[axisIndex('start')]] as StartVal;
 
   if (!filterRealizable(table, fv)) {
     return null;
@@ -294,6 +327,11 @@ function applyDecorations(
 
   let out = applyWhere(q, table, filterCond, gateRel, ev);
   out = applyOrder(out, table, ov);
+  const started = applyStart(out, table, sv, data);
+  if (!started) {
+    return null;
+  }
+  out = started;
   out = applyLimit(out, lv);
   return out;
 }
@@ -305,11 +343,12 @@ function applyDecorations(
 export function decorate(
   table: string,
   a: readonly number[],
+  data: Data,
 ): [AnyQuery, boolean] | null {
   const ev = EXISTS_VALS[a[axisIndex('exists')]] as ExistsVal;
   // oxlint-disable-next-line @typescript-eslint/no-explicit-any
   const root = newStaticQuery(schema, table as any) as AnyQuery;
-  const q = applyDecorations(root, table, a);
+  const q = applyDecorations(root, table, a, data);
   return q ? [q, ev !== 'none'] : null;
 }
 
@@ -324,6 +363,7 @@ export function decorateChild(
   parent: string,
   rel: string,
   a: readonly number[],
+  data: Data,
 ): [AnyQuery, boolean] | null {
   const relInfo = relsOf(parent).find(r => r.name === rel);
   if (!relInfo) {
@@ -342,7 +382,8 @@ export function decorateChild(
   const root = (newStaticQuery(schema, parent as any) as any).related(
     rel,
     // oxlint-disable-next-line @typescript-eslint/no-explicit-any
-    (sub: any) => applyDecorations(sub as AnyQuery, relInfo.child, a) ?? sub,
+    (sub: any) =>
+      applyDecorations(sub as AnyQuery, relInfo.child, a, data) ?? sub,
   );
   return [root as AnyQuery, ev !== 'none'];
 }

--- a/packages/zql-integration-tests/src/chinook/fuzz/driver.ts
+++ b/packages/zql-integration-tests/src/chinook/fuzz/driver.ts
@@ -180,6 +180,7 @@ export async function checkL0Hydrate(
  */
 export async function checkL1(
   delegates: Delegates,
+  data: Data,
 ): Promise<{report: Report; coverage: Coverage}> {
   const rows = greedyCover(2);
   const cov = new Coverage(2);
@@ -190,7 +191,7 @@ export async function checkL1(
   // Root decorations: each covering-array row × each decoratable root.
   for (const row of rows) {
     for (const root of decoratableRoots()) {
-      const res = decorate(root, row);
+      const res = decorate(root, row, data);
       if (!res) {
         continue;
       }
@@ -210,7 +211,7 @@ export async function checkL1(
   // child sort position) — the parity surface the root-only pass misses.
   for (const [parent, rel] of childDecorationPairs()) {
     for (const row of rows) {
-      const res = decorateChild(parent, rel, row);
+      const res = decorateChild(parent, rel, row, data);
       if (!res) {
         continue;
       }
@@ -239,6 +240,7 @@ export async function checkL1(
  */
 export async function checkSwarm(
   delegates: Delegates,
+  data: Data,
   seed: number,
   nMasks: number,
   perMask: number,
@@ -250,7 +252,7 @@ export async function checkSwarm(
   for (let mi = 0; mi < nMasks; mi++) {
     const mask = Mask.random(r);
     for (let qi = 0; qi < perMask; qi++) {
-      const res = swarmGen(r, mask);
+      const res = swarmGen(r, mask, data);
       if (!res) {
         continue;
       }

--- a/packages/zql-integration-tests/src/chinook/fuzz/fuzz.test.ts
+++ b/packages/zql-integration-tests/src/chinook/fuzz/fuzz.test.ts
@@ -18,7 +18,7 @@ import {asQueryInternals} from '../../../../zql/src/query/query-internals.ts';
 import type {AnyQuery} from '../../../../zql/src/query/query.ts';
 import {QueryDelegateImpl as TestMemoryQueryDelegate} from '../../../../zql/src/query/test/query-delegate.ts';
 import {schema} from '../schema.ts';
-import {hasText, pkOf, relsOf, tables} from './axes.ts';
+import {AXES, hasText, pkOf, relsOf, tables} from './axes.ts';
 import {CostModel} from './cost.ts';
 import {
   decorate,
@@ -98,7 +98,7 @@ describe('coverage', () => {
     }
     expect(cov.fraction()).toBe(1);
     expect(cov.missed()).toEqual([]);
-    // Far smaller than the full cross-product (16·7·4·3 = 1344) …
+    // Far smaller than the full cross-product (16·7·4·3·4 = 5376) …
     expect(rows.length).toBeLessThan(200);
     // … but at least the largest single-pair domain product (filter·exists = 16·7).
     expect(rows.length).toBeGreaterThanOrEqual(16 * 7);
@@ -107,15 +107,20 @@ describe('coverage', () => {
   test('observe marks every t-subset; total is the pairwise tuple count', () => {
     const cov = new Coverage(2);
     expect(cov.hitCount()).toBe(0);
-    // domains [16,7,4,3] ⇒ Σ over the 6 axis-pairs of dom_i·dom_j = 285.
+    // Pairwise total is Σ over axis-pairs of dom_i·dom_j.
+    const domains = AXES.map(a => a.values.length);
+    const expected = domains.flatMap((d, i) =>
+      domains.slice(i + 1).map(e => d * e),
+    );
+    const pairCount = (AXES.length * (AXES.length - 1)) / 2;
     const total = cov.total();
-    expect(total).toBe(16 * 7 + 16 * 4 + 16 * 3 + 7 * 4 + 7 * 3 + 4 * 3);
-    cov.observe([0, 0, 0, 0]); // one assignment hits C(4,2) = 6 pairwise tuples
-    expect(cov.hitCount()).toBe(6);
-    cov.observe([1, 1, 1, 1]); // a fully-different assignment adds 6 fresh tuples
-    expect(cov.hitCount()).toBe(12);
-    cov.observe([0, 0, 0, 0]); // re-observing is idempotent
-    expect(cov.hitCount()).toBe(12);
+    expect(total).toBe(expected.reduce((acc, n) => acc + n, 0));
+    cov.observe([0, 0, 0, 0, 0]); // one assignment hits C(N_AXES,2) tuples
+    expect(cov.hitCount()).toBe(pairCount);
+    cov.observe([1, 1, 1, 1, 1]); // a fully-different assignment adds fresh tuples
+    expect(cov.hitCount()).toBe(pairCount * 2);
+    cov.observe([0, 0, 0, 0, 0]); // re-observing is idempotent
+    expect(cov.hitCount()).toBe(pairCount * 2);
   });
 });
 
@@ -171,7 +176,7 @@ describe('L1 covering array', () => {
     const delegate = memoryDelegate();
     const rows = greedyCover(2);
     for (const r of rows) {
-      const res = decorate('track', r);
+      const res = decorate('track', r, data);
       expect(res, `track could not realize ${r}`).not.toBeNull();
       await hydrates(delegate, res![0]);
     }
@@ -183,7 +188,7 @@ describe('L1 covering array', () => {
     const cov = new Coverage(2);
     for (const r of rows) {
       for (const root of decoratableRoots()) {
-        const res = decorate(root, r);
+        const res = decorate(root, r, data);
         if (!res) {
           continue; // unrealizable on this root (text filter on a textless table)
         }
@@ -199,7 +204,7 @@ describe('L1 covering array', () => {
     const rows = greedyCover(2);
     let realized = 0;
     for (const r of rows) {
-      const res = decorateChild('album', 'tracks', r);
+      const res = decorateChild('album', 'tracks', r, data);
       if (!res) {
         continue;
       }
@@ -225,6 +230,9 @@ describe('data-driven literals', () => {
     const comps = data.values('track', 'composer');
     expect(comps.length).toBeGreaterThan(0);
     expect(comps.every(v => v !== null)).toBe(true);
+    const start = data.startRow('track', [['milliseconds', 'asc']]);
+    expect(start?.id).toBeDefined();
+    expect(start?.milliseconds).toBeDefined();
   });
 
   test('text-filter realizability tracks the presence of a text column', () => {
@@ -399,7 +407,7 @@ describe('swarm (L2)', () => {
     let made = 0;
     for (let i = 0; i < 400; i++) {
       const mask = Mask.random(r);
-      const res = swarmGen(r, mask);
+      const res = swarmGen(r, mask, data);
       if (!res) {
         continue; // unrealizable pick (text filter on a textless table) — retry
       }
@@ -414,13 +422,14 @@ describe('swarm (L2)', () => {
 
   test('a disabled axis is pinned to its baseline (none)', () => {
     // Every axis off, no nesting ⇒ a bare decorated root: every axis at value 0 = none.
-    const mask = new Mask([false, false, false, false], false);
-    const res = swarmGen(rng(1), mask);
+    const mask = new Mask([false, false, false, false, false], false);
+    const res = swarmGen(rng(1), mask, data);
     expect(res).not.toBeNull();
     const ast = asQueryInternals(res![0]).ast;
     expect(ast.where).toBeUndefined();
     expect(ast.orderBy ?? []).toHaveLength(0);
     expect(ast.limit).toBeUndefined();
+    expect(ast.start).toBeUndefined();
     expect(ast.related ?? []).toHaveLength(0);
   });
 });

--- a/packages/zql-integration-tests/src/chinook/fuzz/literals.ts
+++ b/packages/zql-integration-tests/src/chinook/fuzz/literals.ts
@@ -18,6 +18,7 @@
 import type {
   Condition,
   LiteralValue,
+  Ordering,
   SimpleCondition,
   SimpleOperator,
 } from '../../../../zero-protocol/src/ast.ts';
@@ -53,13 +54,17 @@ function compareValues(a: Value, b: Value): number {
 export class Data {
   readonly #cols = new Map<string, Value[]>();
   readonly #pk0 = new Map<string, Value[]>();
+  readonly #rows = new Map<string, readonly Row[]>();
+  readonly #pkOf: (table: string) => readonly string[];
 
   /** Index the column values of every table in `data` (keyed by client table name). */
   constructor(
     data: Record<string, Row[]>,
     pkOf: (table: string) => readonly string[],
   ) {
+    this.#pkOf = pkOf;
     for (const [table, rows] of Object.entries(data)) {
+      this.#rows.set(table, rows);
       const columns = new Set<string>();
       for (const row of rows) {
         for (const c of Object.keys(row)) {
@@ -92,6 +97,26 @@ export class Data {
     }
     return vals[Math.floor(vals.length / 2)];
   }
+
+  /**
+   * A present row near the middle of `table` under `orderBy` completed with PK columns.
+   * This gives `start` a non-vacuous cursor that reflects an actual fixture row.
+   */
+  startRow(table: string, orderBy: Ordering | undefined): Row | undefined {
+    const rows = this.#rows.get(table);
+    if (!rows || rows.length === 0) {
+      return undefined;
+    }
+    const ordering = completeOrdering(this.#pkOf(table), orderBy);
+    const sorted = rows.toSorted((a, b) => compareRows(a, b, ordering));
+    return sorted[Math.floor(sorted.length / 2)];
+  }
+
+  /** A null cursor on the first completed ordering term, for null-bound paging cases. */
+  nullStartRow(table: string, orderBy: Ordering | undefined): Row | undefined {
+    const first = completeOrdering(this.#pkOf(table), orderBy)[0]?.[0];
+    return first ? {[first]: null} : undefined;
+  }
 }
 
 function distinctSorted(values: readonly (Value | undefined)[]): Value[] {
@@ -107,6 +132,30 @@ function distinctSorted(values: readonly (Value | undefined)[]): Value[] {
     }
   }
   return out;
+}
+
+function completeOrdering(
+  primaryKey: readonly string[],
+  orderBy: Ordering | undefined,
+): Ordering {
+  const completed = [...(orderBy ?? [])];
+  const seen = new Set(completed.map(([field]) => field));
+  for (const field of primaryKey) {
+    if (!seen.has(field)) {
+      completed.push([field, 'asc']);
+    }
+  }
+  return completed;
+}
+
+function compareRows(a: Row, b: Row, orderBy: Ordering): number {
+  for (const [field, direction] of orderBy) {
+    const comp = compareValues(a[field], b[field]);
+    if (comp !== 0) {
+      return direction === 'asc' ? comp : -comp;
+    }
+  }
+  return 0;
 }
 
 // ── filter lowering (the `filter` axis → a root `where` condition) ───────────────────

--- a/packages/zql-integration-tests/src/chinook/fuzz/metamorphic.ts
+++ b/packages/zql-integration-tests/src/chinook/fuzz/metamorphic.ts
@@ -10,8 +10,7 @@
  * - **LargeLimit** — a `limit` ≥ the result size is a no-op (a non-binding take).
  * - **StartBeforeFirst** — a `start` key below every PK (bare-PK sort) is a no-op (a
  *   non-binding skip). Guarded to single-column numeric PKs. This exercises the IVM's
- *   `start` handling directly — it is oracle-free, so z2s's lack of `start` compilation
- *   (the inert axis dropped from the differential generator) does not apply here.
+ *   `start` handling directly and stays useful as an oracle-free semantic invariant.
  *
  * Each holds by query semantics, so a divergence is an engine bug found without a
  * hand-computed expectation.

--- a/packages/zql-integration-tests/src/chinook/fuzz/mutate.ts
+++ b/packages/zql-integration-tests/src/chinook/fuzz/mutate.ts
@@ -9,8 +9,8 @@
  * `lower(skeleton)`'s AST). A `where`/`order`/`limit` twist needs no correlation, so it
  * splices directly; an `AddExists` twist DOES need correlation keys, so it borrows them
  * from a throwaway builder query ({@link existsConditionFor}) — the same path L1 uses —
- * rather than hand-rolling them. (The `start` twist is dropped: z2s does not compile
- * `start`, so it is an inert axis here — see `axes.ts`.)
+ * rather than hand-rolling them. (The `start` twist is still separate; it needs a
+ * data-driven cursor row to avoid mostly-vacuous mutations.)
  */
 
 import {must} from '../../../../shared/src/must.ts';

--- a/packages/zql-integration-tests/src/chinook/fuzz/swarm.ts
+++ b/packages/zql-integration-tests/src/chinook/fuzz/swarm.ts
@@ -13,6 +13,7 @@
 import type {AnyQuery} from '../../../../zql/src/query/query.ts';
 import {AXES, N_AXES, tables} from './axes.ts';
 import {childDecorationPairs, decorate, decorateChild} from './cover.ts';
+import type {Data} from './literals.ts';
 import type {Rng} from './rng.ts';
 
 /**
@@ -57,12 +58,16 @@ function randomAssignment(rng: Rng, mask: Mask): number[] {
  * enables nesting — a decorated nested collection. `true` iff EXISTS-bearing. `null` if
  * the random pick is unrealizable on the chosen table (the caller retries / skips).
  */
-export function swarmGen(rng: Rng, mask: Mask): [AnyQuery, boolean] | null {
+export function swarmGen(
+  rng: Rng,
+  mask: Mask,
+  data: Data,
+): [AnyQuery, boolean] | null {
   const a = randomAssignment(rng, mask);
   if (mask.nest) {
     const pair = rng.choose(childDecorationPairs());
-    return pair ? decorateChild(pair[0], pair[1], a) : null;
+    return pair ? decorateChild(pair[0], pair[1], a, data) : null;
   }
   const root = rng.choose(tables());
-  return root ? decorate(root, a) : null;
+  return root ? decorate(root, a, data) : null;
 }

--- a/packages/zql-integration-tests/src/chinook/fuzz/tail.ts
+++ b/packages/zql-integration-tests/src/chinook/fuzz/tail.ts
@@ -7,8 +7,8 @@
  *
  * A random query is a random **skeleton** (deeper than the enumerator's caps — depth up
  * to 4, same "no `related` under EXISTS" invariant), lowered via the fluent builder and
- * given an optional random root filter + `order` / `limit`. (The Rust `start`/`select`
- * decorations are dropped — both are inert here; see `axes.ts`.)
+ * given an optional random root filter + `order` / `limit`. The data-driven `start` axis
+ * is covered by L1/swarm; `select` remains absent because mono ZQL has no projection.
  */
 
 import type {AnyQuery} from '../../../../zql/src/query/query.ts';

--- a/packages/zqlite/src/query-builder.test.ts
+++ b/packages/zqlite/src/query-builder.test.ts
@@ -86,6 +86,127 @@ test('optional cursor columns keep IS and IS NULL checks while non-nullable colu
   `);
 });
 
+test('null cursor range starts after null with IS NOT NULL', () => {
+  const columns = {
+    owner: {type: 'string', optional: true},
+    id: {type: 'string'},
+  } as const satisfies Record<string, SchemaValue>;
+
+  expect(
+    format(
+      buildSelectQuery(
+        'issues',
+        columns,
+        undefined,
+        undefined,
+        [['owner', 'asc']],
+        undefined,
+        {
+          row: {owner: null},
+          basis: 'after',
+        },
+      ),
+    ),
+  ).toMatchInlineSnapshot(`
+    {
+      "text": "SELECT "owner","id" FROM "issues" WHERE (("owner" IS NOT NULL)) ORDER BY "owner" asc",
+      "values": [],
+    }
+  `);
+});
+
+test('null cursor descending range has no rows after null', () => {
+  const columns = {
+    owner: {type: 'string', optional: true},
+    id: {type: 'string'},
+  } as const satisfies Record<string, SchemaValue>;
+
+  expect(
+    format(
+      buildSelectQuery(
+        'issues',
+        columns,
+        undefined,
+        undefined,
+        [['owner', 'desc']],
+        undefined,
+        {
+          row: {owner: null},
+          basis: 'after',
+        },
+      ),
+    ),
+  ).toMatchInlineSnapshot(`
+    {
+      "text": "SELECT "owner","id" FROM "issues" WHERE ((FALSE)) ORDER BY "owner" desc",
+      "values": [],
+    }
+  `);
+});
+
+test('null cursor on first column preserves compound tie-breaker ranges', () => {
+  const columns = {
+    owner: {type: 'string', optional: true},
+    id: {type: 'string'},
+  } as const satisfies Record<string, SchemaValue>;
+
+  expect(
+    format(
+      buildSelectQuery(
+        'issues',
+        columns,
+        undefined,
+        undefined,
+        [
+          ['owner', 'desc'],
+          ['id', 'asc'],
+        ],
+        undefined,
+        {
+          row: {owner: null},
+          basis: 'after',
+        },
+      ),
+    ),
+  ).toMatchInlineSnapshot(`
+    {
+      "text": "SELECT "owner","id" FROM "issues" WHERE ((FALSE) OR ("owner" IS ? AND "id" IS NOT NULL)) ORDER BY "owner" desc, "id" asc",
+      "values": [
+        null,
+      ],
+    }
+  `);
+});
+
+test('omitted cursor fields are treated as null', () => {
+  const columns = {
+    id: {type: 'string'},
+    owner: {type: 'string', optional: true},
+  } as const satisfies Record<string, SchemaValue>;
+
+  expect(
+    format(
+      buildSelectQuery(
+        'issues',
+        columns,
+        undefined,
+        undefined,
+        [['id', 'asc']],
+        undefined,
+        {
+          row: {owner: null},
+          basis: 'after',
+        },
+      ),
+    ),
+  ).toMatchInlineSnapshot(`
+    {
+      "text": "SELECT "id","owner" FROM "issues" WHERE (("id" IS NOT NULL)) ORDER BY "id" asc",
+      "values": [],
+    }
+  `);
+});
+
 test('multiConstraints with single column emits IN list', () => {
   const columns = {
     id: {type: 'string'},

--- a/packages/zqlite/src/query-builder.ts
+++ b/packages/zqlite/src/query-builder.ts
@@ -306,6 +306,10 @@ function nullableAwareRangeComparison(
   operator: '>' | '<',
   columnType: SchemaValue,
 ): SQLQuery {
+  if (value === null) {
+    return operator === '>' ? sql`${sql.ident(field)} IS NOT NULL` : sql`FALSE`;
+  }
+
   // For non-nullable columns, skip IS NULL checks to avoid breaking
   // SQLite's MULTI-INDEX OR optimization, which falls back to a full
   // table scan when any OR branch involves NULL.
@@ -328,6 +332,10 @@ function sargableLeadingStartBound(
   operator: '>' | '<',
   columnType: SchemaValue,
 ): SQLQuery | undefined {
+  if (value === null) {
+    return undefined;
+  }
+
   if (columnType.optional === true) {
     return undefined;
   }
@@ -370,7 +378,10 @@ function gatherStartConstraints(
     for (let j = 0; j <= i; j++) {
       if (j === i) {
         const columnType = columnTypes[iField];
-        const constraintValue = toSQLiteType(from[iField], columnType.type);
+        const constraintValue = toSQLiteType(
+          from[iField] ?? null,
+          columnType.type,
+        );
         const operator =
           iDirection === 'asc' ? (reverse ? '<' : '>') : reverse ? '>' : '<';
         if (i === 0) {
@@ -392,7 +403,7 @@ function gatherStartConstraints(
       } else {
         const [jField] = order[j];
         const columnType = columnTypes[jField];
-        const value = toSQLiteType(from[jField], columnType.type);
+        const value = toSQLiteType(from[jField] ?? null, columnType.type);
         group.push(nullableAwareEquality(jField, value, columnType));
       }
     }
@@ -404,7 +415,7 @@ function gatherStartConstraints(
       sql`(${sql.join(
         order.map(([field]) => {
           const columnType = columnTypes[field];
-          const value = toSQLiteType(from[field], columnType.type);
+          const value = toSQLiteType(from[field] ?? null, columnType.type);
           return nullableAwareEquality(field, value, columnType);
         }),
         sql` AND `,


### PR DESCRIPTION
Two big bugs:

1. issue.start(foo) did not compile in z2s (which we use for mutators and our oracle)
2. table source incorrectly compared against `null`  when the cursor was null.  

This expands the fuzzer to include `start` testing which apparently it never included. The expansion of the fuzzer found problem (2). Which is convenient because it was the root cause of the take bound not set issue which I was concurrently working.