### PR TITLE
chore(zero-cache): replica-specific backup paths

### DIFF
--- a/packages/zero-cache/src/db/initial-sync.bench.pg.ts
+++ b/packages/zero-cache/src/db/initial-sync.bench.pg.ts
@@ -137,15 +137,16 @@ describe('zero-cache/initial-sync throughput', () => {
           lc,
           'initial-sync-bench',
           replicaDbFile.path,
-          (log, tx) =>
-            initialSync(
+          async (log, tx) => {
+            await initialSync(
               log,
               shard,
               tx,
               getConnectionURI(upstream),
               {tableCopyWorkers: profile.tableCopyWorkers},
               {bench: 'initial-sync-throughput', profile: profileName},
-            ),
+            );
+          },
         );
         const elapsed = performance.now() - start;
 

--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -1,4 +1,5 @@
 import {consoleLogSink, LogContext} from '@rocicorp/logger';
+import {resolver} from '@rocicorp/resolver';
 import {assert} from '../../../shared/src/asserts.ts';
 import {must} from '../../../shared/src/must.ts';
 import {DatabaseInitError} from '../../../zqlite/src/db.ts';
@@ -8,8 +9,6 @@ import {deleteLiteDB} from '../db/delete-lite-db.ts';
 import {registerSQLiteCorruptionDiagnosticTarget} from '../db/sqlite-corruption.ts';
 import {warmupConnections} from '../db/warmup.ts';
 import {initEventSink, publishCriticalEvent} from '../observability/events.ts';
-import {restoreReplica} from '../services/change-source/common/replica-restore.ts';
-import {upgradeReplica} from '../services/change-source/common/replica-schema.ts';
 import {initializeCustomChangeSource} from '../services/change-source/custom/change-source.ts';
 import {initializePostgresChangeSource} from '../services/change-source/pg/change-source.ts';
 import {createBackupCleanupMonitor} from '../services/change-streamer/backup-cleanup-monitor-factory.ts';
@@ -20,7 +19,12 @@ import {ReplicaMonitor} from '../services/change-streamer/replica-monitor.ts';
 import {initChangeStreamerSchema} from '../services/change-streamer/schema/init.ts';
 import {AutoResetSignal} from '../services/change-streamer/schema/tables.ts';
 import {PurgeLocker} from '../services/change-streamer/storer.ts';
-import {exitAfter, runUntilKilled} from '../services/life-cycle.ts';
+import {
+  exitAfter,
+  ProcessManager,
+  runUntilKilled,
+} from '../services/life-cycle.ts';
+import {startReplicaBackupProcess} from '../services/litestream/commands.ts';
 import {
   changeLogFileName,
   deleteChangeLogDB,
@@ -31,13 +35,16 @@ import {
 } from '../services/replicator/replication-status.ts';
 import {connectPgClient} from '../types/pg.ts';
 import {
+  childWorker,
   parentWorker,
   singleProcessMode,
   type Worker,
 } from '../types/processes.ts';
 import {getShardConfig} from '../types/shards.ts';
+import type {ReplicaFileMode} from '../workers/replicator.ts';
 import {createLogContext} from './logging.ts';
 import {startOtelAuto} from './otel-start.ts';
+import {REPLICATOR_URL} from './worker-urls.ts';
 
 // Default LogContext, overridden in runWorker
 let lc = new LogContext('info', {}, consoleLogSink);
@@ -106,29 +113,17 @@ export default async function runWorker(
     litestream.backupURL && litestream.executable
       ? await new PurgeLocker(lc, shard, changeDB).acquire()
       : null;
-
-  // Restore from litestream if the change-log has entries.
-  if (purgeLock) {
-    try {
-      if (!(await restoreReplica(lc, litestream, replica.file, purgeLock))) {
-        lc.info?.(`no backup found. syncing the replica`);
-      }
-    } catch (e) {
-      lc.error?.(
-        `error restoring backup. resyncing the replica: ${String(e)}`,
-        e,
-      );
-    }
-  }
+  const restoreOptions = {litestream, constraints: purgeLock ?? undefined};
 
   let changeStreamer: ChangeStreamerService | undefined;
+  let backupURL: string | undefined;
 
   const context = getServerContext(config);
 
   for (const first of [true, false]) {
     try {
       // Note: This performs initial sync of the replica if necessary.
-      const {changeSource, subscriptionState} =
+      const {changeSource, subscriptionState, destinationBackupURL} =
         upstream.type === 'pg'
           ? await initializePostgresChangeSource(
               lc,
@@ -141,6 +136,7 @@ export default async function runWorker(
               },
               context,
               replicationLag.reportIntervalMs,
+              restoreOptions,
               purgeLock,
             )
           : await initializeCustomChangeSource(
@@ -149,6 +145,7 @@ export default async function runWorker(
               shard,
               replica.file,
               context,
+              restoreOptions,
             );
 
       const replicationStatusPublisher =
@@ -180,6 +177,7 @@ export default async function runWorker(
         },
         setTimeout,
       );
+      backupURL = destinationBackupURL;
       break;
     } catch (e) {
       if (first && e instanceof AutoResetSignal) {
@@ -220,12 +218,32 @@ export default async function runWorker(
   // impossible: upstream must have advanced in order for replication to be stuck.
   assert(changeStreamer, `resetting replica did not advance replicaVersion`);
 
-  // Perform any upgrades to the replica in case it was restored from an
-  // earlier version. Note that this upgrade is done by the replicator worker
-  // as well (in both the replication-manager and the view-syncer), but the
-  // change-streamer independently reads the replica, and it is fine run the
-  // upgrade logic redundantly since it is idempotent.
-  await upgradeReplica(lc, 'change-streamer-init', replica.file);
+  const processes = new ProcessManager(lc, parent);
+  if (backupURL) {
+    lc.info?.('setting up backup to', backupURL);
+    litestream.backupURL = backupURL;
+    const {promise: backupStarted, resolve} = resolver();
+
+    // Start a backup replicator and corresponding litestream backup process.
+    processes
+      .addWorker(
+        childWorker(REPLICATOR_URL, env, 'backup' satisfies ReplicaFileMode),
+        'supporting',
+        'backup-replicator',
+      )
+      // Wait for the replicator's first message (i.e. "ready") before starting
+      // litestream backup in order to avoid contending on the sqlite lock
+      // when the replicator first prepares the db file.
+      .once('message', () => {
+        processes.addSubprocess(
+          startReplicaBackupProcess(lc, litestream, replica.file),
+          'supporting',
+          'litestream',
+        );
+        resolve();
+      });
+    await backupStarted;
+  }
 
   const backupMonitor = createBackupCleanupMonitor({
     lc,
@@ -257,7 +275,13 @@ export default async function runWorker(
 
   // Note: The changeStreamer itself is not started here; it is started by the
   //       changeStreamerWebServer.
-  return runUntilKilled(lc, parent, changeStreamerWebServer, monitor);
+  try {
+    await runUntilKilled(lc, parent, changeStreamerWebServer, monitor);
+  } catch (err) {
+    processes.logErrorAndExit(err, 'change-streamer');
+  } finally {
+    await processes.shutdown();
+  }
 }
 
 // fork()

--- a/packages/zero-cache/src/server/main.ts
+++ b/packages/zero-cache/src/server/main.ts
@@ -13,7 +13,6 @@ import {
   runUntilKilled,
   type WorkerType,
 } from '../services/life-cycle.ts';
-import {startReplicaBackupProcess} from '../services/litestream/commands.ts';
 import {
   childWorker,
   parentWorker,
@@ -103,7 +102,6 @@ export default async function runWorker(
   const {
     taskID,
     changeStreamer: {mode: changeStreamerMode, uri: changeStreamerURI},
-    replica,
     litestream,
   } = config;
   const runChangeStreamer =
@@ -129,31 +127,9 @@ export default async function runWorker(
       'message',
       changeStreamerStarted,
     );
-
     // Wait for the change-streamer to be ready to guarantee that a replica
     // file is present.
     await changeStreamerReady;
-
-    if (litestream.backupURL) {
-      // Start a backup replicator and corresponding litestream backup process.
-      const {promise: backupReady, resolve} = resolver();
-      const mode: ReplicaFileMode = 'backup';
-      loadWorker(REPLICATOR_URL, 'supporting', mode, mode).once(
-        // Wait for the Replicator's first message (i.e. "ready") before starting
-        // litestream backup in order to avoid contending on the lock when the
-        // replicator first prepares the db file.
-        'message',
-        () => {
-          processes.addSubprocess(
-            startReplicaBackupProcess(lc, litestream, replica.file),
-            'supporting',
-            'litestream',
-          );
-          resolve();
-        },
-      );
-      await backupReady;
-    }
   }
 
   if (numSyncers > 0) {
@@ -228,9 +204,9 @@ export default async function runWorker(
     );
   } catch (err) {
     processes.logErrorAndExit(err, 'dispatcher');
+  } finally {
+    await processes.shutdown();
   }
-
-  await processes.done();
 }
 
 if (!singleProcessMode()) {

--- a/packages/zero-cache/src/server/runner/run-worker.ts
+++ b/packages/zero-cache/src/server/runner/run-worker.ts
@@ -100,7 +100,7 @@ export async function runWorker(
     );
   } catch (err) {
     processes.logErrorAndExit(err, 'main');
+  } finally {
+    await processes.shutdown();
   }
-
-  await processes.done();
 }

--- a/packages/zero-cache/src/services/change-source/common/replica-restore.ts
+++ b/packages/zero-cache/src/services/change-source/common/replica-restore.ts
@@ -10,14 +10,26 @@ import {
   litestreamRestoreMetricAttrs,
   litestreamRestoreRuns,
 } from '../../litestream/metrics.ts';
+import type {SubscriptionState} from '../../replicator/schema/replication-state.ts';
+import type {ChangeSource} from '../change-source.ts';
 
-/** @returns `true` if the replica was restored, `false` if not found */
+export type RestoreOptions = {
+  litestream?: LitestreamConfig;
+  constraints?: ReplicaConstraints | undefined;
+};
+
+export type InitializeResult = {
+  subscriptionState: SubscriptionState;
+  changeSource: ChangeSource;
+  destinationBackupURL: string | undefined;
+};
+
 export async function restoreReplica(
   lc: LogContext,
   config: LitestreamConfig,
   replicaFile: string,
-  replicaConstraints: ReplicaConstraints,
-): Promise<boolean> {
+  replicaConstraints: ReplicaConstraints | undefined,
+): Promise<void> {
   const start = performance.now();
   let result: RestoreResult | undefined;
   try {
@@ -29,7 +41,11 @@ export async function restoreReplica(
       'replication_manager',
     );
     result = attempt.result;
-    return attempt.restored;
+  } catch (e) {
+    lc.error?.(
+      `error restoring backup. resyncing the replica: ${String(e)}`,
+      e,
+    );
   } finally {
     const attrs = litestreamRestoreMetricAttrs(config, 'replication_manager');
     const labels = {...attrs, result: result ?? 'error'};

--- a/packages/zero-cache/src/services/change-source/custom/change-source.ts
+++ b/packages/zero-cache/src/services/change-source/custom/change-source.ts
@@ -22,9 +22,13 @@ import {
   createReplicationStateTables,
   getSubscriptionState,
   initReplicationState,
-  type SubscriptionState,
 } from '../../replicator/schema/replication-state.ts';
 import type {ChangeSource, ChangeStream} from '../change-source.ts';
+import {
+  restoreReplica,
+  type InitializeResult,
+  type RestoreOptions,
+} from '../common/replica-restore.ts';
 import {initReplica} from '../common/replica-schema.ts';
 import {changeStreamMessageSchema} from '../protocol/current/downstream.ts';
 import {
@@ -45,7 +49,20 @@ export async function initializeCustomChangeSource(
   shard: ShardConfig,
   replicaDbFile: string,
   context: ServerContext,
-): Promise<{subscriptionState: SubscriptionState; changeSource: ChangeSource}> {
+  {litestream, constraints}: RestoreOptions = {},
+): Promise<InitializeResult> {
+  // At the moment, the custom change-source implementation does not support
+  // per-RM backups (and thus does not support litestream v5 or RMv2). The
+  // current proposal to support this without requiring additional upstream
+  // state tracking is to:
+  // - use litestream to (ltx) query a fixed pool of subfolders within the
+  //   backupURL (e.g. /a/, /b/, /c/, /d/, /e/)
+  // - restore from the subfolder with the latest ltx file
+  // - backup to the subfolder with the oldest (or non-existent) ltx file
+  if (litestream?.backupURL) {
+    await restoreReplica(lc, litestream, replicaDbFile, constraints);
+  }
+
   await initReplica(
     lc,
     `replica-${shard.appID}-${shard.shardNum}`,
@@ -75,7 +92,11 @@ export async function initializeCustomChangeSource(
     subscriptionState,
   );
 
-  return {subscriptionState, changeSource};
+  return {
+    subscriptionState,
+    changeSource,
+    destinationBackupURL: litestream?.backupURL,
+  };
 }
 
 class CustomChangeSource implements ChangeSource {

--- a/packages/zero-cache/src/services/change-source/pg/change-source.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.ts
@@ -50,7 +50,6 @@ import type {Sink} from '../../../types/streams.ts';
 import {AutoResetSignal} from '../../change-streamer/schema/tables.ts';
 import {
   getSubscriptionStateAndContext,
-  type SubscriptionState,
   type SubscriptionStateAndContext,
 } from '../../replicator/schema/replication-state.ts';
 import type {ChangeSource, ChangeStream} from '../change-source.ts';
@@ -59,6 +58,11 @@ import {
   ChangeStreamMultiplexer,
   type Listener,
 } from '../common/change-stream-multiplexer.ts';
+import {
+  restoreReplica,
+  type InitializeResult,
+  type RestoreOptions,
+} from '../common/replica-restore.ts';
 import {initReplica} from '../common/replica-schema.ts';
 import type {
   BackfillRequest,
@@ -94,7 +98,7 @@ import {fromBigInt, toBigInt, toStateVersionString, type LSN} from './lsn.ts';
 import {registerReplicationSlotHealthMetrics} from './replication-slot-health.ts';
 import {dropOldReplicasAndSlots} from './replication-slots.ts';
 import {replicationEventSchema, type ReplicationEvent} from './schema/ddl.ts';
-import {updateShardSchema} from './schema/init.ts';
+import {ensureShardSchema} from './schema/init.ts';
 import {
   getPublicationInfo,
   type PublishedSchema,
@@ -102,6 +106,7 @@ import {
 } from './schema/published.ts';
 import {
   dropShard,
+  getActiveReplicas,
   getInternalShardConfig,
   getReplicaAtVersion,
   internalPublicationPrefix,
@@ -109,6 +114,7 @@ import {
   replicationSlotPrefix,
   type InternalShardConfig,
   type Replica,
+  type ReplicaState,
 } from './schema/shard.ts';
 import {validate} from './schema/validation.ts';
 
@@ -131,32 +137,50 @@ export async function initializePostgresChangeSource(
   syncOptions: InitialSyncOptions,
   context: ServerContext,
   lagReportIntervalMs = 0,
+  restoreOptions: RestoreOptions = {},
   purgeLock?: PurgeLock | null,
-): Promise<{subscriptionState: SubscriptionState; changeSource: ChangeSource}> {
-  await initReplica(
-    lc,
-    `replica-${shard.appID}-${shard.shardNum}`,
-    replicaDbFile,
-    async (log, tx) => {
-      // In RMv1, the purge lock on the change-db must be released before performing
-      // initial sync; if the change-db and upstream are the same db, a lock-holding
-      // transaction will prevent a replication slot from being created. This awkward
-      // dependency can go away with RMv2.
-      void purgeLock?.release();
-      await initialSync(log, shard, tx, upstreamURI, syncOptions, context);
-    },
-  );
-
-  const replica = new Database(lc, replicaDbFile);
-  const subscriptionState = getSubscriptionStateAndContext(
-    new StatementRunner(replica),
-  );
-  replica.close();
-
-  // Check that upstream is properly setup, and throw an AutoReset to re-run
-  // initial sync if not.
+): Promise<InitializeResult> {
   const db = await connectPgClient(lc, upstreamURI, 'change-source-init');
   try {
+    await ensureShardSchema(lc, db, shard);
+
+    let replicaState = await selectAndRestoreReplica(
+      lc,
+      db,
+      shard,
+      replicaDbFile,
+      restoreOptions,
+    );
+
+    await initReplica(
+      lc,
+      `replica-${shard.appID}-${shard.shardNum}`,
+      replicaDbFile,
+      async (log, tx) => {
+        // In RMv1, the purge lock on the change-db must be released before performing
+        // initial sync; if the change-db and upstream are the same db, a lock-holding
+        // transaction will prevent a replication slot from being created. This awkward
+        // dependency can go away with RMv2.
+        void purgeLock?.release();
+        replicaState = await initialSync(
+          log,
+          shard,
+          tx,
+          upstreamURI,
+          syncOptions,
+          context,
+        );
+      },
+    );
+
+    const replica = new Database(lc, replicaDbFile);
+    const subscriptionState = getSubscriptionStateAndContext(
+      new StatementRunner(replica),
+    );
+    replica.close();
+
+    // Check that upstream is properly setup, and throw an AutoReset to re-run
+    // initial sync if not.
     const upstreamReplica = await checkAndUpdateUpstream(
       lc,
       db,
@@ -174,10 +198,56 @@ export async function initializePostgresChangeSource(
       syncOptions.textCopy,
     );
 
-    return {subscriptionState, changeSource};
+    const destinationBackupURL =
+      replicaState?.backupPath && restoreOptions.litestream?.backupURL
+        ? new URL(
+            replicaState.backupPath,
+            restoreOptions.litestream.backupURL,
+          ).toString()
+        : // For legacy RMv1 replicas (on litestream-v3), backup to the same location
+          restoreOptions.litestream?.backupURL;
+
+    return {subscriptionState, changeSource, destinationBackupURL};
   } finally {
     await db.end();
   }
+}
+
+async function selectAndRestoreReplica(
+  lc: LogContext,
+  sql: PostgresDB,
+  shard: ShardID,
+  replicaFile: string,
+  {litestream, constraints}: RestoreOptions,
+): Promise<ReplicaState | undefined> {
+  if (litestream?.backupURL) {
+    const {backupURL: backupBaseURL} = litestream;
+    const replicas = (await getActiveReplicas(lc, sql, shard)).filter(
+      // filter to the generation specified by the constraints, if present
+      ({generation}) =>
+        generation === (constraints?.replicaVersion ?? generation),
+    );
+    if (replicas.length === 0) {
+      lc.info?.(`no suitable replicas to restore from`, {replicas});
+      return undefined;
+    }
+
+    const [replica] = replicas;
+    const {slot, backupPath, confirmedFlushLsn} = replica;
+    const backupURL = new URL(backupPath ?? '', backupBaseURL).toString();
+    lc.info?.(
+      `restoring replica from ${backupURL} (${slot}@${confirmedFlushLsn})`,
+      {replicas},
+    );
+    await restoreReplica(
+      lc,
+      {...litestream, backupURL}, // includes the replica's backup sub-path
+      replicaFile,
+      constraints,
+    );
+    return replica;
+  }
+  return undefined;
 }
 
 async function checkAndUpdateUpstream(
@@ -190,9 +260,6 @@ async function checkAndUpdateUpstream(
     initialSyncContext,
   }: SubscriptionStateAndContext,
 ) {
-  // Perform any shard schema updates
-  await updateShardSchema(lc, sql, shard, replicaVersion);
-
   const upstreamReplica = await getReplicaAtVersion(
     lc,
     sql,
@@ -502,7 +569,7 @@ class PostgresChangeSource implements ChangeSource {
 
     this.#lc.info?.(
       `started replication stream@${slot} from ${clientWatermark} (replicaVersion: ${
-        this.#replica.version
+        this.#replica.generation
       })`,
     );
 
@@ -518,11 +585,11 @@ class PostgresChangeSource implements ChangeSource {
         this.#lc,
         this.#db,
         this.#shard,
-        this.#replica.version,
+        this.#replica.generation,
       );
       if (replica) {
         this.#lc.info?.(
-          `Shutdown signal from replica@${this.#replica.version}: ${stringify(replica.subscriberContext)}`,
+          `Shutdown signal from replica@${this.#replica.generation}: ${stringify(replica.subscriberContext)}`,
         );
       }
     } catch (e) {
@@ -547,7 +614,7 @@ class PostgresChangeSource implements ChangeSource {
     if (result.length === 0) {
       const slotExpression = replicationSlotPrefix(this.#shard);
       const replicas = await sql`
-        SELECT id, rank, slot, version, "initialSyncContext", "subscriberContext" 
+        SELECT id, rank, slot, generation, "initialSyncContext", "subscriberContext" 
           FROM ${sql(replicasTable)} ORDER BY rank DESC`;
       const slots = await sql`
         SELECT slot_name as slot, active, active_pid as pid

--- a/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
@@ -64,8 +64,10 @@ import {getPublicationInfo} from './schema/published.ts';
 import {
   dropShard,
   getInternalShardConfig,
+  getReplicaState,
   initReplica,
   validatePublications,
+  type ReplicaState,
 } from './schema/shard.ts';
 
 export type InitialSyncOptions = {
@@ -96,6 +98,10 @@ export type InitialSyncOptions = {
 /** Server context to store with the initial sync metadata for debugging. */
 export type ServerContext = JSONObject;
 
+/**
+ * @returns The {@link ReplicaState} of the initialized replica, or `undefined`
+ *          for a shadow sync.
+ */
 export async function initialSync(
   lc: LogContext,
   shard: ShardConfig,
@@ -103,7 +109,7 @@ export async function initialSync(
   upstreamURI: string,
   syncOptions: InitialSyncOptions,
   context: ServerContext,
-) {
+): Promise<ReplicaState | undefined> {
   if (!ALLOWED_APP_ID_CHARACTERS.test(shard.appID)) {
     throw new Error(
       'The App ID may only consist of lower-case letters, numbers, and the underscore character',
@@ -330,6 +336,13 @@ export async function initialSync(
           totalMs: elapsed,
         },
       );
+
+      return slotName && replicaID
+        ? must(
+            await getReplicaState(sql, shard, replicaID),
+            `Missing replica with id ${replicaID}`,
+          )
+        : undefined; // shadow sync only
     } finally {
       // All meaningful errors are handled at the processReadTask() call site.
       void copyPool.end().catch(e => lc.warn?.(`Error closing copyPool`, e));
@@ -353,7 +366,7 @@ export async function initialSync(
           WHERE slot_name = ${slotName};
       `.catch(e => lc.warn?.(`Unable to drop replication slot ${slotName}`, e));
     }
-    await statusPublisher.publishAndThrowError(lc, 'Initializing', e);
+    throw await statusPublisher.publishAndThrowError(lc, 'Initializing', e);
   } finally {
     statusPublisher.stop();
     if (releaseShadowSnapshot) {
@@ -460,6 +473,11 @@ async function ensurePublishedTables(
   const {database, host} = sql.options;
   lc.info?.(`Ensuring upstream PUBLICATION on ${database}@${host}`);
 
+  // Technically, ensureShardSchema() is already called by
+  // initializePostgresChangeSource, so the call here is redundant
+  // but harmless. On the contrary, it makes initial sync more
+  // self-contained (for test setup), and also plays a role in
+  // recovering from corruption (below) after the shard is dropped.
   await ensureShardSchema(lc, sql, shard);
   const {publications} = await getInternalShardConfig(sql, shard);
 

--- a/packages/zero-cache/src/services/change-source/pg/schema/init.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/init.pg.test.ts
@@ -13,11 +13,7 @@ import {
 } from '../../../../test/db.ts';
 import type {PostgresDB} from '../../../../types/pg.ts';
 import {id} from '../../../../types/sql.ts';
-import {
-  CURRENT_SCHEMA_VERSION,
-  ensureShardSchema,
-  updateShardSchema,
-} from './init.ts';
+import {CURRENT_SCHEMA_VERSION, ensureShardSchema} from './init.ts';
 import {createReplica, initReplica, metadataPublicationName} from './shard.ts';
 
 const APP_ID = 'zappz';
@@ -70,6 +66,8 @@ describe('change-streamer/pg/schema/init', () => {
             rank: expect.any(BigInt),
             slot: `${APP_ID}_${SHARD_NUM}_1234`,
             version: '2dhf29ef',
+            generation: '2dhf29ef',
+            backupPath: /\d{10,}/,
             initialSchema: {tables: [], indexes: []},
             initialSyncContext: {foo: 'bar'},
             subscriberContext: null,
@@ -101,6 +99,8 @@ describe('change-streamer/pg/schema/init', () => {
             rank: expect.any(BigInt),
             slot: `${APP_ID}_${SHARD_NUM}_5678`,
             version: 's8dfh2d',
+            generation: 's8dfh2d',
+            backupPath: /\d{10,}/,
             initialSchema: {tables: [], indexes: []},
           },
         ],
@@ -131,10 +131,11 @@ describe('change-streamer/pg/schema/init', () => {
       },
     },
     {
-      name: 'Migration from v5',
+      name: 'Migration from v6',
       upstreamSetup: `
         CREATE SCHEMA ${APP_ID}_${SHARD_NUM};
         CREATE TABLE ${APP_ID}_${SHARD_NUM}."shardConfig" (
+          "replicaVersion" TEXT, 
           "publications"  TEXT[] NOT NULL,
           "ddlDetection"  BOOL NOT NULL,
           "initialSchema" JSON,
@@ -144,8 +145,9 @@ describe('change-streamer/pg/schema/init', () => {
         );
 
         INSERT INTO ${APP_ID}_${SHARD_NUM}."shardConfig" 
-          ("lock", "publications", "ddlDetection", "initialSchema")
-          VALUES (true, 
+          ("lock", "replicaVersion", "publications", "ddlDetection", "initialSchema")
+          VALUES (true,
+            '123',
             ARRAY['_${APP_ID}_metadata_23', '_${APP_ID}_public_23'], 
             true,
             '{"tables":[],"indexes":[]}'
@@ -157,8 +159,8 @@ describe('change-streamer/pg/schema/init', () => {
             FOR TABLE ${APP_ID}_${SHARD_NUM}."clients";
   `,
       existingVersionHistory: {
-        schemaVersion: 5,
-        dataVersion: 5,
+        schemaVersion: 6,
+        dataVersion: 6,
         minSafeVersion: 1,
       },
       upstreamPostState: {
@@ -182,6 +184,8 @@ describe('change-streamer/pg/schema/init', () => {
             rank: expect.any(BigInt),
             slot: `${APP_ID}_${SHARD_NUM}`,
             version: '123',
+            generation: '123',
+            backupPath: null,
             initialSchema: {tables: [], indexes: []},
           },
         ],
@@ -198,38 +202,27 @@ describe('change-streamer/pg/schema/init', () => {
         await createVersionHistoryTable(upstream, schema);
         await upstream`INSERT INTO ${upstream(schema)}."versionHistory"
           ${upstream(c.existingVersionHistory)}`;
-        await updateShardSchema(
-          lc,
+      }
+      await ensureShardSchema(lc, upstream, {
+        appID: APP_ID,
+        shardNum: SHARD_NUM,
+        publications: c.requestedPublications ?? [],
+      });
+      if (c.newReplica) {
+        await createReplica(
           upstream,
-          {
-            appID: APP_ID,
-            shardNum: SHARD_NUM,
-            publications: c.requestedPublications ?? [],
-          },
-          '123',
+          {appID: APP_ID, shardNum: SHARD_NUM},
+          '12345',
+          c.newReplica[0],
+          c.newReplica[1],
         );
-      } else {
-        await ensureShardSchema(lc, upstream, {
-          appID: APP_ID,
-          shardNum: SHARD_NUM,
-          publications: c.requestedPublications ?? [],
-        });
-        if (c.newReplica) {
-          await createReplica(
-            upstream,
-            {appID: APP_ID, shardNum: SHARD_NUM},
-            '12345',
-            c.newReplica[0],
-            c.newReplica[1],
-          );
-          await initReplica(
-            upstream,
-            {appID: APP_ID, shardNum: SHARD_NUM},
-            '12345',
-            {tables: [], indexes: []},
-            {foo: 'bar'},
-          );
-        }
+        await initReplica(
+          upstream,
+          {appID: APP_ID, shardNum: SHARD_NUM},
+          '12345',
+          {tables: [], indexes: []},
+          {foo: 'bar'},
+        );
       }
 
       await expectTablesToMatch(upstream, c.upstreamPostState);

--- a/packages/zero-cache/src/services/change-source/pg/schema/init.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/init.ts
@@ -2,7 +2,6 @@ import type {LogContext} from '@rocicorp/logger';
 import {assert} from '../../../../../../shared/src/asserts.ts';
 import * as v from '../../../../../../shared/src/valita.ts';
 import {
-  getVersionHistory,
   runSchemaMigrations,
   type IncrementalMigrationMap,
   type Migration,
@@ -11,7 +10,6 @@ import type {PostgresDB} from '../../../../types/pg.ts';
 import {upstreamSchema, type ShardConfig} from '../../../../types/shards.ts';
 import {id} from '../../../../types/sql.ts';
 import {AutoResetSignal} from '../../../change-streamer/schema/tables.ts';
-import {decommissionShard} from '../decommission.ts';
 import {publishedSchema} from './published.ts';
 import {
   getMutationsTableDefinition,
@@ -42,94 +40,26 @@ export async function ensureShardSchema(
     // The incremental migration of any existing replicas will be replaced by
     // the incoming replica being synced, so the replicaVersion here is
     // unnecessary.
-    getIncrementalMigrations(shard, 'obsolete'),
+    getIncrementalMigrations(shard),
   );
 }
 
-/**
- * Updates the schema for an existing shard.
- */
-export async function updateShardSchema(
-  lc: LogContext,
-  db: PostgresDB,
-  shard: ShardConfig,
-  replicaVersion: string,
-): Promise<void> {
-  await runSchemaMigrations(
-    lc,
-    `upstream-shard-${shard.appID}`,
-    upstreamSchema(shard),
-    db,
-    {
-      // If the expected existing shard is absent, throw an
-      // AutoResetSignal to backtrack and initial sync.
-      migrateSchema: () => {
-        throw new AutoResetSignal(
-          `upstream shard ${upstreamSchema(shard)} is not initialized`,
-        );
-      },
-    },
-    getIncrementalMigrations(shard, replicaVersion),
-  );
-
-  // The decommission check is run in updateShardSchema so that it happens
-  // after initial sync, and not when the shard schema is initially set up.
-  await decommissionLegacyShard(lc, db, shard);
-}
-
-function getIncrementalMigrations(
-  shard: ShardConfig,
-  replicaVersion?: string,
-): IncrementalMigrationMap {
+function getIncrementalMigrations(shard: ShardConfig): IncrementalMigrationMap {
   const shardConfigTable = `${upstreamSchema(shard)}.shardConfig`;
 
   return {
-    4: {
+    6: {
       migrateSchema: () => {
         throw new AutoResetSignal('resetting to upgrade shard schema');
       },
-      minSafeVersion: 3,
     },
 
-    // v5: changes the upstream schema organization from "zero_{SHARD_ID}" to
-    // the "{APP_ID}_0". An incremental migration indicates that the previous
-    // SHARD_ID was "0" and the new APP_ID is "zero" (i.e. the default values
-    // for those options). In this case, the upstream format is identical, and
-    // no migration is necessary. However, the version is bumped to v5 to
-    // indicate that it was created with the {APP_ID} configuration and should
-    // not be decommissioned as a legacy shard.
+    // v7: Updates the DDL event trigger protocol to v2, and adds support for
+    //     ALTER SCHEMA x RENAME TO y
+    //     (migration logic subsumbed by v23)
 
-    6: {
-      migrateSchema: async (lc, sql) => {
-        assert(
-          replicaVersion,
-          `replicaVersion is always passed for incremental migrations`,
-        );
-        await Promise.all([
-          sql`
-          ALTER TABLE ${sql(shardConfigTable)} ADD "replicaVersion" TEXT`,
-          sql`
-          UPDATE ${sql(shardConfigTable)} SET ${sql({replicaVersion})}`,
-        ]);
-        lc.info?.(
-          `Recorded replicaVersion ${replicaVersion} in upstream shardConfig`,
-        );
-      },
-    },
-
-    // Updates the DDL event trigger protocol to v2, and adds support for
-    // ALTER SCHEMA x RENAME TO y
-    7: {
-      migrateSchema: async (lc, sql) => {
-        const [{publications}] = await sql<{publications: string[]}[]>`
-          SELECT publications FROM ${sql(shardConfigTable)}`;
-        await setupTriggers(lc, sql, {...shard, publications});
-        lc.info?.(`Upgraded to v2 event triggers`);
-      },
-    },
-
-    // Adds support for non-disruptive resyncs, which tracks multiple
-    // replicas with different slot names.
+    // v8: Adds support for non-disruptive resyncs, which tracks multiple
+    //     replicas with different slot names.
     8: {
       migrateSchema: async (lc, sql) => {
         const legacyShardConfigSchema = v.object({
@@ -276,6 +206,29 @@ function getIncrementalMigrations(
         lc.info?.(`Upgraded DDL event triggers`);
       },
     },
+
+    // v24 (1.10.0):
+    // - adds the "backupPath" column for per-replica backups.
+    // - adds the "generation" column to replace "version".
+    24: {
+      migrateSchema: async (_, sql) => {
+        await sql`
+          ALTER TABLE ${sql(upstreamSchema(shard))}.replicas 
+            ADD COLUMN "backupPath" TEXT;
+        `;
+        await sql`
+          ALTER TABLE ${sql(upstreamSchema(shard))}.replicas 
+            ADD COLUMN "generation" TEXT;
+        `;
+      },
+
+      migrateData: async (_, sql) => {
+        // Backfill the "generation" column to eventually replace "version"
+        await sql`
+          UPDATE ${sql(upstreamSchema(shard))}.replicas SET "generation" = "version";
+        `;
+      },
+    },
   };
 }
 
@@ -287,20 +240,3 @@ export const CURRENT_SCHEMA_VERSION = Object.keys(
     publications: ['foo'],
   }),
 ).reduce((prev, curr) => Math.max(prev, parseInt(curr)), 0);
-
-export async function decommissionLegacyShard(
-  lc: LogContext,
-  db: PostgresDB,
-  shard: ShardConfig,
-) {
-  if (shard.appID !== 'zero') {
-    // When migration from non-default shard ids, e.g. "zero_prod" => "prod_0",
-    // clean up the old "zero_prod" shard if it is pre-v5. Note that the v5
-    // check is important to guard against cleaning up a **new** "zero_0" app
-    // that coexists with the current App (with app-id === "0").
-    const versionHistory = await getVersionHistory(db, `zero_${shard.appID}`);
-    if (versionHistory !== null && versionHistory.schemaVersion < 5) {
-      await decommissionShard(lc, db, 'zero', shard.appID);
-    }
-  }
-}

--- a/packages/zero-cache/src/services/change-source/pg/schema/shard.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/shard.pg.test.ts
@@ -89,6 +89,8 @@ describe('change-source/pg', () => {
           id: /\d{10,}/,
           slot: 'zro_0_1234',
           version: '0wdfj02',
+          generation: '0wdfj02',
+          backupPath: /\d{10,}/,
           initialSchema: {tables: [], indexes: []},
           initialSyncContext: {foo: 'bar'},
           subscriberContext: null,

--- a/packages/zero-cache/src/services/change-source/pg/schema/shard.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/shard.ts
@@ -201,6 +201,8 @@ export function shardSetup(
     "rank"               BIGSERIAL,
     "slot"               TEXT NOT NULL,
     "version"            TEXT NOT NULL,
+    "generation"         TEXT,  -- to replace version, NULL-able in the interim
+    "backupPath"         TEXT,  -- subpath within the litestream backup URL
     "initialSchema"      JSON,  -- set after initial sync
     "initialSyncContext" JSON,
     "subscriberContext"  JSON
@@ -229,17 +231,43 @@ const internalShardConfigSchema = v.object({
 
 export type InternalShardConfig = v.Infer<typeof internalShardConfigSchema>;
 
-const replicaSchema = internalShardConfigSchema.extend({
+const replicaInfoSchema = v.object({
   id: v.string(),
   rank: v.bigint(),
   slot: v.string(),
   version: v.string(),
+  generation: v.string().nullable(),
+  backupPath: v.string().nullable(),
+});
+
+const fullReplicaRowSchema = replicaInfoSchema.extend({
   initialSchema: publishedSchema,
   initialSyncContext: jsonObjectSchema.nullable(),
   subscriberContext: jsonObjectSchema.nullable(),
 });
 
+const replicaSchema = internalShardConfigSchema
+  .extend(fullReplicaRowSchema.shape)
+  .map(replica => {
+    const {version, generation, ...r} = replica;
+    return {...r, generation: generation ?? version};
+  });
+
 export type Replica = v.Infer<typeof replicaSchema>;
+
+const replicationSlotStateSchema = v.object({
+  active: v.boolean(),
+  confirmedFlushLsn: v.string().nullable(),
+});
+
+const replicaStateSchema = replicaInfoSchema
+  .extend(replicationSlotStateSchema.shape)
+  .map(replica => {
+    const {version, generation, ...r} = replica;
+    return {...r, generation: generation ?? version};
+  });
+
+export type ReplicaState = v.Infer<typeof replicaStateSchema>;
 
 // triggerSetup is run separately in a sub-transaction (i.e. SAVEPOINT) so
 // that a failure (e.g. due to lack of superuser permissions) can be handled
@@ -269,7 +297,13 @@ export async function createReplica(
   replicaVersion: string,
 ) {
   const schema = upstreamSchema(shard);
-  const values = {id, slot, version: replicaVersion};
+  const values: Partial<v.Infer<typeof fullReplicaRowSchema>> = {
+    id,
+    slot,
+    version: replicaVersion,
+    generation: replicaVersion,
+    backupPath: id,
+  };
   await sql`INSERT INTO ${sql(schema)}.replicas ${sql(values)}`;
 }
 
@@ -288,7 +322,7 @@ export async function initReplica(
 }
 
 /**
- * Gets the latest initialized replica at the specified version.
+ * Gets the latest (by rank) initialized replica at the specified version.
  */
 export async function getReplicaAtVersion(
   lc: LogContext,
@@ -304,6 +338,8 @@ export async function getReplicaAtVersion(
       replicas."rank",
       replicas."slot",
       replicas."version",
+      replicas."generation",
+      replicas."backupPath",
       replicas."initialSchema",
       replicas."initialSyncContext",
       replicas."subscriberContext",
@@ -326,6 +362,55 @@ export async function getReplicaAtVersion(
     return null;
   }
   return v.parse(result[0], replicaSchema, 'passthrough');
+}
+
+export async function getActiveReplicas(
+  lc: LogContext,
+  sql: PostgresDB,
+  shard: ShardID,
+): Promise<ReplicaState[]> {
+  const schema = sql(upstreamSchema(shard));
+  const results = await sql`
+    SELECT
+      replicas."id",
+      replicas."rank",
+      replicas."slot",
+      replicas."version",
+      replicas."generation",
+      replicas."backupPath",
+      slots."active",
+      slots."confirmed_flush_lsn" as "confirmedFlushLsn"
+    FROM ${schema}.replicas JOIN pg_replication_slots slots ON slot = slot_name
+      WHERE "initialSyncContext" IS NOT NULL
+      ORDER BY generation DESC, confirmed_flush_lsn DESC;
+  `;
+  const replicas = v.parse(results, v.array(replicaStateSchema), 'passthrough');
+  lc.info?.(`current replicas`, {replicas});
+  return replicas;
+}
+
+export async function getReplicaState(
+  sql: PostgresDB,
+  shard: ShardID,
+  id: string,
+): Promise<ReplicaState | null> {
+  const schema = sql(upstreamSchema(shard));
+  const results = await sql`
+    SELECT
+      replicas."id",
+      replicas."rank",
+      replicas."slot",
+      replicas."version",
+      replicas."generation",
+      replicas."backupPath",
+      slots."active",
+      slots."confirmed_flush_lsn" as "confirmedFlushLsn"
+    FROM ${schema}.replicas JOIN pg_replication_slots slots ON slot = slot_name
+      WHERE "id" = ${id};
+  `;
+  return results.length
+    ? v.parse(results[0], replicaStateSchema, 'passthrough')
+    : null;
 }
 
 export async function getInternalShardConfig(

--- a/packages/zero-cache/src/services/change-source/pg/sync-schema.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/sync-schema.pg.test.ts
@@ -122,8 +122,8 @@ describe('change-streamer/pg/sync-schema', () => {
           createSilentLogContext(),
           'test',
           replicaFile.path,
-          (log, tx) =>
-            initialSync(
+          async (log, tx) => {
+            await initialSync(
               log,
               shard,
               tx,
@@ -132,7 +132,8 @@ describe('change-streamer/pg/sync-schema', () => {
                 tableCopyWorkers: 5,
               },
               TEST_CONTEXT,
-            ),
+            );
+          },
         );
 
         await expectTables(upstream, c.upstreamPostState);

--- a/packages/zero-cache/src/services/life-cycle.ts
+++ b/packages/zero-cache/src/services/life-cycle.ts
@@ -159,8 +159,11 @@ export class ProcessManager {
     };
   }
 
-  done() {
-    return this.#runningState.stopped();
+  async shutdown() {
+    if (this.#drainStart === 0) {
+      this.#startDrain(GRACEFUL_SHUTDOWN[0]);
+    }
+    await this.#runningState.stopped();
   }
 
   #exit(code: number) {

--- a/packages/zero-cache/src/services/litestream/commands.ts
+++ b/packages/zero-cache/src/services/litestream/commands.ts
@@ -124,7 +124,7 @@ export async function tryRestore(
   lc: LogContext,
   config: LitestreamConfig,
   replicaFile: string,
-  replicaConstraints: ReplicaConstraints,
+  replicaConstraints: ReplicaConstraints | undefined,
   role: LitestreamRole,
 ): Promise<RestoreAttempt> {
   const {backupURL} = config;
@@ -252,31 +252,35 @@ export async function tryRestore(
 function replicaIsValid(
   lc: LogContext,
   replica: string,
-  constraints: ReplicaConstraints,
+  constraints: ReplicaConstraints | undefined,
 ) {
   let db: Database | undefined;
   try {
+    // Note: Open the database and read the subscription state as a
+    // sanity / corruption check, even if there are no constraints.
     db = new Database(lc, replica);
     const {replicaVersion, watermark} = getSubscriptionState(
       new StatementRunner(db),
     );
-    if (replicaVersion !== constraints.replicaVersion) {
-      lc.warn?.(
-        `Local replica version ${replicaVersion} does not match expected replicaVersion ${constraints.replicaVersion}`,
+    if (constraints) {
+      if (replicaVersion !== constraints.replicaVersion) {
+        lc.warn?.(
+          `Local replica version ${replicaVersion} does not match expected replicaVersion ${constraints.replicaVersion}`,
+          constraints,
+        );
+        return false;
+      }
+      if (watermark < constraints.minWatermark) {
+        lc.warn?.(
+          `Local replica watermark ${watermark} is earlier than minWatermark ${constraints.minWatermark}`,
+        );
+        return false;
+      }
+      lc.info?.(
+        `Local replica at version ${replicaVersion} and watermark ${watermark} is compatible`,
         constraints,
       );
-      return false;
     }
-    if (watermark < constraints.minWatermark) {
-      lc.warn?.(
-        `Local replica watermark ${watermark} is earlier than minWatermark ${constraints.minWatermark}`,
-      );
-      return false;
-    }
-    lc.info?.(
-      `Local replica at version ${replicaVersion} and watermark ${watermark} is compatible`,
-      constraints,
-    );
     return true;
   } catch (e) {
     if (isSQLiteCorruption(e)) {

--- a/packages/zero-cache/src/test/pg-bench.pg.test.ts
+++ b/packages/zero-cache/src/test/pg-bench.pg.test.ts
@@ -58,15 +58,16 @@ for (const {fixture, table, indexes, id} of [
           lc,
           `${fixture.fixture}-bench-fixture`,
           replicaFile.path,
-          (log, tx) =>
-            initialSync(
+          async (log, tx) => {
+            await initialSync(
               log,
               shard,
               tx,
               getConnectionURI(upstream),
               {tableCopyWorkers: 2},
               {test: 'pg-bench-fixture-validation'},
-            ),
+            );
+          },
         );
 
         expect(


### PR DESCRIPTION
Associates each initial-sync / replication slot with a unique subpath when backing up with litestream, e.g. `s3://bucket/<timestamp>/`, with backwards-compatible support for using the base `litestream.backupURL` for existing/legacy replication slots.

This achieves forwards-compatibility with litestream-v5 managed backups on RMv2, i.e. a rollback to RMv1 can correctly restore from an RMv2-created replica by understanding the subpath at which the replica was backed up.

> ⚠️ Backups in old folders are not automatically cleaned up with a new initial-sync (nor will they be with RMv2's per-task replicas), so an independent garbage collection mechanism, such as a 1-day life-cycle expiration policy on s3, is recommended for litestream backup files.

### Implementation notes
* A new `backupURL` column is added to the upstream `replicas` table. This is where the replica-specific backup subpath is assigned.
  * (The new `generation` column is added purely to replace the `version` column to migrate to RMv2 terminology. It is not actually relevant to the newly introduced behavior)
* The (litestream) restore logic is pushed into the change-source implementation, as the backup location to restore from is now upstream-specific, and not simply the `backupURL` specified in the runtime config.
  * At the moment, the custom change-source implementation does not support replica-specific backups.
* Similarly, the backup-replicator and litestream (replicate) workers are started as children of the change-streamer process  rather than its siblings, as the litestream backup destination is determined from the change-source initialization logic. 

In addition to allowing the `replicate` destination to diverge from the `restore` destination (as will be required for RMv2), having the change-streamer manage the backup replicator/litestream workers will also facilitate delaying server readiness until a newly initialized replica has been backed up to litestream (a planned improvement).

### Tangential

Support for migrating from a very-old v6 upstream replica (code from before Feb 2025) has been removed in order to simplify the initialization logic.
