### PR TITLE
chore(replicache): fix IndexedDB registry leak from worker test

### DIFF
--- a/packages/replicache/src/worker-test.ts
+++ b/packages/replicache/src/worker-test.ts
@@ -1,8 +1,12 @@
 // This test file is loaded by worker.test.ts
 
+import {LogContext} from '@rocicorp/logger';
 import {assert} from '../../shared/src/asserts.ts';
 import {deepEqual, type JSONValue} from '../../shared/src/json.ts';
 import {asyncIterableToArray} from './async-iterable-to-array.ts';
+import {newIDBStoreWithMemFallback} from './kv/idb-store-with-mem-fallback.ts';
+import {dropDatabase} from './persist/collect-idb-databases.ts';
+import {IDBDatabasesStore} from './persist/idb-databases-store.ts';
 import {Replicache} from './replicache.ts';
 import type {ReadTransaction, WriteTransaction} from './transactions.ts';
 
@@ -40,35 +44,59 @@ async function testGetHasScanOnEmptyDB(name: string) {
     },
   });
 
-  const {testMut} = rep.mutate;
+  try {
+    const {testMut} = rep.mutate;
 
-  for (const [key, value] of Object.entries({
-    a: true,
-    b: false,
-    c: null,
-    d: 'string',
-    e: 12,
-    f: {},
-    g: [],
-    h: {h1: true},
-    i: [0, 1],
-  })) {
-    await testMut({key, value: value as JSONValue});
+    for (const [key, value] of Object.entries({
+      a: true,
+      b: false,
+      c: null,
+      d: 'string',
+      e: 12,
+      f: {},
+      g: [],
+      h: {h1: true},
+      i: [0, 1],
+    })) {
+      await testMut({key, value: value as JSONValue});
+    }
+
+    async function t(tx: ReadTransaction) {
+      assert(
+        (await tx.get('key')) === undefined,
+        'Expected get to return undefined for missing key',
+      );
+      assert(
+        (await tx.has('key')) === false,
+        'Expected has to return false for missing key',
+      );
+
+      const scanItems = await asyncIterableToArray(tx.scan());
+      assert(scanItems.length === 0, 'Expected scan items to be empty');
+    }
+
+    await rep.query(t);
+  } finally {
+    // Workers use the real origin-wide IndexedDB, bypassing vitest browser
+    // mode's per-file storage isolation, so clean up here rather than in
+    // worker.test.ts. dropDatabase removes both the database and its record
+    // in the replicache-dbs-v0 registry.
+    await rep.close();
+    await dropDatabase(rep.idbName);
   }
 
-  async function t(tx: ReadTransaction) {
+  // Verify the registry record is gone; a record left here leaks into every
+  // other browser test file's storage.
+  const store = new IDBDatabasesStore(name =>
+    newIDBStoreWithMemFallback(new LogContext(), name),
+  );
+  try {
+    const dbs = await store.getDatabases();
     assert(
-      (await tx.get('key')) === undefined,
-      'Expected get to return undefined for missing key',
+      !(rep.idbName in dbs),
+      `Expected ${rep.idbName} to have been removed from the registry`,
     );
-    assert(
-      (await tx.has('key')) === false,
-      'Expected has to return false for missing key',
-    );
-
-    const scanItems = await asyncIterableToArray(tx.scan());
-    assert(scanItems.length === 0, 'Expected scan items to be empty');
+  } finally {
+    await store.close();
   }
-
-  await rep.query(t);
 }

--- a/packages/replicache/src/worker.test.ts
+++ b/packages/replicache/src/worker.test.ts
@@ -1,11 +1,5 @@
-import {afterEach, expect, test} from 'vitest';
+import {expect, test} from 'vitest';
 import {sleep} from '../../shared/src/sleep.ts';
-import {closeAllReps, dbsToDrop, deleteAllDatabases} from './test-util.ts';
-
-afterEach(async () => {
-  await closeAllReps();
-  await deleteAllDatabases();
-});
 
 test('worker test', async () => {
   // Need to have the 'new URL' call inside `new Worker` for vite to
@@ -14,13 +8,25 @@ test('worker test', async () => {
     type: 'module',
   });
   const name = 'worker-test';
-  dbsToDrop.add(name);
 
-  const data = await send(w, {name});
-  if (data !== undefined) {
-    throw data;
+  // The worker itself closes its Replicache instance and drops its database
+  // (including the replicache-dbs-v0 registry record). Cleanup must happen in
+  // the worker: workers use the real origin-wide IndexedDB, bypassing vitest
+  // browser mode's per-file storage isolation, so anything left behind leaks
+  // into every other browser test file.
+  try {
+    const data = await send(w, {name});
+    if (data !== undefined) {
+      throw data;
+    }
+    expect(data).toBeUndefined();
+  } finally {
+    // The worker posts its message only after cleanup has finished, so it is
+    // safe to terminate here. This closes any IndexedDB connections still
+    // open in the worker which could otherwise block other test files from
+    // deleting databases.
+    w.terminate();
   }
-  expect(data).toBeUndefined();
 });
 
 function send(w: Worker, data: {name: string}): Promise<unknown> {


### PR DESCRIPTION
## What

Fixes an IndexedDB leak from `worker.test.ts`: the Web Worker it spawns constructed a `Replicache` instance with the default `'idb'` kvStore and never cleaned it up, leaving a `rep:worker-test:7` record in the origin-wide `replicache-dbs-v0` registry.

- The worker (`worker-test.ts`) now closes its Replicache instance and calls `dropDatabase(rep.idbName)` in a `finally`, removing both the KV database and its registry record. It then re-opens the registry and asserts the record is actually gone, so a regression fails this test directly instead of flaking other files. Cleanup/verification errors propagate to the existing `catch` and are posted back to the main thread, failing the test.
- `worker.test.ts` drops its broken main-thread cleanup (`dbsToDrop.add('worker-test')` used the instance name instead of the idbName, and `deleteAllDatabases` never touched the registry record — and it operated on the wrong, isolated storage anyway) and now terminates the worker once it reports back, closing the IndexedDB connection that `dropDatabase`'s internal registry store leaves open.

## Why

Web Workers bypass vitest browser mode's per-file storage isolation, so anything a worker leaves in IndexedDB leaks into every other browser test file for the rest of the run. This caused flaky failures in `persist/collect-idb-databases.test.ts` before that test was made leak-tolerant. Cleanup has to happen inside the worker because only the worker sees the real origin-wide storage.

## Notes for reviewers

- The worker posts its result message only after the `finally` cleanup completes, so `w.terminate()` on the main thread cannot interrupt cleanup.
- The zero-client worker test does not have this issue: `zeroForTest` defaults to `kvStore: 'mem'`, so nothing there touches real IndexedDB.
- Verified: full `pnpm --filter replicache run test` passes (73 files / 798 tests), plus lint, format, and check-types.