### PR TITLE
chore(zero-cache): decouple PurgeLock from restore

### DIFF
--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -116,12 +116,6 @@ export default async function runWorker(
         `error restoring backup. resyncing the replica: ${String(e)}`,
         e,
       );
-
-      // The purgeLock must be released if the backup could not be restored,
-      // or it will otherwise prevent the change-db update after the resync
-      // completes.
-      await purgeLock.release();
-      purgeLock = null;
     }
   }
 

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
@@ -36,6 +36,7 @@ import {
   type Downstream,
 } from './change-streamer.ts';
 import * as ErrorType from './error-type-enum.ts';
+import {initChangeStreamerSchema} from './schema/init.ts';
 import {AutoResetSignal, ensureReplicationConfig} from './schema/tables.ts';
 import {PurgeLocker} from './storer.ts';
 
@@ -79,6 +80,7 @@ describe('change-streamer/service', () => {
     acks = new Queue();
     setTimeoutFn = vi.fn();
 
+    await initChangeStreamerSchema(lc, sql, shard);
     streamer = await initializeStreamer(
       lc,
       shard,

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -41,7 +41,6 @@ import {
 } from './change-streamer.ts';
 import * as ErrorType from './error-type-enum.ts';
 import {Forwarder} from './forwarder.ts';
-import {initChangeStreamerSchema} from './schema/init.ts';
 import {
   AutoResetSignal,
   ensureReplicationConfig,
@@ -77,14 +76,13 @@ export async function initializeStreamer(
   opts: TuningOptions,
   setTimeoutFn = setTimeout,
 ): Promise<ChangeStreamerService> {
-  // Make sure the ChangeLog DB is set up.
-  await initChangeStreamerSchema(lc, changeDB, shard);
   await ensureReplicationConfig(
     lc,
     changeDB,
     subscriptionState,
     shard,
     autoReset,
+    purgeLock ?? undefined,
     setTimeoutFn,
   );
 

--- a/packages/zero-cache/src/services/change-streamer/schema/tables.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/schema/tables.pg.test.ts
@@ -1,6 +1,6 @@
 import {resolver} from '@rocicorp/resolver';
 import postgres from 'postgres';
-import {beforeEach, describe, expect} from 'vitest';
+import {beforeEach, describe, expect, vi} from 'vitest';
 import {createSilentLogContext} from '../../../../../shared/src/logging-test-utils.ts';
 import {Database} from '../../../../../zqlite/src/db.ts';
 import {expectTables, type PgTest, test} from '../../../test/db.ts';
@@ -32,6 +32,7 @@ describe('change-streamer/schema/tables', () => {
   test('ensureReplicationConfig', async () => {
     const replica1 = new Database(lc, ':memory:');
     initReplicationState(replica1, ['zero_data', 'zero_metadata'], '123');
+    const purgeLock = {release: vi.fn()};
 
     await ensureReplicationConfig(
       lc,
@@ -43,6 +44,7 @@ describe('change-streamer/schema/tables', () => {
       },
       shard,
       true,
+      purgeLock,
     );
 
     await expectTables(sql, {
@@ -90,6 +92,7 @@ describe('change-streamer/schema/tables', () => {
       },
       shard,
       true,
+      purgeLock,
     );
 
     await expectTables(sql, {
@@ -182,6 +185,7 @@ describe('change-streamer/schema/tables', () => {
       },
       shard,
       false,
+      purgeLock,
     );
 
     // autoReset with the same version should throw.
@@ -196,8 +200,11 @@ describe('change-streamer/schema/tables', () => {
         },
         shard,
         true,
+        purgeLock,
       ),
     ).rejects.toThrow(AutoResetSignal);
+
+    expect(purgeLock.release).not.toHaveBeenCalled();
 
     // Different replica version should wipe the tables.
     await ensureReplicationConfig(
@@ -210,7 +217,11 @@ describe('change-streamer/schema/tables', () => {
       },
       shard,
       true,
+      purgeLock,
     );
+
+    expect(purgeLock.release).toHaveBeenCalled();
+    purgeLock.release.mockReset();
 
     await expectTables(sql, {
       ['rezo_8/cdc.replicationConfig']: [
@@ -250,8 +261,11 @@ describe('change-streamer/schema/tables', () => {
         },
         shard,
         true,
+        purgeLock,
       ),
     ).rejects.toThrow(AutoResetSignal);
+
+    expect(purgeLock.release).not.toHaveBeenCalled();
   });
 
   test('no deadlocks when table is reset', async () => {
@@ -451,6 +465,7 @@ describe('change-streamer/schema/tables', () => {
         },
         shard,
         true,
+        undefined,
         shortSetTimeout,
       );
 

--- a/packages/zero-cache/src/services/change-streamer/schema/tables.ts
+++ b/packages/zero-cache/src/services/change-streamer/schema/tables.ts
@@ -143,6 +143,10 @@ function createTables(shard: ShardID) {
   );
 }
 
+interface PurgeLock {
+  release(): Promise<void>;
+}
+
 export async function setupCDCTables(
   lc: LogContext,
   db: postgres.TransactionSql,
@@ -168,6 +172,7 @@ export async function ensureReplicationConfig(
   >,
   shard: ShardID,
   autoReset: boolean,
+  purgeLock?: PurgeLock,
   setTimeoutFn: typeof setTimeout = setTimeout,
 ) {
   const {publications, replicaVersion, watermark} = subscriptionState;
@@ -209,6 +214,10 @@ export async function ensureReplicationConfig(
           `Data in cdc tables @${replicaVersion} is incompatible ` +
             `with replica @${replicaConfig.replicaVersion}. Clearing tables.`,
         );
+        // Release any purge lock held by the caller; the changeLog is
+        // incompatible with the replica and needs to be truncated.
+        void purgeLock?.release();
+
         // Note: The order of TRUNCATE matters. The replicationState table is
         //       truncated before the changeLog table, in order to acquire
         //       (exclusive) locks on the tables in the same order that the

--- a/packages/zero-cache/src/services/replicator/replication-resumption.pg.test.ts
+++ b/packages/zero-cache/src/services/replicator/replication-resumption.pg.test.ts
@@ -30,6 +30,7 @@ import {
   type ChangeStreamerService,
   type Downstream,
 } from '../change-streamer/change-streamer.ts';
+import {initChangeStreamerSchema} from '../change-streamer/schema/init.ts';
 import {ReplicationStatusPublisher} from './replication-status.ts';
 import {getSubscriptionState} from './schema/replication-state.ts';
 
@@ -472,6 +473,7 @@ async function startHarness(testDBs: PgTest['testDBs']) {
       );
 
     const faultyChangeSource = new FaultyChangeSource(changeSource);
+    await initChangeStreamerSchema(lc, changeDB, shard);
     const changeStreamer = await initializeStreamer(
       lc,
       shard,

--- a/packages/zero-cache/src/services/replicator/replication-throughput.bench.pg.ts
+++ b/packages/zero-cache/src/services/replicator/replication-throughput.bench.pg.ts
@@ -27,6 +27,7 @@ import {
   type ChangeStreamerService,
   type Downstream,
 } from '../change-streamer/change-streamer.ts';
+import {initChangeStreamerSchema} from '../change-streamer/schema/init.ts';
 import {ReplicationStatusPublisher} from './replication-status.ts';
 import {ReplicatorService} from './replicator.ts';
 import {ThreadWriteWorkerClient} from './write-worker-client.ts';
@@ -138,7 +139,7 @@ async function startReplicationPipeline(testDBs: PgTest['testDBs']) {
     );
 
   await setupReplica(lc, 'serving', {file: replicaDbFile.path});
-
+  await initChangeStreamerSchema(lc, changeDB, shard);
   const changeStreamer = await initializeStreamer(
     lc,
     shard,

--- a/packages/zql-integration-tests/src/chinook/chinook-zero-cache-fuzzer.pg.test.ts
+++ b/packages/zql-integration-tests/src/chinook/chinook-zero-cache-fuzzer.pg.test.ts
@@ -13,6 +13,7 @@ import type {
   ChangeStreamerService,
   Downstream,
 } from '../../../zero-cache/src/services/change-streamer/change-streamer.ts';
+import {initChangeStreamerSchema} from '../../../zero-cache/src/services/change-streamer/schema/init.ts';
 import {ReplicationStatusPublisher} from '../../../zero-cache/src/services/replicator/replication-status.ts';
 import type {ReplicaState} from '../../../zero-cache/src/services/replicator/replicator.ts';
 import {ReplicatorService} from '../../../zero-cache/src/services/replicator/replicator.ts';
@@ -330,6 +331,7 @@ async function startZeroCacheReplica(testDBs: PgTest['testDBs']) {
 
     await setupReplica(lc, 'serving', {file: replicaDbFile.path});
 
+    await initChangeStreamerSchema(lc, changeDB, shard);
     const changeStreamer = await initializeStreamer(
       lc,
       shard,


### PR DESCRIPTION
Remove the logic that releases the purge lock when a litestream restore fails.

Instead, the purge lock is released if needed when the change-streamer schema "ensured" (which happens after initial sync). This has the same result but decouples change-log-specific logic from the litestream restore, the latter of which is being moved into the change-source initialization logic in order to support replica-specific backup locations (for litestream v5 / RMv2).