### PR TITLE
chore(litestream): default to restoring with litestream v5

### DIFF
--- a/packages/zero-cache/src/config/zero-config.test.ts
+++ b/packages/zero-cache/src/config/zero-config.test.ts
@@ -555,9 +555,11 @@ test('zero-cache --help', () => {
                                                                         affording forwards compatibility with a future zero-cache                                                                  
                                                                         version that will use litestream v0.5.x to backup the replica.                                                             
                                                                                                                                                                                                    
-     --litestream-restore-using-v5 boolean                              default: false                                                                                                             
+     --litestream-restore-using-v5 boolean                              default: true                                                                                                              
        ZERO_LITESTREAM_RESTORE_USING_V5 env                                                                                                                                                        
                                                                         Restores the backup using the ZERO_LITESTREAM_EXECUTABLE_V5 if specified.                                                  
+                                                                        This provides a recovery path if rolling back from ZERO_LITESTREAM_BACKUP_USING_V5                                         
+                                                                        as v5 restores from both v3 and v5 backups (whichever is more recent).                                                     
                                                                                                                                                                                                    
      --litestream-backup-using-v5 boolean                               default: false                                                                                                             
        ZERO_LITESTREAM_BACKUP_USING_V5 env                                                                                                                                                         

--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -854,9 +854,11 @@ export const zeroOptions = {
     },
 
     restoreUsingV5: {
-      type: v.boolean().default(false),
+      type: v.boolean().default(true),
       desc: [
         `Restores the backup using the {bold ZERO_LITESTREAM_EXECUTABLE_V5} if specified.`,
+        `This provides a recovery path if rolling back from {bold ZERO_LITESTREAM_BACKUP_USING_V5}`,
+        `as v5 restores from both v3 and v5 backups (whichever is more recent).`,
       ],
     },
 

--- a/packages/zero/Dockerfile
+++ b/packages/zero/Dockerfile
@@ -16,7 +16,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 	--mount=type=cache,target=/go/pkg \
 	go build -ldflags "-s -w -X 'main.Version=${LITESTREAM_VERSION}' -extldflags '-static'" -tags osusergo,netgo,sqlite_omit_load_extension -o /usr/local/bin/litestream ./cmd/litestream
 
-FROM litestream/litestream:0.5.14 AS litestream-v5
+FROM litestream/litestream:0.5.15 AS litestream-v5
 
 FROM node:22.23.1-alpine3.23@sha256:8516dce0483394d5708d4b2ee6cacb79fb1d617ea4e2787c2120bcca92ce372e
 


### PR DESCRIPTION
Default to restoring with litestream v5. Backups are still performed using v3.

This provides a release for safely rolling back from a (future) release that backs up with v5.

This can be disabled with `ZERO_LITESTREAM_RESTORE_USING_V5=false`.

Also bump to the v5 litestream version to 0.5.15.