### PR TITLE
feat(zero-cache): shared-advance eligibility telemetry

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -10,10 +10,15 @@ import {
 import {assert, unreachable} from '../../../../shared/src/asserts.ts';
 import {stringify} from '../../../../shared/src/bigint-json.ts';
 import {CustomKeyMap} from '../../../../shared/src/custom-key-map.ts';
+import {h64} from '../../../../shared/src/hash.ts';
 import {must} from '../../../../shared/src/must.ts';
 import {randInt} from '../../../../shared/src/rand.ts';
 import type {AST} from '../../../../zero-protocol/src/ast.ts';
 import type {ChangeDesiredQueriesMessage} from '../../../../zero-protocol/src/change-desired-queries.ts';
+import {
+  normalizeClientSchema,
+  type ClientSchema,
+} from '../../../../zero-protocol/src/client-schema.ts';
 import type {
   InitConnectionBody,
   InitConnectionMessage,
@@ -159,7 +164,23 @@ export interface ViewSyncer {
   readonly createdAtMs: number;
   readonly servedVersion: string | null;
   readonly servingLagEligible: boolean;
+
+  // Shared-advance eligibility telemetry: which transformed queries this
+  // client group runs, and the identity of its client schema. Pipelines with
+  // the same (clientSchemaKey, transformationHash) across client groups do
+  // identical IVM advance work today; the ratio of total to unique pipelines
+  // on a sync worker is the dedup factor available to shared advancement.
+  pipelineHashes(): readonly PipelineHashInfo[];
+  readonly clientSchemaKey: string | undefined;
 }
+
+export type PipelineHashInfo = {
+  readonly transformationHash: string;
+  // Internal queries (lmids, mutationResults) embed the clientGroupID in
+  // their AST, so they can never be shared across client groups.
+  readonly internal: boolean;
+  readonly queryName: string | undefined;
+};
 
 export type SyncContext = ConnectionSelector & {
   readonly profileID: string | null;
@@ -627,6 +648,44 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
 
   get queryCount(): number {
     return this.#pipelines.initialized() ? this.#pipelines.queries().size : 0;
+  }
+
+  pipelineHashes(): readonly PipelineHashInfo[] {
+    if (!this.#pipelines.initialized()) {
+      return [];
+    }
+    const cvrQueries = this.#cvr?.queries;
+    const hashes: PipelineHashInfo[] = [];
+    for (const [queryID, {transformationHash, queryName}] of this.#pipelines
+      .queries()
+      .entries()) {
+      hashes.push({
+        transformationHash,
+        internal: cvrQueries?.[queryID]?.type === 'internal',
+        queryName,
+      });
+    }
+    return hashes;
+  }
+
+  // The clientSchema object survives CVR snapshot updates by reference, so
+  // cache the derived key on it.
+  #clientSchemaKeyCache:
+    | {readonly schema: ClientSchema; readonly key: string}
+    | undefined;
+
+  get clientSchemaKey(): string | undefined {
+    const schema = this.#cvr?.clientSchema;
+    if (!schema) {
+      return undefined;
+    }
+    if (this.#clientSchemaKeyCache?.schema !== schema) {
+      this.#clientSchemaKeyCache = {
+        schema,
+        key: h64(JSON.stringify(normalizeClientSchema(schema))).toString(36),
+      };
+    }
+    return this.#clientSchemaKeyCache.key;
   }
 
   get rowCount(): number {

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -655,13 +655,19 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
       return [];
     }
     const cvrQueries = this.#cvr?.queries;
+    if (cvrQueries === undefined) {
+      // Without CVR query metadata we can't distinguish internal queries from
+      // client queries; report nothing rather than misclassify every query as
+      // client (which would inflate the client dedup factor).
+      return [];
+    }
     const hashes: PipelineHashInfo[] = [];
     for (const [queryID, {transformationHash, queryName}] of this.#pipelines
       .queries()
       .entries()) {
       hashes.push({
         transformationHash,
-        internal: cvrQueries?.[queryID]?.type === 'internal',
+        internal: cvrQueries[queryID]?.type === 'internal',
         queryName,
       });
     }

--- a/packages/zero-cache/src/workers/syncer.test.ts
+++ b/packages/zero-cache/src/workers/syncer.test.ts
@@ -58,6 +58,7 @@ import type {ViewSyncer} from '../services/view-syncer/view-syncer.ts';
 import type {WebSocketReceiver} from '../types/websocket-handoff.ts';
 import {
   computeMaxServingLagMs,
+  computePipelineDedupStats,
   computeServingLagStatsMs,
   MAX_REPLICA_READY_STATES,
   Syncer,
@@ -120,6 +121,8 @@ function makeFactories(
           createdAtMs: Date.now(),
           servedVersion: null,
           servingLagEligible: true,
+          pipelineHashes: () => [],
+          clientSchemaKey: undefined,
           stop() {
             stopped.resolve();
             return stopped.promise;
@@ -378,6 +381,72 @@ describe('computeServingLagStatsMs', () => {
       maxMs: 0,
     });
     expect(states).toEqual([]);
+  });
+});
+
+describe('computePipelineDedupStats', () => {
+  test('empty', () => {
+    const stats = computePipelineDedupStats([]);
+    expect(stats.clientTotal).toBe(0);
+    expect(stats.internalTotal).toBe(0);
+    expect(stats.clientHashes.size).toBe(0);
+    expect(stats.internalUnique).toBe(0);
+    expect(stats.clientSchemas).toBe(0);
+  });
+
+  test('counts duplicates across client groups by (schemaKey, hash)', () => {
+    const stats = computePipelineDedupStats([
+      {
+        clientSchemaKey: 'schema1',
+        pipelineHashes: () => [
+          {transformationHash: 'aaa', internal: false, queryName: 'issues'},
+          {transformationHash: 'bbb', internal: false, queryName: undefined},
+          {transformationHash: 'lmids', internal: true, queryName: undefined},
+        ],
+      },
+      {
+        clientSchemaKey: 'schema1',
+        pipelineHashes: () => [
+          {transformationHash: 'aaa', internal: false, queryName: 'issues'},
+          {transformationHash: 'lmids', internal: true, queryName: undefined},
+        ],
+      },
+      // Same transformationHash but different clientSchema: not shareable,
+      // so it counts as a distinct unique pipeline.
+      {
+        clientSchemaKey: 'schema2',
+        pipelineHashes: () => [
+          {transformationHash: 'aaa', internal: false, queryName: 'issues'},
+        ],
+      },
+      // Not yet initialized: contributes nothing.
+      {
+        clientSchemaKey: undefined,
+        pipelineHashes: () => [],
+      },
+    ]);
+
+    expect(stats.clientTotal).toBe(4);
+    expect(stats.internalTotal).toBe(2);
+    expect(stats.clientHashes.size).toBe(3);
+    expect(stats.clientHashes.get('schema1/aaa')).toEqual({
+      count: 2,
+      queryName: 'issues',
+    });
+    expect(stats.clientHashes.get('schema1/bbb')).toEqual({
+      count: 1,
+      queryName: undefined,
+    });
+    expect(stats.clientHashes.get('schema2/aaa')).toEqual({
+      count: 1,
+      queryName: 'issues',
+    });
+    // The internal (lmids) hash collides across CGs of the same schema in
+    // this synthetic input, but real internal queries embed the
+    // clientGroupID in their AST and would never collide; the stat exists
+    // to keep them segmented out of the client dedup factor.
+    expect(stats.internalUnique).toBe(1);
+    expect(stats.clientSchemas).toBe(2);
   });
 });
 

--- a/packages/zero-cache/src/workers/syncer.test.ts
+++ b/packages/zero-cache/src/workers/syncer.test.ts
@@ -448,6 +448,31 @@ describe('computePipelineDedupStats', () => {
     expect(stats.internalUnique).toBe(1);
     expect(stats.clientSchemas).toBe(2);
   });
+
+  test('schema-less pipelines are not deduplicated across view-syncers', () => {
+    // A view-syncer with no client schema yet (clientSchemaKey undefined) has
+    // an unknown dedup identity. Two such view-syncers running the same
+    // transformationHash must not collapse into one unique pipeline, which
+    // would overstate the available deduplication.
+    const stats = computePipelineDedupStats([
+      {
+        clientSchemaKey: undefined,
+        pipelineHashes: () => [
+          {transformationHash: 'aaa', internal: false, queryName: 'issues'},
+        ],
+      },
+      {
+        clientSchemaKey: undefined,
+        pipelineHashes: () => [
+          {transformationHash: 'aaa', internal: false, queryName: 'issues'},
+        ],
+      },
+    ]);
+
+    expect(stats.clientTotal).toBe(2);
+    expect(stats.clientHashes.size).toBe(2);
+    expect(stats.clientSchemas).toBe(0);
+  });
 });
 
 function makeParams(clientID: number, params: any = {}) {

--- a/packages/zero-cache/src/workers/syncer.ts
+++ b/packages/zero-cache/src/workers/syncer.ts
@@ -72,8 +72,74 @@ type ServingLagDistribution = ServingLagStats & {
   readonly lagsMs: readonly number[];
 };
 
+export type PipelineDedupViewSyncer = Pick<
+  ViewSyncer,
+  'pipelineHashes' | 'clientSchemaKey'
+>;
+
+export type PipelineDedupStats = {
+  readonly clientTotal: number;
+  readonly internalTotal: number;
+  // (clientSchemaKey, transformationHash) -> occurrence count across client
+  // groups, for client/custom queries.
+  readonly clientHashes: ReadonlyMap<
+    string,
+    {count: number; queryName: string | undefined}
+  >;
+  readonly internalUnique: number;
+  readonly clientSchemas: number;
+};
+
+export function computePipelineDedupStats(
+  viewSyncers: Iterable<PipelineDedupViewSyncer>,
+): PipelineDedupStats {
+  let clientTotal = 0;
+  let internalTotal = 0;
+  const clientHashes = new Map<
+    string,
+    {count: number; queryName: string | undefined}
+  >();
+  const internalHashes = new Set<string>();
+  const schemaKeys = new Set<string>();
+  for (const vs of viewSyncers) {
+    const schemaKey = vs.clientSchemaKey;
+    if (schemaKey !== undefined) {
+      schemaKeys.add(schemaKey);
+    }
+    for (const {
+      transformationHash,
+      internal,
+      queryName,
+    } of vs.pipelineHashes()) {
+      // Pipelines only share when both the client schema (which determines
+      // row keys) and the transformed AST are identical.
+      const key = `${schemaKey}/${transformationHash}`;
+      if (internal) {
+        internalTotal++;
+        internalHashes.add(key);
+      } else {
+        clientTotal++;
+        const entry = clientHashes.get(key);
+        if (entry) {
+          entry.count++;
+        } else {
+          clientHashes.set(key, {count: 1, queryName});
+        }
+      }
+    }
+  }
+  return {
+    clientTotal,
+    internalTotal,
+    clientHashes,
+    internalUnique: internalHashes.size,
+    clientSchemas: schemaKeys.size,
+  };
+}
+
 export const MAX_REPLICA_READY_STATES = 10_000;
 const VIEW_SYNCER_LAG_SAMPLE_INTERVAL_MS = 60_000;
+const SHARED_ADVANCE_ELIGIBILITY_LOG_INTERVAL_MS = 5 * 60_000;
 
 const PROTOCOL_VERSION_ATTRIBUTE = 'protocol.version';
 const FAILURE_REASON_ATTRIBUTE = 'reason';
@@ -332,6 +398,7 @@ export class Syncer implements SingletonService {
   #servingLagDistributionCache: ServingLagDistribution | undefined;
   #servingLagDistributionCacheClearQueued = false;
   #viewSyncerLagSampleInterval: ReturnType<typeof setInterval> | undefined;
+  #eligibilityLogInterval: ReturnType<typeof setInterval> | undefined;
 
   constructor(
     lc: LogContext,
@@ -455,11 +522,48 @@ export class Syncer implements SingletonService {
       result.observe(this.#computeServingLagDistribution().laggingClientGroups);
     });
 
+    getOrCreateGauge(
+      'sync',
+      'pipelines-total',
+      'Query pipelines across all client groups on this worker, by query ' +
+        'type. The ratio to sync.pipelines-unique is the dedup factor ' +
+        'available to shared pipeline advancement.',
+    ).addCallback(result => {
+      const stats = this.#computePipelineDedupStats();
+      result.observe(stats.clientTotal, {type: 'client'});
+      result.observe(stats.internalTotal, {type: 'internal'});
+    });
+
+    getOrCreateGauge(
+      'sync',
+      'pipelines-unique',
+      'Distinct (clientSchema, transformationHash) pipelines across all ' +
+        'client groups on this worker, by query type',
+    ).addCallback(result => {
+      const stats = this.#computePipelineDedupStats();
+      result.observe(stats.clientHashes.size, {type: 'client'});
+      result.observe(stats.internalUnique, {type: 'internal'});
+    });
+
+    getOrCreateGauge(
+      'sync',
+      'client-schemas',
+      'Distinct client schemas across all client groups on this worker',
+    ).addCallback(result => {
+      result.observe(this.#computePipelineDedupStats().clientSchemas);
+    });
+
     this.#viewSyncerLagSampleInterval = setInterval(
       () => this.#recordViewSyncerLagSamples(),
       VIEW_SYNCER_LAG_SAMPLE_INTERVAL_MS,
     );
     this.#viewSyncerLagSampleInterval.unref?.();
+
+    this.#eligibilityLogInterval = setInterval(
+      () => this.#logSharedAdvanceEligibility(),
+      SHARED_ADVANCE_ELIGIBILITY_LOG_INTERVAL_MS,
+    );
+    this.#eligibilityLogInterval.unref?.();
   }
 
   #computeServingLagDistribution(): ServingLagDistribution {
@@ -488,6 +592,31 @@ export class Syncer implements SingletonService {
     for (const lagMs of lagsMs) {
       this.#viewSyncerLag.recordMs(lagMs);
     }
+  }
+
+  #computePipelineDedupStats(): PipelineDedupStats {
+    return computePipelineDedupStats(this.#viewSyncers.getServices());
+  }
+
+  #logSharedAdvanceEligibility(): void {
+    const stats = this.#computePipelineDedupStats();
+    if (stats.clientTotal === 0) {
+      return;
+    }
+    const unique = stats.clientHashes.size;
+    const topDuplicated = [...stats.clientHashes.entries()]
+      .filter(([, {count}]) => count > 1)
+      .sort((a, b) => b[1].count - a[1].count)
+      .slice(0, 10)
+      .map(([key, {count, queryName}]) => ({key, count, queryName}));
+    this.#lc.info?.('shared-advance-eligibility', {
+      clientPipelines: stats.clientTotal,
+      uniqueClientPipelines: unique,
+      dedupFactor: Number((stats.clientTotal / Math.max(unique, 1)).toFixed(2)),
+      internalPipelines: stats.internalTotal,
+      clientSchemas: stats.clientSchemas,
+      topDuplicated,
+    });
   }
 
   #recordReplicaReadyState(state: ReplicaState): void {
@@ -748,6 +877,7 @@ export class Syncer implements SingletonService {
 
   stop() {
     clearInterval(this.#viewSyncerLagSampleInterval);
+    clearInterval(this.#eligibilityLogInterval);
     this.#wss.close();
     this.#stopped.resolve();
     return promiseVoid;

--- a/packages/zero-cache/src/workers/syncer.ts
+++ b/packages/zero-cache/src/workers/syncer.ts
@@ -101,11 +101,18 @@ export function computePipelineDedupStats(
   >();
   const internalHashes = new Set<string>();
   const schemaKeys = new Set<string>();
+  let vsIndex = 0;
   for (const vs of viewSyncers) {
     const schemaKey = vs.clientSchemaKey;
     if (schemaKey !== undefined) {
       schemaKeys.add(schemaKey);
     }
+    // Without a client schema the pipeline's dedup identity is unknown, so key
+    // it uniquely per view-syncer; otherwise schema-less pipelines from
+    // unrelated client groups would collapse under a shared `undefined/<hash>`
+    // key and overstate deduplication.
+    const dedupSchemaKey = schemaKey ?? `#vs${vsIndex}`;
+    vsIndex++;
     for (const {
       transformationHash,
       internal,
@@ -113,7 +120,7 @@ export function computePipelineDedupStats(
     } of vs.pipelineHashes()) {
       // Pipelines only share when both the client schema (which determines
       // row keys) and the transformed AST are identical.
-      const key = `${schemaKey}/${transformationHash}`;
+      const key = `${dedupSchemaKey}/${transformationHash}`;
       if (internal) {
         internalTotal++;
         internalHashes.add(key);
@@ -524,9 +531,9 @@ export class Syncer implements SingletonService {
 
     getOrCreateGauge(
       'sync',
-      'pipelines-total',
+      'pipelines_total',
       'Query pipelines across all client groups on this worker, by query ' +
-        'type. The ratio to sync.pipelines-unique is the dedup factor ' +
+        'type. The ratio to sync.pipelines_unique is the dedup factor ' +
         'available to shared pipeline advancement.',
     ).addCallback(result => {
       const stats = this.#computePipelineDedupStats();
@@ -536,7 +543,7 @@ export class Syncer implements SingletonService {
 
     getOrCreateGauge(
       'sync',
-      'pipelines-unique',
+      'pipelines_unique',
       'Distinct (clientSchema, transformationHash) pipelines across all ' +
         'client groups on this worker, by query type',
     ).addCallback(result => {
@@ -547,7 +554,7 @@ export class Syncer implements SingletonService {
 
     getOrCreateGauge(
       'sync',
-      'client-schemas',
+      'client_schemas',
       'Distinct client schemas across all client groups on this worker',
     ).addCallback(result => {
       result.observe(this.#computePipelineDedupStats().clientSchemas);


### PR DESCRIPTION
## What

Always-on instrumentation (no product behavior change) that measures the **pipeline dedup factor** available to a shared pipeline advancer — lever **A1** of the RM→ViewSyncer fan-out [investigation](https://app.notion.com/p/replicache/Horizontal-scale-fan-out-39c3bed895458075960ef6d35036343f?source=copy_link#14887cea64f04d8682981a84b00eacaf).

## Why

The investigation found the view-syncer's per-client-group IVM advance to be a co-dominant cost: today each client group independently re-reads the change-log and advances its *own* pipeline for the *same* transformed query. Advancing 32 identical logical writes scales near-linearly in client groups (0.54 ms with 1 driver → 15.7 ms with 50). A shared advancer would advance each unique `(clientSchema, transformationHash)` once and multicast the diff — but the payoff depends entirely on how much real-world duplication exists. This telemetry measures that duplication in production so A1 can be justified (or not) with data before it's built.

## How

- **Gauges** (per sync worker): `sync.pipelines-total{type}` vs `sync.pipelines-unique{type}`, plus `sync.client-schemas`. The total/unique ratio for `type=client` is the dedup factor.
- **Log** (every 5 min): `shared-advance-eligibility` — the dedup factor plus the top-10 duplicated pipelines.
- Pipelines only share when **both** the client schema (which determines row keys) and the transformed AST are identical, so the dedup key is `(clientSchemaKey, transformationHash)`. Internal queries (lmids, mutationResults) embed the `clientGroupID` in their AST and can never be shared, so they're segmented out of the client dedup factor.
- `ViewSyncer` exposes `pipelineHashes()` + `clientSchemaKey`; `Syncer` aggregates across its view-syncers via `computePipelineDedupStats()`.

No config flag — pure measurement, always on, adds no work to the hot path (gauge callbacks + one 5-minute interval, both `unref`'d).

## Testing

- New `computePipelineDedupStats` unit tests: empty input; duplicate-counting across client groups keyed by `(schemaKey, hash)`; distinct-schema and internal-query segmentation. Full `syncer.test.ts` suite green (28 tests).
- `tsc` / `oxlint` / `oxfmt` clean on the changed files.

## Provenance

Salvaged as a standalone, production-safe change from the parked fan-out investigation branch (#6233). The P1 multi-CG test harness / advance bench and the reports stay on that branch for a separate PR.
