### PR TITLE
fix(zero-server): make CRUD `insert` a no-op on an existing primary key

### DIFF
--- a/packages/zero-cache/src/services/mutagen/mutagen.pg.test.ts
+++ b/packages/zero-cache/src/services/mutagen/mutagen.pg.test.ts
@@ -59,6 +59,12 @@ async function createTables(db: PostgresDB) {
         time1 TIMESTAMPTZ,
         time2 TIMESTAMPTZ
       );
+      CREATE TABLE compoundpk (
+        a text,
+        b text,
+        c text,
+        PRIMARY KEY(a, b)
+      );
       CREATE TABLE fk_ref (
         id text,
         ref text,
@@ -230,6 +236,155 @@ describe('processMutation', {timeout: 15000}, () => {
     });
   });
 
+  test('insert on an existing primary key is a no-op', async () => {
+    const error1 = await processMutation(
+      lc,
+      undefined,
+      db,
+      SHARD,
+      'abc',
+      {
+        type: MutationType.CRUD,
+        id: 1,
+        clientID: '123',
+        name: '_zero_crud',
+        args: [
+          {
+            ops: [
+              {
+                op: 'insert',
+                tableName: 'types',
+                primaryKey: ['id'],
+                value: {id: '1', num: 5},
+              },
+            ],
+          },
+        ],
+        timestamp: Date.now(),
+      },
+      mockWriteAuthorizer,
+    );
+    expect(error1).undefined;
+
+    // Re-insert the same primary key with a different value. This must be a
+    // no-op (skip-if-exists), leave the original row unchanged, and must not
+    // error, matching the optimistic client behavior.
+    const error2 = await processMutation(
+      lc,
+      undefined,
+      db,
+      SHARD,
+      'abc',
+      {
+        type: MutationType.CRUD,
+        id: 2,
+        clientID: '123',
+        name: '_zero_crud',
+        args: [
+          {
+            ops: [
+              {
+                op: 'insert',
+                tableName: 'types',
+                primaryKey: ['id'],
+                value: {id: '1', num: 99},
+              },
+            ],
+          },
+        ],
+        timestamp: Date.now(),
+      },
+      mockWriteAuthorizer,
+    );
+    expect(error2).undefined;
+
+    await expectTables(db, {
+      types: [{id: '1', num: 5, time1: null, time2: null}],
+      [`${APP_ID}_${SHARD_NUM}.clients`]: [
+        {
+          clientGroupID: 'abc',
+          clientID: '123',
+          lastMutationID: 2n,
+          userID: null,
+        },
+      ],
+    });
+  });
+
+  test('insert on an existing compound primary key is a no-op', async () => {
+    const error1 = await processMutation(
+      lc,
+      undefined,
+      db,
+      SHARD,
+      'abc',
+      {
+        type: MutationType.CRUD,
+        id: 1,
+        clientID: '123',
+        name: '_zero_crud',
+        args: [
+          {
+            ops: [
+              {
+                op: 'insert',
+                tableName: 'compoundpk',
+                primaryKey: ['a', 'b'],
+                value: {a: 'a', b: 'b', c: 'first'},
+              },
+            ],
+          },
+        ],
+        timestamp: Date.now(),
+      },
+      mockWriteAuthorizer,
+    );
+    expect(error1).undefined;
+
+    // Same compound primary key, different non-key value: must be a no-op and
+    // leave the existing row unchanged (exercises `ON CONFLICT (a, b)`).
+    const error2 = await processMutation(
+      lc,
+      undefined,
+      db,
+      SHARD,
+      'abc',
+      {
+        type: MutationType.CRUD,
+        id: 2,
+        clientID: '123',
+        name: '_zero_crud',
+        args: [
+          {
+            ops: [
+              {
+                op: 'insert',
+                tableName: 'compoundpk',
+                primaryKey: ['a', 'b'],
+                value: {a: 'a', b: 'b', c: 'second'},
+              },
+            ],
+          },
+        ],
+        timestamp: Date.now(),
+      },
+      mockWriteAuthorizer,
+    );
+    expect(error2).undefined;
+
+    await expectTables(db, {
+      compoundpk: [{a: 'a', b: 'b', c: 'first'}],
+      [`${APP_ID}_${SHARD_NUM}.clients`]: [
+        {
+          clientGroupID: 'abc',
+          clientID: '123',
+          lastMutationID: 2n,
+          userID: null,
+        },
+      ],
+    });
+  });
+
   test('old mutations that would have errored are skipped', async () => {
     await db`
       INSERT INTO ${db(
@@ -256,7 +411,7 @@ describe('processMutation', {timeout: 15000}, () => {
                 op: 'insert',
                 tableName: 'idonly',
                 primaryKey: ['id'],
-                value: {id: '1'}, // This would result in a duplicate key value if applied.
+                value: {id: '1'}, // Duplicate primary key: a no-op if applied, so this asserts the mutation is skipped via the lastMutationID check, not that it errors.
               },
             ],
           },

--- a/packages/zero-cache/src/services/mutagen/mutagen.ts
+++ b/packages/zero-cache/src/services/mutagen/mutagen.ts
@@ -388,7 +388,10 @@ export function getInsertSQL(
   tx: postgres.TransactionSql,
   create: InsertOp,
 ): postgres.PendingQuery<postgres.Row[]> {
-  return tx`INSERT INTO ${tx(create.tableName)} ${tx(create.value)}`;
+  return tx`
+    INSERT INTO ${tx(create.tableName)} ${tx(create.value)}
+    ON CONFLICT (${tx(create.primaryKey)}) DO NOTHING
+  `;
 }
 
 export function getUpsertSQL(

--- a/packages/zero-server/src/custom.pg.test.ts
+++ b/packages/zero-server/src/custom.pg.test.ts
@@ -120,6 +120,30 @@ describe('makeSchemaCRUD', () => {
     });
   });
 
+  test('insert on an existing primary key is a no-op', async () => {
+    await pg.begin(async tx => {
+      const transaction = new Transaction(tx);
+      const crud = crudProvider(
+        transaction,
+        await getServerSchema(transaction, schema),
+      );
+
+      await crud.basic.insert({id: '1', a: 2, b: 'foo', c: true});
+      await checkDb(tx, 'basic', [{id: '1', a: 2, b: 'foo', c: true}]);
+
+      // Re-inserting the same primary key with different values must not throw
+      // and must leave the existing row unchanged (skip-if-exists), matching the
+      // optimistic client behavior.
+      await crud.basic.insert({id: '1', a: 999, b: 'bar', c: false});
+      await checkDb(tx, 'basic', [{id: '1', a: 2, b: 'foo', c: true}]);
+
+      // Same for a compound primary key.
+      await crud.compoundPk.insert({a: 'a', b: 1, c: 'c'});
+      await crud.compoundPk.insert({a: 'a', b: 1, c: 'different'});
+      await checkDb(tx, 'compoundPk', [{a: 'a', b: 1, c: 'c'}]);
+    });
+  });
+
   test('insert/update/upsert with missing columns', async () => {
     await pg.begin(async tx => {
       const transaction = new Transaction(tx);

--- a/packages/zero-server/src/custom.ts
+++ b/packages/zero-server/src/custom.ts
@@ -353,6 +353,11 @@ function makeServerTableCRUD(schema: TableSchema): TableCRUD<TableSchema> {
       const serverTableSchema = this[serverSchemaSymbol][serverName(schema)];
 
       const targetedColumns = origAndServerNamesFor(Object.keys(value), schema);
+      const primaryKeyColumns = origAndServerNamesFor(
+        schema.primaryKey,
+        schema,
+      );
+
       const stmt = formatPgInternalConvert(
         sql`INSERT INTO ${sql.ident(serverName(schema))} (${sql.join(
           targetedColumns.map(([, serverName]) => sql.ident(serverName)),
@@ -362,7 +367,10 @@ function makeServerTableCRUD(schema: TableSchema): TableCRUD<TableSchema> {
             sqlInsertValue(v, serverTableSchema[serverNameFor(col, schema)]),
           ),
           ', ',
-        )})`,
+        )}) ON CONFLICT (${sql.join(
+          primaryKeyColumns.map(([, serverName]) => sql.ident(serverName)),
+          ', ',
+        )}) DO NOTHING`,
       );
       const tx = this[dbTxSymbol];
       await tx.query(stmt.text, stmt.values);

--- a/packages/zql/src/mutate/crud.ts
+++ b/packages/zql/src/mutate/crud.ts
@@ -13,10 +13,11 @@ export type TransactionMutate<S extends Schema> = SchemaCRUD<S>;
 
 export type TableCRUD<S extends TableSchema> = {
   /**
-   * Writes a row if a row with the same primary key doesn't already exist.
-   * Non-primary-key fields that are 'optional' can be omitted or set to
-   * `undefined`. Such fields will be assigned the value `null` optimistically
-   * and then the default value as defined by the server.
+   * Writes a row. If a row with the same primary key already exists this is a
+   * no-op; the existing row is left unchanged. A collision on any other unique
+   * constraint still throws. Non-primary-key fields that are 'optional' can be
+   * omitted or set to `undefined`. Such fields will be assigned the value
+   * `null` optimistically and then the default value as defined by the server.
    */
   insert: (value: InsertValue<S>) => Promise<void>;
 
@@ -82,10 +83,11 @@ export type UpdateValue<S extends TableSchema> = Expand<
  */
 export type TableMutator<TS extends TableSchema> = {
   /**
-   * Writes a row if a row with the same primary key doesn't already exist.
-   * Non-primary-key fields that are 'optional' can be omitted or set to
-   * `undefined`. Such fields will be assigned the value `null` optimistically
-   * and then the default value as defined by the server.
+   * Writes a row. If a row with the same primary key already exists this is a
+   * no-op; the existing row is left unchanged. A collision on any other unique
+   * constraint still throws. Non-primary-key fields that are 'optional' can be
+   * omitted or set to `undefined`. Such fields will be assigned the value
+   * `null` optimistically and then the default value as defined by the server.
    */
   insert: (value: InsertValue<TS>) => Promise<void>;
 


### PR DESCRIPTION

Fixes [bugs.rocicorp.dev/p/zero/issue/246732](https://bugs.rocicorp.dev/p/zero/issue/246732)

## Problem

`TableCRUD.insert` is documented as skip-if-exists — "Writes a row if a row with the same primary key doesn't already exist" — and the optimistic client honors that literally: `crud-impl.ts` writes only `if (!(await tx.has(key)))`, otherwise it's a silent no-op.

Both server-side CRUD paths violated that contract. They compiled `insert` to a plain `INSERT INTO ... VALUES (...)` with **no** conflict handling, so inserting a row whose primary key already exists raised a Postgres unique-violation (`23505`) instead of skipping:

- **Custom mutators** — `makeServerTableCRUD.insert` in `packages/zero-server/src/custom.ts`
- **Legacy CRUD mutators** — `getInsertSQL` in `packages/zero-cache/src/services/mutagen/mutagen.ts`

This diverged from the client, and from the protocol's own `insertOpSchema` doc ("Inserts if entity with id does not already exist"). Notably, the `upsert` implementation right next to each already used `ON CONFLICT (<pk>) DO UPDATE` — `insert` was simply missing the `DO NOTHING` variant.

### Why it was more than cosmetic

On the custom-mutator path, the entire mutator body runs inside a single transaction. When the `insert` threw partway through a mutator, the transaction rolled back **every** write in that mutator, then the framework re-ran the mutation in error mode (skip the mutator, advance `lastMutationID`) and returned an application error.

So for the same `insert`:

- **Client (optimistic):** the insert no-ops, the mutator keeps going, every later write applies, and the UI shows all of them.
- **Server (authoritative):** the insert throws, the transaction rolls back, every write in the mutator is discarded permanently, and the client's optimistic state is rebased away.

The author wrote to a contract that says a duplicate insert is a legal no-op, and got silent data loss of unrelated writes plus an error they had no reason to handle.

## Fix

Both paths now emit `ON CONFLICT (<pk cols>) DO NOTHING`, matching the client and the protocol contract.

The conflict target is the **primary key specifically** (not a bare `ON CONFLICT DO NOTHING`), so a collision on some *other* unique constraint still throws — which also matches the client, since it only guards on the primary key. Compound primary keys work: the key array renders as a multi-column conflict target (`ON CONFLICT ("a", "b")`), the same rendering `upsert` already relied on.

The `insert` doc comments on `TableCRUD` and `TableMutator` were tightened to state the no-op-on-existing-PK behavior explicitly on both client and server, and that a collision on another unique constraint still throws.

## Behavior change

On the **legacy CRUD path**, a duplicate-PK `insert` previously returned a `MutationFailed` error to the client (and re-ran in error mode to advance `lastMutationID`). It now silently succeeds as a no-op. Any app relying on receiving that error for a duplicate insert would no longer get it — this is the intended, now-consistent behavior. The custom-mutator path had the more severe symptom (whole-mutator rollback), which is fixed as well.
