### PR TITLE
chore(rmv2): observe SQLite change log shadow writes [6/n]

### DIFF
--- a/packages/zero-cache/src/observability/metrics.ts
+++ b/packages/zero-cache/src/observability/metrics.ts
@@ -119,6 +119,27 @@ const LATENCY_HISTOGRAM_BOUNDARIES_S = [
 
 const histograms = cache<Histogram>();
 
+/**
+ * Creates a histogram for dimensionless values without applying the
+ * millisecond-to-second conversion used by the latency helpers below.
+ */
+export function getOrCreateValueHistogram(
+  category: Category,
+  name: string,
+  opts: HistogramOptions,
+): Histogram {
+  const {bucketBoundaries, ...metricOptions} = opts;
+  return histograms(name, name =>
+    getMeter().createHistogram(`zero.${category}.${name}`, {
+      ...metricOptions,
+      advice: {
+        ...metricOptions.advice,
+        explicitBucketBoundaries: bucketBoundaries,
+      },
+    }),
+  );
+}
+
 export function getOrCreateHistogram(
   category: Category,
   name: string,

--- a/packages/zero-cache/src/server/replicator.ts
+++ b/packages/zero-cache/src/server/replicator.ts
@@ -34,6 +34,7 @@ import {
 } from '../services/replicator/replicator.ts';
 import {
   getSQLiteChangeLogInfo,
+  getSQLiteChangeLogStartupInfo,
   logSQLiteChangeLogStartup,
   SQLiteChangeLogObserver,
 } from '../services/replicator/sqlite-change-log-observability.ts';
@@ -50,6 +51,7 @@ import {
   replicaFileModeSchema,
   setUpMessageHandlers,
   setupReplica,
+  type ReplicaFileMode,
   type WalMode,
 } from '../workers/replicator.ts';
 import {createLogContext} from './logging.ts';
@@ -105,11 +107,12 @@ export default async function runWorker(
     dbPath,
   });
 
-  const changeLogInfo = readSQLiteChangeLogInfo(lc, dbPath);
-  logSQLiteChangeLogStartup(lc, fileMode, logsChangeStream, changeLogInfo);
-  const sqliteChangeLogObserver = logsChangeStream
-    ? new SQLiteChangeLogObserver(lc, changeLogInfo)
-    : undefined;
+  const sqliteChangeLogObserver = readSQLiteChangeLog(
+    lc,
+    dbPath,
+    fileMode,
+    logsChangeStream,
+  );
 
   setupMetrics(lc, dbPath, walMode);
 
@@ -163,10 +166,34 @@ export default async function runWorker(
   return running;
 }
 
-function readSQLiteChangeLogInfo(lc: LogContext, file: string) {
+/**
+ * Emits the read-only SQLite change-log startup inspection and, when the writer
+ * is enabled, returns an observer seeded with the retained row/byte totals.
+ *
+ * The totals require a full change-log table scan, so that scan is skipped when
+ * the writer is disabled: an off-mode replica still logs its startup state but
+ * only pays for the indexed schema/state/head lookups.
+ */
+function readSQLiteChangeLog(
+  lc: LogContext,
+  file: string,
+  fileMode: ReplicaFileMode,
+  logsChangeStream: boolean,
+): SQLiteChangeLogObserver | undefined {
   const db = new Database(lc, file, {readonly: true});
   try {
-    return getSQLiteChangeLogInfo(db);
+    if (!logsChangeStream) {
+      logSQLiteChangeLogStartup(
+        lc,
+        fileMode,
+        false,
+        getSQLiteChangeLogStartupInfo(db),
+      );
+      return undefined;
+    }
+    const info = getSQLiteChangeLogInfo(db);
+    logSQLiteChangeLogStartup(lc, fileMode, true, info);
+    return new SQLiteChangeLogObserver(lc, info);
   } finally {
     db.close();
   }

--- a/packages/zero-cache/src/server/replicator.ts
+++ b/packages/zero-cache/src/server/replicator.ts
@@ -173,6 +173,11 @@ export default async function runWorker(
  * The totals require a full change-log table scan, so that scan is skipped when
  * the writer is disabled: an off-mode replica still logs its startup state but
  * only pays for the indexed schema/state/head lookups.
+ *
+ * Only the writer requires a seeded change log, so when it is disabled the
+ * inspection is best-effort: a missing or unseeded log (e.g. a replica that
+ * predates the change-log migration) is warned about rather than crashing the
+ * replicator, keeping `sqliteChangeLogMode=off` a safe rollback.
  */
 function readSQLiteChangeLog(
   lc: LogContext,
@@ -183,12 +188,20 @@ function readSQLiteChangeLog(
   const db = new Database(lc, file, {readonly: true});
   try {
     if (!logsChangeStream) {
-      logSQLiteChangeLogStartup(
-        lc,
-        fileMode,
-        false,
-        getSQLiteChangeLogStartupInfo(db),
-      );
+      try {
+        logSQLiteChangeLogStartup(
+          lc,
+          fileMode,
+          false,
+          getSQLiteChangeLogStartupInfo(db),
+        );
+      } catch (e) {
+        lc.warn?.(
+          'SQLite change-log startup inspection skipped: the change log is ' +
+            'unavailable and the writer is disabled',
+          e,
+        );
+      }
       return undefined;
     }
     const info = getSQLiteChangeLogInfo(db);

--- a/packages/zero-cache/src/server/replicator.ts
+++ b/packages/zero-cache/src/server/replicator.ts
@@ -6,6 +6,7 @@ import {assert} from '../../../shared/src/asserts.ts';
 import {must} from '../../../shared/src/must.ts';
 import {sleep} from '../../../shared/src/sleep.ts';
 import * as v from '../../../shared/src/valita.ts';
+import {Database} from '../../../zqlite/src/db.ts';
 import type {
   LitestreamConfig,
   NormalizedZeroConfig,
@@ -31,6 +32,11 @@ import {
   ReplicatorService,
   type ReplicatorMode,
 } from '../services/replicator/replicator.ts';
+import {
+  getSQLiteChangeLogInfo,
+  logSQLiteChangeLogStartup,
+  SQLiteChangeLogObserver,
+} from '../services/replicator/sqlite-change-log-observability.ts';
 import {ThreadWriteWorkerClient} from '../services/replicator/write-worker-client.ts';
 import {
   parentWorker,
@@ -99,6 +105,12 @@ export default async function runWorker(
     dbPath,
   });
 
+  const changeLogInfo = readSQLiteChangeLogInfo(lc, dbPath);
+  logSQLiteChangeLogStartup(lc, fileMode, logsChangeStream, changeLogInfo);
+  const sqliteChangeLogObserver = logsChangeStream
+    ? new SQLiteChangeLogObserver(lc, changeLogInfo)
+    : undefined;
+
   setupMetrics(lc, dbPath, walMode);
 
   // Create the write worker for async SQLite writes.
@@ -135,6 +147,7 @@ export default async function runWorker(
       ? // publish ReplicationStatusEvents from backup-replicator only
         ReplicationStatusPublisher.forReplicaFile(dbPath)
       : null,
+    sqliteChangeLogObserver,
   );
 
   setUpMessageHandlers(lc, replicator, parent);
@@ -148,6 +161,15 @@ export default async function runWorker(
   }
 
   return running;
+}
+
+function readSQLiteChangeLogInfo(lc: LogContext, file: string) {
+  const db = new Database(lc, file, {readonly: true});
+  try {
+    return getSQLiteChangeLogInfo(db);
+  } finally {
+    db.close();
+  }
 }
 
 function setupMetrics(lc: LogContext, file: string, walMode: WalMode) {

--- a/packages/zero-cache/src/services/change-streamer/change-log-transaction-hash.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-log-transaction-hash.test.ts
@@ -1,0 +1,62 @@
+import {describe, expect, test} from 'vitest';
+import {
+  ChangeLogTransactionHasher,
+  type ChangeLogHashRow,
+} from './change-log-transaction-hash.ts';
+
+const rows: readonly ChangeLogHashRow[] = [
+  {
+    watermark: '06',
+    pos: 0,
+    tag: 'begin',
+    change: '{"tag":"begin"}',
+    precommit: null,
+  },
+  {
+    watermark: '06',
+    pos: 1,
+    tag: 'commit',
+    change: '{"tag":"commit"}',
+    precommit: '06',
+  },
+];
+
+function hash(transactionRows: readonly ChangeLogHashRow[]): string {
+  const hasher = new ChangeLogTransactionHasher();
+  transactionRows.forEach(row => hasher.add(row));
+  return hasher.digest();
+}
+
+describe('change-log transaction hash', () => {
+  test('is stable for identical rows', () => {
+    expect(hash(rows)).toBe(hash(rows));
+    expect(hash(rows)).toHaveLength(64);
+  });
+
+  test.each(['watermark', 'pos', 'tag', 'change', 'precommit'] as const)(
+    'detects a changed %s',
+    field => {
+      const changed = rows.map((row, index) =>
+        index === 1
+          ? {
+              ...row,
+              [field]:
+                field === 'pos'
+                  ? 2
+                  : field === 'precommit'
+                    ? null
+                    : `${row[field]}-changed`,
+            }
+          : row,
+      );
+      expect(hash(changed)).not.toBe(hash(rows));
+    },
+  );
+
+  test('detects reordered rows and unambiguous field boundaries', () => {
+    expect(hash(rows.toReversed())).not.toBe(hash(rows));
+    expect(hash([{...rows[0], tag: 'ab', change: 'c'}, rows[1]])).not.toBe(
+      hash([{...rows[0], tag: 'a', change: 'bc'}, rows[1]]),
+    );
+  });
+});

--- a/packages/zero-cache/src/services/change-streamer/change-log-transaction-hash.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-log-transaction-hash.ts
@@ -1,0 +1,48 @@
+import {createHash, type Hash} from 'node:crypto';
+
+export type ChangeLogHashRow = {
+  readonly watermark: string;
+  readonly pos: number;
+  readonly tag: string;
+  readonly change: string;
+  readonly precommit: string | null;
+};
+
+/**
+ * Computes a stable digest over the fields shared by the Postgres and SQLite
+ * change logs. Values are length-prefixed so different field boundaries cannot
+ * produce the same byte stream.
+ */
+export class ChangeLogTransactionHasher {
+  readonly #hash: Hash;
+
+  constructor() {
+    this.#hash = createHash('sha256');
+    writeString(this.#hash, 'zero-change-log-transaction-v1');
+  }
+
+  add(row: ChangeLogHashRow): void {
+    writeString(this.#hash, row.watermark);
+    writeString(this.#hash, String(row.pos));
+    writeString(this.#hash, row.tag);
+    writeString(this.#hash, row.change);
+    if (row.precommit === null) {
+      this.#hash.update(Uint8Array.of(0));
+    } else {
+      this.#hash.update(Uint8Array.of(1));
+      writeString(this.#hash, row.precommit);
+    }
+  }
+
+  digest(): string {
+    return this.#hash.digest('hex');
+  }
+}
+
+function writeString(hash: Hash, value: string): void {
+  const bytes = Buffer.from(value);
+  const length = Buffer.allocUnsafe(4);
+  length.writeUInt32BE(bytes.byteLength);
+  hash.update(length);
+  hash.update(bytes);
+}

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
@@ -12,6 +12,7 @@ import {sleep} from '../../../../shared/src/sleep.ts';
 import {Database} from '../../../../zqlite/src/db.ts';
 import {StatementRunner} from '../../db/statements.ts';
 import {expectTables, test, type PgTest} from '../../test/db.ts';
+import {DbFile, initDB} from '../../test/lite.ts';
 import type {PostgresDB} from '../../types/pg.ts';
 import type {Source} from '../../types/streams.ts';
 import {Subscription, type Result} from '../../types/subscription.ts';
@@ -19,13 +20,19 @@ import type {ChangeSource} from '../change-source/change-source.ts';
 import {type ChangeStreamMessage} from '../change-source/protocol/current/downstream.ts';
 import type {UpstreamStatusMessage} from '../change-source/protocol/current/status.ts';
 import {exitAfter} from '../life-cycle.ts';
+import {IncrementalSyncer} from '../replicator/incremental-sync.ts';
 import {ReplicationStatusPublisher} from '../replicator/replication-status.ts';
 import {
   getSubscriptionState,
   initReplicationState,
   type SubscriptionState,
 } from '../replicator/schema/replication-state.ts';
+import {
+  getSQLiteChangeLogInfo,
+  SQLiteChangeLogObserver,
+} from '../replicator/sqlite-change-log-observability.ts';
 import {ReplicationMessages} from '../replicator/test-utils.ts';
+import {ThreadWriteWorkerClient} from '../replicator/write-worker-client.ts';
 import {
   initializeStreamer,
   type TuningOptions,
@@ -164,6 +171,157 @@ describe('change-streamer/service', () => {
   }
 
   const messages = new ReplicationMessages({foo: 'id'});
+
+  test('PG stream shadow-writes SQLite without changing PG serving or ACKs', async () => {
+    const dbFile = new DbFile('sqlite-change-log-shadow-integration');
+    const replica = dbFile.connect(lc);
+    replica.pragma('journal_mode = wal');
+    replica.exec(/*sql*/ `
+      CREATE TABLE "_zero.versionHistory" (
+        "dataVersion" INTEGER NOT NULL,
+        "schemaVersion" INTEGER NOT NULL,
+        "minSafeVersion" INTEGER NOT NULL,
+        "lock" INTEGER PRIMARY KEY DEFAULT 1 CHECK ("lock" = 1)
+      );
+      INSERT INTO "_zero.versionHistory"
+        ("dataVersion", "schemaVersion", "minSafeVersion")
+        VALUES (14, 14, 0);
+    `);
+    initReplicationState(replica, ['zero_data'], REPLICA_VERSION);
+    initDB(
+      replica,
+      `
+      CREATE TABLE foo(
+        id TEXT PRIMARY KEY,
+        _0_version TEXT
+      );
+      `,
+    );
+
+    const worker = new ThreadWriteWorkerClient();
+    await worker.init(
+      dbFile.path,
+      'serving',
+      true,
+      {busyTimeout: 30_000, analysisLimit: 1000},
+      {level: 'error', format: 'text'},
+    );
+    const observer = new SQLiteChangeLogObserver(
+      lc,
+      getSQLiteChangeLogInfo(replica),
+    );
+    const syncer = new IncrementalSyncer(
+      lc,
+      'shadow-write-task',
+      'canonical-replicator',
+      {
+        async subscribe(ctx) {
+          const encoded = await streamer.subscribe(ctx);
+          return {
+            cancel: err => encoded.cancel(err),
+            async *[Symbol.asyncIterator]() {
+              for await (const json of encoded) {
+                yield {data: BigIntJSON.parse(json) as Downstream, json};
+              }
+            },
+          };
+        },
+      },
+      worker,
+      'serving',
+      null,
+      observer,
+    );
+    const syncing = syncer.run();
+
+    const liveSub = await streamer.subscribe({
+      protocolVersion: PROTOCOL_VERSION,
+      taskID: 'live-observer-task',
+      id: 'live-observer',
+      mode: 'serving',
+      watermark: REPLICA_VERSION,
+      replicaVersion: REPLICA_VERSION,
+      initial: true,
+    });
+    const live = drainToQueue(liveSub);
+    expect(await nextChange(live)).toMatchObject({tag: 'status'});
+
+    try {
+      changes.push(['begin', messages.begin(), {commitWatermark: '06'}]);
+      changes.push(['data', messages.insert('foo', {id: 'hello'})]);
+      changes.push(['commit', messages.commit(), {watermark: '06'}]);
+
+      expect(await nextChange(live)).toMatchObject({tag: 'begin'});
+      expect(await nextChange(live)).toMatchObject({
+        tag: 'insert',
+        new: {id: 'hello'},
+      });
+      expect(await nextChange(live)).toMatchObject({tag: 'commit'});
+
+      await expectAcks('06');
+      await vi.waitFor(() => {
+        expect(
+          replica
+            .prepare(`SELECT "stateVersion" FROM "_zero.replicationState"`)
+            .get(),
+        ).toEqual({stateVersion: '06'});
+      });
+      expect(
+        replica
+          .prepare(
+            `SELECT max("watermark") AS "watermark" FROM "_zero.changeLogStream"`,
+          )
+          .get(),
+      ).toEqual({watermark: '06'});
+      expect(observer.state()).toMatchObject({
+        receivedHead: '06',
+        sqliteHead: '06',
+        headLag: 0,
+        invariantFailures: 0,
+        hashMatches: 1,
+        hashMismatches: 0,
+        hashUnpaired: 0,
+      });
+
+      const catchupSub = await streamer.subscribe({
+        protocolVersion: PROTOCOL_VERSION,
+        taskID: 'catchup-observer-task',
+        id: 'catchup-observer',
+        mode: 'serving',
+        watermark: REPLICA_VERSION,
+        replicaVersion: REPLICA_VERSION,
+        initial: true,
+      });
+      const catchup = drainToQueue(catchupSub);
+      expect(await nextChange(catchup)).toMatchObject({tag: 'status'});
+      expect(await nextChange(catchup)).toMatchObject({tag: 'begin'});
+      expect(await nextChange(catchup)).toMatchObject({
+        tag: 'insert',
+        new: {id: 'hello'},
+      });
+      expect(await nextChange(catchup)).toMatchObject({tag: 'commit'});
+      // This test has finished exercising catchup. Remove the subscriber
+      // before testing cleanup so its asynchronous consumed ACK cannot race
+      // the purge eligibility check below.
+      catchupSub.cancel();
+
+      streamer.scheduleCleanup('06');
+      const purge = setTimeoutFn.mock.calls.at(-1)?.[0];
+      assert(purge, 'PG change-log purge was not scheduled');
+      await (purge() as unknown as Promise<void>);
+      expect(
+        await sql`SELECT watermark FROM "zoro_3/cdc"."changeLog"
+                    ORDER BY watermark, pos`.values(),
+      ).toEqual([['06'], ['06'], ['06']]);
+    } finally {
+      liveSub.cancel();
+      syncer.stop(lc);
+      await syncing;
+      await worker.stop();
+      replica.close();
+      dbFile.delete();
+    }
+  });
 
   test('get empty changelog state', async () => {
     expect(await streamer.getChangeLogState()).toEqual({

--- a/packages/zero-cache/src/services/replicator/change-log-stream-writer.test.ts
+++ b/packages/zero-cache/src/services/replicator/change-log-stream-writer.test.ts
@@ -5,7 +5,10 @@ import {StatementRunner} from '../../db/statements.ts';
 import {expectTableExact} from '../../test/lite.ts';
 import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
 import {serializeChangeStreamData} from '../change-streamer/change-log-codec.ts';
-import {ChangeLogStreamWriter} from './change-log-stream-writer.ts';
+import {
+  ChangeLogStreamWriter,
+  estimateChangeLogStreamRowBytes,
+} from './change-log-stream-writer.ts';
 import {CHANGE_LOG_STREAM_TABLE} from './schema/change-log-stream.ts';
 import {
   initReplicationState,
@@ -27,41 +30,47 @@ describe('replicator/change-log-stream-writer', () => {
     const writeTimeMs = 1_234_567;
 
     runner.beginImmediate();
-    writer.begin(
-      '06',
-      json(['begin', {tag: 'begin'}, {commitWatermark: '06'}]),
-    );
-    writer.append(
-      json([
-        'data',
-        {
-          tag: 'insert',
-          relation: {
-            schema: 'public',
-            name: 'issues',
-            rowKey: {columns: ['id'], type: 'default'},
-          },
-          new: {id: 9007199254740993n, text: 'before\0after'},
+    const begin = json(['begin', {tag: 'begin'}, {commitWatermark: '06'}]);
+    const insert = json([
+      'data',
+      {
+        tag: 'insert',
+        relation: {
+          schema: 'public',
+          name: 'issues',
+          rowKey: {columns: ['id'], type: 'default'},
         },
-      ]),
-      'insert',
-    );
-    writer.append(
-      json([
-        'data',
-        {
-          tag: 'rename-table',
-          old: {schema: 'public', name: 'issues'},
-          new: {schema: 'public', name: 'renamed'},
-        },
-      ]),
-      'rename-table',
-    );
-    writer.commit(
-      '06',
-      json(['commit', {tag: 'commit'}, {watermark: '06'}]),
-      writeTimeMs,
-    );
+        new: {id: 9007199254740993n, text: 'before\0after'},
+      },
+    ]);
+    const rename = json([
+      'data',
+      {
+        tag: 'rename-table',
+        old: {schema: 'public', name: 'issues'},
+        new: {schema: 'public', name: 'renamed'},
+      },
+    ]);
+    const commit = json(['commit', {tag: 'commit'}, {watermark: '06'}]);
+    writer.begin('06', begin);
+    writer.append(insert, 'insert');
+    writer.append(rename, 'rename-table');
+    const stats = writer.commit('06', commit, writeTimeMs);
+    expect(stats).toEqual({
+      rows: 4,
+      hash: expect.stringMatching(/^[0-9a-f]{64}$/),
+      estimatedBytes:
+        estimateChangeLogStreamRowBytes('06', '{"tag":"begin"}') +
+        estimateChangeLogStreamRowBytes(
+          '06',
+          '{"tag":"insert","relation":{"schema":"public","name":"issues","rowKey":{"columns":["id"],"type":"default"}},"new":{"id":9007199254740993,"text":"before\\u0000after"}}',
+        ) +
+        estimateChangeLogStreamRowBytes(
+          '06',
+          '{"tag":"rename-table","old":{"schema":"public","name":"issues"},"new":{"schema":"public","name":"renamed"}}',
+        ) +
+        estimateChangeLogStreamRowBytes('06', '{"tag":"commit"}', '06', true),
+    });
     updateReplicationWatermark(runner, '06', writeTimeMs);
     runner.commit();
 

--- a/packages/zero-cache/src/services/replicator/change-log-stream-writer.ts
+++ b/packages/zero-cache/src/services/replicator/change-log-stream-writer.ts
@@ -1,10 +1,51 @@
-import {assert} from '../../../../shared/src/asserts.ts';
 import type {Database, Statement} from '../../../../zqlite/src/db.ts';
 import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
 import {extractChangeSubstring} from '../change-streamer/change-log-codec.ts';
+import {ChangeLogTransactionHasher} from '../change-streamer/change-log-transaction-hash.ts';
 import {CHANGE_LOG_STREAM_TABLE} from './schema/change-log-stream.ts';
 
 type ChangeTag = ChangeStreamData[1]['tag'];
+
+export type ChangeLogStreamTransactionStats = {
+  readonly rows: number;
+  readonly estimatedBytes: number;
+  readonly hash: string;
+};
+
+const INTEGER_BYTES = 8;
+
+/**
+ * Estimates the retained payload size of a stream row. This deliberately does
+ * not claim to measure SQLite b-tree/page overhead; it is stable across the
+ * write path and the startup scan used by observability.
+ */
+export function estimateChangeLogStreamRowBytes(
+  watermark: string,
+  change: string,
+  precommit?: string,
+  hasWriteTime = false,
+): number {
+  return (
+    Buffer.byteLength(watermark) +
+    INTEGER_BYTES +
+    Buffer.byteLength(change) +
+    (precommit === undefined ? 0 : Buffer.byteLength(precommit)) +
+    (hasWriteTime ? INTEGER_BYTES : 0)
+  );
+}
+
+export class ChangeLogStreamInvariantError extends Error {
+  override readonly name = 'ChangeLogStreamInvariantError';
+}
+
+function assertInvariant(
+  condition: unknown,
+  message: string,
+): asserts condition {
+  if (!condition) {
+    throw new ChangeLogStreamInvariantError(message);
+  }
+}
 
 /**
  * Appends the canonical downstream stream to the replica-local change log.
@@ -20,6 +61,8 @@ export class ChangeLogStreamWriter {
 
   #watermark: string | undefined;
   #pos = 0;
+  #estimatedBytes = 0;
+  #hasher: ChangeLogTransactionHasher | undefined;
 
   constructor(db: Database) {
     this.#insertChange = db.prepare(/*sql*/ `
@@ -35,55 +78,99 @@ export class ChangeLogStreamWriter {
   }
 
   begin(watermark: string, json: string): void {
-    assert(
+    assertInvariant(
       this.#watermark === undefined,
       `change-log stream transaction already open at ${this.#watermark}`,
     );
     this.#watermark = watermark;
     this.#pos = 0;
-    this.#insertChange.run(
+    const change = extractChangeSubstring(json, 'begin');
+    this.#insertChange.run(watermark, this.#pos, change);
+    this.#hasher = new ChangeLogTransactionHasher();
+    this.#hasher.add({
       watermark,
-      this.#pos,
-      extractChangeSubstring(json, 'begin'),
-    );
+      pos: this.#pos,
+      tag: 'begin',
+      change,
+      precommit: null,
+    });
+    this.#estimatedBytes = estimateChangeLogStreamRowBytes(watermark, change);
   }
 
   append(json: string, tag: ChangeTag): void {
     const watermark = this.#requireWatermark();
-    this.#insertChange.run(
+    const change = extractChangeSubstring(json, tag);
+    this.#insertChange.run(watermark, ++this.#pos, change);
+    this.#requireHasher().add({
       watermark,
-      ++this.#pos,
-      extractChangeSubstring(json, tag),
-    );
+      pos: this.#pos,
+      tag,
+      change,
+      precommit: null,
+    });
+    this.#estimatedBytes += estimateChangeLogStreamRowBytes(watermark, change);
   }
 
-  commit(watermark: string, json: string, writeTimeMs: number): void {
+  commit(
+    watermark: string,
+    json: string,
+    writeTimeMs: number,
+  ): ChangeLogStreamTransactionStats {
     const precommit = this.#requireWatermark();
-    assert(
+    assertInvariant(
       watermark === precommit,
       `change-log stream commit ${watermark} does not match begin ${precommit}`,
     );
+    const change = extractChangeSubstring(json, 'commit');
     this.#insertCommit.run(
       watermark,
       ++this.#pos,
-      extractChangeSubstring(json, 'commit'),
+      change,
       precommit,
       writeTimeMs,
     );
+    const hasher = this.#requireHasher();
+    hasher.add({
+      watermark,
+      pos: this.#pos,
+      tag: 'commit',
+      change,
+      precommit,
+    });
+    const stats = {
+      rows: this.#pos + 1,
+      estimatedBytes:
+        this.#estimatedBytes +
+        estimateChangeLogStreamRowBytes(watermark, change, precommit, true),
+      hash: hasher.digest(),
+    };
     this.#watermark = undefined;
     this.#pos = 0;
+    this.#estimatedBytes = 0;
+    this.#hasher = undefined;
+    return stats;
   }
 
   rollback(): void {
     this.#watermark = undefined;
     this.#pos = 0;
+    this.#estimatedBytes = 0;
+    this.#hasher = undefined;
   }
 
   #requireWatermark(): string {
-    assert(
+    assertInvariant(
       this.#watermark !== undefined,
       'change-log stream message received outside of a transaction',
     );
     return this.#watermark;
+  }
+
+  #requireHasher(): ChangeLogTransactionHasher {
+    assertInvariant(
+      this.#hasher !== undefined,
+      'change-log stream hash received outside of a transaction',
+    );
+    return this.#hasher;
   }
 }

--- a/packages/zero-cache/src/services/replicator/change-processor.test.ts
+++ b/packages/zero-cache/src/services/replicator/change-processor.test.ts
@@ -3894,7 +3894,10 @@ describe('replicator/change-processor change-stream logging', () => {
     const result = process(['commit', issues.commit(), {watermark: '06'}]);
 
     expect(failures).toEqual([]);
-    expect(result).toMatchObject({watermark: '06'});
+    expect(result).toMatchObject({
+      watermark: '06',
+      changeLogStream: {rows: 3, estimatedBytes: expect.any(Number)},
+    });
     expectTableExact(
       replica,
       'issues',

--- a/packages/zero-cache/src/services/replicator/change-processor.ts
+++ b/packages/zero-cache/src/services/replicator/change-processor.ts
@@ -56,7 +56,10 @@ import type {
   TableUpdateMetadata,
 } from '../change-source/protocol/current/data.ts';
 import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
-import {ChangeLogStreamWriter} from './change-log-stream-writer.ts';
+import {
+  ChangeLogStreamWriter,
+  type ChangeLogStreamTransactionStats,
+} from './change-log-stream-writer.ts';
 import type {ReplicatorMode} from './replicator.ts';
 import {ChangeLog, DEL_OP, SET_OP} from './schema/change-log.ts';
 import {ColumnMetadataStore} from './schema/column-metadata.ts';
@@ -77,6 +80,7 @@ export type CommitResult = {
   completedBackfill: DownloadStatus | undefined;
   schemaUpdated: boolean;
   changeLogUpdated: boolean;
+  changeLogStream?: ChangeLogStreamTransactionStats | undefined;
 };
 
 /**
@@ -954,9 +958,14 @@ class TransactionProcessor {
         }: ${stringify(commit)}`,
       );
     }
+    let changeLogStream: ChangeLogStreamTransactionStats | undefined;
     if (changeLogStreamWriter) {
       const writeTimeMs = Date.now();
-      changeLogStreamWriter.commit(watermark, must(canonicalJSON), writeTimeMs);
+      changeLogStream = changeLogStreamWriter.commit(
+        watermark,
+        must(canonicalJSON),
+        writeTimeMs,
+      );
       updateReplicationWatermark(this.#db, watermark, writeTimeMs);
     } else {
       updateReplicationWatermark(this.#db, watermark);
@@ -982,6 +991,7 @@ class TransactionProcessor {
       completedBackfill: this.#completedBackfill,
       schemaUpdated: this.#schemaChanged,
       changeLogUpdated: this.#numChangeLogEntries > 0,
+      ...(changeLogStream === undefined ? {} : {changeLogStream}),
     };
   }
 

--- a/packages/zero-cache/src/services/replicator/incremental-sync.test.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.test.ts
@@ -35,6 +35,7 @@ import {
   createReplicationStateTables,
   initReplicationState,
 } from './schema/replication-state.ts';
+import {SQLiteChangeLogObserver} from './sqlite-change-log-observability.ts';
 import {ReplicationMessages} from './test-utils.ts';
 import {ThreadWriteWorkerClient} from './write-worker-client.ts';
 
@@ -92,6 +93,7 @@ describe('replicator/incremental-sync', () => {
       worker,
       'serving',
       ReplicationStatusPublisher.forReplicaFile(dbFile.path),
+      undefined,
     );
   });
 
@@ -756,6 +758,7 @@ describe('replicator/incremental-sync', () => {
       worker,
       'serving',
       ReplicationStatusPublisher.forReplicaFile(dbFile.path),
+      undefined,
     );
 
     const localSyncing = syncer.run();
@@ -786,6 +789,7 @@ describe('replicator/incremental-sync', () => {
       worker,
       'serving',
       ReplicationStatusPublisher.forReplicaFile(dbFile.path),
+      undefined,
     );
 
     const localSyncing = syncer.run();
@@ -835,6 +839,7 @@ describe('replicator/incremental-sync', () => {
       worker,
       'serving',
       ReplicationStatusPublisher.forReplicaFile(dbFile.path),
+      undefined,
     );
     syncing = syncer.run();
     await vi.waitFor(() => expect(subscribeFn).toHaveBeenCalledTimes(1));
@@ -858,6 +863,60 @@ describe('replicator/incremental-sync', () => {
     syncer.stop(lc);
     void syncing.catch(() => {});
     syncing = undefined;
+  });
+
+  test('an enabled SQLite stream-writer error stops the replicator', async () => {
+    await worker.stop();
+    worker = new ThreadWriteWorkerClient();
+    await worker.init(
+      dbFile.path,
+      'serving',
+      true,
+      {
+        busyTimeout: 30000,
+        analysisLimit: 1000,
+      },
+      {level: 'error', format: 'text'},
+    );
+    initReplicationState(mainDb, ['zero_data'], '02', {}, false);
+    const observer = new SQLiteChangeLogObserver(lc, {
+      schemaVersion: 14,
+      stateWatermark: '02',
+      seedWatermark: '02',
+      headWatermark: '02',
+      rows: 2,
+      estimatedBytes: 50,
+    });
+    syncer = new IncrementalSyncer(
+      lc,
+      TASK_ID,
+      REPLICA_ID,
+      {subscribe: subscribeFn.mockResolvedValue(downstream)},
+      worker,
+      'serving',
+      ReplicationStatusPublisher.forReplicaFile(dbFile.path),
+      observer,
+    );
+    syncing = syncer.run();
+    await vi.waitFor(() => expect(subscribeFn).toHaveBeenCalledTimes(1));
+
+    // Reusing the seed watermark makes the stream insert fail even though the
+    // otherwise-empty replica transaction itself would be valid.
+    downstream.push(['begin', {tag: 'begin'}, {commitWatermark: '02'}]);
+    await syncing;
+    syncing = undefined;
+
+    expect(subscribeFn).toHaveBeenCalledTimes(1);
+    expect(observer.state()).toMatchObject({
+      sqliteHead: '02',
+      rows: 2,
+      rollbacks: 1,
+    });
+    expect(
+      mainDb
+        .prepare(`SELECT "stateVersion" FROM "_zero.replicationState"`)
+        .get(),
+    ).toEqual({stateVersion: '02'});
   });
 
   test('shut down on change-streamer error message', async () => {

--- a/packages/zero-cache/src/services/replicator/incremental-sync.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.ts
@@ -19,6 +19,7 @@ import type {ReplicationStatusPublisher} from './replication-status.ts';
 import type {ReplicaState, ReplicatorMode} from './replicator.ts';
 import {ReplicationReportRecorder} from './reporter/recorder.ts';
 import type {ReplicationReport} from './reporter/report-schema.ts';
+import type {SQLiteChangeLogObserver} from './sqlite-change-log-observability.ts';
 import type {WriteWorkerClient} from './write-worker-client.ts';
 
 type ErrorType = Enum<typeof ErrorType>;
@@ -40,6 +41,7 @@ export class IncrementalSyncer {
   readonly #statusPublisher: ReplicationStatusPublisher | null;
   readonly #notifier: Notifier;
   readonly #reporter: ReplicationReportRecorder;
+  readonly #sqliteChangeLogObserver: SQLiteChangeLogObserver | undefined;
 
   readonly #state = new RunningState('IncrementalSyncer');
 
@@ -57,6 +59,7 @@ export class IncrementalSyncer {
     worker: WriteWorkerClient,
     mode: ReplicatorMode,
     statusPublisher: ReplicationStatusPublisher | null,
+    sqliteChangeLogObserver: SQLiteChangeLogObserver | undefined,
   ) {
     this.#lc = lc;
     this.#taskID = taskID;
@@ -67,6 +70,7 @@ export class IncrementalSyncer {
     this.#statusPublisher = statusPublisher;
     this.#notifier = new Notifier();
     this.#reporter = new ReplicationReportRecorder(lc);
+    this.#sqliteChangeLogObserver = sqliteChangeLogObserver;
   }
 
   async run() {
@@ -177,10 +181,27 @@ export class IncrementalSyncer {
               }
 
               const data = message as ChangeStreamData;
-              const result = await this.#worker.processMessage({
+              const start = performance.now();
+              this.#sqliteChangeLogObserver?.messageReceived(data, json);
+              let result: CommitResult | null;
+              try {
+                result = await this.#worker.processMessage({
+                  data,
+                  json,
+                });
+              } catch (e) {
+                this.#sqliteChangeLogObserver?.messageFailed(
+                  data,
+                  e,
+                  performance.now() - start,
+                );
+                throw e;
+              }
+              this.#sqliteChangeLogObserver?.messageProcessed(
                 data,
-                json,
-              });
+                result,
+                performance.now() - start,
+              );
 
               this.#handleResult(lc, result);
               if (result?.completedBackfill) {
@@ -190,9 +211,11 @@ export class IncrementalSyncer {
             }
           }
         }
+        this.#sqliteChangeLogObserver?.abort();
         this.#worker.abort();
       } catch (e) {
         err = e;
+        this.#sqliteChangeLogObserver?.abort();
         this.#worker.abort();
       } finally {
         downstream?.cancel();

--- a/packages/zero-cache/src/services/replicator/replication-resumption-child.ts
+++ b/packages/zero-cache/src/services/replicator/replication-resumption-child.ts
@@ -249,6 +249,7 @@ export default async function runWorker(
     new IPCChangeStreamer(parent),
     worker,
     null,
+    undefined,
   );
 
   const running = runUntilKilled(lc, parent, replicator);

--- a/packages/zero-cache/src/services/replicator/replication-throughput.bench.pg.ts
+++ b/packages/zero-cache/src/services/replicator/replication-throughput.bench.pg.ts
@@ -185,6 +185,7 @@ async function startReplicationPipeline(testDBs: PgTest['testDBs']) {
     parseStringifiedChangeStreamer(changeStreamer),
     worker,
     null,
+    undefined,
   );
   const replicatorDone = replicator.run();
   cleanup.push(async () => {

--- a/packages/zero-cache/src/services/replicator/replicator.ts
+++ b/packages/zero-cache/src/services/replicator/replicator.ts
@@ -5,6 +5,7 @@ import type {ChangeStreamer} from '../change-streamer/change-streamer.ts';
 import type {Service} from '../service.ts';
 import {IncrementalSyncer} from './incremental-sync.ts';
 import type {ReplicationStatusPublisher} from './replication-status.ts';
+import type {SQLiteChangeLogObserver} from './sqlite-change-log-observability.ts';
 import type {WriteWorkerClient} from './write-worker-client.ts';
 
 /** See {@link ReplicaStateNotifier.subscribe()}. */
@@ -77,6 +78,7 @@ export class ReplicatorService implements Replicator, Service {
     changeStreamer: ChangeStreamer,
     worker: WriteWorkerClient,
     statusPublisher: ReplicationStatusPublisher | null,
+    sqliteChangeLogObserver: SQLiteChangeLogObserver | undefined,
   ) {
     this.id = id;
     this.#lc = lc
@@ -92,6 +94,7 @@ export class ReplicatorService implements Replicator, Service {
       worker,
       mode,
       statusPublisher,
+      sqliteChangeLogObserver,
     );
   }
 

--- a/packages/zero-cache/src/services/replicator/sqlite-change-log-observability.test.ts
+++ b/packages/zero-cache/src/services/replicator/sqlite-change-log-observability.test.ts
@@ -11,6 +11,7 @@ import {ChangeLogTransactionHasher} from '../change-streamer/change-log-transact
 import {initReplicationState} from './schema/replication-state.ts';
 import {
   getSQLiteChangeLogInfo,
+  getSQLiteChangeLogStartupInfo,
   logSQLiteChangeLogStartup,
   SQLiteChangeLogObserver,
 } from './sqlite-change-log-observability.ts';
@@ -98,6 +99,44 @@ describe('SQLite change-log observability', () => {
           sqliteChangeLog: {
             fileMode: 'backup',
             writerEnabled: true,
+            schemaVersion: 14,
+            seedWatermark: '02',
+            headWatermark: '02',
+            stateWatermark: '02',
+          },
+        },
+      ],
+    ]);
+  });
+
+  test('startup info skips the row/byte aggregate for disabled writers', () => {
+    using fixture = setupReplica();
+    const startupInfo = getSQLiteChangeLogStartupInfo(fixture.db);
+
+    // Same schema/state/head as the full read, but no table-scanning totals.
+    expect(startupInfo).toEqual({
+      schemaVersion: 14,
+      stateWatermark: '02',
+      seedWatermark: '02',
+      headWatermark: '02',
+    });
+    const {
+      rows: _rows,
+      estimatedBytes: _bytes,
+      ...head
+    } = getSQLiteChangeLogInfo(fixture.db);
+    expect(startupInfo).toEqual(head);
+
+    logSQLiteChangeLogStartup(fixture.lc, 'serving', false, startupInfo);
+    expect(fixture.sink.messages.at(-1)).toEqual([
+      'info',
+      undefined,
+      [
+        'SQLite change-log startup',
+        {
+          sqliteChangeLog: {
+            fileMode: 'serving',
+            writerEnabled: false,
             schemaVersion: 14,
             seedWatermark: '02',
             headWatermark: '02',

--- a/packages/zero-cache/src/services/replicator/sqlite-change-log-observability.test.ts
+++ b/packages/zero-cache/src/services/replicator/sqlite-change-log-observability.test.ts
@@ -1,0 +1,305 @@
+import {LogContext} from '@rocicorp/logger';
+import {describe, expect, test} from 'vitest';
+import {TestLogSink} from '../../../../shared/src/logging-test-utils.ts';
+import {Database} from '../../../../zqlite/src/db.ts';
+import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
+import {
+  extractChangeSubstring,
+  serializeChangeStreamData,
+} from '../change-streamer/change-log-codec.ts';
+import {ChangeLogTransactionHasher} from '../change-streamer/change-log-transaction-hash.ts';
+import {initReplicationState} from './schema/replication-state.ts';
+import {
+  getSQLiteChangeLogInfo,
+  logSQLiteChangeLogStartup,
+  SQLiteChangeLogObserver,
+} from './sqlite-change-log-observability.ts';
+
+function setupReplica() {
+  const sink = new TestLogSink();
+  const lc = new LogContext('debug', undefined, sink);
+  const db = new Database(lc, ':memory:');
+  db.exec(/*sql*/ `
+    CREATE TABLE "_zero.versionHistory" (
+      "dataVersion" INTEGER NOT NULL,
+      "schemaVersion" INTEGER NOT NULL,
+      "minSafeVersion" INTEGER NOT NULL,
+      "lock" INTEGER PRIMARY KEY DEFAULT 1 CHECK ("lock" = 1)
+    );
+    INSERT INTO "_zero.versionHistory"
+      ("dataVersion", "schemaVersion", "minSafeVersion")
+      VALUES (14, 14, 0);
+  `);
+  initReplicationState(db, ['zero_data'], '02');
+  return {
+    db,
+    lc,
+    sink,
+    [Symbol.dispose]() {
+      db.close();
+    },
+  };
+}
+
+function receive(
+  observer: SQLiteChangeLogObserver,
+  data: ChangeStreamData,
+): void {
+  observer.messageReceived(data, serializeChangeStreamData(data));
+}
+
+function twoRowTransactionHash(watermark: string): string {
+  const begin: ChangeStreamData = [
+    'begin',
+    {tag: 'begin'},
+    {commitWatermark: watermark},
+  ];
+  const commit: ChangeStreamData = ['commit', {tag: 'commit'}, {watermark}];
+  const hasher = new ChangeLogTransactionHasher();
+  hasher.add({
+    watermark,
+    pos: 0,
+    tag: 'begin',
+    change: extractChangeSubstring(serializeChangeStreamData(begin), 'begin'),
+    precommit: null,
+  });
+  hasher.add({
+    watermark,
+    pos: 1,
+    tag: 'commit',
+    change: extractChangeSubstring(serializeChangeStreamData(commit), 'commit'),
+    precommit: watermark,
+  });
+  return hasher.digest();
+}
+
+describe('SQLite change-log observability', () => {
+  test('reads and logs startup state', () => {
+    using fixture = setupReplica();
+    const info = getSQLiteChangeLogInfo(fixture.db);
+
+    expect(info).toMatchObject({
+      schemaVersion: 14,
+      stateWatermark: '02',
+      seedWatermark: '02',
+      headWatermark: '02',
+      rows: 2,
+      estimatedBytes: expect.any(Number),
+    });
+    expect(info.estimatedBytes).toBeGreaterThan(0);
+
+    logSQLiteChangeLogStartup(fixture.lc, 'backup', true, info);
+    expect(fixture.sink.messages.at(-1)).toEqual([
+      'info',
+      undefined,
+      [
+        'SQLite change-log startup',
+        {
+          sqliteChangeLog: {
+            fileMode: 'backup',
+            writerEnabled: true,
+            schemaVersion: 14,
+            seedWatermark: '02',
+            headWatermark: '02',
+            stateWatermark: '02',
+          },
+        },
+      ],
+    ]);
+  });
+
+  test('reports temporary head skew without an invariant failure', () => {
+    using fixture = setupReplica();
+    fixture.db
+      .prepare(`UPDATE "_zero.replicationState" SET "stateVersion" = '06'`)
+      .run();
+    const observer = new SQLiteChangeLogObserver(
+      fixture.lc,
+      getSQLiteChangeLogInfo(fixture.db),
+    );
+
+    expect(observer.state()).toMatchObject({
+      receivedHead: '06',
+      sqliteHead: '02',
+      headLag: 4,
+      rows: 2,
+      rollbacks: 0,
+      invariantFailures: 0,
+    });
+
+    const begin: ChangeStreamData = [
+      'begin',
+      {tag: 'begin'},
+      {commitWatermark: '07'},
+    ];
+    const commit: ChangeStreamData = [
+      'commit',
+      {tag: 'commit'},
+      {watermark: '07'},
+    ];
+    receive(observer, begin);
+    observer.messageProcessed(begin, null, 1);
+    receive(observer, commit);
+    expect(observer.state()).toMatchObject({
+      receivedHead: '07',
+      sqliteHead: '02',
+      headLag: 5,
+      invariantFailures: 0,
+    });
+
+    observer.messageProcessed(
+      commit,
+      {
+        watermark: '07',
+        completedBackfill: undefined,
+        schemaUpdated: false,
+        changeLogUpdated: false,
+        changeLogStream: {
+          rows: 2,
+          estimatedBytes: 100,
+          hash: twoRowTransactionHash('07'),
+        },
+      },
+      2,
+    );
+    expect(observer.state()).toMatchObject({
+      receivedHead: '07',
+      sqliteHead: '07',
+      headLag: 0,
+      rows: 4,
+      estimatedBytes: getSQLiteChangeLogInfo(fixture.db).estimatedBytes + 100,
+      invariantFailures: 0,
+      hashMatches: 1,
+      hashMismatches: 0,
+      hashUnpaired: 0,
+    });
+  });
+
+  test('counts upstream, interrupted, and failed transaction rollbacks', () => {
+    using fixture = setupReplica();
+    const observer = new SQLiteChangeLogObserver(
+      fixture.lc,
+      getSQLiteChangeLogInfo(fixture.db),
+    );
+
+    observer.messageProcessed(
+      ['begin', {tag: 'begin'}, {commitWatermark: '03'}],
+      null,
+      1,
+    );
+    observer.messageProcessed(['rollback', {tag: 'rollback'}], null, 1);
+    observer.messageProcessed(
+      ['begin', {tag: 'begin'}, {commitWatermark: '04'}],
+      null,
+      1,
+    );
+    observer.abort();
+    observer.messageFailed(
+      ['begin', {tag: 'begin'}, {commitWatermark: '05'}],
+      new Error('write failed'),
+      1,
+    );
+
+    expect(observer.state()).toMatchObject({
+      rollbacks: 3,
+      invariantFailures: 0,
+    });
+  });
+
+  test('counts writer invariant errors and malformed commit results', () => {
+    using fixture = setupReplica();
+    const observer = new SQLiteChangeLogObserver(
+      fixture.lc,
+      getSQLiteChangeLogInfo(fixture.db),
+    );
+    const invariantError = new Error('stream position mismatch');
+    invariantError.name = 'ChangeLogStreamInvariantError';
+    observer.messageFailed(
+      ['begin', {tag: 'begin'}, {commitWatermark: '03'}],
+      invariantError,
+      1,
+    );
+    const begin: ChangeStreamData = [
+      'begin',
+      {tag: 'begin'},
+      {commitWatermark: '04'},
+    ];
+    const commit: ChangeStreamData = [
+      'commit',
+      {tag: 'commit'},
+      {watermark: '04'},
+    ];
+    receive(observer, begin);
+    observer.messageProcessed(begin, null, 1);
+    receive(observer, commit);
+    observer.messageProcessed(
+      commit,
+      {
+        watermark: '04',
+        completedBackfill: undefined,
+        schemaUpdated: false,
+        changeLogUpdated: false,
+      },
+      1,
+    );
+
+    expect(observer.state().invariantFailures).toBe(2);
+    expect(observer.state().hashUnpaired).toBe(1);
+  });
+
+  test('counts and logs a transaction hash mismatch', () => {
+    using fixture = setupReplica();
+    const observer = new SQLiteChangeLogObserver(
+      fixture.lc,
+      getSQLiteChangeLogInfo(fixture.db),
+    );
+    const begin: ChangeStreamData = [
+      'begin',
+      {tag: 'begin'},
+      {commitWatermark: '03'},
+    ];
+    const commit: ChangeStreamData = [
+      'commit',
+      {tag: 'commit'},
+      {watermark: '03'},
+    ];
+    receive(observer, begin);
+    observer.messageProcessed(begin, null, 1);
+    receive(observer, commit);
+    observer.messageProcessed(
+      commit,
+      {
+        watermark: '03',
+        completedBackfill: undefined,
+        schemaUpdated: false,
+        changeLogUpdated: false,
+        changeLogStream: {
+          rows: 2,
+          estimatedBytes: 100,
+          hash: '0'.repeat(64),
+        },
+      },
+      1,
+    );
+
+    expect(observer.state()).toMatchObject({
+      hashMatches: 0,
+      hashMismatches: 1,
+      hashUnpaired: 0,
+    });
+    expect(fixture.sink.messages.at(-1)).toEqual([
+      'error',
+      {component: 'sqlite-change-log-observer'},
+      [
+        'SQLite change-log transaction hash mismatch',
+        {
+          sqliteChangeLogHashComparison: {
+            watermark: '03',
+            sourceHash: twoRowTransactionHash('03').slice(0, 16),
+            sqliteHash: '0'.repeat(16),
+          },
+        },
+      ],
+    ]);
+  });
+});

--- a/packages/zero-cache/src/services/replicator/sqlite-change-log-observability.test.ts
+++ b/packages/zero-cache/src/services/replicator/sqlite-change-log-observability.test.ts
@@ -147,6 +147,18 @@ describe('SQLite change-log observability', () => {
     ]);
   });
 
+  test('startup info throws on an unseeded change log', () => {
+    using fixture = setupReplica();
+    // Simulate a replica whose change log has not been seeded (e.g. one that
+    // predates the change-log migration). The off-mode startup path catches
+    // this and warns instead of crashing the replicator.
+    fixture.db.prepare(`DELETE FROM "_zero.changeLogStream"`).run();
+
+    expect(() => getSQLiteChangeLogStartupInfo(fixture.db)).toThrow(
+      'SQLite change log must contain its seed transaction',
+    );
+  });
+
   test('reports temporary head skew without an invariant failure', () => {
     using fixture = setupReplica();
     fixture.db

--- a/packages/zero-cache/src/services/replicator/sqlite-change-log-observability.ts
+++ b/packages/zero-cache/src/services/replicator/sqlite-change-log-observability.ts
@@ -1,0 +1,479 @@
+import type {LogContext} from '@rocicorp/logger';
+import {assert} from '../../../../shared/src/asserts.ts';
+import type {Database} from '../../../../zqlite/src/db.ts';
+import {
+  getOrCreateCounter,
+  getOrCreateGauge,
+  getOrCreateLatencyHistogram,
+  getOrCreateValueHistogram,
+} from '../../observability/metrics.ts';
+import {versionFromLexi} from '../../types/lexi-version.ts';
+import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
+import {extractChangeSubstring} from '../change-streamer/change-log-codec.ts';
+import {ChangeLogTransactionHasher} from '../change-streamer/change-log-transaction-hash.ts';
+import type {CommitResult} from './change-processor.ts';
+import {CHANGE_LOG_STREAM_TABLE} from './schema/change-log-stream.ts';
+
+export type SQLiteChangeLogInfo = {
+  readonly schemaVersion: number;
+  readonly stateWatermark: string;
+  readonly seedWatermark: string;
+  readonly headWatermark: string;
+  readonly rows: number;
+  readonly estimatedBytes: number;
+};
+
+type ChangeLogAggregate = {
+  readonly headWatermark: string | null;
+  readonly rows: number;
+  readonly estimatedBytes: number;
+};
+
+/** Reads the small set of values needed for startup logging and metrics. */
+export function getSQLiteChangeLogInfo(db: Database): SQLiteChangeLogInfo {
+  const version = db
+    .prepare(/*sql*/ `
+      SELECT "schemaVersion"
+        FROM "_zero.versionHistory"
+    `)
+    .get<{schemaVersion: number} | undefined>();
+  const state = db
+    .prepare(/*sql*/ `
+      SELECT state."stateVersion", config."replicaVersion"
+        FROM "_zero.replicationState" AS state,
+             "_zero.replicationConfig" AS config
+    `)
+    .get<{stateVersion: string; replicaVersion: string} | undefined>();
+  const aggregate = db
+    .prepare(/*sql*/ `
+      SELECT max("watermark") AS "headWatermark",
+             count(*) AS "rows",
+             coalesce(sum(
+               length(CAST("watermark" AS BLOB)) +
+               8 +
+               length(CAST("change" AS BLOB)) +
+               coalesce(length(CAST("precommit" AS BLOB)), 0) +
+               CASE WHEN "writeTimeMs" IS NULL THEN 0 ELSE 8 END
+             ), 0) AS "estimatedBytes"
+        FROM "${CHANGE_LOG_STREAM_TABLE}"
+    `)
+    .get<ChangeLogAggregate>();
+
+  assert(version !== undefined, 'replica schema version must be initialized');
+  assert(state !== undefined, 'replication state must be initialized');
+  assert(
+    aggregate.headWatermark !== null,
+    'SQLite change log must contain its seed transaction',
+  );
+  return {
+    schemaVersion: version.schemaVersion,
+    stateWatermark: state.stateVersion,
+    seedWatermark: state.replicaVersion,
+    headWatermark: aggregate.headWatermark,
+    rows: aggregate.rows,
+    estimatedBytes: aggregate.estimatedBytes,
+  };
+}
+
+export function logSQLiteChangeLogStartup(
+  lc: LogContext,
+  fileMode: 'serving' | 'serving-copy' | 'backup',
+  writerEnabled: boolean,
+  info: SQLiteChangeLogInfo,
+): void {
+  lc.info?.('SQLite change-log startup', {
+    sqliteChangeLog: {
+      fileMode,
+      writerEnabled,
+      schemaVersion: info.schemaVersion,
+      seedWatermark: info.seedWatermark,
+      headWatermark: info.headWatermark,
+      stateWatermark: info.stateWatermark,
+    },
+  });
+}
+
+export type SQLiteChangeLogObservabilityState = {
+  readonly receivedHead: string;
+  readonly sqliteHead: string;
+  readonly headLag: number | undefined;
+  readonly rows: number;
+  readonly estimatedBytes: number;
+  readonly rollbacks: number;
+  readonly invariantFailures: number;
+  readonly hashMatches: number;
+  readonly hashMismatches: number;
+  readonly hashUnpaired: number;
+};
+
+const TRANSACTION_ROW_BUCKETS = [2, 3, 5, 10, 25, 50, 100, 250, 1000, 5000];
+
+/**
+ * Records shadow-writer metrics in the replicator process, where OTel is
+ * initialized. State changes only after the corresponding worker operation
+ * succeeds, except receivedHead, which intentionally advances before a commit
+ * is sent to the worker so transient shadow lag is observable.
+ */
+export class SQLiteChangeLogObserver {
+  readonly #lc: LogContext;
+  readonly #messageProcessing = getOrCreateLatencyHistogram(
+    'replica',
+    'sqlite_change_log.message_processing_duration',
+    'Time to process a replication message while SQLite change logging is enabled.',
+  );
+  readonly #commitProcessing = getOrCreateLatencyHistogram(
+    'replica',
+    'sqlite_change_log.commit_duration',
+    'Time to atomically commit replica data and its SQLite change-log transaction.',
+  );
+  readonly #transactionRows = getOrCreateValueHistogram(
+    'replica',
+    'sqlite_change_log.transaction_rows',
+    {
+      description: 'Rows stored per committed SQLite change-log transaction.',
+      unit: '{row}',
+      bucketBoundaries: TRANSACTION_ROW_BUCKETS,
+    },
+  );
+  readonly #rollbackCounter = getOrCreateCounter(
+    'replica',
+    'sqlite_change_log.rollbacks',
+    'SQLite change-log transactions rolled back before commit.',
+  );
+  readonly #invariantFailureCounter = getOrCreateCounter(
+    'replica',
+    'sqlite_change_log.invariant_failures',
+    'Detected SQLite change-log writer invariant failures.',
+  );
+  readonly #hashComparisonCounter = getOrCreateCounter(
+    'replica',
+    'sqlite_change_log.hash_comparisons',
+    'Ephemeral transaction hash comparisons between the received change stream and SQLite change-log writes.',
+  );
+  readonly #hashUnpairedCounter = getOrCreateCounter(
+    'replica',
+    'sqlite_change_log.hash_unpaired',
+    'Committed change-log transactions without both ephemeral hashes available for comparison.',
+  );
+
+  #receivedHead: string;
+  #sqliteHead: string;
+  #rows: number;
+  #estimatedBytes: number;
+  #transactionWatermark: string | undefined;
+  #sourceHasher: ChangeLogTransactionHasher | undefined;
+  #sourcePos = 0;
+  #sourceCommitHash: string | undefined;
+  #rollbacks = 0;
+  #invariantFailures = 0;
+  #hashMatches = 0;
+  #hashMismatches = 0;
+  #hashUnpaired = 0;
+
+  constructor(lc: LogContext, info: SQLiteChangeLogInfo) {
+    this.#lc = lc.withContext('component', 'sqlite-change-log-observer');
+    this.#receivedHead = info.stateWatermark;
+    this.#sqliteHead = info.headWatermark;
+    this.#rows = info.rows;
+    this.#estimatedBytes = info.estimatedBytes;
+
+    getOrCreateGauge(
+      'replica',
+      'sqlite_change_log.rows',
+      'Rows retained in the SQLite change log.',
+    ).addCallback(result => result.observe(this.#rows));
+    getOrCreateGauge('replica', 'sqlite_change_log.retained_bytes', {
+      description:
+        'Estimated UTF-8 payload bytes retained in the SQLite change log.',
+      unit: 'By',
+    }).addCallback(result => result.observe(this.#estimatedBytes));
+    getOrCreateGauge(
+      'replica',
+      'sqlite_change_log.head',
+      'SQLite change-log head converted from its lexicographic watermark.',
+    ).addCallback(result => {
+      const head = watermarkValue(this.#sqliteHead);
+      if (head !== undefined) {
+        result.observe(head);
+      }
+    });
+    getOrCreateGauge(
+      'replica',
+      'sqlite_change_log.head_lag',
+      'Distance from the latest received PG commit to the SQLite change-log head.',
+    ).addCallback(result => {
+      const lag = watermarkDistance(this.#receivedHead, this.#sqliteHead);
+      if (lag !== undefined) {
+        result.observe(lag);
+      }
+    });
+
+    if (info.headWatermark > info.stateWatermark) {
+      this.#invariantFailure(
+        'SQLite change-log head is ahead of replica state',
+        {
+          sqliteHead: info.headWatermark,
+          stateWatermark: info.stateWatermark,
+        },
+      );
+    }
+  }
+
+  messageReceived(data: ChangeStreamData, json: string): void {
+    const tag = data[1].tag;
+    if (data[0] === 'begin') {
+      if (this.#sourceHasher !== undefined) {
+        this.#invariantFailure(
+          'Received change-log begin while a source hash is already open',
+          {receivedWatermark: data[2].commitWatermark},
+        );
+      }
+      const watermark = data[2].commitWatermark;
+      this.#sourceHasher = new ChangeLogTransactionHasher();
+      this.#sourcePos = 0;
+      this.#sourceCommitHash = undefined;
+      this.#sourceHasher.add({
+        watermark,
+        pos: this.#sourcePos,
+        tag,
+        change: extractChangeSubstring(json, tag),
+        precommit: null,
+      });
+      return;
+    }
+
+    if (tag === 'rollback') {
+      this.#resetSourceHash();
+      return;
+    }
+
+    if (data[0] === 'commit') {
+      this.#receivedHead = data[2].watermark;
+    }
+
+    const watermark = this.#transactionWatermark;
+    if (this.#sourceHasher === undefined || watermark === undefined) {
+      this.#invariantFailure(
+        'Received change-log message without an observed transaction',
+        {tag},
+      );
+      return;
+    }
+
+    const commitWatermark =
+      data[0] === 'commit' ? data[2].watermark : watermark;
+    this.#sourceHasher.add({
+      watermark: commitWatermark,
+      pos: ++this.#sourcePos,
+      tag,
+      change: extractChangeSubstring(json, tag),
+      precommit: data[0] === 'commit' ? watermark : null,
+    });
+    if (data[0] === 'commit') {
+      this.#sourceCommitHash = this.#sourceHasher.digest();
+      this.#sourceHasher = undefined;
+    }
+  }
+
+  messageProcessed(
+    data: ChangeStreamData,
+    result: CommitResult | null,
+    durationMs: number,
+  ): void {
+    const tag = data[1].tag;
+    this.#messageProcessing.recordMs(durationMs, {tag, outcome: 'success'});
+
+    if (data[0] === 'begin') {
+      if (this.#transactionWatermark !== undefined) {
+        this.#invariantFailure('SQLite change-log transaction already open', {
+          openWatermark: this.#transactionWatermark,
+          receivedWatermark: data[2].commitWatermark,
+        });
+      }
+      this.#transactionWatermark = data[2].commitWatermark;
+      return;
+    }
+
+    if (tag === 'rollback') {
+      this.#recordRollback('upstream');
+      this.#transactionWatermark = undefined;
+      this.#resetSourceHash();
+      return;
+    }
+
+    if (data[0] !== 'commit') {
+      return;
+    }
+
+    this.#commitProcessing.recordMs(durationMs, {outcome: 'success'});
+    const watermark = data[2].watermark;
+    if (this.#transactionWatermark !== watermark) {
+      this.#invariantFailure(
+        'SQLite change-log commit does not match the observed begin',
+        {openWatermark: this.#transactionWatermark, commitWatermark: watermark},
+      );
+    }
+    if (result?.watermark !== watermark) {
+      this.#invariantFailure(
+        'SQLite change-log commit result has an unexpected watermark',
+        {commitWatermark: watermark, resultWatermark: result?.watermark},
+      );
+    }
+    if (result?.changeLogStream === undefined) {
+      this.#invariantFailure(
+        'SQLite change-log commit result is missing writer statistics',
+        {commitWatermark: watermark},
+      );
+      this.#recordUnpaired(watermark, 'missing-sqlite-hash');
+    } else {
+      this.#rows += result.changeLogStream.rows;
+      this.#estimatedBytes += result.changeLogStream.estimatedBytes;
+      this.#transactionRows.record(result.changeLogStream.rows);
+      this.#compareHashes(
+        watermark,
+        this.#sourceCommitHash,
+        result.changeLogStream.hash,
+      );
+    }
+    if (watermark < this.#sqliteHead) {
+      this.#invariantFailure('SQLite change-log head regressed', {
+        previousHead: this.#sqliteHead,
+        commitWatermark: watermark,
+      });
+    }
+    this.#sqliteHead = watermark;
+    this.#transactionWatermark = undefined;
+    this.#resetSourceHash();
+  }
+
+  messageFailed(
+    data: ChangeStreamData,
+    error: unknown,
+    durationMs: number,
+  ): void {
+    const tag = data[1].tag;
+    this.#messageProcessing.recordMs(durationMs, {tag, outcome: 'error'});
+    if (data[0] === 'commit') {
+      this.#commitProcessing.recordMs(durationMs, {outcome: 'error'});
+      this.#recordUnpaired(data[2].watermark, 'sqlite-commit-failed');
+    }
+    if (
+      error instanceof Error &&
+      error.name === 'ChangeLogStreamInvariantError'
+    ) {
+      this.#invariantFailure(error.message);
+    }
+    if (this.#transactionWatermark !== undefined || data[0] === 'begin') {
+      this.#recordRollback('processing-error');
+    }
+    this.#transactionWatermark = undefined;
+    this.#resetSourceHash();
+  }
+
+  abort(): void {
+    if (this.#transactionWatermark !== undefined) {
+      this.#recordRollback('source-interruption');
+      this.#transactionWatermark = undefined;
+    }
+    this.#resetSourceHash();
+  }
+
+  state(): SQLiteChangeLogObservabilityState {
+    return {
+      receivedHead: this.#receivedHead,
+      sqliteHead: this.#sqliteHead,
+      headLag: watermarkDistance(this.#receivedHead, this.#sqliteHead),
+      rows: this.#rows,
+      estimatedBytes: this.#estimatedBytes,
+      rollbacks: this.#rollbacks,
+      invariantFailures: this.#invariantFailures,
+      hashMatches: this.#hashMatches,
+      hashMismatches: this.#hashMismatches,
+      hashUnpaired: this.#hashUnpaired,
+    };
+  }
+
+  #recordRollback(
+    reason: 'upstream' | 'processing-error' | 'source-interruption',
+  ) {
+    this.#rollbacks++;
+    this.#rollbackCounter.add(1, {reason});
+  }
+
+  #invariantFailure(message: string, details?: Record<string, unknown>) {
+    this.#invariantFailures++;
+    this.#invariantFailureCounter.add(1);
+    this.#lc.error?.(message, details);
+  }
+
+  #compareHashes(
+    watermark: string,
+    sourceHash: string | undefined,
+    sqliteHash: string,
+  ): void {
+    if (sourceHash === undefined) {
+      this.#recordUnpaired(watermark, 'missing-source-hash');
+      return;
+    }
+    if (sourceHash === sqliteHash) {
+      this.#hashMatches++;
+      this.#hashComparisonCounter.add(1, {outcome: 'match'});
+      return;
+    }
+    this.#hashMismatches++;
+    this.#hashComparisonCounter.add(1, {outcome: 'mismatch'});
+    this.#lc.error?.('SQLite change-log transaction hash mismatch', {
+      sqliteChangeLogHashComparison: {
+        watermark,
+        sourceHash: sourceHash.slice(0, 16),
+        sqliteHash: sqliteHash.slice(0, 16),
+      },
+    });
+  }
+
+  #recordUnpaired(
+    watermark: string,
+    reason:
+      | 'missing-source-hash'
+      | 'missing-sqlite-hash'
+      | 'sqlite-commit-failed',
+  ): void {
+    this.#hashUnpaired++;
+    this.#hashUnpairedCounter.add(1, {reason});
+    this.#lc.warn?.('SQLite change-log transaction hash was not compared', {
+      sqliteChangeLogHashComparison: {watermark, reason},
+    });
+  }
+
+  #resetSourceHash(): void {
+    this.#sourceHasher = undefined;
+    this.#sourcePos = 0;
+    this.#sourceCommitHash = undefined;
+  }
+}
+
+function watermarkValue(watermark: string): number | undefined {
+  try {
+    const value = Number(versionFromLexi(watermark));
+    return Number.isFinite(value) ? value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function watermarkDistance(
+  receivedHead: string,
+  sqliteHead: string,
+): number | undefined {
+  if (receivedHead <= sqliteHead) {
+    return 0;
+  }
+  try {
+    const distance =
+      versionFromLexi(receivedHead) - versionFromLexi(sqliteHead);
+    const value = Number(distance);
+    return Number.isFinite(value) ? value : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/zero-cache/src/services/replicator/sqlite-change-log-observability.ts
+++ b/packages/zero-cache/src/services/replicator/sqlite-change-log-observability.ts
@@ -14,23 +14,27 @@ import {ChangeLogTransactionHasher} from '../change-streamer/change-log-transact
 import type {CommitResult} from './change-processor.ts';
 import {CHANGE_LOG_STREAM_TABLE} from './schema/change-log-stream.ts';
 
-export type SQLiteChangeLogInfo = {
+export type SQLiteChangeLogStartupInfo = {
   readonly schemaVersion: number;
   readonly stateWatermark: string;
   readonly seedWatermark: string;
   readonly headWatermark: string;
+};
+
+export type SQLiteChangeLogInfo = SQLiteChangeLogStartupInfo & {
   readonly rows: number;
   readonly estimatedBytes: number;
 };
 
-type ChangeLogAggregate = {
-  readonly headWatermark: string | null;
-  readonly rows: number;
-  readonly estimatedBytes: number;
-};
-
-/** Reads the small set of values needed for startup logging and metrics. */
-export function getSQLiteChangeLogInfo(db: Database): SQLiteChangeLogInfo {
+/**
+ * Reads the schema version, replication state, and change-log head. These are
+ * single-row lookups plus an index-optimized `max()`, so unlike
+ * {@link getSQLiteChangeLogInfo} this does not scan the change-log table and is
+ * cheap to call on every startup, including when the writer is disabled.
+ */
+export function getSQLiteChangeLogStartupInfo(
+  db: Database,
+): SQLiteChangeLogStartupInfo {
   const version = db
     .prepare(/*sql*/ `
       SELECT "schemaVersion"
@@ -44,10 +48,38 @@ export function getSQLiteChangeLogInfo(db: Database): SQLiteChangeLogInfo {
              "_zero.replicationConfig" AS config
     `)
     .get<{stateVersion: string; replicaVersion: string} | undefined>();
+  const head = db
+    .prepare(/*sql*/ `
+      SELECT max("watermark") AS "headWatermark"
+        FROM "${CHANGE_LOG_STREAM_TABLE}"
+    `)
+    .get<{headWatermark: string | null}>();
+
+  assert(version !== undefined, 'replica schema version must be initialized');
+  assert(state !== undefined, 'replication state must be initialized');
+  assert(
+    head.headWatermark !== null,
+    'SQLite change log must contain its seed transaction',
+  );
+  return {
+    schemaVersion: version.schemaVersion,
+    stateWatermark: state.stateVersion,
+    seedWatermark: state.replicaVersion,
+    headWatermark: head.headWatermark,
+  };
+}
+
+/**
+ * Extends {@link getSQLiteChangeLogStartupInfo} with the retained row and
+ * estimated byte totals. Computing these scans the entire change-log table, so
+ * only call this when the totals are consumed, i.e. when the writer (and thus
+ * the observer) is enabled.
+ */
+export function getSQLiteChangeLogInfo(db: Database): SQLiteChangeLogInfo {
+  const startup = getSQLiteChangeLogStartupInfo(db);
   const aggregate = db
     .prepare(/*sql*/ `
-      SELECT max("watermark") AS "headWatermark",
-             count(*) AS "rows",
+      SELECT count(*) AS "rows",
              coalesce(sum(
                length(CAST("watermark" AS BLOB)) +
                8 +
@@ -57,19 +89,10 @@ export function getSQLiteChangeLogInfo(db: Database): SQLiteChangeLogInfo {
              ), 0) AS "estimatedBytes"
         FROM "${CHANGE_LOG_STREAM_TABLE}"
     `)
-    .get<ChangeLogAggregate>();
+    .get<{rows: number; estimatedBytes: number}>();
 
-  assert(version !== undefined, 'replica schema version must be initialized');
-  assert(state !== undefined, 'replication state must be initialized');
-  assert(
-    aggregate.headWatermark !== null,
-    'SQLite change log must contain its seed transaction',
-  );
   return {
-    schemaVersion: version.schemaVersion,
-    stateWatermark: state.stateVersion,
-    seedWatermark: state.replicaVersion,
-    headWatermark: aggregate.headWatermark,
+    ...startup,
     rows: aggregate.rows,
     estimatedBytes: aggregate.estimatedBytes,
   };
@@ -79,7 +102,7 @@ export function logSQLiteChangeLogStartup(
   lc: LogContext,
   fileMode: 'serving' | 'serving-copy' | 'backup',
   writerEnabled: boolean,
-  info: SQLiteChangeLogInfo,
+  info: SQLiteChangeLogStartupInfo,
 ): void {
   lc.info?.('SQLite change-log startup', {
     sqliteChangeLog: {

--- a/packages/zero-cache/src/services/replicator/write-worker.test.ts
+++ b/packages/zero-cache/src/services/replicator/write-worker.test.ts
@@ -140,9 +140,15 @@ describe('write-worker', () => {
       ['data', issues.insert('issues', {issueID: 456, bool: false})],
       ['commit', issues.commit(), {watermark: '06'}],
     ];
+    let commitResult = null;
     for (const message of messages) {
-      await worker.processMessage(serialized(message));
+      commitResult =
+        (await worker.processMessage(serialized(message))) ?? commitResult;
     }
+    expect(commitResult).toMatchObject({
+      watermark: '06',
+      changeLogStream: {rows: 4, estimatedBytes: expect.any(Number)},
+    });
 
     await worker.stop();
     worker = new ThreadWriteWorkerClient();

--- a/packages/zql-integration-tests/src/chinook/chinook-zero-cache-fuzzer.pg.test.ts
+++ b/packages/zql-integration-tests/src/chinook/chinook-zero-cache-fuzzer.pg.test.ts
@@ -374,6 +374,7 @@ async function startZeroCacheReplica(testDBs: PgTest['testDBs']) {
       parseStringifiedChangeStreamer(changeStreamer),
       worker,
       null,
+      undefined,
     );
     const replicatorDone = replicator.run();
     cleanup.push(async () => {


### PR DESCRIPTION
Logs metrics so we can determine if the SQLite change log is performing correctly and roughly matching our current PG change log.

I say "roughly matching" because we will not know if it exactly matches without reading the contents back. A follow up PR does sampled reads to check.

There is a corresponding commit in CloudZero (https://github.com/rocicorp/cloudzero/pull/1396) that will add a dashboard to surface this information. It will look roughly like:


```
### A. Everything is fine

  ┌──────────────────────────────────────────────────────────────────────────────┐
  │ Cloud Zero — SQLite Change Log Rollout                         Last 6 hours  │
  ├──────────────────────────────────────────────────────────────────────────────┤
  │ Writer       Head lag     Hash mismatch   Unpaired    Invariants   Rollbacks │
  │ present: 1   0             0               0           0            0         │
  │              occasional                                                      │
  │              brief spikes                                                    │
  └──────────────────────────────────────────────────────────────────────────────┘

  SQLite head lag
    2 │       ╭╮
    1 │  ╭╮   │╰╮       ╭╮
    0 └──╯╰───╯ └───────╯╰────────────
         Briefly rises during a commit, then returns to zero

  Retained payload / rows
      │      /|      /|      /|
      │     / |     / |     / |
      │____/  |____/  |____/  |____
             purge    purge    purge
      Expected sawtooth or bounded growth

  Message/commit latency           Shadow commit rate
      stable p50/p95/p99             follows transaction traffic
      no upward trend                no unexplained gaps

  Failures                         Production correlates
      rollbacks: 0                  normal PG replication lag
      invariants: 0                 DB/WAL usage remains bounded

  The most important healthy signature is:

  Hash Mismatches = 0
  Unpaired Hashes = 0
  Head Lag returns to 0

  Some short head-lag spikes are normal because the commit is received before SQLite finishes writing it.

  ### B. Things are wrong

  A divergence or writer failure would make the top row immediately noisy:

  ┌──────────────────────────────────────────────────────────────────────────────┐
  │ Writer       Head lag     Hash mismatch   Unpaired    Invariants   Rollbacks │
  │ present: 1   847           3  RED          12 RED      2 RED        18        │
  └──────────────────────────────────────────────────────────────────────────────┘

  SQLite head lag
  850 │                              ╭────────────
  600 │                         ╭────╯
  300 │                    ╭────╯
    0 └────────────────────╯
                           SQLite is no longer catching up

  Retained payload / rows
      │                         /
      │                     ___/
      │                 ___/
      │____________ ___/
                   No purge; storage grows continuously

  Commit latency
      │                      ╭╮
      │                 ╭╮  ╭╯╰╮
      │_________________╯╰──╯  ╰────
                       sustained latency increase

  Failures
      hash mismatch:    nonzero → source and SQLite transaction differed
      unpaired:         nonzero → commit failed or one hash was unavailable
      invariant errors: transaction boundaries/state are inconsistent
      rollbacks:        processing errors or repeated source interruptions
```