### PR TITLE
chore(zero-cache): refactor/separate restore logic

### DIFF
--- a/packages/zero-cache/src/config/normalize.ts
+++ b/packages/zero-cache/src/config/normalize.ts
@@ -24,6 +24,8 @@ export type NormalizedZeroConfig = ZeroConfig & {
   numSyncWorkers: number;
 };
 
+export type LitestreamConfig = NormalizedZeroConfig['litestream'];
+
 export function isDevelopmentMode(): boolean {
   return process.env.NODE_ENV === 'development';
 }

--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -8,6 +8,7 @@ import {deleteLiteDB} from '../db/delete-lite-db.ts';
 import {registerSQLiteCorruptionDiagnosticTarget} from '../db/sqlite-corruption.ts';
 import {warmupConnections} from '../db/warmup.ts';
 import {initEventSink, publishCriticalEvent} from '../observability/events.ts';
+import {restoreReplica} from '../services/change-source/common/replica-restore.ts';
 import {upgradeReplica} from '../services/change-source/common/replica-schema.ts';
 import {initializeCustomChangeSource} from '../services/change-source/custom/change-source.ts';
 import {initializePostgresChangeSource} from '../services/change-source/pg/change-source.ts';
@@ -20,10 +21,6 @@ import {initChangeStreamerSchema} from '../services/change-streamer/schema/init.
 import {AutoResetSignal} from '../services/change-streamer/schema/tables.ts';
 import {PurgeLocker} from '../services/change-streamer/storer.ts';
 import {exitAfter, runUntilKilled} from '../services/life-cycle.ts';
-import {
-  BackupNotFoundException,
-  restoreReplica,
-} from '../services/litestream/commands.ts';
 import {
   replicationStatusError,
   ReplicationStatusPublisher,
@@ -59,6 +56,9 @@ export default async function runWorker(
       flowControlConsensusPaddingSeconds,
       flowControlEventDrivenRelease,
     },
+    autoReset,
+    replicationLag,
+    litestream,
     upstream,
     change,
     replica,
@@ -83,14 +83,11 @@ export default async function runWorker(
     lc,
     change.db,
     'change-streamer',
-    {
-      max: change.maxConns,
-    },
+    {max: change.maxConns},
     {sendStringAsJson: true},
   );
   void warmupConnections(lc, changeDB, 'change').catch(() => {});
 
-  const {autoReset, replicationLag} = config;
   const shard = getShardConfig(config);
 
   // Ensure the change DB schema is initialized/up-to-date.
@@ -100,19 +97,18 @@ export default async function runWorker(
   // purges. This ensures that (this) change-streamer will be able to resume
   // from the backup.
   let purgeLock =
-    config.litestream.backupURL && config.litestream.executable
+    litestream.backupURL && litestream.executable
       ? await new PurgeLocker(lc, shard, changeDB).acquire()
       : null;
 
   // Restore from litestream if the change-log has entries.
   if (purgeLock) {
     try {
-      await restoreReplica(lc, config, purgeLock);
+      if (!(await restoreReplica(lc, litestream, replica.file, purgeLock))) {
+        lc.info?.(`no backup found. syncing the replica`);
+      }
     } catch (e) {
-      // If the restore failed, e.g. due to a corrupt or missing backup, the
-      // replication-manager recovers by re-syncing.
-      const log = e instanceof BackupNotFoundException ? 'warn' : 'error';
-      lc[log]?.(
+      lc.error?.(
         `error restoring backup. resyncing the replica: ${String(e)}`,
         e,
       );

--- a/packages/zero-cache/src/server/main.ts
+++ b/packages/zero-cache/src/server/main.ts
@@ -12,10 +12,7 @@ import {
   runUntilKilled,
   type WorkerType,
 } from '../services/life-cycle.ts';
-import {
-  restoreReplica,
-  startReplicaBackupProcess,
-} from '../services/litestream/commands.ts';
+import {startReplicaBackupProcess} from '../services/litestream/commands.ts';
 import {
   childWorker,
   parentWorker,
@@ -104,6 +101,7 @@ export default async function runWorker(
   const {
     taskID,
     changeStreamer: {mode: changeStreamerMode, uri: changeStreamerURI},
+    replica,
     litestream,
   } = config;
   const runChangeStreamer =
@@ -111,14 +109,7 @@ export default async function runWorker(
 
   let changeStreamer: Worker | undefined;
 
-  if (!runChangeStreamer) {
-    changeStreamer = undefined;
-    if (litestream.executable) {
-      // For view-syncers, the backup is restored here. For the replication-manager,
-      // the backup is restored in the change-streamer worker.
-      await restoreReplica(lc, config, null);
-    }
-  } else {
+  if (runChangeStreamer) {
     const {promise: changeStreamerReady, resolve: changeStreamerStarted} =
       resolver();
     changeStreamer = loadWorker(CHANGE_STREAMER_URL, 'supporting').once(
@@ -141,7 +132,7 @@ export default async function runWorker(
         'message',
         () => {
           processes.addSubprocess(
-            startReplicaBackupProcess(lc, config),
+            startReplicaBackupProcess(lc, litestream, replica.file),
             'supporting',
             'litestream',
           );

--- a/packages/zero-cache/src/server/replicator.ts
+++ b/packages/zero-cache/src/server/replicator.ts
@@ -4,13 +4,28 @@ import type {ObservableCallback} from '@opentelemetry/api';
 import {consoleLogSink, LogContext} from '@rocicorp/logger';
 import {assert} from '../../../shared/src/asserts.ts';
 import {must} from '../../../shared/src/must.ts';
+import {sleep} from '../../../shared/src/sleep.ts';
 import * as v from '../../../shared/src/valita.ts';
+import type {
+  LitestreamConfig,
+  NormalizedZeroConfig,
+} from '../config/normalize.ts';
 import {getNormalizedZeroConfig} from '../config/zero-config.ts';
 import {registerSQLiteCorruptionDiagnosticTarget} from '../db/sqlite-corruption.ts';
 import {initEventSink} from '../observability/events.ts';
 import {getOrCreateGauge} from '../observability/metrics.ts';
 import {ChangeStreamerHttpClient} from '../services/change-streamer/change-streamer-http.ts';
+import {reserveAndGetSnapshotStatus} from '../services/change-streamer/snapshot.ts';
 import {exitAfter, runUntilKilled} from '../services/life-cycle.ts';
+import {
+  tryRestore,
+  type RestoreResult,
+} from '../services/litestream/commands.ts';
+import {
+  litestreamRestoreDuration,
+  litestreamRestoreMetricAttrs,
+  litestreamRestoreRuns,
+} from '../services/litestream/metrics.ts';
 import {ReplicationStatusPublisher} from '../services/replicator/replication-status.ts';
 import {
   ReplicatorService,
@@ -55,6 +70,10 @@ export default async function runWorker(
       dbPath: config.replica.file,
     });
   initEventSink(lc, config);
+
+  if (fileMode === 'serving' && config.litestream.backupURL) {
+    await restoreReplica(lc, config);
+  }
 
   const {file: dbPath, walMode} = await setupReplica(
     lc,
@@ -150,6 +169,53 @@ function observeFileSize(lc: LogContext, file: string): ObservableCallback {
       lc.warn?.(`unable to stat ${file} for size metrics`, e);
     }
   };
+}
+
+const RETRY_INTERVAL_MS = 3000;
+
+// View-syncers (no replicaConstraints) wait indefinitely for the
+// replication-manager to publish a restorable backup. On a fresh stack the
+// first backup is not durable until the initial sync completes and litestream
+// uploads the initial snapshot, which can take many minutes for a large
+// replica. The platform's startup probe budget (which scales with replica
+// size) is the backstop, so restoreReplica must not impose its own shorter
+// cap and self-terminate while the backup is still being produced.
+async function restoreReplica(lc: LogContext, config: NormalizedZeroConfig) {
+  const start = performance.now();
+  let backupURL: string | undefined;
+  let result: RestoreResult | undefined;
+  try {
+    for (;;) {
+      const snapshotStatus = await reserveAndGetSnapshotStatus(lc, config);
+      // The backupURL comes from the replication-manager's snapshot response.
+      ({backupURL} = snapshotStatus);
+      const litestream: LitestreamConfig = {...config.litestream, backupURL};
+      const attempt = await tryRestore(
+        lc,
+        litestream,
+        config.replica.file,
+        snapshotStatus,
+        'view_syncer',
+      );
+      if (attempt.restored) {
+        result = attempt.result;
+        return;
+      }
+      lc.info?.(
+        `replica not found. retrying in ${RETRY_INTERVAL_MS / 1000} seconds`,
+      );
+      await sleep(RETRY_INTERVAL_MS);
+    }
+  } finally {
+    const attrs = litestreamRestoreMetricAttrs(
+      config.litestream,
+      'view_syncer',
+      backupURL,
+    );
+    const labels = {...attrs, result: result ?? 'error'};
+    litestreamRestoreRuns().add(1, labels);
+    litestreamRestoreDuration().recordMs(performance.now() - start, labels);
+  }
 }
 
 // fork()

--- a/packages/zero-cache/src/services/change-source/common/replica-restore.ts
+++ b/packages/zero-cache/src/services/change-source/common/replica-restore.ts
@@ -1,0 +1,39 @@
+import type {LogContext} from '@rocicorp/logger';
+import type {LitestreamConfig} from '../../../config/normalize.ts';
+import {
+  tryRestore,
+  type ReplicaConstraints,
+  type RestoreResult,
+} from '../../litestream/commands.ts';
+import {
+  litestreamRestoreDuration,
+  litestreamRestoreMetricAttrs,
+  litestreamRestoreRuns,
+} from '../../litestream/metrics.ts';
+
+/** @returns `true` if the replica was restored, `false` if not found */
+export async function restoreReplica(
+  lc: LogContext,
+  config: LitestreamConfig,
+  replicaFile: string,
+  replicaConstraints: ReplicaConstraints,
+): Promise<boolean> {
+  const start = performance.now();
+  let result: RestoreResult | undefined;
+  try {
+    const attempt = await tryRestore(
+      lc,
+      config,
+      replicaFile,
+      replicaConstraints,
+      'replication_manager',
+    );
+    result = attempt.result;
+    return attempt.restored;
+  } finally {
+    const attrs = litestreamRestoreMetricAttrs(config, 'replication_manager');
+    const labels = {...attrs, result: result ?? 'error'};
+    litestreamRestoreRuns().add(1, labels);
+    litestreamRestoreDuration().recordMs(performance.now() - start, labels);
+  }
+}

--- a/packages/zero-cache/src/services/change-streamer/backup-cleanup-monitor-factory.ts
+++ b/packages/zero-cache/src/services/change-streamer/backup-cleanup-monitor-factory.ts
@@ -36,7 +36,8 @@ export function createBackupCleanupMonitor({
   vfsBackupWatermarkSource,
   env,
 }: BackupCleanupMonitorFactoryOptions): BackupMonitor | null {
-  const {backupURL, port: metricsPort} = config.litestream;
+  const {litestream, replica} = config;
+  const {backupURL, port: metricsPort} = litestream;
   if (!backupURL) {
     return null;
   }
@@ -65,6 +66,7 @@ export function createBackupCleanupMonitor({
     `http://localhost:${metricsPort}/metrics`,
     changeStreamer,
     initialCleanupDelayMs,
-    verifyBackupState ?? (() => getLastBackupTime(lc, config)),
+    verifyBackupState ??
+      (() => getLastBackupTime(lc, litestream, replica.file)),
   );
 }

--- a/packages/zero-cache/src/services/change-streamer/snapshot.ts
+++ b/packages/zero-cache/src/services/change-streamer/snapshot.ts
@@ -1,5 +1,5 @@
 /**
- * Definitions for the `snapshot` API, which serves the purpose of:
+ * The `snapshot` API serves the purpose of:
  * - informing subscribers (i.e. view-syncers) of the (litestream)
  *   backup location from which to restore a replica snapshot
  * - checking whether a restored backup or existing replica is
@@ -12,7 +12,14 @@
  *   backed up changes.
  */
 
+import type {LogContext} from '@rocicorp/logger';
+import {resolver} from '@rocicorp/resolver';
+import {sleep} from '../../../../shared/src/sleep.ts';
 import * as v from '../../../../shared/src/valita.ts';
+import {type NormalizedZeroConfig} from '../../config/normalize.ts';
+import {getShardConfig} from '../../types/shards.ts';
+import type {Source} from '../../types/streams.ts';
+import {ChangeStreamerHttpClient} from './change-streamer-http.ts';
 
 const statusSchema = v.object({
   tag: v.literal('status'),
@@ -46,3 +53,74 @@ const statusMessageSchema = v.tuple([v.literal('status'), statusSchema]);
 export const snapshotMessageSchema = v.union(statusMessageSchema);
 
 export type SnapshotMessage = v.Infer<typeof statusMessageSchema>;
+
+export function reserveAndGetSnapshotStatus(
+  lc: LogContext,
+  config: NormalizedZeroConfig,
+): Promise<SnapshotStatus> {
+  const {promise: status, resolve, reject} = resolver<SnapshotStatus>();
+
+  void (async function () {
+    const abort = new AbortController();
+    process.on('SIGINT', () => abort.abort());
+    process.on('SIGTERM', () => abort.abort());
+
+    for (let i = 0; ; i++) {
+      let err: unknown;
+      try {
+        let resolved = false;
+        const stream = await reserveSnapshot(lc, config);
+        for await (const msg of stream) {
+          // Capture the value of the status message that the change-streamer
+          // backup monitor returns, and hold the connection open to
+          // "reserve" the snapshot and prevent change log cleanup.
+          resolve(msg[1]);
+          resolved = true;
+        }
+        // The change-streamer itself closes the connection when the
+        // subscription is started (or the reservation retried).
+        if (resolved) {
+          break;
+        }
+      } catch (e) {
+        err = e;
+      }
+      // Retry in the view-syncer since it cannot proceed until it connects
+      // to a (compatible) replication-manager. In particular, a
+      // replication-manager that does not support the view-syncer's
+      // change-streamer protocol will close the stream with an error; this
+      // retry logic essentially delays the startup of a view-syncer until
+      // a compatible replication-manager has been rolled out, allowing
+      // replication-manager and view-syncer services to be updated in
+      // parallel.
+      lc.warn?.(
+        `Unable to reserve snapshot (attempt ${i + 1}). Retrying in 5 seconds.`,
+        String(err),
+      );
+      try {
+        await sleep(5000, abort.signal);
+      } catch (e) {
+        return reject(e);
+      }
+    }
+  })();
+
+  return status;
+}
+
+function reserveSnapshot(
+  lc: LogContext,
+  config: NormalizedZeroConfig,
+): Promise<Source<SnapshotMessage>> {
+  const {taskID, change, changeStreamer} = config;
+  const shardID = getShardConfig(config);
+
+  const changeStreamerClient = new ChangeStreamerHttpClient(
+    lc,
+    shardID,
+    change.db,
+    changeStreamer.uri,
+  );
+
+  return changeStreamerClient.reserveSnapshot(taskID);
+}

--- a/packages/zero-cache/src/services/litestream/commands.test.ts
+++ b/packages/zero-cache/src/services/litestream/commands.test.ts
@@ -9,13 +9,12 @@ import {
   TestLogSink,
 } from '../../../../shared/src/logging-test-utils.ts';
 import {Database} from '../../../../zqlite/src/db.ts';
-import type {ZeroConfig} from '../../config/zero-config.ts';
+import {type NormalizedZeroConfig} from '../../config/normalize.ts';
 import {initReplicationState} from '../replicator/schema/replication-state.ts';
 import {
-  BackupNotFoundException,
   getLastBackupTime,
   parseBackupCreatedTimes,
-  restoreReplica,
+  tryRestore,
 } from './commands.ts';
 import * as litestreamMetrics from './metrics.ts';
 
@@ -33,7 +32,7 @@ vi.mock('node:child_process', async importOriginal => {
 function configWithFakeLitestream(
   sh: string,
   replicaFile?: string,
-): ZeroConfig {
+): NormalizedZeroConfig {
   const dir = mkdtempSync(join(tmpdir(), 'litestream-test-'));
   const executable = join(dir, 'fake-litestream');
   writeFileSync(executable, `#!/bin/sh\n${sh}\n`, {mode: 0o755});
@@ -42,6 +41,7 @@ function configWithFakeLitestream(
     log: {format: 'text'},
     replica: {file: replicaFile ?? join(dir, 'replica.db')},
     litestream: {
+      port: 4850,
       executable,
       backupURL: 's3://fake-bucket/backup',
       configPath: './src/services/litestream/config.yml',
@@ -54,7 +54,7 @@ function configWithFakeLitestream(
       multipartSize: 16 * 1024 * 1024,
       restoreParallelism: 48,
     },
-  } as unknown as ZeroConfig;
+  } as unknown as NormalizedZeroConfig;
 }
 
 function createRestorableReplica(file: string, watermark: string) {
@@ -140,7 +140,7 @@ describe('litestream/commands getLastBackupTime', () => {
   const lc = createSilentLogContext();
 
   test('returns the most recent created time across snapshots and wal', async () => {
-    const config = configWithFakeLitestream(
+    const {litestream, replica} = configWithFakeLitestream(
       `if [ "$1" = "snapshots" ]; then\n` +
         `  echo "replica generation index size created"\n` +
         `  echo "s3 gen 0 100 2025-04-24T00:00:00Z"\n` +
@@ -150,29 +150,29 @@ describe('litestream/commands getLastBackupTime', () => {
         `  echo "s3 gen 2 0 100 2025-04-24T00:10:00Z"\n` +
         `fi`,
     );
-    expect(await getLastBackupTime(lc, config)).toEqual(
+    expect(await getLastBackupTime(lc, litestream, replica.file)).toEqual(
       new Date('2025-04-24T00:10:00Z'),
     );
   });
 
   test('rejects when nothing is listed at the destination', async () => {
-    const config = configWithFakeLitestream(`exit 0`);
-    await expect(getLastBackupTime(lc, config)).rejects.toThrow(
-      /no snapshots or WAL segments listed/,
-    );
+    const {litestream, replica} = configWithFakeLitestream(`exit 0`);
+    await expect(
+      getLastBackupTime(lc, litestream, replica.file),
+    ).rejects.toThrow(/no snapshots or WAL segments listed/);
   });
 
   test('rejects when the litestream process exits non-zero', async () => {
-    const config = configWithFakeLitestream(`exit 1`);
-    await expect(getLastBackupTime(lc, config)).rejects.toThrow(
-      /litestream (snapshots|wal) exited with code 1/,
-    );
+    const {litestream, replica} = configWithFakeLitestream(`exit 1`);
+    await expect(
+      getLastBackupTime(lc, litestream, replica.file),
+    ).rejects.toThrow(/litestream (snapshots|wal) exited with code 1/);
   });
 
   test('rejects (and kills the process) when listing times out', async () => {
     vi.useFakeTimers();
-    const config = configWithFakeLitestream(`sleep 30`);
-    const result = getLastBackupTime(lc, config);
+    const {litestream, replica} = configWithFakeLitestream(`sleep 30`);
+    const result = getLastBackupTime(lc, litestream, replica.file);
     // Surface the rejection synchronously so the unhandled-rejection guard
     // does not fire before we await it below.
     const settled = result.then(
@@ -206,7 +206,7 @@ describe('litestream/commands restoreReplica', () => {
     } as unknown as ReturnType<
       typeof litestreamMetrics.litestreamRestoredDbBytes
     >);
-    const config = configWithFakeLitestream(
+    const {litestream} = configWithFakeLitestream(
       `if [ "$1" = "restore" ]; then\n` +
         `  cp "${source}" "$6"\n` +
         `  exit 0\n` +
@@ -215,10 +215,16 @@ describe('litestream/commands restoreReplica', () => {
       replica,
     );
 
-    await restoreReplica(lc, config, {
-      replicaVersion: '01',
-      minWatermark: '01',
-    });
+    await tryRestore(
+      lc,
+      litestream,
+      replica,
+      {
+        replicaVersion: '01',
+        minWatermark: '01',
+      },
+      'replication_manager',
+    );
 
     expect(existsSync(replica)).toBe(true);
     expect(restoredDbBytesAdd).toHaveBeenCalledWith(
@@ -237,40 +243,23 @@ describe('litestream/commands restoreReplica', () => {
     } as unknown as ReturnType<
       typeof litestreamMetrics.litestreamRestoredDbBytes
     >);
-    const config = configWithFakeLitestream(
+    const {litestream} = configWithFakeLitestream(
       `if [ "$1" = "restore" ]; then\n` + `  exit 0\n` + `fi\n` + `exit 1`,
       replica,
     );
 
-    await restoreReplica(lc, config, {
-      replicaVersion: '01',
-      minWatermark: '01',
-    });
-
-    expect(restoredDbBytesAdd).not.toHaveBeenCalled();
-  });
-
-  test('reports a missing backup when restore exits without a replica', async () => {
-    const restoreAttemptsAdd = vi.fn();
-    vi.spyOn(litestreamMetrics, 'litestreamRestoreAttempts').mockReturnValue({
-      add: restoreAttemptsAdd,
-    } as unknown as ReturnType<
-      typeof litestreamMetrics.litestreamRestoreAttempts
-    >);
-    const config = configWithFakeLitestream(
-      `if [ "$1" = "restore" ]; then\n` + `  exit 0\n` + `fi\n` + `exit 1`,
-    );
-
-    await expect(
-      restoreReplica(lc, config, {
+    await tryRestore(
+      lc,
+      litestream,
+      replica,
+      {
         replicaVersion: '01',
         minWatermark: '01',
-      }),
-    ).rejects.toThrow(BackupNotFoundException);
-    expect(restoreAttemptsAdd).toHaveBeenCalledWith(
-      1,
-      expect.objectContaining({result: 'no_backup'}),
+      },
+      'replication_manager',
     );
+
+    expect(restoredDbBytesAdd).not.toHaveBeenCalled();
   });
 
   test('deletes an incompatible restored replica', async () => {
@@ -278,11 +267,7 @@ describe('litestream/commands restoreReplica', () => {
     const source = join(dir, 'source.db');
     const replica = join(dir, 'replica.db');
     createRestorableReplica(source, '01');
-    const restoreRunsAdd = vi.fn();
     const restoreValidationRecordMs = vi.fn();
-    vi.spyOn(litestreamMetrics, 'litestreamRestoreRuns').mockReturnValue({
-      add: restoreRunsAdd,
-    } as unknown as ReturnType<typeof litestreamMetrics.litestreamRestoreRuns>);
     vi.spyOn(
       litestreamMetrics,
       'litestreamRestoreValidationDuration',
@@ -291,7 +276,7 @@ describe('litestream/commands restoreReplica', () => {
     } as unknown as ReturnType<
       typeof litestreamMetrics.litestreamRestoreValidationDuration
     >);
-    const config = configWithFakeLitestream(
+    const {litestream} = configWithFakeLitestream(
       `if [ "$1" = "restore" ]; then\n` +
         `  cp "${source}" "$6"\n` +
         `  exit 0\n` +
@@ -300,20 +285,25 @@ describe('litestream/commands restoreReplica', () => {
       replica,
     );
 
-    await expect(
-      restoreReplica(lc, config, {
-        replicaVersion: '02',
-        minWatermark: '02',
-      }),
-    ).rejects.toThrow(BackupNotFoundException);
+    expect(
+      await tryRestore(
+        lc,
+        litestream,
+        replica,
+        {
+          replicaVersion: '02',
+          minWatermark: '02',
+        },
+        'replication_manager',
+      ),
+    ).toMatchObject({
+      restored: false,
+      result: 'invalid_replica',
+    });
 
     expect(existsSync(replica)).toBe(false);
     expect(restoreValidationRecordMs).toHaveBeenCalledWith(
       expect.any(Number),
-      expect.objectContaining({result: 'invalid_replica'}),
-    );
-    expect(restoreRunsAdd).toHaveBeenCalledWith(
-      1,
       expect.objectContaining({result: 'invalid_replica'}),
     );
   });
@@ -330,7 +320,7 @@ describe('litestream/commands restoreReplica', () => {
     const source = join(dir, 'source.db');
     const replica = join(dir, 'replica.db');
     createRestorableReplica(source, '01');
-    const config = configWithFakeLitestream(
+    const {litestream} = configWithFakeLitestream(
       `if [ "$1" = "restore" ]; then\n` +
         `  cp "${source}" "$6"\n` +
         `  exit 0\n` +
@@ -339,10 +329,16 @@ describe('litestream/commands restoreReplica', () => {
       replica,
     );
 
-    await restoreReplica(lc, config, {
-      replicaVersion: '01',
-      minWatermark: '01',
-    });
+    await tryRestore(
+      lc,
+      litestream,
+      replica,
+      {
+        replicaVersion: '01',
+        minWatermark: '01',
+      },
+      'replication_manager',
+    );
 
     const restoreCall = spawnMock.mock.calls.find(
       call => Array.isArray(call[1]) && call[1][0] === 'restore',

--- a/packages/zero-cache/src/services/litestream/commands.ts
+++ b/packages/zero-cache/src/services/litestream/commands.ts
@@ -4,23 +4,14 @@ import {existsSync, statSync} from 'node:fs';
 import type {LogContext, LogLevel} from '@rocicorp/logger';
 import {resolver} from '@rocicorp/resolver';
 import {must} from '../../../../shared/src/must.ts';
-import {sleep} from '../../../../shared/src/sleep.ts';
 import {Database} from '../../../../zqlite/src/db.ts';
-import {assertNormalized} from '../../config/normalize.ts';
-import type {ZeroConfig} from '../../config/zero-config.ts';
+import {type LitestreamConfig} from '../../config/normalize.ts';
 import {deleteLiteDB} from '../../db/delete-lite-db.ts';
 import {
   isSQLiteCorruption,
   logSQLiteCorruptionDiagnostics,
 } from '../../db/sqlite-corruption.ts';
 import {StatementRunner} from '../../db/statements.ts';
-import {getShardConfig} from '../../types/shards.ts';
-import type {Source} from '../../types/streams.ts';
-import {ChangeStreamerHttpClient} from '../change-streamer/change-streamer-http.ts';
-import type {
-  SnapshotMessage,
-  SnapshotStatus,
-} from '../change-streamer/snapshot.ts';
 import {getSubscriptionState} from '../replicator/schema/replication-state.ts';
 import {
   litestreamBackupListDuration,
@@ -30,23 +21,22 @@ import {
   litestreamBackupProcessRuns,
   litestreamRestoreAttempts,
   litestreamRestoredDbBytes,
-  litestreamRestoreDuration,
   litestreamRestoreMetricAttrs,
   litestreamRestoreProcessDuration,
-  litestreamRestoreRuns,
   litestreamRestoreValidationDuration,
-  litestreamRestoreWaitDuration,
   type LitestreamRole,
 } from './metrics.ts';
 
-const RETRY_INTERVAL_MS = 3000;
-
-type ReplicaConstraints = {
+export type ReplicaConstraints = {
   replicaVersion: string;
   minWatermark: string;
 };
 
-type RestoreResult = 'success' | 'no_backup' | 'invalid_replica' | 'error';
+export type RestoreResult =
+  | 'success'
+  | 'no_backup'
+  | 'invalid_replica'
+  | 'error';
 
 type RestoreAttempt = {
   restored: boolean;
@@ -62,69 +52,11 @@ export class BackupNotFoundException extends Error {
   }
 }
 
-/**
- * @param replicaConstraints The constraints of the restored backup when
- *        restoring for the change-streamer (replication-manager). For the
- *        view-syncer, this should be unspecified so that the constraints are
- *        retrieved from the replication-manager via the snapshot protocol.
- */
-export async function restoreReplica(
-  lc: LogContext,
-  config: ZeroConfig,
-  replicaConstraints: ReplicaConstraints | null,
-) {
-  const start = performance.now();
-  const role: LitestreamRole = replicaConstraints
-    ? 'replication_manager'
-    : 'view_syncer';
-  let backupURL = config.litestream.backupURL;
-  let result: RestoreResult | undefined;
-  // View-syncers (no replicaConstraints) wait indefinitely for the
-  // replication-manager to publish a restorable backup. On a fresh stack the
-  // first backup is not durable until the initial sync completes and litestream
-  // uploads the initial snapshot, which can take many minutes for a large
-  // replica. The platform's startup probe budget (which scales with replica
-  // size) is the backstop, so restoreReplica must not impose its own shorter
-  // cap and self-terminate while the backup is still being produced.
-  try {
-    for (;;) {
-      const attempt = await tryRestore(lc, config, replicaConstraints, role);
-      backupURL = attempt.backupURL;
-      if (attempt.restored) {
-        result = attempt.result;
-        return;
-      }
-      if (replicaConstraints) {
-        // The replication-manager restores against explicit constraints, so a
-        // missing backup is fatal (e.g. the litestream URL was purposefully
-        // changed to force a resync). Only the view-syncer (no constraints)
-        // waits for a backup to appear.
-        result = attempt.result;
-        throw new BackupNotFoundException(config.litestream.backupURL);
-      }
-      lc.info?.(
-        `replica not found. retrying in ${RETRY_INTERVAL_MS / 1000} seconds`,
-      );
-      await sleep(RETRY_INTERVAL_MS);
-    }
-  } catch (e) {
-    if (e instanceof BackupNotFoundException && result === undefined) {
-      result = 'no_backup';
-    }
-    throw e;
-  } finally {
-    const attrs = litestreamRestoreMetricAttrs(config, role, backupURL);
-    const labels = {...attrs, result: result ?? 'error'};
-    litestreamRestoreRuns().add(1, labels);
-    litestreamRestoreDuration().recordMs(performance.now() - start, labels);
-  }
-}
-
 function getLitestream(
   mode: 'restore' | 'replicate',
-  config: ZeroConfig,
+  config: LitestreamConfig,
+  replicaFile: string,
   logLevelOverride?: LogLevel,
-  backupURLOverride?: string,
 ): {
   litestream: string;
   env: NodeJS.ProcessEnv;
@@ -138,7 +70,7 @@ function getLitestream(
     configPath,
     endpoint,
     region,
-    port = config.port + 2,
+    port,
     checkpointThresholdMB,
     minCheckpointPageCount = checkpointThresholdMB * 250, // SQLite page size is 4KB
     maxCheckpointPageCount = minCheckpointPageCount * 10,
@@ -146,7 +78,7 @@ function getLitestream(
     snapshotBackupIntervalHours,
     multipartConcurrency,
     multipartSize,
-  } = config.litestream;
+  } = config;
 
   const litestream =
     // The v0.5.8+ litestream executable can restore from either the new LTX
@@ -158,8 +90,8 @@ function getLitestream(
     litestream,
     env: {
       ...process.env,
-      ['ZERO_REPLICA_FILE']: config.replica.file,
-      ['ZERO_LITESTREAM_BACKUP_URL']: must(backupURLOverride ?? backupURL),
+      ['ZERO_REPLICA_FILE']: replicaFile,
+      ['ZERO_LITESTREAM_BACKUP_URL']: must(backupURL),
       ['ZERO_LITESTREAM_MIN_CHECKPOINT_PAGE_COUNT']: String(
         minCheckpointPageCount,
       ),
@@ -178,7 +110,7 @@ function getLitestream(
       ),
       ['ZERO_LITESTREAM_MULTIPART_CONCURRENCY']: String(multipartConcurrency),
       ['ZERO_LITESTREAM_MULTIPART_SIZE']: String(multipartSize),
-      ['ZERO_LOG_FORMAT']: config.log.format,
+      ['ZERO_LOG_FORMAT']: 'json',
       ['LITESTREAM_CONFIG']: configPath,
       ['LITESTREAM_PORT']: String(port),
       ...(endpoint ? {['ZERO_LITESTREAM_ENDPOINT']: endpoint} : {}),
@@ -187,42 +119,29 @@ function getLitestream(
   };
 }
 
-async function tryRestore(
+export async function tryRestore(
   lc: LogContext,
-  config: ZeroConfig,
-  replicaConstraints: ReplicaConstraints | null,
+  config: LitestreamConfig,
+  replicaFile: string,
+  replicaConstraints: ReplicaConstraints,
   role: LitestreamRole,
 ): Promise<RestoreAttempt> {
-  let snapshotStatus: SnapshotStatus | undefined;
-  if (!replicaConstraints) {
-    // view-syncers fetch replica constraints from the replication-manager
-    // via the snapshot protocol.
-    const waitStart = performance.now();
-    snapshotStatus = await reserveAndGetSnapshotStatus(lc, config);
-    litestreamRestoreWaitDuration().recordMs(
-      performance.now() - waitStart,
-      litestreamRestoreMetricAttrs(config, role, snapshotStatus.backupURL),
-    );
-    lc.info?.(`restoring backup from ${snapshotStatus.backupURL}`);
-    replicaConstraints = snapshotStatus;
-  }
-
-  const backupURL = snapshotStatus?.backupURL ?? config.litestream.backupURL;
+  const {backupURL} = config;
   const attrs = litestreamRestoreMetricAttrs(config, role, backupURL);
   let result: RestoreResult = 'error';
   try {
-    const replicaExistedBeforeRestore = existsSync(config.replica.file);
+    const replicaExistedBeforeRestore = existsSync(replicaFile);
     const {litestream, env} = getLitestream(
       'restore',
       config,
+      replicaFile,
       'debug', // Include all output from `litestream restore`, as it's minimal.
-      snapshotStatus?.backupURL,
     );
     const {
       restoreParallelism: parallelism,
       multipartConcurrency,
       multipartSize,
-    } = config.litestream;
+    } = config;
     lc.info?.(`starting litestream restore`, {
       restoreParallelism: parallelism,
       multipartConcurrency,
@@ -243,7 +162,7 @@ async function tryRestore(
         '-if-replica-exists',
         '-parallelism',
         String(parallelism),
-        config.replica.file,
+        replicaFile,
       ],
       {env, stdio: ['ignore', 'pipe', 'pipe'], windowsHide: true},
     );
@@ -287,12 +206,12 @@ async function tryRestore(
       );
       throw e;
     }
-    if (!existsSync(config.replica.file)) {
+    if (!existsSync(replicaFile)) {
       result = 'no_backup';
       return {restored: false, backupURL, result};
     }
     const validationStart = performance.now();
-    const valid = replicaIsValid(lc, config.replica.file, replicaConstraints);
+    const valid = replicaIsValid(lc, replicaFile, replicaConstraints);
     litestreamRestoreValidationDuration().recordMs(
       performance.now() - validationStart,
       {...attrs, result: valid ? 'success' : 'invalid_replica'},
@@ -300,22 +219,19 @@ async function tryRestore(
     if (!valid) {
       result = 'invalid_replica';
       lc.info?.(`Deleting local replica and retrying restore`);
-      deleteLiteDB(config.replica.file);
+      deleteLiteDB(replicaFile);
       return {restored: false, backupURL, result};
     }
     result = 'success';
     if (!replicaExistedBeforeRestore) {
-      litestreamRestoredDbBytes().add(statSync(config.replica.file).size, {
+      litestreamRestoredDbBytes().add(statSync(replicaFile).size, {
         ...attrs,
         result: 'success',
       });
     }
     return {restored: true, backupURL, result};
   } finally {
-    litestreamRestoreAttempts().add(1, {
-      ...attrs,
-      result,
-    });
+    litestreamRestoreAttempts().add(1, {...attrs, result});
   }
 }
 
@@ -361,11 +277,12 @@ function replicaIsValid(
 
 export function startReplicaBackupProcess(
   lc: LogContext,
-  config: ZeroConfig,
+  config: LitestreamConfig,
+  replicaFile: string,
 ): ChildProcess {
-  const {litestream, env} = getLitestream('replicate', config);
+  const {litestream, env} = getLitestream('replicate', config, replicaFile);
   const attrs = litestreamBackupProcessMetricAttrs(config);
-  lc.info?.(`starting litestream backup to ${config.litestream.backupURL}`);
+  lc.info?.(`starting litestream backup to ${config.backupURL}`);
   const start = performance.now();
   const proc = spawn(litestream, ['replicate'], {
     env,
@@ -425,11 +342,12 @@ const wsRe = /\s+/;
  */
 export async function getLastBackupTime(
   lc: LogContext,
-  config: ZeroConfig,
+  config: LitestreamConfig,
+  replicaFile: string,
 ): Promise<Date> {
   const [snapshots, wal] = await Promise.all([
-    listBackupCreatedTimes(lc, config, 'snapshots'),
-    listBackupCreatedTimes(lc, config, 'wal'),
+    listBackupCreatedTimes(lc, config, replicaFile, 'snapshots'),
+    listBackupCreatedTimes(lc, config, replicaFile, 'wal'),
   ]);
   const times = [...snapshots, ...wal];
   if (times.length === 0) {
@@ -438,7 +356,7 @@ export async function getLastBackupTime(
     // distinguished from a failed one. Since a valid backup always contains
     // at least one snapshot, an empty listing is treated as a failure.
     throw new Error(
-      `no snapshots or WAL segments listed at ${config.litestream.backupURL}`,
+      `no snapshots or WAL segments listed at ${config.backupURL}`,
     );
   }
   return new Date(Math.max(...times.map(time => time.getTime())));
@@ -457,13 +375,14 @@ export async function getLastBackupTime(
  */
 async function listBackupCreatedTimes(
   lc: LogContext,
-  config: ZeroConfig,
+  config: LitestreamConfig,
+  replicaFile: string,
   command: 'snapshots' | 'wal',
 ): Promise<Date[]> {
   const start = performance.now();
   let result: 'success' | 'empty' | 'timeout' | 'error' = 'error';
-  const {litestream, env} = getLitestream('replicate', config);
-  const proc = spawn(litestream, [command, config.replica.file], {
+  const {litestream, env} = getLitestream('replicate', config, replicaFile);
+  const proc = spawn(litestream, [command, replicaFile], {
     env,
     stdio: ['ignore', 'pipe', 'inherit'],
     windowsHide: true,
@@ -534,76 +453,4 @@ export function parseBackupCreatedTimes(
     times.push(time);
   }
   return times;
-}
-
-function reserveAndGetSnapshotStatus(
-  lc: LogContext,
-  config: ZeroConfig,
-): Promise<SnapshotStatus> {
-  const {promise: status, resolve, reject} = resolver<SnapshotStatus>();
-
-  void (async function () {
-    const abort = new AbortController();
-    process.on('SIGINT', () => abort.abort());
-    process.on('SIGTERM', () => abort.abort());
-
-    for (let i = 0; ; i++) {
-      let err: unknown;
-      try {
-        let resolved = false;
-        const stream = await reserveSnapshot(lc, config);
-        for await (const msg of stream) {
-          // Capture the value of the status message that the change-streamer
-          // backup monitor returns, and hold the connection open to
-          // "reserve" the snapshot and prevent change log cleanup.
-          resolve(msg[1]);
-          resolved = true;
-        }
-        // The change-streamer itself closes the connection when the
-        // subscription is started (or the reservation retried).
-        if (resolved) {
-          break;
-        }
-      } catch (e) {
-        err = e;
-      }
-      // Retry in the view-syncer since it cannot proceed until it connects
-      // to a (compatible) replication-manager. In particular, a
-      // replication-manager that does not support the view-syncer's
-      // change-streamer protocol will close the stream with an error; this
-      // retry logic essentially delays the startup of a view-syncer until
-      // a compatible replication-manager has been rolled out, allowing
-      // replication-manager and view-syncer services to be updated in
-      // parallel.
-      lc.warn?.(
-        `Unable to reserve snapshot (attempt ${i + 1}). Retrying in 5 seconds.`,
-        String(err),
-      );
-      try {
-        await sleep(5000, abort.signal);
-      } catch (e) {
-        return reject(e);
-      }
-    }
-  })();
-
-  return status;
-}
-
-function reserveSnapshot(
-  lc: LogContext,
-  config: ZeroConfig,
-): Promise<Source<SnapshotMessage>> {
-  assertNormalized(config);
-  const {taskID, change, changeStreamer} = config;
-  const shardID = getShardConfig(config);
-
-  const changeStreamerClient = new ChangeStreamerHttpClient(
-    lc,
-    shardID,
-    change.db,
-    changeStreamer.uri,
-  );
-
-  return changeStreamerClient.reserveSnapshot(taskID);
 }

--- a/packages/zero-cache/src/services/litestream/metrics.ts
+++ b/packages/zero-cache/src/services/litestream/metrics.ts
@@ -1,4 +1,4 @@
-import type {ZeroConfig} from '../../config/zero-config.ts';
+import type {LitestreamConfig} from '../../config/normalize.ts';
 import {
   getOrCreateCounter,
   getOrCreateHistogram,
@@ -20,11 +20,11 @@ type LitestreamMultipartMetricAttrs = {
 };
 
 export function litestreamRestoreMetricAttrs(
-  config: ZeroConfig,
+  config: LitestreamConfig,
   role: LitestreamRole,
-  backupURL = config.litestream.backupURL,
+  backupURL = config.backupURL,
 ): LitestreamMetricAttrs & LitestreamMultipartMetricAttrs {
-  const {executable, executableV5, restoreUsingV5} = config.litestream;
+  const {executable, executableV5, restoreUsingV5} = config;
   const selectedExecutable =
     (restoreUsingV5 ? executableV5 : executable) ?? executable;
   return {
@@ -39,21 +39,21 @@ export function litestreamRestoreMetricAttrs(
 }
 
 export function litestreamBackupMetricAttrs(
-  config: ZeroConfig,
+  config: LitestreamConfig,
 ): LitestreamMetricAttrs {
   return {
     role: 'replication_manager',
-    backup_scheme: litestreamBackupScheme(config.litestream.backupURL),
+    backup_scheme: litestreamBackupScheme(config.backupURL),
     litestream:
-      config.litestream.executableV5 !== undefined &&
-      config.litestream.executable === config.litestream.executableV5
+      config.executableV5 !== undefined &&
+      config.executable === config.executableV5
         ? 'v5'
         : 'legacy',
   };
 }
 
 export function litestreamBackupProcessMetricAttrs(
-  config: ZeroConfig,
+  config: LitestreamConfig,
 ): LitestreamMetricAttrs & LitestreamMultipartMetricAttrs {
   return {
     ...litestreamBackupMetricAttrs(config),
@@ -86,13 +86,11 @@ function litestreamBackupScheme(backupURL: string | undefined): string {
 }
 
 function litestreamMultipartMetricAttrs(
-  config: ZeroConfig,
+  config: LitestreamConfig,
 ): LitestreamMultipartMetricAttrs {
   return {
-    multipart_concurrency: config.litestream.multipartConcurrency,
-    multipart_size_mib: Math.round(
-      config.litestream.multipartSize / 1024 / 1024,
-    ),
+    multipart_concurrency: config.multipartConcurrency,
+    multipart_size_mib: Math.round(config.multipartSize / 1024 / 1024),
   };
 }
 


### PR DESCRIPTION
Split the logic for replication-manager vs view-syncer restores. The main motivation is to abstract view-syncer specific logic out of the core litestream library to facilitate adding flexibility to how replicas are restored in the replication-manager.

* The `view-syncer`'s snapshot reservation and continuous retry logic is moved into the `replicator.ts` worker.
* The `replication-manager`'s restore logic is moved into `change-source/replica-restore.ts`. This is mainly a stats-tracking wrapper around the shared `tryRestore()` method remaining in `services/litestream`.
* `main.ts` no longer has any litestream restore logic

This is mostly a behavior-preserving refactoring, with the exception of simplifying the litestream log format to always be 'json'.