### PR TITLE
feat(zero-cache): add metrics to fetch from API server

### DIFF
--- a/packages/zero-cache/src/custom-queries/transform-query.test.ts
+++ b/packages/zero-cache/src/custom-queries/transform-query.test.ts
@@ -200,6 +200,7 @@ describe('CustomQueryTransformer', () => {
   function expectLastTransformFetch(
     queries: Iterable<CustomQueryRecord>,
     options: Parameters<typeof expectContext>[0] = {},
+    operation: 'query' | 'validate_auth' = 'query',
   ) {
     expect(mockFetchFromAPIServer).toHaveBeenLastCalledWith(
       expect.anything(),
@@ -208,6 +209,7 @@ describe('CustomQueryTransformer', () => {
       expectContext(options),
       mockShard,
       transformRequest(queries),
+      {operation},
     );
   }
 
@@ -370,7 +372,7 @@ describe('CustomQueryTransformer', () => {
     const transformer = makeTransformer();
     const result = await transformer.validate(headerOptions, undefined);
 
-    expectLastTransformFetch([]);
+    expectLastTransformFetch([], {}, 'validate_auth');
     expect(result).toEqual({
       kind: 'QueryResponse',
       validation: serverValidated('user-123'),

--- a/packages/zero-cache/src/custom-queries/transform-query.ts
+++ b/packages/zero-cache/src/custom-queries/transform-query.ts
@@ -195,6 +195,7 @@ export class CustomQueryTransformer {
             ctx,
             this.#shard,
             ['transform', request] satisfies TransformRequestMessage,
+            {operation: operation === 'validate' ? 'validate_auth' : 'query'},
           ),
       );
 

--- a/packages/zero-cache/src/custom/fetch.test.ts
+++ b/packages/zero-cache/src/custom/fetch.test.ts
@@ -15,11 +15,13 @@ import {
 } from '../../../shared/src/logging-test-utils.ts';
 import * as v from '../../../shared/src/valita.ts';
 import {ErrorKind} from '../../../zero-protocol/src/error-kind.ts';
+import {ErrorOrigin} from '../../../zero-protocol/src/error-origin.ts';
 import {ErrorReason} from '../../../zero-protocol/src/error-reason.ts';
 import {
   ProtocolError,
   isProtocolError,
 } from '../../../zero-protocol/src/error.ts';
+import {mutateResponseSchema} from '../../../zero-protocol/src/mutate-server.ts';
 import {queryResponseSchema} from '../../../zero-protocol/src/query-server.ts';
 import type {
   ConnectionContext,
@@ -32,6 +34,7 @@ import {
   getBodyPreview,
   urlMatch,
 } from './fetch.ts';
+import * as apiMetrics from './metrics.ts';
 
 const mockFetch = vi.fn() as MockedFunction<typeof fetch>;
 vi.stubGlobal('fetch', mockFetch);
@@ -39,6 +42,38 @@ vi.stubGlobal('fetch', mockFetch);
 const shard: ShardID = {appID: 'test_app', shardNum: 1};
 const baseUrl = 'https://api.example.com/endpoint';
 const allowedPatterns = [compileUrlPattern(baseUrl)];
+
+function mockApiMetrics() {
+  const requestsAdd = vi.fn();
+  const requestDurationRecordMs = vi.fn();
+  const attemptsAdd = vi.fn();
+  const attemptDurationRecordMs = vi.fn();
+  const inFlightAdd = vi.fn();
+
+  vi.spyOn(apiMetrics, 'apiRequests').mockReturnValue({
+    add: requestsAdd,
+  } as unknown as ReturnType<typeof apiMetrics.apiRequests>);
+  vi.spyOn(apiMetrics, 'apiRequestDuration').mockReturnValue({
+    recordMs: requestDurationRecordMs,
+  } as unknown as ReturnType<typeof apiMetrics.apiRequestDuration>);
+  vi.spyOn(apiMetrics, 'apiAttempts').mockReturnValue({
+    add: attemptsAdd,
+  } as unknown as ReturnType<typeof apiMetrics.apiAttempts>);
+  vi.spyOn(apiMetrics, 'apiAttemptDuration').mockReturnValue({
+    recordMs: attemptDurationRecordMs,
+  } as unknown as ReturnType<typeof apiMetrics.apiAttemptDuration>);
+  vi.spyOn(apiMetrics, 'apiInFlight').mockReturnValue({
+    add: inFlightAdd,
+  } as unknown as ReturnType<typeof apiMetrics.apiInFlight>);
+
+  return {
+    requestsAdd,
+    requestDurationRecordMs,
+    attemptsAdd,
+    attemptDurationRecordMs,
+    inFlightAdd,
+  };
+}
 
 afterAll(() => {
   vi.unstubAllGlobals();
@@ -48,6 +83,7 @@ describe('fetchFromAPIServer', () => {
   const lc = createSilentLogContext();
   const body = {test: 'data'};
   const validator = v.object({success: v.boolean()});
+  let metrics: ReturnType<typeof mockApiMetrics>;
 
   type FetchContextOptions = {
     url?: string | undefined;
@@ -92,6 +128,7 @@ describe('fetchFromAPIServer', () => {
   >(
     validator: TValidator,
     source: Parameters<typeof fetchFromAPIServer>[1],
+    metricsOptions: Parameters<typeof fetchFromAPIServer>[6],
     options: FetchContextOptions = {},
     requestBody: typeof body = body,
   ) {
@@ -102,11 +139,14 @@ describe('fetchFromAPIServer', () => {
       makeContext(options),
       shard,
       requestBody,
+      metricsOptions,
     );
   }
 
   beforeEach(() => {
+    vi.restoreAllMocks();
     mockFetch.mockReset();
+    metrics = mockApiMetrics();
     vi.useRealTimers();
   });
 
@@ -116,13 +156,18 @@ describe('fetchFromAPIServer', () => {
       new Response(JSON.stringify(responsePayload), {status: 200}),
     );
 
-    const result = await fetchWithContext(validator, 'push', {
-      headerOptions: {
-        apiKey: 'key-123',
-        cookie: 'session=xyz',
+    const result = await fetchWithContext(
+      validator,
+      'push',
+      {operation: 'mutate'},
+      {
+        headerOptions: {
+          apiKey: 'key-123',
+          cookie: 'session=xyz',
+        },
+        auth: 'token-abc',
       },
-      auth: 'token-abc',
-    });
+    );
 
     expect(result).toEqual(responsePayload);
     const [calledUrl, init] = mockFetch.mock.calls[0]!;
@@ -140,6 +185,331 @@ describe('fetchFromAPIServer', () => {
     });
   });
 
+  test('records API metrics for successful requests', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({success: true}), {status: 200}),
+    );
+
+    await fetchWithContext(validator, 'push', {operation: 'mutate'});
+
+    expect(metrics.inFlightAdd).toHaveBeenNthCalledWith(1, 1, {
+      operation: 'mutate',
+    });
+    expect(metrics.inFlightAdd).toHaveBeenNthCalledWith(2, -1, {
+      operation: 'mutate',
+    });
+    expect(metrics.attemptsAdd).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({
+        operation: 'mutate',
+        attempt: 1,
+        result: 'success',
+        will_retry: false,
+        http_status_code: 200,
+        http_status_class: '2xx',
+      }),
+    );
+    expect(metrics.attemptDurationRecordMs).toHaveBeenCalledWith(
+      expect.any(Number),
+      expect.objectContaining({result: 'success'}),
+    );
+    expect(metrics.requestsAdd).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({
+        operation: 'mutate',
+        result: 'success',
+        attempt_count: 1,
+        http_status_code: 200,
+        http_status_class: '2xx',
+      }),
+    );
+    expect(metrics.requestDurationRecordMs).toHaveBeenCalledWith(
+      expect.any(Number),
+      expect.objectContaining({result: 'success'}),
+    );
+  });
+
+  test('records retry attempts and final success', async () => {
+    vi.useFakeTimers();
+    mockFetch
+      .mockResolvedValueOnce(new Response('bad gateway', {status: 502}))
+      .mockResolvedValueOnce(new Response('bad gateway', {status: 502}))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({success: true}), {status: 200}),
+      );
+
+    const promise = fetchWithContext(validator, 'push', {operation: 'mutate'});
+
+    await vi.advanceTimersByTimeAsync(2400);
+    await promise;
+
+    expect(metrics.attemptsAdd).toHaveBeenCalledTimes(3);
+    expect(metrics.attemptsAdd).toHaveBeenNthCalledWith(
+      1,
+      1,
+      expect.objectContaining({
+        attempt: 1,
+        result: 'http_error',
+        will_retry: true,
+        http_status_code: 502,
+      }),
+    );
+    expect(metrics.attemptsAdd).toHaveBeenNthCalledWith(
+      2,
+      1,
+      expect.objectContaining({
+        attempt: 2,
+        result: 'http_error',
+        will_retry: true,
+        http_status_code: 502,
+      }),
+    );
+    expect(metrics.attemptsAdd).toHaveBeenNthCalledWith(
+      3,
+      1,
+      expect.objectContaining({
+        attempt: 3,
+        result: 'success',
+        will_retry: false,
+        http_status_code: 200,
+      }),
+    );
+    expect(metrics.requestsAdd).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({
+        result: 'success',
+        attempt_count: 3,
+      }),
+    );
+  });
+
+  test('records exhausted HTTP retries as http_error', async () => {
+    vi.useFakeTimers();
+    mockFetch.mockResolvedValue(new Response('bad gateway', {status: 502}));
+
+    const promise = fetchWithContext(validator, 'push', {operation: 'mutate'});
+
+    await Promise.all([
+      expect(promise).rejects.toThrow(/non-OK status 502/),
+      vi.advanceTimersByTimeAsync(5000),
+    ]);
+
+    expect(metrics.attemptsAdd).toHaveBeenCalledTimes(4);
+    expect(metrics.attemptsAdd).toHaveBeenLastCalledWith(
+      1,
+      expect.objectContaining({
+        attempt: 4,
+        result: 'http_error',
+        will_retry: false,
+        http_status_code: 502,
+      }),
+    );
+    expect(metrics.requestsAdd).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({
+        result: 'http_error',
+        attempt_count: 4,
+        http_status_code: 502,
+        error_kind: ErrorKind.PushFailed,
+        error_reason: ErrorReason.HTTP,
+      }),
+    );
+  });
+
+  test('records fetch failed retry attempts', async () => {
+    vi.useFakeTimers();
+    mockFetch
+      .mockRejectedValueOnce(new TypeError('fetch failed'))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({success: true}), {status: 200}),
+      );
+
+    const promise = fetchWithContext(validator, 'push', {operation: 'mutate'});
+
+    await vi.advanceTimersByTimeAsync(1200);
+    await promise;
+
+    expect(metrics.attemptsAdd).toHaveBeenNthCalledWith(
+      1,
+      1,
+      expect.objectContaining({
+        attempt: 1,
+        result: 'fetch_error',
+        will_retry: true,
+      }),
+    );
+    expect(metrics.requestsAdd).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({
+        result: 'success',
+        attempt_count: 2,
+      }),
+    );
+  });
+
+  test('records parse failures as parse_error', async () => {
+    mockFetch.mockResolvedValueOnce(new Response('not-json', {status: 200}));
+
+    await expect(
+      fetchWithContext(validator, 'push', {operation: 'mutate'}),
+    ).rejects.toThrow(/Failed to parse response/);
+
+    expect(metrics.attemptsAdd).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({
+        result: 'parse_error',
+        http_status_code: 200,
+        error_kind: ErrorKind.PushFailed,
+        error_reason: ErrorReason.Parse,
+      }),
+    );
+    expect(metrics.requestsAdd).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({
+        result: 'parse_error',
+        attempt_count: 1,
+        http_status_code: 200,
+      }),
+    );
+  });
+
+  test('records URL allowlist failures without attempts', async () => {
+    await expect(
+      fetchWithContext(
+        validator,
+        'push',
+        {
+          operation: 'mutate',
+        },
+        {
+          url: 'https://evil.example.com/endpoint',
+        },
+      ),
+    ).rejects.toThrow(/not allowed by the ZERO_MUTATE_URL configuration/);
+
+    expect(metrics.attemptsAdd).not.toHaveBeenCalled();
+    expect(metrics.requestsAdd).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({
+        operation: 'mutate',
+        result: 'url_not_allowed',
+        attempt_count: 0,
+        error_kind: ErrorKind.PushFailed,
+        error_reason: ErrorReason.Internal,
+      }),
+    );
+  });
+
+  test('records reserved query params as config_error without attempts', async () => {
+    await expect(
+      fetchWithContext(
+        validator,
+        'push',
+        {operation: 'mutate'},
+        {url: `${baseUrl}?schema=value`},
+      ),
+    ).rejects.toThrow(/reserved query param "schema"/);
+
+    expect(metrics.attemptsAdd).not.toHaveBeenCalled();
+    expect(metrics.requestsAdd).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({
+        operation: 'mutate',
+        result: 'config_error',
+        attempt_count: 0,
+      }),
+    );
+  });
+
+  test('records cleanup type labels', async () => {
+    mockFetch
+      .mockResolvedValueOnce(new Response(JSON.stringify({success: true})))
+      .mockResolvedValueOnce(new Response(JSON.stringify({success: true})));
+
+    await fetchWithContext(validator, 'push', {
+      operation: 'cleanup',
+      cleanupType: 'single',
+    });
+    await fetchWithContext(validator, 'push', {
+      operation: 'cleanup',
+      cleanupType: 'bulk',
+    });
+
+    expect(metrics.requestsAdd).toHaveBeenNthCalledWith(
+      1,
+      1,
+      expect.objectContaining({
+        operation: 'cleanup',
+        cleanup_type: 'single',
+        result: 'success',
+      }),
+    );
+    expect(metrics.requestsAdd).toHaveBeenNthCalledWith(
+      2,
+      1,
+      expect.objectContaining({
+        operation: 'cleanup',
+        cleanup_type: 'bulk',
+        result: 'success',
+      }),
+    );
+  });
+
+  test('records validate_auth operation labels', async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({success: true}), {status: 200}),
+    );
+
+    await fetchWithContext(validator, 'transform', {
+      operation: 'validate_auth',
+    });
+
+    expect(metrics.requestsAdd).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({
+        operation: 'validate_auth',
+        result: 'success',
+      }),
+    );
+  });
+
+  test('records top-level API error responses as api_error', async () => {
+    const responsePayload = {
+      kind: ErrorKind.PushFailed,
+      origin: ErrorOrigin.ZeroCache,
+      reason: ErrorReason.Internal,
+      message: 'app returned an error',
+      mutationIDs: [],
+    } as const;
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify(responsePayload), {status: 200}),
+    );
+
+    const result = await fetchWithContext(mutateResponseSchema, 'push', {
+      operation: 'mutate',
+    });
+
+    expect(result).toEqual(responsePayload);
+    expect(metrics.attemptsAdd).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({
+        result: 'api_error',
+        http_status_code: 200,
+        error_kind: ErrorKind.PushFailed,
+        error_reason: ErrorReason.Internal,
+      }),
+    );
+    expect(metrics.requestsAdd).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({
+        result: 'api_error',
+        attempt_count: 1,
+        error_kind: ErrorKind.PushFailed,
+        error_reason: ErrorReason.Internal,
+      }),
+    );
+  });
+
   test('preserves unknown fields from successful API responses', async () => {
     mockFetch.mockResolvedValueOnce(
       new Response(JSON.stringify({success: true, ignored: 'value'}), {
@@ -147,7 +517,9 @@ describe('fetchFromAPIServer', () => {
       }),
     );
 
-    const result = await fetchWithContext(validator, 'push');
+    const result = await fetchWithContext(validator, 'push', {
+      operation: 'mutate',
+    });
 
     expect(result).toEqual({success: true, ignored: 'value'});
   });
@@ -170,7 +542,9 @@ describe('fetchFromAPIServer', () => {
       new Response(JSON.stringify(legacyResponse), {status: 200}),
     );
 
-    const result = await fetchWithContext(queryResponseSchema, 'transform');
+    const result = await fetchWithContext(queryResponseSchema, 'transform', {
+      operation: 'query',
+    });
 
     expect(result).toEqual(legacyResponse);
   });
@@ -181,7 +555,12 @@ describe('fetchFromAPIServer', () => {
     );
     const urlWithQuery = `${baseUrl}?foo=bar`;
 
-    await fetchWithContext(validator, 'push', {url: urlWithQuery});
+    await fetchWithContext(
+      validator,
+      'push',
+      {operation: 'mutate'},
+      {url: urlWithQuery},
+    );
 
     const calledUrl = mockFetch.mock.calls[0]![0] as string;
     const url = new URL(calledUrl);
@@ -195,7 +574,7 @@ describe('fetchFromAPIServer', () => {
       new Response(JSON.stringify({success: true}), {status: 200}),
     );
 
-    await fetchWithContext(validator, 'push');
+    await fetchWithContext(validator, 'push', {operation: 'mutate'});
 
     const init = mockFetch.mock.calls[0]![1];
     expect(init?.headers).toEqual({'Content-Type': 'application/json'});
@@ -206,17 +585,22 @@ describe('fetchFromAPIServer', () => {
       new Response(JSON.stringify({success: true}), {status: 200}),
     );
 
-    await fetchWithContext(validator, 'push', {
-      headerOptions: {
-        customHeaders: {
-          'x-vercel-automation-bypass-secret': 'my-secret',
-          'x-custom-header': 'custom-value',
-        },
-        requestHeaders: {
-          'x-forwarded-for': '203.0.113.1',
+    await fetchWithContext(
+      validator,
+      'push',
+      {operation: 'mutate'},
+      {
+        headerOptions: {
+          customHeaders: {
+            'x-vercel-automation-bypass-secret': 'my-secret',
+            'x-custom-header': 'custom-value',
+          },
+          requestHeaders: {
+            'x-forwarded-for': '203.0.113.1',
+          },
         },
       },
-    });
+    );
 
     const init = mockFetch.mock.calls[0]![1];
     expect(init?.headers).toEqual({
@@ -232,15 +616,20 @@ describe('fetchFromAPIServer', () => {
       new Response(JSON.stringify({success: true}), {status: 200}),
     );
 
-    await fetchWithContext(validator, 'push', {
-      headerOptions: {
-        apiKey: 'api-key',
-        customHeaders: {
-          'x-vercel-automation-bypass-secret': 'my-secret',
+    await fetchWithContext(
+      validator,
+      'push',
+      {operation: 'mutate'},
+      {
+        headerOptions: {
+          apiKey: 'api-key',
+          customHeaders: {
+            'x-vercel-automation-bypass-secret': 'my-secret',
+          },
         },
+        auth: 'jwt-token',
       },
-      auth: 'jwt-token',
-    });
+    );
 
     const init = mockFetch.mock.calls[0]![1];
     expect(init?.headers).toEqual({
@@ -260,6 +649,7 @@ describe('fetchFromAPIServer', () => {
         makeContext({url: 'https://evil.example.com/endpoint'}),
         shard,
         body,
+        {operation: 'mutate'},
       ),
     ).rejects.toThrow(
       'URL "https://evil.example.com/endpoint" is not allowed by the ZERO_MUTATE_URL configuration',
@@ -276,6 +666,7 @@ describe('fetchFromAPIServer', () => {
         makeContext({url: 'https://evil.example.com/endpoint'}),
         shard,
         body,
+        {operation: 'query'},
       ),
     ).rejects.toThrow(
       'URL "https://evil.example.com/endpoint" is not allowed by the ZERO_QUERY_URL configuration',
@@ -295,6 +686,7 @@ describe('fetchFromAPIServer', () => {
           makeContext({url}),
           shard,
           body,
+          {operation: 'mutate'},
         ),
       ).rejects.toThrow(
         `The push URL cannot contain the reserved query param "${reserved}"`,
@@ -309,7 +701,7 @@ describe('fetchFromAPIServer', () => {
 
     let caught: unknown;
     try {
-      await fetchWithContext(validator, 'push');
+      await fetchWithContext(validator, 'push', {operation: 'mutate'});
     } catch (error) {
       caught = error;
     }
@@ -341,7 +733,7 @@ describe('fetchFromAPIServer', () => {
 
     let caught: unknown;
     try {
-      await fetchWithContext(validator, 'push');
+      await fetchWithContext(validator, 'push', {operation: 'mutate'});
     } catch (error) {
       caught = error;
     }
@@ -367,7 +759,7 @@ describe('fetchFromAPIServer', () => {
 
     let caught: unknown;
     try {
-      await fetchWithContext(validator, 'transform');
+      await fetchWithContext(validator, 'transform', {operation: 'query'});
     } catch (error) {
       caught = error;
     }
@@ -390,7 +782,7 @@ describe('fetchFromAPIServer', () => {
 
     let caught: unknown;
     try {
-      await fetchWithContext(validator, 'transform');
+      await fetchWithContext(validator, 'transform', {operation: 'query'});
     } catch (error) {
       caught = error;
     }
@@ -417,7 +809,7 @@ describe('fetchFromAPIServer', () => {
 
     let caught: unknown;
     try {
-      await fetchWithContext(strictValidator, 'push');
+      await fetchWithContext(strictValidator, 'push', {operation: 'mutate'});
     } catch (error) {
       caught = error;
     }
@@ -442,7 +834,9 @@ describe('fetchFromAPIServer', () => {
 
     let caught: unknown;
     try {
-      await fetchWithContext(strictValidator, 'transform');
+      await fetchWithContext(strictValidator, 'transform', {
+        operation: 'query',
+      });
     } catch (error) {
       caught = error;
     }
@@ -464,7 +858,7 @@ describe('fetchFromAPIServer', () => {
 
     let caught: unknown;
     try {
-      await fetchWithContext(validator, 'push');
+      await fetchWithContext(validator, 'push', {operation: 'mutate'});
     } catch (error) {
       caught = error;
     }
@@ -486,7 +880,7 @@ describe('fetchFromAPIServer', () => {
 
     let caught: unknown;
     try {
-      await fetchWithContext(validator, 'transform');
+      await fetchWithContext(validator, 'transform', {operation: 'query'});
     } catch (error) {
       caught = error;
     }
@@ -516,7 +910,9 @@ describe('fetchFromAPIServer', () => {
           new Response(JSON.stringify({success: true}), {status: 200}),
         );
 
-      const promise = fetchWithContext(validator, 'push');
+      const promise = fetchWithContext(validator, 'push', {
+        operation: 'mutate',
+      });
 
       // 1st retry
       await vi.advanceTimersByTimeAsync(1200);
@@ -535,7 +931,9 @@ describe('fetchFromAPIServer', () => {
           new Response(JSON.stringify({success: true}), {status: 200}),
         );
 
-      const promise = fetchWithContext(validator, 'push');
+      const promise = fetchWithContext(validator, 'push', {
+        operation: 'mutate',
+      });
 
       await vi.advanceTimersByTimeAsync(1200);
 
@@ -551,7 +949,9 @@ describe('fetchFromAPIServer', () => {
           new Response(JSON.stringify({success: true}), {status: 200}),
         );
 
-      const promise = fetchWithContext(validator, 'push');
+      const promise = fetchWithContext(validator, 'push', {
+        operation: 'mutate',
+      });
 
       await vi.advanceTimersByTimeAsync(1200);
 
@@ -563,7 +963,9 @@ describe('fetchFromAPIServer', () => {
     test('fails after max retries (status code)', async () => {
       mockFetch.mockResolvedValue(new Response('bad gateway', {status: 502}));
 
-      const promise = fetchWithContext(validator, 'push');
+      const promise = fetchWithContext(validator, 'push', {
+        operation: 'mutate',
+      });
 
       // Exhaust all retries
       await Promise.all([
@@ -578,7 +980,9 @@ describe('fetchFromAPIServer', () => {
     test('fails after max retries (fetch failed)', async () => {
       mockFetch.mockRejectedValue(new TypeError('fetch failed'));
 
-      const promise = fetchWithContext(validator, 'push');
+      const promise = fetchWithContext(validator, 'push', {
+        operation: 'mutate',
+      });
 
       // Exhaust all retries
       await Promise.all([
@@ -593,7 +997,9 @@ describe('fetchFromAPIServer', () => {
     test('does not retry on other errors', async () => {
       mockFetch.mockResolvedValue(new Response('bad request', {status: 400}));
 
-      const promise = fetchWithContext(validator, 'push');
+      const promise = fetchWithContext(validator, 'push', {
+        operation: 'mutate',
+      });
 
       await expect(promise).rejects.toThrow(/non-OK status 400/);
       expect(mockFetch).toHaveBeenCalledTimes(1);

--- a/packages/zero-cache/src/custom/fetch.test.ts
+++ b/packages/zero-cache/src/custom/fetch.test.ts
@@ -510,6 +510,40 @@ describe('fetchFromAPIServer', () => {
     );
   });
 
+  test('records legacy push error responses as api_error', async () => {
+    const responsePayload = {
+      error: 'unsupportedPushVersion',
+      mutationIDs: [{clientID: 'client-1', id: 1}],
+    } as const;
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify(responsePayload), {status: 200}),
+    );
+
+    const result = await fetchWithContext(mutateResponseSchema, 'push', {
+      operation: 'mutate',
+    });
+
+    expect(result).toEqual(responsePayload);
+    expect(metrics.attemptsAdd).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({
+        result: 'api_error',
+        http_status_code: 200,
+        error_kind: ErrorKind.PushFailed,
+        error_reason: ErrorReason.UnsupportedPushVersion,
+      }),
+    );
+    expect(metrics.requestsAdd).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({
+        result: 'api_error',
+        attempt_count: 1,
+        error_kind: ErrorKind.PushFailed,
+        error_reason: ErrorReason.UnsupportedPushVersion,
+      }),
+    );
+  });
+
   test('preserves unknown fields from successful API responses', async () => {
     mockFetch.mockResolvedValueOnce(
       new Response(JSON.stringify({success: true, ignored: 'value'}), {
@@ -547,6 +581,45 @@ describe('fetchFromAPIServer', () => {
     });
 
     expect(result).toEqual(legacyResponse);
+  });
+
+  test('records legacy transformFailed responses as api_error', async () => {
+    const transformFailedBody = {
+      kind: ErrorKind.TransformFailed,
+      origin: ErrorOrigin.Server,
+      reason: ErrorReason.Parse,
+      message: 'Unable to transform query',
+      queryIDs: ['q1'],
+    } as const;
+    const legacyResponse = ['transformFailed', transformFailedBody] as const;
+
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify(legacyResponse), {status: 200}),
+    );
+
+    const result = await fetchWithContext(queryResponseSchema, 'transform', {
+      operation: 'query',
+    });
+
+    expect(result).toEqual(legacyResponse);
+    expect(metrics.attemptsAdd).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({
+        result: 'api_error',
+        http_status_code: 200,
+        error_kind: ErrorKind.TransformFailed,
+        error_reason: ErrorReason.Parse,
+      }),
+    );
+    expect(metrics.requestsAdd).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({
+        result: 'api_error',
+        attempt_count: 1,
+        error_kind: ErrorKind.TransformFailed,
+        error_reason: ErrorReason.Parse,
+      }),
+    );
   });
 
   test('preserves existing query params when appending reserved ones', async () => {

--- a/packages/zero-cache/src/custom/fetch.ts
+++ b/packages/zero-cache/src/custom/fetch.ts
@@ -16,6 +16,10 @@ import {
   isProtocolError,
   type ErrorBody,
 } from '../../../zero-protocol/src/error.ts';
+import {
+  pushErrorSchema,
+  type PushError,
+} from '../../../zero-protocol/src/push.ts';
 import type {ConnectionContext} from '../services/view-syncer/connection-context-manager.ts';
 import {ProtocolErrorWithLevel} from '../types/error-with-level.ts';
 import {upstreamSchema, type ShardID} from '../types/shards.ts';
@@ -256,20 +260,20 @@ export async function fetchFromAPIServer<TValidator extends Type>(
           const result = validator.parse(json, {
             mode: 'passthrough',
           });
-          const apiErrorBody = apiErrorBodyFromResult(result);
-          if (apiErrorBody) {
+          const apiError = apiErrorFromResult(result);
+          if (apiError) {
             recordApiAttempt(performance.now() - attemptStart, metricAttrs, {
               attempt,
               result: 'api_error',
               willRetry: false,
               response,
-              errorBody: apiErrorBody,
+              errorBody: apiError,
             });
             requestMetricAttrs = apiRequestMetricAttrs(metricAttrs, {
               result: 'api_error',
               attemptCount,
               response,
-              errorBody: apiErrorBody,
+              errorBody: apiError,
             });
           } else {
             recordApiAttempt(performance.now() - attemptStart, metricAttrs, {
@@ -450,9 +454,43 @@ function apiFailedBody(
       };
 }
 
-function apiErrorBodyFromResult(result: unknown): ErrorBody | undefined {
+type ApiErrorMetricBody = {
+  kind: ErrorBody['kind'];
+  reason?: string | undefined;
+};
+
+function apiErrorFromResult(result: unknown): ApiErrorMetricBody | undefined {
   const parsed = errorBodySchema.try(result, {mode: 'passthrough'});
-  return parsed.ok ? parsed.value : undefined;
+  if (parsed.ok) {
+    return parsed.value;
+  }
+
+  if (Array.isArray(result) && result[0] === 'transformFailed') {
+    const legacyTransformFailed = errorBodySchema.try(result[1], {
+      mode: 'passthrough',
+    });
+    return legacyTransformFailed.ok ? legacyTransformFailed.value : undefined;
+  }
+
+  const legacyPushError = pushErrorSchema.try(result, {mode: 'passthrough'});
+  return legacyPushError.ok
+    ? {
+        kind: ErrorKind.PushFailed,
+        reason: legacyPushErrorReason(legacyPushError.value.error),
+      }
+    : undefined;
+}
+
+function legacyPushErrorReason(error: PushError['error']): string {
+  switch (error) {
+    case 'http':
+      return ErrorReason.HTTP;
+    case 'unsupportedPushVersion':
+      return ErrorReason.UnsupportedPushVersion;
+    case 'unsupportedSchemaVersion':
+    case 'zeroPusher':
+      return ErrorReason.Internal;
+  }
 }
 
 type ApiResponseErrorMetricAttrs = Pick<
@@ -464,7 +502,7 @@ type ApiRequestMetricAttrsOptions = {
   result: ApiRequestResult;
   attemptCount: number;
   response?: Response | undefined;
-  errorBody?: ErrorBody | undefined;
+  errorBody?: ApiErrorMetricBody | undefined;
 };
 
 type ApiAttemptMetricAttrsOptions = {
@@ -472,7 +510,7 @@ type ApiAttemptMetricAttrsOptions = {
   result: ApiAttemptResult;
   willRetry: boolean;
   response?: Response | undefined;
-  errorBody?: ErrorBody | undefined;
+  errorBody?: ApiErrorMetricBody | undefined;
 };
 
 function apiRequestMetricAttrs(
@@ -489,7 +527,7 @@ function apiRequestMetricAttrs(
 
 function apiResponseErrorMetricAttrs(
   response: Response | undefined,
-  errorBody: ErrorBody | undefined,
+  errorBody: ApiErrorMetricBody | undefined,
 ): ApiResponseErrorMetricAttrs {
   const attrs: ApiResponseErrorMetricAttrs = {};
 
@@ -500,7 +538,7 @@ function apiResponseErrorMetricAttrs(
 
   if (errorBody) {
     attrs.error_kind = errorBody.kind;
-    if ('reason' in errorBody) {
+    if (errorBody.reason !== undefined) {
       attrs.error_reason = errorBody.reason;
     }
   }

--- a/packages/zero-cache/src/custom/fetch.ts
+++ b/packages/zero-cache/src/custom/fetch.ts
@@ -1,7 +1,7 @@
 import {context, propagation} from '@opentelemetry/api';
 import type {LogContext, LogLevel} from '@rocicorp/logger';
 import 'urlpattern-polyfill';
-import {assert, unreachable} from '../../../shared/src/asserts.ts';
+import {unreachable} from '../../../shared/src/asserts.ts';
 import {getErrorMessage} from '../../../shared/src/error.ts';
 import type {ReadonlyJSONValue} from '../../../shared/src/json.ts';
 import {must} from '../../../shared/src/must.ts';
@@ -11,10 +11,28 @@ import {type Type} from '../../../shared/src/valita.ts';
 import {ErrorKind} from '../../../zero-protocol/src/error-kind.ts';
 import {ErrorOrigin} from '../../../zero-protocol/src/error-origin.ts';
 import {ErrorReason} from '../../../zero-protocol/src/error-reason.ts';
-import {isProtocolError} from '../../../zero-protocol/src/error.ts';
+import {
+  errorBodySchema,
+  isProtocolError,
+  type ErrorBody,
+} from '../../../zero-protocol/src/error.ts';
 import type {ConnectionContext} from '../services/view-syncer/connection-context-manager.ts';
 import {ProtocolErrorWithLevel} from '../types/error-with-level.ts';
 import {upstreamSchema, type ShardID} from '../types/shards.ts';
+import {
+  apiAttemptDuration,
+  apiAttempts,
+  apiInFlight,
+  apiRequestDuration,
+  apiRequests,
+  type ApiAttemptMetricAttrs,
+  type ApiAttemptResult,
+  type ApiCleanupType,
+  type ApiMetricBaseAttrs,
+  type ApiOperation,
+  type ApiRequestMetricAttrs,
+  type ApiRequestResult,
+} from './metrics.ts';
 
 const reservedParams = ['schema', 'appID'];
 
@@ -62,6 +80,16 @@ export const getBodyPreview = async (
 
 const MAX_ATTEMPTS = 4;
 
+type ApiFailedReason =
+  | typeof ErrorReason.HTTP
+  | typeof ErrorReason.Parse
+  | typeof ErrorReason.Internal;
+
+export type FetchMetricsOptions = {
+  operation: ApiOperation;
+  cleanupType?: ApiCleanupType | undefined;
+};
+
 export async function fetchFromAPIServer<TValidator extends Type>(
   validator: TValidator,
   source: 'push' | 'transform',
@@ -69,221 +97,276 @@ export async function fetchFromAPIServer<TValidator extends Type>(
   ctx: ConnectionContext,
   shard: ShardID,
   body: ReadonlyJSONValue,
+  metricsOpts: FetchMetricsOptions,
 ) {
-  const fetchFromAPIServerID = randInt(1, Number.MAX_SAFE_INTEGER).toString(36);
-  lc = lc
-    .withContext('fetchFromAPIServerID', fetchFromAPIServerID)
-    .withContext('source', source);
-
-  const fetchConfig = source === 'push' ? ctx.mutateContext : ctx.queryContext;
-  const url = must(
-    fetchConfig.url,
-    `Fetch config for ${source} is missing URL`,
-  );
-  const headerOptions = fetchConfig.headerOptions;
-
-  lc.debug?.('fetchFromAPIServer called', {
-    url,
-  });
-
-  if (!urlMatch(url, fetchConfig.allowedUrlPatterns ?? [])) {
-    throw new ProtocolErrorWithLevel(
-      source === 'push'
-        ? {
-            kind: ErrorKind.PushFailed,
-            origin: ErrorOrigin.ZeroCache,
-            reason: ErrorReason.Internal,
-            message: `URL "${url}" is not allowed by the ZERO_MUTATE_URL configuration`,
-            mutationIDs: [],
-          }
-        : {
-            kind: ErrorKind.TransformFailed,
-            origin: ErrorOrigin.ZeroCache,
-            reason: ErrorReason.Internal,
-            message: `URL "${url}" is not allowed by the ZERO_QUERY_URL configuration`,
-            queryIDs: [],
-          },
-      'warn',
-    );
-  }
-  const headers: Record<string, string> = {
-    'Content-Type': 'application/json',
-  };
-
-  if (headerOptions.apiKey) {
-    headers['X-Api-Key'] = headerOptions.apiKey;
-  }
-  Object.assign(
-    headers,
-    headerOptions.customHeaders,
-    headerOptions.requestHeaders,
-  );
-  if (ctx.auth?.raw) {
-    headers['Authorization'] = `Bearer ${ctx.auth.raw}`;
-  }
-  if (headerOptions.cookie) {
-    headers['Cookie'] = headerOptions.cookie;
-  }
-  if (headerOptions.origin) {
-    headers['Origin'] = headerOptions.origin;
-  }
-  propagation.inject(context.active(), headers);
-
-  const urlObj = new URL(url);
-  const params = new URLSearchParams(urlObj.search);
-
-  for (const reserved of reservedParams) {
-    assert(
-      !params.has(reserved),
-      `The push URL cannot contain the reserved query param "${reserved}"`,
-    );
-  }
-
-  params.append('schema', upstreamSchema(shard));
-  params.append('appID', shard.appID);
-
-  urlObj.search = params.toString();
-
-  const finalUrl = urlObj.toString();
-
-  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
-    lc = lc.withContext('fetchFromAPIServerAttempt', attempt);
-    lc.debug?.('fetch from API server attempt');
-    const shouldRetry = async () => {
-      if (attempt < MAX_ATTEMPTS) {
-        const delayMs = getBackoffDelayMs(attempt);
-        lc.debug?.(`fetch from API server retrying in ${delayMs} ms`);
-        await sleep(delayMs);
-        return true;
-      }
-      lc.debug?.('fetch from API server reached max attempts, not retrying');
-      return false;
-    };
-    try {
-      const response = await fetch(finalUrl, {
-        method: 'POST',
-        headers,
-        body: JSON.stringify(body),
-      });
-
-      if (!response.ok) {
-        const bodyPreview = await getBodyPreview(response, lc);
-        lc.warn?.('fetch from API server returned non-OK status', {
-          url: finalUrl,
-          status: response.status,
-          bodyPreview,
-        });
-        // Bad Gateway or Gateway Timeout indicate the server was not reached
-        // We retry these if we have retries remaining.
-        if (
-          (response.status === 502 || response.status === 504) &&
-          (await shouldRetry())
-        ) {
-          continue;
+  const metricAttrs: ApiMetricBaseAttrs =
+    metricsOpts.operation === 'cleanup' && metricsOpts.cleanupType !== undefined
+      ? {
+          operation: metricsOpts.operation,
+          cleanup_type: metricsOpts.cleanupType,
         }
+      : {operation: metricsOpts.operation};
+  const requestStart = performance.now();
+  let requestMetricAttrs: ApiRequestMetricAttrs | undefined;
+  let attemptCount = 0;
+  apiInFlight().add(1, metricAttrs);
 
-        throw new ProtocolErrorWithLevel(
-          source === 'push'
-            ? {
-                kind: ErrorKind.PushFailed,
-                origin: ErrorOrigin.ZeroCache,
-                reason: ErrorReason.HTTP,
-                status: response.status,
-                bodyPreview,
-                message: `Fetch from API server returned non-OK status ${response.status}`,
-                mutationIDs: [],
-              }
-            : {
-                kind: ErrorKind.TransformFailed,
-                origin: ErrorOrigin.ZeroCache,
-                reason: ErrorReason.HTTP,
-                status: response.status,
-                bodyPreview,
-                message: `Fetch from API server returned non-OK status ${response.status}`,
-                queryIDs: [],
-              },
-          'warn',
+  try {
+    const fetchFromAPIServerID = randInt(1, Number.MAX_SAFE_INTEGER).toString(
+      36,
+    );
+    lc = lc
+      .withContext('fetchFromAPIServerID', fetchFromAPIServerID)
+      .withContext('source', source);
+
+    const fetchConfig =
+      source === 'push' ? ctx.mutateContext : ctx.queryContext;
+    const url = must(
+      fetchConfig.url,
+      `Fetch config for ${source} is missing URL`,
+    );
+    const headerOptions = fetchConfig.headerOptions;
+
+    lc.debug?.('fetchFromAPIServer called', {
+      url,
+    });
+
+    if (!urlMatch(url, fetchConfig.allowedUrlPatterns ?? [])) {
+      const errorBody = apiFailedBody(
+        source,
+        ErrorReason.Internal,
+        source === 'push'
+          ? `URL "${url}" is not allowed by the ZERO_MUTATE_URL configuration`
+          : `URL "${url}" is not allowed by the ZERO_QUERY_URL configuration`,
+      );
+      requestMetricAttrs = apiRequestMetricAttrs(metricAttrs, {
+        result: 'url_not_allowed',
+        attemptCount,
+        errorBody,
+      });
+      throw new ProtocolErrorWithLevel(errorBody, 'warn');
+    }
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    };
+
+    if (headerOptions.apiKey) {
+      headers['X-Api-Key'] = headerOptions.apiKey;
+    }
+    Object.assign(
+      headers,
+      headerOptions.customHeaders,
+      headerOptions.requestHeaders,
+    );
+    if (ctx.auth?.raw) {
+      headers['Authorization'] = `Bearer ${ctx.auth.raw}`;
+    }
+    if (headerOptions.cookie) {
+      headers['Cookie'] = headerOptions.cookie;
+    }
+    if (headerOptions.origin) {
+      headers['Origin'] = headerOptions.origin;
+    }
+    propagation.inject(context.active(), headers);
+
+    const urlObj = new URL(url);
+    const params = new URLSearchParams(urlObj.search);
+
+    for (const reserved of reservedParams) {
+      if (params.has(reserved)) {
+        requestMetricAttrs = apiRequestMetricAttrs(metricAttrs, {
+          result: 'config_error',
+          attemptCount,
+        });
+        throw new Error(
+          `The push URL cannot contain the reserved query param "${reserved}"`,
         );
       }
+    }
 
+    params.append('schema', upstreamSchema(shard));
+    params.append('appID', shard.appID);
+
+    urlObj.search = params.toString();
+
+    const finalUrl = urlObj.toString();
+
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+      attemptCount = attempt;
+      lc = lc.withContext('fetchFromAPIServerAttempt', attempt);
+      lc.debug?.('fetch from API server attempt');
+      const sleepBeforeRetry = async () => {
+        if (attempt < MAX_ATTEMPTS) {
+          const delayMs = getBackoffDelayMs(attempt);
+          lc.debug?.(`fetch from API server retrying in ${delayMs} ms`);
+          await sleep(delayMs);
+          return true;
+        }
+        lc.debug?.('fetch from API server reached max attempts, not retrying');
+        return false;
+      };
+      const attemptStart = performance.now();
       try {
-        const json = await response.json();
-        const result = validator.parse(json, {
-          mode: 'passthrough',
+        const response = await fetch(finalUrl, {
+          method: 'POST',
+          headers,
+          body: JSON.stringify(body),
         });
-        lc.debug?.('fetch from API server succeeded');
-        return result;
-      } catch (error) {
-        lc.warn?.(
-          'failed to parse response',
-          {
+
+        if (!response.ok) {
+          const bodyPreview = await getBodyPreview(response, lc);
+          lc.warn?.('fetch from API server returned non-OK status', {
             url: finalUrl,
-          },
+            status: response.status,
+            bodyPreview,
+          });
+          // Bad Gateway or Gateway Timeout indicate the server was not reached
+          // We retry these if we have retries remaining.
+          const willRetry =
+            (response.status === 502 || response.status === 504) &&
+            attempt < MAX_ATTEMPTS;
+          recordApiAttempt(performance.now() - attemptStart, metricAttrs, {
+            attempt,
+            result: 'http_error',
+            willRetry,
+            response,
+          });
+          if (willRetry && (await sleepBeforeRetry())) {
+            continue;
+          }
+
+          const errorBody = apiFailedBody(
+            source,
+            ErrorReason.HTTP,
+            `Fetch from API server returned non-OK status ${response.status}`,
+            response,
+            bodyPreview,
+          );
+          requestMetricAttrs = apiRequestMetricAttrs(metricAttrs, {
+            result: 'http_error',
+            attemptCount,
+            response,
+            errorBody,
+          });
+          throw new ProtocolErrorWithLevel(errorBody, 'warn');
+        }
+
+        try {
+          const json = await response.json();
+          const result = validator.parse(json, {
+            mode: 'passthrough',
+          });
+          const apiErrorBody = apiErrorBodyFromResult(result);
+          if (apiErrorBody) {
+            recordApiAttempt(performance.now() - attemptStart, metricAttrs, {
+              attempt,
+              result: 'api_error',
+              willRetry: false,
+              response,
+              errorBody: apiErrorBody,
+            });
+            requestMetricAttrs = apiRequestMetricAttrs(metricAttrs, {
+              result: 'api_error',
+              attemptCount,
+              response,
+              errorBody: apiErrorBody,
+            });
+          } else {
+            recordApiAttempt(performance.now() - attemptStart, metricAttrs, {
+              attempt,
+              result: 'success',
+              willRetry: false,
+              response,
+            });
+            requestMetricAttrs = apiRequestMetricAttrs(metricAttrs, {
+              result: 'success',
+              attemptCount,
+              response,
+            });
+          }
+          lc.debug?.('fetch from API server succeeded');
+          return result;
+        } catch (error) {
+          lc.warn?.(
+            'failed to parse response',
+            {
+              url: finalUrl,
+            },
+            error,
+          );
+
+          const errorBody = apiFailedBody(
+            source,
+            ErrorReason.Parse,
+            `Failed to parse response from API server: ${getErrorMessage(error)}`,
+          );
+          recordApiAttempt(performance.now() - attemptStart, metricAttrs, {
+            attempt,
+            result: 'parse_error',
+            willRetry: false,
+            response,
+            errorBody,
+          });
+          requestMetricAttrs = apiRequestMetricAttrs(metricAttrs, {
+            result: 'parse_error',
+            attemptCount,
+            response,
+            errorBody,
+          });
+          throw new ProtocolErrorWithLevel(errorBody, 'warn', {cause: error});
+        }
+      } catch (error) {
+        if (isProtocolError(error)) {
+          throw error;
+        }
+
+        const isFetchFailed =
+          error instanceof TypeError && error.message === 'fetch failed';
+        // unexpected/unknown errors should be logged at 'error' level so they
+        // are investigated
+        let logLevel: LogLevel = isFetchFailed ? 'warn' : 'error';
+        lc[logLevel]?.(
+          'fetch from API server threw error',
+          {url: finalUrl},
           error,
         );
 
-        throw new ProtocolErrorWithLevel(
-          source === 'push'
-            ? {
-                kind: ErrorKind.PushFailed,
-                origin: ErrorOrigin.ZeroCache,
-                reason: ErrorReason.Parse,
-                message: `Failed to parse response from API server: ${getErrorMessage(error)}`,
-                mutationIDs: [],
-              }
-            : {
-                kind: ErrorKind.TransformFailed,
-                origin: ErrorOrigin.ZeroCache,
-                reason: ErrorReason.Parse,
-                message: `Failed to parse response from API server: ${getErrorMessage(error)}`,
-                queryIDs: [],
-              },
-          'warn',
-          {cause: error},
+        const willRetry = isFetchFailed && attempt < MAX_ATTEMPTS;
+        recordApiAttempt(performance.now() - attemptStart, metricAttrs, {
+          attempt,
+          result: 'fetch_error',
+          willRetry,
+        });
+
+        if (willRetry && (await sleepBeforeRetry())) {
+          continue;
+        }
+
+        const errorBody = apiFailedBody(
+          source,
+          ErrorReason.Internal,
+          `Fetch from API server threw error: ${getErrorMessage(error)}`,
         );
+        requestMetricAttrs = apiRequestMetricAttrs(metricAttrs, {
+          result: 'fetch_error',
+          attemptCount,
+          errorBody,
+        });
+        throw new ProtocolErrorWithLevel(errorBody, logLevel, {cause: error});
       }
-    } catch (error) {
-      if (isProtocolError(error)) {
-        throw error;
-      }
-
-      const isFetchFailed =
-        error instanceof TypeError && error.message === 'fetch failed';
-      // unexpected/unknown errors should be logged at 'error' level so they
-      // are investigated
-      let logLevel: LogLevel = isFetchFailed ? 'warn' : 'error';
-      lc[logLevel]?.(
-        'fetch from API server threw error',
-        {url: finalUrl},
-        error,
-      );
-
-      if (isFetchFailed && (await shouldRetry())) {
-        continue;
-      }
-
-      throw new ProtocolErrorWithLevel(
-        source === 'push'
-          ? {
-              kind: ErrorKind.PushFailed,
-              origin: ErrorOrigin.ZeroCache,
-              reason: ErrorReason.Internal,
-              message: `Fetch from API server threw error: ${getErrorMessage(error)}`,
-              mutationIDs: [],
-            }
-          : {
-              kind: ErrorKind.TransformFailed,
-              origin: ErrorOrigin.ZeroCache,
-              reason: ErrorReason.Internal,
-              message: `Fetch from API server threw error: ${getErrorMessage(error)}`,
-              queryIDs: [],
-            },
-        logLevel,
-        {cause: error},
-      );
     }
+    unreachable();
+  } finally {
+    const attrs =
+      requestMetricAttrs ??
+      apiRequestMetricAttrs(metricAttrs, {
+        result: attemptCount === 0 ? 'config_error' : 'fetch_error',
+        attemptCount,
+      });
+    apiRequests().add(1, attrs);
+    apiRequestDuration().recordMs(performance.now() - requestStart, attrs);
+    apiInFlight().add(-1, metricAttrs);
   }
-  unreachable();
 }
 
 /**
@@ -319,4 +402,130 @@ export function urlMatch(
  */
 function getBackoffDelayMs(attempt: number): number {
   return Math.min(1000, 100 * Math.pow(2, attempt - 1) + Math.random() * 100);
+}
+
+function apiFailedBody(
+  source: 'push' | 'transform',
+  reason: ApiFailedReason,
+  message: string,
+  response?: Response | undefined,
+  bodyPreview?: string | undefined,
+): ErrorBody {
+  if (source === 'push') {
+    return reason === ErrorReason.HTTP
+      ? {
+          kind: ErrorKind.PushFailed,
+          origin: ErrorOrigin.ZeroCache,
+          reason,
+          status: response?.status ?? 0,
+          ...(bodyPreview !== undefined ? {bodyPreview} : {}),
+          message,
+          mutationIDs: [],
+        }
+      : {
+          kind: ErrorKind.PushFailed,
+          origin: ErrorOrigin.ZeroCache,
+          reason,
+          message,
+          mutationIDs: [],
+        };
+  }
+
+  return reason === ErrorReason.HTTP
+    ? {
+        kind: ErrorKind.TransformFailed,
+        origin: ErrorOrigin.ZeroCache,
+        reason,
+        status: response?.status ?? 0,
+        ...(bodyPreview !== undefined ? {bodyPreview} : {}),
+        message,
+        queryIDs: [],
+      }
+    : {
+        kind: ErrorKind.TransformFailed,
+        origin: ErrorOrigin.ZeroCache,
+        reason,
+        message,
+        queryIDs: [],
+      };
+}
+
+function apiErrorBodyFromResult(result: unknown): ErrorBody | undefined {
+  const parsed = errorBodySchema.try(result, {mode: 'passthrough'});
+  return parsed.ok ? parsed.value : undefined;
+}
+
+type ApiResponseErrorMetricAttrs = Pick<
+  ApiRequestMetricAttrs,
+  'http_status_code' | 'http_status_class' | 'error_kind' | 'error_reason'
+>;
+
+type ApiRequestMetricAttrsOptions = {
+  result: ApiRequestResult;
+  attemptCount: number;
+  response?: Response | undefined;
+  errorBody?: ErrorBody | undefined;
+};
+
+type ApiAttemptMetricAttrsOptions = {
+  attempt: number;
+  result: ApiAttemptResult;
+  willRetry: boolean;
+  response?: Response | undefined;
+  errorBody?: ErrorBody | undefined;
+};
+
+function apiRequestMetricAttrs(
+  baseAttrs: ApiMetricBaseAttrs,
+  {result, attemptCount, response, errorBody}: ApiRequestMetricAttrsOptions,
+): ApiRequestMetricAttrs {
+  return {
+    ...baseAttrs,
+    result,
+    attempt_count: attemptCount,
+    ...apiResponseErrorMetricAttrs(response, errorBody),
+  };
+}
+
+function apiResponseErrorMetricAttrs(
+  response: Response | undefined,
+  errorBody: ErrorBody | undefined,
+): ApiResponseErrorMetricAttrs {
+  const attrs: ApiResponseErrorMetricAttrs = {};
+
+  if (response) {
+    attrs.http_status_code = response.status;
+    attrs.http_status_class = `${Math.floor(response.status / 100)}xx`;
+  }
+
+  if (errorBody) {
+    attrs.error_kind = errorBody.kind;
+    if ('reason' in errorBody) {
+      attrs.error_reason = errorBody.reason;
+    }
+  }
+
+  return attrs;
+}
+
+function recordApiAttempt(
+  durationMs: number,
+  baseAttrs: ApiMetricBaseAttrs,
+  {
+    attempt,
+    result,
+    willRetry,
+    response,
+    errorBody,
+  }: ApiAttemptMetricAttrsOptions,
+) {
+  const attrs: ApiAttemptMetricAttrs = {
+    ...baseAttrs,
+    attempt,
+    result,
+    will_retry: willRetry,
+    ...apiResponseErrorMetricAttrs(response, errorBody),
+  };
+  apiAttempts().add(1, attrs);
+  apiAttemptDuration().recordMs(durationMs, attrs);
 }

--- a/packages/zero-cache/src/custom/metrics.ts
+++ b/packages/zero-cache/src/custom/metrics.ts
@@ -1,0 +1,93 @@
+import {
+  getOrCreateCounter,
+  getOrCreateHistogram,
+  getOrCreateUpDownCounter,
+} from '../observability/metrics.ts';
+
+export type ApiOperation = 'mutate' | 'query' | 'cleanup' | 'validate_auth';
+export type ApiCleanupType = 'single' | 'bulk';
+
+export type ApiMetricBaseAttrs = {
+  operation: ApiOperation;
+  cleanup_type?: ApiCleanupType | undefined;
+};
+
+export type ApiRequestResult =
+  | 'success'
+  | 'api_error'
+  | 'http_error'
+  | 'parse_error'
+  | 'fetch_error'
+  | 'url_not_allowed'
+  | 'config_error';
+
+export type ApiAttemptResult =
+  | 'success'
+  | 'api_error'
+  | 'http_error'
+  | 'parse_error'
+  | 'fetch_error';
+
+export type ApiRequestMetricAttrs = ApiMetricBaseAttrs & {
+  result: ApiRequestResult;
+  attempt_count: number;
+  http_status_code?: number | undefined;
+  http_status_class?: `${string}xx` | undefined;
+  error_kind?: string | undefined;
+  error_reason?: string | undefined;
+};
+
+export type ApiAttemptMetricAttrs = ApiMetricBaseAttrs & {
+  attempt: number;
+  result: ApiAttemptResult;
+  will_retry: boolean;
+  http_status_code?: number | undefined;
+  http_status_class?: `${string}xx` | undefined;
+  error_kind?: string | undefined;
+  error_reason?: string | undefined;
+};
+
+const API_DURATION_HISTOGRAM_BOUNDARIES_S = [
+  0.001, 0.002, 0.005, 0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 30, 60,
+  120,
+];
+
+export function apiRequests() {
+  return getOrCreateCounter(
+    'server',
+    'api.requests',
+    'API requests, labeled by operation and result.',
+  );
+}
+
+export function apiRequestDuration() {
+  return getOrCreateHistogram('server', 'api.request_duration', {
+    description: 'End-to-end API request duration, including retries.',
+    unit: 's',
+    bucketBoundaries: API_DURATION_HISTOGRAM_BOUNDARIES_S,
+  });
+}
+
+export function apiAttempts() {
+  return getOrCreateCounter(
+    'server',
+    'api.attempts',
+    'API HTTP fetch attempts',
+  );
+}
+
+export function apiAttemptDuration() {
+  return getOrCreateHistogram('server', 'api.attempt_duration', {
+    description: 'API HTTP fetch attempt duration, excluding retry sleep.',
+    unit: 's',
+    bucketBoundaries: API_DURATION_HISTOGRAM_BOUNDARIES_S,
+  });
+}
+
+export function apiInFlight() {
+  return getOrCreateUpDownCounter(
+    'server',
+    'api.in_flight',
+    'API requests currently in flight.',
+  );
+}

--- a/packages/zero-cache/src/services/mutagen/pusher.ts
+++ b/packages/zero-cache/src/services/mutagen/pusher.ts
@@ -155,6 +155,7 @@ export class PusherService implements Service, Pusher {
         connCtx,
         {appID: this.#config.app.id, shardNum: this.#config.shard.num},
         cleanupBody,
+        {operation: 'cleanup', cleanupType: 'single'},
       );
     } catch (e) {
       this.#lc.warn?.('Failed to send cleanup mutation', {
@@ -214,6 +215,7 @@ export class PusherService implements Service, Pusher {
         connCtx,
         {appID: this.#config.app.id, shardNum: this.#config.shard.num},
         cleanupBody,
+        {operation: 'cleanup', cleanupType: 'bulk'},
       );
     } catch (e) {
       this.#lc.warn?.('Failed to send bulk cleanup mutation', {
@@ -527,6 +529,7 @@ class PushWorker {
           shardNum: this.#config.shard.num,
         },
         entry.push,
+        {operation: 'mutate'},
       );
       if (
         ('kind' in response && response.kind === ErrorKind.PushFailed) ||


### PR DESCRIPTION
## Summary

Adds zero-cache metrics around calls to user API servers for mutate, query, cleanup, and auth-validation operations.

## Details

This records API request, attempt, duration, and in-flight metrics with labels for operation, result, retry behavior, HTTP status, and protocol error details. Cleanup requests also include cleanup type labels.
