### PR TITLE
chore: missing metrics from Greg's doc

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/broadcast.ts
+++ b/packages/zero-cache/src/services/change-streamer/broadcast.ts
@@ -3,6 +3,8 @@ import {resolver} from '@rocicorp/resolver';
 import type {WatermarkedChange} from './change-streamer-service.ts';
 import type {Subscriber} from './subscriber.ts';
 
+export type BroadcastReleaseMode = 'all-subscribers' | 'consensus-timeout';
+
 /**
  * Initiates and tracks the progress of a change broadcasted to
  * a set of subscribers.
@@ -32,6 +34,7 @@ export class Broadcast {
   readonly #completed: Completed[];
   readonly #done = resolver();
   #isDone = false;
+  #releaseMode: BroadcastReleaseMode | undefined;
 
   readonly #watermark: string;
   readonly #majority: number;
@@ -59,7 +62,7 @@ export class Broadcast {
 
     // set done if there are no subscribers (mainly for tests)
     if (this.#pending.size === 0) {
-      this.#setDone();
+      this.#setDone('all-subscribers');
     }
   }
 
@@ -68,12 +71,16 @@ export class Broadcast {
     this.#completed.push({sub, changes, elapsed});
     this.#pending.delete(sub);
     if (this.#pending.size === 0) {
-      this.#setDone();
+      this.#setDone('all-subscribers');
     }
   }
 
-  #setDone() {
+  #setDone(releaseMode: BroadcastReleaseMode) {
+    if (this.#isDone) {
+      return;
+    }
     this.#isDone = true;
+    this.#releaseMode = releaseMode;
     this.#done.resolve();
   }
 
@@ -83,6 +90,10 @@ export class Broadcast {
 
   get done(): Promise<void> {
     return this.#done.promise;
+  }
+
+  get releaseMode(): BroadcastReleaseMode {
+    return this.#releaseMode ?? 'all-subscribers';
   }
 
   /**
@@ -159,6 +170,9 @@ export class Broadcast {
     flowControlConsensusPaddingMs: number,
     now: number,
   ) {
+    if (this.#isDone) {
+      return true;
+    }
     if (this.#pending.size === 0) {
       return true;
     }
@@ -182,7 +196,7 @@ export class Broadcast {
         `continuing with ${this.#pending.size} subscriber(s) still pending`,
         elapsed,
       );
-      this.#setDone();
+      this.#setDone('consensus-timeout');
       return true;
     }
     return false;

--- a/packages/zero-cache/src/services/change-streamer/forwarder.ts
+++ b/packages/zero-cache/src/services/change-streamer/forwarder.ts
@@ -1,5 +1,10 @@
 import type {LogContext} from '@rocicorp/logger';
 import {joinIterables, wrapIterable} from '../../../../shared/src/iterables.ts';
+import {
+  getOrCreateCounter,
+  getOrCreateGauge,
+  getOrCreateLatencyHistogram,
+} from '../../observability/metrics.ts';
 import {Broadcast} from './broadcast.ts';
 import type {ChangeTag, WatermarkedChange} from './change-streamer-service.ts';
 import type {Status} from './change-streamer.ts';
@@ -14,6 +19,16 @@ export class Forwarder {
   readonly #progressMonitorOptions: ProgressMonitorOptions;
   readonly #active = new Set<Subscriber>();
   readonly #queued = new Set<Subscriber>();
+  readonly #flowControlWaits = getOrCreateCounter(
+    'replication',
+    'flow-control.waits',
+    'Flow-control checkpoints completed, labeled by release mode.',
+  );
+  readonly #flowControlWaitTime = getOrCreateLatencyHistogram(
+    'replication',
+    'flow-control.wait-time',
+    'Time replication waits at flow-control checkpoints.',
+  );
   #inTransaction = false;
 
   #currentBroadcast: Broadcast | undefined;
@@ -25,6 +40,50 @@ export class Forwarder {
   ) {
     this.#lc = lc.withContext('component', 'progress-monitor');
     this.#progressMonitorOptions = opts;
+
+    getOrCreateGauge(
+      'replication',
+      'flow-control.active-subscribers',
+      'Active change-stream subscribers receiving live changes.',
+    ).addCallback(result => result.observe(this.#active.size));
+
+    getOrCreateGauge(
+      'replication',
+      'flow-control.queued-subscribers',
+      'Change-stream subscribers waiting for the current transaction to finish before activation.',
+    ).addCallback(result => result.observe(this.#queued.size));
+
+    getOrCreateGauge(
+      'replication',
+      'flow-control.pending-messages',
+      'Downstream change-stream messages not yet acked by subscribers.',
+    ).addCallback(result =>
+      result.observe(this.#subscriberStats().pendingMessages),
+    );
+
+    getOrCreateGauge(
+      'replication',
+      'flow-control.backlog-messages',
+      'Live change-stream messages buffered while subscribers catch up.',
+    ).addCallback(result =>
+      result.observe(this.#subscriberStats().backlogMessages),
+    );
+
+    getOrCreateGauge('replication', 'flow-control.backlog-bytes', {
+      description:
+        'Live change-stream bytes buffered while subscribers catch up.',
+      unit: 'By',
+    }).addCallback(result =>
+      result.observe(this.#subscriberStats().backlogBytes),
+    );
+
+    getOrCreateGauge('replication', 'flow-control.max-backlog-bytes', {
+      description:
+        'Maximum live change-stream bytes buffered by a single subscriber.',
+      unit: 'By',
+    }).addCallback(result =>
+      result.observe(this.#subscriberStats().maxBacklogBytes),
+    );
   }
 
   startProgressMonitor() {
@@ -97,19 +156,42 @@ export class Forwarder {
    * Promise that resolves when replication should continue.
    */
   async forwardWithFlowControl(entry: WatermarkedChange) {
+    const start = performance.now();
     const broadcast = new Broadcast(this.#active.values(), entry);
     this.#updateActiveSubscribers(entry[1]);
 
     // set for progress tracking
     this.#currentBroadcast = broadcast;
 
-    await broadcast.done;
-
-    // Technically #currentBroadcast may have changed, so only
-    // unset if it if is still the same.
-    if (this.#currentBroadcast === broadcast) {
-      this.#currentBroadcast = undefined;
+    try {
+      await broadcast.done;
+      const attributes = {'release.mode': broadcast.releaseMode};
+      this.#flowControlWaits.add(1, attributes);
+      this.#flowControlWaitTime.recordMs(performance.now() - start, attributes);
+    } finally {
+      // Technically #currentBroadcast may have changed, so only
+      // unset if it if is still the same.
+      if (this.#currentBroadcast === broadcast) {
+        this.#currentBroadcast = undefined;
+      }
     }
+  }
+
+  #subscriberStats() {
+    let pendingMessages = 0;
+    let backlogMessages = 0;
+    let backlogBytes = 0;
+    let maxBacklogBytes = 0;
+
+    for (const sub of joinIterables(this.#active, this.#queued)) {
+      const stats = sub.getStats();
+      pendingMessages += stats.pending;
+      backlogMessages += stats.backlog;
+      backlogBytes += stats.backlogBytes;
+      maxBacklogBytes = Math.max(maxBacklogBytes, stats.backlogBytes);
+    }
+
+    return {pendingMessages, backlogMessages, backlogBytes, maxBacklogBytes};
   }
 
   #updateActiveSubscribers(tag: ChangeTag) {

--- a/packages/zero-cache/src/services/view-syncer/cvr-store.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr-store.ts
@@ -22,6 +22,10 @@ import {clampTTL, DEFAULT_TTL_MS} from '../../../../zql/src/query/ttl.ts';
 import * as Mode from '../../db/mode-enum.ts';
 import {runTx} from '../../db/run-transaction.ts';
 import {TransactionPool} from '../../db/transaction-pool.ts';
+import {
+  getOrCreateCounter,
+  getOrCreateLatencyHistogram,
+} from '../../observability/metrics.ts';
 import {recordRowsSynced} from '../../server/anonymous-otel-start.ts';
 import {ProtocolErrorWithLevel} from '../../types/error-with-level.ts';
 import type {PostgresDB, PostgresTransaction} from '../../types/pg.ts';
@@ -71,6 +75,10 @@ export type CVRFlushStats = {
 };
 
 let flushCounter = 0;
+
+const RESULT_ATTRIBUTE = 'result';
+const ERROR_KIND_ATTRIBUTE = 'error.kind';
+const CVR_FLUSH_TYPE_ATTRIBUTE = 'flush.type';
 
 /**
  * Convert TTL/timestamp values for both old (seconds-based) and new (ms-based) columns.
@@ -196,6 +204,21 @@ export class CVRStore {
   );
   readonly #forceUpdates = new CustomKeySet<RowID>(rowIDString);
   readonly #rowCache: RowRecordCache;
+  readonly #cvrLoads = getOrCreateCounter(
+    'sync',
+    'cvr.load',
+    'CVR load attempts, labeled by result.',
+  );
+  readonly #cvrLoadTime = getOrCreateLatencyHistogram(
+    'sync',
+    'cvr.load-time',
+    'Time to load a CVR.',
+  );
+  readonly #cvrFlushes = getOrCreateCounter(
+    'sync',
+    'cvr.flush',
+    'CVR flush attempts, labeled by result and flush.type.',
+  );
   readonly #loadAttemptIntervalMs: number;
   readonly #maxLoadAttempts: number;
   #rowCount: number = 0;
@@ -249,25 +272,42 @@ export class CVRStore {
   }
 
   load(lc: LogContext, lastConnectTime: number): Promise<CVR> {
+    const start = performance.now();
     return startAsyncSpan(tracer, 'cvr.load', async () => {
-      let err: RowsVersionBehindError | undefined;
-      for (let i = 0; i < this.#maxLoadAttempts; i++) {
-        if (i > 0) {
-          await sleep(this.#loadAttemptIntervalMs);
+      try {
+        let err: RowsVersionBehindError | undefined;
+        for (let i = 0; i < this.#maxLoadAttempts; i++) {
+          if (i > 0) {
+            await sleep(this.#loadAttemptIntervalMs);
+          }
+          const result = await this.#load(lc, lastConnectTime);
+          if (result instanceof RowsVersionBehindError) {
+            lc.info?.(`attempt ${i + 1}: ${String(result)}`);
+            err = result;
+            continue;
+          }
+          this.#recordLoad(performance.now() - start, {
+            [RESULT_ATTRIBUTE]: 'success',
+          });
+          return result;
         }
-        const result = await this.#load(lc, lastConnectTime);
-        if (result instanceof RowsVersionBehindError) {
-          lc.info?.(`attempt ${i + 1}: ${String(result)}`);
-          err = result;
-          continue;
-        }
-        return result;
+        assert(err, 'Expected error to be set after retry loop exhausted');
+        throw new ClientNotFoundError(
+          `max attempts exceeded waiting for CVR@${err.cvrVersion} to catch up from ${err.rowsVersion}`,
+        );
+      } catch (e) {
+        this.#recordLoad(performance.now() - start, {
+          [RESULT_ATTRIBUTE]: 'error',
+          [ERROR_KIND_ATTRIBUTE]: cvrErrorKind(e),
+        });
+        throw e;
       }
-      assert(err, 'Expected error to be set after retry loop exhausted');
-      throw new ClientNotFoundError(
-        `max attempts exceeded waiting for CVR@${err.cvrVersion} to catch up from ${err.rowsVersion}`,
-      );
     });
+  }
+
+  #recordLoad(elapsedMs: number, attributes: Record<string, string>) {
+    this.#cvrLoads.add(1, attributes);
+    this.#cvrLoadTime.recordMs(elapsedMs, attributes);
   }
 
   async #load(
@@ -1211,8 +1251,17 @@ export class CVRStore {
         );
         this.#rowCache.recordSyncFlushStats(stats, elapsed);
       }
+      this.#cvrFlushes.add(1, {
+        [RESULT_ATTRIBUTE]: 'success',
+        [CVR_FLUSH_TYPE_ATTRIBUTE]: stats ? 'sync' : 'noop',
+      });
       return stats;
     } catch (e) {
+      this.#cvrFlushes.add(1, {
+        [RESULT_ATTRIBUTE]: 'error',
+        [CVR_FLUSH_TYPE_ATTRIBUTE]: 'sync',
+        [ERROR_KIND_ATTRIBUTE]: cvrErrorKind(e),
+      });
       // Clear cached state if an error (e.g. ConcurrentModificationException) is encountered.
       this.#rowCache.clear();
       throw e;
@@ -1367,6 +1416,22 @@ export class InvalidClientSchemaError extends ProtocolErrorWithLevel {
       {cause},
     );
   }
+}
+
+function cvrErrorKind(e: unknown): string {
+  if (e instanceof ClientNotFoundError) {
+    return 'client_not_found';
+  }
+  if (e instanceof ConcurrentModificationException) {
+    return 'concurrent_modification';
+  }
+  if (e instanceof OwnershipError) {
+    return 'ownership';
+  }
+  if (e instanceof InvalidClientSchemaError) {
+    return 'invalid_client_schema';
+  }
+  return 'error';
 }
 
 export class RowsVersionBehindError extends Error {

--- a/packages/zero-cache/src/services/view-syncer/row-record-cache.ts
+++ b/packages/zero-cache/src/services/view-syncer/row-record-cache.ts
@@ -34,6 +34,8 @@ import {
 import {tracer} from './tracer.ts';
 
 const FLUSH_TYPE_ATTRIBUTE = 'flush.type';
+const RESULT_ATTRIBUTE = 'result';
+const ERROR_KIND_ATTRIBUTE = 'error.kind';
 
 /**
  * The RowRecordCache is an in-memory cache of the `cvr.rows` tables that
@@ -114,6 +116,11 @@ export class RowRecordCache {
     'sync',
     'cvr.rows-flushed',
     'Number of (changed) rows flushed to a CVR',
+  );
+  readonly #cvrFlushes = getOrCreateCounter(
+    'sync',
+    'cvr.flush',
+    'CVR flush attempts, labeled by result and flush.type.',
   );
 
   constructor(
@@ -283,6 +290,10 @@ export class RowRecordCache {
           `flushed ${rows} rows@${versionString(rowsVersion)} (${elapsed} ms)`,
         );
         this.#recordAsyncFlushStats(rows, elapsed);
+        this.#cvrFlushes.add(1, {
+          [RESULT_ATTRIBUTE]: 'success',
+          [FLUSH_TYPE_ATTRIBUTE]: 'async',
+        });
         this.#flushedRowsVersion = rowsVersion;
         // Note: apply() may have called while the transaction was committing,
         //       which will result in looping to commit the next #pendingRowsVersion.
@@ -294,6 +305,11 @@ export class RowRecordCache {
       this.#flushing = null;
     } catch (e) {
       this.#lc.info?.(`row record flush failed`, e);
+      this.#cvrFlushes.add(1, {
+        [RESULT_ATTRIBUTE]: 'error',
+        [FLUSH_TYPE_ATTRIBUTE]: 'async',
+        [ERROR_KIND_ATTRIBUTE]: 'error',
+      });
       flushing.reject(e);
       this.#failService(e);
     }

--- a/packages/zero-cache/src/workers/connection.ts
+++ b/packages/zero-cache/src/workers/connection.ts
@@ -18,6 +18,7 @@ import {
   PROTOCOL_VERSION,
 } from '../../../zero-protocol/src/protocol-version.ts';
 import {upstreamSchema, type Upstream} from '../../../zero-protocol/src/up.ts';
+import {getOrCreateCounter} from '../observability/metrics.ts';
 import {
   ProtocolErrorWithLevel,
   getLogLevel,
@@ -62,6 +63,8 @@ export interface MessageHandler {
 // replication stream (which can similarly be back-pressured):
 // https://github.com/rocicorp/mono/blob/f98cb369a2dbb15650328859c732db358f187ef0/packages/zero-cache/src/services/change-source/pg/logical-replication/stream.ts#L21
 const DOWNSTREAM_MSG_INTERVAL_MS = 6_000;
+const PROTOCOL_VERSION_ATTRIBUTE = 'protocol.version';
+const EVENT_TYPE_ATTRIBUTE = 'event.type';
 
 /**
  * Represents a connection between the client and server.
@@ -79,6 +82,11 @@ export class Connection {
   readonly #onClose: () => void;
   readonly #messageHandler: MessageHandler;
   readonly #downstreamMsgTimer: NodeJS.Timeout | undefined;
+  readonly #webSocketErrors = getOrCreateCounter(
+    'sync',
+    'websocket.errors',
+    'Client WebSocket error events.',
+  );
 
   #viewSyncerOutboundStream: Source<Downstream> | undefined;
   #pusherOutboundStream: Source<Downstream> | undefined;
@@ -251,12 +259,23 @@ export class Connection {
 
   #handleClose = (e: CloseEvent) => {
     const {code, reason, wasClean} = e;
+    if (!wasClean) {
+      this.#recordWebSocketError('unclean_close');
+    }
     this.close('WebSocket close event', {code, reason, wasClean});
   };
 
   #handleError = (e: ErrorEvent) => {
+    this.#recordWebSocketError('error_event');
     this.#lc.warn?.('WebSocket error event', e.message, e.error);
   };
+
+  #recordWebSocketError(eventType: string) {
+    this.#webSocketErrors.add(1, {
+      [PROTOCOL_VERSION_ATTRIBUTE]: this.#protocolVersion,
+      [EVENT_TYPE_ATTRIBUTE]: eventType,
+    });
+  }
 
   #proxyInbound() {
     pipeline(

--- a/packages/zero-cache/src/workers/syncer.ts
+++ b/packages/zero-cache/src/workers/syncer.ts
@@ -13,7 +13,11 @@ import {
 import {resolveAuth, type Auth, type ValidateLegacyJWT} from '../auth/auth.ts';
 import {tokenConfigOptions} from '../auth/jwt.ts';
 import {type ZeroConfig} from '../config/zero-config.ts';
-import {getOrCreateGauge} from '../observability/metrics.ts';
+import {
+  getOrCreateCounter,
+  getOrCreateGauge,
+  getOrCreateUpDownCounter,
+} from '../observability/metrics.ts';
 import {
   recordConnectionAttempted,
   recordConnectionSuccess,
@@ -64,6 +68,9 @@ export type ServingLagStats = {
 };
 
 export const MAX_REPLICA_READY_STATES = 10_000;
+
+const PROTOCOL_VERSION_ATTRIBUTE = 'protocol.version';
+const FAILURE_REASON_ATTRIBUTE = 'reason';
 
 function boundReplicaReadyStates(
   replicaReadyStates: ReplicaReadyState[],
@@ -256,6 +263,26 @@ export class Syncer implements SingletonService {
   readonly #config: ZeroConfig;
   readonly #validateLegacyJWT: ValidateLegacyJWT | undefined;
   readonly #replicaReadyStates: ReplicaReadyState[] = [];
+  readonly #webSocketOpenConnections = getOrCreateUpDownCounter(
+    'sync',
+    'websocket.open-connections',
+    'Open client WebSocket connections.',
+  );
+  readonly #webSocketConnectionAttempts = getOrCreateCounter(
+    'sync',
+    'websocket.connection-attempts',
+    'Client WebSocket connection attempts.',
+  );
+  readonly #webSocketConnectionSuccesses = getOrCreateCounter(
+    'sync',
+    'websocket.connection-successes',
+    'Client WebSocket connections successfully initialized.',
+  );
+  readonly #webSocketConnectionFailures = getOrCreateCounter(
+    'sync',
+    'websocket.connection-failures',
+    'Client WebSocket connection attempts that failed before initialization.',
+  );
   #servingLagStatsCache: ServingLagStats | undefined;
   #servingLagStatsCacheClearQueued = false;
 
@@ -426,6 +453,34 @@ export class Syncer implements SingletonService {
   }
 
   readonly #createConnection = async (ws: WebSocket, params: ConnectParams) => {
+    const metricAttributes = {
+      [PROTOCOL_VERSION_ATTRIBUTE]: params.protocolVersion,
+    };
+    let connectionResultRecorded = false;
+    const recordConnectionFailure = (reason: string) => {
+      if (connectionResultRecorded) {
+        return;
+      }
+      connectionResultRecorded = true;
+      this.#webSocketConnectionFailures.add(1, {
+        ...metricAttributes,
+        [FAILURE_REASON_ATTRIBUTE]: reason,
+      });
+    };
+    const recordConnectionSuccessMetric = () => {
+      if (connectionResultRecorded) {
+        return;
+      }
+      connectionResultRecorded = true;
+      this.#webSocketConnectionSuccesses.add(1, metricAttributes);
+    };
+
+    this.#webSocketConnectionAttempts.add(1, metricAttributes);
+    this.#webSocketOpenConnections.add(1, metricAttributes);
+    ws.once('close', () => {
+      this.#webSocketOpenConnections.add(-1, metricAttributes);
+    });
+
     this.#lc.debug?.(
       'creating connection',
       params.clientGroupID,
@@ -450,6 +505,7 @@ export class Syncer implements SingletonService {
       const hasExactlyOneTokenOption = tokenOptions.length === 1;
       const hasCustomEndpoints = hasPushOrMutate && hasQueries;
       if (!hasExactlyOneTokenOption && !hasCustomEndpoints) {
+        recordConnectionFailure('configuration');
         throw new Error(
           'Exactly one of jwk, secret, or jwksUrl must be set in order to verify tokens but actually the following were set: ' +
             JSON.stringify(tokenOptions) +
@@ -486,10 +542,12 @@ export class Syncer implements SingletonService {
             errorKind: e.message,
           },
         );
+        recordConnectionFailure('auth');
         sendError(this.#lc, ws, e.errorBody);
         ws.close(3000, e.errorBody.message);
         return;
       }
+      recordConnectionFailure('internal');
       throw e;
     }
 
@@ -513,6 +571,7 @@ export class Syncer implements SingletonService {
           'Client groups are pinned to a single userID. Connection userID does not match existing client group userID.',
         origin: ErrorOrigin.ZeroCache,
       });
+      recordConnectionFailure('user_mismatch');
       sendError(this.#lc, ws, error.errorBody);
       ws.close(3000, error.message);
       return;
@@ -568,6 +627,7 @@ export class Syncer implements SingletonService {
         },
       );
     } catch (e) {
+      recordConnectionFailure('internal');
       connContextManager.closeConnection({clientID, wsID: params.wsID});
       mutagen?.unref();
       pusher?.unref();
@@ -576,7 +636,12 @@ export class Syncer implements SingletonService {
 
     this.#connections.set(clientID, connection);
 
-    connection.init() && recordConnectionSuccess();
+    if (connection.init()) {
+      recordConnectionSuccessMetric();
+      recordConnectionSuccess();
+    } else {
+      recordConnectionFailure('protocol_version');
+    }
 
     if (params.initConnectionMsg) {
       this.#lc.debug?.(


### PR DESCRIPTION
# Added Stability Metrics

  ## CVR Metrics

  ### `zero.sync.cvr.load`
  Counter for CVR load attempts.

  Labels:
  - `result`: `success` or `error`
  - `error.kind`: broad error category when `result="error"`

  Use:
  - Derive CVR load error rate.
  - Detect reconnect/resume instability.

  ### `zero.sync.cvr.load-time`
  Latency histogram for CVR load duration.

  Labels:
  - `result`
  - `error.kind` when applicable

  Use:
  - Track p95/p99 CVR load latency.
  - Diagnose slow reconnect/rehome paths.

  ### `zero.sync.cvr.flush`
  Counter for CVR flush attempts.

  Labels:
  - `result`: `success` or `error`
  - `flush.type`: `sync`, `async`, or `noop`
  - `error.kind` when applicable

  Use:
  - Derive CVR flush error rate.
  - Distinguish synchronous client-path flushes from deferred row flushes.

  ## Client WebSocket Metrics

  ### `zero.sync.websocket.open-connections`
  Up/down counter for currently open client WebSocket connections.

  Labels:
  - `protocol.version`

  Use:
  - Track active client connection volume.
  - Detect connection drops during incidents/deployments.

  ### `zero.sync.websocket.connection-attempts`
  Counter for client WebSocket connection attempts.

  Labels:
  - `protocol.version`

  Use:
  - Derive connection rate.
  - Detect reconnect storms.

  ### `zero.sync.websocket.connection-successes`
  Counter for successfully initialized client WebSocket connections.

  Labels:
  - `protocol.version`

  Use:
  - Derive connection success rate:
    `successes / attempts`

  ### `zero.sync.websocket.connection-failures`
  Counter for client WebSocket connection attempts that failed before initialization.

  Labels:
  - `protocol.version`
  - `reason`: broad failure reason, such as auth, user mismatch, protocol version, configuration, or internal error

  Use:
  - Explain drops in connection success rate.
  - Identify auth/protocol/config-related connection failures.

  ### `zero.sync.websocket.errors`
  Counter for WebSocket error events after a connection exists.

  Labels:
  - `protocol.version`
  - `event.type`: `error_event` or `unclean_close`

  Use:
  - Track transport/liveness instability.
  - Correlate with reconnect churn.

  ## Internal Flow-Control Metrics

  ### `zero.replication.flow-control.active-subscribers`
  Gauge for active change-stream subscribers receiving live changes.

  Use:
  - Understand fanout pressure on replication.

  ### `zero.replication.flow-control.queued-subscribers`
  Gauge for subscribers waiting for the current transaction to finish before activation.

  Use:
  - Detect subscriber buildup during long transactions.

  ### `zero.replication.flow-control.pending-messages`
  Gauge for downstream change-stream messages not yet acknowledged.

  Use:
  - Detect slow subscribers or downstream backpressure.

  ### `zero.replication.flow-control.backlog-messages`
  Gauge for live change-stream messages buffered while subscribers catch up.

  Use:
  - Detect catchup backlog growth.

  ### `zero.replication.flow-control.backlog-bytes`
  Gauge for buffered live change-stream bytes across subscribers.

  Use:
  - Track memory pressure from catchup backlog.

  ### `zero.replication.flow-control.max-backlog-bytes`
  Gauge for the largest backlog held by a single subscriber.

  Use:
  - Identify whether backlog pressure is broad or caused by one outlier subscriber.

  ### `zero.replication.flow-control.waits`
  Counter for completed flow-control checkpoints.

  Labels:
  - `release.mode`: `all-subscribers` or `consensus-timeout`

  Use:
  - Track how often replication pauses for downstream flow control.
  - Detect when replication proceeds without all subscribers acknowledging.

  ### `zero.replication.flow-control.wait-time`
  Latency histogram for time spent waiting at flow-control checkpoints.

  Labels:
  - `release.mode`

  Use:
  - Track p95/p99 internal flow-control delay.
  - Correlate replication lag with downstream subscriber slowness.