### PR TITLE
feat(rmv2): add SQLite change log reader [7/n]

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-reader.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-reader.test.ts
@@ -1,0 +1,319 @@
+import {afterEach, describe, expect, test} from 'vitest';
+import {AbortError} from '../../../../shared/src/abort-error.ts';
+import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
+import type {Database} from '../../../../zqlite/src/db.ts';
+import {StatementRunner} from '../../db/statements.ts';
+import {DbFile} from '../../test/lite.ts';
+import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
+import {ChangeLogStreamWriter} from '../replicator/change-log-stream-writer.ts';
+import {
+  initReplicationState,
+  updateReplicationWatermark,
+} from '../replicator/schema/replication-state.ts';
+import {serializeChangeStreamData} from './change-log-codec.ts';
+import type {WatermarkedChange} from './change-streamer.ts';
+import {
+  SQLITE_CHANGE_LOG_READ_BATCH_SQL,
+  SQLiteChangeLogReader,
+} from './sqlite-change-log-reader.ts';
+
+const lc = createSilentLogContext();
+const files: DbFile[] = [];
+
+afterEach(() => {
+  for (const file of files.splice(0)) {
+    file.delete();
+  }
+});
+
+function createReplica(): {db: Database; file: DbFile} {
+  const file = new DbFile('sqlite-change-log-reader');
+  files.push(file);
+  const db = file.connect(lc);
+  db.pragma('journal_mode = wal');
+  initReplicationState(db, ['zero_data'], '02');
+  return {db, file};
+}
+
+function truncate(): ChangeStreamData {
+  return ['data', {tag: 'truncate', relations: []}];
+}
+
+function appendTransaction(
+  db: Database,
+  watermark: string,
+  data: readonly ChangeStreamData[],
+): readonly WatermarkedChange[] {
+  const runner = new StatementRunner(db);
+  const writer = new ChangeLogStreamWriter(db);
+  const begin: ChangeStreamData = [
+    'begin',
+    {tag: 'begin'},
+    {commitWatermark: watermark},
+  ];
+  const commit: ChangeStreamData = ['commit', {tag: 'commit'}, {watermark}];
+
+  runner.beginImmediate();
+  try {
+    writer.begin(watermark, serializeChangeStreamData(begin));
+    for (const message of data) {
+      writer.append(serializeChangeStreamData(message), message[1].tag);
+    }
+    writer.commit(watermark, serializeChangeStreamData(commit), Date.now());
+    updateReplicationWatermark(runner, watermark);
+    runner.commit();
+  } catch (e) {
+    runner.rollback();
+    throw e;
+  }
+
+  return [begin, ...data, commit].map(message => [
+    watermark,
+    message[1].tag,
+    serializeChangeStreamData(message),
+  ]);
+}
+
+async function collect(
+  reader: SQLiteChangeLogReader,
+  fromWatermark: string,
+  throughWatermark: string,
+  batchSize: number,
+): Promise<readonly (readonly WatermarkedChange[])[]> {
+  const batches: (readonly WatermarkedChange[])[] = [];
+  for await (const batch of reader.read(
+    fromWatermark,
+    throughWatermark,
+    batchSize,
+  )) {
+    batches.push(batch);
+  }
+  return batches;
+}
+
+function flatten(
+  batches: readonly (readonly WatermarkedChange[])[],
+): readonly WatermarkedChange[] {
+  return batches.flatMap(batch => batch);
+}
+
+describe('sqlite change log reader', () => {
+  test('plans seed, minimum, middle, head, too-old, missing, and ahead watermarks', () => {
+    const {db, file} = createReplica();
+    using writer = db;
+    appendTransaction(writer, '04', [truncate()]);
+    appendTransaction(writer, '06', [truncate()]);
+    appendTransaction(writer, '08', [truncate()]);
+    using reader = new SQLiteChangeLogReader(lc, file.path);
+
+    const bounds = {minWatermark: '02', headWatermark: '08'};
+    expect(reader.plan('02')).toEqual({kind: 'range', ...bounds});
+    expect(reader.plan('04')).toEqual({kind: 'range', ...bounds});
+    expect(reader.plan('06')).toEqual({kind: 'range', ...bounds});
+    expect(reader.plan('08')).toEqual({kind: 'range', ...bounds});
+    expect(reader.plan('01')).toEqual({kind: 'too-old', ...bounds});
+    expect(reader.plan('05')).toEqual({kind: 'too-old', ...bounds});
+    expect(reader.plan('09')).toEqual({
+      kind: 'ahead',
+      headWatermark: '08',
+    });
+
+    writer
+      .prepare(`DELETE FROM "_zero.changeLogStream" WHERE "watermark" = '02'`)
+      .run();
+    expect(reader.plan('04')).toEqual({
+      kind: 'range',
+      minWatermark: '04',
+      headWatermark: '08',
+    });
+    expect(reader.plan('02')).toEqual({
+      kind: 'too-old',
+      minWatermark: '04',
+      headWatermark: '08',
+    });
+  });
+
+  test('reads a transaction across batches and multiple transactions in one batch', async () => {
+    const {db, file} = createReplica();
+    using writer = db;
+    const tx04 = appendTransaction(writer, '04', [
+      truncate(),
+      truncate(),
+      truncate(),
+      truncate(),
+      truncate(),
+    ]);
+    const tx06 = appendTransaction(writer, '06', [truncate()]);
+    using reader = new SQLiteChangeLogReader(lc, file.path);
+
+    const smallBatches = await collect(reader, '02', '06', 2);
+    expect(smallBatches.map(batch => batch.length)).toEqual([2, 2, 2, 2, 2]);
+    expect(flatten(smallBatches)).toEqual([...tx04, ...tx06]);
+
+    const oneBatch = await collect(reader, '02', '06', 20);
+    expect(oneBatch).toHaveLength(1);
+    expect(oneBatch[0]).toEqual([...tx04, ...tx06]);
+
+    await expect(collect(reader, '06', '06', 2)).resolves.toEqual([]);
+  });
+
+  test('pins the head while another connection appends and purges', async () => {
+    const {db, file} = createReplica();
+    using writer = db;
+    const tx04 = appendTransaction(writer, '04', [
+      truncate(),
+      truncate(),
+      truncate(),
+      truncate(),
+    ]);
+    const tx06 = appendTransaction(writer, '06', [truncate()]);
+    const tx08 = appendTransaction(writer, '08', [truncate()]);
+    using reader = new SQLiteChangeLogReader(lc, file.path);
+
+    const plan = reader.plan('02');
+    expect(plan.kind).toBe('range');
+    if (plan.kind !== 'range') {
+      throw new Error('expected a catchable range');
+    }
+    const iterator = reader
+      .read('02', plan.headWatermark, 3)
+      [Symbol.asyncIterator]();
+    const first = await iterator.next();
+    expect(first.done).toBe(false);
+
+    appendTransaction(writer, '0a', [truncate()]);
+    writer
+      .prepare(`DELETE FROM "_zero.changeLogStream" WHERE "watermark" = '02'`)
+      .run();
+
+    const batches = first.value === undefined ? [] : [first.value];
+    for (;;) {
+      const next = await iterator.next();
+      if (next.done) {
+        break;
+      }
+      batches.push(next.value);
+    }
+    expect(flatten(batches)).toEqual([...tx04, ...tx06, ...tx08]);
+    expect(flatten(batches).at(-1)?.[0]).toBe('08');
+  });
+
+  test('cancellation and abort between batches release the read snapshot', async () => {
+    const {db, file} = createReplica();
+    using writer = db;
+    appendTransaction(writer, '04', [
+      truncate(),
+      truncate(),
+      truncate(),
+      truncate(),
+    ]);
+    using reader = new SQLiteChangeLogReader(lc, file.path);
+
+    const canceled = reader.read('02', '04', 2)[Symbol.asyncIterator]();
+    await expect(canceled.next()).resolves.toMatchObject({done: false});
+    await canceled.return?.();
+    expect(
+      writer.pragma<{busy: number}>('wal_checkpoint(TRUNCATE)')[0]?.busy,
+    ).toBe(0);
+
+    const controller = new AbortController();
+    const aborted = reader
+      .read('02', '04', 2, controller.signal)
+      [Symbol.asyncIterator]();
+    await expect(aborted.next()).resolves.toMatchObject({done: false});
+    controller.abort();
+    await expect(aborted.next()).rejects.toBeInstanceOf(AbortError);
+    expect(
+      writer.pragma<{busy: number}>('wal_checkpoint(TRUNCATE)')[0]?.busy,
+    ).toBe(0);
+  });
+
+  test('close aborts reads and releases the dedicated connection', async () => {
+    const {db, file} = createReplica();
+    using writer = db;
+    appendTransaction(writer, '04', [truncate(), truncate()]);
+    const reader = new SQLiteChangeLogReader(lc, file.path);
+    const iterator = reader.read('02', '04', 1)[Symbol.asyncIterator]();
+    await expect(iterator.next()).resolves.toMatchObject({done: false});
+
+    reader.close();
+    reader.close();
+    expect(() => reader.plan('02')).toThrow(AbortError);
+    await expect(iterator.next()).rejects.toBeInstanceOf(AbortError);
+  });
+
+  test('reconstructs canonical bigint, NUL, schema, backfill, and truncate messages byte-for-byte', async () => {
+    const {db, file} = createReplica();
+    using writer = db;
+    const messages: ChangeStreamData[] = [
+      [
+        'data',
+        {
+          tag: 'insert',
+          relation: {
+            schema: 'public',
+            name: 'items',
+            rowKey: {columns: ['id'], type: 'default'},
+          },
+          new: {id: 9007199254740993n, text: 'before\0after'},
+        },
+      ],
+      [
+        'data',
+        {
+          tag: 'rename-table',
+          old: {schema: 'public', name: 'items'},
+          new: {schema: 'archive', name: 'items'},
+        },
+      ],
+      [
+        'data',
+        {
+          tag: 'backfill',
+          relation: {
+            schema: 'archive',
+            name: 'items',
+            rowKey: {columns: ['id'], type: 'default'},
+          },
+          columns: ['value'],
+          watermark: '03',
+          rowValues: [[9007199254740995n, {nested: 9007199254740997n}]],
+        },
+      ],
+      [
+        'data',
+        {
+          tag: 'truncate',
+          relations: [
+            {
+              schema: 'archive',
+              name: 'items',
+              rowKey: {columns: ['id'], type: 'default'},
+            },
+          ],
+        },
+      ],
+    ];
+    const expected = appendTransaction(writer, '04', messages);
+    using reader = new SQLiteChangeLogReader(lc, file.path);
+
+    const actual = flatten(await collect(reader, '02', '04', 2));
+    expect(actual).toEqual(expected);
+    expect(actual.map(([, , json]) => json)).toEqual(
+      expected.map(([, , json]) => json),
+    );
+  });
+
+  test('continuation and ceiling query uses the primary-key index', () => {
+    const {db} = createReplica();
+    using writer = db;
+    appendTransaction(writer, '04', [truncate()]);
+
+    const plans = writer
+      .prepare(`EXPLAIN QUERY PLAN ${SQLITE_CHANGE_LOG_READ_BATCH_SQL}`)
+      .all<{detail: string}>('02', Number.MAX_SAFE_INTEGER, '04', 100);
+    const details = plans.map(({detail}) => detail).join('\n');
+    expect(details).toMatch(/\bSEARCH\b/);
+    expect(details).not.toMatch(/\bSCAN\b/);
+  });
+});

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-reader.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-reader.test.ts
@@ -1,7 +1,8 @@
+import SQLite3Database from '@rocicorp/zero-sqlite3';
 import {afterEach, describe, expect, test} from 'vitest';
 import {AbortError} from '../../../../shared/src/abort-error.ts';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
-import type {Database} from '../../../../zqlite/src/db.ts';
+import type {Database, Statement} from '../../../../zqlite/src/db.ts';
 import {StatementRunner} from '../../db/statements.ts';
 import {DbFile} from '../../test/lite.ts';
 import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
@@ -13,6 +14,7 @@ import {
 import {serializeChangeStreamData} from './change-log-codec.ts';
 import type {WatermarkedChange} from './change-streamer.ts';
 import {
+  SQLITE_CHANGE_LOG_BOUNDARY_SQL,
   SQLITE_CHANGE_LOG_READ_BATCH_SQL,
   SQLiteChangeLogReader,
 } from './sqlite-change-log-reader.ts';
@@ -95,6 +97,21 @@ function flatten(
   batches: readonly (readonly WatermarkedChange[])[],
 ): readonly WatermarkedChange[] {
   return batches.flatMap(batch => batch);
+}
+
+function countVisitedRows(statement: Statement): number {
+  let visited = 0;
+  for (let i = 0; ; i++) {
+    const nvisit = statement.scanStatus(
+      i,
+      SQLite3Database.SQLITE_SCANSTAT_NVISIT,
+      1,
+    );
+    if (nvisit === undefined) {
+      return visited;
+    }
+    visited += Number(nvisit);
+  }
 }
 
 describe('sqlite change log reader', () => {
@@ -315,5 +332,26 @@ describe('sqlite change log reader', () => {
     const details = plans.map(({detail}) => detail).join('\n');
     expect(details).toMatch(/\bSEARCH\b/);
     expect(details).not.toMatch(/\bSCAN\b/);
+  });
+
+  test('boundary query seeks directly to the final row of a large transaction', () => {
+    const {db} = createReplica();
+    using writer = db;
+    appendTransaction(
+      writer,
+      '04',
+      Array.from({length: 1_000}, () => truncate()),
+    );
+
+    const plans = writer
+      .prepare(`EXPLAIN QUERY PLAN ${SQLITE_CHANGE_LOG_BOUNDARY_SQL}`)
+      .all<{detail: string}>({fromWatermark: '04'});
+    const details = plans.map(({detail}) => detail).join('\n');
+    expect(details).toMatch(/\bSEARCH\b.*\(watermark=\?\)/);
+    expect(details).not.toMatch(/\bSCAN\b|USE TEMP B-TREE/);
+
+    const statement = writer.prepare(SQLITE_CHANGE_LOG_BOUNDARY_SQL);
+    expect(statement.get({fromWatermark: '04'})).toEqual({boundaryExists: 1});
+    expect(countVisitedRows(statement)).toBe(1);
   });
 });

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-reader.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-reader.ts
@@ -7,7 +7,7 @@ import {
   reconstructWatermarkedChange,
   type ChangeLogEntry,
 } from './change-log-codec.ts';
-import type {ChangeTag, WatermarkedChange} from './change-streamer.ts';
+import type {WatermarkedChange} from './change-streamer.ts';
 
 export type CatchupPlan =
   | {
@@ -31,35 +31,7 @@ type PlanRow = {
 
 type ChangeLogRow = ChangeLogEntry & {
   readonly pos: number;
-  readonly tag: string | null;
 };
-
-type TransactionCursor = {
-  watermark: string;
-  nextPos: number;
-  complete: boolean;
-};
-
-const CHANGE_TAGS: ReadonlySet<string> = new Set<ChangeTag>([
-  'begin',
-  'insert',
-  'update',
-  'delete',
-  'truncate',
-  'backfill',
-  'create-table',
-  'rename-table',
-  'update-table-metadata',
-  'add-column',
-  'update-column',
-  'drop-column',
-  'drop-table',
-  'create-index',
-  'drop-index',
-  'backfill-completed',
-  'commit',
-  'rollback',
-]);
 
 /**
  * Seeks to the final position so validating a boundary does not scan every row
@@ -168,7 +140,7 @@ export class SQLiteChangeLogReader implements Disposable {
     // The first query must be strictly after the requested transaction. Every
     // real stream position is far below this sentinel.
     let lastPos = Number.MAX_SAFE_INTEGER;
-    let transaction: TransactionCursor | undefined;
+    let lastTag: string | undefined;
 
     while (true) {
       this.#throwIfAborted(signal);
@@ -184,15 +156,12 @@ export class SQLiteChangeLogReader implements Disposable {
         break;
       }
 
-      const changes: WatermarkedChange[] = [];
-      for (const row of rows) {
-        transaction = validateRow(row, transaction);
-        changes.push(reconstructWatermarkedChange(validatedEntry(row)));
-      }
+      const changes = rows.map(reconstructWatermarkedChange);
       const last = rows.at(-1);
       assert(last !== undefined, 'non-empty batch must have a final row');
       lastWatermark = last.watermark;
       lastPos = last.pos;
+      lastTag = last.tag;
 
       // all() has exhausted the SELECT and closed its implicit read
       // transaction. This yield therefore cannot pin the WAL while subscriber
@@ -202,8 +171,7 @@ export class SQLiteChangeLogReader implements Disposable {
 
     if (fromWatermark !== throughWatermark) {
       assert(
-        transaction?.complete === true &&
-          transaction.watermark === throughWatermark,
+        lastWatermark === throughWatermark && lastTag === 'commit',
         () =>
           `SQLite change log did not end at pinned head ${throughWatermark}`,
       );
@@ -234,60 +202,4 @@ export class SQLiteChangeLogReader implements Disposable {
       throw new AbortError('SQLite change log read aborted');
     }
   }
-}
-
-function validatedEntry(row: ChangeLogRow): ChangeLogEntry {
-  assert(
-    row.tag !== null && CHANGE_TAGS.has(row.tag),
-    () => `invalid SQLite change log tag ${String(row.tag)}`,
-  );
-  return {watermark: row.watermark, tag: row.tag, change: row.change};
-}
-
-function validateRow(
-  row: ChangeLogRow,
-  transaction: TransactionCursor | undefined,
-): TransactionCursor {
-  assert(
-    Number.isSafeInteger(row.pos) && row.pos >= 0,
-    () => `invalid SQLite change log position ${row.pos}`,
-  );
-
-  if (transaction === undefined || row.watermark !== transaction.watermark) {
-    assert(
-      transaction === undefined || transaction.complete,
-      () =>
-        `incomplete SQLite change log transaction ${transaction?.watermark}`,
-    );
-    assert(
-      row.pos === 0 && row.tag === 'begin',
-      () =>
-        `SQLite change log transaction ${row.watermark} does not start with begin at position 0`,
-    );
-    return {watermark: row.watermark, nextPos: 1, complete: false};
-  }
-
-  assert(
-    !transaction.complete,
-    () =>
-      `SQLite change log transaction ${row.watermark} has rows after commit`,
-  );
-  assert(
-    row.pos === transaction.nextPos,
-    () =>
-      `non-contiguous SQLite change log transaction ${row.watermark}: expected position ${transaction.nextPos}, got ${row.pos}`,
-  );
-  assert(
-    row.tag !== 'begin',
-    () => `SQLite change log transaction ${row.watermark} has multiple begins`,
-  );
-  assert(
-    row.tag !== 'rollback',
-    () => `SQLite change log transaction ${row.watermark} contains a rollback`,
-  );
-  return {
-    watermark: transaction.watermark,
-    nextPos: transaction.nextPos + 1,
-    complete: row.tag === 'commit',
-  };
 }

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-reader.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-reader.ts
@@ -1,0 +1,285 @@
+import type {LogContext} from '@rocicorp/logger';
+import {AbortError} from '../../../../shared/src/abort-error.ts';
+import {assert} from '../../../../shared/src/asserts.ts';
+import {Database} from '../../../../zqlite/src/db.ts';
+import {CHANGE_LOG_STREAM_TABLE} from '../replicator/schema/change-log-stream.ts';
+import {
+  reconstructWatermarkedChange,
+  type ChangeLogEntry,
+} from './change-log-codec.ts';
+import type {ChangeTag, WatermarkedChange} from './change-streamer.ts';
+
+export type CatchupPlan =
+  | {
+      readonly kind: 'range';
+      readonly minWatermark: string;
+      readonly headWatermark: string;
+    }
+  | {readonly kind: 'ahead'; readonly headWatermark: string}
+  | {
+      readonly kind: 'too-old';
+      readonly minWatermark: string;
+      readonly headWatermark: string;
+    };
+
+type PlanRow = {
+  readonly headWatermark: string;
+  readonly minWatermark: string | null;
+  readonly subscriberAhead: number;
+  readonly boundaryExists: number;
+};
+
+type ChangeLogRow = ChangeLogEntry & {
+  readonly pos: number;
+  readonly tag: string | null;
+};
+
+type TransactionCursor = {
+  watermark: string;
+  nextPos: number;
+  complete: boolean;
+};
+
+const CHANGE_TAGS: ReadonlySet<string> = new Set<ChangeTag>([
+  'begin',
+  'insert',
+  'update',
+  'delete',
+  'truncate',
+  'backfill',
+  'create-table',
+  'rename-table',
+  'update-table-metadata',
+  'add-column',
+  'update-column',
+  'drop-column',
+  'drop-table',
+  'create-index',
+  'drop-index',
+  'backfill-completed',
+  'commit',
+  'rollback',
+]);
+
+const PLAN_SQL = /*sql*/ `
+  SELECT
+    state."stateVersion" AS "headWatermark",
+    bounds."minWatermark" AS "minWatermark",
+    @fromWatermark > state."stateVersion" AS "subscriberAhead",
+    EXISTS (
+      SELECT 1
+        FROM "${CHANGE_LOG_STREAM_TABLE}"
+        WHERE "watermark" = @fromWatermark
+          AND "precommit" IS NOT NULL
+          AND json_extract("change", '$.tag') = 'commit'
+    ) AS "boundaryExists"
+  FROM "_zero.replicationState" AS state
+  CROSS JOIN (
+    SELECT min("watermark") AS "minWatermark"
+      FROM "${CHANGE_LOG_STREAM_TABLE}"
+  ) AS bounds
+`;
+
+/** Exported so the focused query-plan test covers the production query. */
+export const SQLITE_CHANGE_LOG_READ_BATCH_SQL = /*sql*/ `
+  SELECT
+    "watermark",
+    "pos",
+    json_extract("change", '$.tag') AS "tag",
+    "change"
+  FROM "${CHANGE_LOG_STREAM_TABLE}"
+  WHERE ("watermark", "pos") > (?, ?)
+    AND "watermark" <= ?
+  ORDER BY "watermark", "pos"
+  LIMIT ?
+`;
+
+/**
+ * Reads the replica-local change log without retaining a SQLite snapshot while
+ * a consumer processes a batch.
+ *
+ * The connection is read-only and therefore keeps the journal mode configured
+ * by the replica writer (WAL or WAL2). Callers pin a head with {@link plan}
+ * before passing it to {@link read}.
+ */
+export class SQLiteChangeLogReader implements Disposable {
+  readonly #db: Database;
+  #closed = false;
+
+  constructor(lc: LogContext, replicaFile: string) {
+    this.#db = new Database(
+      lc.withContext('component', 'sqlite-change-log-reader'),
+      replicaFile,
+      {readonly: true},
+    );
+  }
+
+  plan(fromWatermark: string): CatchupPlan {
+    this.#assertOpen();
+    const row = this.#db
+      .prepare(PLAN_SQL)
+      .get<PlanRow | undefined>({fromWatermark});
+    assert(row !== undefined, 'replication state must be initialized');
+    assert(
+      row.minWatermark !== null,
+      'SQLite change log must contain a catchup boundary',
+    );
+
+    if (row.subscriberAhead !== 0) {
+      return {kind: 'ahead', headWatermark: row.headWatermark};
+    }
+    if (fromWatermark < row.minWatermark || row.boundaryExists === 0) {
+      return {
+        kind: 'too-old',
+        minWatermark: row.minWatermark,
+        headWatermark: row.headWatermark,
+      };
+    }
+    return {
+      kind: 'range',
+      minWatermark: row.minWatermark,
+      headWatermark: row.headWatermark,
+    };
+  }
+
+  async *read(
+    fromWatermark: string,
+    throughWatermark: string,
+    batchSize: number,
+    signal?: AbortSignal | undefined,
+  ): AsyncIterable<readonly WatermarkedChange[]> {
+    assert(
+      Number.isSafeInteger(batchSize) && batchSize > 0,
+      'SQLite change log batch size must be a positive safe integer',
+    );
+
+    let lastWatermark = fromWatermark;
+    // The first query must be strictly after the requested transaction. Every
+    // real stream position is far below this sentinel.
+    let lastPos = Number.MAX_SAFE_INTEGER;
+    let transaction: TransactionCursor | undefined;
+
+    while (true) {
+      this.#throwIfAborted(signal);
+      const rows = this.#db.transaction(() =>
+        this.#db
+          .prepare(SQLITE_CHANGE_LOG_READ_BATCH_SQL)
+          .all<ChangeLogRow>(
+            lastWatermark,
+            lastPos,
+            throughWatermark,
+            batchSize,
+          ),
+      );
+      this.#throwIfAborted(signal);
+
+      if (rows.length === 0) {
+        break;
+      }
+
+      const changes: WatermarkedChange[] = [];
+      for (const row of rows) {
+        transaction = validateRow(row, transaction);
+        changes.push(reconstructWatermarkedChange(validatedEntry(row)));
+      }
+      const last = rows.at(-1);
+      assert(last !== undefined, 'non-empty batch must have a final row');
+      lastWatermark = last.watermark;
+      lastPos = last.pos;
+
+      // The read transaction above is already committed. In particular, this
+      // yield cannot pin the WAL while subscriber flow control is pending.
+      yield changes;
+    }
+
+    if (fromWatermark !== throughWatermark) {
+      assert(
+        transaction?.complete === true &&
+          transaction.watermark === throughWatermark,
+        () =>
+          `SQLite change log did not end at pinned head ${throughWatermark}`,
+      );
+    }
+  }
+
+  close(): void {
+    if (this.#closed) {
+      return;
+    }
+    this.#closed = true;
+    this.#db.close();
+  }
+
+  [Symbol.dispose](): void {
+    this.close();
+  }
+
+  #assertOpen(): void {
+    if (this.#closed) {
+      throw new AbortError('SQLite change log reader is closed');
+    }
+  }
+
+  #throwIfAborted(signal: AbortSignal | undefined): void {
+    this.#assertOpen();
+    if (signal?.aborted) {
+      throw new AbortError('SQLite change log read aborted');
+    }
+  }
+}
+
+function validatedEntry(row: ChangeLogRow): ChangeLogEntry {
+  assert(
+    row.tag !== null && CHANGE_TAGS.has(row.tag),
+    () => `invalid SQLite change log tag ${String(row.tag)}`,
+  );
+  return {watermark: row.watermark, tag: row.tag, change: row.change};
+}
+
+function validateRow(
+  row: ChangeLogRow,
+  transaction: TransactionCursor | undefined,
+): TransactionCursor {
+  assert(
+    Number.isSafeInteger(row.pos) && row.pos >= 0,
+    () => `invalid SQLite change log position ${row.pos}`,
+  );
+
+  if (transaction === undefined || row.watermark !== transaction.watermark) {
+    assert(
+      transaction === undefined || transaction.complete,
+      () =>
+        `incomplete SQLite change log transaction ${transaction?.watermark}`,
+    );
+    assert(
+      row.pos === 0 && row.tag === 'begin',
+      () =>
+        `SQLite change log transaction ${row.watermark} does not start with begin at position 0`,
+    );
+    return {watermark: row.watermark, nextPos: 1, complete: false};
+  }
+
+  assert(
+    !transaction.complete,
+    () =>
+      `SQLite change log transaction ${row.watermark} has rows after commit`,
+  );
+  assert(
+    row.pos === transaction.nextPos,
+    () =>
+      `non-contiguous SQLite change log transaction ${row.watermark}: expected position ${transaction.nextPos}, got ${row.pos}`,
+  );
+  assert(
+    row.tag !== 'begin',
+    () => `SQLite change log transaction ${row.watermark} has multiple begins`,
+  );
+  assert(
+    row.tag !== 'rollback',
+    () => `SQLite change log transaction ${row.watermark} contains a rollback`,
+  );
+  return {
+    watermark: transaction.watermark,
+    nextPos: transaction.nextPos + 1,
+    complete: row.tag === 'commit',
+  };
+}

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-reader.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-reader.ts
@@ -1,7 +1,7 @@
 import type {LogContext} from '@rocicorp/logger';
 import {AbortError} from '../../../../shared/src/abort-error.ts';
 import {assert} from '../../../../shared/src/asserts.ts';
-import {Database} from '../../../../zqlite/src/db.ts';
+import {Database, type Statement} from '../../../../zqlite/src/db.ts';
 import {CHANGE_LOG_STREAM_TABLE} from '../replicator/schema/change-log-stream.ts';
 import {
   reconstructWatermarkedChange,
@@ -61,18 +61,27 @@ const CHANGE_TAGS: ReadonlySet<string> = new Set<ChangeTag>([
   'rollback',
 ]);
 
+/**
+ * Seeks to the final position so validating a boundary does not scan every row
+ * of a large transaction. Exported so the focused query-plan test covers the
+ * production subquery.
+ */
+export const SQLITE_CHANGE_LOG_BOUNDARY_SQL = /*sql*/ `
+  SELECT
+    "precommit" = @fromWatermark AND
+      json_extract("change", '$.tag') = 'commit' AS "boundaryExists"
+  FROM "${CHANGE_LOG_STREAM_TABLE}"
+  WHERE "watermark" = @fromWatermark
+  ORDER BY "pos" DESC
+  LIMIT 1
+`;
+
 const PLAN_SQL = /*sql*/ `
   SELECT
     state."stateVersion" AS "headWatermark",
     bounds."minWatermark" AS "minWatermark",
     @fromWatermark > state."stateVersion" AS "subscriberAhead",
-    EXISTS (
-      SELECT 1
-        FROM "${CHANGE_LOG_STREAM_TABLE}"
-        WHERE "watermark" = @fromWatermark
-          AND "precommit" IS NOT NULL
-          AND json_extract("change", '$.tag') = 'commit'
-    ) AS "boundaryExists"
+    coalesce((${SQLITE_CHANGE_LOG_BOUNDARY_SQL}), 0) AS "boundaryExists"
   FROM "_zero.replicationState" AS state
   CROSS JOIN (
     SELECT min("watermark") AS "minWatermark"
@@ -104,6 +113,8 @@ export const SQLITE_CHANGE_LOG_READ_BATCH_SQL = /*sql*/ `
  */
 export class SQLiteChangeLogReader implements Disposable {
   readonly #db: Database;
+  readonly #plan: Statement;
+  readonly #readBatch: Statement;
   #closed = false;
 
   constructor(lc: LogContext, replicaFile: string) {
@@ -112,13 +123,13 @@ export class SQLiteChangeLogReader implements Disposable {
       replicaFile,
       {readonly: true},
     );
+    this.#plan = this.#db.prepare(PLAN_SQL);
+    this.#readBatch = this.#db.prepare(SQLITE_CHANGE_LOG_READ_BATCH_SQL);
   }
 
   plan(fromWatermark: string): CatchupPlan {
     this.#assertOpen();
-    const row = this.#db
-      .prepare(PLAN_SQL)
-      .get<PlanRow | undefined>({fromWatermark});
+    const row = this.#plan.get<PlanRow | undefined>({fromWatermark});
     assert(row !== undefined, 'replication state must be initialized');
     assert(
       row.minWatermark !== null,
@@ -161,15 +172,11 @@ export class SQLiteChangeLogReader implements Disposable {
 
     while (true) {
       this.#throwIfAborted(signal);
-      const rows = this.#db.transaction(() =>
-        this.#db
-          .prepare(SQLITE_CHANGE_LOG_READ_BATCH_SQL)
-          .all<ChangeLogRow>(
-            lastWatermark,
-            lastPos,
-            throughWatermark,
-            batchSize,
-          ),
+      const rows = this.#readBatch.all<ChangeLogRow>(
+        lastWatermark,
+        lastPos,
+        throughWatermark,
+        batchSize,
       );
       this.#throwIfAborted(signal);
 
@@ -187,8 +194,9 @@ export class SQLiteChangeLogReader implements Disposable {
       lastWatermark = last.watermark;
       lastPos = last.pos;
 
-      // The read transaction above is already committed. In particular, this
-      // yield cannot pin the WAL while subscriber flow control is pending.
+      // all() has exhausted the SELECT and closed its implicit read
+      // transaction. This yield therefore cannot pin the WAL while subscriber
+      // flow control is pending.
       yield changes;
     }
 


### PR DESCRIPTION
Adds the SQLite ChangeLog reader. Inert in production but exercised in tests.
