### PR TITLE
chore(zero-cache): suppress historical lag reports

### DIFF
--- a/packages/zero-cache/src/services/change-source/change-source.ts
+++ b/packages/zero-cache/src/services/change-source/change-source.ts
@@ -18,10 +18,14 @@ export type ChangeStream = {
 
 export interface ChangeSource {
   /**
-   * Starts a replication lag reporter, returning the send time of the next
-   * expected report, or `null` if lag reporting is not supported / enabled.
+   * Starts a replication lag reporter, returning the commit time of the first
+   * report, and the send time of the next expected report, or `null` if lag
+   * reporting is not supported / enabled.
    */
-  startLagReporter(): Promise<{nextSendTimeMs: number} | null> | null;
+  startLagReporter(): Promise<{
+    firstCommitTimeMs: number;
+    nextSendTimeMs: number;
+  } | null> | null;
 
   /**
    * Starts a stream of changes starting after the specific watermark,

--- a/packages/zero-cache/src/services/change-source/pg/change-source.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.test.ts
@@ -80,6 +80,7 @@ test('lag reporter retries missing reports', async () => {
 
   try {
     await expect(reporter.initiateLagReport()).resolves.toEqual({
+      firstCommitTimeMs: 1_000,
       nextSendTimeMs: 1_000,
     });
     expect(dbMock).toHaveBeenCalledTimes(2);

--- a/packages/zero-cache/src/services/change-source/pg/change-source.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.ts
@@ -312,7 +312,7 @@ class PostgresChangeSource implements ChangeSource {
     await this.#db.end();
   }
 
-  async startLagReporter(): Promise<{nextSendTimeMs: number} | null> {
+  async startLagReporter() {
     if (this.#lagReporter) {
       try {
         return await this.#lagReporter.initiateLagReport(true);
@@ -781,7 +781,7 @@ export class LagReporter {
         commitTimeMs,
       });
     }
-    return {nextSendTimeMs: now};
+    return {firstCommitTimeMs: commitTimeMs, nextSendTimeMs: now};
   }
 
   /**

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
@@ -108,7 +108,8 @@ describe('change-streamer/service', () => {
             changes,
             acks: {push: status => acks.enqueue(status)},
           }),
-        startLagReporter: () => Promise.resolve({nextSendTimeMs: 123}),
+        startLagReporter: () =>
+          Promise.resolve({firstCommitTimeMs: 100, nextSendTimeMs: 123}),
         stop: () => Promise.resolve(),
       },
       ReplicationStatusPublisher.forTesting(),
@@ -386,7 +387,8 @@ describe('change-streamer/service', () => {
             changes,
             acks: {push: status => acks.enqueue(status)},
           }),
-        startLagReporter: () => Promise.resolve({nextSendTimeMs: 123}),
+        startLagReporter: () =>
+          Promise.resolve({firstCommitTimeMs: 100, nextSendTimeMs: 123}),
         stop: () => Promise.resolve(),
       },
       ReplicationStatusPublisher.forTesting(),
@@ -565,7 +567,8 @@ describe('change-streamer/service', () => {
             changes,
             acks: {push: status => acks.enqueue(status)},
           }),
-        startLagReporter: () => Promise.resolve({nextSendTimeMs: 123}),
+        startLagReporter: () =>
+          Promise.resolve({firstCommitTimeMs: 100, nextSendTimeMs: 123}),
         stop: () => Promise.resolve(),
       },
       ReplicationStatusPublisher.forTesting(),
@@ -698,7 +701,8 @@ describe('change-streamer/service', () => {
             changes,
             acks: {push: status => acks.enqueue(status)},
           }),
-        startLagReporter: () => Promise.resolve({nextSendTimeMs: 123}),
+        startLagReporter: () =>
+          Promise.resolve({firstCommitTimeMs: 100, nextSendTimeMs: 123}),
         stop: () => Promise.resolve(),
       },
       ReplicationStatusPublisher.forTesting(),
@@ -825,6 +829,23 @@ describe('change-streamer/service', () => {
     });
     const downstream = drainToQueue(sub);
 
+    // Ignore lag reports from before this change stream was initialized.
+    changes.push([
+      'status',
+      {
+        ack: false,
+        lagReport: {
+          lastTimings: {
+            sendTimeMs: 10,
+            commitTimeMs: 10,
+            receiveTimeMs: 15,
+          },
+          nextSendTimeMs: 50,
+        },
+      },
+      {watermark: '08'},
+    ]);
+
     changes.push(['begin', messages.begin(), {commitWatermark: '09'}]);
     changes.push(['data', messages.insert('foo', {id: 'hello'})]);
     changes.push(['data', messages.insert('foo', {id: 'world'})]);
@@ -832,6 +853,23 @@ describe('change-streamer/service', () => {
       'commit',
       messages.commit({extra: 'fields'}),
       {watermark: '09'},
+    ]);
+
+    // Ignore lag reports from before this change stream was initialized.
+    changes.push([
+      'status',
+      {
+        ack: false,
+        lagReport: {
+          lastTimings: {
+            sendTimeMs: 50,
+            commitTimeMs: 50,
+            receiveTimeMs: 55,
+          },
+          nextSendTimeMs: 100,
+        },
+      },
+      {watermark: '0a'},
     ]);
 
     expect(await nextChange(downstream)).toMatchObject({
@@ -852,7 +890,7 @@ describe('change-streamer/service', () => {
       extra: 'fields',
     });
 
-    changes.push(['status', {ack: false}, {watermark: '0a'}]);
+    changes.push(['status', {ack: false}, {watermark: '0b'}]);
 
     changes.push([
       'status',
@@ -867,10 +905,10 @@ describe('change-streamer/service', () => {
           nextSendTimeMs: 234,
         },
       },
-      {watermark: '0b'},
+      {watermark: '0c'},
     ]);
 
-    changes.push(['status', {ack: true}, {watermark: '0c'}]);
+    changes.push(['status', {ack: true}, {watermark: '0d'}]);
 
     expect(await nextChange(downstream)).toMatchObject({
       tag: 'status',
@@ -885,7 +923,7 @@ describe('change-streamer/service', () => {
     });
 
     // Await the ACK for the single commit, then the status message with an ack.
-    await expectAcks('09', '0c');
+    await expectAcks('09', '0d');
 
     expect(
       await sql`SELECT watermark, change->'tag' FROM "zoro_3/cdc"."changeLog"`.values(),

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -310,6 +310,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
   );
 
   #latestStatus: Status;
+  #latestLagReportCommitTimeMs = 0;
   #purgeLock: PurgeLock | null;
   #stream: ChangeStream | undefined;
   #sqliteCatchup: SQLiteChangeLogCatchup | undefined;
@@ -369,9 +370,16 @@ class ChangeStreamerImpl implements ChangeStreamerService {
 
     this.#forwarder.startProgressMonitor();
 
-    const lagReport = await this.#source.startLagReporter();
-    if (lagReport) {
-      this.#latestStatus.lagReport = lagReport;
+    const lagReportInit = await this.#source.startLagReporter();
+    if (lagReportInit) {
+      this.#latestStatus.lagReport = {
+        nextSendTimeMs: lagReportInit.nextSendTimeMs,
+      };
+      // Record the commit time of the initiated lag report (i.e. "head")
+      // for the purpose of skipping over any lag reports that are re-streamed
+      // by the change-source in the case of a change-streamer starting from
+      // an older watermark.
+      this.#latestLagReportCommitTimeMs = lagReportInit.firstCommitTimeMs;
     }
 
     // Once this change-streamer acquires "ownership" of the change DB,
@@ -422,12 +430,18 @@ class ChangeStreamerImpl implements ChangeStreamerService {
               if (msg.ack) {
                 this.#storer.status(change); // storer acks once it gets through its queue
               }
-              if (msg.lagReport) {
+              if (
+                msg.lagReport &&
+                msg.lagReport.lastTimings.commitTimeMs >=
+                  this.#latestLagReportCommitTimeMs
+              ) {
                 // Lag reports are not stored in the cdc change log, but rather
                 // only forwarded on "live" connections. When a new subscriber
                 // is catching up, it is initialized with the #latestStatus
                 // from which it can measure lag while catching up.
                 this.#latestStatus.lagReport = msg.lagReport;
+                this.#latestLagReportCommitTimeMs =
+                  msg.lagReport.lastTimings.commitTimeMs;
                 this.#forwarder.sendStatus(this.#latestStatus);
               }
               continue;


### PR DESCRIPTION
Avoid sending historical lag reports, which can appear when a change-streamer subscribes to the logical replication stream at a point in the past (e.g. causing lag reports from the previous RM to be re-streamed). 

This matches the intention of only streaming "live" reports (which is the reason why they are not persisted to the change log), and prevents the confusing situation in which a newly started replication manager results in a replication-lag spike when the parts of the wal are re-streamed:

<img width="694" height="789" alt="Screenshot 2026-07-28 at 12 38 33 PM" src="https://github.com/user-attachments/assets/8c77f0ba-ddde-41c0-9f53-702b60658186" />

Context:
* https://rocicorp.slack.com/archives/C0AK5KX8HGE/p1785003866603819?thread_ts=1784964409.662279&cid=C0AK5KX8HGE