### PR TITLE
fix(zero-cache): log expected reset signals at warn, not error

### DIFF
--- a/packages/zero-cache/src/db/migration-lite.test.ts
+++ b/packages/zero-cache/src/db/migration-lite.test.ts
@@ -1,6 +1,10 @@
-import type {LogContext} from '@rocicorp/logger';
+import {LogContext} from '@rocicorp/logger';
 import {afterEach, beforeEach, describe, expect, test} from 'vitest';
-import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
+import {AbortError} from '../../../shared/src/abort-error.ts';
+import {
+  createSilentLogContext,
+  TestLogSink,
+} from '../../../shared/src/logging-test-utils.ts';
 import type {Database as Db} from '../../../zqlite/src/db.ts';
 import {DbFile} from '../test/lite.ts';
 import {
@@ -367,5 +371,58 @@ describe('db/migration-lite', () => {
 
     expect(err).toBeDefined();
     c.verify(err);
+  });
+
+  test('AbortError is logged at warn, not error', async () => {
+    // AbortErrors (e.g. AutoResetSignal signaling that the replica needs a
+    // reset) are an expected, self-healing control-flow signal and must not be
+    // logged at `error`, which would trip error-based alerting.
+    const sink = new TestLogSink();
+    const lc = new LogContext('debug', undefined, sink);
+
+    const abort = new AbortError('replica database appears corrupt');
+    let caught: unknown;
+    try {
+      await runSchemaMigrations(
+        lc,
+        debugName,
+        dbFile.path,
+        {migrateSchema: () => Promise.reject(abort)},
+        {1: {}},
+      );
+    } catch (e) {
+      caught = e;
+    }
+
+    // The signal still propagates so the caller can resync.
+    expect(caught).toBe(abort);
+
+    const errors = sink.messages.filter(([level]) => level === 'error');
+    const warns = sink.messages.filter(([level]) => level === 'warn');
+    expect(errors).toEqual([]);
+    expect(warns.some(([, , args]) => args.includes(abort))).toBe(true);
+  });
+
+  test('non-AbortError is logged at error', async () => {
+    const sink = new TestLogSink();
+    const lc = new LogContext('debug', undefined, sink);
+
+    const err = new Error('genuine migration failure');
+    let caught: unknown;
+    try {
+      await runSchemaMigrations(
+        lc,
+        debugName,
+        dbFile.path,
+        {migrateSchema: () => Promise.reject(err)},
+        {1: {}},
+      );
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBe(err);
+    const errors = sink.messages.filter(([level]) => level === 'error');
+    expect(errors.some(([, , args]) => args.includes(err))).toBe(true);
   });
 });

--- a/packages/zero-cache/src/db/migration-lite.ts
+++ b/packages/zero-cache/src/db/migration-lite.ts
@@ -1,4 +1,5 @@
 import type {LogContext} from '@rocicorp/logger';
+import {AbortError} from '../../../shared/src/abort-error.ts';
 import {assert} from '../../../shared/src/asserts.ts';
 import {randInt} from '../../../shared/src/rand.ts';
 import * as v from '../../../shared/src/valita.ts';
@@ -171,7 +172,16 @@ export async function runSchemaMigrations(
       } ms)`,
     );
   } catch (e) {
-    log.error?.('Error in ensureSchemaMigrated', e);
+    if (e instanceof AbortError) {
+      // AbortErrors (e.g. AutoResetSignal) are not failures. They are the
+      // expected mechanism for signaling that the replica needs a reset (e.g.
+      // corruption or an incompatible schema version) so that the caller can
+      // resync anew. Logging them at `error` would trip error-based alerting
+      // for a normal, self-healing path.
+      log.warn?.('Replica requires reset; resync will follow', e);
+    } else {
+      log.error?.('Error in ensureSchemaMigrated', e);
+    }
     throw e;
   } finally {
     db.close();
@@ -333,7 +343,14 @@ async function runTransaction<T>(
     db.prepare('COMMIT').run();
     return result;
   } catch (e) {
-    log.error?.('Aborted transaction due to error', e);
+    if (e instanceof AbortError) {
+      // AbortErrors (e.g. AutoResetSignal) are an expected, self-healing
+      // control-flow signal, not a failure. Log at `warn` so the rollback is
+      // still visible without tripping error-based alerting.
+      log.warn?.('Aborted transaction for reset signal', e);
+    } else {
+      log.error?.('Aborted transaction due to error', e);
+    }
     try {
       db.prepare('ROLLBACK').run();
     } catch (rollbackError) {

--- a/packages/zero-cache/src/db/migration.pg.test.ts
+++ b/packages/zero-cache/src/db/migration.pg.test.ts
@@ -1,8 +1,12 @@
-import type {LogContext} from '@rocicorp/logger';
+import {LogContext} from '@rocicorp/logger';
 import {resolver} from '@rocicorp/resolver';
 import postgres from 'postgres';
 import {beforeEach, describe, expect} from 'vitest';
-import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
+import {AbortError} from '../../../shared/src/abort-error.ts';
+import {
+  createSilentLogContext,
+  TestLogSink,
+} from '../../../shared/src/logging-test-utils.ts';
 import {type PgTest, test} from '../test/db.ts';
 import {postgresTypeConfig, type PostgresDB} from '../types/pg.ts';
 import {
@@ -249,6 +253,61 @@ describe('db/migration', () => {
       );
     });
   }
+
+  test('AbortError is logged at warn, not error', async () => {
+    // AbortErrors (e.g. AutoResetSignal signaling that the schema is not
+    // initialized) are an expected, self-healing control-flow signal and must
+    // not be logged at `error`, which would trip error-based alerting.
+    const sink = new TestLogSink();
+    const lc = new LogContext('debug', undefined, sink);
+
+    const abort = new AbortError('shard is not initialized');
+    let caught: unknown;
+    try {
+      await runSchemaMigrations(
+        lc,
+        debugName,
+        schemaName,
+        db,
+        {migrateSchema: () => Promise.reject(abort)},
+        {1: {}},
+      );
+    } catch (e) {
+      caught = e;
+    }
+
+    // The signal still propagates so the caller can resync.
+    expect(caught).toBe(abort);
+
+    const errors = sink.messages.filter(([level]) => level === 'error');
+    const warns = sink.messages.filter(([level]) => level === 'warn');
+    expect(errors).toEqual([]);
+    expect(warns.some(([, , args]) => args.includes(abort))).toBe(true);
+  });
+
+  test('non-AbortError is logged at error', async () => {
+    const sink = new TestLogSink();
+    const lc = new LogContext('debug', undefined, sink);
+
+    const err = new Error('genuine migration failure');
+    let caught: unknown;
+    try {
+      await runSchemaMigrations(
+        lc,
+        debugName,
+        schemaName,
+        db,
+        {migrateSchema: () => Promise.reject(err)},
+        {1: {}},
+      );
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBe(err);
+    const errors = sink.messages.filter(([level]) => level === 'error');
+    expect(errors.some(([, , args]) => args.includes(err))).toBe(true);
+  });
 
   test<PgTest>('concurrent migrations are serialized by advisory lock', async ({
     testDBs,

--- a/packages/zero-cache/src/db/migration.ts
+++ b/packages/zero-cache/src/db/migration.ts
@@ -1,5 +1,6 @@
 import type {LogContext} from '@rocicorp/logger';
 import type postgres from 'postgres';
+import {AbortError} from '../../../shared/src/abort-error.ts';
 import {assert} from '../../../shared/src/asserts.ts';
 import {must} from '../../../shared/src/must.ts';
 import * as v from '../../../shared/src/valita.ts';
@@ -137,7 +138,16 @@ export async function runSchemaMigrations(
 
     log.info?.(`Running ${debugName} at schema v${codeVersion}`);
   } catch (e) {
-    log.error?.('Error in ensureSchemaMigrated', e);
+    if (e instanceof AbortError) {
+      // AbortErrors (e.g. AutoResetSignal) are not failures. They are the
+      // expected mechanism for signaling that the schema is not initialized
+      // (or otherwise needs a reset) so that the caller can backtrack and
+      // resync. Logging them at `error` would trip error-based alerting for a
+      // normal, self-healing path.
+      log.warn?.('Schema requires reset; resync will follow', e);
+    } else {
+      log.error?.('Error in ensureSchemaMigrated', e);
+    }
     throw e;
   } finally {
     void log.flush();


### PR DESCRIPTION
AutoResetSignal (an AbortError) is the intended, self-healing control-flow signal for backtracking and resyncing when an upstream shard schema is not initialized, a replica is corrupt, or the schema needs a reset. The schema migration error handlers logged any thrown value at `error`, so these benign signals were emitted at ERROR level, which tripped log-based alerting for a normal, recoverable path.

Special-case AbortError in the migration catch blocks (both the Postgres and SQLite paths, including the SQLite per-migration transaction rollback) and log it at `warn` instead. Genuine migration failures still log at `error`.