### PR TITLE
feat(zero-cache): add worker startup duration metric

### DIFF
--- a/packages/zero-cache/src/observability/metrics.ts
+++ b/packages/zero-cache/src/observability/metrics.ts
@@ -27,6 +27,10 @@ export const NATIVE_HISTOGRAM_INSTRUMENT_NAMES = [
   'zero.sync.view_syncer_hydration',
 ] as const;
 
+export const LONG_DURATION_HISTOGRAM_BOUNDARIES_S = [
+  1, 2, 5, 10, 30, 60, 120, 300, 600, 1200, 2400, 3600, 7200,
+];
+
 function getMeter() {
   if (!meter) {
     meter = metrics.getMeter('zero');

--- a/packages/zero-cache/src/server/main.ts
+++ b/packages/zero-cache/src/server/main.ts
@@ -7,6 +7,7 @@ import {initEventSink} from '../observability/events.ts';
 import {
   exitAfter,
   ProcessManager,
+  recordStartupDurationMs,
   runUntilKilled,
   type WorkerType,
 } from '../services/life-cycle.ts';
@@ -197,7 +198,9 @@ export default async function runWorker(
   );
   await processes.allWorkersReady();
   clearInterval(logWaiting);
-  lc.info?.(`all workers ready (${Date.now() - startMs} ms)`);
+  const startupDurationMs = Date.now() - startMs;
+  lc.info?.(`all workers ready (${startupDurationMs} ms)`);
+  recordStartupDurationMs(startupDurationMs);
 
   parent.send(['ready', {ready: true}]);
 

--- a/packages/zero-cache/src/services/life-cycle.metrics.test.ts
+++ b/packages/zero-cache/src/services/life-cycle.metrics.test.ts
@@ -1,0 +1,76 @@
+import EventEmitter from 'node:events';
+import {metrics} from '@opentelemetry/api';
+import {
+  AggregationTemporality,
+  DataPointType,
+  InMemoryMetricExporter,
+  MeterProvider,
+  PeriodicExportingMetricReader,
+} from '@opentelemetry/sdk-metrics';
+import {expect, test, vi} from 'vitest';
+import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
+
+test('records startup_duration if OTel starts after ProcessManager construction', async () => {
+  metrics.disable();
+  vi.resetModules();
+
+  const {ProcessManager} = await import('./life-cycle.ts');
+  const {inProcChannel} = await import('../types/processes.ts');
+
+  const processes = new ProcessManager(
+    createSilentLogContext(),
+    new EventEmitter(),
+  );
+  const exporter = new InMemoryMetricExporter(
+    AggregationTemporality.CUMULATIVE,
+  );
+  const provider = new MeterProvider({
+    readers: [
+      new PeriodicExportingMetricReader({
+        exporter,
+        exportIntervalMillis: 60_000,
+      }),
+    ],
+  });
+
+  try {
+    expect(metrics.setGlobalMeterProvider(provider)).toBe(true);
+
+    const [parentPort, childPort] = inProcChannel();
+    processes.addWorker(parentPort, 'user-facing', 'zero-cache');
+
+    childPort.send(['ready', {ready: true}]);
+
+    await processes.allWorkersReady();
+    await provider.forceFlush();
+
+    const startupDuration = exporter
+      .getMetrics()
+      .flatMap(resource => resource.scopeMetrics)
+      .flatMap(scope => scope.metrics)
+      .find(
+        metric => metric.descriptor.name === 'zero.server.startup_duration',
+      );
+
+    expect(startupDuration).toBeDefined();
+    if (startupDuration === undefined) {
+      throw new Error('zero.server.startup_duration was not exported');
+    }
+
+    expect(startupDuration.dataPointType).toBe(DataPointType.HISTOGRAM);
+    if (startupDuration.dataPointType !== DataPointType.HISTOGRAM) {
+      throw new Error('zero.server.startup_duration was not a histogram');
+    }
+
+    expect(startupDuration.dataPoints).toHaveLength(1);
+    expect(startupDuration.dataPoints[0]).toEqual(
+      expect.objectContaining({
+        attributes: {component: 'dispatcher'},
+        value: expect.objectContaining({count: 1}),
+      }),
+    );
+  } finally {
+    await provider.shutdown();
+    metrics.disable();
+  }
+});

--- a/packages/zero-cache/src/services/life-cycle.metrics.test.ts
+++ b/packages/zero-cache/src/services/life-cycle.metrics.test.ts
@@ -1,4 +1,3 @@
-import EventEmitter from 'node:events';
 import {metrics} from '@opentelemetry/api';
 import {
   AggregationTemporality,
@@ -8,19 +7,12 @@ import {
   PeriodicExportingMetricReader,
 } from '@opentelemetry/sdk-metrics';
 import {expect, test, vi} from 'vitest';
-import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
 
-test('records startup_duration if OTel starts after ProcessManager construction', async () => {
+test('records startup_duration if OTel starts after module import', async () => {
   metrics.disable();
   vi.resetModules();
 
-  const {ProcessManager} = await import('./life-cycle.ts');
-  const {inProcChannel} = await import('../types/processes.ts');
-
-  const processes = new ProcessManager(
-    createSilentLogContext(),
-    new EventEmitter(),
-  );
+  const {recordStartupDurationMs} = await import('./life-cycle.ts');
   const exporter = new InMemoryMetricExporter(
     AggregationTemporality.CUMULATIVE,
   );
@@ -36,12 +28,7 @@ test('records startup_duration if OTel starts after ProcessManager construction'
   try {
     expect(metrics.setGlobalMeterProvider(provider)).toBe(true);
 
-    const [parentPort, childPort] = inProcChannel();
-    processes.addWorker(parentPort, 'user-facing', 'zero-cache');
-
-    childPort.send(['ready', {ready: true}]);
-
-    await processes.allWorkersReady();
+    recordStartupDurationMs(123);
     await provider.forceFlush();
 
     const startupDuration = exporter

--- a/packages/zero-cache/src/services/life-cycle.test.ts
+++ b/packages/zero-cache/src/services/life-cycle.test.ts
@@ -3,13 +3,13 @@ import {resolver} from '@rocicorp/resolver';
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
 import {promiseVoid} from '../../../shared/src/resolved-promises.ts';
+import type * as Metrics from '../observability/metrics.ts';
 
 const startupRecordMs = vi.hoisted(() => vi.fn());
 const workerStartupRecordMs = vi.hoisted(() => vi.fn());
 
 vi.mock('../observability/metrics.ts', async importOriginal => {
-  const actual =
-    await importOriginal<typeof import('../observability/metrics.ts')>();
+  const actual = await importOriginal<typeof Metrics>();
   return {
     ...actual,
     getOrCreateHistogram: vi.fn((_category, name) => ({

--- a/packages/zero-cache/src/services/life-cycle.test.ts
+++ b/packages/zero-cache/src/services/life-cycle.test.ts
@@ -4,6 +4,7 @@ import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
 import {promiseVoid} from '../../../shared/src/resolved-promises.ts';
 
+const startupRecordMs = vi.hoisted(() => vi.fn());
 const workerStartupRecordMs = vi.hoisted(() => vi.fn());
 
 vi.mock('../observability/metrics.ts', async importOriginal => {
@@ -11,7 +12,10 @@ vi.mock('../observability/metrics.ts', async importOriginal => {
     await importOriginal<typeof import('../observability/metrics.ts')>();
   return {
     ...actual,
-    getOrCreateHistogram: vi.fn(() => ({recordMs: workerStartupRecordMs})),
+    getOrCreateHistogram: vi.fn((_category, name) => ({
+      recordMs:
+        name === 'startup_duration' ? startupRecordMs : workerStartupRecordMs,
+    })),
   };
 });
 
@@ -82,6 +86,7 @@ describe('shutdown', () => {
   }
 
   beforeEach(async () => {
+    startupRecordMs.mockReset();
     workerStartupRecordMs.mockReset();
 
     // For testing process.exit()
@@ -285,6 +290,21 @@ describe('shutdown', () => {
       worker: 'backup_replicator',
       type: 'supporting',
     });
+  });
+
+  test('records top-level startup duration separately', () => {
+    const [parentPort, childPort] = inProcChannel();
+    processes.addWorker(parentPort, 'user-facing', 'zero-cache');
+
+    childPort.send(['ready', {ready: true}]);
+
+    expect(startupRecordMs).toHaveBeenCalledWith(expect.any(Number), {
+      component: 'dispatcher',
+    });
+    expect(workerStartupRecordMs).not.toHaveBeenCalledWith(
+      expect.any(Number),
+      expect.objectContaining({worker: 'zero_cache'}),
+    );
   });
 });
 

--- a/packages/zero-cache/src/services/life-cycle.test.ts
+++ b/packages/zero-cache/src/services/life-cycle.test.ts
@@ -3,6 +3,18 @@ import {resolver} from '@rocicorp/resolver';
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
 import {promiseVoid} from '../../../shared/src/resolved-promises.ts';
+
+const workerStartupRecordMs = vi.hoisted(() => vi.fn());
+
+vi.mock('../observability/metrics.ts', async importOriginal => {
+  const actual =
+    await importOriginal<typeof import('../observability/metrics.ts')>();
+  return {
+    ...actual,
+    getOrCreateHistogram: vi.fn(() => ({recordMs: workerStartupRecordMs})),
+  };
+});
+
 import {
   exitAfter,
   INTENTIONAL_SHUTDOWN_ERROR_CODE,
@@ -70,6 +82,8 @@ describe('shutdown', () => {
   }
 
   beforeEach(async () => {
+    workerStartupRecordMs.mockReset();
+
     // For testing process.exit()
     process.env['SINGLE_PROCESS'] = '1';
 
@@ -259,6 +273,18 @@ describe('shutdown', () => {
 
     // sort() because order doesn't matter.
     expect(events.sort()).toEqual(expectedEvents.sort());
+  });
+
+  test('records worker startup duration when a worker is ready', () => {
+    const [parentPort, childPort] = inProcChannel();
+    processes.addWorker(parentPort, 'supporting', 'replicator.ts (backup)');
+
+    childPort.send(['ready', {ready: true}]);
+
+    expect(workerStartupRecordMs).toHaveBeenCalledWith(expect.any(Number), {
+      worker: 'backup_replicator',
+      type: 'supporting',
+    });
   });
 });
 

--- a/packages/zero-cache/src/services/life-cycle.test.ts
+++ b/packages/zero-cache/src/services/life-cycle.test.ts
@@ -23,6 +23,7 @@ import {
   exitAfter,
   INTENTIONAL_SHUTDOWN_ERROR_CODE,
   ProcessManager,
+  recordStartupDurationMs,
   runUntilKilled,
   type WorkerType,
 } from '../services/life-cycle.ts';
@@ -292,19 +293,22 @@ describe('shutdown', () => {
     });
   });
 
-  test('records top-level startup duration separately', () => {
+  test('does not record zero-cache as a worker startup duration', () => {
     const [parentPort, childPort] = inProcChannel();
     processes.addWorker(parentPort, 'user-facing', 'zero-cache');
 
     childPort.send(['ready', {ready: true}]);
 
-    expect(startupRecordMs).toHaveBeenCalledWith(expect.any(Number), {
+    expect(startupRecordMs).not.toHaveBeenCalled();
+    expect(workerStartupRecordMs).not.toHaveBeenCalled();
+  });
+
+  test('records top-level startup duration explicitly', () => {
+    recordStartupDurationMs(123);
+
+    expect(startupRecordMs).toHaveBeenCalledWith(123, {
       component: 'dispatcher',
     });
-    expect(workerStartupRecordMs).not.toHaveBeenCalledWith(
-      expect.any(Number),
-      expect.objectContaining({worker: 'zero_cache'}),
-    );
   });
 });
 

--- a/packages/zero-cache/src/services/life-cycle.ts
+++ b/packages/zero-cache/src/services/life-cycle.ts
@@ -78,6 +78,10 @@ function startupDuration() {
   });
 }
 
+export function recordStartupDurationMs(durationMs: number) {
+  startupDuration().recordMs(durationMs, {component: 'dispatcher'});
+}
+
 function workerStartupDuration() {
   return getOrCreateHistogram('server', 'worker_startup_duration', {
     description: 'Duration from starting a worker to its ready signal.',
@@ -223,8 +227,6 @@ export class ProcessManager {
           worker: workerMetricName,
           type,
         });
-      } else {
-        startupDuration().recordMs(elapsed, {component: 'dispatcher'});
       }
       this.#lc.debug?.(`${name} ready (${Date.now() - this.#start} ms)`);
       this.#initializing.delete(id);

--- a/packages/zero-cache/src/services/life-cycle.ts
+++ b/packages/zero-cache/src/services/life-cycle.ts
@@ -3,6 +3,10 @@ import {pid} from 'node:process';
 import type {EventEmitter} from 'stream';
 import type {LogContext} from '@rocicorp/logger';
 import {resolver} from '@rocicorp/resolver';
+import {
+  getOrCreateHistogram,
+  LONG_DURATION_HISTOGRAM_BOUNDARIES_S,
+} from '../observability/metrics.ts';
 import {ConfigurationError} from '../types/configuration-error.ts';
 import {
   singleProcessMode,
@@ -32,6 +36,40 @@ export const FORCEFUL_SHUTDOWN = ['SIGQUIT', 'SIGABRT'] as const;
 
 type GracefulShutdownSignal = (typeof GRACEFUL_SHUTDOWN)[number];
 
+function workerStartupMetricName(name: string): string {
+  if (name === 'zero-cache') {
+    return 'zero_cache';
+  }
+  if (name.startsWith('change-streamer')) {
+    return 'change_streamer';
+  }
+  if (name.startsWith('replicator')) {
+    if (name.includes('(backup)')) {
+      return 'backup_replicator';
+    }
+    if (name.includes('(serving-copy)')) {
+      return 'serving_copy_replicator';
+    }
+    if (name.includes('(serving)')) {
+      return 'serving_replicator';
+    }
+    return 'other';
+  }
+  if (name.startsWith('syncer')) {
+    return 'syncer';
+  }
+  if (name.startsWith('reaper')) {
+    return 'reaper';
+  }
+  if (name.startsWith('shadow-syncer')) {
+    return 'shadow_syncer';
+  }
+  if (name.startsWith('mutator')) {
+    return 'mutator';
+  }
+  return 'other';
+}
+
 // An internal error code used to indicate that a message has already been
 // logged at level ERRROR. When a process exits with this error code, the
 // parent process logs the exit at level WARN instead of ERROR.
@@ -48,6 +86,15 @@ export const INTENTIONAL_SHUTDOWN_ERROR_CODE = 14;
  */
 export class ProcessManager {
   readonly #lc: LogContext;
+  readonly #workerStartupDuration = getOrCreateHistogram(
+    'server',
+    'worker_startup_duration',
+    {
+      description: 'Duration from starting a worker to its ready signal.',
+      unit: 's',
+      bucketBoundaries: LONG_DURATION_HISTOGRAM_BOUNDARIES_S,
+    },
+  );
   readonly #userFacing = new Set<Subprocess>();
   readonly #all = new Set<Subprocess>();
   readonly #exitImpl: (code: number) => never;
@@ -155,12 +202,16 @@ export class ProcessManager {
   addWorker(worker: Worker, type: WorkerType, name: string): Worker {
     this.addSubprocess(worker, type, name);
 
+    const start = performance.now();
     const id = ++this.#nextID;
     this.#initializing.set(id, name);
     const {promise, resolve} = resolver();
     this.#ready.push(promise);
 
     worker.onceMessageType('ready', () => {
+      this.#workerStartupDuration.recordMs(performance.now() - start, {
+        worker: workerStartupMetricName(name),
+      });
       this.#lc.debug?.(`${name} ready (${Date.now() - this.#start} ms)`);
       this.#initializing.delete(id);
       resolve();

--- a/packages/zero-cache/src/services/life-cycle.ts
+++ b/packages/zero-cache/src/services/life-cycle.ts
@@ -70,6 +70,22 @@ function workerStartupMetricName(name: string) {
   return 'other';
 }
 
+function startupDuration() {
+  return getOrCreateHistogram('server', 'startup_duration', {
+    description: 'Duration from starting zero-cache to its ready signal.',
+    unit: 's',
+    bucketBoundaries: LONG_DURATION_HISTOGRAM_BOUNDARIES_S,
+  });
+}
+
+function workerStartupDuration() {
+  return getOrCreateHistogram('server', 'worker_startup_duration', {
+    description: 'Duration from starting a worker to its ready signal.',
+    unit: 's',
+    bucketBoundaries: LONG_DURATION_HISTOGRAM_BOUNDARIES_S,
+  });
+}
+
 // An internal error code used to indicate that a message has already been
 // logged at level ERRROR. When a process exits with this error code, the
 // parent process logs the exit at level WARN instead of ERROR.
@@ -86,24 +102,6 @@ export const INTENTIONAL_SHUTDOWN_ERROR_CODE = 14;
  */
 export class ProcessManager {
   readonly #lc: LogContext;
-  readonly #startupDuration = getOrCreateHistogram(
-    'server',
-    'startup_duration',
-    {
-      description: 'Duration from starting zero-cache to its ready signal.',
-      unit: 's',
-      bucketBoundaries: LONG_DURATION_HISTOGRAM_BOUNDARIES_S,
-    },
-  );
-  readonly #workerStartupDuration = getOrCreateHistogram(
-    'server',
-    'worker_startup_duration',
-    {
-      description: 'Duration from starting a worker to its ready signal.',
-      unit: 's',
-      bucketBoundaries: LONG_DURATION_HISTOGRAM_BOUNDARIES_S,
-    },
-  );
   readonly #userFacing = new Set<Subprocess>();
   readonly #all = new Set<Subprocess>();
   readonly #exitImpl: (code: number) => never;
@@ -221,12 +219,12 @@ export class ProcessManager {
       const elapsed = performance.now() - start;
       const workerMetricName = workerStartupMetricName(name);
       if (workerMetricName) {
-        this.#workerStartupDuration.recordMs(elapsed, {
+        workerStartupDuration().recordMs(elapsed, {
           worker: workerMetricName,
           type,
         });
       } else {
-        this.#startupDuration.recordMs(elapsed, {component: 'dispatcher'});
+        startupDuration().recordMs(elapsed, {component: 'dispatcher'});
       }
       this.#lc.debug?.(`${name} ready (${Date.now() - this.#start} ms)`);
       this.#initializing.delete(id);

--- a/packages/zero-cache/src/services/life-cycle.ts
+++ b/packages/zero-cache/src/services/life-cycle.ts
@@ -36,9 +36,9 @@ export const FORCEFUL_SHUTDOWN = ['SIGQUIT', 'SIGABRT'] as const;
 
 type GracefulShutdownSignal = (typeof GRACEFUL_SHUTDOWN)[number];
 
-function workerStartupMetricName(name: string): string {
+function workerStartupMetricName(name: string) {
   if (name === 'zero-cache') {
-    return 'zero_cache';
+    return undefined;
   }
   if (name.startsWith('change-streamer')) {
     return 'change_streamer';
@@ -86,6 +86,15 @@ export const INTENTIONAL_SHUTDOWN_ERROR_CODE = 14;
  */
 export class ProcessManager {
   readonly #lc: LogContext;
+  readonly #startupDuration = getOrCreateHistogram(
+    'server',
+    'startup_duration',
+    {
+      description: 'Duration from starting zero-cache to its ready signal.',
+      unit: 's',
+      bucketBoundaries: LONG_DURATION_HISTOGRAM_BOUNDARIES_S,
+    },
+  );
   readonly #workerStartupDuration = getOrCreateHistogram(
     'server',
     'worker_startup_duration',
@@ -209,9 +218,16 @@ export class ProcessManager {
     this.#ready.push(promise);
 
     worker.onceMessageType('ready', () => {
-      this.#workerStartupDuration.recordMs(performance.now() - start, {
-        worker: workerStartupMetricName(name),
-      });
+      const elapsed = performance.now() - start;
+      const workerMetricName = workerStartupMetricName(name);
+      if (workerMetricName) {
+        this.#workerStartupDuration.recordMs(elapsed, {
+          worker: workerMetricName,
+          type,
+        });
+      } else {
+        this.#startupDuration.recordMs(elapsed, {component: 'dispatcher'});
+      }
       this.#lc.debug?.(`${name} ready (${Date.now() - this.#start} ms)`);
       this.#initializing.delete(id);
       resolve();

--- a/packages/zero-cache/src/services/litestream/metrics.ts
+++ b/packages/zero-cache/src/services/litestream/metrics.ts
@@ -2,6 +2,7 @@ import type {ZeroConfig} from '../../config/zero-config.ts';
 import {
   getOrCreateCounter,
   getOrCreateHistogram,
+  LONG_DURATION_HISTOGRAM_BOUNDARIES_S,
 } from '../../observability/metrics.ts';
 
 export type LitestreamRole = 'replication_manager' | 'view_syncer';
@@ -17,10 +18,6 @@ type LitestreamMultipartMetricAttrs = {
   multipart_concurrency: number;
   multipart_size_mib: number;
 };
-
-const LITESTREAM_DURATION_HISTOGRAM_BOUNDARIES_S = [
-  1, 2, 5, 10, 30, 60, 120, 300, 600, 1200, 2400, 3600, 7200,
-];
 
 export function litestreamRestoreMetricAttrs(
   config: ZeroConfig,
@@ -191,6 +188,6 @@ function litestreamDurationHistogram(name: string, description: string) {
   return getOrCreateHistogram('replica', name, {
     description,
     unit: 's',
-    bucketBoundaries: LITESTREAM_DURATION_HISTOGRAM_BOUNDARIES_S,
+    bucketBoundaries: LONG_DURATION_HISTOGRAM_BOUNDARIES_S,
   });
 }

--- a/packages/zero-cache/src/services/shadow-sync/shadow-sync-service.ts
+++ b/packages/zero-cache/src/services/shadow-sync/shadow-sync-service.ts
@@ -10,17 +10,21 @@ import {shadowInitialSync} from '../change-source/pg/initial-sync.ts';
 import {RunningState} from '../running-state.ts';
 import type {Service} from '../service.ts';
 
-const shadowSyncRuns = getOrCreateCounter(
-  'replication',
-  'shadow-sync-runs',
-  'Number of shadow initial-sync runs, labeled by result.',
-);
+function shadowSyncRuns() {
+  return getOrCreateCounter(
+    'replication',
+    'shadow-sync-runs',
+    'Number of shadow initial-sync runs, labeled by result.',
+  );
+}
 
-const shadowSyncDuration = getOrCreateLatencyHistogram(
-  'replication',
-  'shadow-sync-duration',
-  'Wall-clock duration of a shadow initial-sync run, labeled by result.',
-);
+function shadowSyncDuration() {
+  return getOrCreateLatencyHistogram(
+    'replication',
+    'shadow-sync-duration',
+    'Wall-clock duration of a shadow initial-sync run, labeled by result.',
+  );
+}
 
 export type ShadowSyncOptions = {
   intervalMs: number;
@@ -83,15 +87,15 @@ export class ShadowSyncService implements Service {
           textCopy !== undefined ? {textCopy} : undefined,
         );
         const elapsed = performance.now() - start;
-        shadowSyncRuns.add(1, {result: 'success'});
-        shadowSyncDuration.recordMs(elapsed, {result: 'success'});
+        shadowSyncRuns().add(1, {result: 'success'});
+        shadowSyncDuration().recordMs(elapsed, {result: 'success'});
         this.#lc.info?.(
           `shadow initial-sync completed (${elapsed.toFixed(0)} ms)`,
         );
       } catch (e) {
         const elapsed = performance.now() - start;
-        shadowSyncRuns.add(1, {result: 'error'});
-        shadowSyncDuration.recordMs(elapsed, {result: 'error'});
+        shadowSyncRuns().add(1, {result: 'error'});
+        shadowSyncDuration().recordMs(elapsed, {result: 'error'});
         this.#lc.error?.(
           `shadow initial-sync failed after ${elapsed.toFixed(0)} ms`,
           e,


### PR DESCRIPTION
## Summary

Add a broad worker startup duration metric for zero-cache worker readiness.

## Motivation

During replication-manager cold starts, we need to understand which worker startup phase is blocking readiness without tying the measurement to a specific implementation detail like SQLite `quick_check`.