### PR TITLE
chore(rmv2): add the incremental change-log purger

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-reader.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-reader.test.ts
@@ -43,6 +43,7 @@ const ANCHOR: ReplicaAnchor = {
   replicaVersion: '01',
   stateVersion: '02',
   writeTimeMs: 1234567890,
+  nowMs: 1234567890,
 };
 
 /** The replica path whose `-change-log` sibling the fixtures build. */

--- a/packages/zero-cache/src/services/replicator/change-log-db.test.ts
+++ b/packages/zero-cache/src/services/replicator/change-log-db.test.ts
@@ -1,6 +1,10 @@
 import {existsSync, mkdirSync, rmSync, statSync, writeFileSync} from 'node:fs';
-import {afterEach, describe, expect, test} from 'vitest';
-import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
+import {LogContext} from '@rocicorp/logger';
+import {afterEach, describe, expect, test, vi} from 'vitest';
+import {
+  createSilentLogContext,
+  TestLogSink,
+} from '../../../../shared/src/logging-test-utils.ts';
 import {Database} from '../../../../zqlite/src/db.ts';
 import {DbFile, expectTableExact} from '../../test/lite.ts';
 import {CREATE_V14_CHANGE_LOG_STREAM} from '../change-source/common/replica-schema.ts';
@@ -26,6 +30,7 @@ const ANCHOR: ReplicaAnchor = {
   replicaVersion: '01',
   stateVersion: '05',
   writeTimeMs: 12345,
+  nowMs: 1_700_000_000_000,
 };
 
 /** The main file and the sidecars `deleteLiteDB` removes. */
@@ -134,6 +139,46 @@ function head(db: Database): string | null {
 
 function meta(db: Database) {
   return db.prepare(/*sql*/ `SELECT * FROM "${CHANGE_LOG_META_TABLE}"`).get();
+}
+
+/** The meta row a reseed at `anchor` writes. */
+function seedMeta(anchor: ReplicaAnchor = ANCHOR) {
+  return {
+    replicaVersion: anchor.replicaVersion,
+    schemaVersion: CHANGE_LOG_DB_SCHEMA_VERSION,
+    seededAtMs: anchor.nowMs,
+    lock: 1,
+  };
+}
+
+const readPragma = Database.prototype.pragma;
+
+function autoVacuum(db: Database): number {
+  const [{auto_vacuum: mode}] = readPragma.call(db, 'auto_vacuum') as [
+    {auto_vacuum: number},
+  ];
+  return mode;
+}
+
+/**
+ * A schema v1 log: the shape 7D shipped, before `seededAtMs` and before
+ * `auto_vacuum`. This is what a staging file looks like on the first start
+ * after slice 8.
+ */
+function createV1Log(replicaFile: string): void {
+  using db = openChangeLogDB(lc, replicaFile, {readonly: false});
+  db.pragma('journal_mode = wal2');
+  db.exec(/*sql*/ `
+    ${CREATE_CHANGE_LOG_STREAM_SCHEMA}
+    CREATE TABLE "${CHANGE_LOG_META_TABLE}" (
+      "replicaVersion" TEXT NOT NULL,
+      "schemaVersion"  INTEGER NOT NULL,
+      "lock"           INTEGER PRIMARY KEY DEFAULT 1 CHECK ("lock" = 1)
+    );
+    INSERT INTO "${CHANGE_LOG_META_TABLE}" ("replicaVersion", "schemaVersion")
+      VALUES ('${ANCHOR.replicaVersion}', 1);
+  `);
+  appendTransaction(db, ANCHOR.stateVersion, '04', 1, 100);
 }
 
 /** A change-log db that is valid and consistent with {@link ANCHOR}. */
@@ -316,6 +361,44 @@ describe('replicator/change-log-db', () => {
       expect(db.pragma('wal_autocheckpoint')).toEqual([
         {wal_autocheckpoint: 1000},
       ]);
+      // 2 == INCREMENTAL, so purge can hand freed pages back to the OS.
+      expect(autoVacuum(db)).toBe(2);
+    });
+
+    // This is the test that pins the pragma *ordering*. SQLite honours a
+    // none -> incremental transition only while the file is empty, and
+    // `journal_mode = wal2` materializes page 1, so appending the pragma
+    // instead of prepending it produces a log that silently never reclaims.
+    test('auto_vacuum survives on the reopened file, not just the connection', () => {
+      const file = newDbFile();
+      {
+        using db = openChangeLogDB(lc, file.path, {readonly: false});
+        applyChangeLogPragmas(db);
+        db.exec(CREATE_CHANGE_LOG_STREAM_SCHEMA);
+      }
+
+      using reopened = openChangeLogDB(lc, file.path, {readonly: true});
+      expect(autoVacuum(reopened)).toBe(2);
+    });
+
+    test('appending the pragma after journal_mode would not take', () => {
+      const file = newDbFile();
+      {
+        using db = openChangeLogDB(lc, file.path, {readonly: false});
+        db.pragma('journal_mode = wal2');
+        db.pragma('auto_vacuum = INCREMENTAL');
+        db.exec(CREATE_CHANGE_LOG_STREAM_SCHEMA);
+        // Nor does dropping and recreating the tables: the mode is a header
+        // property that survives `DROP TABLE`, which is why a wrong mode is
+        // answered with a new file rather than with a reseed.
+        db.pragma('auto_vacuum = INCREMENTAL');
+        db.exec(/*sql*/ `DROP TABLE "${CHANGE_LOG_STREAM_TABLE}"`);
+        db.exec(CREATE_CHANGE_LOG_STREAM_SCHEMA);
+        expect(autoVacuum(db)).toBe(0);
+      }
+
+      using reopened = openChangeLogDB(lc, file.path, {readonly: true});
+      expect(autoVacuum(reopened)).toBe(0);
     });
   });
 
@@ -357,11 +440,7 @@ describe('replicator/change-log-db', () => {
         head: ANCHOR.stateVersion,
         reason: 'created',
       });
-      expect(meta(rebuilt)).toEqual({
-        replicaVersion: ANCHOR.replicaVersion,
-        schemaVersion: CHANGE_LOG_DB_SCHEMA_VERSION,
-        lock: 1,
-      });
+      expect(meta(rebuilt)).toEqual(seedMeta());
       expectTableExact(
         rebuilt,
         CHANGE_LOG_STREAM_TABLE,
@@ -371,6 +450,98 @@ describe('replicator/change-log-db', () => {
         'pos',
       );
       expect(rebuilt.pragma('journal_mode')).toEqual([{journal_mode: 'wal2'}]);
+    });
+
+    test('rebuilds a v1 log and enables incremental vacuum', () => {
+      const file = newDbFile();
+      createV1Log(file.path);
+
+      const {db, result} = openChangeLogDBForWriting(lc, file.path, ANCHOR);
+      using rebuilt = db;
+
+      // 'created' rather than 'schema-mismatch': a reseed cannot enable the
+      // pragma, so the whole file is replaced and the reconcile that follows
+      // runs against a database that does not exist yet.
+      expect(result).toEqual({
+        action: 'reseeded',
+        head: ANCHOR.stateVersion,
+        reason: 'created',
+      });
+      expect(meta(rebuilt)).toEqual(seedMeta());
+      expect(autoVacuum(rebuilt)).toBe(2);
+    });
+
+    // The guard is on the pragma, not only on the version: a file written by a
+    // build whose pragma order was wrong carries the current schema version and
+    // would otherwise reconcile clean and never reclaim.
+    test('rebuilds a current-version log whose pragma never took', () => {
+      const file = newDbFile();
+      {
+        using db = openChangeLogDB(lc, file.path, {readonly: false});
+        db.pragma('journal_mode = wal2');
+        db.pragma('auto_vacuum = INCREMENTAL'); // too late; stays at 0
+        reconcileChangeLog(lc, db, ANCHOR);
+        appendTransaction(db, '07', '05', 2, 100);
+        expect(autoVacuum(db)).toBe(0);
+      }
+
+      const {db, result} = openChangeLogDBForWriting(lc, file.path, ANCHOR);
+      using rebuilt = db;
+
+      expect(result).toEqual({
+        action: 'reseeded',
+        head: ANCHOR.stateVersion,
+        reason: 'created',
+      });
+      expect(autoVacuum(rebuilt)).toBe(2);
+    });
+
+    // A pragma that is still wrong on a brand-new file can only mean the pragma
+    // sequence itself is wrong, which is a code bug present on every start.
+    // Throwing would be a crash loop and rebuilding again would be a reseed per
+    // start, so the log opens and `Database.compact()`'s own mode guard becomes
+    // the fallback.
+    test('opens a log whose pragma is still wrong after one rebuild', () => {
+      const file = newDbFile();
+      const sink = new TestLogSink();
+      const logger = new LogContext('error', undefined, sink);
+      const reads = vi
+        .spyOn(Database.prototype, 'pragma')
+        .mockImplementation(function (this: Database, sql: string) {
+          return sql === 'auto_vacuum'
+            ? [{auto_vacuum: 0}]
+            : // oxlint-disable-next-line no-explicit-any
+              (readPragma.call(this, sql) as any);
+        });
+
+      try {
+        const {db, result} = openChangeLogDBForWriting(
+          logger,
+          file.path,
+          ANCHOR,
+        );
+        using opened = db;
+
+        expect(result).toEqual({
+          action: 'reseeded',
+          head: ANCHOR.stateVersion,
+          reason: 'created',
+        });
+        expect(head(opened)).toBe(ANCHOR.stateVersion);
+        // One read for the initial open and one for the rebuild: no third.
+        expect(
+          reads.mock.calls.filter(([sql]) => sql === 'auto_vacuum'),
+        ).toHaveLength(2);
+      } finally {
+        reads.mockRestore();
+      }
+
+      expect(sink.messages.filter(([level]) => level === 'error')).toHaveLength(
+        1,
+      );
+      expect(sink.messages.at(-1)?.[2][0]).toMatch(
+        /does not support incremental vacuum/,
+      );
     });
 
     // A path that cannot be opened is a problem with the environment rather
@@ -393,7 +564,17 @@ describe('replicator/change-log-db', () => {
   describe('readReplicaAnchor', () => {
     test('reads the replica facts the log is anchored to', () => {
       using replica = createReplica();
-      expect(readReplicaAnchor(replica)).toEqual(ANCHOR);
+      expect(readReplicaAnchor(replica, ANCHOR.nowMs)).toEqual(ANCHOR);
+    });
+
+    // `nowMs` is not a replica fact; it rides along so that `reseed` never
+    // reaches for `Date.now()` itself.
+    test('defaults nowMs to the current time', () => {
+      using replica = createReplica();
+      const before = Date.now();
+      const {nowMs} = readReplicaAnchor(replica);
+      expect(nowMs).toBeGreaterThanOrEqual(before);
+      expect(nowMs).toBeLessThanOrEqual(Date.now());
     });
 
     test('requires initialized replication state', () => {
@@ -421,11 +602,7 @@ describe('replicator/change-log-db', () => {
         reason: 'created',
       });
       expect(head(db)).toBe(ANCHOR.stateVersion);
-      expect(meta(db)).toEqual({
-        replicaVersion: ANCHOR.replicaVersion,
-        schemaVersion: CHANGE_LOG_DB_SCHEMA_VERSION,
-        lock: 1,
-      });
+      expect(meta(db)).toEqual(seedMeta());
       expectTableExact(
         db,
         CHANGE_LOG_STREAM_TABLE,
@@ -466,11 +643,7 @@ describe('replicator/change-log-db', () => {
         head: ANCHOR.stateVersion,
         reason: 'created',
       });
-      expect(meta(db)).toEqual({
-        replicaVersion: ANCHOR.replicaVersion,
-        schemaVersion: CHANGE_LOG_DB_SCHEMA_VERSION,
-        lock: 1,
-      });
+      expect(meta(db)).toEqual(seedMeta());
     });
 
     test('created: meta table without the stream table', () => {
@@ -498,11 +671,7 @@ describe('replicator/change-log-db', () => {
         head: ANCHOR.stateVersion,
         reason: 'schema-mismatch',
       });
-      expect(meta(db)).toEqual({
-        replicaVersion: ANCHOR.replicaVersion,
-        schemaVersion: CHANGE_LOG_DB_SCHEMA_VERSION,
-        lock: 1,
-      });
+      expect(meta(db)).toEqual(seedMeta());
       expectTableExact(
         db,
         CHANGE_LOG_STREAM_TABLE,
@@ -523,11 +692,7 @@ describe('replicator/change-log-db', () => {
         head: ANCHOR.stateVersion,
         reason: 'replica-version-mismatch',
       });
-      expect(meta(db)).toEqual({
-        replicaVersion: ANCHOR.replicaVersion,
-        schemaVersion: CHANGE_LOG_DB_SCHEMA_VERSION,
-        lock: 1,
-      });
+      expect(meta(db)).toEqual(seedMeta());
       expectTableExact(
         db,
         CHANGE_LOG_STREAM_TABLE,
@@ -697,6 +862,30 @@ describe('replicator/change-log-db', () => {
         'watermark',
         'pos',
       );
+    });
+
+    // `seededAtMs` is how a canary decides a log is warm enough to serve, so it
+    // must move on every reseed and stay put through everything else.
+    test('seededAtMs moves on a reseed and survives a truncation', () => {
+      using db = createReconciledLog();
+      expect(meta(db)).toEqual(seedMeta());
+
+      const later = {...ANCHOR, nowMs: ANCHOR.nowMs + 60_000};
+      appendTransaction(db, '09', '05', 2, 100);
+      expect(reconcileChangeLog(lc, db, later)).toEqual({
+        action: 'truncated',
+        head: ANCHOR.stateVersion,
+        rows: 4,
+      });
+      expect(meta(db)).toEqual(seedMeta());
+
+      const reseeded = {...later, stateVersion: '07'};
+      expect(reconcileChangeLog(lc, db, reseeded)).toEqual({
+        action: 'reseeded',
+        head: '07',
+        reason: 'gap',
+      });
+      expect(meta(db)).toEqual(seedMeta(reseeded));
     });
 
     test('a log at the replica head is not written to', () => {

--- a/packages/zero-cache/src/services/replicator/change-log-db.ts
+++ b/packages/zero-cache/src/services/replicator/change-log-db.ts
@@ -15,10 +15,10 @@
  *
  * Disk sizing: a task that writes the log needs room for the replica *plus* one
  * retention window of the change stream — the log's main file, its wal2
- * sidecars, and pages a purge has freed but not yet reused. Nothing purges the
- * log yet (that is parent slice 8), so with the writer enabled it currently
- * grows with the entire change stream since its last reseed, which is one more
- * reason `sqliteChangeLogMode` defaults to `off`. The log is excluded from the
+ * sidecars, and pages a purge has freed but not yet reused. Nothing calls the
+ * purger yet (that is slice 9), so with the writer enabled it currently grows
+ * with the entire change stream since its last reseed, which is one more reason
+ * `sqliteChangeLogMode` defaults to `off`. The log is excluded from the
  * litestream backup, so this is local disk only and never S3.
  */
 
@@ -34,8 +34,16 @@ import {
 /**
  * Bumped whenever the change-log database's schema changes. Since the file is a
  * cache, a mismatch costs one reseed rather than a migration.
+ *
+ * v2 adds `seededAtMs` to the meta table and `auto_vacuum = INCREMENTAL` to the
+ * file. The latter is not a schema change SQLite can be talked into after the
+ * fact, which is why {@link openChangeLogDBForWriting} rebuilds rather than
+ * relying on the reseed a version mismatch triggers.
  */
-export const CHANGE_LOG_DB_SCHEMA_VERSION = 1;
+export const CHANGE_LOG_DB_SCHEMA_VERSION = 2;
+
+/** https://www.sqlite.org/pragma.html#pragma_auto_vacuum */
+const AUTO_VACUUM_INCREMENTAL = 2;
 
 export const CHANGE_LOG_STREAM_TABLE = '_zero.changeLogStream';
 export const CHANGE_LOG_STREAM_WRITE_TIME_INDEX =
@@ -82,11 +90,17 @@ export const CHANGE_LOG_META_TABLE = '_zero.changeLogMeta';
 
 // "replicaVersion" identifies the replica this log was built against, which
 // detects a file left behind by a replica that was since reset and re-synced.
+// "seededAtMs" is when the log last started over, which is how a canary decides
+// whether it is warm enough to serve: a freshly seeded log returns `too-old` to
+// every reconnecting subscriber. `min("writeTimeMs")` cannot answer that — the
+// seed row carries the replica's last *upstream* commit time, which on an idle
+// shard is arbitrarily old and reads as warm.
 // "lock" enforces single-row semantics, as in "_zero.replicationConfig".
 const CREATE_CHANGE_LOG_META_SCHEMA = /*sql*/ `
   CREATE TABLE "${CHANGE_LOG_META_TABLE}" (
     "replicaVersion" TEXT NOT NULL,
     "schemaVersion"  INTEGER NOT NULL,
+    "seededAtMs"     INTEGER NOT NULL,
     "lock"           INTEGER PRIMARY KEY DEFAULT 1 CHECK ("lock" = 1)
   );
 `;
@@ -114,6 +128,15 @@ export type ReplicaAnchor = {
   readonly replicaVersion: string;
   readonly stateVersion: string;
   readonly writeTimeMs: number;
+  /**
+   * Wall-clock time at reconciliation, persisted as `seededAtMs` by a reseed.
+   *
+   * Not a replica fact, but carried here rather than as a parameter: the anchor
+   * is read by {@link readReplicaAnchor} in production and built by hand in
+   * tests, so this is the one place a test can control the clock without a
+   * signature change reaching every caller.
+   */
+  readonly nowMs: number;
 };
 
 type ReplicaAnchorRow = {
@@ -122,7 +145,10 @@ type ReplicaAnchorRow = {
   readonly writeTimeMs: number | null;
 };
 
-export function readReplicaAnchor(replica: Database): ReplicaAnchor {
+export function readReplicaAnchor(
+  replica: Database,
+  nowMs = Date.now(),
+): ReplicaAnchor {
   const row = replica
     .prepare(/*sql*/ `
       SELECT config."replicaVersion",
@@ -141,6 +167,7 @@ export function readReplicaAnchor(replica: Database): ReplicaAnchor {
     replicaVersion: row.replicaVersion,
     stateVersion: row.stateVersion,
     writeTimeMs: row.writeTimeMs,
+    nowMs,
   };
 }
 
@@ -188,12 +215,26 @@ export function openChangeLogDB(
  * node — the task restarts elsewhere, restores the replica from S3, and has no
  * change-log file at all. Whatever a power loss does take is detected as a gap
  * by {@link reconcileChangeLog} and reseeded.
+ *
+ * `auto_vacuum = INCREMENTAL` so that purge can return freed pages to the OS
+ * rather than leaving the file at its high-water mark. **It must be the first
+ * statement here.** SQLite honours a `none` -> `incremental` transition only
+ * while the file is still empty, and `journal_mode = wal2` materializes page 1;
+ * appending the pragma instead of prepending it silently leaves the file at
+ * mode 0 forever, since neither `DROP TABLE` nor a reseed makes a file empty
+ * again. {@link openChangeLogDBForWriting} verifies the result.
  */
 export function applyChangeLogPragmas(db: Database): void {
+  db.pragma('auto_vacuum = INCREMENTAL');
   db.pragma('busy_timeout = 30000');
   db.pragma('analysis_limit = 1000');
   db.pragma('journal_mode = wal2');
   db.pragma('synchronous = NORMAL');
+}
+
+function readAutoVacuum(db: Database): number {
+  const [{auto_vacuum: mode}] = db.pragma<{auto_vacuum: number}>('auto_vacuum');
+  return mode;
 }
 
 /**
@@ -215,12 +256,32 @@ export function applyChangeLogPragmas(db: Database): void {
  * error, a full disk) is a problem with the environment rather than with the
  * file's contents, and deleting a database in response would destroy state
  * without fixing it.
+ *
+ * A file that predates `auto_vacuum = INCREMENTAL` takes the same rebuild, for
+ * the same reason and at the same cost: the pragma only takes on an empty file,
+ * so a reseed cannot enable it. Unlike corruption, a *second* failure there is
+ * tolerated rather than thrown — see {@link ensureIncrementalAutoVacuum}.
  */
 export function openChangeLogDBForWriting(
   lc: LogContext,
   replicaFile: string,
   anchor: ReplicaAnchor,
 ): {db: Database; result: ReconcileResult} {
+  const opened = openOrRebuildCorrupt(lc, replicaFile, anchor);
+  const {db, result} = ensureIncrementalAutoVacuum(
+    lc,
+    replicaFile,
+    anchor,
+    opened,
+  );
+  return {db, result};
+}
+
+function openOrRebuildCorrupt(
+  lc: LogContext,
+  replicaFile: string,
+  anchor: ReplicaAnchor,
+): OpenedChangeLog {
   try {
     return openAndReconcile(lc, replicaFile, anchor);
   } catch (e) {
@@ -232,22 +293,82 @@ export function openChangeLogDBForWriting(
     lc.error?.('rebuilding the corrupt SQLite change log', {
       sqliteChangeLog: {file},
     });
-    deleteChangeLogDB(replicaFile);
-    // Reconciles a database that does not exist, i.e. reseeds with reason
-    // 'created'. A second failure is the environment's, not the file's.
-    return openAndReconcile(lc, replicaFile, anchor);
+    return rebuildChangeLog(lc, replicaFile, anchor);
   }
 }
+
+/**
+ * Rebuilds a log whose `auto_vacuum` mode is not `INCREMENTAL`, which is every
+ * log created before schema v2. Deleting the file is the only way to enable the
+ * pragma: `DROP TABLE` leaves the header's mode intact, and the in-place
+ * alternative — a full `VACUUM` — is an unbounded blocking statement on a file
+ * the writer needs.
+ *
+ * A mode that is still wrong after the rebuild is logged and tolerated, which
+ * is the one place this diverges from the corruption path. The two failures are
+ * not alike: a file that stays corrupt after a rebuild is an environment
+ * problem, but a pragma that stays wrong on a brand-new file can only mean
+ * {@link applyChangeLogPragmas}' statement order is wrong — a code bug, present
+ * on every task, on every start. Throwing there turns a lost optimization into
+ * a crash loop, and rebuilding again turns it into a reseed per start, which is
+ * worse than the freelist growth it was trying to avoid. `Database.compact()`
+ * already warns and no-ops when the mode is not `INCREMENTAL`, so degrading is
+ * the accepted fallback.
+ */
+function ensureIncrementalAutoVacuum(
+  lc: LogContext,
+  replicaFile: string,
+  anchor: ReplicaAnchor,
+  opened: OpenedChangeLog,
+): OpenedChangeLog {
+  if (opened.autoVacuum === AUTO_VACUUM_INCREMENTAL) {
+    return opened;
+  }
+  const file = changeLogFileName(replicaFile);
+  lc.info?.('rebuilding the SQLite change log to enable incremental vacuum', {
+    sqliteChangeLog: {file, autoVacuum: opened.autoVacuum},
+  });
+  opened.db.close();
+  const rebuilt = rebuildChangeLog(lc, replicaFile, anchor);
+  if (rebuilt.autoVacuum !== AUTO_VACUUM_INCREMENTAL) {
+    lc.error?.(
+      'SQLite change log does not support incremental vacuum; ' +
+        'it will plateau at its high-water mark',
+      {sqliteChangeLog: {file, autoVacuum: rebuilt.autoVacuum}},
+    );
+  }
+  return rebuilt;
+}
+
+/** The shared "delete the file and open a new one" body. */
+function rebuildChangeLog(
+  lc: LogContext,
+  replicaFile: string,
+  anchor: ReplicaAnchor,
+): OpenedChangeLog {
+  deleteChangeLogDB(replicaFile);
+  // Reconciles a database that does not exist, i.e. reseeds with reason
+  // 'created'. A second failure is the environment's, not the file's.
+  return openAndReconcile(lc, replicaFile, anchor);
+}
+
+type OpenedChangeLog = {
+  db: Database;
+  result: ReconcileResult;
+  /** Read before reconciling, so a rebuild does not pay for two reseeds. */
+  autoVacuum: number;
+};
 
 function openAndReconcile(
   lc: LogContext,
   replicaFile: string,
   anchor: ReplicaAnchor,
-): {db: Database; result: ReconcileResult} {
+): OpenedChangeLog {
   const db = openChangeLogDB(lc, replicaFile, {readonly: false});
   try {
     applyChangeLogPragmas(db);
-    return {db, result: reconcileChangeLog(lc, db, anchor)};
+    const autoVacuum = readAutoVacuum(db);
+    return {db, result: reconcileChangeLog(lc, db, anchor), autoVacuum};
   } catch (e) {
     // The caller never sees this handle, so it closes here or leaks — and it
     // must be closed before the corruption path deletes the file.
@@ -378,9 +499,10 @@ function reseed(
     ${CREATE_CHANGE_LOG_META_SCHEMA}
   `);
   db.prepare(/*sql*/ `
-    INSERT INTO "${CHANGE_LOG_META_TABLE}" ("replicaVersion", "schemaVersion")
-      VALUES (?, ?)
-  `).run(anchor.replicaVersion, CHANGE_LOG_DB_SCHEMA_VERSION);
+    INSERT INTO "${CHANGE_LOG_META_TABLE}"
+      ("replicaVersion", "schemaVersion", "seededAtMs")
+      VALUES (?, ?, ?)
+  `).run(anchor.replicaVersion, CHANGE_LOG_DB_SCHEMA_VERSION, anchor.nowMs);
   seedChangeLogStream(db, anchor);
 
   lc.info?.('reseeded the SQLite change log', {
@@ -389,6 +511,7 @@ function reseed(
       head: anchor.stateVersion,
       replicaVersion: anchor.replicaVersion,
       schemaVersion: CHANGE_LOG_DB_SCHEMA_VERSION,
+      seededAtMs: anchor.nowMs,
     },
   });
   return {action: 'reseeded', head: anchor.stateVersion, reason};

--- a/packages/zero-cache/src/services/replicator/change-log-stream-writer.test.ts
+++ b/packages/zero-cache/src/services/replicator/change-log-stream-writer.test.ts
@@ -23,6 +23,7 @@ const ANCHOR: ReplicaAnchor = {
   replicaVersion: '01',
   stateVersion: '02',
   writeTimeMs: 1_000,
+  nowMs: 1_000,
 };
 
 const files: DbFile[] = [];

--- a/packages/zero-cache/src/services/replicator/sqlite-change-log-ceiling.bench.ts
+++ b/packages/zero-cache/src/services/replicator/sqlite-change-log-ceiling.bench.ts
@@ -25,6 +25,7 @@
 //   SQLITE_CHANGE_LOG_MODES                 apply,log,combined,separate-files
 //   SQLITE_CHANGE_LOG_LOG_JOURNAL_MODE      wal,wal2   (change-log DB only)
 //   SQLITE_CHANGE_LOG_LOG_SYNCHRONOUS       NORMAL,FULL (change-log DB only)
+//   SQLITE_CHANGE_LOG_LOG_AUTO_VACUUM       NONE,INCREMENTAL (change-log DB only)
 //   SQLITE_CHANGE_LOG_RETENTION_MINUTES     simulated retention window
 //   SQLITE_CHANGE_LOG_RETENTION_WINDOWS     retention windows per bench run
 
@@ -43,17 +44,27 @@ import {DbFile} from '../../test/lite.ts';
 import {versionToLexi} from '../../types/lexi-version.ts';
 import {getPragmaConfig} from '../../workers/replicator.ts';
 import {ZERO_VERSION_COLUMN_NAME} from './schema/constants.ts';
+import {SQLiteChangeLogPurger} from './sqlite-change-log-purger.ts';
 import {applyPragmas} from './write-worker-client.ts';
 
 type WriteMode = 'apply' | 'log' | 'combined' | 'separate-files';
 type Workload = 'small-high-frequency' | 'mixed-row-schema' | 'oversized';
 type JournalMode = 'wal' | 'wal2';
 type Synchronous = 'NORMAL' | 'FULL';
+type AutoVacuum = 'NONE' | 'INCREMENTAL';
 
 /** Durability settings for the change-log DB only (design 4.6). */
 type LogDurability = {
   readonly journalMode: JournalMode;
   readonly synchronous: Synchronous;
+  /**
+   * `INCREMENTAL` buys the ability to return purged pages to the OS, at the
+   * cost of pointer-map pages (roughly one per 200 data pages) that have to be
+   * updated whenever a page moves. That write-path cost is what this axis
+   * exists to measure; the log's pragmas set it first, before `journal_mode`,
+   * because SQLite only honours the transition while the file is empty.
+   */
+  readonly autoVacuum: AutoVacuum;
 };
 
 type MessageSize = {
@@ -183,8 +194,10 @@ const REPLICA_SYNCHRONOUS: Synchronous = 'NORMAL';
 // alternatives rather than asserting the choice.
 const DEFAULT_LOG_JOURNAL_MODES: readonly JournalMode[] = ['wal2'];
 const DEFAULT_LOG_SYNCHRONOUS: readonly Synchronous[] = ['NORMAL'];
+const DEFAULT_LOG_AUTO_VACUUM: readonly AutoVacuum[] = ['INCREMENTAL'];
 const SWEEP_LOG_JOURNAL_MODES: readonly JournalMode[] = ['wal', 'wal2'];
 const SWEEP_LOG_SYNCHRONOUS: readonly Synchronous[] = ['NORMAL', 'FULL'];
+const SWEEP_LOG_AUTO_VACUUM: readonly AutoVacuum[] = ['NONE', 'INCREMENTAL'];
 
 const CORRECTNESS_MODE = booleanFromEnv('SQLITE_CHANGE_LOG_CORRECTNESS', false);
 const GO_NO_GO = booleanFromEnv('SQLITE_CHANGE_LOG_GO_NO_GO', false);
@@ -216,6 +229,13 @@ const READ_BATCH_ROWS = integerFromEnv(
 const PURGE_BATCH_ROWS = integerFromEnv(
   'SQLITE_CHANGE_LOG_PURGE_BATCH_ROWS',
   CORRECTNESS_MODE ? 10 : 1000,
+);
+// The purger's hard bound on any one statement, well under the writer's 30 s
+// busy_timeout. It governs how far the adaptive chunk size can grow, so it is
+// part of what these numbers measure.
+const PURGE_MAX_DURATION_MS = integerFromEnv(
+  'SQLITE_CHANGE_LOG_PURGE_MAX_DURATION_MS',
+  100,
 );
 const BETWEEN_COMMIT_PURGE_ROWS = integerFromEnv(
   'SQLITE_CHANGE_LOG_BETWEEN_COMMIT_PURGE_ROWS',
@@ -405,6 +425,7 @@ function writeModesFromEnv(): WriteMode[] {
 function logDurabilitiesFromEnv(
   journalModeFallback: readonly JournalMode[],
   synchronousFallback: readonly Synchronous[],
+  autoVacuumFallback: readonly AutoVacuum[] = DEFAULT_LOG_AUTO_VACUUM,
 ): LogDurability[] {
   const journalModes = enumListFromEnv(
     'SQLITE_CHANGE_LOG_LOG_JOURNAL_MODE',
@@ -416,8 +437,19 @@ function logDurabilitiesFromEnv(
     ['NORMAL', 'FULL'] as const,
     synchronousFallback,
   );
+  const autoVacuumModes = enumListFromEnv(
+    'SQLITE_CHANGE_LOG_LOG_AUTO_VACUUM',
+    ['NONE', 'INCREMENTAL'] as const,
+    autoVacuumFallback,
+  );
   return journalModes.flatMap(journalMode =>
-    synchronousModes.map(synchronous => ({journalMode, synchronous})),
+    synchronousModes.flatMap(synchronous =>
+      autoVacuumModes.map(autoVacuum => ({
+        journalMode,
+        synchronous,
+        autoVacuum,
+      })),
+    ),
   );
 }
 
@@ -640,6 +672,11 @@ type BenchDBs = {
   readonly log: Database;
   readonly logPath: string;
   readonly separated: boolean;
+  /**
+   * One instance per file, because the purger's chunk size adapts across
+   * batches — a fresh purger per batch would measure only its starting size.
+   */
+  readonly purger: SQLiteChangeLogPurger;
   readonly close: () => void;
 };
 
@@ -661,6 +698,7 @@ function setupDBs(c: BenchCase, testName: string): BenchDBs {
       log: replica,
       logPath: dbFile.path,
       separated: false,
+      purger: new SQLiteChangeLogPurger(replica),
       close: () => replica.close(),
     };
   }
@@ -673,6 +711,10 @@ function setupDBs(c: BenchCase, testName: string): BenchDBs {
   cleanup.push(() => deleteLiteDB(logPath));
 
   const log = new Database(lc, logPath);
+  // First, and before `journal_mode`: SQLite honours a none -> incremental
+  // transition only while the file is still empty, and setting the journal mode
+  // materializes page 1.
+  log.pragma(`auto_vacuum = ${durability.autoVacuum}`);
   log.pragma(`journal_mode = ${durability.journalMode}`);
   log.pragma(`synchronous = ${durability.synchronous}`);
   // Design 4.6: nothing else owns this file, so wal_autocheckpoint keeps its
@@ -687,6 +729,7 @@ function setupDBs(c: BenchCase, testName: string): BenchDBs {
     log,
     logPath,
     separated: true,
+    purger: new SQLiteChangeLogPurger(log),
     close: () => {
       log.close();
       replica.close();
@@ -865,9 +908,10 @@ function runCase(
 
     if (purge !== undefined && writesLog) {
       purgeResults.push(
-        purgeBatch(dbs.log, {
+        purgeBatch(dbs.purger, {
+          // The head cap comes from the log itself now, so the just-committed
+          // watermark only has to be supplied once.
           externalFloor: watermark,
-          stateVersionFloor: watermark,
           retentionCutoffMs:
             purge.kind === 'retention'
               ? writeTimeMs - purge.retentionMs
@@ -982,81 +1026,28 @@ function assertCompleteTransactions(db: Database) {
   expect(incomplete).toEqual([]);
 }
 
+/**
+ * The production purger, timed. The bench used to carry its own copy of this
+ * SQL; slice 8 promoted it to `sqlite-change-log-purger.ts`, so what is
+ * measured here is now what ships — including the strict `<` on the external
+ * floor and the tear that keeps an oversized transaction from becoming one
+ * unbounded DELETE.
+ */
 function purgeBatch(
-  db: Database,
+  purger: SQLiteChangeLogPurger,
   opts: {
     /** The confirmed backup watermark (design 3.2). */
     externalFloor: string;
-    /**
-     * The latest durable transaction, always preserved as a catchup boundary
-     * (storer.ts:286-300). Passed in rather than read from
-     * `_zero.replicationState`, which lives in the other file once separated.
-     */
-    stateVersionFloor: string;
     retentionCutoffMs: number;
     maxRows: number;
   },
 ): PurgeResult {
-  const runner = new StatementRunner(db);
-  const eligibleCommits = db.prepare(/*sql*/ `
-    SELECT "watermark"
-    FROM "_zero.changeLogStream"
-    WHERE "writeTimeMs" IS NOT NULL
-      AND "writeTimeMs" < ?
-      AND "watermark" <= ?
-      AND "watermark" < ?
-    ORDER BY "writeTimeMs", "watermark"
-  `);
-  const countTransaction = db.prepare(/*sql*/ `
-    SELECT count(*) AS "rows"
-    FROM "_zero.changeLogStream"
-    WHERE "watermark" = ?
-  `);
-  const deleteThrough = db.prepare(/*sql*/ `
-    DELETE FROM "_zero.changeLogStream" WHERE "watermark" <= ?
-  `);
-
   const start = performance.now();
-  let deletedRows = 0;
-  let deletedThrough: string | undefined;
-  let moreEligible = false;
-  try {
-    runner.beginImmediate();
-    const candidates = eligibleCommits.all<{watermark: string}>(
-      opts.retentionCutoffMs,
-      opts.externalFloor,
-      opts.stateVersionFloor,
-    );
-    for (const {watermark} of candidates) {
-      const rows = countTransaction.get<{rows: number}>(watermark).rows;
-      if (deletedRows > 0 && deletedRows + rows > opts.maxRows) {
-        moreEligible = true;
-        break;
-      }
-      // Treat maxRows as a soft limit. In particular, the oldest transaction
-      // must be removed even when it is larger than the target batch.
-      deletedRows += rows;
-      deletedThrough = watermark;
-    }
-    if (deletedThrough !== undefined) {
-      deleteThrough.run(deletedThrough);
-    }
-    if (!moreEligible && candidates.length > 0) {
-      moreEligible = deletedThrough !== candidates.at(-1)?.watermark;
-    }
-    runner.commit();
-  } catch (e) {
-    if (db.inTransaction) {
-      runner.rollback();
-    }
-    throw e;
-  }
-  return {
-    elapsedMs: performance.now() - start,
-    deletedRows,
-    deletedThrough,
-    moreEligible,
-  };
+  const result = purger.purgeBatch({
+    ...opts,
+    maxDurationMs: PURGE_MAX_DURATION_MS,
+  });
+  return {elapsedMs: performance.now() - start, ...result};
 }
 
 function runCatchup(
@@ -1158,7 +1149,8 @@ function caseName(c: BenchCase) {
     c.logDurability === undefined
       ? ''
       : ` logJournalMode=${c.logDurability.journalMode}` +
-        ` logSynchronous=${c.logDurability.synchronous}`;
+        ` logSynchronous=${c.logDurability.synchronous}` +
+        ` logAutoVacuum=${c.logDurability.autoVacuum}`;
   return (
     `workload=${c.workload} mode=${c.mode} ` +
     `logicalTxRows=${c.logicalTxRows} sqliteTxRows=${c.sqliteTxRows}` +
@@ -1338,7 +1330,7 @@ function goNoGoKey(c: BenchCase) {
   return c.logDurability === undefined
     ? `${c.workload}:${c.mode}`
     : `${c.workload}:${c.mode}:${c.logDurability.journalMode}:` +
-        c.logDurability.synchronous;
+        `${c.logDurability.synchronous}:${c.logDurability.autoVacuum}`;
 }
 
 function recordGoNoGoResult(c: BenchCase, samples: readonly WriteResult[]) {
@@ -1439,6 +1431,11 @@ function benchmarkEnvironment() {
         'SQLITE_CHANGE_LOG_LOG_SYNCHRONOUS',
         ['NORMAL', 'FULL'] as const,
         DEFAULT_LOG_SYNCHRONOUS,
+      ),
+      defaultAutoVacuum: enumListFromEnv(
+        'SQLITE_CHANGE_LOG_LOG_AUTO_VACUUM',
+        ['NONE', 'INCREMENTAL'] as const,
+        DEFAULT_LOG_AUTO_VACUUM,
       ),
       walAutocheckpoint: 'default',
     },
@@ -1545,12 +1542,17 @@ describe('replicator/sqlite change-log ceiling', () => {
     assertGoNoGoGates();
   });
 
-  // Design 4.6 asserts wal2 + synchronous=NORMAL for the change-log DB. This
-  // measures the alternatives so the default is a recorded decision with a
-  // measured cost, per the slice 7A exit criteria.
+  // Design 4.6 asserts wal2 + synchronous=NORMAL for the change-log DB, and
+  // slice 8 adds auto_vacuum=INCREMENTAL so purge can return pages to the OS.
+  // This measures the alternatives so each default is a recorded decision with
+  // a measured cost, per the slice 7A exit criteria.
   test('log durability trade', {timeout: TEST_TIMEOUT_MS}, () => {
     const cases = makeCases(
-      logDurabilitiesFromEnv(SWEEP_LOG_JOURNAL_MODES, SWEEP_LOG_SYNCHRONOUS),
+      logDurabilitiesFromEnv(
+        SWEEP_LOG_JOURNAL_MODES,
+        SWEEP_LOG_SYNCHRONOUS,
+        SWEEP_LOG_AUTO_VACUUM,
+      ),
     ).filter(
       c => c.mode === 'separate-files' && c.workload === 'small-high-frequency',
     );
@@ -1721,9 +1723,8 @@ describe('replicator/sqlite change-log ceiling', () => {
             verifyCase(dbs, c, write);
             const purges: PurgeResult[] = [];
             for (;;) {
-              const result = purgeBatch(dbs.log, {
+              const result = purgeBatch(dbs.purger, {
                 externalFloor: versionToLexi(c.totalTransactions),
-                stateVersionFloor: versionToLexi(c.totalTransactions),
                 retentionCutoffMs: Number.MAX_SAFE_INTEGER,
                 maxRows: PURGE_BATCH_ROWS,
               });
@@ -1733,8 +1734,15 @@ describe('replicator/sqlite change-log ceiling', () => {
               }
               expect(result.deletedRows).toBeGreaterThan(0);
             }
+            // Slice 8's exit criterion, and the reason this case exists: a
+            // transaction larger than the batch is removed across chunks rather
+            // than in one unbounded DELETE. Before slice 8, `maxRows` was a soft
+            // target and this asserted the opposite.
             expect(
-              purges.some(({deletedRows}) => deletedRows > PURGE_BATCH_ROWS),
+              purges.filter(({deletedRows}) => deletedRows > PURGE_BATCH_ROWS),
+            ).toEqual([]);
+            expect(
+              purges.some(({deletedThrough}) => deletedThrough === undefined),
             ).toBe(true);
             expect(purges.at(-1)?.moreEligible).toBe(false);
             expect(countLogRows(dbs.log)).toBe(c.logicalTxRows + 2);

--- a/packages/zero-cache/src/services/replicator/sqlite-change-log-purger.test.ts
+++ b/packages/zero-cache/src/services/replicator/sqlite-change-log-purger.test.ts
@@ -1,0 +1,1041 @@
+import {afterEach, describe, expect, test} from 'vitest';
+import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
+import type {Database} from '../../../../zqlite/src/db.ts';
+import {StatementRunner} from '../../db/statements.ts';
+import {DbFile} from '../../test/lite.ts';
+import {versionToLexi} from '../../types/lexi-version.ts';
+import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
+import {serializeChangeStreamData} from '../change-streamer/change-log-codec.ts';
+import type {WatermarkedChange} from '../change-streamer/change-streamer.ts';
+import {SQLiteChangeLogReader} from '../change-streamer/sqlite-change-log-reader.ts';
+import {
+  CHANGE_LOG_STREAM_TABLE,
+  CHANGE_LOG_STREAM_WRITE_TIME_INDEX,
+  changeLogFileName,
+  deleteChangeLogDB,
+  openChangeLogDB,
+  openChangeLogDBForWriting,
+  type ReplicaAnchor,
+} from './change-log-db.ts';
+import {ChangeLogStreamWriter} from './change-log-stream-writer.ts';
+import {
+  SQLITE_CHANGE_LOG_ELIGIBLE_COMMITS_SQL,
+  SQLiteChangeLogPurger,
+  type PurgeBatchOptions,
+  type PurgeBatchResult,
+} from './sqlite-change-log-purger.ts';
+
+const lc = createSilentLogContext();
+
+/** Watermarks in the encoding the change stream actually uses. */
+function v(n: number): string {
+  return versionToLexi(n);
+}
+
+const SEED_WATERMARK = v(0);
+const SEED_WRITE_TIME_MS = 1_000;
+
+const ANCHOR: ReplicaAnchor = {
+  replicaVersion: '01',
+  stateVersion: SEED_WATERMARK,
+  writeTimeMs: SEED_WRITE_TIME_MS,
+  nowMs: SEED_WRITE_TIME_MS,
+};
+
+/** A floor above every watermark any fixture writes. */
+const NO_FLOOR = v(1_000_000);
+const NO_CUTOFF = Number.MAX_SAFE_INTEGER;
+
+const files: DbFile[] = [];
+
+afterEach(() => {
+  for (const file of files.splice(0)) {
+    deleteChangeLogDB(file.path);
+    file.delete();
+  }
+});
+
+type Log = {
+  readonly db: Database;
+  readonly path: string;
+  readonly close: () => void;
+};
+
+/**
+ * A real change-log file, seeded at {@link ANCHOR}. Real rather than
+ * `:memory:` because several cases open a second connection.
+ */
+function createLog(): Log {
+  const file = new DbFile('sqlite-change-log-purger');
+  files.push(file);
+  const {db} = openChangeLogDBForWriting(lc, file.path, ANCHOR);
+  return {db, path: changeLogFileName(file.path), close: () => db.close()};
+}
+
+/** Appends a transaction the way the writer does. */
+function append(
+  db: Database,
+  watermark: string,
+  changes: number,
+  writeTimeMs: number,
+): void {
+  const writer = new ChangeLogStreamWriter(new StatementRunner(db));
+  const begin: ChangeStreamData = [
+    'begin',
+    {tag: 'begin'},
+    {commitWatermark: watermark},
+  ];
+  const truncate: ChangeStreamData = ['data', {tag: 'truncate', relations: []}];
+  const commit: ChangeStreamData = ['commit', {tag: 'commit'}, {watermark}];
+  try {
+    writer.begin(watermark, serializeChangeStreamData(begin));
+    for (let i = 0; i < changes; i++) {
+      writer.append(serializeChangeStreamData(truncate), 'truncate');
+    }
+    writer.commit(watermark, serializeChangeStreamData(commit), writeTimeMs);
+  } catch (e) {
+    writer.rollback();
+    throw e;
+  }
+}
+
+/**
+ * Appends `count` transactions of `changes` changes each, numbered from `from`.
+ * `writeTimeMs` advances with the watermark, as the writer's `Date.now()` does.
+ */
+function appendSeries(
+  db: Database,
+  from: number,
+  count: number,
+  changes = 1,
+): string[] {
+  const watermarks: string[] = [];
+  for (let i = 0; i < count; i++) {
+    const n = from + i;
+    append(db, v(n), changes, SEED_WRITE_TIME_MS + n);
+    watermarks.push(v(n));
+  }
+  return watermarks;
+}
+
+function watermarks(db: Database): string[] {
+  return db
+    .prepare(/*sql*/ `
+      SELECT DISTINCT "watermark" FROM "${CHANGE_LOG_STREAM_TABLE}"
+      ORDER BY "watermark"
+    `)
+    .all<{watermark: string}>()
+    .map(({watermark}) => watermark);
+}
+
+function rowCount(db: Database, watermark?: string): number {
+  return watermark === undefined
+    ? db
+        .prepare(
+          /*sql*/ `SELECT count(*) AS "n" FROM "${CHANGE_LOG_STREAM_TABLE}"`,
+        )
+        .get<{n: number}>().n
+    : db
+        .prepare(/*sql*/ `
+          SELECT count(*) AS "n" FROM "${CHANGE_LOG_STREAM_TABLE}"
+          WHERE "watermark" = ?
+        `)
+        .get<{n: number}>(watermark).n;
+}
+
+function bounds(db: Database): {min: string | null; head: string | null} {
+  const row = db
+    .prepare(/*sql*/ `
+      SELECT
+        (SELECT min("watermark") FROM "${CHANGE_LOG_STREAM_TABLE}") AS "min",
+        (SELECT max("watermark") FROM "${CHANGE_LOG_STREAM_TABLE}") AS "head"
+    `)
+    .get<{min: string | null; head: string | null}>();
+  return row;
+}
+
+/**
+ * Invariant 5, as amended: every transaction *above* the minimum is whole. The
+ * minimum is exempt because it is the only one a tear can touch, and it is
+ * checked by {@link expectMinimumIsAValidBoundary}.
+ */
+function expectCompleteAboveMinimum(db: Database) {
+  const incomplete = db
+    .prepare(/*sql*/ `
+      SELECT "watermark"
+      FROM "${CHANGE_LOG_STREAM_TABLE}"
+      WHERE "watermark" > (SELECT min("watermark") FROM "${CHANGE_LOG_STREAM_TABLE}")
+      GROUP BY "watermark"
+      HAVING min("pos") <> 0
+        OR max("pos") <> count(*) - 1
+        OR json_extract(max(CASE WHEN "pos" = 0 THEN "change" END), '$.tag') <> 'begin'
+        OR json_extract(max(CASE WHEN "precommit" IS NOT NULL THEN "change" END), '$.tag') <> 'commit'
+        OR sum(CASE WHEN "precommit" IS NOT NULL THEN 1 ELSE 0 END) <> 1
+    `)
+    .all();
+  expect(incomplete).toEqual([]);
+}
+
+/**
+ * The minimum transaction is either whole or torn, and either way its highest
+ * `pos` is still the `commit` row — which is all `plan()` reads from it.
+ */
+function expectMinimumIsAValidBoundary(db: Database) {
+  const {min} = bounds(db);
+  if (min === null) {
+    return;
+  }
+  const last = db
+    .prepare(/*sql*/ `
+      SELECT "precommit", json_extract("change", '$.tag') AS "tag"
+      FROM "${CHANGE_LOG_STREAM_TABLE}"
+      WHERE "watermark" = ?
+      ORDER BY "pos" DESC
+      LIMIT 1
+    `)
+    .get<{precommit: string | null; tag: string}>(min);
+  expect(last).toEqual({precommit: min, tag: 'commit'});
+}
+
+function expectInvariants(db: Database) {
+  expectCompleteAboveMinimum(db);
+  expectMinimumIsAValidBoundary(db);
+}
+
+const DEFAULTS = {
+  externalFloor: NO_FLOOR,
+  retentionCutoffMs: NO_CUTOFF,
+  maxRows: 1000,
+  maxDurationMs: 100,
+} satisfies PurgeBatchOptions;
+
+function purge(
+  purger: SQLiteChangeLogPurger,
+  opts: Partial<PurgeBatchOptions> = {},
+): PurgeBatchResult {
+  return purger.purgeBatch({...DEFAULTS, ...opts});
+}
+
+/** Drains, returning every batch. Bounded so a non-terminating purge fails. */
+function drain(
+  purger: SQLiteChangeLogPurger,
+  opts: Partial<PurgeBatchOptions> = {},
+  maxBatches = 10_000,
+): PurgeBatchResult[] {
+  const batches: PurgeBatchResult[] = [];
+  for (let i = 0; i < maxBatches; i++) {
+    const result = purge(purger, opts);
+    batches.push(result);
+    if (!result.moreEligible) {
+      return batches;
+    }
+  }
+  throw new Error(`purge did not terminate within ${maxBatches} batches`);
+}
+
+/**
+ * A clock whose every `start`/`end` pair reports `elapsedMs`, so the duration
+ * governor can be driven without depending on how fast a delete happens to run.
+ */
+function fakeClock() {
+  let t = 0;
+  let atStart = true;
+  const clock = {
+    elapsedMs: 0,
+    now: () => {
+      if (atStart) {
+        atStart = false;
+        return t;
+      }
+      atStart = true;
+      t += clock.elapsedMs;
+      return t;
+    },
+  };
+  return clock;
+}
+
+/** The replica path a change-log file hangs off. */
+function replicaFileOf(changeLogPath: string): string {
+  return changeLogPath.replace(/-change-log$/, '');
+}
+
+function queryPlan(db: Database, sql: string, params: unknown): string[] {
+  return db
+    .prepare(`EXPLAIN QUERY PLAN ${sql}`)
+    .all<{detail: string}>(params)
+    .map(({detail}) => detail);
+}
+
+describe('replicator/sqlite-change-log-purger', () => {
+  describe('the three bounds', () => {
+    test('nothing is eligible in a freshly seeded log', () => {
+      const {db, close} = createLog();
+      try {
+        const purger = new SQLiteChangeLogPurger(db);
+
+        // The seed is the head, and the head is never a candidate.
+        expect(purge(purger)).toEqual({
+          deletedRows: 0,
+          deletedThrough: undefined,
+          moreEligible: false,
+        });
+        expect(watermarks(db)).toEqual([SEED_WATERMARK]);
+      } finally {
+        close();
+      }
+    });
+
+    test('the head cap alone retains the latest transaction', () => {
+      const {db, close} = createLog();
+      try {
+        appendSeries(db, 1, 3);
+        const purger = new SQLiteChangeLogPurger(db);
+
+        // No external floor and no time floor: only (b) is doing any work.
+        expect(purge(purger)).toEqual({
+          deletedRows: 8,
+          deletedThrough: v(2),
+          moreEligible: false,
+        });
+        expect(watermarks(db)).toEqual([v(3)]);
+        expectInvariants(db);
+      } finally {
+        close();
+      }
+    });
+
+    test('the external floor alone binds, strictly', () => {
+      const {db, close} = createLog();
+      try {
+        appendSeries(db, 1, 5);
+        const purger = new SQLiteChangeLogPurger(db);
+
+        expect(purge(purger, {externalFloor: v(3)})).toMatchObject({
+          deletedThrough: v(2),
+          moreEligible: false,
+        });
+        // v(3) survives: it is the transaction a follower that restored to the
+        // backup watermark calls plan() with.
+        expect(watermarks(db)).toEqual([v(3), v(4), v(5)]);
+        expectInvariants(db);
+      } finally {
+        close();
+      }
+    });
+
+    test('the time floor alone binds', () => {
+      const {db, close} = createLog();
+      try {
+        appendSeries(db, 1, 5);
+        const purger = new SQLiteChangeLogPurger(db);
+
+        // Transactions carry writeTimeMs = SEED_WRITE_TIME_MS + n.
+        expect(
+          purge(purger, {retentionCutoffMs: SEED_WRITE_TIME_MS + 3}),
+        ).toMatchObject({deletedThrough: v(2), moreEligible: false});
+        expect(watermarks(db)).toEqual([v(3), v(4), v(5)]);
+        expectInvariants(db);
+      } finally {
+        close();
+      }
+    });
+
+    test('the external floor binds when it is lower than the time floor', () => {
+      const {db, close} = createLog();
+      try {
+        appendSeries(db, 1, 5);
+        const purger = new SQLiteChangeLogPurger(db);
+
+        expect(
+          purge(purger, {
+            externalFloor: v(2),
+            retentionCutoffMs: SEED_WRITE_TIME_MS + 4,
+          }),
+        ).toMatchObject({deletedThrough: v(1)});
+        expect(watermarks(db)).toEqual([v(2), v(3), v(4), v(5)]);
+      } finally {
+        close();
+      }
+    });
+
+    test('the time floor binds when it is lower than the external floor', () => {
+      const {db, close} = createLog();
+      try {
+        appendSeries(db, 1, 5);
+        const purger = new SQLiteChangeLogPurger(db);
+
+        expect(
+          purge(purger, {
+            externalFloor: v(4),
+            retentionCutoffMs: SEED_WRITE_TIME_MS + 2,
+          }),
+        ).toMatchObject({deletedThrough: v(1)});
+        expect(watermarks(db)).toEqual([v(2), v(3), v(4), v(5)]);
+      } finally {
+        close();
+      }
+    });
+
+    test('the head cap binds when both floors are above the head', () => {
+      const {db, close} = createLog();
+      try {
+        appendSeries(db, 1, 3);
+        const purger = new SQLiteChangeLogPurger(db);
+
+        // The stale-log case: the backup watermark has run past a log that
+        // stopped advancing, and deleting to it would empty the file.
+        expect(purge(purger, {externalFloor: v(99)})).toMatchObject({
+          deletedThrough: v(2),
+          moreEligible: false,
+        });
+        expect(watermarks(db)).toEqual([v(3)]);
+      } finally {
+        close();
+      }
+    });
+
+    test('a retention cutoff far in the future never purges above the floor', () => {
+      const {db, close} = createLog();
+      try {
+        appendSeries(db, 1, 5);
+        const purger = new SQLiteChangeLogPurger(db);
+
+        // The time bound is ANDed on top of the floor, never an alternative to
+        // it: no cutoff can license deleting the floor's transaction.
+        drain(purger, {
+          externalFloor: v(3),
+          retentionCutoffMs: Number.MAX_SAFE_INTEGER,
+        });
+        expect(watermarks(db)).toEqual([v(3), v(4), v(5)]);
+      } finally {
+        close();
+      }
+    });
+
+    test('a cutoff below every write time purges nothing', () => {
+      const {db, close} = createLog();
+      try {
+        appendSeries(db, 1, 5);
+        const purger = new SQLiteChangeLogPurger(db);
+
+        expect(purge(purger, {retentionCutoffMs: 0})).toEqual({
+          deletedRows: 0,
+          deletedThrough: undefined,
+          moreEligible: false,
+        });
+        expect(rowCount(db)).toBe(2 + 5 * 3);
+      } finally {
+        close();
+      }
+    });
+  });
+
+  describe('the S3 safety property (invariant 14)', () => {
+    // The floor is where "purged" and "gone" become the same thing: the change
+    // log is excluded from the litestream backup, so above the confirmed backup
+    // watermark it is the only copy a restoring follower can catch up from.
+    // This gets its own case rather than being implied by the per-floor tests.
+    test('no transaction at or above a moving floor is ever deleted', () => {
+      const {db, path, close} = createLog();
+      using reader = new SQLiteChangeLogReader(lc, path);
+      try {
+        const purger = new SQLiteChangeLogPurger(db);
+        let next = 1;
+        let floor = 0;
+        // A fixed-seed LCG, so a failure is reproducible.
+        let seed = 0x5eed;
+        const rand = (n: number) => {
+          seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+          return seed % n;
+        };
+
+        for (let round = 0; round < 60; round++) {
+          const appended = 1 + rand(4);
+          appendSeries(db, next, appended, 1 + rand(3));
+          next += appended;
+
+          // The backup watermark only ever advances, and always trails head.
+          floor = Math.min(next - 1, floor + rand(3));
+          const externalFloor = v(floor);
+
+          purge(purger, {
+            externalFloor,
+            retentionCutoffMs: NO_CUTOFF,
+            maxRows: 4 + rand(20),
+          });
+
+          const {min} = bounds(db);
+          expect(min).not.toBeNull();
+          // Row-count form: nothing at or above the floor was removed.
+          expect(min! <= externalFloor).toBe(true);
+          // Plan form: the follower that restored to exactly this watermark can
+          // still catch up from here. This is the assertion that fails on a
+          // non-strict floor comparison, which a row count alone would miss.
+          expect(reader.plan(externalFloor)).toMatchObject({kind: 'range'});
+          expectInvariants(db);
+        }
+      } finally {
+        close();
+      }
+    });
+
+    test('a subscriber exactly at the floor keeps its catchup boundary', () => {
+      const {db, path, close} = createLog();
+      using reader = new SQLiteChangeLogReader(lc, path);
+      try {
+        appendSeries(db, 1, 6);
+        const purger = new SQLiteChangeLogPurger(db);
+
+        drain(purger, {externalFloor: v(4)});
+
+        expect(reader.plan(v(4))).toEqual({
+          kind: 'range',
+          minWatermark: v(4),
+          headWatermark: v(6),
+        });
+        expect(reader.plan(v(3))).toEqual({
+          kind: 'too-old',
+          minWatermark: v(4),
+          headWatermark: v(6),
+        });
+      } finally {
+        close();
+      }
+    });
+  });
+
+  describe('batching', () => {
+    test('deletes fewer than maxRows in one batch', () => {
+      const {db, close} = createLog();
+      try {
+        appendSeries(db, 1, 3);
+        const purger = new SQLiteChangeLogPurger(db);
+
+        expect(purge(purger, {maxRows: 100})).toEqual({
+          deletedRows: 8,
+          deletedThrough: v(2),
+          moreEligible: false,
+        });
+      } finally {
+        close();
+      }
+    });
+
+    test('stops at exactly maxRows and reports more eligible', () => {
+      const {db, close} = createLog();
+      try {
+        // 2 seed rows, then transactions of 3 rows each.
+        appendSeries(db, 1, 6);
+        const purger = new SQLiteChangeLogPurger(db);
+
+        expect(purge(purger, {maxRows: 5})).toEqual({
+          deletedRows: 5,
+          deletedThrough: v(1),
+          moreEligible: true,
+        });
+        expect(watermarks(db)).toEqual([v(2), v(3), v(4), v(5), v(6)]);
+      } finally {
+        close();
+      }
+    });
+
+    test('many small transactions drain across batches', () => {
+      const {db, close} = createLog();
+      try {
+        appendSeries(db, 1, 200);
+        const purger = new SQLiteChangeLogPurger(db);
+
+        const batches = drain(purger, {maxRows: 20});
+
+        expect(batches.length).toBeGreaterThan(1);
+        for (const batch of batches.slice(0, -1)) {
+          expect(batch.deletedRows).toBeGreaterThan(0);
+          expect(batch.deletedRows).toBeLessThanOrEqual(20);
+        }
+        expect(watermarks(db)).toEqual([v(200)]);
+        expectInvariants(db);
+      } finally {
+        close();
+      }
+    });
+
+    test('repeated calls make strictly monotonic progress', () => {
+      const {db, close} = createLog();
+      try {
+        appendSeries(db, 1, 40, 2);
+        const purger = new SQLiteChangeLogPurger(db);
+
+        let previousMin = bounds(db).min;
+        let previousRows = rowCount(db);
+        for (let i = 0; ; i++) {
+          expect(i).toBeLessThan(1000);
+          const batch = purge(purger, {maxRows: 9});
+          const {min} = bounds(db);
+          const rows = rowCount(db);
+          if (batch.deletedRows > 0) {
+            expect(rows).toBeLessThan(previousRows);
+            if (batch.deletedThrough !== undefined) {
+              expect(min! > previousMin!).toBe(true);
+            }
+          }
+          previousMin = min;
+          previousRows = rows;
+          expectInvariants(db);
+          if (!batch.moreEligible) {
+            break;
+          }
+        }
+        expect(watermarks(db)).toEqual([v(40)]);
+      } finally {
+        close();
+      }
+    });
+  });
+
+  describe('the oversized transaction', () => {
+    const CHANGES = 400;
+    const OVERSIZED_ROWS = CHANGES + 2;
+    const MAX_ROWS = 40;
+
+    /** A log whose minimum is one transaction far larger than a batch. */
+    function createOversizedLog() {
+      const log = createLog();
+      append(log.db, v(1), CHANGES, SEED_WRITE_TIME_MS + 1);
+      appendSeries(log.db, 2, 3);
+      const purger = new SQLiteChangeLogPurger(log.db);
+      // The seed goes first and whole; the tear starts on the next batch.
+      expect(purge(purger, {maxRows: MAX_ROWS})).toEqual({
+        deletedRows: 2,
+        deletedThrough: SEED_WATERMARK,
+        moreEligible: true,
+      });
+      expect(bounds(log.db).min).toBe(v(1));
+      return {...log, purger};
+    }
+
+    test('is torn across chunks that each stay within the row target', () => {
+      const {db, close, purger} = createOversizedLog();
+      try {
+        let chunks = 0;
+        let torn = 0;
+        for (let i = 0; ; i++) {
+          expect(i).toBeLessThan(100);
+          const result = purge(purger, {maxRows: MAX_ROWS});
+          expect(result.deletedRows).toBeGreaterThan(0);
+          // The bound that matters: an arbitrarily large transaction never
+          // produces a batch larger than the target.
+          expect(result.deletedRows).toBeLessThanOrEqual(MAX_ROWS);
+          if (result.deletedThrough !== undefined) {
+            break;
+          }
+          chunks++;
+          torn += result.deletedRows;
+          // Mid-tear: the transaction is still the minimum, and its commit row
+          // is still there.
+          expect(bounds(db).min).toBe(v(1));
+          expectInvariants(db);
+        }
+        // 402 rows in 40-row chunks: ten tears, and the two rows that are left
+        // ride out on the next ordinary whole-transaction delete.
+        expect(chunks).toBe(10);
+        expect(torn).toBe(chunks * MAX_ROWS);
+        expect(rowCount(db, v(1))).toBe(0);
+        expect(watermarks(db)).toEqual([v(4)]);
+      } finally {
+        close();
+      }
+    });
+
+    test('keeps plan() answering range at the torn watermark and too-old below', () => {
+      const {path, close, purger} = createOversizedLog();
+      using reader = new SQLiteChangeLogReader(lc, path);
+      try {
+        for (;;) {
+          const result = purge(purger, {maxRows: MAX_ROWS});
+          if (result.deletedThrough !== undefined) {
+            break;
+          }
+          // The boundary check reads the highest `pos` at the watermark, so
+          // deleting bottom-up keeps it valid throughout.
+          expect(reader.plan(v(1))).toMatchObject({
+            kind: 'range',
+            minWatermark: v(1),
+          });
+          expect(reader.plan(SEED_WATERMARK)).toMatchObject({kind: 'too-old'});
+        }
+        // And below the torn watermark it stays too-old after the tear too.
+        expect(reader.plan(SEED_WATERMARK)).toMatchObject({kind: 'too-old'});
+        expect(reader.plan(v(1))).toMatchObject({kind: 'too-old'});
+      } finally {
+        close();
+      }
+    });
+
+    test('the final chunk removes the commit row and advances min together', () => {
+      const {path, close, purger} = createOversizedLog();
+      using observer = openChangeLogDB(lc, replicaFileOf(path), {
+        readonly: true,
+      });
+      try {
+        for (let i = 0; ; i++) {
+          expect(i).toBeLessThan(100);
+          // The floor keeps everything above the torn transaction ineligible,
+          // so the batch that finishes the tear finishes nothing else.
+          const result = purge(purger, {
+            maxRows: MAX_ROWS,
+            externalFloor: v(2),
+          });
+          const {min} = bounds(observer);
+          const remaining = rowCount(observer, v(1));
+          // Seen from another connection, "the boundary is gone" and "the
+          // minimum moved on" are never observable apart: they land in the same
+          // SQLite transaction.
+          expect(remaining === 0).toBe(min !== v(1));
+          if (result.deletedThrough !== undefined) {
+            expect(result.deletedThrough).toBe(v(1));
+            expect(remaining).toBe(0);
+            expect(min).toBe(v(2));
+            expect(result.moreEligible).toBe(false);
+            break;
+          }
+          expect(remaining).toBeGreaterThan(0);
+        }
+      } finally {
+        close();
+      }
+    });
+
+    // The minimum is torn even when it is not itself in the eligible set, which
+    // a writer whose clock went backwards can produce. Safe because both
+    // watermark bounds are prefix-closed — a non-empty eligible set implies
+    // `min < externalFloor` and `min < head` — and the prefix delete the batch
+    // would otherwise run removes the minimum anyway.
+    test('finishes a minimum that the time floor alone would have retained', () => {
+      const file = new DbFile('sqlite-change-log-purger');
+      files.push(file);
+      // The seed carries the replica's last *upstream* commit time, which on a
+      // shard that has just resumed can be later than the changes that follow.
+      const {db} = openChangeLogDBForWriting(lc, file.path, {
+        ...ANCHOR,
+        writeTimeMs: 5_000,
+      });
+      try {
+        append(db, v(1), 400, 2_000);
+        appendSeries(db, 2, 1);
+        const purger = new SQLiteChangeLogPurger(db);
+        const opts = {maxRows: 40, retentionCutoffMs: 3_000};
+
+        // v(1) is eligible and does not fit; the seed is not eligible at all.
+        const first = purge(purger, opts);
+        expect(first).toEqual({
+          deletedRows: 2,
+          deletedThrough: SEED_WATERMARK,
+          moreEligible: true,
+        });
+        expect(bounds(db).min).toBe(v(1));
+
+        drain(purger, opts);
+        expect(watermarks(db)).toEqual([v(2)]);
+        expectInvariants(db);
+      } finally {
+        db.close();
+      }
+    });
+
+    test('a reader started at the torn watermark is unaffected', async () => {
+      const {db, path, close, purger} = createOversizedLog();
+      using reader = new SQLiteChangeLogReader(lc, path);
+      try {
+        const {head} = bounds(db);
+        expect(reader.plan(v(1))).toMatchObject({kind: 'range'});
+
+        const delivered: WatermarkedChange[] = [];
+        for await (const batch of reader.read(v(1), head!, 2)) {
+          delivered.push(...batch);
+          // Interleave the tear with the read. It only ever touches rows the
+          // reader started strictly after.
+          purge(purger, {maxRows: MAX_ROWS, externalFloor: v(2)});
+        }
+
+        expect([...new Set(delivered.map(([watermark]) => watermark))]).toEqual(
+          [v(2), v(3), v(4)],
+        );
+      } finally {
+        close();
+      }
+    });
+
+    test('a crash mid-tear resumes with no recovery state', () => {
+      const {db, path, close, purger} = createOversizedLog();
+      try {
+        expect(purge(purger, {maxRows: MAX_ROWS})).toMatchObject({
+          deletedThrough: undefined,
+          moreEligible: true,
+        });
+        const remaining = rowCount(db, v(1));
+        expect(remaining).toBeGreaterThan(0);
+        expect(remaining).toBeLessThan(OVERSIZED_ROWS);
+        close();
+
+        // Reopening is a reconcile: the tear is at the tail, so the head still
+        // lands on the replica's stateVersion and nothing is wiped.
+        const replicaFile = path.replace(/-change-log$/, '');
+        const {db: reopened, result} = openChangeLogDBForWriting(
+          lc,
+          replicaFile,
+          {...ANCHOR, stateVersion: v(4)},
+        );
+        try {
+          expect(result).toEqual({action: 'none', head: v(4)});
+          expect(rowCount(reopened, v(1))).toBe(remaining);
+
+          drain(new SQLiteChangeLogPurger(reopened), {maxRows: MAX_ROWS});
+          expect(watermarks(reopened)).toEqual([v(4)]);
+          expectInvariants(reopened);
+        } finally {
+          reopened.close();
+        }
+      } finally {
+        close();
+      }
+    });
+
+    test('a tear respects the external floor like any other batch', () => {
+      const {db, close, purger} = createOversizedLog();
+      try {
+        // Only the torn transaction is below the floor, so the drain must stop
+        // once it completes rather than continuing into v(2).
+        drain(purger, {maxRows: MAX_ROWS, externalFloor: v(2)});
+        expect(watermarks(db)).toEqual([v(2), v(3), v(4)]);
+        expectInvariants(db);
+      } finally {
+        close();
+      }
+    });
+  });
+
+  describe('the duration bound', () => {
+    // `maxRows` cannot bound a statement's duration on its own, because row
+    // cost varies with payload size. The purger measures each delete and
+    // shrinks its budget, which is what keeps the change-log write lock from
+    // being held past the writer's 30 s busy_timeout.
+    test('shrinks the row budget when a delete overruns', () => {
+      const {db, close} = createLog();
+      const clock = fakeClock();
+      try {
+        appendSeries(db, 1, 200);
+        const purger = new SQLiteChangeLogPurger(db, clock.now);
+        clock.elapsedMs = 200; // against a 100 ms target
+
+        purge(purger, {maxRows: 64, maxDurationMs: 100});
+        expect(purger.budgetRows).toBe(32);
+        purge(purger, {maxRows: 64, maxDurationMs: 100});
+        expect(purger.budgetRows).toBe(16);
+      } finally {
+        close();
+      }
+    });
+
+    test('grows the budget back once deletes come in under the target', () => {
+      const {db, close} = createLog();
+      const clock = fakeClock();
+      try {
+        // Three-row transactions, so a budget that is a multiple of three is
+        // consumed exactly.
+        appendSeries(db, 1, 100);
+        const purger = new SQLiteChangeLogPurger(db, clock.now);
+        const opts = {maxRows: 66, maxDurationMs: 100};
+
+        clock.elapsedMs = 200;
+        purge(purger, opts);
+        expect(purger.budgetRows).toBe(33);
+
+        clock.elapsedMs = 0;
+        expect(purge(purger, opts).deletedRows).toBe(33);
+        expect(purger.budgetRows).toBe(66);
+      } finally {
+        close();
+      }
+    });
+
+    test('does not grow when the eligible set, not the budget, was the limit', () => {
+      const {db, close} = createLog();
+      const clock = fakeClock();
+      try {
+        appendSeries(db, 1, 30);
+        const purger = new SQLiteChangeLogPurger(db, clock.now);
+        const opts = {maxRows: 66, maxDurationMs: 100};
+
+        clock.elapsedMs = 200;
+        purge(purger, opts);
+        expect(purger.budgetRows).toBe(33);
+
+        // Fast, but only because there was almost nothing left to delete. That
+        // is no evidence that a larger statement would stay under the target.
+        clock.elapsedMs = 0;
+        expect(purge(purger, opts).deletedRows).toBeLessThan(33);
+        expect(purger.budgetRows).toBe(33);
+      } finally {
+        close();
+      }
+    });
+
+    test('never grows past maxRows and never shrinks below one row', () => {
+      const {db, close} = createLog();
+      const clock = fakeClock();
+      try {
+        appendSeries(db, 1, 50);
+        const purger = new SQLiteChangeLogPurger(db, clock.now);
+        clock.elapsedMs = 1_000;
+
+        for (let i = 0; i < 20; i++) {
+          const result = purge(purger, {maxRows: 8, maxDurationMs: 1});
+          expect(result.deletedRows).toBeGreaterThan(0);
+          expect(result.deletedRows).toBeLessThanOrEqual(8);
+          expect(purger.budgetRows!).toBeGreaterThanOrEqual(1);
+          expect(purger.budgetRows!).toBeLessThanOrEqual(8);
+        }
+        // A one-row budget still makes progress, by tearing one row at a time.
+        expect(purger.budgetRows).toBe(1);
+        expect(rowCount(db)).toBeLessThan(2 + 50 * 3);
+        expectInvariants(db);
+      } finally {
+        close();
+      }
+    });
+
+    test('an oversized transaction stays within the duration target', () => {
+      const {db, close} = createLog();
+      try {
+        // A real transaction rather than a stubbed clock: the failure mode is
+        // statement duration.
+        append(db, v(1), 20_000, SEED_WRITE_TIME_MS + 1);
+        appendSeries(db, 2, 1);
+        const purger = new SQLiteChangeLogPurger(db);
+
+        const maxDurationMs = 100;
+        for (const _ of drain(purger, {maxRows: 1000, maxDurationMs})) {
+          // The governor only ever narrows the budget it was given.
+          expect(purger.budgetRows!).toBeLessThanOrEqual(1000);
+        }
+        expect(watermarks(db)).toEqual([v(2)]);
+      } finally {
+        close();
+      }
+    });
+
+    test('rejects a non-positive batch size or duration', () => {
+      const {db, close} = createLog();
+      try {
+        const purger = new SQLiteChangeLogPurger(db);
+        expect(() => purge(purger, {maxRows: 0})).toThrow(/maxRows/);
+        expect(() => purge(purger, {maxRows: 1.5})).toThrow(/maxRows/);
+        expect(() => purge(purger, {maxDurationMs: 0})).toThrow(
+          /maxDurationMs/,
+        );
+        expect(db.inTransaction).toBe(false);
+      } finally {
+        close();
+      }
+    });
+  });
+
+  describe('concurrency', () => {
+    test('a reader on a second connection stays valid across a purge', async () => {
+      const {db, path, close} = createLog();
+      using reader = new SQLiteChangeLogReader(lc, path);
+      try {
+        appendSeries(db, 1, 12, 2);
+        const purger = new SQLiteChangeLogPurger(db);
+
+        const plan = reader.plan(v(6));
+        expect(plan).toMatchObject({kind: 'range', headWatermark: v(12)});
+
+        const delivered: WatermarkedChange[] = [];
+        for await (const batch of reader.read(v(6), v(12), 3)) {
+          delivered.push(...batch);
+          // Purge up to, but never into, the range the reader pinned.
+          purge(purger, {externalFloor: v(6)});
+        }
+
+        expect([...new Set(delivered.map(([watermark]) => watermark))]).toEqual(
+          [v(7), v(8), v(9), v(10), v(11), v(12)],
+        );
+        expect(bounds(db).min).toBe(v(6));
+      } finally {
+        close();
+      }
+    });
+
+    test('rolls the batch back and leaves no transaction open on failure', () => {
+      const {db, close} = createLog();
+      try {
+        appendSeries(db, 1, 4);
+        const purger = new SQLiteChangeLogPurger(db);
+        db.exec(/*sql*/ `
+          CREATE TRIGGER "no_deletes" BEFORE DELETE ON "${CHANGE_LOG_STREAM_TABLE}"
+          BEGIN SELECT RAISE(ABORT, 'boom'); END;
+        `);
+
+        expect(() => purge(purger)).toThrow('boom');
+        expect(db.inTransaction).toBe(false);
+        expect(rowCount(db)).toBe(2 + 4 * 3);
+      } finally {
+        close();
+      }
+    });
+
+    test('does not roll back a transaction the failure already closed', () => {
+      // SQLite rolls back automatically for some errors (SQLITE_FULL,
+      // SQLITE_IOERR); issuing ROLLBACK then throws and masks the real cause.
+      const cause = new Error('database or disk is full');
+      const executed: string[] = [];
+      const fail = () => {
+        throw cause;
+      };
+      const db = {
+        inTransaction: false,
+        exec: (sql: string) => void executed.push(sql),
+        prepare: () => ({all: fail, get: fail, run: fail}),
+      } as unknown as Database;
+
+      expect(() => purge(new SQLiteChangeLogPurger(db))).toThrow(cause);
+      expect(executed).toEqual(['BEGIN IMMEDIATE']);
+    });
+  });
+
+  describe('query plan', () => {
+    test('the eligible-commits query searches the partial index', () => {
+      const {db, close} = createLog();
+      try {
+        appendSeries(db, 1, 20, 50);
+
+        const details = queryPlan(db, SQLITE_CHANGE_LOG_ELIGIBLE_COMMITS_SQL, {
+          retentionCutoffMs: NO_CUTOFF,
+          externalFloor: NO_FLOOR,
+          limit: 10,
+        });
+        const steps = details.filter(detail =>
+          detail.includes(CHANGE_LOG_STREAM_TABLE),
+        );
+        // The retention scan and the head subquery, both seeks. The partial
+        // index carries one entry per transaction rather than one per change,
+        // and the ORDER BY rides it instead of sorting.
+        expect(steps).toHaveLength(2);
+        expect(steps.filter(detail => !detail.startsWith('SEARCH'))).toEqual(
+          [],
+        );
+        expect(steps[0]).toMatch(
+          new RegExp(
+            `USING COVERING INDEX ${CHANGE_LOG_STREAM_WRITE_TIME_INDEX}`,
+          ),
+        );
+        // The ORDER BY rides the index instead of sorting the eligible set.
+        expect(details.join('\n')).not.toMatch(/USE TEMP B-TREE/);
+      } finally {
+        close();
+      }
+    });
+  });
+});

--- a/packages/zero-cache/src/services/replicator/sqlite-change-log-purger.ts
+++ b/packages/zero-cache/src/services/replicator/sqlite-change-log-purger.ts
@@ -1,0 +1,386 @@
+/**
+ * Deletes aged-out transactions from the change-log database, one bounded write
+ * transaction at a time.
+ *
+ * The purger is a pure function of one database: it takes the floors its caller
+ * has already gated on and narrows them, never widens them, and it reads no
+ * replication state. That is what makes it testable without a scheduler and
+ * what lets slice 9 run it from the change-streamer process on a second
+ * writable connection.
+ */
+
+import {assert} from '../../../../shared/src/asserts.ts';
+import type {Database, Statement} from '../../../../zqlite/src/db.ts';
+import {CHANGE_LOG_STREAM_TABLE} from './change-log-db.ts';
+
+/**
+ * The eligible set, as three ANDed bounds. Only the `externalFloor` is a safety
+ * property; the other two make the log serviceable and make purge conservative.
+ *
+ * `"watermark" < @externalFloor` is deliberately strict. A follower that lost
+ * its replica restores it from S3 at watermark `W` and then asks this log for
+ * everything after `W`, which requires the `commit` row *at* `W` to still be
+ * here (`SQLITE_CHANGE_LOG_BOUNDARY_SQL`). Deleting it returns `too-old` to the
+ * very subscriber the floor exists to protect.
+ *
+ * The head is read from the log's own database rather than from the replica's
+ * `stateVersion`: writes are ordered log-first, so the log's head *leads* the
+ * replica, and the two files no longer share a transaction. The cap is inert in
+ * normal operation (`externalFloor <= stateVersion <= head`) and only engages
+ * on a stale log — writer stopped, mode flipped to `off`, another task took
+ * ownership — where deleting to a floor that has run past a frozen log would
+ * empty the file.
+ *
+ * Ordered by `("writeTimeMs", "watermark")` so it rides the partial index,
+ * which carries one entry per transaction rather than one per change. The
+ * `LIMIT` keeps a drain from re-scanning the remaining history on every batch,
+ * which would be quadratic in the number of eligible transactions and would do
+ * it inside the `BEGIN IMMEDIATE`, holding the write lock alongside the delete.
+ *
+ * Exported so the focused query-plan test covers the production query.
+ */
+export const SQLITE_CHANGE_LOG_ELIGIBLE_COMMITS_SQL = /*sql*/ `
+  SELECT "watermark"
+  FROM "${CHANGE_LOG_STREAM_TABLE}"
+  WHERE "writeTimeMs" IS NOT NULL
+    AND "writeTimeMs" < @retentionCutoffMs
+    AND "watermark" < @externalFloor
+    AND "watermark" < (SELECT max("watermark") FROM "${CHANGE_LOG_STREAM_TABLE}")
+  ORDER BY "writeTimeMs", "watermark"
+  LIMIT @limit
+`;
+
+const COUNT_TRANSACTION_SQL = /*sql*/ `
+  SELECT count(*) AS "rows"
+  FROM "${CHANGE_LOG_STREAM_TABLE}"
+  WHERE "watermark" = ?
+`;
+
+/**
+ * A prefix delete, so no transaction between the minimum and the head is ever
+ * split. The `<=` is correct and is not the floor comparison: `deletedThrough`
+ * is a watermark this batch already established as wholly eligible.
+ */
+const DELETE_THROUGH_SQL = /*sql*/ `
+  DELETE FROM "${CHANGE_LOG_STREAM_TABLE}" WHERE "watermark" <= ?
+`;
+
+const MIN_WATERMARK_SQL = /*sql*/ `
+  SELECT min("watermark") AS "minWatermark" FROM "${CHANGE_LOG_STREAM_TABLE}"
+`;
+
+/**
+ * The `pos` at `@offset` rows into the torn transaction, ascending. `undefined`
+ * when fewer than `@offset` rows remain, which is how the tear knows it is on
+ * its final chunk.
+ */
+const TEAR_BOUNDARY_SQL = /*sql*/ `
+  SELECT "pos"
+  FROM "${CHANGE_LOG_STREAM_TABLE}"
+  WHERE "watermark" = @watermark
+  ORDER BY "pos"
+  LIMIT 1 OFFSET @offset
+`;
+
+/**
+ * A range scan on the primary key. Expressed as `"pos" < @pos` rather than
+ * `DELETE ... LIMIT n`, which is both non-portable and the wrong bound: it
+ * carries no guarantee about *which* rows it removes, and the commit row must
+ * survive until the chunk that finishes the tear.
+ */
+const DELETE_BELOW_POS_SQL = /*sql*/ `
+  DELETE FROM "${CHANGE_LOG_STREAM_TABLE}"
+  WHERE "watermark" = @watermark AND "pos" < @pos
+`;
+
+export type PurgeBatchResult = {
+  readonly deletedRows: number;
+  /**
+   * The watermark through which whole transactions were removed. `undefined`
+   * when the batch only tore rows off the minimum transaction without
+   * completing it — in that case `deletedRows > 0` and `moreEligible` is true.
+   */
+  readonly deletedThrough: string | undefined;
+  /** True while a tear is in progress, as well as while whole transactions remain eligible. */
+  readonly moreEligible: boolean;
+};
+
+export type PurgeBatchOptions = {
+  /**
+   * The floor the caller has already gated on subscriber ACKs and snapshot
+   * reservations — normally the confirmed S3 backup watermark. Transactions at
+   * or above it are NOT durable anywhere else: the change log is excluded from
+   * the litestream backup, so this is the boundary a follower restores to and
+   * then catches up from. Compared strictly (`<`), so the transaction *at* the
+   * floor survives as that follower's catchup boundary. The purger narrows this
+   * input and never widens it.
+   */
+  readonly externalFloor: string;
+  /**
+   * A *minimum* retention, ANDed on top of `externalFloor` rather than an
+   * alternative to it. Which of the two binds depends on the backup interval.
+   */
+  readonly retentionCutoffMs: number;
+  /** Starting chunk size. Not the bound — `maxDurationMs` is. */
+  readonly maxRows: number;
+  /**
+   * The hard bound. No single statement in the batch may run longer than this,
+   * because the purger holds the change-log write lock for its duration and the
+   * writer's `busy_timeout` is 30 s. A delete that outlasts it fails the
+   * writer's `BEGIN IMMEDIATE` and stops replication, which is why this is a
+   * precondition of running purge outside the writer's process rather than a
+   * tuning knob.
+   */
+  readonly maxDurationMs: number;
+};
+
+type Statements = {
+  readonly eligibleCommits: Statement;
+  readonly countTransaction: Statement;
+  readonly deleteThrough: Statement;
+  readonly minWatermark: Statement;
+  readonly tearBoundary: Statement;
+  readonly deleteBelowPos: Statement;
+};
+
+export class SQLiteChangeLogPurger {
+  readonly #db: Database;
+  readonly #now: () => number;
+  readonly #stmts: Statements;
+
+  /**
+   * The measured row budget, carried across batches. Row cost varies with
+   * payload size, so `maxRows` alone cannot bound a statement's duration; this
+   * shrinks when a delete overruns `maxDurationMs` and grows back when the
+   * budget — rather than the eligible set — was what limited the batch.
+   */
+  #budgetRows: number | undefined;
+
+  /**
+   * @param db a writable connection to a change log the writer has already
+   *     created and reconciled. Statements are prepared eagerly, so a caller
+   *     that may run before the log exists opens the connection lazily and
+   *     treats construction failure as a skipped cycle.
+   */
+  constructor(
+    db: Database,
+    now: () => number = performance.now.bind(performance),
+  ) {
+    this.#db = db;
+    this.#now = now;
+    this.#stmts = {
+      eligibleCommits: db.prepare(SQLITE_CHANGE_LOG_ELIGIBLE_COMMITS_SQL),
+      countTransaction: db.prepare(COUNT_TRANSACTION_SQL),
+      deleteThrough: db.prepare(DELETE_THROUGH_SQL),
+      minWatermark: db.prepare(MIN_WATERMARK_SQL),
+      tearBoundary: db.prepare(TEAR_BOUNDARY_SQL),
+      deleteBelowPos: db.prepare(DELETE_BELOW_POS_SQL),
+    };
+  }
+
+  /** The row budget the next batch would use. Exposed for tests and metrics. */
+  get budgetRows(): number | undefined {
+    return this.#budgetRows;
+  }
+
+  /**
+   * Removes one bounded batch of aged-out history, in one `BEGIN IMMEDIATE`
+   * transaction. Callers loop while `moreEligible`, releasing whatever guards
+   * they hold between batches.
+   */
+  purgeBatch(opts: PurgeBatchOptions): PurgeBatchResult {
+    const {maxRows, maxDurationMs} = opts;
+    assert(
+      Number.isSafeInteger(maxRows) && maxRows > 0,
+      'change-log purge maxRows must be a positive safe integer',
+    );
+    assert(
+      maxDurationMs > 0,
+      'change-log purge maxDurationMs must be positive',
+    );
+
+    this.#db.exec('BEGIN IMMEDIATE');
+    try {
+      const result = this.#purge(opts);
+      this.#db.exec('COMMIT');
+      return result;
+    } catch (e) {
+      if (this.#db.inTransaction) {
+        this.#db.exec('ROLLBACK');
+      }
+      throw e;
+    }
+  }
+
+  #purge(opts: PurgeBatchOptions): PurgeBatchResult {
+    const {externalFloor, retentionCutoffMs} = opts;
+    const budget = this.#budget(opts.maxRows);
+    // Each transaction is at least a `begin` and a `commit`, so this is the
+    // most candidates that can fit in the budget.
+    const limit = Math.max(1, Math.ceil(budget / 2));
+    const candidates = this.#stmts.eligibleCommits.all<{watermark: string}>({
+      retentionCutoffMs,
+      externalFloor,
+      limit,
+    });
+    if (candidates.length === 0) {
+      return {deletedRows: 0, deletedThrough: undefined, moreEligible: false};
+    }
+
+    // Accounted per candidate rather than per prefix, which is exact as long as
+    // the candidates arrive in watermark order — they do, because the single
+    // writer stamps `writeTimeMs` at commit time. A clock that went backwards
+    // can put a non-candidate below `deletedThrough`, and the prefix delete
+    // then removes more rows than were counted. Not a safety problem: both
+    // watermark bounds are prefix-closed, only the minimum-retention courtesy
+    // is crossed, and `maxRows` is the starting chunk size rather than the
+    // bound — `maxDurationMs` is, and the governor measures what actually ran.
+    let rows = 0;
+    let deletedThrough: string | undefined;
+    for (const {watermark} of candidates) {
+      const {rows: n} = this.#stmts.countTransaction.get<{rows: number}>(
+        watermark,
+      );
+      if (rows + n > budget) {
+        break;
+      }
+      rows += n;
+      deletedThrough = watermark;
+    }
+
+    if (deletedThrough === undefined) {
+      return this.#tear(opts, budget);
+    }
+    const deletedRows = this.#timed(
+      opts,
+      budget,
+      () => this.#stmts.deleteThrough.run(deletedThrough).changes,
+    );
+    return {
+      deletedRows,
+      deletedThrough,
+      moreEligible: this.#anyEligible(opts),
+    };
+  }
+
+  /**
+   * Removes one bounded chunk of the minimum transaction, which is the only
+   * transaction that is ever torn.
+   *
+   * A single upstream transaction can be arbitrarily large — a backfill, a
+   * schema migration — and SQLite cannot yield mid-statement, so the only way
+   * to bound the lock hold is to delete it across several statements. That is
+   * unobservable given three constraints, all of which live here:
+   *
+   * 1. Only `min("watermark")` is torn, so at most one transaction is ever
+   *    partial. A reader never reads *into* a transaction — `read()` starts
+   *    strictly after `(fromWatermark, MAX_SAFE_INTEGER)` — so the only
+   *    transaction a tear can touch is one a subscriber reads *from*, and
+   *    reading from it does not read its rows.
+   * 2. Rows go ascending by `pos`, commit row last. `plan()`'s boundary check
+   *    reads the *highest* `pos` at the watermark and requires it to be the
+   *    `commit`; removing that row first would give a subscriber sitting
+   *    exactly there a spurious `too-old`.
+   * 3. The commit row is removed by a prefix delete, which advances
+   *    `min("watermark")` in the same SQLite transaction, so no state exposes
+   *    the boundary as gone while the minimum still points at it. Normally that
+   *    is {@link SQLiteChangeLogPurger.purgeBatch}'s ordinary whole-transaction
+   *    delete, taken on the batch where what is left of the torn transaction
+   *    finally fits the budget; the branch below is the same delete for the
+   *    case where the minimum is not itself in the eligible set.
+   *
+   * A crash mid-tear needs no recovery state: the torn transaction is still the
+   * minimum and still eligible, so the next batch continues it. `reconcile` is
+   * unaffected — it tests the head, and a tear is at the tail.
+   *
+   * Tearing the minimum is safe even in the unusual case where it is not itself
+   * in the eligible set (a writer whose clock went backwards can put a later
+   * watermark at an earlier `writeTimeMs`). Both watermark bounds are
+   * prefix-closed — a non-empty eligible set implies `min < externalFloor` and
+   * `min < head` — and the prefix delete this batch would otherwise run removes
+   * the minimum anyway. Only the time floor, which is a minimum-retention
+   * courtesy rather than a safety property, can be crossed that way.
+   */
+  #tear(opts: PurgeBatchOptions, budget: number): PurgeBatchResult {
+    const {minWatermark} = this.#stmts.minWatermark.get<{
+      minWatermark: string | null;
+    }>();
+    assert(
+      minWatermark !== null,
+      'change-log purge found eligible transactions in an empty log',
+    );
+
+    const boundary = this.#stmts.tearBoundary.get<{pos: number} | undefined>({
+      watermark: minWatermark,
+      offset: budget,
+    });
+    if (boundary === undefined) {
+      // At most `budget` rows are left at the minimum, which is reachable only
+      // when the minimum is not the transaction that failed to fit — i.e. when
+      // it is not itself eligible. The prefix delete removes it whole and
+      // advances `min("watermark")`.
+      const deletedRows = this.#timed(
+        opts,
+        budget,
+        () => this.#stmts.deleteThrough.run(minWatermark).changes,
+      );
+      return {
+        deletedRows,
+        deletedThrough: minWatermark,
+        moreEligible: this.#anyEligible(opts),
+      };
+    }
+    // `boundary.pos` is the `budget`-th row by `pos`, so this removes exactly
+    // `budget` rows and always makes progress. The commit row is the highest
+    // `pos`, so it can only be reached by the branch above.
+    const deletedRows = this.#timed(
+      opts,
+      budget,
+      () =>
+        this.#stmts.deleteBelowPos.run({
+          watermark: minWatermark,
+          pos: boundary.pos,
+        }).changes,
+    );
+    return {deletedRows, deletedThrough: undefined, moreEligible: true};
+  }
+
+  #anyEligible({externalFloor, retentionCutoffMs}: PurgeBatchOptions): boolean {
+    return (
+      this.#stmts.eligibleCommits.get<{watermark: string} | undefined>({
+        retentionCutoffMs,
+        externalFloor,
+        limit: 1,
+      }) !== undefined
+    );
+  }
+
+  #budget(maxRows: number): number {
+    return Math.max(1, Math.min(maxRows, this.#budgetRows ?? maxRows));
+  }
+
+  /**
+   * Runs a delete and feeds its measured duration back into the row budget.
+   * Growth is gated on the budget having been the binding constraint: a batch
+   * that finished quickly because only four rows were eligible is no evidence
+   * that a larger statement would stay under the target.
+   */
+  #timed(
+    {maxRows, maxDurationMs}: PurgeBatchOptions,
+    budget: number,
+    run: () => number,
+  ): number {
+    const start = this.#now();
+    const deletedRows = run();
+    const elapsedMs = this.#now() - start;
+
+    if (elapsedMs > maxDurationMs) {
+      this.#budgetRows = Math.max(1, Math.floor(budget / 2));
+    } else if (deletedRows >= budget && elapsedMs * 2 <= maxDurationMs) {
+      this.#budgetRows = Math.min(maxRows, budget * 2);
+    } else {
+      this.#budgetRows = budget;
+    }
+    return deletedRows;
+  }
+}

--- a/packages/zero-cache/src/services/replicator/write-worker.test.ts
+++ b/packages/zero-cache/src/services/replicator/write-worker.test.ts
@@ -155,6 +155,8 @@ describe('write-worker', () => {
       meta: {
         replicaVersion: '02',
         schemaVersion: CHANGE_LOG_DB_SCHEMA_VERSION,
+        // The worker's own clock: `readReplicaAnchor` fills it in.
+        seededAtMs: expect.any(Number),
         lock: 1,
       },
       journalMode: [{journal_mode: 'wal2'}],


### PR DESCRIPTION
Retention-floor SQL with bounded progress, testable without a scheduler, on a file that can later reclaim space. Nothing calls it: slice 9 lands the scheduler.

New `sqlite-change-log-purger.ts` promotes the prototype purge statements out of `sqlite-change-log-ceiling.bench.ts`, with three corrections:

- The head cap reads `max("watermark")` from the log's own database instead of taking a `stateVersionFloor` from the replica. Log-first commit ordering makes the log's head lead the replica's `stateVersion`, and the two no longer share a file, so the caller had no way to supply the right value.
- `"watermark" < @externalFloor` is now strict. At `<=` the transaction *at* the confirmed backup watermark is purged, and the follower that restored to it gets `too-old` from `plan()` because its `commit` row is gone. The change log is excluded from the litestream backup, so that transaction is the only copy a restoring follower can catch up from.
- The eligible-commits query is bounded by a `LIMIT`. The bench read the whole eligible set every batch and consumed a prefix of it, so a drain re-scanned the remaining history once per batch -- inside the `BEGIN IMMEDIATE`, where the scan holds the write lock alongside the delete.

`maxRows` also stops being a soft target. It let the oldest transaction through unbounded, so a ten-million-row upstream transaction became one ten-million-row DELETE holding the change-log write lock -- which, once purge runs outside the writer's process, outlasts the writer's 30s busy_timeout and stops replication. SQLite cannot yield mid-statement, so an oversized minimum transaction is instead torn across chunks: only `min("watermark")` is ever torn, rows go ascending by `pos` so the boundary check's commit row survives, and a prefix delete removes that row and advances the minimum together. A crash mid-tear needs no recovery state -- the torn transaction is still the minimum and still eligible. Row cost varies with payload size, so the real bound is `maxDurationMs`: the purger measures each delete and adapts its row budget.

Change-log schema goes to v2:

- `auto_vacuum = INCREMENTAL`, as `applyChangeLogPragmas`' *first* statement. SQLite honours a none -> incremental transition only while the file is empty, and `journal_mode = wal2` materializes page 1, so appending the pragma leaves a log that silently never reclaims. `openChangeLogDBForWriting` reads the mode back and rebuilds once through the file-delete path the corruption case already takes, since `DROP TABLE` cannot enable it. A mode still wrong after that rebuild is logged and tolerated rather than thrown: it can only mean the pragma order itself is wrong, and failing there would be a crash loop on every task while rebuilding again would be a reseed per start.
- `_zero.changeLogMeta` gains `seededAtMs`, which slice 11's warm-up precondition needs and which is free to add while the version is moving. `min("writeTimeMs")` cannot answer it: the seed row carries the replica's last upstream commit time, which on an idle shard reads as warm.

Bench: adds an `autoVacuum` axis and points both purge sites at the shipped purger, so what is measured is what ships. The oversized-purge case now asserts that no batch exceeds the row target and that at least one is a partial tear -- the inverse of what the soft limit required.

auto_vacuum write-path cost, wal2 + synchronous=NORMAL, small-high-frequency, 32MB payload, 5 reps:

  | | NONE | INCREMENTAL | delta |
  | changes/sec      | 28,612     | 27,854     | -2.6%   |
  | log commit p50   | 8.79 us    | 8.83 us    | +0.5%   |
  | log commit p95   | 17.2 us    | 19.0 us    | +10.2%  |
  | log commit p99   | 24.8 us    | 27.6 us    | +11.2%  |
  | change-log bytes | 45,518,848 | 45,563,904 | +0.099% |

  SQLITE_CHANGE_LOG_LOG_JOURNAL_MODE=wal2 \
  SQLITE_CHANGE_LOG_LOG_SYNCHRONOUS=NORMAL \
  SQLITE_CHANGE_LOG_TARGET_PAYLOAD_MB=32 SQLITE_CHANGE_LOG_REPS=5 \
  pnpm --filter zero-cache run bench sqlite-change-log-ceiling \
    -t 'log durability trade'

The p99 delta is 2.8us against the 7A bound of 3x the combined layout's commit, so the pragma stays and slice 9c is worth having.

This amends P§9 invariant 5: every transaction *above* `min("watermark")` is wholly retained; the minimum may be partial while it is being purged, and while torn it keeps its commit row so it remains a valid catchup boundary. At most one transaction is torn at any time. New invariant 14 -- no transaction at or above the confirmed backup watermark is ever purged -- is the strict `<` above.

Production effect: none, no caller. One extra reseed for any staging log at
schema v1, on next replicator start. Rollback: revert. Unblocks slice 9a.