### PR TITLE
ci: parallelize JS workflow jobs

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -37,10 +37,10 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ steps.pnpm-store.outputs.path }}
-          key: pnpm-store-v11-${{ runner.os }}-${{ runner.arch }}-full-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'package.json') }}
+          key: pnpm-store-v11-${{ runner.os }}-${{ runner.arch }}-root-tools-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'package.json') }}
           restore-keys: |
-            pnpm-store-v11-${{ runner.os }}-${{ runner.arch }}-full-
-      - run: pnpm install --frozen-lockfile
+            pnpm-store-v11-${{ runner.os }}-${{ runner.arch }}-root-tools-
+      - run: pnpm install --frozen-lockfile --filter @rocicorp/mono --ignore-scripts
       - run: pnpm exec syncpack lint
 
   verify-deps:
@@ -67,7 +67,7 @@ jobs:
           key: pnpm-store-v11-${{ runner.os }}-${{ runner.arch }}-verify-deps-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'package.json') }}
           restore-keys: |
             pnpm-store-v11-${{ runner.os }}-${{ runner.arch }}-verify-deps-
-      - run: pnpm install --frozen-lockfile --filter verify-package-deps
+      - run: pnpm install --frozen-lockfile --filter verify-package-deps --ignore-scripts
       - run: pnpm run verify-deps
 
   format:
@@ -91,10 +91,10 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ steps.pnpm-store.outputs.path }}
-          key: pnpm-store-v11-${{ runner.os }}-${{ runner.arch }}-full-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'package.json') }}
+          key: pnpm-store-v11-${{ runner.os }}-${{ runner.arch }}-root-tools-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'package.json') }}
           restore-keys: |
-            pnpm-store-v11-${{ runner.os }}-${{ runner.arch }}-full-
-      - run: pnpm install --frozen-lockfile
+            pnpm-store-v11-${{ runner.os }}-${{ runner.arch }}-root-tools-
+      - run: pnpm install --frozen-lockfile --filter @rocicorp/mono --ignore-scripts
       - run: pnpm exec oxfmt --check
 
   lint:
@@ -118,10 +118,10 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ steps.pnpm-store.outputs.path }}
-          key: pnpm-store-v11-${{ runner.os }}-${{ runner.arch }}-full-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'package.json') }}
+          key: pnpm-store-v11-${{ runner.os }}-${{ runner.arch }}-root-tools-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'package.json') }}
           restore-keys: |
-            pnpm-store-v11-${{ runner.os }}-${{ runner.arch }}-full-
-      - run: pnpm install --frozen-lockfile
+            pnpm-store-v11-${{ runner.os }}-${{ runner.arch }}-root-tools-
+      - run: pnpm install --frozen-lockfile --filter @rocicorp/mono --ignore-scripts
       - run: pnpm run lint
 
   check-types:

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 jobs:
-  # Independent checks. Keep these separate so GitHub Actions can run them in parallel.
+  # Fast preflight checks. Expensive jobs wait on these to avoid wasted CI minutes.
   syncpack:
     name: Sync Package Versions
     runs-on: ubuntu-latest
@@ -91,6 +91,7 @@ jobs:
   check-types:
     name: Check Types
     runs-on: ubuntu-latest
+    needs: [syncpack, verify-deps, format, lint]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -109,6 +110,7 @@ jobs:
   zero-docker:
     name: Build Zero Docker Image
     runs-on: ubuntu-latest
+    needs: [syncpack, verify-deps, format, lint]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -148,6 +150,7 @@ jobs:
   test:
     name: Test (Shard ${{ matrix.shard }}/3)
     runs-on: ubuntu-latest
+    needs: [syncpack, verify-deps, format, lint]
     strategy:
       fail-fast: false
       matrix:
@@ -174,6 +177,7 @@ jobs:
   test-pg:
     name: Test PG ${{ matrix.pg-version }} (Shard ${{ matrix.shard }}/2)
     runs-on: ubuntu-latest
+    needs: [syncpack, verify-deps, format, lint]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 jobs:
-  # Gate jobs - must pass before other jobs run
+  # Independent checks. Keep these separate so GitHub Actions can run them in parallel.
   syncpack:
     name: Sync Package Versions
     runs-on: ubuntu-latest
@@ -55,7 +55,6 @@ jobs:
   format:
     name: Oxfmt
     runs-on: ubuntu-latest
-    needs: [syncpack, verify-deps]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -74,7 +73,6 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
-    needs: [syncpack, verify-deps]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -93,7 +91,6 @@ jobs:
   check-types:
     name: Check Types
     runs-on: ubuntu-latest
-    needs: [syncpack, verify-deps]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -112,7 +109,6 @@ jobs:
   zero-docker:
     name: Build Zero Docker Image
     runs-on: ubuntu-latest
-    needs: [syncpack, verify-deps]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -152,7 +148,6 @@ jobs:
   test:
     name: Test (Shard ${{ matrix.shard }}/3)
     runs-on: ubuntu-latest
-    needs: [format, lint, check-types]
     strategy:
       fail-fast: false
       matrix:
@@ -179,7 +174,6 @@ jobs:
   test-pg:
     name: Test PG ${{ matrix.pg-version }} (Shard ${{ matrix.shard }}/2)
     runs-on: ubuntu-latest
-    needs: [format, lint, check-types]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -27,10 +27,19 @@ jobs:
         with:
           version: 11.5.3
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-
         with:
           node-version: 24.x
-          cache: 'pnpm'
+          package-manager-cache: false
+      - name: Get pnpm store path
+        id: pnpm-store
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+      - name: Cache pnpm store
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: pnpm-store-v11-${{ runner.os }}-${{ runner.arch }}-full-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'package.json') }}
+          restore-keys: |
+            pnpm-store-v11-${{ runner.os }}-${{ runner.arch }}-full-
       - run: pnpm install --frozen-lockfile
       - run: pnpm exec syncpack lint
 
@@ -45,10 +54,19 @@ jobs:
         with:
           version: 11.5.3
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-
         with:
           node-version: 24.x
-          cache: 'pnpm'
+          package-manager-cache: false
+      - name: Get pnpm store path
+        id: pnpm-store
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+      - name: Cache pnpm store
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: pnpm-store-v11-${{ runner.os }}-${{ runner.arch }}-verify-deps-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'package.json') }}
+          restore-keys: |
+            pnpm-store-v11-${{ runner.os }}-${{ runner.arch }}-verify-deps-
       - run: pnpm install --frozen-lockfile --filter verify-package-deps
       - run: pnpm run verify-deps
 
@@ -63,10 +81,19 @@ jobs:
         with:
           version: 11.5.3
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-
         with:
           node-version: 24.x
-          cache: 'pnpm'
+          package-manager-cache: false
+      - name: Get pnpm store path
+        id: pnpm-store
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+      - name: Cache pnpm store
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: pnpm-store-v11-${{ runner.os }}-${{ runner.arch }}-full-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'package.json') }}
+          restore-keys: |
+            pnpm-store-v11-${{ runner.os }}-${{ runner.arch }}-full-
       - run: pnpm install --frozen-lockfile
       - run: pnpm exec oxfmt --check
 
@@ -81,10 +108,19 @@ jobs:
         with:
           version: 11.5.3
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-
         with:
           node-version: 24.x
-          cache: 'pnpm'
+          package-manager-cache: false
+      - name: Get pnpm store path
+        id: pnpm-store
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+      - name: Cache pnpm store
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: pnpm-store-v11-${{ runner.os }}-${{ runner.arch }}-full-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'package.json') }}
+          restore-keys: |
+            pnpm-store-v11-${{ runner.os }}-${{ runner.arch }}-full-
       - run: pnpm install --frozen-lockfile
       - run: pnpm run lint
 
@@ -100,10 +136,19 @@ jobs:
         with:
           version: 11.5.3
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-
         with:
           node-version: 24.x
-          cache: 'pnpm'
+          package-manager-cache: false
+      - name: Get pnpm store path
+        id: pnpm-store
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+      - name: Cache pnpm store
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: pnpm-store-v11-${{ runner.os }}-${{ runner.arch }}-full-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'package.json') }}
+          restore-keys: |
+            pnpm-store-v11-${{ runner.os }}-${{ runner.arch }}-full-
       - run: pnpm install --frozen-lockfile
       - run: pnpm run check-types
 
@@ -121,8 +166,18 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24.x
-          cache: 'pnpm'
+          package-manager-cache: false
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+      - name: Get pnpm store path
+        id: pnpm-store
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+      - name: Cache pnpm store
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: pnpm-store-v11-${{ runner.os }}-${{ runner.arch }}-full-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'package.json') }}
+          restore-keys: |
+            pnpm-store-v11-${{ runner.os }}-${{ runner.arch }}-full-
       - run: pnpm install --frozen-lockfile
       - run: pnpm --filter @rocicorp/zero run build
       - name: Pack Zero
@@ -166,7 +221,17 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24.x
-          cache: 'pnpm'
+          package-manager-cache: false
+      - name: Get pnpm store path
+        id: pnpm-store
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+      - name: Cache pnpm store
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: pnpm-store-v11-${{ runner.os }}-${{ runner.arch }}-full-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'package.json') }}
+          restore-keys: |
+            pnpm-store-v11-${{ runner.os }}-${{ runner.arch }}-full-
       - run: pnpm install --frozen-lockfile
       - uses: ./.github/actions/playwright-install
       - name: Run tests
@@ -194,7 +259,17 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24.x
-          cache: 'pnpm'
+          package-manager-cache: false
+      - name: Get pnpm store path
+        id: pnpm-store
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+      - name: Cache pnpm store
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: pnpm-store-v11-${{ runner.os }}-${{ runner.arch }}-full-${{ hashFiles('pnpm-lock.yaml', 'pnpm-workspace.yaml', 'package.json') }}
+          restore-keys: |
+            pnpm-store-v11-${{ runner.os }}-${{ runner.arch }}-full-
       - run: pnpm install --frozen-lockfile
       - name: Run tests
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0


### PR DESCRIPTION
<img width="679" height="522" alt="Screenshot 2026-07-03 at 10 33 30 AM" src="https://github.com/user-attachments/assets/0f86ed4d-c0e4-487c-8e03-ce184191d62e" />
Got these down to ~30s 


- Run fast JS preflight checks in parallel: syncpack, verify-deps, format, and lint.
- Gate expensive jobs on preflight so tests do not run when fmt/lint/package checks fail.
- Let tests, PG tests, typecheck, and Docker build run in parallel after preflight.
- Replace setup-node's shared pnpm cache with explicit scoped pnpm-store caches.
- Use smaller root-tools installs for syncpack, format, and lint.
- Add `--ignore-scripts` for filtered preflight installs where lifecycle scripts are unnecessary.

