### PR TITLE
fix(zero-cache): don't page on transient litestream restore failures (INC-961)

### DIFF
--- a/packages/zero-cache/src/services/litestream/commands.test.ts
+++ b/packages/zero-cache/src/services/litestream/commands.test.ts
@@ -1,3 +1,4 @@
+import * as childProcess from 'node:child_process';
 import {existsSync, mkdtempSync, statSync, writeFileSync} from 'node:fs';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
@@ -17,6 +18,14 @@ import {
   restoreReplica,
 } from './commands.ts';
 import * as litestreamMetrics from './metrics.ts';
+
+// Wrap (don't replace) node:child_process.spawn so tests can assert the args it
+// was called with while it still spawns the fake litestream executable. Node's
+// built-in module exports are non-configurable, so vi.spyOn cannot be used here.
+vi.mock('node:child_process', async importOriginal => {
+  const actual = await importOriginal<typeof childProcess>();
+  return {...actual, spawn: vi.fn(actual.spawn)};
+});
 
 // Writes a fake `litestream` executable that emits `sh` (a POSIX shell
 // snippet that can branch on `$1`, the litestream subcommand) and returns the
@@ -396,5 +405,40 @@ describe('litestream/commands restoreReplica', () => {
         args.some(a => String(a).includes('write WAL segment 169/0')),
       ),
     ).toBe(true);
+  });
+
+  // INC-961: the mechanism that actually prevents the paging is spawning
+  // `litestream restore` with piped (captured) stdio rather than inheriting the
+  // pod's streams — with `stdio: 'inherit'` litestream's own ERROR would reach
+  // the pod's stdout directly, before our retry logic could downgrade it.
+  // Assert the spawn options so a regression back to inheriting is caught.
+  test('spawns `litestream restore` with piped stdio (not inherited)', async () => {
+    const spawnMock = vi.mocked(childProcess.spawn);
+    spawnMock.mockClear();
+    const dir = mkdtempSync(join(tmpdir(), 'litestream-restore-test-'));
+    const source = join(dir, 'source.db');
+    const replica = join(dir, 'replica.db');
+    createRestorableReplica(source, '01');
+    const config = configWithFakeLitestream(
+      `if [ "$1" = "restore" ]; then\n` +
+        `  cp "${source}" "$6"\n` +
+        `  exit 0\n` +
+        `fi\n` +
+        `exit 1`,
+      replica,
+    );
+
+    await restoreReplica(lc, config, {
+      replicaVersion: '01',
+      minWatermark: '01',
+    });
+
+    const restoreCall = spawnMock.mock.calls.find(
+      call => Array.isArray(call[1]) && call[1][0] === 'restore',
+    );
+    expect(restoreCall).toBeDefined();
+    // stdio is [stdin, stdout, stderr]; stdout/stderr must be piped so
+    // litestream's output is captured rather than sent to the pod's stdout.
+    expect(restoreCall?.[2]?.stdio).toEqual(['ignore', 'pipe', 'pipe']);
   });
 });

--- a/packages/zero-cache/src/services/litestream/commands.test.ts
+++ b/packages/zero-cache/src/services/litestream/commands.test.ts
@@ -308,4 +308,93 @@ describe('litestream/commands restoreReplica', () => {
       expect.objectContaining({result: 'invalid_replica'}),
     );
   });
+
+  // INC-961: litestream's own `"level":"ERROR"` restore output must not reach
+  // the pod's stdout on the first (retriable) attempt. Instead, a fake
+  // litestream that fails once and succeeds on the retry should surface the
+  // failure through our logger with the distinct "will retry" message — which
+  // the cloudzero classifier demotes to a non-paging warning — and never the
+  // paging "after retry" message.
+  test('marks a retriable restore failure with a distinct "will retry" message', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'litestream-restore-test-'));
+    const source = join(dir, 'source.db');
+    const replica = join(dir, 'replica.db');
+    createRestorableReplica(source, '01');
+    const sink = new TestLogSink();
+    const lc = new LogContext('debug', undefined, sink);
+    const config = configWithFakeLitestream(
+      `if [ "$1" = "restore" ]; then\n` +
+        `  d=$(dirname "$6")\n` +
+        `  n=$(cat "$d/attempts" 2>/dev/null || echo 0)\n` +
+        `  n=$((n+1))\n` +
+        `  echo "$n" > "$d/attempts"\n` +
+        `  if [ "$n" -eq 1 ]; then\n` +
+        `    echo '{"level":"ERROR","msg":"failed to run","error":"apply WAL segments: write WAL segment 169/0: file does not exist"}'\n` +
+        `    exit 1\n` +
+        `  fi\n` +
+        `  cp "${source}" "$6"\n` +
+        `  exit 0\n` +
+        `fi\n` +
+        `exit 1`,
+      replica,
+    );
+
+    await restoreReplica(lc, config, {
+      replicaVersion: '01',
+      minWatermark: '01',
+    });
+
+    expect(existsSync(replica)).toBe(true);
+    const errorMessages = sink.messages
+      .filter(([level]) => level === 'error')
+      .map(([, , args]) => String(args[0]));
+    // The retriable attempt uses the "will retry" message (demoted to a
+    // non-paging warning by the classifier)...
+    expect(
+      errorMessages.some(m => m.includes('attempt failed, will retry')),
+    ).toBe(true);
+    // ...and never the paging "after retry" message, since the retry succeeded.
+    expect(errorMessages.some(m => m.includes('after retry'))).toBe(false);
+  });
+
+  // If the retry also fails, the failure is real and must surface with the
+  // "after retry" message (carrying litestream's own captured output) that the
+  // classifier routes to a paging critical.
+  test('surfaces an "after retry" ERROR when the retry also fails', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'litestream-restore-test-'));
+    const replica = join(dir, 'replica.db');
+    const sink = new TestLogSink();
+    const lc = new LogContext('debug', undefined, sink);
+    const config = configWithFakeLitestream(
+      `if [ "$1" = "restore" ]; then\n` +
+        `  echo '{"level":"ERROR","msg":"failed to run","error":"apply WAL segments: write WAL segment 169/0: file does not exist"}'\n` +
+        `  exit 1\n` +
+        `fi\n` +
+        `exit 1`,
+      replica,
+    );
+
+    const err = await restoreReplica(lc, config, {
+      replicaVersion: '01',
+      minWatermark: '01',
+    }).then(
+      () => undefined,
+      (e: unknown) => e,
+    );
+    expect(String(err)).toContain('litestream exited with code 1');
+
+    // Exactly one "after retry" ERROR is surfaced (the retriable first attempt
+    // uses the separate "will retry" message), and it carries litestream's own
+    // captured failure output.
+    const afterRetry = sink.messages.filter(
+      ([level, , args]) =>
+        level === 'error' && String(args[0]).includes('after retry'),
+    );
+    expect(afterRetry.length).toBe(1);
+    expect(
+      afterRetry.some(([, , args]) =>
+        args.some(a => String(a).includes('write WAL segment 169/0')),
+      ),
+    ).toBe(true);
+  });
 });

--- a/packages/zero-cache/src/services/litestream/commands.ts
+++ b/packages/zero-cache/src/services/litestream/commands.ts
@@ -94,7 +94,19 @@ export async function restoreReplica(
   try {
     for (;;) {
       try {
-        const attempt = await tryRestore(lc, config, replicaConstraints, role);
+        // `consecutiveErrors` is 0 on a fresh attempt and 1 on the retry, so
+        // `consecutiveErrors >= 1` identifies the final attempt of a streak.
+        // tryRestore surfaces litestream's failure output with a different
+        // message on the final attempt (which the log classifier routes to a
+        // paging alert) than on a retriable earlier attempt (routed to a
+        // non-paging warning). See INC-961.
+        const attempt = await tryRestore(
+          lc,
+          config,
+          replicaConstraints,
+          role,
+          consecutiveErrors >= 1,
+        );
         backupURL = attempt.backupURL;
         if (attempt.restored) {
           result = attempt.result;
@@ -215,6 +227,7 @@ async function tryRestore(
   config: ZeroConfig,
   replicaConstraints: ReplicaConstraints | null,
   role: LitestreamRole,
+  isFinalAttempt: boolean,
 ): Promise<RestoreAttempt> {
   let snapshotStatus: SnapshotStatus | undefined;
   if (!replicaConstraints) {
@@ -251,6 +264,13 @@ async function tryRestore(
       multipartConcurrency,
       multipartSize,
     });
+    // Pipe (rather than inherit) litestream's stdout/stderr so that its own
+    // `"level":"ERROR"` output on a failed restore does not go straight to the
+    // pod's stdout — where a log-scraper alert would page on it — before our
+    // code has decided whether the failure is retriable. The captured output is
+    // re-surfaced through `lc` below with a distinct message per attempt, so a
+    // retriable failure is routed to a non-paging warning and only a post-retry
+    // failure pages. See INC-961.
     const proc = spawn(
       litestream,
       [
@@ -261,8 +281,14 @@ async function tryRestore(
         String(parallelism),
         config.replica.file,
       ],
-      {env, stdio: 'inherit', windowsHide: true},
+      {env, stdio: ['ignore', 'pipe', 'pipe'], windowsHide: true},
     );
+    let stdout = '';
+    let stderr = '';
+    proc.stdout.setEncoding('utf-8');
+    proc.stderr.setEncoding('utf-8');
+    proc.stdout.on('data', chunk => (stdout += chunk));
+    proc.stderr.on('data', chunk => (stderr += chunk));
     const {promise, resolve, reject} = resolver();
     proc.on('error', reject);
     proc.on('close', (code, signal) => {
@@ -281,11 +307,36 @@ async function tryRestore(
         performance.now() - processStart,
         {...attrs, result: 'success'},
       );
+      // A successful restore does not emit ERROR-level output; forward
+      // litestream's own (minimal, debug-level) restore logging to the pod's
+      // stdout/stderr, matching the previous `stdio: 'inherit'` behavior.
+      if (stdout) {
+        process.stdout.write(stdout);
+      }
+      if (stderr) {
+        process.stderr.write(stderr);
+      }
     } catch (e) {
       litestreamRestoreProcessDuration().recordMs(
         performance.now() - processStart,
         {...attrs, result: 'error'},
       );
+      // litestream logs its restore failure at ERROR. Re-surface that captured
+      // output through our logger with a distinct message per attempt, so the
+      // cloudzero log classifier can route them differently: the retriable
+      // earlier attempt to a non-paging warning, and the post-retry failure to
+      // a paging critical. Both are emitted at ERROR because the log scraper
+      // only ingests error-level lines, and both carry our `worker` context,
+      // distinguishing them from litestream's untagged raw output. See INC-961.
+      const output = (stdout + stderr).trim();
+      if (isFinalAttempt) {
+        lc.error?.(`litestream restore failed after retry`, output || e);
+      } else {
+        lc.error?.(
+          `litestream restore attempt failed, will retry`,
+          output || e,
+        );
+      }
       throw e;
     }
     if (!existsSync(config.replica.file)) {


### PR DESCRIPTION
## What & why

Incident [INC-961](https://app.incident.io/rocicorp/incidents/961) paged on a single ERROR-level log line from the `replication-manager` during a routine rolling deploy:

```
{"msg":"failed to run","error":"apply WAL segments: write WAL segment 169/0: file does not exist"}
```

Root cause was a **transient, self-healing** Litestream restore failure — a WAL segment referenced by the restore metadata was momentarily missing (the `replicate` process compacting/rotating a snapshot mid-restore). Litestream's built-in retry succeeded ~1s later and the pod came up healthy. No client impact — a non-actionable page.

`restoreReplica()` spawned `litestream restore` with `stdio: 'inherit'`, so Litestream's own `"level":"ERROR"` output went straight to the pod's stdout on the first (soon-to-be-retried) attempt, where a log-scraper alert paged on it — before our retry logic had a chance to decide the failure was transient. (Our own logger correctly recorded that first attempt at WARN.)

## Changes (`packages/zero-cache/src/services/litestream/commands.ts`)

- Pipe/capture Litestream's stdout/stderr on `restore` instead of inheriting them, so its raw ERROR no longer reaches the pod's stdout directly.
- Re-surface the captured output through our own logger with a **distinct message per attempt**:
  - retriable attempt → `litestream restore attempt failed, will retry`
  - post-retry failure → `litestream restore failed after retry`
- Both are emitted at ERROR (the log scraper only ingests error-level lines) and carry our `worker` context, distinguishing them from Litestream's untagged raw output.
- Successful restores forward Litestream's own (minimal) output to stdout, preserving prior visibility.
- `BackupNotFoundException` handling and all metric recording are unchanged.

## Resulting behavior

| | First error (retried) | Retry also fails |
|---|---|---|
| Slack message | ✅ non-paging warning | ✅ |
| Page / escalation | ❌ no | ✅ critical |

Successful restores (the common case) log nothing.

## Companion change (cloudzero)

The routing of these two messages lives in the log classifier: `rocicorp/cloudzero#1372` adds a `warning` classifier for the `…will retry` message and lets the `…after retry` message fall through to the critical default. **That cloudzero change must ship before this zero image rolls out** — otherwise the newly-ERROR-level `…will retry` line would fall through to critical and page, reintroducing INC-961.

## Testing

`commands.test.ts` — added coverage that the retriable attempt uses the `…will retry` message (and never `…after retry`), and that a double-failure surfaces exactly one `…after retry` ERROR carrying Litestream's captured output. `lint` (0 errors), `format`, `check-types`, and `test` (15/15) all green.
