### PR TITLE
chore(rmv2): add SQLite change log writer [5/n]

### DIFF
--- a/packages/zero-cache/src/config/normalize.test.ts
+++ b/packages/zero-cache/src/config/normalize.test.ts
@@ -7,7 +7,16 @@ function configWith(litestream: Partial<ZeroConfig['litestream']>): ZeroConfig {
     taskID: 'task-id',
     numSyncWorkers: 1,
     adminPassword: 'admin',
-    changeStreamer: {port: 4849, address: 'localhost'},
+    changeStreamer: {
+      port: 4849,
+      address: 'localhost',
+      sqliteChangeLogMode: 'off',
+      sqliteChangeLogReadPercent: 0,
+      sqliteChangeLogRetentionMs: 60_000,
+      sqliteChangeLogReadBatchRows: 1000,
+      sqliteChangeLogPurgeBatchRows: 1000,
+      sqliteChangeLogBarrierTimeoutMs: 30_000,
+    },
     change: {db: 'postgres:///change'},
     cvr: {db: 'postgres:///cvr'},
     litestream: {
@@ -95,5 +104,37 @@ describe('config/normalize litestream v5 gating', () => {
         }),
       ),
     ).not.toThrow();
+  });
+});
+
+describe('config/normalize SQLite change log', () => {
+  test('read percentage is only allowed in serve mode', () => {
+    const config = configWith({});
+    config.changeStreamer.sqliteChangeLogMode = 'compare';
+    config.changeStreamer.sqliteChangeLogReadPercent = 1;
+
+    expect(() => assertNormalized(config)).toThrow(
+      'must be 0 unless --change-streamer-sqlite-change-log-mode=serve',
+    );
+  });
+
+  test('read percentage must be an integer from 0 through 100', () => {
+    for (const percent of [-1, 1.5, 101]) {
+      const config = configWith({});
+      config.changeStreamer.sqliteChangeLogMode = 'serve';
+      config.changeStreamer.sqliteChangeLogReadPercent = percent;
+
+      expect(() => assertNormalized(config)).toThrow(
+        'must be an integer between 0 and 100',
+      );
+    }
+  });
+
+  test('accepts positive integer tuning values', () => {
+    const config = configWith({});
+    config.changeStreamer.sqliteChangeLogMode = 'serve';
+    config.changeStreamer.sqliteChangeLogReadPercent = 100;
+
+    expect(() => assertNormalized(config)).not.toThrow();
   });
 });

--- a/packages/zero-cache/src/config/normalize.ts
+++ b/packages/zero-cache/src/config/normalize.ts
@@ -43,6 +43,35 @@ export function assertNormalized(
   assert(config.taskID, 'missing --task-id');
   assert(config.changeStreamer.port, 'missing --change-streamer-port');
   assert(config.changeStreamer.address, 'missing --change-streamer-address');
+  const {
+    sqliteChangeLogMode,
+    sqliteChangeLogReadPercent,
+    sqliteChangeLogRetentionMs,
+    sqliteChangeLogReadBatchRows,
+    sqliteChangeLogPurgeBatchRows,
+    sqliteChangeLogBarrierTimeoutMs,
+  } = config.changeStreamer;
+  assert(
+    Number.isSafeInteger(sqliteChangeLogReadPercent) &&
+      sqliteChangeLogReadPercent >= 0 &&
+      sqliteChangeLogReadPercent <= 100,
+    '--change-streamer-sqlite-change-log-read-percent must be an integer between 0 and 100',
+  );
+  assert(
+    sqliteChangeLogMode === 'serve' || sqliteChangeLogReadPercent === 0,
+    '--change-streamer-sqlite-change-log-read-percent must be 0 unless --change-streamer-sqlite-change-log-mode=serve',
+  );
+  for (const [flag, value] of [
+    ['retention-ms', sqliteChangeLogRetentionMs],
+    ['read-batch-rows', sqliteChangeLogReadBatchRows],
+    ['purge-batch-rows', sqliteChangeLogPurgeBatchRows],
+    ['barrier-timeout-ms', sqliteChangeLogBarrierTimeoutMs],
+  ] as const) {
+    assert(
+      Number.isSafeInteger(value) && value > 0,
+      `--change-streamer-sqlite-change-log-${flag} must be a positive integer`,
+    );
+  }
   assert(config.litestream.port, 'missing --litestream-port');
   assert(
     !config.litestream.backupUsingV5 || config.litestream.restoreUsingV5,

--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -676,6 +676,47 @@ export const zeroOptions = {
       ],
     },
 
+    sqliteChangeLogMode: {
+      type: v.literalUnion('off', 'write', 'compare', 'serve').default('off'),
+      desc: [
+        `Controls the staged SQLite change-log rollout. Modes are cumulative:`,
+        `{bold off}, {bold write}, {bold compare}, and {bold serve}.`,
+      ],
+      hidden: true,
+    },
+
+    sqliteChangeLogReadPercent: {
+      type: v.number().default(0),
+      desc: [
+        `The stable percentage of eligible catchup subscriptions served from SQLite.`,
+      ],
+      hidden: true,
+    },
+
+    sqliteChangeLogRetentionMs: {
+      type: v.number().default(60_000),
+      desc: [`The minimum time window retained in the SQLite change log.`],
+      hidden: true,
+    },
+
+    sqliteChangeLogReadBatchRows: {
+      type: v.number().default(1000),
+      desc: [`The target number of rows in each SQLite catchup read batch.`],
+      hidden: true,
+    },
+
+    sqliteChangeLogPurgeBatchRows: {
+      type: v.number().default(1000),
+      desc: [`The target number of rows in each SQLite purge batch.`],
+      hidden: true,
+    },
+
+    sqliteChangeLogBarrierTimeoutMs: {
+      type: v.number().default(30_000),
+      desc: [`The maximum wait for the SQLite required-head barrier.`],
+      hidden: true,
+    },
+
     backPressureLimitHeapProportion: {
       type: v.number().default(0.04),
       desc: [

--- a/packages/zero-cache/src/server/main.ts
+++ b/packages/zero-cache/src/server/main.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 import {consoleLogSink, LogContext} from '@rocicorp/logger';
 import {resolver} from '@rocicorp/resolver';
+import {assert} from '../../../shared/src/asserts.ts';
 import {must} from '../../../shared/src/must.ts';
 import {getNormalizedZeroConfig} from '../config/zero-config.ts';
 import {registerSQLiteCorruptionDiagnosticTarget} from '../db/sqlite-corruption.ts';
@@ -21,6 +22,7 @@ import {
 } from '../types/processes.ts';
 import {
   createNotifierFrom,
+  createsCanonicalReplicator,
   handleSubscriptionsFrom,
   type ReplicaFileMode,
   subscribeTo,
@@ -106,6 +108,17 @@ export default async function runWorker(
   } = config;
   const runChangeStreamer =
     changeStreamerMode === 'dedicated' && changeStreamerURI === undefined;
+  const sqliteChangeLogEnabled =
+    config.changeStreamer.sqliteChangeLogMode !== 'off';
+  const hasCanonicalReplicator = createsCanonicalReplicator(
+    runChangeStreamer,
+    litestream.backupURL,
+    numSyncers,
+  );
+  assert(
+    !sqliteChangeLogEnabled || hasCanonicalReplicator,
+    'SQLite change-log writing requires this process tree to create a canonical replicator',
+  );
 
   let changeStreamer: Worker | undefined;
 

--- a/packages/zero-cache/src/server/replicator.ts
+++ b/packages/zero-cache/src/server/replicator.ts
@@ -40,6 +40,7 @@ import {
 import {getShardConfig} from '../types/shards.ts';
 import {
   getPragmaConfig,
+  replicaLogsChangeStream,
   replicaFileModeSchema,
   setUpMessageHandlers,
   setupReplica,
@@ -61,6 +62,18 @@ export default async function runWorker(
 
   const config = getNormalizedZeroConfig({env, argv: args.slice(1)});
   const mode: ReplicatorMode = fileMode === 'backup' ? 'backup' : 'serving';
+  const runningLocalChangeStreamer =
+    config.changeStreamer.mode === 'dedicated' && !config.changeStreamer.uri;
+  const logsChangeStream = replicaLogsChangeStream(
+    fileMode,
+    config.changeStreamer.sqliteChangeLogMode !== 'off',
+    runningLocalChangeStreamer,
+    config.litestream.backupURL,
+  );
+  assert(
+    fileMode !== 'serving-copy' || !logsChangeStream,
+    'serving-copy replicas cannot write the SQLite change log',
+  );
   const workerName = `${mode}-replicator`;
   startOtelAuto(createLogContext(config, workerName, 0, false), workerName, 0);
   lc = createLogContext(config, workerName);
@@ -91,10 +104,8 @@ export default async function runWorker(
   // Create the write worker for async SQLite writes.
   const pragmas = getPragmaConfig(fileMode);
   const workerClient = new ThreadWriteWorkerClient();
-  await workerClient.init(dbPath, mode, pragmas, config.log);
+  await workerClient.init(dbPath, mode, logsChangeStream, pragmas, config.log);
 
-  const runningLocalChangeStreamer =
-    config.changeStreamer.mode === 'dedicated' && !config.changeStreamer.uri;
   const shard = getShardConfig(config);
   const {
     taskID,

--- a/packages/zero-cache/src/services/change-source/custom/change-source.ts
+++ b/packages/zero-cache/src/services/change-source/custom/change-source.ts
@@ -180,6 +180,7 @@ export async function initialSync(
   const processor = new ChangeProcessor(
     new StatementRunner(tx),
     'initial-sync',
+    {logsChangeStream: false},
     (_, err) => {
       throw err;
     },

--- a/packages/zero-cache/src/services/replicator/change-log-stream-writer.test.ts
+++ b/packages/zero-cache/src/services/replicator/change-log-stream-writer.test.ts
@@ -1,0 +1,175 @@
+import {describe, expect, test} from 'vitest';
+import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
+import {Database} from '../../../../zqlite/src/db.ts';
+import {StatementRunner} from '../../db/statements.ts';
+import {expectTableExact} from '../../test/lite.ts';
+import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
+import {serializeChangeStreamData} from '../change-streamer/change-log-codec.ts';
+import {ChangeLogStreamWriter} from './change-log-stream-writer.ts';
+import {CHANGE_LOG_STREAM_TABLE} from './schema/change-log-stream.ts';
+import {
+  initReplicationState,
+  updateReplicationWatermark,
+} from './schema/replication-state.ts';
+
+const lc = createSilentLogContext();
+
+function json(data: ChangeStreamData): string {
+  return serializeChangeStreamData(data);
+}
+
+describe('replicator/change-log-stream-writer', () => {
+  test('writes contiguous positions and commit-only metadata', () => {
+    using db = new Database(lc, ':memory:');
+    initReplicationState(db, ['zero_data'], '02');
+    const runner = new StatementRunner(db);
+    const writer = new ChangeLogStreamWriter(db);
+    const writeTimeMs = 1_234_567;
+
+    runner.beginImmediate();
+    writer.begin(
+      '06',
+      json(['begin', {tag: 'begin'}, {commitWatermark: '06'}]),
+    );
+    writer.append(
+      json([
+        'data',
+        {
+          tag: 'insert',
+          relation: {
+            schema: 'public',
+            name: 'issues',
+            rowKey: {columns: ['id'], type: 'default'},
+          },
+          new: {id: 9007199254740993n, text: 'before\0after'},
+        },
+      ]),
+      'insert',
+    );
+    writer.append(
+      json([
+        'data',
+        {
+          tag: 'rename-table',
+          old: {schema: 'public', name: 'issues'},
+          new: {schema: 'public', name: 'renamed'},
+        },
+      ]),
+      'rename-table',
+    );
+    writer.commit(
+      '06',
+      json(['commit', {tag: 'commit'}, {watermark: '06'}]),
+      writeTimeMs,
+    );
+    updateReplicationWatermark(runner, '06', writeTimeMs);
+    runner.commit();
+
+    expectTableExact(
+      db,
+      CHANGE_LOG_STREAM_TABLE,
+      [
+        {
+          watermark: '02',
+          pos: 0,
+          change: '{"tag":"begin"}',
+          precommit: null,
+          writeTimeMs: null,
+        },
+        {
+          watermark: '02',
+          pos: 1,
+          change: '{"tag":"commit"}',
+          precommit: '02',
+          writeTimeMs: expect.any(Number),
+        },
+        {
+          watermark: '06',
+          pos: 0,
+          change: '{"tag":"begin"}',
+          precommit: null,
+          writeTimeMs: null,
+        },
+        {
+          watermark: '06',
+          pos: 1,
+          change:
+            '{"tag":"insert","relation":{"schema":"public","name":"issues","rowKey":{"columns":["id"],"type":"default"}},"new":{"id":9007199254740993,"text":"before\\u0000after"}}',
+          precommit: null,
+          writeTimeMs: null,
+        },
+        {
+          watermark: '06',
+          pos: 2,
+          change:
+            '{"tag":"rename-table","old":{"schema":"public","name":"issues"},"new":{"schema":"public","name":"renamed"}}',
+          precommit: null,
+          writeTimeMs: null,
+        },
+        {
+          watermark: '06',
+          pos: 3,
+          change: '{"tag":"commit"}',
+          precommit: '06',
+          writeTimeMs,
+        },
+      ],
+      'number',
+      'watermark',
+      'pos',
+    );
+
+    expect(
+      db
+        .prepare(
+          `SELECT "stateVersion", "writeTimeMs" FROM "_zero.replicationState"`,
+        )
+        .get(),
+    ).toEqual({stateVersion: '06', writeTimeMs});
+  });
+
+  test('rollback discards rows and a large transaction is streamed', () => {
+    using db = new Database(lc, ':memory:');
+    initReplicationState(db, ['zero_data'], '02');
+    const runner = new StatementRunner(db);
+    const writer = new ChangeLogStreamWriter(db);
+    const begin = json(['begin', {tag: 'begin'}, {commitWatermark: '06'}]);
+    const truncate = json(['data', {tag: 'truncate', relations: []}]);
+
+    runner.beginImmediate();
+    writer.begin('06', begin);
+    writer.append(truncate, 'truncate');
+    runner.rollback();
+    writer.rollback();
+
+    expect(
+      db
+        .prepare(`SELECT count(*) AS "count" FROM "${CHANGE_LOG_STREAM_TABLE}"`)
+        .get(),
+    ).toEqual({count: 2});
+
+    const rowCount = 2500;
+    runner.beginImmediate();
+    writer.begin('06', begin);
+    for (let i = 0; i < rowCount; i++) {
+      writer.append(truncate, 'truncate');
+    }
+    writer.commit(
+      '06',
+      json(['commit', {tag: 'commit'}, {watermark: '06'}]),
+      789,
+    );
+    updateReplicationWatermark(runner, '06', 789);
+    runner.commit();
+
+    expect(
+      db
+        .prepare(/*sql*/ `
+          SELECT count(*) AS "count", min("pos") AS "minPos", max("pos") AS "maxPos"
+            FROM "${CHANGE_LOG_STREAM_TABLE}"
+            WHERE "watermark" = '06'
+        `)
+        .get(),
+    ).toEqual({count: rowCount + 2, minPos: 0, maxPos: rowCount + 1});
+  });
+});

--- a/packages/zero-cache/src/services/replicator/change-log-stream-writer.ts
+++ b/packages/zero-cache/src/services/replicator/change-log-stream-writer.ts
@@ -1,0 +1,89 @@
+import {assert} from '../../../../shared/src/asserts.ts';
+import type {Database, Statement} from '../../../../zqlite/src/db.ts';
+import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
+import {extractChangeSubstring} from '../change-streamer/change-log-codec.ts';
+import {CHANGE_LOG_STREAM_TABLE} from './schema/change-log-stream.ts';
+
+type ChangeTag = ChangeStreamData[1]['tag'];
+
+/**
+ * Appends the canonical downstream stream to the replica-local change log.
+ *
+ * Transaction ownership deliberately remains with {@link ChangeProcessor}.
+ * This class only tracks the current stream watermark and position, and every
+ * statement it executes participates in the transaction already opened by the
+ * processor.
+ */
+export class ChangeLogStreamWriter {
+  readonly #insertChange: Statement;
+  readonly #insertCommit: Statement;
+
+  #watermark: string | undefined;
+  #pos = 0;
+
+  constructor(db: Database) {
+    this.#insertChange = db.prepare(/*sql*/ `
+      INSERT INTO "${CHANGE_LOG_STREAM_TABLE}"
+        ("watermark", "pos", "change")
+        VALUES (?, ?, ?)
+    `);
+    this.#insertCommit = db.prepare(/*sql*/ `
+      INSERT INTO "${CHANGE_LOG_STREAM_TABLE}"
+        ("watermark", "pos", "change", "precommit", "writeTimeMs")
+        VALUES (?, ?, ?, ?, ?)
+    `);
+  }
+
+  begin(watermark: string, json: string): void {
+    assert(
+      this.#watermark === undefined,
+      `change-log stream transaction already open at ${this.#watermark}`,
+    );
+    this.#watermark = watermark;
+    this.#pos = 0;
+    this.#insertChange.run(
+      watermark,
+      this.#pos,
+      extractChangeSubstring(json, 'begin'),
+    );
+  }
+
+  append(json: string, tag: ChangeTag): void {
+    const watermark = this.#requireWatermark();
+    this.#insertChange.run(
+      watermark,
+      ++this.#pos,
+      extractChangeSubstring(json, tag),
+    );
+  }
+
+  commit(watermark: string, json: string, writeTimeMs: number): void {
+    const precommit = this.#requireWatermark();
+    assert(
+      watermark === precommit,
+      `change-log stream commit ${watermark} does not match begin ${precommit}`,
+    );
+    this.#insertCommit.run(
+      watermark,
+      ++this.#pos,
+      extractChangeSubstring(json, 'commit'),
+      precommit,
+      writeTimeMs,
+    );
+    this.#watermark = undefined;
+    this.#pos = 0;
+  }
+
+  rollback(): void {
+    this.#watermark = undefined;
+    this.#pos = 0;
+  }
+
+  #requireWatermark(): string {
+    assert(
+      this.#watermark !== undefined,
+      'change-log stream message received outside of a transaction',
+    );
+    return this.#watermark;
+  }
+}

--- a/packages/zero-cache/src/services/replicator/change-processor.test.ts
+++ b/packages/zero-cache/src/services/replicator/change-processor.test.ts
@@ -11,8 +11,9 @@ import {
 } from '../../db/lite-tables.ts';
 import type {LiteIndexSpec} from '../../db/specs.ts';
 import {StatementRunner} from '../../db/statements.ts';
-import {expectTables, initDB} from '../../test/lite.ts';
+import {expectTableExact, expectTables, initDB} from '../../test/lite.ts';
 import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
+import {serializeChangeStreamData} from '../change-streamer/change-log-codec.ts';
 import {ChangeProcessor} from './change-processor.ts';
 import {DEL_OP, SET_OP} from './schema/change-log.ts';
 import {ColumnMetadataStore} from './schema/column-metadata.ts';
@@ -36,6 +37,7 @@ describe('replicator/change-processor', () => {
     servingProcessor = new ChangeProcessor(
       new StatementRunner(servingReplica),
       'serving',
+      {logsChangeStream: false},
       (_, err) => {
         throw err;
       },
@@ -45,6 +47,7 @@ describe('replicator/change-processor', () => {
     backupProcessor = new ChangeProcessor(
       new StatementRunner(backupReplica),
       'backup',
+      {logsChangeStream: false},
       (_, err) => {
         throw err;
       },
@@ -3844,6 +3847,176 @@ describe('replicator/change-processor-errors', () => {
       'auto rollback change processor',
     );
     expect(replica.inTransaction).toBe(false);
+  });
+});
+
+describe('replicator/change-processor change-stream logging', () => {
+  let lc: LogContext;
+  let replica: Database;
+  let processor: ChangeProcessor;
+  let failures: unknown[];
+
+  const issues = new ReplicationMessages({issues: 'id'});
+
+  beforeEach(() => {
+    lc = createSilentLogContext();
+    replica = new Database(lc, ':memory:');
+    initReplicationState(replica, ['zero_data'], '02');
+    initDB(
+      replica,
+      `
+      CREATE TABLE issues(
+        id INTEGER PRIMARY KEY,
+        text TEXT,
+        _0_version TEXT
+      );
+      `,
+    );
+    failures = [];
+    processor = createChangeProcessor(replica, (_, err) => failures.push(err), {
+      logsChangeStream: true,
+    });
+  });
+
+  function process(data: ChangeStreamData) {
+    return processor.processMessage(lc, data, serializeChangeStreamData(data));
+  }
+
+  test('atomically applies data, appends the stream, and advances state', () => {
+    process(['begin', issues.begin(), {commitWatermark: '06'}]);
+    process([
+      'data',
+      issues.insert('issues', {
+        id: 9007199254740993n,
+        text: 'before\0after',
+      }),
+    ]);
+    const result = process(['commit', issues.commit(), {watermark: '06'}]);
+
+    expect(failures).toEqual([]);
+    expect(result).toMatchObject({watermark: '06'});
+    expectTableExact(
+      replica,
+      'issues',
+      [
+        {
+          id: 9007199254740993n,
+          text: 'before\0after',
+          _0_version: '06',
+        },
+      ],
+      'bigint',
+      'id',
+    );
+
+    const rows = replica
+      .prepare(/*sql*/ `
+        SELECT "watermark", "pos", "change", "precommit", "writeTimeMs"
+          FROM "_zero.changeLogStream"
+          WHERE "watermark" = '06'
+          ORDER BY "pos"
+      `)
+      .all<{
+        watermark: string;
+        pos: number;
+        change: string;
+        precommit: string | null;
+        writeTimeMs: number | null;
+      }>();
+    expect(rows).toEqual([
+      {
+        watermark: '06',
+        pos: 0,
+        change: '{"tag":"begin"}',
+        precommit: null,
+        writeTimeMs: null,
+      },
+      {
+        watermark: '06',
+        pos: 1,
+        change:
+          '{"tag":"insert","relation":{"tag":"relation","schema":"public","name":"issues","rowKey":{"type":"default","columns":["id"]}},"new":{"id":9007199254740993,"text":"before\\u0000after"}}',
+        precommit: null,
+        writeTimeMs: null,
+      },
+      {
+        watermark: '06',
+        pos: 2,
+        change: '{"tag":"commit"}',
+        precommit: '06',
+        writeTimeMs: expect.any(Number),
+      },
+    ]);
+
+    const state = replica
+      .prepare(/*sql*/ `
+        SELECT "stateVersion", "writeTimeMs"
+          FROM "_zero.replicationState"
+      `)
+      .get<{stateVersion: string; writeTimeMs: number}>();
+    expect(state.stateVersion).toBe('06');
+    expect(state.writeTimeMs).toBe(rows[2].writeTimeMs);
+    expect(
+      replica
+        .prepare(/*sql*/ `
+          SELECT max("watermark") AS "watermark"
+            FROM "_zero.changeLogStream"
+        `)
+        .get(),
+    ).toEqual({watermark: state.stateVersion});
+  });
+
+  test('explicit rollback and abort leave no stream or replica rows', () => {
+    process(['begin', issues.begin(), {commitWatermark: '06'}]);
+    process(['data', issues.insert('issues', {id: 1, text: 'rollback'})]);
+    process(['rollback', {tag: 'rollback'}]);
+
+    process(['begin', issues.begin(), {commitWatermark: '07'}]);
+    process(['data', issues.insert('issues', {id: 2, text: 'abort'})]);
+    processor.abort(lc);
+
+    expect(replica.prepare(`SELECT * FROM issues`).all()).toEqual([]);
+    expect(
+      replica
+        .prepare(/*sql*/ `
+          SELECT "watermark" FROM "_zero.changeLogStream"
+            WHERE "watermark" IN ('06', '07')
+        `)
+        .all(),
+    ).toEqual([]);
+    expect(
+      replica
+        .prepare(`SELECT "stateVersion" FROM "_zero.replicationState"`)
+        .get(),
+    ).toEqual({stateVersion: '02'});
+  });
+
+  test('processing failure rolls back stream rows with replica changes', () => {
+    process(['begin', issues.begin(), {commitWatermark: '06'}]);
+    process(['data', issues.insert('issues', {id: 1, text: 'valid'})]);
+    process([
+      'data',
+      {
+        tag: 'insert',
+        relation: {
+          schema: 'public',
+          name: 'missing',
+          rowKey: {columns: ['id'], type: 'default'},
+        },
+        new: {id: 2},
+      },
+    ]);
+
+    expect(failures).toHaveLength(1);
+    expect(replica.inTransaction).toBe(false);
+    expect(replica.prepare(`SELECT * FROM issues`).all()).toEqual([]);
+    expect(
+      replica
+        .prepare(
+          `SELECT * FROM "_zero.changeLogStream" WHERE "watermark" = '06'`,
+        )
+        .all(),
+    ).toEqual([]);
   });
 });
 

--- a/packages/zero-cache/src/services/replicator/change-processor.ts
+++ b/packages/zero-cache/src/services/replicator/change-processor.ts
@@ -56,6 +56,7 @@ import type {
   TableUpdateMetadata,
 } from '../change-source/protocol/current/data.ts';
 import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
+import {ChangeLogStreamWriter} from './change-log-stream-writer.ts';
 import type {ReplicatorMode} from './replicator.ts';
 import {ChangeLog, DEL_OP, SET_OP} from './schema/change-log.ts';
 import {ColumnMetadataStore} from './schema/column-metadata.ts';
@@ -66,6 +67,10 @@ import {
 import {TableMetadataTracker} from './schema/table-metadata.ts';
 
 export type ChangeProcessorMode = ReplicatorMode | 'initial-sync';
+
+export type ChangeProcessorOptions = {
+  logsChangeStream: boolean;
+};
 
 export type CommitResult = {
   watermark: string;
@@ -88,6 +93,7 @@ export type CommitResult = {
 export class ChangeProcessor {
   readonly #db: StatementRunner;
   readonly #changeLog: ChangeLog;
+  readonly #changeLogStreamWriter: ChangeLogStreamWriter | undefined;
   readonly #tableMetadata: TableMetadataTracker;
   readonly #mode: ChangeProcessorMode;
   readonly #failService: (lc: LogContext, err: unknown) => void;
@@ -104,10 +110,14 @@ export class ChangeProcessor {
   constructor(
     db: StatementRunner,
     mode: ChangeProcessorMode,
+    options: ChangeProcessorOptions,
     failService: (lc: LogContext, err: unknown) => void,
   ) {
     this.#db = db;
     this.#changeLog = new ChangeLog(db.db);
+    this.#changeLogStreamWriter = options.logsChangeStream
+      ? new ChangeLogStreamWriter(db.db)
+      : undefined;
     this.#tableMetadata = new TableMetadataTracker(db.db);
     this.#mode = mode;
     this.#failService = failService;
@@ -118,6 +128,7 @@ export class ChangeProcessor {
       let failureError = err;
       try {
         this.#currentTx?.abort(lc); // roll back any pending transaction.
+        this.#changeLogStreamWriter?.rollback();
       } catch (rollbackError) {
         const combinedError = new Error(
           `Message processing failed and rollback also failed: operation error = ${String(err)}; rollback error = ${String(rollbackError)}`,
@@ -144,6 +155,7 @@ export class ChangeProcessor {
   processMessage(
     lc: LogContext,
     downstream: ChangeStreamData,
+    canonicalJSON?: string | undefined,
   ): CommitResult | null {
     const [type, message] = downstream;
     if (this.#failure) {
@@ -157,7 +169,13 @@ export class ChangeProcessor {
           : type === 'commit'
             ? downstream[2].watermark
             : undefined;
-      return this.#processMessage(lc, message, watermark);
+      if (this.#changeLogStreamWriter) {
+        must(
+          canonicalJSON,
+          'canonical JSON is required when change-stream logging is enabled',
+        );
+      }
+      return this.#processMessage(lc, message, watermark, canonicalJSON);
     } catch (e) {
       this.#fail(lc, e);
     }
@@ -210,6 +228,7 @@ export class ChangeProcessor {
     lc: LogContext,
     msg: Change,
     watermark: string | undefined,
+    canonicalJSON: string | undefined,
   ): CommitResult | null {
     if (msg.tag === 'begin') {
       if (this.#currentTx) {
@@ -220,6 +239,7 @@ export class ChangeProcessor {
         must(watermark),
         msg.json ?? JSON_PARSED,
       );
+      this.#changeLogStreamWriter?.begin(must(watermark), must(canonicalJSON));
       return null;
     }
 
@@ -232,18 +252,27 @@ export class ChangeProcessor {
     }
 
     if (msg.tag === 'commit') {
-      // Undef this.#currentTx to allow the assembly of the next transaction.
-      this.#currentTx = null;
-
       assert(watermark, 'watermark is required for commit messages');
-      return tx.processCommit(msg, watermark);
+      const result = tx.processCommit(
+        msg,
+        watermark,
+        this.#changeLogStreamWriter,
+        canonicalJSON,
+      );
+      // Clear only after a successful commit so #fail can roll back a commit
+      // path that throws before SQLite has committed.
+      this.#currentTx = null;
+      return result;
     }
 
     if (msg.tag === 'rollback') {
-      this.#currentTx?.abort(lc);
+      tx.abort(lc);
+      this.#changeLogStreamWriter?.rollback();
       this.#currentTx = null;
       return null;
     }
+
+    this.#changeLogStreamWriter?.append(must(canonicalJSON), msg.tag);
 
     switch (msg.tag) {
       case 'insert':
@@ -912,7 +941,12 @@ class TransactionProcessor {
     // no backfills are in progress).
   }
 
-  processCommit(commit: MessageCommit, watermark: string): CommitResult {
+  processCommit(
+    commit: MessageCommit,
+    watermark: string,
+    changeLogStreamWriter: ChangeLogStreamWriter | undefined,
+    canonicalJSON: string | undefined,
+  ): CommitResult {
     if (watermark !== this.#version) {
       throw new Error(
         `'commit' version ${watermark} does not match 'begin' version ${
@@ -920,7 +954,13 @@ class TransactionProcessor {
         }: ${stringify(commit)}`,
       );
     }
-    updateReplicationWatermark(this.#db, watermark);
+    if (changeLogStreamWriter) {
+      const writeTimeMs = Date.now();
+      changeLogStreamWriter.commit(watermark, must(canonicalJSON), writeTimeMs);
+      updateReplicationWatermark(this.#db, watermark, writeTimeMs);
+    } else {
+      updateReplicationWatermark(this.#db, watermark);
+    }
 
     if (this.#schemaChanged) {
       const start = Date.now();

--- a/packages/zero-cache/src/services/replicator/incremental-sync.test.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.test.ts
@@ -77,6 +77,7 @@ describe('replicator/incremental-sync', () => {
     await worker.init(
       dbFile.path,
       'serving',
+      false,
       {
         busyTimeout: 30000,
         analysisLimit: 1000,
@@ -795,6 +796,68 @@ describe('replicator/incremental-sync', () => {
 
     syncer.stop(lc);
     void localSyncing.catch(() => {});
+  });
+
+  test('source disconnect rolls back an enabled stream writer transaction', async () => {
+    await worker.stop();
+    worker = new ThreadWriteWorkerClient();
+    await worker.init(
+      dbFile.path,
+      'serving',
+      true,
+      {
+        busyTimeout: 30000,
+        analysisLimit: 1000,
+      },
+      {level: 'error', format: 'text'},
+    );
+    initReplicationState(mainDb, ['zero_data'], '02', {}, false);
+    initDB(
+      mainDb,
+      `
+      CREATE TABLE issues(
+        id INTEGER PRIMARY KEY,
+        _0_version TEXT
+      );
+      `,
+    );
+
+    const {promise: hasRetried, resolve: retried} = resolver<true>();
+    subscribeFn.mockResolvedValueOnce(downstream).mockImplementation(() => {
+      retried(true);
+      return resolver<Source<SerializedDownstream>>().promise;
+    });
+    syncer = new IncrementalSyncer(
+      lc,
+      TASK_ID,
+      REPLICA_ID,
+      {subscribe: subscribeFn},
+      worker,
+      'serving',
+      ReplicationStatusPublisher.forReplicaFile(dbFile.path),
+    );
+    syncing = syncer.run();
+    await vi.waitFor(() => expect(subscribeFn).toHaveBeenCalledTimes(1));
+    const processMessage = vi.spyOn(worker, 'processMessage');
+
+    const issues = new ReplicationMessages({issues: 'id'});
+    downstream.push(['begin', issues.begin(), {commitWatermark: '06'}]);
+    downstream.push(['data', issues.insert('issues', {id: 1})]);
+    await vi.waitFor(() => expect(processMessage).toHaveBeenCalledTimes(2));
+    downstream.fail(new Error('source disconnected'));
+
+    expect(await hasRetried).toBe(true);
+    expect(mainDb.prepare(`SELECT * FROM issues`).all()).toEqual([]);
+    expect(
+      mainDb
+        .prepare(
+          `SELECT * FROM "_zero.changeLogStream" WHERE "watermark" = '06'`,
+        )
+        .all(),
+    ).toEqual([]);
+    syncer.stop(lc);
+    void syncing.catch(() => {});
+    syncing = undefined;
   });
 
   test('shut down on change-streamer error message', async () => {

--- a/packages/zero-cache/src/services/replicator/replication-resumption-child.ts
+++ b/packages/zero-cache/src/services/replicator/replication-resumption-child.ts
@@ -168,10 +168,11 @@ class FailpointWriteWorkerClient implements WriteWorkerClient {
   init(
     dbPath: string,
     mode: Parameters<ThreadWriteWorkerClient['init']>[1],
+    logsChangeStream: boolean,
     pragmas: PragmaConfig,
     logConfig: LogConfig,
   ) {
-    return this.#inner.init(dbPath, mode, pragmas, logConfig);
+    return this.#inner.init(dbPath, mode, logsChangeStream, pragmas, logConfig);
   }
 
   getSubscriptionState() {
@@ -235,7 +236,7 @@ export default async function runWorker(
     parent,
     failpoint,
   );
-  await worker.init(dbPath, 'serving', getPragmaConfig('serving'), {
+  await worker.init(dbPath, 'serving', false, getPragmaConfig('serving'), {
     level: 'error',
     format: 'text',
   });

--- a/packages/zero-cache/src/services/replicator/replication-throughput.bench.pg.ts
+++ b/packages/zero-cache/src/services/replicator/replication-throughput.bench.pg.ts
@@ -166,10 +166,16 @@ async function startReplicationPipeline(testDBs: PgTest['testDBs']) {
   });
 
   const worker = new ThreadWriteWorkerClient();
-  await worker.init(replicaDbFile.path, 'serving', getPragmaConfig('serving'), {
-    level: 'error',
-    format: 'text',
-  });
+  await worker.init(
+    replicaDbFile.path,
+    'serving',
+    false,
+    getPragmaConfig('serving'),
+    {
+      level: 'error',
+      format: 'text',
+    },
+  );
 
   const replicator = new ReplicatorService(
     lc,

--- a/packages/zero-cache/src/services/replicator/schema-change-fuzz.test.ts
+++ b/packages/zero-cache/src/services/replicator/schema-change-fuzz.test.ts
@@ -84,6 +84,7 @@ test('streamed schema changes match a replica rebuilt from the final schema', ()
         const processor = new ChangeProcessor(
           new StatementRunner(streamed),
           'serving',
+          {logsChangeStream: false},
           (_, error) => {
             throw error;
           },

--- a/packages/zero-cache/src/services/replicator/schema/replication-state.ts
+++ b/packages/zero-cache/src/services/replicator/schema/replication-state.ts
@@ -202,13 +202,24 @@ export function getSubscriptionStateAndContext(
 export function updateReplicationWatermark(
   db: StatementRunner,
   watermark: string,
+  writeTimeMs?: number | undefined,
 ) {
-  db.run(
-    /*sql*/ `
-    UPDATE "_zero.replicationState" 
-      SET stateVersion=?, writeTimeMs=unixepoch('subsec') * 1000`,
-    watermark,
-  );
+  if (writeTimeMs === undefined) {
+    db.run(
+      /*sql*/ `
+      UPDATE "_zero.replicationState"
+        SET stateVersion=?, writeTimeMs=unixepoch('subsec') * 1000`,
+      watermark,
+    );
+  } else {
+    db.run(
+      /*sql*/ `
+      UPDATE "_zero.replicationState"
+        SET stateVersion=?, writeTimeMs=?`,
+      watermark,
+      writeTimeMs,
+    );
+  }
 }
 
 export function getReplicationState(db: StatementRunner): ReplicationState {

--- a/packages/zero-cache/src/services/replicator/test-utils.ts
+++ b/packages/zero-cache/src/services/replicator/test-utils.ts
@@ -24,7 +24,10 @@ import type {
   TableDrop,
   TableRename,
 } from '../change-source/protocol/current/data.ts';
-import {ChangeProcessor} from './change-processor.ts';
+import {
+  ChangeProcessor,
+  type ChangeProcessorOptions,
+} from './change-processor.ts';
 
 export interface FakeReplicator {
   processTransaction(
@@ -59,8 +62,14 @@ export function createChangeProcessor(
   failures: (lc: LogContext, err: unknown) => void = (_, err) => {
     throw err;
   },
+  options: ChangeProcessorOptions = {logsChangeStream: false},
 ): ChangeProcessor {
-  return new ChangeProcessor(new StatementRunner(db), 'serving', failures);
+  return new ChangeProcessor(
+    new StatementRunner(db),
+    'serving',
+    options,
+    failures,
+  );
 }
 
 export class ReplicationMessages<

--- a/packages/zero-cache/src/services/replicator/write-worker-client.ts
+++ b/packages/zero-cache/src/services/replicator/write-worker-client.ts
@@ -94,7 +94,7 @@ export function deserializeError(serialized: SerializedError): Error {
 
 // Wire protocol types.
 export type ArgsMap = {
-  init: [string, ChangeProcessorMode, PragmaConfig, LogConfig];
+  init: [string, ChangeProcessorMode, boolean, PragmaConfig, LogConfig];
   getSubscriptionState: [];
   processMessage: [SerializedChangeStreamData];
   abort: [];
@@ -191,10 +191,17 @@ export class ThreadWriteWorkerClient implements WriteWorkerClient {
   init(
     dbPath: string,
     mode: ChangeProcessorMode,
+    logsChangeStream: boolean,
     pragmas: PragmaConfig,
     logConfig: LogConfig,
   ): Promise<void> {
-    return this.#call('init', [dbPath, mode, pragmas, logConfig]);
+    return this.#call('init', [
+      dbPath,
+      mode,
+      logsChangeStream,
+      pragmas,
+      logConfig,
+    ]);
   }
 
   getSubscriptionState(): Promise<SubscriptionState> {

--- a/packages/zero-cache/src/services/replicator/write-worker.test.ts
+++ b/packages/zero-cache/src/services/replicator/write-worker.test.ts
@@ -48,6 +48,7 @@ describe('write-worker', () => {
     await worker.init(
       dbFile.path,
       'serving',
+      false,
       {
         busyTimeout: 30000,
         analysisLimit: 1000,
@@ -110,6 +111,112 @@ describe('write-worker', () => {
     expect(state.watermark).toBe('06');
   });
 
+  test('enabled writer is atomic across abort and worker restart', async () => {
+    await worker.stop();
+    worker = new ThreadWriteWorkerClient();
+    await worker.init(
+      dbFile.path,
+      'serving',
+      true,
+      {
+        busyTimeout: 30000,
+        analysisLimit: 1000,
+      },
+      {level: 'error', format: 'text'},
+    );
+
+    const issues = new ReplicationMessages({issues: ['issueID', 'bool']});
+    await worker.processMessage(
+      serialized(['begin', issues.begin(), {commitWatermark: '05'}]),
+    );
+    await worker.processMessage(
+      serialized(['data', issues.insert('issues', {issueID: 1, bool: true})]),
+    );
+    worker.abort();
+
+    const messages: ChangeStreamData[] = [
+      ['begin', issues.begin(), {commitWatermark: '06'}],
+      ['data', issues.insert('issues', {issueID: 123, bool: true})],
+      ['data', issues.insert('issues', {issueID: 456, bool: false})],
+      ['commit', issues.commit(), {watermark: '06'}],
+    ];
+    for (const message of messages) {
+      await worker.processMessage(serialized(message));
+    }
+
+    await worker.stop();
+    worker = new ThreadWriteWorkerClient();
+    await worker.init(
+      dbFile.path,
+      'serving',
+      true,
+      {
+        busyTimeout: 30000,
+        analysisLimit: 1000,
+      },
+      {level: 'error', format: 'text'},
+    );
+
+    expect(await worker.getSubscriptionState()).toMatchObject({
+      watermark: '06',
+    });
+    expect(
+      mainDb
+        .prepare(/*sql*/ `
+          SELECT "watermark", "pos", json_extract("change", '$.tag') AS "tag",
+                 "precommit", "writeTimeMs"
+            FROM "_zero.changeLogStream"
+            WHERE "watermark" IN ('05', '06')
+            ORDER BY "watermark", "pos"
+        `)
+        .all(),
+    ).toEqual([
+      {
+        watermark: '06',
+        pos: 0,
+        tag: 'begin',
+        precommit: null,
+        writeTimeMs: null,
+      },
+      {
+        watermark: '06',
+        pos: 1,
+        tag: 'insert',
+        precommit: null,
+        writeTimeMs: null,
+      },
+      {
+        watermark: '06',
+        pos: 2,
+        tag: 'insert',
+        precommit: null,
+        writeTimeMs: null,
+      },
+      {
+        watermark: '06',
+        pos: 3,
+        tag: 'commit',
+        precommit: '06',
+        writeTimeMs: expect.any(Number),
+      },
+    ]);
+    const state = mainDb
+      .prepare(
+        `SELECT "stateVersion", "writeTimeMs" FROM "_zero.replicationState"`,
+      )
+      .get<{stateVersion: string; writeTimeMs: number}>();
+    const commit = mainDb
+      .prepare(/*sql*/ `
+        SELECT "writeTimeMs" FROM "_zero.changeLogStream"
+          WHERE "watermark" = '06' AND "precommit" IS NOT NULL
+      `)
+      .get<{writeTimeMs: number}>();
+    expect(state).toEqual({
+      stateVersion: '06',
+      writeTimeMs: commit.writeTimeMs,
+    });
+  });
+
   test('abort rolls back pending transaction', async () => {
     const issues = new ReplicationMessages({issues: ['issueID', 'bool']});
 
@@ -150,6 +257,7 @@ describe('write-worker', () => {
     await worker.init(
       dbFile.path,
       'serving',
+      false,
       {
         busyTimeout: 30000,
         analysisLimit: 1000,

--- a/packages/zero-cache/src/services/replicator/write-worker.ts
+++ b/packages/zero-cache/src/services/replicator/write-worker.ts
@@ -38,6 +38,7 @@ function createAPI(): API {
   let runner: StatementRunner | undefined;
   let processor: ChangeProcessor | undefined;
   let mode: ChangeProcessorMode | undefined;
+  let logsChangeStream: boolean | undefined;
   let lc: LogContext | undefined;
   let replicaDbPath: string | undefined;
   let unregisterCorruptionDiagnosticTarget: (() => void) | undefined;
@@ -49,18 +50,24 @@ function createAPI(): API {
   }
 
   function createProcessor() {
-    processor = new ChangeProcessor(must(runner), must(mode), (_lc, err) => {
-      logCorruptionDiagnostics(err);
-      port.postMessage({
-        writeError: serializeError(err),
-      } satisfies WriteError);
-    });
+    processor = new ChangeProcessor(
+      must(runner),
+      must(mode),
+      {logsChangeStream: must(logsChangeStream)},
+      (_lc, err) => {
+        logCorruptionDiagnostics(err);
+        port.postMessage({
+          writeError: serializeError(err),
+        } satisfies WriteError);
+      },
+    );
   }
 
   return {
     init(
       dbPath: string,
       cpMode: ChangeProcessorMode,
+      shouldLogChangeStream: boolean,
       pragmas: PragmaConfig,
       logConfig: LogConfig,
     ) {
@@ -77,6 +84,7 @@ function createAPI(): API {
         applyPragmas(db, pragmas);
         runner = new StatementRunner(db);
         mode = cpMode;
+        logsChangeStream = shouldLogChangeStream;
         createProcessor();
       } catch (e) {
         logCorruptionDiagnostics(e);
@@ -93,11 +101,9 @@ function createAPI(): API {
       }
     },
 
-    processMessage({data}: SerializedChangeStreamData) {
+    processMessage({data, json}: SerializedChangeStreamData) {
       try {
-        // The canonical JSON is intentionally unused until the SQLite stream
-        // writer is added. ChangeProcessor continues to consume parsed data.
-        return must(processor).processMessage(must(lc), data);
+        return must(processor).processMessage(must(lc), data, json);
       } catch (e) {
         logCorruptionDiagnostics(e);
         throw e;

--- a/packages/zero-cache/src/workers/replicator.test.ts
+++ b/packages/zero-cache/src/workers/replicator.test.ts
@@ -5,6 +5,8 @@ import {inProcChannel} from '../types/processes.ts';
 import {Subscription} from '../types/subscription.ts';
 import {
   createNotifierFrom,
+  createsCanonicalReplicator,
+  replicaLogsChangeStream,
   setUpMessageHandlers,
   subscribeTo,
 } from './replicator.ts';
@@ -12,6 +14,29 @@ import {
 const lc = createSilentLogContext();
 
 describe('workers/replicator', () => {
+  test('selects exactly one canonical SQLite change-log writer', () => {
+    expect(createsCanonicalReplicator(true, 's3://backup', 0)).toBe(true);
+    expect(createsCanonicalReplicator(true, undefined, 1)).toBe(true);
+    expect(createsCanonicalReplicator(true, undefined, 0)).toBe(false);
+    expect(createsCanonicalReplicator(false, undefined, 1)).toBe(false);
+
+    expect(replicaLogsChangeStream('backup', true, true, 's3://backup')).toBe(
+      true,
+    );
+    expect(
+      replicaLogsChangeStream('serving-copy', true, true, 's3://backup'),
+    ).toBe(false);
+    expect(replicaLogsChangeStream('serving', true, true, undefined)).toBe(
+      true,
+    );
+    expect(replicaLogsChangeStream('serving', true, false, undefined)).toBe(
+      false,
+    );
+    expect(replicaLogsChangeStream('serving', false, true, undefined)).toBe(
+      false,
+    );
+  });
+
   test('replicator subscription', async () => {
     const originalSub = Subscription.create<ReplicaState>();
 

--- a/packages/zero-cache/src/workers/replicator.ts
+++ b/packages/zero-cache/src/workers/replicator.ts
@@ -29,6 +29,28 @@ export const replicaFileModeSchema = v.literalUnion(
 
 export type ReplicaFileMode = v.Infer<typeof replicaFileModeSchema>;
 
+export function createsCanonicalReplicator(
+  runsLocalChangeStreamer: boolean,
+  backupURL: string | undefined,
+  numSyncWorkers: number,
+): boolean {
+  return runsLocalChangeStreamer && (Boolean(backupURL) || numSyncWorkers > 0);
+}
+
+export function replicaLogsChangeStream(
+  fileMode: ReplicaFileMode,
+  sqliteChangeLogEnabled: boolean,
+  runsLocalChangeStreamer: boolean,
+  backupURL: string | undefined,
+): boolean {
+  if (!sqliteChangeLogEnabled || !runsLocalChangeStreamer) {
+    return false;
+  }
+  return (
+    fileMode === 'backup' || (fileMode === 'serving' && !Boolean(backupURL))
+  );
+}
+
 export type WalMode = 'wal' | 'wal2';
 
 export function replicaFileName(replicaFile: string, mode: ReplicaFileMode) {

--- a/packages/zql-integration-tests/src/chinook/chinook-zero-cache-fuzzer.pg.test.ts
+++ b/packages/zql-integration-tests/src/chinook/chinook-zero-cache-fuzzer.pg.test.ts
@@ -361,6 +361,7 @@ async function startZeroCacheReplica(testDBs: PgTest['testDBs']) {
     await worker.init(
       replicaDbFile.path,
       'serving',
+      false,
       getPragmaConfig('serving'),
       {level: 'error', format: 'text'},
     );


### PR DESCRIPTION
Writes to the SQLite change log when enabled.

Production state after deployment:

- With the default sqliteChangeLogMode=off, runtime behavior is unchanged and the existing SQLite change-log table remains inert.
- Any non-off mode currently enables only shadow writes on the canonical backup replica, or on the primary serving replica when no backup replica exists. serving-copy and non-canonical process trees do not write.
- Replica changes, stream rows, and stateVersion commit atomically with a shared writeTimeMs. Rollbacks, failures, aborts, and source disconnects leave no partial stream transaction.
- PostgreSQL remains authoritative for catchup, purge, subscriber delivery, and replication-slot ACK durability. This slice does not serve or compare SQLite reads.
- SQLite purge and retention scheduling are not implemented yet, so enabling writes in production would grow the local log without bound. Keep the mode off except for explicitly disk-bounded probes until the purge slice lands.