### PR TITLE
ci: abort playwright install after 20 minutes

### DIFF
--- a/.github/actions/playwright-install/action.yml
+++ b/.github/actions/playwright-install/action.yml
@@ -16,9 +16,9 @@ runs:
         key: playwright-${{ runner.os }}-${{ runner.arch }}-${{ steps.playwright-version.outputs.version }}
     - name: Install Playwright browsers and system deps
       if: steps.playwright-cache.outputs.cache-hit != 'true'
-      run: pnpm exec playwright install --with-deps
+      run: timeout -k 30s 20m pnpm exec playwright install --with-deps
       shell: bash
     - name: Install Playwright system deps only
       if: steps.playwright-cache.outputs.cache-hit == 'true'
-      run: pnpm exec playwright install-deps
+      run: timeout -k 30s 20m pnpm exec playwright install-deps
       shell: bash


### PR DESCRIPTION
Composite action steps do not support timeout-minutes, so wrap the install commands with the timeout command instead. If an install hangs, timeout sends SIGTERM after 20 minutes (SIGKILL 30s later if needed), failing the step and aborting the job.