### PR TITLE
fix(zero-client): avoid unhandled rejection when connect times out

### DIFF
--- a/packages/zero-client/src/client/zero.test.ts
+++ b/packages/zero-client/src/client/zero.test.ts
@@ -73,6 +73,7 @@ import {
 import {createBuilder} from '../../../zql/src/query/create-builder.ts';
 import type {Row} from '../../../zql/src/query/query.ts';
 import {nanoid} from '../util/nanoid.ts';
+import {ActiveClientsManager} from './active-clients-manager.ts';
 import {ClientErrorKind} from './client-error-kind.ts';
 import {ConnectionStatus} from './connection-status.ts';
 import type {ConnectionState} from './connection.ts';
@@ -2684,6 +2685,36 @@ test('Connect timeout', async () => {
   ]);
 
   connectionStatusCleanup();
+});
+
+test('connect timeout while awaiting socket setup does not leak an unhandled rejection', async () => {
+  const unhandledRejections: PromiseRejectionEvent[] = [];
+  const onUnhandled = (event: PromiseRejectionEvent) => {
+    unhandledRejections.push(event);
+    event.preventDefault();
+  };
+  window.addEventListener('unhandledrejection', onUnhandled);
+
+  // Never resolve setup, so #connect is still parked before createSocket when
+  // the connect timeout rejects #connectResolver.
+  vi.spyOn(ActiveClientsManager, 'create').mockReturnValue(new Promise(() => {}));
+
+  try {
+    const z = zeroForTest();
+    await z.waitForConnectionStatus(ConnectionStatus.Connecting);
+    await vi.advanceTimersByTimeAsync(CONNECT_TIMEOUT_MS + 1);
+    await tickAFewTimes(vi);
+
+    expect(
+      unhandledRejections.filter(
+        e =>
+          e.reason instanceof ClientError &&
+          e.reason.kind === ClientErrorKind.ConnectTimeout,
+      ),
+    ).toEqual([]);
+  } finally {
+    window.removeEventListener('unhandledrejection', onUnhandled);
+  }
 });
 
 test('socketOrigin', async () => {

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -420,7 +420,7 @@ export class Zero<
    * It rejects if we hit an error or timeout before the connected message.
    * Used by push/pull helpers to queue work until the connection is usable.
    */
-  #connectResolver = resolver<void>();
+  #connectResolver = connectResolver();
 
   #closeAbortController = new AbortController();
 
@@ -1815,7 +1815,7 @@ export class Zero<
 
     this.#socketResolver = resolver();
     lc.debug?.('Creating new connect resolver');
-    this.#connectResolver = resolver();
+    this.#connectResolver = connectResolver();
     this.#messageCount = 0;
     this.#connectStart = undefined; // don't reset this._totalToConnectStart
     this.#connectedAt = 0;
@@ -2786,6 +2786,12 @@ function addWebSocketIDToLogContext(wsid: string, lc: LogContext): LogContext {
 }
 
 function assertValidRunOptions(_options?: RunOptions): void {}
+
+function connectResolver(): Resolver<void> {
+  const r = resolver<void>();
+  r.promise.catch(() => {}); // the connect timeout may reject before it's awaited
+  return r;
+}
 
 async function makeActiveClientsManager(
   clientGroupID: Promise<string>,


### PR DESCRIPTION
We’ve sporadically seen this fire over the last month for various users.

I suspect this is some transient networking type issue, and not very serious, but it is causing us exception noise.

This implementation mirrors a few other callsites I saw like https://github.com/rocicorp/mono/blob/7da45c5589d550c22b6775f38afdee40fef3847f/packages/zero-cache/src/services/change-streamer/storer.ts#L520

(Note: we do forward connection errors to Sentry as recommended here: https://zero.rocicorp.dev/docs/connection?ref=localfirstnews.com#error, and this isn't coming through that way. It's arriving as an unhandled promise rejection.)