### PR TITLE
feat(zbugs): Add machine-readable markdown view for issues

### DIFF
--- a/apps/zbugs/api/index.ts
+++ b/apps/zbugs/api/index.ts
@@ -18,6 +18,7 @@ import {nanoid} from 'nanoid';
 import {assert} from '../../../packages/shared/src/asserts.ts';
 import {must} from '../../../packages/shared/src/must.ts';
 import {dbProvider, sql} from '../server/db.ts';
+import {registerMachineRoutes} from '../server/machine-routes.ts';
 import {createServerMutators} from '../server/server-mutators.ts';
 import {jwtDataSchema, type JWTData} from '../shared/auth.ts';
 import {queries} from '../shared/queries.ts';
@@ -293,6 +294,8 @@ fastify.get<{
       `OK! You are unsubscribed from <a href="https://bugs.rocicorp.dev/issue/${shortID}">${issue.title}</a>.`,
     );
 });
+
+registerMachineRoutes(fastify, maybeVerifyAuth);
 
 async function maybeVerifyAuth(
   headers: IncomingHttpHeaders,

--- a/apps/zbugs/package.json
+++ b/apps/zbugs/package.json
@@ -51,6 +51,7 @@
     "@rocicorp/zero-virtual": "0.6.3",
     "@schickling/fps-meter": "^0.1.2",
     "classnames": "^2.5.1",
+    "compare-utf8": "^0.2.0",
     "emoji-picker-element": "^1.22.8",
     "emoji-picker-element-data": "^1.6.1",
     "fastify": "^5.0.0",

--- a/apps/zbugs/server/machine-md.test.ts
+++ b/apps/zbugs/server/machine-md.test.ts
@@ -1,7 +1,5 @@
 import {expect, test} from 'vitest';
 import {
-  formatDate,
-  oneLine,
   renderErrorMd,
   renderIssueMd,
   type MdComment,
@@ -130,16 +128,6 @@ test('reactions without creators still count', () => {
     {commentsCapped: false},
   );
   expect(md).toContain('- Reactions: 👀 ×2\n');
-});
-
-test('formatDate', () => {
-  expect(formatDate(Date.UTC(2026, 6, 1, 12, 34, 56, 789))).toBe(
-    '2026-07-01T12:34:56Z',
-  );
-});
-
-test('oneLine', () => {
-  expect(oneLine('  a\r\n b\t\tc  ')).toBe('a b c');
 });
 
 test('renderErrorMd', () => {

--- a/apps/zbugs/server/machine-md.test.ts
+++ b/apps/zbugs/server/machine-md.test.ts
@@ -1,0 +1,149 @@
+import {expect, test} from 'vitest';
+import {
+  formatDate,
+  oneLine,
+  renderErrorMd,
+  renderIssueMd,
+  type MdComment,
+  type MdIssue,
+} from './machine-md.ts';
+
+const fullIssue: MdIssue = {
+  id: 'aB3xY_-9',
+  shortID: 3456,
+  title: 'Query  hangs\nafter reconnect',
+  open: true,
+  visibility: 'public',
+  created: Date.UTC(2026, 0, 2, 3, 4, 5),
+  modified: Date.UTC(2026, 6, 1, 6, 7, 8),
+  description: 'Steps to reproduce:\n\n1. Disconnect\n2. Reconnect',
+  project: {name: 'Zero', lowerCaseName: 'zero'},
+  creator: {login: 'alice'},
+  assignee: {login: 'bob'},
+  labels: [{name: 'perf'}, {name: 'bug'}],
+  emoji: [
+    {value: '👍', creator: {login: 'bob'}},
+    {value: '🎉', creator: {login: 'carol'}},
+    {value: '👍', creator: {login: 'alice'}},
+  ],
+};
+
+const comments: MdComment[] = [
+  {
+    created: Date.UTC(2026, 0, 3),
+    body: 'Repros for me too.',
+    creator: {login: 'carol'},
+    emoji: [{value: '🚀', creator: {login: 'dave'}}],
+  },
+  {
+    created: Date.UTC(2026, 0, 4),
+    body: '',
+    creator: undefined,
+    emoji: [],
+  },
+];
+
+test('renderIssueMd full issue', () => {
+  expect(renderIssueMd(fullIssue, comments, {commentsCapped: false})).toBe(
+    `# Bug 3456: Query hangs after reconnect
+
+- Status: open
+- Project: Zero
+- Creator: @alice
+- Assignee: @bob
+- Labels: bug, perf
+- Created: 2026-01-02T03:04:05Z
+- Modified: 2026-07-01T06:07:08Z
+- Reactions: 🎉 ×1 (carol) · 👍 ×2 (alice, bob)
+- URL: https://bugs.rocicorp.dev/p/zero/issue/3456
+
+## Description
+
+Steps to reproduce:
+
+1. Disconnect
+2. Reconnect
+
+## Comments (2)
+
+### @carol — 2026-01-03T00:00:00Z
+
+Repros for me too.
+
+Reactions: 🚀 ×1 (dave)
+
+### @unknown — 2026-01-04T00:00:00Z
+
+_No content._
+`,
+  );
+});
+
+test('renderIssueMd minimal issue with null shortID', () => {
+  const minimal: MdIssue = {
+    id: 'aB3xY_-9',
+    shortID: null,
+    title: 'Untitled',
+    open: false,
+    visibility: 'internal',
+    created: Date.UTC(2026, 0, 1),
+    modified: Date.UTC(2026, 0, 1),
+    description: '  ',
+  };
+  expect(renderIssueMd(minimal, [], {commentsCapped: false})).toBe(
+    `# Issue aB3xY_-9: Untitled
+
+- Status: closed
+- Visibility: internal
+- Created: 2026-01-01T00:00:00Z
+- Modified: 2026-01-01T00:00:00Z
+
+## Description
+
+_No description._
+
+## Comments (0)
+`,
+  );
+});
+
+test('renderIssueMd capped comments note', () => {
+  const md = renderIssueMd(fullIssue, comments, {commentsCapped: true});
+  expect(md).toContain(
+    '## Comments (2)\n\n_Showing the 2 most recent comments; earlier comments omitted._\n',
+  );
+});
+
+test('renderIssueMd keeps markdown in title to one line', () => {
+  const md = renderIssueMd(
+    {...fullIssue, title: '# nested\r\n\theading '},
+    [],
+    {commentsCapped: false},
+  );
+  expect(md.split('\n')[0]).toBe('# Bug 3456: # nested heading');
+});
+
+test('reactions without creators still count', () => {
+  const md = renderIssueMd(
+    {...fullIssue, emoji: [{value: '👀'}, {value: '👀'}]},
+    [],
+    {commentsCapped: false},
+  );
+  expect(md).toContain('- Reactions: 👀 ×2\n');
+});
+
+test('formatDate', () => {
+  expect(formatDate(Date.UTC(2026, 6, 1, 12, 34, 56, 789))).toBe(
+    '2026-07-01T12:34:56Z',
+  );
+});
+
+test('oneLine', () => {
+  expect(oneLine('  a\r\n b\t\tc  ')).toBe('a b c');
+});
+
+test('renderErrorMd', () => {
+  expect(renderErrorMd('Not Found', 'No such issue.')).toBe(
+    '# Not Found\n\nNo such issue.\n',
+  );
+});

--- a/apps/zbugs/server/machine-md.ts
+++ b/apps/zbugs/server/machine-md.ts
@@ -10,18 +10,21 @@
  * logins.
  */
 
-export const BASE_URL = 'https://bugs.rocicorp.dev';
+import {compareUTF8} from 'compare-utf8';
+import {groupBy} from '../../../packages/shared/src/arrays.ts';
 
-export type MdUser = {readonly login: string};
+const BASE_URL = 'https://bugs.rocicorp.dev';
 
-export type MdEmoji = {
+type MdUser = {readonly login: string};
+
+type MdEmoji = {
   readonly value: string;
   readonly creator?: MdUser | undefined;
 };
 
-export type MdLabel = {readonly name: string};
+type MdLabel = {readonly name: string};
 
-export type MdProject = {
+type MdProject = {
   readonly name: string;
   readonly lowerCaseName: string;
 };
@@ -50,12 +53,12 @@ export type MdIssue = {
 };
 
 /** Formats an epoch-milliseconds timestamp as e.g. `2026-07-01T12:34:56Z`. */
-export function formatDate(epochMillis: number): string {
+function formatDate(epochMillis: number): string {
   return new Date(epochMillis).toISOString().replace(/\.\d+Z$/, 'Z');
 }
 
 /** Collapses all whitespace runs (including newlines) to single spaces. */
-export function oneLine(s: string): string {
+function oneLine(s: string): string {
   return s.replace(/\s+/g, ' ').trim();
 }
 
@@ -66,15 +69,11 @@ export function issueMdPath(
   return `/p/${projectLowerCaseName}/issue/${ref}.md`;
 }
 
-export function issueHumanURL(
+function issueHumanURL(
   projectLowerCaseName: string,
   ref: number | string,
 ): string {
   return `${BASE_URL}/p/${projectLowerCaseName}/issue/${ref}`;
-}
-
-function compare(a: string, b: string): number {
-  return a < b ? -1 : a > b ? 1 : 0;
 }
 
 function formatReactions(
@@ -83,24 +82,15 @@ function formatReactions(
   if (!emoji || emoji.length === 0) {
     return undefined;
   }
-  const groups = new Map<string, {count: number; logins: string[]}>();
-  for (const e of emoji) {
-    let group = groups.get(e.value);
-    if (!group) {
-      group = {count: 0, logins: []};
-      groups.set(e.value, group);
-    }
-    group.count++;
-    if (e.creator) {
-      group.logins.push(e.creator.login);
-    }
-  }
-  return [...groups.entries()]
-    .sort(([a], [b]) => compare(a, b))
-    .map(([value, {count, logins}]) => {
-      const who =
-        logins.length > 0 ? ` (${logins.sort(compare).join(', ')})` : '';
-      return `${value} ×${count}${who}`;
+  return [...groupBy(emoji, e => e.value)]
+    .sort(([a], [b]) => compareUTF8(a, b))
+    .map(([value, group]) => {
+      const logins = group
+        .map(e => e.creator?.login)
+        .filter(login => login !== undefined)
+        .sort(compareUTF8);
+      const who = logins.length > 0 ? ` (${logins.join(', ')})` : '';
+      return `${value} ×${group.length}${who}`;
     })
     .join(' · ');
 }
@@ -126,7 +116,7 @@ export function renderIssueMd(
   if (issue.assignee) {
     lines.push(`- Assignee: @${issue.assignee.login}`);
   }
-  const labels = (issue.labels ?? []).map(l => l.name).sort(compare);
+  const labels = (issue.labels ?? []).map(l => l.name).sort(compareUTF8);
   if (labels.length > 0) {
     lines.push(`- Labels: ${labels.join(', ')}`);
   }

--- a/apps/zbugs/server/machine-md.ts
+++ b/apps/zbugs/server/machine-md.ts
@@ -1,0 +1,176 @@
+/**
+ * Pure renderers for the machine-readable markdown view of an issue, served at
+ * `/p/:projectName/issue/:id.md` for crawlers and AI agents that cannot run
+ * the synced SPA.
+ *
+ * Issue descriptions and comment bodies are already GitHub-flavored markdown,
+ * so they are emitted verbatim; these functions only generate the framing
+ * (heading, metadata list, comment headings). Output is deterministic: labels
+ * are sorted by name and reactions are grouped by emoji value with sorted
+ * logins.
+ */
+
+export const BASE_URL = 'https://bugs.rocicorp.dev';
+
+export type MdUser = {readonly login: string};
+
+export type MdEmoji = {
+  readonly value: string;
+  readonly creator?: MdUser | undefined;
+};
+
+export type MdLabel = {readonly name: string};
+
+export type MdProject = {
+  readonly name: string;
+  readonly lowerCaseName: string;
+};
+
+export type MdComment = {
+  readonly created: number;
+  readonly body: string;
+  readonly creator?: MdUser | undefined;
+  readonly emoji?: readonly MdEmoji[] | undefined;
+};
+
+export type MdIssue = {
+  readonly id: string;
+  readonly shortID?: number | null | undefined;
+  readonly title: string;
+  readonly open: boolean;
+  readonly visibility: string;
+  readonly created: number;
+  readonly modified: number;
+  readonly description: string;
+  readonly project?: MdProject | undefined;
+  readonly creator?: MdUser | undefined;
+  readonly assignee?: MdUser | undefined;
+  readonly labels?: readonly MdLabel[] | undefined;
+  readonly emoji?: readonly MdEmoji[] | undefined;
+};
+
+/** Formats an epoch-milliseconds timestamp as e.g. `2026-07-01T12:34:56Z`. */
+export function formatDate(epochMillis: number): string {
+  return new Date(epochMillis).toISOString().replace(/\.\d+Z$/, 'Z');
+}
+
+/** Collapses all whitespace runs (including newlines) to single spaces. */
+export function oneLine(s: string): string {
+  return s.replace(/\s+/g, ' ').trim();
+}
+
+export function issueMdPath(
+  projectLowerCaseName: string,
+  ref: number | string,
+): string {
+  return `/p/${projectLowerCaseName}/issue/${ref}.md`;
+}
+
+export function issueHumanURL(
+  projectLowerCaseName: string,
+  ref: number | string,
+): string {
+  return `${BASE_URL}/p/${projectLowerCaseName}/issue/${ref}`;
+}
+
+function compare(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+function formatReactions(
+  emoji: readonly MdEmoji[] | undefined,
+): string | undefined {
+  if (!emoji || emoji.length === 0) {
+    return undefined;
+  }
+  const groups = new Map<string, {count: number; logins: string[]}>();
+  for (const e of emoji) {
+    let group = groups.get(e.value);
+    if (!group) {
+      group = {count: 0, logins: []};
+      groups.set(e.value, group);
+    }
+    group.count++;
+    if (e.creator) {
+      group.logins.push(e.creator.login);
+    }
+  }
+  return [...groups.entries()]
+    .sort(([a], [b]) => compare(a, b))
+    .map(([value, {count, logins}]) => {
+      const who =
+        logins.length > 0 ? ` (${logins.sort(compare).join(', ')})` : '';
+      return `${value} ×${count}${who}`;
+    })
+    .join(' · ');
+}
+
+export function renderIssueMd(
+  issue: MdIssue,
+  comments: readonly MdComment[],
+  options: {readonly commentsCapped: boolean},
+): string {
+  const heading =
+    // oxlint-disable-next-line eqeqeq
+    issue.shortID != null ? `Bug ${issue.shortID}` : `Issue ${issue.id}`;
+  const lines: string[] = [];
+  lines.push(`# ${heading}: ${oneLine(issue.title)}`, '');
+
+  lines.push(`- Status: ${issue.open ? 'open' : 'closed'}`);
+  if (issue.project) {
+    lines.push(`- Project: ${issue.project.name}`);
+  }
+  if (issue.creator) {
+    lines.push(`- Creator: @${issue.creator.login}`);
+  }
+  if (issue.assignee) {
+    lines.push(`- Assignee: @${issue.assignee.login}`);
+  }
+  const labels = (issue.labels ?? []).map(l => l.name).sort(compare);
+  if (labels.length > 0) {
+    lines.push(`- Labels: ${labels.join(', ')}`);
+  }
+  if (issue.visibility !== 'public') {
+    lines.push(`- Visibility: ${issue.visibility}`);
+  }
+  lines.push(`- Created: ${formatDate(issue.created)}`);
+  lines.push(`- Modified: ${formatDate(issue.modified)}`);
+  const reactions = formatReactions(issue.emoji);
+  if (reactions) {
+    lines.push(`- Reactions: ${reactions}`);
+  }
+  if (issue.project) {
+    lines.push(
+      `- URL: ${issueHumanURL(issue.project.lowerCaseName, issue.shortID ?? issue.id)}`,
+    );
+  }
+
+  lines.push('', '## Description', '');
+  const description = issue.description.trim();
+  lines.push(description === '' ? '_No description._' : description, '');
+
+  lines.push(`## Comments (${comments.length})`, '');
+  if (options.commentsCapped) {
+    lines.push(
+      `_Showing the ${comments.length} most recent comments; earlier comments omitted._`,
+      '',
+    );
+  }
+  for (const comment of comments) {
+    lines.push(
+      `### @${comment.creator?.login ?? 'unknown'} — ${formatDate(comment.created)}`,
+      '',
+    );
+    const body = comment.body.trim();
+    lines.push(body === '' ? '_No content._' : body, '');
+    const commentReactions = formatReactions(comment.emoji);
+    if (commentReactions) {
+      lines.push(`Reactions: ${commentReactions}`, '');
+    }
+  }
+  return lines.join('\n');
+}
+
+export function renderErrorMd(title: string, detail: string): string {
+  return `# ${title}\n\n${detail}\n`;
+}

--- a/apps/zbugs/server/machine-md.ts
+++ b/apps/zbugs/server/machine-md.ts
@@ -52,14 +52,18 @@ export type MdIssue = {
   readonly emoji?: readonly MdEmoji[] | undefined;
 };
 
+const millisRegex = /\.\d+Z$/;
+
 /** Formats an epoch-milliseconds timestamp as e.g. `2026-07-01T12:34:56Z`. */
 function formatDate(epochMillis: number): string {
-  return new Date(epochMillis).toISOString().replace(/\.\d+Z$/, 'Z');
+  return new Date(epochMillis).toISOString().replace(millisRegex, 'Z');
 }
+
+const whitespaceRegex = /\s+/g;
 
 /** Collapses all whitespace runs (including newlines) to single spaces. */
 function oneLine(s: string): string {
-  return s.replace(/\s+/g, ' ').trim();
+  return s.replace(whitespaceRegex, ' ').trim();
 }
 
 export function issueMdPath(
@@ -83,7 +87,7 @@ function formatReactions(
     return undefined;
   }
   return [...groupBy(emoji, e => e.value)]
-    .sort(([a], [b]) => compareUTF8(a, b))
+    .toSorted(([a], [b]) => compareUTF8(a, b))
     .map(([value, group]) => {
       const logins = group
         .map(e => e.creator?.login)

--- a/apps/zbugs/server/machine-routes.ts
+++ b/apps/zbugs/server/machine-routes.ts
@@ -1,6 +1,7 @@
 import type {IncomingHttpHeaders} from 'http';
 import type {FastifyInstance, FastifyReply} from 'fastify';
 import type {JWTData} from '../shared/auth.ts';
+import {getIDFromString} from '../shared/issue-id.ts';
 import {queries} from '../shared/queries.ts';
 import {builder} from '../shared/schema.ts';
 import {dbProvider} from './db.ts';
@@ -14,20 +15,16 @@ const MAX_COMMENTS = 1000;
 
 type AuthFn = (headers: IncomingHttpHeaders) => Promise<JWTData | undefined>;
 
-// Mirrors getIDFromString in src/pages/issue/get-id.tsx, which is not imported
-// here because it is part of the client bundle. Returns undefined for ids that
-// cannot possibly match (empty, or digits beyond the integer range).
+// Returns undefined for ids that cannot possibly match (empty, or digit
+// strings beyond the safe-integer range).
 function parseIssueID(idStr: string) {
   if (idStr === '') {
     return undefined;
   }
-  if (/[^\d]/.test(idStr)) {
-    return {idField: 'id', idValue: idStr} as const;
-  }
-  const shortID = parseInt(idStr);
-  return Number.isSafeInteger(shortID)
-    ? ({idField: 'shortID', idValue: shortID} as const)
-    : undefined;
+  const parsed = getIDFromString(idStr);
+  return parsed.idField === 'shortID' && !Number.isSafeInteger(parsed.idValue)
+    ? undefined
+    : parsed;
 }
 
 async function fetchIssueForMd(

--- a/apps/zbugs/server/machine-routes.ts
+++ b/apps/zbugs/server/machine-routes.ts
@@ -27,7 +27,7 @@ function parseIssueID(idStr: string) {
     : parsed;
 }
 
-async function fetchIssueForMd(
+function fetchIssueForMd(
   authData: JWTData | undefined,
   idField: 'shortID' | 'id',
   idValue: string | number,
@@ -54,7 +54,7 @@ async function fetchIssueForMd(
     );
     return {
       issue,
-      comments: commentsDesc.slice().reverse(),
+      comments: commentsDesc.toReversed(),
       commentsCapped: commentsDesc.length === MAX_COMMENTS,
     };
   });

--- a/apps/zbugs/server/machine-routes.ts
+++ b/apps/zbugs/server/machine-routes.ts
@@ -1,8 +1,8 @@
 import type {IncomingHttpHeaders} from 'http';
 import type {FastifyInstance, FastifyReply} from 'fastify';
-import type {JWTData} from '../shared/auth.ts';
+import type {JWTData, Role} from '../shared/auth.ts';
 import {getIDFromString} from '../shared/issue-id.ts';
-import {queries} from '../shared/queries.ts';
+import {applyIssuePermissions} from '../shared/queries.ts';
 import {builder} from '../shared/schema.ts';
 import {dbProvider} from './db.ts';
 import {issueMdPath, renderErrorMd, renderIssueMd} from './machine-md.ts';
@@ -27,6 +27,27 @@ function parseIssueID(idStr: string) {
     : parsed;
 }
 
+// The issue tree the markdown view renders. This is issueDetail minus the
+// per-user relationships (viewState, notificationState) and the comment
+// preload: the markdown view has no per-user state, and comments are fetched
+// separately below. Uses the same applyIssuePermissions gate as issueDetail.
+export function issueForMdQuery(
+  idField: 'shortID' | 'id',
+  idValue: string | number,
+  role: Role | undefined,
+) {
+  return applyIssuePermissions(
+    builder.issue
+      .where(idField, idValue)
+      .related('project')
+      .related('creator')
+      .related('assignee')
+      .related('labels')
+      .related('emoji', e => e.related('creator')),
+    role,
+  ).one();
+}
+
 function fetchIssueForMd(
   authData: JWTData | undefined,
   idField: 'shortID' | 'id',
@@ -34,7 +55,7 @@ function fetchIssueForMd(
 ) {
   return dbProvider.transaction(async tx => {
     const issue = await tx.run(
-      queries.issueDetail.fn({args: {idField, id: idValue}, ctx: authData}),
+      issueForMdQuery(idField, idValue, authData?.role),
     );
     if (!issue) {
       return undefined;

--- a/apps/zbugs/server/machine-routes.ts
+++ b/apps/zbugs/server/machine-routes.ts
@@ -1,0 +1,146 @@
+import type {IncomingHttpHeaders} from 'http';
+import type {FastifyInstance, FastifyReply} from 'fastify';
+import type {JWTData} from '../shared/auth.ts';
+import {queries} from '../shared/queries.ts';
+import {builder} from '../shared/schema.ts';
+import {dbProvider} from './db.ts';
+import {issueMdPath, renderErrorMd, renderIssueMd} from './machine-md.ts';
+
+/**
+ * The markdown view caps huge (synthetic) threads at the most recent comments
+ * rather than rendering unboundedly.
+ */
+const MAX_COMMENTS = 1000;
+
+type AuthFn = (headers: IncomingHttpHeaders) => Promise<JWTData | undefined>;
+
+// Mirrors getIDFromString in src/pages/issue/get-id.tsx, which is not imported
+// here because it is part of the client bundle. Returns undefined for ids that
+// cannot possibly match (empty, or digits beyond the integer range).
+function parseIssueID(idStr: string) {
+  if (idStr === '') {
+    return undefined;
+  }
+  if (/[^\d]/.test(idStr)) {
+    return {idField: 'id', idValue: idStr} as const;
+  }
+  const shortID = parseInt(idStr);
+  return Number.isSafeInteger(shortID)
+    ? ({idField: 'shortID', idValue: shortID} as const)
+    : undefined;
+}
+
+async function fetchIssueForMd(
+  authData: JWTData | undefined,
+  idField: 'shortID' | 'id',
+  idValue: string | number,
+) {
+  return dbProvider.transaction(async tx => {
+    const issue = await tx.run(
+      queries.issueDetail.fn({args: {idField, id: idValue}, ctx: authData}),
+    );
+    if (!issue) {
+      return undefined;
+    }
+    // The full thread rather than issueDetail's 50-comment preload. This
+    // query has no visibility gate of its own, which is safe only because it
+    // runs after the permission-gated issueDetail query above returned the
+    // issue, and never for a synced query.
+    const commentsDesc = await tx.run(
+      builder.comment
+        .where('issueID', issue.id)
+        .orderBy('created', 'desc')
+        .orderBy('id', 'desc')
+        .related('creator')
+        .related('emoji', e => e.related('creator'))
+        .limit(MAX_COMMENTS),
+    );
+    return {
+      issue,
+      comments: commentsDesc.slice().reverse(),
+      commentsCapped: commentsDesc.length === MAX_COMMENTS,
+    };
+  });
+}
+
+function sendMarkdown(reply: FastifyReply, body: string): void {
+  reply.type('text/markdown; charset=utf-8').send(body);
+}
+
+function setCacheControl(
+  request: {headers: IncomingHttpHeaders},
+  reply: FastifyReply,
+  publicDirectives: string,
+): void {
+  // Responses to authenticated requests may include internal issues and must
+  // never be cached by the CDN.
+  reply.header(
+    'cache-control',
+    request.headers.authorization
+      ? 'private, no-store'
+      : `public, ${publicDirectives}`,
+  );
+}
+
+export function registerMachineRoutes(
+  fastify: FastifyInstance,
+  auth: AuthFn,
+): void {
+  fastify.get<{Params: {projectName: string; id: string}}>(
+    '/p/:projectName/issue/:id.md',
+    async (request, reply) => {
+      let authData: JWTData | undefined;
+      try {
+        authData = await auth(request.headers);
+      } catch (e) {
+        reply.status(401).header('cache-control', 'private, no-store');
+        sendMarkdown(
+          reply,
+          renderErrorMd(
+            'Unauthorized',
+            e instanceof Error ? e.message : 'Invalid authorization header.',
+          ),
+        );
+        return;
+      }
+
+      const parsed = parseIssueID(request.params.id);
+      const result =
+        parsed &&
+        (await fetchIssueForMd(authData, parsed.idField, parsed.idValue));
+      if (!result) {
+        setCacheControl(request, reply, 's-maxage=60');
+        reply.status(404);
+        sendMarkdown(
+          reply,
+          renderErrorMd(
+            'Not Found',
+            'No such issue, or you do not have permission to view it.',
+          ),
+        );
+        return;
+      }
+
+      const {issue, comments, commentsCapped} = result;
+      if (issue.project) {
+        const ref = String(issue.shortID ?? issue.id);
+        if (
+          request.params.projectName.toLocaleLowerCase() !==
+            issue.project.lowerCaseName ||
+          request.params.id !== ref
+        ) {
+          setCacheControl(request, reply, 's-maxage=300');
+          reply.redirect(issueMdPath(issue.project.lowerCaseName, ref), 308);
+          return;
+        }
+      }
+
+      setCacheControl(
+        request,
+        reply,
+        's-maxage=300, stale-while-revalidate=3600',
+      );
+      sendMarkdown(reply, renderIssueMd(issue, comments, {commentsCapped}));
+    },
+  );
+}

--- a/apps/zbugs/server/machine-routes.ts
+++ b/apps/zbugs/server/machine-routes.ts
@@ -143,7 +143,7 @@ export function registerMachineRoutes(
       if (issue.project) {
         const ref = String(issue.shortID ?? issue.id);
         if (
-          request.params.projectName.toLocaleLowerCase() !==
+          request.params.projectName.toLowerCase() !==
             issue.project.lowerCaseName ||
           request.params.id !== ref
         ) {

--- a/apps/zbugs/shared/issue-id.ts
+++ b/apps/zbugs/shared/issue-id.ts
@@ -1,0 +1,7 @@
+const nonDigitRegex = /[^\d]/;
+
+export function getIDFromString(idStr: string) {
+  const idField = nonDigitRegex.test(idStr) ? 'id' : 'shortID';
+  const idValue = idField === 'shortID' ? parseInt(idStr) : idStr;
+  return {idField, idValue} as const;
+}

--- a/apps/zbugs/shared/issue-id.ts
+++ b/apps/zbugs/shared/issue-id.ts
@@ -2,6 +2,6 @@ const nonDigitRegex = /[^\d]/;
 
 export function getIDFromString(idStr: string) {
   const idField = nonDigitRegex.test(idStr) ? 'id' : 'shortID';
-  const idValue = idField === 'shortID' ? parseInt(idStr) : idStr;
+  const idValue = idField === 'shortID' ? parseInt(idStr, 10) : idStr;
   return {idField, idValue} as const;
 }

--- a/apps/zbugs/shared/queries.ts
+++ b/apps/zbugs/shared/queries.ts
@@ -12,13 +12,11 @@ import type {AuthData, Role} from './auth.ts';
 import {QueryError, QueryErrorCode} from './error.ts';
 import {builder, ZERO_PROJECT_NAME} from './schema.ts';
 
-function applyIssuePermissions<TQuery extends IssueQuery>(
+export function applyIssuePermissions<TQuery extends IssueQuery>(
   q: TQuery,
   role: Role | undefined,
 ): TQuery {
-  return q.where(({or, cmp, cmpLit}) =>
-    or(cmp('visibility', '=', 'public'), cmpLit(role, '=', 'crew')),
-  ) as TQuery;
+  return role === 'crew' ? q : (q.where('visibility', 'public') as TQuery);
 }
 
 const idValidator = z.string();

--- a/apps/zbugs/src/pages/issue/get-id.tsx
+++ b/apps/zbugs/src/pages/issue/get-id.tsx
@@ -1,15 +1,10 @@
 import type {DefaultParams} from 'wouter';
 import {must} from '../../../../../packages/shared/src/must.ts';
+import {getIDFromString} from '../../../shared/issue-id.ts';
+
+export {getIDFromString};
 
 export function getID(params: DefaultParams) {
   const idStr = must(params.id);
   return getIDFromString(idStr);
-}
-
-const nonDigitRegex = /[^\d]/;
-
-export function getIDFromString(idStr: string) {
-  const idField = nonDigitRegex.test(idStr) ? 'id' : 'shortID';
-  const idValue = idField === 'shortID' ? parseInt(idStr) : idStr;
-  return {idField, idValue} as const;
 }

--- a/apps/zbugs/vercel.json
+++ b/apps/zbugs/vercel.json
@@ -18,6 +18,10 @@
       "destination": "/api"
     },
     {
+      "source": "/p/:projectName/issue/:id.md",
+      "destination": "/api"
+    },
+    {
       "source": "/p/roci/:path*",
       "destination": "/roci.html"
     },

--- a/apps/zbugs/vercel.json
+++ b/apps/zbugs/vercel.json
@@ -10,6 +10,54 @@
       ],
       "destination": "https://bugs.rocicorp.dev/p/roci",
       "permanent": true
+    },
+    {
+      "source": "/p/:projectName/issue/:id([^./]+)",
+      "has": [
+        {
+          "type": "header",
+          "key": "accept",
+          "value": ".*text/markdown.*"
+        }
+      ],
+      "destination": "/p/:projectName/issue/:id.md",
+      "permanent": false
+    },
+    {
+      "source": "/p/:projectName/issue/:id([^./]+)",
+      "has": [
+        {
+          "type": "header",
+          "key": "user-agent",
+          "value": ".*(GPTBot|OAI-SearchBot|ChatGPT-User|ClaudeBot|Claude-User|Claude-SearchBot|anthropic-ai|PerplexityBot|Perplexity-User|Google-Extended|CCBot|cohere-ai|Bytespider|meta-external|Applebot-Extended|Amazonbot|Diffbot|DuckAssistBot|MistralAI|curl|Wget|python-requests|python-httpx|aiohttp|Go-http-client|okhttp|Googlebot|[Bb]ingbot|DuckDuckBot|Baiduspider|YandexBot|Slurp).*"
+        }
+      ],
+      "destination": "/p/:projectName/issue/:id.md",
+      "permanent": false
+    },
+    {
+      "source": "/issue/:id([^./]+)",
+      "has": [
+        {
+          "type": "header",
+          "key": "accept",
+          "value": ".*text/markdown.*"
+        }
+      ],
+      "destination": "/p/zero/issue/:id.md",
+      "permanent": false
+    },
+    {
+      "source": "/issue/:id([^./]+)",
+      "has": [
+        {
+          "type": "header",
+          "key": "user-agent",
+          "value": ".*(GPTBot|OAI-SearchBot|ChatGPT-User|ClaudeBot|Claude-User|Claude-SearchBot|anthropic-ai|PerplexityBot|Perplexity-User|Google-Extended|CCBot|cohere-ai|Bytespider|meta-external|Applebot-Extended|Amazonbot|Diffbot|DuckAssistBot|MistralAI|curl|Wget|python-requests|python-httpx|aiohttp|Go-http-client|okhttp|Googlebot|[Bb]ingbot|DuckDuckBot|Baiduspider|YandexBot|Slurp).*"
+        }
+      ],
+      "destination": "/p/zero/issue/:id.md",
+      "permanent": false
     }
   ],
   "rewrites": [

--- a/apps/zbugs/vite.config.ts
+++ b/apps/zbugs/vite.config.ts
@@ -12,10 +12,18 @@ const zeroPath = fileURLToPath(
   new URL('../../packages/zero/src/zero.ts', import.meta.url),
 );
 
+function isFastifyPath(url: string): boolean {
+  const pathname = url.split('?')[0];
+  return (
+    pathname.startsWith('/api') ||
+    (pathname.startsWith('/p/') && pathname.endsWith('.md'))
+  );
+}
+
 async function configureServer(server: ViteDevServer) {
   await fastify.ready();
   server.middlewares.use((req, res, next) => {
-    if (!req.url?.startsWith('/api')) {
+    if (!req.url || !isFastifyPath(req.url)) {
       return next();
     }
     fastify.server.emit('request', req, res);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,6 +142,9 @@ importers:
       classnames:
         specifier: ^2.5.1
         version: 2.5.1
+      compare-utf8:
+        specifier: ^0.2.0
+        version: 0.2.0
       emoji-picker-element:
         specifier: ^1.22.8
         version: 1.29.1
@@ -26555,7 +26558,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.14
+      postcss: 8.5.15
       rolldown: 1.0.1
       tinyglobby: 0.2.16
     optionalDependencies:
@@ -26571,7 +26574,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.14
+      postcss: 8.5.15
       rolldown: 1.0.1
       tinyglobby: 0.2.16
     optionalDependencies:


### PR DESCRIPTION
Add a new markdown endpoint (`/p/:projectName/issue/:id.md`) that serves issues in a machine-readable format for crawlers and AI agents that cannot run the synced SPA.

## Summary
This change introduces a dedicated markdown rendering system for issues, allowing external tools to access issue data in a deterministic, structured format without executing JavaScript.

## Key Changes
- **New `machine-md.ts` module**: Pure renderers for markdown output with deterministic formatting (sorted labels, grouped reactions by emoji with sorted logins)
- **New `machine-routes.ts` module**: Fastify route handler for the `.md` endpoint with proper authentication, caching headers, and redirect handling for canonical URLs
- **Shared `issue-id.ts` module**: Extracted ID parsing logic from the client to be reused by both the SPA and server routes
- **Route registration**: Integrated machine routes into the API server with appropriate cache control policies (private/no-store for authenticated requests, public with CDN caching for public issues)
- **Vite dev server**: Updated to proxy markdown requests to Fastify alongside existing `/api` routes
- **Vercel routing**: Added configuration to route `.md` requests to the API handler

## Implementation Details
- Comments are capped at 1000 to prevent unbounded rendering of synthetic threads
- Output is deterministic: labels sorted by name, reactions grouped by emoji value with sorted creator logins
- Markdown content (descriptions and comment bodies) is emitted verbatim as it's already GitHub-flavored markdown
- Proper HTTP semantics: 404 for missing/unauthorized issues, 308 redirects for non-canonical URLs, appropriate cache headers
- Whitespace in titles is normalized to single spaces for cleaner output
