### PR TITLE
chore: remove quick-check

### DIFF
--- a/packages/zero-cache/src/db/migration-lite.test.ts
+++ b/packages/zero-cache/src/db/migration-lite.test.ts
@@ -1,4 +1,3 @@
-import {closeSync, openSync, writeSync} from 'node:fs';
 import type {LogContext} from '@rocicorp/logger';
 import {afterEach, beforeEach, describe, expect, test} from 'vitest';
 import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
@@ -368,58 +367,5 @@ describe('db/migration-lite', () => {
 
     expect(err).toBeDefined();
     c.verify(err);
-  });
-
-  test('runs quick_check for existing databases', async () => {
-    const lc = createSilentLogContext();
-    const db = dbFile.connect(lc);
-    getVersionHistory(db);
-    db.prepare(
-      `
-      INSERT INTO "_zero.versionHistory" (dataVersion, schemaVersion, minSafeVersion)
-      VALUES (1, 1, 1)
-    `,
-    ).run();
-
-    db.exec(`CREATE TABLE "Payload" (id INTEGER PRIMARY KEY, value BLOB)`);
-    const insert = db.prepare(
-      `INSERT INTO "Payload" (value) VALUES (randomblob(2000))`,
-    );
-    db.transaction(() => {
-      for (let i = 0; i < 200; i++) {
-        insert.run();
-      }
-    });
-
-    const [{page_size: pageSize}] = db.pragma<{page_size: number}>('page_size');
-    const {pageno} = db
-      .prepare(
-        `
-      SELECT pageno FROM dbstat
-      WHERE name = 'Payload' AND pagetype = 'leaf'
-      ORDER BY pageno LIMIT 1 OFFSET 5
-    `,
-      )
-      .get<{pageno: number}>();
-    db.close();
-
-    const fd = openSync(dbFile.path, 'r+');
-    try {
-      writeSync(fd, Buffer.alloc(100, 0xff), 0, 100, (pageno - 1) * pageSize);
-    } finally {
-      closeSync(fd);
-    }
-
-    await expect(
-      runSchemaMigrations(
-        lc,
-        debugName,
-        dbFile.path,
-        {
-          migrateSchema: () => Promise.reject('not expected to run'),
-        },
-        {1: {}},
-      ),
-    ).rejects.toThrow(/database disk image is malformed|quick_check failed/);
   });
 });

--- a/packages/zero-cache/src/db/migration-lite.ts
+++ b/packages/zero-cache/src/db/migration-lite.ts
@@ -102,8 +102,6 @@ export async function runSchemaMigrations(
       }
       return versions;
     });
-    const initialDataVersion = versions.dataVersion;
-
     if (versions.dataVersion < codeVersion) {
       db.unsafeMode(true); // Enables journal_mode = OFF
       db.pragma('locking_mode = EXCLUSIVE');
@@ -146,10 +144,6 @@ export async function runSchemaMigrations(
 
       db.exec('ANALYZE main');
       log.info?.('ANALYZE completed');
-
-      if (initialDataVersion > 0) {
-        assertDatabaseIntegrity(log, debugName, db);
-      }
     } else {
       // Run optimize whenever opening an sqlite db file as recommended in
       // https://www.sqlite.org/pragma.html#pragma_optimize
@@ -159,7 +153,8 @@ export async function runSchemaMigrations(
       // similarly detected in the change-streamer, facilitating an eventual
       // recovery by resyncing the replica anew.
       db.pragma('optimize = 0x10002');
-      assertDatabaseIntegrity(log, debugName, db);
+      // Do not run `quick_check` here. It scans the full database and can
+      // dominate startup time for large replicas or slower disks.
     }
 
     db.pragma('synchronous = NORMAL');
@@ -182,37 +177,6 @@ export async function runSchemaMigrations(
     db.close();
     void log.flush(); // Flush the logs but do not block server progress on it.
   }
-}
-
-export class DatabaseIntegrityError extends Error {
-  readonly name = 'DatabaseIntegrityError';
-  readonly issues: readonly string[];
-
-  constructor(debugName: string, issues: readonly string[]) {
-    super(`SQLite quick_check failed for ${debugName}: ${issues.join('; ')}`);
-    this.issues = issues;
-  }
-}
-
-export function assertDatabaseIntegrity(
-  log: LogContext,
-  debugName: string,
-  db: Db,
-) {
-  const start = Date.now();
-  const rows = db.pragma<{quick_check: string}>('quick_check');
-  const issues =
-    rows.length === 0
-      ? ['PRAGMA quick_check returned no rows']
-      : rows.map(row => row.quick_check).filter(issue => issue !== 'ok');
-
-  if (issues.length > 0) {
-    throw new DatabaseIntegrityError(debugName, issues);
-  }
-
-  log.info?.(
-    `quick_check completed for ${debugName} (${Date.now() - start} ms)`,
-  );
 }
 
 function sorted(

--- a/packages/zero-cache/src/services/change-source/common/replica-schema.test.ts
+++ b/packages/zero-cache/src/services/change-source/common/replica-schema.test.ts
@@ -1,4 +1,3 @@
-import {closeSync, openSync, writeSync} from 'node:fs';
 import {beforeEach, describe, expect, test} from 'vitest';
 import {createSilentLogContext} from '../../../../../shared/src/logging-test-utils.ts';
 import {promiseVoid} from '../../../../../shared/src/resolved-promises.ts';
@@ -7,7 +6,6 @@ import {
   expectMatchingObjectsInTables,
   initDB as initLiteDB,
 } from '../../../test/lite.ts';
-import {AutoResetSignal} from '../../change-streamer/schema/tables.ts';
 import {initReplicationState} from '../../replicator/schema/replication-state.ts';
 import {CREATE_TABLE_METADATA_TABLE} from '../../replicator/schema/table-metadata.ts';
 import {
@@ -16,7 +14,6 @@ import {
   CREATE_V9_TABLE_METADATA_TABLE,
   CURRENT_SCHEMA_VERSION,
   initReplica,
-  upgradeReplica,
 } from './replica-schema.ts';
 
 export const CURRENT_SCHEMA_VERSIONS = {
@@ -489,52 +486,4 @@ describe('replica-schema-migrations', () => {
       });
     });
   }
-
-  test('upgradeReplica resets when quick_check detects corruption', async () => {
-    const replica = replicaFile.connect(lc);
-    replica.exec(CREATE_VERSION_HISTORY);
-    replica
-      .prepare(
-        `
-        INSERT INTO "_zero.versionHistory" (dataVersion, schemaVersion, minSafeVersion)
-        VALUES (?, ?, 1)
-      `,
-      )
-      .run(CURRENT_SCHEMA_VERSION, CURRENT_SCHEMA_VERSION);
-
-    replica.exec(`CREATE TABLE "Payload" (id INTEGER PRIMARY KEY, value BLOB)`);
-    const insert = replica.prepare(
-      `INSERT INTO "Payload" (value) VALUES (randomblob(2000))`,
-    );
-    replica.transaction(() => {
-      for (let i = 0; i < 200; i++) {
-        insert.run();
-      }
-    });
-
-    const [{page_size: pageSize}] = replica.pragma<{page_size: number}>(
-      'page_size',
-    );
-    const {pageno} = replica
-      .prepare(
-        `
-        SELECT pageno FROM dbstat
-        WHERE name = 'Payload' AND pagetype = 'leaf'
-        ORDER BY pageno LIMIT 1 OFFSET 5
-      `,
-      )
-      .get<{pageno: number}>();
-    replica.close();
-
-    const fd = openSync(replicaFile.path, 'r+');
-    try {
-      writeSync(fd, Buffer.alloc(100, 0xff), 0, 100, (pageno - 1) * pageSize);
-    } finally {
-      closeSync(fd);
-    }
-
-    await expect(upgradeReplica(lc, 'test', replicaFile.path)).rejects.toThrow(
-      AutoResetSignal,
-    );
-  });
 });

--- a/packages/zero-cache/src/services/change-source/common/replica-schema.ts
+++ b/packages/zero-cache/src/services/change-source/common/replica-schema.ts
@@ -3,7 +3,6 @@ import {SqliteError} from '@rocicorp/zero-sqlite3';
 import type {Database} from '../../../../../zqlite/src/db.ts';
 import {listTables} from '../../../db/lite-tables.ts';
 import {
-  DatabaseIntegrityError,
   runSchemaMigrations,
   type IncrementalMigrationMap,
   type Migration,
@@ -65,12 +64,9 @@ export async function upgradeReplica(
 }
 
 function throwAutoResetForCorruption(e: unknown): never {
-  if (
-    e instanceof DatabaseIntegrityError ||
-    (e instanceof SqliteError && e.code === 'SQLITE_CORRUPT')
-  ) {
+  if (e instanceof SqliteError && e.code === 'SQLITE_CORRUPT') {
     throw new AutoResetSignal(
-      `replica database failed integrity check: ${String(e)}`,
+      `replica database appears corrupt: ${String(e)}`,
       {cause: e},
     );
   }

--- a/packages/zero-cache/src/services/litestream/commands.ts
+++ b/packages/zero-cache/src/services/litestream/commands.ts
@@ -9,7 +9,6 @@ import {Database} from '../../../../zqlite/src/db.ts';
 import {assertNormalized} from '../../config/normalize.ts';
 import type {ZeroConfig} from '../../config/zero-config.ts';
 import {deleteLiteDB} from '../../db/delete-lite-db.ts';
-import {assertDatabaseIntegrity} from '../../db/migration-lite.ts';
 import {StatementRunner} from '../../db/statements.ts';
 import {getShardConfig} from '../../types/shards.ts';
 import type {Source} from '../../types/streams.ts';
@@ -325,7 +324,6 @@ function replicaIsValid(
   let db: Database | undefined;
   try {
     db = new Database(lc, replica);
-    assertDatabaseIntegrity(lc, 'restored replica', db);
     const {replicaVersion, watermark} = getSubscriptionState(
       new StatementRunner(db),
     );


### PR DESCRIPTION
was seen to be too slow in production although locally it added about 1 second per gig.

removes the quickcheck additions from https://github.com/rocicorp/mono/pull/6174/changes