### PR TITLE
fix(zero-cache): bump same-hash query rehydrates

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/cvr.pg.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.pg.test.ts
@@ -2253,6 +2253,108 @@ describe('view-syncer/cvr', () => {
     });
   });
 
+  test('deleteUnreferencedRows skips row deletes already emitted by received', async () => {
+    const initialState: DBState = {
+      instances: [
+        {
+          clientGroupID: 'abc123',
+          version: '1aa',
+          replicaVersion: '123',
+          lastActive: Date.UTC(2024, 3, 23),
+          ttlClock: ttlClockFromNumber(Date.UTC(2024, 3, 23)),
+          clientSchema: null,
+        },
+      ],
+      clients: [
+        {
+          clientGroupID: 'abc123',
+          clientID: 'fooClient',
+        },
+      ],
+      queries: [
+        {
+          clientGroupID: 'abc123',
+          queryArgs: null,
+          queryName: null,
+          queryHash: 'oneHash',
+          clientAST: {table: 'issues'},
+          transformationHash: 'serverOneHash',
+          transformationVersion: '1aa',
+          patchVersion: '1aa:01',
+          internal: null,
+          deleted: null,
+        },
+        {
+          clientGroupID: 'abc123',
+          queryArgs: null,
+          queryName: null,
+          queryHash: 'twoHash',
+          clientAST: {table: 'issues'},
+          transformationHash: 'serverTwoHash',
+          transformationVersion: '1aa',
+          patchVersion: '1aa:02',
+          internal: null,
+          deleted: null,
+        },
+      ],
+      desires: [
+        {
+          clientGroupID: 'abc123',
+          clientID: 'fooClient',
+          queryHash: 'oneHash',
+          patchVersion: '1a9:01',
+          deleted: null,
+          inactivatedAt: null,
+          ttl: DEFAULT_TTL_MS,
+        },
+      ],
+      rows: [
+        {
+          clientGroupID: 'abc123',
+          rowKey: ROW_KEY1,
+          rowVersion: '03',
+          refCounts: {oneHash: 1},
+          patchVersion: '1a0',
+          schema: 'public',
+          table: 'issues',
+        },
+      ],
+    };
+
+    await setInitialState(cvrDb, initialState);
+
+    const cvrStore = new CVRStore(
+      lc,
+      cvrDb,
+      SHARD,
+      'my-task',
+      'abc123',
+      ON_FAILURE,
+    );
+    const cvr = await cvrStore.load(lc, LAST_CONNECT);
+    const updater = new CVRQueryDrivenUpdater(cvrStore, cvr, '1aa', '123');
+
+    const {newVersion} = updater.trackQueries(
+      lc,
+      [{id: 'oneHash', transformationHash: 'serverOneHash'}],
+      [{id: 'twoHash'}],
+    );
+    expect(newVersion).toEqual({stateVersion: '1aa', configVersion: 1});
+
+    expect(
+      await updater.received(
+        lc,
+        new Map([[ROW_ID1, {refCounts: {oneHash: -1}}]]),
+      ),
+    ).toEqual([
+      {
+        toVersion: newVersion,
+        patch: {type: 'row', op: 'del', id: ROW_ID1},
+      },
+    ] satisfies PatchToVersion[]);
+    expect(await updater.deleteUnreferencedRows(lc)).toEqual([]);
+  });
+
   // ^^: just run this test twice? Once for executed once for transformed
   test('new transformation hash', async () => {
     const initialState: DBState = {

--- a/packages/zero-cache/src/services/view-syncer/cvr.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.ts
@@ -981,10 +981,16 @@ export class CVRQueryDrivenUpdater extends CVRUpdater {
           if (deletedID === null) {
             continue;
           }
+          const lastPatch = this.#lastPatches.get(deletedID);
+          if (lastPatch?.rowVersion === null) {
+            continue;
+          }
+          const toVersion = maxVersion(this._cvr.version, lastPatch?.toVersion);
           patches.push({
-            toVersion: this._cvr.version,
+            toVersion,
             patch: {type: 'row', op: 'del', id: deletedID},
           });
+          this.#lastPatches.set(deletedID, {rowVersion: null, toVersion});
         }
         lc?.debug?.(
           `computed ${patches.length} delete patches (${Date.now() - start} ms)`,

--- a/packages/zero-cache/src/services/view-syncer/cvr.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.ts
@@ -982,7 +982,7 @@ export class CVRQueryDrivenUpdater extends CVRUpdater {
             continue;
           }
           const lastPatch = this.#lastPatches.get(deletedID);
-          if (lastPatch?.rowVersion === null) {
+          if (lastPatch !== undefined && lastPatch.rowVersion === null) {
             continue;
           }
           const toVersion = maxVersion(this._cvr.version, lastPatch?.toVersion);

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg.test.ts
@@ -22,6 +22,7 @@ import type {
 } from '../../../../zero-protocol/src/poke.ts';
 import {PROTOCOL_VERSION} from '../../../../zero-protocol/src/protocol-version.ts';
 import type {UpQueriesPatch} from '../../../../zero-protocol/src/queries-patch.ts';
+import {ChangeType} from '../../../../zql/src/ivm/change-type.ts';
 import {DEFAULT_TTL_MS} from '../../../../zql/src/query/ttl.ts';
 import {type ClientGroupStorage} from '../../../../zqlite/src/database-storage.ts';
 import type {Database} from '../../../../zqlite/src/db.ts';
@@ -45,7 +46,7 @@ import type {ConnectionValidation} from './connection-context-manager.ts';
 import {CVRStore} from './cvr-store.ts';
 import {CVRQueryDrivenUpdater, CVRUpdater} from './cvr.ts';
 import type {DrainCoordinator} from './drain-coordinator.ts';
-import {PipelineDriver} from './pipeline-driver.ts';
+import {type RowChange, PipelineDriver} from './pipeline-driver.ts';
 import {formatSignature, rowIDSignatureUnit} from './row-set-signature.ts';
 import type {RowID} from './schema/types.ts';
 import {ttlClockFromNumber} from './ttl-clock.ts';
@@ -4804,6 +4805,114 @@ describe('view-syncer/service', () => {
       );
     } finally {
       await cleanup();
+    }
+  });
+
+  test('same-hash rehydrate during deleteClients forces a version bump', async () => {
+    pruneIssues('3', '4', '5');
+
+    const ttl = 5000;
+    const {queue: client1} = connectWithQueueAndSource(SYNC_CONTEXT, [
+      {op: 'put', hash: 'query-hash1', ast: ISSUES_QUERY2, ttl},
+    ]);
+    const {queue: client2, source: connectSource2} = connectWithQueueAndSource(
+      {...SYNC_CONTEXT, clientID: 'bar', wsID: 'ws2'},
+      [{op: 'put', hash: 'query-hash2', ast: USERS_QUERY, ttl}],
+    );
+
+    await nextPoke(client1);
+    await nextPoke(client2);
+
+    stateChanges.push({state: 'version-ready'});
+
+    await nextPoke(client1);
+    await nextPoke(client1);
+    await nextPoke(client2);
+    await nextPoke(client2);
+
+    expect(await loadStoredSig('query-hash1')).toEqual(
+      expectedIssuesSig(issueRowID('1'), issueRowID('2')),
+    );
+
+    const originalQueries = PipelineDriver.prototype.queries;
+    const queriesSpy = vi
+      .spyOn(PipelineDriver.prototype, 'queries')
+      .mockImplementation(function (this: PipelineDriver) {
+        const queries = originalQueries.call(this);
+        const filtered = new Map(queries);
+        filtered.delete('query-hash1');
+        return filtered;
+      });
+    const originalAddQuery = PipelineDriver.prototype.addQuery;
+    const addQuerySpy = vi
+      .spyOn(PipelineDriver.prototype, 'addQuery')
+      .mockImplementation(function (
+        this: PipelineDriver,
+        ...args: Parameters<PipelineDriver['addQuery']>
+      ) {
+        const [, queryID] = args;
+        if (queryID !== 'query-hash1') {
+          return originalAddQuery.call(this, ...args);
+        }
+
+        const changes: RowChange[] = [
+          {
+            type: ChangeType.ADD,
+            queryID,
+            table: 'issues',
+            rowKey: {id: '2'},
+            row: {
+              id: '2',
+              title: 'parent issue bar',
+              owner: '101',
+              parent: null,
+              big: -9007199254740991,
+              json: null,
+              _0_version: '01',
+            },
+          },
+          {
+            type: ChangeType.ADD,
+            queryID,
+            table: 'issues',
+            rowKey: {id: '6'},
+            row: {
+              id: '6',
+              title: 'row C',
+              owner: '100',
+              parent: null,
+              big: 0,
+              json: null,
+              _0_version: '01',
+            },
+          },
+        ];
+        return changes;
+      });
+
+    connectSource2.cancel();
+    try {
+      await vs.deleteClients(SYNC_CONTEXT, [
+        'deleteClients',
+        {clientIDs: ['bar']},
+      ]);
+
+      const rowsPoke = await drainUntilRowsPatchOrQuiet(client1, 1000);
+      expect(rowsPoke).toBeDefined();
+
+      const {puts, dels} = rowOpsFor(rowsPoke!, 'issues');
+      expect(dels.map(p => p.id.id)).toEqual(['1']);
+      expect(puts.map(p => p.value.id)).toEqual(['6']);
+
+      if (!rowsPoke!.some(([cmd]) => cmd === 'deleteClients')) {
+        expect(await client1.dequeue()).toEqual([
+          'deleteClients',
+          {clientIDs: ['bar']},
+        ]);
+      }
+    } finally {
+      addQuerySpy.mockRestore();
+      queriesSpy.mockRestore();
     }
   });
 

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -341,6 +341,15 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
       'persistent non-zero values indicate non-deterministic query execution ' +
       '(e.g. Cap operator picking different N-row subsets).',
   );
+  readonly #sameHashRehydrationVersionBumps = getOrCreateCounter(
+    'sync',
+    'query.same-hash-rehydrations-forced-bump',
+    'Number of times query-set reconciliation forced a configVersion bump ' +
+      'for already-gotten same-transformation-hash query rehydration because ' +
+      'trackQueries would not otherwise bump. Expected to be near-zero; ' +
+      'non-zero values indicate ' +
+      'pipeline/CVR row-set drift reached query-set reconciliation.',
+  );
 
   readonly #inspectorDelegate: InspectorDelegate;
 
@@ -2106,12 +2115,38 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
         queryID => this.#pipelines.rowSetSignature(queryID),
       );
 
-      // For queries being re-executed solely due to rowSetSignature drift
-      // (not a transformationHash change), trackQueries does not bump
-      // configVersion. Force a bump so the row diff produced by received()
-      // gets propagated to the client via a poke. Must happen before
-      // startPoke so the pokers see the final cookie version.
-      if (addQueries.some(q => driftedQueryIDs.has(q.id))) {
+      const sameHashRehydratedQueryIDs = addQueries
+        .filter(
+          q => cvr.queries[q.id]?.transformationHash === q.transformationHash,
+        )
+        .map(q => q.id);
+      const trackQueriesWillBumpVersion =
+        stateVersion > cvr.version.stateVersion ||
+        removeQueries.length > 0 ||
+        addQueries.some(
+          q => cvr.queries[q.id]?.transformationHash !== q.transformationHash,
+        );
+
+      // For already-gotten queries being re-executed without a stateVersion
+      // or transformationHash change, trackQueries does not bump configVersion.
+      // Force a bump so any row diff produced by received() gets propagated to
+      // the client via a poke. Must happen before startPoke so the pokers see
+      // the final cookie version.
+      if (
+        sameHashRehydratedQueryIDs.length > 0 &&
+        !trackQueriesWillBumpVersion
+      ) {
+        const drifted = sameHashRehydratedQueryIDs.filter(id =>
+          driftedQueryIDs.has(id),
+        ).length;
+        const missing = sameHashRehydratedQueryIDs.length - drifted;
+        const reason =
+          drifted && missing
+            ? 'mixed'
+            : drifted
+              ? 'row-set-signature-drift'
+              : 'missing-pipeline';
+        this.#sameHashRehydrationVersionBumps.add(1, {reason});
         updater.ensureNewVersion();
       }
 


### PR DESCRIPTION
We hit a case where a query may not exist in the PipelineDriver but exist in the CVR. In this case, we need to hydrate the query. The catch is the row set could change even at the same CVR version.

Our row-set-signature mechanism handled this for all other cases except this one. This case the pipeline is not running so we have no two signatures to compare. The only thing we can do is to bump the cvr version and run the query.