### PR TITLE
chore(rmv2): decline SQLite catchup when the change log is not ready [12/n]

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
@@ -1,3 +1,4 @@
+import {writeFileSync} from 'node:fs';
 import {PG_LOCK_NOT_AVAILABLE} from '@drdgvhbh/postgres-error-codes';
 import {LogContext} from '@rocicorp/logger';
 import {resolver} from '@rocicorp/resolver';
@@ -48,6 +49,7 @@ import {ThreadWriteWorkerClient} from '../replicator/write-worker-client.ts';
 import {serializeChangeStreamData} from './change-log-codec.ts';
 import {
   initializeStreamer,
+  type SQLiteCatchupOptions,
   type TuningOptions,
 } from './change-streamer-service.ts';
 import {
@@ -58,6 +60,7 @@ import {
 import * as ErrorType from './error-type-enum.ts';
 import {initChangeStreamerSchema} from './schema/init.ts';
 import {AutoResetSignal, ensureReplicationConfig} from './schema/tables.ts';
+import {SQLiteChangeLogReader} from './sqlite-change-log-reader.ts';
 import {PurgeLocker} from './storer.ts';
 
 const opts: TuningOptions = {
@@ -191,6 +194,69 @@ describe('change-streamer/service', () => {
     const changeLog = openChangeLogDB(lc, replicaFile.path, {readonly: false});
     reconcileChangeLog(lc, changeLog, readReplicaAnchor(replica));
     return changeLog;
+  }
+
+  /** A replica whose `-change-log` sibling the SQLite catchup tests build. */
+  function createCatchupReplica(name: string): {
+    file: DbFile;
+    replica: Database;
+  } {
+    const file = new DbFile(name);
+    const replica = file.connect(lc);
+    replica.pragma('journal_mode = wal');
+    initReplicationState(replica, ['zero_data'], REPLICA_VERSION);
+    return {file, replica};
+  }
+
+  /** Restarts the streamer with SQLite catchup wired to `sqliteCatchup`. */
+  async function restartWithSQLiteCatchup(
+    sqliteCatchup: SQLiteCatchupOptions,
+  ): Promise<void> {
+    await streamer.stop();
+    await streamerDone;
+
+    changes = Subscription.create();
+    acks = new Queue();
+    streamer = await initializeStreamer(
+      lc,
+      shard,
+      'task-id',
+      'change.streamer:12345',
+      'ws',
+      sql,
+      {
+        startStream: () =>
+          Promise.resolve({
+            initialWatermark: '02',
+            changes,
+            acks: {push: status => acks.enqueue(status)},
+          }),
+        startLagReporter: () =>
+          Promise.resolve({firstCommitTimeMs: 100, nextSendTimeMs: 123}),
+        stop: () => Promise.resolve(),
+      },
+      ReplicationStatusPublisher.forTesting(),
+      replicaConfig,
+      null,
+      true,
+      {...opts, sqliteCatchup},
+      setTimeoutFn as unknown as typeof setTimeout,
+    );
+    streamerDone = streamer.run();
+  }
+
+  /** A serving subscriber, i.e. one eligible for SQLite catchup. */
+  function subscribeServing(id: string): Promise<Source<string>> {
+    return streamer.subscribe({
+      protocolVersion: PROTOCOL_VERSION,
+      taskID: `${id}-task`,
+      id,
+      mode: 'serving',
+      watermark: REPLICA_VERSION,
+      replicaVersion: REPLICA_VERSION,
+      initial: true,
+      logsChangeStream: false,
+    });
   }
 
   /** Applies a transaction the way the write worker does: log first, then replica. */
@@ -854,6 +920,243 @@ describe('change-streamer/service', () => {
     } finally {
       await streamer.stop();
       catchupChangeLog.close();
+      catchupReplica.close();
+      deleteChangeLogDB(catchupReplicaFile.path);
+      catchupReplicaFile.delete();
+    }
+  });
+
+  test('a change-streamer that starts before the change log serves from PG, then from SQLite', async () => {
+    // The replicator has not created the log yet, which is the normal ordering
+    // when both processes start at once.
+    const {file: catchupReplicaFile, replica: catchupReplica} =
+      createCatchupReplica('sqlite-catchup-startup-race');
+    await restartWithSQLiteCatchup({
+      changeLogFile: changeLogFileName(catchupReplicaFile.path),
+      readBatchRows: 2,
+      barrierTimeoutMs: 1_000,
+      barrierPollIntervalMs: 10,
+      shouldUse: () => true,
+    });
+
+    let catchupChangeLog: Database | undefined;
+    try {
+      changes.push(['begin', messages.begin(), {commitWatermark: '04'}]);
+      changes.push(['data', messages.insert('foo', {id: 'from-pg'})]);
+      changes.push(['commit', messages.commit(), {watermark: '04'}]);
+      // SQLite catchup is not eligible until the stream has started and the
+      // forwarded head is known, which the ACK of this commit establishes.
+      await expectAcks('04');
+
+      const pgSub = await subscribeServing('before-change-log');
+      const fromPG = drainToQueue(pgSub);
+      expect(await nextChange(fromPG)).toMatchObject({tag: 'status'});
+      expect(await nextChange(fromPG)).toMatchObject({tag: 'begin'});
+      expect(await nextChange(fromPG)).toMatchObject({
+        tag: 'insert',
+        new: {id: 'from-pg'},
+      });
+      expect(await nextChange(fromPG)).toMatchObject({tag: 'commit'});
+
+      expect(logSink.messages).toContainEqual([
+        'debug',
+        expect.anything(),
+        [
+          expect.stringContaining(
+            'serving before-change-log from PG catchup: cannot read',
+          ),
+          // A readonly handle cannot create the file, so an absent log arrives
+          // as an open error rather than as an empty database.
+          expect.objectContaining({message: expect.stringContaining('unable')}),
+        ],
+      ]);
+      // Startup ordering is not an incident: nothing is warned about until the
+      // log has been unavailable for longer than the threshold.
+      expect(
+        logSink.messages.filter(
+          ([level, , args]) =>
+            level === 'warn' && String(args[0]).includes('PG catchup'),
+        ),
+      ).toEqual([]);
+
+      // The replicator creates and seeds the log, then applies the transaction
+      // to it. Its payload differs from the forwarded one only so that the next
+      // subscriber's changes say which log served it.
+      catchupChangeLog = createChangeLogDB(catchupReplicaFile, catchupReplica);
+      appendSQLiteTransaction(catchupReplica, catchupChangeLog, '04', [
+        ['data', messages.insert('foo', {id: 'from-sqlite'})],
+      ]);
+
+      const sqliteSub = await subscribeServing('after-change-log');
+      const fromSQLite = drainToQueue(sqliteSub);
+      expect(await nextChange(fromSQLite)).toMatchObject({tag: 'status'});
+      expect(await nextChange(fromSQLite)).toMatchObject({tag: 'begin'});
+      expect(await nextChange(fromSQLite)).toMatchObject({
+        tag: 'insert',
+        new: {id: 'from-sqlite'},
+      });
+      expect(await nextChange(fromSQLite)).toMatchObject({tag: 'commit'});
+
+      pgSub.cancel();
+      sqliteSub.cancel();
+    } finally {
+      await streamer.stop();
+      catchupChangeLog?.close();
+      catchupReplica.close();
+      deleteChangeLogDB(catchupReplicaFile.path);
+      catchupReplicaFile.delete();
+    }
+  });
+
+  test('a change log with no changes declines, without caching the failure', async () => {
+    const {file: catchupReplicaFile, replica: catchupReplica} =
+      createCatchupReplica('sqlite-catchup-empty-log');
+    // The file exists but the writer has not reconciled it into a stream table.
+    const catchupChangeLog = openChangeLogDB(lc, catchupReplicaFile.path, {
+      readonly: false,
+    });
+    catchupChangeLog.pragma('journal_mode = wal');
+
+    // Each declined attempt must close the handle it opened, since the next
+    // subscription opens another one.
+    const readerClose = vi.spyOn(SQLiteChangeLogReader.prototype, 'close');
+    await restartWithSQLiteCatchup({
+      changeLogFile: changeLogFileName(catchupReplicaFile.path),
+      readBatchRows: 2,
+      barrierTimeoutMs: 1_000,
+      barrierPollIntervalMs: 10,
+      shouldUse: () => true,
+    });
+
+    try {
+      changes.push(['begin', messages.begin(), {commitWatermark: '04'}]);
+      changes.push(['data', messages.insert('foo', {id: 'from-pg'})]);
+      changes.push(['commit', messages.commit(), {watermark: '04'}]);
+      // SQLite catchup is not eligible until the stream has started and the
+      // forwarded head is known, which the ACK of this commit establishes.
+      await expectAcks('04');
+
+      const noTableSub = await subscribeServing('no-stream-table');
+      const noTable = drainToQueue(noTableSub);
+      expect(await nextChange(noTable)).toMatchObject({tag: 'status'});
+      expect(await nextChange(noTable)).toMatchObject({tag: 'begin'});
+      expect(await nextChange(noTable)).toMatchObject({
+        tag: 'insert',
+        new: {id: 'from-pg'},
+      });
+      expect(await nextChange(noTable)).toMatchObject({tag: 'commit'});
+      expect(readerClose).toHaveBeenCalledTimes(1);
+
+      // A stream table with no rows is equally unserviceable.
+      reconcileChangeLog(
+        lc,
+        catchupChangeLog,
+        readReplicaAnchor(catchupReplica),
+      );
+      catchupChangeLog.prepare(`DELETE FROM "_zero.changeLogStream"`).run();
+
+      const noRowsSub = await subscribeServing('no-rows');
+      const noRows = drainToQueue(noRowsSub);
+      expect(await nextChange(noRows)).toMatchObject({tag: 'status'});
+      expect(await nextChange(noRows)).toMatchObject({tag: 'begin'});
+      expect(await nextChange(noRows)).toMatchObject({
+        tag: 'insert',
+        new: {id: 'from-pg'},
+      });
+      expect(await nextChange(noRows)).toMatchObject({tag: 'commit'});
+      // Constructed again rather than remembered as unusable, and closed again.
+      expect(readerClose).toHaveBeenCalledTimes(2);
+
+      // Reconciling an emptied log reseeds it at the replica head, after which
+      // the writer's transactions make it servable.
+      reconcileChangeLog(
+        lc,
+        catchupChangeLog,
+        readReplicaAnchor(catchupReplica),
+      );
+      appendSQLiteTransaction(catchupReplica, catchupChangeLog, '04', [
+        ['data', messages.insert('foo', {id: 'from-sqlite'})],
+      ]);
+
+      const servedSub = await subscribeServing('served-from-sqlite');
+      const served = drainToQueue(servedSub);
+      expect(await nextChange(served)).toMatchObject({tag: 'status'});
+      expect(await nextChange(served)).toMatchObject({tag: 'begin'});
+      expect(await nextChange(served)).toMatchObject({
+        tag: 'insert',
+        new: {id: 'from-sqlite'},
+      });
+      expect(await nextChange(served)).toMatchObject({tag: 'commit'});
+      // The reader that can serve is retained by the catchup coordinator.
+      expect(readerClose).toHaveBeenCalledTimes(2);
+
+      noTableSub.cancel();
+      noRowsSub.cancel();
+      servedSub.cancel();
+    } finally {
+      await streamer.stop();
+      readerClose.mockRestore();
+      catchupChangeLog.close();
+      catchupReplica.close();
+      deleteChangeLogDB(catchupReplicaFile.path);
+      catchupReplicaFile.delete();
+    }
+  });
+
+  test('an unreadable change log declines rather than failing the subscription', async () => {
+    const {file: catchupReplicaFile, replica: catchupReplica} =
+      createCatchupReplica('sqlite-catchup-corrupt-log');
+    writeFileSync(
+      changeLogFileName(catchupReplicaFile.path),
+      'not a SQLite database',
+    );
+
+    await restartWithSQLiteCatchup({
+      changeLogFile: changeLogFileName(catchupReplicaFile.path),
+      readBatchRows: 2,
+      barrierTimeoutMs: 1_000,
+      barrierPollIntervalMs: 10,
+      shouldUse: () => true,
+      // A zero threshold makes the first decline the "still unavailable" case,
+      // which is the one that warrants a warning.
+      notReadyWarnThresholdMs: 0,
+    });
+
+    try {
+      changes.push(['begin', messages.begin(), {commitWatermark: '04'}]);
+      changes.push(['data', messages.insert('foo', {id: 'from-pg'})]);
+      changes.push(['commit', messages.commit(), {watermark: '04'}]);
+      // SQLite catchup is not eligible until the stream has started and the
+      // forwarded head is known, which the ACK of this commit establishes.
+      await expectAcks('04');
+
+      const sub = await subscribeServing('corrupt-change-log');
+      const served = drainToQueue(sub);
+      expect(await nextChange(served)).toMatchObject({tag: 'status'});
+      expect(await nextChange(served)).toMatchObject({tag: 'begin'});
+      expect(await nextChange(served)).toMatchObject({
+        tag: 'insert',
+        new: {id: 'from-pg'},
+      });
+      expect(await nextChange(served)).toMatchObject({tag: 'commit'});
+
+      expect(logSink.messages).toContainEqual([
+        'warn',
+        expect.anything(),
+        [
+          expect.stringContaining(
+            'serving corrupt-change-log from PG catchup: cannot read',
+          ),
+          expect.anything(),
+        ],
+      ]);
+      expect(logSink.messages.filter(([level]) => level === 'error')).toEqual(
+        [],
+      );
+
+      sub.cancel();
+    } finally {
+      await streamer.stop();
       catchupReplica.close();
       deleteChangeLogDB(catchupReplicaFile.path);
       catchupReplicaFile.delete();

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -79,6 +79,12 @@ export type SQLiteCatchupOptions = {
   shouldUse?: ((ctx: SubscriberContext) => boolean) | undefined;
   /** Slice 9 supplies the writer-serialized purge guard. */
   cleanupGuard?: SQLiteChangeLogCleanupGuard | undefined;
+  /**
+   * How long the change log may be unavailable before declining to serve from
+   * it is reported as a warning rather than a debug line. Defaults to
+   * {@link DEFAULT_CHANGE_LOG_UNAVAILABLE_WARN_THRESHOLD_MS}.
+   */
+  notReadyWarnThresholdMs?: number | undefined;
 };
 
 export type TuningOptions = StorerOptions & {
@@ -134,6 +140,14 @@ export async function initializeStreamer(
 }
 
 const REPLICATION_STATUS_ERROR_DELAY_THRESHOLD_MS = 5000;
+
+// How long the change log may be unavailable before declining to serve from it
+// stops looking like normal startup ordering. A change-streamer routinely
+// starts before the replicator has created and reconciled the log, so early
+// declines are expected. Still declining a minute later means the log is not
+// being written at all -- `sqliteChangeLogMode=off`, a replicator crash loop,
+// or a path mismatch -- which is worth surfacing.
+const DEFAULT_CHANGE_LOG_UNAVAILABLE_WARN_THRESHOLD_MS = 60_000;
 
 /**
  * Upstream-agnostic dispatch of messages in a {@link ChangeStreamMessage} to a
@@ -315,6 +329,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
   #purgeLock: PurgeLock | null;
   #stream: ChangeStream | undefined;
   #sqliteCatchup: SQLiteChangeLogCatchup | undefined;
+  #changeLogUnavailableSince: number | undefined;
   #lastForwardedCommitWatermark: string | undefined;
   #currentTransactionCompletion:
     | Resolver<ForwardedTransactionCompletion>
@@ -775,20 +790,95 @@ class ChangeStreamerImpl implements ChangeStreamerService {
     if (!opts.shouldUse?.(ctx)) {
       return undefined;
     }
-    if (!this.#sqliteCatchup) {
-      this.#sqliteCatchup = new SQLiteChangeLogCatchup(
-        this.#lc,
-        this.#forwarder,
-        new SQLiteChangeLogReader(this.#lc, opts.changeLogFile),
-        {
-          batchSize: opts.readBatchRows,
-          barrierTimeoutMs: opts.barrierTimeoutMs,
-          barrierPollIntervalMs: opts.barrierPollIntervalMs,
-          cleanupGuard: opts.cleanupGuard,
-        },
+    return this.#sqliteCatchup ?? this.#openSQLiteCatchup(opts, ctx);
+  }
+
+  /**
+   * Opens the change log and, if it can serve, wraps it in the coordinator that
+   * subsequent subscriptions reuse.
+   *
+   * The change-streamer and the replicator that writes the log start
+   * independently, so the log may not exist yet, may exist without content, or
+   * may be unreadable. None of those can be allowed to fail a subscription:
+   * this is the last point at which PG catchup is still available -- past
+   * `Forwarder.add()` the subscriber is committed to SQLite -- so each declines
+   * here instead. Neither the failure nor the reader is retained, so a later
+   * subscription retries from scratch.
+   */
+  #openSQLiteCatchup(
+    opts: SQLiteCatchupOptions,
+    ctx: SubscriberContext,
+  ): SQLiteChangeLogCatchup | undefined {
+    let reader: SQLiteChangeLogReader | undefined;
+    try {
+      reader = new SQLiteChangeLogReader(this.#lc, opts.changeLogFile);
+      // `plan()` doubles as the readiness check: it reports `not-ready` when
+      // the writer has not created or seeded the stream table. The barrier
+      // cannot wait its way out of that, since a log with no head can never
+      // reach the required one.
+      if (reader.plan(ctx.watermark).kind === 'not-ready') {
+        reader.close();
+        this.#declineSQLiteCatchup(
+          ctx,
+          opts,
+          `${opts.changeLogFile} has no changes to serve yet`,
+        );
+        return undefined;
+      }
+    } catch (e) {
+      // An absent file is the common case, since a readonly handle cannot
+      // create one. A corrupt or truncated file lands here too, and is equally
+      // not a reason to fail the subscription.
+      reader?.close();
+      this.#declineSQLiteCatchup(
+        ctx,
+        opts,
+        `cannot read ${opts.changeLogFile}`,
+        e,
       );
+      return undefined;
     }
+    this.#changeLogUnavailableSince = undefined;
+    // Readiness is checked once, on the way to the cached coordinator: a log
+    // with content keeps it. Purging preserves the latest transaction as a
+    // catchup boundary, and `reconcileChangeLog` reseeds inside a single
+    // transaction, so a reader never observes an emptied log.
+    this.#sqliteCatchup = new SQLiteChangeLogCatchup(
+      this.#lc,
+      this.#forwarder,
+      reader,
+      {
+        batchSize: opts.readBatchRows,
+        barrierTimeoutMs: opts.barrierTimeoutMs,
+        barrierPollIntervalMs: opts.barrierPollIntervalMs,
+        cleanupGuard: opts.cleanupGuard,
+      },
+    );
     return this.#sqliteCatchup;
+  }
+
+  /**
+   * Reports falling back to PG catchup, tracking how long the log has been
+   * unavailable so that a change-streamer that merely started before its
+   * replicator does not look like an incident.
+   */
+  #declineSQLiteCatchup(
+    ctx: SubscriberContext,
+    opts: SQLiteCatchupOptions,
+    reason: string,
+    error?: unknown,
+  ): void {
+    const now = Date.now();
+    this.#changeLogUnavailableSince ??= now;
+    const unavailableMs = now - this.#changeLogUnavailableSince;
+    const threshold =
+      opts.notReadyWarnThresholdMs ??
+      DEFAULT_CHANGE_LOG_UNAVAILABLE_WARN_THRESHOLD_MS;
+    this.#lc[unavailableMs >= threshold ? 'warn' : 'debug']?.(
+      `serving ${ctx.id} from PG catchup: ${reason} ` +
+        `(unavailable for ${unavailableMs} ms)`,
+      ...(error === undefined ? [] : [error]),
+    );
   }
 }
 

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.ts
@@ -367,7 +367,9 @@ export class SQLiteChangeLogCatchup implements Disposable {
           // A not-ready log has no head to compare, so it can never satisfy
           // the required head: keep waiting for the writer to create and
           // reconcile it, and let the barrier deadline end the subscription
-          // cleanly for a retry. Slice 7E declines these before this point.
+          // cleanly for a retry. Selection declines a not-ready log before a
+          // subscriber gets here, and neither purging nor reconciliation can
+          // empty a log that had content, so this is a belt-and-braces path.
           if (plan.kind !== 'not-ready') {
             observedHead = plan.headWatermark;
             if (plan.headWatermark >= requiredHead) {

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-reader.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-reader.ts
@@ -22,8 +22,9 @@ export type CatchupPlan =
       readonly headWatermark: string;
     }
   // The log exists as a file but has no content to serve: the replicator has
-  // not created or reconciled it yet. Slice 7E declines and falls back to PG
-  // catchup; there is no production caller before then.
+  // not created or reconciled it yet. Subscriber selection treats this as
+  // "decline and fall back to PG catchup", which is why it is a plan rather
+  // than an error.
   | {readonly kind: 'not-ready'};
 
 type PlanRow = {


### PR DESCRIPTION
The change-streamer and the replicator that writes the log start independently (two different processe) so the log may not exist when the first subscription arrives to read it.

Production effect: none — `shouldUse` is still unwired, so no production subscription reaches this code.