### PR TITLE
chore(rmv2): put the sqlite change-log in the change-streamer

### DIFF
--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -224,11 +224,11 @@ export default async function runWorker(
         // TODO: Make deleteLiteDB work with litestream. It will probably have to be
         //       a semantic wipe instead of a file delete.
         deleteLiteDB(replica.file);
-        // The change log is anchored to the replica it was written beside, and
-        // the retry performs a fresh initial sync with a new replicaVersion.
-        // Reconciliation would catch that on its own (as
-        // 'replica-version-mismatch') but only after the writer opened a file
-        // that is known here to be garbage.
+        // The change log carries the identity of the replica it was written
+        // beside, and the retry performs a fresh initial sync with a new
+        // replicaVersion. Reconciliation would catch that on its own (as
+        // 'identity-mismatch') but only after the writer opened a file that is
+        // known here to be garbage.
         deleteChangeLogDB(replica.file);
         // Release the purge lock before retrying. This is safe because the
         // purge lock exists to preserve change-log entries so the new

--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -9,6 +9,7 @@ import {deleteLiteDB} from '../db/delete-lite-db.ts';
 import {registerSQLiteCorruptionDiagnosticTarget} from '../db/sqlite-corruption.ts';
 import {warmupConnections} from '../db/warmup.ts';
 import {initEventSink, publishCriticalEvent} from '../observability/events.ts';
+import {getOrCreateGauge} from '../observability/metrics.ts';
 import {initializeCustomChangeSource} from '../services/change-source/custom/change-source.ts';
 import {initializePostgresChangeSource} from '../services/change-source/pg/change-source.ts';
 import {createBackupCleanupMonitor} from '../services/change-streamer/backup-cleanup-monitor-factory.ts';
@@ -33,6 +34,7 @@ import {
   replicationStatusError,
   ReplicationStatusPublisher,
 } from '../services/replicator/replication-status.ts';
+import {sqliteFileBytes} from '../services/replicator/sqlite-change-log-observability.ts';
 import {connectPgClient} from '../types/pg.ts';
 import {
   childWorker,
@@ -66,6 +68,7 @@ export default async function runWorker(
       backPressureLimitHeapProportion,
       flowControlConsensusPaddingSeconds,
       flowControlEventDrivenRelease,
+      sqliteChangeLogMode,
       sqliteChangeLogReadBatchRows,
       sqliteChangeLogBarrierTimeoutMs,
     },
@@ -119,11 +122,32 @@ export default async function runWorker(
   let backupURL: string | undefined;
 
   const context = getServerContext(config);
+  const sqliteChangeLogEnabled = sqliteChangeLogMode !== 'off';
+  if (sqliteChangeLogEnabled) {
+    const changeLogFile = changeLogFileName(replica.file);
+    registerSQLiteCorruptionDiagnosticTarget({
+      debugName: 'change-streamer change-log',
+      dbPath: changeLogFile,
+    });
+    // The log's bytes are accounted for in the process that writes them. This
+    // is local disk only — the log is excluded from the litestream backup — and
+    // it is a whole-database total, because a table that left the replica left
+    // through its wal: the replica's footprint is what shrank and this is where
+    // it went.
+    getOrCreateGauge('replica', 'sqlite_change_log.file_bytes', {
+      description:
+        `The SQLite change log's total on-disk footprint: its main db file ` +
+        `plus its wal sidecars.`,
+      unit: 'By',
+    }).addCallback(async o =>
+      o.observe(await sqliteFileBytes(lc, changeLogFile)),
+    );
+  }
 
   for (const first of [true, false]) {
     try {
       // Note: This performs initial sync of the replica if necessary.
-      const {changeSource, subscriptionState, destinationBackupURL} =
+      const {changeSource, subscriptionState, destinationBackupURL, replicaID} =
         upstream.type === 'pg'
           ? await initializePostgresChangeSource(
               lc,
@@ -174,6 +198,21 @@ export default async function runWorker(
             readBatchRows: sqliteChangeLogReadBatchRows,
             barrierTimeoutMs: sqliteChangeLogBarrierTimeoutMs,
           },
+          // The presence of these options is the writer's gate. This process
+          // performs the restore and the initial sync, so the replica's
+          // identity is in hand at the moment the log is opened.
+          sqliteChangeLogWriter: sqliteChangeLogEnabled
+            ? {
+                replicaFile: replica.file,
+                identity: {
+                  // RMv2 supplies the epoch; until then the generation and the
+                  // replica ID are the whole of the identity.
+                  epoch: null,
+                  generation: subscriptionState.replicaVersion,
+                  replicaID,
+                },
+              }
+            : undefined,
         },
         setTimeout,
       );

--- a/packages/zero-cache/src/server/main.ts
+++ b/packages/zero-cache/src/server/main.ts
@@ -21,7 +21,6 @@ import {
 } from '../types/processes.ts';
 import {
   createNotifierFrom,
-  createsCanonicalReplicator,
   handleSubscriptionsFrom,
   type ReplicaFileMode,
   subscribeTo,
@@ -108,14 +107,9 @@ export default async function runWorker(
     changeStreamerMode === 'dedicated' && changeStreamerURI === undefined;
   const sqliteChangeLogEnabled =
     config.changeStreamer.sqliteChangeLogMode !== 'off';
-  const hasCanonicalReplicator = createsCanonicalReplicator(
-    runChangeStreamer,
-    litestream.backupURL,
-    numSyncers,
-  );
   assert(
-    !sqliteChangeLogEnabled || hasCanonicalReplicator,
-    'SQLite change-log writing requires this process tree to create a canonical replicator',
+    !sqliteChangeLogEnabled || runChangeStreamer,
+    'SQLite change-log writing requires this process tree to run the change-streamer, which is where the writer lives',
   );
 
   let changeStreamer: Worker | undefined;

--- a/packages/zero-cache/src/server/replicator.ts
+++ b/packages/zero-cache/src/server/replicator.ts
@@ -6,7 +6,6 @@ import {assert} from '../../../shared/src/asserts.ts';
 import {must} from '../../../shared/src/must.ts';
 import {sleep} from '../../../shared/src/sleep.ts';
 import * as v from '../../../shared/src/valita.ts';
-import {Database} from '../../../zqlite/src/db.ts';
 import type {
   LitestreamConfig,
   NormalizedZeroConfig,
@@ -27,24 +26,13 @@ import {
   litestreamRestoreMetricAttrs,
   litestreamRestoreRuns,
 } from '../services/litestream/metrics.ts';
-import {
-  changeLogFileName,
-  deleteChangeLogDB,
-  openChangeLogDB,
-} from '../services/replicator/change-log-db.ts';
+import {deleteChangeLogDB} from '../services/replicator/change-log-db.ts';
 import {ReplicationStatusPublisher} from '../services/replicator/replication-status.ts';
 import {
   ReplicatorService,
   type ReplicatorMode,
 } from '../services/replicator/replicator.ts';
-import {
-  getReplicaChangeLogInfo,
-  getSQLiteChangeLogInfo,
-  logSQLiteChangeLogStartup,
-  recordSQLiteChangeLogReconcile,
-  sqliteFileBytes,
-  SQLiteChangeLogObserver,
-} from '../services/replicator/sqlite-change-log-observability.ts';
+import {sqliteFileBytes} from '../services/replicator/sqlite-change-log-observability.ts';
 import {ThreadWriteWorkerClient} from '../services/replicator/write-worker-client.ts';
 import {
   parentWorker,
@@ -54,11 +42,10 @@ import {
 import {getShardConfig} from '../types/shards.ts';
 import {
   getPragmaConfig,
-  replicaLogsChangeStream,
   replicaFileModeSchema,
+  replicatorDeletesStaleChangeLog,
   setUpMessageHandlers,
   setupReplica,
-  type ReplicaFileMode,
   type WalMode,
 } from '../workers/replicator.ts';
 import {createLogContext} from './logging.ts';
@@ -79,17 +66,8 @@ export default async function runWorker(
   const mode: ReplicatorMode = fileMode === 'backup' ? 'backup' : 'serving';
   const runningLocalChangeStreamer =
     config.changeStreamer.mode === 'dedicated' && !config.changeStreamer.uri;
-  const sqliteChangeLogEnabled =
-    config.changeStreamer.sqliteChangeLogMode !== 'off';
-  const logsChangeStream = replicaLogsChangeStream(
-    fileMode,
-    sqliteChangeLogEnabled,
-    runningLocalChangeStreamer,
-    config.litestream.backupURL,
-  );
-  assert(
-    fileMode !== 'serving-copy' || !logsChangeStream,
-    'serving-copy replicas cannot write the SQLite change log',
+  const deletesStaleChangeLog = replicatorDeletesStaleChangeLog(
+    config.changeStreamer.sqliteChangeLogMode,
   );
   const workerName = `${mode}-replicator`;
   startOtelAuto(createLogContext(config, workerName, 0, false), workerName, 0);
@@ -119,54 +97,19 @@ export default async function runWorker(
     dbPath,
   });
 
-  if (sqliteChangeLogEnabled) {
-    registerSQLiteCorruptionDiagnosticTarget({
-      debugName: `${workerName} change-log`,
-      dbPath: changeLogFileName(dbPath),
-    });
-  } else {
-    // Nothing in this task writes the log, so a file left behind by a run with
-    // the writer enabled would hold local disk indefinitely: it is excluded
-    // from the litestream backup and only the writer purges it. Deleting it is
-    // safe because the log is a cache — re-enabling the writer reseeds at the
-    // replica head — which is also why it is deleted rather than kept around
-    // for a rollback: a stale log is never served, only reseeded.
-    //
-    // The guard is the config rather than the derived `logsChangeStream`.
-    // `logsChangeStream` is false for replicas that coexist with an enabled
-    // writer in the same task (today the serving-copy, whose file is a
-    // different path), so keying deletion on it would delete a live log the
-    // moment a file mode shares the canonical replica's path.
+  if (deletesStaleChangeLog) {
+    // A file left behind by a run with the writer enabled would otherwise hold
+    // local disk indefinitely. See `replicatorDeletesStaleChangeLog` for why
+    // this is keyed on the config flag and nothing else.
     deleteChangeLogDB(dbPath);
   }
 
-  setupMetrics(lc, dbPath, walMode, logsChangeStream);
+  setupMetrics(lc, dbPath, walMode);
 
-  // Create the write worker for async SQLite writes. When the change-log
-  // writer is enabled, init also opens the change-log database beside the
-  // replica and reconciles it against the replica's head.
+  // Create the write worker for async SQLite writes.
   const pragmas = getPragmaConfig(fileMode);
   const workerClient = new ThreadWriteWorkerClient();
-  const reconciled = await workerClient.init(
-    dbPath,
-    mode,
-    logsChangeStream,
-    pragmas,
-    config.log,
-  );
-  if (reconciled) {
-    recordSQLiteChangeLogReconcile(lc, reconciled);
-  }
-
-  // Read after `init`, which creates the change-log database if it is absent
-  // and reconciles it if it is not. Before that call there may be no file to
-  // read, and any head it held would be the pre-reconciliation one.
-  const sqliteChangeLogObserver = readSQLiteChangeLog(
-    lc,
-    dbPath,
-    fileMode,
-    logsChangeStream,
-  );
+  await workerClient.init(dbPath, mode, pragmas, config.log);
 
   const shard = getShardConfig(config);
   const {
@@ -193,12 +136,10 @@ export default async function runWorker(
     mode,
     changeStreamer,
     workerClient,
-    logsChangeStream,
     runningLocalChangeStreamer
       ? // publish ReplicationStatusEvents from backup-replicator only
         ReplicationStatusPublisher.forReplicaFile(dbPath)
       : null,
-    sqliteChangeLogObserver,
   );
 
   setUpMessageHandlers(lc, replicator, parent);
@@ -214,53 +155,7 @@ export default async function runWorker(
   return running;
 }
 
-/**
- * Emits the read-only SQLite change-log startup inspection and, when the writer
- * is enabled, returns an observer seeded with the change log's head and its
- * retained row/byte totals.
- *
- * The totals require a full scan of the change log, so a disabled writer opens
- * no change-log database at all and reports only the replica's own schema and
- * replication state. That path stays best-effort — it warns rather than
- * crashing the replicator — so that `sqliteChangeLogMode=off` remains a safe
- * rollback.
- */
-function readSQLiteChangeLog(
-  lc: LogContext,
-  file: string,
-  fileMode: ReplicaFileMode,
-  logsChangeStream: boolean,
-): SQLiteChangeLogObserver | undefined {
-  using replica = new Database(lc, file, {readonly: true});
-  if (!logsChangeStream) {
-    try {
-      logSQLiteChangeLogStartup(
-        lc,
-        fileMode,
-        false,
-        getReplicaChangeLogInfo(replica),
-      );
-    } catch (e) {
-      lc.warn?.(
-        'SQLite change-log startup inspection skipped: the replica state is ' +
-          'unavailable and the writer is disabled',
-        e,
-      );
-    }
-    return undefined;
-  }
-  using changeLog = openChangeLogDB(lc, file, {readonly: true});
-  const info = getSQLiteChangeLogInfo(replica, changeLog);
-  logSQLiteChangeLogStartup(lc, fileMode, true, info);
-  return new SQLiteChangeLogObserver(lc, info);
-}
-
-function setupMetrics(
-  lc: LogContext,
-  file: string,
-  walMode: WalMode,
-  logsChangeStream: boolean,
-) {
+function setupMetrics(lc: LogContext, file: string, walMode: WalMode) {
   getOrCreateGauge('replica', 'db_size', {
     description:
       `The size of the replica's main db file, ` +
@@ -280,27 +175,15 @@ function setupMetrics(
     }).addCallback(observeFileSize(lc, `${file}-wal2`));
   }
 
-  // The pair that accounts for the change log's bytes. They are whole-database
-  // totals rather than per-file, because a table that leaves the replica leaves
-  // through its wal: the replica's footprint is what shrank, and the change
-  // log's is where it went. Neither is derivable from the other, and the log's
-  // was invisible while it lived inside the replica.
+  // A whole-database total rather than a per-file one. Its counterpart,
+  // `sqlite_change_log.file_bytes`, is emitted by the change-streamer, which is
+  // the process that writes the log.
   getOrCreateGauge('replica', 'file_bytes', {
     description:
       `The replica's total on-disk footprint: its main db file plus its ` +
       `wal sidecars.`,
     unit: 'By',
   }).addCallback(observeSQLiteFileBytes(lc, file));
-
-  if (logsChangeStream) {
-    getOrCreateGauge('replica', 'sqlite_change_log.file_bytes', {
-      description:
-        `The SQLite change log's total on-disk footprint: its main db file ` +
-        `plus its wal sidecars. Local disk only — the log is excluded from ` +
-        `the litestream backup.`,
-      unit: 'By',
-    }).addCallback(observeSQLiteFileBytes(lc, changeLogFileName(file)));
-  }
 }
 
 function observeFileSize(lc: LogContext, file: string): ObservableCallback {

--- a/packages/zero-cache/src/server/replicator.ts
+++ b/packages/zero-cache/src/server/replicator.ts
@@ -26,7 +26,6 @@ import {
   litestreamRestoreMetricAttrs,
   litestreamRestoreRuns,
 } from '../services/litestream/metrics.ts';
-import {deleteChangeLogDB} from '../services/replicator/change-log-db.ts';
 import {ReplicationStatusPublisher} from '../services/replicator/replication-status.ts';
 import {
   ReplicatorService,
@@ -43,7 +42,7 @@ import {getShardConfig} from '../types/shards.ts';
 import {
   getPragmaConfig,
   replicaFileModeSchema,
-  replicatorDeletesStaleChangeLog,
+  deleteStaleChangeLog,
   setUpMessageHandlers,
   setupReplica,
   type WalMode,
@@ -66,9 +65,6 @@ export default async function runWorker(
   const mode: ReplicatorMode = fileMode === 'backup' ? 'backup' : 'serving';
   const runningLocalChangeStreamer =
     config.changeStreamer.mode === 'dedicated' && !config.changeStreamer.uri;
-  const deletesStaleChangeLog = replicatorDeletesStaleChangeLog(
-    config.changeStreamer.sqliteChangeLogMode,
-  );
   const workerName = `${mode}-replicator`;
   startOtelAuto(createLogContext(config, workerName, 0, false), workerName, 0);
   lc = createLogContext(config, workerName);
@@ -97,12 +93,10 @@ export default async function runWorker(
     dbPath,
   });
 
-  if (deletesStaleChangeLog) {
-    // A file left behind by a run with the writer enabled would otherwise hold
-    // local disk indefinitely. See `replicatorDeletesStaleChangeLog` for why
-    // this is keyed on the config flag and nothing else.
-    deleteChangeLogDB(dbPath);
-  }
+  // A file left behind by a run with the writer enabled would otherwise hold
+  // local disk indefinitely. See `replicatorDeletesStaleChangeLog` for why
+  // this is keyed on the config flag and nothing else.
+  deleteStaleChangeLog(config.changeStreamer.sqliteChangeLogMode, dbPath);
 
   setupMetrics(lc, dbPath, walMode);
 

--- a/packages/zero-cache/src/services/change-source/common/replica-restore.ts
+++ b/packages/zero-cache/src/services/change-source/common/replica-restore.ts
@@ -22,6 +22,14 @@ export type InitializeResult = {
   subscriptionState: SubscriptionState;
   changeSource: ChangeSource;
   destinationBackupURL: string | undefined;
+  /**
+   * The replica this change stream belongs to, from the upstream `replicas`
+   * table. It is part of the identity the SQLite change log records, because a
+   * generation (i.e. `replicaVersion`) is shared by every sibling of a forked
+   * replica and so cannot distinguish two siblings' logs. `null` when the
+   * change source has no upstream table to identify itself from.
+   */
+  replicaID: string | null;
 };
 
 export async function restoreReplica(

--- a/packages/zero-cache/src/services/change-source/custom/change-source.ts
+++ b/packages/zero-cache/src/services/change-source/custom/change-source.ts
@@ -96,6 +96,10 @@ export async function initializeCustomChangeSource(
     subscriptionState,
     changeSource,
     destinationBackupURL: litestream?.backupURL,
+    // A custom change source has no upstream `replicas` table to identify
+    // itself from, so the generation is the whole of the SQLite change log's
+    // identity here.
+    replicaID: null,
   };
 }
 
@@ -201,7 +205,6 @@ export async function initialSync(
   const processor = new ChangeProcessor(
     new StatementRunner(tx),
     'initial-sync',
-    {changeLog: undefined},
     (_, err) => {
       throw err;
     },

--- a/packages/zero-cache/src/services/change-source/pg/change-source.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.ts
@@ -207,7 +207,16 @@ export async function initializePostgresChangeSource(
         : // For legacy RMv1 replicas (on litestream-v3), backup to the same location
           restoreOptions.litestream?.backupURL;
 
-    return {subscriptionState, changeSource, destinationBackupURL};
+    return {
+      subscriptionState,
+      changeSource,
+      destinationBackupURL,
+      // The replica this change stream belongs to. It is part of the identity
+      // the SQLite change log records, because a generation (i.e.
+      // `replicaVersion`) is shared by every sibling of a forked replica and so
+      // cannot distinguish two siblings' logs.
+      replicaID: upstreamReplica.id,
+    };
   } finally {
     await db.end();
   }

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
@@ -1,4 +1,4 @@
-import {writeFileSync} from 'node:fs';
+import {existsSync, writeFileSync} from 'node:fs';
 import {PG_LOCK_NOT_AVAILABLE} from '@drdgvhbh/postgres-error-codes';
 import {LogContext} from '@rocicorp/logger';
 import {resolver} from '@rocicorp/resolver';
@@ -53,10 +53,13 @@ import {
   type Downstream,
 } from './change-streamer.ts';
 import * as ErrorType from './error-type-enum.ts';
+import {Forwarder} from './forwarder.ts';
 import {initChangeStreamerSchema} from './schema/init.ts';
 import {AutoResetSignal, ensureReplicationConfig} from './schema/tables.ts';
+import {SQLiteChangeLogCatchup} from './sqlite-change-log-catchup.ts';
 import {SQLiteChangeLogReader} from './sqlite-change-log-reader.ts';
-import {PurgeLocker} from './storer.ts';
+import {SQLiteChangeLogWriter} from './sqlite-change-log-writer.ts';
+import {PurgeLocker, Storer} from './storer.ts';
 
 const opts: TuningOptions = {
   backPressureLimitHeapProportion: 0.04,
@@ -453,7 +456,10 @@ describe('change-streamer/service', () => {
         seedWatermark: REPLICA_VERSION,
       });
 
-      // And a subscriber selected for SQLite is served from it.
+      // And a subscriber selected for SQLite is served from it -- from the
+      // SQLite reader itself, not a silent PG fallback delivering the same
+      // messages.
+      const readerRead = vi.spyOn(SQLiteChangeLogReader.prototype, 'read');
       const sqliteSub = await subscribeServing('from-sqlite');
       const fromSQLite = drainToQueue(sqliteSub);
       expect(await nextChange(fromSQLite)).toMatchObject({tag: 'status'});
@@ -463,9 +469,90 @@ describe('change-streamer/service', () => {
         new: {id: 'hello'},
       });
       expect(await nextChange(fromSQLite)).toMatchObject({tag: 'commit'});
+      expect(readerRead).toHaveBeenCalled();
+      readerRead.mockRestore();
       sqliteSub.cancel();
     } finally {
       liveSub.cancel();
+      await streamer.stop();
+      await streamerDone;
+      deleteChangeLogDB(logFile.path);
+      logFile.delete();
+    }
+  });
+
+  /**
+   * Invariant 1 in its assertable form, against the real stream loop rather
+   * than a model of it: no `await` separates `#storer.store()` from the log's
+   * commit, and the commit precedes the forward of that transaction's `commit`
+   * message. The microtask queued at `store()` is the await-detector — if the
+   * loop yields between the two calls, the microtask runs and the label flips.
+   */
+  test('the log commits in the tick that stores the commit, before the forward', async () => {
+    const events: string[] = [];
+    let microtaskRanSinceStore = false;
+
+    const realStore = Storer.prototype.store;
+    const storeSpy = vi
+      .spyOn(Storer.prototype, 'store')
+      .mockImplementation(function (this: Storer, watermark, data) {
+        if (data[0] === 'commit') {
+          events.push(`store:${watermark}`);
+          microtaskRanSinceStore = false;
+          queueMicrotask(() => {
+            microtaskRanSinceStore = true;
+          });
+        }
+        return realStore.call(this, watermark, data);
+      });
+    const realWrite = SQLiteChangeLogWriter.prototype.write;
+    const writeSpy = vi
+      .spyOn(SQLiteChangeLogWriter.prototype, 'write')
+      .mockImplementation(function (this: SQLiteChangeLogWriter, change, json) {
+        realWrite.call(this, change, json);
+        if (change[0] === 'commit') {
+          events.push(
+            `log-commit:${change[2].watermark}:` +
+              (microtaskRanSinceStore ? 'after-an-await' : 'same-tick'),
+          );
+        }
+      });
+    const realForward = Forwarder.prototype.forward;
+    const forwardSpy = vi
+      .spyOn(Forwarder.prototype, 'forward')
+      .mockImplementation(function (this: Forwarder, entry) {
+        if (entry[1] === 'commit') {
+          events.push(`forward:${entry[0]}`);
+        }
+        return realForward.call(this, entry);
+      });
+
+    const logFile = new DbFile('sqlite-change-log-ordering');
+    await restartWithInlineChangeLogWriter(logFile);
+
+    try {
+      changes.push(['begin', messages.begin(), {commitWatermark: '06'}]);
+      changes.push(['data', messages.insert('foo', {id: 'first'})]);
+      changes.push(['commit', messages.commit(), {watermark: '06'}]);
+      changes.push(['begin', messages.begin(), {commitWatermark: '08'}]);
+      changes.push(['data', messages.insert('foo', {id: 'second'})]);
+      changes.push(['commit', messages.commit(), {watermark: '08'}]);
+      // The upstream ACK follows the storer's Postgres commit, which is behind
+      // everything the events record.
+      await expectAcks('06', '08');
+
+      expect(events).toEqual([
+        'store:06',
+        'log-commit:06:same-tick',
+        'forward:06',
+        'store:08',
+        'log-commit:08:same-tick',
+        'forward:08',
+      ]);
+    } finally {
+      storeSpy.mockRestore();
+      writeSpy.mockRestore();
+      forwardSpy.mockRestore();
       await streamer.stop();
       await streamerDone;
       deleteChangeLogDB(logFile.path);
@@ -790,6 +877,20 @@ describe('change-streamer/service', () => {
    * this log any more.
    */
   test("the writer's commit releases the SQLite barrier", async () => {
+    // The wiring this test exists for: the writer's onCommit callback notifies
+    // the barrier, now that no subscriber's ACK advances this log. Asserted via
+    // spy because the mid-transaction wait below can also be satisfied on its
+    // first plan() read — the required head resolves at forward time, after the
+    // log's commit — which would leave a broken notification path undetected.
+    const onChangeLogCommit = vi.spyOn(
+      SQLiteChangeLogCatchup.prototype,
+      'onChangeLogCommit',
+    );
+    // Pins the source: the catchup below must be served by the SQLite reader.
+    // A silent PG fallback delivers the same messages with the same timing,
+    // since PG catchup also withholds them until the storer commits.
+    const readerRead = vi.spyOn(SQLiteChangeLogReader.prototype, 'read');
+
     const logFile = new DbFile('sqlite-change-log-barrier');
     await restartWithInlineChangeLogWriter(logFile, {
       barrierTimeoutMs: 60_000,
@@ -829,8 +930,115 @@ describe('change-streamer/service', () => {
         new: {id: 'mid-transaction'},
       });
       expect(await nextChange(fromSQLite)).toMatchObject({tag: 'commit'});
+      // The commit's notification reached the barrier, and the messages above
+      // came out of the SQLite reader.
+      expect(onChangeLogCommit).toHaveBeenCalledWith('06');
+      expect(readerRead).toHaveBeenCalled();
       sqliteSub.cancel();
     } finally {
+      onChangeLogCommit.mockRestore();
+      readerRead.mockRestore();
+      liveSub.cancel();
+      await streamer.stop();
+      await streamerDone;
+      deleteChangeLogDB(logFile.path);
+      logFile.delete();
+    }
+  });
+
+  /**
+   * §3.7 at the service level: a write failure costs catchup reach, never the
+   * shard's replication. The writer disables itself, deletes the file, and --
+   * because the reader is cached on the service -- closes it, so no in-process
+   * reader is left serving an unlinked inode while every new open sees nothing.
+   */
+  test('a mid-stream writer failure fails soft without stopping replication', async () => {
+    const readerClose = vi.spyOn(SQLiteChangeLogReader.prototype, 'close');
+    const logFile = new DbFile('sqlite-change-log-fail-soft');
+    await restartWithInlineChangeLogWriter(logFile, {
+      barrierPollIntervalMs: 10,
+      shouldUse: ctx => ctx.id.startsWith('from-sqlite'),
+    });
+
+    const liveSub = await subscribeServing('live-observer');
+    const live = drainToQueue(liveSub);
+    expect(await nextChange(live)).toMatchObject({tag: 'status'});
+
+    try {
+      changes.push(['begin', messages.begin(), {commitWatermark: '06'}]);
+      changes.push(['data', messages.insert('foo', {id: 'logged'})]);
+      changes.push(['commit', messages.commit(), {watermark: '06'}]);
+      expect(await nextChange(live)).toMatchObject({tag: 'begin'});
+      expect(await nextChange(live)).toMatchObject({tag: 'insert'});
+      expect(await nextChange(live)).toMatchObject({tag: 'commit'});
+
+      // A subscriber served from SQLite, so that the service holds the cached
+      // reader the fail-soft below must close.
+      const sqliteSub = await subscribeServing('from-sqlite');
+      const fromSQLite = drainToQueue(sqliteSub);
+      expect(await nextChange(fromSQLite)).toMatchObject({tag: 'status'});
+      expect(await nextChange(fromSQLite)).toMatchObject({tag: 'begin'});
+      expect(await nextChange(fromSQLite)).toMatchObject({
+        tag: 'insert',
+        new: {id: 'logged'},
+      });
+      expect(await nextChange(fromSQLite)).toMatchObject({tag: 'commit'});
+      expect(readerClose).not.toHaveBeenCalled();
+
+      // Breaks the log under the writer: its next insert fails with an error
+      // the file's contents cannot explain, i.e. the generic fail-soft class.
+      {
+        using saboteur = openChangeLogDB(lc, logFile.path, {readonly: false});
+        saboteur.exec(`DROP TABLE "_zero.changeLogStream"`);
+      }
+
+      changes.push(['begin', messages.begin(), {commitWatermark: '08'}]);
+      changes.push(['data', messages.insert('foo', {id: 'after-failure'})]);
+      changes.push(['commit', messages.commit(), {watermark: '08'}]);
+
+      // Replication continues, for the live subscriber and for the one that
+      // was served from SQLite alike.
+      for (const sub of [live, fromSQLite]) {
+        expect(await nextChange(sub)).toMatchObject({tag: 'begin'});
+        expect(await nextChange(sub)).toMatchObject({
+          tag: 'insert',
+          new: {id: 'after-failure'},
+        });
+        expect(await nextChange(sub)).toMatchObject({tag: 'commit'});
+      }
+
+      // The writer disabled itself, deleted the file, and closed the reader.
+      expect(existsSync(changeLogFileName(logFile.path))).toBe(false);
+      expect(readerClose).toHaveBeenCalled();
+      expect(
+        logSink.messages
+          .filter(([level]) => level === 'error')
+          .map(([, , args]) => String(args[0]))
+          .join('\n'),
+      ).toContain('error writing to the SQLite change log');
+
+      // A subscriber arriving after the failure declines to SQLite -- the file
+      // is gone -- and is served everything from PG.
+      const afterSub = await subscribeServing('from-sqlite-after');
+      const after = drainToQueue(afterSub);
+      expect(await nextChange(after)).toMatchObject({tag: 'status'});
+      expect(await nextChange(after)).toMatchObject({tag: 'begin'});
+      expect(await nextChange(after)).toMatchObject({
+        tag: 'insert',
+        new: {id: 'logged'},
+      });
+      expect(await nextChange(after)).toMatchObject({tag: 'commit'});
+      expect(await nextChange(after)).toMatchObject({tag: 'begin'});
+      expect(await nextChange(after)).toMatchObject({
+        tag: 'insert',
+        new: {id: 'after-failure'},
+      });
+      expect(await nextChange(after)).toMatchObject({tag: 'commit'});
+
+      afterSub.cancel();
+      sqliteSub.cancel();
+    } finally {
+      readerClose.mockRestore();
       liveSub.cancel();
       await streamer.stop();
       await streamerDone;

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
@@ -13,7 +13,7 @@ import {sleep} from '../../../../shared/src/sleep.ts';
 import {Database} from '../../../../zqlite/src/db.ts';
 import {StatementRunner} from '../../db/statements.ts';
 import {expectTables, test, type PgTest} from '../../test/db.ts';
-import {DbFile, initDB} from '../../test/lite.ts';
+import {DbFile} from '../../test/lite.ts';
 import type {PostgresDB} from '../../types/pg.ts';
 import type {Source} from '../../types/streams.ts';
 import {Subscription, type Result} from '../../types/subscription.ts';
@@ -28,11 +28,11 @@ import {
   changeLogFileName,
   deleteChangeLogDB,
   openChangeLogDB,
-  readReplicaAnchor,
+  readChangeLogHead,
   reconcileChangeLog,
+  type ChangeLogAnchor,
 } from '../replicator/change-log-db.ts';
 import {ChangeLogStreamWriter} from '../replicator/change-log-stream-writer.ts';
-import {IncrementalSyncer} from '../replicator/incremental-sync.ts';
 import {ReplicationStatusPublisher} from '../replicator/replication-status.ts';
 import {
   getSubscriptionState,
@@ -40,12 +40,7 @@ import {
   type SubscriptionState,
   updateReplicationWatermark,
 } from '../replicator/schema/replication-state.ts';
-import {
-  getSQLiteChangeLogInfo,
-  SQLiteChangeLogObserver,
-} from '../replicator/sqlite-change-log-observability.ts';
 import {ReplicationMessages} from '../replicator/test-utils.ts';
-import {ThreadWriteWorkerClient} from '../replicator/write-worker-client.ts';
 import {serializeChangeStreamData} from './change-log-codec.ts';
 import {
   initializeStreamer,
@@ -189,10 +184,32 @@ describe('change-streamer/service', () => {
 
   const messages = new ReplicationMessages({foo: 'id'});
 
-  /** The change-log database the replicator writes beside `replicaFile`. */
+  /**
+   * The anchor a writer beside `replica` reconciles against. The catchup tests
+   * drive the log from outside the change-streamer so that its content is
+   * controlled independently of the stream, which is what lets them exercise a
+   * head the streamer has not reached; `replica`'s replication state stands in
+   * for the watermark such a stream would resume from.
+   */
+  function anchorFor(replica: Database): ChangeLogAnchor {
+    const {stateVersion, replicaVersion} = replica
+      .prepare(/*sql*/ `
+        SELECT state."stateVersion", config."replicaVersion"
+          FROM "_zero.replicationState" AS state,
+               "_zero.replicationConfig" AS config
+      `)
+      .get<{stateVersion: string; replicaVersion: string}>();
+    return {
+      identity: {epoch: null, generation: replicaVersion, replicaID: null},
+      resumeWatermark: stateVersion,
+      nowMs: Date.now(),
+    };
+  }
+
+  /** The change-log database beside `replicaFile`, seeded and reconciled. */
   function createChangeLogDB(replicaFile: DbFile, replica: Database): Database {
     const changeLog = openChangeLogDB(lc, replicaFile.path, {readonly: false});
-    reconcileChangeLog(lc, changeLog, readReplicaAnchor(replica));
+    reconcileChangeLog(lc, changeLog, anchorFor(replica));
     return changeLog;
   }
 
@@ -245,6 +262,69 @@ describe('change-streamer/service', () => {
     streamerDone = streamer.run();
   }
 
+  /**
+   * Restarts the streamer with the change-log writer enabled, i.e. with the
+   * production topology: this process writes the log from its own stream loop,
+   * and can serve catchup from what it wrote.
+   */
+  async function restartWithInlineChangeLogWriter(
+    logFile: DbFile,
+    sqliteCatchup?: Partial<SQLiteCatchupOptions>,
+  ): Promise<void> {
+    await streamer.stop();
+    await streamerDone;
+
+    changes = Subscription.create();
+    acks = new Queue();
+    streamer = await initializeStreamer(
+      lc,
+      shard,
+      'task-id',
+      'change.streamer:12345',
+      'ws',
+      sql,
+      {
+        startStream: () =>
+          Promise.resolve({
+            initialWatermark: REPLICA_VERSION,
+            changes,
+            acks: {push: status => acks.enqueue(status)},
+          }),
+        startLagReporter: () => null,
+        stop: () => Promise.resolve(),
+      },
+      ReplicationStatusPublisher.forTesting(),
+      replicaConfig,
+      null,
+      true,
+      {
+        ...opts,
+        // No replica beside it: the writer's anchor is the watermark its stream
+        // connection resumes from, which is Postgres's `lastWatermark`.
+        sqliteChangeLogWriter: {
+          replicaFile: logFile.path,
+          identity: {
+            epoch: null,
+            generation: REPLICA_VERSION,
+            replicaID: 'replica-id',
+          },
+        },
+        ...(sqliteCatchup === undefined
+          ? {}
+          : {
+              sqliteCatchup: {
+                changeLogFile: changeLogFileName(logFile.path),
+                readBatchRows: 2,
+                barrierTimeoutMs: 1_000,
+                ...sqliteCatchup,
+              },
+            }),
+      },
+      setTimeoutFn as unknown as typeof setTimeout,
+    );
+    streamerDone = streamer.run();
+  }
+
   /** A serving subscriber, i.e. one eligible for SQLite catchup. */
   function subscribeServing(id: string): Promise<Source<string>> {
     return streamer.subscribe({
@@ -259,7 +339,11 @@ describe('change-streamer/service', () => {
     });
   }
 
-  /** Applies a transaction the way the write worker does: log first, then replica. */
+  /**
+   * Appends a transaction to the log the way the writer does, and advances the
+   * replica's watermark with it so that {@link anchorFor} keeps agreeing with
+   * the log's head.
+   */
   function appendSQLiteTransaction(
     replica: Database,
     changeLog: Database,
@@ -291,81 +375,21 @@ describe('change-streamer/service', () => {
     }
   }
 
-  test('PG stream shadow-writes SQLite without changing PG serving or ACKs', async () => {
-    const dbFile = new DbFile('sqlite-change-log-shadow-integration');
-    const replica = dbFile.connect(lc);
-    replica.pragma('journal_mode = wal');
-    replica.exec(/*sql*/ `
-      CREATE TABLE "_zero.versionHistory" (
-        "dataVersion" INTEGER NOT NULL,
-        "schemaVersion" INTEGER NOT NULL,
-        "minSafeVersion" INTEGER NOT NULL,
-        "lock" INTEGER PRIMARY KEY DEFAULT 1 CHECK ("lock" = 1)
-      );
-      INSERT INTO "_zero.versionHistory"
-        ("dataVersion", "schemaVersion", "minSafeVersion")
-        VALUES (14, 14, 0);
-    `);
-    initReplicationState(replica, ['zero_data'], REPLICA_VERSION);
-    initDB(
-      replica,
-      `
-      CREATE TABLE foo(
-        id TEXT PRIMARY KEY,
-        _0_version TEXT
-      );
-      `,
-    );
-
-    const worker = new ThreadWriteWorkerClient();
-    await worker.init(
-      dbFile.path,
-      'serving',
-      true,
-      {busyTimeout: 30_000, analysisLimit: 1000},
-      {level: 'error', format: 'text'},
-    );
-    // `init` created and reconciled the change log, so its head is readable.
-    using changeLog = openChangeLogDB(lc, dbFile.path, {readonly: true});
-    const observer = new SQLiteChangeLogObserver(
-      lc,
-      getSQLiteChangeLogInfo(replica, changeLog),
-    );
-    const syncer = new IncrementalSyncer(
-      lc,
-      'shadow-write-task',
-      'canonical-replicator',
-      {
-        async subscribe(ctx) {
-          const encoded = await streamer.subscribe(ctx);
-          return {
-            cancel: err => encoded.cancel(err),
-            async *[Symbol.asyncIterator]() {
-              for await (const json of encoded) {
-                yield {data: BigIntJSON.parse(json) as Downstream, json};
-              }
-            },
-          };
-        },
-      },
-      worker,
-      'serving',
-      true,
-      null,
-      observer,
-    );
-    const syncing = syncer.run();
-
-    const liveSub = await streamer.subscribe({
-      protocolVersion: PROTOCOL_VERSION,
-      taskID: 'live-observer-task',
-      id: 'live-observer',
-      mode: 'serving',
-      watermark: REPLICA_VERSION,
-      replicaVersion: REPLICA_VERSION,
-      initial: true,
-      logsChangeStream: false,
+  /**
+   * The whole of slice 7I, end to end: the change-streamer writes the SQLite
+   * change log from its own stream loop, commits it before forwarding each
+   * transaction's `commit`, and can then serve a subscriber's catchup from it —
+   * with the barrier released by the writer's commit rather than by any
+   * subscriber's ACK.
+   */
+  test('the change-streamer writes the log inline and serves catchup from it', async () => {
+    const logFile = new DbFile('sqlite-change-log-inline-writer');
+    await restartWithInlineChangeLogWriter(logFile, {
+      barrierPollIntervalMs: 10,
+      shouldUse: ctx => ctx.id === 'from-sqlite',
     });
+
+    const liveSub = await subscribeServing('live-observer');
     const live = drainToQueue(liveSub);
     expect(await nextChange(live)).toMatchObject({tag: 'status'});
 
@@ -380,85 +404,191 @@ describe('change-streamer/service', () => {
         new: {id: 'hello'},
       });
       expect(await nextChange(live)).toMatchObject({tag: 'commit'});
+      // Invariant 2, at the earliest moment it can be observed: a subscriber
+      // that has the `commit` implies the log already committed it, because the
+      // log's commit precedes the forward.
+      {
+        using log = openChangeLogDB(lc, logFile.path, {readonly: true});
+        expect(readChangeLogHead(log)).toBe('06');
+      }
 
+      // PG serving and the upstream ACK are unchanged.
       await expectAcks('06');
-      await vi.waitFor(() => {
-        expect(
-          replica
-            .prepare(`SELECT "stateVersion" FROM "_zero.replicationState"`)
-            .get(),
-        ).toEqual({stateVersion: '06'});
-      });
-      // The stream is logged to the change-log database beside the replica,
-      // never to the replica itself.
-      using changeLog = openChangeLogDB(lc, dbFile.path, {readonly: true});
+      expect(
+        await sql`SELECT watermark FROM "zoro_3/cdc"."changeLog"
+                    WHERE watermark = '06' ORDER BY pos`.values(),
+      ).toEqual([['06'], ['06'], ['06']]);
+
+      // The log holds the seed transaction at the watermark the stream resumed
+      // from, then the transaction that was just forwarded.
+      using changeLog = openChangeLogDB(lc, logFile.path, {readonly: true});
       expect(
         changeLog
-          .prepare(
-            `SELECT max("watermark") AS "watermark" FROM "_zero.changeLogStream"`,
-          )
-          .get(),
-      ).toEqual({watermark: '06'});
-      expect(
-        replica
-          .prepare(/*sql*/ `SELECT "name" FROM "sqlite_master"
-                       WHERE "tbl_name" = '_zero.changeLogStream'`)
+          .prepare(/*sql*/ `
+            SELECT "watermark", "pos", json_extract("change", '$.tag') AS "tag",
+                   "precommit"
+              FROM "_zero.changeLogStream" ORDER BY "watermark", "pos"
+          `)
           .all(),
-      ).toEqual([]);
-      // Waited for, not asserted directly: the replica's commit is visible to
-      // this connection as soon as the write worker commits it, while the
-      // observer advances only once that worker's reply reaches the syncer.
-      await vi.waitFor(() => {
-        expect(observer.state()).toMatchObject({
-          receivedHead: '06',
-          sqliteHead: '06',
-          headLag: 0,
-          invariantFailures: 0,
-          hashMatches: 1,
-          hashMismatches: 0,
-          hashUnpaired: 0,
-        });
+      ).toEqual([
+        {watermark: '01', pos: 0, tag: 'begin', precommit: null},
+        {watermark: '01', pos: 1, tag: 'commit', precommit: '01'},
+        {watermark: '06', pos: 0, tag: 'begin', precommit: null},
+        {watermark: '06', pos: 1, tag: 'insert', precommit: null},
+        {watermark: '06', pos: 2, tag: 'commit', precommit: '06'},
+      ]);
+      expect(
+        changeLog
+          .prepare(/*sql*/ `
+            SELECT "epoch", "generation", "replicaID", "schemaVersion",
+                   "seedWatermark"
+              FROM "_zero.changeLogMeta"
+          `)
+          .get(),
+      ).toEqual({
+        epoch: null,
+        generation: REPLICA_VERSION,
+        replicaID: 'replica-id',
+        schemaVersion: 2,
+        seedWatermark: REPLICA_VERSION,
       });
 
-      const catchupSub = await streamer.subscribe({
-        protocolVersion: PROTOCOL_VERSION,
-        taskID: 'catchup-observer-task',
-        id: 'catchup-observer',
-        mode: 'serving',
-        watermark: REPLICA_VERSION,
-        replicaVersion: REPLICA_VERSION,
-        initial: true,
-        logsChangeStream: false,
-      });
-      const catchup = drainToQueue(catchupSub);
-      expect(await nextChange(catchup)).toMatchObject({tag: 'status'});
-      expect(await nextChange(catchup)).toMatchObject({tag: 'begin'});
-      expect(await nextChange(catchup)).toMatchObject({
+      // And a subscriber selected for SQLite is served from it.
+      const sqliteSub = await subscribeServing('from-sqlite');
+      const fromSQLite = drainToQueue(sqliteSub);
+      expect(await nextChange(fromSQLite)).toMatchObject({tag: 'status'});
+      expect(await nextChange(fromSQLite)).toMatchObject({tag: 'begin'});
+      expect(await nextChange(fromSQLite)).toMatchObject({
         tag: 'insert',
         new: {id: 'hello'},
       });
-      expect(await nextChange(catchup)).toMatchObject({tag: 'commit'});
-      // This test has finished exercising catchup. Remove the subscriber
-      // before testing cleanup so its asynchronous consumed ACK cannot race
-      // the purge eligibility check below.
-      catchupSub.cancel();
-
-      streamer.scheduleCleanup('06');
-      const purge = setTimeoutFn.mock.calls.at(-1)?.[0];
-      assert(purge, 'PG change-log purge was not scheduled');
-      await (purge() as unknown as Promise<void>);
-      expect(
-        await sql`SELECT watermark FROM "zoro_3/cdc"."changeLog"
-                    ORDER BY watermark, pos`.values(),
-      ).toEqual([['06'], ['06'], ['06']]);
+      expect(await nextChange(fromSQLite)).toMatchObject({tag: 'commit'});
+      sqliteSub.cancel();
     } finally {
       liveSub.cancel();
-      syncer.stop(lc);
-      await syncing;
-      await worker.stop();
-      replica.close();
-      deleteChangeLogDB(dbFile.path);
-      dbFile.delete();
+      await streamer.stop();
+      await streamerDone;
+      deleteChangeLogDB(logFile.path);
+      logFile.delete();
+    }
+  });
+
+  /**
+   * The in-process form of truncate-above, driven by production machinery: a
+   * storer commit fails, the stream is re-established, and its resume watermark
+   * is behind the log's head. The writer inserts with a plain `INSERT`, so an
+   * un-truncated overlap is a constraint violation on the re-delivery.
+   */
+  test('an in-process reconnect below the log head truncates rather than colliding', async () => {
+    await streamer.stop();
+    await streamerDone;
+
+    const logFile = new DbFile('sqlite-change-log-reconnect');
+    const first = Subscription.create<ChangeStreamMessage>();
+    const second = Subscription.create<ChangeStreamMessage>();
+    const {promise: reconnected, resolve: didReconnect} = resolver<true>();
+    streamer = await initializeStreamer(
+      lc,
+      shard,
+      'task-id',
+      'change.streamer:12345',
+      'ws',
+      sql,
+      {
+        startStream: vi
+          .fn()
+          .mockImplementationOnce(() =>
+            Promise.resolve({
+              initialWatermark: REPLICA_VERSION,
+              changes: first,
+              acks: {push: () => {}},
+            }),
+          )
+          .mockImplementationOnce(() => {
+            didReconnect(true);
+            return Promise.resolve({
+              initialWatermark: REPLICA_VERSION,
+              changes: second,
+              acks: {push: () => {}},
+            });
+          })
+          .mockImplementation(() => resolver().promise),
+        startLagReporter: () => null,
+        stop: () => Promise.resolve(),
+      },
+      ReplicationStatusPublisher.forTesting(),
+      replicaConfig,
+      null,
+      true,
+      {
+        ...opts,
+        sqliteChangeLogWriter: {
+          replicaFile: logFile.path,
+          identity: {
+            epoch: null,
+            generation: REPLICA_VERSION,
+            replicaID: 'replica-id',
+          },
+        },
+      },
+      // The real timer, because this test depends on the reconnect backoff
+      // actually firing.
+    );
+    streamerDone = streamer.run();
+
+    const head = () => {
+      using changeLog = openChangeLogDB(lc, logFile.path, {readonly: true});
+      return changeLog
+        .prepare(
+          `SELECT max("watermark") AS "head" FROM "_zero.changeLogStream"`,
+        )
+        .get<{head: string | null}>().head;
+    };
+
+    try {
+      // Makes the storer's commit of '05' fail, so Postgres never records it
+      // while the log already has. `pos` 3 is where the commit row of the
+      // four-message transaction below lands.
+      await sql`INSERT INTO "zoro_3/cdc"."changeLog" (watermark, pos, change)
+        VALUES ('05', 3, ${{conflicting: 'entry'}})`;
+
+      first.push(['begin', messages.begin(), {commitWatermark: '05'}]);
+      first.push(['data', messages.insert('foo', {id: 'logged-not-stored'})]);
+      first.push(['data', messages.insert('foo', {id: 'also-not-stored'})]);
+      first.push(['commit', messages.commit(), {watermark: '05'}]);
+
+      // The reconnect re-reads its resume watermark, finds it behind the log's
+      // head, and truncates '05' away before the new stream starts.
+      expect(await reconnected).toBe(true);
+      expect(head()).toBe(REPLICA_VERSION);
+
+      // The resumed stream re-delivers '05'. Without the truncation this would
+      // violate PRIMARY KEY ("watermark","pos").
+      await sql`DELETE FROM "zoro_3/cdc"."changeLog"
+                  WHERE watermark = '05' AND pos = 3`;
+      second.push(['begin', messages.begin(), {commitWatermark: '05'}]);
+      second.push(['data', messages.insert('foo', {id: 'redelivered'})]);
+      second.push(['data', messages.insert('foo', {id: 'redelivered-too'})]);
+      second.push(['commit', messages.commit(), {watermark: '05'}]);
+
+      await vi.waitFor(() => expect(head()).toBe('05'));
+      // Fail-soft would have deleted the file on a constraint violation, so the
+      // head above already proves there was none. Assert it directly too, since
+      // the whole point of the carve-out is that it is reported rather than
+      // absorbed.
+      expect(
+        logSink.messages
+          .filter(([level]) => level === 'error')
+          .map(([, , args]) => String(args[0]))
+          .filter(m => m.includes('constraint')),
+      ).toEqual([]);
+    } finally {
+      first.cancel();
+      second.cancel();
+      await streamer.stop();
+      await streamerDone;
+      deleteChangeLogDB(logFile.path);
+      logFile.delete();
     }
   });
 
@@ -652,147 +782,67 @@ describe('change-streamer/service', () => {
     }
   });
 
-  test('the change-log writer ACK releases the SQLite barrier', async () => {
-    await streamer.stop();
-    await streamerDone;
+  /**
+   * The barrier, with the writer in-process. A subscriber that registers
+   * mid-transaction must wait for that transaction rather than be served a
+   * truncated view of it, and the wait must end on the writer's own commit: the
+   * poll interval here is far beyond the test timeout, and no subscriber acks
+   * this log any more.
+   */
+  test("the writer's commit releases the SQLite barrier", async () => {
+    const logFile = new DbFile('sqlite-change-log-barrier');
+    await restartWithInlineChangeLogWriter(logFile, {
+      barrierTimeoutMs: 60_000,
+      barrierPollIntervalMs: 60_000,
+      shouldUse: ctx => ctx.id === 'from-sqlite',
+    });
 
-    const catchupReplicaFile = new DbFile('sqlite-catchup-ack-integration');
-    const catchupReplica = catchupReplicaFile.connect(lc);
-    catchupReplica.pragma('journal_mode = wal');
-    initReplicationState(catchupReplica, ['zero_data'], REPLICA_VERSION);
-    const catchupChangeLog = createChangeLogDB(
-      catchupReplicaFile,
-      catchupReplica,
-    );
-
-    changes = Subscription.create();
-    acks = new Queue();
-    streamer = await initializeStreamer(
-      lc,
-      shard,
-      'task-id',
-      'change.streamer:12345',
-      'ws',
-      sql,
-      {
-        startStream: () =>
-          Promise.resolve({
-            initialWatermark: '02',
-            changes,
-            acks: {push: status => acks.enqueue(status)},
-          }),
-        startLagReporter: () =>
-          Promise.resolve({firstCommitTimeMs: 100, nextSendTimeMs: 123}),
-        stop: () => Promise.resolve(),
-      },
-      ReplicationStatusPublisher.forTesting(),
-      replicaConfig,
-      null,
-      true,
-      {
-        ...opts,
-        sqliteCatchup: {
-          changeLogFile: changeLogFileName(catchupReplicaFile.path),
-          readBatchRows: 2,
-          barrierTimeoutMs: 60_000,
-          // Far beyond the test timeout, so only the writer's ACK can release
-          // the barrier. The change log itself is never polled for the head.
-          barrierPollIntervalMs: 60_000,
-          shouldUse: ctx => !ctx.logsChangeStream,
-        },
-      },
-      setTimeoutFn as unknown as typeof setTimeout,
-    );
-    streamerDone = streamer.run();
+    const liveSub = await subscribeServing('live-observer');
+    const live = drainToQueue(liveSub);
+    expect(await nextChange(live)).toMatchObject({tag: 'status'});
 
     try {
-      // Stands in for the replicator that writes the SQLite change log. Like
-      // the real one, it applies a transaction to the replica before its
-      // consumption is acked, which is what makes the ACK mean "durable".
-      const writerSub = await streamer.subscribe({
-        protocolVersion: PROTOCOL_VERSION,
-        taskID: 'task-id',
-        id: 'change-log-writer',
-        mode: 'backup',
-        watermark: REPLICA_VERSION,
-        replicaVersion: REPLICA_VERSION,
-        initial: true,
-        logsChangeStream: true,
+      changes.push(['begin', messages.begin(), {commitWatermark: '06'}]);
+      changes.push(['data', messages.insert('foo', {id: 'mid-transaction'})]);
+      expect(await nextChange(live)).toMatchObject({tag: 'begin'});
+      expect(await nextChange(live)).toMatchObject({
+        tag: 'insert',
+        new: {id: 'mid-transaction'},
       });
-      const applyTransactions = resolver<void>();
-      const received = new Queue<string>();
-      const applied = new Queue<string>();
-      const writing = (async () => {
-        const buffered: ChangeStreamData[] = [];
-        for await (const msg of writerSub) {
-          const down = BigIntJSON.parse(msg) as Downstream;
-          if (down[0] === 'data') {
-            buffered.push(down as ChangeStreamData);
-          } else if (down[0] === 'commit') {
-            const {watermark} = down[2];
-            received.enqueue(watermark);
-            await applyTransactions.promise;
-            appendSQLiteTransaction(
-              catchupReplica,
-              catchupChangeLog,
-              watermark,
-              buffered.splice(0),
-            );
-            applied.enqueue(watermark);
-          }
-        }
-      })();
 
-      changes.push(['begin', messages.begin(), {commitWatermark: '04'}]);
-      changes.push(['data', messages.insert('foo', {id: 'acked'})]);
-      changes.push(['commit', messages.commit(), {watermark: '04'}]);
-      // The commit reached the writer, so it is also the forwarded head that
-      // the next subscriber will have to wait for.
-      expect(await received.dequeue()).toBe('04');
-
-      // The writer has the transaction but has not applied it, so the replica
-      // is behind the head this subscriber requires.
-      const catchupSub = await streamer.subscribe({
-        protocolVersion: PROTOCOL_VERSION,
-        taskID: 'catchup-task',
-        id: 'sqlite-catchup',
-        mode: 'serving',
-        watermark: REPLICA_VERSION,
-        replicaVersion: REPLICA_VERSION,
-        initial: true,
-        logsChangeStream: false,
-      });
-      const caught = drainToQueue(catchupSub);
+      // Registered while '06' is in flight, so its required head is '06'.
+      const sqliteSub = await subscribeServing('from-sqlite');
+      const fromSQLite = drainToQueue(sqliteSub);
       // The barrier holds the subscription: not even the status message is
       // delivered until the required head is readable.
       await sleep(50);
-      expect(caught.size()).toBe(0);
+      expect(fromSQLite.size()).toBe(0);
 
-      applyTransactions.resolve();
-      expect(await applied.dequeue()).toBe('04');
+      changes.push(['commit', messages.commit(), {watermark: '06'}]);
+      expect(await nextChange(live)).toMatchObject({tag: 'commit'});
 
-      // Released by the writer's ACK rather than by a poll.
-      expect(await nextChange(caught)).toMatchObject({tag: 'status'});
-      expect(await nextChange(caught)).toMatchObject({tag: 'begin'});
-      expect(await nextChange(caught)).toMatchObject({
+      // Released by the writer's commit rather than by a poll.
+      expect(await nextChange(fromSQLite)).toMatchObject({tag: 'status'});
+      expect(await nextChange(fromSQLite)).toMatchObject({tag: 'begin'});
+      expect(await nextChange(fromSQLite)).toMatchObject({
         tag: 'insert',
-        new: {id: 'acked'},
+        new: {id: 'mid-transaction'},
       });
-      expect(await nextChange(caught)).toMatchObject({tag: 'commit'});
-
-      catchupSub.cancel();
-      writerSub.cancel();
-      await writing;
+      expect(await nextChange(fromSQLite)).toMatchObject({tag: 'commit'});
+      sqliteSub.cancel();
     } finally {
+      liveSub.cancel();
       await streamer.stop();
-      catchupChangeLog.close();
-      catchupReplica.close();
-      deleteChangeLogDB(catchupReplicaFile.path);
-      catchupReplicaFile.delete();
+      await streamerDone;
+      deleteChangeLogDB(logFile.path);
+      logFile.delete();
     }
   });
 
-  test('backup subscribers and change-log writers cannot select SQLite catchup', async () => {
+  // The exclusion outlives its original reason -- the writer is no longer a
+  // subscriber, so nothing can wait on its own ACK -- because a replicator that
+  // predates the writer's move still sets the parameter. Slice 11 lifts it.
+  test('backup subscribers and legacy change-log writers cannot select SQLite catchup', async () => {
     await streamer.stop();
     await streamerDone;
 
@@ -917,7 +967,11 @@ describe('change-streamer/service', () => {
       expect(logSink.messages).toContainEqual([
         'warn',
         expect.anything(),
-        [expect.stringContaining('it would wait on its own ACK')],
+        [
+          expect.stringContaining(
+            'not serving legacy change-log writer change-log-writer',
+          ),
+        ],
       ]);
 
       observerSub.cancel();
@@ -1054,11 +1108,7 @@ describe('change-streamer/service', () => {
       expect(readerClose).toHaveBeenCalledTimes(1);
 
       // A stream table with no rows is equally unserviceable.
-      reconcileChangeLog(
-        lc,
-        catchupChangeLog,
-        readReplicaAnchor(catchupReplica),
-      );
+      reconcileChangeLog(lc, catchupChangeLog, anchorFor(catchupReplica));
       catchupChangeLog.prepare(`DELETE FROM "_zero.changeLogStream"`).run();
 
       const noRowsSub = await subscribeServing('no-rows');
@@ -1075,11 +1125,7 @@ describe('change-streamer/service', () => {
 
       // Reconciling an emptied log reseeds it at the replica head, after which
       // the writer's transactions make it servable.
-      reconcileChangeLog(
-        lc,
-        catchupChangeLog,
-        readReplicaAnchor(catchupReplica),
-      );
+      reconcileChangeLog(lc, catchupChangeLog, anchorFor(catchupReplica));
       appendSQLiteTransaction(catchupReplica, catchupChangeLog, '04', [
         ['data', messages.insert('foo', {id: 'from-sqlite'})],
       ]);

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -4,7 +4,10 @@ import {resolver, type Resolver} from '@rocicorp/resolver';
 import {assert, unreachable} from '../../../../shared/src/asserts.ts';
 import {promiseVoid} from '../../../../shared/src/resolved-promises.ts';
 import {publishCriticalEvent} from '../../observability/events.ts';
-import {getOrCreateCounter} from '../../observability/metrics.ts';
+import {
+  getOrCreateCounter,
+  getOrCreateLatencyHistogram,
+} from '../../observability/metrics.ts';
 import {
   min,
   type AtLeastOne,
@@ -53,6 +56,10 @@ import {
 } from './sqlite-change-log-catchup.ts';
 import {SQLiteChangeLogReader} from './sqlite-change-log-reader.ts';
 import {
+  SQLiteChangeLogWriter,
+  type SQLiteChangeLogWriterOptions,
+} from './sqlite-change-log-writer.ts';
+import {
   Storer,
   type PurgeLock,
   type TuningOptions as StorerOptions,
@@ -91,6 +98,13 @@ export type TuningOptions = StorerOptions & {
   flowControlConsensusPaddingSeconds: number;
   flowControlEventDrivenRelease?: boolean | undefined;
   sqliteCatchup?: SQLiteCatchupOptions | undefined;
+  /**
+   * Supplied when `sqliteChangeLogMode != off`, i.e. this is the gate on the
+   * change-log writer. Absent, nothing writes the log.
+   */
+  sqliteChangeLogWriter?:
+    | Omit<SQLiteChangeLogWriterOptions, 'onCommit' | 'onDisabled'>
+    | undefined;
 };
 
 /**
@@ -298,6 +312,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
   readonly #forwarder: Forwarder;
   readonly #replicationStatusPublisher: ReplicationStatusPublisher;
   readonly #sqliteCatchupOptions: SQLiteCatchupOptions | undefined;
+  readonly #changeLogWriter: SQLiteChangeLogWriter | undefined;
 
   readonly #autoReset: boolean;
   readonly #state: RunningState;
@@ -323,6 +338,15 @@ class ChangeStreamerImpl implements ChangeStreamerService {
     'changes',
     'Count of replicated changes (DML or DDL statements)',
   );
+  // The number the SQLite change-log commit lands in. It is labeled by whether
+  // the log is being written so that the cost of putting a commit on the
+  // forward path is attributable rather than inferred.
+  readonly #transactionForwardDuration = getOrCreateLatencyHistogram(
+    'replication',
+    'transaction_forward_duration',
+    "Time from receiving a transaction's `begin` to forwarding its `commit`, " +
+      'i.e. the change-streamer half of forward-to-subscriber latency.',
+  );
 
   #latestStatus: Status;
   #latestLagReportCommitTimeMs = 0;
@@ -331,6 +355,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
   #sqliteCatchup: SQLiteChangeLogCatchup | undefined;
   #changeLogUnavailableSince: number | undefined;
   #lastForwardedCommitWatermark: string | undefined;
+  #transactionForwardStartedAt: number | undefined;
   #currentTransactionCompletion:
     | Resolver<ForwardedTransactionCompletion>
     | undefined;
@@ -375,6 +400,17 @@ class ChangeStreamerImpl implements ChangeStreamerService {
     });
     this.#replicationStatusPublisher = replicationStatusPublisher;
     this.#sqliteCatchupOptions = opts.sqliteCatchup;
+    this.#changeLogWriter = opts.sqliteChangeLogWriter
+      ? new SQLiteChangeLogWriter(lc, {
+          ...opts.sqliteChangeLogWriter,
+          onCommit: watermark =>
+            this.#sqliteCatchup?.onChangeLogCommit(watermark),
+          // Fail-soft deletes the file, and the reader is cached here, so it
+          // has to go with it: otherwise it serves an unlinked inode while
+          // every new open sees nothing.
+          onDisabled: () => this.#closeSQLiteCatchup(),
+        })
+      : undefined;
     this.#purgeLock = initialPurgeLock;
     this.#autoReset = autoReset;
     this.#state = new RunningState(this.id, undefined, setTimeoutFn);
@@ -418,6 +454,12 @@ class ChangeStreamerImpl implements ChangeStreamerService {
         // from the durable PG head. Commits observed only since process startup
         // are insufficient after a change-streamer restart.
         this.#lastForwardedCommitWatermark = lastWatermark;
+        // Per stream connection, not once per process: the resume watermark is
+        // re-read on every reconnect, so the log can be holding transactions
+        // above it -- a restarted backfill's abandoned ones, in bulk -- and the
+        // writer's plain INSERT would collide with the first re-delivery.
+        // Ordered before startStream so no change can arrive mid-reconcile.
+        this.#changeLogWriter?.reconcile(lastWatermark);
         const stream = await this.#source.startStream(
           lastWatermark,
           backfillRequests,
@@ -488,6 +530,17 @@ class ChangeStreamerImpl implements ChangeStreamerService {
           }
 
           const json = this.#storer.store(watermark, change);
+          // The SQLite change log commits at transaction boundaries, and its
+          // commit for this transaction lands here -- before the forward of the
+          // `commit` message, and before #recordForwardedTransactionBoundary
+          // advances what #captureRequiredHead reads. No `await` separates it
+          // from #storer.store() above, which is the assertable form of
+          // invariant 1: the storer only enqueues, and its Postgres commit
+          // cannot complete without yielding, so a synchronous SQLite commit in
+          // the same loop iteration always precedes anything that can advance
+          // the watermark this stream would resume from. Never throws; a write
+          // failure disables the writer rather than stopping replication.
+          this.#changeLogWriter?.write(change, json);
           const entry: WatermarkedChange = [watermark, change[1].tag, json];
           unflushedBytes += json.length;
           if (unflushedBytes < flushBytesThreshold) {
@@ -533,6 +586,10 @@ class ChangeStreamerImpl implements ChangeStreamerService {
       if (watermark) {
         this.#lc.warn?.(`aborting interrupted transaction ${watermark}`);
         this.#storer.abort();
+        // Rolling back the log leaves no rows for the interrupted transaction,
+        // so the next connection's reconciliation sees a head at or below its
+        // resume watermark rather than a partial transaction.
+        this.#changeLogWriter?.abort();
         this.#forwarder.forward([watermark, 'rollback', ROLLBACK_JSON]);
         this.#recordForwardedTransactionBoundary('rollback', watermark);
       }
@@ -586,20 +643,16 @@ class ChangeStreamerImpl implements ChangeStreamerService {
     const downstream = Subscription.create<string>({
       cleanup: () => cleanupSubscriber(),
     });
+    // No subscriber's ACK advances the SQLite change log's head any more: the
+    // writer runs in this process, so the barrier is notified from the commit
+    // itself (see #changeLogWriter's onCommit).
     const subscriber = new Subscriber(
       protocolVersion,
       id,
       watermark,
       downstream,
       () => this.#latestStatus,
-      ctx.logsChangeStream
-        ? {
-            // This subscriber writes the SQLite change log that catchup reads,
-            // so its ACKs are what advance that log's head. Routing them to the
-            // barrier saves it from polling the replica for the same fact.
-            onAck: acked => this.#sqliteCatchup?.onChangeLogWriterAck(acked),
-          }
-        : {},
+      {},
     );
     const lc = this.#lc.withContext('subscriber', subscriber.id);
     cleanupSubscriber = () => {
@@ -707,6 +760,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
     this.#state.stop(this.#lc, err);
     this.#stream?.changes.cancel();
     this.#sqliteCatchup?.close();
+    this.#changeLogWriter?.close();
     await this.#storer.stop();
     await this.#source.stop();
   }
@@ -723,10 +777,12 @@ class ChangeStreamerImpl implements ChangeStreamerService {
         );
         this.#currentTransactionCompletion =
           resolver<ForwardedTransactionCompletion>();
+        this.#transactionForwardStartedAt = performance.now();
         break;
       case 'commit': {
         const completion = this.#currentTransactionCompletion;
         assert(completion, 'forwarded commit without a pending transaction');
+        this.#recordTransactionForwardDuration();
         this.#lastForwardedCommitWatermark = watermark;
         this.#currentTransactionCompletion = undefined;
         completion.resolve({kind: 'committed', watermark});
@@ -737,11 +793,32 @@ class ChangeStreamerImpl implements ChangeStreamerService {
         assert(completion, 'forwarded rollback without a pending transaction');
         const committed = this.#lastForwardedCommitWatermark;
         assert(committed, 'last forwarded commit watermark is not initialized');
+        this.#transactionForwardStartedAt = undefined;
         this.#currentTransactionCompletion = undefined;
         completion.resolve({kind: 'rolled-back', watermark: committed});
         break;
       }
     }
+  }
+
+  #recordTransactionForwardDuration() {
+    const startedAt = this.#transactionForwardStartedAt;
+    this.#transactionForwardStartedAt = undefined;
+    if (startedAt !== undefined) {
+      this.#transactionForwardDuration.recordMs(performance.now() - startedAt, {
+        sqlite_change_log: this.#changeLogWriter?.enabled ? 'on' : 'off',
+      });
+    }
+  }
+
+  /**
+   * Closes and forgets the cached catchup coordinator, so that a later
+   * subscription re-opens the log from scratch rather than reading a handle
+   * whose file is gone.
+   */
+  #closeSQLiteCatchup() {
+    this.#sqliteCatchup?.close();
+    this.#sqliteCatchup = undefined;
   }
 
   #captureRequiredHead(): string | Promise<string> {
@@ -775,15 +852,14 @@ class ChangeStreamerImpl implements ChangeStreamerService {
       return undefined;
     }
     if (ctx.logsChangeStream) {
-      // A change-log writer cannot be served from the change log it writes.
-      // The barrier waits for a head that only this subscriber can advance,
-      // and it advances it by consuming the very subscription the barrier is
-      // holding: it would wait on its own ACK until the deadline, on every
-      // reconnect. Enforced here rather than left to the selector so that no
-      // selector can express it.
+      // The reason for this exclusion is gone: the writer is no longer a
+      // subscriber, so nothing can wait on its own ACK, and no replicator this
+      // version ships sets the parameter. It stays until slice 11 lifts it
+      // deliberately, because a subscriber that predates the writer's move does
+      // set it, and serving one from SQLite is a change in behavior rather than
+      // a cleanup.
       this.#lc.warn?.(
-        `not serving change-log writer ${ctx.id} from SQLite catchup: ` +
-          `it would wait on its own ACK`,
+        `not serving legacy change-log writer ${ctx.id} from SQLite catchup`,
       );
       return undefined;
     }

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -156,11 +156,11 @@ export async function initializeStreamer(
 const REPLICATION_STATUS_ERROR_DELAY_THRESHOLD_MS = 5000;
 
 // How long the change log may be unavailable before declining to serve from it
-// stops looking like normal startup ordering. A change-streamer routinely
-// starts before the replicator has created and reconciled the log, so early
+// stops looking like normal startup ordering. Subscriptions can arrive before
+// the stream loop's first reconcile has created and seeded the log, so early
 // declines are expected. Still declining a minute later means the log is not
-// being written at all -- `sqliteChangeLogMode=off`, a replicator crash loop,
-// or a path mismatch -- which is worth surfacing.
+// being written at all -- `sqliteChangeLogMode=off`, a writer that has failed
+// soft, or a path mismatch -- which is worth surfacing.
 const DEFAULT_CHANGE_LOG_UNAVAILABLE_WARN_THRESHOLD_MS = 60_000;
 
 /**
@@ -873,9 +873,10 @@ class ChangeStreamerImpl implements ChangeStreamerService {
    * Opens the change log and, if it can serve, wraps it in the coordinator that
    * subsequent subscriptions reuse.
    *
-   * The change-streamer and the replicator that writes the log start
-   * independently, so the log may not exist yet, may exist without content, or
-   * may be unreadable. None of those can be allowed to fail a subscription:
+   * The log may not exist yet -- the writer creates it at the stream loop's
+   * first reconcile, and deletes it when it fails soft -- or may exist without
+   * content, or may be unreadable. None of those can be allowed to fail a
+   * subscription:
    * this is the last point at which PG catchup is still available -- past
    * `Forwarder.add()` the subscriber is committed to SQLite -- so each declines
    * here instead. Neither the failure nor the reader is retained, so a later
@@ -935,8 +936,8 @@ class ChangeStreamerImpl implements ChangeStreamerService {
 
   /**
    * Reports falling back to PG catchup, tracking how long the log has been
-   * unavailable so that a change-streamer that merely started before its
-   * replicator does not look like an incident.
+   * unavailable so that a subscription that merely arrived before the writer's
+   * first reconcile does not look like an incident.
    */
   #declineSQLiteCatchup(
     ctx: SubscriberContext,

--- a/packages/zero-cache/src/services/change-streamer/change-streamer.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer.ts
@@ -145,11 +145,14 @@ export type SubscriberContext = {
 
   /**
    * Whether the subscriber's replica writes the SQLite change log that the
-   * `change-streamer` reads for catchup (see `replicaLogsChangeStream()`).
-   * Such a subscriber is always co-located with the `change-streamer`, and
-   * is the only thing that advances that change log: its ACKs are what the
-   * SQLite catchup barrier waits on, and it cannot itself be served from
-   * SQLite catchup without waiting on its own ACK.
+   * `change-streamer` reads for catchup.
+   *
+   * Always `false` from this version on: the change-streamer writes that log
+   * itself, from the stream loop, so no subscriber advances it and no
+   * subscriber's ACK releases the catchup barrier. The parameter stays on the
+   * wire because a subscriber that predates the writer's move still sets it,
+   * and such a subscriber is excluded from SQLite catchup until slice 11 lifts
+   * the exclusion deliberately.
    */
   logsChangeStream: boolean;
 };

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.test.ts
@@ -36,7 +36,7 @@ type CatchupFuzzScenario = {
   readonly futureWidths: number[];
   readonly sentinelWidth: number;
   readonly batchSize: number;
-  readonly wakeup: 'ack' | 'early-ack' | 'poll';
+  readonly wakeup: 'commit' | 'early-commit' | 'poll';
 };
 
 const catchupFuzzScenario: fc.Arbitrary<CatchupFuzzScenario> = fc.record({
@@ -54,8 +54,8 @@ const catchupFuzzScenario: fc.Arbitrary<CatchupFuzzScenario> = fc.record({
   sentinelWidth: fc.integer({min: 0, max: 5}),
   batchSize: fc.integer({min: 1, max: 5}),
   wakeup: fc.constantFrom(
-    'ack' as const,
-    'early-ack' as const,
+    'commit' as const,
+    'early-commit' as const,
     'poll' as const,
   ),
 });
@@ -240,9 +240,10 @@ describe('SQLiteChangeLogCatchup', () => {
     }
   });
 
-  test('releases the barrier on the change-log writer ACK', async () => {
-    // A poll interval well beyond the test timeout: only the ACK can release
-    // this barrier, so passing proves it is not polling for the head.
+  test("releases the barrier on the change-log writer's commit", async () => {
+    // A poll interval well beyond the test timeout: only the commit
+    // notification can release this barrier, so passing proves it is not
+    // polling for the head.
     const fixture = createFixture({
       barrierTimeoutMs: 60_000,
       barrierPollIntervalMs: 60_000,
@@ -259,7 +260,7 @@ describe('SQLiteChangeLogCatchup', () => {
     fixture.reader.entries.push(...transaction('06'));
     fixture.reader.boundaries.add('06');
     fixture.reader.head = '06';
-    fixture.coordinator.onChangeLogWriterAck('06');
+    fixture.coordinator.onChangeLogCommit('06');
 
     expect(await takeMarkers(output, 7)).toEqual([
       'status',
@@ -268,7 +269,7 @@ describe('SQLiteChangeLogCatchup', () => {
     ]);
   });
 
-  test('ignores change-log ACKs below the required head', async () => {
+  test('ignores change-log commits below the required head', async () => {
     const fixture = createFixture({
       barrierTimeoutMs: 60_000,
       barrierPollIntervalMs: 60_000,
@@ -280,9 +281,9 @@ describe('SQLiteChangeLogCatchup', () => {
     await fixture.coordinator.catchup(subscriber, () => '06');
     await vi.waitFor(() => expect(plan).toHaveBeenCalledOnce());
 
-    // The writer is still behind the required head. Waking on every ACK would
-    // re-read the replica at the writer's commit rate for no reason.
-    fixture.coordinator.onChangeLogWriterAck('04');
+    // The writer is still behind the required head. Waking on every commit
+    // would re-read the log at the writer's commit rate for no reason.
+    fixture.coordinator.onChangeLogCommit('04');
     await sleep(20);
     expect(plan).toHaveBeenCalledOnce();
     expect(output.size()).toBe(0);
@@ -290,7 +291,7 @@ describe('SQLiteChangeLogCatchup', () => {
     fixture.reader.entries.push(...transaction('06'));
     fixture.reader.boundaries.add('06');
     fixture.reader.head = '06';
-    fixture.coordinator.onChangeLogWriterAck('06');
+    fixture.coordinator.onChangeLogCommit('06');
 
     expect(await takeMarkers(output, 4)).toEqual([
       'status',
@@ -316,14 +317,14 @@ describe('SQLiteChangeLogCatchup', () => {
 
     // An ACK that the reader cannot yet corroborate wakes the barrier but does
     // not release it: plan() decides what is readable.
-    fixture.coordinator.onChangeLogWriterAck('06');
+    fixture.coordinator.onChangeLogCommit('06');
     await vi.waitFor(() => expect(plan).toHaveBeenCalledTimes(2));
     expect(output.size()).toBe(0);
 
     fixture.reader.entries.push(...transaction('06'));
     fixture.reader.boundaries.add('06');
     fixture.reader.head = '06';
-    fixture.coordinator.onChangeLogWriterAck('06');
+    fixture.coordinator.onChangeLogCommit('06');
 
     expect(await takeMarkers(output, 4)).toEqual([
       'status',
@@ -773,18 +774,18 @@ async function runCatchupFuzzScenario(
       ...future,
     ];
     const appliedHead = committed.at(-1)?.watermark ?? FUZZ_SEED_WATERMARK;
-    if (scenario.wakeup === 'early-ack') {
-      coordinator.onChangeLogWriterAck(appliedHead);
-      // Let an early ACK race a plan() that still observes the old head. The
-      // poll backstop must preserve correctness if the notification is spent.
+    if (scenario.wakeup === 'early-commit') {
+      coordinator.onChangeLogCommit(appliedHead);
+      // Let an early notification race a plan() that still observes the old
+      // head. The poll backstop must preserve correctness if it is spent.
       await Promise.resolve();
     }
     applyFuzzTransactions(
       reader,
       committed.filter(tx => !reader.boundaries.has(tx.watermark)),
     );
-    if (scenario.wakeup === 'ack') {
-      coordinator.onChangeLogWriterAck(appliedHead);
+    if (scenario.wakeup === 'commit') {
+      coordinator.onChangeLogCommit(appliedHead);
     }
 
     // This commit is deliberately live-only. Receiving it proves catchup made

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.ts
@@ -29,11 +29,10 @@ export interface SQLiteChangeLogCleanupGuard {
   runWhilePurgeBlocked<T>(register: () => T): Promise<T>;
 }
 
-// How long the barrier waits for the change-log writer's ACK before falling
-// back to reading the replica. The ACK normally arrives first, so this is a
-// backstop for the windows in which no ACK is coming: no writer is subscribed
-// (in which case the change log cannot be advancing either), the writer is
-// mid-reconnect, or it predates the `logsChangeStream` subscription parameter.
+// How long the barrier waits for the change-log writer's commit notification
+// before re-reading the log itself. The notification normally arrives first, so
+// this is a backstop for the windows in which none is coming: the writer is
+// disabled, or it is between stream connections.
 const DEFAULT_BARRIER_POLL_INTERVAL_MS = 1000;
 
 export type SQLiteChangeLogCatchupOptions = {
@@ -83,11 +82,11 @@ export class SQLiteChangeLogCatchup implements Disposable {
     'replication',
     'sqlite_change_log.barrier_wakeups',
     'SQLite catchup barrier waits, labeled by what ended the wait. A ' +
-      'population dominated by "poll" means the change-log writer ACK is not ' +
-      'reaching the barrier.',
+      'population dominated by "poll" means the change-log writer\'s commit ' +
+      'notification is not reaching the barrier.',
   );
   readonly #catchups = new Map<Subscriber, AbortController>();
-  readonly #ackWaiters = new Set<AckWaiter>();
+  readonly #commitWaiters = new Set<CommitWaiter>();
   #closed = false;
 
   constructor(
@@ -147,19 +146,18 @@ export class SQLiteChangeLogCatchup implements Disposable {
   }
 
   /**
-   * Notes that the subscriber writing the SQLite change log has acked
-   * `watermark`, i.e. has durably applied it to the replica this coordinator
-   * reads. That is the only event that advances the change log, so it is what
-   * the barrier waits on instead of polling the replica for it.
+   * Notes that the change-log writer has committed `watermark`, i.e. that the
+   * log's head has advanced to it. The writer runs in this process, so this is
+   * the event itself rather than a subscriber's ACK of it.
    *
-   * The ACK is a wakeup, not an authority: `plan()` still decides what can be
-   * read. An ACK that never arrives costs the barrier a poll interval, and one
+   * It is a wakeup, not an authority: `plan()` still decides what can be read.
+   * A notification that never arrives costs the barrier a poll interval, and one
    * that arrives early costs an extra `plan()` call.
    */
-  onChangeLogWriterAck(watermark: string): void {
-    for (const waiter of this.#ackWaiters) {
+  onChangeLogCommit(watermark: string): void {
+    for (const waiter of this.#commitWaiters) {
       if (watermark >= waiter.watermark) {
-        this.#ackWaiters.delete(waiter);
+        this.#commitWaiters.delete(waiter);
         waiter.resolve();
       }
     }
@@ -419,29 +417,29 @@ export class SQLiteChangeLogCatchup implements Disposable {
   }
 
   /**
-   * Waits for the change-log writer's ACK of `requiredHead`, or the poll
+   * Waits for the change-log writer to commit `requiredHead`, or the poll
    * interval as a backstop.
    *
-   * No ACK can be missed by registering after `plan()` was read, because the
-   * ACK lags the write it acknowledges: if the writer had already acked
-   * `requiredHead`, `plan()` would have seen it.
+   * No notification can be missed by registering after `plan()` was read: the
+   * notification follows the commit it reports, so if the writer had already
+   * committed `requiredHead`, `plan()` would have seen it.
    */
   async #awaitChangeLogProgress(
     requiredHead: string,
     remainingMs: number,
     signal: AbortSignal,
   ): Promise<void> {
-    const acked = resolver<void>();
-    const waiter = {watermark: requiredHead, resolve: acked.resolve};
-    this.#ackWaiters.add(waiter);
-    // Scopes the backstop timer to this wait so that an ACK cancels it rather
+    const committed = resolver<void>();
+    const waiter = {watermark: requiredHead, resolve: committed.resolve};
+    this.#commitWaiters.add(waiter);
+    // Scopes the backstop timer to this wait so that a commit cancels it rather
     // than leaving it to fire against a barrier that has already moved on.
     const poll = new AbortController();
     const abortPoll = () => poll.abort();
     signal.addEventListener('abort', abortPoll, {once: true});
     try {
       const wokenBy = await Promise.race([
-        acked.promise.then(() => 'ack' as const),
+        committed.promise.then(() => 'commit' as const),
         this.#sleep(
           Math.min(this.#barrierPollIntervalMs, remainingMs),
           poll.signal,
@@ -449,7 +447,7 @@ export class SQLiteChangeLogCatchup implements Disposable {
       ]);
       this.#barrierWakeups.add(1, {'wakeup.source': wokenBy});
     } finally {
-      this.#ackWaiters.delete(waiter);
+      this.#commitWaiters.delete(waiter);
       signal.removeEventListener('abort', abortPoll);
       poll.abort();
     }
@@ -462,7 +460,7 @@ export class SQLiteChangeLogCatchup implements Disposable {
   }
 }
 
-type AckWaiter = {watermark: string; resolve: () => void};
+type CommitWaiter = {watermark: string; resolve: () => void};
 
 /**
  * A barrier that gave up on the replica reaching the required head. Both

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-reader.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-reader.test.ts
@@ -13,7 +13,7 @@ import {
   deleteChangeLogDB,
   openChangeLogDB,
   reconcileChangeLog,
-  type ReplicaAnchor,
+  type ChangeLogAnchor,
 } from '../replicator/change-log-db.ts';
 import {ChangeLogStreamWriter} from '../replicator/change-log-stream-writer.ts';
 import {serializeChangeStreamData} from './change-log-codec.ts';
@@ -36,13 +36,13 @@ afterEach(() => {
 });
 
 /**
- * The replica the change log is anchored to. No fixture in this file creates
- * that replica: the reader is served entirely by the change-log database.
+ * The watermark the log is seeded at. No fixture in this file creates a
+ * replica: the reader is served entirely by the change-log database.
  */
-const ANCHOR: ReplicaAnchor = {
-  replicaVersion: '01',
-  stateVersion: '02',
-  writeTimeMs: 1234567890,
+const ANCHOR: ChangeLogAnchor = {
+  identity: {epoch: null, generation: '01', replicaID: null},
+  resumeWatermark: '02',
+  nowMs: 1234567890,
 };
 
 /** The replica path whose `-change-log` sibling the fixtures build. */

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-writer.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-writer.test.ts
@@ -151,6 +151,9 @@ describe('change-streamer/sqlite-change-log-writer', () => {
     expect(fixture.errors().join('\n')).toContain(
       'error writing to the SQLite change log',
     );
+    // The generic policy, not the carve-out: a dropped table is not a missed
+    // truncate-above, so it must not be reported as an invariant failure.
+    expect(fixture.errors().join('\n')).not.toContain('violated a constraint');
 
     // Replication continues: further writes are no-ops rather than throws, and
     // nothing recreates the file.
@@ -188,6 +191,44 @@ describe('change-streamer/sqlite-change-log-writer', () => {
     // Reported before failing soft, so the invariant failure is not absorbed.
     expect(fixture.writer.enabled).toBe(false);
     expect(existsSync(changeLogFileName(fixture.file.path))).toBe(false);
+  });
+
+  test('abort discards an interrupted transaction', () => {
+    using fixture = setup('change-log-writer-abort');
+
+    const begin: ChangeStreamData = [
+      'begin',
+      messages.begin(),
+      {commitWatermark: '04'},
+    ];
+    fixture.writer.write(begin, serializeChangeStreamData(begin));
+    fixture.writer.abort();
+
+    expect(fixture.head()).toBe('02');
+    expect(fixture.commits).toEqual([]);
+    expect(fixture.writer.enabled).toBe(true);
+
+    // The reconnected stream reconciles and re-delivers as if the interrupted
+    // transaction had never arrived.
+    fixture.writer.reconcile('02');
+    transaction(fixture.writer, '04');
+    expect(fixture.head()).toBe('04');
+    expect(fixture.commits).toEqual(['04']);
+  });
+
+  // The stream loop aborts whenever it believes a transaction is open, which
+  // includes the window between the commit-row write and its own bookkeeping --
+  // so an abort can arrive after the log already committed, and must be a
+  // no-op rather than a fail-soft.
+  test('abort with no open transaction is a no-op', () => {
+    using fixture = setup('change-log-writer-abort-idle');
+
+    transaction(fixture.writer, '04');
+    fixture.writer.abort();
+
+    expect(fixture.writer.enabled).toBe(true);
+    expect(fixture.head()).toBe('04');
+    expect(fixture.errors()).toEqual([]);
   });
 
   test('a failure to open the log disables the writer without throwing', () => {

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-writer.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-writer.test.ts
@@ -1,0 +1,238 @@
+import {existsSync} from 'node:fs';
+import {LogContext} from '@rocicorp/logger';
+import {afterEach, describe, expect, test} from 'vitest';
+import {TestLogSink} from '../../../../shared/src/logging-test-utils.ts';
+import {DbFile} from '../../test/lite.ts';
+import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
+import {
+  CHANGE_LOG_STREAM_TABLE,
+  changeLogFileName,
+  deleteChangeLogDB,
+  openChangeLogDB,
+  readChangeLogHead,
+  type ChangeLogIdentity,
+} from '../replicator/change-log-db.ts';
+import {ReplicationMessages} from '../replicator/test-utils.ts';
+import {serializeChangeStreamData} from './change-log-codec.ts';
+import {SQLiteChangeLogWriter} from './sqlite-change-log-writer.ts';
+
+const messages = new ReplicationMessages({foo: 'id'});
+
+const IDENTITY: ChangeLogIdentity = {
+  epoch: null,
+  generation: '01',
+  replicaID: 'replica-id',
+};
+
+const files: DbFile[] = [];
+
+afterEach(() => {
+  let file: DbFile | undefined;
+  while ((file = files.pop())) {
+    deleteChangeLogDB(file.path);
+    file.delete();
+  }
+});
+
+function setup(name: string, resumeWatermark = '02') {
+  const sink = new TestLogSink();
+  const lc = new LogContext('debug', undefined, sink);
+  const file = new DbFile(name);
+  files.push(file);
+  const commits: string[] = [];
+  let disabled = 0;
+  const writer = new SQLiteChangeLogWriter(lc, {
+    replicaFile: file.path,
+    identity: IDENTITY,
+    onCommit: watermark => commits.push(watermark),
+    onDisabled: () => disabled++,
+    now: () => 1_700_000_000_000,
+  });
+  writer.reconcile(resumeWatermark);
+  return {
+    lc,
+    sink,
+    file,
+    writer,
+    commits,
+    disabledCount: () => disabled,
+    head: () => {
+      using db = openChangeLogDB(lc, file.path, {readonly: true});
+      return readChangeLogHead(db);
+    },
+    errors: () =>
+      sink.messages
+        .filter(([level]) => level === 'error')
+        .map(([, , args]) => String(args[0])),
+    [Symbol.dispose]() {
+      writer.close();
+    },
+  };
+}
+
+/** Drives a whole transaction through the writer, as the stream loop does. */
+function transaction(
+  writer: SQLiteChangeLogWriter,
+  watermark: string,
+  ...data: ChangeStreamData[]
+) {
+  const write = (change: ChangeStreamData) =>
+    writer.write(change, serializeChangeStreamData(change));
+  write(['begin', messages.begin(), {commitWatermark: watermark}]);
+  data.forEach(write);
+  write(['commit', messages.commit(), {watermark}]);
+}
+
+describe('change-streamer/sqlite-change-log-writer', () => {
+  test('appends transactions and reports each new head', () => {
+    using fixture = setup('change-log-writer-append');
+
+    transaction(fixture.writer, '04', [
+      'data',
+      messages.insert('foo', {id: 'one'}),
+    ]);
+    transaction(fixture.writer, '06', [
+      'data',
+      messages.insert('foo', {id: 'two'}),
+    ]);
+
+    expect(fixture.commits).toEqual(['04', '06']);
+    expect(fixture.head()).toBe('06');
+    expect(fixture.writer.state()).toMatchObject({
+      sqliteHead: '06',
+      receivedHead: '06',
+      headLag: 0,
+      invariantFailures: 0,
+      hashMatches: 2,
+      hashMismatches: 0,
+      hashUnpaired: 0,
+    });
+  });
+
+  test('an upstream rollback leaves no rows', () => {
+    using fixture = setup('change-log-writer-rollback');
+
+    fixture.writer.write(
+      ['begin', messages.begin(), {commitWatermark: '04'}],
+      serializeChangeStreamData([
+        'begin',
+        messages.begin(),
+        {commitWatermark: '04'},
+      ]),
+    );
+    const rollback: ChangeStreamData = ['rollback', {tag: 'rollback'}];
+    fixture.writer.write(rollback, serializeChangeStreamData(rollback));
+
+    expect(fixture.head()).toBe('02');
+    expect(fixture.commits).toEqual([]);
+    expect(fixture.writer.enabled).toBe(true);
+  });
+
+  // §3.7: nothing in the log is not either already durable in the replica's
+  // backup or re-derivable from the slot, so a write failure must cost catchup
+  // reach rather than the shard's replication.
+  test('a write error disables the writer, deletes the file, and keeps going', () => {
+    using fixture = setup('change-log-writer-fail-soft');
+    // Pulls the table out from under the writer's prepared statements, which is
+    // an error the file's contents cannot explain -- the shape a full disk or an
+    // I/O error takes.
+    {
+      using other = openChangeLogDB(fixture.lc, fixture.file.path, {
+        readonly: false,
+      });
+      other.exec(`DROP TABLE "${CHANGE_LOG_STREAM_TABLE}"`);
+    }
+
+    transaction(fixture.writer, '04');
+
+    expect(fixture.writer.enabled).toBe(false);
+    expect(fixture.disabledCount()).toBe(1);
+    expect(existsSync(changeLogFileName(fixture.file.path))).toBe(false);
+    expect(fixture.errors().join('\n')).toContain(
+      'error writing to the SQLite change log',
+    );
+
+    // Replication continues: further writes are no-ops rather than throws, and
+    // nothing recreates the file.
+    expect(() => transaction(fixture.writer, '06')).not.toThrow();
+    fixture.writer.reconcile('06');
+    expect(existsSync(changeLogFileName(fixture.file.path))).toBe(false);
+    expect(fixture.writer.enabled).toBe(false);
+  });
+
+  // The carve-out that keeps fail-soft from hiding the bug class 7I introduces:
+  // a missed truncate-above is a constraint violation on the writer's plain
+  // INSERT, which is otherwise indistinguishable from a lost cache.
+  test('a constraint violation is counted as an invariant failure', () => {
+    using fixture = setup('change-log-writer-constraint');
+    // A transaction the log already holds, i.e. what reconciliation should have
+    // truncated before the stream re-delivered it.
+    {
+      using other = openChangeLogDB(fixture.lc, fixture.file.path, {
+        readonly: false,
+      });
+      other
+        .prepare(/*sql*/ `
+          INSERT INTO "${CHANGE_LOG_STREAM_TABLE}"
+            ("watermark", "pos", "change") VALUES ('04', 0, '{"tag":"begin"}')
+        `)
+        .run();
+    }
+
+    transaction(fixture.writer, '04');
+
+    expect(fixture.errors().join('\n')).toContain(
+      'violated a constraint, which means a transaction above the resume ' +
+        'watermark was not truncated',
+    );
+    // Reported before failing soft, so the invariant failure is not absorbed.
+    expect(fixture.writer.enabled).toBe(false);
+    expect(existsSync(changeLogFileName(fixture.file.path))).toBe(false);
+  });
+
+  test('a failure to open the log disables the writer without throwing', () => {
+    const sink = new TestLogSink();
+    const lc = new LogContext('debug', undefined, sink);
+    const writer = new SQLiteChangeLogWriter(lc, {
+      // A directory that does not exist: a bad path is an environment problem,
+      // not a corrupt file, so it is not rebuilt through.
+      replicaFile: '/nonexistent-directory/replica.db',
+      identity: IDENTITY,
+    });
+
+    expect(() => writer.reconcile('02')).not.toThrow();
+    expect(writer.enabled).toBe(false);
+    expect(
+      sink.messages
+        .filter(([level]) => level === 'error')
+        .map(([, , args]) => String(args[0]))
+        .join('\n'),
+    ).toContain('error reconciling the SQLite change log');
+  });
+
+  test('reconciling per connection truncates and re-accepts a re-delivery', () => {
+    using fixture = setup('change-log-writer-reconnect');
+
+    transaction(fixture.writer, '04', [
+      'data',
+      messages.insert('foo', {id: 'one'}),
+    ]);
+    transaction(fixture.writer, '06', [
+      'data',
+      messages.insert('foo', {id: 'two'}),
+    ]);
+    expect(fixture.head()).toBe('06');
+
+    // The stream reconnects and resumes below the head.
+    fixture.writer.reconcile('04');
+    expect(fixture.head()).toBe('04');
+
+    transaction(fixture.writer, '06', [
+      'data',
+      messages.insert('foo', {id: 'two again'}),
+    ]);
+    expect(fixture.head()).toBe('06');
+    expect(fixture.writer.enabled).toBe(true);
+    expect(fixture.writer.state()?.invariantFailures).toBe(0);
+  });
+});

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-writer.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-writer.ts
@@ -1,0 +1,274 @@
+import type {LogContext} from '@rocicorp/logger';
+import {SqliteError} from '@rocicorp/zero-sqlite3';
+import {must} from '../../../../shared/src/must.ts';
+import type {Database} from '../../../../zqlite/src/db.ts';
+import {
+  isSQLiteCorruption,
+  logSQLiteCorruptionDiagnostics,
+} from '../../db/sqlite-corruption.ts';
+import {StatementRunner} from '../../db/statements.ts';
+import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
+import {
+  changeLogFileName,
+  deleteChangeLogDB,
+  openChangeLogDBForWriting,
+  reconcileChangeLog,
+  type ChangeLogIdentity,
+} from '../replicator/change-log-db.ts';
+import {ChangeLogStreamWriter} from '../replicator/change-log-stream-writer.ts';
+import {
+  getSQLiteChangeLogInfo,
+  logSQLiteChangeLogStartup,
+  recordSQLiteChangeLogReconcile,
+  SQLiteChangeLogObserver,
+  type ChangeLogCommit,
+  type SQLiteChangeLogObservabilityState,
+} from '../replicator/sqlite-change-log-observability.ts';
+
+export type SQLiteChangeLogWriterOptions = {
+  /** The replica file the log is named after, i.e. `${replicaFile}-change-log`. */
+  replicaFile: string;
+  /** The replica whose contents this log belongs to. */
+  identity: ChangeLogIdentity;
+  /**
+   * Called after each transaction's log commit, with the log's new head. This
+   * is what releases the catchup barrier: after the writer moved in-process,
+   * the head advances here rather than at a subscriber's ACK.
+   */
+  onCommit?: ((watermark: string) => void) | undefined;
+  /**
+   * Called when the writer disables itself and deletes the file. The reader is
+   * cached on the service, so a delete that leaves it open would leave an
+   * in-process reader serving an unlinked inode while every new open sees
+   * nothing.
+   */
+  onDisabled?: (() => void) | undefined;
+  /** Overridable for tests. */
+  now?: (() => number) | undefined;
+};
+
+/**
+ * Appends the canonical change stream to the SQLite change log, from the
+ * change-streamer's own stream loop.
+ *
+ * ### Ordering
+ *
+ * The log's commit for a transaction precedes the forward of that transaction's
+ * `commit` message, and nothing `await`s in between. Everything that can
+ * advance the watermark the stream would resume from — the storer's Postgres
+ * commit, `lastWatermark`, the upstream ACK — runs strictly after it, so the
+ * log's head is always at or above the resume point. A *hole* is therefore
+ * unreachable at any crash timing, and a *phantom* is the normal state, which is
+ * what makes truncate-above the whole of reconciliation.
+ *
+ * ### Fail-soft
+ *
+ * The log is a catchup cache: nothing in it is not either already durable in the
+ * replica's litestream backup or re-derivable from the replication slot. A write
+ * failure must therefore not stop replication for the shard. Corruption is
+ * rebuilt once at open; any other write error — a full disk, an I/O error, a
+ * permissions problem — logs, disables the writer, deletes the file, closes the
+ * reader, and lets the stream continue. The cost is catchup reach, and reach is
+ * recoverable: `too-old` sends a subscriber to a restore.
+ *
+ * One carve-out keeps that from hiding the bug class this topology introduces. A
+ * missed truncate-above surfaces as `SQLITE_CONSTRAINT` on the writer's plain
+ * `INSERT`, which is "any write error other than corruption" and would be
+ * absorbed quietly. It is counted as an invariant failure and alerted on before
+ * failing soft.
+ */
+export class SQLiteChangeLogWriter {
+  readonly #lc: LogContext;
+  readonly #opts: SQLiteChangeLogWriterOptions;
+  readonly #now: () => number;
+
+  #db: Database | undefined;
+  #writer: ChangeLogStreamWriter | undefined;
+  #observer: SQLiteChangeLogObserver | undefined;
+  #disabled = false;
+
+  constructor(lc: LogContext, opts: SQLiteChangeLogWriterOptions) {
+    this.#lc = lc.withContext('component', 'sqlite-change-log-writer');
+    this.#opts = opts;
+    this.#now = opts.now ?? Date.now;
+  }
+
+  /** False once the writer has failed soft, or after {@link close}. */
+  get enabled(): boolean {
+    return !this.#disabled;
+  }
+
+  /** Exposed for tests and for the integration assertions on the metrics. */
+  state(): SQLiteChangeLogObservabilityState | undefined {
+    return this.#observer?.state();
+  }
+
+  /**
+   * Opens the log if necessary and reconciles it against the watermark this
+   * stream connection resumes from.
+   *
+   * This runs per connection rather than once per process: the stream loop
+   * re-reads its resume watermark on every reconnect, so a routine reconnect —
+   * not just a restart — can leave the log holding watermarks above the new
+   * resume point, and the writer's plain `INSERT` would collide with the first
+   * re-delivered transaction.
+   */
+  reconcile(resumeWatermark: string): void {
+    if (this.#disabled) {
+      return;
+    }
+    const {replicaFile, identity} = this.#opts;
+    const anchor = {identity, resumeWatermark, nowMs: this.#now()};
+    try {
+      const db = this.#db;
+      if (db === undefined) {
+        const opened = openChangeLogDBForWriting(this.#lc, replicaFile, anchor);
+        this.#db = opened.db;
+        recordSQLiteChangeLogReconcile(this.#lc, opened.result);
+        const info = getSQLiteChangeLogInfo(opened.db);
+        logSQLiteChangeLogStartup(
+          this.#lc,
+          changeLogFileName(replicaFile),
+          info,
+        );
+        this.#observer = new SQLiteChangeLogObserver(this.#lc, info);
+      } else {
+        const result = reconcileChangeLog(this.#lc, db, anchor);
+        recordSQLiteChangeLogReconcile(this.#lc, result);
+        if (result.action !== 'none') {
+          this.#observer?.reconciled(getSQLiteChangeLogInfo(db));
+        }
+      }
+      // A reseed drops and recreates the stream table, so the append statements
+      // are prepared fresh against whatever the reconciliation left behind.
+      this.#writer = new ChangeLogStreamWriter(
+        new StatementRunner(
+          must(this.#db, 'the SQLite change log is not open'),
+        ),
+      );
+    } catch (e) {
+      this.#failSoft('reconciling the SQLite change log', e);
+    }
+  }
+
+  /**
+   * Writes one stream message, committing at transaction boundaries. Never
+   * throws: a write failure disables the writer instead of failing the stream.
+   */
+  write(change: ChangeStreamData, json: string): void {
+    const writer = this.#writer;
+    if (this.#disabled || writer === undefined) {
+      return;
+    }
+    const observer = this.#observer;
+    observer?.messageReceived(change, json);
+    const [type, msg] = change;
+    const startedAt = performance.now();
+    try {
+      let commit: ChangeLogCommit | null = null;
+      switch (type) {
+        case 'begin':
+          writer.begin(change[2].commitWatermark, json);
+          break;
+        case 'commit': {
+          const {watermark} = change[2];
+          const commitStart = performance.now();
+          const stats = writer.commit(watermark, json, this.#now());
+          commit = {
+            watermark,
+            stats,
+            logCommitMs: performance.now() - commitStart,
+          };
+          break;
+        }
+        case 'rollback':
+          writer.rollback();
+          break;
+        default:
+          writer.append(json, msg.tag);
+          break;
+      }
+      observer?.messageProcessed(change, commit, performance.now() - startedAt);
+      if (commit !== null) {
+        // The head advanced, and it is durable. Releasing the barrier here is
+        // what makes its poll interval a backstop rather than the mechanism.
+        this.#opts.onCommit?.(commit.watermark);
+      }
+    } catch (e) {
+      observer?.messageFailed(change, e, performance.now() - startedAt);
+      if (isConstraintViolation(e)) {
+        // Reconciliation should have truncated whatever this collided with.
+        // Report it as an invariant failure before failing soft, so that a
+        // truncate-above bug cannot look like a lost cache.
+        observer?.invariantFailure(
+          'SQLite change-log insert violated a constraint, which means a ' +
+            'transaction above the resume watermark was not truncated',
+          {tag: msg.tag, error: String(e)},
+        );
+      }
+      this.#failSoft('writing to the SQLite change log', e);
+    }
+  }
+
+  /**
+   * Discards the open transaction, if any. Called when the change stream is
+   * interrupted mid-transaction.
+   */
+  abort(): void {
+    const writer = this.#writer;
+    if (this.#disabled || writer === undefined) {
+      return;
+    }
+    this.#observer?.abort();
+    try {
+      writer.rollback();
+    } catch (e) {
+      this.#failSoft('rolling back the SQLite change log', e);
+    }
+  }
+
+  close(): void {
+    this.#disabled = true;
+    this.#writer = undefined;
+    this.#observer = undefined;
+    const db = this.#db;
+    this.#db = undefined;
+    try {
+      db?.close();
+    } catch (e) {
+      this.#lc.warn?.('error closing the SQLite change log', e);
+    }
+  }
+
+  /**
+   * Logs, disables the writer, deletes the file, and closes the reader, leaving
+   * replication running. Disabling is for the life of the process: a log that
+   * failed a write is not re-opened until the task restarts, so the behavior a
+   * subscriber sees is the same as `sqliteChangeLogMode=off`.
+   */
+  #failSoft(what: string, e: unknown): void {
+    const file = changeLogFileName(this.#opts.replicaFile);
+    if (isSQLiteCorruption(e)) {
+      // Open-time corruption is rebuilt by openChangeLogDBForWriting. Reaching
+      // here means the file went bad under an open handle, which the same
+      // delete-and-reseed answers -- on the next process start rather than now.
+      logSQLiteCorruptionDiagnostics(this.#lc, 'change-log', file, e);
+    }
+    this.#lc.error?.(
+      `error ${what}: disabling the writer and deleting ${file}. ` +
+        `Replication continues; catchup reach is lost until this task restarts.`,
+      e,
+    );
+    this.close();
+    try {
+      deleteChangeLogDB(this.#opts.replicaFile);
+    } catch (deleteError) {
+      this.#lc.error?.(`unable to delete ${file}`, deleteError);
+    }
+    this.#opts.onDisabled?.();
+  }
+}
+
+function isConstraintViolation(e: unknown): boolean {
+  return e instanceof SqliteError && e.code.startsWith('SQLITE_CONSTRAINT');
+}

--- a/packages/zero-cache/src/services/replicator/change-log-crash-recovery.test.ts
+++ b/packages/zero-cache/src/services/replicator/change-log-crash-recovery.test.ts
@@ -1,58 +1,70 @@
 /**
- * Property-based crash injection across the log-first commit ordering.
+ * Property-based crash injection across the change log's commit ordering.
  *
- * The writer commits the change log before the replica, so the window between
- * the two commits is the one place where the two databases legitimately
- * disagree. A crash there must leave a *phantom* — a transaction in the log
- * whose replica commit was lost — and never a *hole*, because a phantom is
- * detectable and repairable at startup while a hole would be served to a
- * subscriber as a silent gap.
+ * The change-streamer commits the log before forwarding a transaction's
+ * `commit` message, and everything that can advance the watermark the stream
+ * would resume from — the storer's Postgres commit, `lastWatermark`, the
+ * upstream ACK — runs strictly after that. So the log's head is always at or
+ * above the resume point: a crash can leave a *phantom* (a transaction the
+ * resumed stream will re-deliver) but never a *hole*, because a phantom is
+ * detectable and truncatable while a hole would be served to a subscriber as a
+ * silent gap.
  *
- * Each generated case runs a change stream through {@link ChangeProcessor},
- * kills the process at a chosen point, then reopens both databases exactly as
- * `write-worker`'s `init` does and asserts design 5.1 invariants 1-4 plus
- * transaction-level contiguity. This is the writer-side companion to the
- * catchup handoff property test in
- * `change-streamer/sqlite-change-log-catchup.test.ts`.
+ * Each generated case drives a change stream through
+ * {@link SQLiteChangeLogWriter}, kills the process at a chosen point relative to
+ * the forward and the Postgres commit, then reopens the log exactly as the next
+ * stream connection does and asserts the ordering invariant plus
+ * transaction-level contiguity.
+ *
+ * The Postgres side is modeled rather than run: what the log is reconciled
+ * against is a single watermark, and the only thing that matters about its
+ * source is *when* it advances relative to the log's commit. The end-to-end
+ * version of this, driven by a real storer failure, is in
+ * `change-streamer/change-streamer-service.pg.test.ts`.
  */
 
 import fc from 'fast-check';
 import {afterEach, describe, expect, test} from 'vitest';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
 import {must} from '../../../../shared/src/must.ts';
-import {Database} from '../../../../zqlite/src/db.ts';
-import {StatementRunner} from '../../db/statements.ts';
-import {DbFile, initDB} from '../../test/lite.ts';
+import type {Database} from '../../../../zqlite/src/db.ts';
+import {DbFile} from '../../test/lite.ts';
 import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
 import {serializeChangeStreamData} from '../change-streamer/change-log-codec.ts';
+import {SQLiteChangeLogWriter} from '../change-streamer/sqlite-change-log-writer.ts';
 import {
-  CHANGE_LOG_META_TABLE,
   CHANGE_LOG_STREAM_TABLE,
   deleteChangeLogDB,
   openChangeLogDB,
-  readReplicaAnchor,
-  reconcileChangeLog,
-  type ReconcileResult,
+  readChangeLogHead,
+  readChangeLogMeta,
+  type ChangeLogIdentity,
 } from './change-log-db.ts';
-import {ChangeProcessor} from './change-processor.ts';
-import {initReplicationState} from './schema/replication-state.ts';
 import {ReplicationMessages} from './test-utils.ts';
 
 const lc = createSilentLogContext();
 const issues = new ReplicationMessages({issues: 'id'});
 
-const REPLICA_VERSION = '02';
+const IDENTITY: ChangeLogIdentity = {
+  epoch: null,
+  generation: '02',
+  replicaID: '1777575698286',
+};
 
-/** Where the process is killed, relative to the two commits. */
+/** Where the process is killed, relative to the forward and the PG commit. */
 type CrashPoint =
-  // The log's COMMIT never runs: both databases end at the previous version.
-  | 'log-commit'
-  // The log is committed; the replica's state update never runs.
-  | 'state-update'
-  // The log is committed and the state updated; the replica's COMMIT never runs.
-  | 'replica-commit'
-  // Not a crash: the source drops mid-transaction and the processor aborts.
-  | 'source-disconnect';
+  // The log's COMMIT never runs: nothing for that transaction is durable.
+  | 'before-log-commit'
+  // The log is committed; the `commit` message is not yet forwarded.
+  | 'after-log-commit'
+  // The `commit` is forwarded; the resume watermark has not advanced.
+  | 'after-forward'
+  // Not a crash: the source drops mid-transaction and the writer rolls back.
+  | 'source-disconnect'
+  // Not a crash either: the whole transaction is logged and forwarded, and the
+  // Postgres commit never lands. This is what a failed storer commit leaves,
+  // and it is the in-process form of 'after-forward'.
+  | 'no-pg-commit';
 
 type Scenario = {
   readonly before: number;
@@ -66,9 +78,9 @@ const scenario: fc.Arbitrary<Scenario> = fc.record({
   changes: fc.integer({min: 0, max: 3}),
   after: fc.integer({min: 0, max: 3}),
   crashPoint: fc.constantFrom<CrashPoint>(
-    'log-commit',
-    'state-update',
-    'replica-commit',
+    'before-log-commit',
+    'after-log-commit',
+    'after-forward',
     'source-disconnect',
   ),
 });
@@ -78,131 +90,63 @@ function watermark(i: number): string {
   return `0${'3456789abcdefghijk'[i]}`;
 }
 
+/**
+ * One change-streamer process: the writer, the watermarks it has forwarded, and
+ * the resume watermark that only a Postgres commit advances.
+ */
+class Session {
+  readonly forwarded: string[] = [];
+  readonly writer: SQLiteChangeLogWriter;
+  #resumeWatermark: string;
+  #dead = false;
+
+  constructor(file: DbFile, resumeWatermark: string) {
+    this.#resumeWatermark = resumeWatermark;
+    this.writer = new SQLiteChangeLogWriter(lc, {
+      replicaFile: file.path,
+      identity: IDENTITY,
+      now: () => 1_700_000_000_000,
+    });
+  }
+
+  get resumeWatermark(): string {
+    return this.#resumeWatermark;
+  }
+
+  reconcile() {
+    this.writer.reconcile(this.#resumeWatermark);
+  }
+
+  write(change: ChangeStreamData) {
+    this.writer.write(change, serializeChangeStreamData(change));
+  }
+
+  forward(change: ChangeStreamData) {
+    if (change[0] === 'commit') {
+      this.forwarded.push(change[2].watermark);
+    }
+  }
+
+  /** The storer's Postgres commit, i.e. the only thing that moves the anchor. */
+  pgCommit(watermark: string) {
+    this.#resumeWatermark = watermark;
+  }
+
+  /**
+   * Kills the process. Closing the handle is what makes this a crash rather
+   * than a shutdown: SQLite discards whatever the open transaction had not
+   * committed, and nothing gets a chance to roll anything back.
+   */
+  kill() {
+    if (!this.#dead) {
+      this.#dead = true;
+      this.writer.close();
+    }
+  }
+}
+
 class Crash extends Error {
   override readonly name = 'InjectedCrash';
-}
-
-/**
- * A replica runner that kills the process at a chosen statement, by closing
- * both connections before throwing. Closing rather than rolling back is what
- * makes this a crash: SQLite discards whatever was not committed, and the
- * processor's own rollback then fails against a closed handle, which is the
- * partial-rollback path `#fail` has to tolerate.
- */
-class CrashingStatementRunner extends StatementRunner {
-  kill: (() => void) | undefined;
-  crashOnStateUpdate = false;
-  crashOnCommit = false;
-
-  override run(sql: string, ...args: unknown[]) {
-    if (this.crashOnStateUpdate && sql.includes('"_zero.replicationState"')) {
-      this.crashOnStateUpdate = false;
-      this.#crash();
-    }
-    return super.run(sql, ...args);
-  }
-
-  override commit() {
-    if (this.crashOnCommit) {
-      this.crashOnCommit = false;
-      this.#crash();
-    }
-    return super.commit();
-  }
-
-  #crash(): never {
-    this.kill?.();
-    throw new Crash('injected crash');
-  }
-}
-
-/** A change-log runner that kills the process instead of committing. */
-class CrashingChangeLogRunner extends StatementRunner {
-  kill: (() => void) | undefined;
-  crashOnCommit = false;
-
-  override commit() {
-    if (this.crashOnCommit) {
-      this.crashOnCommit = false;
-      this.kill?.();
-      throw new Crash('injected crash');
-    }
-    return super.commit();
-  }
-}
-
-type Session = {
-  readonly replica: Database;
-  readonly changeLog: Database;
-  readonly replicaRunner: CrashingStatementRunner;
-  readonly changeLogRunner: CrashingChangeLogRunner;
-  readonly processor: ChangeProcessor;
-  readonly failures: unknown[];
-  readonly reconciled: ReconcileResult;
-  readonly close: () => void;
-};
-
-/** Opens both databases and reconciles, exactly as `write-worker.init` does. */
-function startSession(file: DbFile): Session {
-  const replica = file.connect(lc);
-  const changeLog = openChangeLogDB(lc, file.path, {readonly: false});
-  changeLog.pragma('journal_mode = wal2');
-  const reconciled = reconcileChangeLog(
-    lc,
-    changeLog,
-    readReplicaAnchor(replica),
-  );
-
-  const replicaRunner = new CrashingStatementRunner(replica);
-  const changeLogRunner = new CrashingChangeLogRunner(changeLog);
-  const failures: unknown[] = [];
-  let closed = false;
-  const kill = () => {
-    closed = true;
-    changeLog.close();
-    replica.close();
-  };
-  replicaRunner.kill = kill;
-  changeLogRunner.kill = kill;
-
-  return {
-    replica,
-    changeLog,
-    replicaRunner,
-    changeLogRunner,
-    processor: new ChangeProcessor(
-      replicaRunner,
-      'serving',
-      {changeLog: changeLogRunner},
-      (_, err) => failures.push(err),
-    ),
-    failures,
-    reconciled,
-    close: () => {
-      if (!closed) {
-        closed = true;
-        changeLog.close();
-        replica.close();
-      }
-    },
-  };
-}
-
-function process(session: Session, data: ChangeStreamData) {
-  return session.processor.processMessage(
-    lc,
-    data,
-    serializeChangeStreamData(data),
-  );
-}
-
-/** A whole transaction: begin, `changes` inserts, commit. */
-function transaction(session: Session, wm: string, changes: number): void {
-  process(session, ['begin', issues.begin(), {commitWatermark: wm}]);
-  for (let i = 0; i < changes; i++) {
-    process(session, ['data', issues.insert('issues', {id: i, text: wm})]);
-  }
-  process(session, ['commit', issues.commit(), {watermark: wm}]);
 }
 
 type LogTransaction = {
@@ -246,24 +190,10 @@ function readLog(db: Database): LogTransaction[] {
   return transactions;
 }
 
-function head(db: Database): string | null {
-  return db
-    .prepare(
-      /*sql*/ `SELECT max("watermark") AS "head" FROM "${CHANGE_LOG_STREAM_TABLE}"`,
-    )
-    .get<{head: string | null}>().head;
-}
-
-function stateVersion(db: Database): string {
-  return db
-    .prepare(/*sql*/ `SELECT "stateVersion" FROM "_zero.replicationState"`)
-    .get<{stateVersion: string}>().stateVersion;
-}
-
 /**
- * Design 5.1 invariant 3: every logged transaction is whole — contiguous
- * positions from a `begin` to a `commit` that chains to the previous
- * transaction — and the sequence covers the committed watermarks with no gap.
+ * Every logged transaction is whole — contiguous positions from a `begin` to a
+ * `commit` that chains to the previous transaction — and the sequence covers the
+ * committed watermarks with no gap.
  */
 function expectContiguous(log: LogTransaction[], committed: string[]) {
   expect(log.map(({watermark}) => watermark)).toEqual(committed);
@@ -290,149 +220,155 @@ afterEach(() => {
   }
 });
 
-function newReplica(): DbFile {
+function newReplicaFile(): DbFile {
   const file = new DbFile('change-log-crash-recovery');
   files.push(file);
-  const replica = file.connect(lc);
-  replica.pragma('journal_mode = wal');
-  initReplicationState(replica, ['zero_data'], REPLICA_VERSION);
-  initDB(
-    replica,
-    `
-    CREATE TABLE issues(
-      id INTEGER PRIMARY KEY,
-      text TEXT,
-      _0_version TEXT
-    );
-    `,
-  );
-  replica.close();
   return file;
+}
+
+/** Drives one whole transaction through the loop's order of operations. */
+function transaction(
+  session: Session,
+  wm: string,
+  changes: number,
+  crashPoint?: CrashPoint,
+): void {
+  const messages: ChangeStreamData[] = [
+    ['begin', issues.begin(), {commitWatermark: wm}],
+    ...Array.from(
+      {length: changes},
+      (_, i) =>
+        [
+          'data',
+          issues.insert('issues', {id: i, text: wm}),
+        ] as ChangeStreamData,
+    ),
+  ];
+  for (const message of messages) {
+    session.write(message);
+    session.forward(message);
+  }
+
+  if (crashPoint === 'source-disconnect') {
+    session.writer.abort();
+    return;
+  }
+  if (crashPoint === 'before-log-commit') {
+    session.kill();
+    throw new Crash('killed before the log commit');
+  }
+
+  const commit: ChangeStreamData = ['commit', issues.commit(), {watermark: wm}];
+  session.write(commit);
+  if (crashPoint === 'after-log-commit') {
+    session.kill();
+    throw new Crash('killed after the log commit, before the forward');
+  }
+  session.forward(commit);
+  if (crashPoint === 'after-forward') {
+    session.kill();
+    throw new Crash('killed after the forward, before the PG commit');
+  }
+  if (crashPoint === 'no-pg-commit') {
+    return;
+  }
+  session.pgCommit(wm);
 }
 
 /** What the crash left behind, before and after recovery. */
 type Outcome = {
-  /** The log head and replica state as the recovering process found them. */
-  readonly afterCrash: {logHead: string; stateVersion: string};
-  readonly reconciled: ReconcileResult;
+  readonly afterCrash: {logHead: string; resumeWatermark: string};
   readonly recoveredHead: string;
   readonly resumedHead: string;
 };
 
 function runScenario({before, changes, after, crashPoint}: Scenario): Outcome {
-  const file = newReplica();
+  const file = newReplicaFile();
+  const REPLICA_VERSION = '02';
   const committed = [REPLICA_VERSION];
   const phantomExpected =
-    crashPoint === 'state-update' || crashPoint === 'replica-commit';
+    crashPoint === 'after-log-commit' || crashPoint === 'after-forward';
   let next = 0;
 
   // The process that crashes.
-  const crashed = startSession(file);
+  const crashed = new Session(file, REPLICA_VERSION);
   try {
-    expect(crashed.reconciled).toEqual({
-      action: 'reseeded',
-      head: REPLICA_VERSION,
-      reason: 'created',
-    });
+    crashed.reconcile();
+    expect(crashed.writer.enabled).toBe(true);
     for (let i = 0; i < before; i++) {
       const wm = watermark(next++);
       transaction(crashed, wm, changes);
       committed.push(wm);
     }
-    expect(crashed.failures).toEqual([]);
 
     const crashWatermark = watermark(next++);
-    crashed.replicaRunner.crashOnStateUpdate = crashPoint === 'state-update';
-    crashed.replicaRunner.crashOnCommit = crashPoint === 'replica-commit';
-    crashed.changeLogRunner.crashOnCommit = crashPoint === 'log-commit';
-    if (crashPoint === 'source-disconnect') {
-      process(crashed, [
-        'begin',
-        issues.begin(),
-        {commitWatermark: crashWatermark},
-      ]);
-      for (let i = 0; i < changes; i++) {
-        process(crashed, ['data', issues.insert('issues', {id: i, text: 'x'})]);
-      }
-      crashed.processor.abort(lc);
-    } else {
-      transaction(crashed, crashWatermark, changes);
+    try {
+      transaction(crashed, crashWatermark, changes, crashPoint);
+      expect(crashPoint).toBe('source-disconnect');
+    } catch (e) {
+      expect(e).toBeInstanceOf(Crash);
     }
-    // An abort is expected, so it is not reported to the service; an injected
-    // crash is.
-    expect(crashed.failures).toHaveLength(
-      crashPoint === 'source-disconnect' ? 0 : 1,
-    );
+    // A write failure would have disabled the writer and deleted the file.
+    // Nothing here is a write failure.
+    expect(crashed.writer.state()?.invariantFailures ?? 0).toBe(0);
   } finally {
-    crashed.close();
+    crashed.kill();
   }
 
-  // Invariant 1, observed before any repair: the log never trails the replica,
-  // whatever the crash point.
-  const afterCrash = (() => {
-    using replica = new Database(lc, file.path, {readonly: true});
+  const resumeWatermark = crashed.resumeWatermark;
+  expect(resumeWatermark).toBe(committed.at(-1));
+
+  // Invariant 1, observed before any repair: the log never trails the resume
+  // watermark, whatever the crash point.
+  const logHead = (() => {
     using changeLog = openChangeLogDB(lc, file.path, {readonly: true});
-    return {
-      logHead: must(head(changeLog), 'the log is never empty'),
-      stateVersion: stateVersion(replica),
-    };
+    return must(readChangeLogHead(changeLog), 'the log is never empty');
   })();
-  expect(afterCrash.logHead >= afterCrash.stateVersion).toBe(true);
-  expect(afterCrash.stateVersion).toBe(committed.at(-1));
-  // A crash after the log's commit leaves the phantom behind.
-  expect(afterCrash.logHead).toBe(
-    phantomExpected ? watermark(next - 1) : afterCrash.stateVersion,
-  );
+  expect(logHead >= resumeWatermark).toBe(true);
+  expect(logHead).toBe(phantomExpected ? watermark(next - 1) : resumeWatermark);
 
-  // The process that recovers.
-  const recovered = startSession(file);
+  // The process that recovers. It reconciles against the watermark the stream
+  // resumes from, which is where the crash left Postgres.
+  const recovered = new Session(file, resumeWatermark);
   try {
-    expect(recovered.reconciled).toEqual(
-      phantomExpected
-        ? {
-            action: 'truncated',
-            head: committed.at(-1),
-            rows: changes + 2, // begin + changes + commit
-          }
-        : {action: 'none', head: committed.at(-1)},
-    );
+    recovered.reconcile();
+    expect(recovered.writer.enabled).toBe(true);
 
-    // Invariants 2 and 4.
-    const recoveredHead = must(head(recovered.changeLog));
-    expect(recoveredHead).toBe(stateVersion(recovered.replica));
-    expect(
-      recovered.changeLog
-        .prepare(
-          /*sql*/ `SELECT "replicaVersion" FROM "${CHANGE_LOG_META_TABLE}"`,
-        )
-        .get(),
-    ).toEqual({replicaVersion: REPLICA_VERSION});
-    expectContiguous(readLog(recovered.changeLog), committed);
+    using observer = openChangeLogDB(lc, file.path, {readonly: true});
+    const recoveredHead = must(readChangeLogHead(observer));
+    expect(recoveredHead).toBe(resumeWatermark);
+    expect(readChangeLogMeta(observer)).toMatchObject({
+      ...IDENTITY,
+      // Never a reseed: the crash is always answered by truncate-above.
+      seedWatermark: REPLICA_VERSION,
+    });
+    expectContiguous(readLog(observer), committed);
 
-    // Replication resumes from the recovered head.
+    // Replication resumes from the recovered head, re-delivering nothing and
+    // colliding with nothing.
     for (let i = 0; i < after; i++) {
       const wm = watermark(next++);
       transaction(recovered, wm, changes);
       committed.push(wm);
     }
-    expect(recovered.failures).toEqual([]);
-    const resumedHead = must(head(recovered.changeLog));
-    expect(resumedHead).toBe(stateVersion(recovered.replica));
-    expectContiguous(readLog(recovered.changeLog), committed);
+    expect(recovered.writer.state()?.invariantFailures ?? 0).toBe(0);
+    expect(recovered.writer.enabled).toBe(true);
+    const resumedHead = must(readChangeLogHead(observer));
+    expect(resumedHead).toBe(recovered.resumeWatermark);
+    expectContiguous(readLog(observer), committed);
 
     return {
-      afterCrash,
-      reconciled: recovered.reconciled,
+      afterCrash: {logHead, resumeWatermark},
       recoveredHead,
       resumedHead,
     };
   } finally {
-    recovered.close();
+    recovered.kill();
   }
 }
 
 describe('replicator/change-log crash recovery', () => {
-  test('a crash at any commit point leaves a phantom, never a hole', () => {
+  test('a crash at any point leaves a phantom, never a hole', () => {
     fc.assert(
       fc.property(scenario, s => {
         runScenario(s);
@@ -441,35 +377,42 @@ describe('replicator/change-log crash recovery', () => {
     );
   });
 
-  test('a crash between the two commits leaves the log ahead by one', () => {
+  test('a crash between the log commit and the forward leaves the log ahead by one', () => {
     const outcome = runScenario({
       before: 2,
       changes: 2,
       after: 2,
-      crashPoint: 'state-update',
+      crashPoint: 'after-log-commit',
     });
 
     // '03' and '04' committed, the crash at '05'.
-    expect(outcome.afterCrash).toEqual({logHead: '05', stateVersion: '04'});
-    expect(outcome.reconciled).toEqual({
-      action: 'truncated',
-      head: '04',
-      rows: 4,
-    });
+    expect(outcome.afterCrash).toEqual({logHead: '05', resumeWatermark: '04'});
     expect(outcome.recoveredHead).toBe('04');
     expect(outcome.resumedHead).toBe('07');
   });
 
-  test('an interrupted log commit leaves both databases at the same head', () => {
+  test('a crash between the forward and the PG commit leaves the log ahead by one', () => {
     const outcome = runScenario({
       before: 1,
       changes: 1,
       after: 1,
-      crashPoint: 'log-commit',
+      crashPoint: 'after-forward',
     });
 
-    expect(outcome.afterCrash).toEqual({logHead: '03', stateVersion: '03'});
-    expect(outcome.reconciled).toEqual({action: 'none', head: '03'});
+    expect(outcome.afterCrash).toEqual({logHead: '04', resumeWatermark: '03'});
+    expect(outcome.recoveredHead).toBe('03');
+    expect(outcome.resumedHead).toBe('05');
+  });
+
+  test('an interrupted log commit leaves the log at the resume watermark', () => {
+    const outcome = runScenario({
+      before: 1,
+      changes: 1,
+      after: 1,
+      crashPoint: 'before-log-commit',
+    });
+
+    expect(outcome.afterCrash).toEqual({logHead: '03', resumeWatermark: '03'});
     expect(outcome.resumedHead).toBe('05');
   });
 
@@ -481,41 +424,40 @@ describe('replicator/change-log crash recovery', () => {
       crashPoint: 'source-disconnect',
     });
 
-    expect(outcome.afterCrash).toEqual({logHead: '03', stateVersion: '03'});
-    expect(outcome.reconciled).toEqual({action: 'none', head: '03'});
+    expect(outcome.afterCrash).toEqual({logHead: '03', resumeWatermark: '03'});
     expect(outcome.resumedHead).toBe('05');
   });
 
-  test('a log left behind by a different replica is reseeded, never served', () => {
-    const file = newReplica();
-    const session = startSession(file);
+  // The in-process form of the same repair: no restart, just a stream
+  // connection that resumes below the log's head. The writer inserts with a
+  // plain INSERT, so an un-truncated overlap is a constraint violation on the
+  // first re-delivered transaction.
+  test('an in-process reconnect below the head truncates and re-accepts', () => {
+    const file = newReplicaFile();
+    const session = new Session(file, '02');
     try {
-      transaction(session, watermark(0), 2);
-      expect(session.failures).toEqual([]);
-    } finally {
-      session.close();
-    }
+      session.reconcile();
+      using observer = openChangeLogDB(lc, file.path, {readonly: true});
 
-    // Simulate an auto-reset whose change-log deletion was missed: the replica
-    // is re-synced at a new replicaVersion beside the old log.
-    {
-      using replica = new Database(lc, file.path);
-      replica.exec(/*sql*/ `
-        UPDATE "_zero.replicationConfig" SET "replicaVersion" = '04';
-        UPDATE "_zero.replicationState" SET "stateVersion" = '04';
-      `);
-    }
+      // Two transactions reach the log; only the first reaches Postgres, which
+      // is what a failed storer commit leaves behind.
+      transaction(session, '03', 2);
+      transaction(session, '05', 2, 'no-pg-commit');
+      expect(readChangeLogHead(observer)).toBe('05');
 
-    const reset = startSession(file);
-    try {
-      expect(reset.reconciled).toEqual({
-        action: 'reseeded',
-        head: '04',
-        reason: 'replica-version-mismatch',
-      });
-      expectContiguous(readLog(reset.changeLog), ['04']);
+      // The stream is re-established without a restart. Its resume watermark is
+      // re-read, is behind the log's head, and reconciliation truncates '05'.
+      session.writer.reconcile('03');
+      expect(readChangeLogHead(observer)).toBe('03');
+
+      // The resumed stream re-delivers '05' at the same watermark.
+      transaction(session, '05', 2);
+      expect(session.writer.enabled).toBe(true);
+      expect(session.writer.state()?.invariantFailures).toBe(0);
+      expect(readChangeLogHead(observer)).toBe('05');
+      expectContiguous(readLog(observer), ['02', '03', '05']);
     } finally {
-      reset.close();
+      session.kill();
     }
   });
 });

--- a/packages/zero-cache/src/services/replicator/change-log-db.test.ts
+++ b/packages/zero-cache/src/services/replicator/change-log-db.test.ts
@@ -15,17 +15,26 @@ import {
   deleteChangeLogDB,
   openChangeLogDB,
   openChangeLogDBForWriting,
-  readReplicaAnchor,
+  readChangeLogHead,
+  readChangeLogMeta,
   reconcileChangeLog,
-  type ReplicaAnchor,
+  type ChangeLogAnchor,
 } from './change-log-db.ts';
 
 const lc = createSilentLogContext();
 
-const ANCHOR: ReplicaAnchor = {
-  replicaVersion: '01',
-  stateVersion: '05',
-  writeTimeMs: 12345,
+const NOW_MS = 12345;
+
+/**
+ * The log anchors on the watermark its stream connection resumes from, plus the
+ * replica's identity. Nothing here reads a replica: after the writer moved to
+ * the change-streamer, the replica's state version is a consequence of the log
+ * rather than a constraint on it.
+ */
+const ANCHOR: ChangeLogAnchor = {
+  identity: {epoch: null, generation: '01', replicaID: '1777575698286'},
+  resumeWatermark: '05',
+  nowMs: NOW_MS,
 };
 
 /** The main file and the sidecars `deleteLiteDB` removes. */
@@ -47,38 +56,11 @@ function newDbFile(): DbFile {
   return file;
 }
 
-type PartialAnchor = Omit<Partial<ReplicaAnchor>, 'writeTimeMs'> & {
-  writeTimeMs?: number | null | undefined;
-};
-
-function createReplica(anchor: PartialAnchor = ANCHOR): Database {
-  const db = new Database(lc, ':memory:');
-  db.exec(/*sql*/ `
-    CREATE TABLE "_zero.replicationConfig" (
-      replicaVersion TEXT NOT NULL,
-      publications TEXT NOT NULL,
-      initialSyncContext TEXT DEFAULT '{}',
-      lock INTEGER PRIMARY KEY DEFAULT 1 CHECK (lock=1)
-    );
-    CREATE TABLE "_zero.replicationState" (
-      stateVersion TEXT NOT NULL,
-      writeTimeMs INTEGER,
-      lock INTEGER PRIMARY KEY DEFAULT 1 CHECK (lock=1)
-    );
-  `);
-  if (anchor.replicaVersion !== undefined) {
-    db.prepare(/*sql*/ `
-      INSERT INTO "_zero.replicationConfig" (replicaVersion, publications)
-        VALUES (?, '[]')
-    `).run(anchor.replicaVersion);
-  }
-  if (anchor.stateVersion !== undefined) {
-    db.prepare(/*sql*/ `
-      INSERT INTO "_zero.replicationState" (stateVersion, writeTimeMs)
-        VALUES (?, ?)
-    `).run(anchor.stateVersion, anchor.writeTimeMs ?? null);
-  }
-  return db;
+function anchorAt(
+  resumeWatermark: string,
+  overrides: Partial<ChangeLogAnchor> = {},
+): ChangeLogAnchor {
+  return {...ANCHOR, resumeWatermark, ...overrides};
 }
 
 /**
@@ -105,35 +87,40 @@ function appendTransaction(
   stmt.run(watermark, changes + 1, '{"tag":"commit"}', precommit, writeTimeMs);
 }
 
-function seedRows(anchor: ReplicaAnchor) {
+function seedRows(anchor: ChangeLogAnchor) {
   return [
     {
-      watermark: anchor.stateVersion,
+      watermark: anchor.resumeWatermark,
       pos: 0,
       change: '{"tag":"begin"}',
       precommit: null,
       writeTimeMs: null,
     },
     {
-      watermark: anchor.stateVersion,
+      watermark: anchor.resumeWatermark,
       pos: 1,
       change: '{"tag":"commit"}',
-      precommit: anchor.stateVersion,
-      writeTimeMs: anchor.writeTimeMs,
+      precommit: anchor.resumeWatermark,
+      writeTimeMs: anchor.nowMs,
     },
   ];
 }
 
-function head(db: Database): string | null {
-  return db
-    .prepare(
-      /*sql*/ `SELECT max("watermark") AS "head" FROM "${CHANGE_LOG_STREAM_TABLE}"`,
-    )
-    .get<{head: string | null}>().head;
-}
-
-function meta(db: Database) {
-  return db.prepare(/*sql*/ `SELECT * FROM "${CHANGE_LOG_META_TABLE}"`).get();
+function expectSeededAt(db: Database, anchor: ChangeLogAnchor) {
+  expect(readChangeLogMeta(db)).toEqual({
+    ...anchor.identity,
+    schemaVersion: CHANGE_LOG_DB_SCHEMA_VERSION,
+    seededAtMs: anchor.nowMs,
+    seedWatermark: anchor.resumeWatermark,
+  });
+  expectTableExact(
+    db,
+    CHANGE_LOG_STREAM_TABLE,
+    seedRows(anchor),
+    'number',
+    'watermark',
+    'pos',
+  );
 }
 
 /** A change-log db that is valid and consistent with {@link ANCHOR}. */
@@ -234,6 +221,21 @@ describe('replicator/change-log-db', () => {
           .all();
       expect(schema(changeLog)).toEqual(schema(replica));
     });
+
+    // The whole v2 shape lands in one bump, so that slice 8 can add the
+    // `auto_vacuum` pragma without forcing a second reseed on every task.
+    test('the meta row carries the identity triple and the seed point', () => {
+      using db = createReconciledLog();
+
+      expect(readChangeLogMeta(db)).toEqual({
+        epoch: null,
+        generation: '01',
+        replicaID: '1777575698286',
+        schemaVersion: 2,
+        seededAtMs: NOW_MS,
+        seedWatermark: '05',
+      });
+    });
   });
 
   describe('file naming', () => {
@@ -288,7 +290,7 @@ describe('replicator/change-log-db', () => {
       }
 
       using db = openChangeLogDB(lc, file.path, {readonly: true});
-      expect(head(db)).toBe(ANCHOR.stateVersion);
+      expect(readChangeLogHead(db)).toBe(ANCHOR.resumeWatermark);
     });
 
     // Slice 7E turns this into a decline-and-fall-back-to-PG, rather than a
@@ -307,8 +309,8 @@ describe('replicator/change-log-db', () => {
       applyChangeLogPragmas(db);
 
       expect(db.pragma('journal_mode')).toEqual([{journal_mode: 'wal2'}]);
-      // 1 == NORMAL: the log's commit precedes the replica's on the hot path,
-      // so it does not pay for a second fsync.
+      // 1 == NORMAL: the commit sits on the forward path, so it does not pay
+      // for an fsync.
       expect(db.pragma('synchronous')).toEqual([{synchronous: 1}]);
       expect(db.pragma('busy_timeout')).toEqual([{timeout: 30000}]);
       // Nothing else owns this file, so checkpointing stays automatic rather
@@ -327,20 +329,20 @@ describe('replicator/change-log-db', () => {
         using open = db;
         expect(result).toEqual({
           action: 'reseeded',
-          head: ANCHOR.stateVersion,
+          head: ANCHOR.resumeWatermark,
           reason: 'created',
         });
         expect(open.pragma('journal_mode')).toEqual([{journal_mode: 'wal2'}]);
-        expect(head(open)).toBe(ANCHOR.stateVersion);
+        expect(readChangeLogHead(open)).toBe(ANCHOR.resumeWatermark);
       }
 
       const reopened = openChangeLogDBForWriting(lc, file.path, ANCHOR);
       using db = reopened.db;
       expect(reopened.result).toEqual({
         action: 'none',
-        head: ANCHOR.stateVersion,
+        head: ANCHOR.resumeWatermark,
       });
-      expect(head(db)).toBe(ANCHOR.stateVersion);
+      expect(readChangeLogHead(db)).toBe(ANCHOR.resumeWatermark);
     });
 
     // The divergence from replica corruption: the log is a cache, so a corrupt
@@ -354,27 +356,17 @@ describe('replicator/change-log-db', () => {
 
       expect(result).toEqual({
         action: 'reseeded',
-        head: ANCHOR.stateVersion,
+        head: ANCHOR.resumeWatermark,
         reason: 'created',
       });
-      expect(meta(rebuilt)).toEqual({
-        replicaVersion: ANCHOR.replicaVersion,
-        schemaVersion: CHANGE_LOG_DB_SCHEMA_VERSION,
-        lock: 1,
-      });
-      expectTableExact(
-        rebuilt,
-        CHANGE_LOG_STREAM_TABLE,
-        seedRows(ANCHOR),
-        'number',
-        'watermark',
-        'pos',
-      );
+      expectSeededAt(rebuilt, ANCHOR);
       expect(rebuilt.pragma('journal_mode')).toEqual([{journal_mode: 'wal2'}]);
     });
 
     // A path that cannot be opened is a problem with the environment rather
     // than with the file's contents, so it propagates with the file intact.
+    // The caller answers it by disabling the writer and continuing to
+    // replicate, not by deleting a database that is not the problem.
     test('does not rebuild for a failure that is not corruption', () => {
       const file = newDbFile();
       const dir = changeLogFileName(file.path);
@@ -390,50 +382,16 @@ describe('replicator/change-log-db', () => {
     });
   });
 
-  describe('readReplicaAnchor', () => {
-    test('reads the replica facts the log is anchored to', () => {
-      using replica = createReplica();
-      expect(readReplicaAnchor(replica)).toEqual(ANCHOR);
-    });
-
-    test('requires initialized replication state', () => {
-      using replica = createReplica({replicaVersion: '01'});
-      expect(() => readReplicaAnchor(replica)).toThrow(
-        'replication state must be initialized',
-      );
-    });
-
-    test('requires an initialized writeTimeMs', () => {
-      using replica = createReplica({...ANCHOR, writeTimeMs: null});
-      expect(() => readReplicaAnchor(replica)).toThrow(
-        'replication state writeTimeMs must be initialized',
-      );
-    });
-  });
-
   describe('reconcileChangeLog: reseed reasons', () => {
     test('created: empty database', () => {
       using db = new Database(lc, ':memory:');
 
       expect(reconcileChangeLog(lc, db, ANCHOR)).toEqual({
         action: 'reseeded',
-        head: ANCHOR.stateVersion,
+        head: ANCHOR.resumeWatermark,
         reason: 'created',
       });
-      expect(head(db)).toBe(ANCHOR.stateVersion);
-      expect(meta(db)).toEqual({
-        replicaVersion: ANCHOR.replicaVersion,
-        schemaVersion: CHANGE_LOG_DB_SCHEMA_VERSION,
-        lock: 1,
-      });
-      expectTableExact(
-        db,
-        CHANGE_LOG_STREAM_TABLE,
-        seedRows(ANCHOR),
-        'number',
-        'watermark',
-        'pos',
-      );
+      expectSeededAt(db, ANCHOR);
     });
 
     test('created: stream table without the meta table', () => {
@@ -443,18 +401,11 @@ describe('replicator/change-log-db', () => {
 
       expect(reconcileChangeLog(lc, db, ANCHOR)).toEqual({
         action: 'reseeded',
-        head: ANCHOR.stateVersion,
+        head: ANCHOR.resumeWatermark,
         reason: 'created',
       });
       // The pre-existing rows are wiped, not retained.
-      expectTableExact(
-        db,
-        CHANGE_LOG_STREAM_TABLE,
-        seedRows(ANCHOR),
-        'number',
-        'watermark',
-        'pos',
-      );
+      expectSeededAt(db, ANCHOR);
     });
 
     test('created: meta table without its row', () => {
@@ -463,14 +414,10 @@ describe('replicator/change-log-db', () => {
 
       expect(reconcileChangeLog(lc, db, ANCHOR)).toEqual({
         action: 'reseeded',
-        head: ANCHOR.stateVersion,
+        head: ANCHOR.resumeWatermark,
         reason: 'created',
       });
-      expect(meta(db)).toEqual({
-        replicaVersion: ANCHOR.replicaVersion,
-        schemaVersion: CHANGE_LOG_DB_SCHEMA_VERSION,
-        lock: 1,
-      });
+      expectSeededAt(db, ANCHOR);
     });
 
     test('created: meta table without the stream table', () => {
@@ -479,10 +426,10 @@ describe('replicator/change-log-db', () => {
 
       expect(reconcileChangeLog(lc, db, ANCHOR)).toEqual({
         action: 'reseeded',
-        head: ANCHOR.stateVersion,
+        head: ANCHOR.resumeWatermark,
         reason: 'created',
       });
-      expect(head(db)).toBe(ANCHOR.stateVersion);
+      expect(readChangeLogHead(db)).toBe(ANCHOR.resumeWatermark);
     });
 
     test('schema-mismatch', () => {
@@ -495,47 +442,77 @@ describe('replicator/change-log-db', () => {
 
       expect(reconcileChangeLog(lc, db, ANCHOR)).toEqual({
         action: 'reseeded',
-        head: ANCHOR.stateVersion,
+        head: ANCHOR.resumeWatermark,
         reason: 'schema-mismatch',
       });
-      expect(meta(db)).toEqual({
-        replicaVersion: ANCHOR.replicaVersion,
-        schemaVersion: CHANGE_LOG_DB_SCHEMA_VERSION,
-        lock: 1,
-      });
-      expectTableExact(
-        db,
-        CHANGE_LOG_STREAM_TABLE,
-        seedRows(ANCHOR),
-        'number',
-        'watermark',
-        'pos',
-      );
+      expectSeededAt(db, ANCHOR);
     });
 
-    test('replica-version-mismatch', () => {
-      // A log left behind by a replica that was reset and re-synced.
-      using db = createReconciledLog({...ANCHOR, replicaVersion: '00'});
-      appendTransaction(db, '07', '05', 3, 100);
+    // A v1 log carries a "replicaVersion" where v2 carries the identity triple,
+    // so the version is read on its own: reading the rest of the row would fail
+    // on the missing columns instead of reporting the mismatch that explains it.
+    // This is the upgrade path every existing log takes.
+    test('schema-mismatch: a v1 log is rebuilt rather than read', () => {
+      using db = new Database(lc, ':memory:');
+      db.exec(/*sql*/ `
+        ${CREATE_CHANGE_LOG_STREAM_SCHEMA}
+        CREATE TABLE "${CHANGE_LOG_META_TABLE}" (
+          "replicaVersion" TEXT NOT NULL,
+          "schemaVersion"  INTEGER NOT NULL,
+          "lock"           INTEGER PRIMARY KEY DEFAULT 1 CHECK ("lock" = 1)
+        );
+        INSERT INTO "${CHANGE_LOG_META_TABLE}" ("replicaVersion", "schemaVersion")
+          VALUES ('01', 1);
+      `);
+      appendTransaction(db, '05', '04', 1, 100);
 
       expect(reconcileChangeLog(lc, db, ANCHOR)).toEqual({
         action: 'reseeded',
-        head: ANCHOR.stateVersion,
-        reason: 'replica-version-mismatch',
+        head: ANCHOR.resumeWatermark,
+        reason: 'schema-mismatch',
       });
-      expect(meta(db)).toEqual({
-        replicaVersion: ANCHOR.replicaVersion,
-        schemaVersion: CHANGE_LOG_DB_SCHEMA_VERSION,
-        lock: 1,
+      expectSeededAt(db, ANCHOR);
+    });
+
+    test.each([
+      [
+        'a different generation',
+        {epoch: null, generation: '00', replicaID: 'a'},
+      ],
+      ['a sibling replica ID', {epoch: null, generation: '01', replicaID: 'b'}],
+      ['a different epoch', {epoch: '1', generation: '01', replicaID: 'a'}],
+    ])('identity-mismatch: %s', (_, identity) => {
+      // A leftover log on a reused volume. Under RMv2 the generation alone
+      // cannot catch this: siblings of a forked replica share it.
+      using db = createReconciledLog(anchorAt('05', {identity}));
+      appendTransaction(db, '07', '05', 3, 100);
+
+      const anchor = anchorAt('05', {
+        identity: {epoch: null, generation: '01', replicaID: 'a'},
       });
-      expectTableExact(
-        db,
-        CHANGE_LOG_STREAM_TABLE,
-        seedRows(ANCHOR),
-        'number',
-        'watermark',
-        'pos',
-      );
+      expect(reconcileChangeLog(lc, db, anchor)).toEqual({
+        action: 'reseeded',
+        head: '05',
+        reason: 'identity-mismatch',
+      });
+      expectSeededAt(db, anchor);
+    });
+
+    test('identity: a null epoch and replica ID match only another null', () => {
+      const identity = {epoch: null, generation: '01', replicaID: null};
+      using db = createReconciledLog(anchorAt('05', {identity}));
+
+      expect(reconcileChangeLog(lc, db, anchorAt('05', {identity}))).toEqual({
+        action: 'none',
+        head: '05',
+      });
+      expect(
+        reconcileChangeLog(
+          lc,
+          db,
+          anchorAt('05', {identity: {...identity, replicaID: 'a'}}),
+        ),
+      ).toMatchObject({action: 'reseeded', reason: 'identity-mismatch'});
     });
 
     test('gap: valid meta with an empty log', () => {
@@ -544,49 +521,43 @@ describe('replicator/change-log-db', () => {
 
       expect(reconcileChangeLog(lc, db, ANCHOR)).toEqual({
         action: 'reseeded',
-        head: ANCHOR.stateVersion,
+        head: ANCHOR.resumeWatermark,
         reason: 'gap',
       });
-      expect(head(db)).toBe(ANCHOR.stateVersion);
+      expect(readChangeLogHead(db)).toBe(ANCHOR.resumeWatermark);
     });
 
-    test('gap: head behind the replica', () => {
-      // e.g. the replica advanced while sqliteChangeLogMode was off, or power
-      // was lost with synchronous=NORMAL on the log.
-      using db = createReconciledLog({...ANCHOR, stateVersion: '03'});
+    // The log leads the resume watermark by construction, so this is the state
+    // that says the ordering guarantee did not hold: the writer was disabled for
+    // a while, the file was deleted, or power was lost with synchronous=NORMAL.
+    test('gap: head behind the resume watermark', () => {
+      using db = createReconciledLog(anchorAt('03'));
       appendTransaction(db, '04', '03', 2, 100);
 
       expect(reconcileChangeLog(lc, db, ANCHOR)).toEqual({
         action: 'reseeded',
-        head: ANCHOR.stateVersion,
+        head: ANCHOR.resumeWatermark,
         reason: 'gap',
       });
-      expectTableExact(
-        db,
-        CHANGE_LOG_STREAM_TABLE,
-        seedRows(ANCHOR),
-        'number',
-        'watermark',
-        'pos',
-      );
+      expectSeededAt(db, ANCHOR);
     });
 
-    test('gap: truncation leaves the head behind the replica', () => {
-      using db = createReconciledLog({...ANCHOR, stateVersion: '03'});
+    test('gap: truncation leaves the head behind the resume watermark', () => {
+      using db = createReconciledLog(anchorAt('03'));
       appendTransaction(db, '07', '03', 2, 100);
 
       expect(reconcileChangeLog(lc, db, ANCHOR)).toEqual({
         action: 'reseeded',
-        head: ANCHOR.stateVersion,
+        head: ANCHOR.resumeWatermark,
         reason: 'gap',
       });
-      expect(head(db)).toBe(ANCHOR.stateVersion);
+      expect(readChangeLogHead(db)).toBe(ANCHOR.resumeWatermark);
     });
   });
 
   describe('reconcileChangeLog: truncation', () => {
-    test('removes rows above the replica head and retains the rest', () => {
-      using db = createReconciledLog({...ANCHOR, stateVersion: '02'});
+    test('removes rows above the resume watermark and retains the rest', () => {
+      using db = createReconciledLog(anchorAt('02'));
       appendTransaction(db, '03', '02', 1, 100);
       appendTransaction(db, '05', '03', 1, 200);
       appendTransaction(db, '06', '05', 1, 300);
@@ -595,17 +566,18 @@ describe('replicator/change-log-db', () => {
       // 3 rows in '06' + 4 rows in '07'
       expect(reconcileChangeLog(lc, db, ANCHOR)).toEqual({
         action: 'truncated',
-        head: ANCHOR.stateVersion,
+        head: ANCHOR.resumeWatermark,
         rows: 7,
       });
-      expect(head(db)).toBe(ANCHOR.stateVersion);
+      expect(readChangeLogHead(db)).toBe(ANCHOR.resumeWatermark);
       expect(
         db
           .prepare(/*sql*/ `SELECT DISTINCT "watermark" FROM "${CHANGE_LOG_STREAM_TABLE}"
                        ORDER BY "watermark"`)
           .all(),
       ).toEqual([{watermark: '02'}, {watermark: '03'}, {watermark: '05'}]);
-      // The log's new head transaction is untouched by the truncation.
+      // The log's new head transaction is untouched by the truncation, so it is
+      // still a valid catchup boundary for a subscriber sitting exactly there.
       expect(
         db
           .prepare(/*sql*/ `SELECT * FROM "${CHANGE_LOG_STREAM_TABLE}"
@@ -636,22 +608,22 @@ describe('replicator/change-log-db', () => {
       ]);
     });
 
-    test('removes a phantom transaction whole', () => {
-      // Every row of a transaction carries its commit watermark, so a phantom
+    test('removes a re-delivered transaction whole', () => {
+      // Every row of a transaction carries its commit watermark, so truncation
       // cannot leave an orphaned begin or a mid-transaction row behind.
       using db = createReconciledLog();
       appendTransaction(db, '09', '05', 25, 100);
 
       expect(reconcileChangeLog(lc, db, ANCHOR)).toEqual({
         action: 'truncated',
-        head: ANCHOR.stateVersion,
+        head: ANCHOR.resumeWatermark,
         rows: 27,
       });
       expect(
         db
           .prepare(/*sql*/ `SELECT count(*) AS "rows" FROM "${CHANGE_LOG_STREAM_TABLE}"
-                       WHERE "watermark" > @stateVersion`)
-          .get<{rows: number}>({stateVersion: ANCHOR.stateVersion}).rows,
+                       WHERE "watermark" > @resumeWatermark`)
+          .get<{rows: number}>({resumeWatermark: ANCHOR.resumeWatermark}).rows,
       ).toBe(0);
       expectTableExact(
         db,
@@ -672,46 +644,55 @@ describe('replicator/change-log-db', () => {
       });
       expect(reconcileChangeLog(lc, db, ANCHOR)).toEqual({
         action: 'none',
-        head: ANCHOR.stateVersion,
+        head: ANCHOR.resumeWatermark,
       });
       expect(reconcileChangeLog(lc, db, ANCHOR)).toEqual({
         action: 'none',
-        head: ANCHOR.stateVersion,
+        head: ANCHOR.resumeWatermark,
       });
+    });
+
+    // The reconnect case, which is what makes this per-connection rather than
+    // per-process: the log holds transactions the resumed stream will
+    // re-deliver, and the writer's plain INSERT would collide with them.
+    test('a resume below the head truncates rather than colliding', () => {
+      using db = createReconciledLog(anchorAt('02'));
+      appendTransaction(db, '03', '02', 1, 100);
+      appendTransaction(db, '05', '03', 1, 200);
+
+      expect(reconcileChangeLog(lc, db, anchorAt('03'))).toEqual({
+        action: 'truncated',
+        head: '03',
+        rows: 3,
+      });
+      // Re-appending what was truncated no longer violates the primary key.
+      expect(() => appendTransaction(db, '05', '03', 1, 300)).not.toThrow();
     });
   });
 
   describe('reconcileChangeLog: consistent log', () => {
-    test('an empty-but-valid log at the replica head is a no-op', () => {
+    test('a freshly seeded log at the resume watermark is a no-op', () => {
       using db = createReconciledLog();
 
       expect(reconcileChangeLog(lc, db, ANCHOR)).toEqual({
         action: 'none',
-        head: ANCHOR.stateVersion,
+        head: ANCHOR.resumeWatermark,
       });
-      expectTableExact(
-        db,
-        CHANGE_LOG_STREAM_TABLE,
-        seedRows(ANCHOR),
-        'number',
-        'watermark',
-        'pos',
-      );
+      expectSeededAt(db, ANCHOR);
     });
 
-    test('a log at the replica head is not written to', () => {
+    test('a log at the resume watermark is not written to', () => {
       const file = newDbFile();
       using db = openChangeLogDB(lc, file.path, {readonly: false});
       reconcileChangeLog(lc, db, ANCHOR);
       appendTransaction(db, '07', '05', 2, 100);
-      const state = {...ANCHOR, stateVersion: '07'};
 
       // data_version only advances for writes made by *another* connection.
       using observer = openChangeLogDB(lc, file.path, {readonly: true});
       const dataVersion = () => observer.pragma('data_version');
       const before = dataVersion();
 
-      expect(reconcileChangeLog(lc, db, state)).toEqual({
+      expect(reconcileChangeLog(lc, db, anchorAt('07'))).toEqual({
         action: 'none',
         head: '07',
       });
@@ -734,15 +715,21 @@ describe('replicator/change-log-db', () => {
 
       expect(() => reconcileChangeLog(lc, db, ANCHOR)).toThrow('boom');
       expect(db.inTransaction).toBe(false);
-      // The phantom is still there: nothing was half-applied.
-      expect(head(db)).toBe('09');
+      // The re-delivered transaction is still there: nothing was half-applied.
+      expect(readChangeLogHead(db)).toBe('09');
     });
 
     test('leaves no transaction open when a reseed fails', () => {
       const file = newDbFile();
       {
         using db = openChangeLogDB(lc, file.path, {readonly: false});
-        reconcileChangeLog(lc, db, {...ANCHOR, replicaVersion: '00'});
+        reconcileChangeLog(
+          lc,
+          db,
+          anchorAt('05', {
+            identity: {epoch: null, generation: '00', replicaID: null},
+          }),
+        );
       }
 
       using db = openChangeLogDB(lc, file.path, {readonly: true});

--- a/packages/zero-cache/src/services/replicator/change-log-db.ts
+++ b/packages/zero-cache/src/services/replicator/change-log-db.ts
@@ -5,25 +5,31 @@
  * the upstream replication slot, so it is deliberately excluded from the backup
  * and is never a source of truth.
  *
- * Because it is disposable, it has no migration framework. Any inconsistency
- * with the replica — a schema change, a leftover file from a different replica,
- * a gap left by a crash or by running with the writer disabled, a corrupt file
- * — is resolved by {@link reconcileChangeLog} and
- * {@link openChangeLogDBForWriting}, which truncate the offending rows or wipe
- * and reseed the log at the replica's current head. The worst outcome is a
- * `too-old` for a lagging subscriber; a silently delivered gap is not reachable.
+ * The change-streamer writes it, from the stream loop that fans changes out to
+ * subscribers, and commits it before forwarding each transaction's `commit`
+ * message. Its head is therefore always at or above the watermark the stream
+ * would resume from, which is what {@link reconcileChangeLog} anchors on.
  *
- * Disk sizing: a task that writes the log needs room for the replica *plus* one
- * retention window of the change stream — the log's main file, its wal2
- * sidecars, and pages a purge has freed but not yet reused. Nothing purges the
- * log yet (that is parent slice 8), so with the writer enabled it currently
- * grows with the entire change stream since its last reseed, which is one more
- * reason `sqliteChangeLogMode` defaults to `off`. The log is excluded from the
- * litestream backup, so this is local disk only and never S3.
+ * Because it is disposable, it has no migration framework. Any inconsistency —
+ * a schema change, a leftover file from a different replica, a gap left by a
+ * crash or by running with the writer disabled, a corrupt file — is resolved by
+ * {@link reconcileChangeLog} and {@link openChangeLogDBForWriting}, which
+ * truncate the offending rows or wipe and reseed the log at the resume
+ * watermark. The worst outcome is a `too-old` for a lagging subscriber; a
+ * silently delivered gap is not reachable.
+ *
+ * Disk sizing: a task that writes the log needs room for the replica *plus* the
+ * retained change stream — the log's main file, its wal2 sidecars, and pages a
+ * purge has freed but not yet reused. Nothing purges the log yet (that is slice
+ * 8), so with the writer enabled it currently grows with the entire change
+ * stream since its last reseed, which is one more reason
+ * `sqliteChangeLogMode` defaults to `off`. Once purge lands, retention is
+ * bounded by the confirmed backup watermark rather than by a constant, so it is
+ * a function of the backup interval. The log is excluded from the litestream
+ * backup, so this is local disk only and never S3.
  */
 
 import type {LogContext} from '@rocicorp/logger';
-import {assert} from '../../../../shared/src/asserts.ts';
 import {Database} from '../../../../zqlite/src/db.ts';
 import {deleteLiteDB} from '../../db/delete-lite-db.ts';
 import {
@@ -34,8 +40,13 @@ import {
 /**
  * Bumped whenever the change-log database's schema changes. Since the file is a
  * cache, a mismatch costs one reseed rather than a migration.
+ *
+ * v2 re-homed the writer to the change-streamer: the log anchors on the
+ * watermark its stream connection resumes from rather than on the replica's
+ * state version, and its meta row carries the replica's identity triple plus
+ * the seed point.
  */
-export const CHANGE_LOG_DB_SCHEMA_VERSION = 1;
+export const CHANGE_LOG_DB_SCHEMA_VERSION = 2;
 
 export const CHANGE_LOG_STREAM_TABLE = '_zero.changeLogStream';
 export const CHANGE_LOG_STREAM_WRITE_TIME_INDEX =
@@ -64,7 +75,7 @@ export const CREATE_CHANGE_LOG_STREAM_SCHEMA = /*sql*/ `
 `;
 
 /**
- * Inserts the synthetic begin/commit pair for a `@stateVersion` watermark.
+ * Inserts the synthetic begin/commit pair for the seed watermark.
  *
  * Both rows are inserted by one statement so a caller outside a larger
  * transaction cannot leave a partial seed.
@@ -73,26 +84,45 @@ const SEED_CHANGE_LOG_STREAM_SQL = /*sql*/ `
   INSERT INTO "${CHANGE_LOG_STREAM_TABLE}"
     ("watermark", "pos", "change", "precommit", "writeTimeMs")
   VALUES
-    (@stateVersion, 0, '{"tag":"begin"}', NULL, NULL),
-    (@stateVersion, 1, '{"tag":"commit"}', @stateVersion, @writeTimeMs)
+    (@watermark, 0, '{"tag":"begin"}', NULL, NULL),
+    (@watermark, 1, '{"tag":"commit"}', @watermark, @writeTimeMs)
   ON CONFLICT ("watermark", "pos") DO NOTHING
 `;
 
 export const CHANGE_LOG_META_TABLE = '_zero.changeLogMeta';
 
-// "replicaVersion" identifies the replica this log was built against, which
-// detects a file left behind by a replica that was since reset and re-synced.
-// "lock" enforces single-row semantics, as in "_zero.replicationConfig".
+// The identity triple (see ChangeLogIdentity) detects a file left behind by a
+// different replica -- most concretely, a leftover log on a reused volume.
+//
+// "seededAtMs"    : when the log was seeded, i.e. how far its retention window
+//                   can possibly reach back. Slice 11 uses it as the warm-up
+//                   signal for canary reads.
+// "seedWatermark" : where the log was seeded. `min("watermark")` cannot answer
+//                   this once purge has advanced the minimum, and the
+//                   difference is what distinguishes a log that purged past the
+//                   retention floor (an invariant violation) from one that
+//                   never held that history at all (routine at every fork).
+// "lock"          : enforces single-row semantics, as in
+//                   "_zero.replicationConfig".
 const CREATE_CHANGE_LOG_META_SCHEMA = /*sql*/ `
   CREATE TABLE "${CHANGE_LOG_META_TABLE}" (
-    "replicaVersion" TEXT NOT NULL,
-    "schemaVersion"  INTEGER NOT NULL,
-    "lock"           INTEGER PRIMARY KEY DEFAULT 1 CHECK ("lock" = 1)
+    "epoch"         TEXT,
+    "generation"    TEXT NOT NULL,
+    "replicaID"     TEXT,
+    "schemaVersion" INTEGER NOT NULL,
+    "seededAtMs"    INTEGER NOT NULL,
+    "seedWatermark" TEXT NOT NULL,
+    "lock"          INTEGER PRIMARY KEY DEFAULT 1 CHECK ("lock" = 1)
   );
 `;
 
 /**
  * `${replicaFile}-change-log`, matching the `-serving-copy` convention.
+ *
+ * The name outlives the writer's move into the change-streamer: the
+ * change-streamer derives the path from the replica file it owns, so renaming
+ * would save no plumbing and would orphan the old file on every existing
+ * volume, where nothing would delete it.
  *
  * Its `-wal` / `-wal2` / `-shm` sidecars are suffixes of *this* name, so they
  * never collide with the replica's own sidecars.
@@ -109,48 +139,61 @@ export function deleteChangeLogDB(replicaFile: string): void {
   deleteLiteDB(changeLogFileName(replicaFile));
 }
 
-/** The replica facts the change log is anchored to. */
-export type ReplicaAnchor = {
-  readonly replicaVersion: string;
-  readonly stateVersion: string;
-  readonly writeTimeMs: number;
+/**
+ * Which replica the log's contents belong to.
+ *
+ * `generation` is RMv1's `replicaVersion`: the version at which initial sync
+ * copied every row. It is shared by every sibling of a forked replica, which is
+ * why it cannot be the whole of the identity under RMv2 — `epoch` and
+ * `replicaID` are what distinguish two siblings' logs. Both are `null` until
+ * RMv2 supplies them, and a `null` matches only another `null`, so a log
+ * written before they exist is still recognized as this replica's.
+ */
+export type ChangeLogIdentity = {
+  readonly epoch: string | null;
+  readonly generation: string;
+  readonly replicaID: string | null;
 };
 
-type ReplicaAnchorRow = {
-  readonly replicaVersion: string;
-  readonly stateVersion: string;
-  readonly writeTimeMs: number | null;
+/**
+ * What the log is reconciled against. Reconciliation runs once per stream
+ * connection, since every reconnect can re-read a different resume watermark.
+ */
+export type ChangeLogAnchor = {
+  readonly identity: ChangeLogIdentity;
+  /**
+   * The watermark this stream connection resumes from. The log's own head is
+   * measured against it, and a reseed seeds a synthetic transaction at it.
+   *
+   * Deliberately *not* "the replica's state version": after the writer moved to
+   * the change-streamer, the canonical replicator is a subscriber downstream of
+   * the write loop, so its state version is a consequence of this log rather
+   * than a constraint on it.
+   */
+  readonly resumeWatermark: string;
+  /**
+   * The change-streamer's clock, at reconciliation time. Supplied rather than
+   * read inline so that tests control it. Used for `seededAtMs` and for the
+   * seed transaction's `writeTimeMs`, which is what the purger's time floor
+   * measures.
+   */
+  readonly nowMs: number;
 };
 
-export function readReplicaAnchor(replica: Database): ReplicaAnchor {
-  const row = replica
-    .prepare(/*sql*/ `
-      SELECT config."replicaVersion",
-             state."stateVersion",
-             state."writeTimeMs"
-        FROM "_zero.replicationConfig" AS config,
-             "_zero.replicationState" AS state
-    `)
-    .get<ReplicaAnchorRow | undefined>();
-  assert(row !== undefined, 'replication state must be initialized');
-  assert(
-    row.writeTimeMs !== null,
-    'replication state writeTimeMs must be initialized',
-  );
-  return {
-    replicaVersion: row.replicaVersion,
-    stateVersion: row.stateVersion,
-    writeTimeMs: row.writeTimeMs,
-  };
-}
+/** The meta row, i.e. everything the log records about itself. */
+export type ChangeLogMeta = ChangeLogIdentity & {
+  readonly schemaVersion: number;
+  readonly seededAtMs: number;
+  readonly seedWatermark: string;
+};
 
 /**
  * Opens the change-log database beside `replicaFile`.
  *
  * A writable handle creates the file if it is absent; a `readonly` handle
- * throws, which is the normal state for a change-streamer that starts before
- * the replicator has created the log. Pragmas are the caller's responsibility,
- * since only the writer sets the persistent ones.
+ * throws, which is the normal state for a change-streamer whose writer is
+ * disabled. Pragmas are the caller's responsibility, since only the writer sets
+ * the persistent ones.
  */
 export function openChangeLogDB(
   lc: LogContext,
@@ -165,14 +208,9 @@ export function openChangeLogDB(
 }
 
 /**
- * Configures the change-log database, which the write worker owns exclusively.
- * These are the settings the `separate-files` mode of
+ * Configures the change-log database, which the change-streamer's writer owns
+ * exclusively. These are the settings the `separate-files` mode of
  * `sqlite-change-log-ceiling.bench.ts` measured.
- *
- * They deliberately do not go through `getPragmaConfig` in `workers/replicator`
- * beside the replica's, because the write worker applies them in its own
- * thread and that module reaches the Postgres client through the replica
- * migrations.
  *
  * `wal2` because the log is a continuous append that catchup reads
  * continuously, which is the case wal2 exists for: it avoids checkpoint
@@ -180,14 +218,14 @@ export function openChangeLogDB(
  * keeps its default, unlike the backup replica's 0, which hands checkpointing
  * to litestream — nothing else owns this file.
  *
- * `synchronous = NORMAL` because the log commits *before* the replica on the
- * replication hot path, and NORMAL keeps that from costing a second fsync. It
- * is not a durability compromise here: in WAL mode NORMAL still writes every
- * commit through to the OS, so it survives a process crash, an OOM kill, or a
- * SIGKILL. It is lost only to kernel panic or power loss, and those destroy the
- * node — the task restarts elsewhere, restores the replica from S3, and has no
- * change-log file at all. Whatever a power loss does take is detected as a gap
- * by {@link reconcileChangeLog} and reseeded.
+ * `synchronous = NORMAL` because the commit sits on the forward path, once per
+ * upstream transaction, and NORMAL keeps that from costing an fsync. It is not
+ * a durability compromise here: in WAL mode NORMAL still writes every commit
+ * through to the OS, so it survives a process crash, an OOM kill, or a SIGKILL.
+ * It is lost only to kernel panic or power loss, and those destroy the node —
+ * the task restarts elsewhere, restores the replica from S3, and has no
+ * change-log file at all. Whatever a power loss does take is detected by
+ * {@link reconcileChangeLog} and reseeded.
  */
 export function applyChangeLogPragmas(db: Database): void {
   db.pragma('busy_timeout = 30000');
@@ -206,20 +244,21 @@ export function applyChangeLogPragmas(db: Database): void {
  * corrupt replica is a lost source of truth, so it ends in a restore or an
  * auto-reset; the change log holds nothing that is not either already in the
  * replica's litestream backup or re-derivable from the upstream slot, so the
- * entire response is to delete the file and seed a new one at the replica head.
- * The cost is one retention window of catchup — reconnecting subscribers below
- * the head get `too-old` — which is what every other {@link ReseedReason}
- * costs. Failing startup instead would take the replica down with the cache.
+ * entire response is to delete the file and seed a new one at the resume
+ * watermark. The cost is one retention window of catchup — reconnecting
+ * subscribers below the head get `too-old` — which is what every other
+ * {@link ReseedReason} costs.
  *
  * Only corruption is rebuilt through. Anything else (a bad path, a permissions
  * error, a full disk) is a problem with the environment rather than with the
  * file's contents, and deleting a database in response would destroy state
- * without fixing it.
+ * without fixing it. Those propagate to the caller, which disables the writer
+ * and keeps replicating.
  */
 export function openChangeLogDBForWriting(
   lc: LogContext,
   replicaFile: string,
-  anchor: ReplicaAnchor,
+  anchor: ChangeLogAnchor,
 ): {db: Database; result: ReconcileResult} {
   try {
     return openAndReconcile(lc, replicaFile, anchor);
@@ -242,7 +281,7 @@ export function openChangeLogDBForWriting(
 function openAndReconcile(
   lc: LogContext,
   replicaFile: string,
-  anchor: ReplicaAnchor,
+  anchor: ChangeLogAnchor,
 ): {db: Database; result: ReconcileResult} {
   const db = openChangeLogDB(lc, replicaFile, {readonly: false});
   try {
@@ -259,8 +298,8 @@ function openAndReconcile(
 export type ReseedReason =
   | 'created' // file or table absent
   | 'schema-mismatch'
-  | 'replica-version-mismatch'
-  | 'gap'; // head < stateVersion after truncation
+  | 'identity-mismatch'
+  | 'gap'; // head does not land on the resume watermark after truncation
 
 export type ReconcileResult =
   | {action: 'none'; head: string}
@@ -268,25 +307,38 @@ export type ReconcileResult =
   | {action: 'reseeded'; head: string; reason: ReseedReason};
 
 /**
- * Brings the change log into agreement with the replica, in one transaction on
- * the change-log database.
+ * Brings the change log into agreement with the watermark its stream connection
+ * resumes from, in one transaction on the change-log database:
  *
- * Writes are ordered log-first, so a crash can leave a *phantom* — a
- * transaction in the log whose replica commit was lost — but never a *hole*.
- * A phantom's rows all carry the aborted transaction's commit watermark, which
- * is strictly greater than the replica's `stateVersion`, so deleting on that
- * predicate removes phantoms whole and retains every committed transaction.
+ * ```
+ * head === resumeWatermark  → keep appending
+ * head  >  resumeWatermark  → truncate above resumeWatermark
+ * otherwise                 → wipe, seed at resumeWatermark, record the reason
+ * ```
  *
- * Anything the ordering guarantee does not cover — the file was deleted, the
- * replica ran with the writer disabled, the replica was restored, power was
- * lost with `synchronous=NORMAL` — surfaces as a head that does not land on
- * `stateVersion` after truncation, and is resolved by wiping and reseeding at
- * the replica head.
+ * The log commits before anything that can advance the resume watermark, so a
+ * *phantom* — a transaction the log holds whose watermark the resumed stream
+ * re-delivers — is the normal state, and truncate-above is the whole of
+ * reconciliation rather than a special case. A phantom's rows all carry the
+ * transaction's commit watermark, which is strictly greater than the resume
+ * watermark, so deleting on that predicate removes phantoms whole and retains
+ * every transaction at or below the resume point.
+ *
+ * It must run per stream connection, not once per process: the stream loop
+ * re-reads its resume watermark on every reconnect, and the writer inserts with
+ * a plain `INSERT` against `PRIMARY KEY ("watermark","pos")`, so an
+ * un-truncated overlap is a constraint violation on the first re-delivered
+ * transaction.
+ *
+ * Anything truncation cannot resolve — the file was deleted, the writer was
+ * disabled for a while, the replica was restored, power was lost with
+ * `synchronous=NORMAL` — surfaces as a head that does not land on the resume
+ * watermark, and is resolved by wiping and reseeding there.
  */
 export function reconcileChangeLog(
   lc: LogContext,
   db: Database,
-  anchor: ReplicaAnchor,
+  anchor: ChangeLogAnchor,
 ): ReconcileResult {
   db.exec('BEGIN IMMEDIATE');
   try {
@@ -304,25 +356,26 @@ export function reconcileChangeLog(
 function reconcile(
   lc: LogContext,
   db: Database,
-  anchor: ReplicaAnchor,
+  anchor: ChangeLogAnchor,
 ): ReconcileResult {
   const wipe = wipeReason(db, anchor);
   if (wipe !== undefined) {
     return reseed(lc, db, anchor, wipe);
   }
 
-  let head = readHead(db);
+  const {resumeWatermark} = anchor;
+  let head = readChangeLogHead(db);
   let rows = 0;
-  if (head !== null && head > anchor.stateVersion) {
+  if (head !== null && head > resumeWatermark) {
     rows = db
       .prepare(/*sql*/ `
         DELETE FROM "${CHANGE_LOG_STREAM_TABLE}" WHERE "watermark" > ?
       `)
-      .run(anchor.stateVersion).changes;
-    head = readHead(db);
+      .run(resumeWatermark).changes;
+    head = readChangeLogHead(db);
   }
 
-  if (head !== anchor.stateVersion) {
+  if (head !== resumeWatermark) {
     return reseed(lc, db, anchor, 'gap');
   }
   if (rows > 0) {
@@ -331,7 +384,7 @@ function reconcile(
     });
     return {action: 'truncated', head, rows};
   }
-  lc.debug?.('SQLite change log is consistent with the replica', {
+  lc.debug?.('SQLite change log is at the resume watermark', {
     sqliteChangeLogReconcile: {head},
   });
   return {action: 'none', head};
@@ -339,7 +392,7 @@ function reconcile(
 
 function wipeReason(
   db: Database,
-  anchor: ReplicaAnchor,
+  anchor: ChangeLogAnchor,
 ): ReseedReason | undefined {
   if (
     !tableExists(db, CHANGE_LOG_STREAM_TABLE) ||
@@ -347,19 +400,28 @@ function wipeReason(
   ) {
     return 'created';
   }
-  const meta = db
+  // The schema version is read on its own because it is the one column every
+  // version of this table has had. Reading the rest of a v1 row would fail on
+  // its missing columns instead of reporting the mismatch that explains it.
+  const version = db
     .prepare(/*sql*/ `
-      SELECT "replicaVersion", "schemaVersion" FROM "${CHANGE_LOG_META_TABLE}"
+      SELECT "schemaVersion" FROM "${CHANGE_LOG_META_TABLE}"
     `)
-    .get<{replicaVersion: string; schemaVersion: number} | undefined>();
-  if (meta === undefined) {
+    .get<{schemaVersion: number} | undefined>();
+  if (version === undefined) {
     return 'created';
   }
-  if (meta.schemaVersion !== CHANGE_LOG_DB_SCHEMA_VERSION) {
+  if (version.schemaVersion !== CHANGE_LOG_DB_SCHEMA_VERSION) {
     return 'schema-mismatch';
   }
-  if (meta.replicaVersion !== anchor.replicaVersion) {
-    return 'replica-version-mismatch';
+  const {epoch, generation, replicaID} = readChangeLogMeta(db);
+  const identity = anchor.identity;
+  if (
+    epoch !== identity.epoch ||
+    generation !== identity.generation ||
+    replicaID !== identity.replicaID
+  ) {
+    return 'identity-mismatch';
   }
   return undefined;
 }
@@ -367,9 +429,10 @@ function wipeReason(
 function reseed(
   lc: LogContext,
   db: Database,
-  anchor: ReplicaAnchor,
+  anchor: ChangeLogAnchor,
   reason: ReseedReason,
 ): ReconcileResult {
+  const {identity, resumeWatermark, nowMs} = anchor;
   // Dropping the table drops its partial index with it.
   db.exec(/*sql*/ `
     DROP TABLE IF EXISTS "${CHANGE_LOG_STREAM_TABLE}";
@@ -378,39 +441,68 @@ function reseed(
     ${CREATE_CHANGE_LOG_META_SCHEMA}
   `);
   db.prepare(/*sql*/ `
-    INSERT INTO "${CHANGE_LOG_META_TABLE}" ("replicaVersion", "schemaVersion")
-      VALUES (?, ?)
-  `).run(anchor.replicaVersion, CHANGE_LOG_DB_SCHEMA_VERSION);
+    INSERT INTO "${CHANGE_LOG_META_TABLE}"
+      ("epoch", "generation", "replicaID", "schemaVersion", "seededAtMs",
+       "seedWatermark")
+      VALUES (@epoch, @generation, @replicaID, @schemaVersion, @seededAtMs,
+              @seedWatermark)
+  `).run({
+    epoch: identity.epoch,
+    generation: identity.generation,
+    replicaID: identity.replicaID,
+    schemaVersion: CHANGE_LOG_DB_SCHEMA_VERSION,
+    seededAtMs: nowMs,
+    seedWatermark: resumeWatermark,
+  });
   seedChangeLogStream(db, anchor);
 
   lc.info?.('reseeded the SQLite change log', {
     sqliteChangeLogReconcile: {
       reason,
-      head: anchor.stateVersion,
-      replicaVersion: anchor.replicaVersion,
+      head: resumeWatermark,
+      ...identity,
       schemaVersion: CHANGE_LOG_DB_SCHEMA_VERSION,
+      seededAtMs: nowMs,
     },
   });
-  return {action: 'reseeded', head: anchor.stateVersion, reason};
+  return {action: 'reseeded', head: resumeWatermark, reason};
 }
 
 /**
- * Seeds a valid synthetic transaction at the replica's current watermark,
- * making an otherwise empty log serviceable as a catchup boundary for a
- * subscriber that is exactly at the replica head.
+ * Seeds a valid synthetic transaction at the anchor's resume watermark, making
+ * an otherwise empty log serviceable as a catchup boundary for a subscriber
+ * that is exactly at that watermark.
  */
-export function seedChangeLogStream(db: Database, anchor: ReplicaAnchor): void {
+export function seedChangeLogStream(
+  db: Database,
+  anchor: ChangeLogAnchor,
+): void {
   db.prepare(SEED_CHANGE_LOG_STREAM_SQL).run({
-    stateVersion: anchor.stateVersion,
-    writeTimeMs: anchor.writeTimeMs,
+    watermark: anchor.resumeWatermark,
+    writeTimeMs: anchor.nowMs,
   });
+}
+
+/** Reads the whole meta row. Throws if the log has not been reconciled. */
+export function readChangeLogMeta(db: Database): ChangeLogMeta {
+  const meta = db
+    .prepare(/*sql*/ `
+      SELECT "epoch", "generation", "replicaID", "schemaVersion",
+             "seededAtMs", "seedWatermark"
+        FROM "${CHANGE_LOG_META_TABLE}"
+    `)
+    .get<ChangeLogMeta | undefined>();
+  if (meta === undefined) {
+    throw new Error('the SQLite change log has no meta row');
+  }
+  return meta;
 }
 
 /**
  * `max()` on the primary key's leading column, i.e. an index seek. Null when
  * the log is empty.
  */
-function readHead(db: Database): string | null {
+export function readChangeLogHead(db: Database): string | null {
   const {head} = db
     .prepare(/*sql*/ `
       SELECT max("watermark") AS "head" FROM "${CHANGE_LOG_STREAM_TABLE}"

--- a/packages/zero-cache/src/services/replicator/change-log-stream-writer.test.ts
+++ b/packages/zero-cache/src/services/replicator/change-log-stream-writer.test.ts
@@ -10,7 +10,7 @@ import {
   deleteChangeLogDB,
   openChangeLogDB,
   reconcileChangeLog,
-  type ReplicaAnchor,
+  type ChangeLogAnchor,
 } from './change-log-db.ts';
 import {
   ChangeLogStreamWriter,
@@ -19,10 +19,10 @@ import {
 
 const lc = createSilentLogContext();
 
-const ANCHOR: ReplicaAnchor = {
-  replicaVersion: '01',
-  stateVersion: '02',
-  writeTimeMs: 1_000,
+const ANCHOR: ChangeLogAnchor = {
+  identity: {epoch: null, generation: '01', replicaID: null},
+  resumeWatermark: '02',
+  nowMs: 1_000,
 };
 
 const files: DbFile[] = [];
@@ -35,21 +35,21 @@ afterEach(() => {
   }
 });
 
-/** The seed transaction {@link reconcileChangeLog} writes at the replica head. */
+/** The seed transaction {@link reconcileChangeLog} writes at the resume point. */
 const SEED_ROWS = [
   {
-    watermark: ANCHOR.stateVersion,
+    watermark: ANCHOR.resumeWatermark,
     pos: 0,
     change: '{"tag":"begin"}',
     precommit: null,
     writeTimeMs: null,
   },
   {
-    watermark: ANCHOR.stateVersion,
+    watermark: ANCHOR.resumeWatermark,
     pos: 1,
     change: '{"tag":"commit"}',
-    precommit: ANCHOR.stateVersion,
-    writeTimeMs: ANCHOR.writeTimeMs,
+    precommit: ANCHOR.resumeWatermark,
+    writeTimeMs: ANCHOR.nowMs,
   },
 ];
 
@@ -192,7 +192,7 @@ describe('replicator/change-log-stream-writer', () => {
     expect(db.inTransaction).toBe(true);
     writer.append(TRUNCATE, 'truncate');
     // Nothing is visible to another connection until the writer commits.
-    expect(head(observer)).toBe(ANCHOR.stateVersion);
+    expect(head(observer)).toBe(ANCHOR.resumeWatermark);
 
     writer.commit('06', COMMIT, 789);
     expect(db.inTransaction).toBe(false);
@@ -231,7 +231,7 @@ describe('replicator/change-log-stream-writer', () => {
     writer.append(TRUNCATE, 'truncate');
     writer.rollback();
 
-    expect(head(observer)).toBe(ANCHOR.stateVersion);
+    expect(head(observer)).toBe(ANCHOR.resumeWatermark);
     expect(rowCount(observer)).toBe(SEED_ROWS.length);
   });
 

--- a/packages/zero-cache/src/services/replicator/change-log-stream-writer.ts
+++ b/packages/zero-cache/src/services/replicator/change-log-stream-writer.ts
@@ -52,10 +52,11 @@ function assertInvariant(
  * Appends the canonical downstream stream to the change-log database, which is
  * a separate file from the replica.
  *
- * This class owns the change log's transaction, and its transaction alone. The
- * replica's remains with {@link ChangeProcessor}, which commits the two in a
- * fixed order — log first, then replica (design 4.4) — so that a crash can
- * leave a phantom transaction in the log but never a hole.
+ * This class owns the change log's transaction, and its transaction alone. It is
+ * driven from the change-streamer's stream loop, which commits it before
+ * forwarding a transaction's `commit` message; see `SQLiteChangeLogWriter` in
+ * `change-streamer/sqlite-change-log-writer.ts` for the ordering that makes a
+ * hole unreachable, and for the fail-soft policy that wraps every call here.
  */
 export class ChangeLogStreamWriter {
   readonly #db: StatementRunner;
@@ -152,18 +153,19 @@ export class ChangeLogStreamWriter {
         estimateChangeLogStreamRowBytes(watermark, change, precommit, true),
       hash: hasher.digest(),
     };
-    // The log is durable at `watermark` from here on, while the replica is
-    // still at the previous version. A crash in that window leaves a phantom,
-    // which startup reconciliation truncates.
+    // The log is durable at `watermark` from here on, and nothing that can
+    // advance the watermark the stream would resume from has run yet. A crash in
+    // that window leaves a transaction the resumed stream re-delivers, which
+    // reconciliation truncates.
     this.#db.commit();
     this.#reset();
     return stats;
   }
 
   /**
-   * Discards the open transaction, if any. Safe to call when none is open —
-   * the caller's rollback path also runs after a commit that succeeded and a
-   * subsequent replica write that did not.
+   * Discards the open transaction, if any. Safe to call when none is open — the
+   * caller rolls back on an interrupted change stream, which can arrive between
+   * transactions as well as inside one.
    */
   rollback(): void {
     const {inTransaction} = this.#db.db;

--- a/packages/zero-cache/src/services/replicator/change-processor.test.ts
+++ b/packages/zero-cache/src/services/replicator/change-processor.test.ts
@@ -1,5 +1,5 @@
 import type {LogContext} from '@rocicorp/logger';
-import {afterEach, beforeEach, describe, expect, test} from 'vitest';
+import {beforeEach, describe, expect, test} from 'vitest';
 import type {JSONObject} from '../../../../shared/src/bigint-json.ts';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
 import {must} from '../../../../shared/src/must.ts';
@@ -11,21 +11,8 @@ import {
 } from '../../db/lite-tables.ts';
 import type {LiteIndexSpec} from '../../db/specs.ts';
 import {StatementRunner} from '../../db/statements.ts';
-import {
-  DbFile,
-  expectTableExact,
-  expectTables,
-  initDB,
-} from '../../test/lite.ts';
+import {expectTables, initDB} from '../../test/lite.ts';
 import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
-import {serializeChangeStreamData} from '../change-streamer/change-log-codec.ts';
-import {
-  CHANGE_LOG_STREAM_TABLE,
-  deleteChangeLogDB,
-  openChangeLogDB,
-  readReplicaAnchor,
-  reconcileChangeLog,
-} from './change-log-db.ts';
 import {ChangeProcessor} from './change-processor.ts';
 import {DEL_OP, SET_OP} from './schema/change-log.ts';
 import {ColumnMetadataStore} from './schema/column-metadata.ts';
@@ -34,39 +21,6 @@ import {
   initReplicationState,
 } from './schema/replication-state.ts';
 import {createChangeProcessor, ReplicationMessages} from './test-utils.ts';
-
-/**
- * Exposes the two points inside `processCommit` where the replica is written,
- * so a test can sample the two databases from other connections in between.
- */
-class ObservingStatementRunner extends StatementRunner {
-  onCommit: (() => void) | undefined;
-  onRun: (() => void) | undefined;
-
-  override commit() {
-    this.onCommit?.();
-    return super.commit();
-  }
-
-  override run(sql: string, ...args: unknown[]) {
-    this.onRun?.();
-    return super.run(sql, ...args);
-  }
-}
-
-function head(db: Database): string | null {
-  return db
-    .prepare(
-      /*sql*/ `SELECT max("watermark") AS "head" FROM "${CHANGE_LOG_STREAM_TABLE}"`,
-    )
-    .get<{head: string | null}>().head;
-}
-
-function stateVersion(db: Database): string {
-  return db
-    .prepare(/*sql*/ `SELECT "stateVersion" FROM "_zero.replicationState"`)
-    .get<{stateVersion: string}>().stateVersion;
-}
 
 describe('replicator/change-processor', () => {
   let lc: LogContext;
@@ -82,8 +36,7 @@ describe('replicator/change-processor', () => {
     servingProcessor = new ChangeProcessor(
       new StatementRunner(servingReplica),
       'serving',
-      {changeLog: undefined},
-      (_, err) => {
+      (_, err: unknown) => {
         throw err;
       },
     );
@@ -92,8 +45,7 @@ describe('replicator/change-processor', () => {
     backupProcessor = new ChangeProcessor(
       new StatementRunner(backupReplica),
       'backup',
-      {changeLog: undefined},
-      (_, err) => {
+      (_, err: unknown) => {
         throw err;
       },
     );
@@ -3892,321 +3844,6 @@ describe('replicator/change-processor-errors', () => {
       'auto rollback change processor',
     );
     expect(replica.inTransaction).toBe(false);
-  });
-});
-
-describe('replicator/change-processor change-stream logging', () => {
-  let lc: LogContext;
-  let replicaFile: DbFile;
-  let replica: Database;
-  let replicaRunner: ObservingStatementRunner;
-  let changeLog: Database;
-  let processor: ChangeProcessor;
-  let failures: unknown[];
-
-  const issues = new ReplicationMessages({issues: 'id'});
-
-  beforeEach(() => {
-    lc = createSilentLogContext();
-    // File-backed, so a second connection can observe what is committed while
-    // a transaction is still open.
-    replicaFile = new DbFile('change-processor-change-log');
-    replica = replicaFile.connect(lc);
-    replica.pragma('journal_mode = wal');
-    initReplicationState(replica, ['zero_data'], '02');
-    initDB(
-      replica,
-      `
-      CREATE TABLE issues(
-        id INTEGER PRIMARY KEY,
-        text TEXT,
-        _0_version TEXT
-      );
-      `,
-    );
-    changeLog = openChangeLogDB(lc, replicaFile.path, {readonly: false});
-    changeLog.pragma('journal_mode = wal');
-    reconcileChangeLog(lc, changeLog, readReplicaAnchor(replica));
-
-    failures = [];
-    replicaRunner = new ObservingStatementRunner(replica);
-    processor = new ChangeProcessor(
-      replicaRunner,
-      'serving',
-      {changeLog: new StatementRunner(changeLog)},
-      (_, err) => failures.push(err),
-    );
-  });
-
-  afterEach(() => {
-    changeLog.close();
-    replica.close();
-    deleteChangeLogDB(replicaFile.path);
-    replicaFile.delete();
-  });
-
-  function process(data: ChangeStreamData) {
-    return processor.processMessage(lc, data, serializeChangeStreamData(data));
-  }
-
-  function streamRows(db: Database, watermark: string) {
-    return db
-      .prepare(/*sql*/ `
-        SELECT "watermark", "pos", "change", "precommit", "writeTimeMs"
-          FROM "${CHANGE_LOG_STREAM_TABLE}"
-          WHERE "watermark" = ?
-          ORDER BY "pos"
-      `)
-      .all<{
-        watermark: string;
-        pos: number;
-        change: string;
-        precommit: string | null;
-        writeTimeMs: number | null;
-      }>(watermark);
-  }
-
-  test('applies data, logs the stream to its own database, and advances state', () => {
-    process(['begin', issues.begin(), {commitWatermark: '06'}]);
-    process([
-      'data',
-      issues.insert('issues', {
-        id: 9007199254740993n,
-        text: 'before\0after',
-      }),
-    ]);
-    const result = process(['commit', issues.commit(), {watermark: '06'}]);
-
-    expect(failures).toEqual([]);
-    expect(result).toMatchObject({
-      watermark: '06',
-      changeLogStream: {rows: 3, estimatedBytes: expect.any(Number)},
-      commitTiming: {
-        logCommitMs: expect.any(Number),
-        replicaCommitMs: expect.any(Number),
-      },
-    });
-    expectTableExact(
-      replica,
-      'issues',
-      [
-        {
-          id: 9007199254740993n,
-          text: 'before\0after',
-          _0_version: '06',
-        },
-      ],
-      'bigint',
-      'id',
-    );
-
-    const rows = streamRows(changeLog, '06');
-    expect(rows).toEqual([
-      {
-        watermark: '06',
-        pos: 0,
-        change: '{"tag":"begin"}',
-        precommit: null,
-        writeTimeMs: null,
-      },
-      {
-        watermark: '06',
-        pos: 1,
-        change:
-          '{"tag":"insert","relation":{"tag":"relation","schema":"public","name":"issues","rowKey":{"type":"default","columns":["id"]}},"new":{"id":9007199254740993,"text":"before\\u0000after"}}',
-        precommit: null,
-        writeTimeMs: null,
-      },
-      {
-        watermark: '06',
-        pos: 2,
-        change: '{"tag":"commit"}',
-        precommit: '06',
-        writeTimeMs: expect.any(Number),
-      },
-    ]);
-
-    // The replica does not carry the table at all as of schema v15.
-    expect(
-      replica
-        .prepare(
-          /*sql*/ `SELECT "name" FROM "sqlite_master" WHERE "tbl_name" = ?`,
-        )
-        .all(CHANGE_LOG_STREAM_TABLE),
-    ).toEqual([]);
-
-    const state = replica
-      .prepare(/*sql*/ `
-        SELECT "stateVersion", "writeTimeMs"
-          FROM "_zero.replicationState"
-      `)
-      .get<{stateVersion: string; writeTimeMs: number}>();
-    expect(state.stateVersion).toBe('06');
-    // The same writeTimeMs in both databases, so reconciliation can seed the
-    // log from the replica alone.
-    expect(state.writeTimeMs).toBe(rows[2].writeTimeMs);
-    expect(head(changeLog)).toBe(state.stateVersion);
-  });
-
-  test('the log is durable at the new head while the replica is still behind', () => {
-    using replicaObserver = new Database(lc, replicaFile.path, {
-      readonly: true,
-    });
-    using logObserver = openChangeLogDB(lc, replicaFile.path, {readonly: true});
-    const observed: {logHead: string | null; stateVersion: string}[] = [];
-    const observe = () =>
-      observed.push({
-        logHead: head(logObserver),
-        stateVersion: stateVersion(replicaObserver),
-      });
-
-    // Sampled from another connection at the one point where the two
-    // databases legitimately disagree: after the log's COMMIT and before the
-    // replica's.
-    replicaRunner.onCommit = observe;
-
-    process(['begin', issues.begin(), {commitWatermark: '06'}]);
-    process(['data', issues.insert('issues', {id: 1, text: 'ordering'})]);
-    observe();
-    process(['commit', issues.commit(), {watermark: '06'}]);
-    observe();
-
-    expect(observed).toEqual([
-      // Mid-transaction: neither has the new watermark.
-      {logHead: '02', stateVersion: '02'},
-      // Between the two commits: the log leads the replica.
-      {logHead: '06', stateVersion: '02'},
-      // Both committed.
-      {logHead: '06', stateVersion: '06'},
-    ]);
-  });
-
-  // The two commits are reported separately because they are no longer one
-  // atomic commit, and the second span is the phantom window. Delaying the
-  // replica's commit must therefore land entirely in `replicaCommitMs`.
-  test('commit timing attributes the phantom window to the replica half', () => {
-    const DELAY_MS = 50;
-    replicaRunner.onCommit = () => {
-      const until = performance.now() + DELAY_MS;
-      while (performance.now() < until) {
-        // Busy-wait: the replica's commit is synchronous, so this has to be
-        // too in order to land inside the measured span.
-      }
-    };
-
-    process(['begin', issues.begin(), {commitWatermark: '06'}]);
-    process(['data', issues.insert('issues', {id: 1, text: 'timing'})]);
-    const result = process(['commit', issues.commit(), {watermark: '06'}]);
-
-    expect(failures).toEqual([]);
-    const timing = must(result).commitTiming;
-    expect(timing?.replicaCommitMs).toBeGreaterThanOrEqual(DELAY_MS);
-    expect(timing?.logCommitMs).toBeLessThan(must(timing).replicaCommitMs);
-  });
-
-  test('no interleaving leaves the replica ahead of the log', () => {
-    using replicaObserver = new Database(lc, replicaFile.path, {
-      readonly: true,
-    });
-    using logObserver = openChangeLogDB(lc, replicaFile.path, {readonly: true});
-    const holes: unknown[] = [];
-    const check = () => {
-      const logHead = head(logObserver);
-      const state = stateVersion(replicaObserver);
-      if (logHead === null || logHead < state) {
-        holes.push({logHead, stateVersion: state});
-      }
-    };
-
-    replicaRunner.onCommit = check;
-    replicaRunner.onRun = check;
-    for (const watermark of ['06', '08', '0a']) {
-      process(['begin', issues.begin(), {commitWatermark: watermark}]);
-      check();
-      process(['data', issues.insert('issues', {id: 1, text: watermark})]);
-      check();
-      process(['commit', issues.commit(), {watermark}]);
-      check();
-    }
-
-    expect(failures).toEqual([]);
-    expect(holes).toEqual([]);
-    expect(head(changeLog)).toBe('0a');
-  });
-
-  test('explicit rollback and abort leave no stream or replica rows', () => {
-    process(['begin', issues.begin(), {commitWatermark: '06'}]);
-    process(['data', issues.insert('issues', {id: 1, text: 'rollback'})]);
-    process(['rollback', {tag: 'rollback'}]);
-    expect(changeLog.inTransaction).toBe(false);
-
-    process(['begin', issues.begin(), {commitWatermark: '07'}]);
-    process(['data', issues.insert('issues', {id: 2, text: 'abort'})]);
-    processor.abort(lc);
-    expect(changeLog.inTransaction).toBe(false);
-
-    expect(replica.prepare(`SELECT * FROM issues`).all()).toEqual([]);
-    expect(streamRows(changeLog, '06')).toEqual([]);
-    expect(streamRows(changeLog, '07')).toEqual([]);
-    expect(head(changeLog)).toBe('02');
-    expect(stateVersion(replica)).toBe('02');
-  });
-
-  test('processing failure rolls back both transactions', () => {
-    process(['begin', issues.begin(), {commitWatermark: '06'}]);
-    process(['data', issues.insert('issues', {id: 1, text: 'valid'})]);
-    process([
-      'data',
-      {
-        tag: 'insert',
-        relation: {
-          schema: 'public',
-          name: 'missing',
-          rowKey: {columns: ['id'], type: 'default'},
-        },
-        new: {id: 2},
-      },
-    ]);
-
-    expect(failures).toHaveLength(1);
-    expect(replica.inTransaction).toBe(false);
-    expect(changeLog.inTransaction).toBe(false);
-    expect(replica.prepare(`SELECT * FROM issues`).all()).toEqual([]);
-    expect(streamRows(changeLog, '06')).toEqual([]);
-  });
-
-  test('a replica rollback failure still rolls back the change log', () => {
-    process(['begin', issues.begin(), {commitWatermark: '06'}]);
-    process(['data', issues.insert('issues', {id: 1, text: 'valid'})]);
-    // SQLite rolls back this statement's transaction itself, so the
-    // processor's own ROLLBACK then fails: the change log must not be left
-    // holding its write lock because of it.
-    replica.exec(/*sql*/ `
-      CREATE TRIGGER "AutoRollback" BEFORE INSERT ON issues
-      BEGIN SELECT RAISE(ROLLBACK, 'auto rollback'); END;
-    `);
-    process(['data', issues.insert('issues', {id: 2, text: 'boom'})]);
-
-    expect(failures).toHaveLength(1);
-    expect(String(failures[0])).toContain('auto rollback');
-    expect(String(failures[0])).toContain(
-      'cannot rollback - no transaction is active',
-    );
-    expect(replica.inTransaction).toBe(false);
-    expect(changeLog.inTransaction).toBe(false);
-    expect(streamRows(changeLog, '06')).toEqual([]);
-  });
-
-  test('initial-sync cannot open a second transaction for the log', () => {
-    expect(
-      () =>
-        new ChangeProcessor(
-          new StatementRunner(replica),
-          'initial-sync',
-          {changeLog: new StatementRunner(changeLog)},
-          () => {},
-        ),
-    ).toThrow('initial-sync owns its transaction boundaries');
   });
 });
 

--- a/packages/zero-cache/src/services/replicator/change-processor.ts
+++ b/packages/zero-cache/src/services/replicator/change-processor.ts
@@ -56,10 +56,6 @@ import type {
   TableUpdateMetadata,
 } from '../change-source/protocol/current/data.ts';
 import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
-import {
-  ChangeLogStreamWriter,
-  type ChangeLogStreamTransactionStats,
-} from './change-log-stream-writer.ts';
 import type {ReplicatorMode} from './replicator.ts';
 import {ChangeLog, DEL_OP, SET_OP} from './schema/change-log.ts';
 import {ColumnMetadataStore} from './schema/column-metadata.ts';
@@ -71,41 +67,11 @@ import {TableMetadataTracker} from './schema/table-metadata.ts';
 
 export type ChangeProcessorMode = ReplicatorMode | 'initial-sync';
 
-export type ChangeProcessorOptions = {
-  /**
-   * The change-log database, when the canonical change stream is being logged.
-   * It is a separate file from the replica, with its own transaction, which
-   * {@link ChangeLogStreamWriter} owns and commits before the replica's.
-   */
-  changeLog: StatementRunner | undefined;
-};
-
-/**
- * The two halves of the ordered commit, measured in the write worker so that
- * the IPC round trip is not folded in.
- */
-export type CommitTiming = {
-  /**
-   * Appending the commit row to the change log and committing its transaction.
-   */
-  readonly logCommitMs: number;
-  /**
-   * From the change log's `COMMIT` returning to the replica's — the phantom
-   * window. A crash anywhere in it leaves the log durable at `watermark` and
-   * the replica behind it, which startup reconciliation truncates. Watching it
-   * is watching how much of the change stream a crash can cost.
-   */
-  readonly replicaCommitMs: number;
-};
-
 export type CommitResult = {
   watermark: string;
   completedBackfill: DownloadStatus | undefined;
   schemaUpdated: boolean;
   changeLogUpdated: boolean;
-  changeLogStream?: ChangeLogStreamTransactionStats | undefined;
-  /** Set with {@link changeLogStream}, i.e. only when the log is written. */
-  commitTiming?: CommitTiming | undefined;
 };
 
 /**
@@ -122,7 +88,6 @@ export type CommitResult = {
 export class ChangeProcessor {
   readonly #db: StatementRunner;
   readonly #changeLog: ChangeLog;
-  readonly #changeLogStreamWriter: ChangeLogStreamWriter | undefined;
   readonly #tableMetadata: TableMetadataTracker;
   readonly #mode: ChangeProcessorMode;
   readonly #failService: (lc: LogContext, err: unknown) => void;
@@ -139,19 +104,10 @@ export class ChangeProcessor {
   constructor(
     db: StatementRunner,
     mode: ChangeProcessorMode,
-    options: ChangeProcessorOptions,
     failService: (lc: LogContext, err: unknown) => void,
   ) {
-    assert(
-      options.changeLog === undefined || mode !== 'initial-sync',
-      'initial-sync owns its transaction boundaries and cannot write the ' +
-        'change log, which opens a second one',
-    );
     this.#db = db;
     this.#changeLog = new ChangeLog(db.db);
-    this.#changeLogStreamWriter = options.changeLog
-      ? new ChangeLogStreamWriter(options.changeLog)
-      : undefined;
     this.#tableMetadata = new TableMetadataTracker(db.db);
     this.#mode = mode;
     this.#failService = failService;
@@ -160,13 +116,9 @@ export class ChangeProcessor {
   #fail(lc: LogContext, err: unknown) {
     if (!this.#failure) {
       let failureError = err;
-      // The two transactions are independent, so each is rolled back even if
-      // the other throws. Leaving one open would wedge the next attempt behind
-      // its own write lock.
-      const rollbackErrors = [
-        attempt(() => this.#currentTx?.abort(lc)),
-        attempt(() => this.#changeLogStreamWriter?.rollback()),
-      ].filter(e => e !== undefined);
+      const rollbackErrors = [attempt(() => this.#currentTx?.abort(lc))].filter(
+        e => e !== undefined,
+      );
 
       if (rollbackErrors.length) {
         const combinedError = new Error(
@@ -194,7 +146,6 @@ export class ChangeProcessor {
   processMessage(
     lc: LogContext,
     downstream: ChangeStreamData,
-    canonicalJSON?: string | undefined,
   ): CommitResult | null {
     const [type, message] = downstream;
     if (this.#failure) {
@@ -208,13 +159,7 @@ export class ChangeProcessor {
           : type === 'commit'
             ? downstream[2].watermark
             : undefined;
-      if (this.#changeLogStreamWriter) {
-        must(
-          canonicalJSON,
-          'canonical JSON is required when change-stream logging is enabled',
-        );
-      }
-      return this.#processMessage(lc, message, watermark, canonicalJSON);
+      return this.#processMessage(lc, message, watermark);
     } catch (e) {
       this.#fail(lc, e);
     }
@@ -267,22 +212,16 @@ export class ChangeProcessor {
     lc: LogContext,
     msg: Change,
     watermark: string | undefined,
-    canonicalJSON: string | undefined,
   ): CommitResult | null {
     if (msg.tag === 'begin') {
       if (this.#currentTx) {
         throw new Error(`Already in a transaction ${stringify(msg)}`);
       }
-      // Only the commit order matters. The replica's transaction is opened
-      // first because that is the one that carries the indefinite SQLITE_BUSY
-      // retry for litestream checkpoints; opening the log first would leave it
-      // holding a write lock for the duration of that wait.
       this.#currentTx = this.#beginTransaction(
         lc,
         must(watermark),
         msg.json ?? JSON_PARSED,
       );
-      this.#changeLogStreamWriter?.begin(must(watermark), must(canonicalJSON));
       return null;
     }
 
@@ -296,12 +235,7 @@ export class ChangeProcessor {
 
     if (msg.tag === 'commit') {
       assert(watermark, 'watermark is required for commit messages');
-      const result = tx.processCommit(
-        msg,
-        watermark,
-        this.#changeLogStreamWriter,
-        canonicalJSON,
-      );
+      const result = tx.processCommit(msg, watermark);
       // Clear only after a successful commit so #fail can roll back a commit
       // path that throws before SQLite has committed.
       this.#currentTx = null;
@@ -310,12 +244,9 @@ export class ChangeProcessor {
 
     if (msg.tag === 'rollback') {
       tx.abort(lc);
-      this.#changeLogStreamWriter?.rollback();
       this.#currentTx = null;
       return null;
     }
-
-    this.#changeLogStreamWriter?.append(must(canonicalJSON), msg.tag);
 
     switch (msg.tag) {
       case 'insert':
@@ -984,12 +915,7 @@ class TransactionProcessor {
     // no backfills are in progress).
   }
 
-  processCommit(
-    commit: MessageCommit,
-    watermark: string,
-    changeLogStreamWriter: ChangeLogStreamWriter | undefined,
-    canonicalJSON: string | undefined,
-  ): CommitResult {
+  processCommit(commit: MessageCommit, watermark: string): CommitResult {
     if (watermark !== this.#version) {
       throw new Error(
         `'commit' version ${watermark} does not match 'begin' version ${
@@ -997,31 +923,7 @@ class TransactionProcessor {
         }: ${stringify(commit)}`,
       );
     }
-    // Commit order is load-bearing: the change log commits first, then the
-    // replica (design 4.4). It is what makes `logHead >= stateVersion` hold at
-    // all times, so a crash in between leaves a phantom transaction in the log
-    // — locally detectable and truncated at startup — rather than a hole in it,
-    // which would be silently served to a subscriber as a gap.
-    let changeLogStream: ChangeLogStreamTransactionStats | undefined;
-    // Brackets the log's commit so that the two spans it separates — the log's
-    // own commit cost, and the phantom window that follows it — are measured
-    // rather than inferred from the total. Undefined when nothing is logged.
-    let logCommit: {startedAt: number; endedAt: number} | undefined;
-    if (changeLogStreamWriter) {
-      const writeTimeMs = Date.now();
-      const startedAt = performance.now();
-      changeLogStream = changeLogStreamWriter.commit(
-        watermark,
-        must(canonicalJSON),
-        writeTimeMs,
-      );
-      logCommit = {startedAt, endedAt: performance.now()};
-      // The same writeTimeMs is stored in both databases, so reconciliation
-      // can seed the log from the replica's state alone.
-      updateReplicationWatermark(this.#db, watermark, writeTimeMs);
-    } else {
-      updateReplicationWatermark(this.#db, watermark);
-    }
+    updateReplicationWatermark(this.#db, watermark);
 
     if (this.#schemaChanged) {
       const start = Date.now();
@@ -1034,12 +936,6 @@ class TransactionProcessor {
     if (this.#mode !== 'initial-sync') {
       this.#db.commit();
     }
-    // The replica commit above is unconditional whenever the log was written:
-    // a change processor that logs is never in 'initial-sync' mode.
-    const commitTiming: CommitTiming | undefined = logCommit && {
-      logCommitMs: logCommit.endedAt - logCommit.startedAt,
-      replicaCommitMs: performance.now() - logCommit.endedAt,
-    };
 
     const elapsedMs = Date.now() - this.#startMs;
     this.#lc.debug?.(`Committed tx@${this.#version} (${elapsedMs} ms)`);
@@ -1049,8 +945,6 @@ class TransactionProcessor {
       completedBackfill: this.#completedBackfill,
       schemaUpdated: this.#schemaChanged,
       changeLogUpdated: this.#numChangeLogEntries > 0,
-      ...(changeLogStream === undefined ? {} : {changeLogStream}),
-      ...(commitTiming === undefined ? {} : {commitTiming}),
     };
   }
 

--- a/packages/zero-cache/src/services/replicator/incremental-sync.test.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.test.ts
@@ -30,7 +30,7 @@ import {
   type SubscriberContext,
 } from '../change-streamer/change-streamer.ts';
 import * as ErrorType from '../change-streamer/error-type-enum.ts';
-import {deleteChangeLogDB, openChangeLogDB} from './change-log-db.ts';
+import {deleteChangeLogDB} from './change-log-db.ts';
 import {IncrementalSyncer} from './incremental-sync.ts';
 import {ReplicationStatusPublisher} from './replication-status.ts';
 import {
@@ -38,7 +38,6 @@ import {
   getReplicationState,
   initReplicationState,
 } from './schema/replication-state.ts';
-import {SQLiteChangeLogObserver} from './sqlite-change-log-observability.ts';
 import {ReplicationMessages} from './test-utils.ts';
 import {ThreadWriteWorkerClient} from './write-worker-client.ts';
 
@@ -81,7 +80,6 @@ describe('replicator/incremental-sync', () => {
     await worker.init(
       dbFile.path,
       'serving',
-      false,
       {
         busyTimeout: 30000,
         analysisLimit: 1000,
@@ -95,9 +93,7 @@ describe('replicator/incremental-sync', () => {
       {subscribe: subscribeFn.mockResolvedValue(downstream)},
       worker,
       'serving',
-      false,
       ReplicationStatusPublisher.forReplicaFile(dbFile.path),
-      undefined,
     );
   });
 
@@ -475,10 +471,9 @@ describe('replicator/incremental-sync', () => {
       ]
     `);
     expect(processMessage).toHaveBeenCalledTimes(11);
-    expect(processMessage).toHaveBeenNthCalledWith(1, {
-      data: firstBegin,
-      json: BigIntJSON.stringify(firstBegin),
-    });
+    // The parsed change, and nothing else: the canonical JSON went to the write
+    // worker only for the change log, which the change-streamer now writes.
+    expect(processMessage).toHaveBeenNthCalledWith(1, firstBegin);
   });
 
   test('replicates schema changes', async () => {
@@ -832,9 +827,7 @@ describe('replicator/incremental-sync', () => {
       },
       worker,
       'serving',
-      false,
       ReplicationStatusPublisher.forReplicaFile(dbFile.path),
-      undefined,
     );
 
     const localSyncing = syncer.run();
@@ -864,9 +857,7 @@ describe('replicator/incremental-sync', () => {
       },
       worker,
       'serving',
-      false,
       ReplicationStatusPublisher.forReplicaFile(dbFile.path),
-      undefined,
     );
 
     const localSyncing = syncer.run();
@@ -877,130 +868,6 @@ describe('replicator/incremental-sync', () => {
 
     syncer.stop(lc);
     void localSyncing.catch(() => {});
-  });
-
-  test('source disconnect rolls back an enabled stream writer transaction', async () => {
-    await worker.stop();
-    // The change log is anchored to the replica's state, so the state has to
-    // exist before the worker opens and reconciles it.
-    initReplicationState(mainDb, ['zero_data'], '02', {}, false);
-    worker = new ThreadWriteWorkerClient();
-    await worker.init(
-      dbFile.path,
-      'serving',
-      true,
-      {
-        busyTimeout: 30000,
-        analysisLimit: 1000,
-      },
-      {level: 'error', format: 'text'},
-    );
-    initDB(
-      mainDb,
-      `
-      CREATE TABLE issues(
-        id INTEGER PRIMARY KEY,
-        _0_version TEXT
-      );
-      `,
-    );
-
-    const {promise: hasRetried, resolve: retried} = resolver<true>();
-    subscribeFn.mockResolvedValueOnce(downstream).mockImplementation(() => {
-      retried(true);
-      return resolver<Source<SerializedDownstream>>().promise;
-    });
-    syncer = new IncrementalSyncer(
-      lc,
-      TASK_ID,
-      REPLICA_ID,
-      {subscribe: subscribeFn},
-      worker,
-      'serving',
-      true,
-      ReplicationStatusPublisher.forReplicaFile(dbFile.path),
-      undefined,
-    );
-    syncing = syncer.run();
-    await vi.waitFor(() => expect(subscribeFn).toHaveBeenCalledTimes(1));
-    const processMessage = vi.spyOn(worker, 'processMessage');
-
-    const issues = new ReplicationMessages({issues: 'id'});
-    downstream.push(['begin', issues.begin(), {commitWatermark: '06'}]);
-    downstream.push(['data', issues.insert('issues', {id: 1})]);
-    await vi.waitFor(() => expect(processMessage).toHaveBeenCalledTimes(2));
-    downstream.fail(new Error('source disconnected'));
-
-    expect(await hasRetried).toBe(true);
-    expect(mainDb.prepare(`SELECT * FROM issues`).all()).toEqual([]);
-    {
-      using changeLog = openChangeLogDB(lc, dbFile.path, {readonly: true});
-      expect(
-        changeLog
-          .prepare(
-            `SELECT * FROM "_zero.changeLogStream" WHERE "watermark" = '06'`,
-          )
-          .all(),
-      ).toEqual([]);
-    }
-    syncer.stop(lc);
-    void syncing.catch(() => {});
-    syncing = undefined;
-  });
-
-  test('an enabled SQLite stream-writer error stops the replicator', async () => {
-    await worker.stop();
-    initReplicationState(mainDb, ['zero_data'], '02', {}, false);
-    worker = new ThreadWriteWorkerClient();
-    await worker.init(
-      dbFile.path,
-      'serving',
-      true,
-      {
-        busyTimeout: 30000,
-        analysisLimit: 1000,
-      },
-      {level: 'error', format: 'text'},
-    );
-    const observer = new SQLiteChangeLogObserver(lc, {
-      schemaVersion: 14,
-      stateWatermark: '02',
-      seedWatermark: '02',
-      headWatermark: '02',
-      rows: 2,
-      estimatedBytes: 50,
-    });
-    syncer = new IncrementalSyncer(
-      lc,
-      TASK_ID,
-      REPLICA_ID,
-      {subscribe: subscribeFn.mockResolvedValue(downstream)},
-      worker,
-      'serving',
-      true,
-      ReplicationStatusPublisher.forReplicaFile(dbFile.path),
-      observer,
-    );
-    syncing = syncer.run();
-    await vi.waitFor(() => expect(subscribeFn).toHaveBeenCalledTimes(1));
-
-    // Reusing the seed watermark makes the stream insert fail even though the
-    // otherwise-empty replica transaction itself would be valid.
-    downstream.push(['begin', {tag: 'begin'}, {commitWatermark: '02'}]);
-    await syncing;
-    syncing = undefined;
-
-    expect(subscribeFn).toHaveBeenCalledTimes(1);
-    expect(observer.state()).toMatchObject({
-      sqliteHead: '02',
-      rows: 2,
-      rollbacks: 1,
-    });
-    expect(
-      mainDb
-        .prepare(`SELECT "stateVersion" FROM "_zero.replicationState"`)
-        .get(),
-    ).toEqual({stateVersion: '02'});
   });
 
   test('shut down on change-streamer error message', async () => {

--- a/packages/zero-cache/src/services/replicator/incremental-sync.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.ts
@@ -19,7 +19,6 @@ import type {ReplicationStatusPublisher} from './replication-status.ts';
 import type {ReplicaState, ReplicatorMode} from './replicator.ts';
 import {ReplicationReportRecorder} from './reporter/recorder.ts';
 import type {ReplicationReport} from './reporter/report-schema.ts';
-import type {SQLiteChangeLogObserver} from './sqlite-change-log-observability.ts';
 import type {WriteWorkerClient} from './write-worker-client.ts';
 
 type ErrorType = Enum<typeof ErrorType>;
@@ -38,11 +37,9 @@ export class IncrementalSyncer {
   readonly #changeStreamer: ChangeStreamer;
   readonly #worker: WriteWorkerClient;
   readonly #mode: ReplicatorMode;
-  readonly #logsChangeStream: boolean;
   readonly #statusPublisher: ReplicationStatusPublisher | null;
   readonly #notifier: Notifier;
   readonly #reporter: ReplicationReportRecorder;
-  readonly #sqliteChangeLogObserver: SQLiteChangeLogObserver | undefined;
 
   readonly #state = new RunningState('IncrementalSyncer');
 
@@ -59,9 +56,7 @@ export class IncrementalSyncer {
     changeStreamer: ChangeStreamer,
     worker: WriteWorkerClient,
     mode: ReplicatorMode,
-    logsChangeStream: boolean,
     statusPublisher: ReplicationStatusPublisher | null,
-    sqliteChangeLogObserver: SQLiteChangeLogObserver | undefined,
   ) {
     this.#lc = lc;
     this.#taskID = taskID;
@@ -69,11 +64,9 @@ export class IncrementalSyncer {
     this.#changeStreamer = changeStreamer;
     this.#worker = worker;
     this.#mode = mode;
-    this.#logsChangeStream = logsChangeStream;
     this.#statusPublisher = statusPublisher;
     this.#notifier = new Notifier();
     this.#reporter = new ReplicationReportRecorder(lc);
-    this.#sqliteChangeLogObserver = sqliteChangeLogObserver;
   }
 
   async run() {
@@ -108,7 +101,11 @@ export class IncrementalSyncer {
           watermark,
           replicaVersion,
           initial: watermark === initialWatermark,
-          logsChangeStream: this.#logsChangeStream,
+          // The SQLite change log is written by the change-streamer itself, so
+          // no replicator logs the change stream any more. The parameter stays
+          // on the wire for change-streamers that still exclude a writer from
+          // SQLite catchup.
+          logsChangeStream: false,
         });
         this.#state.resetBackoff();
         unregister = this.#state.cancelOnStop(downstream);
@@ -120,7 +117,7 @@ export class IncrementalSyncer {
 
         let backfillStatus: DownloadStatus | undefined;
 
-        for await (const {data: message, json} of downstream) {
+        for await (const {data: message} of downstream) {
           this.#replicationEvents.add(1);
           switch (message[0]) {
             case 'status': {
@@ -185,27 +182,7 @@ export class IncrementalSyncer {
               }
 
               const data = message as ChangeStreamData;
-              const start = performance.now();
-              this.#sqliteChangeLogObserver?.messageReceived(data, json);
-              let result: CommitResult | null;
-              try {
-                result = await this.#worker.processMessage({
-                  data,
-                  json,
-                });
-              } catch (e) {
-                this.#sqliteChangeLogObserver?.messageFailed(
-                  data,
-                  e,
-                  performance.now() - start,
-                );
-                throw e;
-              }
-              this.#sqliteChangeLogObserver?.messageProcessed(
-                data,
-                result,
-                performance.now() - start,
-              );
+              const result = await this.#worker.processMessage(data);
 
               this.#handleResult(lc, result);
               if (result?.completedBackfill) {
@@ -215,11 +192,9 @@ export class IncrementalSyncer {
             }
           }
         }
-        this.#sqliteChangeLogObserver?.abort();
         this.#worker.abort();
       } catch (e) {
         err = e;
-        this.#sqliteChangeLogObserver?.abort();
         this.#worker.abort();
       } finally {
         downstream?.cancel();

--- a/packages/zero-cache/src/services/replicator/replication-resumption-child.ts
+++ b/packages/zero-cache/src/services/replicator/replication-resumption-child.ts
@@ -6,6 +6,7 @@ import {Queue} from '../../../../shared/src/queue.ts';
 import {parentWorker, type Worker} from '../../types/processes.ts';
 import type {Source} from '../../types/streams.ts';
 import {getPragmaConfig, setupReplica} from '../../workers/replicator.ts';
+import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
 import type {
   ChangeStreamer,
   SerializedDownstream,
@@ -17,7 +18,6 @@ import {ReplicatorService} from './replicator.ts';
 import {
   ThreadWriteWorkerClient,
   type PragmaConfig,
-  type SerializedChangeStreamData,
   type WriteWorkerClient,
 } from './write-worker-client.ts';
 
@@ -168,11 +168,10 @@ class FailpointWriteWorkerClient implements WriteWorkerClient {
   init(
     dbPath: string,
     mode: Parameters<ThreadWriteWorkerClient['init']>[1],
-    logsChangeStream: boolean,
     pragmas: PragmaConfig,
     logConfig: LogConfig,
   ) {
-    return this.#inner.init(dbPath, mode, logsChangeStream, pragmas, logConfig);
+    return this.#inner.init(dbPath, mode, pragmas, logConfig);
   }
 
   getSubscriptionState() {
@@ -180,7 +179,7 @@ class FailpointWriteWorkerClient implements WriteWorkerClient {
   }
 
   async processMessage(
-    downstream: SerializedChangeStreamData,
+    downstream: ChangeStreamData,
   ): Promise<CommitResult | null> {
     const result = await this.#inner.processMessage(downstream);
     if (
@@ -236,7 +235,7 @@ export default async function runWorker(
     parent,
     failpoint,
   );
-  await worker.init(dbPath, 'serving', false, getPragmaConfig('serving'), {
+  await worker.init(dbPath, 'serving', getPragmaConfig('serving'), {
     level: 'error',
     format: 'text',
   });
@@ -248,9 +247,7 @@ export default async function runWorker(
     'serving',
     new IPCChangeStreamer(parent),
     worker,
-    false,
     null,
-    undefined,
   );
 
   const running = runUntilKilled(lc, parent, replicator);

--- a/packages/zero-cache/src/services/replicator/replication-throughput.bench.pg.ts
+++ b/packages/zero-cache/src/services/replicator/replication-throughput.bench.pg.ts
@@ -1,14 +1,11 @@
 // Benchmarks end-to-end logical replication throughput from upstream Postgres
 // writes through the change-streamer and into the SQLite replica.
 //
-// Set SQLITE_CHANGE_LOG_WRITER=1 to also write the canonical change stream to
-// the change-log database beside the replica, which is what the replicator
-// does with `sqliteChangeLogMode` enabled. Running the bench both ways is the
-// slice 7D measurement: the cost of the second, log-first commit on the real
-// write path rather than on the synthetic ceiling harness.
+// The change log is written by the change-streamer rather than by this write
+// path, so there is no writer axis here any more: this measures the replicator's
+// baseline, which is what slice 7I returned it to.
 //
 //   pnpm --filter zero-cache run bench:pg replication-throughput
-//   SQLITE_CHANGE_LOG_WRITER=1 pnpm --filter zero-cache run bench:pg replication-throughput
 
 import {afterEach, describe, expect} from 'vitest';
 import {createManualBenchmarkRecorder} from '../../../../shared/src/bench.ts';
@@ -38,7 +35,6 @@ import {
   type SerializedDownstream,
 } from '../change-streamer/change-streamer.ts';
 import {initChangeStreamerSchema} from '../change-streamer/schema/init.ts';
-import {deleteChangeLogDB} from './change-log-db.ts';
 import {ReplicationStatusPublisher} from './replication-status.ts';
 import {ReplicatorService} from './replicator.ts';
 import {ThreadWriteWorkerClient} from './write-worker-client.ts';
@@ -54,8 +50,6 @@ const APP_ID = 'logical_replication_bench_app';
 const SHARD_NUM = 0;
 const TASK_ID = 'logical-replication-throughput-bench';
 const TEST_TIMEOUT_MS = 900_000;
-
-const LOGS_CHANGE_STREAM = process.env['SQLITE_CHANGE_LOG_WRITER'] === '1';
 
 const lc = createSilentLogContext();
 const shard = {
@@ -178,19 +172,9 @@ async function startReplicationPipeline(testDBs: PgTest['testDBs']) {
   });
 
   const worker = new ThreadWriteWorkerClient();
-  await worker.init(
-    replicaDbFile.path,
-    'serving',
-    LOGS_CHANGE_STREAM,
-    getPragmaConfig('serving'),
-    {
-      level: 'error',
-      format: 'text',
-    },
-  );
-  cleanup.push(() => {
-    deleteChangeLogDB(replicaDbFile.path);
-    return Promise.resolve();
+  await worker.init(replicaDbFile.path, 'serving', getPragmaConfig('serving'), {
+    level: 'error',
+    format: 'text',
   });
 
   const replicator = new ReplicatorService(
@@ -200,9 +184,7 @@ async function startReplicationPipeline(testDBs: PgTest['testDBs']) {
     'serving',
     parseStringifiedChangeStreamer(changeStreamer),
     worker,
-    LOGS_CHANGE_STREAM,
     null,
-    undefined,
   );
   const replicatorDone = replicator.run();
   cleanup.push(async () => {
@@ -264,9 +246,10 @@ describe('replicator/logical replication throughput', () => {
         });
       }
 
+      // The change-log writer is no longer on this path: it lives in the
+      // change-streamer, so this is the write path's baseline again.
       benchmarkRecorder.recordThroughputSamples(
-        'replicator/logical replication end-to-end payload MB ' +
-          `changeLogWriter=${LOGS_CHANGE_STREAM ? 'on' : 'off'}`,
+        'replicator/logical replication end-to-end payload MB',
         samples,
       );
     },

--- a/packages/zero-cache/src/services/replicator/replicator.ts
+++ b/packages/zero-cache/src/services/replicator/replicator.ts
@@ -5,7 +5,6 @@ import type {ChangeStreamer} from '../change-streamer/change-streamer.ts';
 import type {Service} from '../service.ts';
 import {IncrementalSyncer} from './incremental-sync.ts';
 import type {ReplicationStatusPublisher} from './replication-status.ts';
-import type {SQLiteChangeLogObserver} from './sqlite-change-log-observability.ts';
 import type {WriteWorkerClient} from './write-worker-client.ts';
 
 /** See {@link ReplicaStateNotifier.subscribe()}. */
@@ -77,9 +76,7 @@ export class ReplicatorService implements Replicator, Service {
     mode: ReplicatorMode,
     changeStreamer: ChangeStreamer,
     worker: WriteWorkerClient,
-    logsChangeStream: boolean,
     statusPublisher: ReplicationStatusPublisher | null,
-    sqliteChangeLogObserver: SQLiteChangeLogObserver | undefined,
   ) {
     this.id = id;
     this.#lc = lc
@@ -94,9 +91,7 @@ export class ReplicatorService implements Replicator, Service {
       changeStreamer,
       worker,
       mode,
-      logsChangeStream,
       statusPublisher,
-      sqliteChangeLogObserver,
     );
   }
 

--- a/packages/zero-cache/src/services/replicator/schema-change-fuzz.test.ts
+++ b/packages/zero-cache/src/services/replicator/schema-change-fuzz.test.ts
@@ -84,8 +84,7 @@ test('streamed schema changes match a replica rebuilt from the final schema', ()
         const processor = new ChangeProcessor(
           new StatementRunner(streamed),
           'serving',
-          {changeLog: undefined},
-          (_, error) => {
+          (_, error: unknown) => {
             throw error;
           },
         );

--- a/packages/zero-cache/src/services/replicator/sqlite-change-log-metrics.test.ts
+++ b/packages/zero-cache/src/services/replicator/sqlite-change-log-metrics.test.ts
@@ -18,7 +18,10 @@ import {afterEach, expect, test, vi} from 'vitest';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
 import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
 import type {ReseedReason} from './change-log-db.ts';
-import type {CommitResult} from './change-processor.ts';
+import type {
+  ChangeLogCommit,
+  SQLiteChangeLogInfo,
+} from './sqlite-change-log-observability.ts';
 
 afterEach(() => {
   metrics.disable();
@@ -90,7 +93,7 @@ test('each reseed reason increments reconcile_wipes with its own label', async (
   const reasons: ReseedReason[] = [
     'created',
     'schema-mismatch',
-    'replica-version-mismatch',
+    'identity-mismatch',
     'gap',
   ];
 
@@ -102,7 +105,8 @@ test('each reseed reason increments reconcile_wipes with its own label', async (
     });
   }
   // Twice, to show the `gap` series counts rather than latches. A nonzero rate
-  // in steady state is the alert that log-first ordering is not holding.
+  // in steady state is the alert that the log is not leading the resume
+  // watermark.
   recordSQLiteChangeLogReconcile(lc, {
     action: 'reseeded',
     head: '05',
@@ -119,7 +123,7 @@ test('each reseed reason increments reconcile_wipes with its own label', async (
   expect(counts(otel.exporter, `${METRIC}.reconcile_wipes`)).toEqual({
     'created': 1,
     'schema-mismatch': 1,
-    'replica-version-mismatch': 1,
+    'identity-mismatch': 1,
     'gap': 2,
   });
   expect(counts(otel.exporter, `${METRIC}.reconcile_truncated_rows`)).toEqual({
@@ -153,31 +157,33 @@ const BEGIN: ChangeStreamData = [
 ];
 const COMMIT: ChangeStreamData = ['commit', {tag: 'commit'}, {watermark: '06'}];
 
-const COMMIT_RESULT: CommitResult = {
+const COMMIT_RESULT: ChangeLogCommit = {
   watermark: '06',
-  completedBackfill: undefined,
-  schemaUpdated: false,
-  changeLogUpdated: true,
-  changeLogStream: {rows: 2, estimatedBytes: 100, hash: '0'.repeat(64)},
-  commitTiming: {logCommitMs: 4, replicaCommitMs: 11},
+  stats: {rows: 2, estimatedBytes: 100, hash: '0'.repeat(64)},
+  logCommitMs: 4,
 };
 
-test('records the two halves of the ordered commit separately', async () => {
+const INFO: SQLiteChangeLogInfo = {
+  epoch: null,
+  generation: '01',
+  replicaID: null,
+  schemaVersion: 2,
+  seededAtMs: 1_700_000_000_000,
+  seedWatermark: '02',
+  headWatermark: '02',
+  rows: 2,
+  estimatedBytes: 100,
+};
+
+test('records the commit that sits on the forward path', async () => {
   await using otel = withProvider();
   const {SQLiteChangeLogObserver} =
     await import('./sqlite-change-log-observability.ts');
-  const observer = new SQLiteChangeLogObserver(createSilentLogContext(), {
-    schemaVersion: 1,
-    stateWatermark: '02',
-    seedWatermark: '02',
-    headWatermark: '02',
-    rows: 2,
-    estimatedBytes: 100,
-  });
+  const observer = new SQLiteChangeLogObserver(createSilentLogContext(), INFO);
 
   observer.messageProcessed(BEGIN, null, 1);
-  // The 20 ms round trip is the message-processing time; the two commits
-  // inside it are what the write worker measured.
+  // The 20 ms is the whole write of the commit message; the commit inside it is
+  // the part that precedes the forward.
   observer.messageProcessed(COMMIT, COMMIT_RESULT, 20);
   await otel.provider.forceFlush();
 
@@ -185,39 +191,30 @@ test('records the two halves of the ordered commit separately', async () => {
   expect(
     histogram(otel.exporter, `${METRIC}.log_commit_duration`),
   ).toMatchObject({count: 1, sum: 0.004});
+  // There is no second commit to order against any more: the replica's belongs
+  // to a subscriber downstream of this loop.
   expect(
-    histogram(otel.exporter, `${METRIC}.replica_commit_duration`),
-  ).toMatchObject({count: 1, sum: 0.011});
-  // The metric they replaced claimed the two were one atomic commit.
+    dataPoints(otel.exporter, `${METRIC}.replica_commit_duration`),
+  ).toBeUndefined();
   expect(
     dataPoints(otel.exporter, `${METRIC}.commit_duration`),
   ).toBeUndefined();
 });
 
-test('a failed commit times the attempt but neither database', async () => {
+test('a failed commit times the attempt but not the commit', async () => {
   await using otel = withProvider();
   const {SQLiteChangeLogObserver} =
     await import('./sqlite-change-log-observability.ts');
-  const observer = new SQLiteChangeLogObserver(createSilentLogContext(), {
-    schemaVersion: 1,
-    stateWatermark: '02',
-    seedWatermark: '02',
-    headWatermark: '02',
-    rows: 2,
-    estimatedBytes: 100,
-  });
+  const observer = new SQLiteChangeLogObserver(createSilentLogContext(), INFO);
 
   observer.messageProcessed(BEGIN, null, 1);
   observer.messageFailed(COMMIT, new Error('commit failed'), 20);
   await otel.provider.forceFlush();
 
-  // There is no CommitResult to attribute a duration to either half, so the
-  // attempt is timed only by the message-processing histogram.
+  // A failed commit produces no statistics, so there is nothing to attribute a
+  // duration to: the attempt is timed only by the message-processing histogram.
   expect(
     dataPoints(otel.exporter, `${METRIC}.log_commit_duration`),
-  ).toBeUndefined();
-  expect(
-    dataPoints(otel.exporter, `${METRIC}.replica_commit_duration`),
   ).toBeUndefined();
   expect(
     histogram(otel.exporter, `${METRIC}.message_processing_duration`, {

--- a/packages/zero-cache/src/services/replicator/sqlite-change-log-observability.test.ts
+++ b/packages/zero-cache/src/services/replicator/sqlite-change-log-observability.test.ts
@@ -18,52 +18,41 @@ import {
   deleteChangeLogDB,
   openChangeLogDB,
   openChangeLogDBForWriting,
-  readReplicaAnchor,
   reconcileChangeLog,
+  type ChangeLogAnchor,
   type ReconcileResult,
 } from './change-log-db.ts';
-import {initReplicationState} from './schema/replication-state.ts';
 import {
-  getReplicaChangeLogInfo,
   getSQLiteChangeLogInfo,
   getSQLiteChangeLogStartupInfo,
   logSQLiteChangeLogStartup,
   recordSQLiteChangeLogReconcile,
   sqliteFileBytes,
   SQLiteChangeLogObserver,
+  type ChangeLogCommit,
 } from './sqlite-change-log-observability.ts';
 
-function setupReplica() {
+const ANCHOR: ChangeLogAnchor = {
+  identity: {epoch: null, generation: '01', replicaID: '1777575698286'},
+  resumeWatermark: '02',
+  nowMs: 1_700_000_000_000,
+};
+
+/**
+ * A reconciled change log, with no replica beside it: everything reported here
+ * comes from the log itself.
+ */
+function setupChangeLog() {
   const sink = new TestLogSink();
   const lc = new LogContext('debug', undefined, sink);
-  const db = new Database(lc, ':memory:');
-  // The replica's schema version is deliberately not the change log's. Nothing
-  // here reads it — it is present so the tests below can show that the reported
-  // schema version comes from the log rather than from this table.
-  db.exec(/*sql*/ `
-    CREATE TABLE "_zero.versionHistory" (
-      "dataVersion" INTEGER NOT NULL,
-      "schemaVersion" INTEGER NOT NULL,
-      "minSafeVersion" INTEGER NOT NULL,
-      "lock" INTEGER PRIMARY KEY DEFAULT 1 CHECK ("lock" = 1)
-    );
-    INSERT INTO "_zero.versionHistory"
-      ("dataVersion", "schemaVersion", "minSafeVersion")
-      VALUES (15, 15, 0);
-  `);
-  initReplicationState(db, ['zero_data'], '02');
-  // The change log is a separate database as of replica schema v15. Seed it at
-  // the replica head the way the writer's startup reconciliation does.
   const changeLog = new Database(lc, ':memory:');
-  reconcileChangeLog(lc, changeLog, readReplicaAnchor(db));
+  reconcileChangeLog(lc, changeLog, ANCHOR);
   return {
-    db,
     changeLog,
     lc,
     sink,
     [Symbol.dispose]() {
       changeLog.close();
-      db.close();
     },
   };
 }
@@ -73,6 +62,18 @@ function receive(
   data: ChangeStreamData,
 ): void {
   observer.messageReceived(data, serializeChangeStreamData(data));
+}
+
+function commitResult(
+  watermark: string,
+  hash: string,
+  estimatedBytes = 100,
+): ChangeLogCommit {
+  return {
+    watermark,
+    stats: {rows: 2, estimatedBytes, hash},
+    logCommitMs: 0.009,
+  };
 }
 
 function twoRowTransactionHash(watermark: string): string {
@@ -102,23 +103,23 @@ function twoRowTransactionHash(watermark: string): string {
 
 describe('SQLite change-log observability', () => {
   test('reads and logs startup state', () => {
-    using fixture = setupReplica();
-    const info = getSQLiteChangeLogInfo(fixture.db, fixture.changeLog);
+    using fixture = setupChangeLog();
+    const info = getSQLiteChangeLogInfo(fixture.changeLog);
 
-    expect(info).toMatchObject({
-      // The change log's own version, from its meta table — not the replica's
-      // 15, which the two databases now version independently.
+    expect(info).toEqual({
+      epoch: null,
+      generation: '01',
+      replicaID: '1777575698286',
       schemaVersion: CHANGE_LOG_DB_SCHEMA_VERSION,
-      stateWatermark: '02',
+      seededAtMs: ANCHOR.nowMs,
       seedWatermark: '02',
       headWatermark: '02',
       rows: 2,
       estimatedBytes: expect.any(Number),
     });
-    expect(info.schemaVersion).not.toBe(15);
     expect(info.estimatedBytes).toBeGreaterThan(0);
 
-    logSQLiteChangeLogStartup(fixture.lc, 'backup', true, info);
+    logSQLiteChangeLogStartup(fixture.lc, '/data/replica.db-change-log', info);
     expect(fixture.sink.messages.at(-1)).toEqual([
       'info',
       undefined,
@@ -126,12 +127,14 @@ describe('SQLite change-log observability', () => {
         'SQLite change-log startup',
         {
           sqliteChangeLog: {
-            fileMode: 'backup',
-            writerEnabled: true,
+            file: '/data/replica.db-change-log',
+            epoch: null,
+            generation: '01',
+            replicaID: '1777575698286',
             schemaVersion: CHANGE_LOG_DB_SCHEMA_VERSION,
             seedWatermark: '02',
+            seededAtMs: ANCHOR.nowMs,
             headWatermark: '02',
-            stateWatermark: '02',
           },
         },
       ],
@@ -139,16 +142,16 @@ describe('SQLite change-log observability', () => {
   });
 
   test('startup info skips the row/byte aggregate', () => {
-    using fixture = setupReplica();
-    const startupInfo = getSQLiteChangeLogStartupInfo(
-      fixture.db,
-      fixture.changeLog,
-    );
+    using fixture = setupChangeLog();
+    const startupInfo = getSQLiteChangeLogStartupInfo(fixture.changeLog);
 
-    // Same schema/state/head as the full read, but no table-scanning totals.
+    // Same meta and head as the full read, but no table-scanning totals.
     expect(startupInfo).toEqual({
+      epoch: null,
+      generation: '01',
+      replicaID: '1777575698286',
       schemaVersion: CHANGE_LOG_DB_SCHEMA_VERSION,
-      stateWatermark: '02',
+      seededAtMs: ANCHOR.nowMs,
       seedWatermark: '02',
       headWatermark: '02',
     });
@@ -156,92 +159,44 @@ describe('SQLite change-log observability', () => {
       rows: _rows,
       estimatedBytes: _bytes,
       ...head
-    } = getSQLiteChangeLogInfo(fixture.db, fixture.changeLog);
+    } = getSQLiteChangeLogInfo(fixture.changeLog);
     expect(startupInfo).toEqual(head);
   });
 
-  // A disabled writer opens no change-log database, so it reports the replica's
-  // own state and neither a schema version nor a head. The replica has not
-  // carried a copy of the log since schema v15, so there is nothing else it
-  // could report.
-  test('a disabled writer reports replica state without a head', () => {
-    using fixture = setupReplica();
-    const info = getReplicaChangeLogInfo(fixture.db);
-
-    expect(info).toEqual({
-      stateWatermark: '02',
-      seedWatermark: '02',
-    });
-
-    logSQLiteChangeLogStartup(fixture.lc, 'serving', false, info);
-    expect(fixture.sink.messages.at(-1)).toEqual([
-      'info',
-      undefined,
-      [
-        'SQLite change-log startup',
-        {
-          sqliteChangeLog: {
-            fileMode: 'serving',
-            writerEnabled: false,
-            schemaVersion: undefined,
-            seedWatermark: '02',
-            headWatermark: undefined,
-            stateWatermark: '02',
-          },
-        },
-      ],
-    ]);
-  });
-
   test('startup info throws on an unseeded change log', () => {
-    using fixture = setupReplica();
-    // The writer path runs after reconciliation, which cannot leave the log
+    using fixture = setupChangeLog();
+    // The writer reads this after reconciliation, which cannot leave the log
     // empty, so this is the assertion that catches a caller reading the log
     // before it has been reconciled.
     fixture.changeLog.prepare(`DELETE FROM "${CHANGE_LOG_STREAM_TABLE}"`).run();
 
-    expect(() =>
-      getSQLiteChangeLogStartupInfo(fixture.db, fixture.changeLog),
-    ).toThrow('SQLite change log must contain its seed transaction');
-  });
-
-  // Invariant 11: the log's replicaVersion always equals the replica's.
-  // Reconciliation guarantees it by wiping, so reaching the observability seam
-  // with a mismatch means the log was never reconciled against this replica.
-  test('startup info throws on a log anchored to another replica', () => {
-    using fixture = setupReplica();
-    fixture.changeLog
-      .prepare(`UPDATE "${CHANGE_LOG_META_TABLE}" SET "replicaVersion" = '01'`)
-      .run();
-
-    expect(() =>
-      getSQLiteChangeLogStartupInfo(fixture.db, fixture.changeLog),
-    ).toThrow('SQLite change log is anchored to replica version 01, not 02');
+    expect(() => getSQLiteChangeLogStartupInfo(fixture.changeLog)).toThrow(
+      'the SQLite change log must contain its seed transaction',
+    );
   });
 
   test('startup info throws on a log with no meta row', () => {
-    using fixture = setupReplica();
+    using fixture = setupChangeLog();
     fixture.changeLog.prepare(`DELETE FROM "${CHANGE_LOG_META_TABLE}"`).run();
 
-    expect(() =>
-      getSQLiteChangeLogStartupInfo(fixture.db, fixture.changeLog),
-    ).toThrow('SQLite change log must have a meta row');
+    expect(() => getSQLiteChangeLogStartupInfo(fixture.changeLog)).toThrow(
+      'the SQLite change log has no meta row',
+    );
   });
 
-  test('reports temporary head skew without an invariant failure', () => {
-    using fixture = setupReplica();
-    fixture.db
-      .prepare(`UPDATE "_zero.replicationState" SET "stateVersion" = '06'`)
-      .run();
+  // The log commits before the forward, so the received head trails its own
+  // head except *within* a transaction, which is the window this measures.
+  test('reports intra-transaction head skew without an invariant failure', () => {
+    using fixture = setupChangeLog();
     const observer = new SQLiteChangeLogObserver(
       fixture.lc,
-      getSQLiteChangeLogInfo(fixture.db, fixture.changeLog),
+      getSQLiteChangeLogInfo(fixture.changeLog),
     );
 
     expect(observer.state()).toMatchObject({
-      receivedHead: '06',
+      receivedHead: '02',
       sqliteHead: '02',
-      headLag: 4,
+      headLag: 0,
       rows: 2,
       rollbacks: 0,
       invariantFailures: 0,
@@ -269,17 +224,7 @@ describe('SQLite change-log observability', () => {
 
     observer.messageProcessed(
       commit,
-      {
-        watermark: '07',
-        completedBackfill: undefined,
-        schemaUpdated: false,
-        changeLogUpdated: false,
-        changeLogStream: {
-          rows: 2,
-          estimatedBytes: 100,
-          hash: twoRowTransactionHash('07'),
-        },
-      },
+      commitResult('07', twoRowTransactionHash('07')),
       2,
     );
     expect(observer.state()).toMatchObject({
@@ -288,8 +233,7 @@ describe('SQLite change-log observability', () => {
       headLag: 0,
       rows: 4,
       estimatedBytes:
-        getSQLiteChangeLogInfo(fixture.db, fixture.changeLog).estimatedBytes +
-        100,
+        getSQLiteChangeLogInfo(fixture.changeLog).estimatedBytes + 100,
       invariantFailures: 0,
       hashMatches: 1,
       hashMismatches: 0,
@@ -298,10 +242,10 @@ describe('SQLite change-log observability', () => {
   });
 
   test('counts upstream, interrupted, and failed transaction rollbacks', () => {
-    using fixture = setupReplica();
+    using fixture = setupChangeLog();
     const observer = new SQLiteChangeLogObserver(
       fixture.lc,
-      getSQLiteChangeLogInfo(fixture.db, fixture.changeLog),
+      getSQLiteChangeLogInfo(fixture.changeLog),
     );
 
     observer.messageProcessed(
@@ -329,10 +273,10 @@ describe('SQLite change-log observability', () => {
   });
 
   test('counts writer invariant errors and malformed commit results', () => {
-    using fixture = setupReplica();
+    using fixture = setupChangeLog();
     const observer = new SQLiteChangeLogObserver(
       fixture.lc,
-      getSQLiteChangeLogInfo(fixture.db, fixture.changeLog),
+      getSQLiteChangeLogInfo(fixture.changeLog),
     );
     const invariantError = new Error('stream position mismatch');
     invariantError.name = 'ChangeLogStreamInvariantError';
@@ -354,26 +298,76 @@ describe('SQLite change-log observability', () => {
     receive(observer, begin);
     observer.messageProcessed(begin, null, 1);
     receive(observer, commit);
-    observer.messageProcessed(
-      commit,
-      {
-        watermark: '04',
-        completedBackfill: undefined,
-        schemaUpdated: false,
-        changeLogUpdated: false,
-      },
-      1,
-    );
+    observer.messageProcessed(commit, null, 1);
 
     expect(observer.state().invariantFailures).toBe(2);
     expect(observer.state().hashUnpaired).toBe(1);
   });
 
-  test('counts and logs a transaction hash mismatch', () => {
-    using fixture = setupReplica();
+  // A missed truncate-above surfaces as a constraint violation on the writer's
+  // plain INSERT, which fail-soft would otherwise absorb quietly. This is the
+  // seam that keeps it visible.
+  test('records a reported invariant failure', () => {
+    using fixture = setupChangeLog();
     const observer = new SQLiteChangeLogObserver(
       fixture.lc,
-      getSQLiteChangeLogInfo(fixture.db, fixture.changeLog),
+      getSQLiteChangeLogInfo(fixture.changeLog),
+    );
+
+    observer.invariantFailure('constraint violated', {tag: 'begin'});
+
+    expect(observer.state().invariantFailures).toBe(1);
+    expect(fixture.sink.messages.at(-1)).toEqual([
+      'error',
+      {component: 'sqlite-change-log-observer'},
+      ['constraint violated', {tag: 'begin'}],
+    ]);
+  });
+
+  test('restates its totals when reconciliation moves the head', () => {
+    using fixture = setupChangeLog();
+    const observer = new SQLiteChangeLogObserver(
+      fixture.lc,
+      getSQLiteChangeLogInfo(fixture.changeLog),
+    );
+    const begin: ChangeStreamData = [
+      'begin',
+      {tag: 'begin'},
+      {commitWatermark: '07'},
+    ];
+    const commit: ChangeStreamData = [
+      'commit',
+      {tag: 'commit'},
+      {watermark: '07'},
+    ];
+    receive(observer, begin);
+    observer.messageProcessed(begin, null, 1);
+    receive(observer, commit);
+    observer.messageProcessed(
+      commit,
+      commitResult('07', twoRowTransactionHash('07')),
+      1,
+    );
+    expect(observer.state()).toMatchObject({sqliteHead: '07', rows: 4});
+
+    // A reconnect truncated '07' away, so the observer's head and totals are
+    // restated from the log rather than left describing rows that are gone.
+    reconcileChangeLog(fixture.lc, fixture.changeLog, ANCHOR);
+    observer.reconciled(getSQLiteChangeLogInfo(fixture.changeLog));
+
+    expect(observer.state()).toMatchObject({
+      receivedHead: '02',
+      sqliteHead: '02',
+      headLag: 0,
+      rows: 2,
+    });
+  });
+
+  test('counts and logs a transaction hash mismatch', () => {
+    using fixture = setupChangeLog();
+    const observer = new SQLiteChangeLogObserver(
+      fixture.lc,
+      getSQLiteChangeLogInfo(fixture.changeLog),
     );
     const begin: ChangeStreamData = [
       'begin',
@@ -388,21 +382,7 @@ describe('SQLite change-log observability', () => {
     receive(observer, begin);
     observer.messageProcessed(begin, null, 1);
     receive(observer, commit);
-    observer.messageProcessed(
-      commit,
-      {
-        watermark: '03',
-        completedBackfill: undefined,
-        schemaUpdated: false,
-        changeLogUpdated: false,
-        changeLogStream: {
-          rows: 2,
-          estimatedBytes: 100,
-          hash: '0'.repeat(64),
-        },
-      },
-      1,
-    );
+    observer.messageProcessed(commit, commitResult('03', '0'.repeat(64)), 1);
 
     expect(observer.state()).toMatchObject({
       hashMatches: 0,
@@ -441,38 +421,30 @@ describe('SQLite change-log observability on disk', () => {
     const sink = new TestLogSink();
     const lc = new LogContext('debug', undefined, sink);
     dbFile = new DbFile('sqlite-change-log-observability');
-    const replica = dbFile.connect(lc);
-    initReplicationState(replica, ['zero_data'], '02');
-    const {db: changeLog} = openChangeLogDBForWriting(
-      lc,
-      dbFile.path,
-      readReplicaAnchor(replica),
-    );
+    const {db: changeLog} = openChangeLogDBForWriting(lc, dbFile.path, ANCHOR);
     return {
       lc,
       sink,
-      replica,
       changeLog,
       file: dbFile.path,
       [Symbol.dispose]() {
         changeLog.close();
-        replica.close();
       },
     };
   }
 
-  // Metrics are gathered from the replicator process, which holds the log
-  // read-only while the write worker owns the writable handle. A read-only
-  // SQLite connection cannot open a write transaction, so a successful read
-  // through one is the assertion that gathering costs the writer nothing.
+  // The writer owns the writable handle, so anything else — a metrics scrape, a
+  // catchup read — holds the log read-only. A read-only SQLite connection cannot
+  // open a write transaction, so a successful read through one is the assertion
+  // that gathering costs the writer nothing.
   test('gathers info through a read-only change-log handle', () => {
     using files = setupFiles();
     files.changeLog.close();
     using changeLog = openChangeLogDB(files.lc, files.file, {readonly: true});
 
-    expect(getSQLiteChangeLogInfo(files.replica, changeLog)).toMatchObject({
+    expect(getSQLiteChangeLogInfo(changeLog)).toMatchObject({
       schemaVersion: CHANGE_LOG_DB_SCHEMA_VERSION,
-      stateWatermark: '02',
+      seedWatermark: '02',
       headWatermark: '02',
       rows: 2,
     });
@@ -519,7 +491,7 @@ describe('SQLite change-log observability on disk', () => {
     using files = setupFiles();
     // A path under a regular file: ENOTDIR, not ENOENT. Absence is expected
     // and silent; anything else says something is wrong with the environment.
-    const bad = `${files.file}/under-a-file`;
+    const bad = `${changeLogFileName(files.file)}/under-a-file`;
 
     expect(await sqliteFileBytes(files.lc, bad)).toBe(0);
     // Unordered: the three files are stat'd concurrently.
@@ -538,7 +510,8 @@ describe('SQLite change-log observability on disk', () => {
 
 describe('replicator/sqlite-change-log reconcile reporting', () => {
   // Every ReconcileResult, including each wipe reason: `gap` in steady state
-  // means log-first ordering is not holding, and is the one on the alert list.
+  // means the log did not lead the resume watermark, and is the one on the
+  // alert list.
   const cases: [name: string, result: ReconcileResult][] = [
     ['consistent', {action: 'none', head: '05'}],
     ['phantom truncation', {action: 'truncated', head: '05', rows: 27}],
@@ -548,8 +521,8 @@ describe('replicator/sqlite-change-log reconcile reporting', () => {
       {action: 'reseeded', head: '05', reason: 'schema-mismatch'},
     ],
     [
-      'wipe: replica-version-mismatch',
-      {action: 'reseeded', head: '05', reason: 'replica-version-mismatch'},
+      'wipe: identity-mismatch',
+      {action: 'reseeded', head: '05', reason: 'identity-mismatch'},
     ],
     ['wipe: gap', {action: 'reseeded', head: '05', reason: 'gap'}],
   ];

--- a/packages/zero-cache/src/services/replicator/sqlite-change-log-observability.ts
+++ b/packages/zero-cache/src/services/replicator/sqlite-change-log-observability.ts
@@ -1,6 +1,18 @@
+/**
+ * Observability for the SQLite change log.
+ *
+ * Everything here now runs in the **change-streamer** process, which is where
+ * the writer lives. The module stays beside the rest of the change-log code
+ * under `services/replicator/` for the same reason `change-log-db.ts` and
+ * `change-log-stream-writer.ts` do: moving files would obscure the topology
+ * diff, and the writer's home is a property of who calls it rather than of
+ * where it sits. Metric names are unchanged from 7H — only their emitting
+ * process, and therefore their resource attributes, moved.
+ */
+
 import {stat} from 'node:fs/promises';
 import type {LogContext} from '@rocicorp/logger';
-import {assert, unreachable} from '../../../../shared/src/asserts.ts';
+import {unreachable} from '../../../../shared/src/asserts.ts';
 import type {Database} from '../../../../zqlite/src/db.ts';
 import {
   getOrCreateCounter,
@@ -13,24 +25,25 @@ import type {ChangeStreamData} from '../change-source/protocol/current/downstrea
 import {extractChangeSubstring} from '../change-streamer/change-log-codec.ts';
 import {ChangeLogTransactionHasher} from '../change-streamer/change-log-transaction-hash.ts';
 import {
-  CHANGE_LOG_META_TABLE,
   CHANGE_LOG_STREAM_TABLE,
+  readChangeLogHead,
+  readChangeLogMeta,
+  type ChangeLogMeta,
   type ReconcileResult,
 } from './change-log-db.ts';
-import type {CommitResult} from './change-processor.ts';
+import type {ChangeLogStreamTransactionStats} from './change-log-stream-writer.ts';
 
 /**
- * Reports the startup reconciliation of the change-log database against the
- * replica.
+ * Reports the reconciliation of the change-log database against the watermark
+ * the stream connection resumes from. This runs once per stream connection, so
+ * a reconnect storm is visible here as well as a restart.
  *
  * A wipe is not an error — it is how every abnormal change-log state is
  * collapsed into a correct one — but each wipe costs the retention window, so
- * every reconnecting subscriber below the replica head gets `too-old`. The
- * `gap` reason in particular means log-first commit ordering did not hold, so a
- * nonzero rate in steady state is an alert, not a statistic.
- *
- * Called from the replicator process rather than the write worker, which does
- * not start OTel.
+ * every reconnecting subscriber below the head gets `too-old`. The `gap` reason
+ * in particular means the log neither held the resume watermark nor could be
+ * truncated to it, so a nonzero rate in steady state is an alert, not a
+ * statistic.
  */
 export function recordSQLiteChangeLogReconcile(
   lc: LogContext,
@@ -41,16 +54,16 @@ export function recordSQLiteChangeLogReconcile(
       getOrCreateCounter(
         'replica',
         'sqlite_change_log.reconcile_truncated_rows',
-        'Phantom change-log rows removed at startup, i.e. logged transactions ' +
-          'whose replica commit was lost to a crash.',
+        'Phantom change-log rows removed at reconciliation, i.e. rows above ' +
+          'the watermark the change stream resumed from.',
       ).add(result.rows);
       break;
     case 'reseeded':
       getOrCreateCounter(
         'replica',
         'sqlite_change_log.reconcile_wipes',
-        'Change-log wipes at startup, by reason. Each one resets the retention ' +
-          'window, so subscribers below the replica head get `too-old`.',
+        'Change-log wipes at reconciliation, by reason. Each one resets the ' +
+          'retention window, so subscribers below the head get `too-old`.',
       ).add(1, {reason: result.reason});
       break;
     case 'none':
@@ -64,22 +77,11 @@ export function recordSQLiteChangeLogReconcile(
 }
 
 /**
- * The replica-side half of the startup state. The change log no longer lives in
- * the replica, so these are the only change-log-relevant facts a replicator can
- * report without opening the change-log database.
+ * What the log says about itself. Nothing here reads the replica: after the
+ * writer moved to the change-streamer, the replica's state version is a
+ * consequence of this log rather than a fact about it.
  */
-export type ReplicaChangeLogInfo = {
-  readonly stateWatermark: string;
-  readonly seedWatermark: string;
-};
-
-export type SQLiteChangeLogStartupInfo = ReplicaChangeLogInfo & {
-  /**
-   * The change-log database's own schema version, not the replica's. The two
-   * are versioned independently: the log is a cache with no migrations, so a
-   * mismatch costs it a reseed.
-   */
-  readonly schemaVersion: number;
+export type SQLiteChangeLogStartupInfo = ChangeLogMeta & {
   readonly headWatermark: string;
 };
 
@@ -89,87 +91,33 @@ export type SQLiteChangeLogInfo = SQLiteChangeLogStartupInfo & {
 };
 
 /**
- * Reads the replica's replication state. One single-row lookup, and no
- * change-log database required, so this is what a replicator with the writer
- * disabled reports.
- */
-export function getReplicaChangeLogInfo(
-  replica: Database,
-): ReplicaChangeLogInfo {
-  const state = replica
-    .prepare(/*sql*/ `
-      SELECT state."stateVersion", config."replicaVersion"
-        FROM "_zero.replicationState" AS state,
-             "_zero.replicationConfig" AS config
-    `)
-    .get<{stateVersion: string; replicaVersion: string} | undefined>();
-
-  assert(state !== undefined, 'replication state must be initialized');
-  return {
-    stateWatermark: state.stateVersion,
-    seedWatermark: state.replicaVersion,
-  };
-}
-
-/**
- * Adds the change log's own schema version and head, read from the change-log
- * database. The head is an index-optimized `max()`, so unlike
- * {@link getSQLiteChangeLogInfo} this does not scan the log.
+ * Reads the meta row and the head. The head is an index-optimized `max()`, so
+ * unlike {@link getSQLiteChangeLogInfo} this does not scan the log.
  *
- * Both handles are passed in rather than deriving one from the other: state
- * comes from the replica and everything else from the log, and holding them
- * apart is what lets this cross-check the two.
- *
- * Call this after the writer has reconciled the log against the replica, which
- * is the only point at which `headWatermark === stateWatermark` is guaranteed.
+ * Call this after reconciliation, which is the only point at which the head is
+ * known to be the resume watermark.
  */
 export function getSQLiteChangeLogStartupInfo(
-  replica: Database,
   changeLog: Database,
 ): SQLiteChangeLogStartupInfo {
-  const replicaInfo = getReplicaChangeLogInfo(replica);
-  const meta = changeLog
-    .prepare(/*sql*/ `
-      SELECT "schemaVersion", "replicaVersion" FROM "${CHANGE_LOG_META_TABLE}"
-    `)
-    .get<{schemaVersion: number; replicaVersion: string} | undefined>();
-  assert(meta !== undefined, 'SQLite change log must have a meta row');
-  // Reconciliation wipes the log on any disagreement, so a log that survives it
-  // is anchored to this replica. Checking it here is the cheapest place to
-  // notice a log that was served without being reconciled.
-  assert(
-    meta.replicaVersion === replicaInfo.seedWatermark,
-    `SQLite change log is anchored to replica version ${meta.replicaVersion}, ` +
-      `not ${replicaInfo.seedWatermark}`,
-  );
-  const head = changeLog
-    .prepare(/*sql*/ `
-      SELECT max("watermark") AS "headWatermark"
-        FROM "${CHANGE_LOG_STREAM_TABLE}"
-    `)
-    .get<{headWatermark: string | null}>();
-  assert(
-    head.headWatermark !== null,
-    'SQLite change log must contain its seed transaction',
-  );
-  return {
-    ...replicaInfo,
-    schemaVersion: meta.schemaVersion,
-    headWatermark: head.headWatermark,
-  };
+  const meta = readChangeLogMeta(changeLog);
+  const head = readChangeLogHead(changeLog);
+  if (head === null) {
+    throw new Error('the SQLite change log must contain its seed transaction');
+  }
+  return {...meta, headWatermark: head};
 }
 
 /**
  * Extends {@link getSQLiteChangeLogStartupInfo} with the retained row and
  * estimated byte totals. Computing these scans the entire change-log table, so
- * only call this when the totals are consumed, i.e. when the writer (and thus
- * the observer) is enabled.
+ * only call it when the totals are consumed, i.e. when the writer (and thus the
+ * observer) is enabled.
  */
 export function getSQLiteChangeLogInfo(
-  replica: Database,
   changeLog: Database,
 ): SQLiteChangeLogInfo {
-  const startup = getSQLiteChangeLogStartupInfo(replica, changeLog);
+  const startup = getSQLiteChangeLogStartupInfo(changeLog);
   const aggregate = changeLog
     .prepare(/*sql*/ `
       SELECT count(*) AS "rows",
@@ -193,24 +141,19 @@ export function getSQLiteChangeLogInfo(
 
 export function logSQLiteChangeLogStartup(
   lc: LogContext,
-  fileMode: 'serving' | 'serving-copy' | 'backup',
-  writerEnabled: boolean,
-  info: ReplicaChangeLogInfo & {
-    readonly schemaVersion?: number | undefined;
-    readonly headWatermark?: string | undefined;
-  },
+  file: string,
+  info: SQLiteChangeLogStartupInfo,
 ): void {
   lc.info?.('SQLite change-log startup', {
     sqliteChangeLog: {
-      fileMode,
-      writerEnabled,
-      // Both absent when the writer is disabled: there is no change-log
-      // database to read a schema version or a head from, and the replica no
-      // longer carries a copy.
+      file,
+      epoch: info.epoch,
+      generation: info.generation,
+      replicaID: info.replicaID,
       schemaVersion: info.schemaVersion,
       seedWatermark: info.seedWatermark,
+      seededAtMs: info.seededAtMs,
       headWatermark: info.headWatermark,
-      stateWatermark: info.stateWatermark,
     },
   });
 }
@@ -243,6 +186,17 @@ export async function sqliteFileBytes(
   return sizes.reduce((total, size) => total + size, 0);
 }
 
+/** What the writer reports back for a committed transaction. */
+export type ChangeLogCommit = {
+  readonly watermark: string;
+  readonly stats: ChangeLogStreamTransactionStats;
+  /**
+   * Appending the commit row and committing the log's transaction. This is the
+   * cost that sits on the forward path, once per upstream transaction.
+   */
+  readonly logCommitMs: number;
+};
+
 export type SQLiteChangeLogObservabilityState = {
   readonly receivedHead: string;
   readonly sqliteHead: string;
@@ -259,37 +213,29 @@ export type SQLiteChangeLogObservabilityState = {
 const TRANSACTION_ROW_BUCKETS = [2, 3, 5, 10, 25, 50, 100, 250, 1000, 5000];
 
 /**
- * Records shadow-writer metrics in the replicator process, where OTel is
- * initialized. State changes only after the corresponding worker operation
- * succeeds, except receivedHead, which intentionally advances before a commit
- * is sent to the worker so transient shadow lag is observable.
+ * Records writer metrics in the change-streamer process. State changes only
+ * after the corresponding write succeeds, except receivedHead, which advances
+ * when a commit message arrives so that transient lag behind the log is
+ * observable.
  */
 export class SQLiteChangeLogObserver {
   readonly #lc: LogContext;
   readonly #messageProcessing = getOrCreateLatencyHistogram(
     'replica',
     'sqlite_change_log.message_processing_duration',
-    'Time to process a replication message while SQLite change logging is enabled.',
+    'Time to write a replication message to the SQLite change log.',
   );
-  // There is no longer one commit to time. The log and the replica are
-  // separate databases committed in a fixed order, so these are the two halves
-  // of what `sqlite_change_log.commit_duration` used to fuse, and the second is
-  // the phantom window. Both are recorded from the write worker's own
-  // measurements, so neither includes the IPC round trip that
-  // `message_processing_duration` covers; that metric, keyed `tag="commit"`,
-  // is also where a failed commit is still timed.
+  // The commit that sits on the forward path. There is no second commit to
+  // order against any more: the replica's belongs to a subscriber downstream of
+  // this loop, so `sqlite_change_log.replica_commit_duration` and the phantom
+  // window it measured are gone. A failed commit is still timed, by
+  // `message_processing_duration` keyed `tag="commit"`.
   readonly #logCommitDuration = getOrCreateLatencyHistogram(
     'replica',
     'sqlite_change_log.log_commit_duration',
     'Time to append the commit row to the SQLite change log and commit its ' +
-      'transaction.',
-  );
-  readonly #replicaCommitDuration = getOrCreateLatencyHistogram(
-    'replica',
-    'sqlite_change_log.replica_commit_duration',
-    'Time from the SQLite change-log commit returning to the replica commit ' +
-      'returning. This is the phantom window: a crash within it leaves the ' +
-      'log ahead of the replica, to be truncated at startup.',
+      'transaction. This is on the forward path: it precedes the forward of ' +
+      "that transaction's commit message.",
   );
   readonly #transactionRows = getOrCreateValueHistogram(
     'replica',
@@ -337,7 +283,9 @@ export class SQLiteChangeLogObserver {
 
   constructor(lc: LogContext, info: SQLiteChangeLogInfo) {
     this.#lc = lc.withContext('component', 'sqlite-change-log-observer');
-    this.#receivedHead = info.stateWatermark;
+    // Reconciliation has just put the head at the resume watermark, which is
+    // also the point the stream is about to be received from.
+    this.#receivedHead = info.headWatermark;
     this.#sqliteHead = info.headWatermark;
     this.#rows = info.rows;
     this.#estimatedBytes = info.estimatedBytes;
@@ -365,25 +313,22 @@ export class SQLiteChangeLogObserver {
     getOrCreateGauge(
       'replica',
       'sqlite_change_log.head_lag',
-      'Distance from the latest received PG commit to the SQLite change-log head.',
+      'Distance from the latest received commit to the SQLite change-log ' +
+        'head. The log commits before the forward, so this is zero except ' +
+        'within a transaction.',
     ).addCallback(result => {
       const lag = watermarkDistance(this.#receivedHead, this.#sqliteHead);
       if (lag !== undefined) {
         result.observe(lag);
       }
     });
-
-    if (info.headWatermark > info.stateWatermark) {
-      this.#invariantFailure(
-        'SQLite change-log head is ahead of replica state',
-        {
-          sqliteHead: info.headWatermark,
-          stateWatermark: info.stateWatermark,
-        },
-      );
-    }
   }
 
+  /**
+   * Called as each message arrives, before it is written. Hashes the *received*
+   * stream, which is compared against the hash the writer computes over what it
+   * *stored*.
+   */
   messageReceived(data: ChangeStreamData, json: string): void {
     const tag = data[1].tag;
     if (data[0] === 'begin') {
@@ -440,9 +385,10 @@ export class SQLiteChangeLogObserver {
     }
   }
 
+  /** Called after the message has been written to the log. */
   messageProcessed(
     data: ChangeStreamData,
-    result: CommitResult | null,
+    commit: ChangeLogCommit | null,
     durationMs: number,
   ): void {
     const tag = data[1].tag;
@@ -470,39 +416,33 @@ export class SQLiteChangeLogObserver {
       return;
     }
 
-    const timing = result?.commitTiming;
-    if (timing !== undefined) {
-      this.#logCommitDuration.recordMs(timing.logCommitMs);
-      this.#replicaCommitDuration.recordMs(timing.replicaCommitMs);
-    }
     const watermark = data[2].watermark;
+    if (commit !== null) {
+      this.#logCommitDuration.recordMs(commit.logCommitMs);
+    }
     if (this.#transactionWatermark !== watermark) {
       this.#invariantFailure(
         'SQLite change-log commit does not match the observed begin',
         {openWatermark: this.#transactionWatermark, commitWatermark: watermark},
       );
     }
-    if (result?.watermark !== watermark) {
-      this.#invariantFailure(
-        'SQLite change-log commit result has an unexpected watermark',
-        {commitWatermark: watermark, resultWatermark: result?.watermark},
-      );
-    }
-    if (result?.changeLogStream === undefined) {
+    if (commit === null) {
       this.#invariantFailure(
         'SQLite change-log commit result is missing writer statistics',
         {commitWatermark: watermark},
       );
       this.#recordUnpaired(watermark, 'missing-sqlite-hash');
     } else {
-      this.#rows += result.changeLogStream.rows;
-      this.#estimatedBytes += result.changeLogStream.estimatedBytes;
-      this.#transactionRows.record(result.changeLogStream.rows);
-      this.#compareHashes(
-        watermark,
-        this.#sourceCommitHash,
-        result.changeLogStream.hash,
-      );
+      if (commit.watermark !== watermark) {
+        this.#invariantFailure(
+          'SQLite change-log commit result has an unexpected watermark',
+          {commitWatermark: watermark, resultWatermark: commit.watermark},
+        );
+      }
+      this.#rows += commit.stats.rows;
+      this.#estimatedBytes += commit.stats.estimatedBytes;
+      this.#transactionRows.record(commit.stats.rows);
+      this.#compareHashes(watermark, this.#sourceCommitHash, commit.stats.hash);
     }
     if (watermark < this.#sqliteHead) {
       this.#invariantFailure('SQLite change-log head regressed', {
@@ -523,9 +463,9 @@ export class SQLiteChangeLogObserver {
     const tag = data[1].tag;
     this.#messageProcessing.recordMs(durationMs, {tag, outcome: 'error'});
     if (data[0] === 'commit') {
-      // No commit-half durations here: a failure gives no CommitResult, so
-      // there is nothing to attribute to either database. The attempt is timed
-      // by `message_processing_duration{tag="commit",outcome="error"}` above.
+      // No commit duration here: a failed commit produces no statistics, so
+      // there is nothing to attribute. The attempt is timed by
+      // `message_processing_duration{tag="commit",outcome="error"}` above.
       this.#recordUnpaired(data[2].watermark, 'sqlite-commit-failed');
     }
     if (
@@ -541,11 +481,32 @@ export class SQLiteChangeLogObserver {
     this.#resetSourceHash();
   }
 
+  /**
+   * A missed truncate-above surfaces as a constraint violation on the writer's
+   * plain `INSERT`, which the fail-soft policy would otherwise absorb quietly.
+   * Classifying it as an invariant failure is what keeps a reconciliation bug
+   * from looking like a lost cache.
+   */
+  invariantFailure(message: string, details?: Record<string, unknown>): void {
+    this.#invariantFailure(message, details);
+  }
+
+  /** The source interrupted the stream mid-transaction. */
   abort(): void {
     if (this.#transactionWatermark !== undefined) {
       this.#recordRollback('source-interruption');
       this.#transactionWatermark = undefined;
     }
+    this.#resetSourceHash();
+  }
+
+  /** Reconciliation moved the head, so the observer's totals are restated. */
+  reconciled(info: SQLiteChangeLogInfo): void {
+    this.#receivedHead = info.headWatermark;
+    this.#sqliteHead = info.headWatermark;
+    this.#rows = info.rows;
+    this.#estimatedBytes = info.estimatedBytes;
+    this.#transactionWatermark = undefined;
     this.#resetSourceHash();
   }
 

--- a/packages/zero-cache/src/services/replicator/test-utils.ts
+++ b/packages/zero-cache/src/services/replicator/test-utils.ts
@@ -24,10 +24,7 @@ import type {
   TableDrop,
   TableRename,
 } from '../change-source/protocol/current/data.ts';
-import {
-  ChangeProcessor,
-  type ChangeProcessorOptions,
-} from './change-processor.ts';
+import {ChangeProcessor} from './change-processor.ts';
 
 export interface FakeReplicator {
   processTransaction(
@@ -62,14 +59,8 @@ export function createChangeProcessor(
   failures: (lc: LogContext, err: unknown) => void = (_, err) => {
     throw err;
   },
-  options: ChangeProcessorOptions = {changeLog: undefined},
 ): ChangeProcessor {
-  return new ChangeProcessor(
-    new StatementRunner(db),
-    'serving',
-    options,
-    failures,
-  );
+  return new ChangeProcessor(new StatementRunner(db), 'serving', failures);
 }
 
 export class ReplicationMessages<

--- a/packages/zero-cache/src/services/replicator/write-worker-client.ts
+++ b/packages/zero-cache/src/services/replicator/write-worker-client.ts
@@ -5,14 +5,8 @@ import type {LogConfig} from '../../../../shared/src/logging.ts';
 import type {Database} from '../../../../zqlite/src/db.ts';
 import {WRITE_WORKER_URL} from '../../server/worker-urls.ts';
 import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
-import type {ReconcileResult} from './change-log-db.ts';
 import type {ChangeProcessorMode, CommitResult} from './change-processor.ts';
 import type {SubscriptionState} from './schema/replication-state.ts';
-
-export type SerializedChangeStreamData = {
-  data: ChangeStreamData;
-  json: string;
-};
 
 export type PragmaConfig = {
   busyTimeout: number;
@@ -27,9 +21,7 @@ type ErrorHandler = (err: Error) => void;
  */
 export interface WriteWorkerClient {
   getSubscriptionState(): Promise<SubscriptionState>;
-  processMessage(
-    downstream: SerializedChangeStreamData,
-  ): Promise<CommitResult | null>;
+  processMessage(downstream: ChangeStreamData): Promise<CommitResult | null>;
   abort(): void;
   stop(): Promise<void>;
   onError(handler: ErrorHandler): void;
@@ -95,9 +87,9 @@ export function deserializeError(serialized: SerializedError): Error {
 
 // Wire protocol types.
 export type ArgsMap = {
-  init: [string, ChangeProcessorMode, boolean, PragmaConfig, LogConfig];
+  init: [string, ChangeProcessorMode, PragmaConfig, LogConfig];
   getSubscriptionState: [];
-  processMessage: [SerializedChangeStreamData];
+  processMessage: [ChangeStreamData];
   abort: [];
   stop: [];
 };
@@ -107,10 +99,7 @@ export type Method = keyof ArgsMap;
 export type Request<M extends Method = Method> = {method: M; args: ArgsMap[M]};
 
 export type ResultMap = {
-  // The change-log reconciliation, when the writer is enabled. Returned rather
-  // than reported from the worker because OTel is only started in the
-  // replicator process, so metrics recorded in this thread would be dropped.
-  init: ReconcileResult | undefined;
+  init: void;
   getSubscriptionState: SubscriptionState;
   processMessage: CommitResult | null;
   abort: void;
@@ -195,26 +184,17 @@ export class ThreadWriteWorkerClient implements WriteWorkerClient {
   init(
     dbPath: string,
     mode: ChangeProcessorMode,
-    logsChangeStream: boolean,
     pragmas: PragmaConfig,
     logConfig: LogConfig,
-  ): Promise<ReconcileResult | undefined> {
-    return this.#call('init', [
-      dbPath,
-      mode,
-      logsChangeStream,
-      pragmas,
-      logConfig,
-    ]);
+  ): Promise<void> {
+    return this.#call('init', [dbPath, mode, pragmas, logConfig]);
   }
 
   getSubscriptionState(): Promise<SubscriptionState> {
     return this.#call('getSubscriptionState', []);
   }
 
-  processMessage(
-    downstream: SerializedChangeStreamData,
-  ): Promise<CommitResult | null> {
+  processMessage(downstream: ChangeStreamData): Promise<CommitResult | null> {
     return this.#call('processMessage', [downstream]);
   }
 

--- a/packages/zero-cache/src/services/replicator/write-worker.test.ts
+++ b/packages/zero-cache/src/services/replicator/write-worker.test.ts
@@ -1,20 +1,12 @@
 import {once} from 'node:events';
-import {existsSync, writeFileSync} from 'node:fs';
+import {existsSync} from 'node:fs';
 import {Worker} from 'node:worker_threads';
 import {afterEach, beforeEach, describe, expect, test} from 'vitest';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
 import type {Database} from '../../../../zqlite/src/db.ts';
 import {DbFile, initDB} from '../../test/lite.ts';
 import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
-import {serializeChangeStreamData} from '../change-streamer/change-log-codec.ts';
-import {
-  CHANGE_LOG_DB_SCHEMA_VERSION,
-  CHANGE_LOG_META_TABLE,
-  CHANGE_LOG_STREAM_TABLE,
-  changeLogFileName,
-  deleteChangeLogDB,
-  openChangeLogDB,
-} from './change-log-db.ts';
+import {changeLogFileName} from './change-log-db.ts';
 import {initReplicationState} from './schema/replication-state.ts';
 import {ReplicationMessages} from './test-utils.ts';
 import {
@@ -22,12 +14,7 @@ import {
   serializeError,
   ThreadWriteWorkerClient,
   type Request,
-  type SerializedChangeStreamData,
 } from './write-worker-client.ts';
-
-function serialized(data: ChangeStreamData): SerializedChangeStreamData {
-  return {data, json: serializeChangeStreamData(data)};
-}
 
 const PRAGMAS = {busyTimeout: 30000, analysisLimit: 1000};
 const LOG_CONFIG = {level: 'error', format: 'text'} as const;
@@ -36,14 +23,6 @@ describe('write-worker', () => {
   let dbFile: DbFile;
   let mainDb: Database;
   let worker: ThreadWriteWorkerClient;
-
-  /** Reads the change log the worker writes beside the replica. */
-  function readChangeLog<T>(read: (db: Database) => T): T {
-    using db = openChangeLogDB(createSilentLogContext(), dbFile.path, {
-      readonly: true,
-    });
-    return read(db);
-  }
 
   beforeEach(async () => {
     const lc = createSilentLogContext();
@@ -65,22 +44,12 @@ describe('write-worker', () => {
     );
 
     worker = new ThreadWriteWorkerClient();
-    await worker.init(
-      dbFile.path,
-      'serving',
-      false,
-      {
-        busyTimeout: 30000,
-        analysisLimit: 1000,
-      },
-      {level: 'error', format: 'text'},
-    );
+    await worker.init(dbFile.path, 'serving', PRAGMAS, LOG_CONFIG);
   });
 
   afterEach(async () => {
     await worker.stop();
     mainDb.close();
-    deleteChangeLogDB(dbFile.path);
     dbFile.delete();
   });
 
@@ -105,7 +74,7 @@ describe('write-worker', () => {
 
     let commitResult = null;
     for (let i = 0; i < messages.length; i++) {
-      const result = await worker.processMessage(serialized(messages[i]));
+      const result = await worker.processMessage(messages[i]);
       if (result) {
         commitResult = result;
       }
@@ -132,251 +101,36 @@ describe('write-worker', () => {
     expect(state.watermark).toBe('06');
   });
 
-  test('init creates, seeds, and then leaves the change log alone', async () => {
-    await worker.stop();
-    expect(existsSync(changeLogFileName(dbFile.path))).toBe(false);
-
-    worker = new ThreadWriteWorkerClient();
-    expect(
-      await worker.init(dbFile.path, 'serving', true, PRAGMAS, LOG_CONFIG),
-    ).toEqual({action: 'reseeded', head: '02', reason: 'created'});
-    expect(existsSync(changeLogFileName(dbFile.path))).toBe(true);
-    expect(
-      readChangeLog(db => ({
-        meta: db.prepare(`SELECT * FROM "${CHANGE_LOG_META_TABLE}"`).get(),
-        journalMode: db.pragma('journal_mode'),
-        head: db
-          .prepare(
-            `SELECT max("watermark") AS "head" FROM "${CHANGE_LOG_STREAM_TABLE}"`,
-          )
-          .get(),
-      })),
-    ).toEqual({
-      meta: {
-        replicaVersion: '02',
-        schemaVersion: CHANGE_LOG_DB_SCHEMA_VERSION,
-        lock: 1,
-      },
-      journalMode: [{journal_mode: 'wal2'}],
-      head: {head: '02'},
-    });
-
-    // A restart against a consistent log neither truncates nor reseeds.
-    await worker.stop();
-    worker = new ThreadWriteWorkerClient();
-    expect(
-      await worker.init(dbFile.path, 'serving', true, PRAGMAS, LOG_CONFIG),
-    ).toEqual({action: 'none', head: '02'});
-  });
-
-  test('init truncates a phantom transaction left by a crash', async () => {
-    await worker.stop();
-    worker = new ThreadWriteWorkerClient();
-    await worker.init(dbFile.path, 'serving', true, PRAGMAS, LOG_CONFIG);
-    await worker.stop();
-
-    // A transaction that reached the log but whose replica commit was lost.
-    {
-      using log = openChangeLogDB(createSilentLogContext(), dbFile.path, {
-        readonly: false,
-      });
-      log
-        .prepare(/*sql*/ `
-        INSERT INTO "${CHANGE_LOG_STREAM_TABLE}"
-          ("watermark", "pos", "change", "precommit", "writeTimeMs")
-          VALUES ('06', 0, '{"tag":"begin"}', NULL, NULL),
-                 ('06', 1, '{"tag":"commit"}', '02', 123)
-      `)
-        .run();
-    }
-
-    worker = new ThreadWriteWorkerClient();
-    expect(
-      await worker.init(dbFile.path, 'serving', true, PRAGMAS, LOG_CONFIG),
-    ).toEqual({action: 'truncated', head: '02', rows: 2});
-  });
-
-  test('init rebuilds a corrupt change log instead of failing', async () => {
-    await worker.stop();
-    writeFileSync(changeLogFileName(dbFile.path), 'this is not a database');
-
-    // The replica is intact, so the log is rebuilt in place of the file that
-    // cannot be read, rather than taking the replicator down with the cache.
-    worker = new ThreadWriteWorkerClient();
-    expect(
-      await worker.init(dbFile.path, 'serving', true, PRAGMAS, LOG_CONFIG),
-    ).toEqual({action: 'reseeded', head: '02', reason: 'created'});
-
+  // The change log moved to the change-streamer, so no replicator writes it.
+  // A replicator that created one would be writing a file the change-streamer's
+  // writer owns, which on POSIX is invisible rather than loud: both would append
+  // to their own inode.
+  test('the write worker never creates a change log', async () => {
     const issues = new ReplicationMessages({issues: ['issueID', 'bool']});
     for (const message of [
       ['begin', issues.begin(), {commitWatermark: '06'}],
       ['data', issues.insert('issues', {issueID: 1, bool: true})],
       ['commit', issues.commit(), {watermark: '06'}],
     ] satisfies ChangeStreamData[]) {
-      await worker.processMessage(serialized(message));
-    }
-    expect(
-      readChangeLog(db =>
-        db
-          .prepare(
-            `SELECT max("watermark") AS "head" FROM "${CHANGE_LOG_STREAM_TABLE}"`,
-          )
-          .get(),
-      ),
-    ).toEqual({head: '06'});
-  });
-
-  test('the disabled writer does not create a change log', async () => {
-    // `beforeEach` inits with the writer disabled, which is the
-    // `sqliteChangeLogMode=off` shape: a transaction goes through without the
-    // file ever appearing, so deleting a stale one at startup cannot race a
-    // writer.
-    const issues = new ReplicationMessages({issues: ['issueID', 'bool']});
-    for (const message of [
-      ['begin', issues.begin(), {commitWatermark: '06'}],
-      ['data', issues.insert('issues', {issueID: 1, bool: true})],
-      ['commit', issues.commit(), {watermark: '06'}],
-    ] satisfies ChangeStreamData[]) {
-      await worker.processMessage(serialized(message));
+      await worker.processMessage(message);
     }
 
     expect(existsSync(changeLogFileName(dbFile.path))).toBe(false);
-  });
-
-  test('init rejects the change-log writer in initial-sync mode', async () => {
-    await worker.stop();
-    worker = new ThreadWriteWorkerClient();
-    await expect(
-      worker.init(dbFile.path, 'initial-sync', true, PRAGMAS, LOG_CONFIG),
-    ).rejects.toThrow('initial-sync owns its transaction boundaries');
-    expect(existsSync(changeLogFileName(dbFile.path))).toBe(false);
-
-    // Leave a usable worker for the afterEach teardown.
-    await worker.stop();
-    worker = new ThreadWriteWorkerClient();
-    await worker.init(dbFile.path, 'serving', false, PRAGMAS, LOG_CONFIG);
-  });
-
-  test('enabled writer is atomic across abort and worker restart', async () => {
-    await worker.stop();
-    worker = new ThreadWriteWorkerClient();
-    await worker.init(dbFile.path, 'serving', true, PRAGMAS, LOG_CONFIG);
-
-    const issues = new ReplicationMessages({issues: ['issueID', 'bool']});
-    await worker.processMessage(
-      serialized(['begin', issues.begin(), {commitWatermark: '05'}]),
-    );
-    await worker.processMessage(
-      serialized(['data', issues.insert('issues', {issueID: 1, bool: true})]),
-    );
-    worker.abort();
-
-    const messages: ChangeStreamData[] = [
-      ['begin', issues.begin(), {commitWatermark: '06'}],
-      ['data', issues.insert('issues', {issueID: 123, bool: true})],
-      ['data', issues.insert('issues', {issueID: 456, bool: false})],
-      ['commit', issues.commit(), {watermark: '06'}],
-    ];
-    let commitResult = null;
-    for (const message of messages) {
-      commitResult =
-        (await worker.processMessage(serialized(message))) ?? commitResult;
-    }
-    expect(commitResult).toMatchObject({
-      watermark: '06',
-      changeLogStream: {rows: 4, estimatedBytes: expect.any(Number)},
-    });
-
-    await worker.stop();
-    worker = new ThreadWriteWorkerClient();
-    // The aborted transaction left nothing behind, so there is no phantom to
-    // truncate and no gap to reseed.
-    expect(
-      await worker.init(dbFile.path, 'serving', true, PRAGMAS, LOG_CONFIG),
-    ).toEqual({action: 'none', head: '06'});
-
-    expect(await worker.getSubscriptionState()).toMatchObject({
-      watermark: '06',
-    });
-    expect(
-      readChangeLog(db =>
-        db
-          .prepare(/*sql*/ `
-            SELECT "watermark", "pos", json_extract("change", '$.tag') AS "tag",
-                   "precommit", "writeTimeMs"
-              FROM "${CHANGE_LOG_STREAM_TABLE}"
-              WHERE "watermark" IN ('05', '06')
-              ORDER BY "watermark", "pos"
-          `)
-          .all(),
-      ),
-    ).toEqual([
-      {
-        watermark: '06',
-        pos: 0,
-        tag: 'begin',
-        precommit: null,
-        writeTimeMs: null,
-      },
-      {
-        watermark: '06',
-        pos: 1,
-        tag: 'insert',
-        precommit: null,
-        writeTimeMs: null,
-      },
-      {
-        watermark: '06',
-        pos: 2,
-        tag: 'insert',
-        precommit: null,
-        writeTimeMs: null,
-      },
-      {
-        watermark: '06',
-        pos: 3,
-        tag: 'commit',
-        precommit: '06',
-        writeTimeMs: expect.any(Number),
-      },
-    ]);
-    const state = mainDb
-      .prepare(
-        `SELECT "stateVersion", "writeTimeMs" FROM "_zero.replicationState"`,
-      )
-      .get<{stateVersion: string; writeTimeMs: number}>();
-    const commit = readChangeLog(db =>
-      db
-        .prepare(/*sql*/ `
-          SELECT "writeTimeMs" FROM "${CHANGE_LOG_STREAM_TABLE}"
-            WHERE "watermark" = '06' AND "precommit" IS NOT NULL
-        `)
-        .get<{writeTimeMs: number}>(),
-    );
-    expect(state).toEqual({
-      stateVersion: '06',
-      writeTimeMs: commit.writeTimeMs,
-    });
-    // The replica does not carry the table at all as of schema v15.
-    expect(
-      mainDb
-        .prepare(
-          /*sql*/ `SELECT "name" FROM "sqlite_master" WHERE "tbl_name" = ?`,
-        )
-        .all(CHANGE_LOG_STREAM_TABLE),
-    ).toEqual([]);
   });
 
   test('abort rolls back pending transaction', async () => {
     const issues = new ReplicationMessages({issues: ['issueID', 'bool']});
 
     // Start a transaction but don't commit
-    await worker.processMessage(
-      serialized(['begin', issues.begin(), {commitWatermark: '06'}]),
-    );
-    await worker.processMessage(
-      serialized(['data', issues.insert('issues', {issueID: 123, bool: true})]),
-    );
+    await worker.processMessage([
+      'begin',
+      issues.begin(),
+      {commitWatermark: '06'},
+    ]);
+    await worker.processMessage([
+      'data',
+      issues.insert('issues', {issueID: 123, bool: true}),
+    ]);
 
     // Abort should roll back
     worker.abort();
@@ -393,7 +147,7 @@ describe('write-worker', () => {
     ];
 
     for (let i = 0; i < messages.length; i++) {
-      await worker.processMessage(serialized(messages[i]));
+      await worker.processMessage(messages[i]);
     }
 
     const rowsAfter = mainDb.prepare('SELECT issueID FROM issues').all();
@@ -404,16 +158,7 @@ describe('write-worker', () => {
     await worker.stop();
     // Create a new worker for afterEach cleanup
     worker = new ThreadWriteWorkerClient();
-    await worker.init(
-      dbFile.path,
-      'serving',
-      false,
-      {
-        busyTimeout: 30000,
-        analysisLimit: 1000,
-      },
-      {level: 'error', format: 'text'},
-    );
+    await worker.init(dbFile.path, 'serving', PRAGMAS, LOG_CONFIG);
   });
 
   // This test verifies the ChangeProcessor's internal error path:
@@ -428,26 +173,24 @@ describe('write-worker', () => {
 
     // Send a processMessage without a begin - should cause a failure
     await expect(
-      worker.processMessage(
-        serialized([
-          'data',
-          {
-            tag: 'insert',
-            relation: {
-              schema: 'public',
-              name: 'nonexistent',
-              rowKey: {columns: ['id'], type: 'default'},
-            },
-            new: {id: [1, 'int4']},
+      worker.processMessage([
+        'data',
+        {
+          tag: 'insert',
+          relation: {
+            schema: 'public',
+            name: 'nonexistent',
+            rowKey: {columns: ['id'], type: 'default'},
           },
-        ]),
-      ),
+          new: {id: [1, 'int4']},
+        },
+      ]),
     ).rejects.toThrow();
 
     expect(errorReceived).toBeDefined();
   });
 
-  test('worker structured clone preserves the serialized envelope', async () => {
+  test('worker structured clone preserves the change payload', async () => {
     const data: ChangeStreamData = [
       'data',
       {
@@ -465,7 +208,7 @@ describe('write-worker', () => {
     ];
     const request = {
       method: 'processMessage',
-      args: [serialized(data)],
+      args: [data],
     } satisfies Request<'processMessage'>;
     const echoWorker = new Worker(
       /*js*/ `
@@ -481,12 +224,9 @@ describe('write-worker', () => {
       const [roundTripped] = (await response) as [typeof request];
 
       expect(roundTripped).toEqual(request);
-      expect(roundTripped.args[0].data[1]).toMatchObject({
+      expect(roundTripped.args[0][1]).toMatchObject({
         new: {issueID: 9007199254740993n, text: 'before\0after'},
       });
-      expect(roundTripped.args[0].json).toContain(
-        '"text":"before\\u0000after"',
-      );
     } finally {
       await echoWorker.terminate();
     }

--- a/packages/zero-cache/src/services/replicator/write-worker.ts
+++ b/packages/zero-cache/src/services/replicator/write-worker.ts
@@ -1,6 +1,5 @@
 import {parentPort} from 'node:worker_threads';
 import type {LogContext} from '@rocicorp/logger';
-import {assert} from '../../../../shared/src/asserts.ts';
 import type {LogConfig} from '../../../../shared/src/logging.ts';
 import {must} from '../../../../shared/src/must.ts';
 import {Database} from '../../../../zqlite/src/db.ts';
@@ -11,12 +10,7 @@ import {
 } from '../../db/sqlite-corruption.ts';
 import {StatementRunner} from '../../db/statements.ts';
 import {createLogContext} from '../../server/logging.ts';
-import {
-  changeLogFileName,
-  openChangeLogDBForWriting,
-  readReplicaAnchor,
-  type ReconcileResult,
-} from './change-log-db.ts';
+import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
 import {ChangeProcessor, type ChangeProcessorMode} from './change-processor.ts';
 import {getSubscriptionState} from './schema/replication-state.ts';
 import {
@@ -28,7 +22,6 @@ import {
   type Request,
   type Response,
   type ResultMap,
-  type SerializedChangeStreamData,
   type WriteError,
 } from './write-worker-client.ts';
 
@@ -43,13 +36,10 @@ type API = {[M in Method]: (...args: ArgsMap[M]) => ResultMap[M]};
 function createAPI(): API {
   let db: Database | undefined;
   let runner: StatementRunner | undefined;
-  let changeLogDb: Database | undefined;
-  let changeLogRunner: StatementRunner | undefined;
   let processor: ChangeProcessor | undefined;
   let mode: ChangeProcessorMode | undefined;
   let lc: LogContext | undefined;
   let replicaDbPath: string | undefined;
-  let changeLogDbPath: string | undefined;
   let unregisterCorruptionDiagnosticTargets: (() => void)[] = [];
 
   function unregisterCorruptionDiagnostics() {
@@ -57,56 +47,30 @@ function createAPI(): API {
     unregisterCorruptionDiagnosticTargets = [];
   }
 
-  // The write path spans two databases and a SqliteError does not say which
-  // one it came from, so both are dumped.
   function logCorruptionDiagnostics(err: unknown) {
-    if (!lc || !isSQLiteCorruption(err)) {
+    if (!lc || !replicaDbPath || !isSQLiteCorruption(err)) {
       return;
     }
-    if (replicaDbPath) {
-      logSQLiteCorruptionDiagnostics(lc, 'write-worker', replicaDbPath, err);
-    }
-    if (changeLogDbPath) {
-      logSQLiteCorruptionDiagnostics(
-        lc,
-        'write-worker change-log',
-        changeLogDbPath,
-        err,
-      );
-    }
+    logSQLiteCorruptionDiagnostics(lc, 'write-worker', replicaDbPath, err);
   }
 
   function createProcessor() {
-    processor = new ChangeProcessor(
-      must(runner),
-      must(mode),
-      {changeLog: changeLogRunner},
-      (_lc, err) => {
-        logCorruptionDiagnostics(err);
-        port.postMessage({
-          writeError: serializeError(err),
-        } satisfies WriteError);
-      },
-    );
+    processor = new ChangeProcessor(must(runner), must(mode), (_lc, err) => {
+      logCorruptionDiagnostics(err);
+      port.postMessage({
+        writeError: serializeError(err),
+      } satisfies WriteError);
+    });
   }
 
   return {
     init(
       dbPath: string,
       cpMode: ChangeProcessorMode,
-      shouldLogChangeStream: boolean,
       pragmas: PragmaConfig,
       logConfig: LogConfig,
-    ): ReconcileResult | undefined {
-      assert(
-        !shouldLogChangeStream || cpMode !== 'initial-sync',
-        'initial-sync owns its transaction boundaries and cannot write the ' +
-          'change log, which opens a second one',
-      );
+    ): void {
       replicaDbPath = dbPath;
-      changeLogDbPath = shouldLogChangeStream
-        ? changeLogFileName(dbPath)
-        : undefined;
       lc = createLogContext({log: logConfig}, 'write-worker');
       unregisterCorruptionDiagnostics();
       unregisterCorruptionDiagnosticTargets.push(
@@ -115,40 +79,12 @@ function createAPI(): API {
           dbPath,
         }),
       );
-      if (changeLogDbPath) {
-        unregisterCorruptionDiagnosticTargets.push(
-          registerSQLiteCorruptionDiagnosticTarget({
-            debugName: 'write-worker change-log',
-            dbPath: changeLogDbPath,
-          }),
-        );
-      }
       try {
         db = new Database(lc, dbPath);
         applyPragmas(db, pragmas);
         runner = new StatementRunner(db);
         mode = cpMode;
-
-        // The change log lives beside the replica rather than inside it, and
-        // the path is derived here so that the derivation stays the single
-        // source of truth rather than becoming a second IPC argument that
-        // could disagree with it.
-        changeLogDb?.close();
-        changeLogDb = undefined;
-        changeLogRunner = undefined;
-        let reconciled: ReconcileResult | undefined;
-        if (shouldLogChangeStream) {
-          const opened = openChangeLogDBForWriting(
-            must(lc),
-            dbPath,
-            readReplicaAnchor(db),
-          );
-          changeLogDb = opened.db;
-          reconciled = opened.result;
-          changeLogRunner = new StatementRunner(changeLogDb);
-        }
         createProcessor();
-        return reconciled;
       } catch (e) {
         logCorruptionDiagnostics(e);
         throw e;
@@ -164,9 +100,9 @@ function createAPI(): API {
       }
     },
 
-    processMessage({data, json}: SerializedChangeStreamData) {
+    processMessage(downstream: ChangeStreamData) {
       try {
-        return must(processor).processMessage(must(lc), data, json);
+        return must(processor).processMessage(must(lc), downstream);
       } catch (e) {
         logCorruptionDiagnostics(e);
         throw e;
@@ -182,12 +118,8 @@ function createAPI(): API {
       db?.close();
       db = undefined;
       runner = undefined;
-      changeLogDb?.close();
-      changeLogDb = undefined;
-      changeLogRunner = undefined;
       processor = undefined;
       replicaDbPath = undefined;
-      changeLogDbPath = undefined;
       unregisterCorruptionDiagnostics();
     },
   };

--- a/packages/zero-cache/src/workers/replicator.test.ts
+++ b/packages/zero-cache/src/workers/replicator.test.ts
@@ -1,11 +1,14 @@
+import {existsSync, writeFileSync} from 'node:fs';
 import {describe, expect, test, vi} from 'vitest';
 import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
 import {changeLogFileName} from '../services/replicator/change-log-db.ts';
 import type {ReplicaState} from '../services/replicator/replicator.ts';
+import {DbFile} from '../test/lite.ts';
 import {inProcChannel} from '../types/processes.ts';
 import {Subscription} from '../types/subscription.ts';
 import {
   createNotifierFrom,
+  deleteStaleChangeLog,
   replicaFileName,
   replicatorDeletesStaleChangeLog,
   setUpMessageHandlers,
@@ -50,6 +53,27 @@ describe('workers/replicator', () => {
         // Only `off` -- i.e. nothing in the task writes the log -- deletes it.
         expect(replicatorDeletesStaleChangeLog('off')).toBe(true);
       }
+    }
+  });
+
+  // The predicate test above pins the decision; this pins the delete the
+  // replicator actually performs, on a real file.
+  test('deleteStaleChangeLog removes the file only when the writer is off', () => {
+    const replica = new DbFile('replicator-stale-change-log');
+    const logFile = changeLogFileName(replica.path);
+    try {
+      for (const sqliteChangeLogMode of ['write', 'compare', 'serve']) {
+        writeFileSync(logFile, 'the live log');
+        expect(deleteStaleChangeLog(sqliteChangeLogMode, replica.path)).toBe(
+          false,
+        );
+        expect(existsSync(logFile)).toBe(true);
+      }
+      expect(deleteStaleChangeLog('off', replica.path)).toBe(true);
+      expect(existsSync(logFile)).toBe(false);
+    } finally {
+      deleteStaleChangeLog('off', replica.path);
+      replica.delete();
     }
   });
 

--- a/packages/zero-cache/src/workers/replicator.test.ts
+++ b/packages/zero-cache/src/workers/replicator.test.ts
@@ -1,40 +1,56 @@
 import {describe, expect, test, vi} from 'vitest';
 import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
+import {changeLogFileName} from '../services/replicator/change-log-db.ts';
 import type {ReplicaState} from '../services/replicator/replicator.ts';
 import {inProcChannel} from '../types/processes.ts';
 import {Subscription} from '../types/subscription.ts';
 import {
   createNotifierFrom,
-  createsCanonicalReplicator,
-  replicaLogsChangeStream,
+  replicaFileName,
+  replicatorDeletesStaleChangeLog,
   setUpMessageHandlers,
   subscribeTo,
+  type ReplicaFileMode,
 } from './replicator.ts';
 
 const lc = createSilentLogContext();
 
 describe('workers/replicator', () => {
-  test('selects exactly one canonical SQLite change-log writer', () => {
-    expect(createsCanonicalReplicator(true, 's3://backup', 0)).toBe(true);
-    expect(createsCanonicalReplicator(true, undefined, 1)).toBe(true);
-    expect(createsCanonicalReplicator(true, undefined, 0)).toBe(false);
-    expect(createsCanonicalReplicator(false, undefined, 1)).toBe(false);
+  // The change log belongs to the change-streamer, and on POSIX a replicator
+  // that unlinked it would fail quietly: the writer would keep appending to its
+  // own inode while every reader opening by path saw nothing. So the guard has
+  // to hold in both topologies, and its key has to stay the config flag rather
+  // than anything derived per replica.
+  test('no replicator deletes the live change log when the writer is enabled', () => {
+    const REPLICA = '/data/replica.db';
+    const liveLog = changeLogFileName(REPLICA);
 
-    expect(replicaLogsChangeStream('backup', true, true, 's3://backup')).toBe(
-      true,
-    );
-    expect(
-      replicaLogsChangeStream('serving-copy', true, true, 's3://backup'),
-    ).toBe(false);
-    expect(replicaLogsChangeStream('serving', true, true, undefined)).toBe(
-      true,
-    );
-    expect(replicaLogsChangeStream('serving', true, false, undefined)).toBe(
-      false,
-    );
-    expect(replicaLogsChangeStream('serving', false, true, undefined)).toBe(
-      false,
-    );
+    // The `backupURL` topology runs 'backup' + 'serving-copy'; the
+    // no-`backupURL` one runs 'serving'.
+    const topologies: {
+      backupURL: string | undefined;
+      modes: ReplicaFileMode[];
+    }[] = [
+      {backupURL: 's3://backup', modes: ['backup', 'serving-copy']},
+      {backupURL: undefined, modes: ['serving']},
+    ];
+
+    for (const {modes} of topologies) {
+      for (const mode of modes) {
+        const replicatorLog = changeLogFileName(replicaFileName(REPLICA, mode));
+        // Paths coincide for every mode but 'serving-copy', so a delete keyed on
+        // anything but the config flag would take the live log with it.
+        expect(replicatorLog === liveLog).toBe(mode !== 'serving-copy');
+
+        for (const sqliteChangeLogMode of ['write', 'compare', 'serve']) {
+          expect(replicatorDeletesStaleChangeLog(sqliteChangeLogMode)).toBe(
+            false,
+          );
+        }
+        // Only `off` -- i.e. nothing in the task writes the log -- deletes it.
+        expect(replicatorDeletesStaleChangeLog('off')).toBe(true);
+      }
+    }
   });
 
   test('replicator subscription', async () => {

--- a/packages/zero-cache/src/workers/replicator.ts
+++ b/packages/zero-cache/src/workers/replicator.ts
@@ -29,32 +29,32 @@ export const replicaFileModeSchema = v.literalUnion(
 
 export type ReplicaFileMode = v.Infer<typeof replicaFileModeSchema>;
 
-export function createsCanonicalReplicator(
-  runsLocalChangeStreamer: boolean,
-  backupURL: string | undefined,
-  numSyncWorkers: number,
-): boolean {
-  return runsLocalChangeStreamer && (Boolean(backupURL) || numSyncWorkers > 0);
-}
-
-export function replicaLogsChangeStream(
-  fileMode: ReplicaFileMode,
-  sqliteChangeLogEnabled: boolean,
-  runsLocalChangeStreamer: boolean,
-  backupURL: string | undefined,
-): boolean {
-  if (!sqliteChangeLogEnabled || !runsLocalChangeStreamer) {
-    return false;
-  }
-  return (
-    fileMode === 'backup' || (fileMode === 'serving' && !Boolean(backupURL))
-  );
-}
-
 export type WalMode = 'wal' | 'wal2';
 
 export function replicaFileName(replicaFile: string, mode: ReplicaFileMode) {
   return mode === 'serving-copy' ? `${replicaFile}-serving-copy` : replicaFile;
+}
+
+/**
+ * Whether a replicator worker deletes the change-log file beside its replica at
+ * startup.
+ *
+ * The change log belongs to the change-streamer, so this only ever cleans up a
+ * file that nothing is writing. The predicate is deliberately the config flag
+ * and nothing else: keying it on anything derived per replica -- a file mode, or
+ * the retired `logsChangeStream` -- would make every replicator start unlink the
+ * change-streamer's live log, because no replicator writes it any more. Paths
+ * coincide whenever `fileMode !== 'serving-copy'`, so that hazard is real in the
+ * shipped no-`backupURL` configuration.
+ *
+ * Deleting is safe when nothing writes the log: it is excluded from the
+ * litestream backup, only the writer purges it, and re-enabling the writer
+ * reseeds at the resume watermark.
+ */
+export function replicatorDeletesStaleChangeLog(
+  sqliteChangeLogMode: string,
+): boolean {
+  return sqliteChangeLogMode === 'off';
 }
 
 const MILLIS_PER_HOUR = 1000 * 60 * 60;

--- a/packages/zero-cache/src/workers/replicator.ts
+++ b/packages/zero-cache/src/workers/replicator.ts
@@ -5,6 +5,7 @@ import {Database} from '../../../zqlite/src/db.ts';
 import type {ReplicaOptions} from '../config/zero-config.ts';
 import {deleteLiteDB} from '../db/delete-lite-db.ts';
 import {upgradeReplica} from '../services/change-source/common/replica-schema.ts';
+import {deleteChangeLogDB} from '../services/replicator/change-log-db.ts';
 import {Notifier} from '../services/replicator/notifier.ts';
 import type {
   ReplicaState,
@@ -55,6 +56,24 @@ export function replicatorDeletesStaleChangeLog(
   sqliteChangeLogMode: string,
 ): boolean {
   return sqliteChangeLogMode === 'off';
+}
+
+/**
+ * The `mode=off` cleanup itself: deletes the change-log file beside `dbPath`
+ * when {@link replicatorDeletesStaleChangeLog} says nothing writes it, and
+ * reports whether it did. The decision and the delete live in one function so
+ * that the guard test covers the call the replicator actually makes, not just
+ * the predicate.
+ */
+export function deleteStaleChangeLog(
+  sqliteChangeLogMode: string,
+  dbPath: string,
+): boolean {
+  if (!replicatorDeletesStaleChangeLog(sqliteChangeLogMode)) {
+    return false;
+  }
+  deleteChangeLogDB(dbPath);
+  return true;
 }
 
 const MILLIS_PER_HOUR = 1000 * 60 * 60;

--- a/packages/zql-integration-tests/src/chinook/chinook-zero-cache-fuzzer.pg.test.ts
+++ b/packages/zql-integration-tests/src/chinook/chinook-zero-cache-fuzzer.pg.test.ts
@@ -361,9 +361,11 @@ async function startZeroCacheReplica(testDBs: PgTest['testDBs']) {
     await worker.init(
       replicaDbFile.path,
       'serving',
-      false,
       getPragmaConfig('serving'),
-      {level: 'error', format: 'text'},
+      {
+        level: 'error',
+        format: 'text',
+      },
     );
 
     const replicator = new ReplicatorService(
@@ -373,9 +375,7 @@ async function startZeroCacheReplica(testDBs: PgTest['testDBs']) {
       'serving',
       parseStringifiedChangeStreamer(changeStreamer),
       worker,
-      false,
       null,
-      undefined,
     );
     const replicatorDone = replicator.run();
     cleanup.push(async () => {

--- a/tools/tsnapi/__snapshots__/tsnapi/@rocicorp/zero-types/change-protocol/v0/data.snapshot.d.ts
+++ b/tools/tsnapi/__snapshots__/tsnapi/@rocicorp/zero-types/change-protocol/v0/data.snapshot.d.ts
@@ -102,7 +102,7 @@ export declare const backfillSchema: v.ObjectType<{
 }, undefined>;
 export declare const beginSchema: v.ObjectType<{
     tag: v.Type<"begin">;
-    json: v.Optional<"p" | "s">;
+    json: v.Optional<"s" | "p">;
     skipAck: v.Optional<boolean>;
 }, undefined>;
 export declare const commitSchema: v.ObjectType<{

--- a/tools/tsnapi/__snapshots__/tsnapi/@rocicorp/zero-types/change-protocol/v0/downstream.snapshot.d.ts
+++ b/tools/tsnapi/__snapshots__/tsnapi/@rocicorp/zero-types/change-protocol/v0/downstream.snapshot.d.ts
@@ -16,7 +16,7 @@ export declare const changeStreamControlSchema: v.TupleType<[v.Type<"control">, 
 }, undefined>]>;
 export declare const changeStreamDataSchema: v.UnionType<[v.TupleType<[v.Type<"begin">, v.ObjectType<{
     tag: v.Type<"begin">;
-    json: v.Optional<"p" | "s">;
+    json: v.Optional<"s" | "p">;
     skipAck: v.Optional<boolean>;
 }, undefined>, v.ObjectType<{
     commitWatermark: v.Type<string>;
@@ -242,7 +242,7 @@ export declare const changeStreamDataSchema: v.UnionType<[v.TupleType<[v.Type<"b
 }, undefined>]>]>;
 export declare const changeStreamMessageSchema: v.UnionType<[v.UnionType<[v.TupleType<[v.Type<"begin">, v.ObjectType<{
     tag: v.Type<"begin">;
-    json: v.Optional<"p" | "s">;
+    json: v.Optional<"s" | "p">;
     skipAck: v.Optional<boolean>;
 }, undefined>, v.ObjectType<{
     commitWatermark: v.Type<string>;


### PR DESCRIPTION
Puts the writing of the sqlite change log in the change streamer rather than in the replicator worker.

Production effect: none; `sqliteChangeLogMode=off`. Rollback: revert.