### PR TITLE
fix(zero-server): avoid primary key updates in CRUD

### DIFF
--- a/packages/zero-server/src/custom.pg.test.ts
+++ b/packages/zero-server/src/custom.pg.test.ts
@@ -192,6 +192,44 @@ describe('makeSchemaCRUD', () => {
     });
   });
 
+  test('update and upsert allow concurrent foreign key inserts', async () => {
+    await pg`
+      CREATE TABLE basic_refs (
+        id TEXT PRIMARY KEY,
+        basic_id TEXT NOT NULL REFERENCES basic(id)
+      )
+    `;
+    await pg`INSERT INTO basic (id, a, b) VALUES ('1', 1, 'one')`;
+
+    const assertAllowsForeignKeyInsert = async (
+      id: string,
+      operation: (crud: SchemaCRUD<typeof schema>) => Promise<void>,
+    ) => {
+      await pg.begin(async tx => {
+        const transaction = new Transaction(tx);
+        const crud = crudProvider(
+          transaction,
+          await getServerSchema(transaction, schema),
+        );
+        await operation(crud);
+
+        await pg.begin(async concurrent => {
+          await concurrent.unsafe(`SET LOCAL lock_timeout = '100ms'`);
+          await concurrent`
+            INSERT INTO basic_refs (id, basic_id) VALUES (${id}, '1')
+          `;
+        });
+      });
+    };
+
+    await assertAllowsForeignKeyInsert('update', crud =>
+      crud.basic.update({id: '1', b: 'updated'}),
+    );
+    await assertAllowsForeignKeyInsert('upsert', crud =>
+      crud.basic.upsert({id: '1', a: 2, b: 'upserted'}),
+    );
+  });
+
   test('insert/update/upsert with nullable array columns preserves null', async () => {
     await pg.begin(async tx => {
       const transaction = new Transaction(tx);

--- a/packages/zero-server/src/custom.test.ts
+++ b/packages/zero-server/src/custom.test.ts
@@ -264,6 +264,61 @@ describe('CRUDMutatorFactory', () => {
     expect(queries).toHaveLength(1);
   });
 
+  test('uses primary keys only to select an updated row', async () => {
+    const factory = new CRUDMutatorFactory(schema);
+    const {mockTx, queries} = createMockTx();
+    const executor = factory.createExecutor(mockTx, mockServerSchema);
+
+    await executor('basic', 'update', {id: '1', b: 'updated'});
+
+    expect(queries).toEqual([
+      [
+        'UPDATE "basic" SET "b" = $1::text::text WHERE "id" = $2::text',
+        ['updated', '1'],
+      ],
+    ]);
+  });
+
+  test('does not query for an update containing only primary keys', async () => {
+    const factory = new CRUDMutatorFactory(schema);
+    const {mockTx, queries} = createMockTx();
+    const executor = factory.createExecutor(mockTx, mockServerSchema);
+
+    await executor('basic', 'update', {id: '1'});
+
+    expect(queries).toEqual([]);
+  });
+
+  test('does not update primary keys during an upsert', async () => {
+    const factory = new CRUDMutatorFactory(schema);
+    const {mockTx, queries} = createMockTx();
+    const executor = factory.createExecutor(mockTx, mockServerSchema);
+
+    await executor('basic', 'upsert', {id: '1', a: 1, b: 'updated'});
+
+    expect(queries).toEqual([
+      [
+        'INSERT INTO "basic" ("id","a","b") VALUES ($1::text::text, $2::text::integer, $3::text::text) ON CONFLICT ("id") DO UPDATE SET "a" = $2::text::integer, "b" = $3::text::text',
+        ['1', '1', 'updated'],
+      ],
+    ]);
+  });
+
+  test('does nothing on conflict when an upsert has only primary keys', async () => {
+    const factory = new CRUDMutatorFactory(schema);
+    const {mockTx, queries} = createMockTx();
+    const executor = factory.createExecutor(mockTx, mockServerSchema);
+
+    await executor('basic', 'upsert', {id: '1'});
+
+    expect(queries).toEqual([
+      [
+        'INSERT INTO "basic" ("id") VALUES ($1::text::text) ON CONFLICT ("id") DO NOTHING',
+        ['1'],
+      ],
+    ]);
+  });
+
   test('creates isolated executors for different transactions', () => {
     const factory = new CRUDMutatorFactory(schema);
 

--- a/packages/zero-server/src/custom.ts
+++ b/packages/zero-server/src/custom.ts
@@ -453,8 +453,9 @@ function nonPrimaryKeyEntries(
   value: Record<string, unknown>,
   schema: TableSchema,
 ) {
-  const primaryKey = new Set(schema.primaryKey);
-  return Object.entries(value).filter(([name]) => !primaryKey.has(name));
+  return Object.entries(value).filter(
+    ([name]) => !schema.primaryKey.includes(name),
+  );
 }
 
 function serverName(x: {name: string; serverName?: string | undefined}) {

--- a/packages/zero-server/src/custom.ts
+++ b/packages/zero-server/src/custom.ts
@@ -383,6 +383,19 @@ function makeServerTableCRUD(schema: TableSchema): TableCRUD<TableSchema> {
         schema.primaryKey,
         schema,
       );
+      const updatedEntries = nonPrimaryKeyEntries(value, schema);
+      const conflictAction =
+        updatedEntries.length === 0
+          ? sql`DO NOTHING`
+          : sql`DO UPDATE SET ${sql.join(
+              updatedEntries.map(
+                ([col, val]) =>
+                  sql`${sql.ident(
+                    schema.columns[col].serverName ?? col,
+                  )} = ${sqlInsertValue(val, serverTableSchema[serverNameFor(col, schema)])}`,
+              ),
+              ', ',
+            )}`;
       const stmt = formatPgInternalConvert(
         sql`INSERT INTO ${sql.ident(serverName(schema))} (${sql.join(
           targetedColumns.map(([, serverName]) => sql.ident(serverName)),
@@ -395,15 +408,7 @@ function makeServerTableCRUD(schema: TableSchema): TableCRUD<TableSchema> {
         )}) ON CONFLICT (${sql.join(
           primaryKeyColumns.map(([, serverName]) => sql.ident(serverName)),
           ', ',
-        )}) DO UPDATE SET ${sql.join(
-          Object.entries(value).map(
-            ([col, val]) =>
-              sql`${sql.ident(
-                schema.columns[col].serverName ?? col,
-              )} = ${sqlInsertValue(val, serverTableSchema[serverNameFor(col, schema)])}`,
-          ),
-          ', ',
-        )}`,
+        )}) ${conflictAction}`,
       );
       const tx = this[dbTxSymbol];
       await tx.query(stmt.text, stmt.values);
@@ -411,7 +416,13 @@ function makeServerTableCRUD(schema: TableSchema): TableCRUD<TableSchema> {
     async update(this: WithHiddenTxAndSchema, value) {
       value = removeUndefined(value);
       const serverTableSchema = this[serverSchemaSymbol][serverName(schema)];
-      const targetedColumns = origAndServerNamesFor(Object.keys(value), schema);
+      const targetedColumns = origAndServerNamesFor(
+        nonPrimaryKeyEntries(value, schema).map(([name]) => name),
+        schema,
+      );
+      if (targetedColumns.length === 0) {
+        return;
+      }
       const stmt = formatPgInternalConvert(
         sql`UPDATE ${sql.ident(serverName(schema))} SET ${sql.join(
           targetedColumns.map(
@@ -436,6 +447,14 @@ function makeServerTableCRUD(schema: TableSchema): TableCRUD<TableSchema> {
       await tx.query(stmt.text, stmt.values);
     },
   };
+}
+
+function nonPrimaryKeyEntries(
+  value: Record<string, unknown>,
+  schema: TableSchema,
+) {
+  const primaryKey = new Set(schema.primaryKey);
+  return Object.entries(value).filter(([name]) => !primaryKey.has(name));
 }
 
 function serverName(x: {name: string; serverName?: string | undefined}) {


### PR DESCRIPTION
The server CRUD executor currently includes primary-key columns in the `SET` list for `update` and for the conflict branch of `upsert`, even though those values identify the existing row and cannot change through these APIs.

PostgreSQL treats a syntactically updated key column as possibly changing and takes a row lock that conflicts with foreign-key checks on concurrent child inserts. This change leaves primary keys in the `WHERE`, insert values, and conflict target, but excludes them from update assignments. A key-only update becomes a no-op, and a key-only upsert uses `DO NOTHING` on conflict.

The tests pin the generated SQL and verify with PostgreSQL that an open CRUD update or upsert transaction does not block a concurrent foreign-key insert.