### PR TITLE
chore: add process.env flags to control replicache indexes

### DIFF
--- a/packages/replicache/src/db/read.ts
+++ b/packages/replicache/src/db/read.ts
@@ -1,3 +1,4 @@
+import '../process-env.ts';
 import type {Enum} from '../../../shared/src/enum.ts';
 import {BTreeRead} from '../btree/read.ts';
 import type {Read as DagRead} from '../dag/store.ts';
@@ -99,7 +100,10 @@ export function readIndexesForRead(
   dagRead: DagRead,
   formatVersion: FormatVersion,
 ): Map<string, IndexRead> {
-  const m = new Map();
+  const m: Map<string, IndexRead> = new Map();
+  if (process.env.DISABLE_REPLICACHE_INDEXES) {
+    return m;
+  }
   for (const index of commit.indexes) {
     m.set(
       index.definition.name,

--- a/packages/replicache/src/db/write.ts
+++ b/packages/replicache/src/db/write.ts
@@ -1,3 +1,4 @@
+import '../process-env.ts';
 import type {LogContext} from '@rocicorp/logger';
 import {assert} from '../../../shared/src/asserts.ts';
 import type {Enum} from '../../../shared/src/enum.ts';
@@ -83,7 +84,9 @@ export class Write extends Read {
     key: string,
     value: FrozenJSONValue,
   ): Promise<void> {
-    await updateIndexes(lc, this.map, this.indexes, key, value);
+    if (!process.env.DISABLE_REPLICACHE_INDEXES && this.indexes.size > 0) {
+      await updateIndexes(lc, this.map, this.indexes, key, value);
+    }
     await this.map.put(key, value);
   }
 
@@ -103,7 +106,7 @@ export class Write extends Read {
     }
 
     // Update indexes for all entries
-    if (this.indexes.size > 0) {
+    if (!process.env.DISABLE_REPLICACHE_INDEXES && this.indexes.size > 0) {
       // TODO(arv): Indexes can use the optimizePatch pattern too.
       for (const [key, value] of entries) {
         await updateIndexes(lc, this.map, this.indexes, key, value);
@@ -119,7 +122,9 @@ export class Write extends Read {
   }
 
   async del(lc: LogContext, key: string): Promise<boolean> {
-    await updateIndexes(lc, this.map, this.indexes, key, undefined);
+    if (!process.env.DISABLE_REPLICACHE_INDEXES && this.indexes.size > 0) {
+      await updateIndexes(lc, this.map, this.indexes, key, undefined);
+    }
     return this.map.del(key);
   }
 
@@ -235,6 +240,9 @@ export class Write extends Read {
       valueDiff = await diff(basisMap, this.map);
     }
     diffsMap.set('', valueDiff);
+    if (process.env.DISABLE_REPLICACHE_INDEXES) {
+      return diffsMap;
+    }
     let basisIndexes: Map<string, IndexRead>;
     if (this.#basis) {
       basisIndexes = readIndexesForRead(
@@ -390,7 +398,10 @@ export function readIndexesForWrite(
   dagWrite: DagWrite,
   formatVersion: FormatVersion,
 ): Map<string, IndexWrite> {
-  const m = new Map();
+  const m: Map<string, IndexWrite> = new Map();
+  if (process.env.DISABLE_REPLICACHE_INDEXES) {
+    return m;
+  }
   for (const index of commit.indexes) {
     m.set(
       index.definition.name,

--- a/packages/replicache/src/persist/clients.ts
+++ b/packages/replicache/src/persist/clients.ts
@@ -1,3 +1,4 @@
+import '../process-env.ts';
 import type {LogContext} from '@rocicorp/logger';
 import {assert, assertObject} from '../../../shared/src/asserts.ts';
 import type {Enum} from '../../../shared/src/enum.ts';
@@ -343,38 +344,40 @@ export function initClientV6(
 
     // Create indexes
     const indexRecords: IndexRecord[] = [];
-    const {valueHash, indexes: oldIndexes} = snapshot;
-    const map = new BTreeRead(dagWrite, formatVersion, valueHash);
+    if (!process.env.DISABLE_REPLICACHE_INDEXES) {
+      const {valueHash, indexes: oldIndexes} = snapshot;
+      const map = new BTreeRead(dagWrite, formatVersion, valueHash);
 
-    for (const [name, indexDefinition] of Object.entries(indexes)) {
-      const {prefix = '', jsonPointer, allowEmpty = false} = indexDefinition;
-      const chunkIndexDefinition: ChunkIndexDefinition = {
-        name,
-        keyPrefix: prefix,
-        jsonPointer,
-        allowEmpty,
-      };
-
-      const oldIndex = findMatchingOldIndex(oldIndexes, chunkIndexDefinition);
-      if (oldIndex) {
-        indexRecords.push({
-          definition: chunkIndexDefinition,
-          valueHash: oldIndex.valueHash,
-        });
-      } else {
-        const indexBTree = await createIndexBTree(
-          lc,
-          dagWrite,
-          map,
-          prefix,
+      for (const [name, indexDefinition] of Object.entries(indexes)) {
+        const {prefix = '', jsonPointer, allowEmpty = false} = indexDefinition;
+        const chunkIndexDefinition: ChunkIndexDefinition = {
+          name,
+          keyPrefix: prefix,
           jsonPointer,
           allowEmpty,
-          formatVersion,
-        );
-        indexRecords.push({
-          definition: chunkIndexDefinition,
-          valueHash: await indexBTree.flush(),
-        });
+        };
+
+        const oldIndex = findMatchingOldIndex(oldIndexes, chunkIndexDefinition);
+        if (oldIndex) {
+          indexRecords.push({
+            definition: chunkIndexDefinition,
+            valueHash: oldIndex.valueHash,
+          });
+        } else {
+          const indexBTree = await createIndexBTree(
+            lc,
+            dagWrite,
+            map,
+            prefix,
+            jsonPointer,
+            allowEmpty,
+            formatVersion,
+          );
+          indexRecords.push({
+            definition: chunkIndexDefinition,
+            valueHash: await indexBTree.flush(),
+          });
+        }
       }
     }
 

--- a/packages/replicache/src/process-env.ts
+++ b/packages/replicache/src/process-env.ts
@@ -1,0 +1,29 @@
+/**
+ * Ambient typing for the `process.env` flags that builds inline via defines
+ * (see `makeDefine` in shared/src/build.ts and packages/zero/tool/build.ts).
+ *
+ * Import this module for its side effect (the global declaration). Keep the
+ * flags as bare `process.env.X` expressions at every use site — never hoist
+ * them into a shared const or re-export values from here, because bundlers
+ * only constant-fold and dead-code-eliminate the inlined expression itself.
+ *
+ * Declared so that it merges cleanly with @types/node in programs that load
+ * it (e.g. via *.test.node.ts files) and stands alone in browser-only
+ * programs: interfaces merge, and the `var` redeclaration is allowed because
+ * the type is identical.
+ */
+declare global {
+  namespace NodeJS {
+    interface ProcessEnv {
+      ['DISABLE_MUTATION_RECOVERY']?: boolean | undefined;
+      ['DISABLE_REPLICACHE_INDEXES']?: boolean | undefined;
+    }
+    interface Process {
+      env: ProcessEnv;
+    }
+  }
+
+  var process: NodeJS.Process;
+}
+
+export {};

--- a/packages/replicache/src/process-env.ts
+++ b/packages/replicache/src/process-env.ts
@@ -15,8 +15,8 @@
 declare global {
   namespace NodeJS {
     interface ProcessEnv {
-      ['DISABLE_MUTATION_RECOVERY']?: boolean | undefined;
-      ['DISABLE_REPLICACHE_INDEXES']?: boolean | undefined;
+      ['DISABLE_MUTATION_RECOVERY']?: string | undefined;
+      ['DISABLE_REPLICACHE_INDEXES']?: string | undefined;
     }
     interface Process {
       env: ProcessEnv;

--- a/packages/replicache/src/replicache-impl.ts
+++ b/packages/replicache/src/replicache-impl.ts
@@ -129,12 +129,6 @@ import {
   withWriteNoImplicitCommit,
 } from './with-transactions.ts';
 
-declare const process: {
-  env: {
-    ['DISABLE_MUTATION_RECOVERY']?: string | undefined;
-  };
-};
-
 /**
  * The maximum number of time to call out to getAuth before giving up
  * and throwing an error.

--- a/packages/replicache/src/subscriptions.ts
+++ b/packages/replicache/src/subscriptions.ts
@@ -599,7 +599,10 @@ export function scanInfoMatchesKey(
   }
 
   if (process.env.DISABLE_REPLICACHE_INDEXES) {
-    // Indexes are compiled out of this build so index scan infos never exist.
+    // Unreachable in practice: when indexes are disabled no scan subscription
+    // has an indexName and no diff is keyed by one, so changeIndexName and
+    // indexName are both '' and we return above. This early return exists so
+    // that the decodeIndexKey call below can be dead-code eliminated.
     return false;
   }
 

--- a/packages/replicache/src/subscriptions.ts
+++ b/packages/replicache/src/subscriptions.ts
@@ -1,3 +1,4 @@
+import './process-env.ts';
 import type {LogContext} from '@rocicorp/logger';
 import {compareUTF8, greaterThan, lessThan, lessThanEq} from 'compare-utf8';
 import {assert} from '../../shared/src/asserts.ts';
@@ -272,7 +273,7 @@ export class WatchSubscription implements Subscription<Diff | undefined> {
         : undefined;
     };
 
-    if (this.#indexName) {
+    if (!process.env.DISABLE_REPLICACHE_INDEXES && this.#indexName) {
       return invoke<IndexKey>(
         this.#indexName,
         this.#prefix,
@@ -597,6 +598,11 @@ export function scanInfoMatchesKey(
     return true;
   }
 
+  if (process.env.DISABLE_REPLICACHE_INDEXES) {
+    // Indexes are compiled out of this build so index scan infos never exist.
+    return false;
+  }
+
   const [changedKeySecondary, changedKeyPrimary] = decodeIndexKey(changedKey);
 
   if (prefix) {
@@ -656,9 +662,10 @@ function watcherMatchesDiff(
     return true;
   }
 
-  const compareKey = indexName
-    ? (diffOp: InternalDiffOperation) => decodeIndexKey(diffOp.key)[0]
-    : (diffOp: InternalDiffOperation) => diffOp.key;
+  const compareKey =
+    !process.env.DISABLE_REPLICACHE_INDEXES && indexName
+      ? (diffOp: InternalDiffOperation) => decodeIndexKey(diffOp.key)[0]
+      : (diffOp: InternalDiffOperation) => diffOp.key;
   const i = diffBinarySearch(diff, prefix, compareKey);
   return i < diff.length && compareKey(diff[i]).startsWith(prefix);
 }

--- a/packages/replicache/src/transactions.ts
+++ b/packages/replicache/src/transactions.ts
@@ -1,3 +1,4 @@
+import './process-env.ts';
 import type {LogContext} from '@rocicorp/logger';
 import {greaterThan} from 'compare-utf8';
 import type {JSONValue, ReadonlyJSONValue} from '../../shared/src/json.ts';
@@ -402,6 +403,12 @@ async function* getScanIteratorForIndexMap(
   dbRead: Read,
   options: ScanIndexOptions,
 ): AsyncIterable<IndexKeyEntry<ReadonlyJSONValue>> {
+  if (process.env.DISABLE_REPLICACHE_INDEXES) {
+    // Indexes are compiled out of this build so no index name ever exists.
+    // Thrown here (inside the generator) so that the error surfaces on first
+    // iteration, matching getMapForIndex — tx.scan() itself never throws.
+    throw new Error(`Unknown index name: ${options.indexName}`);
+  }
   const map = dbRead.getMapForIndex(options.indexName);
   for await (const entry of map.scan(fromKeyForIndexScanInternal(options))) {
     yield [decodeIndexKey(entry[0]), entry[1]];

--- a/packages/shared/src/build.ts
+++ b/packages/shared/src/build.ts
@@ -50,6 +50,7 @@ export function makeDefine(
     ),
     ['process.env.ZERO_VERSION']: JSON.stringify(getVersion('zero')),
     ['process.env.DISABLE_MUTATION_RECOVERY']: 'false',
+    ['process.env.DISABLE_REPLICACHE_INDEXES']: 'false',
   };
   if (mode === 'unknown') {
     return define;

--- a/packages/zero/tool/build.ts
+++ b/packages/zero/tool/build.ts
@@ -66,6 +66,7 @@ function external(id: string): boolean {
 const define = {
   ...makeDefine('unknown'),
   'process.env.DISABLE_MUTATION_RECOVERY': 'true',
+  'process.env.DISABLE_REPLICACHE_INDEXES': 'true',
 };
 
 // Vite config helper functions


### PR DESCRIPTION
This reduces the binary size by 8.4KB and should make the core a tiny teeny bit faster.