### PR TITLE
chore(rmv2): add SQLite change log purger [9/n]

### DIFF
--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -55,6 +55,8 @@ export default async function runWorker(
       backPressureLimitHeapProportion,
       flowControlConsensusPaddingSeconds,
       flowControlEventDrivenRelease,
+      sqliteChangeLogReadBatchRows,
+      sqliteChangeLogBarrierTimeoutMs,
     },
     autoReset,
     replicationLag,
@@ -165,6 +167,11 @@ export default async function runWorker(
           flowControlEventDrivenRelease,
           statementTimeoutMs: change.statementTimeoutMs,
           changeLogBatchSize: change.logBatchSize,
+          sqliteCatchup: {
+            replicaFile: replica.file,
+            readBatchRows: sqliteChangeLogReadBatchRows,
+            barrierTimeoutMs: sqliteChangeLogBarrierTimeoutMs,
+          },
         },
         setTimeout,
       );

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
@@ -17,15 +17,20 @@ import type {PostgresDB} from '../../types/pg.ts';
 import type {Source} from '../../types/streams.ts';
 import {Subscription, type Result} from '../../types/subscription.ts';
 import type {ChangeSource} from '../change-source/change-source.ts';
-import {type ChangeStreamMessage} from '../change-source/protocol/current/downstream.ts';
+import type {
+  ChangeStreamData,
+  ChangeStreamMessage,
+} from '../change-source/protocol/current/downstream.ts';
 import type {UpstreamStatusMessage} from '../change-source/protocol/current/status.ts';
 import {exitAfter} from '../life-cycle.ts';
+import {ChangeLogStreamWriter} from '../replicator/change-log-stream-writer.ts';
 import {IncrementalSyncer} from '../replicator/incremental-sync.ts';
 import {ReplicationStatusPublisher} from '../replicator/replication-status.ts';
 import {
   getSubscriptionState,
   initReplicationState,
   type SubscriptionState,
+  updateReplicationWatermark,
 } from '../replicator/schema/replication-state.ts';
 import {
   getSQLiteChangeLogInfo,
@@ -33,6 +38,7 @@ import {
 } from '../replicator/sqlite-change-log-observability.ts';
 import {ReplicationMessages} from '../replicator/test-utils.ts';
 import {ThreadWriteWorkerClient} from '../replicator/write-worker-client.ts';
+import {serializeChangeStreamData} from './change-log-codec.ts';
 import {
   initializeStreamer,
   type TuningOptions,
@@ -171,6 +177,35 @@ describe('change-streamer/service', () => {
   }
 
   const messages = new ReplicationMessages({foo: 'id'});
+
+  function appendSQLiteTransaction(
+    replica: Database,
+    watermark: string,
+    data: readonly ChangeStreamData[],
+  ): void {
+    const runner = new StatementRunner(replica);
+    const writer = new ChangeLogStreamWriter(replica);
+    const begin: ChangeStreamData = [
+      'begin',
+      messages.begin(),
+      {commitWatermark: watermark},
+    ];
+    const commit: ChangeStreamData = ['commit', messages.commit(), {watermark}];
+
+    runner.beginImmediate();
+    try {
+      writer.begin(watermark, serializeChangeStreamData(begin));
+      for (const message of data) {
+        writer.append(serializeChangeStreamData(message), message[1].tag);
+      }
+      writer.commit(watermark, serializeChangeStreamData(commit), Date.now());
+      updateReplicationWatermark(runner, watermark);
+      runner.commit();
+    } catch (e) {
+      runner.rollback();
+      throw e;
+    }
+  }
 
   test('PG stream shadow-writes SQLite without changing PG serving or ACKs', async () => {
     const dbFile = new DbFile('sqlite-change-log-shadow-integration');
@@ -320,6 +355,172 @@ describe('change-streamer/service', () => {
       await worker.stop();
       replica.close();
       dbFile.delete();
+    }
+  });
+
+  test('SQLite required head tracks forwarded transaction boundaries', async () => {
+    await streamer.stop();
+    await streamerDone;
+
+    const catchupReplicaFile = new DbFile('sqlite-catchup-service-integration');
+    const catchupReplica = catchupReplicaFile.connect(lc);
+    catchupReplica.pragma('journal_mode = wal');
+    initReplicationState(catchupReplica, ['zero_data'], REPLICA_VERSION);
+
+    changes = Subscription.create();
+    acks = new Queue();
+    streamer = await initializeStreamer(
+      lc,
+      shard,
+      'task-id',
+      'change.streamer:12345',
+      'ws',
+      sql,
+      {
+        startStream: () =>
+          Promise.resolve({
+            initialWatermark: '02',
+            changes,
+            acks: {push: status => acks.enqueue(status)},
+          }),
+        startLagReporter: () => Promise.resolve({nextSendTimeMs: 123}),
+        stop: () => Promise.resolve(),
+      },
+      ReplicationStatusPublisher.forTesting(),
+      replicaConfig,
+      null,
+      true,
+      {
+        ...opts,
+        sqliteCatchup: {
+          replicaFile: catchupReplicaFile.path,
+          readBatchRows: 2,
+          barrierTimeoutMs: 1_000,
+          shouldUse: ctx => ctx.id !== 'live-observer',
+        },
+      },
+      setTimeoutFn as unknown as typeof setTimeout,
+    );
+    streamerDone = streamer.run();
+
+    try {
+      const liveSub = await streamer.subscribe({
+        protocolVersion: PROTOCOL_VERSION,
+        taskID: 'live-task',
+        id: 'live-observer',
+        mode: 'serving',
+        watermark: REPLICA_VERSION,
+        replicaVersion: REPLICA_VERSION,
+        initial: true,
+      });
+      const live = drainToQueue(liveSub);
+      expect(await nextChange(live)).toMatchObject({tag: 'status'});
+
+      const insert04: ChangeStreamData = [
+        'data',
+        messages.insert('foo', {id: 'committed'}),
+      ];
+      changes.push(['begin', messages.begin(), {commitWatermark: '04'}]);
+      changes.push(insert04);
+      expect(await nextChange(live)).toMatchObject({tag: 'begin'});
+      expect(await nextChange(live)).toMatchObject({
+        tag: 'insert',
+        new: {id: 'committed'},
+      });
+
+      const commitSub = await streamer.subscribe({
+        protocolVersion: PROTOCOL_VERSION,
+        taskID: 'commit-task',
+        id: 'commit-catchup',
+        mode: 'serving',
+        watermark: REPLICA_VERSION,
+        replicaVersion: REPLICA_VERSION,
+        initial: true,
+      });
+      const committed = drainToQueue(commitSub);
+
+      changes.push(['commit', messages.commit(), {watermark: '04'}]);
+      expect(await nextChange(live)).toMatchObject({tag: 'commit'});
+      appendSQLiteTransaction(catchupReplica, '04', [insert04]);
+
+      expect(await nextChange(committed)).toMatchObject({tag: 'status'});
+      expect(await nextChange(committed)).toMatchObject({tag: 'begin'});
+      expect(await nextChange(committed)).toMatchObject({
+        tag: 'insert',
+        new: {id: 'committed'},
+      });
+      expect(await nextChange(committed)).toMatchObject({tag: 'commit'});
+
+      changes.push(['begin', messages.begin(), {commitWatermark: '06'}]);
+      changes.push(['data', messages.insert('foo', {id: 'rolled-back'})]);
+      expect(await nextChange(live)).toMatchObject({tag: 'begin'});
+      expect(await nextChange(live)).toMatchObject({
+        tag: 'insert',
+        new: {id: 'rolled-back'},
+      });
+
+      const rollbackSub = await streamer.subscribe({
+        protocolVersion: PROTOCOL_VERSION,
+        taskID: 'rollback-task',
+        id: 'rollback-catchup',
+        mode: 'serving',
+        watermark: '04',
+        replicaVersion: REPLICA_VERSION,
+        initial: true,
+      });
+      const rolledBack = drainToQueue(rollbackSub);
+
+      changes.push(['rollback', messages.rollback()]);
+      expect(await nextChange(live)).toMatchObject({tag: 'rollback'});
+      expect(await nextChange(rolledBack)).toMatchObject({tag: 'status'});
+
+      const insert08: ChangeStreamData = [
+        'data',
+        messages.insert('foo', {id: 'after-rollback'}),
+      ];
+      changes.push(['begin', messages.begin(), {commitWatermark: '08'}]);
+      changes.push(insert08);
+      changes.push(['commit', messages.commit(), {watermark: '08'}]);
+      expect(await nextChange(rolledBack)).toMatchObject({tag: 'begin'});
+      expect(await nextChange(rolledBack)).toMatchObject({
+        tag: 'insert',
+        new: {id: 'after-rollback'},
+      });
+      expect(await nextChange(rolledBack)).toMatchObject({tag: 'commit'});
+      appendSQLiteTransaction(catchupReplica, '08', [insert08]);
+
+      changes.push(['begin', messages.begin(), {commitWatermark: '0a'}]);
+      changes.push(['data', messages.insert('foo', {id: 'interrupted'})]);
+      expect(await nextChange(live)).toMatchObject({tag: 'begin'});
+      expect(await nextChange(live)).toMatchObject({
+        tag: 'insert',
+        new: {id: 'interrupted'},
+      });
+
+      const interruptedSub = await streamer.subscribe({
+        protocolVersion: PROTOCOL_VERSION,
+        taskID: 'interrupted-task',
+        id: 'interrupted-catchup',
+        mode: 'serving',
+        watermark: '08',
+        replicaVersion: REPLICA_VERSION,
+        initial: true,
+      });
+      const interrupted = drainToQueue(interruptedSub);
+
+      changes.end();
+      expect(await nextChange(live)).toMatchObject({tag: 'rollback'});
+      expect(await nextChange(interrupted)).toMatchObject({tag: 'status'});
+      await verifyNoMoreChanges(interrupted);
+
+      liveSub.cancel();
+      commitSub.cancel();
+      rollbackSub.cancel();
+      interruptedSub.cancel();
+    } finally {
+      await streamer.stop();
+      catchupReplica.close();
+      catchupReplicaFile.delete();
     }
   });
 

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -1,7 +1,7 @@
 import {getDefaultHighWaterMark} from 'node:stream';
 import type {LogContext} from '@rocicorp/logger';
-import {resolver} from '@rocicorp/resolver';
-import {unreachable} from '../../../../shared/src/asserts.ts';
+import {resolver, type Resolver} from '@rocicorp/resolver';
+import {assert, unreachable} from '../../../../shared/src/asserts.ts';
 import {promiseVoid} from '../../../../shared/src/resolved-promises.ts';
 import {publishCriticalEvent} from '../../observability/events.ts';
 import {getOrCreateCounter} from '../../observability/metrics.ts';
@@ -19,6 +19,7 @@ import type {
   ChangeStream,
 } from '../change-source/change-source.ts';
 import {
+  type ChangeStreamData,
   type ChangeStreamControl,
   type Rollback,
 } from '../change-source/protocol/current/downstream.ts';
@@ -47,15 +48,31 @@ import {
   markResetRequired,
 } from './schema/tables.ts';
 import {
+  SQLiteChangeLogCatchup,
+  type SQLiteChangeLogCleanupGuard,
+} from './sqlite-change-log-catchup.ts';
+import {SQLiteChangeLogReader} from './sqlite-change-log-reader.ts';
+import {
   Storer,
   type PurgeLock,
   type TuningOptions as StorerOptions,
 } from './storer.ts';
 import {Subscriber} from './subscriber.ts';
 
+export type SQLiteCatchupOptions = {
+  replicaFile: string;
+  readBatchRows: number;
+  barrierTimeoutMs: number;
+  /** Slice 11 supplies the production canary selector. */
+  shouldUse?: ((ctx: SubscriberContext) => boolean) | undefined;
+  /** Slice 9 supplies the writer-serialized purge guard. */
+  cleanupGuard?: SQLiteChangeLogCleanupGuard | undefined;
+};
+
 export type TuningOptions = StorerOptions & {
   flowControlConsensusPaddingSeconds: number;
   flowControlEventDrivenRelease?: boolean | undefined;
+  sqliteCatchup?: SQLiteCatchupOptions | undefined;
 };
 
 /**
@@ -254,6 +271,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
   readonly #storer: Storer;
   readonly #forwarder: Forwarder;
   readonly #replicationStatusPublisher: ReplicationStatusPublisher;
+  readonly #sqliteCatchupOptions: SQLiteCatchupOptions | undefined;
 
   readonly #autoReset: boolean;
   readonly #state: RunningState;
@@ -283,6 +301,11 @@ class ChangeStreamerImpl implements ChangeStreamerService {
   #latestStatus: Status;
   #purgeLock: PurgeLock | null;
   #stream: ChangeStream | undefined;
+  #sqliteCatchup: SQLiteChangeLogCatchup | undefined;
+  #lastForwardedCommitWatermark: string | undefined;
+  #currentTransactionCompletion:
+    | Resolver<ForwardedTransactionCompletion>
+    | undefined;
 
   constructor(
     lc: LogContext,
@@ -323,6 +346,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
       eventDrivenRelease: opts.flowControlEventDrivenRelease,
     });
     this.#replicationStatusPublisher = replicationStatusPublisher;
+    this.#sqliteCatchupOptions = opts.sqliteCatchup;
     this.#purgeLock = initialPurgeLock;
     this.#autoReset = autoReset;
     this.#state = new RunningState(this.id, undefined, setTimeoutFn);
@@ -355,6 +379,10 @@ class ChangeStreamerImpl implements ChangeStreamerService {
       try {
         const {lastWatermark, backfillRequests} =
           await this.#storer.getStartStreamInitializationParameters();
+        // SQLite catchup must not be eligible until this has been initialized
+        // from the durable PG head. Commits observed only since process startup
+        // are insufficient after a change-streamer restart.
+        this.#lastForwardedCommitWatermark = lastWatermark;
         const stream = await this.#source.startStream(
           lastWatermark,
           backfillRequests,
@@ -424,6 +452,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
           if (unflushedBytes < flushBytesThreshold) {
             // pipeline changes until flushBytesThreshold
             this.#forwarder.forward(entry);
+            this.#recordForwardedTransactionBoundary(type, entry[0]);
           } else {
             // Wait for messages to clear socket buffers to ensure that they
             // make their way to subscribers. Without this `await`, the
@@ -432,7 +461,13 @@ class ChangeStreamerImpl implements ChangeStreamerService {
             // (2) prevents subscribers from processing the messages as they
             //     arrive, instead getting them in a large batch after being
             //     idle while they were queued (causing further delays).
-            await this.#forwarder.forwardWithFlowControl(entry);
+            const forwarded = this.#forwarder.forwardWithFlowControl(entry);
+            // forwardWithFlowControl synchronously sends the entry and updates
+            // the Forwarder's transaction state before returning its flow-
+            // control promise. Record the boundary before awaiting that promise
+            // so registrations during the wait observe the forwarded state.
+            this.#recordForwardedTransactionBoundary(type, entry[0]);
+            await forwarded;
             unflushedBytes = 0;
           }
 
@@ -458,6 +493,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
         this.#lc.warn?.(`aborting interrupted transaction ${watermark}`);
         this.#storer.abort();
         this.#forwarder.forward([watermark, 'rollback', ROLLBACK_JSON]);
+        this.#recordForwardedTransactionBoundary('rollback', watermark);
       }
 
       // Backoff and drain any pending entries in the storer before reconnecting.
@@ -500,13 +536,14 @@ class ChangeStreamerImpl implements ChangeStreamerService {
     }
   }
 
-  subscribe(ctx: SubscriberContext): Promise<Source<string>> {
+  async subscribe(ctx: SubscriberContext): Promise<Source<string>> {
     const {protocolVersion, id, mode, replicaVersion, watermark} = ctx;
     if (mode === 'serving') {
       this.#serving.resolve();
     }
+    let cleanupSubscriber = () => {};
     const downstream = Subscription.create<string>({
-      cleanup: () => this.#forwarder.remove(subscriber),
+      cleanup: () => cleanupSubscriber(),
     });
     const subscriber = new Subscriber(
       protocolVersion,
@@ -515,6 +552,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
       downstream,
       () => this.#latestStatus,
     );
+    cleanupSubscriber = () => this.#forwarder.remove(subscriber);
     if (replicaVersion !== this.#replicaVersion) {
       this.#lc.warn?.(
         `rejecting subscriber at replica version ${replicaVersion}`,
@@ -528,10 +566,20 @@ class ChangeStreamerImpl implements ChangeStreamerService {
     } else {
       this.#lc.debug?.(`adding subscriber ${subscriber.id}`);
 
-      this.#forwarder.add(subscriber);
-      this.#storer.catchup(subscriber, mode);
+      const sqliteCatchup = this.#selectSQLiteCatchup(ctx);
+      if (sqliteCatchup) {
+        cleanupSubscriber = () => sqliteCatchup.remove(subscriber);
+        await sqliteCatchup.catchup(subscriber, mode, () =>
+          this.#captureRequiredHead(),
+        );
+      } else {
+        // Keep the existing PG registration/catchup lockstep unchanged when
+        // SQLite was not selected before Forwarder.add().
+        this.#forwarder.add(subscriber);
+        this.#storer.catchup(subscriber, mode);
+      }
     }
-    return Promise.resolve(downstream);
+    return downstream;
   }
 
   scheduleCleanup(watermark: string) {
@@ -607,10 +655,90 @@ class ChangeStreamerImpl implements ChangeStreamerService {
   async stop(err?: unknown) {
     this.#state.stop(this.#lc, err);
     this.#stream?.changes.cancel();
+    this.#sqliteCatchup?.close();
     await this.#storer.stop();
     await this.#source.stop();
   }
+
+  #recordForwardedTransactionBoundary(
+    type: ChangeStreamData[0],
+    watermark: string,
+  ) {
+    switch (type) {
+      case 'begin':
+        assert(
+          this.#currentTransactionCompletion === undefined,
+          'forwarded begin while a transaction is already in progress',
+        );
+        this.#currentTransactionCompletion =
+          resolver<ForwardedTransactionCompletion>();
+        break;
+      case 'commit': {
+        const completion = this.#currentTransactionCompletion;
+        assert(completion, 'forwarded commit without a pending transaction');
+        this.#lastForwardedCommitWatermark = watermark;
+        this.#currentTransactionCompletion = undefined;
+        completion.resolve({kind: 'committed', watermark});
+        break;
+      }
+      case 'rollback': {
+        const completion = this.#currentTransactionCompletion;
+        assert(completion, 'forwarded rollback without a pending transaction');
+        const committed = this.#lastForwardedCommitWatermark;
+        assert(committed, 'last forwarded commit watermark is not initialized');
+        this.#currentTransactionCompletion = undefined;
+        completion.resolve({kind: 'rolled-back', watermark: committed});
+        break;
+      }
+    }
+  }
+
+  #captureRequiredHead(): string | Promise<string> {
+    const committed = this.#lastForwardedCommitWatermark;
+    assert(committed, 'last forwarded commit watermark is not initialized');
+    return (
+      this.#currentTransactionCompletion?.promise.then(
+        completion => completion.watermark,
+      ) ?? committed
+    );
+  }
+
+  #selectSQLiteCatchup(
+    ctx: SubscriberContext,
+  ): SQLiteChangeLogCatchup | undefined {
+    const opts = this.#sqliteCatchupOptions;
+    // Slice 11 supplies a non-default selector. Until then, this keeps all
+    // production subscriptions on PG even though the complete SQLite handoff
+    // path is wired and testable.
+    if (
+      this.#lastForwardedCommitWatermark === undefined ||
+      !opts?.shouldUse?.(ctx)
+    ) {
+      return undefined;
+    }
+    if (!this.#sqliteCatchup) {
+      this.#sqliteCatchup = new SQLiteChangeLogCatchup(
+        this.#lc,
+        this.#forwarder,
+        new SQLiteChangeLogReader(this.#lc, opts.replicaFile),
+        {
+          batchSize: opts.readBatchRows,
+          barrierTimeoutMs: opts.barrierTimeoutMs,
+          cleanupGuard: opts.cleanupGuard,
+          onFatal: async error => {
+            await markResetRequired(this.#changeDB, this.#shard);
+            void this.stop(error);
+          },
+        },
+      );
+    }
+    return this.#sqliteCatchup;
+  }
 }
+
+type ForwardedTransactionCompletion =
+  | {kind: 'committed'; watermark: string}
+  | {kind: 'rolled-back'; watermark: string};
 
 // The delay between receiving an initial, backup-based watermark
 // and performing a check of whether to purge records before it.

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -726,8 +726,11 @@ class ChangeStreamerImpl implements ChangeStreamerService {
           barrierTimeoutMs: opts.barrierTimeoutMs,
           cleanupGuard: opts.cleanupGuard,
           onFatal: async error => {
-            await markResetRequired(this.#changeDB, this.#shard);
-            void this.stop(error);
+            try {
+              await markResetRequired(this.#changeDB, this.#shard);
+            } finally {
+              void this.stop(error);
+            }
           },
         },
       );

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.test.ts
@@ -1,0 +1,462 @@
+import {LogContext} from '@rocicorp/logger';
+import {resolver} from '@rocicorp/resolver';
+import {afterEach, describe, expect, test, vi} from 'vitest';
+import {AbortError} from '../../../../shared/src/abort-error.ts';
+import {BigIntJSON} from '../../../../shared/src/bigint-json.ts';
+import {TestLogSink} from '../../../../shared/src/logging-test-utils.ts';
+import {Queue} from '../../../../shared/src/queue.ts';
+import type {Source} from '../../types/streams.ts';
+import {Subscription} from '../../types/subscription.ts';
+import type {Downstream, WatermarkedChange} from './change-streamer.ts';
+import * as ErrorType from './error-type-enum.ts';
+import {Forwarder} from './forwarder.ts';
+import {AutoResetSignal} from './schema/tables.ts';
+import {
+  SQLiteChangeLogCatchup,
+  SQLiteChangeLogBarrierTimeoutError,
+  type SQLiteChangeLogCatchupReader,
+  type SQLiteChangeLogCleanupGuard,
+} from './sqlite-change-log-catchup.ts';
+import type {CatchupPlan} from './sqlite-change-log-reader.ts';
+import {Subscriber} from './subscriber.ts';
+
+const coordinators: SQLiteChangeLogCatchup[] = [];
+
+describe('SQLiteChangeLogCatchup', () => {
+  afterEach(() => {
+    for (const coordinator of coordinators.splice(0)) {
+      coordinator.close();
+    }
+  });
+
+  test('registers before pinning the head and deduplicates live overlap', async () => {
+    const fixture = createFixture();
+    fixture.reader.head = '04';
+    fixture.reader.entries.push(...transaction('04'));
+    fixture.reader.boundaries.add('04');
+
+    const {subscriber, output} = createSubscriber('01');
+    await fixture.coordinator.catchup(subscriber, 'serving', () => '06');
+
+    // This replay reaches the Forwarder after registration but before SQLite
+    // reaches the required head. It is both in the backlog and, once applied,
+    // in the pinned catchup range.
+    forward(fixture.forwarder, transaction('06'));
+    fixture.reader.entries.push(...transaction('06'));
+    fixture.reader.boundaries.add('06');
+    fixture.reader.head = '06';
+
+    expect(await takeMarkers(output, 7)).toEqual([
+      'status',
+      '04:begin',
+      '04:insert',
+      '04:commit',
+      '06:begin',
+      '06:insert',
+      '06:commit',
+    ]);
+    expect(fixture.reader.reads).toEqual([
+      {from: '01', through: '06', batchSize: 2},
+    ]);
+  });
+
+  test('waits for a mid-transaction commit before choosing the required head', async () => {
+    const fixture = createFixture();
+    fixture.reader.entries.push(...transaction('04'));
+    fixture.reader.boundaries.add('04');
+    fixture.reader.head = '04';
+
+    fixture.forwarder.forward(entry('06', 'begin'));
+    const completion = resolver<string>();
+    const {subscriber, output} = createSubscriber('04');
+    await fixture.coordinator.catchup(
+      subscriber,
+      'serving',
+      () => completion.promise,
+    );
+
+    fixture.forwarder.forward(entry('06', 'insert'));
+    fixture.forwarder.forward(entry('06', 'commit'));
+    fixture.reader.entries.push(...transaction('06'));
+    fixture.reader.boundaries.add('06');
+    fixture.reader.head = '06';
+    completion.resolve('06');
+
+    forward(fixture.forwarder, transaction('08'));
+    expect(await takeMarkers(output, 7)).toEqual([
+      'status',
+      '06:begin',
+      '06:insert',
+      '06:commit',
+      '08:begin',
+      '08:insert',
+      '08:commit',
+    ]);
+  });
+
+  test('uses the prior committed head when the registration transaction rolls back', async () => {
+    const fixture = createFixture();
+    fixture.reader.entries.push(...transaction('04'));
+    fixture.reader.boundaries.add('04');
+    fixture.reader.head = '04';
+
+    fixture.forwarder.forward(entry('06', 'begin'));
+    const completion = resolver<string>();
+    const {subscriber, output} = createSubscriber('01');
+    await fixture.coordinator.catchup(
+      subscriber,
+      'serving',
+      () => completion.promise,
+    );
+    fixture.forwarder.forward(entry('06', 'rollback'));
+    completion.resolve('04');
+
+    forward(fixture.forwarder, transaction('08'));
+    expect(await takeMarkers(output, 7)).toEqual([
+      'status',
+      '04:begin',
+      '04:insert',
+      '04:commit',
+      '08:begin',
+      '08:insert',
+      '08:commit',
+    ]);
+  });
+
+  test('buffers commits that arrive across several catchup batches', async () => {
+    const fixture = createFixture();
+    fixture.reader.entries.push(...transaction('04'), ...transaction('06'));
+    fixture.reader.boundaries.add('04');
+    fixture.reader.boundaries.add('06');
+    fixture.reader.head = '06';
+    const releaseRead = resolver<void>();
+    fixture.reader.beforeRead = releaseRead.promise;
+
+    const {subscriber, output} = createSubscriber('01');
+    await fixture.coordinator.catchup(subscriber, 'serving', () => '06');
+    forward(fixture.forwarder, transaction('08'));
+    forward(fixture.forwarder, transaction('0a'));
+    releaseRead.resolve();
+
+    expect(await takeMarkers(output, 13)).toEqual([
+      'status',
+      ...transactionMarkers('04'),
+      ...transactionMarkers('06'),
+      ...transactionMarkers('08'),
+      ...transactionMarkers('0a'),
+    ]);
+  });
+
+  test('accepts a subscriber ahead of SQLite and filters replayed live commits', async () => {
+    const fixture = createFixture();
+    fixture.reader.entries.push(...transaction('04'));
+    fixture.reader.boundaries.add('04');
+    fixture.reader.head = '04';
+
+    const {subscriber, output} = createSubscriber('06');
+    await fixture.coordinator.catchup(subscriber, 'serving', () => '04');
+    forward(fixture.forwarder, transaction('06'));
+    forward(fixture.forwarder, transaction('08'));
+
+    expect(await takeMarkers(output, 4)).toEqual([
+      'status',
+      ...transactionMarkers('08'),
+    ]);
+  });
+
+  test('closes the restore-skew gap while SQLite replays to the forwarded head', async () => {
+    const fixture = createFixture();
+    fixture.reader.entries.push(...transaction('04'));
+    fixture.reader.boundaries.add('04');
+    fixture.reader.head = '04';
+
+    // The change-streamer already forwarded through 06, but the restored
+    // canonical replica is only at 04. A subscriber reconnecting at 06 must
+    // wait for SQLite to replay 04..06 without receiving 06 twice.
+    const {subscriber, output} = createSubscriber('06');
+    await fixture.coordinator.catchup(subscriber, 'serving', () => '06');
+    forward(fixture.forwarder, transaction('06'));
+    fixture.reader.entries.push(...transaction('06'));
+    fixture.reader.boundaries.add('06');
+    fixture.reader.head = '06';
+    forward(fixture.forwarder, transaction('08'));
+
+    expect(await takeMarkers(output, 4)).toEqual([
+      'status',
+      ...transactionMarkers('08'),
+    ]);
+  });
+
+  test('maps too-old plans to serving and backup policies', async () => {
+    const serving = createFixture();
+    serving.reader.min = '04';
+    serving.reader.head = '06';
+    serving.reader.boundaries.add('04');
+    const servingSub = createSubscriber('01');
+    await serving.coordinator.catchup(
+      servingSub.subscriber,
+      'serving',
+      () => '06',
+    );
+    expect(await servingSub.output.dequeue()).toEqual([
+      'error',
+      {
+        type: ErrorType.WatermarkTooOld,
+        message: 'earliest supported watermark is 04 (requested 01)',
+      },
+    ]);
+    expect(serving.onFatal).not.toHaveBeenCalled();
+
+    const backup = createFixture();
+    backup.reader.min = '04';
+    backup.reader.head = '06';
+    backup.reader.boundaries.add('04');
+    const backupSub = createSubscriber('01');
+    await backup.coordinator.catchup(
+      backupSub.subscriber,
+      'backup',
+      () => '06',
+    );
+    await backupSub.done;
+    await vi.waitFor(() => expect(backup.onFatal).toHaveBeenCalledOnce());
+    expect(backup.onFatal.mock.calls[0][0]).toBeInstanceOf(AutoResetSignal);
+  });
+
+  test('fails only the selected subscription on barrier timeout', async () => {
+    const fixture = createFixture({barrierTimeoutMs: 5});
+    fixture.reader.head = '01';
+    const {subscriber, done} = createSubscriber('01');
+    await fixture.coordinator.catchup(subscriber, 'serving', () => '06');
+
+    await done;
+    expect(fixture.logSink.messages).toContainEqual([
+      'error',
+      expect.anything(),
+      [
+        expect.stringContaining('error while catching up subscriber'),
+        expect.objectContaining({
+          name: SQLiteChangeLogBarrierTimeoutError.name,
+        }),
+      ],
+    ]);
+    expect(fixture.onFatal).not.toHaveBeenCalled();
+  });
+
+  test('fails closed on reader errors after registration', async () => {
+    const fixture = createFixture();
+    fixture.reader.head = '06';
+    fixture.reader.boundaries.add('01');
+    fixture.reader.readError = new Error('broken SQLite read');
+    const {subscriber, done} = createSubscriber('01');
+    await fixture.coordinator.catchup(subscriber, 'serving', () => '06');
+
+    await done;
+    expect(fixture.logSink.messages).toContainEqual([
+      'error',
+      expect.anything(),
+      [
+        expect.stringContaining('error while catching up subscriber'),
+        expect.objectContaining({message: 'broken SQLite read'}),
+      ],
+    ]);
+  });
+
+  test('cancellation and shutdown release catchup resources', async () => {
+    const fixture = createFixture();
+    fixture.reader.head = '01';
+    const first = createSubscriber('01');
+    await fixture.coordinator.catchup(first.subscriber, 'serving', () => '06');
+    fixture.coordinator.remove(first.subscriber);
+
+    const second = createSubscriber('01');
+    await fixture.coordinator.catchup(second.subscriber, 'serving', () => '06');
+    fixture.coordinator.close();
+
+    expect(fixture.reader.closed).toBe(true);
+    expect(fixture.forwarder.getAcks()).toEqual(new Set());
+  });
+
+  test('registers under the cleanup guard before exposing the subscriber ACK', async () => {
+    const guardGate = resolver<void>();
+    const cleanupGuard: SQLiteChangeLogCleanupGuard = {
+      async runWhilePurgeBlocked(register) {
+        await guardGate.promise;
+        return register();
+      },
+    };
+    const fixture = createFixture({cleanupGuard});
+    fixture.reader.head = '01';
+    fixture.reader.boundaries.add('01');
+    const {subscriber} = createSubscriber('01');
+    const registering = fixture.coordinator.catchup(
+      subscriber,
+      'serving',
+      () => '01',
+    );
+
+    expect(fixture.forwarder.getAcks()).toEqual(new Set());
+    guardGate.resolve();
+    await registering;
+    expect(fixture.forwarder.getAcks()).toEqual(new Set(['01']));
+  });
+});
+
+function createFixture(
+  opts: {
+    barrierTimeoutMs?: number | undefined;
+    cleanupGuard?: SQLiteChangeLogCleanupGuard | undefined;
+  } = {},
+) {
+  const logSink = new TestLogSink();
+  const lc = new LogContext('debug', undefined, logSink);
+  const reader = new TestReader();
+  const forwarder = new Forwarder(lc);
+  const onFatal = vi.fn<(error: AutoResetSignal) => Promise<void>>(() =>
+    Promise.resolve(),
+  );
+  const coordinator = new SQLiteChangeLogCatchup(lc, forwarder, reader, {
+    batchSize: 2,
+    barrierTimeoutMs: opts.barrierTimeoutMs ?? 1_000,
+    barrierPollIntervalMs: 1,
+    cleanupGuard: opts.cleanupGuard,
+    onFatal,
+  });
+  coordinators.push(coordinator);
+  return {coordinator, forwarder, logSink, onFatal, reader};
+}
+
+class TestReader implements SQLiteChangeLogCatchupReader {
+  readonly boundaries = new Set(['01']);
+  readonly entries: WatermarkedChange[] = [];
+  readonly reads: {from: string; through: string; batchSize: number}[] = [];
+  min = '01';
+  head = '01';
+  beforeRead: Promise<void> | undefined;
+  readError: Error | undefined;
+  closed = false;
+
+  plan(fromWatermark: string): CatchupPlan {
+    if (fromWatermark > this.head) {
+      return {kind: 'ahead', headWatermark: this.head};
+    }
+    if (fromWatermark < this.min || !this.boundaries.has(fromWatermark)) {
+      return {
+        kind: 'too-old',
+        minWatermark: this.min,
+        headWatermark: this.head,
+      };
+    }
+    return {
+      kind: 'range',
+      minWatermark: this.min,
+      headWatermark: this.head,
+    };
+  }
+
+  async *read(
+    fromWatermark: string,
+    throughWatermark: string,
+    batchSize: number,
+    signal?: AbortSignal,
+  ): AsyncIterable<readonly WatermarkedChange[]> {
+    this.reads.push({
+      from: fromWatermark,
+      through: throughWatermark,
+      batchSize,
+    });
+    await this.beforeRead;
+    if (signal?.aborted) {
+      throw new AbortError();
+    }
+    if (this.readError) {
+      throw this.readError;
+    }
+    const selected = this.entries.filter(
+      ([watermark]) =>
+        watermark > fromWatermark && watermark <= throughWatermark,
+    );
+    for (let i = 0; i < selected.length; i += batchSize) {
+      if (signal?.aborted) {
+        throw new AbortError();
+      }
+      yield selected.slice(i, i + batchSize);
+    }
+  }
+
+  close(): void {
+    this.closed = true;
+  }
+}
+
+function createSubscriber(watermark: string) {
+  const downstream = Subscription.create<string>();
+  const subscriber = new Subscriber(
+    5,
+    `subscriber-${watermark}`,
+    watermark,
+    downstream,
+    () => ({tag: 'status'}),
+  );
+  const {done, output} = drainToQueue(downstream);
+  return {done, subscriber, output};
+}
+
+function drainToQueue(source: Source<string>): {
+  done: Promise<void>;
+  output: Queue<Downstream>;
+} {
+  const queue = new Queue<Downstream>();
+  const done = (async () => {
+    for await (const json of source) {
+      queue.enqueue(BigIntJSON.parse(json) as Downstream);
+    }
+  })();
+  return {done, output: queue};
+}
+
+function entry(
+  watermark: string,
+  tag: 'begin' | 'insert' | 'commit' | 'rollback',
+): WatermarkedChange {
+  const downstreamTag = tag === 'insert' ? 'data' : tag;
+  return [
+    watermark,
+    tag,
+    JSON.stringify([downstreamTag, {tag, marker: `${watermark}:${tag}`}]),
+  ];
+}
+
+function transaction(watermark: string): WatermarkedChange[] {
+  return [
+    entry(watermark, 'begin'),
+    entry(watermark, 'insert'),
+    entry(watermark, 'commit'),
+  ];
+}
+
+function transactionMarkers(watermark: string) {
+  return [`${watermark}:begin`, `${watermark}:insert`, `${watermark}:commit`];
+}
+
+function forward(forwarder: Forwarder, changes: WatermarkedChange[]) {
+  for (const change of changes) {
+    forwarder.forward(change);
+  }
+}
+
+async function takeMarkers(output: Queue<Downstream>, count: number) {
+  const markers: string[] = [];
+  for (let i = 0; i < count; i++) {
+    const downstream = await output.dequeue();
+    if (downstream[0] === 'error') {
+      throw new Error(`unexpected downstream error: ${downstream[1].message}`);
+    }
+    const message = downstream[1];
+    markers.push(
+      message.tag === 'status'
+        ? 'status'
+        : String((message as unknown as {marker: string}).marker),
+    );
+  }
+  return markers;
+}

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.test.ts
@@ -14,6 +14,7 @@ import {AutoResetSignal} from './schema/tables.ts';
 import {
   SQLiteChangeLogCatchup,
   SQLiteChangeLogBarrierTimeoutError,
+  type SQLiteChangeLogCatchupOptions,
   type SQLiteChangeLogCatchupReader,
   type SQLiteChangeLogCleanupGuard,
 } from './sqlite-change-log-catchup.ts';
@@ -242,6 +243,30 @@ describe('SQLiteChangeLogCatchup', () => {
     expect(fixture.onFatal).not.toHaveBeenCalled();
   });
 
+  test('waits on a forwarded transaction with one completion handler', async () => {
+    let now = 0;
+    const fixture = createFixture({
+      barrierTimeoutMs: 5,
+      now: () => now,
+      sleep: ms => {
+        now += ms;
+        return Promise.resolve();
+      },
+    });
+    const completion = resolver<string>();
+    const then = vi.spyOn(completion.promise, 'then');
+    const {subscriber, done} = createSubscriber('01');
+
+    await fixture.coordinator.catchup(
+      subscriber,
+      'serving',
+      () => completion.promise,
+    );
+    await done;
+
+    expect(then).toHaveBeenCalledOnce();
+  });
+
   test('fails closed on reader errors after registration', async () => {
     const fixture = createFixture();
     fixture.reader.head = '06';
@@ -257,6 +282,33 @@ describe('SQLiteChangeLogCatchup', () => {
       [
         expect.stringContaining('error while catching up subscriber'),
         expect.objectContaining({message: 'broken SQLite read'}),
+      ],
+    ]);
+  });
+
+  test('fails the subscriber when fatal handling rejects', async () => {
+    const fatalError = new Error('failed to mark reset required');
+    const onFatal = vi.fn(() => Promise.reject(fatalError));
+    const fixture = createFixture({onFatal});
+    fixture.reader.min = '04';
+    fixture.reader.head = '06';
+    fixture.reader.boundaries.add('04');
+    const {subscriber, done} = createSubscriber('01');
+    const fail = vi.spyOn(subscriber, 'fail');
+
+    await fixture.coordinator.catchup(subscriber, 'backup', () => '06');
+    await vi.waitFor(() => expect(fail).toHaveBeenCalledOnce(), {
+      timeout: 100,
+    });
+    await done;
+    expect(onFatal).toHaveBeenCalledOnce();
+    expect(fail).toHaveBeenCalledWith(expect.any(AutoResetSignal));
+    expect(fixture.logSink.messages).toContainEqual([
+      'error',
+      expect.anything(),
+      [
+        expect.stringContaining('error while handling fatal SQLite catchup'),
+        fatalError,
       ],
     ]);
   });
@@ -305,21 +357,27 @@ function createFixture(
   opts: {
     barrierTimeoutMs?: number | undefined;
     cleanupGuard?: SQLiteChangeLogCleanupGuard | undefined;
+    now?: SQLiteChangeLogCatchupOptions['now'];
+    onFatal?: SQLiteChangeLogCatchupOptions['onFatal'];
+    sleep?: SQLiteChangeLogCatchupOptions['sleep'];
   } = {},
 ) {
   const logSink = new TestLogSink();
   const lc = new LogContext('debug', undefined, logSink);
   const reader = new TestReader();
   const forwarder = new Forwarder(lc);
-  const onFatal = vi.fn<(error: AutoResetSignal) => Promise<void>>(() =>
-    Promise.resolve(),
+  const onFatal = vi.fn(
+    opts.onFatal ??
+      ((_error: AutoResetSignal): Promise<void> => Promise.resolve()),
   );
   const coordinator = new SQLiteChangeLogCatchup(lc, forwarder, reader, {
     batchSize: 2,
     barrierTimeoutMs: opts.barrierTimeoutMs ?? 1_000,
     barrierPollIntervalMs: 1,
     cleanupGuard: opts.cleanupGuard,
+    now: opts.now,
     onFatal,
+    sleep: opts.sleep,
   });
   coordinators.push(coordinator);
   return {coordinator, forwarder, logSink, onFatal, reader};

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.ts
@@ -1,0 +1,328 @@
+import type {LogContext} from '@rocicorp/logger';
+import {AbortError} from '../../../../shared/src/abort-error.ts';
+import {sleep} from '../../../../shared/src/sleep.ts';
+import {getOrCreateCounter} from '../../observability/metrics.ts';
+import type {ReplicatorMode} from '../replicator/replicator.ts';
+import type {WatermarkedChange} from './change-streamer.ts';
+import * as ErrorType from './error-type-enum.ts';
+import type {Forwarder} from './forwarder.ts';
+import {AutoResetSignal} from './schema/tables.ts';
+import type {CatchupPlan} from './sqlite-change-log-reader.ts';
+import type {Subscriber} from './subscriber.ts';
+
+export interface SQLiteChangeLogCatchupReader {
+  plan(fromWatermark: string): CatchupPlan;
+  read(
+    fromWatermark: string,
+    throughWatermark: string,
+    batchSize: number,
+    signal?: AbortSignal,
+  ): AsyncIterable<readonly WatermarkedChange[]>;
+  close(): void;
+}
+
+/**
+ * Slice 9 replaces this no-op implementation with a guard that waits for an
+ * in-flight purge and blocks new purge dispatch while the subscriber's ACK is
+ * made visible to the Forwarder.
+ */
+export interface SQLiteChangeLogCleanupGuard {
+  runWhilePurgeBlocked<T>(register: () => T): Promise<T>;
+}
+
+export type SQLiteChangeLogCatchupOptions = {
+  batchSize: number;
+  barrierTimeoutMs: number;
+  barrierPollIntervalMs?: number | undefined;
+  cleanupGuard?: SQLiteChangeLogCleanupGuard | undefined;
+  onFatal: (error: AutoResetSignal) => Promise<void>;
+  sleep?: typeof sleep | undefined;
+  now?: (() => number) | undefined;
+};
+
+const NOOP_CLEANUP_GUARD: SQLiteChangeLogCleanupGuard = {
+  runWhilePurgeBlocked: register => Promise.resolve(register()),
+};
+
+/**
+ * Coordinates the gap-free transition from replica-local SQLite catchup to
+ * the Forwarder's live stream.
+ *
+ * Registration and required-head capture happen in one synchronous callback.
+ * The subscriber therefore either sees a transaction in SQLite catchup or in
+ * its live backlog (duplicates across that boundary are filtered by
+ * Subscriber), never in neither place.
+ */
+export class SQLiteChangeLogCatchup implements Disposable {
+  readonly #lc: LogContext;
+  readonly #forwarder: Forwarder;
+  readonly #reader: SQLiteChangeLogCatchupReader;
+  readonly #batchSize: number;
+  readonly #barrierTimeoutMs: number;
+  readonly #barrierPollIntervalMs: number;
+  readonly #cleanupGuard: SQLiteChangeLogCleanupGuard;
+  readonly #onFatal: (error: AutoResetSignal) => Promise<void>;
+  readonly #sleep: typeof sleep;
+  readonly #now: () => number;
+  readonly #barrierTimeouts = getOrCreateCounter(
+    'replication',
+    'sqlite_change_log.barrier_timeouts',
+    'SQLite change-log catchups that timed out waiting for the required head.',
+  );
+  readonly #catchups = new Map<Subscriber, AbortController>();
+  #closed = false;
+
+  constructor(
+    lc: LogContext,
+    forwarder: Forwarder,
+    reader: SQLiteChangeLogCatchupReader,
+    opts: SQLiteChangeLogCatchupOptions,
+  ) {
+    this.#lc = lc.withContext('component', 'sqlite-change-log-catchup');
+    this.#forwarder = forwarder;
+    this.#reader = reader;
+    this.#batchSize = opts.batchSize;
+    this.#barrierTimeoutMs = opts.barrierTimeoutMs;
+    this.#barrierPollIntervalMs = opts.barrierPollIntervalMs ?? 10;
+    this.#cleanupGuard = opts.cleanupGuard ?? NOOP_CLEANUP_GUARD;
+    this.#onFatal = opts.onFatal;
+    this.#sleep = opts.sleep ?? sleep;
+    this.#now = opts.now ?? Date.now;
+  }
+
+  /**
+   * Registers the subscriber before resolving. Catchup itself continues in
+   * the background so subscribe() does not wait for SQLite to reach the
+   * required head.
+   */
+  async catchup(
+    subscriber: Subscriber,
+    mode: ReplicatorMode,
+    captureRequiredHead: () => string | Promise<string>,
+  ): Promise<void> {
+    if (this.#closed) {
+      subscriber.fail(new AbortError('SQLite change-log catchup is closed'));
+      return;
+    }
+
+    const abort = new AbortController();
+    this.#catchups.set(subscriber, abort);
+    let requiredHead: string | Promise<string> | undefined;
+    try {
+      await this.#cleanupGuard.runWhilePurgeBlocked(() => {
+        this.#throwIfAborted(abort.signal);
+        requiredHead = captureRequiredHead();
+        this.#forwarder.add(subscriber);
+      });
+    } catch (error) {
+      this.#catchups.delete(subscriber);
+      if (!abort.signal.aborted) {
+        this.#lc.error?.(
+          `error while registering SQLite catchup subscriber ${subscriber.id}`,
+          error,
+        );
+        subscriber.fail(error);
+      }
+      return;
+    }
+
+    void this.#run(
+      subscriber,
+      mode,
+      requiredHead as string | Promise<string>,
+      abort,
+    );
+  }
+
+  remove(subscriber: Subscriber): void {
+    this.#catchups.get(subscriber)?.abort();
+    this.#catchups.delete(subscriber);
+    this.#forwarder.remove(subscriber);
+  }
+
+  close(): void {
+    if (this.#closed) {
+      return;
+    }
+    this.#closed = true;
+    for (const [subscriber, abort] of this.#catchups) {
+      abort.abort();
+      this.#forwarder.remove(subscriber);
+    }
+    this.#catchups.clear();
+    this.#reader.close();
+  }
+
+  [Symbol.dispose](): void {
+    this.close();
+  }
+
+  async #run(
+    subscriber: Subscriber,
+    mode: ReplicatorMode,
+    requiredHead: string | Promise<string>,
+    abort: AbortController,
+  ): Promise<void> {
+    const {signal} = abort;
+    const deadline = this.#now() + this.#barrierTimeoutMs;
+    try {
+      const required = await this.#awaitRequiredHead(
+        requiredHead,
+        deadline,
+        signal,
+      );
+      const plan = await this.#waitForPlan(
+        subscriber.watermark,
+        required,
+        deadline,
+        signal,
+      );
+      this.#throwIfAborted(signal);
+
+      if (plan.kind === 'too-old') {
+        const message =
+          `earliest supported watermark is ${plan.minWatermark} ` +
+          `(requested ${subscriber.watermark})`;
+        if (mode === 'backup') {
+          throw new AutoResetSignal(
+            `backup replica at watermark ${subscriber.watermark} is behind ` +
+              `SQLite change log: ${plan.minWatermark}`,
+          );
+        }
+        this.#lc.warn?.(
+          `rejecting subscriber at watermark ${subscriber.watermark} ` +
+            `(earliest watermark: ${plan.minWatermark})`,
+        );
+        subscriber.close(ErrorType.WatermarkTooOld, message);
+        return;
+      }
+
+      let count = 0;
+      const start = this.#now();
+      if (plan.kind === 'range') {
+        let lastBatchConsumed: Promise<unknown> | undefined;
+        for await (const changes of this.#reader.read(
+          subscriber.watermark,
+          plan.headWatermark,
+          this.#batchSize,
+          signal,
+        )) {
+          const waitStart = this.#now();
+          await lastBatchConsumed;
+          const elapsed = this.#now() - waitStart;
+          if (lastBatchConsumed) {
+            this.#lc[elapsed > 100 ? 'info' : 'debug']?.(
+              `waited ${elapsed.toFixed(3)} ms for ${subscriber.id} to consume ` +
+                `the previous SQLite catchup batch`,
+            );
+          }
+          this.#throwIfAborted(signal);
+          for (const change of changes) {
+            lastBatchConsumed = subscriber.catchup(change);
+            count++;
+          }
+        }
+        await lastBatchConsumed;
+      } else {
+        this.#lc.warn?.(
+          `subscriber ${subscriber.id} at watermark ${subscriber.watermark} ` +
+            `is ahead of the SQLite change-log head ${plan.headWatermark}; ` +
+            `waiting for the replica to catch up`,
+        );
+      }
+
+      this.#throwIfAborted(signal);
+      this.#lc.info?.(
+        `caught up ${subscriber.id} from SQLite with ${count} changes ` +
+          `(${this.#now() - start} ms)`,
+      );
+      // Keep buffering live sends until the asynchronous backlog drain has
+      // established its ordering boundary.
+      void subscriber.setCaughtUp();
+    } catch (error) {
+      if (signal.aborted) {
+        return;
+      }
+      this.#lc.error?.(
+        `error while catching up subscriber ${subscriber.id} from SQLite`,
+        error,
+      );
+      if (error instanceof SQLiteChangeLogBarrierTimeoutError) {
+        this.#barrierTimeouts.add(1);
+      }
+      if (error instanceof AutoResetSignal) {
+        await this.#onFatal(error);
+      }
+      subscriber.fail(error);
+    } finally {
+      if (this.#catchups.get(subscriber) === abort) {
+        this.#catchups.delete(subscriber);
+      }
+    }
+  }
+
+  async #awaitRequiredHead(
+    requiredHead: string | Promise<string>,
+    deadline: number,
+    signal: AbortSignal,
+  ): Promise<string> {
+    if (typeof requiredHead === 'string') {
+      return requiredHead;
+    }
+    while (true) {
+      this.#throwIfAborted(signal);
+      const remaining = deadline - this.#now();
+      if (remaining <= 0) {
+        throw new SQLiteChangeLogBarrierTimeoutError(
+          'timed out waiting for the forwarded transaction to finish',
+        );
+      }
+      const result = await Promise.race([
+        requiredHead.then(value => ({kind: 'required', value}) as const),
+        this.#sleep(
+          Math.min(this.#barrierPollIntervalMs, remaining),
+          signal,
+        ).then(() => ({kind: 'pending'}) as const),
+      ]);
+      if (result.kind === 'required') {
+        return result.value;
+      }
+    }
+  }
+
+  async #waitForPlan(
+    fromWatermark: string,
+    requiredHead: string,
+    deadline: number,
+    signal: AbortSignal,
+  ): Promise<CatchupPlan> {
+    while (true) {
+      this.#throwIfAborted(signal);
+      const plan = this.#reader.plan(fromWatermark);
+      if (plan.headWatermark >= requiredHead) {
+        return plan;
+      }
+      const remaining = deadline - this.#now();
+      if (remaining <= 0) {
+        throw new SQLiteChangeLogBarrierTimeoutError(
+          `timed out waiting for SQLite head ${plan.headWatermark} to reach ` +
+            `required head ${requiredHead}`,
+        );
+      }
+      await this.#sleep(
+        Math.min(this.#barrierPollIntervalMs, remaining),
+        signal,
+      );
+    }
+  }
+
+  #throwIfAborted(signal: AbortSignal): void {
+    if (this.#closed || signal.aborted) {
+      throw new AbortError('SQLite change-log catchup aborted');
+    }
+  }
+}
+
+export class SQLiteChangeLogBarrierTimeoutError extends Error {
+  readonly name = 'SQLiteChangeLogBarrierTimeoutError';
+}

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.ts
@@ -251,7 +251,14 @@ export class SQLiteChangeLogCatchup implements Disposable {
         this.#barrierTimeouts.add(1);
       }
       if (error instanceof AutoResetSignal) {
-        await this.#onFatal(error);
+        try {
+          await this.#onFatal(error);
+        } catch (fatalError) {
+          this.#lc.error?.(
+            `error while handling fatal SQLite catchup failure for ${subscriber.id}`,
+            fatalError,
+          );
+        }
       }
       subscriber.fail(error);
     } finally {
@@ -269,25 +276,23 @@ export class SQLiteChangeLogCatchup implements Disposable {
     if (typeof requiredHead === 'string') {
       return requiredHead;
     }
-    while (true) {
-      this.#throwIfAborted(signal);
-      const remaining = deadline - this.#now();
-      if (remaining <= 0) {
-        throw new SQLiteChangeLogBarrierTimeoutError(
-          'timed out waiting for the forwarded transaction to finish',
-        );
-      }
-      const result = await Promise.race([
-        requiredHead.then(value => ({kind: 'required', value}) as const),
-        this.#sleep(
-          Math.min(this.#barrierPollIntervalMs, remaining),
-          signal,
-        ).then(() => ({kind: 'pending'}) as const),
-      ]);
-      if (result.kind === 'required') {
-        return result.value;
-      }
+    this.#throwIfAborted(signal);
+    const remaining = deadline - this.#now();
+    if (remaining <= 0) {
+      throw new SQLiteChangeLogBarrierTimeoutError(
+        'timed out waiting for the forwarded transaction to finish',
+      );
     }
+    const result = await Promise.race([
+      requiredHead.then(value => ({kind: 'required', value}) as const),
+      this.#sleep(remaining, signal).then(() => ({kind: 'timeout'}) as const),
+    ]);
+    if (result.kind === 'timeout') {
+      throw new SQLiteChangeLogBarrierTimeoutError(
+        'timed out waiting for the forwarded transaction to finish',
+      );
+    }
+    return result.value;
   }
 
   async #waitForPlan(

--- a/packages/zero-cache/src/services/replicator/sqlite-change-log-purger.test.ts
+++ b/packages/zero-cache/src/services/replicator/sqlite-change-log-purger.test.ts
@@ -1,0 +1,438 @@
+import {afterEach, describe, expect, test} from 'vitest';
+import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
+import type {Database} from '../../../../zqlite/src/db.ts';
+import {StatementRunner} from '../../db/statements.ts';
+import {DbFile} from '../../test/lite.ts';
+import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
+import {serializeChangeStreamData} from '../change-streamer/change-log-codec.ts';
+import type {WatermarkedChange} from '../change-streamer/change-streamer.ts';
+import {SQLiteChangeLogReader} from '../change-streamer/sqlite-change-log-reader.ts';
+import {ChangeLogStreamWriter} from './change-log-stream-writer.ts';
+import {CHANGE_LOG_STREAM_WRITE_TIME_INDEX} from './schema/change-log-stream.ts';
+import {
+  initReplicationState,
+  updateReplicationWatermark,
+} from './schema/replication-state.ts';
+import {
+  SQLITE_CHANGE_LOG_TIME_FLOOR_SQL,
+  SQLiteChangeLogPurger,
+  type SQLiteChangeLogPurgeResult,
+} from './sqlite-change-log-purger.ts';
+
+const lc = createSilentLogContext();
+const files: DbFile[] = [];
+
+afterEach(() => {
+  for (const file of files.splice(0)) {
+    file.delete();
+  }
+});
+
+function createReplica(seedWriteTimeMs = 100): {db: Database; file: DbFile} {
+  const file = new DbFile('sqlite-change-log-purger');
+  files.push(file);
+  const db = file.connect(lc);
+  db.pragma('journal_mode = wal');
+  initReplicationState(db, ['zero_data'], '02');
+  db.prepare(/*sql*/ `
+    UPDATE "_zero.changeLogStream"
+    SET "writeTimeMs" = ?
+    WHERE "watermark" = '02' AND "writeTimeMs" IS NOT NULL
+  `).run(seedWriteTimeMs);
+  db.prepare(/*sql*/ `
+    UPDATE "_zero.replicationState" SET "writeTimeMs" = ?
+  `).run(seedWriteTimeMs);
+  return {db, file};
+}
+
+function truncate(): ChangeStreamData {
+  return ['data', {tag: 'truncate', relations: []}];
+}
+
+function appendTransaction(
+  db: Database,
+  watermark: string,
+  totalRows: number,
+  writeTimeMs: number,
+): readonly WatermarkedChange[] {
+  expect(totalRows).toBeGreaterThanOrEqual(2);
+  const runner = new StatementRunner(db);
+  const writer = new ChangeLogStreamWriter(db);
+  const begin: ChangeStreamData = [
+    'begin',
+    {tag: 'begin'},
+    {commitWatermark: watermark},
+  ];
+  const data = Array.from({length: totalRows - 2}, truncate);
+  const commit: ChangeStreamData = ['commit', {tag: 'commit'}, {watermark}];
+
+  runner.beginImmediate();
+  try {
+    writer.begin(watermark, serializeChangeStreamData(begin));
+    for (const message of data) {
+      writer.append(serializeChangeStreamData(message), message[1].tag);
+    }
+    writer.commit(watermark, serializeChangeStreamData(commit), writeTimeMs);
+    updateReplicationWatermark(runner, watermark, writeTimeMs);
+    runner.commit();
+  } catch (e) {
+    runner.rollback();
+    throw e;
+  }
+
+  return [begin, ...data, commit].map(message => [
+    watermark,
+    message[1].tag,
+    serializeChangeStreamData(message),
+  ]);
+}
+
+function watermarks(db: Database): readonly string[] {
+  return db
+    .prepare(/*sql*/ `
+      SELECT DISTINCT "watermark"
+      FROM "_zero.changeLogStream"
+      ORDER BY "watermark"
+    `)
+    .all<{watermark: string}>()
+    .map(({watermark}) => watermark);
+}
+
+function assertCompleteTransactions(db: Database): void {
+  expect(
+    db
+      .prepare(/*sql*/ `
+        SELECT "watermark"
+        FROM "_zero.changeLogStream"
+        GROUP BY "watermark"
+        HAVING min("pos") <> 0
+          OR max("pos") <> count(*) - 1
+          OR json_extract(
+            max(CASE WHEN "pos" = 0 THEN "change" END), '$.tag'
+          ) <> 'begin'
+          OR json_extract(
+            max(CASE WHEN "precommit" IS NOT NULL THEN "change" END), '$.tag'
+          ) <> 'commit'
+          OR sum(CASE WHEN "precommit" IS NOT NULL THEN 1 ELSE 0 END) <> 1
+      `)
+      .all(),
+  ).toEqual([]);
+}
+
+function populateFourTransactions(db: Database): void {
+  appendTransaction(db, '04', 2, 200);
+  appendTransaction(db, '06', 2, 300);
+  appendTransaction(db, '08', 2, 400);
+}
+
+describe('replicator/sqlite-change-log-purger', () => {
+  test.each([
+    {
+      name: 'external floor is limiting',
+      externalFloor: '04',
+      retentionCutoffMs: 250,
+      expectedTimeFloor: '06',
+      expectedEffectiveFloor: '04',
+      expectedWatermarks: ['04', '06', '08'],
+    },
+    {
+      name: 'time floor is limiting',
+      externalFloor: '08',
+      retentionCutoffMs: 250,
+      expectedTimeFloor: '06',
+      expectedEffectiveFloor: '06',
+      expectedWatermarks: ['06', '08'],
+    },
+    {
+      name: 'head caps an ahead external floor',
+      externalFloor: '0a',
+      retentionCutoffMs: 500,
+      expectedTimeFloor: '08',
+      expectedEffectiveFloor: '08',
+      expectedWatermarks: ['08'],
+    },
+    {
+      name: 'equal external and time floors',
+      externalFloor: '06',
+      retentionCutoffMs: 300,
+      expectedTimeFloor: '06',
+      expectedEffectiveFloor: '06',
+      expectedWatermarks: ['06', '08'],
+    },
+    {
+      name: 'time floor and head are equal',
+      externalFloor: '0a',
+      retentionCutoffMs: 400,
+      expectedTimeFloor: '08',
+      expectedEffectiveFloor: '08',
+      expectedWatermarks: ['08'],
+    },
+  ])(
+    'combines retention floors when $name',
+    ({
+      externalFloor,
+      retentionCutoffMs,
+      expectedTimeFloor,
+      expectedEffectiveFloor,
+      expectedWatermarks,
+    }) => {
+      const {db} = createReplica();
+      using writer = db;
+      populateFourTransactions(writer);
+      const purger = new SQLiteChangeLogPurger(writer);
+
+      const result = purger.purgeBatch({
+        externalFloor,
+        retentionCutoffMs,
+        maxRows: 100,
+      });
+
+      expect(result).toMatchObject({
+        headWatermark: '08',
+        timeFloor: expectedTimeFloor,
+        effectiveFloor: expectedEffectiveFloor,
+        moreEligible: false,
+      });
+      expect(result.deletedRows).toBe((4 - expectedWatermarks.length) * 2);
+      expect(watermarks(writer)).toEqual(expectedWatermarks);
+      expect(watermarks(writer)).toContain('08');
+      assertCompleteTransactions(writer);
+    },
+  );
+
+  test.each([
+    {
+      name: 'zero eligible rows',
+      externalFloor: '02',
+      maxRows: 10,
+      expectedDeletedRows: 0,
+      expectedDeletedBefore: undefined,
+    },
+    {
+      name: 'fewer rows than the target',
+      externalFloor: '08',
+      maxRows: 10,
+      expectedDeletedRows: 6,
+      expectedDeletedBefore: '08',
+    },
+    {
+      name: 'exactly the target rows',
+      externalFloor: '08',
+      maxRows: 6,
+      expectedDeletedRows: 6,
+      expectedDeletedBefore: '08',
+    },
+  ])(
+    'handles $name',
+    ({externalFloor, maxRows, expectedDeletedRows, expectedDeletedBefore}) => {
+      const {db} = createReplica();
+      using writer = db;
+      populateFourTransactions(writer);
+      const purger = new SQLiteChangeLogPurger(writer);
+
+      const result = purger.purgeBatch({
+        externalFloor,
+        retentionCutoffMs: Number.MAX_SAFE_INTEGER,
+        maxRows,
+      });
+
+      expect(result).toMatchObject({
+        deletedRows: expectedDeletedRows,
+        deletedBeforeWatermark: expectedDeletedBefore,
+        moreEligible: false,
+      });
+      assertCompleteTransactions(writer);
+    },
+  );
+
+  test('bounds many small transactions and makes monotonic progress', () => {
+    const {db} = createReplica();
+    using writer = db;
+    appendTransaction(writer, '04', 2, 200);
+    appendTransaction(writer, '06', 2, 300);
+    appendTransaction(writer, '08', 2, 400);
+    appendTransaction(writer, '0a', 2, 500);
+    appendTransaction(writer, '0c', 2, 600);
+    const purger = new SQLiteChangeLogPurger(writer);
+    const results: SQLiteChangeLogPurgeResult[] = [];
+
+    do {
+      const result = purger.purgeBatch({
+        externalFloor: '0c',
+        retentionCutoffMs: Number.MAX_SAFE_INTEGER,
+        maxRows: 5,
+      });
+      results.push(result);
+      expect(result.deletedRows).toBeGreaterThan(0);
+      expect(result.deletedRows).toBeLessThanOrEqual(5);
+      expect(watermarks(writer)).toContain('0c');
+      assertCompleteTransactions(writer);
+    } while (results.at(-1)?.moreEligible);
+
+    expect(results.map(({deletedRows}) => deletedRows)).toEqual([4, 4, 2]);
+    expect(
+      results.map(({deletedBeforeWatermark}) => deletedBeforeWatermark),
+    ).toEqual(['06', '0a', '0c']);
+    expect(results.map(({moreEligible}) => moreEligible)).toEqual([
+      true,
+      true,
+      false,
+    ]);
+    expect(watermarks(writer)).toEqual(['0c']);
+
+    expect(
+      purger.purgeBatch({
+        externalFloor: '0c',
+        retentionCutoffMs: Number.MAX_SAFE_INTEGER,
+        maxRows: 5,
+      }),
+    ).toMatchObject({
+      deletedRows: 0,
+      deletedBeforeWatermark: undefined,
+      moreEligible: false,
+    });
+  });
+
+  test('deletes one oversized oldest transaction as a soft-limit batch', () => {
+    const {db} = createReplica();
+    using writer = db;
+    appendTransaction(writer, '04', 9, 200);
+    appendTransaction(writer, '06', 2, 300);
+    appendTransaction(writer, '08', 2, 400);
+    const purger = new SQLiteChangeLogPurger(writer);
+
+    // Remove the seed so 04 is the oldest transaction for the focused call.
+    expect(
+      purger.purgeBatch({
+        externalFloor: '04',
+        retentionCutoffMs: Number.MAX_SAFE_INTEGER,
+        maxRows: 2,
+      }).deletedRows,
+    ).toBe(2);
+
+    const oversized = purger.purgeBatch({
+      externalFloor: '08',
+      retentionCutoffMs: Number.MAX_SAFE_INTEGER,
+      maxRows: 3,
+    });
+    expect(oversized).toMatchObject({
+      deletedRows: 9,
+      deletedBeforeWatermark: '06',
+      moreEligible: true,
+    });
+    expect(watermarks(writer)).toEqual(['06', '08']);
+    assertCompleteTransactions(writer);
+
+    const final = purger.purgeBatch({
+      externalFloor: '08',
+      retentionCutoffMs: Number.MAX_SAFE_INTEGER,
+      maxRows: 3,
+    });
+    expect(final).toMatchObject({
+      deletedRows: 2,
+      deletedBeforeWatermark: '08',
+      moreEligible: false,
+    });
+    expect(watermarks(writer)).toEqual(['08']);
+    assertCompleteTransactions(writer);
+  });
+
+  test('uses the partial write-time index for the retention floor', () => {
+    const {db} = createReplica();
+    using writer = db;
+    populateFourTransactions(writer);
+
+    const plans = writer
+      .prepare(`EXPLAIN QUERY PLAN ${SQLITE_CHANGE_LOG_TIME_FLOOR_SQL}`)
+      .all<{detail: string}>(250);
+    const details = plans.map(({detail}) => detail).join('\n');
+    expect(details).toMatch(
+      new RegExp(
+        `\\bSEARCH\\b.*${CHANGE_LOG_STREAM_WRITE_TIME_INDEX.replaceAll(
+          '.',
+          '\\.',
+        )}`,
+      ),
+    );
+    expect(details).not.toMatch(/\bSCAN\b|USE TEMP B-TREE/);
+  });
+
+  test('preserves a reader pinned on a second connection while purging', async () => {
+    const {db, file} = createReplica();
+    using writer = db;
+    const tx04 = appendTransaction(writer, '04', 2, 200);
+    const tx06 = appendTransaction(writer, '06', 5, 300);
+    const tx08 = appendTransaction(writer, '08', 2, 400);
+    using reader = new SQLiteChangeLogReader(lc, file.path);
+    const plan = reader.plan('04');
+    expect(plan).toMatchObject({kind: 'range', headWatermark: '08'});
+    if (plan.kind !== 'range') {
+      throw new Error('expected a catchable SQLite range');
+    }
+
+    const iterator = reader
+      .read('04', plan.headWatermark, 1)
+      [Symbol.asyncIterator]();
+    const first = await iterator.next();
+    expect(first.done).toBe(false);
+
+    const purger = new SQLiteChangeLogPurger(writer);
+    expect(
+      purger.purgeBatch({
+        externalFloor: '04',
+        retentionCutoffMs: Number.MAX_SAFE_INTEGER,
+        maxRows: 100,
+      }),
+    ).toMatchObject({deletedRows: 2, moreEligible: false});
+
+    const batches: (readonly WatermarkedChange[])[] = [];
+    if (first.value !== undefined) {
+      batches.push(first.value);
+    }
+    for (;;) {
+      const next = await iterator.next();
+      if (next.done) {
+        break;
+      }
+      batches.push(next.value);
+    }
+
+    expect(batches.flatMap(batch => batch)).toEqual([...tx06, ...tx08]);
+    expect(watermarks(writer)).toEqual(['04', '06', '08']);
+    expect(tx04).toHaveLength(2);
+    assertCompleteTransactions(writer);
+  });
+
+  test('validates batch inputs and transaction ownership', () => {
+    const {db} = createReplica();
+    using writer = db;
+    const purger = new SQLiteChangeLogPurger(writer);
+
+    expect(() =>
+      purger.purgeBatch({
+        externalFloor: '02',
+        retentionCutoffMs: Number.NaN,
+        maxRows: 1,
+      }),
+    ).toThrow('retention cutoff must be a safe integer');
+    expect(() =>
+      purger.purgeBatch({
+        externalFloor: '02',
+        retentionCutoffMs: 0,
+        maxRows: 0,
+      }),
+    ).toThrow('purge batch size must be a positive safe integer');
+
+    const runner = new StatementRunner(writer);
+    runner.beginImmediate();
+    expect(() =>
+      purger.purgeBatch({
+        externalFloor: '02',
+        retentionCutoffMs: 0,
+        maxRows: 1,
+      }),
+    ).toThrow('purge must start outside a transaction');
+    expect(writer.inTransaction).toBe(true);
+    runner.rollback();
+  });
+});

--- a/packages/zero-cache/src/services/replicator/sqlite-change-log-purger.ts
+++ b/packages/zero-cache/src/services/replicator/sqlite-change-log-purger.ts
@@ -1,0 +1,202 @@
+import {assert} from '../../../../shared/src/asserts.ts';
+import type {Database, Statement} from '../../../../zqlite/src/db.ts';
+import {StatementRunner} from '../../db/statements.ts';
+import {min} from '../../types/lexi-version.ts';
+import {CHANGE_LOG_STREAM_TABLE} from './schema/change-log-stream.ts';
+
+type WatermarkRow = {
+  readonly watermark: string;
+};
+
+type HeadRow = {
+  readonly headWatermark: string;
+};
+
+export type SQLiteChangeLogPurgeOptions = {
+  /**
+   * The minimum backup/subscriber/snapshot watermark supplied by the
+   * change-streamer. Rows at this watermark are retained.
+   */
+  readonly externalFloor: string;
+  /** The inclusive lower bound of the time-retention window. */
+  readonly retentionCutoffMs: number;
+  /**
+   * Target number of rows to delete. One oversized oldest transaction can
+   * exceed this target so that every productive call makes progress.
+   */
+  readonly maxRows: number;
+};
+
+export type SQLiteChangeLogPurgeResult = {
+  readonly headWatermark: string;
+  readonly timeFloor: string;
+  readonly effectiveFloor: string;
+  readonly deletedRows: number;
+  /** All deleted rows had a watermark strictly below this value. */
+  readonly deletedBeforeWatermark: string | undefined;
+  readonly moreEligible: boolean;
+};
+
+export const SQLITE_CHANGE_LOG_HEAD_SQL = /*sql*/ `
+  SELECT "stateVersion" AS "headWatermark"
+  FROM "_zero.replicationState"
+`;
+
+/** Exported so a focused query-plan test covers the production query. */
+export const SQLITE_CHANGE_LOG_TIME_FLOOR_SQL = /*sql*/ `
+  SELECT "watermark"
+  FROM "${CHANGE_LOG_STREAM_TABLE}"
+  WHERE "writeTimeMs" IS NOT NULL
+    AND "writeTimeMs" >= ?
+  ORDER BY "writeTimeMs", "watermark"
+  LIMIT 1
+`;
+
+export const SQLITE_CHANGE_LOG_OLDEST_ELIGIBLE_SQL = /*sql*/ `
+  SELECT "watermark"
+  FROM "${CHANGE_LOG_STREAM_TABLE}"
+  WHERE "watermark" < ?
+  ORDER BY "watermark", "pos"
+  LIMIT 1
+`;
+
+export const SQLITE_CHANGE_LOG_OFFSET_CANDIDATE_SQL = /*sql*/ `
+  SELECT "watermark"
+  FROM "${CHANGE_LOG_STREAM_TABLE}"
+  WHERE "watermark" < ?
+  ORDER BY "watermark", "pos"
+  LIMIT 1 OFFSET ?
+`;
+
+export const SQLITE_CHANGE_LOG_NEXT_WATERMARK_SQL = /*sql*/ `
+  SELECT "watermark"
+  FROM "${CHANGE_LOG_STREAM_TABLE}"
+  WHERE "watermark" > ?
+    AND "watermark" < ?
+  ORDER BY "watermark", "pos"
+  LIMIT 1
+`;
+
+export const SQLITE_CHANGE_LOG_DELETE_PREFIX_SQL = /*sql*/ `
+  DELETE FROM "${CHANGE_LOG_STREAM_TABLE}"
+  WHERE "watermark" < ?
+`;
+
+/**
+ * Deletes a bounded, transaction-aligned prefix of the replica-local stream
+ * log. The purger owns one short SQLite write transaction per call, but no
+ * scheduling; callers must serialize it with replica application.
+ */
+export class SQLiteChangeLogPurger {
+  readonly #db: Database;
+  readonly #runner: StatementRunner;
+  readonly #head: Statement;
+  readonly #timeFloor: Statement;
+  readonly #oldestEligible: Statement;
+  readonly #offsetCandidate: Statement;
+  readonly #nextWatermark: Statement;
+  readonly #deletePrefix: Statement;
+
+  constructor(db: Database) {
+    this.#db = db;
+    this.#runner = new StatementRunner(db);
+    this.#head = db.prepare(SQLITE_CHANGE_LOG_HEAD_SQL);
+    this.#timeFloor = db.prepare(SQLITE_CHANGE_LOG_TIME_FLOOR_SQL);
+    this.#oldestEligible = db.prepare(SQLITE_CHANGE_LOG_OLDEST_ELIGIBLE_SQL);
+    this.#offsetCandidate = db.prepare(SQLITE_CHANGE_LOG_OFFSET_CANDIDATE_SQL);
+    this.#nextWatermark = db.prepare(SQLITE_CHANGE_LOG_NEXT_WATERMARK_SQL);
+    this.#deletePrefix = db.prepare(SQLITE_CHANGE_LOG_DELETE_PREFIX_SQL);
+  }
+
+  purgeBatch({
+    externalFloor,
+    retentionCutoffMs,
+    maxRows,
+  }: SQLiteChangeLogPurgeOptions): SQLiteChangeLogPurgeResult {
+    assert(
+      Number.isSafeInteger(retentionCutoffMs),
+      'SQLite change log retention cutoff must be a safe integer',
+    );
+    assert(
+      Number.isSafeInteger(maxRows) && maxRows > 0,
+      'SQLite change log purge batch size must be a positive safe integer',
+    );
+    assert(
+      !this.#db.inTransaction,
+      'SQLite change log purge must start outside a transaction',
+    );
+
+    let transactionStarted = false;
+    try {
+      this.#runner.beginImmediate();
+      transactionStarted = true;
+
+      const headRow = this.#head.get<HeadRow | undefined>();
+      assert(headRow !== undefined, 'replication state must be initialized');
+      const {headWatermark} = headRow;
+      const timeFloor =
+        this.#timeFloor.get<WatermarkRow | undefined>(retentionCutoffMs)
+          ?.watermark ?? headWatermark;
+      const effectiveFloor = min(externalFloor, timeFloor, headWatermark);
+
+      const oldestEligible = this.#oldestEligible.get<WatermarkRow | undefined>(
+        effectiveFloor,
+      )?.watermark;
+      if (oldestEligible === undefined) {
+        this.#runner.commit();
+        return {
+          headWatermark,
+          timeFloor,
+          effectiveFloor,
+          deletedRows: 0,
+          deletedBeforeWatermark: undefined,
+          moreEligible: false,
+        };
+      }
+
+      const candidate = this.#offsetCandidate.get<WatermarkRow | undefined>(
+        effectiveFloor,
+        maxRows,
+      )?.watermark;
+
+      let deleteCeiling: string;
+      if (candidate === undefined) {
+        // The complete eligible prefix contains at most maxRows rows.
+        deleteCeiling = effectiveFloor;
+      } else if (candidate !== oldestEligible) {
+        // The target offset reached a later transaction. Stop immediately
+        // before it, keeping this batch at or below maxRows rows.
+        deleteCeiling = candidate;
+      } else {
+        // The oldest transaction alone is larger than maxRows. Delete it as a
+        // soft-limit batch so the purger cannot stall forever.
+        deleteCeiling =
+          this.#nextWatermark.get<WatermarkRow | undefined>(
+            oldestEligible,
+            effectiveFloor,
+          )?.watermark ?? effectiveFloor;
+      }
+
+      const {changes: deletedRows} = this.#deletePrefix.run(deleteCeiling);
+      assert(deletedRows > 0, 'SQLite change log purge must make progress');
+      const moreEligible =
+        this.#oldestEligible.get<WatermarkRow | undefined>(effectiveFloor) !==
+        undefined;
+
+      this.#runner.commit();
+      return {
+        headWatermark,
+        timeFloor,
+        effectiveFloor,
+        deletedRows,
+        deletedBeforeWatermark: deleteCeiling,
+        moreEligible,
+      };
+    } catch (e) {
+      if (transactionStarted && this.#db.inTransaction) {
+        this.#runner.rollback();
+      }
+      throw e;
+    }
+  }
+}


### PR DESCRIPTION
Add a writer-side purger that combines the indexed time-retention floor with the externally supplied safety floor and current replica head, then deletes one transaction-aligned prefix in a short SQLite transaction. Keep maxRows as a soft target only when the oldest eligible transaction is oversized, and return structured progress for future scheduling and metrics.

Production state after deployment:

- Runtime behavior is unchanged because no production caller constructs or schedules the SQLite purger yet. PostgreSQL remains authoritative for catchup, purge, subscriber delivery, and replication-slot ACK durability.
- The purger caps every effective floor at the current replica head, so the latest SQLite transaction is never eligible for deletion even when an external floor is ahead.
- Time retention seeks through the partial writeTimeMs index. External backup, snapshot, and subscriber safety will be supplied by the change-streamer before purge is enabled.
- Each call deletes only a complete transaction prefix in one short BEGIN IMMEDIATE transaction. Normal batches stay at or below maxRows; one oversized oldest transaction may exceed the target so repeated calls cannot stall.
- Structured results expose the selected floors, exclusive delete ceiling, deleted row count, and whether more eligible history remains for a future idle-drain scheduler.
- This slice does not add write-worker RPC, canonical-worker routing, cleanup pause guards, reservation coordination, or idle scheduling. SQLite retention therefore remains unbounded in production, and sustained non-off modes are still unsafe until slice 9 lands.