### PR TITLE
fix(shared): unref TimedCache's interval 

### DIFF
--- a/packages/shared/src/cache.test.ts
+++ b/packages/shared/src/cache.test.ts
@@ -113,6 +113,76 @@ describe('TimedCache', () => {
     vi.advanceTimersByTime(10000);
   });
 
+  test('does not start the cleanup interval until the first set', () => {
+    const cache = new TimedCache<string>(1000);
+    expect(vi.getTimerCount()).toBe(0);
+
+    expect(cache.get('key1')).toBeUndefined();
+    expect(vi.getTimerCount()).toBe(0);
+
+    cache.set('key1', 'value1');
+    expect(vi.getTimerCount()).toBe(1);
+
+    // Subsequent sets reuse the same interval.
+    cache.set('key2', 'value2');
+    expect(vi.getTimerCount()).toBe(1);
+
+    cache.destroy();
+  });
+
+  test('unrefs the cleanup interval so it cannot hold the process open', () => {
+    const unref = vi.fn();
+    const setIntervalSpy = vi
+      .spyOn(globalThis, 'setInterval')
+      .mockReturnValue({unref} as unknown as ReturnType<typeof setInterval>);
+    const clearIntervalSpy = vi
+      .spyOn(globalThis, 'clearInterval')
+      .mockImplementation(() => undefined);
+
+    try {
+      const cache = new TimedCache<string>(1000);
+      expect(setIntervalSpy).not.toHaveBeenCalled();
+
+      cache.set('key1', 'value1');
+      expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+      expect(unref).toHaveBeenCalledTimes(1);
+
+      cache.destroy();
+      expect(clearIntervalSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      setIntervalSpy.mockRestore();
+      clearIntervalSpy.mockRestore();
+    }
+  });
+
+  test('destroy stops the cleanup interval and is idempotent', () => {
+    const cache = new TimedCache<string>(1000);
+
+    cache.set('key1', 'value1');
+    expect(vi.getTimerCount()).toBe(1);
+
+    cache.destroy();
+    expect(vi.getTimerCount()).toBe(0);
+
+    cache.destroy();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  test('set and get after destroy do not throw and do not restart the cleanup interval', () => {
+    const cache = new TimedCache<string>(1000);
+
+    cache.set('key1', 'value1');
+    cache.destroy();
+    expect(vi.getTimerCount()).toBe(0);
+
+    expect(() => cache.set('key2', 'value2')).not.toThrow();
+    expect(() => cache.get('key1')).not.toThrow();
+
+    // set() after destroy is a no-op and never restarts the interval.
+    expect(cache.get('key2')).toBeUndefined();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
   test('works with different value types', () => {
     const cache = new TimedCache<{id: number; name: string}>(1000);
 

--- a/packages/shared/src/cache.ts
+++ b/packages/shared/src/cache.ts
@@ -3,29 +3,39 @@
  * Does not update the expiration time on retrieval.
  * Values are automatically removed from the cache after the TTL expires.
  * The cache is cleaned up periodically based on the TTL so it does
- * not grow indefinitely.
+ * not grow indefinitely. The cleanup interval is started lazily on the
+ * first `set()` and is `unref`ed (where supported) so it never keeps
+ * the process alive.
+ *
+ * Call `destroy()` to stop the cleanup interval and release the cached
+ * values. `destroy()` is idempotent, and a destroyed cache is inert:
+ * `get()` always misses, `set()` is a no-op, and the cleanup interval
+ * is never restarted.
  */
 export class TimedCache<T> {
   readonly #cache: Map<string, {value: T; expiresAt: number}>;
   readonly #ttlMs: number;
-  readonly #intervalHandle: NodeJS.Timeout;
+  #intervalHandle: ReturnType<typeof setInterval> | undefined;
+  #destroyed = false;
 
   constructor(ttlMs: number) {
     this.#cache = new Map();
     this.#ttlMs = ttlMs;
-    this.#intervalHandle = setInterval(() => {
-      const now = Date.now();
-      for (const [key, entry] of this.#cache.entries()) {
-        if (entry.expiresAt < now) {
-          this.#cache.delete(key);
-        }
-      }
-    }, ttlMs * 2);
   }
 
   set(key: string, value: T): void {
-    const entry = {value, expiresAt: Date.now() + this.#ttlMs};
-    this.#cache.set(key, entry);
+    if (this.#destroyed) {
+      return;
+    }
+    if (this.#intervalHandle === undefined) {
+      this.#intervalHandle = setInterval(
+        () => this.#removeExpired(),
+        this.#ttlMs * 2,
+      );
+      // In browsers setInterval returns a number, which has no unref.
+      this.#intervalHandle.unref?.();
+    }
+    this.#cache.set(key, {value, expiresAt: Date.now() + this.#ttlMs});
   }
 
   get(key: string): T | undefined {
@@ -37,8 +47,21 @@ export class TimedCache<T> {
     return entry.value;
   }
 
+  #removeExpired(): void {
+    const now = Date.now();
+    for (const [key, entry] of this.#cache.entries()) {
+      if (entry.expiresAt < now) {
+        this.#cache.delete(key);
+      }
+    }
+  }
+
   destroy(): void {
-    clearInterval(this.#intervalHandle);
+    this.#destroyed = true;
+    if (this.#intervalHandle !== undefined) {
+      clearInterval(this.#intervalHandle);
+      this.#intervalHandle = undefined;
+    }
     this.#cache.clear();
   }
 }

--- a/packages/zero-cache/src/custom-queries/transform-query.test.ts
+++ b/packages/zero-cache/src/custom-queries/transform-query.test.ts
@@ -876,4 +876,27 @@ describe('CustomQueryTransformer', () => {
       queryIDs: ['query1'],
     });
   });
+
+  test('destroy stops the cache cleanup interval and is safe to use after', async () => {
+    mockFetchFromAPIServer.mockResolvedValue(
+      queryResponseMessage(mockQueryResponses, 'user-123'),
+    );
+
+    const transformer = new CustomQueryTransformer(lc, mockShard);
+    await transformer.transform(makeContext(), mockQueries);
+    expect(vi.getTimerCount()).toBe(1);
+
+    transformer.destroy();
+    expect(vi.getTimerCount()).toBe(0);
+
+    // destroy is idempotent.
+    transformer.destroy();
+    expect(vi.getTimerCount()).toBe(0);
+
+    // Use after destroy (e.g. by the InspectorDelegate racing view-syncer
+    // teardown) does not throw and does not restart the cleanup interval.
+    const result = await transformer.transform(makeContext(), mockQueries);
+    expect(result.kind).toBe('success');
+    expect(vi.getTimerCount()).toBe(0);
+  });
 });

--- a/packages/zero-cache/src/custom-queries/transform-query.ts
+++ b/packages/zero-cache/src/custom-queries/transform-query.ts
@@ -91,6 +91,15 @@ export class CustomQueryTransformer {
   }
 
   /**
+   * Stops the cache's periodic cleanup so the transformer can be garbage
+   * collected. Idempotent, and the transformer remains safe to use after
+   * destroy (it just no longer caches).
+   */
+  destroy(): void {
+    this.#cache.destroy();
+  }
+
+  /**
    * Forces the empty `/query` validation request used by auth maintenance.
    *
    * This stays separate from `transform()` because `transform([], ...)`

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -2772,6 +2772,10 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     this.#stopTTLClockInterval();
     this.#stopExpireTimer();
     this.#stopAuthMaintenanceTimer();
+    // The InspectorDelegate shares this transformer and may still use it
+    // after cleanup; a destroyed transformer is safe to use (it just stops
+    // caching and never restarts its cleanup interval).
+    this.#customQueryTransformer?.destroy();
 
     for (const client of this.#clients.values()) {
       if (err) {


### PR DESCRIPTION
TimedCache started a repeating setInterval in its constructor that was never unref()ed and never cleared in production, so Node's timer registry rooted every cache and its Map for the remaining process lifetime. Each client-group activation with custom queries configured created a CustomQueryTransformer (and thus a TimedCache), leaking one 10s interval plus its cache per activation.

- TimedCache: start the cleanup interval lazily on the first set(), unref() it where supported (in browsers setInterval returns a number), and make destroy() idempotent with inert set()/get() afterwards so an in-flight operation racing teardown can never resurrect the interval.
- CustomQueryTransformer: add destroy() that destroys its TimedCache.
- ViewSyncerService: destroy the transformer in #cleanup() alongside the other timer stops.