### PR TITLE
fix(zero-cache): skip backfill for update_schemas defaults

### DIFF
--- a/packages/zero-cache/src/db/pg-to-lite.test.ts
+++ b/packages/zero-cache/src/db/pg-to-lite.test.ts
@@ -1,5 +1,6 @@
 import {expect, test} from 'vitest';
 import {
+  defaultValueMatches,
   mapPostgresToLite,
   mapPostgresToLiteColumn,
   mapPostgresToLiteDefault,
@@ -481,4 +482,68 @@ test.each([
   ["'{}'::integer[]", "'[]'"],
 ])('supported column default %s', (input, output) => {
   expect(mapPostgresToLiteDefault('foo', 'bar', input)).toEqual(output);
+});
+
+test.each([
+  // Numeric literals
+  ['2', 2],
+  ['0', 0],
+  ['-456', -456],
+  ['123.456', 123.456],
+  ['-0.5', -0.5],
+  ['2147483648', 2147483648],
+
+  // Boolean literals
+  ['true', true],
+  ['false', false],
+
+  // Quoted strings with type casts
+  ["'foo'::text", 'foo'],
+  ["'hello world'::varchar", 'hello world'],
+  ["''::text", ''],
+  ["'it''s'::text", "it's"],
+
+  // Quoted numeric literals with type casts (e.g. bigint)
+  ["'2147483648'::bigint", 2147483648],
+  ["'-0.5'::numeric", -0.5],
+])('default value matches %s = %o', (dflt, missingValue) => {
+  expect(defaultValueMatches(dflt, missingValue)).toBe(true);
+});
+
+test.each([
+  // Value mismatches (e.g. default changed after the column was added)
+  ['2', 1],
+  ['true', false],
+  ['false', 0],
+  ["'foo'::text", 'food'],
+  ["'2'::bigint", 2.5],
+
+  // Type mismatches
+  ['2', '2'],
+  ['true', 'true'],
+  ["'foo'::text", 0],
+  ["'true'::text", true],
+
+  // Absent / null values never match
+  [null, 2],
+  [undefined, 2],
+  ['2', undefined],
+  ['2', null],
+  ['', ''],
+
+  // Integers outside of the safe range may lose precision when parsed,
+  // and are never considered equal.
+  ['9007199254740993', 9007199254740993],
+  ["'9007199254740993'::bigint", 9007199254740993],
+
+  // Unsupported (e.g. non-literal) expressions never match
+  ['CURRENT_TIMESTAMP', '2026-07-13 00:00:00'],
+  ['now()', '2026-07-13 00:00:00'],
+  ["nextval('seq'::regclass)", 1],
+  ["'{}'::text[]", []],
+  ['ARRAY[]::text[]', []],
+  ["'{1,2}'::integer[]", [1, 2]],
+  ["'foo'", 'foo'], // bare quoted string without type cast
+])('default value does not match %s = %o', (dflt, missingValue) => {
+  expect(defaultValueMatches(dflt, missingValue)).toBe(false);
 });

--- a/packages/zero-cache/src/db/pg-to-lite.ts
+++ b/packages/zero-cache/src/db/pg-to-lite.ts
@@ -142,6 +142,68 @@ export function mapPostgresToLiteDefault(
   );
 }
 
+/**
+ * Returns whether a column's default expression (as reported by
+ * `pg_get_expr(adbin, adrelid)` in the published schema) is a simple
+ * literal that evaluates to exactly `missingValue` — the JSON encoding of
+ * the column's `pg_attribute.attmissingval`, i.e. the value that all
+ * pre-existing rows contain for a column that was added with Postgres'
+ * fast "default for all rows" optimization.
+ *
+ * This is the condition under which an added column can be replicated by
+ * applying its default directly (i.e. without backfill): the default is
+ * both replicable and guaranteed to reproduce the contents of
+ * pre-existing rows. Note that the current default may differ from the
+ * missing value, e.g. if the default was changed (in the same transaction
+ * or a later one) after the column was added.
+ *
+ * The comparison is conservative: any expression or value that is not
+ * confidently understood compares as `false`, for which callers fall back
+ * to a backfill. In particular, integers outside of the safe range are
+ * never considered equal, since both sides may silently lose precision
+ * when parsed into a `number`.
+ */
+export function defaultValueMatches(
+  dflt: string | null | undefined,
+  missingValue: unknown,
+): boolean {
+  if (dflt == null || missingValue === undefined || missingValue === null) {
+    return false;
+  }
+  if (NUMERIC_LITERAL_REGEX.test(dflt)) {
+    return (
+      typeof missingValue === 'number' && numberMatches(missingValue, dflt)
+    );
+  }
+  if (BOOLEAN_LITERAL_REGEX.test(dflt)) {
+    return missingValue === (dflt === 'true');
+  }
+  const match = QUOTED_STRING_WITH_CAST_REGEX.exec(dflt);
+  if (match) {
+    const literal = match[1].slice(1, -1).replaceAll(`''`, `'`);
+    if (typeof missingValue === 'string') {
+      return missingValue === literal;
+    }
+    // Values of non-text types may be expressed as quoted literals with a
+    // cast (e.g. `'2147483648'::bigint`), while their missing values are
+    // JSON-encoded as numbers.
+    if (typeof missingValue === 'number') {
+      return numberMatches(missingValue, literal);
+    }
+    return false;
+  }
+  return false;
+}
+
+function numberMatches(missingValue: number, literal: string): boolean {
+  return (
+    (Number.isSafeInteger(missingValue) ||
+      (!Number.isInteger(missingValue) &&
+        Math.abs(missingValue) < Number.MAX_SAFE_INTEGER)) &&
+    String(missingValue) === literal
+  );
+}
+
 export function mapPostgresToLiteColumn(
   table: string,
   column: {name: string; spec: ColumnSpec},

--- a/packages/zero-cache/src/db/pg-to-lite.ts
+++ b/packages/zero-cache/src/db/pg-to-lite.ts
@@ -167,7 +167,12 @@ export function defaultValueMatches(
   dflt: string | null | undefined,
   missingValue: unknown,
 ): boolean {
-  if (dflt == null || missingValue === undefined || missingValue === null) {
+  if (
+    dflt === null ||
+    dflt === undefined ||
+    missingValue === undefined ||
+    missingValue === null
+  ) {
     return false;
   }
   if (NUMERIC_LITERAL_REGEX.test(dflt)) {

--- a/packages/zero-cache/src/services/change-source/pg/change-source.end-to-mid.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.end-to-mid.pg.test.ts
@@ -2082,6 +2082,140 @@ describe('change-source/pg/end-to-mid-test', {timeout: 30000}, () => {
       [],
       [],
     ],
+    [
+      'insert into table created via update_schemas()',
+      /*sql*/ `
+      INSERT INTO your.new_table (id) VALUES (99);
+      `,
+      [[{tag: 'insert'}]],
+      {['your.new_table']: [{id: 99n}]},
+      [],
+      [],
+    ],
+    [
+      'column with replicable default covered by update_schemas() call',
+      /*sql*/ `
+      ALTER TABLE your.new_table ADD "enabled" BOOL DEFAULT true;
+      SELECT ${APP_ID}_0.update_schemas();
+      `,
+      [
+        [
+          {
+            tag: 'add-column',
+            table: {schema: 'your', name: 'new_table'},
+            column: {
+              name: 'enabled',
+              spec: {
+                pos: expect.any(Number),
+                dataType: 'bool',
+                dflt: 'true',
+              },
+            },
+            // Note: no `backfill` field. The column was created in the same
+            // transaction as the update_schemas() call, so the default value
+            // is replicated directly, without a backfill.
+          },
+        ],
+      ],
+      // The pre-existing row picks up the replicated default value
+      // immediately (i.e. within the schema change transaction). This would
+      // not (yet) be the case if the column were being backfilled, as
+      // backfilling columns start out hidden with a `null` value.
+      {['your.new_table']: [{id: 99n, enabled: 1n}]},
+      [
+        {
+          name: 'your.new_table',
+          columns: {
+            enabled: {
+              characterMaximumLength: null,
+              dataType: 'bool',
+              elemPgTypeClass: null,
+              dflt: '1',
+              notNull: false,
+              pos: 3,
+            },
+          },
+        },
+      ],
+      [],
+    ],
+    [
+      'column added without an update_schemas() call is not replicated',
+      /*sql*/ `
+      ALTER TABLE your.new_table ADD "num" INT4 DEFAULT 30;
+      `,
+      [],
+      {['your.new_table']: [{id: 99n, enabled: 1n}]},
+      [],
+      [],
+    ],
+    [
+      'column added in an earlier transaction than update_schemas() is backfilled',
+      /*sql*/ `
+      SELECT ${APP_ID}_0.update_schemas();
+      `,
+      [
+        [
+          {
+            tag: 'add-column',
+            table: {schema: 'your', name: 'new_table'},
+            column: {
+              name: 'num',
+              spec: {
+                pos: expect.any(Number),
+                dataType: 'int4',
+                dflt: null,
+              },
+            },
+            // Rows may have been modified between the transaction that
+            // added the column and the update_schemas() call, so the
+            // column values must be backfilled.
+            backfill: {attNum: expect.any(Number)},
+          },
+        ],
+        [{tag: 'backfill'}],
+        [{tag: 'backfill-completed'}],
+      ],
+      {['your.new_table']: [{id: 99n, enabled: 1n, num: 30n}]},
+      [],
+      [],
+    ],
+    [
+      'newly published column not covered by update_schemas() optimization',
+      /*sql*/ `
+      ALTER PUBLICATION zero_some_public SET TABLE existing, TABLE existing_full,
+        TABLE foo (id, int, flt, bool);
+      ALTER TABLE foo ALTER "bool" SET DEFAULT false;
+      SELECT ${APP_ID}_0.update_schemas();
+      `,
+      [
+        [
+          {
+            tag: 'add-column',
+            table: {schema: 'public', name: 'foo'},
+            column: {
+              name: 'bool',
+              spec: {
+                pos: expect.any(Number),
+                dataType: 'bool',
+                dflt: null,
+              },
+            },
+            // Even though the column has a replicable default and its
+            // pg_attribute row was touched in the same transaction as the
+            // update_schemas() call (by the SET DEFAULT), the column itself
+            // is not new; it is a pre-existing column added to the
+            // publication's column list, and thus must be backfilled to
+            // pick up the existing values.
+            backfill: {attNum: expect.any(Number)},
+          },
+        ],
+        [{tag: 'backfill-completed'}],
+      ],
+      {},
+      [],
+      [],
+    ],
   ] satisfies [
     name: string,
     statements: string | string[],

--- a/packages/zero-cache/src/services/change-source/pg/change-source.end-to-mid.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.end-to-mid.pg.test.ts
@@ -2254,6 +2254,45 @@ describe('change-source/pg/end-to-mid-test', {timeout: 30000}, () => {
       [],
       [],
     ],
+    [
+      'column with unchanged text default covered by update_schemas()',
+      /*sql*/ `
+      ALTER TABLE your.new_table ADD "label" TEXT DEFAULT 'unlabeled';
+      SELECT ${APP_ID}_0.update_schemas();
+      `,
+      [
+        [
+          {
+            tag: 'add-column',
+            table: {schema: 'your', name: 'new_table'},
+            column: {
+              name: 'label',
+              spec: {
+                pos: expect.any(Number),
+                dataType: 'text',
+                dflt: `'unlabeled'::text`,
+              },
+            },
+            // No `backfill` field: the current default matches the value
+            // stamped into pre-existing rows when the column was created
+            // (i.e. attmissingval), so the default is replicated directly.
+          },
+        ],
+      ],
+      {
+        ['your.new_table']: [
+          {
+            id: 99n,
+            enabled: 1n,
+            num: 30n,
+            changed_default: 1n,
+            label: 'unlabeled',
+          },
+        ],
+      },
+      [],
+      [],
+    ],
   ] satisfies [
     name: string,
     statements: string | string[],

--- a/packages/zero-cache/src/services/change-source/pg/change-source.end-to-mid.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.end-to-mid.pg.test.ts
@@ -2216,6 +2216,44 @@ describe('change-source/pg/end-to-mid-test', {timeout: 30000}, () => {
       [],
       [],
     ],
+    [
+      'column whose default changed before update_schemas() is backfilled',
+      /*sql*/ `
+      ALTER TABLE your.new_table ADD "changed_default" INT4 DEFAULT 1;
+      ALTER TABLE your.new_table
+        ALTER "changed_default" SET DEFAULT 2;
+      SELECT ${APP_ID}_0.update_schemas();
+      `,
+      [
+        [
+          {
+            tag: 'add-column',
+            table: {schema: 'your', name: 'new_table'},
+            column: {
+              name: 'changed_default',
+              spec: {
+                pos: expect.any(Number),
+                dataType: 'int4',
+                dflt: null,
+              },
+            },
+            // The existing row contains the default from ADD COLUMN (1), not
+            // the current default (2), so replicating the current default
+            // directly would produce the wrong value.
+            backfill: {attNum: expect.any(Number)},
+          },
+        ],
+        [{tag: 'backfill'}],
+        [{tag: 'backfill-completed'}],
+      ],
+      {
+        ['your.new_table']: [
+          {id: 99n, enabled: 1n, num: 30n, changed_default: 1n},
+        ],
+      },
+      [],
+      [],
+    ],
   ] satisfies [
     name: string,
     statements: string | string[],

--- a/packages/zero-cache/src/services/change-source/pg/change-source.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.ts
@@ -1274,6 +1274,7 @@ class ChangeMaker {
             must(prevTbl.get(id)),
             must(nextTbl.get(id)),
             tag,
+            event.newColumns ?? null,
           ),
         );
       }
@@ -1318,6 +1319,7 @@ class ChangeMaker {
     oldTable: PublishedTableWithReplicaIdentity,
     newTable: PublishedTableWithReplicaIdentity,
     ddlTag: string,
+    newColumns: Record<string, number[]> | null,
   ): SchemaChange[] {
     const changes: SchemaChange[] = [];
     if (
@@ -1341,21 +1343,24 @@ class ChangeMaker {
       });
     }
     const table = {schema: newTable.schema, name: newTable.name};
-    const oldColumns = columnsByID(oldTable.columns);
-    const newColumns = columnsByID(newTable.columns);
+    const oldTableColumns = columnsByID(oldTable.columns);
+    const newTableColumns = columnsByID(newTable.columns);
 
     // DROP
-    const [dropped, added] = symmetricDifferences(oldColumns, newColumns);
+    const [dropped, added] = symmetricDifferences(
+      oldTableColumns,
+      newTableColumns,
+    );
     for (const id of dropped) {
-      const {name: column} = must(oldColumns.get(id));
+      const {name: column} = must(oldTableColumns.get(id));
       changes.push({tag: 'drop-column', table, column});
     }
 
     // ALTER
-    const both = intersection(oldColumns, newColumns);
+    const both = intersection(oldTableColumns, newTableColumns);
     for (const id of both) {
-      const {name: oldName, ...oldSpec} = must(oldColumns.get(id));
-      const {name: newName, ...newSpec} = must(newColumns.get(id));
+      const {name: oldName, ...oldSpec} = must(oldTableColumns.get(id));
+      const {name: newName, ...newSpec} = must(newTableColumns.get(id));
       // The three things that we care about are:
       // 1. name
       // 2. type
@@ -1374,19 +1379,24 @@ class ChangeMaker {
       }
     }
 
-    // Only columns introduced by `ALTER TABLE` statements can potentially
-    // skip backfill if they have non-constant defaults. All other scenarios
-    // in which columns are introduced, e.g.
+    // Only columns known to have been *created* by the current command can
+    // potentially skip backfill (if their defaults are replicable), namely:
+    // * columns introduced by an `ALTER TABLE` statement
+    // * columns reported by the event's `newColumns` field to have been
+    //   created in the same (upstream) transaction, which covers the manual
+    //   update_schemas() hook when invoked in the transaction that performed
+    //   the schema change.
+    // All other scenarios in which columns are introduced, e.g.
     // * ALTER PUBLICATION
     // * COMMENT
-    // * MANUAL
-    // * UNKNOWN
-    // must be backfilled.
-    const alwaysBackfill = ddlTag !== 'ALTER TABLE';
+    // * MANUAL / UNKNOWN commands predating the `newColumns` field
+    // must be backfilled, as a newly *published* column may contain
+    // arbitrary values in existing rows.
+    const newColAttNums = new Set(newColumns?.[String(newTable.oid)] ?? []);
 
     // ADD
     for (const id of added) {
-      const {name, ...spec} = must(newColumns.get(id));
+      const {name, ...spec} = must(newTableColumns.get(id));
       const column = {name, spec};
       const addColumn: ColumnAdd = {
         tag: 'add-column',
@@ -1394,6 +1404,8 @@ class ChangeMaker {
         column,
         tableMetadata: getMetadata(newTable),
       };
+      const alwaysBackfill =
+        ddlTag !== 'ALTER TABLE' && !newColAttNums.has(spec.pos);
       if (alwaysBackfill) {
         addColumn.column.spec.dflt = null;
         addColumn.backfill = {attNum: spec.pos} satisfies ColumnMetadata;

--- a/packages/zero-cache/src/services/change-source/pg/change-source.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.ts
@@ -19,6 +19,7 @@ import {
 import * as v from '../../../../../shared/src/valita.ts';
 import {Database} from '../../../../../zqlite/src/db.ts';
 import {
+  defaultValueMatches,
   mapPostgresToLiteColumn,
   UnsupportedColumnDefaultError,
 } from '../../../db/pg-to-lite.ts';
@@ -1275,6 +1276,7 @@ class ChangeMaker {
             must(nextTbl.get(id)),
             tag,
             event.newColumns ?? null,
+            event.missingValues ?? null,
           ),
         );
       }
@@ -1320,6 +1322,7 @@ class ChangeMaker {
     newTable: PublishedTableWithReplicaIdentity,
     ddlTag: string,
     newColumns: Record<string, number[]> | null,
+    missingValues: Record<string, Record<string, unknown>> | null,
   ): SchemaChange[] {
     const changes: SchemaChange[] = [];
     if (
@@ -1379,13 +1382,19 @@ class ChangeMaker {
       }
     }
 
-    // Only columns known to have been *created* by the current command can
-    // potentially skip backfill (if their defaults are replicable), namely:
-    // * columns introduced by an `ALTER TABLE` statement
+    // Only columns known to hold a specific value in all pre-existing rows
+    // can potentially skip backfill, namely:
+    // * columns introduced by an `ALTER TABLE` statement, which diff as a
+    //   single command and thus hold the default reported in the schema.
     // * columns reported by the event's `newColumns` field to have been
-    //   created in the same (upstream) transaction, which covers the manual
-    //   update_schemas() hook when invoked in the transaction that performed
-    //   the schema change.
+    //   created in the same (upstream) transaction — which covers the
+    //   manual update_schemas() hook when invoked in the transaction that
+    //   performed the schema change — *provided that* the current default
+    //   matches the column's "missing value" (i.e. the value stamped into
+    //   pre-existing rows at creation, reported in `missingValues`). The
+    //   two can differ, e.g. if the default was changed after the column
+    //   was added but before the update_schemas() call, in which case the
+    //   column must be backfilled.
     // All other scenarios in which columns are introduced, e.g.
     // * ALTER PUBLICATION
     // * COMMENT
@@ -1393,6 +1402,7 @@ class ChangeMaker {
     // must be backfilled, as a newly *published* column may contain
     // arbitrary values in existing rows.
     const newColAttNums = new Set(newColumns?.[String(newTable.oid)] ?? []);
+    const tableMissingValues = missingValues?.[String(newTable.oid)];
 
     // ADD
     for (const id of added) {
@@ -1405,7 +1415,11 @@ class ChangeMaker {
         tableMetadata: getMetadata(newTable),
       };
       const alwaysBackfill =
-        ddlTag !== 'ALTER TABLE' && !newColAttNums.has(spec.pos);
+        ddlTag !== 'ALTER TABLE' &&
+        !(
+          newColAttNums.has(spec.pos) &&
+          defaultValueMatches(spec.dflt, tableMissingValues?.[spec.pos])
+        );
       if (alwaysBackfill) {
         addColumn.column.spec.dflt = null;
         addColumn.backfill = {attNum: spec.pos} satisfies ColumnMetadata;

--- a/packages/zero-cache/src/services/change-source/pg/schema/ddl.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/ddl.pg.test.ts
@@ -1674,6 +1674,30 @@ describe('change-source/tables/ddl', () => {
       event: {tag: 'UNKNOWN'},
     });
   });
+
+  // Events from future versions of the upstream functions may report the
+  // columns created in the transaction that emitted the event.
+  test('parse ddlUpdateEvent with newColumns', () => {
+    const ddlUpdateEvent: DdlUpdateEvent = {
+      type: 'ddlUpdate',
+      version: 1,
+      context: {query: 'ALTER TABLE pub.foo ADD bar text'},
+      schema: {tables: [], indexes: []},
+      event: {tag: 'ALTER TABLE'},
+      newColumns: {'12345': [4, 7]},
+    };
+    expect(v.parse(ddlUpdateEvent, ddlUpdateEventSchema)).toEqual(
+      ddlUpdateEvent,
+    );
+    expect(
+      v.parse({...ddlUpdateEvent, newColumns: null}, ddlUpdateEventSchema),
+    ).toEqual({...ddlUpdateEvent, newColumns: null});
+
+    const {newColumns: _, ...withoutNewColumns} = ddlUpdateEvent;
+    expect(v.parse(withoutNewColumns, ddlUpdateEventSchema)).toEqual(
+      withoutNewColumns,
+    );
+  });
 });
 
 function parseDDLStartEvent(msg: MessageMessage) {

--- a/packages/zero-cache/src/services/change-source/pg/schema/ddl.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/ddl.ts
@@ -23,6 +23,19 @@ export const ddlEventSchema = triggerEvent.extend({
   version: v.literal(PROTOCOL_VERSION),
   schema: publishedSchema,
   event: v.object({tag: v.string()}),
+  // Maps the OID of each published table to the `attnum`s of published
+  // columns that were created in the (upstream) transaction that emitted
+  // the event. Such columns are guaranteed to have the column default in
+  // all pre-existing rows, and can thus be replicated without backfill if
+  // the default value itself is replicable. Tables whose publication
+  // entries (e.g. column lists) were modified in the same transaction are
+  // excluded, since a newly *published* (as opposed to newly *created*)
+  // column may hold arbitrary values in existing rows.
+  //
+  // The field is absent in messages from older versions of the upstream
+  // functions (in which case backfill decisions fall back to the command
+  // tag heuristic), and `null` when there are no such columns.
+  newColumns: v.record(v.array(v.number())).nullable().optional(),
 });
 
 /**

--- a/packages/zero-cache/src/services/change-source/pg/schema/ddl.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/ddl.ts
@@ -333,6 +333,12 @@ $$ LANGUAGE plpgsql;
 -- same transaction as the schema change statement(s); among other things,
 -- this allows columns added with replicable defaults (e.g. constants) to
 -- be replicated without a backfill.
+--
+-- Note that it must be invoked *before* any subsequent DML on the altered
+-- tables: since this hook emits the schema change at the point of the
+-- call (rather than at each DDL statement, as event triggers do), row
+-- changes between a column's creation and the call reference a column
+-- that the replica does not yet know about, and fail replication.
 CREATE OR REPLACE FUNCTION ${schema}.update_schemas()
 RETURNS void AS $$
 BEGIN

--- a/packages/zero-cache/src/services/change-source/pg/schema/ddl.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/ddl.ts
@@ -36,6 +36,33 @@ export const ddlEventSchema = triggerEvent.extend({
   // functions (in which case backfill decisions fall back to the command
   // tag heuristic), and `null` when there are no such columns.
   newColumns: v.record(v.array(v.number())).nullable().optional(),
+  // Maps the OID of each published table to the "missing value"
+  // (i.e. `pg_attribute.attmissingval`) of each column (keyed by `attnum`)
+  // in `newColumns` that has one. This is the value that all pre-existing
+  // rows contain for a column that was added with Postgres' fast "default
+  // for all rows" optimization, and it is unaffected by later changes to
+  // the column default (which only apply to subsequently created rows).
+  //
+  // A column can thus be replicated without backfill iff its current
+  // default is a replicable expression that evaluates to its missing
+  // value (see `defaultValueMatches()`), as replicating the default is
+  // then guaranteed to reproduce the contents of pre-existing rows.
+  // Columns without an entry (e.g. added without a default, with a
+  // volatile default, or with a default assigned in a later command) must
+  // be backfilled.
+  //
+  // Only values with scalar JSON encodings (numbers, strings, and
+  // booleans) are reported, as only those can provably match a
+  // replicable default expression; columns with other missing values
+  // (e.g. arrays) are not reported, and are thus backfilled.
+  //
+  // Like `newColumns`, the field is absent in messages from older
+  // versions of the upstream functions, and `null` when there are no such
+  // columns.
+  missingValues: v
+    .record(v.record(v.union(v.number(), v.string(), v.boolean())))
+    .nullable()
+    .optional(),
 });
 
 /**
@@ -210,6 +237,7 @@ DECLARE
   prev_schema_specs JSON;
   schema_specs JSON;
   new_columns JSON;
+  missing_values JSON;
   message TEXT;
 BEGIN
   SELECT current FROM ${schema}."publishedSchema" INTO prev_schema_specs;
@@ -219,17 +247,20 @@ BEGIN
     UPDATE ${schema}."publishedSchema" SET current = schema_specs;
 
     -- Report the published columns that were created in the current
-    -- transaction (i.e. pg_attribute rows inserted by this transaction).
-    -- All pre-existing rows of such columns are guaranteed to contain the
-    -- column default, allowing the zero-cache to replicate the default
-    -- directly (i.e. without backfill) if the default value is replicable.
+    -- transaction (i.e. pg_attribute rows inserted by this transaction),
+    -- along with the "missing value" (attmissingval) of each column that
+    -- has one. The missing value is what all pre-existing rows contain
+    -- for a column added with a non-volatile default, and is unaffected
+    -- by later changes to the column default; the zero-cache can thus
+    -- replicate such a column without backfill iff its current default
+    -- evaluates to its missing value.
     --
     -- Tables whose publication entries were touched in the same transaction
     -- (e.g. ALTER PUBLICATION ... SET TABLE with a column list) are excluded,
     -- as a newly *published* column may be a pre-existing column with
     -- arbitrary values in existing rows, which requires a backfill.
-    SELECT json_object_agg(rel_oid, attnums) INTO new_columns FROM (
-      SELECT pc.oid::int8 AS rel_oid, json_agg(DISTINCT attnum) AS attnums
+    WITH new_cols AS (
+      SELECT DISTINCT pc.oid AS rel_oid, attnum, atthasmissing
         FROM pg_attribute
         JOIN pg_class pc ON pc.oid = attrelid
         JOIN pg_namespace pns ON pns.oid = pc.relnamespace
@@ -248,8 +279,23 @@ BEGIN
                 AND pub.pubname IN (${lit(publications)})
                 AND rel.xmin = pg_current_xact_id()::xid
           )
-        GROUP BY pc.oid
-    ) new_cols;
+    )
+    SELECT
+      (SELECT json_object_agg(rel_oid::int8, attnums) FROM (
+        SELECT rel_oid, json_agg(attnum) AS attnums
+          FROM new_cols GROUP BY rel_oid
+      ) attnums_by_table),
+      (SELECT json_object_agg(rel_oid::int8, vals) FROM (
+        SELECT n.rel_oid,
+               json_object_agg(n.attnum, array_to_json(a.attmissingval)->0) AS vals
+          FROM new_cols n
+          JOIN pg_attribute a ON a.attrelid = n.rel_oid AND a.attnum = n.attnum
+          WHERE n.atthasmissing
+            AND json_typeof(array_to_json(a.attmissingval)->0) IN
+              ('number', 'string', 'boolean')
+          GROUP BY n.rel_oid
+      ) vals_by_table)
+      INTO new_columns, missing_values;
   ELSIF event_type = 'ddlStart' THEN
     -- ddlStart events are always be emitted to allow the zero-cache
     -- to track the context of the current command tag in the face of
@@ -269,6 +315,7 @@ BEGIN
     'previousSchema', prev_schema_specs,
     'schema', schema_specs,
     'newColumns', new_columns,
+    'missingValues', missing_values,
     'event', json_build_object('tag', tag),
     'context', ${schema}.get_trigger_context()
   ) INTO message;

--- a/packages/zero-cache/src/services/change-source/pg/schema/ddl.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/ddl.ts
@@ -209,13 +209,47 @@ RETURNS void AS $$
 DECLARE
   prev_schema_specs JSON;
   schema_specs JSON;
+  new_columns JSON;
   message TEXT;
 BEGIN
   SELECT current FROM ${schema}."publishedSchema" INTO prev_schema_specs;
   SELECT ${schema}.schema_specs() INTO schema_specs;
-  
+
   IF prev_schema_specs::text != schema_specs::text THEN
     UPDATE ${schema}."publishedSchema" SET current = schema_specs;
+
+    -- Report the published columns that were created in the current
+    -- transaction (i.e. pg_attribute rows inserted by this transaction).
+    -- All pre-existing rows of such columns are guaranteed to contain the
+    -- column default, allowing the zero-cache to replicate the default
+    -- directly (i.e. without backfill) if the default value is replicable.
+    --
+    -- Tables whose publication entries were touched in the same transaction
+    -- (e.g. ALTER PUBLICATION ... SET TABLE with a column list) are excluded,
+    -- as a newly *published* column may be a pre-existing column with
+    -- arbitrary values in existing rows, which requires a backfill.
+    SELECT json_object_agg(rel_oid, attnums) INTO new_columns FROM (
+      SELECT pc.oid::int8 AS rel_oid, json_agg(DISTINCT attnum) AS attnums
+        FROM pg_attribute
+        JOIN pg_class pc ON pc.oid = attrelid
+        JOIN pg_namespace pns ON pns.oid = pc.relnamespace
+        JOIN pg_publication_tables pb ON
+          pb.schemaname = pns.nspname AND
+          pb.tablename = pc.relname AND
+          attname = ANY(pb.attnames)
+        WHERE pb.pubname IN (${lit(publications)})
+          AND attnum > 0
+          AND NOT attisdropped
+          AND pg_attribute.xmin = pg_current_xact_id()::xid
+          AND NOT EXISTS (
+            SELECT 1 FROM pg_publication_rel rel
+              JOIN pg_publication pub ON pub.oid = rel.prpubid
+              WHERE rel.prrelid = pc.oid
+                AND pub.pubname IN (${lit(publications)})
+                AND rel.xmin = pg_current_xact_id()::xid
+          )
+        GROUP BY pc.oid
+    ) new_cols;
   ELSIF event_type = 'ddlStart' THEN
     -- ddlStart events are always be emitted to allow the zero-cache
     -- to track the context of the current command tag in the face of
@@ -234,6 +268,7 @@ BEGIN
     'version', ${PROTOCOL_VERSION},
     'previousSchema', prev_schema_specs,
     'schema', schema_specs,
+    'newColumns', new_columns,
     'event', json_build_object('tag', tag),
     'context', ${schema}.get_trigger_context()
   ) INTO message;
@@ -246,8 +281,11 @@ END
 $$ LANGUAGE plpgsql;
 
 
--- Hook/workaround to manually trigger replication of schema changes on DBs 
--- that do not support/allow event triggers.
+-- Hook/workaround to manually trigger replication of schema changes on DBs
+-- that do not support/allow event triggers. This should be invoked in the
+-- same transaction as the schema change statement(s); among other things,
+-- this allows columns added with replicable defaults (e.g. constants) to
+-- be replicated without a backfill.
 CREATE OR REPLACE FUNCTION ${schema}.update_schemas()
 RETURNS void AS $$
 BEGIN

--- a/packages/zero-cache/src/services/change-source/pg/schema/init.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/init.ts
@@ -276,6 +276,19 @@ function getIncrementalMigrations(
         lc.info?.(`Upgraded DDL event triggers`);
       },
     },
+
+    // v24: (1.8.0) DDL events report columns created in the same transaction
+    // (`newColumns`), allowing replicable column defaults to skip backfill
+    // when schema changes are replicated via the manual update_schemas()
+    // hook.
+    24: {
+      migrateSchema: async (lc, sql) => {
+        const [{publications}] = await sql<{publications: string[]}[]>`
+          SELECT publications FROM ${sql(shardConfigTable)}`;
+        await setupTriggers(lc, sql, {...shard, publications});
+        lc.info?.(`Upgraded DDL event triggers`);
+      },
+    },
   };
 }
 


### PR DESCRIPTION
Stacked on #6222, which adds the optional `newColumns` field to the DDL event schema; this PR teaches the upstream trigger functions to emit it and uses it.

Teach DDL events to report published columns created in the current transaction, then use that metadata when deciding whether an added column needs backfill. This lets the manual update_schemas() path replicate simple defaults directly when invoked in the same transaction as the schema change.

Keep backfilling columns that are only newly published, since those may hold arbitrary existing values, and add end-to-mid coverage for both paths.

``https://app.notion.com/p/replicache/Apply-backfill-less-defaults-optimization-to-update_schemas-path-3843bed8954580209a05fa5be881a0f2``?source=copy_link