### PR TITLE
fix(zero): drop integration peerDependencies to keep one installed copy

### DIFF
--- a/packages/zero/package.json
+++ b/packages/zero/package.json
@@ -176,6 +176,7 @@
     "analyze-query": "workspace:*",
     "ast-to-zql": "workspace:*",
     "expo-sqlite": ">=15",
+    "oxc-parser": "^0.129.0",
     "replicache": "workspace:*",
     "shared": "workspace:*",
     "syncpack": "^14.3.0",
@@ -191,38 +192,6 @@
     "zero-server": "workspace:*",
     "zero-solid": "workspace:*",
     "zqlite": "workspace:*"
-  },
-  "peerDependencies": {
-    "@op-engineering/op-sqlite": ">=15",
-    "drizzle-orm": "^0.45.2",
-    "expo-sqlite": ">=15",
-    "kysely": "^0.28.17",
-    "pg": "^8.16.3",
-    "react": "^19.2.6",
-    "solid-js": "^1.9.4"
-  },
-  "peerDependenciesMeta": {
-    "@op-engineering/op-sqlite": {
-      "optional": true
-    },
-    "drizzle-orm": {
-      "optional": true
-    },
-    "expo-sqlite": {
-      "optional": true
-    },
-    "kysely": {
-      "optional": true
-    },
-    "pg": {
-      "optional": true
-    },
-    "react": {
-      "optional": true
-    },
-    "solid-js": {
-      "optional": true
-    }
   },
   "engines": {
     "node": ">=22"

--- a/packages/zero/tool/build.ts
+++ b/packages/zero/tool/build.ts
@@ -1,30 +1,67 @@
 // Build script for @rocicorp/zero package
 import {spawn} from 'node:child_process';
 import {existsSync} from 'node:fs';
-import {chmod, copyFile, mkdir, readFile, rm} from 'node:fs/promises';
+import {chmod, copyFile, mkdir, readdir, readFile, rm} from 'node:fs/promises';
 import {builtinModules} from 'node:module';
 import {basename, resolve} from 'node:path';
 import {fileURLToPath} from 'node:url';
+import {parse} from 'oxc-parser';
 import {type InlineConfig, build as viteBuild} from 'vite';
 import {assert} from '../../shared/src/asserts.ts';
 import {makeDefine} from '../../shared/src/build.ts';
-import {getExternalFromPackageJSON} from '../../shared/src/tool/get-external-from-package-json.ts';
 import * as workerUrls from '../../zero-cache/src/server/worker-urls.ts';
 
 const forBundleSizeDashboard = process.argv.includes('--bundle-sizes');
 const watchMode = process.argv.includes('--watch');
 
-async function getExternal(): Promise<string[]> {
-  return [
-    ...(await getExternalFromPackageJSON(import.meta.url, true)),
-    'node:*',
-    'expo*',
-    '@op-engineering/*',
-    ...builtinModules,
-  ].sort();
+// Everything imported by a bare specifier is external; only these modules get
+// bundled into the output. All other runtime deps are declared in
+// dependencies and loaded from node_modules.
+const inlinedModules = new Set([
+  // Transform helpers (e.g. helpers/usingCtx for `using` declarations) that
+  // rolldown injects as imports. Not a real dependency of ours — must ship
+  // inside the bundle.
+  '@oxc-project/runtime',
+]);
+
+// Integration packages imported by adapter entries (./react, ./solid,
+// ./server/adapters/*, ./expo-sqlite, ./op-sqlite). They are intentionally
+// undeclared: consumers that use an adapter entry already depend on the
+// integration themselves, and they must NOT be peerDependencies — pnpm keys a
+// package's installed instance by its resolved peers, so a peer that resolves
+// in some workspace packages and not others (react in a web app, pg in a
+// server package, expo-sqlite in a React Native app) splits @rocicorp/zero
+// into multiple copies. TypeScript then sees distinct module identities and
+// shared schema/query-registry types stop unifying across the workspace (e.g.
+// defineQueries results collapse to `never`), and `declare module
+// '@rocicorp/zero'` augmentations only apply to one copy.
+//
+// This list is not used for bundling (all bare imports are external); it is
+// the allowlist for the post-build check that every bare import in the output
+// is either a declared dependency or a known integration.
+const allowedUndeclaredImports = new Set([
+  '@op-engineering/op-sqlite',
+  'drizzle-orm',
+  'expo-sqlite',
+  'kysely',
+  'pg',
+  'react',
+  'solid-js',
+]);
+
+// '@scope/pkg/subpath' -> '@scope/pkg', 'pkg/subpath' -> 'pkg'.
+function packageName(id: string): string {
+  const parts = id.split('/');
+  return id.startsWith('@') ? parts.slice(0, 2).join('/') : parts[0];
 }
 
-const external = await getExternal();
+function external(id: string): boolean {
+  // Relative/absolute ids and bundler-virtual ids (\0-prefixed) get bundled.
+  if (id.startsWith('.') || id.startsWith('/') || id.startsWith('\0')) {
+    return false;
+  }
+  return !inlinedModules.has(packageName(id));
+}
 
 const define = {
   ...makeDefine('unknown'),
@@ -190,8 +227,83 @@ function assertNoNodeModulesInOut() {
   const nodeModulesPath = resolve('out', 'node_modules');
   if (existsSync(nodeModulesPath)) {
     throw new Error(
-      `Build produced out/node_modules — a third-party package was bundled instead of externalized. ` +
-        `Add it to dependencies or peerDependencies of package.json. Path: ${nodeModulesPath}`,
+      `Build produced out/node_modules — a third-party package was bundled instead of externalized. Path: ${nodeModulesPath}`,
+    );
+  }
+}
+
+async function collectImportSpecifiers(path: string): Promise<string[]> {
+  const source = await readFile(path, 'utf-8');
+  const {module} = await parse(path, source, {sourceType: 'module'});
+
+  const specifiers: string[] = [];
+  for (const imp of module.staticImports) {
+    specifiers.push(imp.moduleRequest.value);
+  }
+  for (const exp of module.staticExports) {
+    for (const entry of exp.entries) {
+      if (entry.moduleRequest) {
+        specifiers.push(entry.moduleRequest.value);
+      }
+    }
+  }
+  for (const imp of module.dynamicImports) {
+    // moduleRequest is a span of the argument expression; only string
+    // literals can be checked statically.
+    const text = source.slice(imp.moduleRequest.start, imp.moduleRequest.end);
+    const quote = text[0];
+    if ((quote === "'" || quote === '"') && text.endsWith(quote)) {
+      specifiers.push(text.slice(1, -1));
+    }
+  }
+  return specifiers;
+}
+
+// Every bare import left in the output must be resolvable by consumers:
+// a declared dependency, a node builtin, or a known integration package
+// (allowedUndeclaredImports). Anything else is a typo or an undeclared
+// dependency and would fail at the consumer's runtime.
+async function assertBareImportsAreDeclared() {
+  const packageJSON = await getPackageJSON();
+  const allowed = new Set([
+    ...Object.keys(packageJSON.dependencies ?? {}),
+    ...allowedUndeclaredImports,
+    ...builtinModules,
+  ]);
+
+  const outDir = resolve('out');
+  const files = (await readdir(outDir, {recursive: true, withFileTypes: true}))
+    .filter(entry => entry.isFile() && entry.name.endsWith('.js'))
+    .map(entry => resolve(entry.parentPath, entry.name));
+
+  const violations = new Map<string, string[]>();
+  await Promise.all(
+    files.map(async path => {
+      for (const id of await collectImportSpecifiers(path)) {
+        if (id.startsWith('.') || id.startsWith('/') || id.startsWith('\0')) {
+          continue;
+        }
+        const name = id.startsWith('node:')
+          ? id.slice('node:'.length).split('/')[0]
+          : packageName(id);
+        if (!allowed.has(name)) {
+          violations.set(id, [
+            ...(violations.get(id) ?? []),
+            path.slice(outDir.length + 1),
+          ]);
+        }
+      }
+    }),
+  );
+
+  if (violations.size > 0) {
+    const details = [...violations]
+      .map(([id, files]) => `  '${id}' in ${files.join(', ')}`)
+      .join('\n');
+    throw new Error(
+      `Build output imports undeclared modules:\n${details}\n` +
+        `Add them to dependencies in package.json, or to allowedUndeclaredImports ` +
+        `in build.ts if consumers provide them.`,
     );
   }
 }
@@ -270,6 +382,7 @@ async function build() {
     await makeBinFilesExecutable();
     await copyStaticFiles();
     assertNoNodeModulesInOut();
+    await assertBareImportsAreDeclared();
   }
 
   const totalDuration = ((performance.now() - startTime) / 1000).toFixed(2);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -930,9 +930,6 @@ importers:
       defu:
         specifier: ^6.1.4
         version: 6.1.7
-      drizzle-orm:
-        specifier: ^0.45.2
-        version: 0.45.2(@electric-sql/pglite@0.4.1)(@op-engineering/op-sqlite@15.2.14(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6))(@opentelemetry/api@1.9.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(magicast@0.5.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(typescript@6.0.3))(@types/pg@8.20.0)(expo-sqlite@55.0.16(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6))(kysely@0.28.17)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.7(patch_hash=2bd119d361250d5ee010b23af4c98504e9c6861b692d2e2ae23b9a9e5de4dbce))(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(magicast@0.5.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))
       eventemitter3:
         specifier: ^5.0.1
         version: 5.0.4
@@ -954,9 +951,6 @@ importers:
       kasi:
         specifier: ^1.1.0
         version: 1.1.2
-      kysely:
-        specifier: ^0.28.17
-        version: 0.28.17
       nanoid:
         specifier: ^5.1.2
         version: 5.1.11
@@ -966,24 +960,15 @@ importers:
       parse-prometheus-text-format:
         specifier: ^1.1.1
         version: 1.1.1
-      pg:
-        specifier: ^8.16.3
-        version: 8.20.0
       pg-format:
         specifier: npm:pg-format-fix@^1.0.5
         version: pg-format-fix@1.0.5
       postgres:
         specifier: 3.4.7
         version: 3.4.7(patch_hash=2bd119d361250d5ee010b23af4c98504e9c6861b692d2e2ae23b9a9e5de4dbce)
-      react:
-        specifier: ^19.2.6
-        version: 19.2.6
       semver:
         specifier: ^7.5.4
         version: 7.8.0
-      solid-js:
-        specifier: ^1.9.4
-        version: 1.9.13
       url-pattern:
         specifier: ^1.0.3
         version: 1.0.3
@@ -1009,6 +994,9 @@ importers:
       expo-sqlite:
         specifier: '>=15'
         version: 55.0.16(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
+      oxc-parser:
+        specifier: ^0.129.0
+        version: 0.129.0
       replicache:
         specifier: workspace:*
         version: link:../replicache
@@ -1947,8 +1935,8 @@ importers:
   tools/verify-package-deps:
     dependencies:
       oxc-parser:
-        specifier: ^0.94.0
-        version: 0.94.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+        specifier: ^0.129.0
+        version: 0.129.0
     devDependencies:
       '@types/node':
         specifier: ^22.10.5
@@ -4815,20 +4803,8 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@oxc-parser/binding-android-arm64@0.94.0':
-    resolution: {integrity: sha512-Ficqj6MggRGFkemU4pVFTyth3jWVL/zpIWjGMTXaPU81l46ZDcYVFWp9ia6nfE5mm8UdVSI2trvmK+BpNUim7g==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [android]
-
   '@oxc-parser/binding-darwin-arm64@0.129.0':
     resolution: {integrity: sha512-QeqThtB8qax4IL+NFBWgshudyKkj5c076L8vyd8PCEx7U1wHyIbH49MEQ5J5iURFhUW5jiFmdnLKEwyOo0GAJA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@oxc-parser/binding-darwin-arm64@0.94.0':
-    resolution: {integrity: sha512-uYyeMH9vMfb0JAdm6ZwHTgcTv53030elQKMnUbux9K5rxOCWbHUyeVACEv86V+E/Ft6RtkvWDIqUY4sYZRmcuQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
@@ -4839,20 +4815,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@oxc-parser/binding-darwin-x64@0.94.0':
-    resolution: {integrity: sha512-Ek1fh8dw6b+/hzLo5jjPuxkshRxekjtTfhfWZ4RehMYiApT8Rj4k+7kcQ+zV1ZaF+1+yLgNqNja2RMRqx3MHzQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [darwin]
-
   '@oxc-parser/binding-freebsd-x64@0.129.0':
     resolution: {integrity: sha512-SPTcDBiHWlgRpWFC1jnoi0sBWqCw4DFR+4b8+dV+NAhUu2ONERWyIVIOCfcE9a8BlvZsDCuXf3l/x7wQUs1Rsw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@oxc-parser/binding-freebsd-x64@0.94.0':
-    resolution: {integrity: sha512-81bE/8F252Ew179uVo9FU67dmRc+n8QSMhj6mmMxisdI3ao5MjCI5jDL19mH3UeQ9uRUBSPFILmHBDQYNZ9oKw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
@@ -4863,20 +4827,8 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@oxc-parser/binding-linux-arm-gnueabihf@0.94.0':
-    resolution: {integrity: sha512-aGOU8IYXVYGN2aRrvcU5+UdM7BzIVlm4m0REQzjpblQKRdZfWFtDBRJez+fK/F10g0H1AU5DQVgbW5aeko49Jw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [linux]
-
   '@oxc-parser/binding-linux-arm-musleabihf@0.129.0':
     resolution: {integrity: sha512-YtSsJ51VysXqlO8Cs2mWTyXvxBRemTHj4WDQjXwKl0SAxh+CVrEdXrdH+RnjxLj3JCUMFeYuHs5c+/DImfbKkg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [linux]
-
-  '@oxc-parser/binding-linux-arm-musleabihf@0.94.0':
-    resolution: {integrity: sha512-69/ZuYSZ4dd7UWoEOyf+pXYPtvUZguDQqjhxMx8fI0J30sEEqs1d/DBLLnog/afHmaapPEIEr6rp9jF6bYcgNw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
@@ -4888,22 +4840,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@oxc-parser/binding-linux-arm64-gnu@0.94.0':
-    resolution: {integrity: sha512-u55PGVVfZF/frpEcv/vowfuqsCd5VKz3wta8KZ3MBxboat7XxgRIMS8VQEBiJ3aYE80taACu5EfPN1y9DhiU0Q==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
   '@oxc-parser/binding-linux-arm64-musl@0.129.0':
     resolution: {integrity: sha512-GghE/bf9ZqgqZFxLacgP0ImVD6UiLKQOpvpgUoIsqjopu2ms/+p1L0d0Dv2Sck+8p0FbKS2WE3IjqmIlLbxJgA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@oxc-parser/binding-linux-arm64-musl@0.94.0':
-    resolution: {integrity: sha512-Qm2SEU7/f2b2Rg76Pj49BdMFF7Vv7+2qLPxaae4aH1515kzVv6nZW0bqCo4fPDDyiE4bryF7Jr+WKhllBxvXPw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -4923,13 +4861,6 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@oxc-parser/binding-linux-riscv64-gnu@0.94.0':
-    resolution: {integrity: sha512-bZO3QAt0lsZjk351mVM85obMivbXG+tDiah5XmmOaGO8k4vEYmoiKr2YHJoA2eNpKhPJF8dNyIS7U+XAvirr9g==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
   '@oxc-parser/binding-linux-riscv64-musl@0.129.0':
     resolution: {integrity: sha512-v2hi8id+M8C0uY8uuG2t2a5vr8H9XyHXiHL12yMdMNtgn04nnM/8hlOGuoJuxVc07PhClNiaoSaY2eXehSRa7w==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -4944,13 +4875,6 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@oxc-parser/binding-linux-s390x-gnu@0.94.0':
-    resolution: {integrity: sha512-IdbJ/rwsaEPQx11mQwGoClqhAmVaAF9+3VmDRYVmfsYsrhX1Ue1HvBdVHDvtHzJDuumC/X/codkVId9Ss+7fVg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
   '@oxc-parser/binding-linux-x64-gnu@0.129.0':
     resolution: {integrity: sha512-hsL/3/kdX9FGLqOj8DR3Eki4Y6zO1i3+ZHhiPwX0hDt4n+18abkfUzePCv3h8SShprwCmwdxPnlrebZ5+MZ+cw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -4958,22 +4882,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@oxc-parser/binding-linux-x64-gnu@0.94.0':
-    resolution: {integrity: sha512-TbtpRdViF3aPCQBKuEo+TcucwW3KFa6bMHVakgaJu12RZrFpO4h1IWppBbuuBQ9X7SfvpgC1YgCDGve9q6fpEA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
   '@oxc-parser/binding-linux-x64-musl@0.129.0':
     resolution: {integrity: sha512-kdXvJ4crOeRld3vWl0J0VU4nmnT4pZ3lKGA5tZ1y0UPWsBtElDYd+jsz4lE36tpAbCiWm0M0PG0laUNBSE+Wlw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@oxc-parser/binding-linux-x64-musl@0.94.0':
-    resolution: {integrity: sha512-hlfoDmWvgSbexoJ9u3KwAJwpeu91FfJR6++fQjeYXD2InK4gZow9o3DRoTpN/kslZwzUNpiRURqxey/RvWh8JQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -4990,19 +4900,8 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
-  '@oxc-parser/binding-wasm32-wasi@0.94.0':
-    resolution: {integrity: sha512-VoCtQZIsRZN8mszbdizh+5MwzbgbMxsPgT2hOzzILQLNY2o2OXG3xSiFNFakVhbWc9qSTaZ/MRDsqR+IM3fLFw==}
-    engines: {node: '>=14.0.0'}
-    cpu: [wasm32]
-
   '@oxc-parser/binding-win32-arm64-msvc@0.129.0':
     resolution: {integrity: sha512-99kH1udLyrts+wGm+u0VhPbogkb2wxc/6J1XMKOpS6Kx5DjBWGRZZfBjfCGI3xKSInpYbZn4TLWLX1Q1GURYwg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [win32]
-
-  '@oxc-parser/binding-win32-arm64-msvc@0.94.0':
-    resolution: {integrity: sha512-3wsbMqV8V7WaLdiQ2oawdgKkCgMHXJ7VDuo6uIcXauU3wK6CG0QyDXRV9bPWzorGLRBUHndu/2VB1+9dgT9fvg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
@@ -5019,20 +4918,11 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@oxc-parser/binding-win32-x64-msvc@0.94.0':
-    resolution: {integrity: sha512-UTQQ1576Nzhh4jr/YmvzqnuwTPOauB/TPzsnWzT+w8InHxL5JA1fmy01wB1F2BWT9AD6YV4BTB1ozRICYdAgjw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [win32]
-
   '@oxc-project/types@0.129.0':
     resolution: {integrity: sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg==}
 
   '@oxc-project/types@0.130.0':
     resolution: {integrity: sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==}
-
-  '@oxc-project/types@0.94.0':
-    resolution: {integrity: sha512-+UgQT/4o59cZfH6Cp7G0hwmqEQ0wE+AdIwhikdwnhWI9Dp8CgSY081+Q3O67/wq3VJu8mgUEB93J9EHHn70fOw==}
 
   '@oxfmt/binding-android-arm-eabi@0.45.0':
     resolution: {integrity: sha512-A/UMxFob1fefCuMeGxQBulGfFE38g2Gm23ynr3u6b+b7fY7/ajGbNsa3ikMIkGMLJW/TRoQaMoP1kME7S+815w==}
@@ -10229,10 +10119,6 @@ packages:
 
   oxc-parser@0.129.0:
     resolution: {integrity: sha512-S6eFI+VLkpyA+/Lf8z6qURjDV6Mgo74SLNznNopHTlQW3hedv2MB/z31kBRuBCCTqZN9HHdva0ojljEhPnBKFA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-
-  oxc-parser@0.94.0:
-    resolution: {integrity: sha512-refms9HQoAlTYIazONYkuX5A3rFGPddbD6Otyc+A0/pj1WTttR8TsZRlMzQxCfhexxfrbinqd7ebkEoYNuCmLQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
   oxfmt@0.45.0:
@@ -17805,49 +17691,25 @@ snapshots:
   '@oxc-parser/binding-android-arm64@0.129.0':
     optional: true
 
-  '@oxc-parser/binding-android-arm64@0.94.0':
-    optional: true
-
   '@oxc-parser/binding-darwin-arm64@0.129.0':
-    optional: true
-
-  '@oxc-parser/binding-darwin-arm64@0.94.0':
     optional: true
 
   '@oxc-parser/binding-darwin-x64@0.129.0':
     optional: true
 
-  '@oxc-parser/binding-darwin-x64@0.94.0':
-    optional: true
-
   '@oxc-parser/binding-freebsd-x64@0.129.0':
-    optional: true
-
-  '@oxc-parser/binding-freebsd-x64@0.94.0':
     optional: true
 
   '@oxc-parser/binding-linux-arm-gnueabihf@0.129.0':
     optional: true
 
-  '@oxc-parser/binding-linux-arm-gnueabihf@0.94.0':
-    optional: true
-
   '@oxc-parser/binding-linux-arm-musleabihf@0.129.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-arm-musleabihf@0.94.0':
     optional: true
 
   '@oxc-parser/binding-linux-arm64-gnu@0.129.0':
     optional: true
 
-  '@oxc-parser/binding-linux-arm64-gnu@0.94.0':
-    optional: true
-
   '@oxc-parser/binding-linux-arm64-musl@0.129.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-arm64-musl@0.94.0':
     optional: true
 
   '@oxc-parser/binding-linux-ppc64-gnu@0.129.0':
@@ -17856,28 +17718,16 @@ snapshots:
   '@oxc-parser/binding-linux-riscv64-gnu@0.129.0':
     optional: true
 
-  '@oxc-parser/binding-linux-riscv64-gnu@0.94.0':
-    optional: true
-
   '@oxc-parser/binding-linux-riscv64-musl@0.129.0':
     optional: true
 
   '@oxc-parser/binding-linux-s390x-gnu@0.129.0':
     optional: true
 
-  '@oxc-parser/binding-linux-s390x-gnu@0.94.0':
-    optional: true
-
   '@oxc-parser/binding-linux-x64-gnu@0.129.0':
     optional: true
 
-  '@oxc-parser/binding-linux-x64-gnu@0.94.0':
-    optional: true
-
   '@oxc-parser/binding-linux-x64-musl@0.129.0':
-    optional: true
-
-  '@oxc-parser/binding-linux-x64-musl@0.94.0':
     optional: true
 
   '@oxc-parser/binding-openharmony-arm64@0.129.0':
@@ -17890,18 +17740,7 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
-  '@oxc-parser/binding-wasm32-wasi@0.94.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
-    dependencies:
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-    optional: true
-
   '@oxc-parser/binding-win32-arm64-msvc@0.129.0':
-    optional: true
-
-  '@oxc-parser/binding-win32-arm64-msvc@0.94.0':
     optional: true
 
   '@oxc-parser/binding-win32-ia32-msvc@0.129.0':
@@ -17910,14 +17749,9 @@ snapshots:
   '@oxc-parser/binding-win32-x64-msvc@0.129.0':
     optional: true
 
-  '@oxc-parser/binding-win32-x64-msvc@0.94.0':
-    optional: true
-
   '@oxc-project/types@0.129.0': {}
 
   '@oxc-project/types@0.130.0': {}
-
-  '@oxc-project/types@0.94.0': {}
 
   '@oxfmt/binding-android-arm-eabi@0.45.0':
     optional: true
@@ -23944,29 +23778,6 @@ snapshots:
       '@oxc-parser/binding-win32-arm64-msvc': 0.129.0
       '@oxc-parser/binding-win32-ia32-msvc': 0.129.0
       '@oxc-parser/binding-win32-x64-msvc': 0.129.0
-
-  oxc-parser@0.94.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
-    dependencies:
-      '@oxc-project/types': 0.94.0
-    optionalDependencies:
-      '@oxc-parser/binding-android-arm64': 0.94.0
-      '@oxc-parser/binding-darwin-arm64': 0.94.0
-      '@oxc-parser/binding-darwin-x64': 0.94.0
-      '@oxc-parser/binding-freebsd-x64': 0.94.0
-      '@oxc-parser/binding-linux-arm-gnueabihf': 0.94.0
-      '@oxc-parser/binding-linux-arm-musleabihf': 0.94.0
-      '@oxc-parser/binding-linux-arm64-gnu': 0.94.0
-      '@oxc-parser/binding-linux-arm64-musl': 0.94.0
-      '@oxc-parser/binding-linux-riscv64-gnu': 0.94.0
-      '@oxc-parser/binding-linux-s390x-gnu': 0.94.0
-      '@oxc-parser/binding-linux-x64-gnu': 0.94.0
-      '@oxc-parser/binding-linux-x64-musl': 0.94.0
-      '@oxc-parser/binding-wasm32-wasi': 0.94.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-      '@oxc-parser/binding-win32-arm64-msvc': 0.94.0
-      '@oxc-parser/binding-win32-x64-msvc': 0.94.0
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
 
   oxfmt@0.45.0:
     dependencies:

--- a/tools/verify-package-deps/package.json
+++ b/tools/verify-package-deps/package.json
@@ -14,7 +14,7 @@
     "check-fmt": "oxfmt --check ."
   },
   "dependencies": {
-    "oxc-parser": "^0.94.0"
+    "oxc-parser": "^0.129.0"
   },
   "devDependencies": {
     "@types/node": "^22.10.5",

--- a/tools/verify-package-deps/src/verify-package-deps.ts
+++ b/tools/verify-package-deps/src/verify-package-deps.ts
@@ -2,7 +2,7 @@
 import {readdir, readFile, writeFile} from 'node:fs/promises';
 import {dirname, join, relative} from 'node:path';
 import {fileURLToPath} from 'node:url';
-import {parseAsync} from 'oxc-parser';
+import {parse} from 'oxc-parser';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const WORKSPACE_ROOT = join(__dirname, '../../..');
@@ -79,7 +79,7 @@ async function extractImports(
   const lines = content.split('\n');
 
   try {
-    const result = await parseAsync(filePath, content);
+    const result = await parse(filePath, content);
 
     // Extract static imports from the module info
     for (const imp of result.module.staticImports) {


### PR DESCRIPTION
pnpm keys a package's installed instance by its resolved peer dependencies. Since 1.7.0 declared react, solid-js, pg, drizzle-orm, kysely, expo-sqlite, and @op-engineering/op-sqlite as (optional) peers, any workspace where those resolve differently across packages installs multiple copies of @rocicorp/zero — e.g. a react@18 web app and a react@19 mobile app, or a web package next to a server package with pg.

TypeScript then sees two module identities: schema/query-registry types from a shared package stop unifying with the app-side copy (defineQueries extension collapses to `never`, useQuery rejects QueryRequest), and `declare module '@rocicorp/zero'` DefaultTypes augmentations only land on one copy.

The peers were added in 31a027f1a to keep the bundler from inlining these packages. Invert the bundling contract instead: every bare import is external by default, with an explicit inlinedModules allowlist for the only thing that must ship inside the bundle (@oxc-project/runtime transform helpers). A post-build check parses every emitted .js file with oxc-parser and asserts each bare import is a declared dependency, a node builtin, or a known integration package — a stronger guard than the previous out/node_modules heuristic, which could not catch undeclared imports that rolldown leaves external (it immediately caught the oxc helper imports that would have broken consumers).

Since the repo keeps a single version of each dependency, verify-package-deps moves from oxc-parser ^0.94.0 to ^0.129.0 (parseAsync was renamed to parse).

Verified against a dual-react (18/19) pnpm workspace repro: with this package, one store entry (no __react suffix) and all packages typecheck; vite resolves zero's react import per-app (sourcemap-checked both directions). Trade-off: no install-time peer version signal, and unbundled node resolution of an integration import falls back to pnpm's hoisted copy — ambiguous only when a workspace has multiple versions of that integration, the exact case peers turned into a hard fork.