### PR TITLE
chore(rmv2): manage the change-log file's lifecycle [13/n]

### DIFF
--- a/packages/zero-cache/src/server/change-streamer.pg.test.ts
+++ b/packages/zero-cache/src/server/change-streamer.pg.test.ts
@@ -1,3 +1,4 @@
+import {existsSync, writeFileSync} from 'node:fs';
 import {gunzipSync} from 'node:zlib';
 import {getLocal, type Mockttp} from 'mockttp';
 import {expect, vi} from 'vitest';
@@ -11,6 +12,10 @@ import {initChangeStreamerSchema} from '../services/change-streamer/schema/init.
 import {ensureReplicationConfig} from '../services/change-streamer/schema/tables.ts';
 import type * as LifeCycle from '../services/life-cycle.ts';
 import type * as LitestreamCommands from '../services/litestream/commands.ts';
+import {
+  changeLogFileName,
+  deleteChangeLogDB,
+} from '../services/replicator/change-log-db.ts';
 import {replicationStatusError} from '../services/replicator/replication-status.ts';
 import {getSubscriptionState} from '../services/replicator/schema/replication-state.ts';
 import {getConnectionURI, test, type PgTest} from '../test/db.ts';
@@ -202,6 +207,14 @@ test('change-streamer startup does not deadlock on autoreset retry when change a
     await initialSource.stop();
     await upstream`SELECT pg_drop_replication_slot(${oldSlot})`;
 
+    // The auto-reset resyncs the replica at a new replicaVersion, so the
+    // change log written beside the old one must not survive it. Asserted here
+    // rather than in a test of its own because this is the only scenario that
+    // reaches the AutoResetSignal retry, and reaching it costs a full sync.
+    const changeLog = changeLogFileName(replicaFile.path);
+    writeFileSync(changeLog, '');
+    writeFileSync(`${changeLog}-wal2`, '');
+
     const [worker, parent] = inProcChannel();
     const ready = new Promise<void>(resolve => {
       parent.onceMessageType('ready', () => {
@@ -258,8 +271,12 @@ test('change-streamer startup does not deadlock on autoreset retry when change a
     `;
     expect(liveSlots[0].slot).toBe(oldSlot); // same slot name
     expect(liveSlots[0].id).not.toBe(oldID); // was reused for new replica
+
+    expect(existsSync(changeLog)).toBe(false);
+    expect(existsSync(`${changeLog}-wal2`)).toBe(false);
   } finally {
     await initialSource?.stop().catch(() => {});
+    deleteChangeLogDB(replicaFile.path);
     replicaFile.delete();
     await testDBs.drop(upstream);
   }

--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -21,7 +21,10 @@ import {initChangeStreamerSchema} from '../services/change-streamer/schema/init.
 import {AutoResetSignal} from '../services/change-streamer/schema/tables.ts';
 import {PurgeLocker} from '../services/change-streamer/storer.ts';
 import {exitAfter, runUntilKilled} from '../services/life-cycle.ts';
-import {changeLogFileName} from '../services/replicator/change-log-db.ts';
+import {
+  changeLogFileName,
+  deleteChangeLogDB,
+} from '../services/replicator/change-log-db.ts';
 import {
   replicationStatusError,
   ReplicationStatusPublisher,
@@ -184,6 +187,12 @@ export default async function runWorker(
         // TODO: Make deleteLiteDB work with litestream. It will probably have to be
         //       a semantic wipe instead of a file delete.
         deleteLiteDB(replica.file);
+        // The change log is anchored to the replica it was written beside, and
+        // the retry performs a fresh initial sync with a new replicaVersion.
+        // Reconciliation would catch that on its own (as
+        // 'replica-version-mismatch') but only after the writer opened a file
+        // that is known here to be garbage.
+        deleteChangeLogDB(replica.file);
         // Release the purge lock before retrying. This is safe because the
         // purge lock exists to preserve change-log entries so the new
         // change-streamer can resume from the backup replica's watermark.

--- a/packages/zero-cache/src/server/replicator.ts
+++ b/packages/zero-cache/src/server/replicator.ts
@@ -27,6 +27,10 @@ import {
   litestreamRestoreMetricAttrs,
   litestreamRestoreRuns,
 } from '../services/litestream/metrics.ts';
+import {
+  changeLogFileName,
+  deleteChangeLogDB,
+} from '../services/replicator/change-log-db.ts';
 import {ReplicationStatusPublisher} from '../services/replicator/replication-status.ts';
 import {
   ReplicatorService,
@@ -73,9 +77,11 @@ export default async function runWorker(
   const mode: ReplicatorMode = fileMode === 'backup' ? 'backup' : 'serving';
   const runningLocalChangeStreamer =
     config.changeStreamer.mode === 'dedicated' && !config.changeStreamer.uri;
+  const sqliteChangeLogEnabled =
+    config.changeStreamer.sqliteChangeLogMode !== 'off';
   const logsChangeStream = replicaLogsChangeStream(
     fileMode,
-    config.changeStreamer.sqliteChangeLogMode !== 'off',
+    sqliteChangeLogEnabled,
     runningLocalChangeStreamer,
     config.litestream.backupURL,
   );
@@ -110,6 +116,27 @@ export default async function runWorker(
     debugName: `${workerName} replica`,
     dbPath,
   });
+
+  if (sqliteChangeLogEnabled) {
+    registerSQLiteCorruptionDiagnosticTarget({
+      debugName: `${workerName} change-log`,
+      dbPath: changeLogFileName(dbPath),
+    });
+  } else {
+    // Nothing in this task writes the log, so a file left behind by a run with
+    // the writer enabled would hold local disk indefinitely: it is excluded
+    // from the litestream backup and only the writer purges it. Deleting it is
+    // safe because the log is a cache — re-enabling the writer reseeds at the
+    // replica head — which is also why it is deleted rather than kept around
+    // for a rollback: a stale log is never served, only reseeded.
+    //
+    // The guard is the config rather than the derived `logsChangeStream`.
+    // `logsChangeStream` is false for replicas that coexist with an enabled
+    // writer in the same task (today the serving-copy, whose file is a
+    // different path), so keying deletion on it would delete a live log the
+    // moment a file mode shares the canonical replica's path.
+    deleteChangeLogDB(dbPath);
+  }
 
   const sqliteChangeLogObserver = readSQLiteChangeLog(
     lc,

--- a/packages/zero-cache/src/services/litestream/commands.test.ts
+++ b/packages/zero-cache/src/services/litestream/commands.test.ts
@@ -1,5 +1,11 @@
 import * as childProcess from 'node:child_process';
-import {existsSync, mkdtempSync, statSync, writeFileSync} from 'node:fs';
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import {LogContext} from '@rocicorp/logger';
@@ -8,8 +14,10 @@ import {
   createSilentLogContext,
   TestLogSink,
 } from '../../../../shared/src/logging-test-utils.ts';
+import {must} from '../../../../shared/src/must.ts';
 import {Database} from '../../../../zqlite/src/db.ts';
 import {type NormalizedZeroConfig} from '../../config/normalize.ts';
+import {changeLogFileName} from '../replicator/change-log-db.ts';
 import {initReplicationState} from '../replicator/schema/replication-state.ts';
 import {
   getLastBackupTime,
@@ -233,6 +241,66 @@ describe('litestream/commands restoreReplica', () => {
     );
   });
 
+  test('deletes a change log left beside a restored replica', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'litestream-restore-test-'));
+    const source = join(dir, 'source.db');
+    const replica = join(dir, 'replica.db');
+    createRestorableReplica(source, '01');
+    // A change log whose replica is gone: the file it was anchored to is not
+    // the one this restore materializes.
+    const staleLog = changeLogFileName(replica);
+    writeFileSync(staleLog, '');
+    writeFileSync(`${staleLog}-wal2`, '');
+    const {litestream} = configWithFakeLitestream(
+      `if [ "$1" = "restore" ]; then\n` +
+        `  cp "${source}" "$6"\n` +
+        `  exit 0\n` +
+        `fi\n` +
+        `exit 1`,
+      replica,
+    );
+
+    expect(
+      await tryRestore(
+        lc,
+        litestream,
+        replica,
+        {replicaVersion: '01', minWatermark: '01'},
+        'replication_manager',
+      ),
+    ).toMatchObject({restored: true, result: 'success'});
+
+    expect(existsSync(replica)).toBe(true);
+    expect(existsSync(staleLog)).toBe(false);
+    expect(existsSync(`${staleLog}-wal2`)).toBe(false);
+  });
+
+  // The process-restart path: `-if-db-not-exists` makes the restore a no-op,
+  // and the change log beside the reused replica is still the one written
+  // against it. Deleting it would cost every reconnecting subscriber a
+  // `too-old` on every deploy.
+  test('keeps the change log when the restore reuses an existing replica', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'litestream-restore-test-'));
+    const replica = join(dir, 'replica.db');
+    createRestorableReplica(replica, '01');
+    const log = changeLogFileName(replica);
+    writeFileSync(log, '');
+    const {litestream} = configWithFakeLitestream(
+      `if [ "$1" = "restore" ]; then\n` + `  exit 0\n` + `fi\n` + `exit 1`,
+      replica,
+    );
+
+    await tryRestore(
+      lc,
+      litestream,
+      replica,
+      {replicaVersion: '01', minWatermark: '01'},
+      'replication_manager',
+    );
+
+    expect(existsSync(log)).toBe(true);
+  });
+
   test('does not record restored bytes when reusing an existing replica', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'litestream-restore-test-'));
     const replica = join(dir, 'replica.db');
@@ -284,6 +352,7 @@ describe('litestream/commands restoreReplica', () => {
         `exit 1`,
       replica,
     );
+    writeFileSync(changeLogFileName(replica), '');
 
     expect(
       await tryRestore(
@@ -302,6 +371,9 @@ describe('litestream/commands restoreReplica', () => {
     });
 
     expect(existsSync(replica)).toBe(false);
+    // The change log went with it; the next attempt reseeds against whatever
+    // replica it restores.
+    expect(existsSync(changeLogFileName(replica))).toBe(false);
     expect(restoreValidationRecordMs).toHaveBeenCalledWith(
       expect.any(Number),
       expect.objectContaining({result: 'invalid_replica'}),
@@ -347,5 +419,35 @@ describe('litestream/commands restoreReplica', () => {
     // stdio is [stdin, stdout, stderr]; stdout/stderr must be piped so
     // litestream's output is captured rather than sent to the pod's stdout.
     expect(restoreCall?.[2]?.stdio).toEqual(['ignore', 'pipe', 'pipe']);
+  });
+
+  // The change log is a local cache that is deliberately not backed up: it
+  // holds nothing that is not already in the replica's backup or re-derivable
+  // from the upstream slot, and shipping it would give back the S3 and
+  // follower-download savings the separate file exists to win.
+  test('the rendered litestream config never backs up the change-log database', () => {
+    const replica = join(
+      mkdtempSync(join(tmpdir(), 'litestream-config-test-')),
+      'replica.db',
+    );
+    const {litestream} = configWithFakeLitestream('exit 0', replica);
+    // The variables `getLitestream` substitutes into the config it hands
+    // litestream; `ZERO_REPLICA_FILE` is always the replica, never a path
+    // derived from it.
+    const env: Record<string, string> = {
+      ZERO_REPLICA_FILE: replica,
+      ZERO_LITESTREAM_BACKUP_URL: must(litestream.backupURL),
+    };
+    const yaml = readFileSync(
+      new URL('./config.yml', import.meta.url),
+      'utf-8',
+    ).replace(/\$\{(\w+)\}/g, (_, name: string) => env[name] ?? '');
+
+    const paths = Array.from(
+      yaml.matchAll(/^\s*-?\s*path:\s*(\S+)\s*$/gm),
+      ([, path]) => path,
+    );
+    expect(paths).toEqual([replica]);
+    expect(paths).not.toContain(changeLogFileName(replica));
   });
 });

--- a/packages/zero-cache/src/services/litestream/commands.ts
+++ b/packages/zero-cache/src/services/litestream/commands.ts
@@ -12,6 +12,7 @@ import {
   logSQLiteCorruptionDiagnostics,
 } from '../../db/sqlite-corruption.ts';
 import {StatementRunner} from '../../db/statements.ts';
+import {deleteChangeLogDB} from '../replicator/change-log-db.ts';
 import {getSubscriptionState} from '../replicator/schema/replication-state.ts';
 import {
   litestreamBackupListDuration,
@@ -220,10 +221,23 @@ export async function tryRestore(
       result = 'invalid_replica';
       lc.info?.(`Deleting local replica and retrying restore`);
       deleteLiteDB(replicaFile);
+      deleteChangeLogDB(replicaFile);
       return {restored: false, backupURL, result};
     }
     result = 'success';
     if (!replicaExistedBeforeRestore) {
+      // This restore materialized the replica file, so any change log beside it
+      // was written against a replica that is no longer there. Reconciliation
+      // is the safety net — a restored replica keeps its replicaVersion, so the
+      // rule falls through to truncate-or-reseed on head mismatch — but the log
+      // is a cache and deleting it here is the explicit statement that nothing
+      // in it survives the restore.
+      //
+      // A restore that reuses an existing replica (`-if-db-not-exists` made it
+      // a no-op) deliberately keeps the log: that is the process-restart path,
+      // where the log is still the one written beside this exact replica and
+      // discarding it would cost every reconnecting subscriber a `too-old`.
+      deleteChangeLogDB(replicaFile);
       litestreamRestoredDbBytes().add(statSync(replicaFile).size, {
         ...attrs,
         result: 'success',

--- a/packages/zero-cache/src/services/replicator/change-log-db.test.ts
+++ b/packages/zero-cache/src/services/replicator/change-log-db.test.ts
@@ -1,4 +1,4 @@
-import {existsSync, writeFileSync} from 'node:fs';
+import {existsSync, mkdirSync, rmSync, statSync, writeFileSync} from 'node:fs';
 import {afterEach, describe, expect, test} from 'vitest';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
 import {Database} from '../../../../zqlite/src/db.ts';
@@ -10,6 +10,7 @@ import {
   changeLogFileName,
   deleteChangeLogDB,
   openChangeLogDB,
+  openChangeLogDBForWriting,
   readReplicaAnchor,
   reconcileChangeLog,
   type ReplicaAnchor,
@@ -223,6 +224,77 @@ describe('replicator/change-log-db', () => {
       expect(db.pragma('wal_autocheckpoint')).toEqual([
         {wal_autocheckpoint: 1000},
       ]);
+    });
+  });
+
+  describe('openChangeLogDBForWriting', () => {
+    test('creates and seeds the log, then leaves it alone', () => {
+      const file = newDbFile();
+      {
+        const {db, result} = openChangeLogDBForWriting(lc, file.path, ANCHOR);
+        using open = db;
+        expect(result).toEqual({
+          action: 'reseeded',
+          head: ANCHOR.stateVersion,
+          reason: 'created',
+        });
+        expect(open.pragma('journal_mode')).toEqual([{journal_mode: 'wal2'}]);
+        expect(head(open)).toBe(ANCHOR.stateVersion);
+      }
+
+      const reopened = openChangeLogDBForWriting(lc, file.path, ANCHOR);
+      using db = reopened.db;
+      expect(reopened.result).toEqual({
+        action: 'none',
+        head: ANCHOR.stateVersion,
+      });
+      expect(head(db)).toBe(ANCHOR.stateVersion);
+    });
+
+    // The divergence from replica corruption: the log is a cache, so a corrupt
+    // file costs a retention window rather than a restore or an auto-reset.
+    test('rebuilds a corrupt log rather than failing startup', () => {
+      const file = newDbFile();
+      writeFileSync(changeLogFileName(file.path), 'this is not a database');
+
+      const {db, result} = openChangeLogDBForWriting(lc, file.path, ANCHOR);
+      using rebuilt = db;
+
+      expect(result).toEqual({
+        action: 'reseeded',
+        head: ANCHOR.stateVersion,
+        reason: 'created',
+      });
+      expect(meta(rebuilt)).toEqual({
+        replicaVersion: ANCHOR.replicaVersion,
+        schemaVersion: CHANGE_LOG_DB_SCHEMA_VERSION,
+        lock: 1,
+      });
+      expectTableExact(
+        rebuilt,
+        CHANGE_LOG_STREAM_TABLE,
+        seedRows(ANCHOR),
+        'number',
+        'watermark',
+        'pos',
+      );
+      expect(rebuilt.pragma('journal_mode')).toEqual([{journal_mode: 'wal2'}]);
+    });
+
+    // A path that cannot be opened is a problem with the environment rather
+    // than with the file's contents, so it propagates with the file intact.
+    test('does not rebuild for a failure that is not corruption', () => {
+      const file = newDbFile();
+      const dir = changeLogFileName(file.path);
+      mkdirSync(dir);
+      try {
+        expect(() => openChangeLogDBForWriting(lc, file.path, ANCHOR)).toThrow(
+          /unable to open database file/,
+        );
+        expect(statSync(dir).isDirectory()).toBe(true);
+      } finally {
+        rmSync(dir, {recursive: true, force: true});
+      }
     });
   });
 

--- a/packages/zero-cache/src/services/replicator/change-log-db.ts
+++ b/packages/zero-cache/src/services/replicator/change-log-db.ts
@@ -7,16 +7,29 @@
  *
  * Because it is disposable, it has no migration framework. Any inconsistency
  * with the replica — a schema change, a leftover file from a different replica,
- * a gap left by a crash or by running with the writer disabled — is resolved by
- * {@link reconcileChangeLog}, which either truncates the offending rows or wipes
- * and reseeds the log at the replica's current head. The worst outcome is a
+ * a gap left by a crash or by running with the writer disabled, a corrupt file
+ * — is resolved by {@link reconcileChangeLog} and
+ * {@link openChangeLogDBForWriting}, which truncate the offending rows or wipe
+ * and reseed the log at the replica's current head. The worst outcome is a
  * `too-old` for a lagging subscriber; a silently delivered gap is not reachable.
+ *
+ * Disk sizing: a task that writes the log needs room for the replica *plus* one
+ * retention window of the change stream — the log's main file, its wal2
+ * sidecars, and pages a purge has freed but not yet reused. Nothing purges the
+ * log yet (that is parent slice 8), so with the writer enabled it currently
+ * grows with the entire change stream since its last reseed, which is one more
+ * reason `sqliteChangeLogMode` defaults to `off`. The log is excluded from the
+ * litestream backup, so this is local disk only and never S3.
  */
 
 import type {LogContext} from '@rocicorp/logger';
 import {assert} from '../../../../shared/src/asserts.ts';
 import {Database} from '../../../../zqlite/src/db.ts';
 import {deleteLiteDB} from '../../db/delete-lite-db.ts';
+import {
+  isSQLiteCorruption,
+  logSQLiteCorruptionDiagnostics,
+} from '../../db/sqlite-corruption.ts';
 import {
   CHANGE_LOG_STREAM_TABLE,
   CREATE_CHANGE_LOG_STREAM_SCHEMA,
@@ -145,6 +158,66 @@ export function applyChangeLogPragmas(db: Database): void {
   db.pragma('analysis_limit = 1000');
   db.pragma('journal_mode = wal2');
   db.pragma('synchronous = NORMAL');
+}
+
+/**
+ * Opens the change-log database for the writer, applies its pragmas, and
+ * reconciles it against `anchor`, returning the handle and what reconciliation
+ * had to do.
+ *
+ * Corruption is answered with a rebuild rather than an escalation, which is a
+ * deliberate divergence from how the replica's own corruption is handled. A
+ * corrupt replica is a lost source of truth, so it ends in a restore or an
+ * auto-reset; the change log holds nothing that is not either already in the
+ * replica's litestream backup or re-derivable from the upstream slot, so the
+ * entire response is to delete the file and seed a new one at the replica head.
+ * The cost is one retention window of catchup — reconnecting subscribers below
+ * the head get `too-old` — which is what every other {@link ReseedReason}
+ * costs. Failing startup instead would take the replica down with the cache.
+ *
+ * Only corruption is rebuilt through. Anything else (a bad path, a permissions
+ * error, a full disk) is a problem with the environment rather than with the
+ * file's contents, and deleting a database in response would destroy state
+ * without fixing it.
+ */
+export function openChangeLogDBForWriting(
+  lc: LogContext,
+  replicaFile: string,
+  anchor: ReplicaAnchor,
+): {db: Database; result: ReconcileResult} {
+  try {
+    return openAndReconcile(lc, replicaFile, anchor);
+  } catch (e) {
+    if (!isSQLiteCorruption(e)) {
+      throw e;
+    }
+    const file = changeLogFileName(replicaFile);
+    logSQLiteCorruptionDiagnostics(lc, 'change-log', file, e);
+    lc.error?.('rebuilding the corrupt SQLite change log', {
+      sqliteChangeLog: {file},
+    });
+    deleteChangeLogDB(replicaFile);
+    // Reconciles a database that does not exist, i.e. reseeds with reason
+    // 'created'. A second failure is the environment's, not the file's.
+    return openAndReconcile(lc, replicaFile, anchor);
+  }
+}
+
+function openAndReconcile(
+  lc: LogContext,
+  replicaFile: string,
+  anchor: ReplicaAnchor,
+): {db: Database; result: ReconcileResult} {
+  const db = openChangeLogDB(lc, replicaFile, {readonly: false});
+  try {
+    applyChangeLogPragmas(db);
+    return {db, result: reconcileChangeLog(lc, db, anchor)};
+  } catch (e) {
+    // The caller never sees this handle, so it closes here or leaks — and it
+    // must be closed before the corruption path deletes the file.
+    db.close();
+    throw e;
+  }
 }
 
 export type ReseedReason =

--- a/packages/zero-cache/src/services/replicator/write-worker.test.ts
+++ b/packages/zero-cache/src/services/replicator/write-worker.test.ts
@@ -1,5 +1,5 @@
 import {once} from 'node:events';
-import {existsSync} from 'node:fs';
+import {existsSync, writeFileSync} from 'node:fs';
 import {Worker} from 'node:worker_threads';
 import {afterEach, beforeEach, describe, expect, test} from 'vitest';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
@@ -194,6 +194,53 @@ describe('write-worker', () => {
     expect(
       await worker.init(dbFile.path, 'serving', true, PRAGMAS, LOG_CONFIG),
     ).toEqual({action: 'truncated', head: '02', rows: 2});
+  });
+
+  test('init rebuilds a corrupt change log instead of failing', async () => {
+    await worker.stop();
+    writeFileSync(changeLogFileName(dbFile.path), 'this is not a database');
+
+    // The replica is intact, so the log is rebuilt in place of the file that
+    // cannot be read, rather than taking the replicator down with the cache.
+    worker = new ThreadWriteWorkerClient();
+    expect(
+      await worker.init(dbFile.path, 'serving', true, PRAGMAS, LOG_CONFIG),
+    ).toEqual({action: 'reseeded', head: '02', reason: 'created'});
+
+    const issues = new ReplicationMessages({issues: ['issueID', 'bool']});
+    for (const message of [
+      ['begin', issues.begin(), {commitWatermark: '06'}],
+      ['data', issues.insert('issues', {issueID: 1, bool: true})],
+      ['commit', issues.commit(), {watermark: '06'}],
+    ] satisfies ChangeStreamData[]) {
+      await worker.processMessage(serialized(message));
+    }
+    expect(
+      readChangeLog(db =>
+        db
+          .prepare(
+            `SELECT max("watermark") AS "head" FROM "${CHANGE_LOG_STREAM_TABLE}"`,
+          )
+          .get(),
+      ),
+    ).toEqual({head: '06'});
+  });
+
+  test('the disabled writer does not create a change log', async () => {
+    // `beforeEach` inits with the writer disabled, which is the
+    // `sqliteChangeLogMode=off` shape: a transaction goes through without the
+    // file ever appearing, so deleting a stale one at startup cannot race a
+    // writer.
+    const issues = new ReplicationMessages({issues: ['issueID', 'bool']});
+    for (const message of [
+      ['begin', issues.begin(), {commitWatermark: '06'}],
+      ['data', issues.insert('issues', {issueID: 1, bool: true})],
+      ['commit', issues.commit(), {watermark: '06'}],
+    ] satisfies ChangeStreamData[]) {
+      await worker.processMessage(serialized(message));
+    }
+
+    expect(existsSync(changeLogFileName(dbFile.path))).toBe(false);
   });
 
   test('init rejects the change-log writer in initial-sync mode', async () => {

--- a/packages/zero-cache/src/services/replicator/write-worker.ts
+++ b/packages/zero-cache/src/services/replicator/write-worker.ts
@@ -12,10 +12,9 @@ import {
 import {StatementRunner} from '../../db/statements.ts';
 import {createLogContext} from '../../server/logging.ts';
 import {
-  applyChangeLogPragmas,
-  openChangeLogDB,
+  changeLogFileName,
+  openChangeLogDBForWriting,
   readReplicaAnchor,
-  reconcileChangeLog,
   type ReconcileResult,
 } from './change-log-db.ts';
 import {ChangeProcessor, type ChangeProcessorMode} from './change-processor.ts';
@@ -50,11 +49,30 @@ function createAPI(): API {
   let mode: ChangeProcessorMode | undefined;
   let lc: LogContext | undefined;
   let replicaDbPath: string | undefined;
-  let unregisterCorruptionDiagnosticTarget: (() => void) | undefined;
+  let changeLogDbPath: string | undefined;
+  let unregisterCorruptionDiagnosticTargets: (() => void)[] = [];
 
+  function unregisterCorruptionDiagnostics() {
+    unregisterCorruptionDiagnosticTargets.forEach(unregister => unregister());
+    unregisterCorruptionDiagnosticTargets = [];
+  }
+
+  // The write path spans two databases and a SqliteError does not say which
+  // one it came from, so both are dumped.
   function logCorruptionDiagnostics(err: unknown) {
-    if (lc && replicaDbPath && isSQLiteCorruption(err)) {
+    if (!lc || !isSQLiteCorruption(err)) {
+      return;
+    }
+    if (replicaDbPath) {
       logSQLiteCorruptionDiagnostics(lc, 'write-worker', replicaDbPath, err);
+    }
+    if (changeLogDbPath) {
+      logSQLiteCorruptionDiagnostics(
+        lc,
+        'write-worker change-log',
+        changeLogDbPath,
+        err,
+      );
     }
   }
 
@@ -86,13 +104,25 @@ function createAPI(): API {
           'change log, which opens a second one',
       );
       replicaDbPath = dbPath;
+      changeLogDbPath = shouldLogChangeStream
+        ? changeLogFileName(dbPath)
+        : undefined;
       lc = createLogContext({log: logConfig}, 'write-worker');
-      unregisterCorruptionDiagnosticTarget?.();
-      unregisterCorruptionDiagnosticTarget =
+      unregisterCorruptionDiagnostics();
+      unregisterCorruptionDiagnosticTargets.push(
         registerSQLiteCorruptionDiagnosticTarget({
           debugName: 'write-worker',
           dbPath,
-        });
+        }),
+      );
+      if (changeLogDbPath) {
+        unregisterCorruptionDiagnosticTargets.push(
+          registerSQLiteCorruptionDiagnosticTarget({
+            debugName: 'write-worker change-log',
+            dbPath: changeLogDbPath,
+          }),
+        );
+      }
       try {
         db = new Database(lc, dbPath);
         applyPragmas(db, pragmas);
@@ -108,13 +138,13 @@ function createAPI(): API {
         changeLogRunner = undefined;
         let reconciled: ReconcileResult | undefined;
         if (shouldLogChangeStream) {
-          changeLogDb = openChangeLogDB(must(lc), dbPath, {readonly: false});
-          applyChangeLogPragmas(changeLogDb);
-          reconciled = reconcileChangeLog(
+          const opened = openChangeLogDBForWriting(
             must(lc),
-            changeLogDb,
+            dbPath,
             readReplicaAnchor(db),
           );
+          changeLogDb = opened.db;
+          reconciled = opened.result;
           changeLogRunner = new StatementRunner(changeLogDb);
         }
         createProcessor();
@@ -157,8 +187,8 @@ function createAPI(): API {
       changeLogRunner = undefined;
       processor = undefined;
       replicaDbPath = undefined;
-      unregisterCorruptionDiagnosticTarget?.();
-      unregisterCorruptionDiagnosticTarget = undefined;
+      changeLogDbPath = undefined;
+      unregisterCorruptionDiagnostics();
     },
   };
 }


### PR DESCRIPTION
The change log is now created, deleted, and diagnosed alongside the replica in every path that manipulates the replica, so no path can leave a change-log file whose `replicaVersion` disagrees with the replica beside it.

