### PR TITLE
chore(rmv2): enforce change log db invariants at startup [9/n]

### DIFF
--- a/packages/zero-cache/src/services/replicator/change-log-db.test.ts
+++ b/packages/zero-cache/src/services/replicator/change-log-db.test.ts
@@ -1,0 +1,587 @@
+import {existsSync, writeFileSync} from 'node:fs';
+import {afterEach, describe, expect, test} from 'vitest';
+import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
+import {Database} from '../../../../zqlite/src/db.ts';
+import {DbFile, expectTableExact} from '../../test/lite.ts';
+import {
+  CHANGE_LOG_DB_SCHEMA_VERSION,
+  CHANGE_LOG_META_TABLE,
+  changeLogFileName,
+  deleteChangeLogDB,
+  openChangeLogDB,
+  readReplicaAnchor,
+  reconcileChangeLog,
+  type ReplicaAnchor,
+} from './change-log-db.ts';
+import {
+  CHANGE_LOG_STREAM_TABLE,
+  CREATE_CHANGE_LOG_STREAM_SCHEMA,
+} from './schema/change-log-stream.ts';
+
+const lc = createSilentLogContext();
+
+const ANCHOR: ReplicaAnchor = {
+  replicaVersion: '01',
+  stateVersion: '05',
+  writeTimeMs: 12345,
+};
+
+/** The main file and the sidecars `deleteLiteDB` removes. */
+const SIDECARS = ['', '-wal', '-wal2', '-shm'];
+
+const dbFiles: DbFile[] = [];
+
+afterEach(() => {
+  let file: DbFile | undefined;
+  while ((file = dbFiles.pop())) {
+    deleteChangeLogDB(file.path);
+    file.delete();
+  }
+});
+
+function newDbFile(): DbFile {
+  const file = new DbFile('change-log-db-test');
+  dbFiles.push(file);
+  return file;
+}
+
+type PartialAnchor = Omit<Partial<ReplicaAnchor>, 'writeTimeMs'> & {
+  writeTimeMs?: number | null | undefined;
+};
+
+function createReplica(anchor: PartialAnchor = ANCHOR): Database {
+  const db = new Database(lc, ':memory:');
+  db.exec(/*sql*/ `
+    CREATE TABLE "_zero.replicationConfig" (
+      replicaVersion TEXT NOT NULL,
+      publications TEXT NOT NULL,
+      initialSyncContext TEXT DEFAULT '{}',
+      lock INTEGER PRIMARY KEY DEFAULT 1 CHECK (lock=1)
+    );
+    CREATE TABLE "_zero.replicationState" (
+      stateVersion TEXT NOT NULL,
+      writeTimeMs INTEGER,
+      lock INTEGER PRIMARY KEY DEFAULT 1 CHECK (lock=1)
+    );
+  `);
+  if (anchor.replicaVersion !== undefined) {
+    db.prepare(/*sql*/ `
+      INSERT INTO "_zero.replicationConfig" (replicaVersion, publications)
+        VALUES (?, '[]')
+    `).run(anchor.replicaVersion);
+  }
+  if (anchor.stateVersion !== undefined) {
+    db.prepare(/*sql*/ `
+      INSERT INTO "_zero.replicationState" (stateVersion, writeTimeMs)
+        VALUES (?, ?)
+    `).run(anchor.stateVersion, anchor.writeTimeMs ?? null);
+  }
+  return db;
+}
+
+/**
+ * Appends a transaction the way the writer does: every row carries the
+ * transaction's *commit* watermark, and only the commit row carries
+ * `precommit` and `writeTimeMs`.
+ */
+function appendTransaction(
+  db: Database,
+  watermark: string,
+  precommit: string,
+  changes: number,
+  writeTimeMs: number,
+) {
+  const stmt = db.prepare(/*sql*/ `
+    INSERT INTO "${CHANGE_LOG_STREAM_TABLE}"
+      ("watermark", "pos", "change", "precommit", "writeTimeMs")
+      VALUES (?, ?, ?, ?, ?)
+  `);
+  stmt.run(watermark, 0, '{"tag":"begin"}', null, null);
+  for (let i = 1; i <= changes; i++) {
+    stmt.run(watermark, i, `{"tag":"insert","pos":${i}}`, null, null);
+  }
+  stmt.run(watermark, changes + 1, '{"tag":"commit"}', precommit, writeTimeMs);
+}
+
+function seedRows(anchor: ReplicaAnchor) {
+  return [
+    {
+      watermark: anchor.stateVersion,
+      pos: 0,
+      change: '{"tag":"begin"}',
+      precommit: null,
+      writeTimeMs: null,
+    },
+    {
+      watermark: anchor.stateVersion,
+      pos: 1,
+      change: '{"tag":"commit"}',
+      precommit: anchor.stateVersion,
+      writeTimeMs: anchor.writeTimeMs,
+    },
+  ];
+}
+
+function head(db: Database): string | null {
+  return db
+    .prepare(
+      /*sql*/ `SELECT max("watermark") AS "head" FROM "${CHANGE_LOG_STREAM_TABLE}"`,
+    )
+    .get<{head: string | null}>().head;
+}
+
+function meta(db: Database) {
+  return db.prepare(/*sql*/ `SELECT * FROM "${CHANGE_LOG_META_TABLE}"`).get();
+}
+
+/** A change-log db that is valid and consistent with {@link ANCHOR}. */
+function createReconciledLog(anchor = ANCHOR): Database {
+  const db = new Database(lc, ':memory:');
+  reconcileChangeLog(lc, db, anchor);
+  return db;
+}
+
+describe('replicator/change-log-db', () => {
+  describe('file naming', () => {
+    test('the log and its sidecars never collide with the replica', () => {
+      const replica = '/data/sync-replica.db';
+      expect(changeLogFileName(replica)).toBe(
+        '/data/sync-replica.db-change-log',
+      );
+
+      // Every change-log sidecar is a suffix of the change-log name itself,
+      // and none of them is a sidecar of the replica.
+      const replicaFiles = new Set(SIDECARS.map(s => replica + s));
+      const logFiles = SIDECARS.map(s => changeLogFileName(replica) + s);
+      expect(logFiles.filter(f => replicaFiles.has(f))).toEqual([]);
+    });
+
+    test('deleteChangeLogDB removes only the change-log files', () => {
+      const file = newDbFile();
+      const replicaFiles = SIDECARS.map(s => file.path + s);
+      const logFiles = SIDECARS.map(s => changeLogFileName(file.path) + s);
+      for (const f of [...replicaFiles, ...logFiles]) {
+        writeFileSync(f, '');
+      }
+
+      deleteChangeLogDB(file.path);
+
+      expect(replicaFiles.filter(f => !existsSync(f))).toEqual([]);
+      expect(logFiles.filter(f => existsSync(f))).toEqual([]);
+    });
+
+    test('deleteChangeLogDB is a no-op when the log is absent', () => {
+      const file = newDbFile();
+      expect(() => deleteChangeLogDB(file.path)).not.toThrow();
+      expect(existsSync(changeLogFileName(file.path))).toBe(false);
+    });
+  });
+
+  describe('openChangeLogDB', () => {
+    test('creates the file beside the replica when writable', () => {
+      const file = newDbFile();
+      using db = openChangeLogDB(lc, file.path, {readonly: false});
+
+      expect(db.name).toBe(changeLogFileName(file.path));
+      expect(existsSync(changeLogFileName(file.path))).toBe(true);
+    });
+
+    test('opens an existing file readonly', () => {
+      const file = newDbFile();
+      {
+        using db = openChangeLogDB(lc, file.path, {readonly: false});
+        reconcileChangeLog(lc, db, ANCHOR);
+      }
+
+      using db = openChangeLogDB(lc, file.path, {readonly: true});
+      expect(head(db)).toBe(ANCHOR.stateVersion);
+    });
+
+    // Slice 7E turns this into a decline-and-fall-back-to-PG, rather than a
+    // failed subscription.
+    test('readonly open of an absent log throws', () => {
+      const file = newDbFile();
+      expect(() => openChangeLogDB(lc, file.path, {readonly: true})).toThrow();
+    });
+  });
+
+  describe('readReplicaAnchor', () => {
+    test('reads the replica facts the log is anchored to', () => {
+      using replica = createReplica();
+      expect(readReplicaAnchor(replica)).toEqual(ANCHOR);
+    });
+
+    test('requires initialized replication state', () => {
+      using replica = createReplica({replicaVersion: '01'});
+      expect(() => readReplicaAnchor(replica)).toThrow(
+        'replication state must be initialized',
+      );
+    });
+
+    test('requires an initialized writeTimeMs', () => {
+      using replica = createReplica({...ANCHOR, writeTimeMs: null});
+      expect(() => readReplicaAnchor(replica)).toThrow(
+        'replication state writeTimeMs must be initialized',
+      );
+    });
+  });
+
+  describe('reconcileChangeLog: reseed reasons', () => {
+    test('created: empty database', () => {
+      using db = new Database(lc, ':memory:');
+
+      expect(reconcileChangeLog(lc, db, ANCHOR)).toEqual({
+        action: 'reseeded',
+        head: ANCHOR.stateVersion,
+        reason: 'created',
+      });
+      expect(head(db)).toBe(ANCHOR.stateVersion);
+      expect(meta(db)).toEqual({
+        replicaVersion: ANCHOR.replicaVersion,
+        schemaVersion: CHANGE_LOG_DB_SCHEMA_VERSION,
+        lock: 1,
+      });
+      expectTableExact(
+        db,
+        CHANGE_LOG_STREAM_TABLE,
+        seedRows(ANCHOR),
+        'number',
+        'watermark',
+        'pos',
+      );
+    });
+
+    test('created: stream table without the meta table', () => {
+      using db = new Database(lc, ':memory:');
+      db.exec(CREATE_CHANGE_LOG_STREAM_SCHEMA);
+      appendTransaction(db, '05', '04', 3, 100);
+
+      expect(reconcileChangeLog(lc, db, ANCHOR)).toEqual({
+        action: 'reseeded',
+        head: ANCHOR.stateVersion,
+        reason: 'created',
+      });
+      // The pre-existing rows are wiped, not retained.
+      expectTableExact(
+        db,
+        CHANGE_LOG_STREAM_TABLE,
+        seedRows(ANCHOR),
+        'number',
+        'watermark',
+        'pos',
+      );
+    });
+
+    test('created: meta table without its row', () => {
+      using db = createReconciledLog();
+      db.exec(/*sql*/ `DELETE FROM "${CHANGE_LOG_META_TABLE}"`);
+
+      expect(reconcileChangeLog(lc, db, ANCHOR)).toEqual({
+        action: 'reseeded',
+        head: ANCHOR.stateVersion,
+        reason: 'created',
+      });
+      expect(meta(db)).toEqual({
+        replicaVersion: ANCHOR.replicaVersion,
+        schemaVersion: CHANGE_LOG_DB_SCHEMA_VERSION,
+        lock: 1,
+      });
+    });
+
+    test('created: meta table without the stream table', () => {
+      using db = createReconciledLog();
+      db.exec(/*sql*/ `DROP TABLE "${CHANGE_LOG_STREAM_TABLE}"`);
+
+      expect(reconcileChangeLog(lc, db, ANCHOR)).toEqual({
+        action: 'reseeded',
+        head: ANCHOR.stateVersion,
+        reason: 'created',
+      });
+      expect(head(db)).toBe(ANCHOR.stateVersion);
+    });
+
+    test('schema-mismatch', () => {
+      using db = createReconciledLog();
+      appendTransaction(db, '07', '05', 3, 100);
+      db.exec(/*sql*/ `
+        UPDATE "${CHANGE_LOG_META_TABLE}"
+          SET "schemaVersion" = ${CHANGE_LOG_DB_SCHEMA_VERSION + 1}
+      `);
+
+      expect(reconcileChangeLog(lc, db, ANCHOR)).toEqual({
+        action: 'reseeded',
+        head: ANCHOR.stateVersion,
+        reason: 'schema-mismatch',
+      });
+      expect(meta(db)).toEqual({
+        replicaVersion: ANCHOR.replicaVersion,
+        schemaVersion: CHANGE_LOG_DB_SCHEMA_VERSION,
+        lock: 1,
+      });
+      expectTableExact(
+        db,
+        CHANGE_LOG_STREAM_TABLE,
+        seedRows(ANCHOR),
+        'number',
+        'watermark',
+        'pos',
+      );
+    });
+
+    test('replica-version-mismatch', () => {
+      // A log left behind by a replica that was reset and re-synced.
+      using db = createReconciledLog({...ANCHOR, replicaVersion: '00'});
+      appendTransaction(db, '07', '05', 3, 100);
+
+      expect(reconcileChangeLog(lc, db, ANCHOR)).toEqual({
+        action: 'reseeded',
+        head: ANCHOR.stateVersion,
+        reason: 'replica-version-mismatch',
+      });
+      expect(meta(db)).toEqual({
+        replicaVersion: ANCHOR.replicaVersion,
+        schemaVersion: CHANGE_LOG_DB_SCHEMA_VERSION,
+        lock: 1,
+      });
+      expectTableExact(
+        db,
+        CHANGE_LOG_STREAM_TABLE,
+        seedRows(ANCHOR),
+        'number',
+        'watermark',
+        'pos',
+      );
+    });
+
+    test('gap: valid meta with an empty log', () => {
+      using db = createReconciledLog();
+      db.exec(/*sql*/ `DELETE FROM "${CHANGE_LOG_STREAM_TABLE}"`);
+
+      expect(reconcileChangeLog(lc, db, ANCHOR)).toEqual({
+        action: 'reseeded',
+        head: ANCHOR.stateVersion,
+        reason: 'gap',
+      });
+      expect(head(db)).toBe(ANCHOR.stateVersion);
+    });
+
+    test('gap: head behind the replica', () => {
+      // e.g. the replica advanced while sqliteChangeLogMode was off, or power
+      // was lost with synchronous=NORMAL on the log.
+      using db = createReconciledLog({...ANCHOR, stateVersion: '03'});
+      appendTransaction(db, '04', '03', 2, 100);
+
+      expect(reconcileChangeLog(lc, db, ANCHOR)).toEqual({
+        action: 'reseeded',
+        head: ANCHOR.stateVersion,
+        reason: 'gap',
+      });
+      expectTableExact(
+        db,
+        CHANGE_LOG_STREAM_TABLE,
+        seedRows(ANCHOR),
+        'number',
+        'watermark',
+        'pos',
+      );
+    });
+
+    test('gap: truncation leaves the head behind the replica', () => {
+      using db = createReconciledLog({...ANCHOR, stateVersion: '03'});
+      appendTransaction(db, '07', '03', 2, 100);
+
+      expect(reconcileChangeLog(lc, db, ANCHOR)).toEqual({
+        action: 'reseeded',
+        head: ANCHOR.stateVersion,
+        reason: 'gap',
+      });
+      expect(head(db)).toBe(ANCHOR.stateVersion);
+    });
+  });
+
+  describe('reconcileChangeLog: truncation', () => {
+    test('removes rows above the replica head and retains the rest', () => {
+      using db = createReconciledLog({...ANCHOR, stateVersion: '02'});
+      appendTransaction(db, '03', '02', 1, 100);
+      appendTransaction(db, '05', '03', 1, 200);
+      appendTransaction(db, '06', '05', 1, 300);
+      appendTransaction(db, '07', '06', 2, 400);
+
+      // 3 rows in '06' + 4 rows in '07'
+      expect(reconcileChangeLog(lc, db, ANCHOR)).toEqual({
+        action: 'truncated',
+        head: ANCHOR.stateVersion,
+        rows: 7,
+      });
+      expect(head(db)).toBe(ANCHOR.stateVersion);
+      expect(
+        db
+          .prepare(/*sql*/ `SELECT DISTINCT "watermark" FROM "${CHANGE_LOG_STREAM_TABLE}"
+                       ORDER BY "watermark"`)
+          .all(),
+      ).toEqual([{watermark: '02'}, {watermark: '03'}, {watermark: '05'}]);
+      // The log's new head transaction is untouched by the truncation.
+      expect(
+        db
+          .prepare(/*sql*/ `SELECT * FROM "${CHANGE_LOG_STREAM_TABLE}"
+                       WHERE "watermark" = '05' ORDER BY "pos"`)
+          .all(),
+      ).toEqual([
+        {
+          watermark: '05',
+          pos: 0,
+          change: '{"tag":"begin"}',
+          precommit: null,
+          writeTimeMs: null,
+        },
+        {
+          watermark: '05',
+          pos: 1,
+          change: '{"tag":"insert","pos":1}',
+          precommit: null,
+          writeTimeMs: null,
+        },
+        {
+          watermark: '05',
+          pos: 2,
+          change: '{"tag":"commit"}',
+          precommit: '03',
+          writeTimeMs: 200,
+        },
+      ]);
+    });
+
+    test('removes a phantom transaction whole', () => {
+      // Every row of a transaction carries its commit watermark, so a phantom
+      // cannot leave an orphaned begin or a mid-transaction row behind.
+      using db = createReconciledLog();
+      appendTransaction(db, '09', '05', 25, 100);
+
+      expect(reconcileChangeLog(lc, db, ANCHOR)).toEqual({
+        action: 'truncated',
+        head: ANCHOR.stateVersion,
+        rows: 27,
+      });
+      expect(
+        db
+          .prepare(/*sql*/ `SELECT count(*) AS "rows" FROM "${CHANGE_LOG_STREAM_TABLE}"
+                       WHERE "watermark" > @stateVersion`)
+          .get<{rows: number}>({stateVersion: ANCHOR.stateVersion}).rows,
+      ).toBe(0);
+      expectTableExact(
+        db,
+        CHANGE_LOG_STREAM_TABLE,
+        seedRows(ANCHOR),
+        'number',
+        'watermark',
+        'pos',
+      );
+    });
+
+    test('is idempotent', () => {
+      using db = createReconciledLog();
+      appendTransaction(db, '09', '05', 2, 100);
+
+      expect(reconcileChangeLog(lc, db, ANCHOR)).toMatchObject({
+        action: 'truncated',
+      });
+      expect(reconcileChangeLog(lc, db, ANCHOR)).toEqual({
+        action: 'none',
+        head: ANCHOR.stateVersion,
+      });
+      expect(reconcileChangeLog(lc, db, ANCHOR)).toEqual({
+        action: 'none',
+        head: ANCHOR.stateVersion,
+      });
+    });
+  });
+
+  describe('reconcileChangeLog: consistent log', () => {
+    test('an empty-but-valid log at the replica head is a no-op', () => {
+      using db = createReconciledLog();
+
+      expect(reconcileChangeLog(lc, db, ANCHOR)).toEqual({
+        action: 'none',
+        head: ANCHOR.stateVersion,
+      });
+      expectTableExact(
+        db,
+        CHANGE_LOG_STREAM_TABLE,
+        seedRows(ANCHOR),
+        'number',
+        'watermark',
+        'pos',
+      );
+    });
+
+    test('a log at the replica head is not written to', () => {
+      const file = newDbFile();
+      using db = openChangeLogDB(lc, file.path, {readonly: false});
+      reconcileChangeLog(lc, db, ANCHOR);
+      appendTransaction(db, '07', '05', 2, 100);
+      const state = {...ANCHOR, stateVersion: '07'};
+
+      // data_version only advances for writes made by *another* connection.
+      using observer = openChangeLogDB(lc, file.path, {readonly: true});
+      const dataVersion = () => observer.pragma('data_version');
+      const before = dataVersion();
+
+      expect(reconcileChangeLog(lc, db, state)).toEqual({
+        action: 'none',
+        head: '07',
+      });
+      expect(dataVersion()).toEqual(before);
+
+      // Control: a write does move it.
+      appendTransaction(db, '09', '07', 1, 200);
+      expect(dataVersion()).not.toEqual(before);
+    });
+  });
+
+  describe('reconcileChangeLog: transaction', () => {
+    test('rolls back everything on failure', () => {
+      using db = createReconciledLog();
+      appendTransaction(db, '09', '05', 2, 100);
+      db.exec(/*sql*/ `
+        CREATE TRIGGER "no_deletes" BEFORE DELETE ON "${CHANGE_LOG_STREAM_TABLE}"
+        BEGIN SELECT RAISE(ABORT, 'boom'); END;
+      `);
+
+      expect(() => reconcileChangeLog(lc, db, ANCHOR)).toThrow('boom');
+      expect(db.inTransaction).toBe(false);
+      // The phantom is still there: nothing was half-applied.
+      expect(head(db)).toBe('09');
+    });
+
+    test('leaves no transaction open when a reseed fails', () => {
+      const file = newDbFile();
+      {
+        using db = openChangeLogDB(lc, file.path, {readonly: false});
+        reconcileChangeLog(lc, db, {...ANCHOR, replicaVersion: '00'});
+      }
+
+      using db = openChangeLogDB(lc, file.path, {readonly: true});
+      expect(() => reconcileChangeLog(lc, db, ANCHOR)).toThrow(
+        'attempt to write a readonly database',
+      );
+      expect(db.inTransaction).toBe(false);
+    });
+
+    test('does not roll back a transaction the failure already closed', () => {
+      // SQLite rolls back automatically for some errors (SQLITE_FULL,
+      // SQLITE_IOERR); issuing ROLLBACK then throws and masks the real cause.
+      const cause = new Error('database or disk is full');
+      const executed: string[] = [];
+      const db = {
+        inTransaction: false,
+        exec: (sql: string) => void executed.push(sql),
+        prepare: () => {
+          throw cause;
+        },
+      } as unknown as Database;
+
+      expect(() => reconcileChangeLog(lc, db, ANCHOR)).toThrow(cause);
+      expect(executed).toEqual(['BEGIN IMMEDIATE']);
+    });
+  });
+});

--- a/packages/zero-cache/src/services/replicator/change-log-db.ts
+++ b/packages/zero-cache/src/services/replicator/change-log-db.ts
@@ -1,0 +1,289 @@
+/**
+ * The change log lives in its own SQLite database, `${replicaFile}-change-log`,
+ * rather than in the replica file. It is a catchup cache: everything it holds is
+ * either already durable in the replica's litestream backup or re-derivable from
+ * the upstream replication slot, so it is deliberately excluded from the backup
+ * and is never a source of truth.
+ *
+ * Because it is disposable, it has no migration framework. Any inconsistency
+ * with the replica — a schema change, a leftover file from a different replica,
+ * a gap left by a crash or by running with the writer disabled — is resolved by
+ * {@link reconcileChangeLog}, which either truncates the offending rows or wipes
+ * and reseeds the log at the replica's current head. The worst outcome is a
+ * `too-old` for a lagging subscriber; a silently delivered gap is not reachable.
+ */
+
+import type {LogContext} from '@rocicorp/logger';
+import {assert} from '../../../../shared/src/asserts.ts';
+import {Database} from '../../../../zqlite/src/db.ts';
+import {deleteLiteDB} from '../../db/delete-lite-db.ts';
+import {
+  CHANGE_LOG_STREAM_TABLE,
+  CREATE_CHANGE_LOG_STREAM_SCHEMA,
+  SEED_CHANGE_LOG_STREAM_SQL,
+} from './schema/change-log-stream.ts';
+
+/**
+ * Bumped whenever the change-log database's schema changes. Since the file is a
+ * cache, a mismatch costs one reseed rather than a migration.
+ */
+export const CHANGE_LOG_DB_SCHEMA_VERSION = 1;
+
+export const CHANGE_LOG_META_TABLE = '_zero.changeLogMeta';
+
+// "replicaVersion" identifies the replica this log was built against, which
+// detects a file left behind by a replica that was since reset and re-synced.
+// "lock" enforces single-row semantics, as in "_zero.replicationConfig".
+const CREATE_CHANGE_LOG_META_SCHEMA = /*sql*/ `
+  CREATE TABLE "${CHANGE_LOG_META_TABLE}" (
+    "replicaVersion" TEXT NOT NULL,
+    "schemaVersion"  INTEGER NOT NULL,
+    "lock"           INTEGER PRIMARY KEY DEFAULT 1 CHECK ("lock" = 1)
+  );
+`;
+
+/**
+ * `${replicaFile}-change-log`, matching the `-serving-copy` convention.
+ *
+ * Its `-wal` / `-wal2` / `-shm` sidecars are suffixes of *this* name, so they
+ * never collide with the replica's own sidecars.
+ */
+export function changeLogFileName(replicaFile: string): string {
+  return `${replicaFile}-change-log`;
+}
+
+/**
+ * Removes the change-log database and its `-wal` / `-wal2` / `-shm` sidecars.
+ * Safe to call when the file does not exist.
+ */
+export function deleteChangeLogDB(replicaFile: string): void {
+  deleteLiteDB(changeLogFileName(replicaFile));
+}
+
+/** The replica facts the change log is anchored to. */
+export type ReplicaAnchor = {
+  readonly replicaVersion: string;
+  readonly stateVersion: string;
+  readonly writeTimeMs: number;
+};
+
+type ReplicaAnchorRow = {
+  readonly replicaVersion: string;
+  readonly stateVersion: string;
+  readonly writeTimeMs: number | null;
+};
+
+export function readReplicaAnchor(replica: Database): ReplicaAnchor {
+  const row = replica
+    .prepare(/*sql*/ `
+      SELECT config."replicaVersion",
+             state."stateVersion",
+             state."writeTimeMs"
+        FROM "_zero.replicationConfig" AS config,
+             "_zero.replicationState" AS state
+    `)
+    .get<ReplicaAnchorRow | undefined>();
+  assert(row !== undefined, 'replication state must be initialized');
+  assert(
+    row.writeTimeMs !== null,
+    'replication state writeTimeMs must be initialized',
+  );
+  return {
+    replicaVersion: row.replicaVersion,
+    stateVersion: row.stateVersion,
+    writeTimeMs: row.writeTimeMs,
+  };
+}
+
+/**
+ * Opens the change-log database beside `replicaFile`.
+ *
+ * A writable handle creates the file if it is absent; a `readonly` handle
+ * throws, which is the normal state for a change-streamer that starts before
+ * the replicator has created the log. Pragmas are the caller's responsibility,
+ * since only the writer sets the persistent ones.
+ */
+export function openChangeLogDB(
+  lc: LogContext,
+  replicaFile: string,
+  opts: {readonly: boolean},
+): Database {
+  return new Database(
+    lc.withContext('component', 'change-log-db'),
+    changeLogFileName(replicaFile),
+    {readonly: opts.readonly},
+  );
+}
+
+export type ReseedReason =
+  | 'created' // file or table absent
+  | 'schema-mismatch'
+  | 'replica-version-mismatch'
+  | 'gap'; // head < stateVersion after truncation
+
+export type ReconcileResult =
+  | {action: 'none'; head: string}
+  | {action: 'truncated'; head: string; rows: number}
+  | {action: 'reseeded'; head: string; reason: ReseedReason};
+
+/**
+ * Brings the change log into agreement with the replica, in one transaction on
+ * the change-log database.
+ *
+ * Writes are ordered log-first, so a crash can leave a *phantom* — a
+ * transaction in the log whose replica commit was lost — but never a *hole*.
+ * A phantom's rows all carry the aborted transaction's commit watermark, which
+ * is strictly greater than the replica's `stateVersion`, so deleting on that
+ * predicate removes phantoms whole and retains every committed transaction.
+ *
+ * Anything the ordering guarantee does not cover — the file was deleted, the
+ * replica ran with the writer disabled, the replica was restored, power was
+ * lost with `synchronous=NORMAL` — surfaces as a head that does not land on
+ * `stateVersion` after truncation, and is resolved by wiping and reseeding at
+ * the replica head.
+ */
+export function reconcileChangeLog(
+  lc: LogContext,
+  db: Database,
+  anchor: ReplicaAnchor,
+): ReconcileResult {
+  db.exec('BEGIN IMMEDIATE');
+  try {
+    const result = reconcile(lc, db, anchor);
+    db.exec('COMMIT');
+    return result;
+  } catch (e) {
+    if (db.inTransaction) {
+      db.exec('ROLLBACK');
+    }
+    throw e;
+  }
+}
+
+function reconcile(
+  lc: LogContext,
+  db: Database,
+  anchor: ReplicaAnchor,
+): ReconcileResult {
+  const wipe = wipeReason(db, anchor);
+  if (wipe !== undefined) {
+    return reseed(lc, db, anchor, wipe);
+  }
+
+  let head = readHead(db);
+  let rows = 0;
+  if (head !== null && head > anchor.stateVersion) {
+    rows = db
+      .prepare(/*sql*/ `
+        DELETE FROM "${CHANGE_LOG_STREAM_TABLE}" WHERE "watermark" > ?
+      `)
+      .run(anchor.stateVersion).changes;
+    head = readHead(db);
+  }
+
+  if (head !== anchor.stateVersion) {
+    return reseed(lc, db, anchor, 'gap');
+  }
+  if (rows > 0) {
+    lc.info?.('truncated phantom transactions from the SQLite change log', {
+      sqliteChangeLogReconcile: {head, rows},
+    });
+    return {action: 'truncated', head, rows};
+  }
+  lc.debug?.('SQLite change log is consistent with the replica', {
+    sqliteChangeLogReconcile: {head},
+  });
+  return {action: 'none', head};
+}
+
+function wipeReason(
+  db: Database,
+  anchor: ReplicaAnchor,
+): ReseedReason | undefined {
+  if (
+    !tableExists(db, CHANGE_LOG_STREAM_TABLE) ||
+    !tableExists(db, CHANGE_LOG_META_TABLE)
+  ) {
+    return 'created';
+  }
+  const meta = db
+    .prepare(/*sql*/ `
+      SELECT "replicaVersion", "schemaVersion" FROM "${CHANGE_LOG_META_TABLE}"
+    `)
+    .get<{replicaVersion: string; schemaVersion: number} | undefined>();
+  if (meta === undefined) {
+    return 'created';
+  }
+  if (meta.schemaVersion !== CHANGE_LOG_DB_SCHEMA_VERSION) {
+    return 'schema-mismatch';
+  }
+  if (meta.replicaVersion !== anchor.replicaVersion) {
+    return 'replica-version-mismatch';
+  }
+  return undefined;
+}
+
+function reseed(
+  lc: LogContext,
+  db: Database,
+  anchor: ReplicaAnchor,
+  reason: ReseedReason,
+): ReconcileResult {
+  // Dropping the table drops its partial index with it.
+  db.exec(/*sql*/ `
+    DROP TABLE IF EXISTS "${CHANGE_LOG_STREAM_TABLE}";
+    DROP TABLE IF EXISTS "${CHANGE_LOG_META_TABLE}";
+    ${CREATE_CHANGE_LOG_STREAM_SCHEMA}
+    ${CREATE_CHANGE_LOG_META_SCHEMA}
+  `);
+  db.prepare(/*sql*/ `
+    INSERT INTO "${CHANGE_LOG_META_TABLE}" ("replicaVersion", "schemaVersion")
+      VALUES (?, ?)
+  `).run(anchor.replicaVersion, CHANGE_LOG_DB_SCHEMA_VERSION);
+  seedChangeLogStream(db, anchor);
+
+  lc.info?.('reseeded the SQLite change log', {
+    sqliteChangeLogReconcile: {
+      reason,
+      head: anchor.stateVersion,
+      replicaVersion: anchor.replicaVersion,
+      schemaVersion: CHANGE_LOG_DB_SCHEMA_VERSION,
+    },
+  });
+  return {action: 'reseeded', head: anchor.stateVersion, reason};
+}
+
+/**
+ * Seeds a valid synthetic transaction at the replica's current watermark,
+ * making an otherwise empty log serviceable as a catchup boundary for a
+ * subscriber that is exactly at the replica head.
+ */
+export function seedChangeLogStream(db: Database, anchor: ReplicaAnchor): void {
+  db.prepare(SEED_CHANGE_LOG_STREAM_SQL).run({
+    stateVersion: anchor.stateVersion,
+    writeTimeMs: anchor.writeTimeMs,
+  });
+}
+
+/**
+ * `max()` on the primary key's leading column, i.e. an index seek. Null when
+ * the log is empty.
+ */
+function readHead(db: Database): string | null {
+  const {head} = db
+    .prepare(/*sql*/ `
+      SELECT max("watermark") AS "head" FROM "${CHANGE_LOG_STREAM_TABLE}"
+    `)
+    .get<{head: string | null}>();
+  return head;
+}
+
+function tableExists(db: Database, table: string): boolean {
+  return (
+    db
+      .prepare(/*sql*/ `
+        SELECT 1 FROM "sqlite_master" WHERE "type" = 'table' AND "name" = ?
+      `)
+      .get<{1: number} | undefined>(table) !== undefined
+  );
+}

--- a/packages/zero-cache/src/services/replicator/schema/change-log-stream.ts
+++ b/packages/zero-cache/src/services/replicator/schema/change-log-stream.ts
@@ -25,6 +25,22 @@ export const CREATE_CHANGE_LOG_STREAM_INDEX = /*sql*/ `
 export const CREATE_CHANGE_LOG_STREAM_SCHEMA =
   CREATE_CHANGE_LOG_STREAM_TABLE + CREATE_CHANGE_LOG_STREAM_INDEX;
 
+/**
+ * Inserts the synthetic begin/commit pair for a `@stateVersion` watermark.
+ *
+ * The insert is idempotent because migrateData can run again after a rollback
+ * followed by a roll-forward. Both rows are inserted by one statement so a
+ * caller outside a larger transaction cannot leave a partial seed.
+ */
+export const SEED_CHANGE_LOG_STREAM_SQL = /*sql*/ `
+  INSERT INTO "${CHANGE_LOG_STREAM_TABLE}"
+    ("watermark", "pos", "change", "precommit", "writeTimeMs")
+  VALUES
+    (@stateVersion, 0, '{"tag":"begin"}', NULL, NULL),
+    (@stateVersion, 1, '{"tag":"commit"}', @stateVersion, @writeTimeMs)
+  ON CONFLICT ("watermark", "pos") DO NOTHING
+`;
+
 type ReplicationState = {
   stateVersion: string;
   writeTimeMs: number | null;
@@ -33,9 +49,10 @@ type ReplicationState = {
 /**
  * Seeds a valid synthetic transaction at the replica's current watermark.
  *
- * The insert is idempotent because migrateData can run again after a rollback
- * followed by a roll-forward. Both rows are inserted by one statement so a
- * caller outside a larger transaction cannot leave a partial seed.
+ * This is the in-replica variant, used by initial sync and by replica-schema
+ * migration 14. The change-log database uses the anchor-parameterized
+ * `seedChangeLogStream` in `change-log-db.ts` instead, since the state it seeds
+ * from lives in a different file.
  */
 export function seedChangeLogStream(db: Database): void {
   const state = db
@@ -50,12 +67,5 @@ export function seedChangeLogStream(db: Database): void {
     'replication state writeTimeMs must be initialized',
   );
 
-  db.prepare(/*sql*/ `
-    INSERT INTO "${CHANGE_LOG_STREAM_TABLE}"
-      ("watermark", "pos", "change", "precommit", "writeTimeMs")
-    VALUES
-      (@stateVersion, 0, '{"tag":"begin"}', NULL, NULL),
-      (@stateVersion, 1, '{"tag":"commit"}', @stateVersion, @writeTimeMs)
-    ON CONFLICT ("watermark", "pos") DO NOTHING
-  `).run(state);
+  db.prepare(SEED_CHANGE_LOG_STREAM_SQL).run(state);
 }


### PR DESCRIPTION
Because the change log is now a separate DB we need to ensure it never drifts from the replica.

Asks and resolves some questions at start:

- new replica file is downloaded? wipe the change log
- change log schema changed? wipe the change log
- change log is ahead of the replica? truncate the change log

Presumably many of these things should be impossible due to ephemeral disks but... better to not take that chance and this catches if someone self hosts on persistent disks.