### PR TITLE
chore(zero-cache): add per-table phase timing logs

### DIFF
--- a/packages/zero-cache/src/db/initial-sync.bench.pg.ts
+++ b/packages/zero-cache/src/db/initial-sync.bench.pg.ts
@@ -29,7 +29,7 @@ const PROFILES = {
   'mixed-regression': {
     fixture: {fixture: 'mixed', rows: 250_000},
     warmupReps: 1,
-    reps: 10,
+    reps: 5,
     tableCopyWorkers: 4,
     timeoutMs: 3_600_000,
   },
@@ -43,7 +43,7 @@ const PROFILES = {
   'wide-text-full': {
     fixture: {fixture: 'wide-text', rows: 10_000, payloadBytes: 683_000},
     warmupReps: 1,
-    reps: 10,
+    reps: 3,
     tableCopyWorkers: 4,
     timeoutMs: 7_200_000,
   },
@@ -64,7 +64,7 @@ const PROFILES = {
   'large-payload-full': {
     fixture: {fixture: 'large-payload', rows: 10_000, payloadBytes: 275_000},
     warmupReps: 1,
-    reps: 10,
+    reps: 3,
     tableCopyWorkers: 4,
     timeoutMs: 7_200_000,
   },

--- a/packages/zero-cache/src/services/change-source/pg/initial-sync-metrics.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync-metrics.test.ts
@@ -1,0 +1,124 @@
+import {metrics} from '@opentelemetry/api';
+import {
+  AggregationTemporality,
+  DataPointType,
+  InMemoryMetricExporter,
+  MeterProvider,
+  PeriodicExportingMetricReader,
+} from '@opentelemetry/sdk-metrics';
+import {afterEach, describe, expect, test, vi} from 'vitest';
+
+afterEach(() => {
+  metrics.disable();
+  vi.resetModules();
+});
+
+describe('createCopyMetricBatcher', () => {
+  test('flushes below, at, and above the byte threshold', async () => {
+    const {COPY_METRIC_BATCH_BYTES, createCopyMetricBatcher} =
+      await import('./initial-sync.ts');
+    const record = vi.fn();
+    const batcher = createCopyMetricBatcher(record);
+
+    batcher.add(COPY_METRIC_BATCH_BYTES - 1);
+    expect(record).not.toHaveBeenCalled();
+
+    batcher.add(1);
+    expect(record).toHaveBeenLastCalledWith(COPY_METRIC_BATCH_BYTES, 2);
+
+    batcher.add(COPY_METRIC_BATCH_BYTES + 1);
+    expect(record).toHaveBeenLastCalledWith(COPY_METRIC_BATCH_BYTES + 1, 1);
+  });
+
+  test('flushes residual totals only once', async () => {
+    const {createCopyMetricBatcher} = await import('./initial-sync.ts');
+    const record = vi.fn();
+    const batcher = createCopyMetricBatcher(record);
+
+    batcher.add(100);
+    batcher.add(200);
+    batcher.flush();
+    batcher.flush();
+
+    expect(record).toHaveBeenCalledOnce();
+    expect(record).toHaveBeenCalledWith(300, 2);
+  });
+});
+
+test('exports exact byte and chunk totals with active OTel', async () => {
+  const {COPY_METRIC_BATCH_BYTES, initialSyncCopyMetrics} =
+    await import('./initial-sync.ts');
+  const exporter = new InMemoryMetricExporter(
+    AggregationTemporality.CUMULATIVE,
+  );
+  const provider = new MeterProvider({
+    readers: [
+      new PeriodicExportingMetricReader({
+        exporter,
+        exportIntervalMillis: 60_000,
+      }),
+    ],
+  });
+
+  try {
+    expect(metrics.setGlobalMeterProvider(provider)).toBe(true);
+    const copyMetrics = initialSyncCopyMetrics({
+      syncMode: 'initial',
+      copyFormat: 'binary',
+    });
+
+    copyMetrics.add(COPY_METRIC_BATCH_BYTES - 1);
+    copyMetrics.add(2);
+    copyMetrics.add(3);
+    copyMetrics.flush();
+    await provider.forceFlush();
+
+    expect(
+      metricValue(exporter, 'zero.replication.initial_sync_copy_stream'),
+    ).toBe(COPY_METRIC_BATCH_BYTES + 4);
+    expect(
+      metricValue(exporter, 'zero.replication.initial_sync_copy_chunks'),
+    ).toBe(3);
+  } finally {
+    await provider.shutdown();
+  }
+});
+
+test('works with the no-op OTel provider', async () => {
+  const {COPY_METRIC_BATCH_BYTES, initialSyncCopyMetrics} =
+    await import('./initial-sync.ts');
+  const copyMetrics = initialSyncCopyMetrics({
+    syncMode: 'shadow',
+    copyFormat: 'text',
+  });
+
+  expect(() => {
+    copyMetrics.add(COPY_METRIC_BATCH_BYTES);
+    copyMetrics.add(1);
+    copyMetrics.flush();
+    copyMetrics.flush();
+  }).not.toThrow();
+});
+
+function metricValue(exporter: InMemoryMetricExporter, name: string) {
+  const metric = exporter
+    .getMetrics()
+    .flatMap(resource => resource.scopeMetrics)
+    .flatMap(scope => scope.metrics)
+    .find(metric => metric.descriptor.name === name);
+
+  expect(metric).toBeDefined();
+  if (metric === undefined) {
+    throw new Error(`${name} was not exported`);
+  }
+  expect(metric.dataPointType).toBe(DataPointType.SUM);
+  if (metric.dataPointType !== DataPointType.SUM) {
+    throw new Error(`${name} was not a sum`);
+  }
+  expect(metric.dataPoints).toHaveLength(1);
+  expect(metric.dataPoints[0]?.attributes).toEqual({
+    sync_mode: 'initial',
+    copy_format: 'binary',
+  });
+  return metric.dataPoints[0]?.value;
+}

--- a/packages/zero-cache/src/services/change-source/pg/initial-sync.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync.pg.test.ts
@@ -2868,6 +2868,64 @@ describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
   });
 
   test.each([
+    {copyFormat: 'binary', textCopy: false},
+    {copyFormat: 'text', textCopy: true},
+  ] as const)(
+    'logs $copyFormat COPY phase timings',
+    async ({copyFormat, textCopy}) => {
+      await upstream`
+      CREATE TABLE populated(id int4 PRIMARY KEY);
+      INSERT INTO populated SELECT g FROM generate_series(1, 10) g;
+      CREATE TABLE empty(id int4 PRIMARY KEY);
+    `.simple();
+
+      const sink = new TestLogSink();
+      const lc = new LogContext('info', undefined, sink);
+      const replica = new Database(lc, ':memory:');
+      await initialSync(
+        lc,
+        {appID: APP_ID, shardNum: SHARD_NUM, publications: []},
+        replica,
+        getConnectionURI(upstream),
+        {tableCopyWorkers: 2, textCopy},
+        TEST_CONTEXT,
+      );
+
+      const timings = sink.messages
+        .flatMap(([, , args]) => args)
+        .filter(
+          (
+            arg,
+          ): arg is {
+            replicaTable: string;
+            copyFormat: string;
+            sourceWaitMs: number;
+            processingMs: number;
+            flushMs: number;
+            elapsedMs: number;
+          } =>
+            typeof arg === 'object' &&
+            arg !== null &&
+            'sourceWaitMs' in arg &&
+            (arg.replicaTable === 'populated' || arg.replicaTable === 'empty'),
+        );
+      expect(timings).toHaveLength(2);
+      for (const timing of timings) {
+        expect(timing.copyFormat).toBe(copyFormat);
+        expect(timing.sourceWaitMs).toEqual(expect.any(Number));
+        expect(timing.processingMs).toEqual(expect.any(Number));
+        expect(Number.isFinite(timing.sourceWaitMs)).toBe(true);
+        expect(Number.isFinite(timing.processingMs)).toBe(true);
+        expect(timing.sourceWaitMs).toBeGreaterThanOrEqual(0);
+        expect(timing.processingMs).toBeGreaterThanOrEqual(timing.flushMs);
+        expect(timing.sourceWaitMs + timing.processingMs).toBeLessThanOrEqual(
+          timing.elapsedMs,
+        );
+      }
+    },
+  );
+
+  test.each([
     'UPPERCASE',
     'dashes-not-allowed',
     'spaces not allowed',

--- a/packages/zero-cache/src/services/change-source/pg/initial-sync.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync.pg.test.ts
@@ -2907,6 +2907,7 @@ describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
             typeof arg === 'object' &&
             arg !== null &&
             'sourceWaitMs' in arg &&
+            'replicaTable' in arg &&
             (arg.replicaTable === 'populated' || arg.replicaTable === 'empty'),
         );
       expect(timings).toHaveLength(2);

--- a/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
@@ -851,6 +851,7 @@ type CopyResult = {
 const INITIAL_SYNC_DURATION_HISTOGRAM_BOUNDARIES_S = [
   1, 2, 5, 10, 30, 60, 120, 300, 600, 1200, 2400, 3600, 7200,
 ];
+export const COPY_METRIC_BATCH_BYTES = 8 * 1024 * 1024;
 const SLOW_COPY_FLUSH_MS = 10_000;
 
 // change-streamer imports this module before startOtelAuto() runs, so create
@@ -932,6 +933,43 @@ function initialSyncCopyChunks() {
     'initial_sync_copy_chunks',
     'PostgreSQL COPY stream chunks processed during initial sync.',
   );
+}
+
+export function createCopyMetricBatcher(
+  record: (bytes: number, chunks: number) => void,
+) {
+  let bytes = 0;
+  let chunks = 0;
+
+  function flush() {
+    if (chunks === 0) {
+      return;
+    }
+    record(bytes, chunks);
+    bytes = 0;
+    chunks = 0;
+  }
+
+  return {
+    add(chunkBytes: number) {
+      bytes += chunkBytes;
+      chunks++;
+      if (bytes >= COPY_METRIC_BATCH_BYTES) {
+        flush();
+      }
+    },
+    flush,
+  };
+}
+
+export function initialSyncCopyMetrics(attrs: InitialSyncMetricAttrs) {
+  const labels = initialSyncMetricAttrs(attrs);
+  const copyStreamMetric = initialSyncCopyStream();
+  const copyChunksMetric = initialSyncCopyChunks();
+  return createCopyMetricBatcher((bytes, chunks) => {
+    copyStreamMetric.add(bytes, labels);
+    copyChunksMetric.add(chunks, labels);
+  });
 }
 
 function initialSyncDurationHistogram(name: string, description: string) {
@@ -1139,9 +1177,7 @@ async function copyBinary(
 ): Promise<CopyResult> {
   const start = performance.now();
   const copyFormat: CopyFormat = 'binary';
-  const metricLabels = initialSyncMetricAttrs({syncMode, copyFormat});
-  const copyStreamMetric = initialSyncCopyStream();
-  const copyChunksMetric = initialSyncCopyChunks();
+  const copyMetrics = initialSyncCopyMetrics({syncMode, copyFormat});
   let flushMs = 0;
   let copyBytes = 0;
 
@@ -1240,8 +1276,7 @@ async function copyBinary(
       ) {
         try {
           copyBytes += chunk.length;
-          copyStreamMetric.add(chunk.length, metricLabels);
-          copyChunksMetric.add(1, metricLabels);
+          copyMetrics.add(chunk.length);
           for (const fieldBuf of binaryParser.parse(chunk)) {
             const fieldSize = fieldBuf === null ? 4 : fieldBuf.length;
             pendingSize += fieldSize;
@@ -1266,11 +1301,17 @@ async function copyBinary(
 
       final: (callback: (error?: Error) => void) => {
         try {
+          copyMetrics.flush();
           flush();
           callback();
         } catch (e) {
           callback(e instanceof Error ? e : new Error(String(e)));
         }
+      },
+
+      destroy(error, callback) {
+        copyMetrics.flush();
+        callback(error);
       },
     }),
   );
@@ -1312,9 +1353,7 @@ async function copyText(
 ): Promise<CopyResult> {
   const start = performance.now();
   const copyFormat: CopyFormat = 'text';
-  const metricLabels = initialSyncMetricAttrs({syncMode, copyFormat});
-  const copyStreamMetric = initialSyncCopyStream();
-  const copyChunksMetric = initialSyncCopyChunks();
+  const copyMetrics = initialSyncCopyMetrics({syncMode, copyFormat});
   let flushMs = 0;
   let copyBytes = 0;
 
@@ -1414,8 +1453,7 @@ async function copyText(
       ) {
         try {
           copyBytes += chunk.length;
-          copyStreamMetric.add(chunk.length, metricLabels);
-          copyChunksMetric.add(1, metricLabels);
+          copyMetrics.add(chunk.length);
           for (const text of tsvParser.parse(chunk)) {
             const fieldSize = text === null ? 4 : text.length;
             pendingSize += fieldSize;
@@ -1440,11 +1478,17 @@ async function copyText(
 
       final: (callback: (error?: Error) => void) => {
         try {
+          copyMetrics.flush();
           flush();
           callback();
         } catch (e) {
           callback(e instanceof Error ? e : new Error(String(e)));
         }
+      },
+
+      destroy(error, callback) {
+        copyMetrics.flush();
+        callback(error);
       },
     }),
   );

--- a/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
@@ -845,6 +845,8 @@ type CopyResult = {
   estimatedBytes: number | undefined;
   flushMs: number;
   elapsedMs: number;
+  sourceWaitMs: number;
+  processingMs: number;
   copyBytes: number;
 };
 
@@ -1180,6 +1182,7 @@ async function copyBinary(
   const copyMetrics = initialSyncCopyMetrics({syncMode, copyFormat});
   let flushMs = 0;
   let copyBytes = 0;
+  let processingMs = 0;
 
   const tableName = liteTableName(table);
   const orderedColumns = Object.entries(table.columns);
@@ -1262,6 +1265,7 @@ async function copyBinary(
 
   lc.info?.(`Starting binary copy stream of ${tableName}:`, select);
 
+  const copyStreamStart = performance.now();
   await pipeline(
     await from
       .unsafe(`COPY (${select}) TO STDOUT WITH (FORMAT binary)`)
@@ -1274,6 +1278,7 @@ async function copyBinary(
         _encoding: string,
         callback: (error?: Error) => void,
       ) {
+        const processingStart = performance.now();
         try {
           copyBytes += chunk.length;
           copyMetrics.add(chunk.length);
@@ -1293,18 +1298,23 @@ async function copyBinary(
               }
             }
           }
+          processingMs += performance.now() - processingStart;
           callback();
         } catch (e) {
+          processingMs += performance.now() - processingStart;
           callback(e instanceof Error ? e : new Error(String(e)));
         }
       },
 
       final: (callback: (error?: Error) => void) => {
+        const processingStart = performance.now();
         try {
           copyMetrics.flush();
           flush();
+          processingMs += performance.now() - processingStart;
           callback();
         } catch (e) {
+          processingMs += performance.now() - processingStart;
           callback(e instanceof Error ? e : new Error(String(e)));
         }
       },
@@ -1316,6 +1326,10 @@ async function copyBinary(
     }),
   );
 
+  const sourceWaitMs = Math.max(
+    0,
+    performance.now() - copyStreamStart - processingMs,
+  );
   const elapsed = performance.now() - start;
   const result = {
     schema: table.schema,
@@ -1329,6 +1343,8 @@ async function copyBinary(
     estimatedBytes: status.totalBytes,
     flushMs,
     elapsedMs: elapsed,
+    sourceWaitMs,
+    processingMs,
     copyBytes,
   } satisfies CopyResult;
 
@@ -1356,6 +1372,7 @@ async function copyText(
   const copyMetrics = initialSyncCopyMetrics({syncMode, copyFormat});
   let flushMs = 0;
   let copyBytes = 0;
+  let processingMs = 0;
 
   const tableName = liteTableName(table);
   const orderedColumns = Object.entries(table.columns);
@@ -1441,6 +1458,7 @@ async function copyText(
   const tsvParser = new TsvParser();
   let col = 0;
 
+  const copyStreamStart = performance.now();
   await pipeline(
     await from.unsafe(`COPY (${select}) TO STDOUT`).readable(),
     new Writable({
@@ -1451,6 +1469,7 @@ async function copyText(
         _encoding: string,
         callback: (error?: Error) => void,
       ) {
+        const processingStart = performance.now();
         try {
           copyBytes += chunk.length;
           copyMetrics.add(chunk.length);
@@ -1470,18 +1489,23 @@ async function copyText(
               }
             }
           }
+          processingMs += performance.now() - processingStart;
           callback();
         } catch (e) {
+          processingMs += performance.now() - processingStart;
           callback(e instanceof Error ? e : new Error(String(e)));
         }
       },
 
       final: (callback: (error?: Error) => void) => {
+        const processingStart = performance.now();
         try {
           copyMetrics.flush();
           flush();
+          processingMs += performance.now() - processingStart;
           callback();
         } catch (e) {
+          processingMs += performance.now() - processingStart;
           callback(e instanceof Error ? e : new Error(String(e)));
         }
       },
@@ -1493,6 +1517,10 @@ async function copyText(
     }),
   );
 
+  const sourceWaitMs = Math.max(
+    0,
+    performance.now() - copyStreamStart - processingMs,
+  );
   const elapsed = performance.now() - start;
   const result = {
     schema: table.schema,
@@ -1506,6 +1534,8 @@ async function copyText(
     estimatedBytes: status.totalBytes,
     flushMs,
     elapsedMs: elapsed,
+    sourceWaitMs,
+    processingMs,
     copyBytes,
   } satisfies CopyResult;
   lc.info?.(


### PR DESCRIPTION

### What

Adds per-table phase timings to initial sync completion logs so source waiting can be distinguished from destination processing for both binary and text COPY.

### Why

A table's total COPY duration and SQLite flush time do not show whether the remaining time is spent waiting for PostgreSQL or processing data inside Zero. This distinction helps determine whether parser, decoding, SQLite, or source-side work is the useful optimization target.

### Changes

- Adds `sourceWaitMs` and `processingMs` to the existing per-table COPY completion record.
- Measures parser, decoding, metric bookkeeping, SQLite statement, and final-flush work inside destination callbacks.
- Derives source wait as COPY stream wall time outside synchronous destination processing.

