### PR TITLE
fix(zero-cache): make the socket inactivity watchdog survive TLS upgrade

### DIFF
--- a/packages/zero-cache/src/types/pg.test.ts
+++ b/packages/zero-cache/src/types/pg.test.ts
@@ -607,7 +607,6 @@ describe('inactivityTimeoutSocket', () => {
 
     // postgres.js reads socket.host as the SNI servername in secure().
     expect(socket).toMatchObject({host: '127.0.0.1', port});
-    expect(socket.timeout).toBe(120_000);
   });
 
   test('resets the connection after inactivity', async () => {
@@ -655,11 +654,27 @@ describe('inactivityTimeoutSocket', () => {
     expect(socket.destroyed).toBe(true);
   });
 
-  test('timeout of 0 disables the timer', async () => {
-    const port = await listen();
+  test('watchdog survives the removeAllListeners() of a TLS upgrade', async () => {
+    const port = await listen(); // server accepts but never responds
+    const socket = inactivityTimeoutSocket(lc, 100)(factoryOptions(port));
+    await connected(socket);
+
+    // postgres.js removes all listeners from the raw socket when upgrading
+    // it to TLS (secure() in connection.js). The watchdog must still fire.
+    socket.removeAllListeners();
+
+    socket.write('BEGIN');
+    await new Promise<void>(resolve => socket.once('close', resolve));
+    expect(socket.destroyed).toBe(true);
+  });
+
+  test('timeout of 0 disables the watchdog', async () => {
+    const port = await listen(); // server accepts but never responds
     const socket = inactivityTimeoutSocket(lc, 0)(factoryOptions(port));
     await connected(socket);
 
-    expect(socket.timeout).toBeUndefined();
+    // No amount of silence resets the connection.
+    await new Promise(resolve => setTimeout(resolve, 300));
+    expect(socket.destroyed).toBe(false);
   });
 });

--- a/packages/zero-cache/src/types/pg.ts
+++ b/packages/zero-cache/src/types/pg.ts
@@ -374,13 +374,38 @@ export function inactivityTimeoutSocket(
       ? options.path
       : `${options.host[0]}:${options.port[0]}`;
     if (timeoutMs > 0) {
-      socket.setTimeout(timeoutMs, () => {
-        lc.warn?.(
-          `resetting connection to ${target} after ${timeoutMs} ms of inactivity ` +
-            `(likely half-open); in-flight queries will be rejected`,
-        );
-        socket.resetAndDestroy();
-      });
+      // socket.setTimeout() cannot be used here: it registers its callback
+      // as a 'timeout' event listener, and postgres.js removes all listeners
+      // from the raw socket when upgrading it to TLS (removeAllListeners()
+      // in secure()), which would silently disarm the watchdog on every TLS
+      // connection. An interval is not a socket listener, so it survives the
+      // upgrade, and encrypted traffic still flows through this raw socket,
+      // advancing its byte counters.
+      //
+      // The counters are sampled once per timeout period, so a half-open
+      // socket is reset after one to two timeout periods of inactivity.
+      let lastActivity = -1;
+      const watchdog = setInterval(() => {
+        if (socket.destroyed) {
+          clearInterval(watchdog);
+          return;
+        }
+        const activity = socket.bytesRead + socket.bytesWritten;
+        if (activity === lastActivity) {
+          lc.warn?.(
+            `resetting connection to ${target} after ${timeoutMs} ms of inactivity ` +
+              `(likely half-open); in-flight queries will be rejected`,
+          );
+          clearInterval(watchdog);
+          socket.resetAndDestroy();
+        } else {
+          lastActivity = activity;
+        }
+      }, timeoutMs);
+      watchdog.unref();
+      // Best-effort cleanup; removed on TLS upgrade, in which case the
+      // destroyed check above clears the (unref'ed) interval instead.
+      socket.once('close', () => clearInterval(watchdog));
     }
     if (options.path) {
       socket.connect(options.path);


### PR DESCRIPTION
Auditing against postgres.js 3.4.7 revealed that socket.setTimeout() registers its callback as a 'timeout' event listener, and secure() in postgres.js calls removeAllListeners() on the raw socket before wrapping it with tls.connect() — silently disarming the watchdog on every TLS connection, i.e. exactly the deployments (PlanetScale et al) this guard is for. Plaintext connections were unaffected, which is why tests passed.

Replace setTimeout() with an interval that samples the raw socket's bytesRead+bytesWritten: intervals are not socket listeners, so the TLS upgrade cannot remove them, and encrypted traffic still flows through the raw socket, advancing its counters. A half-open socket is now reset after one to two timeout periods of inactivity. The interval is unref'ed and self-clears once the socket is destroyed.

Adds a regression test that simulates the TLS upgrade's removeAllListeners() and asserts the reset still fires.