### PR TITLE
chore(zero-cache): fix view-syncer restores

### DIFF
--- a/packages/zero-cache/src/server/replicator.ts
+++ b/packages/zero-cache/src/server/replicator.ts
@@ -92,7 +92,10 @@ export default async function runWorker(
     });
   initEventSink(lc, config);
 
-  if (fileMode === 'serving' && config.litestream.backupURL) {
+  if (
+    fileMode === 'serving' &&
+    (config.litestream.executable || config.litestream.executableV5)
+  ) {
     await restoreReplica(lc, config);
   }
 


### PR DESCRIPTION
Fix view-syncer restores, broken by an error in the refactoring in https://github.com/rocicorp/mono/pull/6268.

The previous logic used `config.litestream.executable` as the condition for whether to restore from litestream, while the refactor erroneously used `config.litestream.backupURL`. The latter is not necessarily set in view-syncer configs.