### PR TITLE
perf(zero-cache): batch initial sync copy metrics

### DIFF
--- a/packages/zero-cache/src/db/initial-sync.bench.pg.ts
+++ b/packages/zero-cache/src/db/initial-sync.bench.pg.ts
@@ -29,7 +29,7 @@ const PROFILES = {
   'mixed-regression': {
     fixture: {fixture: 'mixed', rows: 250_000},
     warmupReps: 1,
-    reps: 10,
+    reps: 5,
     tableCopyWorkers: 4,
     timeoutMs: 3_600_000,
   },
@@ -43,7 +43,7 @@ const PROFILES = {
   'wide-text-full': {
     fixture: {fixture: 'wide-text', rows: 10_000, payloadBytes: 683_000},
     warmupReps: 1,
-    reps: 10,
+    reps: 3,
     tableCopyWorkers: 4,
     timeoutMs: 7_200_000,
   },
@@ -64,7 +64,7 @@ const PROFILES = {
   'large-payload-full': {
     fixture: {fixture: 'large-payload', rows: 10_000, payloadBytes: 275_000},
     warmupReps: 1,
-    reps: 10,
+    reps: 3,
     tableCopyWorkers: 4,
     timeoutMs: 7_200_000,
   },

--- a/packages/zero-cache/src/services/change-source/pg/initial-sync-metrics.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync-metrics.test.ts
@@ -1,0 +1,124 @@
+import {metrics} from '@opentelemetry/api';
+import {
+  AggregationTemporality,
+  DataPointType,
+  InMemoryMetricExporter,
+  MeterProvider,
+  PeriodicExportingMetricReader,
+} from '@opentelemetry/sdk-metrics';
+import {afterEach, describe, expect, test, vi} from 'vitest';
+
+afterEach(() => {
+  metrics.disable();
+  vi.resetModules();
+});
+
+describe('createCopyMetricBatcher', () => {
+  test('flushes below, at, and above the byte threshold', async () => {
+    const {COPY_METRIC_BATCH_BYTES, createCopyMetricBatcher} =
+      await import('./initial-sync.ts');
+    const record = vi.fn();
+    const batcher = createCopyMetricBatcher(record);
+
+    batcher.add(COPY_METRIC_BATCH_BYTES - 1);
+    expect(record).not.toHaveBeenCalled();
+
+    batcher.add(1);
+    expect(record).toHaveBeenLastCalledWith(COPY_METRIC_BATCH_BYTES, 2);
+
+    batcher.add(COPY_METRIC_BATCH_BYTES + 1);
+    expect(record).toHaveBeenLastCalledWith(COPY_METRIC_BATCH_BYTES + 1, 1);
+  });
+
+  test('flushes residual totals only once', async () => {
+    const {createCopyMetricBatcher} = await import('./initial-sync.ts');
+    const record = vi.fn();
+    const batcher = createCopyMetricBatcher(record);
+
+    batcher.add(100);
+    batcher.add(200);
+    batcher.flush();
+    batcher.flush();
+
+    expect(record).toHaveBeenCalledOnce();
+    expect(record).toHaveBeenCalledWith(300, 2);
+  });
+});
+
+test('exports exact byte and chunk totals with active OTel', async () => {
+  const {COPY_METRIC_BATCH_BYTES, initialSyncCopyMetrics} =
+    await import('./initial-sync.ts');
+  const exporter = new InMemoryMetricExporter(
+    AggregationTemporality.CUMULATIVE,
+  );
+  const provider = new MeterProvider({
+    readers: [
+      new PeriodicExportingMetricReader({
+        exporter,
+        exportIntervalMillis: 60_000,
+      }),
+    ],
+  });
+
+  try {
+    expect(metrics.setGlobalMeterProvider(provider)).toBe(true);
+    const copyMetrics = initialSyncCopyMetrics({
+      syncMode: 'initial',
+      copyFormat: 'binary',
+    });
+
+    copyMetrics.add(COPY_METRIC_BATCH_BYTES - 1);
+    copyMetrics.add(2);
+    copyMetrics.add(3);
+    copyMetrics.flush();
+    await provider.forceFlush();
+
+    expect(
+      metricValue(exporter, 'zero.replication.initial_sync_copy_stream'),
+    ).toBe(COPY_METRIC_BATCH_BYTES + 4);
+    expect(
+      metricValue(exporter, 'zero.replication.initial_sync_copy_chunks'),
+    ).toBe(3);
+  } finally {
+    await provider.shutdown();
+  }
+});
+
+test('works with the no-op OTel provider', async () => {
+  const {COPY_METRIC_BATCH_BYTES, initialSyncCopyMetrics} =
+    await import('./initial-sync.ts');
+  const copyMetrics = initialSyncCopyMetrics({
+    syncMode: 'shadow',
+    copyFormat: 'text',
+  });
+
+  expect(() => {
+    copyMetrics.add(COPY_METRIC_BATCH_BYTES);
+    copyMetrics.add(1);
+    copyMetrics.flush();
+    copyMetrics.flush();
+  }).not.toThrow();
+});
+
+function metricValue(exporter: InMemoryMetricExporter, name: string) {
+  const metric = exporter
+    .getMetrics()
+    .flatMap(resource => resource.scopeMetrics)
+    .flatMap(scope => scope.metrics)
+    .find(metric => metric.descriptor.name === name);
+
+  expect(metric).toBeDefined();
+  if (metric === undefined) {
+    throw new Error(`${name} was not exported`);
+  }
+  expect(metric.dataPointType).toBe(DataPointType.SUM);
+  if (metric.dataPointType !== DataPointType.SUM) {
+    throw new Error(`${name} was not a sum`);
+  }
+  expect(metric.dataPoints).toHaveLength(1);
+  expect(metric.dataPoints[0]?.attributes).toEqual({
+    sync_mode: 'initial',
+    copy_format: 'binary',
+  });
+  return metric.dataPoints[0]?.value;
+}

--- a/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
@@ -851,6 +851,7 @@ type CopyResult = {
 const INITIAL_SYNC_DURATION_HISTOGRAM_BOUNDARIES_S = [
   1, 2, 5, 10, 30, 60, 120, 300, 600, 1200, 2400, 3600, 7200,
 ];
+export const COPY_METRIC_BATCH_BYTES = 8 * 1024 * 1024;
 const SLOW_COPY_FLUSH_MS = 10_000;
 
 // change-streamer imports this module before startOtelAuto() runs, so create
@@ -932,6 +933,43 @@ function initialSyncCopyChunks() {
     'initial_sync_copy_chunks',
     'PostgreSQL COPY stream chunks processed during initial sync.',
   );
+}
+
+export function createCopyMetricBatcher(
+  record: (bytes: number, chunks: number) => void,
+) {
+  let bytes = 0;
+  let chunks = 0;
+
+  function flush() {
+    if (chunks === 0) {
+      return;
+    }
+    record(bytes, chunks);
+    bytes = 0;
+    chunks = 0;
+  }
+
+  return {
+    add(chunkBytes: number) {
+      bytes += chunkBytes;
+      chunks++;
+      if (bytes >= COPY_METRIC_BATCH_BYTES) {
+        flush();
+      }
+    },
+    flush,
+  };
+}
+
+export function initialSyncCopyMetrics(attrs: InitialSyncMetricAttrs) {
+  const labels = initialSyncMetricAttrs(attrs);
+  const copyStreamMetric = initialSyncCopyStream();
+  const copyChunksMetric = initialSyncCopyChunks();
+  return createCopyMetricBatcher((bytes, chunks) => {
+    copyStreamMetric.add(bytes, labels);
+    copyChunksMetric.add(chunks, labels);
+  });
 }
 
 function initialSyncDurationHistogram(name: string, description: string) {
@@ -1139,9 +1177,7 @@ async function copyBinary(
 ): Promise<CopyResult> {
   const start = performance.now();
   const copyFormat: CopyFormat = 'binary';
-  const metricLabels = initialSyncMetricAttrs({syncMode, copyFormat});
-  const copyStreamMetric = initialSyncCopyStream();
-  const copyChunksMetric = initialSyncCopyChunks();
+  const copyMetrics = initialSyncCopyMetrics({syncMode, copyFormat});
   let flushMs = 0;
   let copyBytes = 0;
 
@@ -1240,8 +1276,7 @@ async function copyBinary(
       ) {
         try {
           copyBytes += chunk.length;
-          copyStreamMetric.add(chunk.length, metricLabels);
-          copyChunksMetric.add(1, metricLabels);
+          copyMetrics.add(chunk.length);
           for (const fieldBuf of binaryParser.parse(chunk)) {
             const fieldSize = fieldBuf === null ? 4 : fieldBuf.length;
             pendingSize += fieldSize;
@@ -1266,11 +1301,17 @@ async function copyBinary(
 
       final: (callback: (error?: Error) => void) => {
         try {
+          copyMetrics.flush();
           flush();
           callback();
         } catch (e) {
           callback(e instanceof Error ? e : new Error(String(e)));
         }
+      },
+
+      destroy(error, callback) {
+        copyMetrics.flush();
+        callback(error);
       },
     }),
   );
@@ -1312,9 +1353,7 @@ async function copyText(
 ): Promise<CopyResult> {
   const start = performance.now();
   const copyFormat: CopyFormat = 'text';
-  const metricLabels = initialSyncMetricAttrs({syncMode, copyFormat});
-  const copyStreamMetric = initialSyncCopyStream();
-  const copyChunksMetric = initialSyncCopyChunks();
+  const copyMetrics = initialSyncCopyMetrics({syncMode, copyFormat});
   let flushMs = 0;
   let copyBytes = 0;
 
@@ -1414,8 +1453,7 @@ async function copyText(
       ) {
         try {
           copyBytes += chunk.length;
-          copyStreamMetric.add(chunk.length, metricLabels);
-          copyChunksMetric.add(1, metricLabels);
+          copyMetrics.add(chunk.length);
           for (const text of tsvParser.parse(chunk)) {
             const fieldSize = text === null ? 4 : text.length;
             pendingSize += fieldSize;
@@ -1440,11 +1478,17 @@ async function copyText(
 
       final: (callback: (error?: Error) => void) => {
         try {
+          copyMetrics.flush();
           flush();
           callback();
         } catch (e) {
           callback(e instanceof Error ? e : new Error(String(e)));
         }
+      },
+
+      destroy(error, callback) {
+        copyMetrics.flush();
+        callback(error);
       },
     }),
   );


### PR DESCRIPTION

### What

Batches initial-sync COPY byte and chunk metric updates into 8 MiB increments instead of recording both OpenTelemetry counters for every PostgreSQL COPY chunk.

### Why

Initial sync currently calls the OpenTelemetry metrics API twice per COPY chunk. Large initial syncs can process many small chunks, making metric recording part of the hot path even though only the eventual byte and chunk totals matter.

Batching preserves the exported totals and labels while reducing calls into the metrics SDK.

### Changes

- Adds a small accumulator that flushes COPY byte and chunk totals every 8 MiB.
- Uses the accumulator in both binary and text COPY paths.
- Flushes residual totals on normal completion and stream destruction.
- Makes flushing idempotent so finalization and automatic destruction cannot duplicate metrics.

**Active OpenTelemetry initial sync**

| Profile | Rows | Payload MB (decimal) | Median MiB/s | Average MiB/s | Median elapsed | Average elapsed | Cumulative speedup vs [#6235](https://github.com/rocicorp/mono/pull/6235) |
|---|---:|---:|---:|---:|---:|---:|---:|
| `mixed-regression` | 250,000 | 493.787499 | 336.76 | 311.69 | 1.40s | 1.51s | +13.11% |
| `wide-text-scaled` | 1,000 | 683 | 340.87 | 345.82 | 1.91s | 1.88s | +0.08% |
| `wide-text-full` | 10,000 | 6,830 | 132.57 | 139.96 | 49.13s | 46.54s | +14.86% |
| `large-payload-scaled` | 2,000 | 550 | 323.84 | 229.82 | 1.62s | 2.28s | +25.34% |
| `large-payload-full` | 10,000 | 2,750 | 195.16 | 203.26 | 13.44s | 12.90s | +34.77% |
