### PR TITLE
fix(zero-cache): reset half-open pg sockets after inactivity

### DIFF
--- a/packages/zero-cache/src/types/pg.test.ts
+++ b/packages/zero-cache/src/types/pg.test.ts
@@ -4,8 +4,13 @@ import {
   type Server,
   type Socket,
 } from 'node:net';
+import {LogContext} from '@rocicorp/logger';
 import postgres from 'postgres';
 import {afterEach, describe, expect, test} from 'vitest';
+import {
+  createSilentLogContext,
+  TestLogSink,
+} from '../../../shared/src/logging-test-utils.ts';
 import {
   inactivityTimeoutSocket,
   isPostgresConfigError,
@@ -562,6 +567,7 @@ describe('serializeTime (via postgresTypeConfig)', () => {
 });
 
 describe('inactivityTimeoutSocket', () => {
+  const lc = createSilentLogContext();
   let server: Server;
   let cleanup: (() => void)[] = [];
 
@@ -596,7 +602,7 @@ describe('inactivityTimeoutSocket', () => {
 
   test('connects and exposes host/port for TLS SNI', async () => {
     const port = await listen();
-    const socket = inactivityTimeoutSocket(120_000)(factoryOptions(port));
+    const socket = inactivityTimeoutSocket(lc, 120_000)(factoryOptions(port));
     await connected(socket);
 
     // postgres.js reads socket.host as the SNI servername in secure().
@@ -605,14 +611,25 @@ describe('inactivityTimeoutSocket', () => {
   });
 
   test('resets the connection after inactivity', async () => {
+    const logSink = new TestLogSink();
+    const warnLc = new LogContext('warn', undefined, logSink);
     const port = await listen(); // server accepts but never responds
-    const socket = inactivityTimeoutSocket(100)(factoryOptions(port));
+    const socket = inactivityTimeoutSocket(warnLc, 100)(factoryOptions(port));
     await connected(socket);
 
     // Simulate a query that never gets a response.
     socket.write('BEGIN');
     await new Promise<void>(resolve => socket.once('close', resolve));
     expect(socket.destroyed).toBe(true);
+
+    // The reset is logged so that occurrences are visible in production.
+    expect(logSink.messages).toMatchObject([
+      [
+        'warn',
+        undefined,
+        [expect.stringContaining('after 100 ms of inactivity')],
+      ],
+    ]);
   });
 
   test('activity resets the inactivity timer', async () => {
@@ -620,7 +637,7 @@ describe('inactivityTimeoutSocket', () => {
       // Server echoes everything back, i.e. the connection has activity.
       socket.on('data', data => socket.write(data));
     });
-    const socket = inactivityTimeoutSocket(200)(factoryOptions(port));
+    const socket = inactivityTimeoutSocket(lc, 200)(factoryOptions(port));
     await connected(socket);
 
     let closed = false;
@@ -640,7 +657,7 @@ describe('inactivityTimeoutSocket', () => {
 
   test('timeout of 0 disables the timer', async () => {
     const port = await listen();
-    const socket = inactivityTimeoutSocket(0)(factoryOptions(port));
+    const socket = inactivityTimeoutSocket(lc, 0)(factoryOptions(port));
     await connected(socket);
 
     expect(socket.timeout).toBeUndefined();

--- a/packages/zero-cache/src/types/pg.test.ts
+++ b/packages/zero-cache/src/types/pg.test.ts
@@ -1,6 +1,13 @@
-import postgres from 'postgres';
-import {describe, expect, test} from 'vitest';
 import {
+  createServer,
+  type AddressInfo,
+  type Server,
+  type Socket,
+} from 'node:net';
+import postgres from 'postgres';
+import {afterEach, describe, expect, test} from 'vitest';
+import {
+  inactivityTimeoutSocket,
   isPostgresConfigError,
   millisecondsToPostgresTime,
   postgresTimeToMilliseconds,
@@ -551,5 +558,91 @@ describe('serializeTime (via postgresTypeConfig)', () => {
       const serialized = time.serialize(ms) as string;
       expect(postgresTimeToMilliseconds(serialized)).toBe(ms);
     });
+  });
+});
+
+describe('inactivityTimeoutSocket', () => {
+  let server: Server;
+  let cleanup: (() => void)[] = [];
+
+  function listen(onConnection?: (socket: Socket) => void) {
+    server = createServer(socket => {
+      // The client resets (RSTs) the connection, which surfaces here as an
+      // ECONNRESET 'error' event on the server side of the socket.
+      socket.on('error', () => {});
+      onConnection?.(socket);
+    });
+    cleanup.push(() => server.close());
+    return new Promise<number>(resolve => {
+      server.listen(0, '127.0.0.1', () =>
+        resolve((server.address() as AddressInfo).port),
+      );
+    });
+  }
+
+  function factoryOptions(port: number) {
+    return {host: ['127.0.0.1'], port: [port]};
+  }
+
+  function connected(socket: Socket) {
+    cleanup.push(() => socket.destroy());
+    return new Promise<void>(resolve => socket.once('connect', resolve));
+  }
+
+  afterEach(() => {
+    cleanup.forEach(fn => fn());
+    cleanup = [];
+  });
+
+  test('connects and exposes host/port for TLS SNI', async () => {
+    const port = await listen();
+    const socket = inactivityTimeoutSocket(120_000)(factoryOptions(port));
+    await connected(socket);
+
+    // postgres.js reads socket.host as the SNI servername in secure().
+    expect(socket).toMatchObject({host: '127.0.0.1', port});
+    expect(socket.timeout).toBe(120_000);
+  });
+
+  test('resets the connection after inactivity', async () => {
+    const port = await listen(); // server accepts but never responds
+    const socket = inactivityTimeoutSocket(100)(factoryOptions(port));
+    await connected(socket);
+
+    // Simulate a query that never gets a response.
+    socket.write('BEGIN');
+    await new Promise<void>(resolve => socket.once('close', resolve));
+    expect(socket.destroyed).toBe(true);
+  });
+
+  test('activity resets the inactivity timer', async () => {
+    const port = await listen(socket => {
+      // Server echoes everything back, i.e. the connection has activity.
+      socket.on('data', data => socket.write(data));
+    });
+    const socket = inactivityTimeoutSocket(200)(factoryOptions(port));
+    await connected(socket);
+
+    let closed = false;
+    socket.once('close', () => (closed = true));
+
+    // Keep the wire active well past the 200ms timeout.
+    const ping = setInterval(() => socket.write('ping'), 50);
+    cleanup.push(() => clearInterval(ping));
+    await new Promise(resolve => setTimeout(resolve, 600));
+    expect(closed).toBe(false);
+
+    // Then go silent (the server never initiates) and expect the reset.
+    clearInterval(ping);
+    await new Promise<void>(resolve => socket.once('close', resolve));
+    expect(socket.destroyed).toBe(true);
+  });
+
+  test('timeout of 0 disables the timer', async () => {
+    const port = await listen();
+    const socket = inactivityTimeoutSocket(0)(factoryOptions(port));
+    await connected(socket);
+
+    expect(socket.timeout).toBeUndefined();
   });
 });

--- a/packages/zero-cache/src/types/pg.ts
+++ b/packages/zero-cache/src/types/pg.ts
@@ -1,3 +1,4 @@
+import {Socket} from 'node:net';
 import {
   PG_CONFIGURATION_LIMIT_EXCEEDED,
   PG_CONNECTION_DOES_NOT_EXIST,
@@ -329,6 +330,61 @@ export type PostgresTransaction = postgres.TransactionSql<{
   json: JSONValue;
 }>;
 
+// Guards against half-open TCP connections, which otherwise hang the pool
+// indefinitely: a proxy can keep the client-facing socket alive (ACKing TCP
+// keepalives) after its backend is gone, so no 'close' or 'error' event ever
+// fires and statements like BEGIN / COMMIT — which are not covered by the
+// TransactionPool's statementResponseTimeout — await forever.
+// See https://github.com/porsager/postgres/issues/1089.
+//
+// If no bytes are read or written for this long, the socket is reset, which
+// rejects all in-flight queries and lets the pool recover. Wire activity
+// resets the timer, so streaming operations (e.g. COPY) are safe, but
+// statements that legitimately compute silently for longer (e.g. index
+// builds in migrations) must raise this. Settable as an emergency measure
+// (0 disables); deliberately not exposed as a server option.
+const SOCKET_INACTIVITY_TIMEOUT_MS = parseInt(
+  process.env.ZERO_PG_SOCKET_INACTIVITY_TIMEOUT ?? '120000',
+);
+
+type SocketFactoryOptions = {
+  host: string[];
+  port: number[];
+  path?: string | false;
+};
+
+/**
+ * Creates the custom socket factory passed to postgres.js via its (untyped)
+ * `socket` option. postgres.js does not call `connect()` on custom sockets,
+ * and its TLS upgrade reads `socket.host` for the SNI servername, so the
+ * factory must handle both itself.
+ *
+ * Note: unlike postgres.js's internal socket, reconnects do not rotate
+ * through multiple hosts; multi-host URIs are not used by the zero-cache.
+ *
+ * Exported for testing.
+ */
+export function inactivityTimeoutSocket(
+  timeoutMs = SOCKET_INACTIVITY_TIMEOUT_MS,
+) {
+  return (options: SocketFactoryOptions): Socket => {
+    const socket = new Socket();
+    if (timeoutMs > 0) {
+      socket.setTimeout(timeoutMs, () => socket.resetAndDestroy());
+    }
+    if (options.path) {
+      socket.connect(options.path);
+    } else {
+      const [host] = options.host;
+      const [port] = options.port;
+      socket.connect(port, host);
+      // Read by postgres.js for the TLS SNI servername.
+      Object.assign(socket, {host, port});
+    }
+    return socket;
+  };
+}
+
 export function pgClient(
   lc: LogContext,
   connectionURI: string,
@@ -380,11 +436,20 @@ export function pgClient(
   const maxLifetimeSeconds = randInt(5 * 60, 10 * 60);
   const providedConnection = options?.connection ?? {};
 
+  // postgres.js supports a custom socket factory via the `socket` option,
+  // but it is missing from its type declarations, hence the untyped spread.
+  const socketFactory = {socket: inactivityTimeoutSocket()};
+
   return postgres(connectionURI, {
     ...postgresTypeConfig(opts),
     onnotice,
     ['max_lifetime']: maxLifetimeSeconds,
+    // Close idle connections cleanly before the socket inactivity timer
+    // (which cannot distinguish an idle pool connection from a hung query)
+    // resets them.
+    ['idle_timeout']: 60,
     ssl,
+    ...socketFactory,
     ...options,
     connection: {
       ...providedConnection,

--- a/packages/zero-cache/src/types/pg.ts
+++ b/packages/zero-cache/src/types/pg.ts
@@ -365,12 +365,22 @@ type SocketFactoryOptions = {
  * Exported for testing.
  */
 export function inactivityTimeoutSocket(
+  lc: LogContext,
   timeoutMs = SOCKET_INACTIVITY_TIMEOUT_MS,
 ) {
   return (options: SocketFactoryOptions): Socket => {
     const socket = new Socket();
+    const target = options.path
+      ? options.path
+      : `${options.host[0]}:${options.port[0]}`;
     if (timeoutMs > 0) {
-      socket.setTimeout(timeoutMs, () => socket.resetAndDestroy());
+      socket.setTimeout(timeoutMs, () => {
+        lc.warn?.(
+          `resetting connection to ${target} after ${timeoutMs} ms of inactivity ` +
+            `(likely half-open); in-flight queries will be rejected`,
+        );
+        socket.resetAndDestroy();
+      });
     }
     if (options.path) {
       socket.connect(options.path);
@@ -438,7 +448,9 @@ export function pgClient(
 
   // postgres.js supports a custom socket factory via the `socket` option,
   // but it is missing from its type declarations, hence the untyped spread.
-  const socketFactory = {socket: inactivityTimeoutSocket()};
+  const socketFactory = {
+    socket: inactivityTimeoutSocket(lc.withContext('appName', applicationName)),
+  };
 
   return postgres(connectionURI, {
     ...postgresTypeConfig(opts),


### PR DESCRIPTION
A proxy can keep the client-facing TCP socket alive after its backend is gone, so no 'close'/'error' event ever fires and statements like BEGIN / COMMIT — which postgres.js awaits with no timeout and which are not covered by the TransactionPool's statementResponseTimeout — hang forever (see porsager/postgres#1089). This wedged the change-streamer's storer in production: back pressure was applied and never released because the drain loop was stuck on a silent socket.

Supply a custom socket factory to postgres.js that resets the connection after 2 minutes without wire activity (ZERO_PG_SOCKET_INACTIVITY_TIMEOUT overrides; 0 disables). The reset rejects all in-flight queries through the existing error path, letting the pool fail and recover. Idle pool connections are closed cleanly via idle_timeout before the reset timer can fire.

Notes:
- postgres.js does not call connect() on custom sockets and reads socket.host for the TLS SNI servername, so the factory handles both.
- Wire activity resets the timer, so streaming ops (e.g. COPY) are safe; statements that compute silently for longer (e.g. index builds) need the env override.