### PR TITLE
chore(rmv2): retarget the change-log writer to its own database [11/n]

### DIFF
--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -21,6 +21,7 @@ import {initChangeStreamerSchema} from '../services/change-streamer/schema/init.
 import {AutoResetSignal} from '../services/change-streamer/schema/tables.ts';
 import {PurgeLocker} from '../services/change-streamer/storer.ts';
 import {exitAfter, runUntilKilled} from '../services/life-cycle.ts';
+import {changeLogFileName} from '../services/replicator/change-log-db.ts';
 import {
   replicationStatusError,
   ReplicationStatusPublisher,
@@ -169,7 +170,7 @@ export default async function runWorker(
           statementTimeoutMs: change.statementTimeoutMs,
           changeLogBatchSize: change.logBatchSize,
           sqliteCatchup: {
-            replicaFile: replica.file,
+            changeLogFile: changeLogFileName(replica.file),
             readBatchRows: sqliteChangeLogReadBatchRows,
             barrierTimeoutMs: sqliteChangeLogBarrierTimeoutMs,
           },

--- a/packages/zero-cache/src/server/replicator.ts
+++ b/packages/zero-cache/src/server/replicator.ts
@@ -36,6 +36,7 @@ import {
   getSQLiteChangeLogInfo,
   getSQLiteChangeLogStartupInfo,
   logSQLiteChangeLogStartup,
+  recordSQLiteChangeLogReconcile,
   SQLiteChangeLogObserver,
 } from '../services/replicator/sqlite-change-log-observability.ts';
 import {ThreadWriteWorkerClient} from '../services/replicator/write-worker-client.ts';
@@ -119,10 +120,21 @@ export default async function runWorker(
 
   setupMetrics(lc, dbPath, walMode);
 
-  // Create the write worker for async SQLite writes.
+  // Create the write worker for async SQLite writes. When the change-log
+  // writer is enabled, init also opens the change-log database beside the
+  // replica and reconciles it against the replica's head.
   const pragmas = getPragmaConfig(fileMode);
   const workerClient = new ThreadWriteWorkerClient();
-  await workerClient.init(dbPath, mode, logsChangeStream, pragmas, config.log);
+  const reconciled = await workerClient.init(
+    dbPath,
+    mode,
+    logsChangeStream,
+    pragmas,
+    config.log,
+  );
+  if (reconciled) {
+    recordSQLiteChangeLogReconcile(lc, reconciled);
+  }
 
   const shard = getShardConfig(config);
   const {

--- a/packages/zero-cache/src/services/change-source/custom/change-source.ts
+++ b/packages/zero-cache/src/services/change-source/custom/change-source.ts
@@ -180,7 +180,7 @@ export async function initialSync(
   const processor = new ChangeProcessor(
     new StatementRunner(tx),
     'initial-sync',
-    {logsChangeStream: false},
+    {changeLog: undefined},
     (_, err) => {
       throw err;
     },

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
@@ -23,6 +23,13 @@ import type {
 } from '../change-source/protocol/current/downstream.ts';
 import type {UpstreamStatusMessage} from '../change-source/protocol/current/status.ts';
 import {exitAfter} from '../life-cycle.ts';
+import {
+  changeLogFileName,
+  deleteChangeLogDB,
+  openChangeLogDB,
+  readReplicaAnchor,
+  reconcileChangeLog,
+} from '../replicator/change-log-db.ts';
 import {ChangeLogStreamWriter} from '../replicator/change-log-stream-writer.ts';
 import {IncrementalSyncer} from '../replicator/incremental-sync.ts';
 import {ReplicationStatusPublisher} from '../replicator/replication-status.ts';
@@ -179,13 +186,22 @@ describe('change-streamer/service', () => {
 
   const messages = new ReplicationMessages({foo: 'id'});
 
+  /** The change-log database the replicator writes beside `replicaFile`. */
+  function createChangeLogDB(replicaFile: DbFile, replica: Database): Database {
+    const changeLog = openChangeLogDB(lc, replicaFile.path, {readonly: false});
+    reconcileChangeLog(lc, changeLog, readReplicaAnchor(replica));
+    return changeLog;
+  }
+
+  /** Applies a transaction the way the write worker does: log first, then replica. */
   function appendSQLiteTransaction(
     replica: Database,
+    changeLog: Database,
     watermark: string,
     data: readonly ChangeStreamData[],
   ): void {
     const runner = new StatementRunner(replica);
-    const writer = new ChangeLogStreamWriter(replica);
+    const writer = new ChangeLogStreamWriter(new StatementRunner(changeLog));
     const begin: ChangeStreamData = [
       'begin',
       messages.begin(),
@@ -204,6 +220,7 @@ describe('change-streamer/service', () => {
       runner.commit();
     } catch (e) {
       runner.rollback();
+      writer.rollback();
       throw e;
     }
   }
@@ -304,13 +321,23 @@ describe('change-streamer/service', () => {
             .get(),
         ).toEqual({stateVersion: '06'});
       });
+      // The stream is logged to the change-log database beside the replica,
+      // never to the replica itself.
+      using changeLog = openChangeLogDB(lc, dbFile.path, {readonly: true});
+      expect(
+        changeLog
+          .prepare(
+            `SELECT max("watermark") AS "watermark" FROM "_zero.changeLogStream"`,
+          )
+          .get(),
+      ).toEqual({watermark: '06'});
       expect(
         replica
           .prepare(
             `SELECT max("watermark") AS "watermark" FROM "_zero.changeLogStream"`,
           )
           .get(),
-      ).toEqual({watermark: '06'});
+      ).toEqual({watermark: REPLICA_VERSION});
       expect(observer.state()).toMatchObject({
         receivedHead: '06',
         sqliteHead: '06',
@@ -358,6 +385,7 @@ describe('change-streamer/service', () => {
       await syncing;
       await worker.stop();
       replica.close();
+      deleteChangeLogDB(dbFile.path);
       dbFile.delete();
     }
   });
@@ -370,6 +398,10 @@ describe('change-streamer/service', () => {
     const catchupReplica = catchupReplicaFile.connect(lc);
     catchupReplica.pragma('journal_mode = wal');
     initReplicationState(catchupReplica, ['zero_data'], REPLICA_VERSION);
+    const catchupChangeLog = createChangeLogDB(
+      catchupReplicaFile,
+      catchupReplica,
+    );
 
     changes = Subscription.create();
     acks = new Queue();
@@ -398,7 +430,7 @@ describe('change-streamer/service', () => {
       {
         ...opts,
         sqliteCatchup: {
-          replicaFile: catchupReplicaFile.path,
+          changeLogFile: changeLogFileName(catchupReplicaFile.path),
           readBatchRows: 2,
           barrierTimeoutMs: 1_000,
           // Nothing here acks the change log, so the barrier relies on its
@@ -451,7 +483,9 @@ describe('change-streamer/service', () => {
 
       changes.push(['commit', messages.commit(), {watermark: '04'}]);
       expect(await nextChange(live)).toMatchObject({tag: 'commit'});
-      appendSQLiteTransaction(catchupReplica, '04', [insert04]);
+      appendSQLiteTransaction(catchupReplica, catchupChangeLog, '04', [
+        insert04,
+      ]);
 
       expect(await nextChange(committed)).toMatchObject({tag: 'status'});
       expect(await nextChange(committed)).toMatchObject({tag: 'begin'});
@@ -504,7 +538,9 @@ describe('change-streamer/service', () => {
         new: {id: 'after-rollback'},
       });
       expect(await nextChange(live)).toMatchObject({tag: 'commit'});
-      appendSQLiteTransaction(catchupReplica, '08', [insert08]);
+      appendSQLiteTransaction(catchupReplica, catchupChangeLog, '08', [
+        insert08,
+      ]);
 
       changes.push(['begin', messages.begin(), {commitWatermark: '0a'}]);
       changes.push(['data', messages.insert('foo', {id: 'interrupted'})]);
@@ -537,7 +573,9 @@ describe('change-streamer/service', () => {
       interruptedSub.cancel();
     } finally {
       await streamer.stop();
+      catchupChangeLog.close();
       catchupReplica.close();
+      deleteChangeLogDB(catchupReplicaFile.path);
       catchupReplicaFile.delete();
     }
   });
@@ -550,6 +588,10 @@ describe('change-streamer/service', () => {
     const catchupReplica = catchupReplicaFile.connect(lc);
     catchupReplica.pragma('journal_mode = wal');
     initReplicationState(catchupReplica, ['zero_data'], REPLICA_VERSION);
+    const catchupChangeLog = createChangeLogDB(
+      catchupReplicaFile,
+      catchupReplica,
+    );
 
     changes = Subscription.create();
     acks = new Queue();
@@ -578,7 +620,7 @@ describe('change-streamer/service', () => {
       {
         ...opts,
         sqliteCatchup: {
-          replicaFile: catchupReplicaFile.path,
+          changeLogFile: changeLogFileName(catchupReplicaFile.path),
           readBatchRows: 2,
           barrierTimeoutMs: 60_000,
           // Far beyond the test timeout, so only the writer's ACK can release
@@ -620,6 +662,7 @@ describe('change-streamer/service', () => {
             await applyTransactions.promise;
             appendSQLiteTransaction(
               catchupReplica,
+              catchupChangeLog,
               watermark,
               buffered.splice(0),
             );
@@ -670,7 +713,9 @@ describe('change-streamer/service', () => {
       await writing;
     } finally {
       await streamer.stop();
+      catchupChangeLog.close();
       catchupReplica.close();
+      deleteChangeLogDB(catchupReplicaFile.path);
       catchupReplicaFile.delete();
     }
   });
@@ -683,6 +728,10 @@ describe('change-streamer/service', () => {
     const catchupReplica = catchupReplicaFile.connect(lc);
     catchupReplica.pragma('journal_mode = wal');
     initReplicationState(catchupReplica, ['zero_data'], REPLICA_VERSION);
+    const catchupChangeLog = createChangeLogDB(
+      catchupReplicaFile,
+      catchupReplica,
+    );
 
     changes = Subscription.create();
     acks = new Queue();
@@ -712,7 +761,7 @@ describe('change-streamer/service', () => {
       {
         ...opts,
         sqliteCatchup: {
-          replicaFile: catchupReplicaFile.path,
+          changeLogFile: changeLogFileName(catchupReplicaFile.path),
           readBatchRows: 2,
           barrierTimeoutMs: 60_000,
           barrierPollIntervalMs: 60_000,
@@ -804,7 +853,9 @@ describe('change-streamer/service', () => {
       writerSub.cancel();
     } finally {
       await streamer.stop();
+      catchupChangeLog.close();
       catchupReplica.close();
+      deleteChangeLogDB(catchupReplicaFile.path);
       catchupReplicaFile.delete();
     }
   });

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -60,7 +60,8 @@ import {
 import {Subscriber} from './subscriber.ts';
 
 export type SQLiteCatchupOptions = {
-  replicaFile: string;
+  /** The change-log database, i.e. `changeLogFileName(replicaFile)`. */
+  changeLogFile: string;
   readBatchRows: number;
   barrierTimeoutMs: number;
   /**
@@ -778,7 +779,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
       this.#sqliteCatchup = new SQLiteChangeLogCatchup(
         this.#lc,
         this.#forwarder,
-        new SQLiteChangeLogReader(this.#lc, opts.replicaFile),
+        new SQLiteChangeLogReader(this.#lc, opts.changeLogFile),
         {
           batchSize: opts.readBatchRows,
           barrierTimeoutMs: opts.barrierTimeoutMs,

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-reader.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-reader.test.ts
@@ -70,8 +70,7 @@ function appendTransaction(
   watermark: string,
   data: readonly ChangeStreamData[],
 ): readonly WatermarkedChange[] {
-  const runner = new StatementRunner(db);
-  const writer = new ChangeLogStreamWriter(db);
+  const writer = new ChangeLogStreamWriter(new StatementRunner(db));
   const begin: ChangeStreamData = [
     'begin',
     {tag: 'begin'},
@@ -79,18 +78,14 @@ function appendTransaction(
   ];
   const commit: ChangeStreamData = ['commit', {tag: 'commit'}, {watermark}];
 
-  // Slice 7D moves this transaction into the writer itself; until then the
-  // caller owns it, as ChangeProcessor does.
-  runner.beginImmediate();
   try {
     writer.begin(watermark, serializeChangeStreamData(begin));
     for (const message of data) {
       writer.append(serializeChangeStreamData(message), message[1].tag);
     }
     writer.commit(watermark, serializeChangeStreamData(commit), Date.now());
-    runner.commit();
   } catch (e) {
-    runner.rollback();
+    writer.rollback();
     throw e;
   }
 

--- a/packages/zero-cache/src/services/replicator/change-log-crash-recovery.test.ts
+++ b/packages/zero-cache/src/services/replicator/change-log-crash-recovery.test.ts
@@ -1,0 +1,521 @@
+/**
+ * Property-based crash injection across the log-first commit ordering.
+ *
+ * The writer commits the change log before the replica, so the window between
+ * the two commits is the one place where the two databases legitimately
+ * disagree. A crash there must leave a *phantom* — a transaction in the log
+ * whose replica commit was lost — and never a *hole*, because a phantom is
+ * detectable and repairable at startup while a hole would be served to a
+ * subscriber as a silent gap.
+ *
+ * Each generated case runs a change stream through {@link ChangeProcessor},
+ * kills the process at a chosen point, then reopens both databases exactly as
+ * `write-worker`'s `init` does and asserts design 5.1 invariants 1-4 plus
+ * transaction-level contiguity. This is the writer-side companion to the
+ * catchup handoff property test in
+ * `change-streamer/sqlite-change-log-catchup.test.ts`.
+ */
+
+import fc from 'fast-check';
+import {afterEach, describe, expect, test} from 'vitest';
+import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
+import {must} from '../../../../shared/src/must.ts';
+import {Database} from '../../../../zqlite/src/db.ts';
+import {StatementRunner} from '../../db/statements.ts';
+import {DbFile, initDB} from '../../test/lite.ts';
+import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
+import {serializeChangeStreamData} from '../change-streamer/change-log-codec.ts';
+import {
+  CHANGE_LOG_META_TABLE,
+  deleteChangeLogDB,
+  openChangeLogDB,
+  readReplicaAnchor,
+  reconcileChangeLog,
+  type ReconcileResult,
+} from './change-log-db.ts';
+import {ChangeProcessor} from './change-processor.ts';
+import {CHANGE_LOG_STREAM_TABLE} from './schema/change-log-stream.ts';
+import {initReplicationState} from './schema/replication-state.ts';
+import {ReplicationMessages} from './test-utils.ts';
+
+const lc = createSilentLogContext();
+const issues = new ReplicationMessages({issues: 'id'});
+
+const REPLICA_VERSION = '02';
+
+/** Where the process is killed, relative to the two commits. */
+type CrashPoint =
+  // The log's COMMIT never runs: both databases end at the previous version.
+  | 'log-commit'
+  // The log is committed; the replica's state update never runs.
+  | 'state-update'
+  // The log is committed and the state updated; the replica's COMMIT never runs.
+  | 'replica-commit'
+  // Not a crash: the source drops mid-transaction and the processor aborts.
+  | 'source-disconnect';
+
+type Scenario = {
+  readonly before: number;
+  readonly changes: number;
+  readonly after: number;
+  readonly crashPoint: CrashPoint;
+};
+
+const scenario: fc.Arbitrary<Scenario> = fc.record({
+  before: fc.integer({min: 0, max: 4}),
+  changes: fc.integer({min: 0, max: 3}),
+  after: fc.integer({min: 0, max: 3}),
+  crashPoint: fc.constantFrom<CrashPoint>(
+    'log-commit',
+    'state-update',
+    'replica-commit',
+    'source-disconnect',
+  ),
+});
+
+/** Lexicographic watermarks, in order, starting after the replica version. */
+function watermark(i: number): string {
+  return `0${'3456789abcdefghijk'[i]}`;
+}
+
+class Crash extends Error {
+  override readonly name = 'InjectedCrash';
+}
+
+/**
+ * A replica runner that kills the process at a chosen statement, by closing
+ * both connections before throwing. Closing rather than rolling back is what
+ * makes this a crash: SQLite discards whatever was not committed, and the
+ * processor's own rollback then fails against a closed handle, which is the
+ * partial-rollback path `#fail` has to tolerate.
+ */
+class CrashingStatementRunner extends StatementRunner {
+  kill: (() => void) | undefined;
+  crashOnStateUpdate = false;
+  crashOnCommit = false;
+
+  override run(sql: string, ...args: unknown[]) {
+    if (this.crashOnStateUpdate && sql.includes('"_zero.replicationState"')) {
+      this.crashOnStateUpdate = false;
+      this.#crash();
+    }
+    return super.run(sql, ...args);
+  }
+
+  override commit() {
+    if (this.crashOnCommit) {
+      this.crashOnCommit = false;
+      this.#crash();
+    }
+    return super.commit();
+  }
+
+  #crash(): never {
+    this.kill?.();
+    throw new Crash('injected crash');
+  }
+}
+
+/** A change-log runner that kills the process instead of committing. */
+class CrashingChangeLogRunner extends StatementRunner {
+  kill: (() => void) | undefined;
+  crashOnCommit = false;
+
+  override commit() {
+    if (this.crashOnCommit) {
+      this.crashOnCommit = false;
+      this.kill?.();
+      throw new Crash('injected crash');
+    }
+    return super.commit();
+  }
+}
+
+type Session = {
+  readonly replica: Database;
+  readonly changeLog: Database;
+  readonly replicaRunner: CrashingStatementRunner;
+  readonly changeLogRunner: CrashingChangeLogRunner;
+  readonly processor: ChangeProcessor;
+  readonly failures: unknown[];
+  readonly reconciled: ReconcileResult;
+  readonly close: () => void;
+};
+
+/** Opens both databases and reconciles, exactly as `write-worker.init` does. */
+function startSession(file: DbFile): Session {
+  const replica = file.connect(lc);
+  const changeLog = openChangeLogDB(lc, file.path, {readonly: false});
+  changeLog.pragma('journal_mode = wal2');
+  const reconciled = reconcileChangeLog(
+    lc,
+    changeLog,
+    readReplicaAnchor(replica),
+  );
+
+  const replicaRunner = new CrashingStatementRunner(replica);
+  const changeLogRunner = new CrashingChangeLogRunner(changeLog);
+  const failures: unknown[] = [];
+  let closed = false;
+  const kill = () => {
+    closed = true;
+    changeLog.close();
+    replica.close();
+  };
+  replicaRunner.kill = kill;
+  changeLogRunner.kill = kill;
+
+  return {
+    replica,
+    changeLog,
+    replicaRunner,
+    changeLogRunner,
+    processor: new ChangeProcessor(
+      replicaRunner,
+      'serving',
+      {changeLog: changeLogRunner},
+      (_, err) => failures.push(err),
+    ),
+    failures,
+    reconciled,
+    close: () => {
+      if (!closed) {
+        closed = true;
+        changeLog.close();
+        replica.close();
+      }
+    },
+  };
+}
+
+function process(session: Session, data: ChangeStreamData) {
+  return session.processor.processMessage(
+    lc,
+    data,
+    serializeChangeStreamData(data),
+  );
+}
+
+/** A whole transaction: begin, `changes` inserts, commit. */
+function transaction(session: Session, wm: string, changes: number): void {
+  process(session, ['begin', issues.begin(), {commitWatermark: wm}]);
+  for (let i = 0; i < changes; i++) {
+    process(session, ['data', issues.insert('issues', {id: i, text: wm})]);
+  }
+  process(session, ['commit', issues.commit(), {watermark: wm}]);
+}
+
+type LogTransaction = {
+  readonly watermark: string;
+  readonly tags: readonly string[];
+  readonly precommits: readonly (string | null)[];
+  readonly positions: readonly number[];
+};
+
+function readLog(db: Database): LogTransaction[] {
+  const rows = db
+    .prepare(/*sql*/ `
+      SELECT "watermark", "pos", json_extract("change", '$.tag') AS "tag",
+             "precommit"
+        FROM "${CHANGE_LOG_STREAM_TABLE}"
+        ORDER BY "watermark", "pos"
+    `)
+    .all<{
+      watermark: string;
+      pos: number;
+      tag: string;
+      precommit: string | null;
+    }>();
+
+  const transactions: LogTransaction[] = [];
+  for (const row of rows) {
+    let last = transactions.at(-1);
+    if (last?.watermark !== row.watermark) {
+      last = {
+        watermark: row.watermark,
+        tags: [],
+        precommits: [],
+        positions: [],
+      };
+      transactions.push(last);
+    }
+    (last.tags as string[]).push(row.tag);
+    (last.precommits as (string | null)[]).push(row.precommit);
+    (last.positions as number[]).push(row.pos);
+  }
+  return transactions;
+}
+
+function head(db: Database): string | null {
+  return db
+    .prepare(
+      /*sql*/ `SELECT max("watermark") AS "head" FROM "${CHANGE_LOG_STREAM_TABLE}"`,
+    )
+    .get<{head: string | null}>().head;
+}
+
+function stateVersion(db: Database): string {
+  return db
+    .prepare(/*sql*/ `SELECT "stateVersion" FROM "_zero.replicationState"`)
+    .get<{stateVersion: string}>().stateVersion;
+}
+
+/**
+ * Design 5.1 invariant 3: every logged transaction is whole — contiguous
+ * positions from a `begin` to a `commit` that chains to the previous
+ * transaction — and the sequence covers the committed watermarks with no gap.
+ */
+function expectContiguous(log: LogTransaction[], committed: string[]) {
+  expect(log.map(({watermark}) => watermark)).toEqual(committed);
+  for (const tx of log) {
+    expect(tx.positions).toEqual(tx.positions.map((_, i) => i));
+    expect(tx.tags.at(0)).toBe('begin');
+    expect(tx.tags.at(-1)).toBe('commit');
+    expect(tx.tags.slice(1, -1).includes('begin')).toBe(false);
+    expect(tx.tags.slice(1, -1).includes('commit')).toBe(false);
+    // Only the commit row carries a precommit, and it marks the transaction
+    // boundary the reader validates a catchup range against.
+    expect(tx.precommits.slice(0, -1).every(p => p === null)).toBe(true);
+    expect(tx.precommits.at(-1)).toBe(tx.watermark);
+  }
+}
+
+const files: DbFile[] = [];
+
+afterEach(() => {
+  let file: DbFile | undefined;
+  while ((file = files.pop())) {
+    deleteChangeLogDB(file.path);
+    file.delete();
+  }
+});
+
+function newReplica(): DbFile {
+  const file = new DbFile('change-log-crash-recovery');
+  files.push(file);
+  const replica = file.connect(lc);
+  replica.pragma('journal_mode = wal');
+  initReplicationState(replica, ['zero_data'], REPLICA_VERSION);
+  initDB(
+    replica,
+    `
+    CREATE TABLE issues(
+      id INTEGER PRIMARY KEY,
+      text TEXT,
+      _0_version TEXT
+    );
+    `,
+  );
+  replica.close();
+  return file;
+}
+
+/** What the crash left behind, before and after recovery. */
+type Outcome = {
+  /** The log head and replica state as the recovering process found them. */
+  readonly afterCrash: {logHead: string; stateVersion: string};
+  readonly reconciled: ReconcileResult;
+  readonly recoveredHead: string;
+  readonly resumedHead: string;
+};
+
+function runScenario({before, changes, after, crashPoint}: Scenario): Outcome {
+  const file = newReplica();
+  const committed = [REPLICA_VERSION];
+  const phantomExpected =
+    crashPoint === 'state-update' || crashPoint === 'replica-commit';
+  let next = 0;
+
+  // The process that crashes.
+  const crashed = startSession(file);
+  try {
+    expect(crashed.reconciled).toEqual({
+      action: 'reseeded',
+      head: REPLICA_VERSION,
+      reason: 'created',
+    });
+    for (let i = 0; i < before; i++) {
+      const wm = watermark(next++);
+      transaction(crashed, wm, changes);
+      committed.push(wm);
+    }
+    expect(crashed.failures).toEqual([]);
+
+    const crashWatermark = watermark(next++);
+    crashed.replicaRunner.crashOnStateUpdate = crashPoint === 'state-update';
+    crashed.replicaRunner.crashOnCommit = crashPoint === 'replica-commit';
+    crashed.changeLogRunner.crashOnCommit = crashPoint === 'log-commit';
+    if (crashPoint === 'source-disconnect') {
+      process(crashed, [
+        'begin',
+        issues.begin(),
+        {commitWatermark: crashWatermark},
+      ]);
+      for (let i = 0; i < changes; i++) {
+        process(crashed, ['data', issues.insert('issues', {id: i, text: 'x'})]);
+      }
+      crashed.processor.abort(lc);
+    } else {
+      transaction(crashed, crashWatermark, changes);
+    }
+    // An abort is expected, so it is not reported to the service; an injected
+    // crash is.
+    expect(crashed.failures).toHaveLength(
+      crashPoint === 'source-disconnect' ? 0 : 1,
+    );
+  } finally {
+    crashed.close();
+  }
+
+  // Invariant 1, observed before any repair: the log never trails the replica,
+  // whatever the crash point.
+  const afterCrash = (() => {
+    using replica = new Database(lc, file.path, {readonly: true});
+    using changeLog = openChangeLogDB(lc, file.path, {readonly: true});
+    return {
+      logHead: must(head(changeLog), 'the log is never empty'),
+      stateVersion: stateVersion(replica),
+    };
+  })();
+  expect(afterCrash.logHead >= afterCrash.stateVersion).toBe(true);
+  expect(afterCrash.stateVersion).toBe(committed.at(-1));
+  // A crash after the log's commit leaves the phantom behind.
+  expect(afterCrash.logHead).toBe(
+    phantomExpected ? watermark(next - 1) : afterCrash.stateVersion,
+  );
+
+  // The process that recovers.
+  const recovered = startSession(file);
+  try {
+    expect(recovered.reconciled).toEqual(
+      phantomExpected
+        ? {
+            action: 'truncated',
+            head: committed.at(-1),
+            rows: changes + 2, // begin + changes + commit
+          }
+        : {action: 'none', head: committed.at(-1)},
+    );
+
+    // Invariants 2 and 4.
+    const recoveredHead = must(head(recovered.changeLog));
+    expect(recoveredHead).toBe(stateVersion(recovered.replica));
+    expect(
+      recovered.changeLog
+        .prepare(
+          /*sql*/ `SELECT "replicaVersion" FROM "${CHANGE_LOG_META_TABLE}"`,
+        )
+        .get(),
+    ).toEqual({replicaVersion: REPLICA_VERSION});
+    expectContiguous(readLog(recovered.changeLog), committed);
+
+    // Replication resumes from the recovered head.
+    for (let i = 0; i < after; i++) {
+      const wm = watermark(next++);
+      transaction(recovered, wm, changes);
+      committed.push(wm);
+    }
+    expect(recovered.failures).toEqual([]);
+    const resumedHead = must(head(recovered.changeLog));
+    expect(resumedHead).toBe(stateVersion(recovered.replica));
+    expectContiguous(readLog(recovered.changeLog), committed);
+
+    return {
+      afterCrash,
+      reconciled: recovered.reconciled,
+      recoveredHead,
+      resumedHead,
+    };
+  } finally {
+    recovered.close();
+  }
+}
+
+describe('replicator/change-log crash recovery', () => {
+  test('a crash at any commit point leaves a phantom, never a hole', () => {
+    fc.assert(
+      fc.property(scenario, s => {
+        runScenario(s);
+      }),
+      {numRuns: 40},
+    );
+  });
+
+  test('a crash between the two commits leaves the log ahead by one', () => {
+    const outcome = runScenario({
+      before: 2,
+      changes: 2,
+      after: 2,
+      crashPoint: 'state-update',
+    });
+
+    // '03' and '04' committed, the crash at '05'.
+    expect(outcome.afterCrash).toEqual({logHead: '05', stateVersion: '04'});
+    expect(outcome.reconciled).toEqual({
+      action: 'truncated',
+      head: '04',
+      rows: 4,
+    });
+    expect(outcome.recoveredHead).toBe('04');
+    expect(outcome.resumedHead).toBe('07');
+  });
+
+  test('an interrupted log commit leaves both databases at the same head', () => {
+    const outcome = runScenario({
+      before: 1,
+      changes: 1,
+      after: 1,
+      crashPoint: 'log-commit',
+    });
+
+    expect(outcome.afterCrash).toEqual({logHead: '03', stateVersion: '03'});
+    expect(outcome.reconciled).toEqual({action: 'none', head: '03'});
+    expect(outcome.resumedHead).toBe('05');
+  });
+
+  test('a source disconnect mid-transaction leaves no trace', () => {
+    const outcome = runScenario({
+      before: 1,
+      changes: 2,
+      after: 1,
+      crashPoint: 'source-disconnect',
+    });
+
+    expect(outcome.afterCrash).toEqual({logHead: '03', stateVersion: '03'});
+    expect(outcome.reconciled).toEqual({action: 'none', head: '03'});
+    expect(outcome.resumedHead).toBe('05');
+  });
+
+  test('a log left behind by a different replica is reseeded, never served', () => {
+    const file = newReplica();
+    const session = startSession(file);
+    try {
+      transaction(session, watermark(0), 2);
+      expect(session.failures).toEqual([]);
+    } finally {
+      session.close();
+    }
+
+    // Simulate an auto-reset whose change-log deletion was missed: the replica
+    // is re-synced at a new replicaVersion beside the old log.
+    {
+      using replica = new Database(lc, file.path);
+      replica.exec(/*sql*/ `
+        UPDATE "_zero.replicationConfig" SET "replicaVersion" = '04';
+        UPDATE "_zero.replicationState" SET "stateVersion" = '04';
+      `);
+    }
+
+    const reset = startSession(file);
+    try {
+      expect(reset.reconciled).toEqual({
+        action: 'reseeded',
+        head: '04',
+        reason: 'replica-version-mismatch',
+      });
+      expectContiguous(readLog(reset.changeLog), ['04']);
+    } finally {
+      reset.close();
+    }
+  });
+});

--- a/packages/zero-cache/src/services/replicator/change-log-db.test.ts
+++ b/packages/zero-cache/src/services/replicator/change-log-db.test.ts
@@ -4,6 +4,7 @@ import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.
 import {Database} from '../../../../zqlite/src/db.ts';
 import {DbFile, expectTableExact} from '../../test/lite.ts';
 import {
+  applyChangeLogPragmas,
   CHANGE_LOG_DB_SCHEMA_VERSION,
   CHANGE_LOG_META_TABLE,
   changeLogFileName,
@@ -202,6 +203,26 @@ describe('replicator/change-log-db', () => {
     test('readonly open of an absent log throws', () => {
       const file = newDbFile();
       expect(() => openChangeLogDB(lc, file.path, {readonly: true})).toThrow();
+    });
+  });
+
+  describe('applyChangeLogPragmas', () => {
+    test('configures the durability the benchmark settled on', () => {
+      const file = newDbFile();
+      using db = openChangeLogDB(lc, file.path, {readonly: false});
+
+      applyChangeLogPragmas(db);
+
+      expect(db.pragma('journal_mode')).toEqual([{journal_mode: 'wal2'}]);
+      // 1 == NORMAL: the log's commit precedes the replica's on the hot path,
+      // so it does not pay for a second fsync.
+      expect(db.pragma('synchronous')).toEqual([{synchronous: 1}]);
+      expect(db.pragma('busy_timeout')).toEqual([{timeout: 30000}]);
+      // Nothing else owns this file, so checkpointing stays automatic rather
+      // than being handed to litestream as it is for the backup replica.
+      expect(db.pragma('wal_autocheckpoint')).toEqual([
+        {wal_autocheckpoint: 1000},
+      ]);
     });
   });
 

--- a/packages/zero-cache/src/services/replicator/change-log-db.ts
+++ b/packages/zero-cache/src/services/replicator/change-log-db.ts
@@ -115,6 +115,38 @@ export function openChangeLogDB(
   );
 }
 
+/**
+ * Configures the change-log database, which the write worker owns exclusively.
+ * These are the settings the `separate-files` mode of
+ * `sqlite-change-log-ceiling.bench.ts` measured.
+ *
+ * They deliberately do not go through `getPragmaConfig` in `workers/replicator`
+ * beside the replica's, because the write worker applies them in its own
+ * thread and that module reaches the Postgres client through the replica
+ * migrations.
+ *
+ * `wal2` because the log is a continuous append that catchup reads
+ * continuously, which is the case wal2 exists for: it avoids checkpoint
+ * starvation without needing an autocheckpoint. `wal_autocheckpoint` therefore
+ * keeps its default, unlike the backup replica's 0, which hands checkpointing
+ * to litestream — nothing else owns this file.
+ *
+ * `synchronous = NORMAL` because the log commits *before* the replica on the
+ * replication hot path, and NORMAL keeps that from costing a second fsync. It
+ * is not a durability compromise here: in WAL mode NORMAL still writes every
+ * commit through to the OS, so it survives a process crash, an OOM kill, or a
+ * SIGKILL. It is lost only to kernel panic or power loss, and those destroy the
+ * node — the task restarts elsewhere, restores the replica from S3, and has no
+ * change-log file at all. Whatever a power loss does take is detected as a gap
+ * by {@link reconcileChangeLog} and reseeded.
+ */
+export function applyChangeLogPragmas(db: Database): void {
+  db.pragma('busy_timeout = 30000');
+  db.pragma('analysis_limit = 1000');
+  db.pragma('journal_mode = wal2');
+  db.pragma('synchronous = NORMAL');
+}
+
 export type ReseedReason =
   | 'created' // file or table absent
   | 'schema-mismatch'

--- a/packages/zero-cache/src/services/replicator/change-log-stream-writer.test.ts
+++ b/packages/zero-cache/src/services/replicator/change-log-stream-writer.test.ts
@@ -1,36 +1,104 @@
-import {describe, expect, test} from 'vitest';
+import {afterEach, describe, expect, test} from 'vitest';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
 import {Database} from '../../../../zqlite/src/db.ts';
 import {StatementRunner} from '../../db/statements.ts';
-import {expectTableExact} from '../../test/lite.ts';
+import {DbFile, expectTableExact} from '../../test/lite.ts';
 import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
 import {serializeChangeStreamData} from '../change-streamer/change-log-codec.ts';
+import {
+  deleteChangeLogDB,
+  openChangeLogDB,
+  reconcileChangeLog,
+  type ReplicaAnchor,
+} from './change-log-db.ts';
 import {
   ChangeLogStreamWriter,
   estimateChangeLogStreamRowBytes,
 } from './change-log-stream-writer.ts';
 import {CHANGE_LOG_STREAM_TABLE} from './schema/change-log-stream.ts';
-import {
-  initReplicationState,
-  updateReplicationWatermark,
-} from './schema/replication-state.ts';
 
 const lc = createSilentLogContext();
+
+const ANCHOR: ReplicaAnchor = {
+  replicaVersion: '01',
+  stateVersion: '02',
+  writeTimeMs: 1_000,
+};
+
+const files: DbFile[] = [];
+
+afterEach(() => {
+  let file: DbFile | undefined;
+  while ((file = files.pop())) {
+    deleteChangeLogDB(file.path);
+    file.delete();
+  }
+});
+
+/** The seed transaction {@link reconcileChangeLog} writes at the replica head. */
+const SEED_ROWS = [
+  {
+    watermark: ANCHOR.stateVersion,
+    pos: 0,
+    change: '{"tag":"begin"}',
+    precommit: null,
+    writeTimeMs: null,
+  },
+  {
+    watermark: ANCHOR.stateVersion,
+    pos: 1,
+    change: '{"tag":"commit"}',
+    precommit: ANCHOR.stateVersion,
+    writeTimeMs: ANCHOR.writeTimeMs,
+  },
+];
+
+function createChangeLog(): Database {
+  const db = new Database(lc, ':memory:');
+  reconcileChangeLog(lc, db, ANCHOR);
+  return db;
+}
+
+/** A file-backed change log, so a second connection can observe durability. */
+function createChangeLogFile(): {db: Database; observer: Database} {
+  const file = new DbFile('change-log-stream-writer-test');
+  files.push(file);
+  const db = openChangeLogDB(lc, file.path, {readonly: false});
+  db.pragma('journal_mode = wal');
+  reconcileChangeLog(lc, db, ANCHOR);
+  return {db, observer: openChangeLogDB(lc, file.path, {readonly: true})};
+}
 
 function json(data: ChangeStreamData): string {
   return serializeChangeStreamData(data);
 }
 
+function head(db: Database): string | null {
+  return db
+    .prepare(
+      /*sql*/ `SELECT max("watermark") AS "head" FROM "${CHANGE_LOG_STREAM_TABLE}"`,
+    )
+    .get<{head: string | null}>().head;
+}
+
+function rowCount(db: Database): number {
+  return db
+    .prepare(
+      /*sql*/ `SELECT count(*) AS "count" FROM "${CHANGE_LOG_STREAM_TABLE}"`,
+    )
+    .get<{count: number}>().count;
+}
+
+const BEGIN = json(['begin', {tag: 'begin'}, {commitWatermark: '06'}]);
+const COMMIT = json(['commit', {tag: 'commit'}, {watermark: '06'}]);
+const TRUNCATE = json(['data', {tag: 'truncate', relations: []}]);
+
 describe('replicator/change-log-stream-writer', () => {
   test('writes contiguous positions and commit-only metadata', () => {
-    using db = new Database(lc, ':memory:');
-    initReplicationState(db, ['zero_data'], '02');
-    const runner = new StatementRunner(db);
-    const writer = new ChangeLogStreamWriter(db);
+    using db = createChangeLog();
+    const writer = new ChangeLogStreamWriter(new StatementRunner(db));
     const writeTimeMs = 1_234_567;
 
-    runner.beginImmediate();
-    const begin = json(['begin', {tag: 'begin'}, {commitWatermark: '06'}]);
     const insert = json([
       'data',
       {
@@ -51,11 +119,10 @@ describe('replicator/change-log-stream-writer', () => {
         new: {schema: 'public', name: 'renamed'},
       },
     ]);
-    const commit = json(['commit', {tag: 'commit'}, {watermark: '06'}]);
-    writer.begin('06', begin);
+    writer.begin('06', BEGIN);
     writer.append(insert, 'insert');
     writer.append(rename, 'rename-table');
-    const stats = writer.commit('06', commit, writeTimeMs);
+    const stats = writer.commit('06', COMMIT, writeTimeMs);
     expect(stats).toEqual({
       rows: 4,
       hash: expect.stringMatching(/^[0-9a-f]{64}$/),
@@ -71,27 +138,12 @@ describe('replicator/change-log-stream-writer', () => {
         ) +
         estimateChangeLogStreamRowBytes('06', '{"tag":"commit"}', '06', true),
     });
-    updateReplicationWatermark(runner, '06', writeTimeMs);
-    runner.commit();
 
     expectTableExact(
       db,
       CHANGE_LOG_STREAM_TABLE,
       [
-        {
-          watermark: '02',
-          pos: 0,
-          change: '{"tag":"begin"}',
-          precommit: null,
-          writeTimeMs: null,
-        },
-        {
-          watermark: '02',
-          pos: 1,
-          change: '{"tag":"commit"}',
-          precommit: '02',
-          writeTimeMs: expect.any(Number),
-        },
+        ...SEED_ROWS,
         {
           watermark: '06',
           pos: 0,
@@ -127,49 +179,72 @@ describe('replicator/change-log-stream-writer', () => {
       'watermark',
       'pos',
     );
-
-    expect(
-      db
-        .prepare(
-          `SELECT "stateVersion", "writeTimeMs" FROM "_zero.replicationState"`,
-        )
-        .get(),
-    ).toEqual({stateVersion: '06', writeTimeMs});
   });
 
-  test('rollback discards rows and a large transaction is streamed', () => {
-    using db = new Database(lc, ':memory:');
-    initReplicationState(db, ['zero_data'], '02');
-    const runner = new StatementRunner(db);
-    const writer = new ChangeLogStreamWriter(db);
-    const begin = json(['begin', {tag: 'begin'}, {commitWatermark: '06'}]);
-    const truncate = json(['data', {tag: 'truncate', relations: []}]);
+  test('owns its transaction, which is durable at commit', () => {
+    const {db, observer} = createChangeLogFile();
+    using _db = db;
+    using _observer = observer;
+    const writer = new ChangeLogStreamWriter(new StatementRunner(db));
 
-    runner.beginImmediate();
-    writer.begin('06', begin);
-    writer.append(truncate, 'truncate');
-    runner.rollback();
+    expect(db.inTransaction).toBe(false);
+    writer.begin('06', BEGIN);
+    expect(db.inTransaction).toBe(true);
+    writer.append(TRUNCATE, 'truncate');
+    // Nothing is visible to another connection until the writer commits.
+    expect(head(observer)).toBe(ANCHOR.stateVersion);
+
+    writer.commit('06', COMMIT, 789);
+    expect(db.inTransaction).toBe(false);
+    expect(head(observer)).toBe('06');
+  });
+
+  test('rollback discards the transaction and is safe outside one', () => {
+    using db = createChangeLog();
+    const writer = new ChangeLogStreamWriter(new StatementRunner(db));
+
+    writer.begin('06', BEGIN);
+    writer.append(TRUNCATE, 'truncate');
     writer.rollback();
 
-    expect(
-      db
-        .prepare(`SELECT count(*) AS "count" FROM "${CHANGE_LOG_STREAM_TABLE}"`)
-        .get(),
-    ).toEqual({count: 2});
+    expect(db.inTransaction).toBe(false);
+    expect(rowCount(db)).toBe(SEED_ROWS.length);
 
-    const rowCount = 2500;
-    runner.beginImmediate();
-    writer.begin('06', begin);
-    for (let i = 0; i < rowCount; i++) {
-      writer.append(truncate, 'truncate');
+    // The processor's failure path also rolls back after a commit that
+    // succeeded and a replica write that did not.
+    expect(() => writer.rollback()).not.toThrow();
+    expect(rowCount(db)).toBe(SEED_ROWS.length);
+
+    // The writer is reusable afterwards.
+    writer.begin('06', BEGIN);
+    writer.commit('06', COMMIT, 789);
+    expect(head(db)).toBe('06');
+  });
+
+  test('rolls back a transaction that was never committed by the caller', () => {
+    const {db, observer} = createChangeLogFile();
+    using _db = db;
+    using _observer = observer;
+    const writer = new ChangeLogStreamWriter(new StatementRunner(db));
+
+    writer.begin('06', BEGIN);
+    writer.append(TRUNCATE, 'truncate');
+    writer.rollback();
+
+    expect(head(observer)).toBe(ANCHOR.stateVersion);
+    expect(rowCount(observer)).toBe(SEED_ROWS.length);
+  });
+
+  test('streams a large transaction', () => {
+    using db = createChangeLog();
+    const writer = new ChangeLogStreamWriter(new StatementRunner(db));
+
+    const rows = 2500;
+    writer.begin('06', BEGIN);
+    for (let i = 0; i < rows; i++) {
+      writer.append(TRUNCATE, 'truncate');
     }
-    writer.commit(
-      '06',
-      json(['commit', {tag: 'commit'}, {watermark: '06'}]),
-      789,
-    );
-    updateReplicationWatermark(runner, '06', 789);
-    runner.commit();
+    writer.commit('06', COMMIT, 789);
 
     expect(
       db
@@ -179,6 +254,19 @@ describe('replicator/change-log-stream-writer', () => {
             WHERE "watermark" = '06'
         `)
         .get(),
-    ).toEqual({count: rowCount + 2, minPos: 0, maxPos: rowCount + 1});
+    ).toEqual({count: rows + 2, minPos: 0, maxPos: rows + 1});
+  });
+
+  test('a second begin without a commit is an invariant failure', () => {
+    using db = createChangeLog();
+    const writer = new ChangeLogStreamWriter(new StatementRunner(db));
+
+    writer.begin('06', BEGIN);
+    expect(() => writer.begin('07', BEGIN)).toThrow(
+      'change-log stream transaction already open at 06',
+    );
+    // The open transaction is the first one, not a nested second.
+    writer.rollback();
+    expect(db.inTransaction).toBe(false);
   });
 });

--- a/packages/zero-cache/src/services/replicator/change-log-stream-writer.ts
+++ b/packages/zero-cache/src/services/replicator/change-log-stream-writer.ts
@@ -1,4 +1,5 @@
-import type {Database, Statement} from '../../../../zqlite/src/db.ts';
+import type {Statement} from '../../../../zqlite/src/db.ts';
+import type {StatementRunner} from '../../db/statements.ts';
 import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
 import {extractChangeSubstring} from '../change-streamer/change-log-codec.ts';
 import {ChangeLogTransactionHasher} from '../change-streamer/change-log-transaction-hash.ts';
@@ -48,14 +49,16 @@ function assertInvariant(
 }
 
 /**
- * Appends the canonical downstream stream to the replica-local change log.
+ * Appends the canonical downstream stream to the change-log database, which is
+ * a separate file from the replica.
  *
- * Transaction ownership deliberately remains with {@link ChangeProcessor}.
- * This class only tracks the current stream watermark and position, and every
- * statement it executes participates in the transaction already opened by the
- * processor.
+ * This class owns the change log's transaction, and its transaction alone. The
+ * replica's remains with {@link ChangeProcessor}, which commits the two in a
+ * fixed order — log first, then replica (design 4.4) — so that a crash can
+ * leave a phantom transaction in the log but never a hole.
  */
 export class ChangeLogStreamWriter {
+  readonly #db: StatementRunner;
   readonly #insertChange: Statement;
   readonly #insertCommit: Statement;
 
@@ -64,13 +67,14 @@ export class ChangeLogStreamWriter {
   #estimatedBytes = 0;
   #hasher: ChangeLogTransactionHasher | undefined;
 
-  constructor(db: Database) {
-    this.#insertChange = db.prepare(/*sql*/ `
+  constructor(db: StatementRunner) {
+    this.#db = db;
+    this.#insertChange = db.db.prepare(/*sql*/ `
       INSERT INTO "${CHANGE_LOG_STREAM_TABLE}"
         ("watermark", "pos", "change")
         VALUES (?, ?, ?)
     `);
-    this.#insertCommit = db.prepare(/*sql*/ `
+    this.#insertCommit = db.db.prepare(/*sql*/ `
       INSERT INTO "${CHANGE_LOG_STREAM_TABLE}"
         ("watermark", "pos", "change", "precommit", "writeTimeMs")
         VALUES (?, ?, ?, ?, ?)
@@ -82,6 +86,10 @@ export class ChangeLogStreamWriter {
       this.#watermark === undefined,
       `change-log stream transaction already open at ${this.#watermark}`,
     );
+    // This process is the sole writer of the change-log database, so the write
+    // lock is taken up front rather than risking a failed upgrade from a
+    // deferred transaction partway through the append.
+    this.#db.beginImmediate();
     this.#watermark = watermark;
     this.#pos = 0;
     const change = extractChangeSubstring(json, 'begin');
@@ -144,14 +152,28 @@ export class ChangeLogStreamWriter {
         estimateChangeLogStreamRowBytes(watermark, change, precommit, true),
       hash: hasher.digest(),
     };
-    this.#watermark = undefined;
-    this.#pos = 0;
-    this.#estimatedBytes = 0;
-    this.#hasher = undefined;
+    // The log is durable at `watermark` from here on, while the replica is
+    // still at the previous version. A crash in that window leaves a phantom,
+    // which startup reconciliation truncates.
+    this.#db.commit();
+    this.#reset();
     return stats;
   }
 
+  /**
+   * Discards the open transaction, if any. Safe to call when none is open —
+   * the caller's rollback path also runs after a commit that succeeded and a
+   * subsequent replica write that did not.
+   */
   rollback(): void {
+    const {inTransaction} = this.#db.db;
+    this.#reset();
+    if (inTransaction) {
+      this.#db.rollback();
+    }
+  }
+
+  #reset(): void {
     this.#watermark = undefined;
     this.#pos = 0;
     this.#estimatedBytes = 0;

--- a/packages/zero-cache/src/services/replicator/change-processor.test.ts
+++ b/packages/zero-cache/src/services/replicator/change-processor.test.ts
@@ -1,5 +1,5 @@
 import type {LogContext} from '@rocicorp/logger';
-import {beforeEach, describe, expect, test} from 'vitest';
+import {afterEach, beforeEach, describe, expect, test} from 'vitest';
 import type {JSONObject} from '../../../../shared/src/bigint-json.ts';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
 import {must} from '../../../../shared/src/must.ts';
@@ -11,10 +11,22 @@ import {
 } from '../../db/lite-tables.ts';
 import type {LiteIndexSpec} from '../../db/specs.ts';
 import {StatementRunner} from '../../db/statements.ts';
-import {expectTableExact, expectTables, initDB} from '../../test/lite.ts';
+import {
+  DbFile,
+  expectTableExact,
+  expectTables,
+  initDB,
+} from '../../test/lite.ts';
 import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
 import {serializeChangeStreamData} from '../change-streamer/change-log-codec.ts';
+import {
+  deleteChangeLogDB,
+  openChangeLogDB,
+  readReplicaAnchor,
+  reconcileChangeLog,
+} from './change-log-db.ts';
 import {ChangeProcessor} from './change-processor.ts';
+import {CHANGE_LOG_STREAM_TABLE} from './schema/change-log-stream.ts';
 import {DEL_OP, SET_OP} from './schema/change-log.ts';
 import {ColumnMetadataStore} from './schema/column-metadata.ts';
 import {
@@ -22,6 +34,39 @@ import {
   initReplicationState,
 } from './schema/replication-state.ts';
 import {createChangeProcessor, ReplicationMessages} from './test-utils.ts';
+
+/**
+ * Exposes the two points inside `processCommit` where the replica is written,
+ * so a test can sample the two databases from other connections in between.
+ */
+class ObservingStatementRunner extends StatementRunner {
+  onCommit: (() => void) | undefined;
+  onRun: (() => void) | undefined;
+
+  override commit() {
+    this.onCommit?.();
+    return super.commit();
+  }
+
+  override run(sql: string, ...args: unknown[]) {
+    this.onRun?.();
+    return super.run(sql, ...args);
+  }
+}
+
+function head(db: Database): string | null {
+  return db
+    .prepare(
+      /*sql*/ `SELECT max("watermark") AS "head" FROM "${CHANGE_LOG_STREAM_TABLE}"`,
+    )
+    .get<{head: string | null}>().head;
+}
+
+function stateVersion(db: Database): string {
+  return db
+    .prepare(/*sql*/ `SELECT "stateVersion" FROM "_zero.replicationState"`)
+    .get<{stateVersion: string}>().stateVersion;
+}
 
 describe('replicator/change-processor', () => {
   let lc: LogContext;
@@ -37,7 +82,7 @@ describe('replicator/change-processor', () => {
     servingProcessor = new ChangeProcessor(
       new StatementRunner(servingReplica),
       'serving',
-      {logsChangeStream: false},
+      {changeLog: undefined},
       (_, err) => {
         throw err;
       },
@@ -47,7 +92,7 @@ describe('replicator/change-processor', () => {
     backupProcessor = new ChangeProcessor(
       new StatementRunner(backupReplica),
       'backup',
-      {logsChangeStream: false},
+      {changeLog: undefined},
       (_, err) => {
         throw err;
       },
@@ -3852,7 +3897,10 @@ describe('replicator/change-processor-errors', () => {
 
 describe('replicator/change-processor change-stream logging', () => {
   let lc: LogContext;
+  let replicaFile: DbFile;
   let replica: Database;
+  let replicaRunner: ObservingStatementRunner;
+  let changeLog: Database;
   let processor: ChangeProcessor;
   let failures: unknown[];
 
@@ -3860,7 +3908,11 @@ describe('replicator/change-processor change-stream logging', () => {
 
   beforeEach(() => {
     lc = createSilentLogContext();
-    replica = new Database(lc, ':memory:');
+    // File-backed, so a second connection can observe what is committed while
+    // a transaction is still open.
+    replicaFile = new DbFile('change-processor-change-log');
+    replica = replicaFile.connect(lc);
+    replica.pragma('journal_mode = wal');
     initReplicationState(replica, ['zero_data'], '02');
     initDB(
       replica,
@@ -3872,17 +3924,49 @@ describe('replicator/change-processor change-stream logging', () => {
       );
       `,
     );
+    changeLog = openChangeLogDB(lc, replicaFile.path, {readonly: false});
+    changeLog.pragma('journal_mode = wal');
+    reconcileChangeLog(lc, changeLog, readReplicaAnchor(replica));
+
     failures = [];
-    processor = createChangeProcessor(replica, (_, err) => failures.push(err), {
-      logsChangeStream: true,
-    });
+    replicaRunner = new ObservingStatementRunner(replica);
+    processor = new ChangeProcessor(
+      replicaRunner,
+      'serving',
+      {changeLog: new StatementRunner(changeLog)},
+      (_, err) => failures.push(err),
+    );
+  });
+
+  afterEach(() => {
+    changeLog.close();
+    replica.close();
+    deleteChangeLogDB(replicaFile.path);
+    replicaFile.delete();
   });
 
   function process(data: ChangeStreamData) {
     return processor.processMessage(lc, data, serializeChangeStreamData(data));
   }
 
-  test('atomically applies data, appends the stream, and advances state', () => {
+  function streamRows(db: Database, watermark: string) {
+    return db
+      .prepare(/*sql*/ `
+        SELECT "watermark", "pos", "change", "precommit", "writeTimeMs"
+          FROM "${CHANGE_LOG_STREAM_TABLE}"
+          WHERE "watermark" = ?
+          ORDER BY "pos"
+      `)
+      .all<{
+        watermark: string;
+        pos: number;
+        change: string;
+        precommit: string | null;
+        writeTimeMs: number | null;
+      }>(watermark);
+  }
+
+  test('applies data, logs the stream to its own database, and advances state', () => {
     process(['begin', issues.begin(), {commitWatermark: '06'}]);
     process([
       'data',
@@ -3912,20 +3996,7 @@ describe('replicator/change-processor change-stream logging', () => {
       'id',
     );
 
-    const rows = replica
-      .prepare(/*sql*/ `
-        SELECT "watermark", "pos", "change", "precommit", "writeTimeMs"
-          FROM "_zero.changeLogStream"
-          WHERE "watermark" = '06'
-          ORDER BY "pos"
-      `)
-      .all<{
-        watermark: string;
-        pos: number;
-        change: string;
-        precommit: string | null;
-        writeTimeMs: number | null;
-      }>();
+    const rows = streamRows(changeLog, '06');
     expect(rows).toEqual([
       {
         watermark: '06',
@@ -3951,6 +4022,10 @@ describe('replicator/change-processor change-stream logging', () => {
       },
     ]);
 
+    // The replica's own copy of the table is still present but no longer
+    // written; slice 7G drops it.
+    expect(streamRows(replica, '06')).toEqual([]);
+
     const state = replica
       .prepare(/*sql*/ `
         SELECT "stateVersion", "writeTimeMs"
@@ -3958,43 +4033,94 @@ describe('replicator/change-processor change-stream logging', () => {
       `)
       .get<{stateVersion: string; writeTimeMs: number}>();
     expect(state.stateVersion).toBe('06');
+    // The same writeTimeMs in both databases, so reconciliation can seed the
+    // log from the replica alone.
     expect(state.writeTimeMs).toBe(rows[2].writeTimeMs);
-    expect(
-      replica
-        .prepare(/*sql*/ `
-          SELECT max("watermark") AS "watermark"
-            FROM "_zero.changeLogStream"
-        `)
-        .get(),
-    ).toEqual({watermark: state.stateVersion});
+    expect(head(changeLog)).toBe(state.stateVersion);
+  });
+
+  test('the log is durable at the new head while the replica is still behind', () => {
+    using replicaObserver = new Database(lc, replicaFile.path, {
+      readonly: true,
+    });
+    using logObserver = openChangeLogDB(lc, replicaFile.path, {readonly: true});
+    const observed: {logHead: string | null; stateVersion: string}[] = [];
+    const observe = () =>
+      observed.push({
+        logHead: head(logObserver),
+        stateVersion: stateVersion(replicaObserver),
+      });
+
+    // Sampled from another connection at the one point where the two
+    // databases legitimately disagree: after the log's COMMIT and before the
+    // replica's.
+    replicaRunner.onCommit = observe;
+
+    process(['begin', issues.begin(), {commitWatermark: '06'}]);
+    process(['data', issues.insert('issues', {id: 1, text: 'ordering'})]);
+    observe();
+    process(['commit', issues.commit(), {watermark: '06'}]);
+    observe();
+
+    expect(observed).toEqual([
+      // Mid-transaction: neither has the new watermark.
+      {logHead: '02', stateVersion: '02'},
+      // Between the two commits: the log leads the replica.
+      {logHead: '06', stateVersion: '02'},
+      // Both committed.
+      {logHead: '06', stateVersion: '06'},
+    ]);
+  });
+
+  test('no interleaving leaves the replica ahead of the log', () => {
+    using replicaObserver = new Database(lc, replicaFile.path, {
+      readonly: true,
+    });
+    using logObserver = openChangeLogDB(lc, replicaFile.path, {readonly: true});
+    const holes: unknown[] = [];
+    const check = () => {
+      const logHead = head(logObserver);
+      const state = stateVersion(replicaObserver);
+      if (logHead === null || logHead < state) {
+        holes.push({logHead, stateVersion: state});
+      }
+    };
+
+    replicaRunner.onCommit = check;
+    replicaRunner.onRun = check;
+    for (const watermark of ['06', '08', '0a']) {
+      process(['begin', issues.begin(), {commitWatermark: watermark}]);
+      check();
+      process(['data', issues.insert('issues', {id: 1, text: watermark})]);
+      check();
+      process(['commit', issues.commit(), {watermark}]);
+      check();
+    }
+
+    expect(failures).toEqual([]);
+    expect(holes).toEqual([]);
+    expect(head(changeLog)).toBe('0a');
   });
 
   test('explicit rollback and abort leave no stream or replica rows', () => {
     process(['begin', issues.begin(), {commitWatermark: '06'}]);
     process(['data', issues.insert('issues', {id: 1, text: 'rollback'})]);
     process(['rollback', {tag: 'rollback'}]);
+    expect(changeLog.inTransaction).toBe(false);
 
     process(['begin', issues.begin(), {commitWatermark: '07'}]);
     process(['data', issues.insert('issues', {id: 2, text: 'abort'})]);
     processor.abort(lc);
+    expect(changeLog.inTransaction).toBe(false);
 
     expect(replica.prepare(`SELECT * FROM issues`).all()).toEqual([]);
-    expect(
-      replica
-        .prepare(/*sql*/ `
-          SELECT "watermark" FROM "_zero.changeLogStream"
-            WHERE "watermark" IN ('06', '07')
-        `)
-        .all(),
-    ).toEqual([]);
-    expect(
-      replica
-        .prepare(`SELECT "stateVersion" FROM "_zero.replicationState"`)
-        .get(),
-    ).toEqual({stateVersion: '02'});
+    expect(streamRows(changeLog, '06')).toEqual([]);
+    expect(streamRows(changeLog, '07')).toEqual([]);
+    expect(head(changeLog)).toBe('02');
+    expect(stateVersion(replica)).toBe('02');
   });
 
-  test('processing failure rolls back stream rows with replica changes', () => {
+  test('processing failure rolls back both transactions', () => {
     process(['begin', issues.begin(), {commitWatermark: '06'}]);
     process(['data', issues.insert('issues', {id: 1, text: 'valid'})]);
     process([
@@ -4012,14 +4138,43 @@ describe('replicator/change-processor change-stream logging', () => {
 
     expect(failures).toHaveLength(1);
     expect(replica.inTransaction).toBe(false);
+    expect(changeLog.inTransaction).toBe(false);
     expect(replica.prepare(`SELECT * FROM issues`).all()).toEqual([]);
+    expect(streamRows(changeLog, '06')).toEqual([]);
+  });
+
+  test('a replica rollback failure still rolls back the change log', () => {
+    process(['begin', issues.begin(), {commitWatermark: '06'}]);
+    process(['data', issues.insert('issues', {id: 1, text: 'valid'})]);
+    // SQLite rolls back this statement's transaction itself, so the
+    // processor's own ROLLBACK then fails: the change log must not be left
+    // holding its write lock because of it.
+    replica.exec(/*sql*/ `
+      CREATE TRIGGER "AutoRollback" BEFORE INSERT ON issues
+      BEGIN SELECT RAISE(ROLLBACK, 'auto rollback'); END;
+    `);
+    process(['data', issues.insert('issues', {id: 2, text: 'boom'})]);
+
+    expect(failures).toHaveLength(1);
+    expect(String(failures[0])).toContain('auto rollback');
+    expect(String(failures[0])).toContain(
+      'cannot rollback - no transaction is active',
+    );
+    expect(replica.inTransaction).toBe(false);
+    expect(changeLog.inTransaction).toBe(false);
+    expect(streamRows(changeLog, '06')).toEqual([]);
+  });
+
+  test('initial-sync cannot open a second transaction for the log', () => {
     expect(
-      replica
-        .prepare(
-          `SELECT * FROM "_zero.changeLogStream" WHERE "watermark" = '06'`,
-        )
-        .all(),
-    ).toEqual([]);
+      () =>
+        new ChangeProcessor(
+          new StatementRunner(replica),
+          'initial-sync',
+          {changeLog: new StatementRunner(changeLog)},
+          () => {},
+        ),
+    ).toThrow('initial-sync owns its transaction boundaries');
   });
 });
 

--- a/packages/zero-cache/src/services/replicator/change-processor.ts
+++ b/packages/zero-cache/src/services/replicator/change-processor.ts
@@ -72,7 +72,12 @@ import {TableMetadataTracker} from './schema/table-metadata.ts';
 export type ChangeProcessorMode = ReplicatorMode | 'initial-sync';
 
 export type ChangeProcessorOptions = {
-  logsChangeStream: boolean;
+  /**
+   * The change-log database, when the canonical change stream is being logged.
+   * It is a separate file from the replica, with its own transaction, which
+   * {@link ChangeLogStreamWriter} owns and commits before the replica's.
+   */
+  changeLog: StatementRunner | undefined;
 };
 
 export type CommitResult = {
@@ -117,10 +122,15 @@ export class ChangeProcessor {
     options: ChangeProcessorOptions,
     failService: (lc: LogContext, err: unknown) => void,
   ) {
+    assert(
+      options.changeLog === undefined || mode !== 'initial-sync',
+      'initial-sync owns its transaction boundaries and cannot write the ' +
+        'change log, which opens a second one',
+    );
     this.#db = db;
     this.#changeLog = new ChangeLog(db.db);
-    this.#changeLogStreamWriter = options.logsChangeStream
-      ? new ChangeLogStreamWriter(db.db)
+    this.#changeLogStreamWriter = options.changeLog
+      ? new ChangeLogStreamWriter(options.changeLog)
       : undefined;
     this.#tableMetadata = new TableMetadataTracker(db.db);
     this.#mode = mode;
@@ -130,12 +140,17 @@ export class ChangeProcessor {
   #fail(lc: LogContext, err: unknown) {
     if (!this.#failure) {
       let failureError = err;
-      try {
-        this.#currentTx?.abort(lc); // roll back any pending transaction.
-        this.#changeLogStreamWriter?.rollback();
-      } catch (rollbackError) {
+      // The two transactions are independent, so each is rolled back even if
+      // the other throws. Leaving one open would wedge the next attempt behind
+      // its own write lock.
+      const rollbackErrors = [
+        attempt(() => this.#currentTx?.abort(lc)),
+        attempt(() => this.#changeLogStreamWriter?.rollback()),
+      ].filter(e => e !== undefined);
+
+      if (rollbackErrors.length) {
         const combinedError = new Error(
-          `Message processing failed and rollback also failed: operation error = ${String(err)}; rollback error = ${String(rollbackError)}`,
+          `Message processing failed and rollback also failed: operation error = ${String(err)}; rollback error = ${rollbackErrors.map(String).join('; ')}`,
         );
         combinedError.cause = err;
         failureError = combinedError;
@@ -238,6 +253,10 @@ export class ChangeProcessor {
       if (this.#currentTx) {
         throw new Error(`Already in a transaction ${stringify(msg)}`);
       }
+      // Only the commit order matters. The replica's transaction is opened
+      // first because that is the one that carries the indefinite SQLITE_BUSY
+      // retry for litestream checkpoints; opening the log first would leave it
+      // holding a write lock for the duration of that wait.
       this.#currentTx = this.#beginTransaction(
         lc,
         must(watermark),
@@ -958,6 +977,11 @@ class TransactionProcessor {
         }: ${stringify(commit)}`,
       );
     }
+    // Commit order is load-bearing: the change log commits first, then the
+    // replica (design 4.4). It is what makes `logHead >= stateVersion` hold at
+    // all times, so a crash in between leaves a phantom transaction in the log
+    // — locally detectable and truncated at startup — rather than a hole in it,
+    // which would be silently served to a subscriber as a gap.
     let changeLogStream: ChangeLogStreamTransactionStats | undefined;
     if (changeLogStreamWriter) {
       const writeTimeMs = Date.now();
@@ -966,6 +990,8 @@ class TransactionProcessor {
         must(canonicalJSON),
         writeTimeMs,
       );
+      // The same writeTimeMs is stored in both databases, so reconciliation
+      // can seed the log from the replica's state alone.
       updateReplicationWatermark(this.#db, watermark, writeTimeMs);
     } else {
       updateReplicationWatermark(this.#db, watermark);
@@ -1009,6 +1035,16 @@ function getBackfilledColumns(
     return undefined; // common case
   }
   return backfilling.filter(col => col in row);
+}
+
+/** Runs `fn`, returning its error rather than throwing it. */
+function attempt(fn: () => void): unknown {
+  try {
+    fn();
+    return undefined;
+  } catch (e) {
+    return e ?? new Error('rollback failed');
+  }
 }
 
 function ensureError(err: unknown): Error {

--- a/packages/zero-cache/src/services/replicator/incremental-sync.test.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.test.ts
@@ -30,6 +30,7 @@ import {
   type SubscriberContext,
 } from '../change-streamer/change-streamer.ts';
 import * as ErrorType from '../change-streamer/error-type-enum.ts';
+import {deleteChangeLogDB, openChangeLogDB} from './change-log-db.ts';
 import {IncrementalSyncer} from './incremental-sync.ts';
 import {ReplicationStatusPublisher} from './replication-status.ts';
 import {
@@ -108,6 +109,7 @@ describe('replicator/incremental-sync', () => {
     await syncing?.catch(() => {});
     await worker?.stop();
     mainDb?.close();
+    deleteChangeLogDB(dbFile.path);
     dbFile?.delete();
   });
 
@@ -879,6 +881,9 @@ describe('replicator/incremental-sync', () => {
 
   test('source disconnect rolls back an enabled stream writer transaction', async () => {
     await worker.stop();
+    // The change log is anchored to the replica's state, so the state has to
+    // exist before the worker opens and reconciles it.
+    initReplicationState(mainDb, ['zero_data'], '02', {}, false);
     worker = new ThreadWriteWorkerClient();
     await worker.init(
       dbFile.path,
@@ -890,7 +895,6 @@ describe('replicator/incremental-sync', () => {
       },
       {level: 'error', format: 'text'},
     );
-    initReplicationState(mainDb, ['zero_data'], '02', {}, false);
     initDB(
       mainDb,
       `
@@ -929,13 +933,16 @@ describe('replicator/incremental-sync', () => {
 
     expect(await hasRetried).toBe(true);
     expect(mainDb.prepare(`SELECT * FROM issues`).all()).toEqual([]);
-    expect(
-      mainDb
-        .prepare(
-          `SELECT * FROM "_zero.changeLogStream" WHERE "watermark" = '06'`,
-        )
-        .all(),
-    ).toEqual([]);
+    {
+      using changeLog = openChangeLogDB(lc, dbFile.path, {readonly: true});
+      expect(
+        changeLog
+          .prepare(
+            `SELECT * FROM "_zero.changeLogStream" WHERE "watermark" = '06'`,
+          )
+          .all(),
+      ).toEqual([]);
+    }
     syncer.stop(lc);
     void syncing.catch(() => {});
     syncing = undefined;
@@ -943,6 +950,7 @@ describe('replicator/incremental-sync', () => {
 
   test('an enabled SQLite stream-writer error stops the replicator', async () => {
     await worker.stop();
+    initReplicationState(mainDb, ['zero_data'], '02', {}, false);
     worker = new ThreadWriteWorkerClient();
     await worker.init(
       dbFile.path,
@@ -954,7 +962,6 @@ describe('replicator/incremental-sync', () => {
       },
       {level: 'error', format: 'text'},
     );
-    initReplicationState(mainDb, ['zero_data'], '02', {}, false);
     const observer = new SQLiteChangeLogObserver(lc, {
       schemaVersion: 14,
       stateWatermark: '02',

--- a/packages/zero-cache/src/services/replicator/replication-throughput.bench.pg.ts
+++ b/packages/zero-cache/src/services/replicator/replication-throughput.bench.pg.ts
@@ -1,5 +1,14 @@
 // Benchmarks end-to-end logical replication throughput from upstream Postgres
 // writes through the change-streamer and into the SQLite replica.
+//
+// Set SQLITE_CHANGE_LOG_WRITER=1 to also write the canonical change stream to
+// the change-log database beside the replica, which is what the replicator
+// does with `sqliteChangeLogMode` enabled. Running the bench both ways is the
+// slice 7D measurement: the cost of the second, log-first commit on the real
+// write path rather than on the synthetic ceiling harness.
+//
+//   pnpm --filter zero-cache run bench:pg replication-throughput
+//   SQLITE_CHANGE_LOG_WRITER=1 pnpm --filter zero-cache run bench:pg replication-throughput
 
 import {afterEach, describe, expect} from 'vitest';
 import {createManualBenchmarkRecorder} from '../../../../shared/src/bench.ts';
@@ -29,6 +38,7 @@ import {
   type SerializedDownstream,
 } from '../change-streamer/change-streamer.ts';
 import {initChangeStreamerSchema} from '../change-streamer/schema/init.ts';
+import {deleteChangeLogDB} from './change-log-db.ts';
 import {ReplicationStatusPublisher} from './replication-status.ts';
 import {ReplicatorService} from './replicator.ts';
 import {ThreadWriteWorkerClient} from './write-worker-client.ts';
@@ -44,6 +54,8 @@ const APP_ID = 'logical_replication_bench_app';
 const SHARD_NUM = 0;
 const TASK_ID = 'logical-replication-throughput-bench';
 const TEST_TIMEOUT_MS = 900_000;
+
+const LOGS_CHANGE_STREAM = process.env['SQLITE_CHANGE_LOG_WRITER'] === '1';
 
 const lc = createSilentLogContext();
 const shard = {
@@ -169,13 +181,17 @@ async function startReplicationPipeline(testDBs: PgTest['testDBs']) {
   await worker.init(
     replicaDbFile.path,
     'serving',
-    false,
+    LOGS_CHANGE_STREAM,
     getPragmaConfig('serving'),
     {
       level: 'error',
       format: 'text',
     },
   );
+  cleanup.push(() => {
+    deleteChangeLogDB(replicaDbFile.path);
+    return Promise.resolve();
+  });
 
   const replicator = new ReplicatorService(
     lc,
@@ -184,7 +200,7 @@ async function startReplicationPipeline(testDBs: PgTest['testDBs']) {
     'serving',
     parseStringifiedChangeStreamer(changeStreamer),
     worker,
-    false,
+    LOGS_CHANGE_STREAM,
     null,
     undefined,
   );
@@ -249,7 +265,8 @@ describe('replicator/logical replication throughput', () => {
       }
 
       benchmarkRecorder.recordThroughputSamples(
-        'replicator/logical replication end-to-end payload MB',
+        'replicator/logical replication end-to-end payload MB ' +
+          `changeLogWriter=${LOGS_CHANGE_STREAM ? 'on' : 'off'}`,
         samples,
       );
     },

--- a/packages/zero-cache/src/services/replicator/schema-change-fuzz.test.ts
+++ b/packages/zero-cache/src/services/replicator/schema-change-fuzz.test.ts
@@ -84,7 +84,7 @@ test('streamed schema changes match a replica rebuilt from the final schema', ()
         const processor = new ChangeProcessor(
           new StatementRunner(streamed),
           'serving',
-          {logsChangeStream: false},
+          {changeLog: undefined},
           (_, error) => {
             throw error;
           },

--- a/packages/zero-cache/src/services/replicator/sqlite-change-log-observability.test.ts
+++ b/packages/zero-cache/src/services/replicator/sqlite-change-log-observability.test.ts
@@ -8,11 +8,13 @@ import {
   serializeChangeStreamData,
 } from '../change-streamer/change-log-codec.ts';
 import {ChangeLogTransactionHasher} from '../change-streamer/change-log-transaction-hash.ts';
+import type {ReconcileResult} from './change-log-db.ts';
 import {initReplicationState} from './schema/replication-state.ts';
 import {
   getSQLiteChangeLogInfo,
   getSQLiteChangeLogStartupInfo,
   logSQLiteChangeLogStartup,
+  recordSQLiteChangeLogReconcile,
   SQLiteChangeLogObserver,
 } from './sqlite-change-log-observability.ts';
 
@@ -351,6 +353,38 @@ describe('SQLite change-log observability', () => {
           },
         },
       ],
+    ]);
+  });
+});
+
+describe('replicator/sqlite-change-log reconcile reporting', () => {
+  // Every ReconcileResult, including each wipe reason: `gap` in steady state
+  // means log-first ordering is not holding, and is the one on the alert list.
+  const cases: [name: string, result: ReconcileResult][] = [
+    ['consistent', {action: 'none', head: '05'}],
+    ['phantom truncation', {action: 'truncated', head: '05', rows: 27}],
+    ['wipe: created', {action: 'reseeded', head: '05', reason: 'created'}],
+    [
+      'wipe: schema-mismatch',
+      {action: 'reseeded', head: '05', reason: 'schema-mismatch'},
+    ],
+    [
+      'wipe: replica-version-mismatch',
+      {action: 'reseeded', head: '05', reason: 'replica-version-mismatch'},
+    ],
+    ['wipe: gap', {action: 'reseeded', head: '05', reason: 'gap'}],
+  ];
+
+  test.each(cases)('%s', (_name, result) => {
+    const sink = new TestLogSink();
+    const lc = new LogContext('debug', undefined, sink);
+
+    recordSQLiteChangeLogReconcile(lc, result);
+
+    expect(sink.messages.at(-1)).toEqual([
+      'debug',
+      undefined,
+      ['SQLite change-log reconciliation', {sqliteChangeLogReconcile: result}],
     ]);
   });
 });

--- a/packages/zero-cache/src/services/replicator/sqlite-change-log-observability.ts
+++ b/packages/zero-cache/src/services/replicator/sqlite-change-log-observability.ts
@@ -1,5 +1,5 @@
 import type {LogContext} from '@rocicorp/logger';
-import {assert} from '../../../../shared/src/asserts.ts';
+import {assert, unreachable} from '../../../../shared/src/asserts.ts';
 import type {Database} from '../../../../zqlite/src/db.ts';
 import {
   getOrCreateCounter,
@@ -11,8 +11,53 @@ import {versionFromLexi} from '../../types/lexi-version.ts';
 import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
 import {extractChangeSubstring} from '../change-streamer/change-log-codec.ts';
 import {ChangeLogTransactionHasher} from '../change-streamer/change-log-transaction-hash.ts';
+import type {ReconcileResult} from './change-log-db.ts';
 import type {CommitResult} from './change-processor.ts';
 import {CHANGE_LOG_STREAM_TABLE} from './schema/change-log-stream.ts';
+
+/**
+ * Reports the startup reconciliation of the change-log database against the
+ * replica.
+ *
+ * A wipe is not an error — it is how every abnormal change-log state is
+ * collapsed into a correct one — but each wipe costs the retention window, so
+ * every reconnecting subscriber below the replica head gets `too-old`. The
+ * `gap` reason in particular means log-first commit ordering did not hold, so a
+ * nonzero rate in steady state is an alert, not a statistic.
+ *
+ * Called from the replicator process rather than the write worker, which does
+ * not start OTel.
+ */
+export function recordSQLiteChangeLogReconcile(
+  lc: LogContext,
+  result: ReconcileResult,
+): void {
+  switch (result.action) {
+    case 'truncated':
+      getOrCreateCounter(
+        'replica',
+        'sqlite_change_log.reconcile_truncated_rows',
+        'Phantom change-log rows removed at startup, i.e. logged transactions ' +
+          'whose replica commit was lost to a crash.',
+      ).add(result.rows);
+      break;
+    case 'reseeded':
+      getOrCreateCounter(
+        'replica',
+        'sqlite_change_log.reconcile_wipes',
+        'Change-log wipes at startup, by reason. Each one resets the retention ' +
+          'window, so subscribers below the replica head get `too-old`.',
+      ).add(1, {reason: result.reason});
+      break;
+    case 'none':
+      break;
+    default:
+      unreachable(result);
+  }
+  lc.debug?.('SQLite change-log reconciliation', {
+    sqliteChangeLogReconcile: result,
+  });
+}
 
 export type SQLiteChangeLogStartupInfo = {
   readonly schemaVersion: number;

--- a/packages/zero-cache/src/services/replicator/test-utils.ts
+++ b/packages/zero-cache/src/services/replicator/test-utils.ts
@@ -62,7 +62,7 @@ export function createChangeProcessor(
   failures: (lc: LogContext, err: unknown) => void = (_, err) => {
     throw err;
   },
-  options: ChangeProcessorOptions = {logsChangeStream: false},
+  options: ChangeProcessorOptions = {changeLog: undefined},
 ): ChangeProcessor {
   return new ChangeProcessor(
     new StatementRunner(db),

--- a/packages/zero-cache/src/services/replicator/write-worker-client.ts
+++ b/packages/zero-cache/src/services/replicator/write-worker-client.ts
@@ -5,6 +5,7 @@ import type {LogConfig} from '../../../../shared/src/logging.ts';
 import type {Database} from '../../../../zqlite/src/db.ts';
 import {WRITE_WORKER_URL} from '../../server/worker-urls.ts';
 import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
+import type {ReconcileResult} from './change-log-db.ts';
 import type {ChangeProcessorMode, CommitResult} from './change-processor.ts';
 import type {SubscriptionState} from './schema/replication-state.ts';
 
@@ -106,7 +107,10 @@ export type Method = keyof ArgsMap;
 export type Request<M extends Method = Method> = {method: M; args: ArgsMap[M]};
 
 export type ResultMap = {
-  init: void;
+  // The change-log reconciliation, when the writer is enabled. Returned rather
+  // than reported from the worker because OTel is only started in the
+  // replicator process, so metrics recorded in this thread would be dropped.
+  init: ReconcileResult | undefined;
   getSubscriptionState: SubscriptionState;
   processMessage: CommitResult | null;
   abort: void;
@@ -194,7 +198,7 @@ export class ThreadWriteWorkerClient implements WriteWorkerClient {
     logsChangeStream: boolean,
     pragmas: PragmaConfig,
     logConfig: LogConfig,
-  ): Promise<void> {
+  ): Promise<ReconcileResult | undefined> {
     return this.#call('init', [
       dbPath,
       mode,

--- a/packages/zero-cache/src/services/replicator/write-worker.test.ts
+++ b/packages/zero-cache/src/services/replicator/write-worker.test.ts
@@ -1,4 +1,5 @@
 import {once} from 'node:events';
+import {existsSync} from 'node:fs';
 import {Worker} from 'node:worker_threads';
 import {afterEach, beforeEach, describe, expect, test} from 'vitest';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
@@ -6,6 +7,14 @@ import type {Database} from '../../../../zqlite/src/db.ts';
 import {DbFile, initDB} from '../../test/lite.ts';
 import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
 import {serializeChangeStreamData} from '../change-streamer/change-log-codec.ts';
+import {
+  CHANGE_LOG_DB_SCHEMA_VERSION,
+  CHANGE_LOG_META_TABLE,
+  changeLogFileName,
+  deleteChangeLogDB,
+  openChangeLogDB,
+} from './change-log-db.ts';
+import {CHANGE_LOG_STREAM_TABLE} from './schema/change-log-stream.ts';
 import {initReplicationState} from './schema/replication-state.ts';
 import {ReplicationMessages} from './test-utils.ts';
 import {
@@ -20,10 +29,21 @@ function serialized(data: ChangeStreamData): SerializedChangeStreamData {
   return {data, json: serializeChangeStreamData(data)};
 }
 
+const PRAGMAS = {busyTimeout: 30000, analysisLimit: 1000};
+const LOG_CONFIG = {level: 'error', format: 'text'} as const;
+
 describe('write-worker', () => {
   let dbFile: DbFile;
   let mainDb: Database;
   let worker: ThreadWriteWorkerClient;
+
+  /** Reads the change log the worker writes beside the replica. */
+  function readChangeLog<T>(read: (db: Database) => T): T {
+    using db = openChangeLogDB(createSilentLogContext(), dbFile.path, {
+      readonly: true,
+    });
+    return read(db);
+  }
 
   beforeEach(async () => {
     const lc = createSilentLogContext();
@@ -60,6 +80,7 @@ describe('write-worker', () => {
   afterEach(async () => {
     await worker.stop();
     mainDb.close();
+    deleteChangeLogDB(dbFile.path);
     dbFile.delete();
   });
 
@@ -111,19 +132,88 @@ describe('write-worker', () => {
     expect(state.watermark).toBe('06');
   });
 
+  test('init creates, seeds, and then leaves the change log alone', async () => {
+    await worker.stop();
+    expect(existsSync(changeLogFileName(dbFile.path))).toBe(false);
+
+    worker = new ThreadWriteWorkerClient();
+    expect(
+      await worker.init(dbFile.path, 'serving', true, PRAGMAS, LOG_CONFIG),
+    ).toEqual({action: 'reseeded', head: '02', reason: 'created'});
+    expect(existsSync(changeLogFileName(dbFile.path))).toBe(true);
+    expect(
+      readChangeLog(db => ({
+        meta: db.prepare(`SELECT * FROM "${CHANGE_LOG_META_TABLE}"`).get(),
+        journalMode: db.pragma('journal_mode'),
+        head: db
+          .prepare(
+            `SELECT max("watermark") AS "head" FROM "${CHANGE_LOG_STREAM_TABLE}"`,
+          )
+          .get(),
+      })),
+    ).toEqual({
+      meta: {
+        replicaVersion: '02',
+        schemaVersion: CHANGE_LOG_DB_SCHEMA_VERSION,
+        lock: 1,
+      },
+      journalMode: [{journal_mode: 'wal2'}],
+      head: {head: '02'},
+    });
+
+    // A restart against a consistent log neither truncates nor reseeds.
+    await worker.stop();
+    worker = new ThreadWriteWorkerClient();
+    expect(
+      await worker.init(dbFile.path, 'serving', true, PRAGMAS, LOG_CONFIG),
+    ).toEqual({action: 'none', head: '02'});
+  });
+
+  test('init truncates a phantom transaction left by a crash', async () => {
+    await worker.stop();
+    worker = new ThreadWriteWorkerClient();
+    await worker.init(dbFile.path, 'serving', true, PRAGMAS, LOG_CONFIG);
+    await worker.stop();
+
+    // A transaction that reached the log but whose replica commit was lost.
+    {
+      using log = openChangeLogDB(createSilentLogContext(), dbFile.path, {
+        readonly: false,
+      });
+      log
+        .prepare(/*sql*/ `
+        INSERT INTO "${CHANGE_LOG_STREAM_TABLE}"
+          ("watermark", "pos", "change", "precommit", "writeTimeMs")
+          VALUES ('06', 0, '{"tag":"begin"}', NULL, NULL),
+                 ('06', 1, '{"tag":"commit"}', '02', 123)
+      `)
+        .run();
+    }
+
+    worker = new ThreadWriteWorkerClient();
+    expect(
+      await worker.init(dbFile.path, 'serving', true, PRAGMAS, LOG_CONFIG),
+    ).toEqual({action: 'truncated', head: '02', rows: 2});
+  });
+
+  test('init rejects the change-log writer in initial-sync mode', async () => {
+    await worker.stop();
+    worker = new ThreadWriteWorkerClient();
+    await expect(
+      worker.init(dbFile.path, 'initial-sync', true, PRAGMAS, LOG_CONFIG),
+    ).rejects.toThrow('initial-sync owns its transaction boundaries');
+    expect(existsSync(changeLogFileName(dbFile.path))).toBe(false);
+
+    // Leave a usable worker for the afterEach teardown.
+    await worker.stop();
+    worker = new ThreadWriteWorkerClient();
+    await worker.init(dbFile.path, 'serving', false, PRAGMAS, LOG_CONFIG);
+  });
+
   test('enabled writer is atomic across abort and worker restart', async () => {
     await worker.stop();
     worker = new ThreadWriteWorkerClient();
-    await worker.init(
-      dbFile.path,
-      'serving',
-      true,
-      {
-        busyTimeout: 30000,
-        analysisLimit: 1000,
-      },
-      {level: 'error', format: 'text'},
-    );
+    await worker.init(dbFile.path, 'serving', true, PRAGMAS, LOG_CONFIG);
 
     const issues = new ReplicationMessages({issues: ['issueID', 'bool']});
     await worker.processMessage(
@@ -152,30 +242,27 @@ describe('write-worker', () => {
 
     await worker.stop();
     worker = new ThreadWriteWorkerClient();
-    await worker.init(
-      dbFile.path,
-      'serving',
-      true,
-      {
-        busyTimeout: 30000,
-        analysisLimit: 1000,
-      },
-      {level: 'error', format: 'text'},
-    );
+    // The aborted transaction left nothing behind, so there is no phantom to
+    // truncate and no gap to reseed.
+    expect(
+      await worker.init(dbFile.path, 'serving', true, PRAGMAS, LOG_CONFIG),
+    ).toEqual({action: 'none', head: '06'});
 
     expect(await worker.getSubscriptionState()).toMatchObject({
       watermark: '06',
     });
     expect(
-      mainDb
-        .prepare(/*sql*/ `
-          SELECT "watermark", "pos", json_extract("change", '$.tag') AS "tag",
-                 "precommit", "writeTimeMs"
-            FROM "_zero.changeLogStream"
-            WHERE "watermark" IN ('05', '06')
-            ORDER BY "watermark", "pos"
-        `)
-        .all(),
+      readChangeLog(db =>
+        db
+          .prepare(/*sql*/ `
+            SELECT "watermark", "pos", json_extract("change", '$.tag') AS "tag",
+                   "precommit", "writeTimeMs"
+              FROM "${CHANGE_LOG_STREAM_TABLE}"
+              WHERE "watermark" IN ('05', '06')
+              ORDER BY "watermark", "pos"
+          `)
+          .all(),
+      ),
     ).toEqual([
       {
         watermark: '06',
@@ -211,16 +298,26 @@ describe('write-worker', () => {
         `SELECT "stateVersion", "writeTimeMs" FROM "_zero.replicationState"`,
       )
       .get<{stateVersion: string; writeTimeMs: number}>();
-    const commit = mainDb
-      .prepare(/*sql*/ `
-        SELECT "writeTimeMs" FROM "_zero.changeLogStream"
-          WHERE "watermark" = '06' AND "precommit" IS NOT NULL
-      `)
-      .get<{writeTimeMs: number}>();
+    const commit = readChangeLog(db =>
+      db
+        .prepare(/*sql*/ `
+          SELECT "writeTimeMs" FROM "${CHANGE_LOG_STREAM_TABLE}"
+            WHERE "watermark" = '06' AND "precommit" IS NOT NULL
+        `)
+        .get<{writeTimeMs: number}>(),
+    );
     expect(state).toEqual({
       stateVersion: '06',
       writeTimeMs: commit.writeTimeMs,
     });
+    // The replica's own copy of the table is no longer written.
+    expect(
+      mainDb
+        .prepare(/*sql*/ `
+          SELECT max("watermark") AS "head" FROM "${CHANGE_LOG_STREAM_TABLE}"
+        `)
+        .get(),
+    ).toEqual({head: '02'});
   });
 
   test('abort rolls back pending transaction', async () => {

--- a/packages/zero-cache/src/services/replicator/write-worker.ts
+++ b/packages/zero-cache/src/services/replicator/write-worker.ts
@@ -1,5 +1,6 @@
 import {parentPort} from 'node:worker_threads';
 import type {LogContext} from '@rocicorp/logger';
+import {assert} from '../../../../shared/src/asserts.ts';
 import type {LogConfig} from '../../../../shared/src/logging.ts';
 import {must} from '../../../../shared/src/must.ts';
 import {Database} from '../../../../zqlite/src/db.ts';
@@ -10,6 +11,13 @@ import {
 } from '../../db/sqlite-corruption.ts';
 import {StatementRunner} from '../../db/statements.ts';
 import {createLogContext} from '../../server/logging.ts';
+import {
+  applyChangeLogPragmas,
+  openChangeLogDB,
+  readReplicaAnchor,
+  reconcileChangeLog,
+  type ReconcileResult,
+} from './change-log-db.ts';
 import {ChangeProcessor, type ChangeProcessorMode} from './change-processor.ts';
 import {getSubscriptionState} from './schema/replication-state.ts';
 import {
@@ -36,9 +44,10 @@ type API = {[M in Method]: (...args: ArgsMap[M]) => ResultMap[M]};
 function createAPI(): API {
   let db: Database | undefined;
   let runner: StatementRunner | undefined;
+  let changeLogDb: Database | undefined;
+  let changeLogRunner: StatementRunner | undefined;
   let processor: ChangeProcessor | undefined;
   let mode: ChangeProcessorMode | undefined;
-  let logsChangeStream: boolean | undefined;
   let lc: LogContext | undefined;
   let replicaDbPath: string | undefined;
   let unregisterCorruptionDiagnosticTarget: (() => void) | undefined;
@@ -53,7 +62,7 @@ function createAPI(): API {
     processor = new ChangeProcessor(
       must(runner),
       must(mode),
-      {logsChangeStream: must(logsChangeStream)},
+      {changeLog: changeLogRunner},
       (_lc, err) => {
         logCorruptionDiagnostics(err);
         port.postMessage({
@@ -70,7 +79,12 @@ function createAPI(): API {
       shouldLogChangeStream: boolean,
       pragmas: PragmaConfig,
       logConfig: LogConfig,
-    ) {
+    ): ReconcileResult | undefined {
+      assert(
+        !shouldLogChangeStream || cpMode !== 'initial-sync',
+        'initial-sync owns its transaction boundaries and cannot write the ' +
+          'change log, which opens a second one',
+      );
       replicaDbPath = dbPath;
       lc = createLogContext({log: logConfig}, 'write-worker');
       unregisterCorruptionDiagnosticTarget?.();
@@ -84,8 +98,27 @@ function createAPI(): API {
         applyPragmas(db, pragmas);
         runner = new StatementRunner(db);
         mode = cpMode;
-        logsChangeStream = shouldLogChangeStream;
+
+        // The change log lives beside the replica rather than inside it, and
+        // the path is derived here so that the derivation stays the single
+        // source of truth rather than becoming a second IPC argument that
+        // could disagree with it.
+        changeLogDb?.close();
+        changeLogDb = undefined;
+        changeLogRunner = undefined;
+        let reconciled: ReconcileResult | undefined;
+        if (shouldLogChangeStream) {
+          changeLogDb = openChangeLogDB(must(lc), dbPath, {readonly: false});
+          applyChangeLogPragmas(changeLogDb);
+          reconciled = reconcileChangeLog(
+            must(lc),
+            changeLogDb,
+            readReplicaAnchor(db),
+          );
+          changeLogRunner = new StatementRunner(changeLogDb);
+        }
         createProcessor();
+        return reconciled;
       } catch (e) {
         logCorruptionDiagnostics(e);
         throw e;
@@ -119,6 +152,9 @@ function createAPI(): API {
       db?.close();
       db = undefined;
       runner = undefined;
+      changeLogDb?.close();
+      changeLogDb = undefined;
+      changeLogRunner = undefined;
       processor = undefined;
       replicaDbPath = undefined;
       unregisterCorruptionDiagnosticTarget?.();


### PR DESCRIPTION
The sqlite change stream now goes to the `${replicaFile}-change-log` database rather than into the replica (see https://github.com/rocicorp/mono/pull/6276), and the two databases commit in a fixed order.

Per upstream transaction there are now two commits on two connections:

  1. change-log DB — begin row, change rows, commit row, COMMIT
  2. replica DB — apply rows, `_zero.changeLog2`, state version, COMMIT

That order is required. It makes `logHead >= stateVersion` hold at all times, so a crash between the two commits leaves a *phantom* — a transaction in the log whose replica commit was lost — which startup reconciliation truncates. It can never leave a *hole*, which `plan()` would report as a servable range and `read()` would deliver to a subscriber as a silent gap.

This is all still off in prod until a config flip.
