### PR TITLE
chore(rmv2): factor out codec for sharing w/ sqlite and pg changelog [1/n]

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/broadcast.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/broadcast.test.ts
@@ -4,7 +4,7 @@ import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.
 import {sleep} from '../../../../shared/src/sleep.ts';
 import {ReplicationMessages} from '../replicator/test-utils.ts';
 import {Broadcast} from './broadcast.ts';
-import type {WatermarkedChange} from './change-streamer-service.ts';
+import type {WatermarkedChange} from './change-streamer.ts';
 import {createSubscriber} from './test-utils.ts';
 
 const json = BigIntJSON.stringify;

--- a/packages/zero-cache/src/services/change-streamer/broadcast.ts
+++ b/packages/zero-cache/src/services/change-streamer/broadcast.ts
@@ -1,6 +1,6 @@
 import type {LogContext} from '@rocicorp/logger';
 import {resolver} from '@rocicorp/resolver';
-import type {WatermarkedChange} from './change-streamer-service.ts';
+import type {WatermarkedChange} from './change-streamer.ts';
 import type {Subscriber} from './subscriber.ts';
 
 export type BroadcastReleaseMode = 'all-subscribers' | 'consensus-timeout';

--- a/packages/zero-cache/src/services/change-streamer/change-log-codec.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-log-codec.test.ts
@@ -1,0 +1,220 @@
+import {describe, expect, test} from 'vitest';
+import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
+import {
+  extractChangeSubstring,
+  reconstructWatermarkedChange,
+  serializeChangeStreamData,
+  type ChangeLogEntry,
+} from './change-log-codec.ts';
+import type {ChangeTag, WatermarkedChange} from './change-streamer.ts';
+
+type Fixture = {
+  name: string;
+  watermark: string;
+  data: ChangeStreamData;
+  json: string;
+  change: string;
+};
+
+const fixtures: Fixture[] = [
+  {
+    name: 'begin',
+    watermark: '01',
+    data: [
+      'begin',
+      {tag: 'begin', json: 's', skipAck: true},
+      {commitWatermark: '01'},
+    ],
+    json: '["begin",{"tag":"begin","json":"s","skipAck":true},{"commitWatermark":"01"}]',
+    change: '{"tag":"begin","json":"s","skipAck":true}',
+  },
+  {
+    name: 'data',
+    watermark: '02',
+    data: [
+      'data',
+      {
+        tag: 'insert',
+        relation: {
+          schema: 'public',
+          name: 'items',
+          rowKey: {columns: ['id'], type: 'default'},
+        },
+        new: {
+          id: 9007199254740993n,
+          nested: {
+            big: -9007199254740994n,
+            values: [{}, []],
+          },
+          escapedNul: 'before\0after',
+          quotes: '"quoted"',
+          backslash: 'a\\b',
+          unicode: '雪 ☃',
+          emptyObject: {},
+          emptyArray: [],
+        },
+      },
+    ],
+    json: '["data",{"tag":"insert","relation":{"schema":"public","name":"items","rowKey":{"columns":["id"],"type":"default"}},"new":{"id":9007199254740993,"nested":{"big":-9007199254740994,"values":[{},[]]},"escapedNul":"before\\u0000after","quotes":"\\"quoted\\"","backslash":"a\\\\b","unicode":"雪 ☃","emptyObject":{},"emptyArray":[]}}]',
+    change:
+      '{"tag":"insert","relation":{"schema":"public","name":"items","rowKey":{"columns":["id"],"type":"default"}},"new":{"id":9007199254740993,"nested":{"big":-9007199254740994,"values":[{},[]]},"escapedNul":"before\\u0000after","quotes":"\\"quoted\\"","backslash":"a\\\\b","unicode":"雪 ☃","emptyObject":{},"emptyArray":[]}}',
+  },
+  {
+    name: 'schema',
+    watermark: '03',
+    data: [
+      'data',
+      {
+        tag: 'rename-table',
+        old: {schema: 'public', name: 'before'},
+        new: {schema: 'archive', name: 'after'},
+      },
+    ],
+    json: '["data",{"tag":"rename-table","old":{"schema":"public","name":"before"},"new":{"schema":"archive","name":"after"}}]',
+    change:
+      '{"tag":"rename-table","old":{"schema":"public","name":"before"},"new":{"schema":"archive","name":"after"}}',
+  },
+  {
+    name: 'truncate',
+    watermark: '04',
+    data: [
+      'data',
+      {
+        tag: 'truncate',
+        relations: [
+          {
+            schema: 'public',
+            name: 'items',
+            rowKey: {columns: ['id'], type: 'default'},
+          },
+          {
+            schema: 'public',
+            name: 'events',
+            rowKey: {columns: [], type: 'nothing'},
+          },
+        ],
+      },
+    ],
+    json: '["data",{"tag":"truncate","relations":[{"schema":"public","name":"items","rowKey":{"columns":["id"],"type":"default"}},{"schema":"public","name":"events","rowKey":{"columns":[],"type":"nothing"}}]}]',
+    change:
+      '{"tag":"truncate","relations":[{"schema":"public","name":"items","rowKey":{"columns":["id"],"type":"default"}},{"schema":"public","name":"events","rowKey":{"columns":[],"type":"nothing"}}]}',
+  },
+  {
+    name: 'backfill',
+    watermark: '05',
+    data: [
+      'data',
+      {
+        tag: 'backfill',
+        relation: {
+          schema: 'public',
+          name: 'items',
+          rowKey: {columns: ['id'], type: 'default'},
+        },
+        columns: [],
+        watermark: '04',
+        rowValues: [
+          [9007199254740995n, {nested: {big: 9007199254740997n}}, [], {}],
+        ],
+        status: {rows: 1, totalRows: 1, totalBytes: 0},
+      },
+    ],
+    json: '["data",{"tag":"backfill","relation":{"schema":"public","name":"items","rowKey":{"columns":["id"],"type":"default"}},"columns":[],"watermark":"04","rowValues":[[9007199254740995,{"nested":{"big":9007199254740997}},[],{}]],"status":{"rows":1,"totalRows":1,"totalBytes":0}}]',
+    change:
+      '{"tag":"backfill","relation":{"schema":"public","name":"items","rowKey":{"columns":["id"],"type":"default"}},"columns":[],"watermark":"04","rowValues":[[9007199254740995,{"nested":{"big":9007199254740997}},[],{}]],"status":{"rows":1,"totalRows":1,"totalBytes":0}}',
+  },
+  {
+    name: 'commit',
+    watermark: '06',
+    data: ['commit', {tag: 'commit'}, {watermark: '06'}],
+    json: '["commit",{"tag":"commit"},{"watermark":"06"}]',
+    change: '{"tag":"commit"}',
+  },
+  {
+    name: 'rollback',
+    watermark: '07',
+    data: ['rollback', {tag: 'rollback'}],
+    json: '["rollback",{"tag":"rollback"}]',
+    change: '{"tag":"rollback"}',
+  },
+];
+
+describe('change log codec', () => {
+  test.each(fixtures)(
+    '$name has an exact canonical representation',
+    fixture => {
+      const {watermark, data, json, change} = fixture;
+      const tag = data[1].tag;
+      const serialized = serializeChangeStreamData(data);
+
+      expect(serialized).toBe(json);
+      expect(extractChangeSubstring(serialized, tag)).toBe(change);
+
+      const entry = {watermark, tag, change};
+      expect(reconstructWatermarkedChange(entry)).toEqual([
+        watermark,
+        tag,
+        json,
+      ]);
+    },
+  );
+
+  test.each(fixtures)(
+    '$name preserves the pre-extraction PG representation',
+    ({watermark, data}) => {
+      const json = serializeChangeStreamData(data);
+      const tag = data[1].tag;
+      const change = extractChangeSubstring(json, tag);
+      const entry = {watermark, tag, change};
+
+      expect(change).toBe(legacyExtractChangeSubstring(json, tag));
+      expect(reconstructWatermarkedChange(entry)).toEqual(
+        legacyReconstructWatermarkedChange(entry),
+      );
+    },
+  );
+});
+
+function legacyExtractChangeSubstring(
+  streamMessageJSON: string,
+  tag: ChangeTag,
+): string {
+  switch (tag) {
+    case 'begin':
+    case 'commit':
+      return streamMessageJSON.substring(
+        streamMessageJSON.indexOf(',') + 1,
+        streamMessageJSON.lastIndexOf(','),
+      );
+    default:
+      return streamMessageJSON.substring(
+        streamMessageJSON.indexOf(',') + 1,
+        streamMessageJSON.lastIndexOf(']'),
+      );
+  }
+}
+
+function legacyReconstructWatermarkedChange(
+  entry: ChangeLogEntry,
+): WatermarkedChange {
+  const {watermark, change} = entry;
+  const tag = entry.tag as ChangeTag;
+  switch (tag) {
+    case 'begin':
+      return [
+        watermark,
+        tag,
+        `["begin",${change},{"commitWatermark":"${watermark}"}]`,
+      ];
+    case 'commit':
+      return [
+        watermark,
+        tag,
+        `["commit",${change},{"watermark":"${watermark}"}]`,
+      ];
+    case 'rollback':
+      return [watermark, tag, `["rollback",${change}]`];
+    default:
+      return [watermark, tag, `["data",${change}]`];
+  }
+}

--- a/packages/zero-cache/src/services/change-streamer/change-log-codec.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-log-codec.ts
@@ -1,0 +1,69 @@
+import {BigIntJSON} from '../../../../shared/src/bigint-json.ts';
+import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
+import type {ChangeTag, WatermarkedChange} from './change-streamer.ts';
+
+export type ChangeLogEntry = {
+  watermark: string;
+  tag: string;
+  change: string;
+};
+
+/** Serializes a data-plane message to the canonical downstream JSON form. */
+export function serializeChangeStreamData(data: ChangeStreamData): string {
+  return BigIntJSON.stringify(data);
+}
+
+/**
+ * Extracts the stringified change message from the stringified stream message
+ * (the second tuple element). This allows the stream message to be stringified
+ * once while storing only the change message in the change log for backwards
+ * compatibility.
+ */
+export function extractChangeSubstring(
+  streamMessageJSON: string,
+  tag: ChangeTag | undefined,
+): string {
+  switch (tag) {
+    case 'begin':
+    case 'commit':
+      // e.g.
+      // ["begin",<message-json>,{"commitWatermark":"92fj2d0s"}]
+      // ["commit",<message-json>,{"watermark":"92fj2d0s"}]
+      return streamMessageJSON.substring(
+        streamMessageJSON.indexOf(',') + 1,
+        streamMessageJSON.lastIndexOf(','),
+      );
+    default:
+      // ["data",<message-json>]
+      return streamMessageJSON.substring(
+        streamMessageJSON.indexOf(',') + 1,
+        streamMessageJSON.lastIndexOf(']'),
+      );
+  }
+}
+
+/** Reconstructs the canonical downstream JSON around a stored change. */
+export function reconstructWatermarkedChange(
+  entry: ChangeLogEntry,
+): WatermarkedChange {
+  const {watermark, change} = entry;
+  const tag = entry.tag as ChangeTag;
+  switch (tag) {
+    case 'begin':
+      return [
+        watermark,
+        tag,
+        `["begin",${change},{"commitWatermark":"${watermark}"}]`,
+      ];
+    case 'commit':
+      return [
+        watermark,
+        tag,
+        `["commit",${change},{"watermark":"${watermark}"}]`,
+      ];
+    case 'rollback':
+      return [watermark, tag, `["rollback",${change}]`];
+    default:
+      return [watermark, tag, `["data",${change}]`];
+  }
+}

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -20,7 +20,6 @@ import type {
 } from '../change-source/change-source.ts';
 import {
   type ChangeStreamControl,
-  type ChangeStreamData,
   type Rollback,
 } from '../change-source/protocol/current/downstream.ts';
 import {
@@ -35,6 +34,7 @@ import {
   UnrecoverableError,
 } from '../running-state.ts';
 import {
+  type WatermarkedChange,
   type ChangeStreamerService,
   type Status,
   type SubscriberContext,
@@ -107,28 +107,6 @@ export async function initializeStreamer(
 }
 
 const REPLICATION_STATUS_ERROR_DELAY_THRESHOLD_MS = 5000;
-
-export type ChangeTag = ChangeStreamData[1]['tag'];
-
-/**
- * Internally all Downstream messages (not just commits) are given a watermark.
- * These are used for internal ordering for:
- * 1. Replaying new changes in the Storer
- * 2. Filtering old changes in the Subscriber
- *
- * However, only the watermark for `Commit` messages are exposed to
- * subscribers, as that is the only semantically correct watermark to
- * use for tracking a position in a replication stream.
- *
- * Additionally, the ChangeStreamData is eagerly stringified once, after which
- * the string is passed to the changeLog and all subscribers, eliminating
- * redundant stringification and reducing GC churn.
- */
-export type WatermarkedChange = [
-  watermark: string,
-  tag: ChangeTag,
-  json: string,
-];
 
 /**
  * Upstream-agnostic dispatch of messages in a {@link ChangeStreamMessage} to a

--- a/packages/zero-cache/src/services/change-streamer/change-streamer.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer.ts
@@ -1,13 +1,32 @@
 import type {Enum} from '../../../../shared/src/enum.ts';
 import * as v from '../../../../shared/src/valita.ts';
 import type {Source} from '../../types/streams.ts';
-import {changeStreamDataSchema} from '../change-source/protocol/current/downstream.ts';
+import {
+  changeStreamDataSchema,
+  type ChangeStreamData,
+} from '../change-source/protocol/current/downstream.ts';
 import type {ReplicatorMode} from '../replicator/replicator.ts';
 import {changeSourceTimingsSchema} from '../replicator/reporter/report-schema.ts';
 import type {Service} from '../service.ts';
 import * as ErrorType from './error-type-enum.ts';
 
 type ErrorType = Enum<typeof ErrorType>;
+
+export type ChangeTag = ChangeStreamData[1]['tag'];
+
+/**
+ * Internally all downstream messages (not just commits) are given a watermark.
+ * These are used for internal ordering while replaying stored changes and
+ * filtering changes already seen by a subscriber.
+ *
+ * Only commit watermarks are exposed to subscribers. The JSON string is the
+ * canonical serialization shared by storage and live forwarding.
+ */
+export type WatermarkedChange = [
+  watermark: string,
+  tag: ChangeTag,
+  json: string,
+];
 
 /**
  * The ChangeStreamer is the component between replicators ("subscribers")

--- a/packages/zero-cache/src/services/change-streamer/forwarder.ts
+++ b/packages/zero-cache/src/services/change-streamer/forwarder.ts
@@ -6,8 +6,7 @@ import {
   getOrCreateLatencyHistogram,
 } from '../../observability/metrics.ts';
 import {Broadcast, type EarlyReleaseOptions} from './broadcast.ts';
-import type {ChangeTag, WatermarkedChange} from './change-streamer-service.ts';
-import type {Status} from './change-streamer.ts';
+import type {ChangeTag, Status, WatermarkedChange} from './change-streamer.ts';
 import type {Subscriber} from './subscriber.ts';
 
 export type ProgressMonitorOptions = {

--- a/packages/zero-cache/src/services/change-streamer/storer.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.pg.test.ts
@@ -14,15 +14,11 @@ import {
 } from '../change-source/protocol/current/downstream.ts';
 import type {UpstreamStatusMessage} from '../change-source/protocol/current/status.ts';
 import {ReplicationMessages} from '../replicator/test-utils.ts';
+import {extractChangeSubstring} from './change-log-codec.ts';
 import {type Downstream} from './change-streamer.ts';
 import * as ErrorType from './error-type-enum.ts';
 import {ensureReplicationConfig, setupCDCTables} from './schema/tables.ts';
-import {
-  extractChangeSubstring,
-  PurgeLocker,
-  Storer,
-  type TuningOptions,
-} from './storer.ts';
+import {PurgeLocker, Storer, type TuningOptions} from './storer.ts';
 import {createSubscriber} from './test-utils.ts';
 
 const opts: TuningOptions = {

--- a/packages/zero-cache/src/services/change-streamer/storer.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.ts
@@ -4,7 +4,6 @@ import {resolver, type Resolver} from '@rocicorp/resolver';
 import {type PendingQuery, type Row} from 'postgres';
 import {AbortError} from '../../../../shared/src/abort-error.ts';
 import {assert} from '../../../../shared/src/asserts.ts';
-import {BigIntJSON} from '../../../../shared/src/bigint-json.ts';
 import {Queue} from '../../../../shared/src/queue.ts';
 import {promiseVoid} from '../../../../shared/src/resolved-promises.ts';
 import * as v from '../../../../shared/src/valita.ts';
@@ -35,7 +34,12 @@ import type {
 } from '../change-source/protocol/current/status.ts';
 import type {ReplicatorMode} from '../replicator/replicator.ts';
 import type {Service} from '../service.ts';
-import type {ChangeTag, WatermarkedChange} from './change-streamer-service.ts';
+import {
+  extractChangeSubstring,
+  reconstructWatermarkedChange,
+  serializeChangeStreamData,
+  type ChangeLogEntry,
+} from './change-log-codec.ts';
 import * as ErrorType from './error-type-enum.ts';
 import {
   AutoResetSignal,
@@ -313,7 +317,7 @@ export class Storer implements Service {
     // Eagerly stringify the JSON payload to:
     // - avoid redundant stringification when fanning out to subscribers
     // - efficiently estimate the amount of memory the payload consumes
-    const json = BigIntJSON.stringify(data);
+    const json = serializeChangeStreamData(data);
     this.#approximateQueuedBytes += json.length;
 
     const change = data[1];
@@ -714,7 +718,9 @@ export class Storer implements Service {
               // Catchup starts from *after* the watermark.
               watermarkFound = true;
             } else if (watermarkFound) {
-              lastBatchConsumed = sub.catchup(toDownstream(entry));
+              lastBatchConsumed = sub.catchup(
+                reconstructWatermarkedChange(entry),
+              );
               count++;
             } else if (mode === 'backup') {
               throw new AutoResetSignal(
@@ -926,65 +932,6 @@ export class Storer implements Service {
       this.#queue.enqueue('stop');
     }
     return this.#stopped;
-  }
-}
-
-/**
- * Extracts the stringified change message from the stringified
- * stream message (e.g. the second tuple element). This optimization
- * facilitates stringifying (and sharing the result of) the stream
- * message exactly once, but storing only the change message substring
- * in the changeLog for backwards compatibility.
- */
-export function extractChangeSubstring(
-  streamMessageJSON: string,
-  tag: Change['tag'] | undefined,
-) {
-  switch (tag) {
-    case 'begin':
-    case 'commit':
-      // e.g.
-      // ["begin",<message-json>,{"commitWatermark":"92fj2d0s"}]
-      // ["commit",<message-json>,{"watermark":"92fj2d0s"}]
-      return streamMessageJSON.substring(
-        streamMessageJSON.indexOf(',') + 1,
-        streamMessageJSON.lastIndexOf(','),
-      );
-    default:
-      // ["data",<message-json>]
-      return streamMessageJSON.substring(
-        streamMessageJSON.indexOf(',') + 1,
-        streamMessageJSON.lastIndexOf(']'),
-      );
-  }
-}
-
-type ChangeLogEntry = {
-  watermark: string;
-  tag: string;
-  change: string;
-};
-
-function toDownstream(entry: ChangeLogEntry): WatermarkedChange {
-  const {watermark, change} = entry;
-  const tag = entry.tag as ChangeTag;
-  switch (tag) {
-    case 'begin':
-      return [
-        watermark,
-        tag,
-        `["begin",${change},{"commitWatermark":"${watermark}"}]`,
-      ];
-    case 'commit':
-      return [
-        watermark,
-        tag,
-        `["commit",${change},{"watermark":"${watermark}"}]`,
-      ];
-    case 'rollback':
-      return [watermark, tag, `["rollback",${change}]`];
-    default:
-      return [watermark, tag, `["data",${change}]`];
   }
 }
 

--- a/packages/zero-cache/src/services/change-streamer/subscriber.ts
+++ b/packages/zero-cache/src/services/change-streamer/subscriber.ts
@@ -7,8 +7,12 @@ import {promiseVoid} from '../../../../shared/src/resolved-promises.ts';
 import {RingBuffer} from '../../../../shared/src/ring-buffer.ts';
 import {max} from '../../types/lexi-version.ts';
 import type {Subscription} from '../../types/subscription.ts';
-import type {ChangeTag, WatermarkedChange} from './change-streamer-service.ts';
-import {type Downstream, type Status} from './change-streamer.ts';
+import type {
+  ChangeTag,
+  Downstream,
+  Status,
+  WatermarkedChange,
+} from './change-streamer.ts';
 import * as ErrorType from './error-type-enum.ts';
 
 type ErrorType = Enum<typeof ErrorType>;


### PR DESCRIPTION
Factor out the change streamer codec for us in RMv2 and legacy change log