### PR TITLE
chore: chart a path for full E2E fuzzing 

### DIFF
--- a/ZERO_QUERY_FUZZER_EXPANSION_DESIGN.md
+++ b/ZERO_QUERY_FUZZER_EXPANSION_DESIGN.md
@@ -1,0 +1,551 @@
+# Zero Query Fuzzer Expansion Design
+
+## Purpose
+
+Zero already has a coverage-driven fuzzer for the core ZQL IVM engine. It checks
+that generated Zero queries hydrate and maintain the same results as the same
+query evaluated against PostgreSQL.
+
+The same correctness principle should apply at every layer of Zero:
+
+```text
+query through Zero == same query over PostgreSQL
+```
+
+For maintained queries, the invariant is:
+
+```text
+incrementally maintained Zero result == fresh PostgreSQL result
+after the same committed writes
+```
+
+This design expands the fuzzer in concentric circles, starting with the current
+IVM engine fuzzer and then adding the production layers that stand between
+PostgreSQL and an application-visible result.
+
+## Goals
+
+- Reuse the current fuzzer's query generation, coverage strategy, shrinking, and
+  regression corpus wherever possible.
+- Test each Zero layer against the same PostgreSQL oracle.
+- Keep failures reproducible by recording seeds, generated schemas, queries,
+  writes, barriers, and observed results.
+- Add layers incrementally so failures remain debuggable.
+- Catch bugs in replication, storage, protocol translation, client
+  materialization, and subscription lifecycle that the current IVM-only fuzzer
+  cannot see.
+
+## Non-Goals
+
+- This is not a replacement for focused unit tests or integration tests.
+- This is not initially a performance benchmark. The fuzzer may collect timing
+  data to debug barriers, but its primary output is correctness.
+- This is not one monolithic end-to-end fuzzer. Each layer should remain
+  independently runnable.
+- This does not require every outer layer to support the full random surface on
+  day one.
+
+## Current State
+
+The current fuzzer lives under:
+
+```text
+packages/zql-integration-tests/src/chinook/
+```
+
+It already provides several useful building blocks:
+
+- a deterministic mini Chinook fixture
+- generated query skeletons and decorations
+- pairwise coverage over query axes
+- randomized sweep and scale lanes
+- push histories for incremental maintenance checks
+- PostgreSQL oracle comparison
+- shrink-to-repro support
+- committed regression replay
+
+Today, the fuzzer primarily exercises the core query engine:
+
+```text
+PostgreSQL oracle
+        ^
+        |
+generated query
+        |
+        v
+IVM memory/sqlite views
+```
+
+That is the right innermost layer. The expansion should preserve it as the
+fastest and most debuggable signal.
+
+## Layered Model
+
+The fuzzer should grow outward in layers. Each layer has the same high-level
+shape:
+
+1. Generate a schema, data fixture, query, and write sequence.
+2. Apply the writes to PostgreSQL.
+3. Wait until the layer under test has observed a declared consistency barrier.
+4. Read the result through the layer under test.
+5. Read the same query freshly from PostgreSQL.
+6. Normalize both results.
+7. Compare.
+8. On divergence, write a replayable artifact.
+
+### L0: IVM Engine
+
+This is the existing fuzzer.
+
+Path under test:
+
+```text
+generated rows and pushes -> IVM memory/sqlite views
+```
+
+Oracle:
+
+```text
+fresh PostgreSQL query through z2s
+```
+
+Purpose:
+
+- Keep the fastest correctness signal.
+- Preserve high-quality shrinking.
+- Validate query semantics and incremental maintenance independent of
+  replication, networking, and client state.
+
+Expected cadence:
+
+- Backbone on every PR.
+- Larger sweeps in slower CI or nightly jobs.
+
+### L1: Replicator + zero-cache Storage
+
+This is the highest-value next layer.
+
+Path under test:
+
+```text
+PostgreSQL writes
+  -> logical replication
+  -> zero-cache replica storage
+  -> server-side query/view evaluation
+```
+
+Oracle:
+
+```text
+fresh PostgreSQL query after the same committed writes
+```
+
+Purpose:
+
+- Catch WAL decoding and replication ordering bugs.
+- Catch schema/name mapping mismatches.
+- Catch type conversion bugs between PostgreSQL and the replica.
+- Catch SQLite replica storage differences.
+- Catch transaction boundary and delete/update/insert sequencing issues.
+- Catch server-side query evaluation bugs in the context zero-cache actually
+  runs.
+
+The key new requirement is a reliable replication barrier. After a PostgreSQL
+transaction commits, the harness must be able to wait until zero-cache has
+applied at least that transaction before comparing results.
+
+Useful barrier forms, in order of preference:
+
+- source commit LSN observed and applied by zero-cache
+- explicit high-water marker row written in the same transaction
+- zero-cache debug or test hook reporting applied replication position
+- polling a generated marker query through zero-cache until visible
+
+The LSN-based barrier is preferred because it is precise and independent of the
+generated query. Marker rows are simpler but can accidentally share query bugs
+with the layer being tested.
+
+### L2: zero-cache Protocol
+
+This layer adds the server protocol without requiring a full browser or
+application client.
+
+Path under test:
+
+```text
+PostgreSQL writes
+  -> logical replication
+  -> zero-cache replica storage
+  -> view-syncer
+  -> Zero protocol messages
+  -> synthetic protocol client result
+```
+
+Oracle:
+
+```text
+fresh PostgreSQL query after the same committed writes
+```
+
+Purpose:
+
+- Catch protocol serialization bugs.
+- Catch patch/diff construction bugs.
+- Catch query registration and unsubscribe lifecycle issues.
+- Catch initial hydrate versus subsequent diff mismatches.
+- Catch reconnect and resume issues if enabled for a given run.
+
+This layer needs two barriers:
+
+- a replication barrier proving zero-cache has applied the PostgreSQL writes
+- a client observation barrier proving the synthetic client has received all
+  protocol changes for that applied position
+
+The synthetic client should expose a materialized result set per subscribed
+query. The fuzzer should compare that materialized result to PostgreSQL after
+initial sync and after every generated write step.
+
+### L3: zero-client
+
+This layer adds the public client data path.
+
+Path under test:
+
+```text
+PostgreSQL writes
+  -> logical replication
+  -> zero-cache
+  -> Zero protocol
+  -> zero-client
+  -> application-visible query result
+```
+
+Oracle:
+
+```text
+fresh PostgreSQL query after the same committed writes
+```
+
+Purpose:
+
+- Catch client-side materialization bugs.
+- Catch subscription lifecycle bugs.
+- Catch local cache application bugs.
+- Catch client-side type conversion and normalization bugs.
+- Catch reconnect, resume, and hydration edge cases.
+
+This layer should start in a Node or headless test environment if possible. A
+browser lane can come later for IndexedDB and real browser scheduling behavior.
+
+### L4: Full Client Behavior
+
+This is the broadest and slowest layer.
+
+Path under test:
+
+```text
+PostgreSQL writes and client mutations
+  -> server mutation handling
+  -> PostgreSQL
+  -> logical replication
+  -> zero-cache
+  -> Zero protocol
+  -> zero-client
+  -> application-visible query result
+```
+
+Oracle:
+
+```text
+fresh PostgreSQL query after committed server state
+```
+
+Purpose:
+
+- Catch optimistic mutation and rebase bugs.
+- Catch multi-client interaction bugs.
+- Catch auth and permission-filter bugs.
+- Catch disconnect, reconnect, and resume bugs under writes.
+- Catch application-like workflows that combine reads and writes.
+
+This should be a later layer. It has the largest state space and the weakest
+shrinking story, so it should reuse minimized cases from inner layers whenever
+possible.
+
+## Shared Harness Concepts
+
+### Generated Case
+
+Every layer should consume the same logical case format:
+
+```text
+schema
+initial data
+query set
+write sequence
+normalization policy
+seed and generator labels
+```
+
+Early implementations can continue using the Chinook schema and mini fixture.
+Later implementations can add generated schemas as a separate axis.
+
+### PostgreSQL Oracle
+
+PostgreSQL remains the source of truth. For every comparison point, the harness
+should evaluate the equivalent query freshly against PostgreSQL after the
+expected writes have committed.
+
+The oracle path should be as direct as possible:
+
+```text
+generated ZQL/AST -> SQL -> PostgreSQL result
+```
+
+The oracle should not pass through zero-cache, protocol code, or client code.
+
+### Barriers
+
+Outer-layer fuzzing is only meaningful if comparisons happen after the layer has
+caught up to the intended PostgreSQL state.
+
+The harness should model barriers explicitly:
+
+```typescript
+type Barrier = {
+  readonly pgCommit: unknown;
+  readonly replicaApplied?: unknown | undefined;
+  readonly clientObserved?: unknown | undefined;
+};
+```
+
+The exact representation can vary by layer, but every comparison should say
+which barrier it waited for.
+
+Required barriers:
+
+- L0: none beyond the direct push step
+- L1: PostgreSQL commit observed by zero-cache
+- L2: PostgreSQL commit observed by zero-cache and protocol client
+- L3: PostgreSQL commit observed by zero-client materialization
+- L4: committed server state observed by every participating client
+
+### Normalization
+
+Some differences between PostgreSQL and Zero are not correctness bugs unless the
+query requested semantics that make them observable. The fuzzer should normalize
+or reject cases where comparison would be ambiguous.
+
+Important rules:
+
+- Require explicit ordering before comparing ordered result arrays.
+- Treat unordered results as sets or multisets with stable row identity.
+- Normalize timestamp precision.
+- Normalize numeric representations where PostgreSQL and JavaScript differ.
+- Normalize JSON object key order.
+- Make NULL and undefined handling explicit.
+- Avoid locale-sensitive collation unless it is the axis being tested.
+- Preserve duplicate rows if the query semantics allow duplicates.
+- Include permission filters in the PostgreSQL oracle when testing auth.
+
+The normalization policy should be stored in the replay artifact so a failure
+can be reproduced exactly.
+
+### Replay Artifact
+
+Every failing outer-layer case should produce a durable artifact. It should be
+possible to replay the artifact without rerunning the original random search.
+
+Suggested fields:
+
+```json
+{
+  "layer": "zero-cache",
+  "seed": 12648430,
+  "label": "L1|album|filter:eq|push:edit",
+  "schema": {},
+  "initialData": {},
+  "queries": [],
+  "writes": [],
+  "barriers": [],
+  "normalization": {},
+  "expectedPgSnapshots": [],
+  "observedZeroSnapshots": [],
+  "notes": "short human context"
+}
+```
+
+Inner-layer regressions can stay close to the current compact AST format. Outer
+layers need more operational data because process state, replication position,
+and client observation points matter.
+
+## Test Lanes
+
+The fuzzer should keep separate lanes with different cost and blast radius.
+
+### Backbone
+
+Runs on every PR.
+
+- deterministic mini fixture
+- bounded query depth
+- small write sequences
+- L0 always
+- L1 once stable
+- L2 smoke once stable
+
+Backbone should favor structure and coverage over randomness.
+
+### Sweep
+
+Runs in slower CI or manually.
+
+- seeded randomized cases
+- broader query decorations
+- larger write sequences
+- L0 and L1 by default
+- L2 and L3 as budgets allow
+
+Sweep should report all failures in a batch, then shrink or minimize within a
+bounded budget.
+
+### Scale
+
+Runs nightly or manually.
+
+- full Chinook fixture or larger generated fixtures
+- more relationships and deeper queries
+- larger write histories
+- reconnect/resume axes for client layers
+
+Scale is allowed to be slower and less shrink-friendly, but failures must still
+produce replay artifacts.
+
+### Regression Replay
+
+Runs on every PR.
+
+- committed minimized repros
+- no randomness
+- stable fixture
+- layer-specific replay entry points
+
+Regression replay is the permanent guardrail for bugs found by any lane.
+
+## Query and Write Generation
+
+The current query generator should remain the core. Outer layers should add
+axes gradually:
+
+- PostgreSQL type coverage: integers, floats, text, booleans, timestamps, JSON,
+  nullable columns
+- primary key shapes: single-column and compound keys
+- relationship shapes: one-to-one, one-to-many, many-to-one
+- write kinds: insert, update, delete
+- transaction shapes: single-row and multi-row transactions
+- update shapes: membership-preserving, membership-entering, membership-leaving,
+  order-boundary-crossing
+- subscription shapes: initial hydrate, maintained push, unsubscribe,
+  resubscribe
+- client shapes: one client, multiple clients, reconnect, resume
+
+The generator should keep a cost model so outer layers do not accidentally
+create cases that are too large to debug.
+
+## Debugging Workflow
+
+When a divergence is found:
+
+1. Save the replay artifact.
+2. Try to reproduce at the same layer.
+3. If the failure is in an outer layer, attempt to project the case inward:
+   - L3 failure -> replay through L2
+   - L2 failure -> replay through L1
+   - L1 failure -> replay through L0 if it can be represented as direct pushes
+4. Shrink the innermost layer that still reproduces.
+5. Commit the smallest useful regression artifact.
+
+This keeps outer-layer fuzzing from turning into opaque end-to-end failures.
+
+## Implementation Plan
+
+### Phase 1: Shared Case Format
+
+- Extract or define a serializable fuzzer case model.
+- Keep compatibility with the current Chinook fuzzer.
+- Add replay plumbing that can target different layers.
+- Record normalization policy with each case.
+
+### Phase 2: L1 zero-cache Harness
+
+- Start PostgreSQL and zero-cache in a test-owned lifecycle.
+- Apply the mini schema and seed data.
+- Register or execute generated queries through the server-side zero-cache path.
+- Apply generated writes to PostgreSQL.
+- Wait for a replication barrier.
+- Compare zero-cache results to PostgreSQL snapshots.
+- Save replay artifacts on divergence.
+
+This phase should be the first expansion target because it covers the largest
+new production surface while remaining easier to debug than a client test.
+
+### Phase 3: L2 Synthetic Protocol Client
+
+- Add a protocol-level synthetic client.
+- Subscribe to generated queries.
+- Materialize protocol messages into result sets.
+- Compare after initial hydrate and after each write barrier.
+- Add reconnect/resubscribe only after the steady-state path is stable.
+
+### Phase 4: L3 zero-client Harness
+
+- Run generated subscriptions through `zero-client`.
+- Compare application-visible results to PostgreSQL.
+- Add browser-backed storage as a separate lane after Node or headless support
+  is stable.
+
+### Phase 5: L4 Client Mutations and Multi-Client
+
+- Add generated client mutations.
+- Compare only after server commit semantics are clear.
+- Add multiple clients and reconnect/resume axes.
+- Add auth and permission-filter axes with oracle-side permission evaluation.
+
+## Risks
+
+- Barrier bugs can look like query bugs. The harness should report barrier state
+  separately from result divergence.
+- PostgreSQL and JavaScript type differences can create false positives.
+  Normalization must be explicit and conservative.
+- Outer-layer failures are harder to shrink. Projecting failures inward should
+  be part of the workflow, not an afterthought.
+- Process lifecycle can make tests flaky. Each lane needs strict startup,
+  readiness, timeout, and cleanup handling.
+- A generated query without explicit order can produce unstable row order.
+  Comparison must respect query semantics rather than array incidental order.
+
+## Open Questions
+
+- What is the best zero-cache test hook for an applied replication LSN?
+- Should L1 execute queries through an internal server API, the same
+  view-syncer path used by protocol clients, or both as separate lanes?
+- How much of the current Chinook fuzzer case model can be serialized without
+  loss?
+- Where should outer-layer regression artifacts live?
+- Which subset of generated PostgreSQL types should be enabled first?
+- Should generated schemas be a near-term axis, or should the first outer-layer
+  harness stay on deterministic Chinook fixtures?
+
+## Recommendation
+
+Build the expansion in this order:
+
+1. Preserve and continue improving the current L0 IVM fuzzer.
+2. Add L1 for replicator plus zero-cache with an explicit replication barrier.
+3. Add L2 with a synthetic protocol client.
+4. Add L3 with `zero-client`.
+5. Add L4 for multi-client, optimistic mutations, reconnect, resume, and auth.
+
+This gives the best correctness coverage per debugging cost. The shared
+PostgreSQL oracle remains the center of the design, while each outer layer adds
+one production boundary at a time.

--- a/packages/shared/src/tool/vitest-config.ts
+++ b/packages/shared/src/tool/vitest-config.ts
@@ -5,6 +5,7 @@ import {makeDefine} from '../build.ts';
 
 export const CI = process.env['CI'] === 'true' || process.env['CI'] === '1';
 const {VITEST_BROWSER} = process.env;
+const coverageInclude = ['src/**/*.{js,jsx,ts,tsx,mjs,mts,cjs,cts}'];
 
 function assertValidBrowser(
   browser: string | undefined,
@@ -68,7 +69,7 @@ export default defineConfig({
 
     coverage: {
       provider: 'v8',
-      include: ['src/**'],
+      include: coverageInclude,
     },
     typecheck: {
       enabled: false,

--- a/packages/zero-cache/vitest.config.ts
+++ b/packages/zero-cache/vitest.config.ts
@@ -1,6 +1,8 @@
 import {defineConfig, mergeConfig} from 'vitest/config';
 import config, {CI} from '../shared/src/tool/vitest-config.ts';
 
+const coverageInclude = ['src/**/*.{js,jsx,ts,tsx,mjs,mts,cjs,cts}'];
+
 function nameFromURL(url: string) {
   // importer looks like file://....../packages/NAME/... and we want the NAME
   return url.match(/\/packages\/([^/]+)/)?.[1] ?? 'unknown';
@@ -18,7 +20,7 @@ export function configForVersion(version: number, url: string) {
       coverage: {
         enabled: !CI, // Don't run coverage in continuous integration.
         reporter: [['html'], ['clover', {file: 'coverage.xml'}]],
-        include: ['src/**'],
+        include: coverageInclude,
       },
       retry: CI ? 2 : 0,
       testTimeout: TIMEOUT,
@@ -44,7 +46,7 @@ export function configForNoPg(url: string) {
       coverage: {
         enabled: !CI, // Don't run coverage in continuous integration.
         reporter: [['html'], ['clover', {file: 'coverage.xml'}]],
-        include: ['src/**'],
+        include: coverageInclude,
       },
     },
   });

--- a/packages/zql-integration-tests/src/chinook/chinook-zero-cache-fuzzer.pg.test.ts
+++ b/packages/zql-integration-tests/src/chinook/chinook-zero-cache-fuzzer.pg.test.ts
@@ -1,0 +1,349 @@
+import {expect} from 'vitest';
+import {testLogConfig} from '../../../otel/src/test-log-config.ts';
+import {BigIntJSON} from '../../../shared/src/bigint-json.ts';
+import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
+import {initializePostgresChangeSource} from '../../../zero-cache/src/services/change-source/pg/change-source.ts';
+import {initializeStreamer} from '../../../zero-cache/src/services/change-streamer/change-streamer-service.ts';
+import type {
+  ChangeStreamer,
+  ChangeStreamerService,
+  Downstream,
+} from '../../../zero-cache/src/services/change-streamer/change-streamer.ts';
+import {ReplicationStatusPublisher} from '../../../zero-cache/src/services/replicator/replication-status.ts';
+import type {ReplicaState} from '../../../zero-cache/src/services/replicator/replicator.ts';
+import {ReplicatorService} from '../../../zero-cache/src/services/replicator/replicator.ts';
+import {ThreadWriteWorkerClient} from '../../../zero-cache/src/services/replicator/write-worker-client.ts';
+import {
+  getConnectionURI,
+  test,
+  type PgTest,
+} from '../../../zero-cache/src/test/db.ts';
+import {DbFile} from '../../../zero-cache/src/test/lite.ts';
+import type {PostgresDB} from '../../../zero-cache/src/types/pg.ts';
+import type {Source} from '../../../zero-cache/src/types/streams.ts';
+import {
+  getPragmaConfig,
+  setupReplica,
+} from '../../../zero-cache/src/workers/replicator.ts';
+import {getServerSchema} from '../../../zero-server/src/schema.ts';
+import {Transaction} from '../../../zero-server/src/test/util.ts';
+import {asQueryInternals} from '../../../zql/src/query/query-internals.ts';
+import type {AnyQuery} from '../../../zql/src/query/query.ts';
+import {Database} from '../../../zqlite/src/db.ts';
+import {
+  mapResultToClientNames,
+  newQueryDelegate,
+} from '../../../zqlite/src/test/source-factory.ts';
+import '../helpers/comparePg.ts';
+import {TestPGQueryDelegate} from '../helpers/runner.ts';
+import {pkOf} from './fuzz/axes.ts';
+import {CostModel} from './fuzz/cost.ts';
+import {
+  checkQueryCases,
+  enumerate,
+  l1QueryCases,
+  mutationQueryCases,
+  panicIfFailed,
+  skeletonQueryCases,
+  swarmQueryCases,
+  tailQueryCases,
+} from './fuzz/driver.ts';
+import {Data} from './fuzz/literals.ts';
+import {miniData, miniPgContent} from './fuzz/mini.ts';
+import {builder, schema} from './schema.ts';
+
+const lc = createSilentLogContext();
+
+const APP_ID = 'zql_integration_zero_cache_fuzzer';
+const SHARD_NUM = 0;
+const TASK_ID = 'zql-integration-zero-cache-fuzzer';
+const TIMEOUT_MS = 120_000;
+const SEED = 0x00c0ffee;
+
+const shard = {
+  appID: APP_ID,
+  shardNum: SHARD_NUM,
+  publications: [],
+};
+
+const streamerOptions = {
+  backPressureLimitHeapProportion: 0.04,
+  flowControlConsensusPaddingSeconds: 1,
+  statementTimeoutMs: 20_000,
+  changeLogBatchSize: 2000,
+};
+
+const data = new Data(miniData, pkOf);
+const L0_QUERY_CASES = skeletonQueryCases(
+  enumerate({depth: 1, related: 1, exists: 1}),
+);
+const L1_QUERY_CASES = l1QueryCases(data);
+const ZERO_CACHE_QUERY_CASES = [
+  ...L0_QUERY_CASES,
+  ...L1_QUERY_CASES.cases,
+  ...swarmQueryCases(data, SEED, 16, 4),
+  ...mutationQueryCases(
+    enumerate({depth: 2, related: 1, exists: 1}).slice(0, 100),
+    SEED ^ 0x5eed,
+  ),
+  ...tailQueryCases(CostModel.fromData(miniData, 1_000_000), SEED, 150).cases,
+];
+
+type ChinookSchema = typeof schema;
+
+function parseStringifiedSource(source: Source<string>): Source<Downstream> {
+  return {
+    cancel: err => source.cancel(err),
+    async *[Symbol.asyncIterator]() {
+      for await (const msg of source) {
+        yield BigIntJSON.parse(msg) as Downstream;
+      }
+    },
+  };
+}
+
+function parseStringifiedChangeStreamer(
+  streamer: ChangeStreamerService,
+): ChangeStreamer {
+  return {
+    async subscribe(ctx) {
+      return parseStringifiedSource(await streamer.subscribe(ctx));
+    },
+  };
+}
+
+async function withTimeout<T>(
+  promise: Promise<T>,
+  description: string,
+): Promise<T> {
+  let timeout: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(
+          () => reject(new Error(`timed out waiting for ${description}`)),
+          TIMEOUT_MS,
+        );
+      }),
+    ]);
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+async function startZeroCacheReplica(testDBs: PgTest['testDBs']) {
+  const cleanup: (() => Promise<void> | void)[] = [];
+
+  try {
+    const upstream = await testDBs.create(
+      'chinook_zero_cache_fuzzer_upstream',
+      {typeOpts: false},
+    );
+    const changeDB = await testDBs.create('chinook_zero_cache_fuzzer_change', {
+      typeOpts: {sendStringAsJson: true},
+    });
+    cleanup.push(() => testDBs.drop(upstream, changeDB));
+
+    await upstream.unsafe(miniPgContent());
+
+    const replicaDbFile = new DbFile('chinook-zero-cache-fuzzer');
+    cleanup.push(() => replicaDbFile.delete());
+
+    const {subscriptionState, changeSource} =
+      await initializePostgresChangeSource(
+        lc,
+        getConnectionURI(upstream),
+        shard,
+        replicaDbFile.path,
+        {tableCopyWorkers: 1},
+        {suite: 'chinook-zero-cache-fuzzer'},
+      );
+
+    await setupReplica(lc, 'serving', {file: replicaDbFile.path});
+
+    const changeStreamer = await initializeStreamer(
+      lc,
+      shard,
+      TASK_ID,
+      'change-streamer:zero-cache-fuzzer',
+      'ws',
+      changeDB,
+      changeSource,
+      ReplicationStatusPublisher.forReplicaFile(replicaDbFile.path, () =>
+        Promise.resolve(),
+      ),
+      subscriptionState,
+      null,
+      true,
+      streamerOptions,
+    );
+    const changeStreamerDone = changeStreamer.run();
+    cleanup.push(async () => {
+      await changeStreamer.stop();
+      await changeStreamerDone;
+    });
+
+    const worker = new ThreadWriteWorkerClient();
+    await worker.init(
+      replicaDbFile.path,
+      'serving',
+      getPragmaConfig('serving'),
+      {level: 'error', format: 'text'},
+    );
+
+    const replicator = new ReplicatorService(
+      lc,
+      TASK_ID,
+      'chinook-zero-cache-fuzzer-replicator',
+      'serving',
+      parseStringifiedChangeStreamer(changeStreamer),
+      worker,
+      null,
+    );
+    const replicatorDone = replicator.run();
+    cleanup.push(async () => {
+      await replicator.stop();
+      await replicatorDone;
+    });
+
+    const notifications = replicator.subscribe();
+    const versions = notifications[Symbol.asyncIterator]();
+    cleanup.push(() => notifications.cancel());
+    await withTimeout(versions.next(), 'initial replica version');
+
+    const replica = new Database(lc, replicaDbFile.path);
+    cleanup.push(() => replica.close());
+    const sqlite = newQueryDelegate(lc, testLogConfig, replica, schema);
+
+    const serverSchema = await upstream.begin(tx =>
+      getServerSchema(new Transaction(tx), schema),
+    );
+    const pg = new TestPGQueryDelegate(upstream, schema, serverSchema);
+
+    return {
+      upstream,
+      pg,
+      sqlite,
+      async waitForReplicaVersion(description: string): Promise<ReplicaState> {
+        const {done, value} = await withTimeout(
+          versions.next(),
+          `replica version after ${description}`,
+        );
+        if (done) {
+          throw new Error(`replica notifications ended after ${description}`);
+        }
+        return value;
+      },
+      async cleanup() {
+        for (const fn of cleanup.reverse()) {
+          await fn();
+        }
+        cleanup.length = 0;
+      },
+    };
+  } catch (e) {
+    for (const fn of cleanup.reverse()) {
+      await fn();
+    }
+    throw e;
+  }
+}
+
+async function expectReplicaMatchesPG({
+  pg,
+  sqlite,
+  query,
+}: {
+  pg: TestPGQueryDelegate;
+  sqlite: ReturnType<typeof newQueryDelegate>;
+  query: AnyQuery;
+}) {
+  const pgResult = await pg.run(query);
+  const rootTable = asQueryInternals(query).ast
+    .table as keyof ChinookSchema['tables'];
+  const sqliteResult = mapResultToClientNames(
+    await sqlite.run(query),
+    schema,
+    rootTable,
+  );
+
+  expect(sqliteResult).toEqualPg(pgResult);
+}
+
+async function insertTrack(upstream: PostgresDB) {
+  await upstream`
+    INSERT INTO track (
+      track_id,
+      name,
+      album_id,
+      media_type_id,
+      genre_id,
+      composer,
+      milliseconds,
+      bytes,
+      unit_price
+    ) VALUES (
+      108,
+      't-replicated',
+      20,
+      1,
+      2,
+      'Zero',
+      123000,
+      123456,
+      0.99
+    )`;
+}
+
+async function moveTrackOutOfQuery(upstream: PostgresDB) {
+  await upstream`
+    UPDATE track
+       SET album_id = 10
+     WHERE track_id = 108`;
+}
+
+async function deleteTrack(upstream: PostgresDB) {
+  await upstream`
+    DELETE FROM track
+     WHERE track_id = 105`;
+}
+
+test(
+  `zero-cache replica stays query-equivalent to PostgreSQL for ${ZERO_CACHE_QUERY_CASES.length} generated query cases and replicated writes`,
+  {timeout: TIMEOUT_MS},
+  async ({testDBs}: PgTest) => {
+    const harness = await startZeroCacheReplica(testDBs);
+    try {
+      expect(L1_QUERY_CASES.coverage.fraction()).toBe(1);
+      const report = await checkQueryCases(ZERO_CACHE_QUERY_CASES, query =>
+        expectReplicaMatchesPG({...harness, query}),
+      );
+      expect(report.total).toBeGreaterThan(500);
+      panicIfFailed(report, 12);
+
+      const query = builder.album
+        .where('id', '=', 20)
+        .related('tracks', t => t.orderBy('id', 'asc'))
+        .one();
+
+      await expectReplicaMatchesPG({...harness, query});
+
+      await insertTrack(harness.upstream);
+      await harness.waitForReplicaVersion('track insert');
+      await expectReplicaMatchesPG({...harness, query});
+
+      await moveTrackOutOfQuery(harness.upstream);
+      await harness.waitForReplicaVersion('track update');
+      await expectReplicaMatchesPG({...harness, query});
+
+      await deleteTrack(harness.upstream);
+      await harness.waitForReplicaVersion('track delete');
+      await expectReplicaMatchesPG({...harness, query});
+    } finally {
+      await harness.cleanup();
+    }
+  },
+);

--- a/packages/zql-integration-tests/src/chinook/chinook-zero-cache-fuzzer.pg.test.ts
+++ b/packages/zql-integration-tests/src/chinook/chinook-zero-cache-fuzzer.pg.test.ts
@@ -25,8 +25,13 @@ import {
   getPragmaConfig,
   setupReplica,
 } from '../../../zero-cache/src/workers/replicator.ts';
+import type {Row} from '../../../zero-protocol/src/data.ts';
 import {getServerSchema} from '../../../zero-server/src/schema.ts';
 import {Transaction} from '../../../zero-server/src/test/util.ts';
+import type {
+  Schema as ZeroSchema,
+  TableSchema,
+} from '../../../zero-types/src/schema.ts';
 import {asQueryInternals} from '../../../zql/src/query/query-internals.ts';
 import type {AnyQuery} from '../../../zql/src/query/query.ts';
 import {Database} from '../../../zqlite/src/db.ts';
@@ -50,6 +55,8 @@ import {
 } from './fuzz/driver.ts';
 import {Data} from './fuzz/literals.ts';
 import {miniData, miniPgContent} from './fuzz/mini.ts';
+import {pushForSkeleton, type Mutation} from './fuzz/push.ts';
+import {label as skeletonLabel, lower, type Skeleton} from './fuzz/skeleton.ts';
 import {builder, schema} from './schema.ts';
 
 const lc = createSilentLogContext();
@@ -59,6 +66,7 @@ const SHARD_NUM = 0;
 const TASK_ID = 'zql-integration-zero-cache-fuzzer';
 const TIMEOUT_MS = 120_000;
 const SEED = 0x00c0ffee;
+const writeSchema: ZeroSchema = schema;
 
 const shard = {
   appID: APP_ID,
@@ -78,6 +86,25 @@ const L0_QUERY_CASES = skeletonQueryCases(
   enumerate({depth: 1, related: 1, exists: 1}),
 );
 const L1_QUERY_CASES = l1QueryCases(data);
+const WRITE_FUZZ_EXTRA_LABELS = [
+  'album(ex:track)',
+  'employee(ex:employee)',
+  'invoice(ex:invoiceLine)',
+  'playlist(ex:track)',
+  'track(ex:playlist)',
+];
+const WRITE_FUZZ_SKELETONS = selectWriteFuzzSkeletons(
+  enumerate({depth: 1, related: 1, exists: 1}),
+);
+const WRITE_FUZZ_CASES = WRITE_FUZZ_SKELETONS.map(s => ({
+  label: `write|${skeletonLabel(s)}`,
+  mutations: pushForSkeleton(data, s, 1),
+  query: lower(s),
+}));
+const WRITE_FUZZ_WRITE_COUNT = WRITE_FUZZ_CASES.reduce(
+  (n, c) => n + c.mutations.length,
+  0,
+);
 const ZERO_CACHE_QUERY_CASES = [
   ...L0_QUERY_CASES,
   ...L1_QUERY_CASES.cases,
@@ -90,6 +117,38 @@ const ZERO_CACHE_QUERY_CASES = [
 ];
 
 type ChinookSchema = typeof schema;
+
+function selectWriteFuzzSkeletons(
+  skeletons: readonly Skeleton[],
+): readonly Skeleton[] {
+  const out: Skeleton[] = [];
+  const seen = new Set<string>();
+
+  const add = (s: Skeleton | undefined) => {
+    if (!s) {
+      return;
+    }
+    const key = skeletonLabel(s);
+    if (!seen.has(key)) {
+      seen.add(key);
+      out.push(s);
+    }
+  };
+
+  const roots = new Set(skeletons.map(s => s.table));
+  for (const root of roots) {
+    add(
+      skeletons.find(
+        s => s.table === root && s.children.some(c => c.kind === 'related'),
+      ) ?? skeletons.find(s => s.table === root),
+    );
+  }
+  for (const label of WRITE_FUZZ_EXTRA_LABELS) {
+    add(skeletons.find(s => skeletonLabel(s) === label));
+  }
+
+  return out;
+}
 
 function parseStringifiedSource(source: Source<string>): Source<Downstream> {
   return {
@@ -273,6 +332,129 @@ async function expectReplicaMatchesPG({
   expect(sqliteResult).toEqualPg(pgResult);
 }
 
+function tableSchema(table: string): TableSchema {
+  const tableDef = writeSchema.tables[table];
+  if (!tableDef) {
+    throw new Error(`unknown table ${table}`);
+  }
+  return tableDef;
+}
+
+function serverTableName(table: string): string {
+  const tableDef = tableSchema(table);
+  return tableDef.serverName ?? table;
+}
+
+function serverColumnName(table: string, column: string): string {
+  const columnDef = tableSchema(table).columns[column];
+  if (!columnDef) {
+    throw new Error(`unknown column ${table}.${column}`);
+  }
+  return columnDef.serverName ?? column;
+}
+
+function toServerRow(table: string, row: Row): Row {
+  const out: Record<string, Row[string]> = {};
+  for (const [column, value] of Object.entries(row)) {
+    out[serverColumnName(table, column)] = value;
+  }
+  return out;
+}
+
+function definedRowValue(
+  table: string,
+  column: string,
+  row: Row,
+): Exclude<Row[string], undefined> {
+  const value = row[column];
+  if (value === undefined) {
+    throw new Error(`missing value for ${table}.${column}`);
+  }
+  return value;
+}
+
+function primaryKeyConditions(upstream: PostgresDB, table: string, row: Row) {
+  return tableSchema(table).primaryKey.flatMap((column, i) => {
+    const condition = upstream`${upstream(serverColumnName(table, column))} = ${definedRowValue(
+      table,
+      column,
+      row,
+    )}`;
+    return i === 0 ? [condition] : [upstream`AND`, condition];
+  });
+}
+
+function mutationDescription(mutation: Mutation): string {
+  const pks = tableSchema(mutation.table)
+    .primaryKey.map(column => `${column}=${String(mutation.row[column])}`)
+    .join(',');
+  return `${mutation.kind} ${mutation.table}(${pks})`;
+}
+
+function expectSingleAffectedRow(
+  result: readonly unknown[],
+  description: string,
+) {
+  expect(result.length, description).toBe(1);
+}
+
+async function applyWriteFuzzMutation(
+  upstream: PostgresDB,
+  mutation: Mutation,
+) {
+  const table = serverTableName(mutation.table);
+  switch (mutation.kind) {
+    case 'remove': {
+      const result = await upstream`
+        DELETE FROM ${upstream(table)}
+         WHERE ${primaryKeyConditions(upstream, mutation.table, mutation.row)}
+        RETURNING 1`;
+      expectSingleAffectedRow(result, mutationDescription(mutation));
+      break;
+    }
+    case 'add': {
+      const result = await upstream`
+        INSERT INTO ${upstream(table)}
+        ${upstream(toServerRow(mutation.table, mutation.row))}
+        RETURNING 1`;
+      expectSingleAffectedRow(result, mutationDescription(mutation));
+      break;
+    }
+    case 'edit': {
+      const result = await upstream`
+        UPDATE ${upstream(table)}
+           SET ${upstream(toServerRow(mutation.table, mutation.row))}
+         WHERE ${primaryKeyConditions(upstream, mutation.table, mutation.old)}
+        RETURNING 1`;
+      expectSingleAffectedRow(result, mutationDescription(mutation));
+      break;
+    }
+  }
+}
+
+async function checkWriteFuzzCases(
+  harness: Awaited<ReturnType<typeof startZeroCacheReplica>>,
+): Promise<number> {
+  let writeCount = 0;
+  for (const c of WRITE_FUZZ_CASES) {
+    await expectReplicaMatchesPG({...harness, query: c.query});
+    for (let i = 0; i < c.mutations.length; i++) {
+      const mutation = c.mutations[i];
+      const description = `${c.label}#${i}:${mutationDescription(mutation)}`;
+      await applyWriteFuzzMutation(harness.upstream, mutation);
+      writeCount += 1;
+      await harness.waitForReplicaVersion(description);
+      try {
+        await expectReplicaMatchesPG({...harness, query: c.query});
+      } catch (e) {
+        const msg = e instanceof Error ? (e.stack ?? e.message) : String(e);
+        throw new Error(`write fuzz divergence after ${description}\n${msg}`);
+      }
+    }
+  }
+  return writeCount;
+}
+
 async function insertTrack(upstream: PostgresDB) {
   await upstream`
     INSERT INTO track (
@@ -312,7 +494,7 @@ async function deleteTrack(upstream: PostgresDB) {
 }
 
 test(
-  `zero-cache replica stays query-equivalent to PostgreSQL for ${ZERO_CACHE_QUERY_CASES.length} generated query cases and replicated writes`,
+  `zero-cache replica stays query-equivalent to PostgreSQL for ${ZERO_CACHE_QUERY_CASES.length} generated query cases, ${WRITE_FUZZ_WRITE_COUNT} generated writes, and replicated writes`,
   {timeout: TIMEOUT_MS},
   async ({testDBs}: PgTest) => {
     const harness = await startZeroCacheReplica(testDBs);
@@ -323,6 +505,10 @@ test(
       );
       expect(report.total).toBeGreaterThan(500);
       panicIfFailed(report, 12);
+
+      expect(WRITE_FUZZ_CASES.length).toBeGreaterThan(10);
+      const writeCount = await checkWriteFuzzCases(harness);
+      expect(writeCount).toBe(WRITE_FUZZ_WRITE_COUNT);
 
       const query = builder.album
         .where('id', '=', 20)

--- a/packages/zql-integration-tests/src/chinook/fuzz/driver.ts
+++ b/packages/zql-integration-tests/src/chinook/fuzz/driver.ts
@@ -94,6 +94,23 @@ export type Report = {
   readonly failures: Array<[string, string]>;
 };
 
+/** One generated hydrate/query case, independent of the execution target. */
+export type QueryCase = {
+  readonly label: string;
+  readonly query: AnyQuery;
+};
+
+/** One generated mutation-maintenance case, independent of the execution target. */
+export type PushCase = QueryCase & {
+  readonly mutations: readonly Mutation[];
+};
+
+/** A target-specific checker for a generated query case. */
+export type QueryCaseChecker = (
+  query: AnyQuery,
+  label: string,
+) => Promise<void>;
+
 /** Run `fn` (a parity assert), returning its error message on failure (truncated). */
 export async function capture(fn: () => Promise<void>): Promise<string | null> {
   try {
@@ -103,6 +120,165 @@ export async function capture(fn: () => Promise<void>): Promise<string | null> {
     const msg = e instanceof Error ? (e.stack ?? e.message) : String(e);
     return msg.slice(0, 1500);
   }
+}
+
+/**
+ * Run generated query cases through a target-provided checker. This is the shared
+ * concentric-ring harness: the corpus is generated once, and each ring supplies only
+ * the layer-specific comparison implementation.
+ */
+export async function checkQueryCases(
+  cases: readonly QueryCase[],
+  check: QueryCaseChecker,
+): Promise<Report> {
+  const failures: Array<[string, string]> = [];
+  for (const c of cases) {
+    const msg = await capture(() => check(c.query, c.label));
+    if (msg) {
+      failures.push([c.label, msg]);
+    }
+  }
+  return {total: cases.length, failures};
+}
+
+/** The L0 structural skeleton corpus as target-independent query cases. */
+export function skeletonQueryCases(
+  skels: readonly Skeleton[],
+): readonly QueryCase[] {
+  return skels.map(s => ({label: label(s), query: lower(s)}));
+}
+
+/** The L1 pairwise-decoration corpus as target-independent query cases. */
+export function l1QueryCases(data: Data): {
+  readonly cases: readonly QueryCase[];
+  readonly coverage: Coverage;
+} {
+  const rows = greedyCover(2);
+  const coverage = new Coverage(2);
+  const cases: QueryCase[] = [];
+
+  for (const row of rows) {
+    for (const root of decoratableRoots()) {
+      const res = decorate(root, row, data);
+      if (!res) {
+        continue;
+      }
+      cases.push({
+        label: `L1|${root}|${rowLabel(row)}`,
+        query: res[0],
+      });
+      coverage.observe(row);
+    }
+  }
+
+  for (const [parent, rel] of childDecorationPairs()) {
+    for (const row of rows) {
+      const res = decorateChild(parent, rel, row, data);
+      if (!res) {
+        continue;
+      }
+      cases.push({
+        label: `L1|${parent}.${rel}|${rowLabel(row)}`,
+        query: res[0],
+      });
+      coverage.observe(row);
+    }
+  }
+
+  return {cases, coverage};
+}
+
+/** The L2 swarm corpus as target-independent query cases. */
+export function swarmQueryCases(
+  data: Data,
+  seed: number,
+  nMasks: number,
+  perMask: number,
+): readonly QueryCase[] {
+  const r = rng(seed);
+  const cases: QueryCase[] = [];
+  for (let mi = 0; mi < nMasks; mi++) {
+    const mask = Mask.random(r);
+    for (let qi = 0; qi < perMask; qi++) {
+      const res = swarmGen(r, mask, data);
+      if (!res) {
+        continue;
+      }
+      cases.push({
+        label: `swarm|seed${seed}|m${mi}q${qi}`,
+        query: res[0],
+      });
+    }
+  }
+  return cases;
+}
+
+/** The L3 mutation-from-corpus cases as target-independent query cases. */
+export function mutationQueryCases(
+  corpus: readonly Skeleton[],
+  seed: number,
+): readonly QueryCase[] {
+  const r = rng(seed);
+  return corpus.map(s => {
+    const baseAst = asQueryInternals(lower(s)).ast;
+    const mutated = mutate(r, baseAst);
+    return {label: `mutate|${label(s)}`, query: wrapAst(mutated)};
+  });
+}
+
+/** The L4 random-tail generated cases after cost gating. */
+export type TailCases = {
+  readonly cases: readonly QueryCase[];
+  readonly generated: number;
+  readonly gated: number;
+};
+
+export function tailQueryCases(
+  cost: CostModel,
+  seed: number,
+  n: number,
+  bounds: DeepBounds = tailBounds(),
+): TailCases {
+  const r = rng(seed);
+  const cases: QueryCase[] = [];
+  let generated = 0;
+  let gated = 0;
+  for (let i = 0; i < n; i++) {
+    const res = tailGen(r, bounds);
+    if (!res) {
+      continue;
+    }
+    generated += 1;
+    const ast = asQueryInternals(res[0]).ast;
+    if (cost.tooExpensive(ast)) {
+      gated += 1;
+      continue;
+    }
+    cases.push({label: `tail|seed${seed}|${i}`, query: res[0]});
+  }
+  return {cases, generated, gated};
+}
+
+/** Flip-invariance variants as target-independent query cases. */
+export function flipQueryCases(
+  skels: readonly Skeleton[],
+  maxFlips = 4,
+): readonly QueryCase[] {
+  const cases: QueryCase[] = [];
+  for (const s of skels) {
+    const base = asQueryInternals(lower(s)).ast;
+    const k = flippableExistsCount(base);
+    if (k === 0 || k > maxFlips) {
+      continue;
+    }
+    for (const bits of flipAssignments(k)) {
+      cases.push({
+        label: `flip|${label(s)}|${bits.map(b => (b ? 1 : 0)).join('')}`,
+        query: wrapAst(setFlips(base, bits)),
+      });
+    }
+  }
+  return cases;
 }
 
 /** Whether `ast` (re-wrapped as a query) still diverges from the oracle. */
@@ -162,12 +338,19 @@ export async function checkL0Hydrate(
   delegates: Delegates,
   skels: readonly Skeleton[],
 ): Promise<Report> {
+  return await checkHydrateCases(delegates, skeletonQueryCases(skels));
+}
+
+async function checkHydrateCases(
+  delegates: Delegates,
+  cases: readonly QueryCase[],
+): Promise<Report> {
   const failures: Array<[string, string]> = [];
   const budget = {remaining: SHRINK_BUDGET};
-  for (const s of skels) {
-    await checkHydrate(delegates, lower(s), label(s), failures, budget);
+  for (const c of cases) {
+    await checkHydrate(delegates, c.query, c.label, failures, budget);
   }
-  return {total: skels.length, failures};
+  return {total: cases.length, failures};
 }
 
 /**
@@ -182,52 +365,8 @@ export async function checkL1(
   delegates: Delegates,
   data: Data,
 ): Promise<{report: Report; coverage: Coverage}> {
-  const rows = greedyCover(2);
-  const cov = new Coverage(2);
-  const failures: Array<[string, string]> = [];
-  const budget = {remaining: SHRINK_BUDGET};
-  let total = 0;
-
-  // Root decorations: each covering-array row × each decoratable root.
-  for (const row of rows) {
-    for (const root of decoratableRoots()) {
-      const res = decorate(root, row, data);
-      if (!res) {
-        continue;
-      }
-      total += 1;
-      await checkHydrate(
-        delegates,
-        res[0],
-        `L1|${root}|${rowLabel(row)}`,
-        failures,
-        budget,
-      );
-      cov.observe(row);
-    }
-  }
-
-  // Child decorations: each row lowered onto a NESTED collection (per-parent refill,
-  // child sort position) — the parity surface the root-only pass misses.
-  for (const [parent, rel] of childDecorationPairs()) {
-    for (const row of rows) {
-      const res = decorateChild(parent, rel, row, data);
-      if (!res) {
-        continue;
-      }
-      total += 1;
-      await checkHydrate(
-        delegates,
-        res[0],
-        `L1|${parent}.${rel}|${rowLabel(row)}`,
-        failures,
-        budget,
-      );
-      cov.observe(row);
-    }
-  }
-
-  return {report: {total, failures}, coverage: cov};
+  const {cases, coverage} = l1QueryCases(data);
+  return {report: await checkHydrateCases(delegates, cases), coverage};
 }
 
 // ── the randomized layers (L2 swarm / L3 mutation / L4 random tail) ────────────────────
@@ -245,28 +384,10 @@ export async function checkSwarm(
   nMasks: number,
   perMask: number,
 ): Promise<Report> {
-  const r = rng(seed);
-  const failures: Array<[string, string]> = [];
-  const budget = {remaining: SHRINK_BUDGET};
-  let total = 0;
-  for (let mi = 0; mi < nMasks; mi++) {
-    const mask = Mask.random(r);
-    for (let qi = 0; qi < perMask; qi++) {
-      const res = swarmGen(r, mask, data);
-      if (!res) {
-        continue;
-      }
-      total += 1;
-      await checkHydrate(
-        delegates,
-        res[0],
-        `swarm|seed${seed}|m${mi}q${qi}`,
-        failures,
-        budget,
-      );
-    }
-  }
-  return {total, failures};
+  return await checkHydrateCases(
+    delegates,
+    swarmQueryCases(data, seed, nMasks, perMask),
+  );
 }
 
 /**
@@ -279,21 +400,7 @@ export async function checkMutate(
   corpus: readonly Skeleton[],
   seed: number,
 ): Promise<Report> {
-  const r = rng(seed);
-  const failures: Array<[string, string]> = [];
-  const budget = {remaining: SHRINK_BUDGET};
-  for (const s of corpus) {
-    const baseAst = asQueryInternals(lower(s)).ast;
-    const mutated = mutate(r, baseAst);
-    await checkHydrate(
-      delegates,
-      wrapAst(mutated),
-      `mutate|${label(s)}`,
-      failures,
-      budget,
-    );
-  }
-  return {total: corpus.length, failures};
+  return await checkHydrateCases(delegates, mutationQueryCases(corpus, seed));
 }
 
 /** The L4 random-tail outcome — the gated (too-expensive, skipped) count reported, not
@@ -318,33 +425,12 @@ export async function checkTail(
   n: number,
   bounds: DeepBounds = tailBounds(),
 ): Promise<TailReport> {
-  const r = rng(seed);
-  const failures: Array<[string, string]> = [];
-  const budget = {remaining: SHRINK_BUDGET};
-  let generated = 0;
-  let gated = 0;
-  let total = 0;
-  for (let i = 0; i < n; i++) {
-    const res = tailGen(r, bounds);
-    if (!res) {
-      continue;
-    }
-    generated += 1;
-    const ast = asQueryInternals(res[0]).ast;
-    if (cost.tooExpensive(ast)) {
-      gated += 1; // static gate: skip + count, never run
-      continue;
-    }
-    total += 1;
-    await checkHydrate(
-      delegates,
-      res[0],
-      `tail|seed${seed}|${i}`,
-      failures,
-      budget,
-    );
-  }
-  return {report: {total, failures}, generated, gated};
+  const {cases, generated, gated} = tailQueryCases(cost, seed, n, bounds);
+  return {
+    report: await checkHydrateCases(delegates, cases),
+    generated,
+    gated,
+  };
 }
 
 // ── flip-invariance (plan-choice invariance of EXISTS gates) ──────────────────────────
@@ -362,27 +448,7 @@ export async function checkFlipInvariance(
   skels: readonly Skeleton[],
   maxFlips = 4,
 ): Promise<Report> {
-  const failures: Array<[string, string]> = [];
-  const budget = {remaining: SHRINK_BUDGET};
-  let total = 0;
-  for (const s of skels) {
-    const base = asQueryInternals(lower(s)).ast;
-    const k = flippableExistsCount(base);
-    if (k === 0 || k > maxFlips) {
-      continue;
-    }
-    for (const bits of flipAssignments(k)) {
-      total += 1;
-      await checkHydrate(
-        delegates,
-        wrapAst(setFlips(base, bits)),
-        `flip|${label(s)}|${bits.map(b => (b ? 1 : 0)).join('')}`,
-        failures,
-        budget,
-      );
-    }
-  }
-  return {total, failures};
+  return await checkHydrateCases(delegates, flipQueryCases(skels, maxFlips));
 }
 
 // ── the four-phase push protocol (per-step parity) ────────────────────────────────────
@@ -480,6 +546,48 @@ async function pushWalk(
   }
 }
 
+/** Push-maintenance cases generated from skeletons, independent of the target. */
+export function pushCases(
+  data: Data,
+  skels: readonly Skeleton[],
+  n: number,
+): readonly PushCase[] {
+  const cases: PushCase[] = [];
+  for (const s of skels) {
+    const mutations = pushForSkeleton(data, s, n);
+    if (mutations.length === 0) {
+      continue;
+    }
+    cases.push({
+      label: `push|${label(s)}`,
+      query: lower(s),
+      mutations,
+    });
+  }
+  return cases;
+}
+
+/** Top-N push-maintenance cases generated from skeletons, independent of the target. */
+export function decoratedPushCases(
+  data: Data,
+  skels: readonly Skeleton[],
+  n: number,
+): readonly PushCase[] {
+  const cases: PushCase[] = [];
+  for (const s of skels) {
+    const mutations = pushForSkeleton(data, s, n);
+    if (mutations.length === 0) {
+      continue;
+    }
+    cases.push({
+      label: `decpush|${label(s)}`,
+      query: applyLimit(applyOrder(lower(s), s.table, 'asc1'), 'small'),
+      mutations,
+    });
+  }
+  return cases;
+}
+
 /**
  * **Push sweep:** lower each skeleton, generate its four-phase push history (root +
  * deepest leaf), and check per-step push parity inside a rolled-back transaction. `n`
@@ -493,21 +601,16 @@ export async function checkPushWalk(
   n: number,
 ): Promise<Report> {
   const failures: Array<[string, string]> = [];
-  let total = 0;
-  for (const s of skels) {
-    const mutations = pushForSkeleton(data, s, n);
-    if (mutations.length === 0) {
-      continue;
-    }
-    total += 1;
+  const cases = pushCases(data, skels, n);
+  for (const c of cases) {
     const msg = await capture(() =>
-      transact(d => pushWalk(d, lower(s), mutations)),
+      transact(d => pushWalk(d, c.query, c.mutations)),
     );
     if (msg) {
-      failures.push([`push|${label(s)}`, msg]);
+      failures.push([c.label, msg]);
     }
   }
-  return {total, failures};
+  return {total: cases.length, failures};
 }
 
 /**
@@ -527,22 +630,16 @@ export async function checkDecoratedPush(
   n: number,
 ): Promise<Report> {
   const failures: Array<[string, string]> = [];
-  let total = 0;
-  for (const s of skels) {
-    const mutations = pushForSkeleton(data, s, n);
-    if (mutations.length === 0) {
-      continue;
-    }
-    total += 1;
-    const topN = applyLimit(applyOrder(lower(s), s.table, 'asc1'), 'small');
+  const cases = decoratedPushCases(data, skels, n);
+  for (const c of cases) {
     const msg = await capture(() =>
-      transact(d => pushWalk(d, topN, mutations)),
+      transact(d => pushWalk(d, c.query, c.mutations)),
     );
     if (msg) {
-      failures.push([`decpush|${label(s)}`, msg]);
+      failures.push([c.label, msg]);
     }
   }
-  return {total, failures};
+  return {total: cases.length, failures};
 }
 
 /**


### PR DESCRIPTION
We fuzz the IVM engine with the observation:
1. Any ZQL query should match a PG query
2. Any update to a ZQL query should match a fresh hydrate

Given that, we can expand our fuzzer out in circles. From Engine -> ZeroCache -> Repliactor+Cache -> Repliactor+Cache+Client

Finally, we can add proxies at every network boundary to test network fault injection.