### PR TITLE
fix(zero-cache): treat wal_sender_timeout=0 as disabled in replication liveness

### DIFF
--- a/packages/zero-cache/src/services/change-source/pg/logical-replication/stream.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/logical-replication/stream.test.ts
@@ -1,0 +1,47 @@
+import {describe, expect, test} from 'vitest';
+import {computeLivenessTimings} from './stream.ts';
+
+describe('computeLivenessTimings', () => {
+  // Regression test for https://github.com/rocicorp/mono/pull/6047, which
+  // introduced the inbound-liveness watchdog. Postgres treats
+  // `wal_sender_timeout = 0` as "disabled", but the watchdog derived every
+  // threshold by plain arithmetic on that value, collapsing them all to 0.
+  // That fired the teardown on the first tick (and busy-spun the timer at a
+  // 0ms interval), producing a continuous reconnect storm for anyone running
+  // with wal_sender_timeout disabled.
+  test('a disabled (0) wal_sender_timeout disables the liveness timer', () => {
+    expect(computeLivenessTimings(0)).toEqual({
+      enabled: false,
+      manualKeepaliveTimeout: 0,
+      inboundTimeoutMs: 0,
+      timerIntervalMs: 0,
+    });
+  });
+
+  test('non-positive / non-finite timeouts are also treated as disabled', () => {
+    expect(computeLivenessTimings(-1).enabled).toBe(false);
+    expect(computeLivenessTimings(NaN).enabled).toBe(false);
+  });
+
+  test('derives timings from the default 60s wal_sender_timeout', () => {
+    expect(computeLivenessTimings(60_000)).toEqual({
+      enabled: true,
+      manualKeepaliveTimeout: 45_000, // 75%
+      inboundTimeoutMs: 120_000, // 2x
+      timerIntervalMs: 9_000, // manualKeepaliveTimeout / 5
+    });
+  });
+
+  test('any positive timeout yields positive, non-degenerate timings', () => {
+    // A zero polling interval would busy-spin setInterval, and a zero inbound
+    // threshold would tear the stream down immediately — the exact failure the
+    // disabled-case guard exists to prevent. Neither may happen while enabled.
+    for (const ms of [1_000, 10_000, 30_000, 60_000, 300_000]) {
+      const t = computeLivenessTimings(ms);
+      expect(t.enabled).toBe(true);
+      expect(t.timerIntervalMs).toBeGreaterThan(0);
+      expect(t.inboundTimeoutMs).toBeGreaterThan(0);
+      expect(t.manualKeepaliveTimeout).toBeGreaterThan(0);
+    }
+  });
+});

--- a/packages/zero-cache/src/services/change-source/pg/logical-replication/stream.ts
+++ b/packages/zero-cache/src/services/change-source/pg/logical-replication/stream.ts
@@ -74,10 +74,18 @@ export async function subscribe(
   >`SELECT EXTRACT(EPOCH FROM (setting || unit)::interval) * 1000 
         AS "walSenderTimeoutMs" FROM pg_settings
         WHERE name = 'wal_sender_timeout'`.simple();
-  const manualKeepaliveTimeout = Math.floor(walSenderTimeoutMs * 0.75);
+  const {
+    enabled: livenessEnabled,
+    manualKeepaliveTimeout,
+    inboundTimeoutMs,
+    timerIntervalMs,
+  } = computeLivenessTimings(walSenderTimeoutMs);
   lc.info?.(
-    `wal_sender_timeout: ${walSenderTimeoutMs}ms. ` +
-      `Ensuring manual keepalives at least every ${manualKeepaliveTimeout}ms`,
+    livenessEnabled
+      ? `wal_sender_timeout: ${walSenderTimeoutMs}ms. ` +
+          `Ensuring manual keepalives at least every ${manualKeepaliveTimeout}ms`
+      : `wal_sender_timeout is disabled (0); skipping manual keepalives and ` +
+          `inbound liveness detection.`,
   );
 
   const [readable, writable] = await startReplicationStream(
@@ -95,38 +103,36 @@ export async function subscribe(
     lastAckTime = Date.now();
   }
 
-  // Postgres promises to send a keepalive at roughly wal_sender_timeout / 2.
-  // If we go long enough without receiving anything (data or keepalive), the
-  // inbound half of the connection is silently dead — our outbound acks keep
-  // flowing into the void, neither side errors, and the change-source sits
-  // there forever. Tear down the readable to force a reconnect.
-  //
-  // The threshold is 2x wal_sender_timeout — i.e. two consecutive keepalives
-  // missed — to avoid spurious reconnects from a single delayed keepalive
-  // (PG scheduling jitter under load, our own event-loop stalls, etc.).
-  const inboundTimeoutMs = walSenderTimeoutMs * 2;
+  // Tear down the readable to force a reconnect if the inbound half of the
+  // connection goes silent (our outbound acks keep flowing into the void,
+  // neither side errors, and the change-source would otherwise sit there
+  // forever). See computeLivenessTimings for the derivation of these
+  // thresholds — and why the whole timer is disabled when wal_sender_timeout
+  // is 0.
   let lastReceivedTime = Date.now();
 
-  const livenessTimer = setInterval(() => {
-    const now = Date.now();
-    if (now - lastAckTime > manualKeepaliveTimeout) {
-      sendAck(0n);
-      lc.debug?.(`sent manual keepalive`);
-    }
-    const sinceLastReceived = now - lastReceivedTime;
-    if (sinceLastReceived > inboundTimeoutMs && !readable.destroyed) {
-      lc.warn?.(
-        `no message received from ${db.options.host} in ${sinceLastReceived}ms ` +
-          `(> 2x wal_sender_timeout ${walSenderTimeoutMs}ms). Destroying ` +
-          `replication stream to force reconnect.`,
-      );
-      readable.destroy(
-        new Error(
-          `replication stream inbound timeout after ${sinceLastReceived}ms`,
-        ),
-      );
-    }
-  }, manualKeepaliveTimeout / 5);
+  const livenessTimer = livenessEnabled
+    ? setInterval(() => {
+        const now = Date.now();
+        if (now - lastAckTime > manualKeepaliveTimeout) {
+          sendAck(0n);
+          lc.debug?.(`sent manual keepalive`);
+        }
+        const sinceLastReceived = now - lastReceivedTime;
+        if (sinceLastReceived > inboundTimeoutMs && !readable.destroyed) {
+          lc.warn?.(
+            `no message received from ${db.options.host} in ${sinceLastReceived}ms ` +
+              `(> 2x wal_sender_timeout ${walSenderTimeoutMs}ms). Destroying ` +
+              `replication stream to force reconnect.`,
+          );
+          readable.destroy(
+            new Error(
+              `replication stream inbound timeout after ${sinceLastReceived}ms`,
+            ),
+          );
+        }
+      }, timerIntervalMs)
+    : undefined;
 
   let destroyed = false;
   const typeParsers = await getTypeParsers(db, {returnJsonAsString: true});
@@ -171,6 +177,53 @@ export async function subscribe(
   return {
     messages,
     acks: {push: sendAck},
+  };
+}
+
+/**
+ * Derives the timings for the replication liveness timer from the server's
+ * `wal_sender_timeout` (in milliseconds).
+ *
+ * Postgres treats `wal_sender_timeout = 0` as "disabled": it will neither
+ * terminate an idle wal sender nor emit the periodic keepalives it otherwise
+ * sends at roughly `wal_sender_timeout / 2`. Every timing below is derived from
+ * that interval, so a disabled timeout disables the liveness machinery entirely
+ * (`enabled: false`). Otherwise the derived thresholds would all collapse to 0,
+ * inverting the intended meaning: the inbound watchdog would fire on the very
+ * first tick and destroy the stream, while the timer itself would busy-spin at
+ * a 0ms interval — together producing a continuous reconnect storm.
+ *
+ * https://www.postgresql.org/docs/current/runtime-config-replication.html#GUC-WAL-SENDER-TIMEOUT
+ */
+export function computeLivenessTimings(walSenderTimeoutMs: number): {
+  enabled: boolean;
+  manualKeepaliveTimeout: number;
+  inboundTimeoutMs: number;
+  timerIntervalMs: number;
+} {
+  // Guard with `!(x > 0)` so that 0, negative, and NaN values all disable the
+  // timer rather than producing degenerate (zero / NaN) thresholds.
+  if (!(walSenderTimeoutMs > 0)) {
+    return {
+      enabled: false,
+      manualKeepaliveTimeout: 0,
+      inboundTimeoutMs: 0,
+      timerIntervalMs: 0,
+    };
+  }
+  // Send a manual keepalive if nothing has been sent in the last 75% of the
+  // wal_sender_timeout, so Postgres never times us out under back-pressure.
+  const manualKeepaliveTimeout = Math.floor(walSenderTimeoutMs * 0.75);
+  return {
+    enabled: true,
+    manualKeepaliveTimeout,
+    // Force a reconnect after 2x wal_sender_timeout — i.e. two consecutive
+    // missed keepalives — without any inbound message, to avoid spurious
+    // reconnects from a single delayed keepalive (PG scheduling jitter under
+    // load, our own event-loop stalls, etc.).
+    inboundTimeoutMs: walSenderTimeoutMs * 2,
+    // Poll at 1/5th of the manual keepalive interval.
+    timerIntervalMs: manualKeepaliveTimeout / 5,
   };
 }
 


### PR DESCRIPTION
## Problem

A user upgrading to `zero` **1.8.0** hit a continuous zero-cache replication reconnect storm. Their Postgres was configured with `wal_sender_timeout = 0` (disabled).

Postgres treats `wal_sender_timeout = 0` as **disabled**: it neither times out an idle wal sender nor emits the periodic keepalives it otherwise sends at roughly `wal_sender_timeout / 2`.

The inbound-liveness watchdog added in #6047 derives every threshold by plain arithmetic on that value, so a disabled (`0`) timeout collapses them all to `0`:

```
inboundTimeoutMs        = walSenderTimeoutMs * 2       => 0
manualKeepaliveTimeout  = floor(... * 0.75)            => 0
setInterval(..., manualKeepaliveTimeout / 5)           => 0ms  (busy loop)
```

The inbound check (`sinceLastReceived > inboundTimeoutMs`) then trips on the first tick and calls `readable.destroy()`, which fails the subscription and forces a reconnect. The reconnect re-reads `wal_sender_timeout = 0`, re-arms the same 0-thresholds, and destroys again within ~1ms — a permanent reconnect storm. It's guaranteed rather than intermittent because with the timeout disabled, Postgres also stops sending the periodic keepalives the watchdog assumes will arrive.

This is a regression: before #6047 the timer only sent manual keepalives and never tore the stream down, so a `0` timeout was benign (a wasteful hot timer, but replication worked).

## Fix

Extract the timeout-derived timings into a pure, tested helper `computeLivenessTimings()` and treat a non-positive (`0` / negative / `NaN`) `wal_sender_timeout` as **disabled**, skipping the liveness timer entirely (`livenessTimer = undefined`). This matches Postgres semantics — a disabled upstream timeout disables our timeout-derived machinery — and, as a bonus, removes the pre-existing 0ms busy-loop for that configuration.

For any positive `wal_sender_timeout` the behavior is unchanged.

## Testing

- `pnpm --filter zero-cache check-types` — passes.
- New unit tests in `stream.test.ts` cover the disabled case (`0` / negative / `NaN` → timer disabled), the default 60s derivation (45s / 120s / 9s), and that any positive timeout yields non-degenerate (non-zero) timings. All pass.

> Note: `oxlint` and the `.pg.test.ts` suite could not be executed in my sandbox (its dependency install is missing `tsgolint` and the native `@rocicorp/zero-sqlite3` build), so I'm relying on CI for the full lint + pg-integration run.
