### PR TITLE
feat(zero-cache): add optional newColumns field to DDL events

### DIFF
--- a/packages/zero-cache/src/services/change-source/pg/schema/ddl.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/ddl.pg.test.ts
@@ -1674,6 +1674,30 @@ describe('change-source/tables/ddl', () => {
       event: {tag: 'UNKNOWN'},
     });
   });
+
+  // Events from future versions of the upstream functions may report the
+  // columns created in the transaction that emitted the event.
+  test('parse ddlUpdateEvent with newColumns', () => {
+    const ddlUpdateEvent: DdlUpdateEvent = {
+      type: 'ddlUpdate',
+      version: 1,
+      context: {query: 'ALTER TABLE pub.foo ADD bar text'},
+      schema: {tables: [], indexes: []},
+      event: {tag: 'ALTER TABLE'},
+      newColumns: {'12345': [4, 7]},
+    };
+    expect(v.parse(ddlUpdateEvent, ddlUpdateEventSchema)).toEqual(
+      ddlUpdateEvent,
+    );
+    expect(
+      v.parse({...ddlUpdateEvent, newColumns: null}, ddlUpdateEventSchema),
+    ).toEqual({...ddlUpdateEvent, newColumns: null});
+
+    const {newColumns: _, ...withoutNewColumns} = ddlUpdateEvent;
+    expect(v.parse(withoutNewColumns, ddlUpdateEventSchema)).toEqual(
+      withoutNewColumns,
+    );
+  });
 });
 
 function parseDDLStartEvent(msg: MessageMessage) {

--- a/packages/zero-cache/src/services/change-source/pg/schema/ddl.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/ddl.ts
@@ -23,6 +23,19 @@ export const ddlEventSchema = triggerEvent.extend({
   version: v.literal(PROTOCOL_VERSION),
   schema: publishedSchema,
   event: v.object({tag: v.string()}),
+  // Maps the OID of each published table to the `attnum`s of published
+  // columns that were created in the (upstream) transaction that emitted
+  // the event. Such columns are guaranteed to have the column default in
+  // all pre-existing rows, and can thus be replicated without backfill if
+  // the default value itself is replicable. Tables whose publication
+  // entries (e.g. column lists) were modified in the same transaction are
+  // excluded, since a newly *published* (as opposed to newly *created*)
+  // column may hold arbitrary values in existing rows.
+  //
+  // The field is absent in messages from older versions of the upstream
+  // functions (in which case backfill decisions fall back to the command
+  // tag heuristic), and `null` when there are no such columns.
+  newColumns: v.record(v.array(v.number())).nullable().optional(),
 });
 
 /**


### PR DESCRIPTION
Split out of #6194: declare the optional `newColumns` field on DDL events before anything emits it.

`newColumns` maps the OID of each published table to the `attnum`s of published columns created in the (upstream) transaction that emitted the event. #6194 will teach the upstream trigger functions to populate the field and use it to skip backfill for columns added with replicable defaults via the manual `update_schemas()` path.

Landing the reader-side declaration first, per the usual two-phase protocol rollout, lets this sit for a release so that every version in the rollback window understands the field before the trigger functions start emitting it.

Also adds a parse test covering messages with `newColumns` present, `null`, and absent.

`https://app.notion.com/p/replicache/Apply-backfill-less-defaults-optimization-to-update_schemas-path-3843bed8954580209a05fa5be881a0f2`
