### PR TITLE
chore(rmv2): reuse serialized change-stream messages [4/n]

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/change-streamer-http.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-http.pg.test.ts
@@ -294,16 +294,28 @@ describe('change-streamer/http', () => {
 
       expect(endReservationFn).toHaveBeenCalledWith('foo-task');
 
-      downstream.push(
-        JSON.stringify(['begin', {tag: 'begin'}, {commitWatermark: '456'}]),
-      );
-      downstream.push(
-        JSON.stringify(['commit', {tag: 'commit'}, {watermark: '456'}]),
-      );
+      const begin = JSON.stringify([
+        'begin',
+        {tag: 'begin'},
+        {commitWatermark: '456'},
+      ]);
+      const commit = JSON.stringify([
+        'commit',
+        {tag: 'commit'},
+        {watermark: '456'},
+      ]);
+      downstream.push(begin);
+      downstream.push(commit);
 
       expect(await drain(2, sub)).toEqual([
-        ['begin', {tag: 'begin'}, {commitWatermark: '456'}],
-        ['commit', {tag: 'commit'}, {watermark: '456'}],
+        {
+          data: ['begin', {tag: 'begin'}, {commitWatermark: '456'}],
+          json: begin,
+        },
+        {
+          data: ['commit', {tag: 'commit'}, {watermark: '456'}],
+          json: commit,
+        },
       ]);
 
       // Draining the client-side subscription should cancel it, closing the
@@ -339,33 +351,8 @@ describe('change-streamer/http', () => {
       big3: BigInt(Number.MAX_SAFE_INTEGER) + 3n,
     });
 
-    downstream.push(BigIntJSON.stringify(['data', insert]));
-    expect(await drain(1, sub)).toMatchInlineSnapshot(`
-      [
-        [
-          "data",
-          {
-            "new": {
-              "big1": 9007199254740992n,
-              "big2": 9007199254740993n,
-              "big3": 9007199254740994n,
-              "id": "foo",
-            },
-            "relation": {
-              "name": "issues",
-              "rowKey": {
-                "columns": [
-                  "id",
-                ],
-                "type": "default",
-              },
-              "schema": "public",
-              "tag": "relation",
-            },
-            "tag": "insert",
-          },
-        ],
-      ]
-    `);
+    const json = BigIntJSON.stringify(['data', insert]);
+    downstream.push(json);
+    expect(await drain(1, sub)).toEqual([{data: ['data', insert], json}]);
   });
 });

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-http.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-http.ts
@@ -10,6 +10,7 @@ import {type Worker} from '../../types/processes.ts';
 import {type ShardID} from '../../types/shards.ts';
 import {
   streamIn,
+  streamInStringified,
   streamOut,
   streamOutStringified,
   type Source,
@@ -24,7 +25,7 @@ import {
   PROTOCOL_VERSION,
   type ChangeStreamer,
   type ChangeStreamerService,
-  type Downstream,
+  type SerializedDownstream,
   type SubscriberContext,
 } from './change-streamer.ts';
 import {discoverChangeStreamerAddress} from './schema/tables.ts';
@@ -232,13 +233,15 @@ export class ChangeStreamerHttpClient implements ChangeStreamer {
     return streamIn(this.#lc, ws, snapshotMessageSchema);
   }
 
-  async subscribe(ctx: SubscriberContext): Promise<Source<Downstream>> {
+  async subscribe(
+    ctx: SubscriberContext,
+  ): Promise<Source<SerializedDownstream>> {
     const uri = await this.#resolveChangeStreamer(CHANGES_PATH);
 
     const params = getParams(ctx);
     const ws = new WebSocket(uri + `?${params.toString()}`);
 
-    return streamIn(this.#lc, ws, downstreamSchema);
+    return streamInStringified(this.#lc, ws, downstreamSchema);
   }
 }
 

--- a/packages/zero-cache/src/services/change-streamer/change-streamer.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer.ts
@@ -1,6 +1,6 @@
 import type {Enum} from '../../../../shared/src/enum.ts';
 import * as v from '../../../../shared/src/valita.ts';
-import type {Source} from '../../types/streams.ts';
+import type {ParsedJSON, Source} from '../../types/streams.ts';
 import {
   changeStreamDataSchema,
   type ChangeStreamData,
@@ -66,9 +66,10 @@ export interface ChangeStreamer {
   /**
    * Subscribes to changes based on the supplied subscriber `ctx`,
    * which indicates the watermark at which the subscriber is up to
-   * date.
+   * date. Each result contains both parsed, validated data and the exact JSON
+   * payload sent by the ChangeStreamerService.
    */
-  subscribe(ctx: SubscriberContext): Promise<Source<Downstream>>;
+  subscribe(ctx: SubscriberContext): Promise<Source<SerializedDownstream>>;
 }
 
 // v1: v0.18
@@ -212,6 +213,9 @@ export function errorTypeToReadableName(val: ErrorType) {
  * manual intervention (e.g. configuration / operational error).
  */
 export type Downstream = v.Infer<typeof downstreamSchema>;
+
+/** A downstream message and its canonical ChangeStreamer JSON. */
+export type SerializedDownstream = ParsedJSON<Downstream>;
 
 export interface ChangeStreamerService
   extends Omit<ChangeStreamer, 'subscribe'>, Service {

--- a/packages/zero-cache/src/services/replicator/incremental-sync.test.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.test.ts
@@ -9,19 +9,23 @@ import {
   vi,
   type MockedFunction,
 } from 'vitest';
-import type {JSONObject} from '../../../../shared/src/bigint-json.ts';
+import {
+  BigIntJSON,
+  type JSONObject,
+} from '../../../../shared/src/bigint-json.ts';
 import type {Enum} from '../../../../shared/src/enum.ts';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
 import type {ZeroEvent} from '../../../../zero-events/src/index.ts';
 import type {Database} from '../../../../zqlite/src/db.ts';
 import {initEventSinkForTesting} from '../../observability/events.ts';
 import {DbFile, expectTables, initDB} from '../../test/lite.ts';
+import type {Source} from '../../types/streams.ts';
 import {Subscription} from '../../types/subscription.ts';
 import {orTimeoutWith} from '../../types/timeout.ts';
-import * as changeLogCodec from '../change-streamer/change-log-codec.ts';
 import {
   PROTOCOL_VERSION,
   type Downstream,
+  type SerializedDownstream,
   type SubscriberContext,
 } from '../change-streamer/change-streamer.ts';
 import * as ErrorType from '../change-streamer/error-type-enum.ts';
@@ -33,14 +37,6 @@ import {
 } from './schema/replication-state.ts';
 import {ReplicationMessages} from './test-utils.ts';
 import {ThreadWriteWorkerClient} from './write-worker-client.ts';
-
-vi.mock('../change-streamer/change-log-codec.ts', async importOriginal => {
-  const actual = await importOriginal<typeof changeLogCodec>();
-  return {
-    ...actual,
-    serializeChangeStreamData: vi.fn(actual.serializeChangeStreamData),
-  };
-});
 
 type ErrorType = Enum<typeof ErrorType>;
 
@@ -54,21 +50,23 @@ describe('replicator/incremental-sync', () => {
   let worker: ThreadWriteWorkerClient;
   let syncer: IncrementalSyncer;
   let syncing: Promise<void> | undefined;
-  let downstream: Subscription<Downstream>;
+  let downstream: Subscription<SerializedDownstream, Downstream>;
   let eventSink: ZeroEvent[];
   let subscribeFn: MockedFunction<
-    (ctx: SubscriberContext) => Promise<Subscription<Downstream>>
+    (ctx: SubscriberContext) => Promise<Source<SerializedDownstream>>
   >;
 
   beforeEach(async () => {
-    vi.mocked(changeLogCodec.serializeChangeStreamData).mockClear();
     lc = createSilentLogContext();
     dbFile = new DbFile('incremental-sync-test');
     mainDb = dbFile.connect(lc);
     mainDb.pragma('journal_mode = wal');
     createReplicationStateTables(mainDb);
 
-    downstream = Subscription.create();
+    downstream = new Subscription({}, data => ({
+      data,
+      json: BigIntJSON.stringify(data),
+    }));
     eventSink = [];
     initEventSinkForTesting(
       eventSink,
@@ -109,6 +107,7 @@ describe('replicator/incremental-sync', () => {
 
   test('replicates transactions', async () => {
     const issues = new ReplicationMessages({issues: ['issueID', 'bool']});
+    const processMessage = vi.spyOn(worker, 'processMessage');
 
     initReplicationState(mainDb, ['zero_data'], '02', {}, false);
 
@@ -147,9 +146,15 @@ describe('replicator/incremental-sync', () => {
       initial: true,
     });
 
+    const firstBegin = [
+      'begin',
+      issues.begin(),
+      {commitWatermark: '06'},
+    ] satisfies Downstream;
+
     for (const change of [
       ['status', {tag: 'status'}],
-      ['begin', issues.begin(), {commitWatermark: '06'}],
+      firstBegin,
       ['data', issues.insert('issues', {issueID: 123, bool: true})],
       ['data', issues.insert('issues', {issueID: 456, bool: false})],
       ['commit', issues.commit(), {watermark: '06'}],
@@ -393,7 +398,11 @@ describe('replicator/incremental-sync', () => {
         },
       ]
     `);
-    expect(changeLogCodec.serializeChangeStreamData).toHaveBeenCalledTimes(11);
+    expect(processMessage).toHaveBeenCalledTimes(11);
+    expect(processMessage).toHaveBeenNthCalledWith(1, {
+      data: firstBegin,
+      json: BigIntJSON.stringify(firstBegin),
+    });
   });
 
   test('replicates schema changes', async () => {
@@ -790,6 +799,7 @@ describe('replicator/incremental-sync', () => {
 
   test('shut down on change-streamer error message', async () => {
     initReplicationState(mainDb, ['zero_data'], '02', {}, false);
+    const processMessage = vi.spyOn(worker, 'processMessage');
 
     const syncing = syncer.run();
 
@@ -800,6 +810,6 @@ describe('replicator/incremental-sync', () => {
 
     // Should stop / resolve
     await syncing;
-    expect(changeLogCodec.serializeChangeStreamData).not.toHaveBeenCalled();
+    expect(processMessage).not.toHaveBeenCalled();
   });
 });

--- a/packages/zero-cache/src/services/replicator/incremental-sync.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.ts
@@ -5,12 +5,11 @@ import {getOrCreateCounter} from '../../observability/metrics.ts';
 import type {Source} from '../../types/streams.ts';
 import type {DownloadStatus} from '../change-source/protocol/current.ts';
 import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
-import {serializeChangeStreamData} from '../change-streamer/change-log-codec.ts';
 import {
   errorTypeToReadableName,
   PROTOCOL_VERSION,
   type ChangeStreamer,
-  type Downstream,
+  type SerializedDownstream,
 } from '../change-streamer/change-streamer.ts';
 import type * as ErrorType from '../change-streamer/error-type-enum.ts';
 import {RunningState} from '../running-state.ts';
@@ -89,7 +88,7 @@ export class IncrementalSyncer {
       const {replicaVersion, watermark} =
         await this.#worker.getSubscriptionState();
 
-      let downstream: Source<Downstream> | undefined;
+      let downstream: Source<SerializedDownstream> | undefined;
       let unregister = () => {};
       let err: unknown | undefined;
 
@@ -113,7 +112,7 @@ export class IncrementalSyncer {
 
         let backfillStatus: DownloadStatus | undefined;
 
-        for await (const message of downstream) {
+        for await (const {data: message, json} of downstream) {
           this.#replicationEvents.add(1);
           switch (message[0]) {
             case 'status': {
@@ -180,7 +179,7 @@ export class IncrementalSyncer {
               const data = message as ChangeStreamData;
               const result = await this.#worker.processMessage({
                 data,
-                json: serializeChangeStreamData(data),
+                json,
               });
 
               this.#handleResult(lc, result);

--- a/packages/zero-cache/src/services/replicator/replication-resumption-child.ts
+++ b/packages/zero-cache/src/services/replicator/replication-resumption-child.ts
@@ -8,8 +8,8 @@ import type {Source} from '../../types/streams.ts';
 import {getPragmaConfig, setupReplica} from '../../workers/replicator.ts';
 import type {
   ChangeStreamer,
+  SerializedDownstream,
   SubscriberContext,
-  Downstream,
 } from '../change-streamer/change-streamer.ts';
 import {exitAfter, runUntilKilled} from '../life-cycle.ts';
 import type {CommitResult} from './change-processor.ts';
@@ -24,7 +24,10 @@ import {
 type ChildFailpoint = 'none' | 'after-sqlite-commit-before-ack';
 
 type ParentMessage =
-  | ['replication-resumption:downstream', {seq: number; msg: Downstream}]
+  | [
+      'replication-resumption:downstream',
+      {seq: number; msg: SerializedDownstream},
+    ]
   | ['replication-resumption:source-error', {message: string}]
   | ['replication-resumption:source-end', Record<string, never>];
 
@@ -64,17 +67,17 @@ class IPCChangeStreamer implements ChangeStreamer {
     this.#parent = parent;
   }
 
-  subscribe(ctx: SubscriberContext): Promise<Source<Downstream>> {
+  subscribe(ctx: SubscriberContext): Promise<Source<SerializedDownstream>> {
     send(this.#parent, ['replication-resumption:subscribe', ctx]);
     return Promise.resolve(new IPCDownstreamSource(this.#parent));
   }
 }
 
 type QueueEntry =
-  | {type: 'message'; seq: number; msg: Downstream}
+  | {type: 'message'; seq: number; msg: SerializedDownstream}
   | {type: 'end'};
 
-class IPCDownstreamSource implements Source<Downstream> {
+class IPCDownstreamSource implements Source<SerializedDownstream> {
   readonly #parent: Worker;
   readonly #queue = new Queue<QueueEntry>();
   #canceled = false;
@@ -112,7 +115,7 @@ class IPCDownstreamSource implements Source<Downstream> {
     this.#queue.enqueue({type: 'end'});
   }
 
-  [Symbol.asyncIterator](): AsyncIterator<Downstream> {
+  [Symbol.asyncIterator](): AsyncIterator<SerializedDownstream> {
     let previousSeq: number | undefined;
     return {
       next: async () => {

--- a/packages/zero-cache/src/services/replicator/replication-resumption.pg.test.ts
+++ b/packages/zero-cache/src/services/replicator/replication-resumption.pg.test.ts
@@ -29,6 +29,7 @@ import {
   type ChangeStreamer,
   type ChangeStreamerService,
   type Downstream,
+  type SerializedDownstream,
 } from '../change-streamer/change-streamer.ts';
 import {initChangeStreamerSchema} from '../change-streamer/schema/init.ts';
 import {ReplicationStatusPublisher} from './replication-status.ts';
@@ -142,7 +143,10 @@ type ParentMessage =
     ];
 
 type ChildMessage =
-  | ['replication-resumption:downstream', {seq: number; msg: Downstream}]
+  | [
+      'replication-resumption:downstream',
+      {seq: number; msg: SerializedDownstream},
+    ]
   | ['replication-resumption:source-error', {message: string}]
   | ['replication-resumption:source-end', Record<string, never>];
 
@@ -277,7 +281,10 @@ class ForkedReplicator {
         const seq = ++this.#seq;
         sendChild(this.#child, [
           'replication-resumption:downstream',
-          {seq, msg: BigIntJSON.parse(value) as Downstream},
+          {
+            seq,
+            msg: {data: BigIntJSON.parse(value) as Downstream, json: value},
+          },
         ]);
         await this.#waitForConsumed(bridge, seq);
         consumed();

--- a/packages/zero-cache/src/services/replicator/replication-throughput.bench.pg.ts
+++ b/packages/zero-cache/src/services/replicator/replication-throughput.bench.pg.ts
@@ -26,6 +26,7 @@ import {
   type ChangeStreamer,
   type ChangeStreamerService,
   type Downstream,
+  type SerializedDownstream,
 } from '../change-streamer/change-streamer.ts';
 import {initChangeStreamerSchema} from '../change-streamer/schema/init.ts';
 import {ReplicationStatusPublisher} from './replication-status.ts';
@@ -71,12 +72,14 @@ afterEach(async () => {
   await runCleanup();
 });
 
-function parseStringifiedSource(source: Source<string>): Source<Downstream> {
+function parseStringifiedSource(
+  source: Source<string>,
+): Source<SerializedDownstream> {
   return {
     cancel: err => source.cancel(err),
     async *[Symbol.asyncIterator]() {
-      for await (const msg of source) {
-        yield BigIntJSON.parse(msg) as Downstream;
+      for await (const json of source) {
+        yield {data: BigIntJSON.parse(json) as Downstream, json};
       }
     },
   };

--- a/packages/zero-cache/src/types/streams.test.ts
+++ b/packages/zero-cache/src/types/streams.test.ts
@@ -17,6 +17,7 @@ import * as v from '../../../shared/src/valita.ts';
 import {
   stream,
   streamIn,
+  streamInStringified,
   streamOut,
   streamOutStringified,
   type Sink,
@@ -268,6 +269,14 @@ describe('streams with internal acks', () => {
     };
   }
 
+  async function startStringifiedReceiver() {
+    ws = new WebSocket(`http://localhost:${port}/`);
+    return {
+      ws,
+      consumer: await streamInStringified(lc, ws, messageSchema),
+    };
+  }
+
   test('one at a time', async () => {
     let num = 0;
 
@@ -447,11 +456,8 @@ describe('streams with internal acks', () => {
     ]);
   });
 
-  async function drain(
-    num: number,
-    consumer: Source<Message>,
-  ): Promise<Message[]> {
-    const drained: Message[] = [];
+  async function drain<T>(num: number, consumer: Source<T>): Promise<T[]> {
+    const drained: T[] = [];
     let i = 0;
     for await (const msg of consumer) {
       drained.push(msg);
@@ -472,11 +478,21 @@ describe('streams with internal acks', () => {
   });
 
   test('stringified source', async () => {
-    stringifiedProducer.push('{"from":1,"to":2,"str":"foo","extra":"bar"}');
+    const json =
+      '{"from":1,"to":2,"str":"before\\u0000after","big":9007199254740993}';
+    stringifiedProducer.push(json);
 
-    const {consumer} = await startReceiver();
+    const {consumer} = await startStringifiedReceiver();
     expect(await drain(1, consumer)).toEqual([
-      {from: 1, to: 2, str: 'foo', extra: 'bar'},
+      {
+        data: {
+          from: 1,
+          to: 2,
+          str: 'before\0after',
+          big: 9007199254740993n,
+        },
+        json,
+      },
     ]);
   });
 

--- a/packages/zero-cache/src/types/streams.ts
+++ b/packages/zero-cache/src/types/streams.ts
@@ -216,12 +216,10 @@ const ackSchema = v.object({ack: v.number()});
 
 type Ack = v.Infer<typeof ackSchema>;
 
-type Streamed<T> = {
-  /** Application-level message. */
-  msg: T;
-
-  /** ID used for the Ack message. */
-  id: number;
+/** A parsed JSON value paired with the exact source text it was parsed from. */
+export type ParsedJSON<T> = {
+  data: T;
+  json: string;
 };
 
 export function streamOut<T extends JSONValue>(
@@ -308,11 +306,35 @@ async function streamOutInternal<T extends JSONValue>(
   }
 }
 
-export async function streamIn<T extends JSONValue>(
+export function streamIn<T extends JSONValue>(
   lc: LogContext,
   source: WebSocket,
   schema: v.Type<T>,
 ): Promise<Source<T>> {
+  return streamInInternal(lc, source, schema, data => data);
+}
+
+/**
+ * Streams in messages sent by {@link streamOutStringified}, preserving the
+ * exact application-level JSON alongside its parsed and validated value.
+ */
+export function streamInStringified<T extends JSONValue>(
+  lc: LogContext,
+  source: WebSocket,
+  schema: v.Type<T>,
+): Promise<Source<ParsedJSON<T>>> {
+  return streamInInternal(lc, source, schema, (data, frame, id) => ({
+    data,
+    json: extractStringifiedMessage(frame, id),
+  }));
+}
+
+async function streamInInternal<T extends JSONValue, Out>(
+  lc: LogContext,
+  source: WebSocket,
+  schema: v.Type<T>,
+  transform: (data: T, frame: string, id: number) => Out,
+): Promise<Source<Out>> {
   expectPingsForLiveness(lc, source, PING_INTERVAL_MS);
 
   const streamedSchema = v.object({
@@ -320,12 +342,15 @@ export async function streamIn<T extends JSONValue>(
     id: v.number(),
   });
 
-  const sink: Subscription<T, Streamed<T>> = new Subscription<T, Streamed<T>>(
+  const sink: Subscription<Out, {id: number; data: Out}> = new Subscription<
+    Out,
+    {id: number; data: Out}
+  >(
     {
       consumed: ({id}) => source.send(JSON.stringify({ack: id} satisfies Ack)),
       cleanup: () => closer.close(),
     },
-    ({msg}) => msg,
+    ({data}) => data,
   );
 
   const closer = WebSocketCloser.forSink(lc, source, sink, handleMessage);
@@ -341,7 +366,7 @@ export async function streamIn<T extends JSONValue>(
       const msg = v.parse(value, streamedSchema, 'passthrough');
       // Enable for debugging. Otherwise too verbose.
       // lc.debug?.(`received`, data);
-      sink.push(msg);
+      sink.push({id: msg.id, data: transform(msg.msg, data, msg.id)});
     } catch (e) {
       closer.close(e);
     }
@@ -349,6 +374,15 @@ export async function streamIn<T extends JSONValue>(
 
   await closer.connected;
   return sink;
+}
+
+function extractStringifiedMessage(frame: string, id: number): string {
+  const prefix = `{"id":${id},"msg":`;
+  assert(
+    frame.startsWith(prefix) && frame.endsWith('}'),
+    `invalid streamed message frame`,
+  );
+  return frame.slice(prefix.length, -1);
 }
 
 class WebSocketCloser {
@@ -368,10 +402,10 @@ class WebSocketCloser {
     return new WebSocketCloser(lc, ws, () => stream.cancel());
   }
 
-  static forSink<T>(
+  static forSink<T, Input>(
     lc: LogContext,
     ws: WebSocket,
-    stream: Subscription<T, Streamed<T>>,
+    stream: Subscription<T, Input>,
     messageHandler: (e: MessageEvent) => void | undefined,
   ) {
     // If the websocket is closed, call end() to allow the downstream Sink

--- a/packages/zql-integration-tests/src/chinook/chinook-zero-cache-fuzzer.pg.test.ts
+++ b/packages/zql-integration-tests/src/chinook/chinook-zero-cache-fuzzer.pg.test.ts
@@ -12,6 +12,7 @@ import type {
   ChangeStreamer,
   ChangeStreamerService,
   Downstream,
+  SerializedDownstream,
 } from '../../../zero-cache/src/services/change-streamer/change-streamer.ts';
 import {initChangeStreamerSchema} from '../../../zero-cache/src/services/change-streamer/schema/init.ts';
 import {ReplicationStatusPublisher} from '../../../zero-cache/src/services/replicator/replication-status.ts';
@@ -247,12 +248,14 @@ function selectWriteFuzzSkeletons(
   return out;
 }
 
-function parseStringifiedSource(source: Source<string>): Source<Downstream> {
+function parseStringifiedSource(
+  source: Source<string>,
+): Source<SerializedDownstream> {
   return {
     cancel: err => source.cancel(err),
     async *[Symbol.asyncIterator]() {
-      for await (const msg of source) {
-        yield BigIntJSON.parse(msg) as Downstream;
+      for await (const json of source) {
+        yield {data: BigIntJSON.parse(json) as Downstream, json};
       }
     },
   };

--- a/packages/zql/src/query/query-impl.ts
+++ b/packages/zql/src/query/query-impl.ts
@@ -300,7 +300,7 @@ export class QueryImpl<
             },
             this.customQueryID,
             relationship,
-          ),
+          ) as AnyQuery,
         ),
       );
 
@@ -487,7 +487,7 @@ export class QueryImpl<
             defaultFormat,
             this.customQueryID,
             undefined,
-          ),
+          ) as AnyQuery,
         ),
       );
       return {
@@ -566,8 +566,12 @@ export class QueryImpl<
     return this.#ast;
   }
 
-  expressionBuilder() {
-    return new ExpressionBuilder(this.#exists);
+  expressionBuilder(): ExpressionBuilder<TTable, TSchema> {
+    return new ExpressionBuilder<TTable, TSchema>(
+      this.#exists as ConstructorParameters<
+        typeof ExpressionBuilder<TTable, TSchema>
+      >[0],
+    );
   }
 }
 


### PR DESCRIPTION
tldr: 
- Follow up to https://github.com/rocicorp/mono/pull/6257
- passes the change JSON all the way down to the sqlite writer rather than parsing and re-stringifying.

---

Preserve the exact application-level JSON received from the change-streamer alongside each parsed and validated downstream message, then pass that JSON through the replicator to the SQLite write worker instead of serializing the parsed message again.

Production state after deployment:

- The PG storer remains the sole canonical serializer for live data-plane messages. The JSON it forwards over WebSocket is reused by the canonical SQLite change-log writer.
- Every replicator still parses and validates each downstream message for replica application, but no longer calls BigIntJSON.stringify() again for begin, data, commit, or rollback messages.
- The internal WebSocket protocol and payload bytes are unchanged; the client extracts the existing msg JSON from the validated stream frame.
- Parsed data and canonical JSON still cross the write-worker boundary together. Replica writes, SQLite change-log bytes, transaction boundaries, notifications, errors, subscriber delivery, and PostgreSQL ACK behavior remain unchanged.
- Status and error messages retain their received JSON at the ChangeStreamer client boundary but remain outside the write-worker and persisted stream-log paths.
- There are no schema, persisted-format, configuration, rollout, or compatibility changes. The production effect is reduced serialization CPU and temporary allocation in each replicator.