### PR TITLE
chore(rmv2): add SQLite change log schema [2/n]

### DIFF
--- a/packages/zero-cache/src/services/change-source/common/replica-schema.test.ts
+++ b/packages/zero-cache/src/services/change-source/common/replica-schema.test.ts
@@ -6,6 +6,7 @@ import {
   expectMatchingObjectsInTables,
   initDB as initLiteDB,
 } from '../../../test/lite.ts';
+import {CREATE_CHANGE_LOG_STREAM_SCHEMA} from '../../replicator/schema/change-log-stream.ts';
 import {initReplicationState} from '../../replicator/schema/replication-state.ts';
 import {CREATE_TABLE_METADATA_TABLE} from '../../replicator/schema/table-metadata.ts';
 import {
@@ -448,6 +449,76 @@ describe('replica-schema-migrations', () => {
             lock: 1,
           },
         ],
+        ['_zero.changeLogStream']: [
+          {
+            watermark: '123',
+            pos: 0,
+            change: '{"tag":"begin"}',
+            precommit: null,
+            writeTimeMs: null,
+          },
+          {
+            watermark: '123',
+            pos: 1,
+            change: '{"tag":"commit"}',
+            precommit: '123',
+            writeTimeMs: 12345,
+          },
+        ],
+      },
+    },
+    {
+      fromSchemaVersion: 14,
+      fromDataVersion: 13,
+      desc: 'does not duplicate the seed after rollback and rollforward',
+      replicaSetup:
+        /*sql*/ `CREATE TABLE "_zero.replicationState" (
+          stateVersion TEXT NOT NULL,
+          writeTimeMs INTEGER,
+          lock INTEGER PRIMARY KEY DEFAULT 1 CHECK (lock=1)
+        );` + CREATE_CHANGE_LOG_STREAM_SCHEMA,
+      replicaPreState: {
+        ['_zero.replicationState']: [
+          {
+            stateVersion: '123',
+            writeTimeMs: 12345,
+            lock: 1,
+          },
+        ],
+        ['_zero.changeLogStream']: [
+          {
+            watermark: '123',
+            pos: 0,
+            change: '{"tag":"begin"}',
+            precommit: null,
+            writeTimeMs: null,
+          },
+          {
+            watermark: '123',
+            pos: 1,
+            change: '{"tag":"commit"}',
+            precommit: '123',
+            writeTimeMs: 12345,
+          },
+        ],
+      },
+      replicaPostState: {
+        ['_zero.changeLogStream']: [
+          {
+            watermark: '123',
+            pos: 0,
+            change: '{"tag":"begin"}',
+            precommit: null,
+            writeTimeMs: null,
+          },
+          {
+            watermark: '123',
+            pos: 1,
+            change: '{"tag":"commit"}',
+            precommit: '123',
+            writeTimeMs: 12345,
+          },
+        ],
       },
     },
   ];
@@ -472,6 +543,16 @@ describe('replica-schema-migrations', () => {
             minSafeVersion: 1,
           },
         ],
+        ...(c.fromSchemaVersion === 0 ||
+        c.replicaPreState?.['_zero.replicationState']
+          ? {}
+          : {
+              ['_zero.replicationState']: [
+                {
+                  stateVersion: '123',
+                },
+              ],
+            }),
         ...c.replicaPreState,
       });
 

--- a/packages/zero-cache/src/services/change-source/common/replica-schema.ts
+++ b/packages/zero-cache/src/services/change-source/common/replica-schema.ts
@@ -11,6 +11,10 @@ import {
   logSQLiteCorruptionDiagnostics,
 } from '../../../db/sqlite-corruption.ts';
 import {AutoResetSignal} from '../../change-streamer/schema/tables.ts';
+import {
+  CREATE_CHANGE_LOG_STREAM_SCHEMA,
+  seedChangeLogStream,
+} from '../../replicator/schema/change-log-stream.ts';
 import {populateFromExistingTables} from '../../replicator/schema/column-metadata.ts';
 import {
   CREATE_RUNTIME_EVENTS_TABLE,
@@ -240,6 +244,16 @@ export const schemaVersionMigrationMap: IncrementalMigrationMap = {
       db.exec(/*sql*/ `
         UPDATE "_zero.replicationState" 
           SET writeTimeMs = COALESCE(writeTimeMs, unixepoch('subsec') * 1000)`);
+    },
+  },
+
+  14: {
+    migrateSchema: (_, db) => {
+      db.exec(CREATE_CHANGE_LOG_STREAM_SCHEMA);
+    },
+
+    migrateData: (_, db) => {
+      seedChangeLogStream(db);
     },
   },
 };

--- a/packages/zero-cache/src/services/replicator/incremental-sync.test.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.test.ts
@@ -310,7 +310,7 @@ describe('replicator/incremental-sync', () => {
                 "unique": true,
               },
             ],
-            "replicaSize": 57344,
+            "replicaSize": 69632,
             "tables": [
               {
                 "columns": [
@@ -453,7 +453,7 @@ describe('replicator/incremental-sync', () => {
                 "unique": true,
               },
             ],
-            "replicaSize": 57344,
+            "replicaSize": 69632,
             "tables": [
               {
                 "columns": [
@@ -507,7 +507,7 @@ describe('replicator/incremental-sync', () => {
                 "unique": true,
               },
             ],
-            "replicaSize": 65536,
+            "replicaSize": 77824,
             "tables": [
               {
                 "columns": [

--- a/packages/zero-cache/src/services/replicator/schema/change-log-stream.test.ts
+++ b/packages/zero-cache/src/services/replicator/schema/change-log-stream.test.ts
@@ -1,0 +1,139 @@
+import {describe, expect, test} from 'vitest';
+import {createSilentLogContext} from '../../../../../shared/src/logging-test-utils.ts';
+import {Database} from '../../../../../zqlite/src/db.ts';
+import {expectTableExact} from '../../../test/lite.ts';
+import {
+  CHANGE_LOG_STREAM_TABLE,
+  CHANGE_LOG_STREAM_WRITE_TIME_INDEX,
+  CREATE_CHANGE_LOG_STREAM_SCHEMA,
+  seedChangeLogStream,
+} from './change-log-stream.ts';
+
+function createTestDB(): Database {
+  const db = new Database(createSilentLogContext(), ':memory:');
+  db.exec(/*sql*/ `
+    CREATE TABLE "_zero.replicationState" (
+      "stateVersion" TEXT NOT NULL,
+      "writeTimeMs" INTEGER,
+      "lock" INTEGER PRIMARY KEY DEFAULT 1 CHECK ("lock" = 1)
+    );
+    ${CREATE_CHANGE_LOG_STREAM_SCHEMA}
+  `);
+  return db;
+}
+
+describe('replicator/schema/change-log-stream', () => {
+  test('creates the stream table and partial retention index', () => {
+    using db = createTestDB();
+
+    expect(
+      db.prepare(`PRAGMA table_info("${CHANGE_LOG_STREAM_TABLE}")`).all(),
+    ).toEqual([
+      {
+        cid: 0,
+        name: 'watermark',
+        type: 'TEXT',
+        notnull: 1,
+        dflt_value: null,
+        pk: 1,
+      },
+      {
+        cid: 1,
+        name: 'pos',
+        type: 'INTEGER',
+        notnull: 1,
+        dflt_value: null,
+        pk: 2,
+      },
+      {
+        cid: 2,
+        name: 'change',
+        type: 'TEXT',
+        notnull: 1,
+        dflt_value: null,
+        pk: 0,
+      },
+      {
+        cid: 3,
+        name: 'precommit',
+        type: 'TEXT',
+        notnull: 0,
+        dflt_value: null,
+        pk: 0,
+      },
+      {
+        cid: 4,
+        name: 'writeTimeMs',
+        type: 'INTEGER',
+        notnull: 0,
+        dflt_value: null,
+        pk: 0,
+      },
+    ]);
+
+    expect(
+      db.prepare(`PRAGMA index_list("${CHANGE_LOG_STREAM_TABLE}")`).all(),
+    ).toEqual(
+      expect.arrayContaining([
+        {
+          seq: expect.any(Number),
+          name: CHANGE_LOG_STREAM_WRITE_TIME_INDEX,
+          unique: 0,
+          origin: 'c',
+          partial: 1,
+        },
+      ]),
+    );
+    expect(
+      db
+        .prepare(`PRAGMA index_info("${CHANGE_LOG_STREAM_WRITE_TIME_INDEX}")`)
+        .all(),
+    ).toEqual([
+      {seqno: 0, cid: 4, name: 'writeTimeMs'},
+      {seqno: 1, cid: 0, name: 'watermark'},
+    ]);
+  });
+
+  test('seeds one complete transaction idempotently', () => {
+    using db = createTestDB();
+    db.prepare(/*sql*/ `
+      INSERT INTO "_zero.replicationState" ("stateVersion", "writeTimeMs")
+      VALUES ('01', 12345)
+    `).run();
+
+    seedChangeLogStream(db);
+    seedChangeLogStream(db);
+
+    expectTableExact(
+      db,
+      CHANGE_LOG_STREAM_TABLE,
+      [
+        {
+          watermark: '01',
+          pos: 0,
+          change: '{"tag":"begin"}',
+          precommit: null,
+          writeTimeMs: null,
+        },
+        {
+          watermark: '01',
+          pos: 1,
+          change: '{"tag":"commit"}',
+          precommit: '01',
+          writeTimeMs: 12345,
+        },
+      ],
+      'number',
+      'watermark',
+      'pos',
+    );
+
+    expect(
+      db
+        .prepare(
+          `SELECT * FROM "${CHANGE_LOG_STREAM_TABLE}" WHERE "watermark" > ?`,
+        )
+        .all('01'),
+    ).toEqual([]);
+  });
+});

--- a/packages/zero-cache/src/services/replicator/schema/change-log-stream.ts
+++ b/packages/zero-cache/src/services/replicator/schema/change-log-stream.ts
@@ -1,0 +1,61 @@
+import {assert} from '../../../../../shared/src/asserts.ts';
+import type {Database} from '../../../../../zqlite/src/db.ts';
+
+export const CHANGE_LOG_STREAM_TABLE = '_zero.changeLogStream';
+export const CHANGE_LOG_STREAM_WRITE_TIME_INDEX =
+  '_zero.changeLogStream_writeTimeMs';
+
+export const CREATE_CHANGE_LOG_STREAM_TABLE = /*sql*/ `
+  CREATE TABLE "${CHANGE_LOG_STREAM_TABLE}" (
+    "watermark"   TEXT NOT NULL,
+    "pos"         INTEGER NOT NULL,
+    "change"      TEXT NOT NULL,
+    "precommit"   TEXT,
+    "writeTimeMs" INTEGER,
+    PRIMARY KEY ("watermark", "pos")
+  );
+`;
+
+export const CREATE_CHANGE_LOG_STREAM_INDEX = /*sql*/ `
+  CREATE INDEX "${CHANGE_LOG_STREAM_WRITE_TIME_INDEX}"
+    ON "${CHANGE_LOG_STREAM_TABLE}" ("writeTimeMs", "watermark")
+    WHERE "writeTimeMs" IS NOT NULL;
+`;
+
+export const CREATE_CHANGE_LOG_STREAM_SCHEMA =
+  CREATE_CHANGE_LOG_STREAM_TABLE + CREATE_CHANGE_LOG_STREAM_INDEX;
+
+type ReplicationState = {
+  stateVersion: string;
+  writeTimeMs: number | null;
+};
+
+/**
+ * Seeds a valid synthetic transaction at the replica's current watermark.
+ *
+ * The insert is idempotent because migrateData can run again after a rollback
+ * followed by a roll-forward. Both rows are inserted by one statement so a
+ * caller outside a larger transaction cannot leave a partial seed.
+ */
+export function seedChangeLogStream(db: Database): void {
+  const state = db
+    .prepare(/*sql*/ `
+      SELECT "stateVersion", "writeTimeMs"
+        FROM "_zero.replicationState"
+    `)
+    .get<ReplicationState | undefined>();
+  assert(state !== undefined, 'replication state must be initialized');
+  assert(
+    state.writeTimeMs !== null,
+    'replication state writeTimeMs must be initialized',
+  );
+
+  db.prepare(/*sql*/ `
+    INSERT INTO "${CHANGE_LOG_STREAM_TABLE}"
+      ("watermark", "pos", "change", "precommit", "writeTimeMs")
+    VALUES
+      (@stateVersion, 0, '{"tag":"begin"}', NULL, NULL),
+      (@stateVersion, 1, '{"tag":"commit"}', @stateVersion, @writeTimeMs)
+    ON CONFLICT ("watermark", "pos") DO NOTHING
+  `).run(state);
+}

--- a/packages/zero-cache/src/services/replicator/schema/replication-state.test.ts
+++ b/packages/zero-cache/src/services/replicator/schema/replication-state.test.ts
@@ -25,6 +25,10 @@ describe('replicator/schema/replication-state', () => {
   });
 
   test('initial replication state', () => {
+    const {writeTimeMs} = db.db
+      .prepare(`SELECT writeTimeMs FROM "_zero.replicationState"`)
+      .get<{writeTimeMs: number}>();
+
     expectMatchingObjectsInTables(db.db, {
       ['_zero.replicationConfig']: [
         {
@@ -45,6 +49,22 @@ describe('replicator/schema/replication-state', () => {
         {
           event: 'sync',
           timestamp: expect.any(String),
+        },
+      ],
+      ['_zero.changeLogStream']: [
+        {
+          watermark: '0a',
+          pos: 0,
+          change: '{"tag":"begin"}',
+          precommit: null,
+          writeTimeMs: null,
+        },
+        {
+          watermark: '0a',
+          pos: 1,
+          change: '{"tag":"commit"}',
+          precommit: '0a',
+          writeTimeMs,
         },
       ],
     });

--- a/packages/zero-cache/src/services/replicator/schema/replication-state.ts
+++ b/packages/zero-cache/src/services/replicator/schema/replication-state.ts
@@ -13,6 +13,10 @@ import {
 import * as v from '../../../../../shared/src/valita.ts';
 import type {Database} from '../../../../../zqlite/src/db.ts';
 import type {StatementRunner} from '../../../db/statements.ts';
+import {
+  CREATE_CHANGE_LOG_STREAM_SCHEMA,
+  seedChangeLogStream,
+} from './change-log-stream.ts';
 import {CREATE_CHANGELOG_SCHEMA} from './change-log.ts';
 import {CREATE_COLUMN_METADATA_TABLE} from './column-metadata.ts';
 import {ZERO_VERSION_COLUMN_NAME} from './constants.ts';
@@ -67,6 +71,7 @@ const CREATE_REPLICATION_STATE_SCHEMA =
   );
   ` +
   CREATE_CHANGELOG_SCHEMA +
+  CREATE_CHANGE_LOG_STREAM_SCHEMA +
   CREATE_RUNTIME_EVENTS_TABLE +
   CREATE_COLUMN_METADATA_TABLE +
   CREATE_TABLE_METADATA_TABLE;
@@ -136,6 +141,7 @@ export function initReplicationState(
     INSERT INTO "_zero.replicationState" (stateVersion, writeTimeMs) 
       VALUES (?, unixepoch('subsec') * 1000)
     `).run(watermark);
+  seedChangeLogStream(db);
   recordEvent(db, 'sync');
 }
 


### PR DESCRIPTION
Add the _zero.changeLogStream table and partial retention index to fresh replicas and the additive v14 migration. Seed an idempotent synthetic begin/commit transaction at the replica's current stateVersion and reuse its writeTimeMs as the initial retained boundary.

Production state after deployment:

- Fresh, restored, and upgraded replicas contain the new table, index, and exactly one synthetic two-row transaction at their migration watermark.
- Existing stream history is not backfilled. A future SQLite reader could only serve requests at or after the synthetic seed boundary.
- This slice does not append ongoing changes, read from the table, or purge it. After seeding, the table remains inert and has negligible disk cost.
- PostgreSQL remains the authoritative change log for catchup, purge, subscriber delivery, and replication-slot ACK durability.
- _zero.changeLog2 and replica data semantics are unchanged. The migration is additive, does not raise the minimum safe version or trigger an auto-reset, and older builds safely ignore the table.
- Rollback followed by roll-forward is safe because seeding is idempotent and cannot duplicate the synthetic rows.

```
 Column         Purpose
━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 watermark      The lexicographically sortable version identifying the transaction. Every
                row belonging to a transaction gets the same watermark. For the latest
                transaction, it matches _zero.replicationState.stateVersion. Catchup and
                purge compare watermarks to select whole transactions. It is TEXT because
                Zero versions are encoded strings and may have forms such as 123.01, rather
                than being plain integers.
─────────────  ─────────────────────────────────────────────────────────────────────────────
 pos            The message’s zero-based position inside the transaction. 0 is begin,
                intermediate positions are data/schema/truncate/backfill messages, and the
                final position is commit. It is a dedicated stream counter, separate from
                _zero.changeLog2’s row-operation counter.
─────────────  ─────────────────────────────────────────────────────────────────────────────
 change         The canonical JSON text for the inner change object, such as
                {"tag":"begin"} or {"tag":"insert", ...}. It does not store the outer
                ["begin", ...], ["data", ...], or ["commit", ...] envelope, nor duplicate
                the watermark metadata. The reader reconstructs those around the stored
                text.
─────────────  ─────────────────────────────────────────────────────────────────────────────
 precommit      Populated only on the commit row. It contains the transaction watermark
                remembered from the corresponding begin. The writer verifies that it equals
                the final commit watermark. In well-formed SQLite rows it is therefore
                normally identical to watermark. It preserves the old PG concept, provides
                integrity/debugging information, and acts as an explicit marker that a
                watermark is a complete catchup boundary. It does not mean “the previous
                committed transaction.”
─────────────  ─────────────────────────────────────────────────────────────────────────────
 writeTimeMs    Populated only on the commit row. It is the local Unix epoch time in
                milliseconds captured while committing the transaction—not the original
                PostgreSQL commit timestamp. The exact same value is written to
                _zero.replicationState.writeTimeMs. It supports time-based retention and
                backup/replication lag accounting.
```