### PR TITLE
fix(zero-cache): skip litestream restore in the change-streamer when backups are not configured

### DIFF
--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -100,7 +100,14 @@ export default async function runWorker(
   let purgeLock = await new PurgeLocker(lc, shard, changeDB).acquire();
 
   // Restore from litestream if the change-log has entries.
-  if (purgeLock) {
+  if (purgeLock && !config.litestream.backupURL) {
+    // litestream backups are not configured (e.g. local development), so
+    // there is no backup to restore. Release the purgeLock so that it does
+    // not prevent the change-db update after the (re)sync completes.
+    lc.debug?.('no litestream backup configured. skipping restore');
+    await purgeLock.release();
+    purgeLock = null;
+  } else if (purgeLock) {
     try {
       await restoreReplica(lc, config, purgeLock);
     } catch (e) {


### PR DESCRIPTION
## What

`runWorker` in `change-streamer.ts` calls `restoreReplica` whenever the purge lock is acquired, without checking whether litestream backups are configured. This PR skips the restore — and releases the purge lock, exactly as the existing failure path does — when `litestream.backupURL` is not set.

## Why

On every change-streamer start without litestream configured (the default for local development with `zero-cache-dev`), the restore attempt fails and this pair is logged at `warn`/`error` level, with full stack traces:

```
restore attempt failed. retrying once ... Error: Missing --litestream-executable
error restoring backup. resyncing the replica: Error: Missing --litestream-executable
```

The chain is `restoreReplica` → `tryRestore` → `getLitestream`, which throws `Missing --litestream-executable` before the backup URL is even consulted.

The noise is misleading in two ways:

- It reads like real trouble (error level + stack trace) although there is nothing to restore by construction. While debugging an actual local incident recently (zero-cache crashing on a full disk), these messages sent us down the wrong path before we found the real error.
- "resyncing the replica" suggests a full resync on every start, but the actual resync decision happens later and no-ops on a valid replica.

`main.ts` already guards its own litestream calls: [`if (litestream.executable)`](https://github.com/rocicorp/mono/blob/2a9bee3d874f26605dc89bd44910234114331f8d/packages/zero-cache/src/server/main.ts#L116) for the view-syncer-side restore and [`if (litestream.backupURL)`](https://github.com/rocicorp/mono/blob/2a9bee3d874f26605dc89bd44910234114331f8d/packages/zero-cache/src/server/main.ts#L133) for the backup process. The change-streamer path is the only unguarded one.

## How

The guard uses `litestream.backupURL` rather than `executable` because the backup URL is the operative "backups enabled" signal: the official container image always ships the litestream executable, so an executable-based guard would not help image-based deployments that run with backups disabled. A configured `backupURL` without an executable still fails loudly, which seems right for a genuine misconfiguration.

A `debug`-level line is logged when the restore is skipped.

## Testing

Verified against the published `@rocicorp/zero@1.8.0` build by applying the equivalent patch to the compiled `change-streamer.js` (via bun `patchedDependencies`): with no litestream config, a cold start performs the initial sync and a warm start comes up clean — in both cases without the spurious restore errors. With `backupURL` configured the guarded branch is not taken, so restore behavior is unchanged.
