### PR TITLE
feat(zero-cache): event-driven flow-control release

### DIFF
--- a/packages/zero-cache/src/config/zero-config.test.ts
+++ b/packages/zero-cache/src/config/zero-config.test.ts
@@ -450,6 +450,16 @@ test('zero-cache --help', () => {
                                                                         Set this to a negative number to disable early flow control releases. (Not recommended, but                                
                                                                         available as an emergency measure.)                                                                                        
                                                                                                                                                                                                    
+     --change-streamer-flow-control-event-driven-release boolean        default: false                                                                                                             
+       ZERO_CHANGE_STREAMER_FLOW_CONTROL_EVENT_DRIVEN_RELEASE env                                                                                                                                  
+                                                                        When enabled, flow control releases replication as soon as the                                                             
+                                                                        consensus-timeout condition is met (a majority of subscribers have                                                         
+                                                                        acked and the flowControlConsensusPaddingSeconds interval has elapsed),                                                    
+                                                                        rather than waiting for the next periodic (1 second) progress check.                                                       
+                                                                                                                                                                                                   
+                                                                        This reduces replication latency when a slow subscriber would otherwise                                                    
+                                                                        hold the stream at each flow-control checkpoint until the next tick.                                                       
+                                                                                                                                                                                                   
      --task-id string                                                   optional                                                                                                                   
        ZERO_TASK_ID env                                                                                                                                                                            
                                                                         Globally unique identifier for the zero-cache instance.                                                                    

--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -717,6 +717,19 @@ export const zeroOptions = {
         `available as an emergency measure.)`,
       ],
     },
+
+    flowControlEventDrivenRelease: {
+      type: v.boolean().default(false),
+      desc: [
+        `When enabled, flow control releases replication as soon as the`,
+        `consensus-timeout condition is met (a majority of subscribers have`,
+        `acked and the flowControlConsensusPaddingSeconds interval has elapsed),`,
+        `rather than waiting for the next periodic (1 second) progress check.`,
+        ``,
+        `This reduces replication latency when a slow subscriber would otherwise`,
+        `hold the stream at each flow-control checkpoint until the next tick.`,
+      ],
+    },
   },
 
   taskID: {

--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -57,6 +57,7 @@ export default async function runWorker(
       startupDelayMs,
       backPressureLimitHeapProportion,
       flowControlConsensusPaddingSeconds,
+      flowControlEventDrivenRelease,
     },
     upstream,
     change,
@@ -166,6 +167,7 @@ export default async function runWorker(
         {
           backPressureLimitHeapProportion,
           flowControlConsensusPaddingSeconds,
+          flowControlEventDrivenRelease,
           statementTimeoutMs: change.statementTimeoutMs,
           changeLogBatchSize: change.logBatchSize,
         },

--- a/packages/zero-cache/src/services/change-streamer/broadcast.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/broadcast.test.ts
@@ -126,12 +126,24 @@ describe('change-streamer/broadcast', () => {
   ];
 
   function captureTimers() {
-    const scheduled: {cb: () => void; ms: number | undefined}[] = [];
+    const scheduled: {
+      cb: () => void;
+      ms: number | undefined;
+      handle: number;
+    }[] = [];
+    const cleared: number[] = [];
+    let nextHandle = 1;
     const setTimeoutFn = ((cb: () => void, ms?: number) => {
-      scheduled.push({cb, ms});
-      return 0;
+      const handle = nextHandle++;
+      scheduled.push({cb, ms, handle});
+      return handle;
     }) as unknown as typeof setTimeout;
-    return {scheduled, setTimeoutFn};
+    const clearTimeoutFn = ((handle?: number) => {
+      if (handle !== undefined) {
+        cleared.push(handle);
+      }
+    }) as unknown as typeof clearTimeout;
+    return {scheduled, cleared, setTimeoutFn, clearTimeoutFn};
   }
 
   test('event-driven early release once a majority acks', async () => {
@@ -139,11 +151,12 @@ describe('change-streamer/broadcast', () => {
     const [sub2] = createSubscriber('00', true);
     const [sub3] = createSubscriber('00', true);
     const [sub4] = createSubscriber('00', true);
-    const {scheduled, setTimeoutFn} = captureTimers();
+    const {scheduled, setTimeoutFn, clearTimeoutFn} = captureTimers();
 
     const broadcast = new Broadcast([sub1, sub2, sub3, sub4], begin, {
       consensusTimeoutMs: 2000,
       setTimeoutFn,
+      clearTimeoutFn,
     });
 
     // Two acks: below the majority of 3, so no early-release timer is armed.
@@ -173,11 +186,12 @@ describe('change-streamer/broadcast', () => {
     const [sub3] = createSubscriber('00', true);
     const [sub4] = createSubscriber('00', true);
     const [sub5] = createSubscriber('00', true);
-    const {scheduled, setTimeoutFn} = captureTimers();
+    const {scheduled, cleared, setTimeoutFn, clearTimeoutFn} = captureTimers();
 
     const broadcast = new Broadcast([sub1, sub2, sub3, sub4, sub5], begin, {
       consensusTimeoutMs: 2000,
       setTimeoutFn,
+      clearTimeoutFn,
     });
 
     // Majority of 5 is 3: arms the timer.
@@ -187,10 +201,12 @@ describe('change-streamer/broadcast', () => {
     await sleep(1);
     expect(scheduled).toHaveLength(1);
 
-    // A later completion re-arms (new generation) instead of releasing now.
+    // A later completion re-arms (new generation) instead of releasing now, and
+    // cancels the previously-armed timer so stale timers don't accumulate.
     sub4.close();
     await sleep(1);
     expect(scheduled).toHaveLength(2);
+    expect(cleared).toContain(scheduled[0].handle);
     expect(broadcast.isDone).toBe(false);
 
     // The stale (first-generation) timer must not release the broadcast.
@@ -207,11 +223,12 @@ describe('change-streamer/broadcast', () => {
     const [sub1] = createSubscriber('00', true);
     const [sub2] = createSubscriber('00', true);
     const [sub3] = createSubscriber('00', true);
-    const {scheduled, setTimeoutFn} = captureTimers();
+    const {scheduled, cleared, setTimeoutFn, clearTimeoutFn} = captureTimers();
 
     const broadcast = new Broadcast([sub1, sub2, sub3], begin, {
       consensusTimeoutMs: 2000,
       setTimeoutFn,
+      clearTimeoutFn,
     });
 
     // Majority of 3 is 2: arms the timer.
@@ -224,6 +241,8 @@ describe('change-streamer/broadcast', () => {
     sub3.close();
     await broadcast.done;
     expect(broadcast.releaseMode).toBe('all-subscribers');
+    // Resolving cancels the pending early-release timer.
+    expect(cleared).toContain(scheduled[0].handle);
 
     // A late timer callback is a no-op: the broadcast is already done.
     scheduled[0].cb();

--- a/packages/zero-cache/src/services/change-streamer/broadcast.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/broadcast.test.ts
@@ -4,6 +4,7 @@ import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.
 import {sleep} from '../../../../shared/src/sleep.ts';
 import {ReplicationMessages} from '../replicator/test-utils.ts';
 import {Broadcast} from './broadcast.ts';
+import type {WatermarkedChange} from './change-streamer-service.ts';
 import {createSubscriber} from './test-utils.ts';
 
 const json = BigIntJSON.stringify;
@@ -116,5 +117,116 @@ describe('change-streamer/broadcast', () => {
 
     await broadcast.done;
     expect(broadcast.isDone).toBe(true);
+  });
+
+  const begin: WatermarkedChange = [
+    '11',
+    'begin',
+    json(['begin', messages.begin(), {commitWatermark: '13'}]),
+  ];
+
+  function captureTimers() {
+    const scheduled: {cb: () => void; ms: number | undefined}[] = [];
+    const setTimeoutFn = ((cb: () => void, ms?: number) => {
+      scheduled.push({cb, ms});
+      return 0;
+    }) as unknown as typeof setTimeout;
+    return {scheduled, setTimeoutFn};
+  }
+
+  test('event-driven early release once a majority acks', async () => {
+    const [sub1] = createSubscriber('00', true);
+    const [sub2] = createSubscriber('00', true);
+    const [sub3] = createSubscriber('00', true);
+    const [sub4] = createSubscriber('00', true);
+    const {scheduled, setTimeoutFn} = captureTimers();
+
+    const broadcast = new Broadcast([sub1, sub2, sub3, sub4], begin, {
+      consensusTimeoutMs: 2000,
+      setTimeoutFn,
+    });
+
+    // Two acks: below the majority of 3, so no early-release timer is armed.
+    sub1.close();
+    sub2.close();
+    await sleep(1);
+    expect(scheduled).toHaveLength(0);
+    expect(broadcast.isDone).toBe(false);
+
+    // Third ack reaches the majority: the release timer is armed.
+    sub3.close();
+    await sleep(1);
+    expect(scheduled).toHaveLength(1);
+    expect(scheduled[0].ms).toBe(2000);
+    expect(broadcast.isDone).toBe(false);
+
+    // Firing the timer releases via consensus-timeout, without a 1s tick.
+    scheduled[0].cb();
+    await broadcast.done;
+    expect(broadcast.isDone).toBe(true);
+    expect(broadcast.releaseMode).toBe('consensus-timeout');
+  });
+
+  test('early-release timer re-arms on later completions; stale timers are ignored', async () => {
+    const [sub1] = createSubscriber('00', true);
+    const [sub2] = createSubscriber('00', true);
+    const [sub3] = createSubscriber('00', true);
+    const [sub4] = createSubscriber('00', true);
+    const [sub5] = createSubscriber('00', true);
+    const {scheduled, setTimeoutFn} = captureTimers();
+
+    const broadcast = new Broadcast([sub1, sub2, sub3, sub4, sub5], begin, {
+      consensusTimeoutMs: 2000,
+      setTimeoutFn,
+    });
+
+    // Majority of 5 is 3: arms the timer.
+    sub1.close();
+    sub2.close();
+    sub3.close();
+    await sleep(1);
+    expect(scheduled).toHaveLength(1);
+
+    // A later completion re-arms (new generation) instead of releasing now.
+    sub4.close();
+    await sleep(1);
+    expect(scheduled).toHaveLength(2);
+    expect(broadcast.isDone).toBe(false);
+
+    // The stale (first-generation) timer must not release the broadcast.
+    scheduled[0].cb();
+    expect(broadcast.isDone).toBe(false);
+
+    // The latest timer releases it.
+    scheduled[1].cb();
+    await broadcast.done;
+    expect(broadcast.releaseMode).toBe('consensus-timeout');
+  });
+
+  test('all-subscribers release takes precedence over a pending early-release timer', async () => {
+    const [sub1] = createSubscriber('00', true);
+    const [sub2] = createSubscriber('00', true);
+    const [sub3] = createSubscriber('00', true);
+    const {scheduled, setTimeoutFn} = captureTimers();
+
+    const broadcast = new Broadcast([sub1, sub2, sub3], begin, {
+      consensusTimeoutMs: 2000,
+      setTimeoutFn,
+    });
+
+    // Majority of 3 is 2: arms the timer.
+    sub1.close();
+    sub2.close();
+    await sleep(1);
+    expect(scheduled).toHaveLength(1);
+
+    // All subscribers ack before the timer fires.
+    sub3.close();
+    await broadcast.done;
+    expect(broadcast.releaseMode).toBe('all-subscribers');
+
+    // A late timer callback is a no-op: the broadcast is already done.
+    scheduled[0].cb();
+    expect(broadcast.releaseMode).toBe('all-subscribers');
   });
 });

--- a/packages/zero-cache/src/services/change-streamer/broadcast.ts
+++ b/packages/zero-cache/src/services/change-streamer/broadcast.ts
@@ -6,6 +6,19 @@ import type {Subscriber} from './subscriber.ts';
 export type BroadcastReleaseMode = 'all-subscribers' | 'consensus-timeout';
 
 /**
+ * Enables event-driven early release of a {@link Broadcast}. When provided, the
+ * broadcast resolves exactly `consensusTimeoutMs` after the most recent
+ * subscriber completion once a majority has acked, instead of relying on the
+ * Forwarder's periodic progress tick to call {@link Broadcast.checkProgress()}.
+ */
+export type EarlyReleaseOptions = {
+  /** Milliseconds to wait after the majority acks before releasing. */
+  consensusTimeoutMs: number;
+  /** Injectable timer, for deterministic testing. */
+  setTimeoutFn?: typeof setTimeout;
+};
+
+/**
  * Initiates and tracks the progress of a change broadcasted to
  * a set of subscribers.
  *
@@ -42,15 +55,27 @@ export class Broadcast {
   readonly #start = performance.now();
   #latestCompleted = Number.MAX_VALUE;
 
+  // When set, the broadcast schedules its own consensus-timeout release instead
+  // of waiting for the Forwarder's periodic progress tick.
+  readonly #earlyReleaseTimeoutMs: number | undefined;
+  readonly #setTimeout: typeof setTimeout;
+  #earlyReleaseGeneration = 0;
+
   /**
    * Broadcasts the `change` to the `subscribers` and tracks their
    * completion.
    */
-  constructor(subscribers: Iterable<Subscriber>, change: WatermarkedChange) {
+  constructor(
+    subscribers: Iterable<Subscriber>,
+    change: WatermarkedChange,
+    earlyRelease?: EarlyReleaseOptions,
+  ) {
     this.#pending = new Set(subscribers);
     this.#completed = [];
     this.#watermark = change[0];
     this.#majority = Math.floor(this.#pending.size / 2) + 1;
+    this.#earlyReleaseTimeoutMs = earlyRelease?.consensusTimeoutMs;
+    this.#setTimeout = earlyRelease?.setTimeoutFn ?? setTimeout;
 
     for (const sub of this.#pending) {
       const changes = sub.numPending + 1; // add one for this `change`
@@ -72,7 +97,31 @@ export class Broadcast {
     this.#pending.delete(sub);
     if (this.#pending.size === 0) {
       this.#setDone('all-subscribers');
+      return;
     }
+    // Event-driven consensus-timeout: once a majority has acked, resolve exactly
+    // #earlyReleaseTimeoutMs after this (the most recent) completion instead of
+    // waiting up to a full progress-tick interval for checkProgress() to run.
+    // Each later completion re-arms the timer; checkProgress() remains as a
+    // fallback and for logging.
+    if (
+      this.#earlyReleaseTimeoutMs !== undefined &&
+      this.#completed.length >= this.#majority
+    ) {
+      this.#scheduleEarlyRelease();
+    }
+  }
+
+  #scheduleEarlyRelease() {
+    const generation = ++this.#earlyReleaseGeneration;
+    this.#setTimeout(() => {
+      // Skip if a later completion superseded this timer or the broadcast has
+      // already resolved (e.g. all subscribers acked).
+      if (this.#isDone || generation !== this.#earlyReleaseGeneration) {
+        return;
+      }
+      this.#setDone('consensus-timeout');
+    }, this.#earlyReleaseTimeoutMs);
   }
 
   #setDone(releaseMode: BroadcastReleaseMode) {

--- a/packages/zero-cache/src/services/change-streamer/broadcast.ts
+++ b/packages/zero-cache/src/services/change-streamer/broadcast.ts
@@ -16,6 +16,8 @@ export type EarlyReleaseOptions = {
   consensusTimeoutMs: number;
   /** Injectable timer, for deterministic testing. */
   setTimeoutFn?: typeof setTimeout;
+  /** Injectable timer cancellation, for deterministic testing. */
+  clearTimeoutFn?: typeof clearTimeout;
 };
 
 /**
@@ -59,7 +61,9 @@ export class Broadcast {
   // of waiting for the Forwarder's periodic progress tick.
   readonly #earlyReleaseTimeoutMs: number | undefined;
   readonly #setTimeout: typeof setTimeout;
+  readonly #clearTimeout: typeof clearTimeout;
   #earlyReleaseGeneration = 0;
+  #earlyReleaseTimer: ReturnType<typeof setTimeout> | undefined;
 
   /**
    * Broadcasts the `change` to the `subscribers` and tracks their
@@ -76,6 +80,7 @@ export class Broadcast {
     this.#majority = Math.floor(this.#pending.size / 2) + 1;
     this.#earlyReleaseTimeoutMs = earlyRelease?.consensusTimeoutMs;
     this.#setTimeout = earlyRelease?.setTimeoutFn ?? setTimeout;
+    this.#clearTimeout = earlyRelease?.clearTimeoutFn ?? clearTimeout;
 
     for (const sub of this.#pending) {
       const changes = sub.numPending + 1; // add one for this `change`
@@ -114,9 +119,14 @@ export class Broadcast {
 
   #scheduleEarlyRelease() {
     const generation = ++this.#earlyReleaseGeneration;
-    this.#setTimeout(() => {
+    // Cancel the timer armed by an earlier completion so stale timers don't
+    // accumulate (each retaining this Broadcast in memory and adding callback
+    // load) when many subscribers complete after the majority is reached.
+    this.#clearTimeout(this.#earlyReleaseTimer);
+    this.#earlyReleaseTimer = this.#setTimeout(() => {
       // Skip if a later completion superseded this timer or the broadcast has
-      // already resolved (e.g. all subscribers acked).
+      // already resolved (e.g. all subscribers acked). The generation check
+      // still guards the race where a timer fires just before it is cleared.
       if (this.#isDone || generation !== this.#earlyReleaseGeneration) {
         return;
       }
@@ -130,6 +140,8 @@ export class Broadcast {
     }
     this.#isDone = true;
     this.#releaseMode = releaseMode;
+    this.#clearTimeout(this.#earlyReleaseTimer);
+    this.#earlyReleaseTimer = undefined;
     this.#done.resolve();
   }
 

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -56,6 +56,7 @@ import {Subscriber} from './subscriber.ts';
 
 export type TuningOptions = StorerOptions & {
   flowControlConsensusPaddingSeconds: number;
+  flowControlEventDrivenRelease?: boolean | undefined;
 };
 
 /**
@@ -343,6 +344,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
     this.#forwarder = new Forwarder(lc, {
       flowControlConsensusPaddingSeconds:
         opts.flowControlConsensusPaddingSeconds,
+      eventDrivenRelease: opts.flowControlEventDrivenRelease,
     });
     this.#replicationStatusPublisher = replicationStatusPublisher;
     this.#purgeLock = initialPurgeLock;

--- a/packages/zero-cache/src/services/change-streamer/forwarder.ts
+++ b/packages/zero-cache/src/services/change-streamer/forwarder.ts
@@ -16,14 +16,16 @@ export type ProgressMonitorOptions = {
   // as the majority-plus-padding condition is met, instead of waiting for the
   // 1s progress tick to call checkProgress().
   eventDrivenRelease?: boolean | undefined;
-  // Injectable timer, for deterministic testing.
+  // Injectable timers, for deterministic testing.
   setTimeoutFn?: typeof setTimeout | undefined;
+  clearTimeoutFn?: typeof clearTimeout | undefined;
 };
 
 export class Forwarder {
   readonly #lc: LogContext;
   readonly #progressMonitorOptions: ProgressMonitorOptions;
   readonly #setTimeout: typeof setTimeout;
+  readonly #clearTimeout: typeof clearTimeout;
   readonly #active = new Set<Subscriber>();
   readonly #queued = new Set<Subscriber>();
   readonly #flowControlWaits = getOrCreateCounter(
@@ -48,6 +50,7 @@ export class Forwarder {
     this.#lc = lc.withContext('component', 'progress-monitor');
     this.#progressMonitorOptions = opts;
     this.#setTimeout = opts.setTimeoutFn ?? setTimeout;
+    this.#clearTimeout = opts.clearTimeoutFn ?? clearTimeout;
 
     getOrCreateGauge(
       'replication',
@@ -170,6 +173,7 @@ export class Forwarder {
     return {
       consensusTimeoutMs: flowControlConsensusPaddingSeconds * 1000,
       setTimeoutFn: this.#setTimeout,
+      clearTimeoutFn: this.#clearTimeout,
     };
   }
 

--- a/packages/zero-cache/src/services/change-streamer/forwarder.ts
+++ b/packages/zero-cache/src/services/change-streamer/forwarder.ts
@@ -5,18 +5,25 @@ import {
   getOrCreateGauge,
   getOrCreateLatencyHistogram,
 } from '../../observability/metrics.ts';
-import {Broadcast} from './broadcast.ts';
+import {Broadcast, type EarlyReleaseOptions} from './broadcast.ts';
 import type {ChangeTag, WatermarkedChange} from './change-streamer-service.ts';
 import type {Status} from './change-streamer.ts';
 import type {Subscriber} from './subscriber.ts';
 
 export type ProgressMonitorOptions = {
   flowControlConsensusPaddingSeconds: number;
+  // When true, broadcasts schedule their own consensus-timeout release as soon
+  // as the majority-plus-padding condition is met, instead of waiting for the
+  // 1s progress tick to call checkProgress().
+  eventDrivenRelease?: boolean | undefined;
+  // Injectable timer, for deterministic testing.
+  setTimeoutFn?: typeof setTimeout | undefined;
 };
 
 export class Forwarder {
   readonly #lc: LogContext;
   readonly #progressMonitorOptions: ProgressMonitorOptions;
+  readonly #setTimeout: typeof setTimeout;
   readonly #active = new Set<Subscriber>();
   readonly #queued = new Set<Subscriber>();
   readonly #flowControlWaits = getOrCreateCounter(
@@ -40,6 +47,7 @@ export class Forwarder {
   ) {
     this.#lc = lc.withContext('component', 'progress-monitor');
     this.#progressMonitorOptions = opts;
+    this.#setTimeout = opts.setTimeoutFn ?? setTimeout;
 
     getOrCreateGauge(
       'replication',
@@ -151,13 +159,31 @@ export class Forwarder {
     }
   }
 
+  #earlyReleaseOptions(): EarlyReleaseOptions | undefined {
+    const {flowControlConsensusPaddingSeconds, eventDrivenRelease} =
+      this.#progressMonitorOptions;
+    // A negative padding disables early release entirely (mirrors the
+    // checkProgress() path, which is skipped when padding < 0).
+    if (!eventDrivenRelease || flowControlConsensusPaddingSeconds < 0) {
+      return undefined;
+    }
+    return {
+      consensusTimeoutMs: flowControlConsensusPaddingSeconds * 1000,
+      setTimeoutFn: this.#setTimeout,
+    };
+  }
+
   /**
    * The flow-control-aware equivalent of {@link forward()}, returning a
    * Promise that resolves when replication should continue.
    */
   async forwardWithFlowControl(entry: WatermarkedChange) {
     const start = performance.now();
-    const broadcast = new Broadcast(this.#active.values(), entry);
+    const broadcast = new Broadcast(
+      this.#active.values(),
+      entry,
+      this.#earlyReleaseOptions(),
+    );
     this.#updateActiveSubscribers(entry[1]);
 
     // set for progress tracking


### PR DESCRIPTION
## What

Makes the change-streamer's early **consensus-timeout** flow-control release **event-driven** instead of gated by the 1-second progress-monitor tick. Off by default behind a config flag.

## Why

Flow control resumes replication once a majority of subscribers have acked and `flowControlConsensusPaddingSeconds` has elapsed. Today that release condition (`Broadcast.checkProgress()`) is evaluated **only** by the Forwarder's 1 s `setInterval` (`forwarder.ts`). So even when the condition is already satisfied, the stream resumes up to ~1 s late.

This is the non-monotonic slow-subscriber penalty measured in the RM→ViewSyncer fan-out investigation: a *mildly*-slow subscriber (2–5 ms/msg) stays in the pending set at every checkpoint, and the whole stream waits for the next tick each time — collapsing healthy subscribers from ~2000/s to ~48/s (40×). `padding=0` doesn't help, because the release is still tick-gated.

## How

Once a majority acks, `Broadcast` schedules its own release exactly `flowControlConsensusPaddingSeconds` after the **most recent** completion (re-armed on each later completion via a monotonic generation guard so stale timers are ignored). The majority-plus-padding **condition is identical** to today — only the timing becomes precise. The 1 s tick and `checkProgress()` remain in place as a fallback and for logging, and `'all-subscribers'` release still takes precedence.

Gated behind a new flag, default **false** (no behavior change unless enabled):

```
changeStreamer.flowControlEventDrivenRelease
ZERO_CHANGE_STREAMER_FLOW_CONTROL_EVENT_DRIVEN_RELEASE
```

A negative `flowControlConsensusPaddingSeconds` still disables early release entirely, mirroring the existing `checkProgress()` path.

## Testing

- New unit tests in `broadcast.test.ts` (PG-free, injected timer): timer arms at majority; re-arms on later completions with stale timers ignored; `all-subscribers` precedence over a pending timer.
- Full `change-streamer` unit suite (`broadcast` / `forwarder` / `subscriber`) green; `--help` snapshot regenerated; `oxfmt` / `oxlint` / `tsc` clean.
- No perf numbers yet — this is a latency-precision change; a before/after on the fan-out harness (slow-subscriber scenario) is the natural follow-up.

