### PR TITLE
chore(deps): upgrade typescript to 7.0.2

### DIFF
--- a/.syncpackrc
+++ b/.syncpackrc
@@ -1,4 +1,12 @@
 {
+  "versionGroups": [
+    {
+      "label": "replicache-doc pins TypeScript 6.x: its typedoc/docusaurus toolchain does not support the TypeScript 7 native compiler",
+      "packages": ["replicache-doc"],
+      "dependencies": ["typescript"],
+      "isIgnored": true
+    }
+  ],
   "semverGroups": [
     {
       "range": "~",

--- a/apps/otel-proxy/package.json
+++ b/apps/otel-proxy/package.json
@@ -19,7 +19,7 @@
     "@types/node": "^22.10.5",
     "@vitest/coverage-v8": "^4.1.6",
     "oxfmt": "^0.45.0",
-    "typescript": "~6.0.2",
+    "typescript": "~7.0.2",
     "vitest": "^4.1.6"
   },
   "packageManager": "pnpm@11.5.3"

--- a/apps/zbugs/package.json
+++ b/apps/zbugs/package.json
@@ -93,7 +93,7 @@
     "rehype-video": "^2.3.0",
     "shared": "workspace:*",
     "tailwindcss": "^3.0.23",
-    "typescript": "~6.0.2",
+    "typescript": "~7.0.2",
     "vite": "^8.0.13",
     "vite-bundle-analyzer": "^1.3.8",
     "vite-plugin-svgr": "^5.2.0",

--- a/apps/zero-throughput/package.json
+++ b/apps/zero-throughput/package.json
@@ -28,7 +28,7 @@
     "@types/ws": "^8.5.12",
     "oxfmt": "^0.45.0",
     "shared": "workspace:*",
-    "typescript": "~6.0.2",
+    "typescript": "~7.0.2",
     "zero-protocol": "workspace:*",
     "zero-schema": "workspace:*",
     "zql": "workspace:*"

--- a/apps/zql-viz/package.json
+++ b/apps/zql-viz/package.json
@@ -25,7 +25,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@vitejs/plugin-react": "^6.0.1",
-    "typescript": "~6.0.2",
+    "typescript": "~7.0.2",
     "vite": "^8.0.13",
     "zero-types": "workspace:*",
     "zql": "workspace:*"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "syncpack": "^14.3.0",
     "tsnapi": "^0.3.2",
     "turbo": "^2.4.4",
-    "typescript": "~6.0.2",
+    "typescript": "~7.0.2",
     "vitest": "^4.1.6",
     "zx": "^8.8.5"
   },

--- a/packages/datadog/package.json
+++ b/packages/datadog/package.json
@@ -21,7 +21,7 @@
     "@vitest/runner": "^4.1.6",
     "oxfmt": "^0.45.0",
     "shared": "workspace:*",
-    "typescript": "~6.0.2",
+    "typescript": "~7.0.2",
     "vitest": "^4.1.6"
   },
   "packageManager": "pnpm@11.5.3"

--- a/packages/otel/package.json
+++ b/packages/otel/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "oxfmt": "^0.45.0",
     "shared": "workspace:*",
-    "typescript": "~6.0.2"
+    "typescript": "~7.0.2"
   },
   "packageManager": "pnpm@11.5.3"
 }

--- a/packages/replicache-perf/package.json
+++ b/packages/replicache-perf/package.json
@@ -28,7 +28,7 @@
     "playwright-core": "1.53.2",
     "replicache": "workspace:*",
     "shared": "workspace:*",
-    "typescript": "~6.0.2",
+    "typescript": "~7.0.2",
     "vite": "^8.0.13",
     "xbytes": "^1.7.0"
   },

--- a/packages/replicache/package.json
+++ b/packages/replicache/package.json
@@ -94,7 +94,7 @@
     "oxfmt": "^0.45.0",
     "playwright": "^1.60.0",
     "shared": "workspace:*",
-    "typescript": "~6.0.2",
+    "typescript": "~7.0.2",
     "vitest": "^4.1.6",
     "xbytes": "^1.7.0"
   },

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -53,7 +53,7 @@
     "package-up": "^5.0.0",
     "playwright": "^1.60.0",
     "type-fest": "^4.30.0",
-    "typescript": "~6.0.2",
+    "typescript": "~7.0.2",
     "vitest": "^4.1.6"
   },
   "packageManager": "pnpm@11.5.3"

--- a/packages/zero-cache/package.json
+++ b/packages/zero-cache/package.json
@@ -96,7 +96,7 @@
     "oxfmt": "^0.45.0",
     "shared": "workspace:*",
     "testcontainers": "^10.28.0",
-    "typescript": "~6.0.2",
+    "typescript": "~7.0.2",
     "vitest": "^4.1.6",
     "zero-permissions": "workspace:*",
     "zero-protocol": "workspace:*",

--- a/packages/zero-cache/tsconfig.json
+++ b/packages/zero-cache/tsconfig.json
@@ -2,9 +2,6 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "types": ["node"],
-    // This package only type-checks (noEmit) and never emits .d.ts, so it opts
-    // out of TypeScript 7's declaration-emit portability check (TS2883), which
-    // flags cross-package relative source imports in pnpm's symlinked layout.
     "declaration": false,
     "declarationMap": false
   },

--- a/packages/zero-cache/tsconfig.json
+++ b/packages/zero-cache/tsconfig.json
@@ -1,7 +1,12 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "types": ["node"]
+    "types": ["node"],
+    // This package only type-checks (noEmit) and never emits .d.ts, so it opts
+    // out of TypeScript 7's declaration-emit portability check (TS2883), which
+    // flags cross-package relative source imports in pnpm's symlinked layout.
+    "declaration": false,
+    "declarationMap": false
   },
   "include": ["src", "bench", "tool"]
 }

--- a/packages/zero-client/package.json
+++ b/packages/zero-client/package.json
@@ -40,7 +40,7 @@
     "playwright": "^1.60.0",
     "replicache": "workspace:*",
     "shared": "workspace:*",
-    "typescript": "~6.0.2",
+    "typescript": "~7.0.2",
     "vitest": "^4.1.6",
     "zero-permissions": "workspace:*",
     "zero-protocol": "workspace:*",

--- a/packages/zero-events/package.json
+++ b/packages/zero-events/package.json
@@ -37,7 +37,7 @@
     "esbuild": "0.27.7",
     "oxfmt": "^0.45.0",
     "shared": "workspace:*",
-    "typescript": "~6.0.2",
+    "typescript": "~7.0.2",
     "vitest": "^4.1.6"
   },
   "packageManager": "pnpm@11.5.3"

--- a/packages/zero-permissions/package.json
+++ b/packages/zero-permissions/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "oxfmt": "^0.45.0",
-    "typescript": "~6.0.2",
+    "typescript": "~7.0.2",
     "vitest": "^4.1.6"
   },
   "packageManager": "pnpm@11.5.3"

--- a/packages/zero-permissions/tsconfig.json
+++ b/packages/zero-permissions/tsconfig.json
@@ -1,9 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    // This package only type-checks (noEmit) and never emits .d.ts, so it opts
-    // out of TypeScript 7's declaration-emit portability check (TS2883), which
-    // flags cross-package relative source imports in pnpm's symlinked layout.
     "declaration": false,
     "declarationMap": false
   },

--- a/packages/zero-permissions/tsconfig.json
+++ b/packages/zero-permissions/tsconfig.json
@@ -1,4 +1,11 @@
 {
   "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    // This package only type-checks (noEmit) and never emits .d.ts, so it opts
+    // out of TypeScript 7's declaration-emit portability check (TS2883), which
+    // flags cross-package relative source imports in pnpm's symlinked layout.
+    "declaration": false,
+    "declarationMap": false
+  },
   "include": ["src"]
 }

--- a/packages/zero-protocol/package.json
+++ b/packages/zero-protocol/package.json
@@ -22,7 +22,7 @@
     "fast-check": "^3.18.0",
     "oxfmt": "^0.45.0",
     "shared": "workspace:*",
-    "typescript": "~6.0.2",
+    "typescript": "~7.0.2",
     "vitest": "^4.1.6",
     "zero-types": "workspace:*"
   },

--- a/packages/zero-react/tsconfig.json
+++ b/packages/zero-react/tsconfig.json
@@ -2,9 +2,6 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "jsx": "react-jsx",
-    // This package only type-checks (noEmit) and never emits .d.ts, so it opts
-    // out of TypeScript 7's declaration-emit portability check (TS2883), which
-    // flags cross-package relative source imports in pnpm's symlinked layout.
     "declaration": false,
     "declarationMap": false
   },

--- a/packages/zero-react/tsconfig.json
+++ b/packages/zero-react/tsconfig.json
@@ -1,7 +1,12 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    // This package only type-checks (noEmit) and never emits .d.ts, so it opts
+    // out of TypeScript 7's declaration-emit portability check (TS2883), which
+    // flags cross-package relative source imports in pnpm's symlinked layout.
+    "declaration": false,
+    "declarationMap": false
   },
   "include": ["src"]
 }

--- a/packages/zero-types/package.json
+++ b/packages/zero-types/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "oxfmt": "^0.45.0",
     "shared": "workspace:*",
-    "typescript": "~6.0.2",
+    "typescript": "~7.0.2",
     "vitest": "^4.1.6"
   },
   "packageManager": "pnpm@11.5.3"

--- a/packages/zero/package.json
+++ b/packages/zero/package.json
@@ -182,7 +182,7 @@
     "syncpack": "^14.3.0",
     "typedoc": "^0.28.17",
     "typedoc-plugin-markdown": "^4.10.0",
-    "typescript": "~6.0.2",
+    "typescript": "~7.0.2",
     "vite": "^8.0.13",
     "vitest": "^4.1.6",
     "zero-cache": "workspace:*",

--- a/packages/zql-benchmarks/package.json
+++ b/packages/zql-benchmarks/package.json
@@ -29,7 +29,7 @@
     "otel": "workspace:*",
     "oxfmt": "^0.45.0",
     "shared": "workspace:*",
-    "typescript": "~6.0.2",
+    "typescript": "~7.0.2",
     "vitest": "^4.1.6",
     "zero-cache": "workspace:*",
     "zero-protocol": "workspace:*",

--- a/packages/zql-benchmarks/tsconfig.json
+++ b/packages/zql-benchmarks/tsconfig.json
@@ -2,7 +2,12 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "..",
-    "outDir": "dist"
+    "outDir": "dist",
+    // This package only type-checks (noEmit) and never emits .d.ts, so it opts
+    // out of TypeScript 7's declaration-emit portability check (TS2883), which
+    // flags cross-package relative source imports in pnpm's symlinked layout.
+    "declaration": false,
+    "declarationMap": false
   },
   "include": ["src/**/*.ts"]
 }

--- a/packages/zql-benchmarks/tsconfig.json
+++ b/packages/zql-benchmarks/tsconfig.json
@@ -3,9 +3,6 @@
   "compilerOptions": {
     "rootDir": "..",
     "outDir": "dist",
-    // This package only type-checks (noEmit) and never emits .d.ts, so it opts
-    // out of TypeScript 7's declaration-emit portability check (TS2883), which
-    // flags cross-package relative source imports in pnpm's symlinked layout.
     "declaration": false,
     "declarationMap": false
   },

--- a/packages/zql-integration-tests/package.json
+++ b/packages/zql-integration-tests/package.json
@@ -30,7 +30,7 @@
     "oxfmt": "^0.45.0",
     "pg": "^8.16.3",
     "shared": "workspace:*",
-    "typescript": "~6.0.2",
+    "typescript": "~7.0.2",
     "vitest": "^4.1.6",
     "z2s": "workspace:*",
     "zero-cache": "workspace:*",

--- a/packages/zql-integration-tests/tsconfig.json
+++ b/packages/zql-integration-tests/tsconfig.json
@@ -3,9 +3,6 @@
   "compilerOptions": {
     "rootDir": "..",
     "outDir": "dist",
-    // This package only type-checks (noEmit) and never emits .d.ts, so it opts
-    // out of TypeScript 7's declaration-emit portability check (TS2883), which
-    // flags cross-package relative source imports in pnpm's symlinked layout.
     "declaration": false,
     "declarationMap": false
   },

--- a/packages/zql-integration-tests/tsconfig.json
+++ b/packages/zql-integration-tests/tsconfig.json
@@ -2,7 +2,12 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "..",
-    "outDir": "dist"
+    "outDir": "dist",
+    // This package only type-checks (noEmit) and never emits .d.ts, so it opts
+    // out of TypeScript 7's declaration-emit portability check (TS2883), which
+    // flags cross-package relative source imports in pnpm's symlinked layout.
+    "declaration": false,
+    "declarationMap": false
   },
   "include": ["src/**/*.ts", "../zql-benchmarks/src/chinook.bench.ts"]
 }

--- a/packages/zql/package.json
+++ b/packages/zql/package.json
@@ -28,7 +28,7 @@
     "otel": "workspace:*",
     "oxfmt": "^0.45.0",
     "shared": "workspace:*",
-    "typescript": "~6.0.2",
+    "typescript": "~7.0.2",
     "vitest": "^4.1.6",
     "zero-protocol": "workspace:*",
     "zero-types": "workspace:*"

--- a/packages/zql/tsconfig.json
+++ b/packages/zql/tsconfig.json
@@ -2,9 +2,6 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "types": ["node"],
-    // This package only type-checks (noEmit) and never emits .d.ts, so it opts
-    // out of TypeScript 7's declaration-emit portability check (TS2883), which
-    // flags cross-package relative source imports in pnpm's symlinked layout.
     "declaration": false,
     "declarationMap": false
   },

--- a/packages/zql/tsconfig.json
+++ b/packages/zql/tsconfig.json
@@ -1,7 +1,12 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "types": ["node"]
+    "types": ["node"],
+    // This package only type-checks (noEmit) and never emits .d.ts, so it opts
+    // out of TypeScript 7's declaration-emit portability check (TS2883), which
+    // flags cross-package relative source imports in pnpm's symlinked layout.
+    "declaration": false,
+    "declarationMap": false
   },
   "include": ["src/**/*.ts"]
 }

--- a/packages/zqlite-zql-test/package.json
+++ b/packages/zqlite-zql-test/package.json
@@ -23,7 +23,7 @@
     "@vitest/runner": "^4.1.6",
     "oxfmt": "^0.45.0",
     "shared": "workspace:*",
-    "typescript": "~6.0.2",
+    "typescript": "~7.0.2",
     "vitest": "^4.1.6"
   },
   "packageManager": "pnpm@11.5.3"

--- a/packages/zqlite/package.json
+++ b/packages/zqlite/package.json
@@ -34,7 +34,7 @@
     "otel": "workspace:*",
     "oxfmt": "^0.45.0",
     "shared": "workspace:*",
-    "typescript": "~6.0.2",
+    "typescript": "~7.0.2",
     "vitest": "^4.1.6",
     "zero-protocol": "workspace:*",
     "zero-schema": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,8 +74,8 @@ importers:
         specifier: ^2.4.4
         version: 2.9.14
       typescript:
-        specifier: ~6.0.2
-        version: 6.0.3
+        specifier: ~7.0.2
+        version: 7.0.2
       vitest:
         specifier: ^4.1.6
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0))
@@ -95,8 +95,8 @@ importers:
         specifier: ^0.45.0
         version: 0.45.0
       typescript:
-        specifier: ~6.0.2
-        version: 6.0.3
+        specifier: ~7.0.2
+        version: 7.0.2
       vitest:
         specifier: ^4.1.6
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0))
@@ -247,7 +247,7 @@ importers:
         version: 0.31.10
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@electric-sql/pglite@0.4.1)(@op-engineering/op-sqlite@15.2.14(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6))(@opentelemetry/api@1.9.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(magicast@0.5.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))(typescript@6.0.3))(@types/pg@8.20.0)(expo-sqlite@55.0.16(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6))(kysely@0.28.17)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.7(patch_hash=2bd119d361250d5ee010b23af4c98504e9c6861b692d2e2ae23b9a9e5de4dbce))(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(magicast@0.5.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3))
+        version: 0.45.2(@electric-sql/pglite@0.4.1)(@op-engineering/op-sqlite@15.2.14(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6))(@opentelemetry/api@1.9.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(magicast@0.5.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@7.0.2))(typescript@7.0.2))(@types/pg@8.20.0)(expo-sqlite@55.0.16(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6))(kysely@0.28.17)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.7(patch_hash=2bd119d361250d5ee010b23af4c98504e9c6861b692d2e2ae23b9a9e5de4dbce))(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(magicast@0.5.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@7.0.2))
       oxfmt:
         specifier: ^0.45.0
         version: 0.45.0
@@ -264,8 +264,8 @@ importers:
         specifier: ^3.0.23
         version: 3.4.19(tsx@4.22.0)(yaml@2.9.0)
       typescript:
-        specifier: ~6.0.2
-        version: 6.0.3
+        specifier: ~7.0.2
+        version: 7.0.2
       vite:
         specifier: ^8.0.13
         version: 8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0)
@@ -274,7 +274,7 @@ importers:
         version: 1.3.8
       vite-plugin-svgr:
         specifier: ^5.2.0
-        version: 5.2.0(typescript@6.0.3)(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0))
+        version: 5.2.0(typescript@7.0.2)(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.6
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0))
@@ -307,8 +307,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/shared
       typescript:
-        specifier: ~6.0.2
-        version: 6.0.3
+        specifier: ~7.0.2
+        version: 7.0.2
       zero-protocol:
         specifier: workspace:*
         version: link:../../packages/zero-protocol
@@ -356,8 +356,8 @@ importers:
         specifier: ^6.0.1
         version: 6.0.2(babel-plugin-react-compiler@1.0.0)(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0))
       typescript:
-        specifier: ~6.0.2
-        version: 6.0.3
+        specifier: ~7.0.2
+        version: 7.0.2
       vite:
         specifier: ^8.0.13
         version: 8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0)
@@ -469,8 +469,8 @@ importers:
         specifier: workspace:*
         version: link:../shared
       typescript:
-        specifier: ~6.0.2
-        version: 6.0.3
+        specifier: ~7.0.2
+        version: 7.0.2
       vitest:
         specifier: ^4.1.6
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0))
@@ -500,8 +500,8 @@ importers:
         specifier: workspace:*
         version: link:../shared
       typescript:
-        specifier: ~6.0.2
-        version: 6.0.3
+        specifier: ~7.0.2
+        version: 7.0.2
 
   packages/replicache:
     dependencies:
@@ -564,8 +564,8 @@ importers:
         specifier: workspace:*
         version: link:../shared
       typescript:
-        specifier: ~6.0.2
-        version: 6.0.3
+        specifier: ~7.0.2
+        version: 7.0.2
       vitest:
         specifier: ^4.1.6
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0))
@@ -673,8 +673,8 @@ importers:
         specifier: workspace:*
         version: link:../shared
       typescript:
-        specifier: ~6.0.2
-        version: 6.0.3
+        specifier: ~7.0.2
+        version: 7.0.2
       vite:
         specifier: ^8.0.13
         version: 8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0)
@@ -771,8 +771,8 @@ importers:
         specifier: ^4.30.0
         version: 4.41.0
       typescript:
-        specifier: ~6.0.2
-        version: 6.0.3
+        specifier: ~7.0.2
+        version: 7.0.2
       vitest:
         specifier: ^4.1.6
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0))
@@ -1005,13 +1005,13 @@ importers:
         version: 14.3.1
       typedoc:
         specifier: ^0.28.17
-        version: 0.28.19(typescript@6.0.3)
+        version: 0.28.19(typescript@7.0.2)
       typedoc-plugin-markdown:
         specifier: ^4.10.0
-        version: 4.11.0(typedoc@0.28.19(typescript@6.0.3))
+        version: 4.11.0(typedoc@0.28.19(typescript@7.0.2))
       typescript:
-        specifier: ~6.0.2
-        version: 6.0.3
+        specifier: ~7.0.2
+        version: 7.0.2
       vite:
         specifier: ^8.0.13
         version: 8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0)
@@ -1215,8 +1215,8 @@ importers:
         specifier: ^10.28.0
         version: 10.28.0
       typescript:
-        specifier: ~6.0.2
-        version: 6.0.3
+        specifier: ~7.0.2
+        version: 7.0.2
       vitest:
         specifier: ^4.1.6
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0))
@@ -1270,8 +1270,8 @@ importers:
         specifier: workspace:*
         version: link:../shared
       typescript:
-        specifier: ~6.0.2
-        version: 6.0.3
+        specifier: ~7.0.2
+        version: 7.0.2
       vitest:
         specifier: ^4.1.6
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0))
@@ -1303,8 +1303,8 @@ importers:
         specifier: workspace:*
         version: link:../shared
       typescript:
-        specifier: ~6.0.2
-        version: 6.0.3
+        specifier: ~7.0.2
+        version: 7.0.2
       vitest:
         specifier: ^4.1.6
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0))
@@ -1331,8 +1331,8 @@ importers:
         specifier: ^0.45.0
         version: 0.45.0
       typescript:
-        specifier: ~6.0.2
-        version: 6.0.3
+        specifier: ~7.0.2
+        version: 7.0.2
       vitest:
         specifier: ^4.1.6
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0))
@@ -1378,8 +1378,8 @@ importers:
         specifier: workspace:*
         version: link:../shared
       typescript:
-        specifier: ~6.0.2
-        version: 6.0.3
+        specifier: ~7.0.2
+        version: 7.0.2
       vitest:
         specifier: ^4.1.6
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0))
@@ -1564,8 +1564,8 @@ importers:
         specifier: workspace:*
         version: link:../shared
       typescript:
-        specifier: ~6.0.2
-        version: 6.0.3
+        specifier: ~7.0.2
+        version: 7.0.2
       vitest:
         specifier: ^4.1.6
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0))
@@ -1604,8 +1604,8 @@ importers:
         specifier: workspace:*
         version: link:../shared
       typescript:
-        specifier: ~6.0.2
-        version: 6.0.3
+        specifier: ~7.0.2
+        version: 7.0.2
       vitest:
         specifier: ^4.1.6
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0))
@@ -1634,8 +1634,8 @@ importers:
         specifier: workspace:*
         version: link:../shared
       typescript:
-        specifier: ~6.0.2
-        version: 6.0.3
+        specifier: ~7.0.2
+        version: 7.0.2
       vitest:
         specifier: ^4.1.6
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0))
@@ -1691,8 +1691,8 @@ importers:
         specifier: workspace:*
         version: link:../shared
       typescript:
-        specifier: ~6.0.2
-        version: 6.0.3
+        specifier: ~7.0.2
+        version: 7.0.2
       vitest:
         specifier: ^4.1.6
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0))
@@ -1758,8 +1758,8 @@ importers:
         specifier: workspace:*
         version: link:../shared
       typescript:
-        specifier: ~6.0.2
-        version: 6.0.3
+        specifier: ~7.0.2
+        version: 7.0.2
       vitest:
         specifier: ^4.1.6
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0))
@@ -1792,8 +1792,8 @@ importers:
         specifier: workspace:*
         version: link:../shared
       typescript:
-        specifier: ~6.0.2
-        version: 6.0.3
+        specifier: ~7.0.2
+        version: 7.0.2
       vitest:
         specifier: ^4.1.6
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0))
@@ -1823,8 +1823,8 @@ importers:
         specifier: ^0.45.0
         version: 0.45.0
       typescript:
-        specifier: ~6.0.2
-        version: 6.0.3
+        specifier: ~7.0.2
+        version: 7.0.2
       vitest:
         specifier: ^4.1.6
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0))
@@ -1945,8 +1945,8 @@ importers:
         specifier: ^0.45.0
         version: 0.45.0
       typescript:
-        specifier: ~6.0.2
-        version: 6.0.3
+        specifier: ~7.0.2
+        version: 7.0.2
 
 packages:
 
@@ -6245,6 +6245,126 @@ packages:
 
   '@types/yargs@17.0.35':
     resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    resolution: {integrity: sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    resolution: {integrity: sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    resolution: {integrity: sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    resolution: {integrity: sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    resolution: {integrity: sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    resolution: {integrity: sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    resolution: {integrity: sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    resolution: {integrity: sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    resolution: {integrity: sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    resolution: {integrity: sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    resolution: {integrity: sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    resolution: {integrity: sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    resolution: {integrity: sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    resolution: {integrity: sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    resolution: {integrity: sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    resolution: {integrity: sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    resolution: {integrity: sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
 
   '@ungap/structured-clone@1.3.1':
     resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
@@ -12326,6 +12446,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@7.0.2:
+    resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
+    engines: {node: '>=16.20.0'}
+    hasBin: true
+
   typical@7.3.0:
     resolution: {integrity: sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==}
     engines: {node: '>=12.17'}
@@ -16115,23 +16240,23 @@ snapshots:
   '@esbuild/win32-x64@0.27.7':
     optional: true
 
-  '@expo/cli@55.0.30(@expo/dom-webview@55.0.6)(expo-constants@55.0.16(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6)))(expo-font@55.0.8(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6))(expo@55.0.24)(react-dom@19.2.6(react@19.2.6))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)(typescript@6.0.3)':
+  '@expo/cli@55.0.30(@expo/dom-webview@55.0.6)(expo-constants@55.0.16(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6)))(expo-font@55.0.8(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6))(expo@55.0.24)(react-dom@19.2.6(react@19.2.6))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)(typescript@7.0.2)':
     dependencies:
       '@expo/code-signing-certificates': 0.0.6
-      '@expo/config': 55.0.17(typescript@6.0.3)
+      '@expo/config': 55.0.17(typescript@7.0.2)
       '@expo/config-plugins': 55.0.9
       '@expo/devcert': 1.2.1
       '@expo/env': 2.1.2
-      '@expo/image-utils': 0.8.14(typescript@6.0.3)
+      '@expo/image-utils': 0.8.14(typescript@7.0.2)
       '@expo/json-file': 10.2.0
       '@expo/log-box': 55.0.12(@expo/dom-webview@55.0.6)(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       '@expo/metro': 55.1.1
-      '@expo/metro-config': 55.0.21(expo@55.0.24)(typescript@6.0.3)
+      '@expo/metro-config': 55.0.21(expo@55.0.24)(typescript@7.0.2)
       '@expo/osascript': 2.6.0
       '@expo/package-manager': 1.12.0
       '@expo/plist': 0.5.3
-      '@expo/prebuild-config': 55.0.18(expo@55.0.24)(typescript@6.0.3)
-      '@expo/require-utils': 55.0.5(typescript@6.0.3)
+      '@expo/prebuild-config': 55.0.18(expo@55.0.24)(typescript@7.0.2)
+      '@expo/require-utils': 55.0.5(typescript@7.0.2)
       '@expo/router-server': 55.0.17(expo-constants@55.0.16(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6)))(expo-font@55.0.8(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6))(expo-server@55.0.10)(expo@55.0.24)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@expo/schema-utils': 55.0.4
       '@expo/spawn-async': 1.8.0
@@ -16149,7 +16274,7 @@ snapshots:
       connect: 3.7.0
       debug: 4.4.3
       dnssd-advertise: 1.1.4
-      expo: 55.0.24(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.6(react@19.2.6))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+      expo: 55.0.24(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.6(react@19.2.6))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)(typescript@7.0.2)
       expo-server: 55.0.10
       fetch-nodeshim: 0.4.10
       getenv: 2.0.0
@@ -16214,12 +16339,12 @@ snapshots:
 
   '@expo/config-types@55.0.5': {}
 
-  '@expo/config@55.0.17(typescript@6.0.3)':
+  '@expo/config@55.0.17(typescript@7.0.2)':
     dependencies:
       '@expo/config-plugins': 55.0.9
       '@expo/config-types': 55.0.5
       '@expo/json-file': 10.2.0
-      '@expo/require-utils': 55.0.5(typescript@6.0.3)
+      '@expo/require-utils': 55.0.5(typescript@7.0.2)
       deepmerge: 4.3.1
       getenv: 2.0.0
       glob: 13.0.6
@@ -16246,7 +16371,7 @@ snapshots:
 
   '@expo/dom-webview@55.0.6(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)':
     dependencies:
-      expo: 55.0.24(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.6(react@19.2.6))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+      expo: 55.0.24(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.6(react@19.2.6))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)(typescript@7.0.2)
       react: 19.2.6
       react-native: 0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6)
 
@@ -16282,9 +16407,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@expo/image-utils@0.8.14(typescript@6.0.3)':
+  '@expo/image-utils@0.8.14(typescript@7.0.2)':
     dependencies:
-      '@expo/require-utils': 55.0.5(typescript@6.0.3)
+      '@expo/require-utils': 55.0.5(typescript@7.0.2)
       '@expo/spawn-async': 1.8.0
       chalk: 4.1.2
       getenv: 2.0.0
@@ -16305,9 +16430,9 @@ snapshots:
       '@babel/code-frame': 7.29.0
       json5: 2.2.3
 
-  '@expo/local-build-cache-provider@55.0.13(typescript@6.0.3)':
+  '@expo/local-build-cache-provider@55.0.13(typescript@7.0.2)':
     dependencies:
-      '@expo/config': 55.0.17(typescript@6.0.3)
+      '@expo/config': 55.0.17(typescript@7.0.2)
       chalk: 4.1.2
     transitivePeerDependencies:
       - supports-color
@@ -16317,17 +16442,17 @@ snapshots:
     dependencies:
       '@expo/dom-webview': 55.0.6(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       anser: 1.4.10
-      expo: 55.0.24(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.6(react@19.2.6))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+      expo: 55.0.24(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.6(react@19.2.6))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)(typescript@7.0.2)
       react: 19.2.6
       react-native: 0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6)
       stacktrace-parser: 0.1.11
 
-  '@expo/metro-config@55.0.21(expo@55.0.24)(typescript@6.0.3)':
+  '@expo/metro-config@55.0.21(expo@55.0.24)(typescript@7.0.2)':
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
-      '@expo/config': 55.0.17(typescript@6.0.3)
+      '@expo/config': 55.0.17(typescript@7.0.2)
       '@expo/env': 2.1.2
       '@expo/json-file': 10.0.14
       '@expo/metro': 55.1.1
@@ -16344,7 +16469,7 @@ snapshots:
       postcss: 8.5.15
       resolve-from: 5.0.0
     optionalDependencies:
-      expo: 55.0.24(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.6(react@19.2.6))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+      expo: 55.0.24(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.6(react@19.2.6))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)(typescript@7.0.2)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -16391,16 +16516,16 @@ snapshots:
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
 
-  '@expo/prebuild-config@55.0.18(expo@55.0.24)(typescript@6.0.3)':
+  '@expo/prebuild-config@55.0.18(expo@55.0.24)(typescript@7.0.2)':
     dependencies:
-      '@expo/config': 55.0.17(typescript@6.0.3)
+      '@expo/config': 55.0.17(typescript@7.0.2)
       '@expo/config-plugins': 55.0.9
       '@expo/config-types': 55.0.5
-      '@expo/image-utils': 0.8.14(typescript@6.0.3)
+      '@expo/image-utils': 0.8.14(typescript@7.0.2)
       '@expo/json-file': 10.2.0
       '@react-native/normalize-colors': 0.83.6
       debug: 4.4.3
-      expo: 55.0.24(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.6(react@19.2.6))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+      expo: 55.0.24(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.6(react@19.2.6))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)(typescript@7.0.2)
       resolve-from: 5.0.0
       semver: 7.8.0
       xml2js: 0.6.0
@@ -16408,20 +16533,20 @@ snapshots:
       - supports-color
       - typescript
 
-  '@expo/require-utils@55.0.5(typescript@6.0.3)':
+  '@expo/require-utils@55.0.5(typescript@7.0.2)':
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/core': 7.29.0
       '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0)
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: 7.0.2
     transitivePeerDependencies:
       - supports-color
 
   '@expo/router-server@55.0.17(expo-constants@55.0.16(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6)))(expo-font@55.0.8(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6))(expo-server@55.0.10)(expo@55.0.24)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       debug: 4.4.3
-      expo: 55.0.24(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.6(react@19.2.6))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+      expo: 55.0.24(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.6(react@19.2.6))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)(typescript@7.0.2)
       expo-constants: 55.0.16(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))
       expo-font: 55.0.8(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       expo-server: 55.0.10
@@ -18062,6 +18187,14 @@ snapshots:
       prisma: 7.8.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(magicast@0.5.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
       typescript: 6.0.3
 
+  '@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(magicast@0.5.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@7.0.2))(typescript@7.0.2)':
+    dependencies:
+      '@prisma/client-runtime-utils': 7.8.0
+    optionalDependencies:
+      prisma: 7.8.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(magicast@0.5.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@7.0.2)
+      typescript: 7.0.2
+    optional: true
+
   '@prisma/config@7.8.0(magicast@0.5.3)':
     dependencies:
       c12: 3.3.4(magicast@0.5.3)
@@ -18096,6 +18229,29 @@ snapshots:
       zeptomatch: 2.1.0
     transitivePeerDependencies:
       - typescript
+
+  '@prisma/dev@0.24.3(typescript@7.0.2)':
+    dependencies:
+      '@electric-sql/pglite': 0.4.1
+      '@electric-sql/pglite-socket': 0.1.1(@electric-sql/pglite@0.4.1)
+      '@electric-sql/pglite-tools': 0.3.1(@electric-sql/pglite@0.4.1)
+      '@hono/node-server': 1.19.14(hono@4.12.18)
+      '@prisma/get-platform': 7.2.0
+      '@prisma/query-plan-executor': 7.2.0
+      '@prisma/streams-local': 0.1.2
+      foreground-child: 3.3.1
+      get-port-please: 3.2.0
+      hono: 4.12.18
+      http-status-codes: 2.3.0
+      pathe: 2.0.3
+      proper-lockfile: 4.1.2
+      remeda: 2.33.4
+      std-env: 3.10.0
+      valibot: 1.2.0(typescript@7.0.2)
+      zeptomatch: 2.1.0
+    transitivePeerDependencies:
+      - typescript
+    optional: true
 
   '@prisma/driver-adapter-utils@7.8.0':
     dependencies:
@@ -18689,6 +18845,17 @@ snapshots:
       - supports-color
       - typescript
 
+  '@svgr/core@8.1.0(typescript@7.0.2)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@svgr/babel-preset': 8.1.0(@babel/core@7.29.0)
+      camelcase: 6.3.0
+      cosmiconfig: 8.3.6(typescript@7.0.2)
+      snake-case: 3.0.4
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   '@svgr/hast-util-to-babel-ast@8.0.0':
     dependencies:
       '@babel/types': 7.29.0
@@ -18699,6 +18866,16 @@ snapshots:
       '@babel/core': 7.29.0
       '@svgr/babel-preset': 8.1.0(@babel/core@7.29.0)
       '@svgr/core': 8.1.0(typescript@6.0.3)
+      '@svgr/hast-util-to-babel-ast': 8.0.0
+      svg-parser: 2.0.4
+    transitivePeerDependencies:
+      - supports-color
+
+  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@7.0.2))':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@svgr/babel-preset': 8.1.0(@babel/core@7.29.0)
+      '@svgr/core': 8.1.0(typescript@7.0.2)
       '@svgr/hast-util-to-babel-ast': 8.0.0
       svg-parser: 2.0.4
     transitivePeerDependencies:
@@ -19134,6 +19311,66 @@ snapshots:
   '@types/yargs@17.0.35':
     dependencies:
       '@types/yargs-parser': 21.0.3
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    optional: true
 
   '@ungap/structured-clone@1.3.1': {}
 
@@ -19758,7 +19995,7 @@ snapshots:
       resolve-from: 5.0.0
     optionalDependencies:
       '@babel/runtime': 7.29.2
-      expo: 55.0.24(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.6(react@19.2.6))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+      expo: 55.0.24(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.6(react@19.2.6))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)(typescript@7.0.2)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -20395,6 +20632,15 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
+  cosmiconfig@8.3.6(typescript@7.0.2):
+    dependencies:
+      import-fresh: 3.3.1
+      js-yaml: 4.1.1
+      parse-json: 5.2.0
+      path-type: 4.0.0
+    optionalDependencies:
+      typescript: 7.0.2
+
   cpu-features@0.0.10:
     dependencies:
       buildcheck: 0.0.7
@@ -20833,6 +21079,20 @@ snapshots:
       postgres: 3.4.7(patch_hash=2bd119d361250d5ee010b23af4c98504e9c6861b692d2e2ae23b9a9e5de4dbce)
       prisma: 7.8.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(magicast@0.5.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
 
+  drizzle-orm@0.45.2(@electric-sql/pglite@0.4.1)(@op-engineering/op-sqlite@15.2.14(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6))(@opentelemetry/api@1.9.1)(@prisma/client@7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(magicast@0.5.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@7.0.2))(typescript@7.0.2))(@types/pg@8.20.0)(expo-sqlite@55.0.16(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6))(kysely@0.28.17)(mysql2@3.15.3)(pg@8.20.0)(postgres@3.4.7(patch_hash=2bd119d361250d5ee010b23af4c98504e9c6861b692d2e2ae23b9a9e5de4dbce))(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(magicast@0.5.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@7.0.2)):
+    optionalDependencies:
+      '@electric-sql/pglite': 0.4.1
+      '@op-engineering/op-sqlite': 15.2.14(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
+      '@opentelemetry/api': 1.9.1
+      '@prisma/client': 7.8.0(prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(magicast@0.5.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@7.0.2))(typescript@7.0.2)
+      '@types/pg': 8.20.0
+      expo-sqlite: 55.0.16(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
+      kysely: 0.28.17
+      mysql2: 3.15.3
+      pg: 8.20.0
+      postgres: 3.4.7(patch_hash=2bd119d361250d5ee010b23af4c98504e9c6861b692d2e2ae23b9a9e5de4dbce)
+      prisma: 7.8.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(magicast@0.5.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@7.0.2)
+
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -21090,10 +21350,10 @@ snapshots:
 
   expect-type@1.3.0: {}
 
-  expo-asset@55.0.17(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)(typescript@6.0.3):
+  expo-asset@55.0.17(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)(typescript@7.0.2):
     dependencies:
-      '@expo/image-utils': 0.8.14(typescript@6.0.3)
-      expo: 55.0.24(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.6(react@19.2.6))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+      '@expo/image-utils': 0.8.14(typescript@7.0.2)
+      expo: 55.0.24(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.6(react@19.2.6))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)(typescript@7.0.2)
       expo-constants: 55.0.16(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))
       react: 19.2.6
       react-native: 0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6)
@@ -21104,31 +21364,31 @@ snapshots:
   expo-constants@55.0.16(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6)):
     dependencies:
       '@expo/env': 2.1.2
-      expo: 55.0.24(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.6(react@19.2.6))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+      expo: 55.0.24(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.6(react@19.2.6))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)(typescript@7.0.2)
       react-native: 0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6)
     transitivePeerDependencies:
       - supports-color
 
   expo-file-system@55.0.21(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6)):
     dependencies:
-      expo: 55.0.24(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.6(react@19.2.6))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+      expo: 55.0.24(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.6(react@19.2.6))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)(typescript@7.0.2)
       react-native: 0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6)
 
   expo-font@55.0.8(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6):
     dependencies:
-      expo: 55.0.24(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.6(react@19.2.6))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+      expo: 55.0.24(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.6(react@19.2.6))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)(typescript@7.0.2)
       fontfaceobserver: 2.3.0
       react: 19.2.6
       react-native: 0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6)
 
   expo-keep-awake@55.0.8(expo@55.0.24)(react@19.2.6):
     dependencies:
-      expo: 55.0.24(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.6(react@19.2.6))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+      expo: 55.0.24(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.6(react@19.2.6))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)(typescript@7.0.2)
       react: 19.2.6
 
-  expo-modules-autolinking@55.0.22(typescript@6.0.3):
+  expo-modules-autolinking@55.0.22(typescript@7.0.2):
     dependencies:
-      '@expo/require-utils': 55.0.5(typescript@6.0.3)
+      '@expo/require-utils': 55.0.5(typescript@7.0.2)
       '@expo/spawn-async': 1.8.0
       chalk: 4.1.2
       commander: 7.2.0
@@ -21147,31 +21407,31 @@ snapshots:
   expo-sqlite@55.0.16(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6):
     dependencies:
       await-lock: 2.2.2
-      expo: 55.0.24(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.6(react@19.2.6))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+      expo: 55.0.24(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.6(react@19.2.6))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)(typescript@7.0.2)
       react: 19.2.6
       react-native: 0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6)
 
-  expo@55.0.24(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.6(react@19.2.6))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)(typescript@6.0.3):
+  expo@55.0.24(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.6(react@19.2.6))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)(typescript@7.0.2):
     dependencies:
       '@babel/runtime': 7.29.2
-      '@expo/cli': 55.0.30(@expo/dom-webview@55.0.6)(expo-constants@55.0.16(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6)))(expo-font@55.0.8(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6))(expo@55.0.24)(react-dom@19.2.6(react@19.2.6))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
-      '@expo/config': 55.0.17(typescript@6.0.3)
+      '@expo/cli': 55.0.30(@expo/dom-webview@55.0.6)(expo-constants@55.0.16(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6)))(expo-font@55.0.8(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6))(expo@55.0.24)(react-dom@19.2.6(react@19.2.6))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)(typescript@7.0.2)
+      '@expo/config': 55.0.17(typescript@7.0.2)
       '@expo/config-plugins': 55.0.9
       '@expo/devtools': 55.0.3(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       '@expo/fingerprint': 0.16.7
-      '@expo/local-build-cache-provider': 55.0.13(typescript@6.0.3)
+      '@expo/local-build-cache-provider': 55.0.13(typescript@7.0.2)
       '@expo/log-box': 55.0.12(@expo/dom-webview@55.0.6)(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       '@expo/metro': 55.1.1
-      '@expo/metro-config': 55.0.21(expo@55.0.24)(typescript@6.0.3)
+      '@expo/metro-config': 55.0.21(expo@55.0.24)(typescript@7.0.2)
       '@expo/vector-icons': 15.1.1(expo-font@55.0.8(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       '@ungap/structured-clone': 1.3.1
       babel-preset-expo: 55.0.22(@babel/core@7.29.0)(@babel/runtime@7.29.2)(expo@55.0.24)(react-refresh@0.14.2)
-      expo-asset: 55.0.17(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+      expo-asset: 55.0.17(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)(typescript@7.0.2)
       expo-constants: 55.0.16(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))
       expo-file-system: 55.0.21(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))
       expo-font: 55.0.8(expo@55.0.24)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       expo-keep-awake: 55.0.8(expo@55.0.24)(react@19.2.6)
-      expo-modules-autolinking: 55.0.22(typescript@6.0.3)
+      expo-modules-autolinking: 55.0.22(typescript@7.0.2)
       expo-modules-core: 55.0.25(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6))(react@19.2.6)
       pretty-format: 29.7.0
       react: 19.2.6
@@ -24836,6 +25096,24 @@ snapshots:
       - react
       - react-dom
 
+  prisma@7.8.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(magicast@0.5.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@7.0.2):
+    dependencies:
+      '@prisma/config': 7.8.0(magicast@0.5.3)
+      '@prisma/dev': 0.24.3(typescript@7.0.2)
+      '@prisma/engines': 7.8.0
+      '@prisma/studio-core': 0.27.3(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      mysql2: 3.15.3
+      postgres: 3.4.7(patch_hash=2bd119d361250d5ee010b23af4c98504e9c6861b692d2e2ae23b9a9e5de4dbce)
+    optionalDependencies:
+      typescript: 7.0.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+      - magicast
+      - react
+      - react-dom
+    optional: true
+
   prismjs@1.30.0: {}
 
   proc-log@4.2.0: {}
@@ -26325,6 +26603,10 @@ snapshots:
     dependencies:
       typedoc: 0.28.19(typescript@6.0.3)
 
+  typedoc-plugin-markdown@4.11.0(typedoc@0.28.19(typescript@7.0.2)):
+    dependencies:
+      typedoc: 0.28.19(typescript@7.0.2)
+
   typedoc@0.28.19(typescript@6.0.3):
     dependencies:
       '@gerrit0/mini-shiki': 3.23.0
@@ -26334,9 +26616,41 @@ snapshots:
       typescript: 6.0.3
       yaml: 2.9.0
 
+  typedoc@0.28.19(typescript@7.0.2):
+    dependencies:
+      '@gerrit0/mini-shiki': 3.23.0
+      lunr: 2.3.9
+      markdown-it: 14.1.1
+      minimatch: 10.2.5
+      typescript: 7.0.2
+      yaml: 2.9.0
+
   typescript@5.8.2: {}
 
   typescript@6.0.3: {}
+
+  typescript@7.0.2:
+    optionalDependencies:
+      '@typescript/typescript-aix-ppc64': 7.0.2
+      '@typescript/typescript-darwin-arm64': 7.0.2
+      '@typescript/typescript-darwin-x64': 7.0.2
+      '@typescript/typescript-freebsd-arm64': 7.0.2
+      '@typescript/typescript-freebsd-x64': 7.0.2
+      '@typescript/typescript-linux-arm': 7.0.2
+      '@typescript/typescript-linux-arm64': 7.0.2
+      '@typescript/typescript-linux-loong64': 7.0.2
+      '@typescript/typescript-linux-mips64el': 7.0.2
+      '@typescript/typescript-linux-ppc64': 7.0.2
+      '@typescript/typescript-linux-riscv64': 7.0.2
+      '@typescript/typescript-linux-s390x': 7.0.2
+      '@typescript/typescript-linux-x64': 7.0.2
+      '@typescript/typescript-netbsd-arm64': 7.0.2
+      '@typescript/typescript-netbsd-x64': 7.0.2
+      '@typescript/typescript-openbsd-arm64': 7.0.2
+      '@typescript/typescript-openbsd-x64': 7.0.2
+      '@typescript/typescript-sunos-x64': 7.0.2
+      '@typescript/typescript-win32-arm64': 7.0.2
+      '@typescript/typescript-win32-x64': 7.0.2
 
   typical@7.3.0: {}
 
@@ -26504,6 +26818,11 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
+  valibot@1.2.0(typescript@7.0.2):
+    optionalDependencies:
+      typescript: 7.0.2
+    optional: true
+
   validate-npm-package-name@5.0.1: {}
 
   value-equal@1.0.1: {}
@@ -26540,11 +26859,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-svgr@5.2.0(typescript@6.0.3)(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0)):
+  vite-plugin-svgr@5.2.0(typescript@7.0.2)(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0)):
     dependencies:
       '@rollup/pluginutils': 5.3.0
-      '@svgr/core': 8.1.0(typescript@6.0.3)
-      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@6.0.3))
+      '@svgr/core': 8.1.0(typescript@7.0.2)
+      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@7.0.2))
       vite: 8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - rollup

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "@types/node": "^22.10.5",
     "oxfmt": "^0.45.0",
-    "typescript": "~6.0.2",
+    "typescript": "~7.0.2",
     "vitest": "^4.1.6"
   },
   "engines": {

--- a/tools/tsnapi/__snapshots__/tsnapi/@rocicorp/zero-types/change-protocol/v0/data.snapshot.d.ts
+++ b/tools/tsnapi/__snapshots__/tsnapi/@rocicorp/zero-types/change-protocol/v0/data.snapshot.d.ts
@@ -49,8 +49,8 @@ export declare const addColumnSchema: v.ObjectType<{
         spec: v.ObjectType<{
             pos: v.Type<number>;
             dataType: v.Type<string>;
-            pgTypeClass: v.Optional<"e" | "d" | "b" | "c" | "p" | "r" | "m">;
-            elemPgTypeClass: v.Optional<"e" | "d" | "b" | "c" | "p" | "r" | "m" | null>;
+            pgTypeClass: v.Optional<"b" | "c" | "d" | "e" | "m" | "p" | "r">;
+            elemPgTypeClass: v.Optional<"b" | "c" | "d" | "e" | "m" | "p" | "r" | null>;
             characterMaximumLength: v.Optional<number | null>;
             notNull: v.Optional<boolean | null>;
             dflt: v.Optional<string | null>;
@@ -69,15 +69,15 @@ export declare const backfillCompletedSchema: v.ObjectType<{
         name: v.Type<string>;
         rowKey: v.ObjectType<{
             columns: v.ArrayType<v.Type<string>>;
-            type: v.Optional<"default" | "nothing" | "full" | "index">;
+            type: v.Optional<"default" | "full" | "index" | "nothing">;
         }, undefined>;
     }, undefined>;
     columns: v.ArrayType<v.Type<string>>;
     watermark: v.Type<string>;
     status: v.Optional<{
-        totalBytes?: number | undefined;
         rows: number;
         totalRows: number;
+        totalBytes?: number | undefined;
     }>;
 }, undefined>;
 export declare const backfillIDSchema: v.Type<Record<string, import("./json.ts").JSONValue | undefined>>;
@@ -88,16 +88,16 @@ export declare const backfillSchema: v.ObjectType<{
         name: v.Type<string>;
         rowKey: v.ObjectType<{
             columns: v.ArrayType<v.Type<string>>;
-            type: v.Optional<"default" | "nothing" | "full" | "index">;
+            type: v.Optional<"default" | "full" | "index" | "nothing">;
         }, undefined>;
     }, undefined>;
     columns: v.ArrayType<v.Type<string>>;
     watermark: v.Type<string>;
     rowValues: v.ArrayType<v.ArrayType<v.Type<import("../../../../../../shared/src/bigint-json.ts").JSONValue>>>;
     status: v.Optional<{
-        totalBytes?: number | undefined;
         rows: number;
         totalRows: number;
+        totalBytes?: number | undefined;
     }>;
 }, undefined>;
 export declare const beginSchema: v.ObjectType<{
@@ -124,13 +124,13 @@ export declare const createTableSchema: v.ObjectType<{
     spec: v.ObjectType<Omit<{
         name: v.Type<string>;
         columns: v.Type<Record<string, {
-            pgTypeClass?: "e" | "d" | "b" | "c" | "p" | "r" | "m" | undefined;
-            elemPgTypeClass?: "e" | "d" | "b" | "c" | "p" | "r" | "m" | null | undefined;
+            pos: number;
+            dataType: string;
+            pgTypeClass?: "b" | "c" | "d" | "e" | "m" | "p" | "r" | undefined;
+            elemPgTypeClass?: "b" | "c" | "d" | "e" | "m" | "p" | "r" | null | undefined;
             characterMaximumLength?: number | null | undefined;
             notNull?: boolean | null | undefined;
             dflt?: string | null | undefined;
-            pos: number;
-            dataType: string;
         }>>;
         primaryKey: v.Optional<string[]>;
     }, "schema"> & {
@@ -145,54 +145,54 @@ export declare const createTableSchema: v.ObjectType<{
 export declare const dataChangeSchema: v.UnionType<[v.ObjectType<{
     tag: v.Type<"insert">;
     relation: v.Type<{
-        rowKey: {
-            type?: "default" | "nothing" | "full" | "index" | undefined;
-            columns: string[];
-        };
-        keyColumns?: string[] | undefined;
-        replicaIdentity?: "default" | "nothing" | "full" | "index" | undefined;
         schema: string;
         name: string;
+        keyColumns?: string[] | undefined;
+        replicaIdentity?: "default" | "full" | "index" | "nothing" | undefined;
+        rowKey: {
+            columns: string[];
+            type?: "default" | "full" | "index" | "nothing" | undefined;
+        };
     }>;
     new: v.Type<Record<string, import("../../../../../../shared/src/bigint-json.ts").JSONValue>>;
 }, undefined>, v.ObjectType<{
     tag: v.Type<"update">;
     relation: v.Type<{
-        rowKey: {
-            type?: "default" | "nothing" | "full" | "index" | undefined;
-            columns: string[];
-        };
-        keyColumns?: string[] | undefined;
-        replicaIdentity?: "default" | "nothing" | "full" | "index" | undefined;
         schema: string;
         name: string;
+        keyColumns?: string[] | undefined;
+        replicaIdentity?: "default" | "full" | "index" | "nothing" | undefined;
+        rowKey: {
+            columns: string[];
+            type?: "default" | "full" | "index" | "nothing" | undefined;
+        };
     }>;
     key: v.Type<Record<string, import("../../../../../../shared/src/bigint-json.ts").JSONValue> | null>;
     new: v.Type<Record<string, import("../../../../../../shared/src/bigint-json.ts").JSONValue>>;
 }, undefined>, v.ObjectType<{
     tag: v.Type<"delete">;
     relation: v.Type<{
-        rowKey: {
-            type?: "default" | "nothing" | "full" | "index" | undefined;
-            columns: string[];
-        };
-        keyColumns?: string[] | undefined;
-        replicaIdentity?: "default" | "nothing" | "full" | "index" | undefined;
         schema: string;
         name: string;
+        keyColumns?: string[] | undefined;
+        replicaIdentity?: "default" | "full" | "index" | "nothing" | undefined;
+        rowKey: {
+            columns: string[];
+            type?: "default" | "full" | "index" | "nothing" | undefined;
+        };
     }>;
     key: v.Type<Record<string, import("../../../../../../shared/src/bigint-json.ts").JSONValue>>;
 }, undefined>, v.ObjectType<{
     tag: v.Type<"truncate">;
     relations: v.ArrayType<v.Type<{
-        rowKey: {
-            type?: "default" | "nothing" | "full" | "index" | undefined;
-            columns: string[];
-        };
-        keyColumns?: string[] | undefined;
-        replicaIdentity?: "default" | "nothing" | "full" | "index" | undefined;
         schema: string;
         name: string;
+        keyColumns?: string[] | undefined;
+        replicaIdentity?: "default" | "full" | "index" | "nothing" | undefined;
+        rowKey: {
+            columns: string[];
+            type?: "default" | "full" | "index" | "nothing" | undefined;
+        };
     }>>;
 }, undefined>, v.ObjectType<{
     tag: v.Type<"backfill">;
@@ -201,29 +201,29 @@ export declare const dataChangeSchema: v.UnionType<[v.ObjectType<{
         name: v.Type<string>;
         rowKey: v.ObjectType<{
             columns: v.ArrayType<v.Type<string>>;
-            type: v.Optional<"default" | "nothing" | "full" | "index">;
+            type: v.Optional<"default" | "full" | "index" | "nothing">;
         }, undefined>;
     }, undefined>;
     columns: v.ArrayType<v.Type<string>>;
     watermark: v.Type<string>;
     rowValues: v.ArrayType<v.ArrayType<v.Type<import("../../../../../../shared/src/bigint-json.ts").JSONValue>>>;
     status: v.Optional<{
-        totalBytes?: number | undefined;
         rows: number;
         totalRows: number;
+        totalBytes?: number | undefined;
     }>;
 }, undefined>]>;
 export declare const deleteSchema: v.ObjectType<{
     tag: v.Type<"delete">;
     relation: v.Type<{
-        rowKey: {
-            type?: "default" | "nothing" | "full" | "index" | undefined;
-            columns: string[];
-        };
-        keyColumns?: string[] | undefined;
-        replicaIdentity?: "default" | "nothing" | "full" | "index" | undefined;
         schema: string;
         name: string;
+        keyColumns?: string[] | undefined;
+        replicaIdentity?: "default" | "full" | "index" | "nothing" | undefined;
+        rowKey: {
+            columns: string[];
+            type?: "default" | "full" | "index" | "nothing" | undefined;
+        };
     }>;
     key: v.Type<Record<string, import("../../../../../../shared/src/bigint-json.ts").JSONValue>>;
 }, undefined>;
@@ -261,14 +261,14 @@ export declare const identifierSchema: v.ObjectType<{
 export declare const insertSchema: v.ObjectType<{
     tag: v.Type<"insert">;
     relation: v.Type<{
-        rowKey: {
-            type?: "default" | "nothing" | "full" | "index" | undefined;
-            columns: string[];
-        };
-        keyColumns?: string[] | undefined;
-        replicaIdentity?: "default" | "nothing" | "full" | "index" | undefined;
         schema: string;
         name: string;
+        keyColumns?: string[] | undefined;
+        replicaIdentity?: "default" | "full" | "index" | "nothing" | undefined;
+        rowKey: {
+            columns: string[];
+            type?: "default" | "full" | "index" | "nothing" | undefined;
+        };
     }>;
     new: v.Type<Record<string, import("../../../../../../shared/src/bigint-json.ts").JSONValue>>;
 }, undefined>;
@@ -277,18 +277,18 @@ export declare const newRelationSchema: v.ObjectType<{
     name: v.Type<string>;
     rowKey: v.ObjectType<{
         columns: v.ArrayType<v.Type<string>>;
-        type: v.Optional<"default" | "nothing" | "full" | "index">;
+        type: v.Optional<"default" | "full" | "index" | "nothing">;
     }, undefined>;
 }, undefined>;
 export declare const relationSchema: v.Type<{
-    rowKey: {
-        type?: "default" | "nothing" | "full" | "index" | undefined;
-        columns: string[];
-    };
-    keyColumns?: string[] | undefined;
-    replicaIdentity?: "default" | "nothing" | "full" | "index" | undefined;
     schema: string;
     name: string;
+    keyColumns?: string[] | undefined;
+    replicaIdentity?: "default" | "full" | "index" | "nothing" | undefined;
+    rowKey: {
+        columns: string[];
+        type?: "default" | "full" | "index" | "nothing" | undefined;
+    };
 }>;
 export declare const renameTableSchema: v.ObjectType<{
     tag: v.Type<"rename-table">;
@@ -310,13 +310,13 @@ export declare const schemaChangeSchema: v.UnionType<[v.ObjectType<{
     spec: v.ObjectType<Omit<{
         name: v.Type<string>;
         columns: v.Type<Record<string, {
-            pgTypeClass?: "e" | "d" | "b" | "c" | "p" | "r" | "m" | undefined;
-            elemPgTypeClass?: "e" | "d" | "b" | "c" | "p" | "r" | "m" | null | undefined;
+            pos: number;
+            dataType: string;
+            pgTypeClass?: "b" | "c" | "d" | "e" | "m" | "p" | "r" | undefined;
+            elemPgTypeClass?: "b" | "c" | "d" | "e" | "m" | "p" | "r" | null | undefined;
             characterMaximumLength?: number | null | undefined;
             notNull?: boolean | null | undefined;
             dflt?: string | null | undefined;
-            pos: number;
-            dataType: string;
         }>>;
         primaryKey: v.Optional<string[]>;
     }, "schema"> & {
@@ -360,8 +360,8 @@ export declare const schemaChangeSchema: v.UnionType<[v.ObjectType<{
         spec: v.ObjectType<{
             pos: v.Type<number>;
             dataType: v.Type<string>;
-            pgTypeClass: v.Optional<"e" | "d" | "b" | "c" | "p" | "r" | "m">;
-            elemPgTypeClass: v.Optional<"e" | "d" | "b" | "c" | "p" | "r" | "m" | null>;
+            pgTypeClass: v.Optional<"b" | "c" | "d" | "e" | "m" | "p" | "r">;
+            elemPgTypeClass: v.Optional<"b" | "c" | "d" | "e" | "m" | "p" | "r" | null>;
             characterMaximumLength: v.Optional<number | null>;
             notNull: v.Optional<boolean | null>;
             dflt: v.Optional<string | null>;
@@ -383,8 +383,8 @@ export declare const schemaChangeSchema: v.UnionType<[v.ObjectType<{
         spec: v.ObjectType<{
             pos: v.Type<number>;
             dataType: v.Type<string>;
-            pgTypeClass: v.Optional<"e" | "d" | "b" | "c" | "p" | "r" | "m">;
-            elemPgTypeClass: v.Optional<"e" | "d" | "b" | "c" | "p" | "r" | "m" | null>;
+            pgTypeClass: v.Optional<"b" | "c" | "d" | "e" | "m" | "p" | "r">;
+            elemPgTypeClass: v.Optional<"b" | "c" | "d" | "e" | "m" | "p" | "r" | null>;
             characterMaximumLength: v.Optional<number | null>;
             notNull: v.Optional<boolean | null>;
             dflt: v.Optional<string | null>;
@@ -395,8 +395,8 @@ export declare const schemaChangeSchema: v.UnionType<[v.ObjectType<{
         spec: v.ObjectType<{
             pos: v.Type<number>;
             dataType: v.Type<string>;
-            pgTypeClass: v.Optional<"e" | "d" | "b" | "c" | "p" | "r" | "m">;
-            elemPgTypeClass: v.Optional<"e" | "d" | "b" | "c" | "p" | "r" | "m" | null>;
+            pgTypeClass: v.Optional<"b" | "c" | "d" | "e" | "m" | "p" | "r">;
+            elemPgTypeClass: v.Optional<"b" | "c" | "d" | "e" | "m" | "p" | "r" | null>;
             characterMaximumLength: v.Optional<number | null>;
             notNull: v.Optional<boolean | null>;
             dflt: v.Optional<string | null>;
@@ -438,15 +438,15 @@ export declare const schemaChangeSchema: v.UnionType<[v.ObjectType<{
         name: v.Type<string>;
         rowKey: v.ObjectType<{
             columns: v.ArrayType<v.Type<string>>;
-            type: v.Optional<"default" | "nothing" | "full" | "index">;
+            type: v.Optional<"default" | "full" | "index" | "nothing">;
         }, undefined>;
     }, undefined>;
     columns: v.ArrayType<v.Type<string>>;
     watermark: v.Type<string>;
     status: v.Optional<{
-        totalBytes?: number | undefined;
         rows: number;
         totalRows: number;
+        totalBytes?: number | undefined;
     }>;
 }, undefined>]>;
 export declare const tableMetadataSchema: v.ObjectType<{
@@ -455,14 +455,14 @@ export declare const tableMetadataSchema: v.ObjectType<{
 export declare const truncateSchema: v.ObjectType<{
     tag: v.Type<"truncate">;
     relations: v.ArrayType<v.Type<{
-        rowKey: {
-            type?: "default" | "nothing" | "full" | "index" | undefined;
-            columns: string[];
-        };
-        keyColumns?: string[] | undefined;
-        replicaIdentity?: "default" | "nothing" | "full" | "index" | undefined;
         schema: string;
         name: string;
+        keyColumns?: string[] | undefined;
+        replicaIdentity?: "default" | "full" | "index" | "nothing" | undefined;
+        rowKey: {
+            columns: string[];
+            type?: "default" | "full" | "index" | "nothing" | undefined;
+        };
     }>>;
 }, undefined>;
 export declare const updateColumnSchema: v.ObjectType<{
@@ -476,8 +476,8 @@ export declare const updateColumnSchema: v.ObjectType<{
         spec: v.ObjectType<{
             pos: v.Type<number>;
             dataType: v.Type<string>;
-            pgTypeClass: v.Optional<"e" | "d" | "b" | "c" | "p" | "r" | "m">;
-            elemPgTypeClass: v.Optional<"e" | "d" | "b" | "c" | "p" | "r" | "m" | null>;
+            pgTypeClass: v.Optional<"b" | "c" | "d" | "e" | "m" | "p" | "r">;
+            elemPgTypeClass: v.Optional<"b" | "c" | "d" | "e" | "m" | "p" | "r" | null>;
             characterMaximumLength: v.Optional<number | null>;
             notNull: v.Optional<boolean | null>;
             dflt: v.Optional<string | null>;
@@ -488,8 +488,8 @@ export declare const updateColumnSchema: v.ObjectType<{
         spec: v.ObjectType<{
             pos: v.Type<number>;
             dataType: v.Type<string>;
-            pgTypeClass: v.Optional<"e" | "d" | "b" | "c" | "p" | "r" | "m">;
-            elemPgTypeClass: v.Optional<"e" | "d" | "b" | "c" | "p" | "r" | "m" | null>;
+            pgTypeClass: v.Optional<"b" | "c" | "d" | "e" | "m" | "p" | "r">;
+            elemPgTypeClass: v.Optional<"b" | "c" | "d" | "e" | "m" | "p" | "r" | null>;
             characterMaximumLength: v.Optional<number | null>;
             notNull: v.Optional<boolean | null>;
             dflt: v.Optional<string | null>;
@@ -499,14 +499,14 @@ export declare const updateColumnSchema: v.ObjectType<{
 export declare const updateSchema: v.ObjectType<{
     tag: v.Type<"update">;
     relation: v.Type<{
-        rowKey: {
-            type?: "default" | "nothing" | "full" | "index" | undefined;
-            columns: string[];
-        };
-        keyColumns?: string[] | undefined;
-        replicaIdentity?: "default" | "nothing" | "full" | "index" | undefined;
         schema: string;
         name: string;
+        keyColumns?: string[] | undefined;
+        replicaIdentity?: "default" | "full" | "index" | "nothing" | undefined;
+        rowKey: {
+            columns: string[];
+            type?: "default" | "full" | "index" | "nothing" | undefined;
+        };
     }>;
     key: v.Type<Record<string, import("../../../../../../shared/src/bigint-json.ts").JSONValue> | null>;
     new: v.Type<Record<string, import("../../../../../../shared/src/bigint-json.ts").JSONValue>>;

--- a/tools/tsnapi/__snapshots__/tsnapi/@rocicorp/zero-types/change-protocol/v0/downstream.snapshot.d.ts
+++ b/tools/tsnapi/__snapshots__/tsnapi/@rocicorp/zero-types/change-protocol/v0/downstream.snapshot.d.ts
@@ -23,54 +23,54 @@ export declare const changeStreamDataSchema: v.UnionType<[v.TupleType<[v.Type<"b
 }, undefined>]>, v.TupleType<[v.Type<"data">, v.UnionType<[v.UnionType<[v.ObjectType<{
     tag: v.Type<"insert">;
     relation: v.Type<{
-        rowKey: {
-            type?: "default" | "nothing" | "full" | "index" | undefined;
-            columns: string[];
-        };
-        keyColumns?: string[] | undefined;
-        replicaIdentity?: "default" | "nothing" | "full" | "index" | undefined;
         schema: string;
         name: string;
+        keyColumns?: string[] | undefined;
+        replicaIdentity?: "default" | "full" | "index" | "nothing" | undefined;
+        rowKey: {
+            columns: string[];
+            type?: "default" | "full" | "index" | "nothing" | undefined;
+        };
     }>;
     new: v.Type<Record<string, import("../../../../../../shared/src/bigint-json.ts").JSONValue>>;
 }, undefined>, v.ObjectType<{
     tag: v.Type<"update">;
     relation: v.Type<{
-        rowKey: {
-            type?: "default" | "nothing" | "full" | "index" | undefined;
-            columns: string[];
-        };
-        keyColumns?: string[] | undefined;
-        replicaIdentity?: "default" | "nothing" | "full" | "index" | undefined;
         schema: string;
         name: string;
+        keyColumns?: string[] | undefined;
+        replicaIdentity?: "default" | "full" | "index" | "nothing" | undefined;
+        rowKey: {
+            columns: string[];
+            type?: "default" | "full" | "index" | "nothing" | undefined;
+        };
     }>;
     key: v.Type<Record<string, import("../../../../../../shared/src/bigint-json.ts").JSONValue> | null>;
     new: v.Type<Record<string, import("../../../../../../shared/src/bigint-json.ts").JSONValue>>;
 }, undefined>, v.ObjectType<{
     tag: v.Type<"delete">;
     relation: v.Type<{
-        rowKey: {
-            type?: "default" | "nothing" | "full" | "index" | undefined;
-            columns: string[];
-        };
-        keyColumns?: string[] | undefined;
-        replicaIdentity?: "default" | "nothing" | "full" | "index" | undefined;
         schema: string;
         name: string;
+        keyColumns?: string[] | undefined;
+        replicaIdentity?: "default" | "full" | "index" | "nothing" | undefined;
+        rowKey: {
+            columns: string[];
+            type?: "default" | "full" | "index" | "nothing" | undefined;
+        };
     }>;
     key: v.Type<Record<string, import("../../../../../../shared/src/bigint-json.ts").JSONValue>>;
 }, undefined>, v.ObjectType<{
     tag: v.Type<"truncate">;
     relations: v.ArrayType<v.Type<{
-        rowKey: {
-            type?: "default" | "nothing" | "full" | "index" | undefined;
-            columns: string[];
-        };
-        keyColumns?: string[] | undefined;
-        replicaIdentity?: "default" | "nothing" | "full" | "index" | undefined;
         schema: string;
         name: string;
+        keyColumns?: string[] | undefined;
+        replicaIdentity?: "default" | "full" | "index" | "nothing" | undefined;
+        rowKey: {
+            columns: string[];
+            type?: "default" | "full" | "index" | "nothing" | undefined;
+        };
     }>>;
 }, undefined>, v.ObjectType<{
     tag: v.Type<"backfill">;
@@ -79,29 +79,29 @@ export declare const changeStreamDataSchema: v.UnionType<[v.TupleType<[v.Type<"b
         name: v.Type<string>;
         rowKey: v.ObjectType<{
             columns: v.ArrayType<v.Type<string>>;
-            type: v.Optional<"default" | "nothing" | "full" | "index">;
+            type: v.Optional<"default" | "full" | "index" | "nothing">;
         }, undefined>;
     }, undefined>;
     columns: v.ArrayType<v.Type<string>>;
     watermark: v.Type<string>;
     rowValues: v.ArrayType<v.ArrayType<v.Type<import("../../../../../../shared/src/bigint-json.ts").JSONValue>>>;
     status: v.Optional<{
-        totalBytes?: number | undefined;
         rows: number;
         totalRows: number;
+        totalBytes?: number | undefined;
     }>;
 }, undefined>]>, v.UnionType<[v.ObjectType<{
     tag: v.Type<"create-table">;
     spec: v.ObjectType<Omit<{
         name: v.Type<string>;
         columns: v.Type<Record<string, {
-            pgTypeClass?: "e" | "d" | "b" | "c" | "p" | "r" | "m" | undefined;
-            elemPgTypeClass?: "e" | "d" | "b" | "c" | "p" | "r" | "m" | null | undefined;
+            pos: number;
+            dataType: string;
+            pgTypeClass?: "b" | "c" | "d" | "e" | "m" | "p" | "r" | undefined;
+            elemPgTypeClass?: "b" | "c" | "d" | "e" | "m" | "p" | "r" | null | undefined;
             characterMaximumLength?: number | null | undefined;
             notNull?: boolean | null | undefined;
             dflt?: string | null | undefined;
-            pos: number;
-            dataType: string;
         }>>;
         primaryKey: v.Optional<string[]>;
     }, "schema"> & {
@@ -145,8 +145,8 @@ export declare const changeStreamDataSchema: v.UnionType<[v.TupleType<[v.Type<"b
         spec: v.ObjectType<{
             pos: v.Type<number>;
             dataType: v.Type<string>;
-            pgTypeClass: v.Optional<"e" | "d" | "b" | "c" | "p" | "r" | "m">;
-            elemPgTypeClass: v.Optional<"e" | "d" | "b" | "c" | "p" | "r" | "m" | null>;
+            pgTypeClass: v.Optional<"b" | "c" | "d" | "e" | "m" | "p" | "r">;
+            elemPgTypeClass: v.Optional<"b" | "c" | "d" | "e" | "m" | "p" | "r" | null>;
             characterMaximumLength: v.Optional<number | null>;
             notNull: v.Optional<boolean | null>;
             dflt: v.Optional<string | null>;
@@ -168,8 +168,8 @@ export declare const changeStreamDataSchema: v.UnionType<[v.TupleType<[v.Type<"b
         spec: v.ObjectType<{
             pos: v.Type<number>;
             dataType: v.Type<string>;
-            pgTypeClass: v.Optional<"e" | "d" | "b" | "c" | "p" | "r" | "m">;
-            elemPgTypeClass: v.Optional<"e" | "d" | "b" | "c" | "p" | "r" | "m" | null>;
+            pgTypeClass: v.Optional<"b" | "c" | "d" | "e" | "m" | "p" | "r">;
+            elemPgTypeClass: v.Optional<"b" | "c" | "d" | "e" | "m" | "p" | "r" | null>;
             characterMaximumLength: v.Optional<number | null>;
             notNull: v.Optional<boolean | null>;
             dflt: v.Optional<string | null>;
@@ -180,8 +180,8 @@ export declare const changeStreamDataSchema: v.UnionType<[v.TupleType<[v.Type<"b
         spec: v.ObjectType<{
             pos: v.Type<number>;
             dataType: v.Type<string>;
-            pgTypeClass: v.Optional<"e" | "d" | "b" | "c" | "p" | "r" | "m">;
-            elemPgTypeClass: v.Optional<"e" | "d" | "b" | "c" | "p" | "r" | "m" | null>;
+            pgTypeClass: v.Optional<"b" | "c" | "d" | "e" | "m" | "p" | "r">;
+            elemPgTypeClass: v.Optional<"b" | "c" | "d" | "e" | "m" | "p" | "r" | null>;
             characterMaximumLength: v.Optional<number | null>;
             notNull: v.Optional<boolean | null>;
             dflt: v.Optional<string | null>;
@@ -223,15 +223,15 @@ export declare const changeStreamDataSchema: v.UnionType<[v.TupleType<[v.Type<"b
         name: v.Type<string>;
         rowKey: v.ObjectType<{
             columns: v.ArrayType<v.Type<string>>;
-            type: v.Optional<"default" | "nothing" | "full" | "index">;
+            type: v.Optional<"default" | "full" | "index" | "nothing">;
         }, undefined>;
     }, undefined>;
     columns: v.ArrayType<v.Type<string>>;
     watermark: v.Type<string>;
     status: v.Optional<{
-        totalBytes?: number | undefined;
         rows: number;
         totalRows: number;
+        totalBytes?: number | undefined;
     }>;
 }, undefined>]>]>]>, v.TupleType<[v.Type<"commit">, v.ObjectType<{
     tag: v.Type<"commit">;
@@ -249,54 +249,54 @@ export declare const changeStreamMessageSchema: v.UnionType<[v.UnionType<[v.Tupl
 }, undefined>]>, v.TupleType<[v.Type<"data">, v.UnionType<[v.UnionType<[v.ObjectType<{
     tag: v.Type<"insert">;
     relation: v.Type<{
-        rowKey: {
-            type?: "default" | "nothing" | "full" | "index" | undefined;
-            columns: string[];
-        };
-        keyColumns?: string[] | undefined;
-        replicaIdentity?: "default" | "nothing" | "full" | "index" | undefined;
         schema: string;
         name: string;
+        keyColumns?: string[] | undefined;
+        replicaIdentity?: "default" | "full" | "index" | "nothing" | undefined;
+        rowKey: {
+            columns: string[];
+            type?: "default" | "full" | "index" | "nothing" | undefined;
+        };
     }>;
     new: v.Type<Record<string, import("../../../../../../shared/src/bigint-json.ts").JSONValue>>;
 }, undefined>, v.ObjectType<{
     tag: v.Type<"update">;
     relation: v.Type<{
-        rowKey: {
-            type?: "default" | "nothing" | "full" | "index" | undefined;
-            columns: string[];
-        };
-        keyColumns?: string[] | undefined;
-        replicaIdentity?: "default" | "nothing" | "full" | "index" | undefined;
         schema: string;
         name: string;
+        keyColumns?: string[] | undefined;
+        replicaIdentity?: "default" | "full" | "index" | "nothing" | undefined;
+        rowKey: {
+            columns: string[];
+            type?: "default" | "full" | "index" | "nothing" | undefined;
+        };
     }>;
     key: v.Type<Record<string, import("../../../../../../shared/src/bigint-json.ts").JSONValue> | null>;
     new: v.Type<Record<string, import("../../../../../../shared/src/bigint-json.ts").JSONValue>>;
 }, undefined>, v.ObjectType<{
     tag: v.Type<"delete">;
     relation: v.Type<{
-        rowKey: {
-            type?: "default" | "nothing" | "full" | "index" | undefined;
-            columns: string[];
-        };
-        keyColumns?: string[] | undefined;
-        replicaIdentity?: "default" | "nothing" | "full" | "index" | undefined;
         schema: string;
         name: string;
+        keyColumns?: string[] | undefined;
+        replicaIdentity?: "default" | "full" | "index" | "nothing" | undefined;
+        rowKey: {
+            columns: string[];
+            type?: "default" | "full" | "index" | "nothing" | undefined;
+        };
     }>;
     key: v.Type<Record<string, import("../../../../../../shared/src/bigint-json.ts").JSONValue>>;
 }, undefined>, v.ObjectType<{
     tag: v.Type<"truncate">;
     relations: v.ArrayType<v.Type<{
-        rowKey: {
-            type?: "default" | "nothing" | "full" | "index" | undefined;
-            columns: string[];
-        };
-        keyColumns?: string[] | undefined;
-        replicaIdentity?: "default" | "nothing" | "full" | "index" | undefined;
         schema: string;
         name: string;
+        keyColumns?: string[] | undefined;
+        replicaIdentity?: "default" | "full" | "index" | "nothing" | undefined;
+        rowKey: {
+            columns: string[];
+            type?: "default" | "full" | "index" | "nothing" | undefined;
+        };
     }>>;
 }, undefined>, v.ObjectType<{
     tag: v.Type<"backfill">;
@@ -305,29 +305,29 @@ export declare const changeStreamMessageSchema: v.UnionType<[v.UnionType<[v.Tupl
         name: v.Type<string>;
         rowKey: v.ObjectType<{
             columns: v.ArrayType<v.Type<string>>;
-            type: v.Optional<"default" | "nothing" | "full" | "index">;
+            type: v.Optional<"default" | "full" | "index" | "nothing">;
         }, undefined>;
     }, undefined>;
     columns: v.ArrayType<v.Type<string>>;
     watermark: v.Type<string>;
     rowValues: v.ArrayType<v.ArrayType<v.Type<import("../../../../../../shared/src/bigint-json.ts").JSONValue>>>;
     status: v.Optional<{
-        totalBytes?: number | undefined;
         rows: number;
         totalRows: number;
+        totalBytes?: number | undefined;
     }>;
 }, undefined>]>, v.UnionType<[v.ObjectType<{
     tag: v.Type<"create-table">;
     spec: v.ObjectType<Omit<{
         name: v.Type<string>;
         columns: v.Type<Record<string, {
-            pgTypeClass?: "e" | "d" | "b" | "c" | "p" | "r" | "m" | undefined;
-            elemPgTypeClass?: "e" | "d" | "b" | "c" | "p" | "r" | "m" | null | undefined;
+            pos: number;
+            dataType: string;
+            pgTypeClass?: "b" | "c" | "d" | "e" | "m" | "p" | "r" | undefined;
+            elemPgTypeClass?: "b" | "c" | "d" | "e" | "m" | "p" | "r" | null | undefined;
             characterMaximumLength?: number | null | undefined;
             notNull?: boolean | null | undefined;
             dflt?: string | null | undefined;
-            pos: number;
-            dataType: string;
         }>>;
         primaryKey: v.Optional<string[]>;
     }, "schema"> & {
@@ -371,8 +371,8 @@ export declare const changeStreamMessageSchema: v.UnionType<[v.UnionType<[v.Tupl
         spec: v.ObjectType<{
             pos: v.Type<number>;
             dataType: v.Type<string>;
-            pgTypeClass: v.Optional<"e" | "d" | "b" | "c" | "p" | "r" | "m">;
-            elemPgTypeClass: v.Optional<"e" | "d" | "b" | "c" | "p" | "r" | "m" | null>;
+            pgTypeClass: v.Optional<"b" | "c" | "d" | "e" | "m" | "p" | "r">;
+            elemPgTypeClass: v.Optional<"b" | "c" | "d" | "e" | "m" | "p" | "r" | null>;
             characterMaximumLength: v.Optional<number | null>;
             notNull: v.Optional<boolean | null>;
             dflt: v.Optional<string | null>;
@@ -394,8 +394,8 @@ export declare const changeStreamMessageSchema: v.UnionType<[v.UnionType<[v.Tupl
         spec: v.ObjectType<{
             pos: v.Type<number>;
             dataType: v.Type<string>;
-            pgTypeClass: v.Optional<"e" | "d" | "b" | "c" | "p" | "r" | "m">;
-            elemPgTypeClass: v.Optional<"e" | "d" | "b" | "c" | "p" | "r" | "m" | null>;
+            pgTypeClass: v.Optional<"b" | "c" | "d" | "e" | "m" | "p" | "r">;
+            elemPgTypeClass: v.Optional<"b" | "c" | "d" | "e" | "m" | "p" | "r" | null>;
             characterMaximumLength: v.Optional<number | null>;
             notNull: v.Optional<boolean | null>;
             dflt: v.Optional<string | null>;
@@ -406,8 +406,8 @@ export declare const changeStreamMessageSchema: v.UnionType<[v.UnionType<[v.Tupl
         spec: v.ObjectType<{
             pos: v.Type<number>;
             dataType: v.Type<string>;
-            pgTypeClass: v.Optional<"e" | "d" | "b" | "c" | "p" | "r" | "m">;
-            elemPgTypeClass: v.Optional<"e" | "d" | "b" | "c" | "p" | "r" | "m" | null>;
+            pgTypeClass: v.Optional<"b" | "c" | "d" | "e" | "m" | "p" | "r">;
+            elemPgTypeClass: v.Optional<"b" | "c" | "d" | "e" | "m" | "p" | "r" | null>;
             characterMaximumLength: v.Optional<number | null>;
             notNull: v.Optional<boolean | null>;
             dflt: v.Optional<string | null>;
@@ -449,15 +449,15 @@ export declare const changeStreamMessageSchema: v.UnionType<[v.UnionType<[v.Tupl
         name: v.Type<string>;
         rowKey: v.ObjectType<{
             columns: v.ArrayType<v.Type<string>>;
-            type: v.Optional<"default" | "nothing" | "full" | "index">;
+            type: v.Optional<"default" | "full" | "index" | "nothing">;
         }, undefined>;
     }, undefined>;
     columns: v.ArrayType<v.Type<string>>;
     watermark: v.Type<string>;
     status: v.Optional<{
-        totalBytes?: number | undefined;
         rows: number;
         totalRows: number;
+        totalBytes?: number | undefined;
     }>;
 }, undefined>]>]>]>, v.TupleType<[v.Type<"commit">, v.ObjectType<{
     tag: v.Type<"commit">;

--- a/tools/verify-package-deps/package.json
+++ b/tools/verify-package-deps/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@types/node": "^22.10.5",
     "oxfmt": "^0.45.0",
-    "typescript": "~6.0.2"
+    "typescript": "~7.0.2"
   },
   "engines": {
     "node": ">=22"


### PR DESCRIPTION
Bump typescript from ~6.0.2 to ~7.0.2 across all workspace packages, except replicache-doc.

replicache-doc stays on ~6.0.2 because its documentation toolchain (typedoc / docusaurus) does not support the TypeScript 7 native compiler — typedoc's peer range tops out at typescript 6.0.x. A syncpack versionGroup marks this as a deliberate, ignored exception so `syncpack lint` still passes.

TypeScript 7 enforces the declaration-emit portability check (TS2883) more strictly. Six internal packages that only type-check (noEmit) and never emit .d.ts — zql, zql-integration-tests, zero-cache, zero-permissions, zql-benchmarks, zero-react — trip this on cross-package relative source imports under pnpm's symlinked layout. They opt out via declaration/declarationMap: false, since the check is moot for packages that don't emit declarations. Packages that do emit declarations (replicache, zero, zero-events) are unaffected and keep the check.

Regenerate the tsnapi API snapshots to reflect TS7's declaration emit ordering (alphabetized union literals, required-before-optional properties); the public API surface is unchanged.
