### PR TITLE
perf(zero-server): introspect the server schema from pg_catalog

### DIFF
--- a/packages/zero-server/src/custom.test.ts
+++ b/packages/zero-server/src/custom.test.ts
@@ -385,7 +385,7 @@ describe('CRUDMutatorFactory', () => {
     const factory = new CRUDMutatorFactory(simpleSchema);
     const {mockTx} = createMockTx();
 
-    // Mock the information_schema query that getServerSchema uses
+    // Mock the introspection query that getServerSchema uses
     const mockSchemaRows = [
       {
         schema: 'public',
@@ -431,7 +431,7 @@ describe('CRUDMutatorFactory', () => {
     const originalQuery = mockTx.query;
     mockTx.query = vi.fn((...args: unknown[]) => {
       const sql = args[0] as string;
-      if (sql.includes('information_schema')) {
+      if (sql.includes('pg_attribute')) {
         return Promise.resolve(mockSchemaRows);
       }
       return originalQuery.apply(
@@ -450,7 +450,7 @@ describe('CRUDMutatorFactory', () => {
     // Verify mutate works
     void tx.mutate.basic.insert({id: '1', a: 1, b: 'test'});
 
-    // The information_schema query + the insert
+    // The introspection query + the insert
     expect(mockTx.query).toHaveBeenCalled();
   });
 
@@ -520,7 +520,7 @@ describe('CRUDMutatorFactory', () => {
         wrappedTransaction: null,
         query: (...args: unknown[]) => {
           const sql = args[0] as string;
-          if (sql.includes('information_schema')) {
+          if (sql.includes('pg_attribute')) {
             serverSchemaFetchCount++;
             return Promise.resolve(mockSchemaRows);
           }
@@ -614,7 +614,7 @@ describe('CRUDMutatorFactory', () => {
         wrappedTransaction: null,
         query: (...args: unknown[]) => {
           const sql = args[0] as string;
-          if (sql.includes('information_schema')) {
+          if (sql.includes('pg_attribute')) {
             serverSchemaFetchCount++;
             return Promise.resolve(mockSchemaRows);
           }

--- a/packages/zero-server/src/schema.pg.test.ts
+++ b/packages/zero-server/src/schema.pg.test.ts
@@ -1,0 +1,249 @@
+import {beforeEach, describe, expect, test} from 'vitest';
+import {testDBs} from '../../zero-cache/src/test/db.ts';
+import type {PostgresDB} from '../../zero-cache/src/types/pg.ts';
+import {serverSchemaQuery} from './schema.ts';
+
+type Row = Record<string, unknown>;
+
+// A catalog that exercises every branch of the expressions in
+// serverSchemaQuery: domains (including over enums, arrays and parameterized
+// types), enum arrays, composite types, extension types, the bit / varbit and
+// float / integer precision special cases, views, dropped and generated
+// columns, and a table outside the public schema.
+const catalogSql = /*sql*/ `
+CREATE EXTENSION IF NOT EXISTS citext;
+
+CREATE SCHEMA alternate_schema;
+
+CREATE TYPE mood AS ENUM ('happy', 'sad');
+CREATE TYPE point3 AS (x FLOAT8, y FLOAT8, z FLOAT8);
+
+CREATE DOMAIN short_text AS VARCHAR(10);
+CREATE DOMAIN exact_amount AS NUMERIC(8, 3);
+CREATE DOMAIN a_mood AS mood;
+CREATE DOMAIN int_array AS INT4[];
+CREATE DOMAIN counter AS BIGINT;
+
+CREATE TABLE numbers (
+  id SERIAL PRIMARY KEY,
+  int_2 SMALLINT,
+  int_4 INTEGER,
+  int_8 BIGINT,
+  float_4 REAL,
+  float_8 DOUBLE PRECISION,
+  exact NUMERIC(8, 3),
+  inexact NUMERIC
+);
+
+CREATE TABLE strings (
+  id TEXT PRIMARY KEY,
+  fixed CHAR(10),
+  varying VARCHAR(20),
+  unbounded TEXT,
+  unbounded_bpchar BPCHAR,
+  insensitive CITEXT,
+  bits BIT(8),
+  varbits BIT VARYING(16),
+  blob BYTEA
+);
+
+CREATE TABLE exotic (
+  id UUID PRIMARY KEY,
+  state mood,
+  states mood[],
+  coords point3,
+  ip INET,
+  mac MACADDR,
+  doc JSON,
+  docb JSONB,
+  tags TEXT[],
+  amounts NUMERIC(8, 3)[],
+  moment TIMESTAMPTZ,
+  day DATE,
+  span INTERVAL
+);
+
+CREATE TABLE domains (
+  id short_text PRIMARY KEY,
+  amount exact_amount,
+  state a_mood,
+  states a_mood[],
+  numbers int_array,
+  hits counter
+);
+
+CREATE TABLE quirks (
+  id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  doubled INTEGER GENERATED ALWAYS AS (id * 2) STORED,
+  kept TEXT,
+  dropped TEXT
+);
+ALTER TABLE quirks DROP COLUMN dropped;
+
+CREATE VIEW numbers_view AS SELECT id, exact FROM numbers;
+CREATE MATERIALIZED VIEW numbers_matview AS SELECT id FROM numbers;
+
+CREATE TABLE alternate_schema.numbers (LIKE numbers);
+`;
+
+const tables = [
+  ['public', 'numbers'],
+  ['public', 'strings'],
+  ['public', 'exotic'],
+  ['public', 'domains'],
+  ['public', 'quirks'],
+  ['public', 'numbers_view'],
+  ['public', 'numbers_matview'],
+  ['alternate_schema', 'numbers'],
+] as const;
+
+// The information_schema query that serverSchemaQuery replaced, kept so that
+// the replacement can be diffed against it. The table pairs are inlined because
+// the two queries do not bind their parameters in the same order.
+function informationSchemaQuery(
+  schemaTablePairs: readonly (readonly [string, string])[],
+) {
+  const inClause = schemaTablePairs
+    .map(([schema, table]) => `('${schema}'::text, '${table}'::text)`)
+    .join(',');
+  return /*sql*/ `
+      SELECT
+          c.table_schema::text AS schema,
+          c.table_name::text AS table,
+          c.column_name::text AS column,
+          c.data_type::text AS "dataType",
+          c.character_maximum_length AS length,
+          c.numeric_precision AS precision,
+          c.numeric_scale AS scale,
+          t.typtype::text AS typtype,
+          t.typname::text AS typename,
+          CASE WHEN t.typelem <> 0 THEN et.typtype::text ELSE NULL END AS "elemTyptype",
+          CASE WHEN t.typelem <> 0 THEN et.typname::text ELSE NULL END AS "elemTypname"
+      FROM
+          information_schema.columns c
+      JOIN
+          pg_catalog.pg_type t ON c.udt_name = t.typname
+      LEFT JOIN
+          pg_catalog.pg_type et ON t.typelem = et.oid
+      JOIN
+          pg_catalog.pg_namespace n ON t.typnamespace = n.oid
+      WHERE
+          (c.table_schema, c.table_name) IN (${inClause})
+    `;
+}
+
+function sorted(rows: readonly Row[]) {
+  return rows.toSorted((a, b) =>
+    `${a.schema}.${a.table}.${a.column}`.localeCompare(
+      `${b.schema}.${b.table}.${b.column}`,
+    ),
+  );
+}
+
+function run(pg: PostgresDB, pairs: readonly (readonly [string, string])[]) {
+  const {text, values} = serverSchemaQuery(pairs);
+  return pg.unsafe(text, values as string[]);
+}
+
+describe('serverSchemaQuery', () => {
+  let pg: PostgresDB;
+
+  beforeEach(async () => {
+    pg = await testDBs.create('server-schema-query-test');
+    await pg.unsafe(catalogSql);
+  });
+
+  test('returns what information_schema returned', async () => {
+    const actual = await run(pg, tables);
+    const expected = await pg.unsafe(informationSchemaQuery(tables));
+
+    expect(sorted(actual)).toEqual(sorted(expected));
+
+    // Guard against both queries being wrong in the same way.
+    const columns = actual.map(r => `${r.table}.${r.column}`);
+    expect(columns).toContain('numbers_view.exact'); // views are included
+    expect(columns).toContain('quirks.doubled'); // so are generated columns
+    expect(columns).not.toContain('quirks.dropped'); // dropped columns are not
+    expect(columns).not.toContain('numbers_matview.id'); // nor are matviews
+  });
+
+  test.each([
+    // integers report a precision and a scale, floats only a precision
+    ['numbers.int_2', {dataType: 'smallint', precision: 16, scale: 0}],
+    ['numbers.int_8', {dataType: 'bigint', precision: 64, scale: 0}],
+    ['numbers.float_4', {dataType: 'real', precision: 24, scale: null}],
+    [
+      'numbers.float_8',
+      {dataType: 'double precision', precision: 53, scale: null},
+    ],
+    ['numbers.exact', {dataType: 'numeric', precision: 8, scale: 3}],
+    ['numbers.inexact', {dataType: 'numeric', precision: null, scale: null}],
+    // char and varchar subtract the header from their typmod, bit and varbit
+    // do not
+    ['strings.fixed', {dataType: 'character', length: 10, typename: 'bpchar'}],
+    [
+      'strings.varying',
+      {dataType: 'character varying', length: 20, typename: 'varchar'},
+    ],
+    ['strings.unbounded_bpchar', {dataType: 'character', length: null}],
+    ['strings.bits', {dataType: 'bit', length: 8}],
+    ['strings.varbits', {dataType: 'bit varying', length: 16}],
+    // types outside pg_catalog are USER-DEFINED, and typtype identifies them
+    ['strings.insensitive', {dataType: 'USER-DEFINED', typename: 'citext'}],
+    ['exotic.state', {dataType: 'USER-DEFINED', typtype: 'e'}],
+    ['exotic.coords', {dataType: 'USER-DEFINED', typtype: 'c'}],
+    [
+      'exotic.states',
+      {dataType: 'ARRAY', elemTyptype: 'e', elemTypname: 'mood'},
+    ],
+    // arrays report no precision or scale, even when their element type has one
+    [
+      'exotic.amounts',
+      {dataType: 'ARRAY', elemTypname: 'numeric', precision: null, scale: null},
+    ],
+    // domains report their base type
+    [
+      'domains.id',
+      {dataType: 'character varying', length: 10, typename: 'varchar'},
+    ],
+    [
+      'domains.amount',
+      {dataType: 'numeric', precision: 8, scale: 3, typename: 'numeric'},
+    ],
+    [
+      'domains.state',
+      {dataType: 'USER-DEFINED', typtype: 'e', typename: 'mood'},
+    ],
+    // an array of a domain is not itself a domain, so the element type is the
+    // domain rather than what the domain wraps
+    [
+      'domains.states',
+      {dataType: 'ARRAY', elemTyptype: 'd', elemTypname: 'a_mood'},
+    ],
+    ['domains.numbers', {dataType: 'ARRAY', elemTypname: 'int4'}],
+    ['domains.hits', {dataType: 'bigint', precision: 64, scale: 0}],
+  ] as const)('%s', async (column, expected) => {
+    const rows = await run(pg, tables);
+    const [table, name] = column.split('.');
+    expect(
+      rows.find(r => r.table === table && r.column === name),
+    ).toMatchObject(expected);
+  });
+
+  test('does not duplicate columns whose type name is ambiguous', async () => {
+    // udt_name only carries a type's name, so joining pg_type on it matched
+    // every schema that declares a type with that name.
+    await pg.unsafe(`CREATE TYPE alternate_schema.mood AS ENUM ('meh')`);
+
+    const rows = await run(pg, [['public', 'exotic']]);
+    expect(rows.filter(r => r.column === 'state')).toEqual([
+      expect.objectContaining({typtype: 'e', typename: 'mood'}),
+    ]);
+
+    expect(
+      (await pg.unsafe(informationSchemaQuery([['public', 'exotic']]))).filter(
+        r => r.column === 'state',
+      ),
+    ).toHaveLength(2);
+  });
+});

--- a/packages/zero-server/src/schema.ts
+++ b/packages/zero-server/src/schema.ts
@@ -136,7 +136,9 @@ export function serverSchemaQuery(
   // the single level domain unwrap that data_type and udt_name perform (`ut`),
   // and the view's own relkind, attnum and privilege filters. pg_type is joined
   // by OID rather than by udt_name, which additionally avoids duplicate rows
-  // when two schemas declare a type with the same name.
+  // when two schemas declare a type with the same name. The types those
+  // functions special case are named through regtype, which the parser resolves
+  // while planning.
   const query = sql`
       SELECT
           n.nspname::text AS schema,
@@ -149,20 +151,20 @@ export function serverSchemaQuery(
           END::text AS "dataType",
           CASE
               WHEN tm.typmod = -1 THEN NULL
-              WHEN ut.oid IN (1042, 1043) THEN tm.typmod - 4
-              WHEN ut.oid IN (1560, 1562) THEN tm.typmod
+              WHEN ut.oid IN ('pg_catalog.bpchar'::regtype, 'pg_catalog.varchar'::regtype) THEN tm.typmod - 4
+              WHEN ut.oid IN ('pg_catalog.bit'::regtype, 'pg_catalog.varbit'::regtype) THEN tm.typmod
           END AS length,
           CASE ut.oid
-              WHEN 21 THEN 16
-              WHEN 23 THEN 32
-              WHEN 20 THEN 64
-              WHEN 700 THEN 24
-              WHEN 701 THEN 53
-              WHEN 1700 THEN CASE WHEN tm.typmod = -1 THEN NULL ELSE ((tm.typmod - 4) >> 16) & 65535 END
+              WHEN 'pg_catalog.int2'::regtype THEN 16
+              WHEN 'pg_catalog.int4'::regtype THEN 32
+              WHEN 'pg_catalog.int8'::regtype THEN 64
+              WHEN 'pg_catalog.float4'::regtype THEN 24
+              WHEN 'pg_catalog.float8'::regtype THEN 53
+              WHEN 'pg_catalog.numeric'::regtype THEN CASE WHEN tm.typmod = -1 THEN NULL ELSE ((tm.typmod - 4) >> 16) & 65535 END
           END AS precision,
           CASE
-              WHEN ut.oid IN (21, 23, 20) THEN 0
-              WHEN ut.oid = 1700 AND tm.typmod <> -1 THEN (tm.typmod - 4) & 65535
+              WHEN ut.oid IN ('pg_catalog.int2'::regtype, 'pg_catalog.int4'::regtype, 'pg_catalog.int8'::regtype) THEN 0
+              WHEN ut.oid = 'pg_catalog.numeric'::regtype AND tm.typmod <> -1 THEN (tm.typmod - 4) & 65535
           END AS scale,
           ut.typtype::text AS typtype,
           ut.typname::text AS typename,

--- a/packages/zero-server/src/schema.ts
+++ b/packages/zero-server/src/schema.ts
@@ -48,39 +48,7 @@ export async function getServerSchema<S extends Schema>(
     return {}; // No pairs to query for
   }
 
-  // Cast all inputs to text and all outputs to text to avoid
-  // any conversions customer's DBTransaction impl has on other types.
-  const inClause = sql.join(
-    schemaTablePairs.map(
-      ([schema, table]) => sql`(${schema}::text, ${table}::text)`,
-    ),
-    ',',
-  );
-  const query = sql`
-      SELECT
-          c.table_schema::text AS schema,
-          c.table_name::text AS table,
-          c.column_name::text AS column,
-          c.data_type::text AS "dataType",
-          c.character_maximum_length AS length,
-          c.numeric_precision AS precision,
-          c.numeric_scale AS scale,
-          t.typtype::text AS typtype,
-          t.typname::text AS typename,
-          CASE WHEN t.typelem <> 0 THEN et.typtype::text ELSE NULL END AS "elemTyptype",
-          CASE WHEN t.typelem <> 0 THEN et.typname::text ELSE NULL END AS "elemTypname"
-      FROM
-          information_schema.columns c
-      JOIN
-          pg_catalog.pg_type t ON c.udt_name = t.typname
-      LEFT JOIN
-          pg_catalog.pg_type et ON t.typelem = et.oid
-      JOIN
-          pg_catalog.pg_namespace n ON t.typnamespace = n.oid
-      WHERE
-          (c.table_schema, c.table_name) IN (${inClause})
-    `;
-  const {text, values} = formatPg(query);
+  const {text, values} = serverSchemaQuery(schemaTablePairs);
   const results: Iterable<ServerSchemaRow> = (await dbTransaction.query(
     text,
     values,
@@ -139,6 +107,93 @@ export async function getServerSchema<S extends Schema>(
   assert(errors.length === 0, () => makeSchemaIncompatibleErrorMessage(errors));
 
   return serverSchema;
+}
+
+/**
+ * The query behind {@linkcode getServerSchema}, exported so that it can be
+ * diffed against the `information_schema` query it replaced.
+ */
+export function serverSchemaQuery(
+  schemaTablePairs: readonly (readonly [string, string])[],
+): {text: string; values: unknown[]} {
+  // Cast all inputs to text and all outputs to text to avoid
+  // any conversions customer's DBTransaction impl has on other types.
+  const inClause = sql.join(
+    schemaTablePairs.map(
+      ([schema, table]) => sql`(${schema}::text, ${table}::text)`,
+    ),
+    ',',
+  );
+  // Read pg_catalog directly instead of information_schema.columns. The view
+  // derives every column it returns through the information_schema._pg_*
+  // functions and a per column privilege check, which is several times slower
+  // than the query below. Server processes run this on the first transaction
+  // they serve, so serverless deployments pay for it on every cold start.
+  //
+  // The expressions below reproduce the parts of the view's definition that we
+  // select, down to the int4 wire types of length, precision and scale: the
+  // _pg_char_max_length / _pg_numeric_precision / _pg_numeric_scale arithmetic,
+  // the single level domain unwrap that data_type and udt_name perform (`ut`),
+  // and the view's own relkind, attnum and privilege filters. pg_type is joined
+  // by OID rather than by udt_name, which additionally avoids duplicate rows
+  // when two schemas declare a type with the same name.
+  const query = sql`
+      SELECT
+          n.nspname::text AS schema,
+          cl.relname::text AS table,
+          a.attname::text AS column,
+          CASE
+              WHEN ut.typelem <> 0 AND ut.typlen = -1 THEN 'ARRAY'
+              WHEN nut.nspname = 'pg_catalog' THEN pg_catalog.format_type(ut.oid, NULL)
+              ELSE 'USER-DEFINED'
+          END::text AS "dataType",
+          CASE
+              WHEN tm.typmod = -1 THEN NULL
+              WHEN ut.oid IN (1042, 1043) THEN tm.typmod - 4
+              WHEN ut.oid IN (1560, 1562) THEN tm.typmod
+          END AS length,
+          CASE ut.oid
+              WHEN 21 THEN 16
+              WHEN 23 THEN 32
+              WHEN 20 THEN 64
+              WHEN 700 THEN 24
+              WHEN 701 THEN 53
+              WHEN 1700 THEN CASE WHEN tm.typmod = -1 THEN NULL ELSE ((tm.typmod - 4) >> 16) & 65535 END
+          END AS precision,
+          CASE
+              WHEN ut.oid IN (21, 23, 20) THEN 0
+              WHEN ut.oid = 1700 AND tm.typmod <> -1 THEN (tm.typmod - 4) & 65535
+          END AS scale,
+          ut.typtype::text AS typtype,
+          ut.typname::text AS typename,
+          CASE WHEN ut.typelem <> 0 THEN et.typtype::text ELSE NULL END AS "elemTyptype",
+          CASE WHEN ut.typelem <> 0 THEN et.typname::text ELSE NULL END AS "elemTypname"
+      FROM
+          pg_catalog.pg_attribute a
+      JOIN
+          pg_catalog.pg_class cl ON cl.oid = a.attrelid
+      JOIN
+          pg_catalog.pg_namespace n ON n.oid = cl.relnamespace
+      JOIN
+          pg_catalog.pg_type t ON t.oid = a.atttypid
+      JOIN
+          pg_catalog.pg_type ut ON ut.oid = CASE WHEN t.typtype = 'd' THEN t.typbasetype ELSE t.oid END
+      JOIN
+          pg_catalog.pg_namespace nut ON nut.oid = ut.typnamespace
+      LEFT JOIN
+          pg_catalog.pg_type et ON et.oid = ut.typelem
+      CROSS JOIN LATERAL
+          (SELECT CASE WHEN t.typtype = 'd' THEN t.typtypmod ELSE a.atttypmod END AS typmod) tm
+      WHERE
+          a.attnum > 0
+          AND NOT a.attisdropped
+          AND cl.relkind IN ('r', 'v', 'f', 'p')
+          AND NOT pg_catalog.pg_is_other_temp_schema(n.oid)
+          AND (pg_catalog.pg_has_role(cl.relowner, 'USAGE')
+               OR pg_catalog.has_column_privilege(cl.oid, a.attnum, 'SELECT, INSERT, UPDATE, REFERENCES'))
+          AND (n.nspname, cl.relname) IN (${inClause})
+    `;
+  return formatPg(query);
 }
 
 function makeSchemaIncompatibleErrorMessage(


### PR DESCRIPTION
Issues are disabled on this repo, so the problem statement is inline rather than in a linked issue.

## Problem

`getServerSchema` introspects the server schema through `information_schema.columns`. Server processes run it on the first transaction they serve, so on serverless deployments it runs once per worker per route, on every cold start.

`CRUDMutatorFactory` caches the result per factory instance, so a long-lived process pays once. On Vercel Fluid / Lambda style workers the process *is* the cache lifetime, so the query runs again on every push-handler cold start, every custom-query route cold start, and every worker recycle (scale to zero, deploy, memory pressure). The per-call cost gets multiplied by request fan-out and deploy frequency.

Measured on a production healthcare SaaS on Postgres (517 tables), API on serverless functions, connecting as a non-superuser application role:

- **10,500 executions/day** of this one statement against a single database
- **~430 ms** mean execution time
- **37-40% of total database time** — the largest single source of load, ahead of every application query
- a second deployment recorded **106K executions in a 3 hour window** during a period of frequent deploys

`information_schema.columns` is a view over `pg_attribute` that derives `data_type`, `character_maximum_length`, `numeric_precision`, `numeric_scale` and `udt_name` through the `information_schema._pg_*` SQL functions and applies `has_column_privilege` per column. `zero-cache` already moved publication introspection off it in #1484 for the same reason ("the raw `pg_catalog` tables […] the former is much faster"); this query is on the request path.

Separately, `JOIN pg_catalog.pg_type t ON c.udt_name = t.typname` joins by type *name*, so a column whose type name is not unique in the database yields one row per matching schema and `getServerSchema` keeps whichever row arrives last.

## What changed

- The query now reads `pg_catalog.pg_attribute` / `pg_class` / `pg_namespace` / `pg_type` and joins `pg_type` by OID. It reproduces the view's definition for the columns Zero selects: the `_pg_char_max_length` / `_pg_numeric_precision` / `_pg_numeric_scale` arithmetic, the single level domain unwrap that `data_type` and `udt_name` perform, and the view's own `relkind`, `attnum`, `attisdropped`, temp-schema and privilege filters.
- The SQL moved into an exported `serverSchemaQuery()` so it can be tested directly, the way `publishedSchemaQuery` is in `zero-cache`. `getServerSchema`'s behavior is unchanged.
- New `packages/zero-server/src/schema.pg.test.ts`.
- Three mocks in `custom.test.ts` recognized the introspection query with `sql.includes('information_schema')`; they now match on `pg_attribute`.

Results are unchanged, down to the wire types: `length`, `precision` and `scale` stay `int4` (`information_schema` returns them as the `cardinal_number` domain over `int4`, which drivers surface as numbers), everything else stays `::text`.

## Equivalence

`schema.pg.test.ts` runs both queries — the new one and a verbatim copy of the one it replaces — against the same database and asserts strict deep equality of all 11 columns over 49 columns of a catalog built to hit every branch: domains over `varchar(n)`, `numeric(p,s)`, an enum, an array and `bigint`; enum arrays, domain arrays, `numeric(p,s)` arrays; composite types; an extension type (`citext`); `bit(n)` / `bit varying(n)` (whose typmod is *not* offset by 4, unlike `char` / `varchar`); `real` / `double precision` (which report binary precision 24 / 53); `smallint` / `integer` / `bigint` (which report scale 0); unparameterized `numeric` (null precision and scale); a view; a materialized view; a generated column; a dropped column; and a table outside `public`. A second test pins the values the compatibility check actually reads, per column, and a third covers the ambiguous type name case.

Before this PR we validated the same query against real data: field-by-field over 1,306 columns / 75 tables of the production database above, then over its whole catalog (8,762 columns) with the table filter removed — zero differences either time. Repeated for this PR on a synthetic 500 table catalog (8,073 columns, 900 in scope): `EXCEPT ALL` empty in both directions.

## Performance

Stock `postgres:17` container, 2,000 tables / 26,073 columns, 75 tables requested, as a role that owns nothing, 6 runs each:

| query | execution time |
| --- | --- |
| `information_schema.columns` | 10.3 – 13.9 ms |
| `pg_catalog` | 1.9 – 2.1 ms |

On the production database the same comparison was ~430 ms → ~11 ms at its 75 table scope, and 1,871 ms → 109 ms introspecting the whole 517 table catalog.

## Testing

`pnpm --filter zero-server run test` — 425 tests pass across the `pg-15`, `pg-16`, `pg-17`, `pg-18` and `no-pg` projects (Docker testcontainers, local macOS). `check-types`, `lint`, `check-format` and `verify-deps` are clean. I have not run the full repo suite or the browser/perf projects.

## Notes

- This query is running in our production deployment, applied to the published `@rocicorp/zero` build with `patch-package` plus a build-time guard that fails if the patch does not apply, so the SQL here is what is in production rather than a fresh translation.
- Materialized views stay excluded, because `information_schema.columns` excludes `relkind = 'm'` and the replacement keeps that filter. Same for other sessions' temp tables.
- Longer term, caching the schema beyond the process lifetime would attack the same problem from the other side and compose with this. That needs an invalidation story; making the query cheap does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
