### PR TITLE
chore(rmv2): pass serialized changes to write worker [3/n]

### DIFF
--- a/packages/zero-cache/src/services/change-source/protocol/current/downstream.ts
+++ b/packages/zero-cache/src/services/change-source/protocol/current/downstream.ts
@@ -33,6 +33,11 @@ export type Rollback = v.Infer<typeof rollback>;
 export const changeStreamDataSchema = v.union(begin, data, commit, rollback);
 export type ChangeStreamData = v.Infer<typeof changeStreamDataSchema>;
 
+export type SerializedChangeStreamData = {
+  data: ChangeStreamData;
+  json: string;
+};
+
 export const changeStreamControlSchema = v.tuple([
   v.literal('control'),
   resetRequiredSchema, // TODO: Add statusRequestedSchema

--- a/packages/zero-cache/src/services/change-source/protocol/current/downstream.ts
+++ b/packages/zero-cache/src/services/change-source/protocol/current/downstream.ts
@@ -33,11 +33,6 @@ export type Rollback = v.Infer<typeof rollback>;
 export const changeStreamDataSchema = v.union(begin, data, commit, rollback);
 export type ChangeStreamData = v.Infer<typeof changeStreamDataSchema>;
 
-export type SerializedChangeStreamData = {
-  data: ChangeStreamData;
-  json: string;
-};
-
 export const changeStreamControlSchema = v.tuple([
   v.literal('control'),
   resetRequiredSchema, // TODO: Add statusRequestedSchema

--- a/packages/zero-cache/src/services/replicator/incremental-sync.test.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.test.ts
@@ -18,6 +18,7 @@ import {initEventSinkForTesting} from '../../observability/events.ts';
 import {DbFile, expectTables, initDB} from '../../test/lite.ts';
 import {Subscription} from '../../types/subscription.ts';
 import {orTimeoutWith} from '../../types/timeout.ts';
+import * as changeLogCodec from '../change-streamer/change-log-codec.ts';
 import {
   PROTOCOL_VERSION,
   type Downstream,
@@ -32,6 +33,14 @@ import {
 } from './schema/replication-state.ts';
 import {ReplicationMessages} from './test-utils.ts';
 import {ThreadWriteWorkerClient} from './write-worker-client.ts';
+
+vi.mock('../change-streamer/change-log-codec.ts', async importOriginal => {
+  const actual = await importOriginal<typeof changeLogCodec>();
+  return {
+    ...actual,
+    serializeChangeStreamData: vi.fn(actual.serializeChangeStreamData),
+  };
+});
 
 type ErrorType = Enum<typeof ErrorType>;
 
@@ -52,6 +61,7 @@ describe('replicator/incremental-sync', () => {
   >;
 
   beforeEach(async () => {
+    vi.mocked(changeLogCodec.serializeChangeStreamData).mockClear();
     lc = createSilentLogContext();
     dbFile = new DbFile('incremental-sync-test');
     mainDb = dbFile.connect(lc);
@@ -143,6 +153,9 @@ describe('replicator/incremental-sync', () => {
       ['data', issues.insert('issues', {issueID: 123, bool: true})],
       ['data', issues.insert('issues', {issueID: 456, bool: false})],
       ['commit', issues.commit(), {watermark: '06'}],
+
+      ['begin', issues.begin(), {commitWatermark: '08'}],
+      ['rollback', issues.rollback()],
 
       ['begin', issues.begin(), {commitWatermark: '0b'}],
       [
@@ -380,6 +393,7 @@ describe('replicator/incremental-sync', () => {
         },
       ]
     `);
+    expect(changeLogCodec.serializeChangeStreamData).toHaveBeenCalledTimes(11);
   });
 
   test('replicates schema changes', async () => {
@@ -786,5 +800,6 @@ describe('replicator/incremental-sync', () => {
 
     // Should stop / resolve
     await syncing;
+    expect(changeLogCodec.serializeChangeStreamData).not.toHaveBeenCalled();
   });
 });

--- a/packages/zero-cache/src/services/replicator/incremental-sync.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.ts
@@ -5,6 +5,7 @@ import {getOrCreateCounter} from '../../observability/metrics.ts';
 import type {Source} from '../../types/streams.ts';
 import type {DownloadStatus} from '../change-source/protocol/current.ts';
 import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
+import {serializeChangeStreamData} from '../change-streamer/change-log-codec.ts';
 import {
   errorTypeToReadableName,
   PROTOCOL_VERSION,
@@ -176,9 +177,11 @@ export class IncrementalSyncer {
                 backfillStatus = status; // Update the current status
               }
 
-              const result = await this.#worker.processMessage(
-                message as ChangeStreamData,
-              );
+              const data = message as ChangeStreamData;
+              const result = await this.#worker.processMessage({
+                data,
+                json: serializeChangeStreamData(data),
+              });
 
               this.#handleResult(lc, result);
               if (result?.completedBackfill) {

--- a/packages/zero-cache/src/services/replicator/replication-resumption-child.ts
+++ b/packages/zero-cache/src/services/replicator/replication-resumption-child.ts
@@ -6,7 +6,7 @@ import {Queue} from '../../../../shared/src/queue.ts';
 import {parentWorker, type Worker} from '../../types/processes.ts';
 import type {Source} from '../../types/streams.ts';
 import {getPragmaConfig, setupReplica} from '../../workers/replicator.ts';
-import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
+import type {SerializedChangeStreamData} from '../change-source/protocol/current/downstream.ts';
 import type {
   ChangeStreamer,
   SubscriberContext,
@@ -176,7 +176,7 @@ class FailpointWriteWorkerClient implements WriteWorkerClient {
   }
 
   async processMessage(
-    downstream: ChangeStreamData,
+    downstream: SerializedChangeStreamData,
   ): Promise<CommitResult | null> {
     const result = await this.#inner.processMessage(downstream);
     if (

--- a/packages/zero-cache/src/services/replicator/replication-resumption-child.ts
+++ b/packages/zero-cache/src/services/replicator/replication-resumption-child.ts
@@ -6,7 +6,6 @@ import {Queue} from '../../../../shared/src/queue.ts';
 import {parentWorker, type Worker} from '../../types/processes.ts';
 import type {Source} from '../../types/streams.ts';
 import {getPragmaConfig, setupReplica} from '../../workers/replicator.ts';
-import type {SerializedChangeStreamData} from '../change-source/protocol/current/downstream.ts';
 import type {
   ChangeStreamer,
   SubscriberContext,
@@ -18,6 +17,7 @@ import {ReplicatorService} from './replicator.ts';
 import {
   ThreadWriteWorkerClient,
   type PragmaConfig,
+  type SerializedChangeStreamData,
   type WriteWorkerClient,
 } from './write-worker-client.ts';
 

--- a/packages/zero-cache/src/services/replicator/write-worker-client.ts
+++ b/packages/zero-cache/src/services/replicator/write-worker-client.ts
@@ -4,7 +4,7 @@ import {assert} from '../../../../shared/src/asserts.ts';
 import type {LogConfig} from '../../../../shared/src/logging.ts';
 import type {Database} from '../../../../zqlite/src/db.ts';
 import {WRITE_WORKER_URL} from '../../server/worker-urls.ts';
-import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
+import type {SerializedChangeStreamData} from '../change-source/protocol/current/downstream.ts';
 import type {ChangeProcessorMode, CommitResult} from './change-processor.ts';
 import type {SubscriptionState} from './schema/replication-state.ts';
 
@@ -21,7 +21,9 @@ type ErrorHandler = (err: Error) => void;
  */
 export interface WriteWorkerClient {
   getSubscriptionState(): Promise<SubscriptionState>;
-  processMessage(downstream: ChangeStreamData): Promise<CommitResult | null>;
+  processMessage(
+    downstream: SerializedChangeStreamData,
+  ): Promise<CommitResult | null>;
   abort(): void;
   stop(): Promise<void>;
   onError(handler: ErrorHandler): void;
@@ -89,7 +91,7 @@ export function deserializeError(serialized: SerializedError): Error {
 export type ArgsMap = {
   init: [string, ChangeProcessorMode, PragmaConfig, LogConfig];
   getSubscriptionState: [];
-  processMessage: [ChangeStreamData];
+  processMessage: [SerializedChangeStreamData];
   abort: [];
   stop: [];
 };
@@ -194,7 +196,9 @@ export class ThreadWriteWorkerClient implements WriteWorkerClient {
     return this.#call('getSubscriptionState', []);
   }
 
-  processMessage(downstream: ChangeStreamData): Promise<CommitResult | null> {
+  processMessage(
+    downstream: SerializedChangeStreamData,
+  ): Promise<CommitResult | null> {
     return this.#call('processMessage', [downstream]);
   }
 

--- a/packages/zero-cache/src/services/replicator/write-worker-client.ts
+++ b/packages/zero-cache/src/services/replicator/write-worker-client.ts
@@ -4,9 +4,14 @@ import {assert} from '../../../../shared/src/asserts.ts';
 import type {LogConfig} from '../../../../shared/src/logging.ts';
 import type {Database} from '../../../../zqlite/src/db.ts';
 import {WRITE_WORKER_URL} from '../../server/worker-urls.ts';
-import type {SerializedChangeStreamData} from '../change-source/protocol/current/downstream.ts';
+import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
 import type {ChangeProcessorMode, CommitResult} from './change-processor.ts';
 import type {SubscriptionState} from './schema/replication-state.ts';
+
+export type SerializedChangeStreamData = {
+  data: ChangeStreamData;
+  json: string;
+};
 
 export type PragmaConfig = {
   busyTimeout: number;

--- a/packages/zero-cache/src/services/replicator/write-worker.test.ts
+++ b/packages/zero-cache/src/services/replicator/write-worker.test.ts
@@ -4,10 +4,7 @@ import {afterEach, beforeEach, describe, expect, test} from 'vitest';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
 import type {Database} from '../../../../zqlite/src/db.ts';
 import {DbFile, initDB} from '../../test/lite.ts';
-import type {
-  ChangeStreamData,
-  SerializedChangeStreamData,
-} from '../change-source/protocol/current/downstream.ts';
+import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
 import {serializeChangeStreamData} from '../change-streamer/change-log-codec.ts';
 import {initReplicationState} from './schema/replication-state.ts';
 import {ReplicationMessages} from './test-utils.ts';
@@ -16,6 +13,7 @@ import {
   serializeError,
   ThreadWriteWorkerClient,
   type Request,
+  type SerializedChangeStreamData,
 } from './write-worker-client.ts';
 
 function serialized(data: ChangeStreamData): SerializedChangeStreamData {

--- a/packages/zero-cache/src/services/replicator/write-worker.test.ts
+++ b/packages/zero-cache/src/services/replicator/write-worker.test.ts
@@ -1,15 +1,26 @@
+import {once} from 'node:events';
+import {Worker} from 'node:worker_threads';
 import {afterEach, beforeEach, describe, expect, test} from 'vitest';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
 import type {Database} from '../../../../zqlite/src/db.ts';
 import {DbFile, initDB} from '../../test/lite.ts';
-import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
+import type {
+  ChangeStreamData,
+  SerializedChangeStreamData,
+} from '../change-source/protocol/current/downstream.ts';
+import {serializeChangeStreamData} from '../change-streamer/change-log-codec.ts';
 import {initReplicationState} from './schema/replication-state.ts';
 import {ReplicationMessages} from './test-utils.ts';
 import {
   deserializeError,
   serializeError,
   ThreadWriteWorkerClient,
+  type Request,
 } from './write-worker-client.ts';
+
+function serialized(data: ChangeStreamData): SerializedChangeStreamData {
+  return {data, json: serializeChangeStreamData(data)};
+}
 
 describe('write-worker', () => {
   let dbFile: DbFile;
@@ -74,7 +85,7 @@ describe('write-worker', () => {
 
     let commitResult = null;
     for (let i = 0; i < messages.length; i++) {
-      const result = await worker.processMessage(messages[i]);
+      const result = await worker.processMessage(serialized(messages[i]));
       if (result) {
         commitResult = result;
       }
@@ -105,15 +116,12 @@ describe('write-worker', () => {
     const issues = new ReplicationMessages({issues: ['issueID', 'bool']});
 
     // Start a transaction but don't commit
-    await worker.processMessage([
-      'begin',
-      issues.begin(),
-      {commitWatermark: '06'},
-    ]);
-    await worker.processMessage([
-      'data',
-      issues.insert('issues', {issueID: 123, bool: true}),
-    ]);
+    await worker.processMessage(
+      serialized(['begin', issues.begin(), {commitWatermark: '06'}]),
+    );
+    await worker.processMessage(
+      serialized(['data', issues.insert('issues', {issueID: 123, bool: true})]),
+    );
 
     // Abort should roll back
     worker.abort();
@@ -130,7 +138,7 @@ describe('write-worker', () => {
     ];
 
     for (let i = 0; i < messages.length; i++) {
-      await worker.processMessage(messages[i]);
+      await worker.processMessage(serialized(messages[i]));
     }
 
     const rowsAfter = mainDb.prepare('SELECT issueID FROM issues').all();
@@ -164,21 +172,68 @@ describe('write-worker', () => {
 
     // Send a processMessage without a begin - should cause a failure
     await expect(
-      worker.processMessage([
-        'data',
-        {
-          tag: 'insert',
-          relation: {
-            schema: 'public',
-            name: 'nonexistent',
-            rowKey: {columns: ['id'], type: 'default'},
+      worker.processMessage(
+        serialized([
+          'data',
+          {
+            tag: 'insert',
+            relation: {
+              schema: 'public',
+              name: 'nonexistent',
+              rowKey: {columns: ['id'], type: 'default'},
+            },
+            new: {id: [1, 'int4']},
           },
-          new: {id: [1, 'int4']},
-        },
-      ]),
+        ]),
+      ),
     ).rejects.toThrow();
 
     expect(errorReceived).toBeDefined();
+  });
+
+  test('worker structured clone preserves the serialized envelope', async () => {
+    const data: ChangeStreamData = [
+      'data',
+      {
+        tag: 'insert',
+        relation: {
+          schema: 'public',
+          name: 'issues',
+          rowKey: {columns: ['issueID'], type: 'default'},
+        },
+        new: {
+          issueID: 9007199254740993n,
+          text: 'before\0after',
+        },
+      },
+    ];
+    const request = {
+      method: 'processMessage',
+      args: [serialized(data)],
+    } satisfies Request<'processMessage'>;
+    const echoWorker = new Worker(
+      /*js*/ `
+        const {parentPort} = require('node:worker_threads');
+        parentPort.once('message', message => parentPort.postMessage(message));
+      `,
+      {eval: true},
+    );
+
+    try {
+      const response = once(echoWorker, 'message');
+      echoWorker.postMessage(request);
+      const [roundTripped] = (await response) as [typeof request];
+
+      expect(roundTripped).toEqual(request);
+      expect(roundTripped.args[0].data[1]).toMatchObject({
+        new: {issueID: 9007199254740993n, text: 'before\0after'},
+      });
+      expect(roundTripped.args[0].json).toContain(
+        '"text":"before\\u0000after"',
+      );
+    } finally {
+      await echoWorker.terminate();
+    }
   });
 
   test('error serialization preserves useful fields', () => {

--- a/packages/zero-cache/src/services/replicator/write-worker.ts
+++ b/packages/zero-cache/src/services/replicator/write-worker.ts
@@ -10,7 +10,6 @@ import {
 } from '../../db/sqlite-corruption.ts';
 import {StatementRunner} from '../../db/statements.ts';
 import {createLogContext} from '../../server/logging.ts';
-import type {SerializedChangeStreamData} from '../change-source/protocol/current/downstream.ts';
 import {ChangeProcessor, type ChangeProcessorMode} from './change-processor.ts';
 import {getSubscriptionState} from './schema/replication-state.ts';
 import {
@@ -22,6 +21,7 @@ import {
   type Request,
   type Response,
   type ResultMap,
+  type SerializedChangeStreamData,
   type WriteError,
 } from './write-worker-client.ts';
 

--- a/packages/zero-cache/src/services/replicator/write-worker.ts
+++ b/packages/zero-cache/src/services/replicator/write-worker.ts
@@ -10,7 +10,7 @@ import {
 } from '../../db/sqlite-corruption.ts';
 import {StatementRunner} from '../../db/statements.ts';
 import {createLogContext} from '../../server/logging.ts';
-import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
+import type {SerializedChangeStreamData} from '../change-source/protocol/current/downstream.ts';
 import {ChangeProcessor, type ChangeProcessorMode} from './change-processor.ts';
 import {getSubscriptionState} from './schema/replication-state.ts';
 import {
@@ -93,9 +93,11 @@ function createAPI(): API {
       }
     },
 
-    processMessage(downstream: ChangeStreamData) {
+    processMessage({data}: SerializedChangeStreamData) {
       try {
-        return must(processor).processMessage(must(lc), downstream);
+        // The canonical JSON is intentionally unused until the SQLite stream
+        // writer is added. ChangeProcessor continues to consume parsed data.
+        return must(processor).processMessage(must(lc), data);
       } catch (e) {
         logCorruptionDiagnostics(e);
         throw e;


### PR DESCRIPTION
Note: https://github.com/rocicorp/mono/pull/6262 removes duplicate JSON encoding so we encode once and pass same payload to PG and SQLite change loggers

The JSON we're passing here is the payload to eventually be written to the SQLite change log. Right now we don't write it, this PR just adds the plumbing to get it there.

---


Carry parsed ChangeStreamData and its canonical BigIntJSON serialization together across the write-worker RPC. Serialize each data-plane message once at IncrementalSyncer ingress and verify that structured clone preserves the canonical JSON, including big integers and escaped NUL characters.

Production state after deployment:

- Every begin, data, commit, and rollback message sent to the SQLite write worker includes both parsed data and its canonical JSON representation.
- The worker continues applying only the parsed data and intentionally ignores the JSON. Replica contents, transaction boundaries, notifications, errors, subscriber delivery, and PostgreSQL ACK behavior remain unchanged.
- Status, error, and control messages stay outside the envelope because they are not part of the persisted data-plane stream.
- This commit does not write or read the SQLite stream log and introduces no persisted-format dependency. PostgreSQL remains the only change-log store.
- The production effect is limited to one canonical serialization per data-plane message and a modest increase in worker IPC payload size.