### PR TITLE
chore(zero-cache): fix auto-reset regression

### DIFF
--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -137,6 +137,7 @@ export default async function runWorker(
               },
               context,
               replicationLag.reportIntervalMs,
+              purgeLock,
             )
           : await initializeCustomChangeSource(
               lc,

--- a/packages/zero-cache/src/services/change-source/pg/change-source.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.ts
@@ -114,6 +114,10 @@ import {validate} from './schema/validation.ts';
 
 const REPLICA_SLOT_CLEANUP_INTERVAL_MS = 30_000;
 
+interface PurgeLock {
+  release(): Promise<void>;
+}
+
 /**
  * Initializes a Postgres change source, including the initial sync of the
  * replica, before streaming changes from the corresponding logical replication
@@ -127,12 +131,20 @@ export async function initializePostgresChangeSource(
   syncOptions: InitialSyncOptions,
   context: ServerContext,
   lagReportIntervalMs = 0,
+  purgeLock?: PurgeLock | null,
 ): Promise<{subscriptionState: SubscriptionState; changeSource: ChangeSource}> {
   await initReplica(
     lc,
     `replica-${shard.appID}-${shard.shardNum}`,
     replicaDbFile,
-    (log, tx) => initialSync(log, shard, tx, upstreamURI, syncOptions, context),
+    async (log, tx) => {
+      // In RMv1, the purge lock on the change-db must be released before performing
+      // initial sync; if the change-db and upstream are the same db, a lock-holding
+      // transaction will prevent a replication slot from being created. This awkward
+      // dependency can go away with RMv2.
+      void purgeLock?.release();
+      await initialSync(log, shard, tx, upstreamURI, syncOptions, context);
+    },
   );
 
   const replica = new Database(lc, replicaDbFile);


### PR DESCRIPTION
Fix an auto-reset regression introduced in https://github.com/rocicorp/mono/pull/6266.

The PurgeLock cannot be completely separated from initial sync in the case that the upstream and change db's are the same Postgres cluster. In that case, the lock-holding PurgeLock transaction prevents the replication slot from being created. Since this requires the change-db schema to have been initialized, the specific case that it breaks is auto-reset.

The purge-lock is thus explicitly released when initial sync is about to happen. This dependency is specific to RMv1 and can be removed with RMv2.