### PR TITLE
chore(rmv2): add SQLite catchup handoff [8/n]

### DIFF
--- a/packages/zero-cache/src/config/normalize.test.ts
+++ b/packages/zero-cache/src/config/normalize.test.ts
@@ -15,7 +15,7 @@ function configWith(litestream: Partial<ZeroConfig['litestream']>): ZeroConfig {
       sqliteChangeLogRetentionMs: 60_000,
       sqliteChangeLogReadBatchRows: 1000,
       sqliteChangeLogPurgeBatchRows: 1000,
-      sqliteChangeLogBarrierTimeoutMs: 30_000,
+      sqliteChangeLogBarrierTimeoutMs: 300_000,
     },
     change: {db: 'postgres:///change'},
     cvr: {db: 'postgres:///cvr'},

--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -712,8 +712,15 @@ export const zeroOptions = {
     },
 
     sqliteChangeLogBarrierTimeoutMs: {
-      type: v.number().default(30_000),
-      desc: [`The maximum wait for the SQLite required-head barrier.`],
+      type: v.number().default(300_000),
+      desc: [
+        `The maximum wait for the SQLite required-head barrier. This is a`,
+        `backstop for a wedged replica on an idle shard, where waiting costs`,
+        `nothing and would otherwise go unnoticed. A shard with traffic is`,
+        `bounded well before this by the subscriber's backlog reaching its`,
+        `high water mark, which is the point at which waiting starts holding`,
+        `up replication.`,
+      ],
       hidden: true,
     },
 

--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -55,6 +55,8 @@ export default async function runWorker(
       backPressureLimitHeapProportion,
       flowControlConsensusPaddingSeconds,
       flowControlEventDrivenRelease,
+      sqliteChangeLogReadBatchRows,
+      sqliteChangeLogBarrierTimeoutMs,
     },
     autoReset,
     replicationLag,
@@ -165,6 +167,11 @@ export default async function runWorker(
           flowControlEventDrivenRelease,
           statementTimeoutMs: change.statementTimeoutMs,
           changeLogBatchSize: change.logBatchSize,
+          sqliteCatchup: {
+            replicaFile: replica.file,
+            readBatchRows: sqliteChangeLogReadBatchRows,
+            barrierTimeoutMs: sqliteChangeLogBarrierTimeoutMs,
+          },
         },
         setTimeout,
       );

--- a/packages/zero-cache/src/server/replicator.ts
+++ b/packages/zero-cache/src/server/replicator.ts
@@ -149,6 +149,7 @@ export default async function runWorker(
     mode,
     changeStreamer,
     workerClient,
+    logsChangeStream,
     runningLocalChangeStreamer
       ? // publish ReplicationStatusEvents from backup-replicator only
         ReplicationStatusPublisher.forReplicaFile(dbPath)

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-http.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-http.pg.test.ts
@@ -280,6 +280,8 @@ describe('change-streamer/http', () => {
         replicaVersion: 'abc',
         watermark: '123',
         initial: true,
+        // Non-default so that the roundtrip below pins the parameter.
+        logsChangeStream: true,
       } as const;
       await setChangeStreamerAddress(addr());
       const client = autoDiscover
@@ -341,6 +343,7 @@ describe('change-streamer/http', () => {
       replicaVersion: 'abc',
       watermark: '123',
       initial: true,
+      logsChangeStream: false,
     });
 
     const messages = new ReplicationMessages({issues: 'id'});

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-http.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-http.ts
@@ -260,6 +260,10 @@ export function getSubscriberContext(req: RequestHeaders): SubscriberContext {
     replicaVersion: params.get('replicaVersion', true),
     watermark: params.get('watermark', true),
     initial: params.getBoolean('initial'),
+    // Absent for subscribers that predate the parameter, which is the safe
+    // default: the barrier falls back to polling rather than waiting on an
+    // ACK that would never be attributed to a writer.
+    logsChangeStream: params.getBoolean('logsChangeStream'),
   };
 }
 
@@ -294,5 +298,6 @@ function getParams(ctx: SubscriberContext): URLSearchParams {
     ...stringParams,
     taskID: ctx.taskID ? ctx.taskID : '',
     initial: ctx.initial ? 'true' : 'false',
+    logsChangeStream: ctx.logsChangeStream ? 'true' : 'false',
   });
 }

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
@@ -672,7 +672,7 @@ describe('change-streamer/service', () => {
     }
   });
 
-  test('a change-log writer is never served from the change log it writes', async () => {
+  test('backup subscribers and change-log writers cannot select SQLite catchup', async () => {
     await streamer.stop();
     await streamerDone;
 
@@ -683,6 +683,7 @@ describe('change-streamer/service', () => {
 
     changes = Subscription.create();
     acks = new Queue();
+    const shouldUse = vi.fn(() => true);
     streamer = await initializeStreamer(
       lc,
       shard,
@@ -711,10 +712,9 @@ describe('change-streamer/service', () => {
           readBatchRows: 2,
           barrierTimeoutMs: 60_000,
           barrierPollIntervalMs: 60_000,
-          // The selector mistake this guards against: a canary that picks the
-          // one subscriber that cannot be served from SQLite. Nothing here
-          // advances the replica, so a barrier would hold until the deadline.
-          shouldUse: ctx => ctx.logsChangeStream,
+          // Deliberately attempts to select every subscriber. Eligibility
+          // checks must run first and cannot be overridden by this selector.
+          shouldUse,
         },
       },
       setTimeoutFn as unknown as typeof setTimeout,
@@ -742,16 +742,43 @@ describe('change-streamer/service', () => {
       // made to wait for.
       expect(await nextChange(observed)).toMatchObject({tag: 'begin'});
 
+      shouldUse.mockClear();
+      const backupSub = await streamer.subscribe({
+        protocolVersion: PROTOCOL_VERSION,
+        taskID: 'backup-task',
+        id: 'backup-reader',
+        mode: 'backup',
+        watermark: REPLICA_VERSION,
+        replicaVersion: REPLICA_VERSION,
+        initial: true,
+        logsChangeStream: false,
+      });
+      expect(shouldUse).not.toHaveBeenCalled();
+      const backed = drainToQueue(backupSub);
+
+      // Backup subscribers retain the PG catchup/recovery policy.
+      expect(await nextChange(backed)).toMatchObject({tag: 'status'});
+      expect(await nextChange(backed)).toMatchObject({tag: 'begin'});
+      expect(await nextChange(backed)).toMatchObject({
+        tag: 'insert',
+        new: {id: 'forwarded'},
+      });
+      expect(await nextChange(backed)).toMatchObject({tag: 'commit'});
+
+      shouldUse.mockClear();
       const writerSub = await streamer.subscribe({
         protocolVersion: PROTOCOL_VERSION,
         taskID: 'task-id',
         id: 'change-log-writer',
-        mode: 'backup',
+        // A single-node canonical writer has serving mode, so the independent
+        // logsChangeStream guard remains necessary.
+        mode: 'serving',
         watermark: REPLICA_VERSION,
         replicaVersion: REPLICA_VERSION,
         initial: true,
         logsChangeStream: true,
       });
+      expect(shouldUse).not.toHaveBeenCalled();
       const written = drainToQueue(writerSub);
 
       // Served from PG instead of waiting on itself.
@@ -769,6 +796,7 @@ describe('change-streamer/service', () => {
       ]);
 
       observerSub.cancel();
+      backupSub.cancel();
       writerSub.cancel();
     } finally {
       await streamer.stop();

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
@@ -17,15 +17,20 @@ import type {PostgresDB} from '../../types/pg.ts';
 import type {Source} from '../../types/streams.ts';
 import {Subscription, type Result} from '../../types/subscription.ts';
 import type {ChangeSource} from '../change-source/change-source.ts';
-import {type ChangeStreamMessage} from '../change-source/protocol/current/downstream.ts';
+import type {
+  ChangeStreamData,
+  ChangeStreamMessage,
+} from '../change-source/protocol/current/downstream.ts';
 import type {UpstreamStatusMessage} from '../change-source/protocol/current/status.ts';
 import {exitAfter} from '../life-cycle.ts';
+import {ChangeLogStreamWriter} from '../replicator/change-log-stream-writer.ts';
 import {IncrementalSyncer} from '../replicator/incremental-sync.ts';
 import {ReplicationStatusPublisher} from '../replicator/replication-status.ts';
 import {
   getSubscriptionState,
   initReplicationState,
   type SubscriptionState,
+  updateReplicationWatermark,
 } from '../replicator/schema/replication-state.ts';
 import {
   getSQLiteChangeLogInfo,
@@ -33,6 +38,7 @@ import {
 } from '../replicator/sqlite-change-log-observability.ts';
 import {ReplicationMessages} from '../replicator/test-utils.ts';
 import {ThreadWriteWorkerClient} from '../replicator/write-worker-client.ts';
+import {serializeChangeStreamData} from './change-log-codec.ts';
 import {
   initializeStreamer,
   type TuningOptions,
@@ -171,6 +177,35 @@ describe('change-streamer/service', () => {
   }
 
   const messages = new ReplicationMessages({foo: 'id'});
+
+  function appendSQLiteTransaction(
+    replica: Database,
+    watermark: string,
+    data: readonly ChangeStreamData[],
+  ): void {
+    const runner = new StatementRunner(replica);
+    const writer = new ChangeLogStreamWriter(replica);
+    const begin: ChangeStreamData = [
+      'begin',
+      messages.begin(),
+      {commitWatermark: watermark},
+    ];
+    const commit: ChangeStreamData = ['commit', messages.commit(), {watermark}];
+
+    runner.beginImmediate();
+    try {
+      writer.begin(watermark, serializeChangeStreamData(begin));
+      for (const message of data) {
+        writer.append(serializeChangeStreamData(message), message[1].tag);
+      }
+      writer.commit(watermark, serializeChangeStreamData(commit), Date.now());
+      updateReplicationWatermark(runner, watermark);
+      runner.commit();
+    } catch (e) {
+      runner.rollback();
+      throw e;
+    }
+  }
 
   test('PG stream shadow-writes SQLite without changing PG serving or ACKs', async () => {
     const dbFile = new DbFile('sqlite-change-log-shadow-integration');
@@ -320,6 +355,172 @@ describe('change-streamer/service', () => {
       await worker.stop();
       replica.close();
       dbFile.delete();
+    }
+  });
+
+  test('SQLite required head tracks forwarded transaction boundaries', async () => {
+    await streamer.stop();
+    await streamerDone;
+
+    const catchupReplicaFile = new DbFile('sqlite-catchup-service-integration');
+    const catchupReplica = catchupReplicaFile.connect(lc);
+    catchupReplica.pragma('journal_mode = wal');
+    initReplicationState(catchupReplica, ['zero_data'], REPLICA_VERSION);
+
+    changes = Subscription.create();
+    acks = new Queue();
+    streamer = await initializeStreamer(
+      lc,
+      shard,
+      'task-id',
+      'change.streamer:12345',
+      'ws',
+      sql,
+      {
+        startStream: () =>
+          Promise.resolve({
+            initialWatermark: '02',
+            changes,
+            acks: {push: status => acks.enqueue(status)},
+          }),
+        startLagReporter: () => Promise.resolve({nextSendTimeMs: 123}),
+        stop: () => Promise.resolve(),
+      },
+      ReplicationStatusPublisher.forTesting(),
+      replicaConfig,
+      null,
+      true,
+      {
+        ...opts,
+        sqliteCatchup: {
+          replicaFile: catchupReplicaFile.path,
+          readBatchRows: 2,
+          barrierTimeoutMs: 1_000,
+          shouldUse: ctx => ctx.id !== 'live-observer',
+        },
+      },
+      setTimeoutFn as unknown as typeof setTimeout,
+    );
+    streamerDone = streamer.run();
+
+    try {
+      const liveSub = await streamer.subscribe({
+        protocolVersion: PROTOCOL_VERSION,
+        taskID: 'live-task',
+        id: 'live-observer',
+        mode: 'serving',
+        watermark: REPLICA_VERSION,
+        replicaVersion: REPLICA_VERSION,
+        initial: true,
+      });
+      const live = drainToQueue(liveSub);
+      expect(await nextChange(live)).toMatchObject({tag: 'status'});
+
+      const insert04: ChangeStreamData = [
+        'data',
+        messages.insert('foo', {id: 'committed'}),
+      ];
+      changes.push(['begin', messages.begin(), {commitWatermark: '04'}]);
+      changes.push(insert04);
+      expect(await nextChange(live)).toMatchObject({tag: 'begin'});
+      expect(await nextChange(live)).toMatchObject({
+        tag: 'insert',
+        new: {id: 'committed'},
+      });
+
+      const commitSub = await streamer.subscribe({
+        protocolVersion: PROTOCOL_VERSION,
+        taskID: 'commit-task',
+        id: 'commit-catchup',
+        mode: 'serving',
+        watermark: REPLICA_VERSION,
+        replicaVersion: REPLICA_VERSION,
+        initial: true,
+      });
+      const committed = drainToQueue(commitSub);
+
+      changes.push(['commit', messages.commit(), {watermark: '04'}]);
+      expect(await nextChange(live)).toMatchObject({tag: 'commit'});
+      appendSQLiteTransaction(catchupReplica, '04', [insert04]);
+
+      expect(await nextChange(committed)).toMatchObject({tag: 'status'});
+      expect(await nextChange(committed)).toMatchObject({tag: 'begin'});
+      expect(await nextChange(committed)).toMatchObject({
+        tag: 'insert',
+        new: {id: 'committed'},
+      });
+      expect(await nextChange(committed)).toMatchObject({tag: 'commit'});
+
+      changes.push(['begin', messages.begin(), {commitWatermark: '06'}]);
+      changes.push(['data', messages.insert('foo', {id: 'rolled-back'})]);
+      expect(await nextChange(live)).toMatchObject({tag: 'begin'});
+      expect(await nextChange(live)).toMatchObject({
+        tag: 'insert',
+        new: {id: 'rolled-back'},
+      });
+
+      const rollbackSub = await streamer.subscribe({
+        protocolVersion: PROTOCOL_VERSION,
+        taskID: 'rollback-task',
+        id: 'rollback-catchup',
+        mode: 'serving',
+        watermark: '04',
+        replicaVersion: REPLICA_VERSION,
+        initial: true,
+      });
+      const rolledBack = drainToQueue(rollbackSub);
+
+      changes.push(['rollback', messages.rollback()]);
+      expect(await nextChange(live)).toMatchObject({tag: 'rollback'});
+      expect(await nextChange(rolledBack)).toMatchObject({tag: 'status'});
+
+      const insert08: ChangeStreamData = [
+        'data',
+        messages.insert('foo', {id: 'after-rollback'}),
+      ];
+      changes.push(['begin', messages.begin(), {commitWatermark: '08'}]);
+      changes.push(insert08);
+      changes.push(['commit', messages.commit(), {watermark: '08'}]);
+      expect(await nextChange(rolledBack)).toMatchObject({tag: 'begin'});
+      expect(await nextChange(rolledBack)).toMatchObject({
+        tag: 'insert',
+        new: {id: 'after-rollback'},
+      });
+      expect(await nextChange(rolledBack)).toMatchObject({tag: 'commit'});
+      appendSQLiteTransaction(catchupReplica, '08', [insert08]);
+
+      changes.push(['begin', messages.begin(), {commitWatermark: '0a'}]);
+      changes.push(['data', messages.insert('foo', {id: 'interrupted'})]);
+      expect(await nextChange(live)).toMatchObject({tag: 'begin'});
+      expect(await nextChange(live)).toMatchObject({
+        tag: 'insert',
+        new: {id: 'interrupted'},
+      });
+
+      const interruptedSub = await streamer.subscribe({
+        protocolVersion: PROTOCOL_VERSION,
+        taskID: 'interrupted-task',
+        id: 'interrupted-catchup',
+        mode: 'serving',
+        watermark: '08',
+        replicaVersion: REPLICA_VERSION,
+        initial: true,
+      });
+      const interrupted = drainToQueue(interruptedSub);
+
+      changes.end();
+      expect(await nextChange(live)).toMatchObject({tag: 'rollback'});
+      expect(await nextChange(interrupted)).toMatchObject({tag: 'status'});
+      await verifyNoMoreChanges(interrupted);
+
+      liveSub.cancel();
+      commitSub.cancel();
+      rollbackSub.cancel();
+      interruptedSub.cancel();
+    } finally {
+      await streamer.stop();
+      catchupReplica.close();
+      catchupReplicaFile.delete();
     }
   });
 

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
@@ -672,6 +672,111 @@ describe('change-streamer/service', () => {
     }
   });
 
+  test('a change-log writer is never served from the change log it writes', async () => {
+    await streamer.stop();
+    await streamerDone;
+
+    const catchupReplicaFile = new DbFile('sqlite-catchup-writer-integration');
+    const catchupReplica = catchupReplicaFile.connect(lc);
+    catchupReplica.pragma('journal_mode = wal');
+    initReplicationState(catchupReplica, ['zero_data'], REPLICA_VERSION);
+
+    changes = Subscription.create();
+    acks = new Queue();
+    streamer = await initializeStreamer(
+      lc,
+      shard,
+      'task-id',
+      'change.streamer:12345',
+      'ws',
+      sql,
+      {
+        startStream: () =>
+          Promise.resolve({
+            initialWatermark: '02',
+            changes,
+            acks: {push: status => acks.enqueue(status)},
+          }),
+        startLagReporter: () => Promise.resolve({nextSendTimeMs: 123}),
+        stop: () => Promise.resolve(),
+      },
+      ReplicationStatusPublisher.forTesting(),
+      replicaConfig,
+      null,
+      true,
+      {
+        ...opts,
+        sqliteCatchup: {
+          replicaFile: catchupReplicaFile.path,
+          readBatchRows: 2,
+          barrierTimeoutMs: 60_000,
+          barrierPollIntervalMs: 60_000,
+          // The selector mistake this guards against: a canary that picks the
+          // one subscriber that cannot be served from SQLite. Nothing here
+          // advances the replica, so a barrier would hold until the deadline.
+          shouldUse: ctx => ctx.logsChangeStream,
+        },
+      },
+      setTimeoutFn as unknown as typeof setTimeout,
+    );
+    streamerDone = streamer.run();
+
+    try {
+      const observerSub = await streamer.subscribe({
+        protocolVersion: PROTOCOL_VERSION,
+        taskID: 'observer-task',
+        id: 'observer',
+        mode: 'serving',
+        watermark: REPLICA_VERSION,
+        replicaVersion: REPLICA_VERSION,
+        initial: true,
+        logsChangeStream: false,
+      });
+      const observed = drainToQueue(observerSub);
+      expect(await nextChange(observed)).toMatchObject({tag: 'status'});
+
+      changes.push(['begin', messages.begin(), {commitWatermark: '04'}]);
+      changes.push(['data', messages.insert('foo', {id: 'forwarded'})]);
+      changes.push(['commit', messages.commit(), {watermark: '04'}]);
+      // Establishes a forwarded head, which is what the writer would then be
+      // made to wait for.
+      expect(await nextChange(observed)).toMatchObject({tag: 'begin'});
+
+      const writerSub = await streamer.subscribe({
+        protocolVersion: PROTOCOL_VERSION,
+        taskID: 'task-id',
+        id: 'change-log-writer',
+        mode: 'backup',
+        watermark: REPLICA_VERSION,
+        replicaVersion: REPLICA_VERSION,
+        initial: true,
+        logsChangeStream: true,
+      });
+      const written = drainToQueue(writerSub);
+
+      // Served from PG instead of waiting on itself.
+      expect(await nextChange(written)).toMatchObject({tag: 'status'});
+      expect(await nextChange(written)).toMatchObject({tag: 'begin'});
+      expect(await nextChange(written)).toMatchObject({
+        tag: 'insert',
+        new: {id: 'forwarded'},
+      });
+      expect(await nextChange(written)).toMatchObject({tag: 'commit'});
+      expect(logSink.messages).toContainEqual([
+        'warn',
+        expect.anything(),
+        [expect.stringContaining('it would wait on its own ACK')],
+      ]);
+
+      observerSub.cancel();
+      writerSub.cancel();
+    } finally {
+      await streamer.stop();
+      catchupReplica.close();
+      catchupReplicaFile.delete();
+    }
+  });
+
   test('get empty changelog state', async () => {
     expect(await streamer.getChangeLogState()).toEqual({
       minWatermark: '01',

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
@@ -264,6 +264,7 @@ describe('change-streamer/service', () => {
       },
       worker,
       'serving',
+      true,
       null,
       observer,
     );
@@ -277,6 +278,7 @@ describe('change-streamer/service', () => {
       watermark: REPLICA_VERSION,
       replicaVersion: REPLICA_VERSION,
       initial: true,
+      logsChangeStream: false,
     });
     const live = drainToQueue(liveSub);
     expect(await nextChange(live)).toMatchObject({tag: 'status'});
@@ -326,6 +328,7 @@ describe('change-streamer/service', () => {
         watermark: REPLICA_VERSION,
         replicaVersion: REPLICA_VERSION,
         initial: true,
+        logsChangeStream: false,
       });
       const catchup = drainToQueue(catchupSub);
       expect(await nextChange(catchup)).toMatchObject({tag: 'status'});
@@ -396,6 +399,9 @@ describe('change-streamer/service', () => {
           replicaFile: catchupReplicaFile.path,
           readBatchRows: 2,
           barrierTimeoutMs: 1_000,
+          // Nothing here acks the change log, so the barrier relies on its
+          // backstop poll. Keep it short rather than waiting out the default.
+          barrierPollIntervalMs: 10,
           shouldUse: ctx => ctx.id !== 'live-observer',
         },
       },
@@ -412,6 +418,7 @@ describe('change-streamer/service', () => {
         watermark: REPLICA_VERSION,
         replicaVersion: REPLICA_VERSION,
         initial: true,
+        logsChangeStream: false,
       });
       const live = drainToQueue(liveSub);
       expect(await nextChange(live)).toMatchObject({tag: 'status'});
@@ -436,6 +443,7 @@ describe('change-streamer/service', () => {
         watermark: REPLICA_VERSION,
         replicaVersion: REPLICA_VERSION,
         initial: true,
+        logsChangeStream: false,
       });
       const committed = drainToQueue(commitSub);
 
@@ -467,6 +475,7 @@ describe('change-streamer/service', () => {
         watermark: '04',
         replicaVersion: REPLICA_VERSION,
         initial: true,
+        logsChangeStream: false,
       });
       const rolledBack = drainToQueue(rollbackSub);
 
@@ -511,6 +520,7 @@ describe('change-streamer/service', () => {
         watermark: '08',
         replicaVersion: REPLICA_VERSION,
         initial: true,
+        logsChangeStream: false,
       });
       const interrupted = drainToQueue(interruptedSub);
 
@@ -523,6 +533,138 @@ describe('change-streamer/service', () => {
       commitSub.cancel();
       rollbackSub.cancel();
       interruptedSub.cancel();
+    } finally {
+      await streamer.stop();
+      catchupReplica.close();
+      catchupReplicaFile.delete();
+    }
+  });
+
+  test('the change-log writer ACK releases the SQLite barrier', async () => {
+    await streamer.stop();
+    await streamerDone;
+
+    const catchupReplicaFile = new DbFile('sqlite-catchup-ack-integration');
+    const catchupReplica = catchupReplicaFile.connect(lc);
+    catchupReplica.pragma('journal_mode = wal');
+    initReplicationState(catchupReplica, ['zero_data'], REPLICA_VERSION);
+
+    changes = Subscription.create();
+    acks = new Queue();
+    streamer = await initializeStreamer(
+      lc,
+      shard,
+      'task-id',
+      'change.streamer:12345',
+      'ws',
+      sql,
+      {
+        startStream: () =>
+          Promise.resolve({
+            initialWatermark: '02',
+            changes,
+            acks: {push: status => acks.enqueue(status)},
+          }),
+        startLagReporter: () => Promise.resolve({nextSendTimeMs: 123}),
+        stop: () => Promise.resolve(),
+      },
+      ReplicationStatusPublisher.forTesting(),
+      replicaConfig,
+      null,
+      true,
+      {
+        ...opts,
+        sqliteCatchup: {
+          replicaFile: catchupReplicaFile.path,
+          readBatchRows: 2,
+          barrierTimeoutMs: 60_000,
+          // Far beyond the test timeout, so only the writer's ACK can release
+          // the barrier. The change log itself is never polled for the head.
+          barrierPollIntervalMs: 60_000,
+          shouldUse: ctx => !ctx.logsChangeStream,
+        },
+      },
+      setTimeoutFn as unknown as typeof setTimeout,
+    );
+    streamerDone = streamer.run();
+
+    try {
+      // Stands in for the replicator that writes the SQLite change log. Like
+      // the real one, it applies a transaction to the replica before its
+      // consumption is acked, which is what makes the ACK mean "durable".
+      const writerSub = await streamer.subscribe({
+        protocolVersion: PROTOCOL_VERSION,
+        taskID: 'task-id',
+        id: 'change-log-writer',
+        mode: 'backup',
+        watermark: REPLICA_VERSION,
+        replicaVersion: REPLICA_VERSION,
+        initial: true,
+        logsChangeStream: true,
+      });
+      const applyTransactions = resolver<void>();
+      const received = new Queue<string>();
+      const applied = new Queue<string>();
+      const writing = (async () => {
+        const buffered: ChangeStreamData[] = [];
+        for await (const msg of writerSub) {
+          const down = BigIntJSON.parse(msg) as Downstream;
+          if (down[0] === 'data') {
+            buffered.push(down as ChangeStreamData);
+          } else if (down[0] === 'commit') {
+            const {watermark} = down[2];
+            received.enqueue(watermark);
+            await applyTransactions.promise;
+            appendSQLiteTransaction(
+              catchupReplica,
+              watermark,
+              buffered.splice(0),
+            );
+            applied.enqueue(watermark);
+          }
+        }
+      })();
+
+      changes.push(['begin', messages.begin(), {commitWatermark: '04'}]);
+      changes.push(['data', messages.insert('foo', {id: 'acked'})]);
+      changes.push(['commit', messages.commit(), {watermark: '04'}]);
+      // The commit reached the writer, so it is also the forwarded head that
+      // the next subscriber will have to wait for.
+      expect(await received.dequeue()).toBe('04');
+
+      // The writer has the transaction but has not applied it, so the replica
+      // is behind the head this subscriber requires.
+      const catchupSub = await streamer.subscribe({
+        protocolVersion: PROTOCOL_VERSION,
+        taskID: 'catchup-task',
+        id: 'sqlite-catchup',
+        mode: 'serving',
+        watermark: REPLICA_VERSION,
+        replicaVersion: REPLICA_VERSION,
+        initial: true,
+        logsChangeStream: false,
+      });
+      const caught = drainToQueue(catchupSub);
+      // The barrier holds the subscription: not even the status message is
+      // delivered until the required head is readable.
+      await sleep(50);
+      expect(caught.size()).toBe(0);
+
+      applyTransactions.resolve();
+      expect(await applied.dequeue()).toBe('04');
+
+      // Released by the writer's ACK rather than by a poll.
+      expect(await nextChange(caught)).toMatchObject({tag: 'status'});
+      expect(await nextChange(caught)).toMatchObject({tag: 'begin'});
+      expect(await nextChange(caught)).toMatchObject({
+        tag: 'insert',
+        new: {id: 'acked'},
+      });
+      expect(await nextChange(caught)).toMatchObject({tag: 'commit'});
+
+      catchupSub.cancel();
+      writerSub.cancel();
+      await writing;
     } finally {
       await streamer.stop();
       catchupReplica.close();
@@ -546,6 +688,7 @@ describe('change-streamer/service', () => {
       watermark: '01',
       replicaVersion: REPLICA_VERSION,
       initial: true,
+      logsChangeStream: false,
     });
     const downstream = drainToQueue(sub);
 
@@ -673,6 +816,7 @@ describe('change-streamer/service', () => {
       watermark: '01',
       replicaVersion: REPLICA_VERSION,
       initial: true,
+      logsChangeStream: false,
     });
 
     changes.push(['status', {ack: true}, {watermark: '0a'}]);
@@ -791,6 +935,7 @@ describe('change-streamer/service', () => {
       watermark: '01',
       replicaVersion: REPLICA_VERSION,
       initial: true,
+      logsChangeStream: false,
     });
 
     // Process more upstream changes.
@@ -889,6 +1034,7 @@ describe('change-streamer/service', () => {
       watermark: '0b',
       replicaVersion: REPLICA_VERSION,
       initial: true,
+      logsChangeStream: false,
     });
 
     // Process more upstream changes.
@@ -1000,6 +1146,7 @@ describe('change-streamer/service', () => {
       watermark: '01',
       replicaVersion: REPLICA_VERSION,
       initial: true,
+      logsChangeStream: false,
     });
     const downstream = drainToQueue(sub);
 
@@ -1104,6 +1251,7 @@ describe('change-streamer/service', () => {
       watermark: '01',
       replicaVersion: REPLICA_VERSION,
       initial: true,
+      logsChangeStream: false,
     });
     const catchup = drainToQueue(catchupSub);
     expect(await nextChange(catchup)).toMatchObject({tag: 'status'});
@@ -1155,6 +1303,7 @@ describe('change-streamer/service', () => {
         watermark: '04',
         replicaVersion: REPLICA_VERSION,
         initial: true,
+        logsChangeStream: false,
       }),
     );
     expect(await nextChange(sub04)).toMatchObject({tag: 'status'});
@@ -1168,6 +1317,7 @@ describe('change-streamer/service', () => {
         watermark: '08',
         replicaVersion: REPLICA_VERSION,
         initial: true,
+        logsChangeStream: false,
       }),
     );
     expect(await nextChange(sub08)).toMatchObject({tag: 'status'});
@@ -1181,6 +1331,7 @@ describe('change-streamer/service', () => {
         watermark: '02',
         replicaVersion: REPLICA_VERSION,
         initial: true,
+        logsChangeStream: false,
       }),
     );
     expect(await sub02.dequeue()).toEqual([
@@ -1218,6 +1369,7 @@ describe('change-streamer/service', () => {
       watermark: '06',
       replicaVersion: REPLICA_VERSION,
       initial: true,
+      logsChangeStream: false,
     });
 
     const sub2 = await streamer.subscribe({
@@ -1228,6 +1380,7 @@ describe('change-streamer/service', () => {
       watermark: '04',
       replicaVersion: REPLICA_VERSION,
       initial: true,
+      logsChangeStream: false,
     });
 
     expect(
@@ -1301,6 +1454,7 @@ describe('change-streamer/service', () => {
       watermark: '04',
       replicaVersion: REPLICA_VERSION,
       initial: true,
+      logsChangeStream: false,
     });
 
     const msgs = drainToQueue(sub3);
@@ -1322,6 +1476,7 @@ describe('change-streamer/service', () => {
       watermark: '06',
       replicaVersion: REPLICA_VERSION + 'foobar',
       initial: true,
+      logsChangeStream: false,
     });
 
     const msgs = drainToQueue(sub);
@@ -1694,6 +1849,7 @@ describe('change-streamer/service', () => {
       watermark: '01',
       replicaVersion: REPLICA_VERSION,
       initial: true,
+      logsChangeStream: false,
     });
     const downstream = drainToQueue(sub);
 
@@ -1851,6 +2007,7 @@ describe('change-streamer/service', () => {
       watermark: '02', // Too early
       replicaVersion: REPLICA_VERSION,
       initial: true,
+      logsChangeStream: false,
     });
 
     await streamerDone;
@@ -1886,6 +2043,7 @@ describe('change-streamer/service', () => {
       watermark: '01',
       replicaVersion: REPLICA_VERSION,
       initial: true,
+      logsChangeStream: false,
     });
 
     const msgs = drainToQueue(sub);
@@ -1913,6 +2071,7 @@ describe('change-streamer/service', () => {
       watermark: '01',
       replicaVersion: REPLICA_VERSION,
       initial: true,
+      logsChangeStream: false,
     });
 
     const msgs = drainToQueue(sub);

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
@@ -487,6 +487,12 @@ describe('change-streamer/service', () => {
         new: {id: 'after-rollback'},
       });
       expect(await nextChange(rolledBack)).toMatchObject({tag: 'commit'});
+      expect(await nextChange(live)).toMatchObject({tag: 'begin'});
+      expect(await nextChange(live)).toMatchObject({
+        tag: 'insert',
+        new: {id: 'after-rollback'},
+      });
+      expect(await nextChange(live)).toMatchObject({tag: 'commit'});
       appendSQLiteTransaction(catchupReplica, '08', [insert08]);
 
       changes.push(['begin', messages.begin(), {commitWatermark: '0a'}]);

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -1,7 +1,7 @@
 import {getDefaultHighWaterMark} from 'node:stream';
 import type {LogContext} from '@rocicorp/logger';
-import {resolver} from '@rocicorp/resolver';
-import {unreachable} from '../../../../shared/src/asserts.ts';
+import {resolver, type Resolver} from '@rocicorp/resolver';
+import {assert, unreachable} from '../../../../shared/src/asserts.ts';
 import {promiseVoid} from '../../../../shared/src/resolved-promises.ts';
 import {publishCriticalEvent} from '../../observability/events.ts';
 import {getOrCreateCounter} from '../../observability/metrics.ts';
@@ -19,6 +19,7 @@ import type {
   ChangeStream,
 } from '../change-source/change-source.ts';
 import {
+  type ChangeStreamData,
   type ChangeStreamControl,
   type Rollback,
 } from '../change-source/protocol/current/downstream.ts';
@@ -47,15 +48,31 @@ import {
   markResetRequired,
 } from './schema/tables.ts';
 import {
+  SQLiteChangeLogCatchup,
+  type SQLiteChangeLogCleanupGuard,
+} from './sqlite-change-log-catchup.ts';
+import {SQLiteChangeLogReader} from './sqlite-change-log-reader.ts';
+import {
   Storer,
   type PurgeLock,
   type TuningOptions as StorerOptions,
 } from './storer.ts';
 import {Subscriber} from './subscriber.ts';
 
+export type SQLiteCatchupOptions = {
+  replicaFile: string;
+  readBatchRows: number;
+  barrierTimeoutMs: number;
+  /** Slice 11 supplies the production canary selector. */
+  shouldUse?: ((ctx: SubscriberContext) => boolean) | undefined;
+  /** Slice 9 supplies the writer-serialized purge guard. */
+  cleanupGuard?: SQLiteChangeLogCleanupGuard | undefined;
+};
+
 export type TuningOptions = StorerOptions & {
   flowControlConsensusPaddingSeconds: number;
   flowControlEventDrivenRelease?: boolean | undefined;
+  sqliteCatchup?: SQLiteCatchupOptions | undefined;
 };
 
 /**
@@ -254,6 +271,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
   readonly #storer: Storer;
   readonly #forwarder: Forwarder;
   readonly #replicationStatusPublisher: ReplicationStatusPublisher;
+  readonly #sqliteCatchupOptions: SQLiteCatchupOptions | undefined;
 
   readonly #autoReset: boolean;
   readonly #state: RunningState;
@@ -283,6 +301,11 @@ class ChangeStreamerImpl implements ChangeStreamerService {
   #latestStatus: Status;
   #purgeLock: PurgeLock | null;
   #stream: ChangeStream | undefined;
+  #sqliteCatchup: SQLiteChangeLogCatchup | undefined;
+  #lastForwardedCommitWatermark: string | undefined;
+  #currentTransactionCompletion:
+    | Resolver<ForwardedTransactionCompletion>
+    | undefined;
 
   constructor(
     lc: LogContext,
@@ -323,6 +346,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
       eventDrivenRelease: opts.flowControlEventDrivenRelease,
     });
     this.#replicationStatusPublisher = replicationStatusPublisher;
+    this.#sqliteCatchupOptions = opts.sqliteCatchup;
     this.#purgeLock = initialPurgeLock;
     this.#autoReset = autoReset;
     this.#state = new RunningState(this.id, undefined, setTimeoutFn);
@@ -355,6 +379,10 @@ class ChangeStreamerImpl implements ChangeStreamerService {
       try {
         const {lastWatermark, backfillRequests} =
           await this.#storer.getStartStreamInitializationParameters();
+        // SQLite catchup must not be eligible until this has been initialized
+        // from the durable PG head. Commits observed only since process startup
+        // are insufficient after a change-streamer restart.
+        this.#lastForwardedCommitWatermark = lastWatermark;
         const stream = await this.#source.startStream(
           lastWatermark,
           backfillRequests,
@@ -424,6 +452,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
           if (unflushedBytes < flushBytesThreshold) {
             // pipeline changes until flushBytesThreshold
             this.#forwarder.forward(entry);
+            this.#recordForwardedTransactionBoundary(type, entry[0]);
           } else {
             // Wait for messages to clear socket buffers to ensure that they
             // make their way to subscribers. Without this `await`, the
@@ -432,7 +461,13 @@ class ChangeStreamerImpl implements ChangeStreamerService {
             // (2) prevents subscribers from processing the messages as they
             //     arrive, instead getting them in a large batch after being
             //     idle while they were queued (causing further delays).
-            await this.#forwarder.forwardWithFlowControl(entry);
+            const forwarded = this.#forwarder.forwardWithFlowControl(entry);
+            // forwardWithFlowControl synchronously sends the entry and updates
+            // the Forwarder's transaction state before returning its flow-
+            // control promise. Record the boundary before awaiting that promise
+            // so registrations during the wait observe the forwarded state.
+            this.#recordForwardedTransactionBoundary(type, entry[0]);
+            await forwarded;
             unflushedBytes = 0;
           }
 
@@ -458,6 +493,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
         this.#lc.warn?.(`aborting interrupted transaction ${watermark}`);
         this.#storer.abort();
         this.#forwarder.forward([watermark, 'rollback', ROLLBACK_JSON]);
+        this.#recordForwardedTransactionBoundary('rollback', watermark);
       }
 
       // Backoff and drain any pending entries in the storer before reconnecting.
@@ -500,13 +536,14 @@ class ChangeStreamerImpl implements ChangeStreamerService {
     }
   }
 
-  subscribe(ctx: SubscriberContext): Promise<Source<string>> {
+  async subscribe(ctx: SubscriberContext): Promise<Source<string>> {
     const {protocolVersion, id, mode, replicaVersion, watermark} = ctx;
     if (mode === 'serving') {
       this.#serving.resolve();
     }
+    let cleanupSubscriber = () => {};
     const downstream = Subscription.create<string>({
-      cleanup: () => this.#forwarder.remove(subscriber),
+      cleanup: () => cleanupSubscriber(),
     });
     const subscriber = new Subscriber(
       protocolVersion,
@@ -515,6 +552,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
       downstream,
       () => this.#latestStatus,
     );
+    cleanupSubscriber = () => this.#forwarder.remove(subscriber);
     if (replicaVersion !== this.#replicaVersion) {
       this.#lc.warn?.(
         `rejecting subscriber at replica version ${replicaVersion}`,
@@ -528,10 +566,20 @@ class ChangeStreamerImpl implements ChangeStreamerService {
     } else {
       this.#lc.debug?.(`adding subscriber ${subscriber.id}`);
 
-      this.#forwarder.add(subscriber);
-      this.#storer.catchup(subscriber, mode);
+      const sqliteCatchup = this.#selectSQLiteCatchup(ctx);
+      if (sqliteCatchup) {
+        cleanupSubscriber = () => sqliteCatchup.remove(subscriber);
+        await sqliteCatchup.catchup(subscriber, mode, () =>
+          this.#captureRequiredHead(),
+        );
+      } else {
+        // Keep the existing PG registration/catchup lockstep unchanged when
+        // SQLite was not selected before Forwarder.add().
+        this.#forwarder.add(subscriber);
+        this.#storer.catchup(subscriber, mode);
+      }
     }
-    return Promise.resolve(downstream);
+    return downstream;
   }
 
   scheduleCleanup(watermark: string) {
@@ -607,10 +655,90 @@ class ChangeStreamerImpl implements ChangeStreamerService {
   async stop(err?: unknown) {
     this.#state.stop(this.#lc, err);
     this.#stream?.changes.cancel();
+    this.#sqliteCatchup?.close();
     await this.#storer.stop();
     await this.#source.stop();
   }
+
+  #recordForwardedTransactionBoundary(
+    type: ChangeStreamData[0],
+    watermark: string,
+  ) {
+    switch (type) {
+      case 'begin':
+        assert(
+          this.#currentTransactionCompletion === undefined,
+          'forwarded begin while a transaction is already in progress',
+        );
+        this.#currentTransactionCompletion =
+          resolver<ForwardedTransactionCompletion>();
+        break;
+      case 'commit': {
+        const completion = this.#currentTransactionCompletion;
+        assert(completion, 'forwarded commit without a pending transaction');
+        this.#lastForwardedCommitWatermark = watermark;
+        this.#currentTransactionCompletion = undefined;
+        completion.resolve({kind: 'committed', watermark});
+        break;
+      }
+      case 'rollback': {
+        const completion = this.#currentTransactionCompletion;
+        assert(completion, 'forwarded rollback without a pending transaction');
+        const committed = this.#lastForwardedCommitWatermark;
+        assert(committed, 'last forwarded commit watermark is not initialized');
+        this.#currentTransactionCompletion = undefined;
+        completion.resolve({kind: 'rolled-back', watermark: committed});
+        break;
+      }
+    }
+  }
+
+  #captureRequiredHead(): string | Promise<string> {
+    const committed = this.#lastForwardedCommitWatermark;
+    assert(committed, 'last forwarded commit watermark is not initialized');
+    return (
+      this.#currentTransactionCompletion?.promise.then(
+        completion => completion.watermark,
+      ) ?? committed
+    );
+  }
+
+  #selectSQLiteCatchup(
+    ctx: SubscriberContext,
+  ): SQLiteChangeLogCatchup | undefined {
+    const opts = this.#sqliteCatchupOptions;
+    // Slice 11 supplies a non-default selector. Until then, this keeps all
+    // production subscriptions on PG even though the complete SQLite handoff
+    // path is wired and testable.
+    if (
+      this.#lastForwardedCommitWatermark === undefined ||
+      !opts?.shouldUse?.(ctx)
+    ) {
+      return undefined;
+    }
+    if (!this.#sqliteCatchup) {
+      this.#sqliteCatchup = new SQLiteChangeLogCatchup(
+        this.#lc,
+        this.#forwarder,
+        new SQLiteChangeLogReader(this.#lc, opts.replicaFile),
+        {
+          batchSize: opts.readBatchRows,
+          barrierTimeoutMs: opts.barrierTimeoutMs,
+          cleanupGuard: opts.cleanupGuard,
+          onFatal: async error => {
+            await markResetRequired(this.#changeDB, this.#shard);
+            void this.stop(error);
+          },
+        },
+      );
+    }
+    return this.#sqliteCatchup;
+  }
 }
+
+type ForwardedTransactionCompletion =
+  | {kind: 'committed'; watermark: string}
+  | {kind: 'rolled-back'; watermark: string};
 
 // The delay between receiving an initial, backup-based watermark
 // and performing a check of whether to purge records before it.

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -63,6 +63,11 @@ export type SQLiteCatchupOptions = {
   replicaFile: string;
   readBatchRows: number;
   barrierTimeoutMs: number;
+  /**
+   * Backstop for the change-log writer's ACK, which is what normally releases
+   * the barrier. Defaults to the catchup coordinator's interval.
+   */
+  barrierPollIntervalMs?: number | undefined;
   /** Slice 11 supplies the production canary selector. */
   shouldUse?: ((ctx: SubscriberContext) => boolean) | undefined;
   /** Slice 9 supplies the writer-serialized purge guard. */
@@ -551,6 +556,14 @@ class ChangeStreamerImpl implements ChangeStreamerService {
       watermark,
       downstream,
       () => this.#latestStatus,
+      ctx.logsChangeStream
+        ? {
+            // This subscriber writes the SQLite change log that catchup reads,
+            // so its ACKs are what advance that log's head. Routing them to the
+            // barrier saves it from polling the replica for the same fact.
+            onAck: acked => this.#sqliteCatchup?.onChangeLogWriterAck(acked),
+          }
+        : {},
     );
     cleanupSubscriber = () => this.#forwarder.remove(subscriber);
     if (replicaVersion !== this.#replicaVersion) {
@@ -724,6 +737,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
         {
           batchSize: opts.readBatchRows,
           barrierTimeoutMs: opts.barrierTimeoutMs,
+          barrierPollIntervalMs: opts.barrierPollIntervalMs,
           cleanupGuard: opts.cleanupGuard,
           onFatal: async error => {
             try {

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -71,9 +71,9 @@ export type SQLiteCatchupOptions = {
   /**
    * Slice 11 supplies the production canary selector.
    *
-   * It does not need to exclude the change-log writer: subscribers with
-   * `logsChangeStream` are rejected regardless of what this returns, since
-   * serving one from SQLite would make it wait on its own ACK.
+   * It does not need to exclude backup subscribers or the change-log writer:
+   * eligibility checks reject both before invoking this selector. Serving a
+   * writer from SQLite would make it wait on its own ACK.
    */
   shouldUse?: ((ctx: SubscriberContext) => boolean) | undefined;
   /** Slice 9 supplies the writer-serialized purge guard. */
@@ -588,7 +588,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
       const sqliteCatchup = this.#selectSQLiteCatchup(ctx);
       if (sqliteCatchup) {
         cleanupSubscriber = () => sqliteCatchup.remove(subscriber);
-        await sqliteCatchup.catchup(subscriber, mode, () =>
+        await sqliteCatchup.catchup(subscriber, () =>
           this.#captureRequiredHead(),
         );
       } else {
@@ -729,10 +729,17 @@ class ChangeStreamerImpl implements ChangeStreamerService {
     // Slice 11 supplies a non-default selector. Until then, this keeps all
     // production subscriptions on PG even though the complete SQLite handoff
     // path is wired and testable.
-    if (
-      this.#lastForwardedCommitWatermark === undefined ||
-      !opts?.shouldUse?.(ctx)
-    ) {
+    if (this.#lastForwardedCommitWatermark === undefined || !opts) {
+      return undefined;
+    }
+    // SQLite catchup is only for disposable serving replicas. Backup
+    // subscribers retain the existing PG recovery policy until RMv2 can
+    // resume the canonical replica directly from replica/backup/slot state.
+    // Enforce this before the selector so no canary policy can override it.
+    if (ctx.mode !== 'serving') {
+      this.#lc.debug?.(
+        `not serving backup subscriber ${ctx.id} from SQLite catchup`,
+      );
       return undefined;
     }
     if (ctx.logsChangeStream) {
@@ -748,6 +755,9 @@ class ChangeStreamerImpl implements ChangeStreamerService {
       );
       return undefined;
     }
+    if (!opts.shouldUse?.(ctx)) {
+      return undefined;
+    }
     if (!this.#sqliteCatchup) {
       this.#sqliteCatchup = new SQLiteChangeLogCatchup(
         this.#lc,
@@ -758,13 +768,6 @@ class ChangeStreamerImpl implements ChangeStreamerService {
           barrierTimeoutMs: opts.barrierTimeoutMs,
           barrierPollIntervalMs: opts.barrierPollIntervalMs,
           cleanupGuard: opts.cleanupGuard,
-          onFatal: async error => {
-            try {
-              await markResetRequired(this.#changeDB, this.#shard);
-            } finally {
-              void this.stop(error);
-            }
-          },
         },
       );
     }

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -68,7 +68,13 @@ export type SQLiteCatchupOptions = {
    * the barrier. Defaults to the catchup coordinator's interval.
    */
   barrierPollIntervalMs?: number | undefined;
-  /** Slice 11 supplies the production canary selector. */
+  /**
+   * Slice 11 supplies the production canary selector.
+   *
+   * It does not need to exclude the change-log writer: subscribers with
+   * `logsChangeStream` are rejected regardless of what this returns, since
+   * serving one from SQLite would make it wait on its own ACK.
+   */
   shouldUse?: ((ctx: SubscriberContext) => boolean) | undefined;
   /** Slice 9 supplies the writer-serialized purge guard. */
   cleanupGuard?: SQLiteChangeLogCleanupGuard | undefined;
@@ -727,6 +733,19 @@ class ChangeStreamerImpl implements ChangeStreamerService {
       this.#lastForwardedCommitWatermark === undefined ||
       !opts?.shouldUse?.(ctx)
     ) {
+      return undefined;
+    }
+    if (ctx.logsChangeStream) {
+      // A change-log writer cannot be served from the change log it writes.
+      // The barrier waits for a head that only this subscriber can advance,
+      // and it advances it by consuming the very subscription the barrier is
+      // holding: it would wait on its own ACK until the deadline, on every
+      // reconnect. Enforced here rather than left to the selector so that no
+      // selector can express it.
+      this.#lc.warn?.(
+        `not serving change-log writer ${ctx.id} from SQLite catchup: ` +
+          `it would wait on its own ACK`,
+      );
       return undefined;
     }
     if (!this.#sqliteCatchup) {

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -726,8 +726,11 @@ class ChangeStreamerImpl implements ChangeStreamerService {
           barrierTimeoutMs: opts.barrierTimeoutMs,
           cleanupGuard: opts.cleanupGuard,
           onFatal: async error => {
-            await markResetRequired(this.#changeDB, this.#shard);
-            void this.stop(error);
+            try {
+              await markResetRequired(this.#changeDB, this.#shard);
+            } finally {
+              void this.stop(error);
+            }
           },
         },
       );

--- a/packages/zero-cache/src/services/change-streamer/change-streamer.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer.ts
@@ -142,6 +142,16 @@ export type SubscriberContext = {
    * are safe to purge from the Storer.
    */
   initial: boolean;
+
+  /**
+   * Whether the subscriber's replica writes the SQLite change log that the
+   * `change-streamer` reads for catchup (see `replicaLogsChangeStream()`).
+   * Such a subscriber is always co-located with the `change-streamer`, and
+   * is the only thing that advances that change log: its ACKs are what the
+   * SQLite catchup barrier waits on, and it cannot itself be served from
+   * SQLite catchup without waiting on its own ACK.
+   */
+  logsChangeStream: boolean;
 };
 
 /**

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.test.ts
@@ -1,0 +1,462 @@
+import {LogContext} from '@rocicorp/logger';
+import {resolver} from '@rocicorp/resolver';
+import {afterEach, describe, expect, test, vi} from 'vitest';
+import {AbortError} from '../../../../shared/src/abort-error.ts';
+import {BigIntJSON} from '../../../../shared/src/bigint-json.ts';
+import {TestLogSink} from '../../../../shared/src/logging-test-utils.ts';
+import {Queue} from '../../../../shared/src/queue.ts';
+import type {Source} from '../../types/streams.ts';
+import {Subscription} from '../../types/subscription.ts';
+import type {Downstream, WatermarkedChange} from './change-streamer.ts';
+import * as ErrorType from './error-type-enum.ts';
+import {Forwarder} from './forwarder.ts';
+import {AutoResetSignal} from './schema/tables.ts';
+import {
+  SQLiteChangeLogCatchup,
+  SQLiteChangeLogBarrierTimeoutError,
+  type SQLiteChangeLogCatchupReader,
+  type SQLiteChangeLogCleanupGuard,
+} from './sqlite-change-log-catchup.ts';
+import type {CatchupPlan} from './sqlite-change-log-reader.ts';
+import {Subscriber} from './subscriber.ts';
+
+const coordinators: SQLiteChangeLogCatchup[] = [];
+
+describe('SQLiteChangeLogCatchup', () => {
+  afterEach(() => {
+    for (const coordinator of coordinators.splice(0)) {
+      coordinator.close();
+    }
+  });
+
+  test('registers before pinning the head and deduplicates live overlap', async () => {
+    const fixture = createFixture();
+    fixture.reader.head = '04';
+    fixture.reader.entries.push(...transaction('04'));
+    fixture.reader.boundaries.add('04');
+
+    const {subscriber, output} = createSubscriber('01');
+    await fixture.coordinator.catchup(subscriber, 'serving', () => '06');
+
+    // This replay reaches the Forwarder after registration but before SQLite
+    // reaches the required head. It is both in the backlog and, once applied,
+    // in the pinned catchup range.
+    forward(fixture.forwarder, transaction('06'));
+    fixture.reader.entries.push(...transaction('06'));
+    fixture.reader.boundaries.add('06');
+    fixture.reader.head = '06';
+
+    expect(await takeMarkers(output, 7)).toEqual([
+      'status',
+      '04:begin',
+      '04:insert',
+      '04:commit',
+      '06:begin',
+      '06:insert',
+      '06:commit',
+    ]);
+    expect(fixture.reader.reads).toEqual([
+      {from: '01', through: '06', batchSize: 2},
+    ]);
+  });
+
+  test('waits for a mid-transaction commit before choosing the required head', async () => {
+    const fixture = createFixture();
+    fixture.reader.entries.push(...transaction('04'));
+    fixture.reader.boundaries.add('04');
+    fixture.reader.head = '04';
+
+    fixture.forwarder.forward(entry('06', 'begin'));
+    const completion = resolver<string>();
+    const {subscriber, output} = createSubscriber('04');
+    await fixture.coordinator.catchup(
+      subscriber,
+      'serving',
+      () => completion.promise,
+    );
+
+    fixture.forwarder.forward(entry('06', 'insert'));
+    fixture.forwarder.forward(entry('06', 'commit'));
+    fixture.reader.entries.push(...transaction('06'));
+    fixture.reader.boundaries.add('06');
+    fixture.reader.head = '06';
+    completion.resolve('06');
+
+    forward(fixture.forwarder, transaction('08'));
+    expect(await takeMarkers(output, 7)).toEqual([
+      'status',
+      '06:begin',
+      '06:insert',
+      '06:commit',
+      '08:begin',
+      '08:insert',
+      '08:commit',
+    ]);
+  });
+
+  test('uses the prior committed head when the registration transaction rolls back', async () => {
+    const fixture = createFixture();
+    fixture.reader.entries.push(...transaction('04'));
+    fixture.reader.boundaries.add('04');
+    fixture.reader.head = '04';
+
+    fixture.forwarder.forward(entry('06', 'begin'));
+    const completion = resolver<string>();
+    const {subscriber, output} = createSubscriber('01');
+    await fixture.coordinator.catchup(
+      subscriber,
+      'serving',
+      () => completion.promise,
+    );
+    fixture.forwarder.forward(entry('06', 'rollback'));
+    completion.resolve('04');
+
+    forward(fixture.forwarder, transaction('08'));
+    expect(await takeMarkers(output, 7)).toEqual([
+      'status',
+      '04:begin',
+      '04:insert',
+      '04:commit',
+      '08:begin',
+      '08:insert',
+      '08:commit',
+    ]);
+  });
+
+  test('buffers commits that arrive across several catchup batches', async () => {
+    const fixture = createFixture();
+    fixture.reader.entries.push(...transaction('04'), ...transaction('06'));
+    fixture.reader.boundaries.add('04');
+    fixture.reader.boundaries.add('06');
+    fixture.reader.head = '06';
+    const releaseRead = resolver<void>();
+    fixture.reader.beforeRead = releaseRead.promise;
+
+    const {subscriber, output} = createSubscriber('01');
+    await fixture.coordinator.catchup(subscriber, 'serving', () => '06');
+    forward(fixture.forwarder, transaction('08'));
+    forward(fixture.forwarder, transaction('0a'));
+    releaseRead.resolve();
+
+    expect(await takeMarkers(output, 13)).toEqual([
+      'status',
+      ...transactionMarkers('04'),
+      ...transactionMarkers('06'),
+      ...transactionMarkers('08'),
+      ...transactionMarkers('0a'),
+    ]);
+  });
+
+  test('accepts a subscriber ahead of SQLite and filters replayed live commits', async () => {
+    const fixture = createFixture();
+    fixture.reader.entries.push(...transaction('04'));
+    fixture.reader.boundaries.add('04');
+    fixture.reader.head = '04';
+
+    const {subscriber, output} = createSubscriber('06');
+    await fixture.coordinator.catchup(subscriber, 'serving', () => '04');
+    forward(fixture.forwarder, transaction('06'));
+    forward(fixture.forwarder, transaction('08'));
+
+    expect(await takeMarkers(output, 4)).toEqual([
+      'status',
+      ...transactionMarkers('08'),
+    ]);
+  });
+
+  test('closes the restore-skew gap while SQLite replays to the forwarded head', async () => {
+    const fixture = createFixture();
+    fixture.reader.entries.push(...transaction('04'));
+    fixture.reader.boundaries.add('04');
+    fixture.reader.head = '04';
+
+    // The change-streamer already forwarded through 06, but the restored
+    // canonical replica is only at 04. A subscriber reconnecting at 06 must
+    // wait for SQLite to replay 04..06 without receiving 06 twice.
+    const {subscriber, output} = createSubscriber('06');
+    await fixture.coordinator.catchup(subscriber, 'serving', () => '06');
+    forward(fixture.forwarder, transaction('06'));
+    fixture.reader.entries.push(...transaction('06'));
+    fixture.reader.boundaries.add('06');
+    fixture.reader.head = '06';
+    forward(fixture.forwarder, transaction('08'));
+
+    expect(await takeMarkers(output, 4)).toEqual([
+      'status',
+      ...transactionMarkers('08'),
+    ]);
+  });
+
+  test('maps too-old plans to serving and backup policies', async () => {
+    const serving = createFixture();
+    serving.reader.min = '04';
+    serving.reader.head = '06';
+    serving.reader.boundaries.add('04');
+    const servingSub = createSubscriber('01');
+    await serving.coordinator.catchup(
+      servingSub.subscriber,
+      'serving',
+      () => '06',
+    );
+    expect(await servingSub.output.dequeue()).toEqual([
+      'error',
+      {
+        type: ErrorType.WatermarkTooOld,
+        message: 'earliest supported watermark is 04 (requested 01)',
+      },
+    ]);
+    expect(serving.onFatal).not.toHaveBeenCalled();
+
+    const backup = createFixture();
+    backup.reader.min = '04';
+    backup.reader.head = '06';
+    backup.reader.boundaries.add('04');
+    const backupSub = createSubscriber('01');
+    await backup.coordinator.catchup(
+      backupSub.subscriber,
+      'backup',
+      () => '06',
+    );
+    await backupSub.done;
+    await vi.waitFor(() => expect(backup.onFatal).toHaveBeenCalledOnce());
+    expect(backup.onFatal.mock.calls[0][0]).toBeInstanceOf(AutoResetSignal);
+  });
+
+  test('fails only the selected subscription on barrier timeout', async () => {
+    const fixture = createFixture({barrierTimeoutMs: 5});
+    fixture.reader.head = '01';
+    const {subscriber, done} = createSubscriber('01');
+    await fixture.coordinator.catchup(subscriber, 'serving', () => '06');
+
+    await done;
+    expect(fixture.logSink.messages).toContainEqual([
+      'error',
+      expect.anything(),
+      [
+        expect.stringContaining('error while catching up subscriber'),
+        expect.objectContaining({
+          name: SQLiteChangeLogBarrierTimeoutError.name,
+        }),
+      ],
+    ]);
+    expect(fixture.onFatal).not.toHaveBeenCalled();
+  });
+
+  test('fails closed on reader errors after registration', async () => {
+    const fixture = createFixture();
+    fixture.reader.head = '06';
+    fixture.reader.boundaries.add('01');
+    fixture.reader.readError = new Error('broken SQLite read');
+    const {subscriber, done} = createSubscriber('01');
+    await fixture.coordinator.catchup(subscriber, 'serving', () => '06');
+
+    await done;
+    expect(fixture.logSink.messages).toContainEqual([
+      'error',
+      expect.anything(),
+      [
+        expect.stringContaining('error while catching up subscriber'),
+        expect.objectContaining({message: 'broken SQLite read'}),
+      ],
+    ]);
+  });
+
+  test('cancellation and shutdown release catchup resources', async () => {
+    const fixture = createFixture();
+    fixture.reader.head = '01';
+    const first = createSubscriber('01');
+    await fixture.coordinator.catchup(first.subscriber, 'serving', () => '06');
+    fixture.coordinator.remove(first.subscriber);
+
+    const second = createSubscriber('01');
+    await fixture.coordinator.catchup(second.subscriber, 'serving', () => '06');
+    fixture.coordinator.close();
+
+    expect(fixture.reader.closed).toBe(true);
+    expect(fixture.forwarder.getAcks()).toEqual(new Set());
+  });
+
+  test('registers under the cleanup guard before exposing the subscriber ACK', async () => {
+    const guardGate = resolver<void>();
+    const cleanupGuard: SQLiteChangeLogCleanupGuard = {
+      async runWhilePurgeBlocked(register) {
+        await guardGate.promise;
+        return register();
+      },
+    };
+    const fixture = createFixture({cleanupGuard});
+    fixture.reader.head = '01';
+    fixture.reader.boundaries.add('01');
+    const {subscriber} = createSubscriber('01');
+    const registering = fixture.coordinator.catchup(
+      subscriber,
+      'serving',
+      () => '01',
+    );
+
+    expect(fixture.forwarder.getAcks()).toEqual(new Set());
+    guardGate.resolve();
+    await registering;
+    expect(fixture.forwarder.getAcks()).toEqual(new Set(['01']));
+  });
+});
+
+function createFixture(
+  opts: {
+    barrierTimeoutMs?: number | undefined;
+    cleanupGuard?: SQLiteChangeLogCleanupGuard | undefined;
+  } = {},
+) {
+  const logSink = new TestLogSink();
+  const lc = new LogContext('debug', undefined, logSink);
+  const reader = new TestReader();
+  const forwarder = new Forwarder(lc);
+  const onFatal = vi.fn<(error: AutoResetSignal) => Promise<void>>(() =>
+    Promise.resolve(),
+  );
+  const coordinator = new SQLiteChangeLogCatchup(lc, forwarder, reader, {
+    batchSize: 2,
+    barrierTimeoutMs: opts.barrierTimeoutMs ?? 1_000,
+    barrierPollIntervalMs: 1,
+    cleanupGuard: opts.cleanupGuard,
+    onFatal,
+  });
+  coordinators.push(coordinator);
+  return {coordinator, forwarder, logSink, onFatal, reader};
+}
+
+class TestReader implements SQLiteChangeLogCatchupReader {
+  readonly boundaries = new Set(['01']);
+  readonly entries: WatermarkedChange[] = [];
+  readonly reads: {from: string; through: string; batchSize: number}[] = [];
+  min = '01';
+  head = '01';
+  beforeRead: Promise<void> | undefined;
+  readError: Error | undefined;
+  closed = false;
+
+  plan(fromWatermark: string): CatchupPlan {
+    if (fromWatermark > this.head) {
+      return {kind: 'ahead', headWatermark: this.head};
+    }
+    if (fromWatermark < this.min || !this.boundaries.has(fromWatermark)) {
+      return {
+        kind: 'too-old',
+        minWatermark: this.min,
+        headWatermark: this.head,
+      };
+    }
+    return {
+      kind: 'range',
+      minWatermark: this.min,
+      headWatermark: this.head,
+    };
+  }
+
+  async *read(
+    fromWatermark: string,
+    throughWatermark: string,
+    batchSize: number,
+    signal?: AbortSignal,
+  ): AsyncIterable<readonly WatermarkedChange[]> {
+    this.reads.push({
+      from: fromWatermark,
+      through: throughWatermark,
+      batchSize,
+    });
+    await this.beforeRead;
+    if (signal?.aborted) {
+      throw new AbortError();
+    }
+    if (this.readError) {
+      throw this.readError;
+    }
+    const selected = this.entries.filter(
+      ([watermark]) =>
+        watermark > fromWatermark && watermark <= throughWatermark,
+    );
+    for (let i = 0; i < selected.length; i += batchSize) {
+      if (signal?.aborted) {
+        throw new AbortError();
+      }
+      yield selected.slice(i, i + batchSize);
+    }
+  }
+
+  close(): void {
+    this.closed = true;
+  }
+}
+
+function createSubscriber(watermark: string) {
+  const downstream = Subscription.create<string>();
+  const subscriber = new Subscriber(
+    5,
+    `subscriber-${watermark}`,
+    watermark,
+    downstream,
+    () => ({tag: 'status'}),
+  );
+  const {done, output} = drainToQueue(downstream);
+  return {done, subscriber, output};
+}
+
+function drainToQueue(source: Source<string>): {
+  done: Promise<void>;
+  output: Queue<Downstream>;
+} {
+  const queue = new Queue<Downstream>();
+  const done = (async () => {
+    for await (const json of source) {
+      queue.enqueue(BigIntJSON.parse(json) as Downstream);
+    }
+  })();
+  return {done, output: queue};
+}
+
+function entry(
+  watermark: string,
+  tag: 'begin' | 'insert' | 'commit' | 'rollback',
+): WatermarkedChange {
+  const downstreamTag = tag === 'insert' ? 'data' : tag;
+  return [
+    watermark,
+    tag,
+    JSON.stringify([downstreamTag, {tag, marker: `${watermark}:${tag}`}]),
+  ];
+}
+
+function transaction(watermark: string): WatermarkedChange[] {
+  return [
+    entry(watermark, 'begin'),
+    entry(watermark, 'insert'),
+    entry(watermark, 'commit'),
+  ];
+}
+
+function transactionMarkers(watermark: string) {
+  return [`${watermark}:begin`, `${watermark}:insert`, `${watermark}:commit`];
+}
+
+function forward(forwarder: Forwarder, changes: WatermarkedChange[]) {
+  for (const change of changes) {
+    forwarder.forward(change);
+  }
+}
+
+async function takeMarkers(output: Queue<Downstream>, count: number) {
+  const markers: string[] = [];
+  for (let i = 0; i < count; i++) {
+    const downstream = await output.dequeue();
+    if (downstream[0] === 'error') {
+      throw new Error(`unexpected downstream error: ${downstream[1].message}`);
+    }
+    const message = downstream[1];
+    markers.push(
+      message.tag === 'status'
+        ? 'status'
+        : String((message as unknown as {marker: string}).marker),
+    );
+  }
+  return markers;
+}

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.test.ts
@@ -1,5 +1,6 @@
 import {LogContext} from '@rocicorp/logger';
-import {resolver} from '@rocicorp/resolver';
+import {resolver, type Resolver} from '@rocicorp/resolver';
+import fc from 'fast-check';
 import {afterEach, describe, expect, test, vi} from 'vitest';
 import {AbortError} from '../../../../shared/src/abort-error.ts';
 import {BigIntJSON} from '../../../../shared/src/bigint-json.ts';
@@ -24,6 +25,41 @@ import type {CatchupPlan} from './sqlite-change-log-reader.ts';
 import {Subscriber, type SubscriberOptions} from './subscriber.ts';
 
 const coordinators: SQLiteChangeLogCatchup[] = [];
+
+const FUZZ_SEED_WATERMARK = '0001';
+type CatchupFuzzScenario = {
+  readonly priorWidths: number[];
+  readonly requestedPosition: number;
+  readonly sqlitePosition: number;
+  readonly registrationPhase: 'between' | 'after-begin' | 'after-data';
+  readonly inFlightCommits: boolean;
+  readonly inFlightWidth: number;
+  readonly futureWidths: number[];
+  readonly sentinelWidth: number;
+  readonly batchSize: number;
+  readonly wakeup: 'ack' | 'early-ack' | 'poll';
+};
+
+const catchupFuzzScenario: fc.Arbitrary<CatchupFuzzScenario> = fc.record({
+  priorWidths: fc.array(fc.integer({min: 0, max: 5}), {maxLength: 5}),
+  requestedPosition: fc.nat({max: 100}),
+  sqlitePosition: fc.nat({max: 100}),
+  registrationPhase: fc.constantFrom(
+    'between' as const,
+    'after-begin' as const,
+    'after-data' as const,
+  ),
+  inFlightCommits: fc.boolean(),
+  inFlightWidth: fc.integer({min: 0, max: 5}),
+  futureWidths: fc.array(fc.integer({min: 0, max: 5}), {maxLength: 5}),
+  sentinelWidth: fc.integer({min: 0, max: 5}),
+  batchSize: fc.integer({min: 1, max: 5}),
+  wakeup: fc.constantFrom(
+    'ack' as const,
+    'early-ack' as const,
+    'poll' as const,
+  ),
+});
 
 describe('SQLiteChangeLogCatchup', () => {
   afterEach(() => {
@@ -188,6 +224,29 @@ describe('SQLiteChangeLogCatchup', () => {
       'status',
       ...transactionMarkers('08'),
     ]);
+  });
+
+  test('fuzzes gap-free catchup-to-live interleavings', async () => {
+    // Reuse one fixture per batch size. Constructing a Forwarder per fast-check
+    // run would register hundreds of process-lifetime metric callbacks.
+    const fixtures = new Map(
+      [1, 2, 3, 4, 5].map(
+        batchSize => [batchSize, createFixture({batchSize})] as const,
+      ),
+    );
+
+    try {
+      await fc.assert(
+        fc.asyncProperty(catchupFuzzScenario, scenario =>
+          runCatchupFuzzScenario(fixtures.get(scenario.batchSize), scenario),
+        ),
+        {numRuns: 500},
+      );
+    } finally {
+      for (const {coordinator} of fixtures.values()) {
+        coordinator.close();
+      }
+    }
   });
 
   test('releases the barrier on the change-log writer ACK', async () => {
@@ -530,6 +589,7 @@ describe('SQLiteChangeLogCatchup', () => {
 
 function createFixture(
   opts: {
+    batchSize?: number | undefined;
     barrierTimeoutMs?: number | undefined;
     barrierPollIntervalMs?: number | undefined;
     cleanupGuard?: SQLiteChangeLogCleanupGuard | undefined;
@@ -547,7 +607,7 @@ function createFixture(
       ((_error: AutoResetSignal): Promise<void> => Promise.resolve()),
   );
   const coordinator = new SQLiteChangeLogCatchup(lc, forwarder, reader, {
-    batchSize: 2,
+    batchSize: opts.batchSize ?? 2,
     barrierTimeoutMs: opts.barrierTimeoutMs ?? 1_000,
     barrierPollIntervalMs: opts.barrierPollIntervalMs ?? 1,
     cleanupGuard: opts.cleanupGuard,
@@ -673,16 +733,208 @@ function transactionMarkers(watermark: string) {
   return [`${watermark}:begin`, `${watermark}:insert`, `${watermark}:commit`];
 }
 
+type FuzzTransaction = {
+  readonly changes: WatermarkedChange[];
+  readonly markers: string[];
+  readonly watermark: string;
+};
+
+function fuzzTransaction(index: number, width: number): FuzzTransaction {
+  const watermark = String((index + 1) * 2).padStart(4, '0');
+  const inserts = Array.from({length: width}, (_, i) => {
+    const marker = `${watermark}:insert-${i}`;
+    return {
+      change: [
+        watermark,
+        'insert',
+        JSON.stringify(['data', {tag: 'insert', marker}]),
+      ] satisfies WatermarkedChange,
+      marker,
+    };
+  });
+  return {
+    watermark,
+    changes: [
+      entry(watermark, 'begin'),
+      ...inserts.map(({change}) => change),
+      entry(watermark, 'commit'),
+    ],
+    markers: [
+      `${watermark}:begin`,
+      ...inserts.map(({marker}) => marker),
+      `${watermark}:commit`,
+    ],
+  };
+}
+
+async function runCatchupFuzzScenario(
+  fixture: ReturnType<typeof createFixture> | undefined,
+  scenario: CatchupFuzzScenario,
+): Promise<void> {
+  if (!fixture) {
+    throw new Error(`missing fixture for batch size ${scenario.batchSize}`);
+  }
+  const {coordinator, forwarder, onFatal, reader} = fixture;
+  expect(forwarder.getAcks()).toEqual(new Set());
+  resetFuzzReader(reader);
+  onFatal.mockClear();
+
+  let nextIndex = 0;
+  const prior = scenario.priorWidths.map(width =>
+    fuzzTransaction(nextIndex++, width),
+  );
+  for (const tx of prior) {
+    forward(forwarder, tx.changes);
+  }
+
+  const sqlitePosition =
+    scenario.sqlitePosition % (scenario.priorWidths.length + 1);
+  applyFuzzTransactions(reader, prior.slice(0, sqlitePosition));
+
+  const requestedPosition =
+    scenario.requestedPosition % (scenario.priorWidths.length + 1);
+  const requestedWatermark =
+    requestedPosition === 0
+      ? FUZZ_SEED_WATERMARK
+      : (prior.at(requestedPosition - 1)?.watermark ?? FUZZ_SEED_WATERMARK);
+
+  let requiredHead: string | Promise<string> =
+    prior.at(-1)?.watermark ?? FUZZ_SEED_WATERMARK;
+  let inFlight:
+    | {
+        readonly completion: Resolver<string>;
+        readonly forwardedEntries: number;
+        readonly tx: FuzzTransaction;
+      }
+    | undefined;
+  if (scenario.registrationPhase !== 'between') {
+    const tx = fuzzTransaction(nextIndex++, scenario.inFlightWidth);
+    const forwardedEntries =
+      scenario.registrationPhase === 'after-begin' ? 1 : tx.changes.length - 1;
+    forward(forwarder, tx.changes.slice(0, forwardedEntries));
+    const completion = resolver<string>();
+    requiredHead = completion.promise;
+    inFlight = {completion, forwardedEntries, tx};
+  }
+
+  const {done, output, subscriber} = createSubscriber(requestedWatermark);
+  try {
+    await coordinator.catchup(subscriber, 'serving', () => requiredHead);
+
+    if (inFlight) {
+      const {completion, forwardedEntries, tx} = inFlight;
+      if (scenario.inFlightCommits) {
+        forward(forwarder, tx.changes.slice(forwardedEntries));
+        completion.resolve(tx.watermark);
+      } else {
+        forward(
+          forwarder,
+          tx.changes.slice(forwardedEntries, tx.changes.length - 1),
+        );
+        forwarder.forward(entry(tx.watermark, 'rollback'));
+        completion.resolve(prior.at(-1)?.watermark ?? FUZZ_SEED_WATERMARK);
+      }
+    }
+
+    const future = scenario.futureWidths.map(width =>
+      fuzzTransaction(nextIndex++, width),
+    );
+    for (const tx of future) {
+      forward(forwarder, tx.changes);
+    }
+
+    const committed = [
+      ...prior,
+      ...(inFlight && scenario.inFlightCommits ? [inFlight.tx] : []),
+      ...future,
+    ];
+    const appliedHead = committed.at(-1)?.watermark ?? FUZZ_SEED_WATERMARK;
+    if (scenario.wakeup === 'early-ack') {
+      coordinator.onChangeLogWriterAck(appliedHead);
+      // Let an early ACK race a plan() that still observes the old head. The
+      // poll backstop must preserve correctness if the notification is spent.
+      await Promise.resolve();
+    }
+    applyFuzzTransactions(
+      reader,
+      committed.filter(tx => !reader.boundaries.has(tx.watermark)),
+    );
+    if (scenario.wakeup === 'ack') {
+      coordinator.onChangeLogWriterAck(appliedHead);
+    }
+
+    // This commit is deliberately live-only. Receiving it proves catchup made
+    // the transition and provides an ordering sentinel after every overlap.
+    const sentinel = fuzzTransaction(nextIndex, scenario.sentinelWidth);
+    forward(forwarder, sentinel.changes);
+
+    const expected = [
+      'status',
+      ...committed
+        .filter(tx => tx.watermark > requestedWatermark)
+        .flatMap(tx => tx.markers),
+      ...sentinel.markers,
+    ];
+    expect(await takeMarkers(output, expected.length, 250)).toEqual(expected);
+    await vi.waitFor(() => expect(subscriber.numPending).toBe(0), {
+      timeout: 250,
+    });
+    expect(subscriber.acked).toBe(sentinel.watermark);
+    expect(output.size()).toBe(0);
+    expect(onFatal).not.toHaveBeenCalled();
+  } finally {
+    coordinator.remove(subscriber);
+    await done;
+    expect(forwarder.getAcks()).toEqual(new Set());
+  }
+}
+
+function resetFuzzReader(reader: TestReader): void {
+  reader.boundaries.clear();
+  reader.boundaries.add(FUZZ_SEED_WATERMARK);
+  reader.entries.splice(0);
+  reader.reads.splice(0);
+  reader.min = FUZZ_SEED_WATERMARK;
+  reader.head = FUZZ_SEED_WATERMARK;
+  reader.beforeRead = undefined;
+  reader.readError = undefined;
+}
+
+function applyFuzzTransactions(
+  reader: TestReader,
+  transactions: readonly FuzzTransaction[],
+): void {
+  for (const tx of transactions) {
+    reader.entries.push(...tx.changes);
+    reader.boundaries.add(tx.watermark);
+    reader.head = tx.watermark;
+  }
+}
+
 function forward(forwarder: Forwarder, changes: WatermarkedChange[]) {
   for (const change of changes) {
     forwarder.forward(change);
   }
 }
 
-async function takeMarkers(output: Queue<Downstream>, count: number) {
+async function takeMarkers(
+  output: Queue<Downstream>,
+  count: number,
+  timeoutMs?: number,
+) {
   const markers: string[] = [];
   for (let i = 0; i < count; i++) {
-    const downstream = await output.dequeue();
+    const timeout = [
+      'error',
+      {type: ErrorType.Unknown, message: 'timed out waiting for fuzz output'},
+    ] satisfies Downstream;
+    const downstream =
+      timeoutMs === undefined
+        ? await output.dequeue()
+        : await output.dequeue(timeout, timeoutMs);
+    if (downstream === timeout) {
+      throw new Error(timeout[1].message);
+    }
     if (downstream[0] === 'error') {
       throw new Error(`unexpected downstream error: ${downstream[1].message}`);
     }

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.test.ts
@@ -257,6 +257,10 @@ describe('SQLiteChangeLogCatchup', () => {
 
     const plan = vi.spyOn(fixture.reader, 'plan');
     const {subscriber, output} = createSubscriber('01');
+    const backlogFull = subscriber.whenBacklogFull();
+    const backlogThen = vi.spyOn(backlogFull.promise, 'then');
+    const cancelBacklogWait = vi.spyOn(backlogFull, 'cancel');
+    vi.spyOn(subscriber, 'whenBacklogFull').mockReturnValue(backlogFull);
     await fixture.coordinator.catchup(subscriber, 'serving', () => '06');
     await vi.waitFor(() => expect(plan).toHaveBeenCalledOnce());
 
@@ -275,6 +279,8 @@ describe('SQLiteChangeLogCatchup', () => {
       'status',
       ...transactionMarkers('06'),
     ]);
+    expect(backlogThen).toHaveBeenCalledOnce();
+    expect(cancelBacklogWait).toHaveBeenCalledOnce();
   });
 
   test('maps too-old plans to serving and backup policies', async () => {
@@ -437,9 +443,13 @@ describe('SQLiteChangeLogCatchup', () => {
     fixture.reader.head = '06';
     fixture.reader.boundaries.add('01');
     fixture.reader.readError = new Error('broken SQLite read');
-    const {subscriber, done} = createSubscriber('01');
+    const {subscriber, done, output} = createSubscriber('01');
     await fixture.coordinator.catchup(subscriber, 'serving', () => '06');
 
+    expect(await output.dequeue()).toEqual([
+      'error',
+      {type: ErrorType.Unknown, message: 'Error: broken SQLite read'},
+    ]);
     await done;
     expect(fixture.logSink.messages).toContainEqual([
       'error',

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.test.ts
@@ -467,11 +467,11 @@ describe('SQLiteChangeLogCatchup', () => {
     const {subscriber, done, output} = createSubscriber('01');
     await fixture.coordinator.catchup(subscriber, () => '06');
 
-    expect(await output.dequeue()).toEqual([
-      'error',
-      {type: ErrorType.Unknown, message: 'Error: broken SQLite read'},
-    ]);
+    // fail() ends the subscription without a downstream ['error', ...], so the
+    // subscriber reconnects instead of restoring a replica. The error reaches
+    // operators through the log below, not through the subscriber.
     await done;
+    expect(output.size()).toBe(0);
     expect(fixture.logSink.messages).toContainEqual([
       'error',
       expect.anything(),

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.test.ts
@@ -224,18 +224,25 @@ describe('SQLiteChangeLogCatchup', () => {
     expect(backup.onFatal.mock.calls[0][0]).toBeInstanceOf(AutoResetSignal);
   });
 
-  test('fails only the selected subscription on barrier timeout', async () => {
+  test('ends only the selected subscription, cleanly, on barrier timeout', async () => {
     const fixture = createFixture({barrierTimeoutMs: 5});
     fixture.reader.head = '01';
-    const {subscriber, done} = createSubscriber('01');
+    const {subscriber, done, output} = createSubscriber('01');
+    const fail = vi.spyOn(subscriber, 'fail');
     await fixture.coordinator.catchup(subscriber, 'serving', () => '06');
 
     await done;
+    // A clean cancel rather than an ['error', ...] message. IncrementalSyncer
+    // treats any error message as terminal and restores from litestream; a
+    // clean end backs off and re-subscribes, which is what "the replica is not
+    // caught up yet" warrants.
+    expect(fail).not.toHaveBeenCalled();
+    expect(output.size()).toBe(0);
     expect(fixture.logSink.messages).toContainEqual([
-      'error',
+      'warn',
       expect.anything(),
       [
-        expect.stringContaining('error while catching up subscriber'),
+        expect.stringContaining('to retry SQLite catchup'),
         expect.objectContaining({
           name: SQLiteChangeLogBarrierTimeoutError.name,
         }),

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.test.ts
@@ -14,6 +14,7 @@ import {AutoResetSignal} from './schema/tables.ts';
 import {
   SQLiteChangeLogCatchup,
   SQLiteChangeLogBarrierTimeoutError,
+  type SQLiteChangeLogCatchupOptions,
   type SQLiteChangeLogCatchupReader,
   type SQLiteChangeLogCleanupGuard,
 } from './sqlite-change-log-catchup.ts';
@@ -242,6 +243,30 @@ describe('SQLiteChangeLogCatchup', () => {
     expect(fixture.onFatal).not.toHaveBeenCalled();
   });
 
+  test('waits on a forwarded transaction with one completion handler', async () => {
+    let now = 0;
+    const fixture = createFixture({
+      barrierTimeoutMs: 5,
+      now: () => now,
+      sleep: ms => {
+        now += ms;
+        return Promise.resolve();
+      },
+    });
+    const completion = resolver<string>();
+    const then = vi.spyOn(completion.promise, 'then');
+    const {subscriber, done} = createSubscriber('01');
+
+    await fixture.coordinator.catchup(
+      subscriber,
+      'serving',
+      () => completion.promise,
+    );
+    await done;
+
+    expect(then).toHaveBeenCalledOnce();
+  });
+
   test('fails closed on reader errors after registration', async () => {
     const fixture = createFixture();
     fixture.reader.head = '06';
@@ -257,6 +282,33 @@ describe('SQLiteChangeLogCatchup', () => {
       [
         expect.stringContaining('error while catching up subscriber'),
         expect.objectContaining({message: 'broken SQLite read'}),
+      ],
+    ]);
+  });
+
+  test('fails the subscriber when fatal handling rejects', async () => {
+    const fatalError = new Error('failed to mark reset required');
+    const onFatal = vi.fn(() => Promise.reject(fatalError));
+    const fixture = createFixture({onFatal});
+    fixture.reader.min = '04';
+    fixture.reader.head = '06';
+    fixture.reader.boundaries.add('04');
+    const {subscriber, done} = createSubscriber('01');
+    const fail = vi.spyOn(subscriber, 'fail');
+
+    await fixture.coordinator.catchup(subscriber, 'backup', () => '06');
+    await vi.waitFor(() => expect(fail).toHaveBeenCalledOnce(), {
+      timeout: 100,
+    });
+    await done;
+    expect(onFatal).toHaveBeenCalledOnce();
+    expect(fail).toHaveBeenCalledWith(expect.any(AutoResetSignal));
+    expect(fixture.logSink.messages).toContainEqual([
+      'error',
+      expect.anything(),
+      [
+        expect.stringContaining('error while handling fatal SQLite catchup'),
+        fatalError,
       ],
     ]);
   });
@@ -305,21 +357,27 @@ function createFixture(
   opts: {
     barrierTimeoutMs?: number | undefined;
     cleanupGuard?: SQLiteChangeLogCleanupGuard | undefined;
+    now?: SQLiteChangeLogCatchupOptions['now'];
+    onFatal?: SQLiteChangeLogCatchupOptions['onFatal'];
+    sleep?: SQLiteChangeLogCatchupOptions['sleep'];
   } = {},
 ) {
   const logSink = new TestLogSink();
   const lc = new LogContext('debug', undefined, logSink);
   const reader = new TestReader();
   const forwarder = new Forwarder(lc);
-  const onFatal = vi.fn<(error: AutoResetSignal) => Promise<void>>(() =>
-    Promise.resolve(),
+  const onFatal = vi.fn(
+    opts.onFatal ??
+      ((_error: AutoResetSignal): Promise<void> => Promise.resolve()),
   );
   const coordinator = new SQLiteChangeLogCatchup(lc, forwarder, reader, {
     batchSize: 2,
     barrierTimeoutMs: opts.barrierTimeoutMs ?? 1_000,
     barrierPollIntervalMs: 1,
     cleanupGuard: opts.cleanupGuard,
+    now: opts.now,
     onFatal,
+    sleep: opts.sleep,
   });
   coordinators.push(coordinator);
   return {coordinator, forwarder, logSink, onFatal, reader};

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.test.ts
@@ -189,6 +189,93 @@ describe('SQLiteChangeLogCatchup', () => {
     ]);
   });
 
+  test('releases the barrier on the change-log writer ACK', async () => {
+    // A poll interval well beyond the test timeout: only the ACK can release
+    // this barrier, so passing proves it is not polling for the head.
+    const fixture = createFixture({
+      barrierTimeoutMs: 60_000,
+      barrierPollIntervalMs: 60_000,
+    });
+    fixture.reader.entries.push(...transaction('04'));
+    fixture.reader.boundaries.add('04');
+    fixture.reader.head = '04';
+
+    const plan = vi.spyOn(fixture.reader, 'plan');
+    const {subscriber, output} = createSubscriber('01');
+    await fixture.coordinator.catchup(subscriber, 'serving', () => '06');
+    await vi.waitFor(() => expect(plan).toHaveBeenCalledOnce());
+
+    fixture.reader.entries.push(...transaction('06'));
+    fixture.reader.boundaries.add('06');
+    fixture.reader.head = '06';
+    fixture.coordinator.onChangeLogWriterAck('06');
+
+    expect(await takeMarkers(output, 7)).toEqual([
+      'status',
+      ...transactionMarkers('04'),
+      ...transactionMarkers('06'),
+    ]);
+  });
+
+  test('ignores change-log ACKs below the required head', async () => {
+    const fixture = createFixture({
+      barrierTimeoutMs: 60_000,
+      barrierPollIntervalMs: 60_000,
+    });
+    fixture.reader.head = '04';
+
+    const plan = vi.spyOn(fixture.reader, 'plan');
+    const {subscriber, output} = createSubscriber('01');
+    await fixture.coordinator.catchup(subscriber, 'serving', () => '06');
+    await vi.waitFor(() => expect(plan).toHaveBeenCalledOnce());
+
+    // The writer is still behind the required head. Waking on every ACK would
+    // re-read the replica at the writer's commit rate for no reason.
+    fixture.coordinator.onChangeLogWriterAck('04');
+    await sleep(20);
+    expect(plan).toHaveBeenCalledOnce();
+    expect(output.size()).toBe(0);
+
+    fixture.reader.entries.push(...transaction('06'));
+    fixture.reader.boundaries.add('06');
+    fixture.reader.head = '06';
+    fixture.coordinator.onChangeLogWriterAck('06');
+
+    expect(await takeMarkers(output, 4)).toEqual([
+      'status',
+      ...transactionMarkers('06'),
+    ]);
+  });
+
+  test('re-reads the replica rather than trusting the ACK', async () => {
+    const fixture = createFixture({
+      barrierTimeoutMs: 60_000,
+      barrierPollIntervalMs: 60_000,
+    });
+    fixture.reader.head = '04';
+
+    const plan = vi.spyOn(fixture.reader, 'plan');
+    const {subscriber, output} = createSubscriber('01');
+    await fixture.coordinator.catchup(subscriber, 'serving', () => '06');
+    await vi.waitFor(() => expect(plan).toHaveBeenCalledOnce());
+
+    // An ACK that the reader cannot yet corroborate wakes the barrier but does
+    // not release it: plan() decides what is readable.
+    fixture.coordinator.onChangeLogWriterAck('06');
+    await vi.waitFor(() => expect(plan).toHaveBeenCalledTimes(2));
+    expect(output.size()).toBe(0);
+
+    fixture.reader.entries.push(...transaction('06'));
+    fixture.reader.boundaries.add('06');
+    fixture.reader.head = '06';
+    fixture.coordinator.onChangeLogWriterAck('06');
+
+    expect(await takeMarkers(output, 4)).toEqual([
+      'status',
+      ...transactionMarkers('06'),
+    ]);
+  });
+
   test('maps too-old plans to serving and backup policies', async () => {
     const serving = createFixture();
     serving.reader.min = '04';
@@ -396,6 +483,7 @@ describe('SQLiteChangeLogCatchup', () => {
 function createFixture(
   opts: {
     barrierTimeoutMs?: number | undefined;
+    barrierPollIntervalMs?: number | undefined;
     cleanupGuard?: SQLiteChangeLogCleanupGuard | undefined;
     now?: SQLiteChangeLogCatchupOptions['now'];
     onFatal?: SQLiteChangeLogCatchupOptions['onFatal'];
@@ -413,7 +501,7 @@ function createFixture(
   const coordinator = new SQLiteChangeLogCatchup(lc, forwarder, reader, {
     batchSize: 2,
     barrierTimeoutMs: opts.barrierTimeoutMs ?? 1_000,
-    barrierPollIntervalMs: 1,
+    barrierPollIntervalMs: opts.barrierPollIntervalMs ?? 1,
     cleanupGuard: opts.cleanupGuard,
     now: opts.now,
     onFatal,

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.test.ts
@@ -5,6 +5,7 @@ import {AbortError} from '../../../../shared/src/abort-error.ts';
 import {BigIntJSON} from '../../../../shared/src/bigint-json.ts';
 import {TestLogSink} from '../../../../shared/src/logging-test-utils.ts';
 import {Queue} from '../../../../shared/src/queue.ts';
+import {sleep} from '../../../../shared/src/sleep.ts';
 import type {Source} from '../../types/streams.ts';
 import {Subscription} from '../../types/subscription.ts';
 import type {Downstream, WatermarkedChange} from './change-streamer.ts';
@@ -243,28 +244,60 @@ describe('SQLiteChangeLogCatchup', () => {
     expect(fixture.onFatal).not.toHaveBeenCalled();
   });
 
-  test('waits on a forwarded transaction with one completion handler', async () => {
-    let now = 0;
-    const fixture = createFixture({
-      barrierTimeoutMs: 5,
-      now: () => now,
-      sleep: ms => {
-        now += ms;
-        return Promise.resolve();
-      },
-    });
+  test('waits out a transaction longer than the barrier timeout', async () => {
+    const fixture = createFixture({barrierTimeoutMs: 5});
+    fixture.reader.entries.push(...transaction('04'));
+    fixture.reader.boundaries.add('04');
+    fixture.reader.head = '04';
+
     const completion = resolver<string>();
     const then = vi.spyOn(completion.promise, 'then');
-    const {subscriber, done} = createSubscriber('01');
+    const {subscriber, output} = createSubscriber('01');
+    const fail = vi.spyOn(subscriber, 'fail');
 
     await fixture.coordinator.catchup(
       subscriber,
       'serving',
       () => completion.promise,
     );
-    await done;
 
+    // Well past barrierTimeoutMs with the transaction still in flight. The
+    // barrier bounds replica lag, so this wait must not consume its budget.
+    await sleep(50);
+    expect(fail).not.toHaveBeenCalled();
+
+    fixture.reader.entries.push(...transaction('06'));
+    fixture.reader.boundaries.add('06');
+    fixture.reader.head = '06';
+    completion.resolve('06');
+
+    // The barrier still has its full budget once the required head is known.
+    expect(await takeMarkers(output, 7)).toEqual([
+      'status',
+      ...transactionMarkers('04'),
+      ...transactionMarkers('06'),
+    ]);
     expect(then).toHaveBeenCalledOnce();
+  });
+
+  test('aborting during the required-head wait releases the subscriber', async () => {
+    const fixture = createFixture();
+    const completion = resolver<string>();
+    const {subscriber, done} = createSubscriber('01');
+    const fail = vi.spyOn(subscriber, 'fail');
+
+    await fixture.coordinator.catchup(
+      subscriber,
+      'serving',
+      () => completion.promise,
+    );
+    fixture.coordinator.remove(subscriber);
+
+    await done;
+    expect(fail).not.toHaveBeenCalled();
+    expect(
+      fixture.logSink.messages.filter(([level]) => level === 'error'),
+    ).toEqual([]);
   });
 
   test('fails closed on reader errors after registration', async () => {

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.test.ts
@@ -12,7 +12,6 @@ import {Subscription} from '../../types/subscription.ts';
 import type {Downstream, WatermarkedChange} from './change-streamer.ts';
 import * as ErrorType from './error-type-enum.ts';
 import {Forwarder} from './forwarder.ts';
-import {AutoResetSignal} from './schema/tables.ts';
 import {
   SQLiteChangeLogCatchup,
   SQLiteChangeLogBarrierBacklogError,
@@ -75,7 +74,7 @@ describe('SQLiteChangeLogCatchup', () => {
     fixture.reader.boundaries.add('04');
 
     const {subscriber, output} = createSubscriber('01');
-    await fixture.coordinator.catchup(subscriber, 'serving', () => '06');
+    await fixture.coordinator.catchup(subscriber, () => '06');
 
     // This replay reaches the Forwarder after registration but before SQLite
     // reaches the required head. It is both in the backlog and, once applied,
@@ -108,11 +107,7 @@ describe('SQLiteChangeLogCatchup', () => {
     fixture.forwarder.forward(entry('06', 'begin'));
     const completion = resolver<string>();
     const {subscriber, output} = createSubscriber('04');
-    await fixture.coordinator.catchup(
-      subscriber,
-      'serving',
-      () => completion.promise,
-    );
+    await fixture.coordinator.catchup(subscriber, () => completion.promise);
 
     fixture.forwarder.forward(entry('06', 'insert'));
     fixture.forwarder.forward(entry('06', 'commit'));
@@ -142,11 +137,7 @@ describe('SQLiteChangeLogCatchup', () => {
     fixture.forwarder.forward(entry('06', 'begin'));
     const completion = resolver<string>();
     const {subscriber, output} = createSubscriber('01');
-    await fixture.coordinator.catchup(
-      subscriber,
-      'serving',
-      () => completion.promise,
-    );
+    await fixture.coordinator.catchup(subscriber, () => completion.promise);
     fixture.forwarder.forward(entry('06', 'rollback'));
     completion.resolve('04');
 
@@ -172,7 +163,7 @@ describe('SQLiteChangeLogCatchup', () => {
     fixture.reader.beforeRead = releaseRead.promise;
 
     const {subscriber, output} = createSubscriber('01');
-    await fixture.coordinator.catchup(subscriber, 'serving', () => '06');
+    await fixture.coordinator.catchup(subscriber, () => '06');
     forward(fixture.forwarder, transaction('08'));
     forward(fixture.forwarder, transaction('0a'));
     releaseRead.resolve();
@@ -193,7 +184,7 @@ describe('SQLiteChangeLogCatchup', () => {
     fixture.reader.head = '04';
 
     const {subscriber, output} = createSubscriber('06');
-    await fixture.coordinator.catchup(subscriber, 'serving', () => '04');
+    await fixture.coordinator.catchup(subscriber, () => '04');
     forward(fixture.forwarder, transaction('06'));
     forward(fixture.forwarder, transaction('08'));
 
@@ -213,7 +204,7 @@ describe('SQLiteChangeLogCatchup', () => {
     // canonical replica is only at 04. A subscriber reconnecting at 06 must
     // wait for SQLite to replay 04..06 without receiving 06 twice.
     const {subscriber, output} = createSubscriber('06');
-    await fixture.coordinator.catchup(subscriber, 'serving', () => '06');
+    await fixture.coordinator.catchup(subscriber, () => '06');
     forward(fixture.forwarder, transaction('06'));
     fixture.reader.entries.push(...transaction('06'));
     fixture.reader.boundaries.add('06');
@@ -262,7 +253,7 @@ describe('SQLiteChangeLogCatchup', () => {
 
     const plan = vi.spyOn(fixture.reader, 'plan');
     const {subscriber, output} = createSubscriber('01');
-    await fixture.coordinator.catchup(subscriber, 'serving', () => '06');
+    await fixture.coordinator.catchup(subscriber, () => '06');
     await vi.waitFor(() => expect(plan).toHaveBeenCalledOnce());
 
     fixture.reader.entries.push(...transaction('06'));
@@ -286,7 +277,7 @@ describe('SQLiteChangeLogCatchup', () => {
 
     const plan = vi.spyOn(fixture.reader, 'plan');
     const {subscriber, output} = createSubscriber('01');
-    await fixture.coordinator.catchup(subscriber, 'serving', () => '06');
+    await fixture.coordinator.catchup(subscriber, () => '06');
     await vi.waitFor(() => expect(plan).toHaveBeenCalledOnce());
 
     // The writer is still behind the required head. Waking on every ACK would
@@ -320,7 +311,7 @@ describe('SQLiteChangeLogCatchup', () => {
     const backlogThen = vi.spyOn(backlogFull.promise, 'then');
     const cancelBacklogWait = vi.spyOn(backlogFull, 'cancel');
     vi.spyOn(subscriber, 'whenBacklogFull').mockReturnValue(backlogFull);
-    await fixture.coordinator.catchup(subscriber, 'serving', () => '06');
+    await fixture.coordinator.catchup(subscriber, () => '06');
     await vi.waitFor(() => expect(plan).toHaveBeenCalledOnce());
 
     // An ACK that the reader cannot yet corroborate wakes the barrier but does
@@ -342,39 +333,20 @@ describe('SQLiteChangeLogCatchup', () => {
     expect(cancelBacklogWait).toHaveBeenCalledOnce();
   });
 
-  test('maps too-old plans to serving and backup policies', async () => {
-    const serving = createFixture();
-    serving.reader.min = '04';
-    serving.reader.head = '06';
-    serving.reader.boundaries.add('04');
-    const servingSub = createSubscriber('01');
-    await serving.coordinator.catchup(
-      servingSub.subscriber,
-      'serving',
-      () => '06',
-    );
-    expect(await servingSub.output.dequeue()).toEqual([
+  test('maps too-old plans to WatermarkTooOld', async () => {
+    const fixture = createFixture();
+    fixture.reader.min = '04';
+    fixture.reader.head = '06';
+    fixture.reader.boundaries.add('04');
+    const {output, subscriber} = createSubscriber('01');
+    await fixture.coordinator.catchup(subscriber, () => '06');
+    expect(await output.dequeue()).toEqual([
       'error',
       {
         type: ErrorType.WatermarkTooOld,
         message: 'earliest supported watermark is 04 (requested 01)',
       },
     ]);
-    expect(serving.onFatal).not.toHaveBeenCalled();
-
-    const backup = createFixture();
-    backup.reader.min = '04';
-    backup.reader.head = '06';
-    backup.reader.boundaries.add('04');
-    const backupSub = createSubscriber('01');
-    await backup.coordinator.catchup(
-      backupSub.subscriber,
-      'backup',
-      () => '06',
-    );
-    await backupSub.done;
-    await vi.waitFor(() => expect(backup.onFatal).toHaveBeenCalledOnce());
-    expect(backup.onFatal.mock.calls[0][0]).toBeInstanceOf(AutoResetSignal);
   });
 
   test('gives up the barrier once the subscriber backlog fills', async () => {
@@ -390,7 +362,7 @@ describe('SQLiteChangeLogCatchup', () => {
       backlogHighWaterBytes: 1,
     });
     const fail = vi.spyOn(subscriber, 'fail');
-    await fixture.coordinator.catchup(subscriber, 'serving', () => '06');
+    await fixture.coordinator.catchup(subscriber, () => '06');
 
     // Past the high water mark this subscriber's send() no longer resolves,
     // so it holds up the flushes that would advance the replica it waits on.
@@ -411,7 +383,6 @@ describe('SQLiteChangeLogCatchup', () => {
         }),
       ],
     ]);
-    expect(fixture.onFatal).not.toHaveBeenCalled();
   });
 
   test('ends only the selected subscription, cleanly, on barrier timeout', async () => {
@@ -419,7 +390,7 @@ describe('SQLiteChangeLogCatchup', () => {
     fixture.reader.head = '01';
     const {subscriber, done, output} = createSubscriber('01');
     const fail = vi.spyOn(subscriber, 'fail');
-    await fixture.coordinator.catchup(subscriber, 'serving', () => '06');
+    await fixture.coordinator.catchup(subscriber, () => '06');
 
     await done;
     // A clean cancel rather than an ['error', ...] message. IncrementalSyncer
@@ -438,7 +409,6 @@ describe('SQLiteChangeLogCatchup', () => {
         }),
       ],
     ]);
-    expect(fixture.onFatal).not.toHaveBeenCalled();
   });
 
   test('waits out a transaction longer than the barrier timeout', async () => {
@@ -452,11 +422,7 @@ describe('SQLiteChangeLogCatchup', () => {
     const {subscriber, output} = createSubscriber('01');
     const fail = vi.spyOn(subscriber, 'fail');
 
-    await fixture.coordinator.catchup(
-      subscriber,
-      'serving',
-      () => completion.promise,
-    );
+    await fixture.coordinator.catchup(subscriber, () => completion.promise);
 
     // Well past barrierTimeoutMs with the transaction still in flight. The
     // barrier bounds replica lag, so this wait must not consume its budget.
@@ -483,11 +449,7 @@ describe('SQLiteChangeLogCatchup', () => {
     const {subscriber, done} = createSubscriber('01');
     const fail = vi.spyOn(subscriber, 'fail');
 
-    await fixture.coordinator.catchup(
-      subscriber,
-      'serving',
-      () => completion.promise,
-    );
+    await fixture.coordinator.catchup(subscriber, () => completion.promise);
     fixture.coordinator.remove(subscriber);
 
     await done;
@@ -503,7 +465,7 @@ describe('SQLiteChangeLogCatchup', () => {
     fixture.reader.boundaries.add('01');
     fixture.reader.readError = new Error('broken SQLite read');
     const {subscriber, done, output} = createSubscriber('01');
-    await fixture.coordinator.catchup(subscriber, 'serving', () => '06');
+    await fixture.coordinator.catchup(subscriber, () => '06');
 
     expect(await output.dequeue()).toEqual([
       'error',
@@ -520,42 +482,15 @@ describe('SQLiteChangeLogCatchup', () => {
     ]);
   });
 
-  test('fails the subscriber when fatal handling rejects', async () => {
-    const fatalError = new Error('failed to mark reset required');
-    const onFatal = vi.fn(() => Promise.reject(fatalError));
-    const fixture = createFixture({onFatal});
-    fixture.reader.min = '04';
-    fixture.reader.head = '06';
-    fixture.reader.boundaries.add('04');
-    const {subscriber, done} = createSubscriber('01');
-    const fail = vi.spyOn(subscriber, 'fail');
-
-    await fixture.coordinator.catchup(subscriber, 'backup', () => '06');
-    await vi.waitFor(() => expect(fail).toHaveBeenCalledOnce(), {
-      timeout: 100,
-    });
-    await done;
-    expect(onFatal).toHaveBeenCalledOnce();
-    expect(fail).toHaveBeenCalledWith(expect.any(AutoResetSignal));
-    expect(fixture.logSink.messages).toContainEqual([
-      'error',
-      expect.anything(),
-      [
-        expect.stringContaining('error while handling fatal SQLite catchup'),
-        fatalError,
-      ],
-    ]);
-  });
-
   test('cancellation and shutdown release catchup resources', async () => {
     const fixture = createFixture();
     fixture.reader.head = '01';
     const first = createSubscriber('01');
-    await fixture.coordinator.catchup(first.subscriber, 'serving', () => '06');
+    await fixture.coordinator.catchup(first.subscriber, () => '06');
     fixture.coordinator.remove(first.subscriber);
 
     const second = createSubscriber('01');
-    await fixture.coordinator.catchup(second.subscriber, 'serving', () => '06');
+    await fixture.coordinator.catchup(second.subscriber, () => '06');
     fixture.coordinator.close();
 
     expect(fixture.reader.closed).toBe(true);
@@ -574,11 +509,7 @@ describe('SQLiteChangeLogCatchup', () => {
     fixture.reader.head = '01';
     fixture.reader.boundaries.add('01');
     const {subscriber} = createSubscriber('01');
-    const registering = fixture.coordinator.catchup(
-      subscriber,
-      'serving',
-      () => '01',
-    );
+    const registering = fixture.coordinator.catchup(subscriber, () => '01');
 
     expect(fixture.forwarder.getAcks()).toEqual(new Set());
     guardGate.resolve();
@@ -594,7 +525,6 @@ function createFixture(
     barrierPollIntervalMs?: number | undefined;
     cleanupGuard?: SQLiteChangeLogCleanupGuard | undefined;
     now?: SQLiteChangeLogCatchupOptions['now'];
-    onFatal?: SQLiteChangeLogCatchupOptions['onFatal'];
     sleep?: SQLiteChangeLogCatchupOptions['sleep'];
   } = {},
 ) {
@@ -602,21 +532,16 @@ function createFixture(
   const lc = new LogContext('debug', undefined, logSink);
   const reader = new TestReader();
   const forwarder = new Forwarder(lc);
-  const onFatal = vi.fn(
-    opts.onFatal ??
-      ((_error: AutoResetSignal): Promise<void> => Promise.resolve()),
-  );
   const coordinator = new SQLiteChangeLogCatchup(lc, forwarder, reader, {
     batchSize: opts.batchSize ?? 2,
     barrierTimeoutMs: opts.barrierTimeoutMs ?? 1_000,
     barrierPollIntervalMs: opts.barrierPollIntervalMs ?? 1,
     cleanupGuard: opts.cleanupGuard,
     now: opts.now,
-    onFatal,
     sleep: opts.sleep,
   });
   coordinators.push(coordinator);
-  return {coordinator, forwarder, logSink, onFatal, reader};
+  return {coordinator, forwarder, logSink, reader};
 }
 
 class TestReader implements SQLiteChangeLogCatchupReader {
@@ -774,10 +699,9 @@ async function runCatchupFuzzScenario(
   if (!fixture) {
     throw new Error(`missing fixture for batch size ${scenario.batchSize}`);
   }
-  const {coordinator, forwarder, onFatal, reader} = fixture;
+  const {coordinator, forwarder, reader} = fixture;
   expect(forwarder.getAcks()).toEqual(new Set());
   resetFuzzReader(reader);
-  onFatal.mockClear();
 
   let nextIndex = 0;
   const prior = scenario.priorWidths.map(width =>
@@ -819,7 +743,7 @@ async function runCatchupFuzzScenario(
 
   const {done, output, subscriber} = createSubscriber(requestedWatermark);
   try {
-    await coordinator.catchup(subscriber, 'serving', () => requiredHead);
+    await coordinator.catchup(subscriber, () => requiredHead);
 
     if (inFlight) {
       const {completion, forwardedEntries, tx} = inFlight;
@@ -881,7 +805,6 @@ async function runCatchupFuzzScenario(
     });
     expect(subscriber.acked).toBe(sentinel.watermark);
     expect(output.size()).toBe(0);
-    expect(onFatal).not.toHaveBeenCalled();
   } finally {
     coordinator.remove(subscriber);
     await done;

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.test.ts
@@ -14,13 +14,14 @@ import {Forwarder} from './forwarder.ts';
 import {AutoResetSignal} from './schema/tables.ts';
 import {
   SQLiteChangeLogCatchup,
+  SQLiteChangeLogBarrierBacklogError,
   SQLiteChangeLogBarrierTimeoutError,
   type SQLiteChangeLogCatchupOptions,
   type SQLiteChangeLogCatchupReader,
   type SQLiteChangeLogCleanupGuard,
 } from './sqlite-change-log-catchup.ts';
 import type {CatchupPlan} from './sqlite-change-log-reader.ts';
-import {Subscriber} from './subscriber.ts';
+import {Subscriber, type SubscriberOptions} from './subscriber.ts';
 
 const coordinators: SQLiteChangeLogCatchup[] = [];
 
@@ -311,6 +312,43 @@ describe('SQLiteChangeLogCatchup', () => {
     expect(backup.onFatal.mock.calls[0][0]).toBeInstanceOf(AutoResetSignal);
   });
 
+  test('gives up the barrier once the subscriber backlog fills', async () => {
+    // Long enough that only the backlog can end this wait. Bytes, not time,
+    // are the real bound; the deadline is only a backstop for an idle shard.
+    const fixture = createFixture({
+      barrierTimeoutMs: 60_000,
+      barrierPollIntervalMs: 60_000,
+    });
+    fixture.reader.head = '01';
+
+    const {subscriber, done, output} = createSubscriber('01', {
+      backlogHighWaterBytes: 1,
+    });
+    const fail = vi.spyOn(subscriber, 'fail');
+    await fixture.coordinator.catchup(subscriber, 'serving', () => '06');
+
+    // Past the high water mark this subscriber's send() no longer resolves,
+    // so it holds up the flushes that would advance the replica it waits on.
+    forward(fixture.forwarder, transaction('06'));
+
+    await done;
+    // A clean end, same as a barrier timeout: reconnecting is cheaper than
+    // holding replication while the backlog grows.
+    expect(fail).not.toHaveBeenCalled();
+    expect(output.size()).toBe(0);
+    expect(fixture.logSink.messages).toContainEqual([
+      'warn',
+      expect.anything(),
+      [
+        expect.stringContaining('to retry SQLite catchup'),
+        expect.objectContaining({
+          name: SQLiteChangeLogBarrierBacklogError.name,
+        }),
+      ],
+    ]);
+    expect(fixture.onFatal).not.toHaveBeenCalled();
+  });
+
   test('ends only the selected subscription, cleanly, on barrier timeout', async () => {
     const fixture = createFixture({barrierTimeoutMs: 5});
     fixture.reader.head = '01';
@@ -574,7 +612,7 @@ class TestReader implements SQLiteChangeLogCatchupReader {
   }
 }
 
-function createSubscriber(watermark: string) {
+function createSubscriber(watermark: string, options: SubscriberOptions = {}) {
   const downstream = Subscription.create<string>();
   const subscriber = new Subscriber(
     5,
@@ -582,6 +620,7 @@ function createSubscriber(watermark: string) {
     watermark,
     downstream,
     () => ({tag: 'status'}),
+    options,
   );
   const {done, output} = drainToQueue(downstream);
   return {done, subscriber, output};

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.ts
@@ -1,0 +1,328 @@
+import type {LogContext} from '@rocicorp/logger';
+import {AbortError} from '../../../../shared/src/abort-error.ts';
+import {sleep} from '../../../../shared/src/sleep.ts';
+import {getOrCreateCounter} from '../../observability/metrics.ts';
+import type {ReplicatorMode} from '../replicator/replicator.ts';
+import type {WatermarkedChange} from './change-streamer.ts';
+import * as ErrorType from './error-type-enum.ts';
+import type {Forwarder} from './forwarder.ts';
+import {AutoResetSignal} from './schema/tables.ts';
+import type {CatchupPlan} from './sqlite-change-log-reader.ts';
+import type {Subscriber} from './subscriber.ts';
+
+export interface SQLiteChangeLogCatchupReader {
+  plan(fromWatermark: string): CatchupPlan;
+  read(
+    fromWatermark: string,
+    throughWatermark: string,
+    batchSize: number,
+    signal?: AbortSignal,
+  ): AsyncIterable<readonly WatermarkedChange[]>;
+  close(): void;
+}
+
+/**
+ * Slice 9 replaces this no-op implementation with a guard that waits for an
+ * in-flight purge and blocks new purge dispatch while the subscriber's ACK is
+ * made visible to the Forwarder.
+ */
+export interface SQLiteChangeLogCleanupGuard {
+  runWhilePurgeBlocked<T>(register: () => T): Promise<T>;
+}
+
+export type SQLiteChangeLogCatchupOptions = {
+  batchSize: number;
+  barrierTimeoutMs: number;
+  barrierPollIntervalMs?: number | undefined;
+  cleanupGuard?: SQLiteChangeLogCleanupGuard | undefined;
+  onFatal: (error: AutoResetSignal) => Promise<void>;
+  sleep?: typeof sleep | undefined;
+  now?: (() => number) | undefined;
+};
+
+const NOOP_CLEANUP_GUARD: SQLiteChangeLogCleanupGuard = {
+  runWhilePurgeBlocked: register => Promise.resolve(register()),
+};
+
+/**
+ * Coordinates the gap-free transition from replica-local SQLite catchup to
+ * the Forwarder's live stream.
+ *
+ * Registration and required-head capture happen in one synchronous callback.
+ * The subscriber therefore either sees a transaction in SQLite catchup or in
+ * its live backlog (duplicates across that boundary are filtered by
+ * Subscriber), never in neither place.
+ */
+export class SQLiteChangeLogCatchup implements Disposable {
+  readonly #lc: LogContext;
+  readonly #forwarder: Forwarder;
+  readonly #reader: SQLiteChangeLogCatchupReader;
+  readonly #batchSize: number;
+  readonly #barrierTimeoutMs: number;
+  readonly #barrierPollIntervalMs: number;
+  readonly #cleanupGuard: SQLiteChangeLogCleanupGuard;
+  readonly #onFatal: (error: AutoResetSignal) => Promise<void>;
+  readonly #sleep: typeof sleep;
+  readonly #now: () => number;
+  readonly #barrierTimeouts = getOrCreateCounter(
+    'replication',
+    'sqlite_change_log.barrier_timeouts',
+    'SQLite change-log catchups that timed out waiting for the required head.',
+  );
+  readonly #catchups = new Map<Subscriber, AbortController>();
+  #closed = false;
+
+  constructor(
+    lc: LogContext,
+    forwarder: Forwarder,
+    reader: SQLiteChangeLogCatchupReader,
+    opts: SQLiteChangeLogCatchupOptions,
+  ) {
+    this.#lc = lc.withContext('component', 'sqlite-change-log-catchup');
+    this.#forwarder = forwarder;
+    this.#reader = reader;
+    this.#batchSize = opts.batchSize;
+    this.#barrierTimeoutMs = opts.barrierTimeoutMs;
+    this.#barrierPollIntervalMs = opts.barrierPollIntervalMs ?? 10;
+    this.#cleanupGuard = opts.cleanupGuard ?? NOOP_CLEANUP_GUARD;
+    this.#onFatal = opts.onFatal;
+    this.#sleep = opts.sleep ?? sleep;
+    this.#now = opts.now ?? Date.now;
+  }
+
+  /**
+   * Registers the subscriber before resolving. Catchup itself continues in
+   * the background so subscribe() does not wait for SQLite to reach the
+   * required head.
+   */
+  async catchup(
+    subscriber: Subscriber,
+    mode: ReplicatorMode,
+    captureRequiredHead: () => string | Promise<string>,
+  ): Promise<void> {
+    if (this.#closed) {
+      subscriber.fail(new AbortError('SQLite change-log catchup is closed'));
+      return;
+    }
+
+    const abort = new AbortController();
+    this.#catchups.set(subscriber, abort);
+    let requiredHead: string | Promise<string> | undefined;
+    try {
+      await this.#cleanupGuard.runWhilePurgeBlocked(() => {
+        this.#throwIfAborted(abort.signal);
+        requiredHead = captureRequiredHead();
+        this.#forwarder.add(subscriber);
+      });
+    } catch (error) {
+      this.#catchups.delete(subscriber);
+      if (!abort.signal.aborted) {
+        this.#lc.error?.(
+          `error while registering SQLite catchup subscriber ${subscriber.id}`,
+          error,
+        );
+        subscriber.fail(error);
+      }
+      return;
+    }
+
+    void this.#run(
+      subscriber,
+      mode,
+      requiredHead as string | Promise<string>,
+      abort,
+    );
+  }
+
+  remove(subscriber: Subscriber): void {
+    this.#catchups.get(subscriber)?.abort();
+    this.#catchups.delete(subscriber);
+    this.#forwarder.remove(subscriber);
+  }
+
+  close(): void {
+    if (this.#closed) {
+      return;
+    }
+    this.#closed = true;
+    for (const [subscriber, abort] of this.#catchups) {
+      abort.abort();
+      this.#forwarder.remove(subscriber);
+    }
+    this.#catchups.clear();
+    this.#reader.close();
+  }
+
+  [Symbol.dispose](): void {
+    this.close();
+  }
+
+  async #run(
+    subscriber: Subscriber,
+    mode: ReplicatorMode,
+    requiredHead: string | Promise<string>,
+    abort: AbortController,
+  ): Promise<void> {
+    const {signal} = abort;
+    const deadline = this.#now() + this.#barrierTimeoutMs;
+    try {
+      const required = await this.#awaitRequiredHead(
+        requiredHead,
+        deadline,
+        signal,
+      );
+      const plan = await this.#waitForPlan(
+        subscriber.watermark,
+        required,
+        deadline,
+        signal,
+      );
+      this.#throwIfAborted(signal);
+
+      if (plan.kind === 'too-old') {
+        const message =
+          `earliest supported watermark is ${plan.minWatermark} ` +
+          `(requested ${subscriber.watermark})`;
+        if (mode === 'backup') {
+          throw new AutoResetSignal(
+            `backup replica at watermark ${subscriber.watermark} is behind ` +
+              `SQLite change log: ${plan.minWatermark}`,
+          );
+        }
+        this.#lc.warn?.(
+          `rejecting subscriber at watermark ${subscriber.watermark} ` +
+            `(earliest watermark: ${plan.minWatermark})`,
+        );
+        subscriber.close(ErrorType.WatermarkTooOld, message);
+        return;
+      }
+
+      let count = 0;
+      const start = this.#now();
+      if (plan.kind === 'range') {
+        let lastBatchConsumed: Promise<unknown> | undefined;
+        for await (const changes of this.#reader.read(
+          subscriber.watermark,
+          plan.headWatermark,
+          this.#batchSize,
+          signal,
+        )) {
+          const waitStart = this.#now();
+          await lastBatchConsumed;
+          const elapsed = this.#now() - waitStart;
+          if (lastBatchConsumed) {
+            this.#lc[elapsed > 100 ? 'info' : 'debug']?.(
+              `waited ${elapsed.toFixed(3)} ms for ${subscriber.id} to consume ` +
+                `the previous SQLite catchup batch`,
+            );
+          }
+          this.#throwIfAborted(signal);
+          for (const change of changes) {
+            lastBatchConsumed = subscriber.catchup(change);
+            count++;
+          }
+        }
+        await lastBatchConsumed;
+      } else {
+        this.#lc.warn?.(
+          `subscriber ${subscriber.id} at watermark ${subscriber.watermark} ` +
+            `is ahead of the SQLite change-log head ${plan.headWatermark}; ` +
+            `waiting for the replica to catch up`,
+        );
+      }
+
+      this.#throwIfAborted(signal);
+      this.#lc.info?.(
+        `caught up ${subscriber.id} from SQLite with ${count} changes ` +
+          `(${this.#now() - start} ms)`,
+      );
+      // Keep buffering live sends until the asynchronous backlog drain has
+      // established its ordering boundary.
+      void subscriber.setCaughtUp();
+    } catch (error) {
+      if (signal.aborted) {
+        return;
+      }
+      this.#lc.error?.(
+        `error while catching up subscriber ${subscriber.id} from SQLite`,
+        error,
+      );
+      if (error instanceof SQLiteChangeLogBarrierTimeoutError) {
+        this.#barrierTimeouts.add(1);
+      }
+      if (error instanceof AutoResetSignal) {
+        await this.#onFatal(error);
+      }
+      subscriber.fail(error);
+    } finally {
+      if (this.#catchups.get(subscriber) === abort) {
+        this.#catchups.delete(subscriber);
+      }
+    }
+  }
+
+  async #awaitRequiredHead(
+    requiredHead: string | Promise<string>,
+    deadline: number,
+    signal: AbortSignal,
+  ): Promise<string> {
+    if (typeof requiredHead === 'string') {
+      return requiredHead;
+    }
+    while (true) {
+      this.#throwIfAborted(signal);
+      const remaining = deadline - this.#now();
+      if (remaining <= 0) {
+        throw new SQLiteChangeLogBarrierTimeoutError(
+          'timed out waiting for the forwarded transaction to finish',
+        );
+      }
+      const result = await Promise.race([
+        requiredHead.then(value => ({kind: 'required', value}) as const),
+        this.#sleep(
+          Math.min(this.#barrierPollIntervalMs, remaining),
+          signal,
+        ).then(() => ({kind: 'pending'}) as const),
+      ]);
+      if (result.kind === 'required') {
+        return result.value;
+      }
+    }
+  }
+
+  async #waitForPlan(
+    fromWatermark: string,
+    requiredHead: string,
+    deadline: number,
+    signal: AbortSignal,
+  ): Promise<CatchupPlan> {
+    while (true) {
+      this.#throwIfAborted(signal);
+      const plan = this.#reader.plan(fromWatermark);
+      if (plan.headWatermark >= requiredHead) {
+        return plan;
+      }
+      const remaining = deadline - this.#now();
+      if (remaining <= 0) {
+        throw new SQLiteChangeLogBarrierTimeoutError(
+          `timed out waiting for SQLite head ${plan.headWatermark} to reach ` +
+            `required head ${requiredHead}`,
+        );
+      }
+      await this.#sleep(
+        Math.min(this.#barrierPollIntervalMs, remaining),
+        signal,
+      );
+    }
+  }
+
+  #throwIfAborted(signal: AbortSignal): void {
+    if (this.#closed || signal.aborted) {
+      throw new AbortError('SQLite change-log catchup aborted');
+    }
+  }
+}
+
+export class SQLiteChangeLogBarrierTimeoutError extends Error {
+  readonly name = 'SQLiteChangeLogBarrierTimeoutError';
+}

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.ts
@@ -251,7 +251,14 @@ export class SQLiteChangeLogCatchup implements Disposable {
         this.#barrierTimeouts.add(1);
       }
       if (error instanceof AutoResetSignal) {
-        await this.#onFatal(error);
+        try {
+          await this.#onFatal(error);
+        } catch (fatalError) {
+          this.#lc.error?.(
+            `error while handling fatal SQLite catchup failure for ${subscriber.id}`,
+            fatalError,
+          );
+        }
       }
       subscriber.fail(error);
     } finally {
@@ -269,25 +276,23 @@ export class SQLiteChangeLogCatchup implements Disposable {
     if (typeof requiredHead === 'string') {
       return requiredHead;
     }
-    while (true) {
-      this.#throwIfAborted(signal);
-      const remaining = deadline - this.#now();
-      if (remaining <= 0) {
-        throw new SQLiteChangeLogBarrierTimeoutError(
-          'timed out waiting for the forwarded transaction to finish',
-        );
-      }
-      const result = await Promise.race([
-        requiredHead.then(value => ({kind: 'required', value}) as const),
-        this.#sleep(
-          Math.min(this.#barrierPollIntervalMs, remaining),
-          signal,
-        ).then(() => ({kind: 'pending'}) as const),
-      ]);
-      if (result.kind === 'required') {
-        return result.value;
-      }
+    this.#throwIfAborted(signal);
+    const remaining = deadline - this.#now();
+    if (remaining <= 0) {
+      throw new SQLiteChangeLogBarrierTimeoutError(
+        'timed out waiting for the forwarded transaction to finish',
+      );
     }
+    const result = await Promise.race([
+      requiredHead.then(value => ({kind: 'required', value}) as const),
+      this.#sleep(remaining, signal).then(() => ({kind: 'timeout'}) as const),
+    ]);
+    if (result.kind === 'timeout') {
+      throw new SQLiteChangeLogBarrierTimeoutError(
+        'timed out waiting for the forwarded transaction to finish',
+      );
+    }
+    return result.value;
   }
 
   async #waitForPlan(

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.ts
@@ -164,13 +164,22 @@ export class SQLiteChangeLogCatchup implements Disposable {
     abort: AbortController,
   ): Promise<void> {
     const {signal} = abort;
-    const deadline = this.#now() + this.#barrierTimeoutMs;
     try {
-      const required = await this.#awaitRequiredHead(
-        requiredHead,
-        deadline,
-        signal,
-      );
+      const requiredHeadStart = this.#now();
+      const required = await this.#awaitRequiredHead(requiredHead, signal);
+      const requiredHeadWaitMs = this.#now() - requiredHeadStart;
+      if (requiredHeadWaitMs > this.#barrierTimeoutMs) {
+        this.#lc.info?.(
+          `waited ${requiredHeadWaitMs} ms for the forwarded transaction to ` +
+            `commit before starting the SQLite barrier for ${subscriber.id}`,
+        );
+      }
+      // The barrier bounds replica lag, not upstream transaction duration, so
+      // its deadline starts once the required head is known. Sharing one
+      // deadline with the wait above would fail subscribers that registered
+      // during a transaction longer than barrierTimeoutMs, however current
+      // the replica is.
+      const deadline = this.#now() + this.#barrierTimeoutMs;
       const plan = await this.#waitForPlan(
         subscriber.watermark,
         required,
@@ -268,31 +277,38 @@ export class SQLiteChangeLogCatchup implements Disposable {
     }
   }
 
+  /**
+   * Waits for the transaction that was in flight at registration to finish.
+   *
+   * This wait is bounded by the upstream transaction rather than by
+   * `barrierTimeoutMs`: the completion settles on both commit and rollback,
+   * and an interrupted change stream forwards a synthetic rollback, so it
+   * always settles. Aborting -- the subscriber disconnecting or the service
+   * shutting down -- is what releases it early.
+   */
   async #awaitRequiredHead(
     requiredHead: string | Promise<string>,
-    deadline: number,
     signal: AbortSignal,
   ): Promise<string> {
     if (typeof requiredHead === 'string') {
       return requiredHead;
     }
     this.#throwIfAborted(signal);
-    const remaining = deadline - this.#now();
-    if (remaining <= 0) {
-      throw new SQLiteChangeLogBarrierTimeoutError(
-        'timed out waiting for the forwarded transaction to finish',
-      );
+    let onAbort: (() => void) | undefined;
+    try {
+      return await Promise.race([
+        requiredHead,
+        new Promise<never>((_, reject) => {
+          onAbort = () =>
+            reject(new AbortError('SQLite change-log catchup aborted'));
+          signal.addEventListener('abort', onAbort, {once: true});
+        }),
+      ]);
+    } finally {
+      if (onAbort) {
+        signal.removeEventListener('abort', onAbort);
+      }
     }
-    const result = await Promise.race([
-      requiredHead.then(value => ({kind: 'required', value}) as const),
-      this.#sleep(remaining, signal).then(() => ({kind: 'timeout'}) as const),
-    ]);
-    if (result.kind === 'timeout') {
-      throw new SQLiteChangeLogBarrierTimeoutError(
-        'timed out waiting for the forwarded transaction to finish',
-      );
-    }
-    return result.value;
   }
 
   async #waitForPlan(

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.ts
@@ -3,11 +3,9 @@ import {resolver} from '@rocicorp/resolver';
 import {AbortError} from '../../../../shared/src/abort-error.ts';
 import {sleep} from '../../../../shared/src/sleep.ts';
 import {getOrCreateCounter} from '../../observability/metrics.ts';
-import type {ReplicatorMode} from '../replicator/replicator.ts';
 import type {WatermarkedChange} from './change-streamer.ts';
 import * as ErrorType from './error-type-enum.ts';
 import type {Forwarder} from './forwarder.ts';
-import {AutoResetSignal} from './schema/tables.ts';
 import type {CatchupPlan} from './sqlite-change-log-reader.ts';
 import type {Subscriber} from './subscriber.ts';
 
@@ -43,7 +41,6 @@ export type SQLiteChangeLogCatchupOptions = {
   barrierTimeoutMs: number;
   barrierPollIntervalMs?: number | undefined;
   cleanupGuard?: SQLiteChangeLogCleanupGuard | undefined;
-  onFatal: (error: AutoResetSignal) => Promise<void>;
   sleep?: typeof sleep | undefined;
   now?: (() => number) | undefined;
 };
@@ -53,8 +50,8 @@ const NOOP_CLEANUP_GUARD: SQLiteChangeLogCleanupGuard = {
 };
 
 /**
- * Coordinates the gap-free transition from replica-local SQLite catchup to
- * the Forwarder's live stream.
+ * Coordinates a serving subscriber's gap-free transition from replica-local
+ * SQLite catchup to the Forwarder's live stream.
  *
  * Registration and required-head capture happen in one synchronous callback.
  * The subscriber therefore either sees a transaction in SQLite catchup or in
@@ -69,7 +66,6 @@ export class SQLiteChangeLogCatchup implements Disposable {
   readonly #barrierTimeoutMs: number;
   readonly #barrierPollIntervalMs: number;
   readonly #cleanupGuard: SQLiteChangeLogCleanupGuard;
-  readonly #onFatal: (error: AutoResetSignal) => Promise<void>;
   readonly #sleep: typeof sleep;
   readonly #now: () => number;
   readonly #barrierTimeouts = getOrCreateCounter(
@@ -108,7 +104,6 @@ export class SQLiteChangeLogCatchup implements Disposable {
     this.#barrierPollIntervalMs =
       opts.barrierPollIntervalMs ?? DEFAULT_BARRIER_POLL_INTERVAL_MS;
     this.#cleanupGuard = opts.cleanupGuard ?? NOOP_CLEANUP_GUARD;
-    this.#onFatal = opts.onFatal;
     this.#sleep = opts.sleep ?? sleep;
     this.#now = opts.now ?? Date.now;
   }
@@ -120,7 +115,6 @@ export class SQLiteChangeLogCatchup implements Disposable {
    */
   async catchup(
     subscriber: Subscriber,
-    mode: ReplicatorMode,
     captureRequiredHead: () => string | Promise<string>,
   ): Promise<void> {
     if (this.#closed) {
@@ -149,12 +143,7 @@ export class SQLiteChangeLogCatchup implements Disposable {
       return;
     }
 
-    void this.#run(
-      subscriber,
-      mode,
-      requiredHead as string | Promise<string>,
-      abort,
-    );
+    void this.#run(subscriber, requiredHead as string | Promise<string>, abort);
   }
 
   /**
@@ -201,7 +190,6 @@ export class SQLiteChangeLogCatchup implements Disposable {
 
   async #run(
     subscriber: Subscriber,
-    mode: ReplicatorMode,
     requiredHead: string | Promise<string>,
     abort: AbortController,
   ): Promise<void> {
@@ -234,12 +222,6 @@ export class SQLiteChangeLogCatchup implements Disposable {
         const message =
           `earliest supported watermark is ${plan.minWatermark} ` +
           `(requested ${subscriber.watermark})`;
-        if (mode === 'backup') {
-          throw new AutoResetSignal(
-            `backup replica at watermark ${subscriber.watermark} is behind ` +
-              `SQLite change log: ${plan.minWatermark}`,
-          );
-        }
         this.#lc.warn?.(
           `rejecting subscriber at watermark ${subscriber.watermark} ` +
             `(earliest watermark: ${plan.minWatermark})`,
@@ -317,16 +299,6 @@ export class SQLiteChangeLogCatchup implements Disposable {
         `error while catching up subscriber ${subscriber.id} from SQLite`,
         error,
       );
-      if (error instanceof AutoResetSignal) {
-        try {
-          await this.#onFatal(error);
-        } catch (fatalError) {
-          this.#lc.error?.(
-            `error while handling fatal SQLite catchup failure for ${subscriber.id}`,
-            fatalError,
-          );
-        }
-      }
       subscriber.fail(error);
     } finally {
       if (this.#catchups.get(subscriber) === abort) {

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.ts
@@ -1,4 +1,5 @@
 import type {LogContext} from '@rocicorp/logger';
+import {resolver} from '@rocicorp/resolver';
 import {AbortError} from '../../../../shared/src/abort-error.ts';
 import {sleep} from '../../../../shared/src/sleep.ts';
 import {getOrCreateCounter} from '../../observability/metrics.ts';
@@ -29,6 +30,13 @@ export interface SQLiteChangeLogCatchupReader {
 export interface SQLiteChangeLogCleanupGuard {
   runWhilePurgeBlocked<T>(register: () => T): Promise<T>;
 }
+
+// How long the barrier waits for the change-log writer's ACK before falling
+// back to reading the replica. The ACK normally arrives first, so this is a
+// backstop for the windows in which no ACK is coming: no writer is subscribed
+// (in which case the change log cannot be advancing either), the writer is
+// mid-reconnect, or it predates the `logsChangeStream` subscription parameter.
+const DEFAULT_BARRIER_POLL_INTERVAL_MS = 1000;
 
 export type SQLiteChangeLogCatchupOptions = {
   batchSize: number;
@@ -69,7 +77,15 @@ export class SQLiteChangeLogCatchup implements Disposable {
     'sqlite_change_log.barrier_timeouts',
     'SQLite change-log catchups that timed out waiting for the required head.',
   );
+  readonly #barrierWakeups = getOrCreateCounter(
+    'replication',
+    'sqlite_change_log.barrier_wakeups',
+    'SQLite catchup barrier waits, labeled by what ended the wait. A ' +
+      'population dominated by "poll" means the change-log writer ACK is not ' +
+      'reaching the barrier.',
+  );
   readonly #catchups = new Map<Subscriber, AbortController>();
+  readonly #ackWaiters = new Set<AckWaiter>();
   #closed = false;
 
   constructor(
@@ -83,7 +99,8 @@ export class SQLiteChangeLogCatchup implements Disposable {
     this.#reader = reader;
     this.#batchSize = opts.batchSize;
     this.#barrierTimeoutMs = opts.barrierTimeoutMs;
-    this.#barrierPollIntervalMs = opts.barrierPollIntervalMs ?? 10;
+    this.#barrierPollIntervalMs =
+      opts.barrierPollIntervalMs ?? DEFAULT_BARRIER_POLL_INTERVAL_MS;
     this.#cleanupGuard = opts.cleanupGuard ?? NOOP_CLEANUP_GUARD;
     this.#onFatal = opts.onFatal;
     this.#sleep = opts.sleep ?? sleep;
@@ -132,6 +149,25 @@ export class SQLiteChangeLogCatchup implements Disposable {
       requiredHead as string | Promise<string>,
       abort,
     );
+  }
+
+  /**
+   * Notes that the subscriber writing the SQLite change log has acked
+   * `watermark`, i.e. has durably applied it to the replica this coordinator
+   * reads. That is the only event that advances the change log, so it is what
+   * the barrier waits on instead of polling the replica for it.
+   *
+   * The ACK is a wakeup, not an authority: `plan()` still decides what can be
+   * read. An ACK that never arrives costs the barrier a poll interval, and one
+   * that arrives early costs an extra `plan()` call.
+   */
+  onChangeLogWriterAck(watermark: string): void {
+    for (const waiter of this.#ackWaiters) {
+      if (watermark >= waiter.watermark) {
+        this.#ackWaiters.delete(waiter);
+        waiter.resolve();
+      }
+    }
   }
 
   remove(subscriber: Subscriber): void {
@@ -344,10 +380,44 @@ export class SQLiteChangeLogCatchup implements Disposable {
             `required head ${requiredHead}`,
         );
       }
-      await this.#sleep(
-        Math.min(this.#barrierPollIntervalMs, remaining),
-        signal,
-      );
+      await this.#awaitChangeLogProgress(requiredHead, remaining, signal);
+    }
+  }
+
+  /**
+   * Waits for a reason to re-read the replica: the change-log writer's ACK of
+   * `requiredHead`, or the poll interval as a backstop.
+   *
+   * No ACK can be missed by registering after `plan()` was read, because the
+   * ACK lags the write it acknowledges: if the writer had already acked
+   * `requiredHead`, `plan()` would have seen it.
+   */
+  async #awaitChangeLogProgress(
+    requiredHead: string,
+    remainingMs: number,
+    signal: AbortSignal,
+  ): Promise<void> {
+    const acked = resolver<void>();
+    const waiter = {watermark: requiredHead, resolve: acked.resolve};
+    this.#ackWaiters.add(waiter);
+    // Scopes the backstop timer to this wait so that an ACK cancels it rather
+    // than leaving it to fire against a barrier that has already moved on.
+    const poll = new AbortController();
+    const abortPoll = () => poll.abort();
+    signal.addEventListener('abort', abortPoll, {once: true});
+    try {
+      const wokenBy = await Promise.race([
+        acked.promise.then(() => 'ack' as const),
+        this.#sleep(
+          Math.min(this.#barrierPollIntervalMs, remainingMs),
+          poll.signal,
+        ).then(() => 'poll' as const),
+      ]);
+      this.#barrierWakeups.add(1, {'wakeup.source': wokenBy});
+    } finally {
+      this.#ackWaiters.delete(waiter);
+      signal.removeEventListener('abort', abortPoll);
+      poll.abort();
     }
   }
 
@@ -357,6 +427,8 @@ export class SQLiteChangeLogCatchup implements Disposable {
     }
   }
 }
+
+type AckWaiter = {watermark: string; resolve: () => void};
 
 export class SQLiteChangeLogBarrierTimeoutError extends Error {
   readonly name = 'SQLiteChangeLogBarrierTimeoutError';

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.ts
@@ -77,6 +77,12 @@ export class SQLiteChangeLogCatchup implements Disposable {
     'sqlite_change_log.barrier_timeouts',
     'SQLite change-log catchups that timed out waiting for the required head.',
   );
+  readonly #barrierBacklogOverflows = getOrCreateCounter(
+    'replication',
+    'sqlite_change_log.barrier_backlog_overflows',
+    'SQLite change-log catchups abandoned because the subscriber backlog ' +
+      'reached its high water mark while waiting for the required head.',
+  );
   readonly #barrierWakeups = getOrCreateCounter(
     'replication',
     'sqlite_change_log.barrier_wakeups',
@@ -217,7 +223,7 @@ export class SQLiteChangeLogCatchup implements Disposable {
       // the replica is.
       const deadline = this.#now() + this.#barrierTimeoutMs;
       const plan = await this.#waitForPlan(
-        subscriber.watermark,
+        subscriber,
         required,
         deadline,
         signal,
@@ -288,16 +294,18 @@ export class SQLiteChangeLogCatchup implements Disposable {
       if (signal.aborted) {
         return;
       }
-      if (error instanceof SQLiteChangeLogBarrierTimeoutError) {
-        this.#barrierTimeouts.add(1);
-        // A barrier timeout means the replica has not caught up *yet*, not
-        // that it cannot serve this subscriber. End the subscription cleanly
-        // so the client reconnects and retries: IncrementalSyncer treats any
-        // ['error', ...] message as terminal and restores a fresh replica from
-        // litestream, whereas a clean end backs off and re-subscribes. If
-        // retries keep failing until the change log is purged past the
-        // subscriber's watermark, plan() returns 'too-old', which is terminal
-        // by design.
+      if (error instanceof SQLiteChangeLogBarrierError) {
+        if (error instanceof SQLiteChangeLogBarrierTimeoutError) {
+          this.#barrierTimeouts.add(1);
+        }
+        // Giving up on the barrier means the replica has not caught up *yet*,
+        // not that it cannot serve this subscriber. End the subscription
+        // cleanly so the client reconnects and retries: IncrementalSyncer
+        // treats any ['error', ...] message as terminal and restores a fresh
+        // replica from litestream, whereas a clean end backs off and
+        // re-subscribes. If retries keep failing until the change log is purged
+        // past the subscriber's watermark, plan() returns 'too-old', which is
+        // terminal by design.
         this.#lc.warn?.(
           `ending subscription for ${subscriber.id} to retry SQLite catchup`,
           error,
@@ -362,14 +370,18 @@ export class SQLiteChangeLogCatchup implements Disposable {
   }
 
   async #waitForPlan(
-    fromWatermark: string,
+    subscriber: Subscriber,
     requiredHead: string,
     deadline: number,
     signal: AbortSignal,
   ): Promise<CatchupPlan> {
+    // Registered once for the whole barrier rather than per wait, both to
+    // bound the waiters a long barrier accumulates and because the crossing
+    // is one-way: the backlog cannot shrink while catchup is buffering it.
+    const backlogFull = subscriber.whenBacklogFull();
     while (true) {
       this.#throwIfAborted(signal);
-      const plan = this.#reader.plan(fromWatermark);
+      const plan = this.#reader.plan(subscriber.watermark);
       if (plan.headWatermark >= requiredHead) {
         return plan;
       }
@@ -380,13 +392,31 @@ export class SQLiteChangeLogCatchup implements Disposable {
             `required head ${requiredHead}`,
         );
       }
-      await this.#awaitChangeLogProgress(requiredHead, remaining, signal);
+      await this.#awaitChangeLogProgress(
+        requiredHead,
+        remaining,
+        backlogFull,
+        signal,
+      );
+      // Bytes, not time, are what the barrier actually costs: past the high
+      // water mark this subscriber's send() no longer resolves, so it holds up
+      // every flush and, with no other subscriber to form a majority, stalls
+      // replication -- which stalls the very replica the barrier waits on.
+      if (subscriber.backlogFull) {
+        this.#barrierBacklogOverflows.add(1);
+        throw new SQLiteChangeLogBarrierBacklogError(
+          `backlog for subscriber ${subscriber.id} reached its high water ` +
+            `mark while waiting for SQLite head ${plan.headWatermark} to ` +
+            `reach required head ${requiredHead}`,
+        );
+      }
     }
   }
 
   /**
-   * Waits for a reason to re-read the replica: the change-log writer's ACK of
-   * `requiredHead`, or the poll interval as a backstop.
+   * Waits for a reason to stop waiting: the change-log writer's ACK of
+   * `requiredHead`, the subscriber's backlog filling up, or the poll interval
+   * as a backstop.
    *
    * No ACK can be missed by registering after `plan()` was read, because the
    * ACK lags the write it acknowledges: if the writer had already acked
@@ -395,6 +425,7 @@ export class SQLiteChangeLogCatchup implements Disposable {
   async #awaitChangeLogProgress(
     requiredHead: string,
     remainingMs: number,
+    backlogFull: Promise<void>,
     signal: AbortSignal,
   ): Promise<void> {
     const acked = resolver<void>();
@@ -408,6 +439,7 @@ export class SQLiteChangeLogCatchup implements Disposable {
     try {
       const wokenBy = await Promise.race([
         acked.promise.then(() => 'ack' as const),
+        backlogFull.then(() => 'backlog' as const),
         this.#sleep(
           Math.min(this.#barrierPollIntervalMs, remainingMs),
           poll.signal,
@@ -430,6 +462,19 @@ export class SQLiteChangeLogCatchup implements Disposable {
 
 type AckWaiter = {watermark: string; resolve: () => void};
 
-export class SQLiteChangeLogBarrierTimeoutError extends Error {
+/**
+ * A barrier that gave up on the replica reaching the required head. Both
+ * reasons mean "not yet", not "never", so both end the subscription cleanly
+ * for a retry rather than failing it.
+ */
+export class SQLiteChangeLogBarrierError extends Error {}
+
+/** The replica did not reach the required head before the deadline. */
+export class SQLiteChangeLogBarrierTimeoutError extends SQLiteChangeLogBarrierError {
   readonly name = 'SQLiteChangeLogBarrierTimeoutError';
+}
+
+/** Waiting any longer would have cost more than reconnecting. */
+export class SQLiteChangeLogBarrierBacklogError extends SQLiteChangeLogBarrierError {
+  readonly name = 'SQLiteChangeLogBarrierBacklogError';
 }

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.ts
@@ -375,48 +375,72 @@ export class SQLiteChangeLogCatchup implements Disposable {
     deadline: number,
     signal: AbortSignal,
   ): Promise<CatchupPlan> {
-    // Registered once for the whole barrier rather than per wait, both to
-    // bound the waiters a long barrier accumulates and because the crossing
-    // is one-way: the backlog cannot shrink while catchup is buffering it.
+    // Race backlog growth once around the whole polling loop. Attaching the
+    // same unresolved promise to every per-poll race would retain one reaction
+    // per iteration until the subscriber's backlog eventually filled.
     const backlogFull = subscriber.whenBacklogFull();
-    while (true) {
-      this.#throwIfAborted(signal);
-      const plan = this.#reader.plan(subscriber.watermark);
-      if (plan.headWatermark >= requiredHead) {
-        return plan;
-      }
-      const remaining = deadline - this.#now();
-      if (remaining <= 0) {
-        throw new SQLiteChangeLogBarrierTimeoutError(
-          `timed out waiting for SQLite head ${plan.headWatermark} to reach ` +
-            `required head ${requiredHead}`,
-        );
-      }
-      await this.#awaitChangeLogProgress(
-        requiredHead,
-        remaining,
-        backlogFull,
-        signal,
-      );
-      // Bytes, not time, are what the barrier actually costs: past the high
-      // water mark this subscriber's send() no longer resolves, so it holds up
-      // every flush and, with no other subscriber to form a majority, stalls
-      // replication -- which stalls the very replica the barrier waits on.
-      if (subscriber.backlogFull) {
+    const barrier = new AbortController();
+    const abortBarrier = () => barrier.abort();
+    signal.addEventListener('abort', abortBarrier, {once: true});
+    if (signal.aborted) {
+      barrier.abort();
+    }
+
+    let observedHead = subscriber.watermark;
+    try {
+      const planReady = (async () => {
+        while (true) {
+          this.#throwIfAborted(barrier.signal);
+          const plan = this.#reader.plan(subscriber.watermark);
+          observedHead = plan.headWatermark;
+          if (plan.headWatermark >= requiredHead) {
+            return plan;
+          }
+          const remaining = deadline - this.#now();
+          if (remaining <= 0) {
+            throw new SQLiteChangeLogBarrierTimeoutError(
+              `timed out waiting for SQLite head ${plan.headWatermark} to ` +
+                `reach required head ${requiredHead}`,
+            );
+          }
+          await this.#awaitChangeLogProgress(
+            requiredHead,
+            remaining,
+            barrier.signal,
+          );
+        }
+      })();
+
+      const backlogOverflow = backlogFull.promise.then(() => {
+        this.#throwIfAborted(signal);
+        // close() also resolves backlog waiters so none are stranded. The
+        // backlog is cleared first, which distinguishes close from overflow.
+        if (!subscriber.backlogFull) {
+          return new Promise<never>(() => {});
+        }
+        this.#barrierWakeups.add(1, {'wakeup.source': 'backlog'});
+        // Bytes, not time, are what the barrier actually costs: past the high
+        // water mark this subscriber's send() no longer resolves, so it holds
+        // up every flush and can stall the replica this barrier waits on.
         this.#barrierBacklogOverflows.add(1);
         throw new SQLiteChangeLogBarrierBacklogError(
           `backlog for subscriber ${subscriber.id} reached its high water ` +
-            `mark while waiting for SQLite head ${plan.headWatermark} to ` +
+            `mark while waiting for SQLite head ${observedHead} to ` +
             `reach required head ${requiredHead}`,
         );
-      }
+      });
+
+      return await Promise.race([planReady, backlogOverflow]);
+    } finally {
+      signal.removeEventListener('abort', abortBarrier);
+      barrier.abort();
+      backlogFull.cancel();
     }
   }
 
   /**
-   * Waits for a reason to stop waiting: the change-log writer's ACK of
-   * `requiredHead`, the subscriber's backlog filling up, or the poll interval
-   * as a backstop.
+   * Waits for the change-log writer's ACK of `requiredHead`, or the poll
+   * interval as a backstop.
    *
    * No ACK can be missed by registering after `plan()` was read, because the
    * ACK lags the write it acknowledges: if the writer had already acked
@@ -425,7 +449,6 @@ export class SQLiteChangeLogCatchup implements Disposable {
   async #awaitChangeLogProgress(
     requiredHead: string,
     remainingMs: number,
-    backlogFull: Promise<void>,
     signal: AbortSignal,
   ): Promise<void> {
     const acked = resolver<void>();
@@ -439,7 +462,6 @@ export class SQLiteChangeLogCatchup implements Disposable {
     try {
       const wokenBy = await Promise.race([
         acked.promise.then(() => 'ack' as const),
-        backlogFull.then(() => 'backlog' as const),
         this.#sleep(
           Math.min(this.#barrierPollIntervalMs, remainingMs),
           poll.signal,

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.ts
@@ -252,13 +252,27 @@ export class SQLiteChangeLogCatchup implements Disposable {
       if (signal.aborted) {
         return;
       }
+      if (error instanceof SQLiteChangeLogBarrierTimeoutError) {
+        this.#barrierTimeouts.add(1);
+        // A barrier timeout means the replica has not caught up *yet*, not
+        // that it cannot serve this subscriber. End the subscription cleanly
+        // so the client reconnects and retries: IncrementalSyncer treats any
+        // ['error', ...] message as terminal and restores a fresh replica from
+        // litestream, whereas a clean end backs off and re-subscribes. If
+        // retries keep failing until the change log is purged past the
+        // subscriber's watermark, plan() returns 'too-old', which is terminal
+        // by design.
+        this.#lc.warn?.(
+          `ending subscription for ${subscriber.id} to retry SQLite catchup`,
+          error,
+        );
+        subscriber.close();
+        return;
+      }
       this.#lc.error?.(
         `error while catching up subscriber ${subscriber.id} from SQLite`,
         error,
       );
-      if (error instanceof SQLiteChangeLogBarrierTimeoutError) {
-        this.#barrierTimeouts.add(1);
-      }
       if (error instanceof AutoResetSignal) {
         try {
           await this.#onFatal(error);

--- a/packages/zero-cache/src/services/change-streamer/storer.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.pg.test.ts
@@ -984,21 +984,12 @@ describe('change-streamer/storer', () => {
       // Prevent the beforeEach cleanup from re-throwing the rejected done.
       done = Promise.resolve();
 
-      // Subscribers that were waiting to be caught up receive the terminal
-      // error and are canceled after consuming it.
+      // Subscribers that were waiting to be caught up are canceled without a
+      // downstream error, so they reconnect rather than restoring a replica.
+      // An ownership handoff is a routine event; it must not fan out into a
+      // fleet-wide litestream restore.
       for (const stream of [stream1, stream2]) {
         const iterator = stream[Symbol.asyncIterator]();
-        const error = await iterator.next();
-        expect(error.done).toBeFalsy();
-        expect(JSON.parse(error.value as string)).toEqual([
-          'error',
-          {
-            type: ErrorType.Unknown,
-            message: expect.stringContaining(
-              'changeLog ownership has been assumed by other-task',
-            ),
-          },
-        ]);
         expect((await iterator.next()).done).toBe(true);
       }
       expect(stream1.active).toBe(false);

--- a/packages/zero-cache/src/services/change-streamer/storer.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.pg.test.ts
@@ -984,7 +984,23 @@ describe('change-streamer/storer', () => {
       // Prevent the beforeEach cleanup from re-throwing the rejected done.
       done = Promise.resolve();
 
-      // subscribers that were waiting to be caught up should be canceled
+      // Subscribers that were waiting to be caught up receive the terminal
+      // error and are canceled after consuming it.
+      for (const stream of [stream1, stream2]) {
+        const iterator = stream[Symbol.asyncIterator]();
+        const error = await iterator.next();
+        expect(error.done).toBe(false);
+        expect(JSON.parse(error.value as string)).toEqual([
+          'error',
+          {
+            type: ErrorType.Unknown,
+            message: expect.stringContaining(
+              'changeLog ownership has been assumed by other-task',
+            ),
+          },
+        ]);
+        expect((await iterator.next()).done).toBe(true);
+      }
       expect(stream1.active).toBe(false);
       expect(stream2.active).toBe(false);
     });

--- a/packages/zero-cache/src/services/change-streamer/storer.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.pg.test.ts
@@ -989,7 +989,7 @@ describe('change-streamer/storer', () => {
       for (const stream of [stream1, stream2]) {
         const iterator = stream[Symbol.asyncIterator]();
         const error = await iterator.next();
-        expect(error.done).toBe(false);
+        expect(error.done).toBeFalsy();
         expect(JSON.parse(error.value as string)).toEqual([
           'error',
           {

--- a/packages/zero-cache/src/services/change-streamer/subscriber.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/subscriber.test.ts
@@ -1,5 +1,6 @@
 import {describe, expect, test} from 'vitest';
 import {ReplicationMessages} from '../replicator/test-utils.ts';
+import * as ErrorType from './error-type-enum.ts';
 import {createSubscriber} from './test-utils.ts';
 
 const json = JSON.stringify;
@@ -264,7 +265,8 @@ describe('change-streamer/subscriber', () => {
     });
 
     let full = false;
-    void sub.whenBacklogFull().then(() => {
+    const backlogFull = sub.whenBacklogFull();
+    void backlogFull.promise.then(() => {
       full = true;
     });
     expect(sub.backlogFull).toBe(false);
@@ -294,7 +296,8 @@ describe('change-streamer/subscriber', () => {
     });
 
     let full = false;
-    const waiting = sub.whenBacklogFull().then(() => {
+    const backlogFull = sub.whenBacklogFull();
+    const waiting = backlogFull.promise.then(() => {
       full = true;
     });
 
@@ -304,6 +307,48 @@ describe('change-streamer/subscriber', () => {
     // caller that re-checks does not mistake this for an overflow.
     expect(full).toBe(true);
     expect(sub.backlogFull).toBe(false);
+  });
+
+  test('whenBacklogFull waiters can be cancelled', async () => {
+    const [sub] = createSubscriber('00', false, {
+      backlogHighWaterBytes: 1,
+    });
+
+    let full = false;
+    const backlogFull = sub.whenBacklogFull();
+    void backlogFull.promise.then(() => {
+      full = true;
+    });
+    backlogFull.cancel();
+
+    const blocked = sub.send([
+      '11',
+      'begin',
+      json(['begin', messages.begin(), {commitWatermark: '12'}]),
+    ]);
+    await Promise.resolve();
+    expect(sub.backlogFull).toBe(true);
+    expect(full).toBe(false);
+
+    sub.close();
+    await blocked;
+    await Promise.resolve();
+    expect(full).toBe(false);
+  });
+
+  test('fail sends the Unknown error code', async () => {
+    const [sub, , receiver] = createSubscriber();
+    const iterator = receiver[Symbol.asyncIterator]();
+
+    sub.fail(new Error('boom'));
+
+    const error = await iterator.next();
+    expect(error.done).toBeFalsy();
+    expect(JSON.parse(error.value as string)).toEqual([
+      'error',
+      {type: ErrorType.Unknown, message: 'Error: boom'},
+    ]);
+    expect((await iterator.next()).done).toBe(true);
   });
 
   test('close releases backlog backpressure', async () => {

--- a/packages/zero-cache/src/services/change-streamer/subscriber.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/subscriber.test.ts
@@ -336,17 +336,29 @@ describe('change-streamer/subscriber', () => {
     expect(full).toBe(false);
   });
 
-  test('fail sends the Unknown error code', async () => {
+  test('fail ends the subscription without sending an error', async () => {
     const [sub, , receiver] = createSubscriber();
     const iterator = receiver[Symbol.asyncIterator]();
 
     sub.fail(new Error('boom'));
 
+    // No ['error', ...] downstream: IncrementalSyncer would treat it as
+    // terminal and restore a fresh replica, where these failures only warrant
+    // a reconnect.
+    expect((await iterator.next()).done).toBe(true);
+  });
+
+  test('close with an error type sends it downstream', async () => {
+    const [sub, , receiver] = createSubscriber();
+    const iterator = receiver[Symbol.asyncIterator]();
+
+    sub.close(ErrorType.WatermarkTooOld, 'too old');
+
     const error = await iterator.next();
     expect(error.done).toBeFalsy();
     expect(JSON.parse(error.value as string)).toEqual([
       'error',
-      {type: ErrorType.Unknown, message: 'Error: boom'},
+      {type: ErrorType.WatermarkTooOld, message: 'too old'},
     ]);
     expect((await iterator.next()).done).toBe(true);
   });

--- a/packages/zero-cache/src/services/change-streamer/subscriber.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/subscriber.test.ts
@@ -439,4 +439,50 @@ describe('change-streamer/subscriber', () => {
       sub.sampleProcessRate(performance.now()).getStats().processRate,
     ).toBeGreaterThan(0);
   });
+
+  test('onAck reports each advance of the acked watermark', async () => {
+    const acks: string[] = [];
+    const [sub, _, receiver] = createSubscriber('00', true, {
+      onAck: watermark => acks.push(watermark),
+    });
+
+    void sub.send([
+      '11',
+      'begin',
+      json(['begin', messages.begin(), {commitWatermark: '12'}]),
+    ]);
+    void sub.send([
+      '12',
+      'commit',
+      json(['commit', messages.commit(), {watermark: '12'}]),
+    ]);
+    void sub.send([
+      '21',
+      'begin',
+      json(['begin', messages.begin(), {commitWatermark: '22'}]),
+    ]);
+    void sub.send([
+      '22',
+      'commit',
+      json(['commit', messages.commit(), {watermark: '22'}]),
+    ]);
+    // Trailing message: a commit is only acked once the consumer moves past it.
+    void sub.send([
+      '31',
+      'begin',
+      json(['begin', messages.begin(), {commitWatermark: '32'}]),
+    ]);
+
+    let count = 0;
+    for await (const _json of receiver) {
+      // The status message from setCaughtUp() plus the five sends.
+      if (++count === 6) {
+        sub.close();
+      }
+    }
+
+    // Only commits are acked, and only when the subscriber confirms them.
+    expect(acks).toEqual(['12', '22']);
+    expect(sub.acked).toBe('22');
+  });
 });

--- a/packages/zero-cache/src/services/change-streamer/subscriber.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/subscriber.test.ts
@@ -258,6 +258,54 @@ describe('change-streamer/subscriber', () => {
     expect(released).toBe(true);
   });
 
+  test('whenBacklogFull resolves at the same point send() blocks', async () => {
+    const [sub] = createSubscriber('00', false, {
+      backlogHighWaterBytes: 1_000,
+    });
+
+    let full = false;
+    void sub.whenBacklogFull().then(() => {
+      full = true;
+    });
+    expect(sub.backlogFull).toBe(false);
+
+    const small = json(['begin', messages.begin(), {commitWatermark: '12'}]);
+    expect(small.length).toBeLessThan(1_000);
+    let released = false;
+    void sub.send(['11', 'begin', small]).then(() => {
+      released = true;
+    });
+
+    await Promise.resolve();
+    expect(full).toBe(false);
+    expect(released).toBe(true);
+
+    // Enough to cross the mark, which is exactly where send() stops resolving.
+    void sub.send(['12', 'commit', 'x'.repeat(1_000)]);
+
+    await Promise.resolve();
+    expect(sub.backlogFull).toBe(true);
+    expect(full).toBe(true);
+  });
+
+  test('close releases whenBacklogFull waiters', async () => {
+    const [sub] = createSubscriber('00', false, {
+      backlogHighWaterBytes: 1,
+    });
+
+    let full = false;
+    const waiting = sub.whenBacklogFull().then(() => {
+      full = true;
+    });
+
+    sub.close();
+    await waiting;
+    // Resolved so the waiter is not stranded, but the backlog is gone, so a
+    // caller that re-checks does not mistake this for an overflow.
+    expect(full).toBe(true);
+    expect(sub.backlogFull).toBe(false);
+  });
+
   test('close releases backlog backpressure', async () => {
     const [sub] = createSubscriber('00', false, {
       backlogHighWaterBytes: 1,

--- a/packages/zero-cache/src/services/change-streamer/subscriber.ts
+++ b/packages/zero-cache/src/services/change-streamer/subscriber.ts
@@ -54,6 +54,7 @@ export class Subscriber {
   #backlogInFlightBytes = 0;
   #backlogDrain: Promise<void> | null = null;
   readonly #backlogBackpressure: ByteBackpressureGate;
+  readonly #backlogFullWaiters: Resolver<void>[] = [];
   readonly #onAck: ((watermark: string) => void) | undefined;
 
   constructor(
@@ -84,6 +85,32 @@ export class Subscriber {
 
   get acked() {
     return this.#acked;
+  }
+
+  /**
+   * Whether the backlog of live changes buffered during catchup has reached the
+   * point at which {@link send()} stops resolving. Past it the subscriber is no
+   * longer free: it holds up every subsequent flush, and with no other
+   * subscriber to form a majority it stalls replication outright.
+   */
+  get backlogFull() {
+    return (
+      this.#bufferedBacklogBytes >= this.#backlogBackpressure.highWaterBytes
+    );
+  }
+
+  /**
+   * Resolves the first time {@link backlogFull} becomes true, so that a caller
+   * holding the subscriber in catchup can give up at the moment the subscriber
+   * starts costing replication rather than on a timer.
+   */
+  whenBacklogFull(): Promise<void> {
+    if (this.backlogFull) {
+      return promiseVoid;
+    }
+    const r = resolver<void>();
+    this.#backlogFullWaiters.push(r);
+    return r.promise;
   }
 
   send(change: WatermarkedChange): Promise<void> {
@@ -273,6 +300,11 @@ export class Subscriber {
     this.#backlog = null;
     this.#backlogBytes = 0;
     this.#backlogBackpressure.releaseAll();
+    // The backlog can no longer grow, so nothing would ever resolve these.
+    // Waiters re-check backlogFull, which is now false, and see the close.
+    for (const waiter of this.#backlogFullWaiters.splice(0)) {
+      waiter.resolve();
+    }
 
     if (error) {
       // Wait for the ACK of the error message before closing the connection.
@@ -299,6 +331,11 @@ export class Subscriber {
     assert(this.#backlog, 'cannot push to backlog after catchup completed');
     this.#backlog.push(change);
     this.#backlogBytes += change[2].length;
+    if (this.backlogFull) {
+      for (const waiter of this.#backlogFullWaiters.splice(0)) {
+        waiter.resolve();
+      }
+    }
   }
 
   #maybeWaitForBacklogSpace(): Promise<void> {

--- a/packages/zero-cache/src/services/change-streamer/subscriber.ts
+++ b/packages/zero-cache/src/services/change-streamer/subscriber.ts
@@ -23,6 +23,13 @@ const DEFAULT_BACKLOG_LOW_WATER_RATIO = 0.8;
 export type SubscriberOptions = {
   backlogHighWaterBytes?: number | undefined;
   backlogLowWaterRatio?: number | undefined;
+
+  /**
+   * Called whenever the subscriber's acked watermark advances, i.e. when it
+   * has confirmed that a commit was durably applied to its replica. The ACK
+   * therefore lags the subscriber's replica rather than leading it.
+   */
+  onAck?: ((watermark: string) => void) | undefined;
 };
 
 /**
@@ -47,6 +54,7 @@ export class Subscriber {
   #backlogInFlightBytes = 0;
   #backlogDrain: Promise<void> | null = null;
   readonly #backlogBackpressure: ByteBackpressureGate;
+  readonly #onAck: ((watermark: string) => void) | undefined;
 
   constructor(
     protocolVersion: number,
@@ -67,6 +75,7 @@ export class Subscriber {
       options.backlogHighWaterBytes ?? DEFAULT_BACKLOG_HIGH_WATER_BYTES,
       options.backlogLowWaterRatio ?? DEFAULT_BACKLOG_LOW_WATER_RATIO,
     );
+    this.#onAck = options.onAck;
   }
 
   get watermark() {
@@ -150,7 +159,14 @@ export class Subscriber {
     }
     const result = await this.#sendStringifiedDownstream(json);
     if (tag === 'commit' && result === 'consumed') {
-      this.#acked = max(this.#acked, watermark);
+      // Sends can complete out of order (e.g. the bounded window in
+      // #drainBacklog), so the ack only advances monotonically, and listeners
+      // are only notified when it does.
+      const acked = max(this.#acked, watermark);
+      if (acked !== this.#acked) {
+        this.#acked = acked;
+        this.#onAck?.(acked);
+      }
     }
   }
 

--- a/packages/zero-cache/src/services/change-streamer/subscriber.ts
+++ b/packages/zero-cache/src/services/change-streamer/subscriber.ts
@@ -13,7 +13,7 @@ import type {
   Status,
   WatermarkedChange,
 } from './change-streamer.ts';
-import * as ErrorType from './error-type-enum.ts';
+import type * as ErrorType from './error-type-enum.ts';
 
 type ErrorType = Enum<typeof ErrorType>;
 
@@ -301,8 +301,20 @@ export class Subscriber {
     return true;
   }
 
-  fail(err?: unknown) {
-    this.close(ErrorType.Unknown, String(err));
+  /**
+   * Ends the subscription without sending a downstream `['error', ...]`.
+   *
+   * This is deliberate, and not the same as reporting the failure to the
+   * subscriber: `IncrementalSyncer` treats any `['error', ...]` as terminal and
+   * shuts down to restore a fresh replica from litestream, whereas a clean end
+   * backs off and re-subscribes. The failures routed here -- storer catchup
+   * errors, backlog drain errors, backup-monitor errors -- are transient, so a
+   * reconnect is the proportionate response and a fleet-wide restore is not.
+   *
+   * Callers are responsible for logging `err`; it is not carried downstream.
+   */
+  fail(_err?: unknown) {
+    this.close();
   }
 
   close(error?: ErrorType, message?: string) {

--- a/packages/zero-cache/src/services/change-streamer/subscriber.ts
+++ b/packages/zero-cache/src/services/change-streamer/subscriber.ts
@@ -32,6 +32,11 @@ export type SubscriberOptions = {
   onAck?: ((watermark: string) => void) | undefined;
 };
 
+export type BacklogFullWait = {
+  readonly promise: Promise<void>;
+  cancel(): void;
+};
+
 /**
  * Encapsulates a subscriber to changes. All subscribers start in a
  * "catchup" phase in which changes are buffered in a backlog while the
@@ -54,7 +59,7 @@ export class Subscriber {
   #backlogInFlightBytes = 0;
   #backlogDrain: Promise<void> | null = null;
   readonly #backlogBackpressure: ByteBackpressureGate;
-  readonly #backlogFullWaiters: Resolver<void>[] = [];
+  readonly #backlogFullWaiters = new Set<Resolver<void>>();
   readonly #onAck: ((watermark: string) => void) | undefined;
 
   constructor(
@@ -102,15 +107,21 @@ export class Subscriber {
   /**
    * Resolves the first time {@link backlogFull} becomes true, so that a caller
    * holding the subscriber in catchup can give up at the moment the subscriber
-   * starts costing replication rather than on a timer.
+   * starts costing replication rather than on a timer. Call cancel() when the
+   * wait is no longer needed so the subscriber does not retain it.
    */
-  whenBacklogFull(): Promise<void> {
+  whenBacklogFull(): BacklogFullWait {
     if (this.backlogFull) {
-      return promiseVoid;
+      return {promise: promiseVoid, cancel() {}};
     }
     const r = resolver<void>();
-    this.#backlogFullWaiters.push(r);
-    return r.promise;
+    this.#backlogFullWaiters.add(r);
+    return {
+      promise: r.promise,
+      cancel: () => {
+        this.#backlogFullWaiters.delete(r);
+      },
+    };
   }
 
   send(change: WatermarkedChange): Promise<void> {
@@ -302,11 +313,9 @@ export class Subscriber {
     this.#backlogBackpressure.releaseAll();
     // The backlog can no longer grow, so nothing would ever resolve these.
     // Waiters re-check backlogFull, which is now false, and see the close.
-    for (const waiter of this.#backlogFullWaiters.splice(0)) {
-      waiter.resolve();
-    }
+    this.#resolveBacklogFullWaiters();
 
-    if (error) {
+    if (error !== undefined) {
       // Wait for the ACK of the error message before closing the connection.
       void this.#sendDownstream(['error', {type: error, message}]).finally(() =>
         this.#downstream.cancel(),
@@ -332,9 +341,15 @@ export class Subscriber {
     this.#backlog.push(change);
     this.#backlogBytes += change[2].length;
     if (this.backlogFull) {
-      for (const waiter of this.#backlogFullWaiters.splice(0)) {
-        waiter.resolve();
-      }
+      this.#resolveBacklogFullWaiters();
+    }
+  }
+
+  #resolveBacklogFullWaiters() {
+    const waiters = [...this.#backlogFullWaiters];
+    this.#backlogFullWaiters.clear();
+    for (const waiter of waiters) {
+      waiter.resolve();
     }
   }
 

--- a/packages/zero-cache/src/services/replicator/incremental-sync.test.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.test.ts
@@ -17,6 +17,7 @@ import type {Enum} from '../../../../shared/src/enum.ts';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
 import type {ZeroEvent} from '../../../../zero-events/src/index.ts';
 import type {Database} from '../../../../zqlite/src/db.ts';
+import {StatementRunner} from '../../db/statements.ts';
 import {initEventSinkForTesting} from '../../observability/events.ts';
 import {DbFile, expectTables, initDB} from '../../test/lite.ts';
 import type {Source} from '../../types/streams.ts';
@@ -33,6 +34,7 @@ import {IncrementalSyncer} from './incremental-sync.ts';
 import {ReplicationStatusPublisher} from './replication-status.ts';
 import {
   createReplicationStateTables,
+  getReplicationState,
   initReplicationState,
 } from './schema/replication-state.ts';
 import {SQLiteChangeLogObserver} from './sqlite-change-log-observability.ts';
@@ -107,6 +109,73 @@ describe('replicator/incremental-sync', () => {
     await worker?.stop();
     mainDb?.close();
     dbFile?.delete();
+  });
+
+  test('a commit is durable before it is acked', async () => {
+    const issues = new ReplicationMessages({issues: ['issueID']});
+
+    initReplicationState(mainDb, ['zero_data'], '02', {}, false);
+    initDB(
+      mainDb,
+      `
+    CREATE TABLE issues(
+      issueID INTEGER,
+      _0_version TEXT,
+      PRIMARY KEY(issueID)
+    );
+      `,
+    );
+
+    // The change-streamer reads an ACK as proof that the commit is on disk:
+    // the SQLite catchup barrier waits on it, and #purgeOldChanges deletes on
+    // the strength of it. Sample the replica at the moment the ACK fires --
+    // it must never be behind the commit being acked. Batching commits or
+    // making the write async would break both callers here.
+    const replica = new StatementRunner(mainDb);
+    const acked: {watermark: string; stateVersion: string}[] = [];
+    downstream = new Subscription<SerializedDownstream, Downstream>(
+      {
+        consumed: message => {
+          if (message[0] === 'commit') {
+            acked.push({
+              watermark: message[2].watermark,
+              stateVersion: getReplicationState(replica).stateVersion,
+            });
+          }
+        },
+      },
+      data => ({data, json: BigIntJSON.stringify(data)}),
+    );
+    subscribeFn.mockResolvedValue(downstream);
+
+    syncing = syncer.run();
+    const notifications = syncer.subscribe();
+    const versionReady = notifications[Symbol.asyncIterator]();
+    await versionReady.next(); // Get the initial nextStateVersion.
+
+    for (const change of [
+      ['status', {tag: 'status'}],
+      ['begin', issues.begin(), {commitWatermark: '06'}],
+      ['data', issues.insert('issues', {issueID: 123})],
+      ['commit', issues.commit(), {watermark: '06'}],
+
+      ['begin', issues.begin(), {commitWatermark: '08'}],
+      ['data', issues.insert('issues', {issueID: 456})],
+      ['commit', issues.commit(), {watermark: '08'}],
+    ] satisfies Downstream[]) {
+      downstream.push(change);
+      if (change[0] === 'commit') {
+        await Promise.race([versionReady.next(), syncing]);
+      }
+    }
+
+    // The ACK of a commit fires when the consumer moves past it, which is one
+    // message later, so wait for both rather than assuming they have landed.
+    await vi.waitFor(() => expect(acked).toHaveLength(2));
+    expect(acked).toEqual([
+      {watermark: '06', stateVersion: '06'},
+      {watermark: '08', stateVersion: '08'},
+    ]);
   });
 
   test('replicates transactions', async () => {

--- a/packages/zero-cache/src/services/replicator/incremental-sync.test.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.test.ts
@@ -92,6 +92,7 @@ describe('replicator/incremental-sync', () => {
       {subscribe: subscribeFn.mockResolvedValue(downstream)},
       worker,
       'serving',
+      false,
       ReplicationStatusPublisher.forReplicaFile(dbFile.path),
       undefined,
     );
@@ -147,6 +148,7 @@ describe('replicator/incremental-sync', () => {
       replicaVersion: '02',
       watermark: '02',
       initial: true,
+      logsChangeStream: false,
     });
 
     const firstBegin = [
@@ -439,6 +441,7 @@ describe('replicator/incremental-sync', () => {
       replicaVersion: '09',
       watermark: '09',
       initial: true,
+      logsChangeStream: false,
     });
 
     for (const change of [
@@ -616,6 +619,7 @@ describe('replicator/incremental-sync', () => {
       replicaVersion: '09',
       watermark: '09',
       initial: true,
+      logsChangeStream: false,
     });
 
     const next = versionReady.next();
@@ -757,6 +761,7 @@ describe('replicator/incremental-sync', () => {
       },
       worker,
       'serving',
+      false,
       ReplicationStatusPublisher.forReplicaFile(dbFile.path),
       undefined,
     );
@@ -788,6 +793,7 @@ describe('replicator/incremental-sync', () => {
       },
       worker,
       'serving',
+      false,
       ReplicationStatusPublisher.forReplicaFile(dbFile.path),
       undefined,
     );
@@ -838,6 +844,7 @@ describe('replicator/incremental-sync', () => {
       {subscribe: subscribeFn},
       worker,
       'serving',
+      true,
       ReplicationStatusPublisher.forReplicaFile(dbFile.path),
       undefined,
     );
@@ -894,6 +901,7 @@ describe('replicator/incremental-sync', () => {
       {subscribe: subscribeFn.mockResolvedValue(downstream)},
       worker,
       'serving',
+      true,
       ReplicationStatusPublisher.forReplicaFile(dbFile.path),
       observer,
     );

--- a/packages/zero-cache/src/services/replicator/incremental-sync.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.ts
@@ -38,6 +38,7 @@ export class IncrementalSyncer {
   readonly #changeStreamer: ChangeStreamer;
   readonly #worker: WriteWorkerClient;
   readonly #mode: ReplicatorMode;
+  readonly #logsChangeStream: boolean;
   readonly #statusPublisher: ReplicationStatusPublisher | null;
   readonly #notifier: Notifier;
   readonly #reporter: ReplicationReportRecorder;
@@ -58,6 +59,7 @@ export class IncrementalSyncer {
     changeStreamer: ChangeStreamer,
     worker: WriteWorkerClient,
     mode: ReplicatorMode,
+    logsChangeStream: boolean,
     statusPublisher: ReplicationStatusPublisher | null,
     sqliteChangeLogObserver: SQLiteChangeLogObserver | undefined,
   ) {
@@ -67,6 +69,7 @@ export class IncrementalSyncer {
     this.#changeStreamer = changeStreamer;
     this.#worker = worker;
     this.#mode = mode;
+    this.#logsChangeStream = logsChangeStream;
     this.#statusPublisher = statusPublisher;
     this.#notifier = new Notifier();
     this.#reporter = new ReplicationReportRecorder(lc);
@@ -105,6 +108,7 @@ export class IncrementalSyncer {
           watermark,
           replicaVersion,
           initial: watermark === initialWatermark,
+          logsChangeStream: this.#logsChangeStream,
         });
         this.#state.resetBackoff();
         unregister = this.#state.cancelOnStop(downstream);

--- a/packages/zero-cache/src/services/replicator/replication-resumption-child.ts
+++ b/packages/zero-cache/src/services/replicator/replication-resumption-child.ts
@@ -248,6 +248,7 @@ export default async function runWorker(
     'serving',
     new IPCChangeStreamer(parent),
     worker,
+    false,
     null,
     undefined,
   );

--- a/packages/zero-cache/src/services/replicator/replication-throughput.bench.pg.ts
+++ b/packages/zero-cache/src/services/replicator/replication-throughput.bench.pg.ts
@@ -184,6 +184,7 @@ async function startReplicationPipeline(testDBs: PgTest['testDBs']) {
     'serving',
     parseStringifiedChangeStreamer(changeStreamer),
     worker,
+    false,
     null,
     undefined,
   );

--- a/packages/zero-cache/src/services/replicator/replicator.ts
+++ b/packages/zero-cache/src/services/replicator/replicator.ts
@@ -77,6 +77,7 @@ export class ReplicatorService implements Replicator, Service {
     mode: ReplicatorMode,
     changeStreamer: ChangeStreamer,
     worker: WriteWorkerClient,
+    logsChangeStream: boolean,
     statusPublisher: ReplicationStatusPublisher | null,
     sqliteChangeLogObserver: SQLiteChangeLogObserver | undefined,
   ) {
@@ -93,6 +94,7 @@ export class ReplicatorService implements Replicator, Service {
       changeStreamer,
       worker,
       mode,
+      logsChangeStream,
       statusPublisher,
       sqliteChangeLogObserver,
     );

--- a/packages/zql-integration-tests/src/chinook/chinook-zero-cache-fuzzer.pg.test.ts
+++ b/packages/zql-integration-tests/src/chinook/chinook-zero-cache-fuzzer.pg.test.ts
@@ -373,6 +373,7 @@ async function startZeroCacheReplica(testDBs: PgTest['testDBs']) {
       'serving',
       parseStringifiedChangeStreamer(changeStreamer),
       worker,
+      false,
       null,
       undefined,
     );


### PR DESCRIPTION
This does SQLite catchup against the SQLite change log.

**Note:** This'll be changing quite a bit as the current change log in this PR (and prior PRs) is stored in the replica file. It should be its own SQLite file. Follow up PRs will undertake this refactoring.


----

This is currently off in production.

## Algo

A subscriber connects. It checks SQLite to see what transaction it has durably recorded. After that, we wait till all in-flight transactions are persisted to SQLite. The reason here is because we stream transactions out from the RM before saving to SQLite so a subscriber can connect in a window where:

a. transactions have left
b. those transactions are not in the change log

**Example:**

Subscriber watermark:       50
Forwarder already through: 101
SQLite currently through:   98

The sequence is:

1. Register subscriber with Forwarder
2. Capture requiredHead = 101
3. plan() reports SQLite head = 98
4. Park subscriber; do not start reading yet
5. SQLite writes 99, 100, 101
6. plan() now reports head >= 101
7. Pin that new head and read SQLite from 50 through it
8. Drain the subscriber’s live backlog
9. Continue direct live forwarding

While steps 4–7 happen:

- Transactions 99–101 were forwarded before registration, so they are not in this subscriber’s backlog. They must come from SQLite.
- Transactions forwarded after registration—say 102+—are buffered in the subscriber’s live backlog.
- If the eventual pinned SQLite head includes some of 102+, those transactions exist in both catchup and the backlog. Subscriber watermark deduplication
  removes the overlap.

The backlog is bounded and participates in flow control, so an extremely slow catchup can eventually backpressure live replication rather than grow memory
without limit.

## Catch cooperatively schedules at async/batch boundaries.

- Each catchup runs as a detached async task.
- It yields while waiting for the required head, barrier polling, and subscriber consumption.
- Each SQLite all() query and row reconstruction is synchronous and blocks the change-streamer event loop for that batch.
- There is no explicit setImmediate()/macrotask yield between batches.

Batches are bounded and each read transaction closes promptly. It might need explicit yielding for
event-loop fairness if benchmarks show that many fast catchups or oversized batches hurt live-stream latency.

## Catchups are concurrent, not globally serialized.

Every subscriber gets its own #run() invocation in packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.ts:156.

They are concurrent async tasks but not parallel SQLite executions:
- All use one shared SQLiteChangeLogReader.
- All run on the same JavaScript thread.
- Synchronous SQLite batch queries execute one at a time.
- Tasks interleave when they reach an await.

There is currently no catchup concurrency limiter.

## Catchup is served from the change-streamer’s main JavaScript thread.

packages/zero-cache/src/services/change-streamer/change-streamer-service.ts:539 lazily creates SQLiteChangeLogReader directly. It does not send reads to
ThreadWriteWorkerClient.

More precisely, this is the main thread of the change-streamer worker process—not the overall zero-cache parent process and not the canonical SQLite write
worker.

## It does not pin one long-lived SQLite transaction.

The sequence is:

plan()
   → read head/min/boundary in one short statement
   → remember headWatermark as a value

read(..., through=headWatermark)
   → SELECT next LIMIT batchSize
   → fully exhaust statement and close its implicit read transaction
   → yield batch
   → repeat with a new short read transaction

The keyset query is bounded by the remembered head:

```
WHERE ("watermark", "pos") > (?, ?)
 AND "watermark" <= ?
ORDER BY "watermark", "pos"
LIMIT ?
```