### PR TITLE
feat(zero-cache): add litestream backup and restore metrics

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/litestream3-backup-monitor.ts
+++ b/packages/zero-cache/src/services/change-streamer/litestream3-backup-monitor.ts
@@ -11,6 +11,11 @@ import {
   getOrCreateGauge,
 } from '../../observability/metrics.ts';
 import {Subscription} from '../../types/subscription.ts';
+import {
+  litestreamBackupVerificationDuration,
+  litestreamMonitorMetricAttrs,
+  litestreamSnapshotReservationDuration,
+} from '../litestream/metrics.ts';
 import {RunningState, UnrecoverableError} from '../running-state.ts';
 import type {BackupMonitor} from './backup-monitor.ts';
 import type {ChangeStreamerService} from './change-streamer.ts';
@@ -287,7 +292,7 @@ export class Litestream3BackupMonitor implements BackupMonitor {
    */
   async #confirmRestorableBackup(): Promise<boolean> {
     try {
-      this.#lastVerifiedUploadTime = await this.#verifyBackupState();
+      this.#lastVerifiedUploadTime = await this.#verifyBackupStateTimed();
       return true;
     } catch (e) {
       this.#lc.info?.(`backup not yet restorable at ${this.#backupURL}`, e);
@@ -303,9 +308,13 @@ export class Litestream3BackupMonitor implements BackupMonitor {
     this.#reservations.delete(taskID);
     const {start, sub} = res;
     sub.cancel(); // closes the connection if still open
+    const duration = Date.now() - start.getTime();
+    litestreamSnapshotReservationDuration().recordMs(duration, {
+      ...litestreamMonitorMetricAttrs(this.#backupURL, 'legacy', 'view_syncer'),
+      result: updateCleanupDelay ? 'success' : 'cancelled',
+    });
 
     if (updateCleanupDelay) {
-      const duration = Date.now() - start.getTime();
       this.#lc.info?.(`snapshot initialized by ${taskID} in ${duration} ms`);
       if (duration > this.#cleanupDelayMs) {
         this.#cleanupDelayMs = duration;
@@ -417,7 +426,7 @@ export class Litestream3BackupMonitor implements BackupMonitor {
     const claimedTime = must(this.#watermarks.get(maxWatermark));
     if (!this.#confirmedDurable(claimedTime)) {
       try {
-        this.#lastVerifiedUploadTime = await this.#verifyBackupState();
+        this.#lastVerifiedUploadTime = await this.#verifyBackupStateTimed();
       } catch (e) {
         this.#purgesBlocked.add(1, {reason: 'verification-failed'});
         // Skipping the purge is safe: the change-log just grows.
@@ -469,6 +478,28 @@ export class Litestream3BackupMonitor implements BackupMonitor {
       }
     }
     this.#lastWatermark = verifiedWatermark;
+  }
+
+  async #verifyBackupStateTimed(): Promise<Date> {
+    const start = performance.now();
+    let result: 'success' | 'error' = 'error';
+    try {
+      const ret = await this.#verifyBackupState();
+      result = 'success';
+      return ret;
+    } finally {
+      litestreamBackupVerificationDuration().recordMs(
+        performance.now() - start,
+        {
+          ...litestreamMonitorMetricAttrs(
+            this.#backupURL,
+            'legacy',
+            'replication_manager',
+          ),
+          result,
+        },
+      );
+    }
   }
 
   /**

--- a/packages/zero-cache/src/services/change-streamer/vfs-backup-monitor.ts
+++ b/packages/zero-cache/src/services/change-streamer/vfs-backup-monitor.ts
@@ -5,6 +5,11 @@ import {
   getOrCreateGauge,
 } from '../../observability/metrics.ts';
 import {Subscription} from '../../types/subscription.ts';
+import {
+  litestreamBackupVerificationDuration,
+  litestreamMonitorMetricAttrs,
+  litestreamSnapshotReservationDuration,
+} from '../litestream/metrics.ts';
 import type {VfsBackupWatermark} from '../litestream/vfs-watermark-reader.ts';
 import {RunningState} from '../running-state.ts';
 import type {BackupMonitor} from './backup-monitor.ts';
@@ -114,9 +119,13 @@ export class VfsBackupMonitor implements BackupMonitor {
     this.#reservations.delete(taskID);
     const {start, sub} = res;
     sub.cancel();
+    const duration = Date.now() - start.getTime();
+    litestreamSnapshotReservationDuration().recordMs(duration, {
+      ...litestreamMonitorMetricAttrs(this.#backupURL, 'v5', 'view_syncer'),
+      result: updateCleanupDelay ? 'success' : 'cancelled',
+    });
 
     if (updateCleanupDelay) {
-      const duration = Date.now() - start.getTime();
       this.#lc.info?.(`snapshot initialized by ${taskID} in ${duration} ms`);
       if (duration > this.#cleanupDelayMs) {
         this.#cleanupDelayMs = duration;
@@ -143,7 +152,7 @@ export class VfsBackupMonitor implements BackupMonitor {
   };
 
   async #checkWatermark(): Promise<void> {
-    const watermark = await this.#source.readWatermark();
+    const watermark = await this.#readWatermarkTimed();
     this.#latestBackupWatermark = watermark;
     if (
       watermark.watermark > this.#lastWatermark &&
@@ -159,6 +168,28 @@ export class VfsBackupMonitor implements BackupMonitor {
         },
       );
       this.#watermarks.set(watermark.watermark, watermark);
+    }
+  }
+
+  async #readWatermarkTimed(): Promise<VfsBackupWatermark> {
+    const start = performance.now();
+    let result: 'success' | 'error' = 'error';
+    try {
+      const ret = await this.#source.readWatermark();
+      result = 'success';
+      return ret;
+    } finally {
+      litestreamBackupVerificationDuration().recordMs(
+        performance.now() - start,
+        {
+          ...litestreamMonitorMetricAttrs(
+            this.#backupURL,
+            'v5',
+            'replication_manager',
+          ),
+          result,
+        },
+      );
     }
   }
 

--- a/packages/zero-cache/src/services/litestream/commands.test.ts
+++ b/packages/zero-cache/src/services/litestream/commands.test.ts
@@ -1,4 +1,4 @@
-import {existsSync, mkdtempSync, writeFileSync} from 'node:fs';
+import {existsSync, mkdtempSync, statSync, writeFileSync} from 'node:fs';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import {LogContext} from '@rocicorp/logger';
@@ -16,6 +16,7 @@ import {
   parseBackupCreatedTimes,
   restoreReplica,
 } from './commands.ts';
+import * as litestreamMetrics from './metrics.ts';
 
 // Writes a fake `litestream` executable that emits `sh` (a POSIX shell
 // snippet that can branch on `$1`, the litestream subcommand) and returns the
@@ -181,11 +182,21 @@ describe('litestream/commands getLastBackupTime', () => {
 describe('litestream/commands restoreReplica', () => {
   const lc = createSilentLogContext();
 
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   test('restores and validates a compatible replica', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'litestream-restore-test-'));
     const source = join(dir, 'source.db');
     const replica = join(dir, 'replica.db');
     createRestorableReplica(source, '01');
+    const restoredDbBytesAdd = vi.fn();
+    vi.spyOn(litestreamMetrics, 'litestreamRestoredDbBytes').mockReturnValue({
+      add: restoredDbBytesAdd,
+    } as unknown as ReturnType<
+      typeof litestreamMetrics.litestreamRestoredDbBytes
+    >);
     const config = configWithFakeLitestream(
       `if [ "$1" = "restore" ]; then\n` +
         `  cp "${source}" "$6"\n` +
@@ -201,6 +212,33 @@ describe('litestream/commands restoreReplica', () => {
     });
 
     expect(existsSync(replica)).toBe(true);
+    expect(restoredDbBytesAdd).toHaveBeenCalledWith(
+      statSync(replica).size,
+      expect.objectContaining({result: 'success'}),
+    );
+  });
+
+  test('does not record restored bytes when reusing an existing replica', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'litestream-restore-test-'));
+    const replica = join(dir, 'replica.db');
+    createRestorableReplica(replica, '01');
+    const restoredDbBytesAdd = vi.fn();
+    vi.spyOn(litestreamMetrics, 'litestreamRestoredDbBytes').mockReturnValue({
+      add: restoredDbBytesAdd,
+    } as unknown as ReturnType<
+      typeof litestreamMetrics.litestreamRestoredDbBytes
+    >);
+    const config = configWithFakeLitestream(
+      `if [ "$1" = "restore" ]; then\n` + `  exit 0\n` + `fi\n` + `exit 1`,
+      replica,
+    );
+
+    await restoreReplica(lc, config, {
+      replicaVersion: '01',
+      minWatermark: '01',
+    });
+
+    expect(restoredDbBytesAdd).not.toHaveBeenCalled();
   });
 
   test('reports a missing backup when restore exits without a replica', async () => {

--- a/packages/zero-cache/src/services/litestream/commands.test.ts
+++ b/packages/zero-cache/src/services/litestream/commands.test.ts
@@ -242,6 +242,12 @@ describe('litestream/commands restoreReplica', () => {
   });
 
   test('reports a missing backup when restore exits without a replica', async () => {
+    const restoreAttemptsAdd = vi.fn();
+    vi.spyOn(litestreamMetrics, 'litestreamRestoreAttempts').mockReturnValue({
+      add: restoreAttemptsAdd,
+    } as unknown as ReturnType<
+      typeof litestreamMetrics.litestreamRestoreAttempts
+    >);
     const config = configWithFakeLitestream(
       `if [ "$1" = "restore" ]; then\n` + `  exit 0\n` + `fi\n` + `exit 1`,
     );
@@ -252,6 +258,10 @@ describe('litestream/commands restoreReplica', () => {
         minWatermark: '01',
       }),
     ).rejects.toThrow(BackupNotFoundException);
+    expect(restoreAttemptsAdd).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({result: 'no_backup'}),
+    );
   });
 
   test('deletes an incompatible restored replica', async () => {
@@ -259,6 +269,15 @@ describe('litestream/commands restoreReplica', () => {
     const source = join(dir, 'source.db');
     const replica = join(dir, 'replica.db');
     createRestorableReplica(source, '01');
+    const restoreValidationRecordMs = vi.fn();
+    vi.spyOn(
+      litestreamMetrics,
+      'litestreamRestoreValidationDuration',
+    ).mockReturnValue({
+      recordMs: restoreValidationRecordMs,
+    } as unknown as ReturnType<
+      typeof litestreamMetrics.litestreamRestoreValidationDuration
+    >);
     const config = configWithFakeLitestream(
       `if [ "$1" = "restore" ]; then\n` +
         `  cp "${source}" "$6"\n` +
@@ -276,5 +295,9 @@ describe('litestream/commands restoreReplica', () => {
     ).rejects.toThrow(BackupNotFoundException);
 
     expect(existsSync(replica)).toBe(false);
+    expect(restoreValidationRecordMs).toHaveBeenCalledWith(
+      expect.any(Number),
+      expect.objectContaining({result: 'invalid_replica'}),
+    );
   });
 });

--- a/packages/zero-cache/src/services/litestream/commands.test.ts
+++ b/packages/zero-cache/src/services/litestream/commands.test.ts
@@ -1,4 +1,4 @@
-import {mkdtempSync, writeFileSync} from 'node:fs';
+import {existsSync, mkdtempSync, writeFileSync} from 'node:fs';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import {LogContext} from '@rocicorp/logger';
@@ -7,8 +7,54 @@ import {
   createSilentLogContext,
   TestLogSink,
 } from '../../../../shared/src/logging-test-utils.ts';
+import {Database} from '../../../../zqlite/src/db.ts';
 import type {ZeroConfig} from '../../config/zero-config.ts';
-import {getLastBackupTime, parseBackupCreatedTimes} from './commands.ts';
+import {initReplicationState} from '../replicator/schema/replication-state.ts';
+import {
+  BackupNotFoundException,
+  getLastBackupTime,
+  parseBackupCreatedTimes,
+  restoreReplica,
+} from './commands.ts';
+
+// Writes a fake `litestream` executable that emits `sh` (a POSIX shell
+// snippet that can branch on `$1`, the litestream subcommand) and returns the
+// config pointing at it.
+function configWithFakeLitestream(
+  sh: string,
+  replicaFile?: string,
+): ZeroConfig {
+  const dir = mkdtempSync(join(tmpdir(), 'litestream-test-'));
+  const executable = join(dir, 'fake-litestream');
+  writeFileSync(executable, `#!/bin/sh\n${sh}\n`, {mode: 0o755});
+  return {
+    port: 4848,
+    log: {format: 'text'},
+    replica: {file: replicaFile ?? join(dir, 'replica.db')},
+    litestream: {
+      executable,
+      backupURL: 's3://fake-bucket/backup',
+      configPath: './src/services/litestream/config.yml',
+      logLevel: 'warn',
+      restoreUsingV5: false,
+      checkpointThresholdMB: 40,
+      incrementalBackupIntervalMinutes: 15,
+      snapshotBackupIntervalHours: 12,
+      multipartConcurrency: 48,
+      multipartSize: 16 * 1024 * 1024,
+      restoreParallelism: 48,
+    },
+  } as unknown as ZeroConfig;
+}
+
+function createRestorableReplica(file: string, watermark: string) {
+  const db = new Database(createSilentLogContext(), file);
+  try {
+    initReplicationState(db, ['zero_pub'], watermark);
+  } finally {
+    db.close();
+  }
+}
 
 describe('litestream/commands parseBackupCreatedTimes', () => {
   const lc = createSilentLogContext();
@@ -81,33 +127,6 @@ describe('litestream/commands getLastBackupTime', () => {
     vi.useRealTimers();
   });
 
-  // Writes a fake `litestream` executable that emits `sh` (a POSIX shell
-  // snippet that can branch on `$1`, the snapshots|wal subcommand) and
-  // returns the config pointing at it.
-  function configWithFakeLitestream(sh: string): ZeroConfig {
-    const dir = mkdtempSync(join(tmpdir(), 'litestream-test-'));
-    const executable = join(dir, 'fake-litestream');
-    writeFileSync(executable, `#!/bin/sh\n${sh}\n`, {mode: 0o755});
-    return {
-      port: 4848,
-      log: {format: 'text'},
-      replica: {file: join(dir, 'replica.db')},
-      litestream: {
-        executable,
-        backupURL: 's3://fake-bucket/backup',
-        configPath: './src/services/litestream/config.yml',
-        logLevel: 'warn',
-        restoreUsingV5: false,
-        checkpointThresholdMB: 40,
-        incrementalBackupIntervalMinutes: 15,
-        snapshotBackupIntervalHours: 12,
-        multipartConcurrency: 48,
-        multipartSize: 16 * 1024 * 1024,
-        restoreParallelism: 48,
-      },
-    } as unknown as ZeroConfig;
-  }
-
   const lc = createSilentLogContext();
 
   test('returns the most recent created time across snapshots and wal', async () => {
@@ -156,5 +175,68 @@ describe('litestream/commands getLastBackupTime', () => {
     expect(String(outcome.ok === false && outcome.e)).toMatch(
       /timed out listing backup state/,
     );
+  });
+});
+
+describe('litestream/commands restoreReplica', () => {
+  const lc = createSilentLogContext();
+
+  test('restores and validates a compatible replica', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'litestream-restore-test-'));
+    const source = join(dir, 'source.db');
+    const replica = join(dir, 'replica.db');
+    createRestorableReplica(source, '01');
+    const config = configWithFakeLitestream(
+      `if [ "$1" = "restore" ]; then\n` +
+        `  cp "${source}" "$6"\n` +
+        `  exit 0\n` +
+        `fi\n` +
+        `exit 1`,
+      replica,
+    );
+
+    await restoreReplica(lc, config, {
+      replicaVersion: '01',
+      minWatermark: '01',
+    });
+
+    expect(existsSync(replica)).toBe(true);
+  });
+
+  test('reports a missing backup when restore exits without a replica', async () => {
+    const config = configWithFakeLitestream(
+      `if [ "$1" = "restore" ]; then\n` + `  exit 0\n` + `fi\n` + `exit 1`,
+    );
+
+    await expect(
+      restoreReplica(lc, config, {
+        replicaVersion: '01',
+        minWatermark: '01',
+      }),
+    ).rejects.toThrow(BackupNotFoundException);
+  });
+
+  test('deletes an incompatible restored replica', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'litestream-restore-test-'));
+    const source = join(dir, 'source.db');
+    const replica = join(dir, 'replica.db');
+    createRestorableReplica(source, '01');
+    const config = configWithFakeLitestream(
+      `if [ "$1" = "restore" ]; then\n` +
+        `  cp "${source}" "$6"\n` +
+        `  exit 0\n` +
+        `fi\n` +
+        `exit 1`,
+      replica,
+    );
+
+    await expect(
+      restoreReplica(lc, config, {
+        replicaVersion: '02',
+        minWatermark: '02',
+      }),
+    ).rejects.toThrow(BackupNotFoundException);
+
+    expect(existsSync(replica)).toBe(false);
   });
 });

--- a/packages/zero-cache/src/services/litestream/commands.test.ts
+++ b/packages/zero-cache/src/services/litestream/commands.test.ts
@@ -269,7 +269,11 @@ describe('litestream/commands restoreReplica', () => {
     const source = join(dir, 'source.db');
     const replica = join(dir, 'replica.db');
     createRestorableReplica(source, '01');
+    const restoreRunsAdd = vi.fn();
     const restoreValidationRecordMs = vi.fn();
+    vi.spyOn(litestreamMetrics, 'litestreamRestoreRuns').mockReturnValue({
+      add: restoreRunsAdd,
+    } as unknown as ReturnType<typeof litestreamMetrics.litestreamRestoreRuns>);
     vi.spyOn(
       litestreamMetrics,
       'litestreamRestoreValidationDuration',
@@ -297,6 +301,10 @@ describe('litestream/commands restoreReplica', () => {
     expect(existsSync(replica)).toBe(false);
     expect(restoreValidationRecordMs).toHaveBeenCalledWith(
       expect.any(Number),
+      expect.objectContaining({result: 'invalid_replica'}),
+    );
+    expect(restoreRunsAdd).toHaveBeenCalledWith(
+      1,
       expect.objectContaining({result: 'invalid_replica'}),
     );
   });

--- a/packages/zero-cache/src/services/litestream/commands.ts
+++ b/packages/zero-cache/src/services/litestream/commands.ts
@@ -43,9 +43,12 @@ type ReplicaConstraints = {
   minWatermark: string;
 };
 
+type RestoreResult = 'success' | 'no_backup' | 'invalid_replica' | 'error';
+
 type RestoreAttempt = {
   restored: boolean;
   backupURL: string | undefined;
+  result: RestoreResult;
 };
 
 export class BackupNotFoundException extends Error {
@@ -72,7 +75,7 @@ export async function restoreReplica(
     ? 'replication_manager'
     : 'view_syncer';
   let backupURL = config.litestream.backupURL;
-  let result: 'success' | 'no_backup' | 'error' = 'error';
+  let result: RestoreResult | undefined;
   // View-syncers (no replicaConstraints) wait indefinitely for the
   // replication-manager to publish a restorable backup. On a fresh stack the
   // first backup is not durable until the initial sync completes and litestream
@@ -91,11 +94,22 @@ export async function restoreReplica(
         const attempt = await tryRestore(lc, config, replicaConstraints, role);
         backupURL = attempt.backupURL;
         if (attempt.restored) {
-          result = 'success';
+          result = attempt.result;
           return;
         }
         consecutiveErrors = 0;
+        if (replicaConstraints) {
+          // The replication-manager restores against explicit constraints, so a
+          // missing backup is fatal (e.g. the litestream URL was purposefully
+          // changed to force a resync). Only the view-syncer (no constraints)
+          // waits for a backup to appear.
+          result = attempt.result;
+          throw new BackupNotFoundException(config.litestream.backupURL);
+        }
       } catch (e) {
+        if (e instanceof BackupNotFoundException) {
+          throw e;
+        }
         if (++consecutiveErrors <= 1) {
           // A restore will fail if the `replicate` process creates a new
           // snapshot (and compacts old files) at the same time. Snapshots are
@@ -107,26 +121,19 @@ export async function restoreReplica(
         // If it fails again on the retry, though, bail.
         throw e;
       }
-      if (replicaConstraints) {
-        // The replication-manager restores against explicit constraints, so a
-        // missing backup is fatal (e.g. the litestream URL was purposefully
-        // changed to force a resync). Only the view-syncer (no constraints)
-        // waits for a backup to appear.
-        throw new BackupNotFoundException(config.litestream.backupURL);
-      }
       lc.info?.(
         `replica not found. retrying in ${RETRY_INTERVAL_MS / 1000} seconds`,
       );
       await sleep(RETRY_INTERVAL_MS);
     }
   } catch (e) {
-    if (e instanceof BackupNotFoundException) {
+    if (e instanceof BackupNotFoundException && result === undefined) {
       result = 'no_backup';
     }
     throw e;
   } finally {
     const attrs = litestreamRestoreMetricAttrs(config, role, backupURL);
-    const labels = {...attrs, result};
+    const labels = {...attrs, result: result ?? 'error'};
     litestreamRestoreRuns().add(1, labels);
     litestreamRestoreDuration().recordMs(performance.now() - start, labels);
   }
@@ -222,7 +229,7 @@ async function tryRestore(
 
   const backupURL = snapshotStatus?.backupURL ?? config.litestream.backupURL;
   const attrs = litestreamRestoreMetricAttrs(config, role, backupURL);
-  let result: 'success' | 'no_backup' | 'invalid_replica' | 'error' = 'error';
+  let result: RestoreResult = 'error';
   try {
     const replicaExistedBeforeRestore = existsSync(config.replica.file);
     const {litestream, env} = getLitestream(
@@ -280,7 +287,7 @@ async function tryRestore(
     }
     if (!existsSync(config.replica.file)) {
       result = 'no_backup';
-      return {restored: false, backupURL};
+      return {restored: false, backupURL, result};
     }
     const validationStart = performance.now();
     const valid = replicaIsValid(lc, config.replica.file, replicaConstraints);
@@ -292,7 +299,7 @@ async function tryRestore(
       result = 'invalid_replica';
       lc.info?.(`Deleting local replica and retrying restore`);
       deleteLiteDB(config.replica.file);
-      return {restored: false, backupURL};
+      return {restored: false, backupURL, result};
     }
     result = 'success';
     if (!replicaExistedBeforeRestore) {
@@ -301,7 +308,7 @@ async function tryRestore(
         result: 'success',
       });
     }
-    return {restored: true, backupURL};
+    return {restored: true, backupURL, result};
   } finally {
     litestreamRestoreAttempts().add(1, {
       ...attrs,

--- a/packages/zero-cache/src/services/litestream/commands.ts
+++ b/packages/zero-cache/src/services/litestream/commands.ts
@@ -224,6 +224,7 @@ async function tryRestore(
   const attrs = litestreamRestoreMetricAttrs(config, role, backupURL);
   let result: 'success' | 'no_backup' | 'invalid_replica' | 'error' = 'error';
   try {
+    const replicaExistedBeforeRestore = existsSync(config.replica.file);
     const {litestream, env} = getLitestream(
       'restore',
       config,
@@ -294,10 +295,12 @@ async function tryRestore(
       return {restored: false, backupURL};
     }
     result = 'success';
-    litestreamRestoredDbBytes().add(statSync(config.replica.file).size, {
-      ...attrs,
-      result: 'success',
-    });
+    if (!replicaExistedBeforeRestore) {
+      litestreamRestoredDbBytes().add(statSync(config.replica.file).size, {
+        ...attrs,
+        result: 'success',
+      });
+    }
     return {restored: true, backupURL};
   } finally {
     litestreamRestoreAttempts().add(1, {

--- a/packages/zero-cache/src/services/litestream/commands.ts
+++ b/packages/zero-cache/src/services/litestream/commands.ts
@@ -1,6 +1,6 @@
 import type {ChildProcess} from 'node:child_process';
 import {spawn} from 'node:child_process';
-import {existsSync} from 'node:fs';
+import {existsSync, statSync} from 'node:fs';
 import type {LogContext, LogLevel} from '@rocicorp/logger';
 import {resolver} from '@rocicorp/resolver';
 import {must} from '../../../../shared/src/must.ts';
@@ -19,12 +19,33 @@ import type {
   SnapshotStatus,
 } from '../change-streamer/snapshot.ts';
 import {getSubscriptionState} from '../replicator/schema/replication-state.ts';
+import {
+  litestreamBackupListDuration,
+  litestreamBackupMetricAttrs,
+  litestreamBackupProcessMetricAttrs,
+  litestreamBackupProcessDuration,
+  litestreamBackupProcessRuns,
+  litestreamRestoreAttempts,
+  litestreamRestoredDbBytes,
+  litestreamRestoreDuration,
+  litestreamRestoreMetricAttrs,
+  litestreamRestoreProcessDuration,
+  litestreamRestoreRuns,
+  litestreamRestoreValidationDuration,
+  litestreamRestoreWaitDuration,
+  type LitestreamRole,
+} from './metrics.ts';
 
 const RETRY_INTERVAL_MS = 3000;
 
 type ReplicaConstraints = {
   replicaVersion: string;
   minWatermark: string;
+};
+
+type RestoreAttempt = {
+  restored: boolean;
+  backupURL: string | undefined;
 };
 
 export class BackupNotFoundException extends Error {
@@ -46,6 +67,12 @@ export async function restoreReplica(
   config: ZeroConfig,
   replicaConstraints: ReplicaConstraints | null,
 ) {
+  const start = performance.now();
+  const role: LitestreamRole = replicaConstraints
+    ? 'replication_manager'
+    : 'view_syncer';
+  let backupURL = config.litestream.backupURL;
+  let result: 'success' | 'no_backup' | 'error' = 'error';
   // View-syncers (no replicaConstraints) wait indefinitely for the
   // replication-manager to publish a restorable backup. On a fresh stack the
   // first backup is not durable until the initial sync completes and litestream
@@ -58,35 +85,50 @@ export async function restoreReplica(
   // `replicate` process compacting a snapshot mid-restore) — which is retried
   // once — from a "backup not found" result, which is expected while waiting.
   let consecutiveErrors = 0;
-  for (;;) {
-    try {
-      if (await tryRestore(lc, config, replicaConstraints)) {
-        return;
+  try {
+    for (;;) {
+      try {
+        const attempt = await tryRestore(lc, config, replicaConstraints, role);
+        backupURL = attempt.backupURL;
+        if (attempt.restored) {
+          result = 'success';
+          return;
+        }
+        consecutiveErrors = 0;
+      } catch (e) {
+        if (++consecutiveErrors <= 1) {
+          // A restore will fail if the `replicate` process creates a new
+          // snapshot (and compacts old files) at the same time. Snapshots are
+          // infrequent (e.g. once every 12 hours), and the scenario is
+          // recoverable with a retry.
+          lc.warn?.(`restore attempt failed. retrying once`, e);
+          continue;
+        }
+        // If it fails again on the retry, though, bail.
+        throw e;
       }
-      consecutiveErrors = 0;
-    } catch (e) {
-      if (++consecutiveErrors <= 1) {
-        // A restore will fail if the `replicate` process creates a new
-        // snapshot (and compacts old files) at the same time. Snapshots are
-        // infrequent (e.g. once every 12 hours), and the scenario is
-        // recoverable with a retry.
-        lc.warn?.(`restore attempt failed. retrying once`, e);
-        continue;
+      if (replicaConstraints) {
+        // The replication-manager restores against explicit constraints, so a
+        // missing backup is fatal (e.g. the litestream URL was purposefully
+        // changed to force a resync). Only the view-syncer (no constraints)
+        // waits for a backup to appear.
+        throw new BackupNotFoundException(config.litestream.backupURL);
       }
-      // If it fails again on the retry, though, bail.
-      throw e;
+      lc.info?.(
+        `replica not found. retrying in ${RETRY_INTERVAL_MS / 1000} seconds`,
+      );
+      await sleep(RETRY_INTERVAL_MS);
     }
-    if (replicaConstraints) {
-      // The replication-manager restores against explicit constraints, so a
-      // missing backup is fatal (e.g. the litestream URL was purposefully
-      // changed to force a resync). Only the view-syncer (no constraints)
-      // waits for a backup to appear.
-      throw new BackupNotFoundException(config.litestream.backupURL);
+  } catch (e) {
+    if (e instanceof BackupNotFoundException) {
+      result = 'no_backup';
     }
-    lc.info?.(
-      `replica not found. retrying in ${RETRY_INTERVAL_MS / 1000} seconds`,
-    );
-    await sleep(RETRY_INTERVAL_MS);
+    throw e;
+  } finally {
+    const attrs = litestreamRestoreMetricAttrs(config, role, backupURL);
+    const labels = {...attrs, result};
+    litestreamRestoreRuns().add(1, labels);
+    litestreamRestoreDuration().recordMs(performance.now() - start, labels);
   }
 }
 
@@ -162,56 +204,107 @@ async function tryRestore(
   lc: LogContext,
   config: ZeroConfig,
   replicaConstraints: ReplicaConstraints | null,
-) {
+  role: LitestreamRole,
+): Promise<RestoreAttempt> {
   let snapshotStatus: SnapshotStatus | undefined;
   if (!replicaConstraints) {
     // view-syncers fetch replica constraints from the replication-manager
     // via the snapshot protocol.
+    const waitStart = performance.now();
     snapshotStatus = await reserveAndGetSnapshotStatus(lc, config);
+    litestreamRestoreWaitDuration().recordMs(
+      performance.now() - waitStart,
+      litestreamRestoreMetricAttrs(config, role, snapshotStatus.backupURL),
+    );
     lc.info?.(`restoring backup from ${snapshotStatus.backupURL}`);
     replicaConstraints = snapshotStatus;
   }
 
-  const {litestream, env} = getLitestream(
-    'restore',
-    config,
-    'debug', // Include all output from `litestream restore`, as it's minimal.
-    snapshotStatus?.backupURL,
-  );
-  const {restoreParallelism: parallelism} = config.litestream;
-  const proc = spawn(
-    litestream,
-    [
+  const backupURL = snapshotStatus?.backupURL ?? config.litestream.backupURL;
+  const attrs = litestreamRestoreMetricAttrs(config, role, backupURL);
+  let result: 'success' | 'no_backup' | 'invalid_replica' | 'error' = 'error';
+  try {
+    const {litestream, env} = getLitestream(
       'restore',
-      '-if-db-not-exists',
-      '-if-replica-exists',
-      '-parallelism',
-      String(parallelism),
-      config.replica.file,
-    ],
-    {env, stdio: 'inherit', windowsHide: true},
-  );
-  const {promise, resolve, reject} = resolver();
-  proc.on('error', reject);
-  proc.on('close', (code, signal) => {
-    if (signal) {
-      reject(`litestream killed with ${signal}`);
-    } else if (code !== 0) {
-      reject(`litestream exited with code ${code}`);
-    } else {
-      resolve();
+      config,
+      'debug', // Include all output from `litestream restore`, as it's minimal.
+      snapshotStatus?.backupURL,
+    );
+    const {
+      restoreParallelism: parallelism,
+      multipartConcurrency,
+      multipartSize,
+    } = config.litestream;
+    lc.info?.(`starting litestream restore`, {
+      restoreParallelism: parallelism,
+      multipartConcurrency,
+      multipartSize,
+    });
+    const proc = spawn(
+      litestream,
+      [
+        'restore',
+        '-if-db-not-exists',
+        '-if-replica-exists',
+        '-parallelism',
+        String(parallelism),
+        config.replica.file,
+      ],
+      {env, stdio: 'inherit', windowsHide: true},
+    );
+    const {promise, resolve, reject} = resolver();
+    proc.on('error', reject);
+    proc.on('close', (code, signal) => {
+      if (signal) {
+        reject(`litestream killed with ${signal}`);
+      } else if (code !== 0) {
+        reject(`litestream exited with code ${code}`);
+      } else {
+        resolve();
+      }
+    });
+    const processStart = performance.now();
+    try {
+      await promise;
+      litestreamRestoreProcessDuration().recordMs(
+        performance.now() - processStart,
+        {...attrs, result: 'success'},
+      );
+    } catch (e) {
+      litestreamRestoreProcessDuration().recordMs(
+        performance.now() - processStart,
+        {...attrs, result: 'error'},
+      );
+      throw e;
     }
-  });
-  await promise;
-  if (!existsSync(config.replica.file)) {
-    return false;
+    if (!existsSync(config.replica.file)) {
+      result = 'no_backup';
+      return {restored: false, backupURL};
+    }
+    const validationStart = performance.now();
+    const valid = replicaIsValid(lc, config.replica.file, replicaConstraints);
+    litestreamRestoreValidationDuration().recordMs(
+      performance.now() - validationStart,
+      {...attrs, result: valid ? 'success' : 'invalid_replica'},
+    );
+    if (!valid) {
+      result = 'invalid_replica';
+      lc.info?.(`Deleting local replica and retrying restore`);
+      deleteLiteDB(config.replica.file);
+      return {restored: false, backupURL};
+    }
+    result = 'success';
+    litestreamRestoredDbBytes().add(statSync(config.replica.file).size, {
+      ...attrs,
+      result: 'success',
+    });
+    return {restored: true, backupURL};
+  } finally {
+    litestreamRestoreAttempts().add(1, {
+      ...attrs,
+      result,
+    });
   }
-  if (!replicaIsValid(lc, config.replica.file, replicaConstraints)) {
-    lc.info?.(`Deleting local replica and retrying restore`);
-    deleteLiteDB(config.replica.file);
-    return false;
-  }
-  return true;
 }
 
 function replicaIsValid(
@@ -257,12 +350,43 @@ export function startReplicaBackupProcess(
   config: ZeroConfig,
 ): ChildProcess {
   const {litestream, env} = getLitestream('replicate', config);
+  const attrs = litestreamBackupProcessMetricAttrs(config);
   lc.info?.(`starting litestream backup to ${config.litestream.backupURL}`);
-  return spawn(litestream, ['replicate'], {
+  const start = performance.now();
+  const proc = spawn(litestream, ['replicate'], {
     env,
     stdio: 'inherit',
     windowsHide: true,
   });
+  let recorded = false;
+  const record = (result: 'success' | 'error' | 'stopped') => {
+    if (recorded) {
+      return;
+    }
+    recorded = true;
+    const labels = {...attrs, result};
+    litestreamBackupProcessRuns().add(1, labels);
+    litestreamBackupProcessDuration().recordMs(
+      performance.now() - start,
+      labels,
+    );
+  };
+  proc.on('error', e => {
+    lc.warn?.(`litestream backup process error`, e);
+    record('error');
+  });
+  proc.on('close', (code, signal) => {
+    if (signal) {
+      lc.info?.(`litestream backup process stopped`, {signal});
+      record('stopped');
+    } else if (code === 0) {
+      record('success');
+    } else {
+      lc.warn?.(`litestream backup process exited with code ${code}`);
+      record('error');
+    }
+  });
+  return proc;
 }
 
 // Listing the backup state requires a few S3 LIST requests, which should
@@ -322,6 +446,8 @@ async function listBackupCreatedTimes(
   config: ZeroConfig,
   command: 'snapshots' | 'wal',
 ): Promise<Date[]> {
+  const start = performance.now();
+  let result: 'success' | 'empty' | 'timeout' | 'error' = 'error';
   const {litestream, env} = getLitestream('replicate', config);
   const proc = spawn(litestream, [command, config.replica.file], {
     env,
@@ -343,18 +469,24 @@ async function listBackupCreatedTimes(
     }
   });
   const timeout = setTimeout(() => {
+    result = 'timeout';
     reject(new Error(`timed out listing backup state (litestream ${command})`));
     proc.kill('SIGKILL');
   }, LIST_BACKUP_TIMEOUT_MS);
 
-  let output: string;
   try {
-    output = await promise;
+    const output = await promise;
+    const times = parseBackupCreatedTimes(lc, command, output);
+    result = times.length ? 'success' : 'empty';
+    return times;
   } finally {
     clearTimeout(timeout);
+    litestreamBackupListDuration().recordMs(performance.now() - start, {
+      ...litestreamBackupMetricAttrs(config),
+      command,
+      result,
+    });
   }
-
-  return parseBackupCreatedTimes(lc, command, output);
 }
 
 /**

--- a/packages/zero-cache/src/services/litestream/metrics.ts
+++ b/packages/zero-cache/src/services/litestream/metrics.ts
@@ -27,10 +27,16 @@ export function litestreamRestoreMetricAttrs(
   role: LitestreamRole,
   backupURL = config.litestream.backupURL,
 ): LitestreamMetricAttrs & LitestreamMultipartMetricAttrs {
+  const {executable, executableV5, restoreUsingV5} = config.litestream;
+  const selectedExecutable =
+    (restoreUsingV5 ? executableV5 : executable) ?? executable;
   return {
     role,
     backup_scheme: litestreamBackupScheme(backupURL),
-    litestream: config.litestream.restoreUsingV5 ? 'v5' : 'legacy',
+    litestream:
+      executableV5 !== undefined && selectedExecutable === executableV5
+        ? 'v5'
+        : 'legacy',
     ...litestreamMultipartMetricAttrs(config),
   };
 }

--- a/packages/zero-cache/src/services/litestream/metrics.ts
+++ b/packages/zero-cache/src/services/litestream/metrics.ts
@@ -1,0 +1,190 @@
+import type {ZeroConfig} from '../../config/zero-config.ts';
+import {
+  getOrCreateCounter,
+  getOrCreateHistogram,
+} from '../../observability/metrics.ts';
+
+export type LitestreamRole = 'replication_manager' | 'view_syncer';
+export type LitestreamVersion = 'legacy' | 'v5';
+
+export type LitestreamMetricAttrs = {
+  role: LitestreamRole;
+  backup_scheme: string;
+  litestream: LitestreamVersion;
+};
+
+type LitestreamMultipartMetricAttrs = {
+  multipart_concurrency: number;
+  multipart_size_mib: number;
+};
+
+const LITESTREAM_DURATION_HISTOGRAM_BOUNDARIES_S = [
+  1, 2, 5, 10, 30, 60, 120, 300, 600, 1200, 2400, 3600, 7200,
+];
+
+export function litestreamRestoreMetricAttrs(
+  config: ZeroConfig,
+  role: LitestreamRole,
+  backupURL = config.litestream.backupURL,
+): LitestreamMetricAttrs & LitestreamMultipartMetricAttrs {
+  return {
+    role,
+    backup_scheme: litestreamBackupScheme(backupURL),
+    litestream: config.litestream.restoreUsingV5 ? 'v5' : 'legacy',
+    ...litestreamMultipartMetricAttrs(config),
+  };
+}
+
+export function litestreamBackupMetricAttrs(
+  config: ZeroConfig,
+): LitestreamMetricAttrs {
+  return {
+    role: 'replication_manager',
+    backup_scheme: litestreamBackupScheme(config.litestream.backupURL),
+    litestream:
+      config.litestream.executableV5 !== undefined &&
+      config.litestream.executable === config.litestream.executableV5
+        ? 'v5'
+        : 'legacy',
+  };
+}
+
+export function litestreamBackupProcessMetricAttrs(
+  config: ZeroConfig,
+): LitestreamMetricAttrs & LitestreamMultipartMetricAttrs {
+  return {
+    ...litestreamBackupMetricAttrs(config),
+    ...litestreamMultipartMetricAttrs(config),
+  };
+}
+
+export function litestreamMonitorMetricAttrs(
+  backupURL: string,
+  litestream: LitestreamVersion,
+  role: LitestreamRole,
+): LitestreamMetricAttrs {
+  return {
+    role,
+    backup_scheme: litestreamBackupScheme(backupURL),
+    litestream,
+  };
+}
+
+function litestreamBackupScheme(backupURL: string | undefined): string {
+  if (!backupURL) {
+    return 'unknown';
+  }
+  try {
+    const protocol = new URL(backupURL).protocol;
+    return protocol.endsWith(':') ? protocol.slice(0, -1) : protocol;
+  } catch {
+    return 'unknown';
+  }
+}
+
+function litestreamMultipartMetricAttrs(
+  config: ZeroConfig,
+): LitestreamMultipartMetricAttrs {
+  return {
+    multipart_concurrency: config.litestream.multipartConcurrency,
+    multipart_size_mib: Math.round(
+      config.litestream.multipartSize / 1024 / 1024,
+    ),
+  };
+}
+
+export function litestreamRestoreRuns() {
+  return getOrCreateCounter(
+    'replica',
+    'litestream_restore_runs',
+    'Litestream restore runs, labeled by result.',
+  );
+}
+
+export function litestreamRestoreAttempts() {
+  return getOrCreateCounter(
+    'replica',
+    'litestream_restore_attempts',
+    'Litestream restore subprocess attempts, labeled by result.',
+  );
+}
+
+export function litestreamRestoredDbBytes() {
+  return getOrCreateCounter('replica', 'litestream_restored_db', {
+    description:
+      'SQLite database bytes restored by successful litestream restores.',
+    unit: 'bytes',
+  });
+}
+
+export function litestreamBackupProcessRuns() {
+  return getOrCreateCounter(
+    'replica',
+    'litestream_backup_process_runs',
+    'Litestream backup process exits, labeled by result.',
+  );
+}
+
+export function litestreamRestoreDuration() {
+  return litestreamDurationHistogram(
+    'litestream_restore_duration',
+    'Wall-clock duration of a litestream restore run, labeled by result.',
+  );
+}
+
+export function litestreamRestoreWaitDuration() {
+  return litestreamDurationHistogram(
+    'litestream_restore_wait_duration',
+    'Time spent waiting for the replication-manager snapshot status before restoring.',
+  );
+}
+
+export function litestreamRestoreProcessDuration() {
+  return litestreamDurationHistogram(
+    'litestream_restore_process_duration',
+    'Wall-clock duration of the litestream restore subprocess.',
+  );
+}
+
+export function litestreamRestoreValidationDuration() {
+  return litestreamDurationHistogram(
+    'litestream_restore_validation_duration',
+    'Time spent validating a restored replica database.',
+  );
+}
+
+export function litestreamBackupProcessDuration() {
+  return litestreamDurationHistogram(
+    'litestream_backup_process_duration',
+    'Runtime duration of the litestream backup subprocess before it exits.',
+  );
+}
+
+export function litestreamBackupListDuration() {
+  return litestreamDurationHistogram(
+    'litestream_backup_list_duration',
+    'Duration of litestream backup destination listing commands.',
+  );
+}
+
+export function litestreamBackupVerificationDuration() {
+  return litestreamDurationHistogram(
+    'litestream_backup_verification_duration',
+    'Duration of verifying the actual backup state in the backup destination.',
+  );
+}
+
+export function litestreamSnapshotReservationDuration() {
+  return litestreamDurationHistogram(
+    'litestream_snapshot_reservation_duration',
+    'Duration of a snapshot reservation while a view-syncer restores and subscribes.',
+  );
+}
+
+function litestreamDurationHistogram(name: string, description: string) {
+  return getOrCreateHistogram('replica', name, {
+    description,
+    unit: 's',
+    bucketBoundaries: LITESTREAM_DURATION_HISTOGRAM_BOUNDARIES_S,
+  });
+}


### PR DESCRIPTION
## Summary

Adds litestream backup and restore observability for zero-cache.

## Changes

- Add shared litestream metric helpers for role, backup scheme, litestream version, and bounded multipart config labels.
- Record restore run, restore attempt, restore subprocess, restore validation, snapshot wait, and restored DB size metrics.
- Record backup subprocess exit/duration metrics.
- Record backup destination listing duration metrics.
- Record backup verification and snapshot reservation duration metrics for both legacy litestream and v5/VFS backup monitors.
- Add restore tests covering compatible restore, missing backup, and incompatible restored replica cleanup.

## Future Work

We can eventually add direct prometheus scraping from litestream v5.