### PR TITLE
chore: inject random faults into the replicator (sigkill, network termination, restart) and compare DBs

### DIFF
--- a/packages/zero-cache/src/services/replicator/replication-resumption-child.ts
+++ b/packages/zero-cache/src/services/replicator/replication-resumption-child.ts
@@ -258,7 +258,12 @@ export default async function runWorker(
 }
 
 if (parentWorker) {
+  const parent = parentWorker;
+  const [dbPath, failpointArg] = process.argv.slice(2);
+  if (!dbPath) {
+    throw new Error('replication resumption child requires a replica db path');
+  }
   void exitAfter(lc, () =>
-    runWorker(parentWorker, process.env, ...process.argv.slice(2)),
+    runWorker(parent, process.env, dbPath, failpointArg),
   );
 }

--- a/packages/zero-cache/src/services/replicator/replication-resumption-child.ts
+++ b/packages/zero-cache/src/services/replicator/replication-resumption-child.ts
@@ -1,0 +1,264 @@
+import {pid} from 'node:process';
+import {LogContext} from '@rocicorp/logger';
+import {resolver} from '@rocicorp/resolver';
+import type {LogConfig} from '../../../../shared/src/logging.ts';
+import {Queue} from '../../../../shared/src/queue.ts';
+import {parentWorker, type Worker} from '../../types/processes.ts';
+import type {Source} from '../../types/streams.ts';
+import {getPragmaConfig, setupReplica} from '../../workers/replicator.ts';
+import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
+import type {
+  ChangeStreamer,
+  SubscriberContext,
+  Downstream,
+} from '../change-streamer/change-streamer.ts';
+import {exitAfter, runUntilKilled} from '../life-cycle.ts';
+import type {CommitResult} from './change-processor.ts';
+import {ReplicatorService} from './replicator.ts';
+import {
+  ThreadWriteWorkerClient,
+  type PragmaConfig,
+  type WriteWorkerClient,
+} from './write-worker-client.ts';
+
+type ChildFailpoint = 'none' | 'after-sqlite-commit-before-ack';
+
+type ParentMessage =
+  | ['replication-resumption:downstream', {seq: number; msg: Downstream}]
+  | ['replication-resumption:source-error', {message: string}]
+  | ['replication-resumption:source-end', Record<string, never>];
+
+type ChildMessage =
+  | ['replication-resumption:ready', {pid: number}]
+  | ['replication-resumption:subscribe', SubscriberContext]
+  | ['replication-resumption:consumed', {seq: number}]
+  | ['replication-resumption:cancel', Record<string, never>]
+  | [
+      'replication-resumption:failpoint',
+      {name: Exclude<ChildFailpoint, 'none'>; watermark: string},
+    ];
+
+const lc = new LogContext('error');
+
+function send(parent: Worker, msg: ChildMessage): void {
+  parent.send(msg as never);
+}
+
+function parentMessage(data: unknown): ParentMessage | undefined {
+  if (!Array.isArray(data) || data.length !== 2) {
+    return undefined;
+  }
+  switch (data[0]) {
+    case 'replication-resumption:downstream':
+    case 'replication-resumption:source-error':
+    case 'replication-resumption:source-end':
+      return data as ParentMessage;
+  }
+  return undefined;
+}
+
+class IPCChangeStreamer implements ChangeStreamer {
+  readonly #parent: Worker;
+
+  constructor(parent: Worker) {
+    this.#parent = parent;
+  }
+
+  subscribe(ctx: SubscriberContext): Promise<Source<Downstream>> {
+    send(this.#parent, ['replication-resumption:subscribe', ctx]);
+    return Promise.resolve(new IPCDownstreamSource(this.#parent));
+  }
+}
+
+type QueueEntry =
+  | {type: 'message'; seq: number; msg: Downstream}
+  | {type: 'end'};
+
+class IPCDownstreamSource implements Source<Downstream> {
+  readonly #parent: Worker;
+  readonly #queue = new Queue<QueueEntry>();
+  #canceled = false;
+
+  constructor(parent: Worker) {
+    this.#parent = parent;
+    this.#parent.on('message', this.#onMessage);
+  }
+
+  readonly #onMessage = (data: unknown) => {
+    const msg = parentMessage(data);
+    if (!msg) {
+      return;
+    }
+    switch (msg[0]) {
+      case 'replication-resumption:downstream':
+        this.#queue.enqueue({type: 'message', ...msg[1]});
+        break;
+      case 'replication-resumption:source-error':
+        this.#queue.enqueueRejection(new Error(msg[1].message));
+        break;
+      case 'replication-resumption:source-end':
+        this.#queue.enqueue({type: 'end'});
+        break;
+    }
+  };
+
+  cancel(): void {
+    if (this.#canceled) {
+      return;
+    }
+    this.#canceled = true;
+    this.#parent.off('message', this.#onMessage);
+    send(this.#parent, ['replication-resumption:cancel', {}]);
+    this.#queue.enqueue({type: 'end'});
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<Downstream> {
+    let previousSeq: number | undefined;
+    return {
+      next: async () => {
+        if (previousSeq !== undefined) {
+          send(this.#parent, [
+            'replication-resumption:consumed',
+            {seq: previousSeq},
+          ]);
+          previousSeq = undefined;
+        }
+
+        const entry = await this.#queue.dequeue();
+        if (entry.type === 'end') {
+          return {value: undefined, done: true};
+        }
+        previousSeq = entry.seq;
+        return {value: entry.msg, done: false};
+      },
+      return: value => {
+        if (previousSeq !== undefined) {
+          send(this.#parent, [
+            'replication-resumption:consumed',
+            {seq: previousSeq},
+          ]);
+          previousSeq = undefined;
+        }
+        this.cancel();
+        return Promise.resolve({value, done: true});
+      },
+    };
+  }
+}
+
+class FailpointWriteWorkerClient implements WriteWorkerClient {
+  readonly #inner: ThreadWriteWorkerClient;
+  readonly #parent: Worker;
+  readonly #failpoint: ChildFailpoint;
+  #triggered = false;
+
+  constructor(
+    inner: ThreadWriteWorkerClient,
+    parent: Worker,
+    failpoint: ChildFailpoint,
+  ) {
+    this.#inner = inner;
+    this.#parent = parent;
+    this.#failpoint = failpoint;
+  }
+
+  init(
+    dbPath: string,
+    mode: Parameters<ThreadWriteWorkerClient['init']>[1],
+    pragmas: PragmaConfig,
+    logConfig: LogConfig,
+  ) {
+    return this.#inner.init(dbPath, mode, pragmas, logConfig);
+  }
+
+  getSubscriptionState() {
+    return this.#inner.getSubscriptionState();
+  }
+
+  async processMessage(
+    downstream: ChangeStreamData,
+  ): Promise<CommitResult | null> {
+    const result = await this.#inner.processMessage(downstream);
+    if (
+      result?.watermark &&
+      this.#failpoint === 'after-sqlite-commit-before-ack' &&
+      !this.#triggered
+    ) {
+      this.#triggered = true;
+      send(this.#parent, [
+        'replication-resumption:failpoint',
+        {name: this.#failpoint, watermark: result.watermark},
+      ]);
+      await resolver<never>().promise;
+    }
+    return result;
+  }
+
+  abort() {
+    this.#inner.abort();
+  }
+
+  stop() {
+    return this.#inner.stop();
+  }
+
+  onError(handler: (err: Error) => void) {
+    this.#inner.onError(handler);
+  }
+}
+
+function parseFailpoint(value: string | undefined): ChildFailpoint {
+  switch (value) {
+    case undefined:
+    case 'none':
+      return 'none';
+    case 'after-sqlite-commit-before-ack':
+      return value;
+  }
+  throw new Error(`unknown replication resumption failpoint: ${value}`);
+}
+
+export default async function runWorker(
+  parent: Worker,
+  _env: NodeJS.ProcessEnv,
+  dbPath: string,
+  failpointArg?: string,
+): Promise<void> {
+  const failpoint = parseFailpoint(failpointArg);
+  await setupReplica(lc, 'serving', {file: dbPath});
+
+  const worker = new FailpointWriteWorkerClient(
+    new ThreadWriteWorkerClient(),
+    parent,
+    failpoint,
+  );
+  await worker.init(dbPath, 'serving', getPragmaConfig('serving'), {
+    level: 'error',
+    format: 'text',
+  });
+
+  const replicator = new ReplicatorService(
+    lc,
+    'replication-resumption-test',
+    `replication-resumption-child-${pid}`,
+    'serving',
+    new IPCChangeStreamer(parent),
+    worker,
+    null,
+  );
+
+  const running = runUntilKilled(lc, parent, replicator);
+
+  for await (const _ of replicator.subscribe()) {
+    send(parent, ['replication-resumption:ready', {pid}]);
+    break;
+  }
+
+  return running;
+}
+
+if (parentWorker) {
+  void exitAfter(lc, () =>
+    runWorker(parentWorker, process.env, ...process.argv.slice(2)),
+  );
+}

--- a/packages/zero-cache/src/services/replicator/replication-resumption.pg.test.ts
+++ b/packages/zero-cache/src/services/replicator/replication-resumption.pg.test.ts
@@ -1,0 +1,450 @@
+import {LogContext} from '@rocicorp/logger';
+import {expect} from 'vitest';
+import {BigIntJSON} from '../../../../shared/src/bigint-json.ts';
+import {sleep} from '../../../../shared/src/sleep.ts';
+import {Database} from '../../../../zqlite/src/db.ts';
+import {StatementRunner} from '../../db/statements.ts';
+import {getConnectionURI, test, type PgTest} from '../../test/db.ts';
+import {DbFile} from '../../test/lite.ts';
+import type {PostgresDB} from '../../types/pg.ts';
+import type {Source} from '../../types/streams.ts';
+import {getPragmaConfig, setupReplica} from '../../workers/replicator.ts';
+import type {
+  ChangeSource,
+  ChangeStream,
+} from '../change-source/change-source.ts';
+import {initializePostgresChangeSource} from '../change-source/pg/change-source.ts';
+import {toBigInt} from '../change-source/pg/lsn.ts';
+import type {
+  BackfillRequest,
+  ChangeSourceUpstream,
+} from '../change-source/protocol/current.ts';
+import {
+  initializeStreamer,
+  type TuningOptions,
+} from '../change-streamer/change-streamer-service.ts';
+import {
+  type ChangeStreamer,
+  type ChangeStreamerService,
+  type Downstream,
+} from '../change-streamer/change-streamer.ts';
+import {ReplicationStatusPublisher} from './replication-status.ts';
+import {ReplicatorService} from './replicator.ts';
+import {getSubscriptionState} from './schema/replication-state.ts';
+import {ThreadWriteWorkerClient} from './write-worker-client.ts';
+
+const lc = new LogContext('error');
+
+const APP_ID = 'replication_resumption';
+const SHARD_NUM = 0;
+const TASK_ID = 'replication-resumption-test';
+const PUBLICATION = 'zero_replication_resumption';
+const TIMEOUT_MS = 120_000;
+
+const shard = {
+  appID: APP_ID,
+  shardNum: SHARD_NUM,
+  publications: [PUBLICATION],
+};
+
+const streamerOptions: TuningOptions = {
+  backPressureLimitHeapProportion: 0.04,
+  flowControlConsensusPaddingSeconds: 1,
+  statementTimeoutMs: 20_000,
+  changeLogBatchSize: 100,
+};
+
+type SourceFault = 'drop-upstream-ack';
+
+type FooRow = {
+  id: string;
+  value: string;
+  n: number;
+};
+
+function isCommitAck(msg: ChangeSourceUpstream): boolean {
+  return msg[0] === 'status' && 'tag' in msg[1] && msg[1].tag === 'commit';
+}
+
+function parseStringifiedSource(source: Source<string>): Source<Downstream> {
+  return {
+    cancel: err => source.cancel(err),
+    async *[Symbol.asyncIterator]() {
+      for await (const msg of source) {
+        yield BigIntJSON.parse(msg) as Downstream;
+      }
+    },
+  };
+}
+
+function parseStringifiedChangeStreamer(
+  streamer: ChangeStreamerService,
+): ChangeStreamer {
+  return {
+    async subscribe(ctx) {
+      return parseStringifiedSource(await streamer.subscribe(ctx));
+    },
+  };
+}
+
+class FaultyChangeSource implements ChangeSource {
+  readonly #inner: ChangeSource;
+  readonly #faults: SourceFault[] = [];
+
+  constructor(inner: ChangeSource) {
+    this.#inner = inner;
+  }
+
+  injectNextCommitAckFault(fault: SourceFault) {
+    this.#faults.push(fault);
+  }
+
+  get pendingFaults() {
+    return this.#faults.length;
+  }
+
+  startLagReporter() {
+    return this.#inner.startLagReporter();
+  }
+
+  async startStream(
+    afterWatermark: string,
+    backfillRequests: BackfillRequest[] = [],
+  ): Promise<ChangeStream> {
+    const stream = await this.#inner.startStream(
+      afterWatermark,
+      backfillRequests,
+    );
+    return {
+      changes: stream.changes,
+      acks: {
+        push: msg => {
+          if (!isCommitAck(msg)) {
+            stream.acks.push(msg);
+            return;
+          }
+
+          const fault = this.#faults.shift();
+          switch (fault) {
+            case undefined:
+              stream.acks.push(msg);
+              return;
+
+            case 'drop-upstream-ack':
+              stream.changes.cancel(
+                new Error(`injected fault: ${fault} at ${msg[2].watermark}`),
+              );
+              return;
+          }
+        },
+      },
+    };
+  }
+
+  stop() {
+    return this.#inner.stop();
+  }
+}
+
+function pgRows(upstream: PostgresDB): Promise<FooRow[]> {
+  return upstream<FooRow[]>`
+    SELECT id, value, n
+      FROM foo
+     ORDER BY id`;
+}
+
+function replicaRows(replicaDbFile: DbFile): FooRow[] {
+  const replica = new Database(lc, replicaDbFile.path);
+  try {
+    return replica
+      .prepare(
+        `
+        SELECT id, value, n
+          FROM foo
+         ORDER BY id`,
+      )
+      .all<FooRow>();
+  } finally {
+    replica.close();
+  }
+}
+
+function replicaWatermark(replicaDbFile: DbFile): string {
+  const replica = new Database(lc, replicaDbFile.path);
+  try {
+    return getSubscriptionState(new StatementRunner(replica)).watermark;
+  } finally {
+    replica.close();
+  }
+}
+
+async function expectSlotHealthy(upstream: PostgresDB) {
+  const [{slot}] = await upstream<{slot: string}[]>`
+    SELECT slot
+      FROM ${upstream(`${APP_ID}_${SHARD_NUM}.replicas`)}
+     ORDER BY rank DESC
+     LIMIT 1`;
+  const rows = await upstream<
+    {
+      confirmedFlushLSN: string | null;
+      restartLSN: string | null;
+      walStatus: string | null;
+    }[]
+  >`
+    SELECT confirmed_flush_lsn as "confirmedFlushLSN",
+           restart_lsn as "restartLSN",
+           wal_status as "walStatus"
+      FROM pg_replication_slots
+     WHERE slot_name = ${slot}`;
+
+  expect(rows).toHaveLength(1);
+  const [state] = rows;
+  expect(state.confirmedFlushLSN).not.toBeNull();
+  expect(state.restartLSN).not.toBeNull();
+  expect(state.walStatus).not.toBe('lost');
+
+  return {
+    slot,
+    confirmedFlushLSN: toBigInt(state.confirmedFlushLSN ?? '0/0'),
+  };
+}
+
+async function eventuallyExpectReplicaMatches(
+  upstream: PostgresDB,
+  replicaDbFile: DbFile,
+  description: string,
+) {
+  const deadline = Date.now() + 30_000;
+  let lastError: unknown;
+
+  while (Date.now() < deadline) {
+    try {
+      expect(replicaRows(replicaDbFile)).toEqual(await pgRows(upstream));
+      await expectSlotHealthy(upstream);
+      return;
+    } catch (e) {
+      lastError = e;
+      await sleep(50);
+    }
+  }
+
+  const watermark = replicaWatermark(replicaDbFile);
+  const actualRows = replicaRows(replicaDbFile);
+  const expectedRows = await pgRows(upstream);
+  const details =
+    lastError instanceof Error ? (lastError.stack ?? lastError.message) : '';
+  throw new Error(
+    `timed out waiting for replica to match PG after ${description} ` +
+      `(replica watermark ${watermark})\n` +
+      `replica rows: ${JSON.stringify(actualRows)}\n` +
+      `pg rows: ${JSON.stringify(expectedRows)}\n` +
+      details,
+  );
+}
+
+async function startHarness(testDBs: PgTest['testDBs']) {
+  const cleanup: (() => Promise<void> | void)[] = [];
+
+  try {
+    const upstream = await testDBs.create('replication_resumption_upstream', {
+      typeOpts: false,
+    });
+    const changeDB = await testDBs.create('replication_resumption_change', {
+      typeOpts: {sendStringAsJson: true},
+    });
+    cleanup.push(() => testDBs.drop(upstream, changeDB));
+
+    await upstream.unsafe(`
+      CREATE TABLE foo(
+        id TEXT PRIMARY KEY,
+        value TEXT NOT NULL,
+        n INT4 NOT NULL
+      );
+
+      INSERT INTO foo(id, value, n) VALUES
+        ('a', 'initial-a', 1),
+        ('z', 'initial-z', 26);
+
+      CREATE PUBLICATION ${PUBLICATION} FOR TABLE foo;
+    `);
+
+    const replicaDbFile = new DbFile('replication-resumption');
+    cleanup.push(() => replicaDbFile.delete());
+
+    const {subscriptionState, changeSource} =
+      await initializePostgresChangeSource(
+        lc,
+        getConnectionURI(upstream),
+        shard,
+        replicaDbFile.path,
+        {tableCopyWorkers: 1},
+        {suite: 'replication-resumption'},
+      );
+
+    await setupReplica(lc, 'serving', {file: replicaDbFile.path});
+
+    const faultyChangeSource = new FaultyChangeSource(changeSource);
+    const changeStreamer = await initializeStreamer(
+      lc,
+      shard,
+      TASK_ID,
+      'change-streamer:replication-resumption',
+      'ws',
+      changeDB,
+      faultyChangeSource,
+      ReplicationStatusPublisher.forTesting(),
+      subscriptionState,
+      null,
+      true,
+      streamerOptions,
+    );
+    const changeStreamerDone = changeStreamer.run();
+    cleanup.push(async () => {
+      await changeStreamer.stop();
+      await changeStreamerDone;
+    });
+
+    let replicator: ReplicatorService | undefined;
+    let replicatorDone: Promise<void> | undefined;
+
+    async function stopReplicator() {
+      if (!replicator || !replicatorDone) {
+        return;
+      }
+      const current = replicator;
+      const currentDone = replicatorDone;
+      replicator = undefined;
+      replicatorDone = undefined;
+      await current.stop();
+      await currentDone;
+    }
+
+    async function startReplicator() {
+      const worker = new ThreadWriteWorkerClient();
+      await worker.init(
+        replicaDbFile.path,
+        'serving',
+        getPragmaConfig('serving'),
+        {level: 'error', format: 'text'},
+      );
+      replicator = new ReplicatorService(
+        lc,
+        TASK_ID,
+        'replication-resumption-replicator',
+        'serving',
+        parseStringifiedChangeStreamer(changeStreamer),
+        worker,
+        null,
+      );
+      replicatorDone = replicator.run();
+    }
+
+    await startReplicator();
+    cleanup.push(stopReplicator);
+
+    await eventuallyExpectReplicaMatches(upstream, replicaDbFile, 'startup');
+
+    return {
+      upstream,
+      replicaDbFile,
+      faultyChangeSource,
+      async restartReplicator() {
+        await stopReplicator();
+        await startReplicator();
+        await eventuallyExpectReplicaMatches(
+          upstream,
+          replicaDbFile,
+          'replicator restart',
+        );
+      },
+      async cleanup() {
+        for (const fn of cleanup.reverse()) {
+          await fn();
+        }
+        cleanup.length = 0;
+      },
+    };
+  } catch (e) {
+    for (const fn of cleanup.reverse()) {
+      await fn();
+    }
+    throw e;
+  }
+}
+
+test(
+  'replication resumes from durable state after injected PG and replicator faults',
+  {timeout: TIMEOUT_MS},
+  async ({testDBs}: PgTest) => {
+    const harness = await startHarness(testDBs);
+    let previousConfirmedFlushLSN = 0n;
+
+    async function mutateAndVerify(
+      description: string,
+      mutate: () => Promise<unknown>,
+    ) {
+      await mutate();
+      await eventuallyExpectReplicaMatches(
+        harness.upstream,
+        harness.replicaDbFile,
+        description,
+      );
+      const {confirmedFlushLSN} = await expectSlotHealthy(harness.upstream);
+      expect(confirmedFlushLSN).toBeGreaterThanOrEqual(
+        previousConfirmedFlushLSN,
+      );
+      previousConfirmedFlushLSN = confirmedFlushLSN;
+    }
+
+    try {
+      await mutateAndVerify(
+        'baseline insert',
+        () => harness.upstream`
+        INSERT INTO foo(id, value, n) VALUES ('b', 'baseline', 2)`,
+      );
+
+      harness.faultyChangeSource.injectNextCommitAckFault('drop-upstream-ack');
+      await mutateAndVerify(
+        'commit stored before upstream ACK is dropped',
+        () =>
+          harness.upstream`
+          UPDATE foo SET value = 'ack-dropped', n = n + 10 WHERE id = 'a'`,
+      );
+
+      harness.faultyChangeSource.injectNextCommitAckFault('drop-upstream-ack');
+      await mutateAndVerify(
+        'second commit stored before upstream ACK is dropped',
+        () =>
+          harness.upstream`
+          INSERT INTO foo(id, value, n) VALUES ('c', 'ack-dropped-again', 3)`,
+      );
+
+      await harness.restartReplicator();
+
+      await mutateAndVerify(
+        'replicator restart and multi-row transaction',
+        () =>
+          harness.upstream.begin(async tx => {
+            await tx`DELETE FROM foo WHERE id = 'b'`;
+            await tx`
+            UPDATE foo SET value = 'worker-result-lost', n = n + 1
+             WHERE id = 'z'`;
+            await tx`
+            INSERT INTO foo(id, value, n)
+            VALUES ('d', 'same-pg-transaction', 4)`;
+          }),
+      );
+
+      await mutateAndVerify(
+        'post-fault transaction proves resumed stream',
+        () =>
+          harness.upstream`
+          UPDATE foo SET value = 'resumed', n = n + 1 WHERE id = 'c'`,
+      );
+
+      expect(harness.faultyChangeSource.pendingFaults).toBe(0);
+    } finally {
+      await harness.cleanup();
+    }
+  },
+);

--- a/packages/zero-cache/src/services/replicator/replication-resumption.pg.test.ts
+++ b/packages/zero-cache/src/services/replicator/replication-resumption.pg.test.ts
@@ -1,14 +1,16 @@
 import {LogContext} from '@rocicorp/logger';
+import {resolver, type Resolver} from '@rocicorp/resolver';
 import {expect} from 'vitest';
 import {BigIntJSON} from '../../../../shared/src/bigint-json.ts';
+import {Queue} from '../../../../shared/src/queue.ts';
 import {sleep} from '../../../../shared/src/sleep.ts';
 import {Database} from '../../../../zqlite/src/db.ts';
 import {StatementRunner} from '../../db/statements.ts';
 import {getConnectionURI, test, type PgTest} from '../../test/db.ts';
 import {DbFile} from '../../test/lite.ts';
 import type {PostgresDB} from '../../types/pg.ts';
+import {forkChildWorker, type Worker} from '../../types/processes.ts';
 import type {Source} from '../../types/streams.ts';
-import {getPragmaConfig, setupReplica} from '../../workers/replicator.ts';
 import type {
   ChangeSource,
   ChangeStream,
@@ -29,9 +31,7 @@ import {
   type Downstream,
 } from '../change-streamer/change-streamer.ts';
 import {ReplicationStatusPublisher} from './replication-status.ts';
-import {ReplicatorService} from './replicator.ts';
 import {getSubscriptionState} from './schema/replication-state.ts';
-import {ThreadWriteWorkerClient} from './write-worker-client.ts';
 
 const lc = new LogContext('error');
 
@@ -40,6 +40,7 @@ const SHARD_NUM = 0;
 const TASK_ID = 'replication-resumption-test';
 const PUBLICATION = 'zero_replication_resumption';
 const TIMEOUT_MS = 120_000;
+const CHILD_URL = new URL('./replication-resumption-child.ts', import.meta.url);
 
 const shard = {
   appID: APP_ID,
@@ -55,6 +56,7 @@ const streamerOptions: TuningOptions = {
 };
 
 type SourceFault = 'drop-upstream-ack';
+type ChildFailpoint = 'none' | 'after-sqlite-commit-before-ack';
 
 type FooRow = {
   id: string;
@@ -64,27 +66,6 @@ type FooRow = {
 
 function isCommitAck(msg: ChangeSourceUpstream): boolean {
   return msg[0] === 'status' && 'tag' in msg[1] && msg[1].tag === 'commit';
-}
-
-function parseStringifiedSource(source: Source<string>): Source<Downstream> {
-  return {
-    cancel: err => source.cancel(err),
-    async *[Symbol.asyncIterator]() {
-      for await (const msg of source) {
-        yield BigIntJSON.parse(msg) as Downstream;
-      }
-    },
-  };
-}
-
-function parseStringifiedChangeStreamer(
-  streamer: ChangeStreamerService,
-): ChangeStreamer {
-  return {
-    async subscribe(ctx) {
-      return parseStringifiedSource(await streamer.subscribe(ctx));
-    },
-  };
 }
 
 class FaultyChangeSource implements ChangeSource {
@@ -143,6 +124,215 @@ class FaultyChangeSource implements ChangeSource {
 
   stop() {
     return this.#inner.stop();
+  }
+}
+
+type ParentMessage =
+  | ['replication-resumption:ready', {pid: number}]
+  | [
+      'replication-resumption:subscribe',
+      Parameters<ChangeStreamer['subscribe']>[0],
+    ]
+  | ['replication-resumption:consumed', {seq: number}]
+  | ['replication-resumption:cancel', Record<string, never>]
+  | [
+      'replication-resumption:failpoint',
+      {name: Exclude<ChildFailpoint, 'none'>; watermark: string},
+    ];
+
+type ChildMessage =
+  | ['replication-resumption:downstream', {seq: number; msg: Downstream}]
+  | ['replication-resumption:source-error', {message: string}]
+  | ['replication-resumption:source-end', Record<string, never>];
+
+function parentMessage(data: unknown): ParentMessage | undefined {
+  if (!Array.isArray(data) || data.length !== 2) {
+    return undefined;
+  }
+  switch (data[0]) {
+    case 'replication-resumption:ready':
+    case 'replication-resumption:subscribe':
+    case 'replication-resumption:consumed':
+    case 'replication-resumption:cancel':
+    case 'replication-resumption:failpoint':
+      return data as ParentMessage;
+  }
+  return undefined;
+}
+
+function sendChild(child: Worker, msg: ChildMessage): void {
+  child.send(msg as never);
+}
+
+type ActiveBridge = {
+  source: Source<string>;
+  waiters: Map<number, Resolver<void, Error>>;
+};
+
+class ForkedReplicator {
+  readonly #changeStreamer: ChangeStreamerService;
+  readonly #child: Worker;
+  readonly #ready = resolver<void, Error>();
+  readonly #closed = resolver<void>();
+  readonly #failpoints = new Queue<{
+    name: Exclude<ChildFailpoint, 'none'>;
+    watermark: string;
+  }>();
+  readonly #bridges = new Set<ActiveBridge>();
+
+  #closedFlag = false;
+  #seq = 0;
+
+  constructor(
+    changeStreamer: ChangeStreamerService,
+    replicaPath: string,
+    failpoint: ChildFailpoint = 'none',
+  ) {
+    this.#changeStreamer = changeStreamer;
+    this.#child = forkChildWorker(
+      CHILD_URL,
+      process.env,
+      replicaPath,
+      failpoint,
+    );
+    this.#child.on('message', this.#onMessage);
+    this.#child.on('error', err => {
+      this.#ready.reject(err);
+      this.#failpoints.enqueueRejection(err);
+    });
+    this.#child.on('close', () => this.#onClose());
+  }
+
+  get pid() {
+    return this.#child.pid;
+  }
+
+  ready() {
+    return this.#ready.promise;
+  }
+
+  waitForFailpoint() {
+    return this.#failpoints.dequeue();
+  }
+
+  async stop(signal: NodeJS.Signals = 'SIGTERM') {
+    if (!this.#closedFlag) {
+      this.#child.kill(signal);
+    }
+    await this.#closed.promise;
+  }
+
+  readonly #onMessage = (data: unknown) => {
+    const msg = parentMessage(data);
+    if (!msg) {
+      return;
+    }
+    switch (msg[0]) {
+      case 'replication-resumption:ready':
+        this.#ready.resolve();
+        break;
+      case 'replication-resumption:subscribe':
+        void this.#bridge(msg[1]);
+        break;
+      case 'replication-resumption:consumed':
+        this.#resolveConsumed(msg[1].seq);
+        break;
+      case 'replication-resumption:cancel':
+        this.#cancelBridges();
+        break;
+      case 'replication-resumption:failpoint':
+        this.#failpoints.enqueue(msg[1]);
+        break;
+    }
+  };
+
+  #onClose() {
+    if (this.#closedFlag) {
+      return;
+    }
+    this.#closedFlag = true;
+    const err = new Error(
+      `forked replicator ${this.#child.pid ?? '<unknown>'} closed`,
+    );
+    this.#ready.reject(err);
+    this.#failpoints.enqueueRejection(err);
+    this.#cancelBridges(err);
+    this.#child.off('message', this.#onMessage);
+    this.#closed.resolve();
+  }
+
+  async #bridge(ctx: Parameters<ChangeStreamer['subscribe']>[0]) {
+    const source = await this.#changeStreamer.subscribe(ctx);
+    const bridge: ActiveBridge = {source, waiters: new Map()};
+    this.#bridges.add(bridge);
+
+    try {
+      const pipeline = source.pipeline;
+      if (!pipeline) {
+        throw new Error('change-streamer source does not support pipelining');
+      }
+
+      for await (const {value, consumed} of pipeline) {
+        const seq = ++this.#seq;
+        sendChild(this.#child, [
+          'replication-resumption:downstream',
+          {seq, msg: BigIntJSON.parse(value) as Downstream},
+        ]);
+        await this.#waitForConsumed(bridge, seq);
+        consumed();
+      }
+
+      if (!this.#closedFlag) {
+        sendChild(this.#child, ['replication-resumption:source-end', {}]);
+      }
+    } catch (e) {
+      if (!this.#closedFlag) {
+        const message = e instanceof Error ? e.message : String(e);
+        sendChild(this.#child, [
+          'replication-resumption:source-error',
+          {message},
+        ]);
+      }
+    } finally {
+      this.#bridges.delete(bridge);
+      this.#rejectWaiters(bridge, new Error('change-streamer bridge stopped'));
+      source.cancel();
+    }
+  }
+
+  #waitForConsumed(bridge: ActiveBridge, seq: number): Promise<void> {
+    if (this.#closedFlag) {
+      throw new Error('forked replicator closed');
+    }
+    const r = resolver<void, Error>();
+    bridge.waiters.set(seq, r);
+    return r.promise;
+  }
+
+  #resolveConsumed(seq: number) {
+    for (const bridge of this.#bridges) {
+      const waiter = bridge.waiters.get(seq);
+      if (waiter) {
+        bridge.waiters.delete(seq);
+        waiter.resolve();
+        return;
+      }
+    }
+  }
+
+  #cancelBridges(err = new Error('forked replicator closed')) {
+    for (const bridge of this.#bridges) {
+      this.#rejectWaiters(bridge, err);
+      bridge.source.cancel(err);
+    }
+    this.#bridges.clear();
+  }
+
+  #rejectWaiters(bridge: ActiveBridge, err: Error) {
+    for (const waiter of bridge.waiters.values()) {
+      waiter.reject(err);
+    }
+    bridge.waiters.clear();
   }
 }
 
@@ -281,8 +471,6 @@ async function startHarness(testDBs: PgTest['testDBs']) {
         {suite: 'replication-resumption'},
       );
 
-    await setupReplica(lc, 'serving', {file: replicaDbFile.path});
-
     const faultyChangeSource = new FaultyChangeSource(changeSource);
     const changeStreamer = await initializeStreamer(
       lc,
@@ -304,39 +492,24 @@ async function startHarness(testDBs: PgTest['testDBs']) {
       await changeStreamerDone;
     });
 
-    let replicator: ReplicatorService | undefined;
-    let replicatorDone: Promise<void> | undefined;
+    let replicator: ForkedReplicator | undefined;
 
-    async function stopReplicator() {
-      if (!replicator || !replicatorDone) {
+    async function stopReplicator(signal: NodeJS.Signals = 'SIGTERM') {
+      if (!replicator) {
         return;
       }
       const current = replicator;
-      const currentDone = replicatorDone;
       replicator = undefined;
-      replicatorDone = undefined;
-      await current.stop();
-      await currentDone;
+      await current.stop(signal);
     }
 
-    async function startReplicator() {
-      const worker = new ThreadWriteWorkerClient();
-      await worker.init(
+    async function startReplicator(failpoint: ChildFailpoint = 'none') {
+      replicator = new ForkedReplicator(
+        changeStreamer,
         replicaDbFile.path,
-        'serving',
-        getPragmaConfig('serving'),
-        {level: 'error', format: 'text'},
+        failpoint,
       );
-      replicator = new ReplicatorService(
-        lc,
-        TASK_ID,
-        'replication-resumption-replicator',
-        'serving',
-        parseStringifiedChangeStreamer(changeStreamer),
-        worker,
-        null,
-      );
-      replicatorDone = replicator.run();
+      await replicator.ready();
     }
 
     await startReplicator();
@@ -348,14 +521,23 @@ async function startHarness(testDBs: PgTest['testDBs']) {
       upstream,
       replicaDbFile,
       faultyChangeSource,
-      async restartReplicator() {
+      async restartReplicator(failpoint: ChildFailpoint = 'none') {
         await stopReplicator();
-        await startReplicator();
+        await startReplicator(failpoint);
         await eventuallyExpectReplicaMatches(
           upstream,
           replicaDbFile,
           'replicator restart',
         );
+      },
+      async killAtFailpoint(signal: NodeJS.Signals = 'SIGKILL') {
+        if (!replicator) {
+          throw new Error('replicator is not running');
+        }
+        const current = replicator;
+        const failpoint = await current.waitForFailpoint();
+        await stopReplicator(signal);
+        return failpoint;
       },
       async cleanup() {
         for (const fn of cleanup.reverse()) {
@@ -384,6 +566,10 @@ test(
       mutate: () => Promise<unknown>,
     ) {
       await mutate();
+      await verifyReplica(description);
+    }
+
+    async function verifyReplica(description: string) {
       await eventuallyExpectReplicaMatches(
         harness.upstream,
         harness.replicaDbFile,
@@ -421,18 +607,21 @@ test(
 
       await harness.restartReplicator();
 
-      await mutateAndVerify(
-        'replicator restart and multi-row transaction',
-        () =>
-          harness.upstream.begin(async tx => {
-            await tx`DELETE FROM foo WHERE id = 'b'`;
-            await tx`
-            UPDATE foo SET value = 'worker-result-lost', n = n + 1
+      await harness.restartReplicator('after-sqlite-commit-before-ack');
+      await harness.upstream.begin(async tx => {
+        await tx`DELETE FROM foo WHERE id = 'b'`;
+        await tx`
+            UPDATE foo SET value = 'killed-after-sqlite-commit', n = n + 1
              WHERE id = 'z'`;
-            await tx`
+        await tx`
             INSERT INTO foo(id, value, n)
             VALUES ('d', 'same-pg-transaction', 4)`;
-          }),
+      });
+      const failpoint = await harness.killAtFailpoint();
+      expect(failpoint.name).toBe('after-sqlite-commit-before-ack');
+      await harness.restartReplicator();
+      await verifyReplica(
+        'process killed after SQLite commit before downstream ACK',
       );
 
       await mutateAndVerify(


### PR DESCRIPTION
The replicator's replica should always match PG after they have caught up to one another. Nomatter what faults happen in between. The runs various faults and compares DBs after.