### PR TITLE
feat(zero-cache): added replication slot metrics

### DIFF
--- a/packages/zero-cache/src/services/change-source/pg/change-source.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.ts
@@ -91,6 +91,7 @@ import type {
 } from './logical-replication/pgoutput.types.ts';
 import {subscribe, type StreamMessage} from './logical-replication/stream.ts';
 import {fromBigInt, toBigInt, toStateVersionString, type LSN} from './lsn.ts';
+import {registerReplicationSlotHealthMetrics} from './replication-slot-health.ts';
 import {dropOldReplicasAndSlots} from './replication-slots.ts';
 import {replicationEventSchema, type ReplicationEvent} from './schema/ddl.ts';
 import {updateShardSchema} from './schema/init.ts';
@@ -265,6 +266,7 @@ class PostgresChangeSource implements ChangeSource {
   readonly #context: ServerContext;
   readonly #lagReporter: LagReporter | null;
   readonly #textCopy: boolean;
+  #stopped = false;
 
   constructor(
     lc: LogContext,
@@ -295,9 +297,16 @@ class PostgresChangeSource implements ChangeSource {
             lagReportIntervalMs,
           )
         : null;
+    registerReplicationSlotHealthMetrics(
+      this.#lc,
+      this.#db,
+      replica.slot,
+      () => this.#stopped,
+    );
   }
 
   async stop(): Promise<void> {
+    this.#stopped = true;
     this.#lagReporter?.stop();
     clearTimeout(this.#cleanupTimer);
     await this.#db.end();

--- a/packages/zero-cache/src/services/change-source/pg/replication-slot-health.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/replication-slot-health.pg.test.ts
@@ -1,0 +1,47 @@
+import {expect} from 'vitest';
+import {createSilentLogContext} from '../../../../../shared/src/logging-test-utils.ts';
+import {getConnectionURI, type PgTest, test} from '../../../test/db.ts';
+import {pgClient} from '../../../types/pg.ts';
+import {
+  queryReplicationSlotHealth,
+  slotHealthStatus,
+} from './replication-slot-health.ts';
+import {createReplicationSlot} from './replication-slots.ts';
+
+test('queryReplicationSlotHealth reads pg_replication_slots', async ({
+  testDBs,
+}: PgTest) => {
+  const lc = createSilentLogContext();
+  const upstream = await testDBs.create('replication_slot_health');
+  const slotName = `slot_health_${Date.now()}`;
+  const session = pgClient(lc, getConnectionURI(upstream), 'slot-health', {
+    max: 1,
+    ['fetch_types']: false,
+    connection: {replication: 'database'},
+  });
+
+  try {
+    const slot = await createReplicationSlot(lc, session, {slotName});
+    const row = await queryReplicationSlotHealth(upstream, slot.slot_name);
+
+    expect(row).toBeDefined();
+    expect(slotHealthStatus(row)).not.toBe('missing');
+    expect(row?.retainedWalBytes).toEqual(expect.any(Number));
+    expect(row?.retainedWalBytes).toBeGreaterThanOrEqual(0);
+    if (row?.safeWalBytes !== null) {
+      expect(row?.safeWalBytes).toEqual(expect.any(Number));
+      expect(row?.safeWalBytes).toBeGreaterThanOrEqual(0);
+    }
+
+    await expect(
+      queryReplicationSlotHealth(upstream, `${slotName}_missing`),
+    ).resolves.toBeUndefined();
+  } finally {
+    await session.end().catch(() => {});
+    await upstream`
+      SELECT pg_drop_replication_slot(slot_name)
+      FROM pg_replication_slots
+      WHERE slot_name = ${slotName} AND NOT active`;
+    await testDBs.drop(upstream);
+  }
+});

--- a/packages/zero-cache/src/services/change-source/pg/replication-slot-health.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/replication-slot-health.test.ts
@@ -1,0 +1,174 @@
+import type {ObservableResult} from '@opentelemetry/api';
+import {expect, test, vi, beforeEach} from 'vitest';
+import {createSilentLogContext} from '../../../../../shared/src/logging-test-utils.ts';
+import type {PostgresDB} from '../../../types/pg.ts';
+import {
+  registerReplicationSlotHealthMetrics,
+  type SlotHealthRow,
+  slotHealthStatus,
+} from './replication-slot-health.ts';
+
+type GaugeCallback = (result: ObservableResult) => unknown;
+
+const gaugeCallbacks = vi.hoisted(() => new Map<string, GaugeCallback>());
+const getOrCreateGauge = vi.hoisted(() =>
+  vi.fn((_category: unknown, name: string) => ({
+    addCallback: (callback: GaugeCallback) => {
+      gaugeCallbacks.set(name, callback);
+    },
+  })),
+);
+
+vi.mock('../../../observability/metrics.ts', () => ({getOrCreateGauge}));
+
+beforeEach(() => {
+  gaugeCallbacks.clear();
+  getOrCreateGauge.mockClear();
+});
+
+test('slotHealthStatus classifies slot rows', () => {
+  expect(slotHealthStatus(undefined)).toBe('missing');
+  expect(slotHealthStatus({restartLSN: null, walStatus: 'reserved'})).toBe(
+    'lost',
+  );
+  expect(slotHealthStatus({restartLSN: '0/1', walStatus: 'lost'})).toBe('lost');
+  expect(slotHealthStatus({restartLSN: '0/1', walStatus: 'reserved'})).toBe(
+    'ok',
+  );
+  expect(slotHealthStatus({restartLSN: '0/1', walStatus: 'extended'})).toBe(
+    'ok',
+  );
+  expect(slotHealthStatus({restartLSN: '0/1', walStatus: 'unreserved'})).toBe(
+    'unreserved',
+  );
+  expect(slotHealthStatus({restartLSN: '0/1', walStatus: null})).toBe(
+    'unknown',
+  );
+  expect(slotHealthStatus({restartLSN: '0/1', walStatus: 'future'})).toBe(
+    'unknown',
+  );
+});
+
+test('slot health metrics observe current slot status and WAL bytes', async () => {
+  const {db} = registerForRows([
+    {
+      restartLSN: '0/1',
+      walStatus: 'reserved',
+      retainedWalBytes: 123,
+      safeWalBytes: 456,
+    },
+  ]);
+
+  const health = await observeGauge('slot_health');
+  expect(statusObservations(health.observe)).toEqual({
+    ok: 1,
+    unreserved: 0,
+    lost: 0,
+    missing: 0,
+    unknown: 0,
+  });
+
+  const retained = await observeGauge('slot_retained_wal_bytes');
+  expect(retained.observe).toHaveBeenCalledExactlyOnceWith(123, {
+    slot: 'slot_1',
+  });
+
+  const safe = await observeGauge('slot_safe_wal_bytes');
+  expect(safe.observe).toHaveBeenCalledExactlyOnceWith(456, {slot: 'slot_1'});
+  expect(db).toHaveBeenCalledTimes(3);
+});
+
+test('slot health metric observes missing when the slot row is absent', async () => {
+  registerForRows([]);
+
+  const health = await observeGauge('slot_health');
+  expect(statusObservations(health.observe)).toMatchObject({missing: 1});
+});
+
+test('slot health metric observes unknown on query error', async () => {
+  registerForError(new Error('boom'));
+
+  const health = await observeGauge('slot_health');
+  expect(statusObservations(health.observe)).toMatchObject({unknown: 1});
+});
+
+test('byte metrics skip null values', async () => {
+  registerForRows([
+    {
+      restartLSN: '0/1',
+      walStatus: 'reserved',
+      retainedWalBytes: 123,
+      safeWalBytes: null,
+    },
+  ]);
+
+  const safe = await observeGauge('slot_safe_wal_bytes');
+  expect(safe.observe).not.toHaveBeenCalled();
+});
+
+test('slot health metrics do not query after the change source stops', async () => {
+  const {db} = registerForRows(
+    [
+      {
+        restartLSN: '0/1',
+        walStatus: 'reserved',
+        retainedWalBytes: 123,
+        safeWalBytes: 456,
+      },
+    ],
+    true,
+  );
+
+  for (const name of [
+    'slot_health',
+    'slot_retained_wal_bytes',
+    'slot_safe_wal_bytes',
+  ]) {
+    const {observe} = await observeGauge(name);
+    expect(observe).not.toHaveBeenCalled();
+  }
+  expect(db).not.toHaveBeenCalled();
+});
+
+function registerForRows(rows: SlotHealthRow[], stopped = false) {
+  const db = vi.fn(() => rows);
+  registerReplicationSlotHealthMetrics(
+    createSilentLogContext(),
+    db as unknown as PostgresDB,
+    'slot_1',
+    () => stopped,
+  );
+  return {db};
+}
+
+function registerForError(error: unknown) {
+  const db = vi.fn(() => {
+    throw error;
+  });
+  registerReplicationSlotHealthMetrics(
+    createSilentLogContext(),
+    db as unknown as PostgresDB,
+    'slot_1',
+    () => false,
+  );
+  return {db};
+}
+
+async function observeGauge(name: string) {
+  const callback = gaugeCallbacks.get(name);
+  if (!callback) {
+    throw new Error(`missing callback for ${name}`);
+  }
+  const observe = vi.fn();
+  await callback({observe} as unknown as ObservableResult);
+  return {observe};
+}
+
+function statusObservations(observe: ReturnType<typeof vi.fn>) {
+  return Object.fromEntries(
+    observe.mock.calls.map(([value, attributes]) => [
+      (attributes as {status: string}).status,
+      value,
+    ]),
+  );
+}

--- a/packages/zero-cache/src/services/change-source/pg/replication-slot-health.ts
+++ b/packages/zero-cache/src/services/change-source/pg/replication-slot-health.ts
@@ -1,0 +1,124 @@
+import type {ObservableResult} from '@opentelemetry/api';
+import type {LogContext} from '@rocicorp/logger';
+import {getOrCreateGauge} from '../../../observability/metrics.ts';
+import type {PostgresDB} from '../../../types/pg.ts';
+
+const SLOT_HEALTH_STATUSES = [
+  'ok',
+  'unreserved',
+  'lost',
+  'missing',
+  'unknown',
+] as const;
+
+export type SlotHealthStatus = (typeof SLOT_HEALTH_STATUSES)[number];
+
+export type SlotHealthRow = {
+  readonly restartLSN: string | null;
+  readonly walStatus: string | null;
+  readonly retainedWalBytes: number | null;
+  readonly safeWalBytes: number | null;
+};
+
+export function slotHealthStatus(
+  row: Pick<SlotHealthRow, 'restartLSN' | 'walStatus'> | undefined,
+): SlotHealthStatus {
+  if (row === undefined) {
+    return 'missing';
+  }
+  if (row.restartLSN === null || row.walStatus === 'lost') {
+    return 'lost';
+  }
+  switch (row.walStatus) {
+    case 'reserved':
+    case 'extended':
+      return 'ok';
+    case 'unreserved':
+      return 'unreserved';
+    default:
+      return 'unknown';
+  }
+}
+
+export function registerReplicationSlotHealthMetrics(
+  lc: LogContext,
+  db: PostgresDB,
+  slot: string,
+  isStopped: () => boolean,
+): void {
+  getOrCreateGauge('replication', 'slot_health', {
+    description: 'Health of the active logical replication slot.',
+    unit: '1',
+  }).addCallback(async result => {
+    if (isStopped()) {
+      return;
+    }
+
+    let status: SlotHealthStatus;
+    try {
+      status = slotHealthStatus(await queryReplicationSlotHealth(db, slot));
+    } catch (e) {
+      lc.warn?.(`error querying replication slot health`, e);
+      status = 'unknown';
+    }
+
+    for (const s of SLOT_HEALTH_STATUSES) {
+      result.observe(s === status ? 1 : 0, {slot, status: s});
+    }
+  });
+
+  getOrCreateGauge('replication', 'slot_retained_wal_bytes', {
+    description: 'WAL bytes retained by the active logical replication slot.',
+    unit: 'By',
+  }).addCallback(result =>
+    observeSlotBytes(lc, db, slot, isStopped, result, 'retainedWalBytes'),
+  );
+
+  getOrCreateGauge('replication', 'slot_safe_wal_bytes', {
+    description:
+      'WAL bytes the active logical replication slot can retain before loss.',
+    unit: 'By',
+  }).addCallback(result =>
+    observeSlotBytes(lc, db, slot, isStopped, result, 'safeWalBytes'),
+  );
+}
+
+async function observeSlotBytes(
+  lc: LogContext,
+  db: PostgresDB,
+  slot: string,
+  isStopped: () => boolean,
+  result: ObservableResult,
+  field: 'retainedWalBytes' | 'safeWalBytes',
+): Promise<void> {
+  if (isStopped()) {
+    return;
+  }
+  try {
+    const row = await queryReplicationSlotHealth(db, slot);
+    const value = row?.[field];
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      result.observe(value, {slot});
+    }
+  } catch (e) {
+    lc.warn?.(`error querying replication slot ${field}`, e);
+  }
+}
+
+export async function queryReplicationSlotHealth(
+  db: PostgresDB,
+  slot: string,
+): Promise<SlotHealthRow | undefined> {
+  const rows = await db<SlotHealthRow[]>`
+    SELECT
+      restart_lsn AS "restartLSN",
+      wal_status AS "walStatus",
+      CASE
+        WHEN restart_lsn IS NULL THEN NULL
+        ELSE pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn)::float8
+      END AS "retainedWalBytes",
+      safe_wal_size::float8 AS "safeWalBytes"
+    FROM pg_replication_slots
+    WHERE slot_name = ${slot}`;
+  return rows[0];
+}


### PR DESCRIPTION
## Summary

Adds minimal Postgres replication slot health metrics for the active Zero replication slot:

- `zero.replication.slot_health`
- `zero.replication.slot_retained_wal_bytes`
- `zero.replication.slot_safe_wal_bytes`

These help diagnose slot invalidation incidents by showing whether the active slot is healthy/missing/lost and how much WAL it is retaining.