### PR TITLE
chore: fix various lag metrics to be aggregable across time and space (pods)

### DIFF
--- a/packages/zero-cache/src/observability/metrics.ts
+++ b/packages/zero-cache/src/observability/metrics.ts
@@ -24,6 +24,7 @@ type HistogramOptions = Options & {bucketBoundaries: number[]};
 
 export const NATIVE_HISTOGRAM_INSTRUMENT_NAMES = [
   'zero.sync.view_syncer_lag',
+  'zero.sync.view_syncer_hydration',
 ] as const;
 
 function getMeter() {

--- a/packages/zero-cache/src/observability/metrics.ts
+++ b/packages/zero-cache/src/observability/metrics.ts
@@ -22,6 +22,10 @@ let meter: Meter | undefined;
 type Options = MetricOptions & {description: string};
 type HistogramOptions = Options & {bucketBoundaries: number[]};
 
+export const NATIVE_HISTOGRAM_INSTRUMENT_NAMES = [
+  'zero.sync.view_syncer_lag',
+] as const;
+
 function getMeter() {
   if (!meter) {
     meter = metrics.getMeter('zero');
@@ -124,6 +128,23 @@ export function getOrCreateHistogram(
         explicitBucketBoundaries: bucketBoundaries,
       },
     }),
+  );
+  return {
+    recordMs: (durationMs, attributes) =>
+      h.record(durationMs / 1000, attributes),
+  };
+}
+
+// Add instruments created through this helper to
+// NATIVE_HISTOGRAM_INSTRUMENT_NAMES so the SDK exports them as exponential
+// histograms.
+export function getOrCreateNativeHistogram(
+  category: Category,
+  name: string,
+  opts: Options,
+): LatencyHistogram {
+  const h = histograms(name, name =>
+    getMeter().createHistogram(`zero.${category}.${name}`, opts),
   );
   return {
     recordMs: (durationMs, attributes) =>

--- a/packages/zero-cache/src/server/otel-diag-integration.test.ts
+++ b/packages/zero-cache/src/server/otel-diag-integration.test.ts
@@ -60,6 +60,12 @@ vi.mock('@opentelemetry/exporter-metrics-otlp-http', () => ({
 }));
 
 vi.mock('@opentelemetry/sdk-metrics', () => ({
+  AggregationType: {
+    EXPONENTIAL_HISTOGRAM: 5,
+  },
+  InstrumentType: {
+    HISTOGRAM: 4,
+  },
   MeterProvider: vi.fn(function () {
     return {
       getMeter: vi.fn().mockReturnValue({

--- a/packages/zero-cache/src/server/otel-start.ts
+++ b/packages/zero-cache/src/server/otel-start.ts
@@ -1,6 +1,7 @@
 import {logs} from '@opentelemetry/api-logs';
 import {getNodeAutoInstrumentations} from '@opentelemetry/auto-instrumentations-node';
 import {resourceFromAttributes} from '@opentelemetry/resources';
+import {AggregationType, InstrumentType} from '@opentelemetry/sdk-metrics';
 import {NodeSDK} from '@opentelemetry/sdk-node';
 import {ATTR_SERVICE_VERSION} from '@opentelemetry/semantic-conventions';
 import type {LogContext} from '@rocicorp/logger';
@@ -10,6 +11,7 @@ import {
   otelMetricsEnabled,
   otelTracesEnabled,
 } from '../../../otel/src/enabled.ts';
+import {NATIVE_HISTOGRAM_INSTRUMENT_NAMES} from '../observability/metrics.ts';
 import {setupOtelDiagnosticLogger} from './otel-diag-logger.ts';
 
 class OtelManager {
@@ -70,6 +72,11 @@ class OtelManager {
     const sdk = new NodeSDK({
       resource,
       autoDetectResources: true,
+      views: NATIVE_HISTOGRAM_INSTRUMENT_NAMES.map(instrumentName => ({
+        instrumentName,
+        instrumentType: InstrumentType.HISTOGRAM,
+        aggregation: {type: AggregationType.EXPONENTIAL_HISTOGRAM},
+      })),
       instrumentations:
         process.env.OTEL_NODE_ENABLED_INSTRUMENTATIONS ||
         process.env.OTEL_NODE_DISABLED_INSTRUMENTATIONS

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -48,6 +48,7 @@ import type {
 import {
   getOrCreateCounter,
   getOrCreateLatencyHistogram,
+  getOrCreateNativeHistogram,
   getOrCreateUpDownCounter,
 } from '../../observability/metrics.ts';
 import type {InspectorDelegate} from '../../server/inspector-delegate.ts';
@@ -296,6 +297,17 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     'sync',
     'hydration-time',
     'Time to hydrate a query.',
+  );
+  readonly #viewSyncerHydration = getOrCreateNativeHistogram(
+    'sync',
+    'view_syncer_hydration',
+    {
+      description:
+        'Time from ViewSyncer query sync requiring hydration to output for a ' +
+        'client group. Includes query transformation, query materialization, ' +
+        'CVR flush, catchup, and pokeEnd.',
+      unit: 's',
+    },
   );
   readonly #transactionAdvanceTime = getOrCreateLatencyHistogram(
     'sync',
@@ -1817,6 +1829,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     driftedQueryIDs: Set<string> = new Set(),
   ) {
     return startAsyncSpan(tracer, 'vs.#syncQueryPipelineSet', async span => {
+      const start = performance.now();
       span.setAttribute('clientGroupID', this.id);
       assert(
         this.#pipelines.initialized(),
@@ -2044,6 +2057,9 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
           Array.from(removeQueriesQueryIds, id => ({id})),
           driftedQueryIDs,
         );
+        if (addQueries.length > 0) {
+          this.#viewSyncerHydration.recordMs(performance.now() - start);
+        }
       } else {
         await this.#catchupClients(lc, cvr);
       }

--- a/packages/zero-cache/src/workers/syncer.ts
+++ b/packages/zero-cache/src/workers/syncer.ts
@@ -206,6 +206,9 @@ function computeServingLagDistributionMs(
   return {
     activeClientGroups: lags.length,
     laggingClientGroups,
+    // The percentile fields are for the legacy serving_lag_stats gauge.
+    // The native view_syncer_lag histogram records lagsMs and computes
+    // percentiles in Prometheus/AMP.
     minMs: lags[0] ?? 0,
     p50Ms: percentileNearestRank(lags, 50),
     p75Ms: percentileNearestRank(lags, 75),

--- a/packages/zero-cache/src/workers/syncer.ts
+++ b/packages/zero-cache/src/workers/syncer.ts
@@ -68,7 +68,7 @@ export type ServingLagStats = {
   readonly maxMs: number;
 };
 
-type ServingLagSnapshot = ServingLagStats & {
+type ServingLagDistribution = ServingLagStats & {
   readonly lagsMs: readonly number[];
 };
 
@@ -170,11 +170,11 @@ function percentileNearestRank(
   return sortedValues[index];
 }
 
-function computeServingLagSnapshotMs(
+function computeServingLagDistributionMs(
   now: number,
   replicaReadyStates: ReplicaReadyState[],
   viewSyncers: Iterable<ServingLagViewSyncer>,
-): ServingLagSnapshot {
+): ServingLagDistribution {
   const lags: number[] = [];
   let laggingClientGroups = 0;
   let firstNeededIndex = replicaReadyStates.length;
@@ -220,19 +220,19 @@ export function computeServingLagStatsMs(
   replicaReadyStates: ReplicaReadyState[],
   viewSyncers: Iterable<ServingLagViewSyncer>,
 ): ServingLagStats {
-  const snapshot = computeServingLagSnapshotMs(
+  const distribution = computeServingLagDistributionMs(
     now,
     replicaReadyStates,
     viewSyncers,
   );
   return {
-    activeClientGroups: snapshot.activeClientGroups,
-    laggingClientGroups: snapshot.laggingClientGroups,
-    minMs: snapshot.minMs,
-    p50Ms: snapshot.p50Ms,
-    p75Ms: snapshot.p75Ms,
-    p99Ms: snapshot.p99Ms,
-    maxMs: snapshot.maxMs,
+    activeClientGroups: distribution.activeClientGroups,
+    laggingClientGroups: distribution.laggingClientGroups,
+    minMs: distribution.minMs,
+    p50Ms: distribution.p50Ms,
+    p75Ms: distribution.p75Ms,
+    p99Ms: distribution.p99Ms,
+    maxMs: distribution.maxMs,
   };
 }
 
@@ -322,8 +322,8 @@ export class Syncer implements SingletonService {
       unit: 's',
     },
   );
-  #servingLagStatsCache: ServingLagSnapshot | undefined;
-  #servingLagStatsCacheClearQueued = false;
+  #servingLagDistributionCache: ServingLagDistribution | undefined;
+  #servingLagDistributionCacheClearQueued = false;
   #viewSyncerLagSampleInterval: ReturnType<typeof setInterval> | undefined;
 
   constructor(
@@ -422,7 +422,7 @@ export class Syncer implements SingletonService {
         'and pokeEnd.',
       unit: 'millisecond',
     }).addCallback(result => {
-      result.observe(this.#computeServingLagStats().maxMs);
+      result.observe(this.#computeServingLagDistribution().maxMs);
     });
 
     getOrCreateGauge('sync', 'serving_lag_stats', {
@@ -432,7 +432,7 @@ export class Syncer implements SingletonService {
         'CVR flush, and pokeEnd.',
       unit: 'millisecond',
     }).addCallback(result => {
-      const stats = this.#computeServingLagStats();
+      const stats = this.#computeServingLagDistribution();
       result.observe(stats.minMs, {stat: 'min'});
       result.observe(stats.p50Ms, {stat: 'p50'});
       result.observe(stats.p75Ms, {stat: 'p75'});
@@ -445,7 +445,7 @@ export class Syncer implements SingletonService {
       'serving_lagging_client_groups',
       'Number of active client groups with unserved replica changes',
     ).addCallback(result => {
-      result.observe(this.#computeServingLagStats().laggingClientGroups);
+      result.observe(this.#computeServingLagDistribution().laggingClientGroups);
     });
 
     this.#viewSyncerLagSampleInterval = setInterval(
@@ -455,29 +455,29 @@ export class Syncer implements SingletonService {
     this.#viewSyncerLagSampleInterval.unref?.();
   }
 
-  #computeServingLagStats(): ServingLagSnapshot {
-    if (this.#servingLagStatsCache) {
-      return this.#servingLagStatsCache;
+  #computeServingLagDistribution(): ServingLagDistribution {
+    if (this.#servingLagDistributionCache) {
+      return this.#servingLagDistributionCache;
     }
 
-    const stats = computeServingLagSnapshotMs(
+    const distribution = computeServingLagDistributionMs(
       Date.now(),
       this.#replicaReadyStates,
       this.#viewSyncers.getServices(),
     );
-    this.#servingLagStatsCache = stats;
-    if (!this.#servingLagStatsCacheClearQueued) {
-      this.#servingLagStatsCacheClearQueued = true;
+    this.#servingLagDistributionCache = distribution;
+    if (!this.#servingLagDistributionCacheClearQueued) {
+      this.#servingLagDistributionCacheClearQueued = true;
       queueMicrotask(() => {
-        this.#servingLagStatsCache = undefined;
-        this.#servingLagStatsCacheClearQueued = false;
+        this.#servingLagDistributionCache = undefined;
+        this.#servingLagDistributionCacheClearQueued = false;
       });
     }
-    return stats;
+    return distribution;
   }
 
   #recordViewSyncerLagSamples(): void {
-    const {lagsMs} = this.#computeServingLagStats();
+    const {lagsMs} = this.#computeServingLagDistribution();
     for (const lagMs of lagsMs) {
       this.#viewSyncerLag.recordMs(lagMs);
     }

--- a/packages/zero-cache/src/workers/syncer.ts
+++ b/packages/zero-cache/src/workers/syncer.ts
@@ -16,6 +16,7 @@ import {type ZeroConfig} from '../config/zero-config.ts';
 import {
   getOrCreateCounter,
   getOrCreateGauge,
+  getOrCreateNativeHistogram,
   getOrCreateUpDownCounter,
 } from '../observability/metrics.ts';
 import {
@@ -67,7 +68,12 @@ export type ServingLagStats = {
   readonly maxMs: number;
 };
 
+type ServingLagSnapshot = ServingLagStats & {
+  readonly lagsMs: readonly number[];
+};
+
 export const MAX_REPLICA_READY_STATES = 10_000;
+const VIEW_SYNCER_LAG_SAMPLE_INTERVAL_MS = 60_000;
 
 const PROTOCOL_VERSION_ATTRIBUTE = 'protocol.version';
 const FAILURE_REASON_ATTRIBUTE = 'reason';
@@ -164,11 +170,11 @@ function percentileNearestRank(
   return sortedValues[index];
 }
 
-export function computeServingLagStatsMs(
+function computeServingLagSnapshotMs(
   now: number,
   replicaReadyStates: ReplicaReadyState[],
   viewSyncers: Iterable<ServingLagViewSyncer>,
-): ServingLagStats {
+): ServingLagSnapshot {
   const lags: number[] = [];
   let laggingClientGroups = 0;
   let firstNeededIndex = replicaReadyStates.length;
@@ -205,6 +211,28 @@ export function computeServingLagStatsMs(
     p75Ms: percentileNearestRank(lags, 75),
     p99Ms: percentileNearestRank(lags, 99),
     maxMs: lags.at(-1) ?? 0,
+    lagsMs: lags,
+  };
+}
+
+export function computeServingLagStatsMs(
+  now: number,
+  replicaReadyStates: ReplicaReadyState[],
+  viewSyncers: Iterable<ServingLagViewSyncer>,
+): ServingLagStats {
+  const snapshot = computeServingLagSnapshotMs(
+    now,
+    replicaReadyStates,
+    viewSyncers,
+  );
+  return {
+    activeClientGroups: snapshot.activeClientGroups,
+    laggingClientGroups: snapshot.laggingClientGroups,
+    minMs: snapshot.minMs,
+    p50Ms: snapshot.p50Ms,
+    p75Ms: snapshot.p75Ms,
+    p99Ms: snapshot.p99Ms,
+    maxMs: snapshot.maxMs,
   };
 }
 
@@ -283,8 +311,20 @@ export class Syncer implements SingletonService {
     'websocket.connection_failures',
     'Client WebSocket connection attempts that failed before initialization.',
   );
-  #servingLagStatsCache: ServingLagStats | undefined;
+  readonly #viewSyncerLag = getOrCreateNativeHistogram(
+    'sync',
+    'view_syncer_lag',
+    {
+      description:
+        'Lag from replica-ready change to ViewSyncer output for active ' +
+        'client groups. A change is output after IVM advancement, CVR flush, ' +
+        'and pokeEnd.',
+      unit: 's',
+    },
+  );
+  #servingLagStatsCache: ServingLagSnapshot | undefined;
   #servingLagStatsCacheClearQueued = false;
+  #viewSyncerLagSampleInterval: ReturnType<typeof setInterval> | undefined;
 
   constructor(
     lc: LogContext,
@@ -407,14 +447,20 @@ export class Syncer implements SingletonService {
     ).addCallback(result => {
       result.observe(this.#computeServingLagStats().laggingClientGroups);
     });
+
+    this.#viewSyncerLagSampleInterval = setInterval(
+      () => this.#recordViewSyncerLagSamples(),
+      VIEW_SYNCER_LAG_SAMPLE_INTERVAL_MS,
+    );
+    this.#viewSyncerLagSampleInterval.unref?.();
   }
 
-  #computeServingLagStats(): ServingLagStats {
+  #computeServingLagStats(): ServingLagSnapshot {
     if (this.#servingLagStatsCache) {
       return this.#servingLagStatsCache;
     }
 
-    const stats = computeServingLagStatsMs(
+    const stats = computeServingLagSnapshotMs(
       Date.now(),
       this.#replicaReadyStates,
       this.#viewSyncers.getServices(),
@@ -428,6 +474,13 @@ export class Syncer implements SingletonService {
       });
     }
     return stats;
+  }
+
+  #recordViewSyncerLagSamples(): void {
+    const {lagsMs} = this.#computeServingLagStats();
+    for (const lagMs of lagsMs) {
+      this.#viewSyncerLag.recordMs(lagMs);
+    }
   }
 
   #recordReplicaReadyState(state: ReplicaState): void {
@@ -687,6 +740,7 @@ export class Syncer implements SingletonService {
   }
 
   stop() {
+    clearInterval(this.#viewSyncerLagSampleInterval);
     this.#wss.close();
     this.#stopped.resolve();
     return promiseVoid;


### PR DESCRIPTION
Serving lag was a computed point in time percentile which cannot be aggregated. Move to a native histogram which can be aggregated over minutes, hours, days, etc. as well as across pods.