### PR TITLE
fix(zqlite): bound the StatementCache with LRU eviction

### DIFF
--- a/packages/zqlite/src/internal/statement-cache.test.ts
+++ b/packages/zqlite/src/internal/statement-cache.test.ts
@@ -1,7 +1,11 @@
 import {expect, test} from 'vitest';
 import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
 import {Database} from '../db.ts';
-import {type CachedStatement, StatementCache} from './statement-cache.ts';
+import {
+  type CachedStatement,
+  DEFAULT_MAX_CACHED_STATEMENTS,
+  StatementCache,
+} from './statement-cache.ts';
 
 test('Same sql results in same statement instance. The same instance is not outstanding twice.', () => {
   const db = new Database(createSilentLogContext(), ':memory:');
@@ -60,4 +64,140 @@ test('Same sql results in same statement instance. The same instance is not outs
 
   // all statements are outstanding
   expect(cache.size).toBe(0);
+});
+
+test('cache is bounded: returning past maxSize evicts the least recently used statements', () => {
+  const db = new Database(createSilentLogContext(), ':memory:');
+  const cache = new StatementCache(db, 3);
+  expect(cache.maxSize).toBe(3);
+
+  const returned: CachedStatement[] = [];
+  for (let i = 0; i < 5; ++i) {
+    const stmt = cache.get(`SELECT ${i}`);
+    cache.return(stmt);
+    returned.push(stmt);
+    expect(cache.size).toBe(Math.min(i + 1, 3));
+  }
+
+  // The 3 most recently used statements are retained and served from the
+  // cache (same instance).
+  for (let i = 2; i < 5; ++i) {
+    expect(cache.get(`SELECT ${i}`).statement).toBe(returned[i].statement);
+  }
+
+  // The 2 least recently used statements were evicted, so a fresh
+  // statement is prepared.
+  for (let i = 0; i < 2; ++i) {
+    expect(cache.get(`SELECT ${i}`).statement).not.toBe(returned[i].statement);
+  }
+});
+
+test('returning a statement refreshes its recency', () => {
+  const db = new Database(createSilentLogContext(), ':memory:');
+  const cache = new StatementCache(db, 3);
+
+  const returned: CachedStatement[] = [];
+  for (let i = 0; i < 3; ++i) {
+    const stmt = cache.get(`SELECT ${i}`);
+    cache.return(stmt);
+    returned.push(stmt);
+  }
+
+  // Touch 'SELECT 0', making 'SELECT 1' the least recently used.
+  cache.use('SELECT 0', () => {});
+
+  // Push the cache over its bound.
+  cache.return(cache.get('SELECT 3'));
+
+  expect(cache.size).toBe(3);
+  expect(cache.get('SELECT 1').statement).not.toBe(returned[1].statement);
+  expect(cache.get('SELECT 0').statement).toBe(returned[0].statement);
+  expect(cache.get('SELECT 2').statement).toBe(returned[2].statement);
+});
+
+test('a cache hit refreshes the recency of remaining statements for the same sql', () => {
+  const db = new Database(createSilentLogContext(), ':memory:');
+  const cache = new StatementCache(db, 3);
+
+  // Two copies of 'SELECT 0', then 'SELECT 1'. Recency order (LRU first):
+  // 'SELECT 0', 'SELECT 1'.
+  const a1 = cache.get('SELECT 0');
+  const a2 = cache.get('SELECT 0');
+  cache.return(a1);
+  cache.return(a2);
+  const b = cache.get('SELECT 1');
+  cache.return(b);
+  expect(cache.size).toBe(3);
+
+  // A hit on 'SELECT 0' moves its remaining cached copy to the most
+  // recently used position: 'SELECT 1' is now the LRU.
+  const gotten = cache.get('SELECT 0');
+  expect(cache.size).toBe(2);
+  cache.return(gotten);
+  expect(cache.size).toBe(3);
+
+  // Push the cache over its bound; 'SELECT 1' is evicted, both copies of
+  // 'SELECT 0' are retained.
+  cache.return(cache.get('SELECT 2'));
+  expect(cache.size).toBe(3);
+  expect(cache.get('SELECT 0').statement).toBe(gotten.statement);
+  expect(cache.get('SELECT 0').statement).toBe(a1.statement);
+  expect(cache.get('SELECT 1').statement).not.toBe(b.statement);
+});
+
+test('in-flight statements are never evicted and stay usable', () => {
+  const db = new Database(createSilentLogContext(), ':memory:');
+  const cache = new StatementCache(db, 2);
+
+  // Check out more statements than the cache can hold.
+  const outstanding: CachedStatement[] = [];
+  for (let i = 0; i < 5; ++i) {
+    outstanding.push(cache.get(`SELECT ${i}`));
+  }
+  // Outstanding statements are not in the cache.
+  expect(cache.size).toBe(0);
+
+  // Fill the cache to its bound with other statements; eviction churn must
+  // not affect the outstanding statements.
+  for (let i = 5; i < 10; ++i) {
+    cache.return(cache.get(`SELECT ${i}`));
+  }
+  expect(cache.size).toBe(2);
+
+  for (let i = 0; i < 5; ++i) {
+    expect(outstanding[i].statement.get<Record<string, number>>()).toEqual({
+      [`${i}`]: i,
+    });
+  }
+
+  // Returning the outstanding statements only retains up to the bound.
+  for (const stmt of outstanding) {
+    cache.return(stmt);
+  }
+  expect(cache.size).toBe(2);
+});
+
+test('duplicate statements for the same sql count against the bound', () => {
+  const db = new Database(createSilentLogContext(), ':memory:');
+  const cache = new StatementCache(db, 1);
+
+  const first = cache.get('SELECT 1');
+  const second = cache.get('SELECT 1');
+  cache.return(first);
+  cache.return(second);
+
+  expect(cache.size).toBe(1);
+  // The least recently returned copy was evicted.
+  expect(cache.get('SELECT 1').statement).toBe(second.statement);
+});
+
+test('the default bound applies when none is given', () => {
+  const db = new Database(createSilentLogContext(), ':memory:');
+  const cache = new StatementCache(db);
+  expect(cache.maxSize).toBe(DEFAULT_MAX_CACHED_STATEMENTS);
+
+  for (let i = 0; i < DEFAULT_MAX_CACHED_STATEMENTS + 1; ++i) {
+    cache.return(cache.get(`SELECT ${i}`));
+  }
+  expect(cache.size).toBe(DEFAULT_MAX_CACHED_STATEMENTS);
 });

--- a/packages/zqlite/src/internal/statement-cache.ts
+++ b/packages/zqlite/src/internal/statement-cache.ts
@@ -6,6 +6,20 @@ export type CachedStatement = {
   sql: string;
   statement: Statement;
 };
+
+/**
+ * The default maximum number of statements retained by a StatementCache.
+ *
+ * Each cached statement holds a native `sqlite3_stmt` handle (prepared
+ * bytecode + SQLite-side memory), so the cache must be bounded. The bound
+ * needs enough headroom for callers with a large working set of distinct
+ * SQL — e.g. the replication change-processor prepares several statements
+ * per table (with additional variants for partial-column updates) through
+ * a single cache — while still capping growth from unbounded key spaces
+ * such as client-influenced query shapes.
+ */
+export const DEFAULT_MAX_CACHED_STATEMENTS = 1_000;
+
 /**
  * SQLite statement preparation isn't cheap as it involves evaluating possible
  * query plans and picking the best one (in addition to parsing the SQL).
@@ -30,19 +44,34 @@ export type CachedStatement = {
  * It is not an error to fail to call `return` on a statement.
  * Failing to call return will only prevent the statement from being reused
  * by other callers. It will not cause a resource leak.
+ *
+ * The cache is bounded: it retains at most `maxSize` statements, evicting
+ * the least recently used statements when the bound is exceeded. Only idle
+ * (returned) statements are ever evicted — statements checked out via `get`
+ * are not in the cache and thus never touched by eviction. Evicting a
+ * statement drops the cache's reference to it; the native `sqlite3_stmt`
+ * handle is finalized when the Statement object is garbage collected.
  */
 export class StatementCache {
+  // Map insertion order doubles as recency order: entries are re-inserted
+  // on every `get` hit and `return`, so the first entry in the map is the
+  // least recently used. Within an entry's array, the first statement is
+  // the least recently returned.
   #cache: CachedStatementMap = new Map<string, Statement[]>();
   readonly #db: Database;
+  readonly #maxSize: number;
   #size: number = 0;
 
   /**
    * The db connection used to prepare the statement.
    * It is an error to use a statement prepared on one connection with another connection.
    * @param db
+   * @param maxSize the maximum number of statements to retain in the cache.
    */
-  constructor(db: Database) {
+  constructor(db: Database, maxSize: number = DEFAULT_MAX_CACHED_STATEMENTS) {
+    assert(maxSize >= 0, 'maxSize must not be negative');
     this.#db = db;
+    this.#maxSize = maxSize;
   }
 
   // the number of statements in the cache
@@ -50,21 +79,17 @@ export class StatementCache {
     return this.#size;
   }
 
+  // the maximum number of statements the cache will retain
+  get maxSize() {
+    return this.#maxSize;
+  }
+
   drop(n: number) {
     assert(n >= 0, 'Cannot drop a negative number of items');
     assert(n <= this.#size, 'Cannot drop more items than are in the cache');
 
-    let remaining = n;
-    for (const [sql, statements] of this.#cache.entries()) {
-      if (remaining >= statements.length) {
-        this.#cache.delete(sql);
-        remaining -= statements.length;
-        this.#size -= statements.length;
-      } else {
-        statements.splice(0, remaining);
-        this.#size -= remaining;
-        break;
-      }
+    for (let i = 0; i < n; i++) {
+      this.#evictLeastRecentlyUsed();
     }
   }
 
@@ -87,8 +112,11 @@ export class StatementCache {
     if (statements && statements.length > 0) {
       const statement = statements.pop()!;
       this.#size--;
-      if (statements.length === 0) {
-        this.#cache.delete(sql);
+      this.#cache.delete(sql);
+      if (statements.length > 0) {
+        // Re-insert so the remaining statements for this sql are marked
+        // as most recently used.
+        this.#cache.set(sql, statements);
       }
       return {sql, statement};
     }
@@ -111,17 +139,38 @@ export class StatementCache {
 
   /**
    * Add a statement back to the cache so someone else can use it later.
+   *
+   * If this pushes the cache over its maximum size, the least recently
+   * used statements are evicted.
    * @param statement
    */
   return(statement: CachedStatement) {
     const {sql} = statement;
-    if (!this.#cache.has(sql)) {
-      this.#cache.set(sql, []);
+    let statements = this.#cache.get(sql);
+    if (statements === undefined) {
+      statements = [];
+    } else {
+      // Delete so the re-insert below moves this sql to the most recently
+      // used position.
+      this.#cache.delete(sql);
     }
-    const statements = this.#cache.get(sql);
-    if (statements) {
-      statements.push(statement.statement);
-      this.#size++;
+    statements.push(statement.statement);
+    this.#cache.set(sql, statements);
+    this.#size++;
+
+    while (this.#size > this.#maxSize) {
+      this.#evictLeastRecentlyUsed();
+    }
+  }
+
+  #evictLeastRecentlyUsed() {
+    const lru = this.#cache.entries().next();
+    assert(!lru.done, 'Cannot evict from an empty cache');
+    const [sql, statements] = lru.value;
+    statements.shift();
+    this.#size--;
+    if (statements.length === 0) {
+      this.#cache.delete(sql);
     }
   }
 }


### PR DESCRIPTION
StatementCache.return() previously pushed statements back into the cache with no size check, so every distinct SQL text permanently retained a native sqlite3_stmt handle. TableSource.fetch builds SQL from the query AST (a client-influenced key space) and TableSources live for the view-syncer lifetime, so distinct query shapes accumulated native statement handles without bound.

Make the cache an LRU with a configurable maxSize (default 1000):

- Map insertion order doubles as recency order; entries are re-inserted on every get hit and return, so the first entry is the LRU.
- return() evicts least recently used statements once the bound is exceeded. Evicted statements are released to GC, which finalizes the underlying native handle.
- Only idle statements are evicted; in-flight statements are checked out of the cache by get() and are never touched.
- drop(n) is reimplemented on the same eviction path.

The default bound leaves headroom for the replication change-processor, which prepares several statements per table (plus partial-column update variants) through a single StatementRunner cache.