### PR TITLE
chore(rmv2): schedule the change-log purge in-process 

### DIFF
--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -68,7 +68,9 @@ export default async function runWorker(
       flowControlConsensusPaddingSeconds,
       flowControlEventDrivenRelease,
       sqliteChangeLogMode,
+      sqliteChangeLogRetentionMs,
       sqliteChangeLogReadBatchRows,
+      sqliteChangeLogPurgeBatchRows,
       sqliteChangeLogBarrierTimeoutMs,
     },
     autoReset,
@@ -213,6 +215,15 @@ export default async function runWorker(
                   generation: subscriptionState.replicaVersion,
                   replicaID,
                 },
+              }
+            : undefined,
+          // The purge scheduler shares the writer's gate -- mode, not the
+          // read path -- because `write` mode, with no read selector at all,
+          // is the configuration it ships in.
+          sqliteChangeLogPurge: sqliteChangeLogEnabled
+            ? {
+                retentionMs: sqliteChangeLogRetentionMs,
+                batchRows: sqliteChangeLogPurgeBatchRows,
               }
             : undefined,
         },

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
@@ -326,6 +326,7 @@ describe('change-streamer/service', () => {
   async function restartWithInlineChangeLogWriter(
     logFile: DbFile,
     sqliteCatchup?: Partial<SQLiteCatchupOptions>,
+    sqliteChangeLogPurge?: TuningOptions['sqliteChangeLogPurge'],
   ): Promise<void> {
     await streamer.stop();
     await streamerDone;
@@ -366,6 +367,7 @@ describe('change-streamer/service', () => {
             replicaID: 'replica-id',
           },
         },
+        ...(sqliteChangeLogPurge === undefined ? {} : {sqliteChangeLogPurge}),
         ...(sqliteCatchup === undefined
           ? {}
           : {
@@ -528,6 +530,77 @@ describe('change-streamer/service', () => {
       sqliteSub.cancel();
     } finally {
       liveSub.cancel();
+      await streamer.stop();
+      await streamerDone;
+      deleteChangeLogDB(logFile.path);
+      logFile.delete();
+    }
+  });
+
+  test('SQLite cleanup continues independently after PG reaches the floor', async () => {
+    const logFile = new DbFile('sqlite-change-log-independent-purge');
+    await restartWithInlineChangeLogWriter(logFile, undefined, {
+      retentionMs: 1,
+      batchRows: 2,
+      maxBatchesPerPass: 1,
+      now: () => Date.now() + 60_000,
+      yieldFn: () => Promise.resolve(),
+    });
+
+    const watermarks = ['03', '04', '05', '06', '07', '08', '09'];
+    try {
+      for (const watermark of watermarks) {
+        changes.push(['begin', messages.begin(), {commitWatermark: watermark}]);
+        changes.push(['commit', messages.commit(), {watermark}]);
+      }
+      await expectAcks(...watermarks);
+
+      const sqliteMinWatermark = () => {
+        using log = openChangeLogDB(lc, logFile.path, {readonly: true});
+        return log
+          .prepare(/*sql*/ `
+            SELECT min("watermark") AS "watermark"
+              FROM "_zero.changeLogStream"
+          `)
+          .get<{watermark: string}>().watermark;
+      };
+      expect(sqliteMinWatermark()).toBe(REPLICA_VERSION);
+
+      setTimeoutFn.mockClear();
+      const pgPurge = vi.spyOn(Storer.prototype, 'purgeRecordsBefore');
+      try {
+        streamer.trackBackupWatermark('08');
+        const initial = setTimeoutFn.mock.calls.slice(0, 2);
+        expect(initial.map(call => call[1])).toEqual([30_000, 30_000]);
+        await Promise.all(
+          initial.map(call => call[0]() as unknown as Promise<void>),
+        );
+
+        let timerIndex = initial.length;
+        let sqlitePasses = 1;
+        while (sqliteMinWatermark() !== '08') {
+          const call = setTimeoutFn.mock.calls[timerIndex];
+          assert(call, `cleanup timer ${timerIndex} was not scheduled`);
+          expect(call[1]).toBe(0);
+          timerIndex++;
+          sqlitePasses++;
+          await (call[0]() as unknown as Promise<void>);
+
+          // PG reaches the floor in the first pass. Later level-triggered
+          // passes belong solely to SQLite's bounded drain.
+          expect(pgPurge).toHaveBeenCalledTimes(1);
+          expect(sqlitePasses).toBeLessThan(10);
+        }
+
+        expect(sqlitePasses).toBeGreaterThan(1);
+        expect(
+          await sql`SELECT min(watermark) FROM "zoro_3/cdc"."changeLog"`.values(),
+        ).toEqual([['08']]);
+        expect(setTimeoutFn).toHaveBeenCalledTimes(timerIndex);
+      } finally {
+        pgPurge.mockRestore();
+      }
+    } finally {
       await streamer.stop();
       await streamerDone;
       deleteChangeLogDB(logFile.path);

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
@@ -2292,6 +2292,31 @@ describe('change-streamer/service', () => {
     ]);
   });
 
+  test('change log cleanup reaches the backup watermark with no subscribers', async () => {
+    await sql`
+      INSERT INTO "zoro_3/cdc"."changeLog" (watermark, pos, change) VALUES ('03', 0, '{"tag":"begin"}'::json);
+      INSERT INTO "zoro_3/cdc"."changeLog" (watermark, pos, change) VALUES ('04', 0, '{"tag":"commit"}'::json);
+      INSERT INTO "zoro_3/cdc"."changeLog" (watermark, pos, change) VALUES ('05', 0, '{"tag":"begin"}'::json);
+      INSERT INTO "zoro_3/cdc"."changeLog" (watermark, pos, change) VALUES ('06', 0, '{"tag":"commit"}'::json);
+      INSERT INTO "zoro_3/cdc"."changeLog" (watermark, pos, change) VALUES ('07', 0, '{"tag":"begin"}'::json);
+      INSERT INTO "zoro_3/cdc"."changeLog" (watermark, pos, change) VALUES ('08', 0, '{"tag":"commit"}'::json);
+      UPDATE "zoro_3/cdc"."replicationState" SET "lastWatermark" = '08';
+    `.simple();
+
+    streamer.trackBackupWatermark('06');
+
+    expect(setTimeoutFn).toHaveBeenCalledTimes(1);
+    expect(setTimeoutFn.mock.calls[0][1]).toBe(30_000);
+
+    await (setTimeoutFn.mock.calls[0][0]() as unknown as Promise<void>);
+    expect(
+      await sql`SELECT watermark FROM "zoro_3/cdc"."changeLog"`.values(),
+    ).toEqual([['06'], ['07'], ['08']]);
+
+    // Cleanup reached the confirmed backup watermark, so it is not re-armed.
+    expect(setTimeoutFn).toHaveBeenCalledTimes(1);
+  });
+
   test('startSnapshotReservation throws when backups are not configured', async () => {
     // The default `streamer` fixture is initialized with a `null` backupURL.
     await expect(

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
@@ -327,6 +327,7 @@ describe('change-streamer/service', () => {
     logFile: DbFile,
     sqliteCatchup?: Partial<SQLiteCatchupOptions>,
     sqliteChangeLogPurge?: TuningOptions['sqliteChangeLogPurge'],
+    backupURL?: string,
   ): Promise<void> {
     await streamer.stop();
     await streamerDone;
@@ -352,7 +353,7 @@ describe('change-streamer/service', () => {
       },
       ReplicationStatusPublisher.forTesting(),
       replicaConfig,
-      null,
+      backupURL === undefined ? null : {backupURL, litestreamVersion: 'legacy'},
       null,
       true,
       {
@@ -382,6 +383,17 @@ describe('change-streamer/service', () => {
       setTimeoutFn as unknown as typeof setTimeout,
     );
     streamerDone = streamer.run();
+  }
+
+  /** The oldest watermark retained in the SQLite change log beside `logFile`. */
+  function sqliteMinWatermark(logFile: DbFile): string {
+    using log = openChangeLogDB(lc, logFile.path, {readonly: true});
+    return log
+      .prepare(/*sql*/ `
+        SELECT min("watermark") AS "watermark"
+          FROM "_zero.changeLogStream"
+      `)
+      .get<{watermark: string}>().watermark;
   }
 
   /** A serving subscriber, i.e. one eligible for SQLite catchup. */
@@ -555,16 +567,7 @@ describe('change-streamer/service', () => {
       }
       await expectAcks(...watermarks);
 
-      const sqliteMinWatermark = () => {
-        using log = openChangeLogDB(lc, logFile.path, {readonly: true});
-        return log
-          .prepare(/*sql*/ `
-            SELECT min("watermark") AS "watermark"
-              FROM "_zero.changeLogStream"
-          `)
-          .get<{watermark: string}>().watermark;
-      };
-      expect(sqliteMinWatermark()).toBe(REPLICA_VERSION);
+      expect(sqliteMinWatermark(logFile)).toBe(REPLICA_VERSION);
 
       setTimeoutFn.mockClear();
       const pgPurge = vi.spyOn(Storer.prototype, 'purgeRecordsBefore');
@@ -578,7 +581,7 @@ describe('change-streamer/service', () => {
 
         let timerIndex = initial.length;
         let sqlitePasses = 1;
-        while (sqliteMinWatermark() !== '08') {
+        while (sqliteMinWatermark(logFile) !== '08') {
           const call = setTimeoutFn.mock.calls[timerIndex];
           assert(call, `cleanup timer ${timerIndex} was not scheduled`);
           expect(call[1]).toBe(0);
@@ -600,6 +603,182 @@ describe('change-streamer/service', () => {
       } finally {
         pgPurge.mockRestore();
       }
+    } finally {
+      await streamer.stop();
+      await streamerDone;
+      deleteChangeLogDB(logFile.path);
+      logFile.delete();
+    }
+  });
+
+  /**
+   * The SQLite floor's live constraint is level-triggered, not edge-triggered:
+   * backup monitors never resend an unchanged floor, so once a laggard's ACK
+   * holds a purge below the backup watermark, only the coordinator's own
+   * deferred retries can finish the job when the laggard catches up.
+   */
+  test('a laggard ACK holds the SQLite floor until its subscriber catches up', async () => {
+    const logFile = new DbFile('sqlite-change-log-laggard-purge');
+    await restartWithInlineChangeLogWriter(logFile, undefined, {
+      retentionMs: 1,
+      batchRows: 100,
+      now: () => Date.now() + 60_000,
+      yieldFn: () => Promise.resolve(),
+    });
+
+    const watermarks = ['03', '04', '05', '06', '07', '08'];
+    try {
+      for (const watermark of watermarks) {
+        changes.push(['begin', messages.begin(), {commitWatermark: watermark}]);
+        changes.push(['commit', messages.commit(), {watermark}]);
+      }
+      await expectAcks(...watermarks);
+      expect(sqliteMinWatermark(logFile)).toBe(REPLICA_VERSION);
+
+      // A serving subscriber whose ACK ('04') trails the backup watermark.
+      const laggard = await streamer.subscribe({
+        protocolVersion: PROTOCOL_VERSION,
+        taskID: 'laggard-task',
+        id: 'laggard',
+        mode: 'serving',
+        watermark: '04',
+        replicaVersion: REPLICA_VERSION,
+        initial: true,
+        logsChangeStream: false,
+      });
+
+      let fired = 0;
+      const fireNextTimer = async () => {
+        const call = setTimeoutFn.mock.calls[fired];
+        assert(call, `cleanup timer ${fired} was not scheduled`);
+        expect(call[1]).toBe(30_000);
+        fired++;
+        await (call[0]() as unknown as Promise<void>);
+      };
+
+      setTimeoutFn.mockClear();
+      streamer.trackBackupWatermark('08');
+
+      // One PG and one SQLite cleanup pass: both purge up to the laggard's
+      // ACK and stop there.
+      await fireNextTimer();
+      await fireNextTimer();
+      expect(sqliteMinWatermark(logFile)).toBe('04');
+
+      // Both loops re-armed themselves even though the SQLite pass found
+      // nothing left below its floor: the floor has not reached the backup
+      // watermark, so cleanup must keep re-evaluating.
+      await fireNextTimer();
+      await fireNextTimer();
+      expect(sqliteMinWatermark(logFile)).toBe('04');
+
+      // The laggard consumes through '08', advancing its ACK ...
+      const msgs = drainToQueue(laggard);
+      for (;;) {
+        const msg = await msgs.dequeue();
+        if (msg[0] === 'commit' && msg[2].watermark === '08') {
+          break;
+        }
+      }
+      // ... and the still-armed retries drain both change logs to the backup
+      // watermark without another trackBackupWatermark() call.
+      let passes = 0;
+      while (sqliteMinWatermark(logFile) !== '08') {
+        await fireNextTimer();
+        expect(++passes).toBeLessThan(10);
+      }
+      while (fired < setTimeoutFn.mock.calls.length) {
+        await fireNextTimer();
+      }
+      expect(
+        await sql`SELECT min(watermark) FROM "zoro_3/cdc"."changeLog"`.values(),
+      ).toEqual([['08']]);
+      // Both floors reached the backup watermark: the loops disarmed.
+      expect(setTimeoutFn).toHaveBeenCalledTimes(fired);
+    } finally {
+      await streamer.stop();
+      await streamerDone;
+      deleteChangeLogDB(logFile.path);
+      logFile.delete();
+    }
+  });
+
+  /**
+   * The reservation/purge wiring end to end: `startSnapshotReservation`
+   * pauses the SQLite purge scheduler, and the reservation's close routes
+   * through `SnapshotReservations`' onClose to the scheduler's resume — so a
+   * restoring follower's advertised bounds stay servable, and the log is not
+   * pinned once the restore is over.
+   */
+  test('a snapshot reservation pauses the SQLite purge until it closes', async () => {
+    const logFile = new DbFile('sqlite-change-log-reservation-pause');
+    await restartWithInlineChangeLogWriter(
+      logFile,
+      undefined,
+      {
+        retentionMs: 1,
+        batchRows: 100,
+        now: () => Date.now() + 60_000,
+        yieldFn: () => Promise.resolve(),
+      },
+      's3://foo/bar',
+    );
+
+    const watermarks = ['03', '04', '05', '06', '07', '08'];
+    try {
+      for (const watermark of watermarks) {
+        changes.push(['begin', messages.begin(), {commitWatermark: watermark}]);
+        changes.push(['commit', messages.commit(), {watermark}]);
+      }
+      await expectAcks(...watermarks);
+      expect(sqliteMinWatermark(logFile)).toBe(REPLICA_VERSION);
+
+      // A view-syncer reserves a snapshot while it restores from backup.
+      const reservation =
+        await streamer.startSnapshotReservation('view-syncer-1');
+      const snapshots = drainSnapshotMessages(reservation);
+
+      setTimeoutFn.mockClear();
+      streamer.trackBackupWatermark('08');
+      expect(await snapshots.dequeue()).toEqual([
+        'status',
+        {
+          tag: 'status',
+          backupURL: 's3://foo/bar',
+          replicaVersion: REPLICA_VERSION,
+          minWatermark: '08',
+        },
+      ]);
+
+      let fired = 0;
+      const fireNextTimer = async () => {
+        const call = setTimeoutFn.mock.calls[fired];
+        assert(call, `cleanup timer ${fired} was not scheduled`);
+        expect(call[1]).toBe(30_000);
+        fired++;
+        await (call[0]() as unknown as Promise<void>);
+      };
+
+      // The confirmed reservation does not hold the PG purge below the
+      // backup watermark ...
+      await fireNextTimer();
+      expect(
+        await sql`SELECT min(watermark) FROM "zoro_3/cdc"."changeLog"`.values(),
+      ).toEqual([['08']]);
+      // ... but it pauses the SQLite purge outright: each pass declines and
+      // re-arms rather than invalidating the advertised snapshot bounds.
+      await fireNextTimer();
+      expect(sqliteMinWatermark(logFile)).toBe(REPLICA_VERSION);
+      await fireNextTimer();
+      expect(sqliteMinWatermark(logFile)).toBe(REPLICA_VERSION);
+
+      // Closing the reservation resumes purging: the next armed pass drains
+      // the SQLite log to the floor.
+      reservation.cancel();
+      await fireNextTimer();
+      expect(sqliteMinWatermark(logFile)).toBe('08');
+      // Cleanup reached the backup watermark: nothing further is armed.
+      expect(setTimeoutFn).toHaveBeenCalledTimes(fired);
     } finally {
       await streamer.stop();
       await streamerDone;
@@ -2388,6 +2567,107 @@ describe('change-streamer/service', () => {
 
     // Cleanup reached the confirmed backup watermark, so it is not re-armed.
     expect(setTimeoutFn).toHaveBeenCalledTimes(1);
+  });
+
+  test('an unchanged behind-backup floor is logged only once', async () => {
+    await sql`
+      INSERT INTO "zoro_3/cdc"."changeLog" (watermark, pos, change) VALUES ('03', 0, '{"tag":"begin"}'::json);
+      INSERT INTO "zoro_3/cdc"."changeLog" (watermark, pos, change) VALUES ('04', 0, '{"tag":"commit"}'::json);
+      INSERT INTO "zoro_3/cdc"."changeLog" (watermark, pos, change) VALUES ('05', 0, '{"tag":"begin"}'::json);
+      INSERT INTO "zoro_3/cdc"."changeLog" (watermark, pos, change) VALUES ('06', 0, '{"tag":"commit"}'::json);
+      INSERT INTO "zoro_3/cdc"."changeLog" (watermark, pos, change) VALUES ('07', 0, '{"tag":"begin"}'::json);
+      INSERT INTO "zoro_3/cdc"."changeLog" (watermark, pos, change) VALUES ('08', 0, '{"tag":"commit"}'::json);
+      UPDATE "zoro_3/cdc"."replicationState" SET "lastWatermark" = '08';
+    `.simple();
+
+    // Two idle subscribers pin the cleanup floor below the backup. The
+    // level-triggered retry re-evaluates the floor every pass, and must not
+    // repeat the laggard warning while the blocking floor stands still.
+    const sub1 = await streamer.subscribe({
+      protocolVersion: PROTOCOL_VERSION,
+      taskID: 'task-id',
+      id: 'myid1',
+      mode: 'serving',
+      watermark: '04',
+      replicaVersion: REPLICA_VERSION,
+      initial: true,
+      logsChangeStream: false,
+    });
+    const sub2 = await streamer.subscribe({
+      protocolVersion: PROTOCOL_VERSION,
+      taskID: 'task-id',
+      id: 'myid2',
+      mode: 'serving',
+      watermark: '06',
+      replicaVersion: REPLICA_VERSION,
+      initial: true,
+      logsChangeStream: false,
+    });
+
+    const behindLogs = () =>
+      logSink.messages.filter(
+        ([, , args]) =>
+          typeof args[0] === 'string' &&
+          args[0].startsWith('At least one client is behind backup'),
+      );
+    let fired = 0;
+    const fireNextTimer = async () => {
+      const call = setTimeoutFn.mock.calls[fired];
+      assert(call, `cleanup timer ${fired} was not scheduled`);
+      expect(call[1]).toBe(30_000);
+      fired++;
+      await (call[0]() as unknown as Promise<void>);
+    };
+
+    setTimeoutFn.mockClear();
+    streamer.trackBackupWatermark('08');
+
+    // The first pass logs the blocking floor ('04') and purges up to it.
+    await fireNextTimer();
+    expect(behindLogs()).toHaveLength(1);
+    expect(
+      await sql`SELECT watermark FROM "zoro_3/cdc"."changeLog"`.values(),
+    ).toEqual([['04'], ['05'], ['06'], ['07'], ['08']]);
+
+    // The retry re-evaluates the same floor: no repeated line.
+    await fireNextTimer();
+    expect(behindLogs()).toHaveLength(1);
+
+    // The blocking floor moves ('04' -> '06'), still behind the backup:
+    // logged anew, again only once.
+    sub1.cancel();
+    await fireNextTimer();
+    expect(behindLogs()).toHaveLength(2);
+    await fireNextTimer();
+    expect(behindLogs()).toHaveLength(2);
+
+    // With no laggard left, the floor reaches the backup watermark: purge
+    // completes silently and the cleanup loop disarms.
+    sub2.cancel();
+    await fireNextTimer();
+    expect(behindLogs()).toHaveLength(2);
+    expect(
+      await sql`SELECT watermark FROM "zoro_3/cdc"."changeLog"`.values(),
+    ).toEqual([['08']]);
+    expect(setTimeoutFn).toHaveBeenCalledTimes(5);
+
+    // A new backup outrunning a client is a new condition: logged again.
+    const sub3 = await streamer.subscribe({
+      protocolVersion: PROTOCOL_VERSION,
+      taskID: 'task-id',
+      id: 'myid3',
+      mode: 'serving',
+      watermark: '08',
+      replicaVersion: REPLICA_VERSION,
+      initial: true,
+      logsChangeStream: false,
+    });
+    streamer.trackBackupWatermark('0a');
+    await fireNextTimer();
+    expect(behindLogs()).toHaveLength(3);
+    await fireNextTimer();
+    expect(behindLogs()).toHaveLength(3);
+    sub3.cancel();
   });
 
   test('startSnapshotReservation throws when backups are not configured', async () => {

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -8,11 +8,7 @@ import {
   getOrCreateCounter,
   getOrCreateLatencyHistogram,
 } from '../../observability/metrics.ts';
-import {
-  min,
-  type AtLeastOne,
-  type LexiVersion,
-} from '../../types/lexi-version.ts';
+import {min} from '../../types/lexi-version.ts';
 import type {PostgresDB} from '../../types/pg.ts';
 import type {ShardID} from '../../types/shards.ts';
 import type {Source} from '../../types/streams.ts';
@@ -856,16 +852,11 @@ class ChangeStreamerImpl implements ChangeStreamerService {
         ...this.#forwarder.getAcks(),
         ...(this.#reservations?.getReservedWatermarks() ?? []),
       ];
-      if (current.length === 0) {
-        // Also not expected, but possible (e.g. subscriber connects, then disconnects).
-        // Bail to be safe.
-        this.#lc.warn?.('No subscribers to confirm cleanup');
-        return;
-      }
-      const purgeWatermark = min(
-        this.#backupWatermark,
-        ...(current as AtLeastOne<LexiVersion>),
-      );
+      // The cleanup delay above is the grace period for disconnected
+      // subscribers to reconnect and expose their ACKs. Once it expires, an
+      // empty set places no additional constraint on the confirmed backup
+      // watermark and must not pin the change log indefinitely.
+      const purgeWatermark = min(this.#backupWatermark, ...current);
       if (purgeWatermark > this.#purgedWatermark) {
         if (purgeWatermark < this.#backupWatermark) {
           this.#lc.info?.(

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -57,6 +57,10 @@ import {
   SQLiteChangeLogCatchup,
   type SQLiteChangeLogCleanupGuard,
 } from './sqlite-change-log-catchup.ts';
+import {
+  SQLiteChangeLogPurgeScheduler,
+  type SQLiteChangeLogPurgeSchedulerOptions,
+} from './sqlite-change-log-purge-scheduler.ts';
 import {SQLiteChangeLogReader} from './sqlite-change-log-reader.ts';
 import {
   SQLiteChangeLogWriter,
@@ -92,7 +96,11 @@ export type SQLiteCatchupOptions = {
    * writer from SQLite would make it wait on its own ACK.
    */
   shouldUse?: ((ctx: SubscriberContext) => boolean) | undefined;
-  /** Slice 9 supplies the writer-serialized purge guard. */
+  /**
+   * Overrides the purge scheduler's guard, for tests. When absent, the
+   * service supplies the scheduler's real writer-serialized guard, or the
+   * catchup's no-op default when purging is not configured.
+   */
   cleanupGuard?: SQLiteChangeLogCleanupGuard | undefined;
   /**
    * How long the change log may be unavailable before declining to serve from
@@ -113,6 +121,15 @@ export type TuningOptions = StorerOptions & {
   sqliteChangeLogWriter?:
     | Omit<SQLiteChangeLogWriterOptions, 'onCommit' | 'onDisabled'>
     | undefined;
+  /**
+   * Also supplied when `sqliteChangeLogMode != off`, and deliberately not
+   * gated on the read path: in `write` mode no reader ever opens, and this is
+   * the configuration the purge scheduler actually ships in. The scheduler
+   * runs on the writer's own connection, so with the writer absent (mode
+   * `off`) it is never constructed, and a leftover file on disk is left to
+   * the replicator's cleanup.
+   */
+  sqliteChangeLogPurge?: SQLiteChangeLogPurgeSchedulerOptions | undefined;
 };
 
 /**
@@ -324,6 +341,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
   readonly #replicationStatusPublisher: ReplicationStatusPublisher;
   readonly #sqliteCatchupOptions: SQLiteCatchupOptions | undefined;
   readonly #changeLogWriter: SQLiteChangeLogWriter | undefined;
+  readonly #purgeScheduler: SQLiteChangeLogPurgeScheduler | undefined;
 
   readonly #autoReset: boolean;
   readonly #state: RunningState;
@@ -413,20 +431,49 @@ class ChangeStreamerImpl implements ChangeStreamerService {
       eventDrivenRelease: opts.flowControlEventDrivenRelease,
     });
     this.#reservations = backupConfig
-      ? new SnapshotReservations(lc, backupConfig)
+      ? new SnapshotReservations(lc, backupConfig, taskID =>
+          this.#purgeScheduler?.resume(taskID),
+        )
       : undefined;
     this.#replicationStatusPublisher = replicationStatusPublisher;
-    this.#sqliteCatchupOptions = opts.sqliteCatchup;
     this.#changeLogWriter = opts.sqliteChangeLogWriter
       ? new SQLiteChangeLogWriter(lc, {
           ...opts.sqliteChangeLogWriter,
-          onCommit: watermark =>
-            this.#sqliteCatchup?.onChangeLogCommit(watermark),
+          onCommit: watermark => {
+            this.#sqliteCatchup?.onChangeLogCommit(watermark);
+            // The commit closed the log's transaction, i.e. opened a purge
+            // window (§3.3).
+            this.#purgeScheduler?.onWriterIdle();
+          },
           // Fail-soft deletes the file, and the reader is cached here, so it
           // has to go with it: otherwise it serves an unlinked inode while
           // every new open sees nothing.
           onDisabled: () => this.#closeSQLiteCatchup(),
         })
+      : undefined;
+    // The purge scheduler runs on the writer's own connection, which is also
+    // its gate: no writer (mode `off`) means no scheduler, and a writer that
+    // has not created the file yet -- or failed soft and deleted it -- makes
+    // cycles skip rather than fail, so a late-appearing file is picked up
+    // without a restart.
+    this.#purgeScheduler =
+      opts.sqliteChangeLogPurge && this.#changeLogWriter
+        ? new SQLiteChangeLogPurgeScheduler(
+            lc,
+            () => this.#changeLogWriter?.connection,
+            () => this.#forwarder.getAcks(),
+            opts.sqliteChangeLogPurge,
+          )
+        : undefined;
+    this.#sqliteCatchupOptions = opts.sqliteCatchup
+      ? {
+          ...opts.sqliteCatchup,
+          // The real cleanup guard, in place of the catchup's no-op default:
+          // registration and purge batches now serialize on one mutex.
+          cleanupGuard:
+            opts.sqliteCatchup.cleanupGuard ??
+            this.#purgeScheduler?.cleanupGuard,
+        }
       : undefined;
     this.#purgeLock = initialPurgeLock;
     this.#autoReset = autoReset;
@@ -607,6 +654,9 @@ class ChangeStreamerImpl implements ChangeStreamerService {
         // so the next connection's reconciliation sees a head at or below its
         // resume watermark rather than a partial transaction.
         this.#changeLogWriter?.abort();
+        // A rollback ends the log's open transaction without a commit
+        // notification; wake any purge batch waiting for that window.
+        this.#purgeScheduler?.onWriterIdle();
         this.#forwarder.forward([watermark, 'rollback', ROLLBACK_JSON]);
         this.#recordForwardedTransactionBoundary('rollback', watermark);
       }
@@ -714,9 +764,17 @@ class ChangeStreamerImpl implements ChangeStreamerService {
     }
     const downstream = this.#reservations.open(taskID);
 
-    // If a backup has been confirmed, immediately confirm the reservation.
-    await this.#confirmReservations();
-    return downstream;
+    try {
+      // Wait for an in-flight SQLite purge batch before reading and
+      // advertising the reservation's bounds.
+      await (this.#purgeScheduler?.pause(taskID) ?? promiseVoid);
+      // If a backup has been confirmed, immediately confirm the reservation.
+      await this.#confirmReservations();
+      return downstream;
+    } catch (e) {
+      this.#reservations.close(taskID);
+      throw e;
+    }
   }
 
   trackBackupWatermark(watermark: string) {
@@ -823,6 +881,15 @@ class ChangeStreamerImpl implements ChangeStreamerService {
           `Purged ${deleted} changes before ${purgeWatermark} (${elapsed} ms)`,
         );
         this.#purgedWatermark = purgeWatermark;
+        // The SQLite arm: the same floor, in the same cycle, behind the same
+        // decline gate as the PG purge above. Ordered after it, in its own
+        // try/catch, so a SQLite failure can neither suppress the PG purge
+        // nor roll back the PG watermark accounting above.
+        try {
+          await this.#purgeScheduler?.purge(purgeWatermark);
+        } catch (e) {
+          this.#lc.warn?.(`error purging the SQLite change log`, e);
+        }
       }
     } catch (e) {
       this.#lc.warn?.(`error purging change log`, e);
@@ -834,6 +901,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
   async stop(err?: unknown) {
     this.#state.stop(this.#lc, err);
     this.#stream?.changes.cancel();
+    this.#purgeScheduler?.stop();
     this.#sqliteCatchup?.close();
     this.#changeLogWriter?.close();
     await this.#storer.stop();

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -55,6 +55,7 @@ import {
 } from './sqlite-change-log-catchup.ts';
 import {
   SQLiteChangeLogPurgeScheduler,
+  type PurgeContinuation,
   type SQLiteChangeLogPurgeSchedulerOptions,
 } from './sqlite-change-log-purge-scheduler.ts';
 import {SQLiteChangeLogReader} from './sqlite-change-log-reader.ts';
@@ -375,9 +376,15 @@ class ChangeStreamerImpl implements ChangeStreamerService {
   #latestStatus: Status;
   #latestLagReportCommitTimeMs = 0;
   #backupWatermark: string | undefined;
-  #purgedWatermark: string = '';
+  #pgPurgedWatermark: string = '';
+  #sqlitePurgeContinuation: PurgeContinuation | undefined;
   #purgeLock: PurgeLock | null;
-  #purgeTimer: NodeJS.Timeout | undefined;
+  // PG and SQLite intentionally own separate level-triggered loops. Neither
+  // waits for, advances, or retries the other.
+  #pgPurgeScheduled = false;
+  #pgPurgeRunning = false;
+  #sqlitePurgeScheduled = false;
+  #sqlitePurgeRunning = false;
   #stream: ChangeStream | undefined;
   #sqliteCatchup: SQLiteChangeLogCatchup | undefined;
   #changeLogUnavailableSince: number | undefined;
@@ -780,7 +787,12 @@ class ChangeStreamerImpl implements ChangeStreamerService {
     //       cleanup of the change-log can trail that based on where
     //       current subscribers are, and our policy for how much buffer
     //       is kept around for reconnecting view-syncers.
-    this.#maybeScheduleCleanup();
+    // The durable backup floor is an independent input to each change-log
+    // implementation. SQLite receives it even when the PG log has already
+    // reached this watermark.
+    this.#requestSQLitePurge('deferred');
+    this.#maybeSchedulePGPurge();
+    this.#maybeScheduleSQLitePurge();
 
     // Confirm any waiting reservations now that a backup has been confirmed.
     // Note that this is asynchronous and best effort; if it fails, the watermark
@@ -808,17 +820,47 @@ class ChangeStreamerImpl implements ChangeStreamerService {
     }
   }
 
-  #maybeScheduleCleanup() {
+  #maybeSchedulePGPurge(): void {
+    const backupWatermark = this.#backupWatermark;
     if (
-      this.#purgeTimer === undefined &&
-      this.#backupWatermark !== undefined &&
-      this.#purgedWatermark < this.#backupWatermark
+      this.#pgPurgeScheduled ||
+      this.#pgPurgeRunning ||
+      backupWatermark === undefined ||
+      this.#pgPurgedWatermark >= backupWatermark
     ) {
-      this.#purgeTimer = this.#state.setTimeout(() => {
-        this.#purgeTimer = undefined;
-        return this.#purgeOldChanges();
-      }, CLEANUP_DELAY_MS);
+      return;
     }
+    this.#pgPurgeScheduled = true;
+    this.#state.setTimeout(() => {
+      this.#pgPurgeScheduled = false;
+      this.#pgPurgeRunning = true;
+      return this.#purgePGChangeLog().finally(() => {
+        this.#pgPurgeRunning = false;
+        this.#maybeSchedulePGPurge();
+      });
+    }, CLEANUP_DELAY_MS);
+  }
+
+  #maybeScheduleSQLitePurge(): void {
+    if (
+      this.#sqlitePurgeScheduled ||
+      this.#sqlitePurgeRunning ||
+      this.#backupWatermark === undefined ||
+      this.#sqlitePurgeContinuation === undefined
+    ) {
+      return;
+    }
+    const delay =
+      this.#sqlitePurgeContinuation === 'immediate' ? 0 : CLEANUP_DELAY_MS;
+    this.#sqlitePurgeScheduled = true;
+    this.#state.setTimeout(() => {
+      this.#sqlitePurgeScheduled = false;
+      this.#sqlitePurgeRunning = true;
+      return this.#purgeSQLiteChangeLog().finally(() => {
+        this.#sqlitePurgeRunning = false;
+        this.#maybeScheduleSQLitePurge();
+      });
+    }, delay);
   }
 
   async #getChangeLogState(): Promise<{
@@ -837,55 +879,93 @@ class ChangeStreamerImpl implements ChangeStreamerService {
     };
   }
 
-  /**
-   * Makes a best effort to purge the change log. In the event of a database
-   * error, exceptions will be logged and swallowed, so this method is safe
-   * to run in a timeout.
-   */
-  async #purgeOldChanges(): Promise<void> {
-    if (!this.#backupWatermark) {
-      this.#lc.warn?.('No backup watermark tracked for cleanup'); // Not expected.
+  #getCleanupFloor(): {
+    backupWatermark: string;
+    purgeWatermark: string;
+    current: string[];
+  } {
+    const backupWatermark = this.#backupWatermark;
+    assert(
+      backupWatermark !== undefined,
+      'cleanup cannot run without a backup watermark',
+    );
+    const current = [
+      ...this.#forwarder.getAcks(),
+      ...(this.#reservations?.getReservedWatermarks() ?? []),
+    ];
+    // The cleanup delay above is the grace period for disconnected
+    // subscribers to reconnect and expose their ACKs. Once it expires, an
+    // empty set places no additional constraint on the confirmed backup
+    // watermark and must not pin either change log indefinitely.
+    return {
+      backupWatermark,
+      purgeWatermark: min(backupWatermark, ...current),
+      current,
+    };
+  }
+
+  async #purgePGChangeLog(): Promise<void> {
+    try {
+      const {backupWatermark, purgeWatermark, current} =
+        this.#getCleanupFloor();
+      if (purgeWatermark < backupWatermark) {
+        this.#lc.info?.(
+          `At least one client is behind backup ${backupWatermark}`,
+          {watermarks: current},
+        );
+      }
+      if (purgeWatermark <= this.#pgPurgedWatermark) {
+        return;
+      }
+      this.#lc.info?.(`Purging PG changes before ${purgeWatermark} ...`);
+      const start = performance.now();
+      const deleted = await this.#storer.purgeRecordsBefore(purgeWatermark);
+      const elapsed = (performance.now() - start).toFixed(2);
+      this.#lc.info?.(
+        `Purged ${deleted} PG changes before ${purgeWatermark} (${elapsed} ms)`,
+      );
+      this.#pgPurgedWatermark = purgeWatermark;
+    } catch (e) {
+      this.#lc.warn?.(`error purging the PG change log`, e);
+    }
+  }
+
+  async #purgeSQLiteChangeLog(): Promise<void> {
+    const scheduler = this.#purgeScheduler;
+    if (!scheduler) {
       return;
     }
     try {
-      const current = [
-        ...this.#forwarder.getAcks(),
-        ...(this.#reservations?.getReservedWatermarks() ?? []),
-      ];
-      // The cleanup delay above is the grace period for disconnected
-      // subscribers to reconnect and expose their ACKs. Once it expires, an
-      // empty set places no additional constraint on the confirmed backup
-      // watermark and must not pin the change log indefinitely.
-      const purgeWatermark = min(this.#backupWatermark, ...current);
-      if (purgeWatermark > this.#purgedWatermark) {
-        if (purgeWatermark < this.#backupWatermark) {
-          this.#lc.info?.(
-            `At least one client is behind backup ${this.#backupWatermark}`,
-            {watermarks: current},
-          );
-        }
-        this.#lc.info?.(`Purging changes before ${purgeWatermark} ...`);
-        const start = performance.now();
-        const deleted = await this.#storer.purgeRecordsBefore(purgeWatermark);
-        const elapsed = (performance.now() - start).toFixed(2);
-        this.#lc.info?.(
-          `Purged ${deleted} changes before ${purgeWatermark} (${elapsed} ms)`,
-        );
-        this.#purgedWatermark = purgeWatermark;
-        // The SQLite arm: the same floor, in the same cycle, behind the same
-        // decline gate as the PG purge above. Ordered after it, in its own
-        // try/catch, so a SQLite failure can neither suppress the PG purge
-        // nor roll back the PG watermark accounting above.
-        try {
-          await this.#purgeScheduler?.purge(purgeWatermark);
-        } catch (e) {
-          this.#lc.warn?.(`error purging the SQLite change log`, e);
-        }
+      const {backupWatermark, purgeWatermark} = this.#getCleanupFloor();
+      // Consume the request before starting. A backup notification that
+      // arrives during this pass records another request, which is merged with
+      // the continuation returned by this pass rather than being overwritten.
+      this.#sqlitePurgeContinuation = undefined;
+      if (purgeWatermark < backupWatermark) {
+        // Live constraint changes are not edge-triggered. Keep evaluating the
+        // floor until it reaches the durable backup watermark, independently
+        // of whether the PG implementation still exists.
+        this.#requestSQLitePurge('deferred');
       }
+      const result = await scheduler.purge(purgeWatermark);
+      this.#requestSQLitePurge(result.continuation);
     } catch (e) {
-      this.#lc.warn?.(`error purging change log`, e);
-    } finally {
-      this.#maybeScheduleCleanup();
+      // purge() is fail-soft, but retain the coordinator's retry if an
+      // unexpected caller-boundary failure escapes it.
+      this.#requestSQLitePurge('deferred');
+      this.#lc.warn?.(`error purging the SQLite change log`, e);
+    }
+  }
+
+  #requestSQLitePurge(continuation: PurgeContinuation | undefined): void {
+    if (!this.#purgeScheduler || continuation === undefined) {
+      return;
+    }
+    if (
+      continuation === 'immediate' ||
+      this.#sqlitePurgeContinuation === undefined
+    ) {
+      this.#sqlitePurgeContinuation = continuation;
     }
   }
 

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -377,6 +377,13 @@ class ChangeStreamerImpl implements ChangeStreamerService {
   #latestLagReportCommitTimeMs = 0;
   #backupWatermark: string | undefined;
   #pgPurgedWatermark: string = '';
+  /**
+   * The floor last logged as held back by a laggard. The level-triggered
+   * retry re-evaluates every {@link CLEANUP_DELAY_MS}; logging only when the
+   * blocking floor moves keeps a stuck subscriber from emitting the same
+   * line indefinitely.
+   */
+  #loggedBehindWatermark: string | undefined;
   #sqlitePurgeContinuation: PurgeContinuation | undefined;
   #purgeLock: PurgeLock | null;
   // PG and SQLite intentionally own separate level-triggered loops. Neither
@@ -915,10 +922,15 @@ class ChangeStreamerImpl implements ChangeStreamerService {
       const {backupWatermark, purgeWatermark, current} =
         this.#getCleanupFloor();
       if (purgeWatermark < backupWatermark) {
-        this.#lc.info?.(
-          `At least one client is behind backup ${backupWatermark}`,
-          {watermarks: current},
-        );
+        if (this.#loggedBehindWatermark !== purgeWatermark) {
+          this.#loggedBehindWatermark = purgeWatermark;
+          this.#lc.info?.(
+            `At least one client is behind backup ${backupWatermark}`,
+            {watermarks: current},
+          );
+        }
+      } else {
+        this.#loggedBehindWatermark = undefined;
       }
       if (purgeWatermark <= this.#pgPurgedWatermark) {
         return;

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -775,7 +775,13 @@ class ChangeStreamerImpl implements ChangeStreamerService {
       await this.#confirmReservations();
       return downstream;
     } catch (e) {
-      this.#reservations.close(taskID);
+      // Cancel the reservation this call opened, not whatever currently
+      // holds the task's slot: an overlapping retry for the same taskID may
+      // have already replaced it, and a by-taskID close would tear down the
+      // replacement and release its purge pause while it is advertising
+      // snapshot bounds. cancel() routes through the subscription's cleanup,
+      // which closes the reservation only if this instance still owns it.
+      downstream.cancel();
       throw e;
     }
   }

--- a/packages/zero-cache/src/services/change-streamer/snapshot-reservations.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/snapshot-reservations.test.ts
@@ -129,6 +129,36 @@ describe('change-streamer/snapshot-reservations', () => {
     expect(reservations.getReservedWatermarks()).toEqual(['watermark-1']);
   });
 
+  test('cancelling a superseded reservation leaves the replacement intact', async () => {
+    // The onClose callback stands in for the purge-pause release the
+    // change-streamer wires up: it must fire once per closed reservation,
+    // never for a superseded instance's late cancel.
+    const closed: string[] = [];
+    const reservations = new SnapshotReservations(
+      createSilentLogContext(),
+      {backupURL: 's3://foo/bar', litestreamVersion: 'v5'},
+      taskID => closed.push(taskID),
+    );
+    const sub1 = reservations.open('task-1');
+    const sub2 = reservations.open('task-1');
+    expect(closed).toEqual(['task-1']);
+
+    // The superseded caller's failure path cancels the downstream it owns.
+    // The instance guard makes it a no-op: the replacement stays open, and
+    // its purge pause is not released a second time.
+    sub1.cancel();
+    expect(closed).toEqual(['task-1']);
+    expect(reservations.confirmationsRequired()).toBe(true);
+
+    const message = getFirstMessage(sub2);
+    reservations.confirm('replica-v1', 'watermark-1');
+    await message;
+    expect(reservations.getReservedWatermarks()).toEqual(['watermark-1']);
+
+    reservations.close('task-1');
+    expect(closed).toEqual(['task-1', 'task-1']);
+  });
+
   test('close() cancels and removes the reservation', async () => {
     const reservations = newReservations();
     const sub = reservations.open('task-1');

--- a/packages/zero-cache/src/services/change-streamer/snapshot-reservations.ts
+++ b/packages/zero-cache/src/services/change-streamer/snapshot-reservations.ts
@@ -11,11 +11,17 @@ import type {SnapshotMessage} from './snapshot.ts';
 export class SnapshotReservations {
   readonly #lc: LogContext;
   readonly #backupConfig: BackupConfig;
+  readonly #onClose: ((taskID: string) => void) | undefined;
   readonly #reservations = new Map<string, Reservation>();
 
-  constructor(lc: LogContext, backupConfig: BackupConfig) {
+  constructor(
+    lc: LogContext,
+    backupConfig: BackupConfig,
+    onClose?: ((taskID: string) => void) | undefined,
+  ) {
     this.#lc = lc.withContext('component', 'snapshot-reserver');
     this.#backupConfig = backupConfig;
+    this.#onClose = onClose;
   }
 
   open(taskID: string): Source<SnapshotMessage> {
@@ -42,6 +48,7 @@ export class SnapshotReservations {
     ) {
       // Note: delete first, so that the reservation is gone when close() is called.
       this.#reservations.delete(taskID);
+      this.#onClose?.(taskID);
       res.close();
 
       const duration = Date.now() - res.startTime.getTime();

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-purge-scheduler.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-purge-scheduler.test.ts
@@ -258,7 +258,7 @@ describe('change-streamer/sqlite-change-log-purge-scheduler', () => {
     expect(minWatermark(db)).toBe(v(15));
   });
 
-  test('declines when a subscriber ACK is behind the floor, and with no subscribers', async () => {
+  test('declines only when a connected subscriber ACK is behind the floor', async () => {
     const {db, scheduler, setAcks} = setup();
     appendSeries(db, 1, 10);
 
@@ -268,13 +268,6 @@ describe('change-streamer/sqlite-change-log-purge-scheduler', () => {
     expect(result.deletedRows).toBe(0);
 
     setAcks([]);
-    result = await scheduler.purge(v(8));
-    expect(result.stopped).toBe('no-subscribers');
-    expect(result.deletedRows).toBe(0);
-
-    // The gate is evaluated at dispatch, not at schedule: once the lagging
-    // subscriber has ACKed past the floor, the same floor purges.
-    setAcks([v(8), v(20)]);
     result = await scheduler.purge(v(8));
     expect(result.stopped).toBeUndefined();
     expect(minWatermark(db)).toBe(v(8));
@@ -299,12 +292,6 @@ describe('change-streamer/sqlite-change-log-purge-scheduler', () => {
     expect(minWatermark(db)).toBe(v(8));
     // Drained to the floor with nothing below it: no timer left armed.
     expect(timers.delays()).toEqual([]);
-
-    // The no-subscribers decline re-arms the same way.
-    setAcks([]);
-    const noSubs = await scheduler.purge(v(9));
-    expect(noSubs.stopped).toBe('no-subscribers');
-    expect(timers.delays()).toEqual([30_000]);
   });
 
   test('a registration mid-drain is honored by the very next batch', async () => {

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-purge-scheduler.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-purge-scheduler.test.ts
@@ -439,6 +439,47 @@ describe('change-streamer/sqlite-change-log-purge-scheduler', () => {
     expect(minWatermark(db)).toBe(v(8));
   });
 
+  test('pause resolves only once the in-flight batch has completed', async () => {
+    const {db, scheduler} = setup({batchRows: 4});
+    appendSeries(db, 1, 30);
+
+    // Hold the purge mutex, as a catchup registration does, so that the
+    // cycle's first batch queues behind it: a batch "in flight" — dispatched
+    // but not yet run — at the moment the reservation arrives.
+    let releaseGuard!: () => void;
+    const registration = scheduler.cleanupGuard.runWhilePurgeBlocked(
+      () => new Promise<void>(resolve => (releaseGuard = resolve)),
+    );
+    await microtasks();
+
+    const cycle = scheduler.purge(v(25));
+    await microtasks(); // the batch's lock acquisition is now queued
+
+    let minAtResume: string | null | undefined;
+    const paused = scheduler.pause('restorer').then(() => {
+      minAtResume = minWatermark(db);
+    });
+
+    // The barrier: the pause was issued after the batch was dispatched, so
+    // its promise must not resolve while that batch is still pending.
+    await microtasks();
+    expect(minAtResume).toBeUndefined();
+
+    releaseGuard();
+    await registration;
+    await paused;
+
+    // The queued batch ran to completion *before* the pause resolved — the
+    // bounds a backup monitor reads after awaiting the pause cannot be
+    // invalidated by a batch that was already on its way in...
+    expect(minAtResume).toBe(v(1));
+    // ...and no batch runs after it: the drain is interrupted, not finished.
+    const result = await cycle;
+    expect(result.stopped).toBe('paused');
+    expect(result.batches).toBe(1);
+    expect(minWatermark(db)).toBe(v(1));
+  });
+
   test('a pause lands between batches and interrupts the drain', async () => {
     const fixture = setup({
       batchRows: 4,

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-purge-scheduler.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-purge-scheduler.test.ts
@@ -735,6 +735,36 @@ describe('change-streamer/sqlite-change-log-purge-scheduler', () => {
     }
   });
 
+  test('a later batch failure preserves completed work and probes the floor', async () => {
+    let failDeletes = false;
+    const fixture = setup({
+      batchRows: 4,
+      yieldFn: () => {
+        if (!failDeletes) {
+          failDeletes = true;
+          fixture.db.exec(/*sql*/ `
+            CREATE TRIGGER "fail-purge-delete"
+            BEFORE DELETE ON "${CHANGE_LOG_STREAM_TABLE}"
+            BEGIN
+              SELECT RAISE(ABORT, 'injected purge failure');
+            END
+          `);
+        }
+        return Promise.resolve();
+      },
+    });
+    const {db, scheduler, timers} = fixture;
+    appendSeries(db, 1, 30);
+
+    const result = await scheduler.purge(v(25));
+
+    expect(result.stopped).toBe('error');
+    expect(result.batches).toBe(1);
+    expect(result.deletedRows).toBeGreaterThan(0);
+    expect(result.probe).toBe('retained');
+    expect(timers.delays()).toEqual([30_000]);
+  });
+
   test('a failed cycle reports an error and re-arms instead of throwing', async () => {
     const {db, scheduler, timers} = setup();
     appendSeries(db, 1, 10);

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-purge-scheduler.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-purge-scheduler.test.ts
@@ -1,3 +1,4 @@
+import fc from 'fast-check';
 import {afterEach, describe, expect, test} from 'vitest';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
 import type {Database} from '../../../../zqlite/src/db.ts';
@@ -16,6 +17,7 @@ import {ChangeLogStreamWriter} from '../replicator/change-log-stream-writer.ts';
 import {serializeChangeStreamData} from './change-log-codec.ts';
 import {
   SQLiteChangeLogPurgeScheduler,
+  type PurgePassResult,
   type SQLiteChangeLogPurgeSchedulerOptions,
 } from './sqlite-change-log-purge-scheduler.ts';
 import {SQLiteChangeLogReader} from './sqlite-change-log-reader.ts';
@@ -764,5 +766,445 @@ describe('change-streamer/sqlite-change-log-purge-scheduler', () => {
     writer.rollback();
 
     expect((await scheduler.purge(NO_FLOOR)).stopped).toBe('stopped');
+  });
+
+  describe('property: invariants hold under arbitrary interleavings', () => {
+    /** Rows per watermark: the granularity of the deletion-legality checks. */
+    function rowCounts(db: Database): Map<string, number> {
+      return new Map(
+        db
+          .prepare(/*sql*/ `
+            SELECT "watermark", count(*) AS "n"
+            FROM "${CHANGE_LOG_STREAM_TABLE}"
+            GROUP BY "watermark"
+          `)
+          .all<{watermark: string; n: number}>()
+          .map(({watermark, n}) => [watermark, n]),
+      );
+    }
+
+    function totalRows(db: Database): number {
+      return db
+        .prepare(
+          /*sql*/ `SELECT count(*) AS "n" FROM "${CHANGE_LOG_STREAM_TABLE}"`,
+        )
+        .get<{n: number}>().n;
+    }
+
+    /**
+     * The floor used when a dispatch lands above every committed watermark: a
+     * value no fuzzed append can reach, so the pass stays in the stale-log
+     * regime (probe `ahead`) rather than being crossed by later appends,
+     * which would place the floor between real watermarks and manufacture a
+     * spurious `violation`. Production floors are backup watermarks, i.e.
+     * monotone and always either a committed watermark or from before the log.
+     */
+    const FROZEN_FLOOR = 1_000_000;
+
+    // Dispatch and pump are weighted up: they are what makes a pass start and
+    // make progress, so their density decides how many deletion events land
+    // inside interesting windows (open reservations, low ACKs, open
+    // transactions) rather than in the drained finale.
+    const command = fc.oneof(
+      {
+        // The cleanup coordinator supplies a new durable floor.
+        arbitrary: fc.record({
+          kind: fc.constant('dispatch' as const),
+          floorNum: fc.integer({min: 0, max: 60}),
+        }),
+        weight: 3,
+      },
+      {
+        // Releases one parked between-batch yield.
+        arbitrary: fc.record({kind: fc.constant('pump' as const)}),
+        weight: 3,
+      },
+      {
+        // A whole committed transaction between the writer's commits.
+        arbitrary: fc.record({
+          kind: fc.constant('append' as const),
+          width: fc.integer({min: 0, max: 3}),
+          ageMs: fc.integer({min: -2_000, max: 5_000}),
+        }),
+        weight: 2,
+      },
+      // The writer's open-transaction window, and both ways out of it:
+      // commit notifies; rollback is silent, leaving only the poll.
+      fc.record({
+        kind: fc.constant('begin' as const),
+        width: fc.integer({min: 0, max: 3}),
+      }),
+      fc.record({
+        kind: fc.constant('commit' as const),
+        ageMs: fc.integer({min: -2_000, max: 5_000}),
+      }),
+      fc.record({kind: fc.constant('rollback' as const)}),
+      // Snapshot reservations, including unbalanced and surplus schedules.
+      fc.record({
+        kind: fc.constant('pause' as const),
+        task: fc.constantFrom('task-a', 'task-b'),
+      }),
+      fc.record({
+        kind: fc.constant('resume' as const),
+        task: fc.constantFrom('task-a', 'task-b'),
+      }),
+      // A catchup registration swapping the live ACK set under the guard.
+      fc.record({
+        kind: fc.constant('register' as const),
+        ackNums: fc.array(fc.integer({min: 0, max: 70}), {maxLength: 2}),
+      }),
+      fc.record({
+        kind: fc.constant('advanceClock' as const),
+        ms: fc.integer({min: 0, max: 5_000}),
+      }),
+      fc.record({kind: fc.constant('fireTimers' as const)}),
+    );
+
+    const schedulerFuzzScenario = fc.record({
+      batchRows: fc.integer({min: 1, max: 8}),
+      maxBatchesPerPass: fc.integer({min: 1, max: 4}),
+      seedTxs: fc.integer({min: 0, max: 8}),
+      cmds: fc.array(command, {minLength: 1, maxLength: 40}),
+      finalFloorNum: fc.integer({min: 0, max: 60}),
+    });
+
+    test('any interleaving preserves the gates and drains to quiescence', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          schedulerFuzzScenario,
+          async ({
+            batchRows,
+            maxBatchesPerPass,
+            seedTxs,
+            cmds,
+            finalFloorNum,
+          }) => {
+            // The yield gate: purge parks between batches until a pump (or
+            // the finale) releases it, so batch boundaries land exactly at
+            // chosen command points rather than wherever the microtask queue
+            // happens to put them.
+            let gated = true;
+            const parkedYields: Array<() => void> = [];
+            const fixture = setup({
+              batchRows,
+              maxBatchesPerPass,
+              yieldFn: () =>
+                gated
+                  ? new Promise<void>(resolve => parkedYields.push(resolve))
+                  : Promise.resolve(),
+            });
+            const {db, file, scheduler, timers, setAcks, setNow} = fixture;
+            try {
+              appendSeries(db, 1, seedTxs);
+              const committed = Array.from({length: seedTxs + 1}, (_, i) => i);
+              let nextWm = seedTxs + 1;
+              let openTx:
+                | {
+                    writer: ChangeLogStreamWriter;
+                    watermark: string;
+                    wmNum: number;
+                  }
+                | undefined;
+              let nowMs = LONG_AGO;
+              let acks: string[] = [];
+              setAcks(acks);
+              const pauses = new Map<string, number>();
+              const pauseTotal = () =>
+                [...pauses.values()].reduce((a, b) => a + b, 0);
+              let floorNum: number | undefined;
+              let insertedTotal = totalRows(db);
+              const results: PurgePassResult[] = [];
+              let inflight: Promise<void> | undefined;
+              let settled: PurgePassResult | undefined;
+
+              const snapFloor = (n: number) => {
+                const snapped =
+                  n > committed.at(-1)!
+                    ? FROZEN_FLOOR
+                    : committed.reduce((best, w) => (w <= n ? w : best), 0);
+                return Math.max(snapped, floorNum ?? 0);
+              };
+
+              // Rows enter and leave via the writer only synchronously, so
+              // measuring around each writer operation attributes every other
+              // row-count change to purge batches.
+              const measureInsert = (fn: () => void) => {
+                const before = totalRows(db);
+                fn();
+                insertedTotal += totalRows(db) - before;
+              };
+
+              const checkResult = (r: PurgePassResult) => {
+                // Health: the writer's windows were respected (no nested
+                // BEGIN error), the connection never went away, and history
+                // at or above the floor was never purged.
+                expect([
+                  undefined,
+                  'paused',
+                  'subscriber-behind',
+                  'batch-limit',
+                ]).toContain(r.stopped);
+                expect(r.probe).not.toBe('violation');
+                expect(r.batches).toBeLessThanOrEqual(maxBatchesPerPass);
+                if (r.stopped === 'batch-limit') {
+                  expect(r.batches).toBe(maxBatchesPerPass);
+                  expect(r.continuation).toBe('immediate');
+                } else if (r.stopped !== undefined) {
+                  expect(r.continuation).toBe('deferred');
+                }
+                if (r.stopped === undefined && r.continuation === undefined) {
+                  // No floor is lost: a pass reporting quiescence left
+                  // nothing below both the floor and the head.
+                  const wms = [...rowCounts(db).keys()];
+                  const head = wms.reduce((a, b) => (a > b ? a : b));
+                  for (const w of wms) {
+                    expect(w >= r.floor || w === head).toBe(true);
+                  }
+                }
+              };
+
+              const apply = async (cmd: (typeof cmds)[number]) => {
+                switch (cmd.kind) {
+                  case 'dispatch':
+                    // The coordinator runs one pass at a time.
+                    if (inflight === undefined) {
+                      floorNum = snapFloor(cmd.floorNum);
+                      inflight = scheduler.purge(v(floorNum)).then(r => {
+                        settled = r;
+                      });
+                    }
+                    break;
+                  case 'append':
+                    if (openTx === undefined) {
+                      const wm = nextWm++;
+                      measureInsert(() =>
+                        append(db, v(wm), cmd.width, nowMs - cmd.ageMs),
+                      );
+                      committed.push(wm);
+                    }
+                    break;
+                  case 'begin':
+                    if (openTx === undefined) {
+                      const wmNum = nextWm++;
+                      const watermark = v(wmNum);
+                      const writer = new ChangeLogStreamWriter(
+                        new StatementRunner(db),
+                      );
+                      measureInsert(() => {
+                        writer.begin(
+                          watermark,
+                          serializeChangeStreamData([
+                            'begin',
+                            {tag: 'begin'},
+                            {commitWatermark: watermark},
+                          ]),
+                        );
+                        for (let i = 0; i < cmd.width; i++) {
+                          writer.append(
+                            serializeChangeStreamData([
+                              'data',
+                              {tag: 'truncate', relations: []},
+                            ]),
+                            'truncate',
+                          );
+                        }
+                      });
+                      openTx = {writer, watermark, wmNum};
+                    }
+                    break;
+                  case 'commit':
+                    if (openTx !== undefined) {
+                      const {writer, watermark, wmNum} = openTx;
+                      measureInsert(() =>
+                        writer.commit(
+                          watermark,
+                          serializeChangeStreamData([
+                            'commit',
+                            {tag: 'commit'},
+                            {watermark},
+                          ]),
+                          nowMs - cmd.ageMs,
+                        ),
+                      );
+                      committed.push(wmNum);
+                      openTx = undefined;
+                      scheduler.onWriterIdle();
+                    }
+                    break;
+                  case 'rollback':
+                    if (openTx !== undefined) {
+                      // Deliberately no onWriterIdle(): an interrupted
+                      // stream's rollback is silent, and only the poll finds
+                      // the window it opens.
+                      const {writer} = openTx;
+                      measureInsert(() => writer.rollback());
+                      openTx = undefined;
+                    }
+                    break;
+                  case 'pause':
+                    pauses.set(cmd.task, (pauses.get(cmd.task) ?? 0) + 1);
+                    await scheduler.pause(cmd.task);
+                    break;
+                  case 'resume': {
+                    const count = pauses.get(cmd.task);
+                    if (count !== undefined) {
+                      if (count > 1) {
+                        pauses.set(cmd.task, count - 1);
+                      } else {
+                        pauses.delete(cmd.task);
+                      }
+                    }
+                    scheduler.resume(cmd.task);
+                    break;
+                  }
+                  case 'register':
+                    await scheduler.cleanupGuard.runWhilePurgeBlocked(() => {
+                      acks = cmd.ackNums.map(v);
+                      setAcks(acks);
+                    });
+                    break;
+                  case 'advanceClock':
+                    nowMs += cmd.ms;
+                    setNow(nowMs);
+                    break;
+                  case 'fireTimers':
+                    timers.fire();
+                    break;
+                  case 'pump':
+                    parkedYields.shift()?.();
+                    break;
+                }
+              };
+
+              for (const cmd of cmds) {
+                const before = rowCounts(db);
+                const acksBefore = acks;
+                const pausedBefore = pauseTotal() > 0;
+                const rolledBack =
+                  cmd.kind === 'rollback' ? openTx?.watermark : undefined;
+                await apply(cmd);
+                await microtasks();
+                const after = rowCounts(db);
+
+                const deleted = [...before.keys()].filter(
+                  w => w !== rolledBack && (after.get(w) ?? 0) < before.get(w)!,
+                );
+                if (deleted.length > 0) {
+                  // Only a purge batch deletes rows, and only legally: below
+                  // the dispatched floor, below the head, and below every
+                  // live subscriber ACK.
+                  expect(floorNum).toBeDefined();
+                  const head = [...after.keys()].reduce((a, b) =>
+                    a > b ? a : b,
+                  );
+                  for (const w of deleted) {
+                    expect(w < v(floorNum!)).toBe(true);
+                    expect(w < head).toBe(true);
+                  }
+                  if (cmd.kind !== 'register' && acksBefore.length > 0) {
+                    const minAck = acksBefore.reduce((a, b) => (a < b ? a : b));
+                    for (const w of deleted) {
+                      expect(w < minAck).toBe(true);
+                    }
+                  }
+                  // Exclusion: never while a reservation was effective
+                  // throughout the step.
+                  expect(pausedBefore && pauseTotal() > 0).toBe(false);
+                }
+
+                if (settled !== undefined) {
+                  results.push(settled);
+                  checkResult(settled);
+                  settled = undefined;
+                  inflight = undefined;
+                }
+              }
+
+              // The finale: close the writer's window, end every reservation,
+              // move every ACK out of the way, age all history out, open the
+              // yield gate, and drain as the level-triggered coordinator
+              // would. A raised floor must always be drained to.
+              if (openTx !== undefined) {
+                const {writer, watermark, wmNum} = openTx;
+                measureInsert(() =>
+                  writer.commit(
+                    watermark,
+                    serializeChangeStreamData([
+                      'commit',
+                      {tag: 'commit'},
+                      {watermark},
+                    ]),
+                    nowMs,
+                  ),
+                );
+                committed.push(wmNum);
+                openTx = undefined;
+                scheduler.onWriterIdle();
+              }
+              for (const [task, count] of pauses) {
+                for (let i = 0; i < count; i++) {
+                  scheduler.resume(task);
+                }
+              }
+              pauses.clear();
+              acks = [];
+              setAcks(acks);
+              nowMs += 100_000_000;
+              setNow(nowMs);
+              gated = false;
+              parkedYields.splice(0).forEach(release => release());
+              timers.fire();
+              if (inflight !== undefined) {
+                await inflight;
+                expect(settled).toBeDefined();
+                results.push(settled!);
+                checkResult(settled!);
+                settled = undefined;
+                inflight = undefined;
+              }
+
+              floorNum = snapFloor(finalFloorNum);
+              const finalFloor = v(floorNum);
+              let last: PurgePassResult;
+              for (let passes = 0; ; passes++) {
+                // Termination: the drain reaches quiescence in bounded passes.
+                expect(passes).toBeLessThan(200);
+                last = await scheduler.purge(finalFloor);
+                results.push(last);
+                checkResult(last);
+                if (last.continuation === undefined) {
+                  break;
+                }
+              }
+              expect(last.stopped).toBeUndefined();
+
+              // Quiescence is stable, and no timer or yield is left parked.
+              const extra = await scheduler.purge(finalFloor);
+              results.push(extra);
+              expect(extra.deletedRows).toBe(0);
+              expect(extra.continuation).toBeUndefined();
+              expect(timers.delays()).toEqual([]);
+              expect(parkedYields).toEqual([]);
+
+              // Accounting: every row ever inserted was either deleted by
+              // exactly the batches that reported it, or is still in the log.
+              expect(
+                results.reduce((sum, {deletedRows}) => sum + deletedRows, 0),
+              ).toBe(insertedTotal - totalRows(db));
+            } finally {
+              scheduler.stop();
+              parkedYields.splice(0).forEach(release => release());
+              const index = files.indexOf(file);
+              if (index >= 0) {
+                files.splice(index, 1);
+              }
+              deleteChangeLogDB(file.path);
+              file.delete();
+            }
+          },
+        ),
+        {numRuns: 1000},
+      );
+    });
   });
 });

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-purge-scheduler.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-purge-scheduler.test.ts
@@ -280,6 +280,33 @@ describe('change-streamer/sqlite-change-log-purge-scheduler', () => {
     expect(minWatermark(db)).toBe(v(8));
   });
 
+  test('a decline arms the recheck timer, which alone lifts it', async () => {
+    const {db, scheduler, timers, setAcks} = setup();
+    appendSeries(db, 1, 10);
+
+    setAcks([v(3)]);
+    const declined = await scheduler.purge(v(8));
+    expect(declined.stopped).toBe('subscriber-behind');
+    // Nothing notifies when the lagging subscriber ACKs past the floor, so
+    // the recheck timer is the only thing that ever lifts a decline.
+    expect(timers.delays()).toEqual([30_000]);
+
+    // The subscriber catches up; the timer alone — no new purge() dispatch —
+    // resumes the drain.
+    setAcks([v(20)]);
+    timers.fire();
+    await microtasks();
+    expect(minWatermark(db)).toBe(v(8));
+    // Drained to the floor with nothing below it: no timer left armed.
+    expect(timers.delays()).toEqual([]);
+
+    // The no-subscribers decline re-arms the same way.
+    setAcks([]);
+    const noSubs = await scheduler.purge(v(9));
+    expect(noSubs.stopped).toBe('no-subscribers');
+    expect(timers.delays()).toEqual([30_000]);
+  });
+
   test('a registration mid-drain is honored by the very next batch', async () => {
     const fixture = setup({
       batchRows: 6,
@@ -362,6 +389,35 @@ describe('change-streamer/sqlite-change-log-purge-scheduler', () => {
 
     expect(result.stopped).toBeUndefined();
     expect(watermarks(db)).toEqual([v(40)]);
+  });
+
+  test('the poll backstop finds the purge window a silent rollback opens', async () => {
+    const {db, scheduler, timers} = setup();
+    appendSeries(db, 1, 10);
+
+    const writer = new ChangeLogStreamWriter(new StatementRunner(db));
+    writer.begin(
+      v(40),
+      serializeChangeStreamData([
+        'begin',
+        {tag: 'begin'},
+        {commitWatermark: v(40)},
+      ]),
+    );
+
+    const cycle = scheduler.purge(v(8));
+    await microtasks();
+    expect(timers.delays()).toEqual([1_000]); // parked on the poll
+
+    // An interrupted stream rolls back with no commit notification —
+    // deliberately no onWriterIdle() here. Only the poll can find the window
+    // the rollback opened.
+    writer.rollback();
+    timers.fire();
+    const result = await cycle;
+
+    expect(result.stopped).toBeUndefined();
+    expect(minWatermark(db)).toBe(v(8));
   });
 
   test('an appending writer interleaves with a drain that tears an oversized transaction', async () => {
@@ -478,6 +534,87 @@ describe('change-streamer/sqlite-change-log-purge-scheduler', () => {
     expect(result.stopped).toBe('paused');
     expect(result.batches).toBe(1);
     expect(minWatermark(db)).toBe(v(1));
+  });
+
+  test('a batch queued behind a registration re-checks the writer under the lock', async () => {
+    const {db, scheduler, timers} = setup();
+    appendSeries(db, 1, 10);
+
+    let releaseGuard!: () => void;
+    const registration = scheduler.cleanupGuard.runWhilePurgeBlocked(
+      () => new Promise<void>(resolve => (releaseGuard = resolve)),
+    );
+    await microtasks();
+
+    const cycle = scheduler.purge(v(8));
+    await microtasks(); // the batch's lock acquisition is now queued
+
+    // The writer begins a transaction while the batch waits on the mutex —
+    // everything the loop's unlocked checks established is now stale.
+    const writer = new ChangeLogStreamWriter(new StatementRunner(db));
+    writer.begin(
+      v(40),
+      serializeChangeStreamData([
+        'begin',
+        {tag: 'begin'},
+        {commitWatermark: v(40)},
+      ]),
+    );
+
+    releaseGuard();
+    await registration;
+    const winner = await Promise.race([
+      cycle.then(() => 'done'),
+      microtasks().then(() => 'waiting'),
+    ]);
+    // The batch retried instead of running BEGIN IMMEDIATE inside the
+    // writer's open transaction: nothing was purged, and the cycle is parked
+    // on the commit notification with the poll as a backstop.
+    expect(winner).toBe('waiting');
+    expect(watermarks(db)).toContain(SEED_WATERMARK);
+    expect(timers.delays()).toEqual([1_000]);
+
+    writer.commit(
+      v(40),
+      serializeChangeStreamData([
+        'commit',
+        {tag: 'commit'},
+        {watermark: v(40)},
+      ]),
+      LONG_AGO - 1,
+    );
+    scheduler.onWriterIdle();
+    const result = await cycle;
+    expect(result.stopped).toBeUndefined();
+    expect(minWatermark(db)).toBe(v(8));
+  });
+
+  test('a batch queued behind a registration skips a writer that failed soft', async () => {
+    const {db, scheduler, timers, setConnection} = setup();
+    appendSeries(db, 1, 10);
+
+    let releaseGuard!: () => void;
+    const registration = scheduler.cleanupGuard.runWhilePurgeBlocked(
+      () => new Promise<void>(resolve => (releaseGuard = resolve)),
+    );
+    await microtasks();
+
+    const cycle = scheduler.purge(v(8));
+    await microtasks(); // the batch's lock acquisition is now queued
+
+    // The writer fails soft while the batch waits on the mutex.
+    setConnection(undefined);
+
+    releaseGuard();
+    await registration;
+    const result = await cycle;
+
+    // The batch's locked re-check saw the connection change and retried; the
+    // loop then skipped rather than purging on the stale handle.
+    expect(result.stopped).toBe('writer-unavailable');
+    expect(result.deletedRows).toBe(0);
+    expect(watermarks(db)).toContain(SEED_WATERMARK);
+    expect(timers.delays()).toEqual([30_000]);
   });
 
   test('a pause lands between batches and interrupts the drain', async () => {

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-purge-scheduler.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-purge-scheduler.test.ts
@@ -348,6 +348,36 @@ describe('change-streamer/sqlite-change-log-purge-scheduler', () => {
     expect(minWatermark(db)).toBe(v(20));
   });
 
+  test('a floor raised as the captured floor drains keeps the cycle running', async () => {
+    let scheduler!: SQLiteChangeLogPurgeScheduler;
+    let second: Promise<unknown> | undefined;
+    let raiseFloor = true;
+    const fixture = setup({
+      batchRows: 1_000,
+      now: () => {
+        if (raiseFloor) {
+          raiseFloor = false;
+          // Run after purgeBatch() has reported that floor 10 is drained but
+          // before #runCycle() resumes from awaiting the lock.
+          queueMicrotask(() => {
+            second = scheduler.purge(v(20));
+          });
+        }
+        return LONG_AGO;
+      },
+    });
+    ({scheduler} = fixture);
+    appendSeries(fixture.db, 1, 30);
+
+    const first = scheduler.purge(v(10));
+    const result = await first;
+
+    expect(second).toBe(first);
+    expect(result.floor).toBe(v(20));
+    expect(minWatermark(fixture.db)).toBe(v(20));
+    expect(fixture.timers.delays()).toEqual([]);
+  });
+
   test("purges only between the writer's commits", async () => {
     const {db, scheduler, timers} = setup();
     appendSeries(db, 1, 10);

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-purge-scheduler.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-purge-scheduler.test.ts
@@ -1,0 +1,591 @@
+import {afterEach, describe, expect, test} from 'vitest';
+import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
+import type {Database} from '../../../../zqlite/src/db.ts';
+import {StatementRunner} from '../../db/statements.ts';
+import {DbFile} from '../../test/lite.ts';
+import {versionToLexi} from '../../types/lexi-version.ts';
+import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
+import {
+  CHANGE_LOG_STREAM_TABLE,
+  changeLogFileName,
+  deleteChangeLogDB,
+  openChangeLogDBForWriting,
+  type ChangeLogAnchor,
+} from '../replicator/change-log-db.ts';
+import {ChangeLogStreamWriter} from '../replicator/change-log-stream-writer.ts';
+import {serializeChangeStreamData} from './change-log-codec.ts';
+import {
+  SQLiteChangeLogPurgeScheduler,
+  type SQLiteChangeLogPurgeSchedulerOptions,
+} from './sqlite-change-log-purge-scheduler.ts';
+import {SQLiteChangeLogReader} from './sqlite-change-log-reader.ts';
+
+const lc = createSilentLogContext();
+
+/** Watermarks in the encoding the change stream actually uses. */
+function v(n: number): string {
+  return versionToLexi(n);
+}
+
+const SEED_WATERMARK = v(0);
+const SEED_WRITE_TIME_MS = 1_000;
+
+/** A floor above every watermark any fixture writes. */
+const NO_FLOOR = v(1_000_000);
+
+/** A clock far enough ahead that every fixture row is past retention. */
+const LONG_AGO = 10_000_000;
+
+const files: DbFile[] = [];
+
+afterEach(() => {
+  for (const file of files.splice(0)) {
+    deleteChangeLogDB(file.path);
+    file.delete();
+  }
+});
+
+/** Appends a transaction the way the writer does. */
+function append(
+  db: Database,
+  watermark: string,
+  changes: number,
+  writeTimeMs: number,
+): void {
+  const writer = new ChangeLogStreamWriter(new StatementRunner(db));
+  const begin: ChangeStreamData = [
+    'begin',
+    {tag: 'begin'},
+    {commitWatermark: watermark},
+  ];
+  const truncate: ChangeStreamData = ['data', {tag: 'truncate', relations: []}];
+  const commit: ChangeStreamData = ['commit', {tag: 'commit'}, {watermark}];
+  try {
+    writer.begin(watermark, serializeChangeStreamData(begin));
+    for (let i = 0; i < changes; i++) {
+      writer.append(serializeChangeStreamData(truncate), 'truncate');
+    }
+    writer.commit(watermark, serializeChangeStreamData(commit), writeTimeMs);
+  } catch (e) {
+    writer.rollback();
+    throw e;
+  }
+}
+
+/**
+ * Appends `count` transactions of `changes` changes each, numbered from
+ * `from`, with `writeTimeMs` advancing with the watermark.
+ */
+function appendSeries(
+  db: Database,
+  from: number,
+  count: number,
+  changes = 1,
+): void {
+  for (let i = 0; i < count; i++) {
+    const n = from + i;
+    append(db, v(n), changes, SEED_WRITE_TIME_MS + n);
+  }
+}
+
+function watermarks(db: Database): string[] {
+  return db
+    .prepare(/*sql*/ `
+      SELECT DISTINCT "watermark" FROM "${CHANGE_LOG_STREAM_TABLE}"
+      ORDER BY "watermark"
+    `)
+    .all<{watermark: string}>()
+    .map(({watermark}) => watermark);
+}
+
+function minWatermark(db: Database): string | null {
+  return db
+    .prepare(/*sql*/ `
+      SELECT min("watermark") AS "min" FROM "${CHANGE_LOG_STREAM_TABLE}"
+    `)
+    .get<{min: string | null}>().min;
+}
+
+type FakeTimers = {
+  /** Pending delays, in scheduling order. */
+  delays(): number[];
+  /** Fires every currently pending timer. */
+  fire(): void;
+};
+
+type Fixture = {
+  db: Database;
+  file: DbFile;
+  scheduler: SQLiteChangeLogPurgeScheduler;
+  timers: FakeTimers;
+  setAcks(acks: string[]): void;
+  setNow(nowMs: number): void;
+  setConnection(db: Database | undefined): void;
+};
+
+function setup(
+  opts: Partial<SQLiteChangeLogPurgeSchedulerOptions> & {
+    resumeWatermark?: string;
+    connected?: boolean;
+  } = {},
+): Fixture {
+  const file = new DbFile('sqlite-change-log-purge-scheduler');
+  files.push(file);
+  const anchor: ChangeLogAnchor = {
+    identity: {epoch: null, generation: '01', replicaID: null},
+    resumeWatermark: opts.resumeWatermark ?? SEED_WATERMARK,
+    nowMs: SEED_WRITE_TIME_MS,
+  };
+  const {db} = openChangeLogDBForWriting(lc, file.path, anchor);
+
+  let connection: Database | undefined =
+    (opts.connected ?? true) ? db : undefined;
+  let acks: string[] = [NO_FLOOR];
+  let nowMs = LONG_AGO;
+
+  const pending = new Map<number, {fn: () => void; delay: number}>();
+  let nextTimer = 1;
+  const setTimeoutFn = ((fn: () => void, delay?: number) => {
+    const id = nextTimer++;
+    pending.set(id, {fn, delay: delay ?? 0});
+    return id;
+  }) as unknown as typeof setTimeout;
+  const clearTimeoutFn = ((id: unknown) => {
+    pending.delete(id as number);
+  }) as unknown as typeof clearTimeout;
+
+  const scheduler = new SQLiteChangeLogPurgeScheduler(
+    lc,
+    () => connection,
+    () => acks,
+    {
+      retentionMs: 1_000,
+      batchRows: 10,
+      statementTargetMs: 1_000,
+      maxBatchesPerCycle: 100,
+      recheckIntervalMs: 30_000,
+      inTransactionPollMs: 1_000,
+      now: () => nowMs,
+      setTimeoutFn,
+      clearTimeoutFn,
+      yieldFn: () => Promise.resolve(),
+      ...opts,
+    },
+  );
+
+  return {
+    db,
+    file,
+    scheduler,
+    timers: {
+      delays: () => Array.from(pending.values(), ({delay}) => delay),
+      fire: () => {
+        const due = [...pending.values()];
+        pending.clear();
+        due.forEach(({fn}) => fn());
+      },
+    },
+    setAcks: next => {
+      acks = next;
+    },
+    setNow: next => {
+      nowMs = next;
+    },
+    setConnection: next => {
+      connection = next;
+    },
+  };
+}
+
+/** Enough microtask turns for any settled work to finish, without timers. */
+async function microtasks(turns = 50): Promise<void> {
+  for (let i = 0; i < turns; i++) {
+    await Promise.resolve();
+  }
+}
+
+describe('change-streamer/sqlite-change-log-purge-scheduler', () => {
+  test('drains eligible history and retains the transaction at the floor', async () => {
+    const {db, scheduler, file} = setup();
+    appendSeries(db, 1, 20);
+
+    const result = await scheduler.purge(v(10));
+
+    expect(result.stopped).toBeUndefined();
+    expect(result.deletedRows).toBeGreaterThan(0);
+    // Strictly below the floor: the transaction *at* the floor survives as a
+    // restoring follower's catchup boundary.
+    expect(minWatermark(db)).toBe(v(10));
+    expect(result.probe).toBe('retained');
+
+    using reader = new SQLiteChangeLogReader(lc, changeLogFileName(file.path));
+    expect(reader.plan(v(10)).kind).toBe('range');
+    expect(reader.plan(v(9)).kind).toBe('too-old');
+  });
+
+  test('the head cap retains the latest transaction under a stale-log floor', async () => {
+    const {db, scheduler} = setup();
+    appendSeries(db, 1, 5);
+
+    const result = await scheduler.purge(NO_FLOOR);
+
+    expect(result.stopped).toBeUndefined();
+    expect(watermarks(db)).toEqual([v(5)]);
+    // The floor ran past a frozen log; nothing at the floor was ever purged.
+    expect(result.probe).toBe('ahead');
+  });
+
+  test('bounded batches per cycle, with an immediate continuation', async () => {
+    const {db, scheduler, timers} = setup({
+      batchRows: 4,
+      maxBatchesPerCycle: 2,
+    });
+    appendSeries(db, 1, 20);
+
+    const first = await scheduler.purge(v(15));
+    expect(first.stopped).toBe('batch-limit');
+    expect(first.batches).toBe(2);
+    expect(minWatermark(db)).not.toBe(v(15));
+    // The continuation is scheduled immediately -- the limit bounds one
+    // cycle's bookkeeping, not the drain.
+    expect(timers.delays()).toEqual([0]);
+
+    // Repeated dispatches drain to the floor.
+    for (let i = 0; i < 10; i++) {
+      timers.fire();
+      await scheduler.purge(v(15));
+    }
+    expect(minWatermark(db)).toBe(v(15));
+  });
+
+  test('declines when a subscriber ACK is behind the floor, and with no subscribers', async () => {
+    const {db, scheduler, setAcks} = setup();
+    appendSeries(db, 1, 10);
+
+    setAcks([v(3)]);
+    let result = await scheduler.purge(v(8));
+    expect(result.stopped).toBe('subscriber-behind');
+    expect(result.deletedRows).toBe(0);
+
+    setAcks([]);
+    result = await scheduler.purge(v(8));
+    expect(result.stopped).toBe('no-subscribers');
+    expect(result.deletedRows).toBe(0);
+
+    // The gate is evaluated at dispatch, not at schedule: once the lagging
+    // subscriber has ACKed past the floor, the same floor purges.
+    setAcks([v(8), v(20)]);
+    result = await scheduler.purge(v(8));
+    expect(result.stopped).toBeUndefined();
+    expect(minWatermark(db)).toBe(v(8));
+  });
+
+  test('a registration mid-drain is honored by the very next batch', async () => {
+    const fixture = setup({
+      batchRows: 6,
+      yieldFn: async () => {
+        // Runs between batches, where the guard must be free: a guard held
+        // for the cycle would deadlock this registration.
+        if (!registered) {
+          registered = true;
+          await fixture.scheduler.cleanupGuard.runWhilePurgeBlocked(() => {
+            fixture.setAcks([v(15)]);
+          });
+        }
+      },
+    });
+    let registered = false;
+    const {db, scheduler, file} = fixture;
+    appendSeries(db, 1, 30);
+
+    const result = await scheduler.purge(NO_FLOOR);
+
+    // The batch after the registration saw the new ACK and declined, so the
+    // range the subscriber needs survives.
+    expect(registered).toBe(true);
+    expect(result.stopped).toBe('subscriber-behind');
+    using reader = new SQLiteChangeLogReader(lc, changeLogFileName(file.path));
+    expect(reader.plan(v(15)).kind).toBe('range');
+  });
+
+  test('a floor raised by a coalesced dispatch applies to the running drain', async () => {
+    const {db, scheduler} = setup({batchRows: 4});
+    appendSeries(db, 1, 30);
+
+    const first = scheduler.purge(v(10));
+    const second = scheduler.purge(v(20));
+    // The second dispatch coalesced into the running cycle...
+    expect(second).toBe(first);
+    await first;
+    // ...and raised its floor.
+    expect(minWatermark(db)).toBe(v(20));
+  });
+
+  test("purges only between the writer's commits", async () => {
+    const {db, scheduler, timers} = setup();
+    appendSeries(db, 1, 10);
+
+    // The writer opens a transaction, as the stream loop does mid-transaction.
+    const writer = new ChangeLogStreamWriter(new StatementRunner(db));
+    writer.begin(
+      v(40),
+      serializeChangeStreamData([
+        'begin',
+        {tag: 'begin'},
+        {commitWatermark: v(40)},
+      ]),
+    );
+    expect(db.inTransaction).toBe(true);
+
+    const cycle = scheduler.purge(NO_FLOOR);
+    const winner = await Promise.race([
+      cycle.then(() => 'done'),
+      microtasks().then(() => 'waiting'),
+    ]);
+    // No batch ran inside the writer's open transaction; the cycle is parked
+    // on the commit notification, with the poll interval as a backstop.
+    expect(winner).toBe('waiting');
+    expect(watermarks(db)).toContain(SEED_WATERMARK);
+    expect(timers.delays()).toEqual([1_000]);
+
+    writer.commit(
+      v(40),
+      serializeChangeStreamData([
+        'commit',
+        {tag: 'commit'},
+        {watermark: v(40)},
+      ]),
+      LONG_AGO - 1,
+    );
+    scheduler.onWriterIdle();
+    const result = await cycle;
+
+    expect(result.stopped).toBeUndefined();
+    expect(watermarks(db)).toEqual([v(40)]);
+  });
+
+  test('an appending writer interleaves with a drain that tears an oversized transaction', async () => {
+    const fixture = setup({
+      batchRows: 8,
+      yieldFn: () => {
+        // A live write stream between batches: the guard and the connection
+        // are both free, so the append must succeed mid-drain.
+        appended++;
+        append(fixture.db, v(100 + appended), 1, LONG_AGO - 1);
+        return Promise.resolve();
+      },
+    });
+    let appended = 0;
+    const {db, scheduler} = fixture;
+    // One transaction far larger than a batch, i.e. the tear (§3.5), followed
+    // by a small one so the oversized transaction is not the head (which is
+    // never a purge candidate).
+    append(db, v(1), 60, SEED_WRITE_TIME_MS + 1);
+    append(db, v(2), 1, SEED_WRITE_TIME_MS + 2);
+
+    const result = await scheduler.purge(NO_FLOOR);
+
+    expect(result.stopped).toBeUndefined();
+    expect(result.batches).toBeGreaterThan(3);
+    expect(appended).toBeGreaterThan(0);
+    // The torn transaction is gone whole; the live appends all survived.
+    const retained = watermarks(db);
+    expect(retained).not.toContain(v(1));
+    for (let i = 1; i <= appended; i++) {
+      expect(retained).toContain(v(100 + i));
+    }
+  });
+
+  test('reservations pause purging and resume only when every one has ended', async () => {
+    const {db, scheduler, timers, setNow} = setup();
+    appendSeries(db, 1, 10);
+
+    await scheduler.pause('task-a');
+    await scheduler.pause('task-b');
+
+    const paused = await scheduler.purge(v(8));
+    expect(paused.stopped).toBe('paused');
+    expect(paused.deletedRows).toBe(0);
+    expect(watermarks(db)).toContain(SEED_WATERMARK);
+
+    scheduler.resume('task-a');
+    expect(timers.delays()).toEqual([]); // task-b still holds a reservation
+    const stillPaused = await scheduler.purge(v(8));
+    expect(stillPaused.stopped).toBe('paused');
+
+    scheduler.resume('task-b');
+    expect(timers.delays()).toEqual([0]);
+    setNow(LONG_AGO + 1);
+    timers.fire();
+    await scheduler.purge(v(8));
+    expect(minWatermark(db)).toBe(v(8));
+  });
+
+  test('overlapping reservations from one taskID are reference-counted', async () => {
+    const {db, scheduler} = setup();
+    appendSeries(db, 1, 10);
+
+    // A reservation retry can resolve its old resume after its new suspend.
+    await scheduler.pause('task-a');
+    await scheduler.pause('task-a');
+    scheduler.resume('task-a');
+
+    const result = await scheduler.purge(v(8));
+    expect(result.stopped).toBe('paused');
+
+    scheduler.resume('task-a');
+    scheduler.resume('task-a'); // unknown once the count is drained: ignored
+    expect((await scheduler.purge(v(8))).stopped).toBeUndefined();
+    expect(minWatermark(db)).toBe(v(8));
+  });
+
+  test('a pause lands between batches and interrupts the drain', async () => {
+    const fixture = setup({
+      batchRows: 4,
+      yieldFn: async () => {
+        if (!paused) {
+          paused = true;
+          await fixture.scheduler.pause('restorer');
+        }
+      },
+    });
+    let paused = false;
+    const {db, scheduler, timers} = fixture;
+    appendSeries(db, 1, 30);
+
+    const result = await scheduler.purge(v(25));
+    expect(result.stopped).toBe('paused');
+    expect(result.batches).toBeGreaterThan(0);
+    const atPause = watermarks(db);
+    expect(atPause.length).toBeGreaterThan(1); // the drain did not finish
+
+    // Ending the reservation resumes the interrupted drain.
+    scheduler.resume('restorer');
+    timers.fire();
+    await scheduler.purge(v(25));
+    expect(minWatermark(db)).toBe(v(25));
+  });
+
+  test('skips at debug until the writer opens the log, then picks it up', async () => {
+    const {db, scheduler, timers, setConnection} = setup({connected: false});
+    appendSeries(db, 1, 10);
+
+    const skipped = await scheduler.purge(v(8));
+    expect(skipped.stopped).toBe('writer-unavailable');
+    expect(skipped.probe).toBeUndefined();
+    expect(watermarks(db)).toContain(SEED_WATERMARK);
+    expect(timers.delays()).toEqual([30_000]);
+
+    // The change-log file appears (the writer's first reconcile): the next
+    // cycle picks it up without a restart.
+    setConnection(db);
+    timers.fire();
+    await scheduler.purge(v(8));
+    expect(minWatermark(db)).toBe(v(8));
+  });
+
+  test('a quiet source still drains once young history ages out', async () => {
+    const {db, scheduler, timers, setNow} = setup();
+    appendSeries(db, 1, 30);
+    // Only transactions written before the cutoff are eligible on the first
+    // cycle; the rest are within the minimum retention window.
+    setNow(SEED_WRITE_TIME_MS + 20 + 1_000);
+
+    const first = await scheduler.purge(v(25));
+    expect(first.stopped).toBeUndefined();
+    expect(minWatermark(db)).toBe(v(20));
+    // History below the floor remains, so the recheck timer is armed.
+    expect(timers.delays()).toEqual([30_000]);
+
+    // No new cleanup watermark ever arrives; the clock alone releases the
+    // rest.
+    setNow(LONG_AGO);
+    timers.fire();
+    await scheduler.purge(v(25));
+    expect(minWatermark(db)).toBe(v(25));
+  });
+
+  test('a stale floor stalls purge; the boundary stays servable end to end', async () => {
+    const {db, scheduler, file, setNow} = setup();
+    appendSeries(db, 1, 10);
+    setNow(LONG_AGO);
+
+    // The backup watermark is W: purge, then restore-then-catch-up from W.
+    await scheduler.purge(v(5));
+    using reader = new SQLiteChangeLogReader(lc, changeLogFileName(file.path));
+    expect(reader.plan(v(5)).kind).toBe('range');
+
+    // Live traffic continues but the backup watermark is held stale: purge
+    // must stall at the floor rather than advance past it.
+    appendSeries(db, 11, 10);
+    setNow(LONG_AGO + 10_000);
+    const stalled = await scheduler.purge(v(5));
+    expect(stalled.deletedRows).toBe(0);
+    expect(minWatermark(db)).toBe(v(5));
+    expect(reader.plan(v(5)).kind).toBe('range');
+
+    // The backup advances; the old boundary ages out, the new one survives.
+    await scheduler.purge(v(15));
+    expect(reader.plan(v(15)).kind).toBe('range');
+    expect(reader.plan(v(5)).kind).toBe('too-old');
+  });
+
+  test('the probe distinguishes a cold log from a violation', async () => {
+    // A log seeded above the floor never held that history: `too-old` at the
+    // floor is the routine state at every fork and resumption, not an alert.
+    {
+      const {scheduler, setAcks} = setup({resumeWatermark: v(100)});
+      setAcks([v(200)]);
+      const result = await scheduler.purge(v(50));
+      expect(result.stopped).toBeUndefined();
+      expect(result.deletedRows).toBe(0);
+      expect(result.probe).toBe('cold-log');
+    }
+
+    // A log seeded below the floor whose history at the floor is gone has
+    // purged past it: the violation the probe exists to catch.
+    {
+      const {db, scheduler} = setup();
+      appendSeries(db, 1, 20);
+      // Not the purger's doing -- its own tests pin that it cannot -- but the
+      // state a wrong floor would leave behind.
+      db.exec(/*sql*/ `
+        DELETE FROM "${CHANGE_LOG_STREAM_TABLE}" WHERE "watermark" <= '${v(10)}'
+      `);
+      const result = await scheduler.purge(v(10));
+      expect(result.probe).toBe('violation');
+    }
+  });
+
+  test('a failed cycle reports an error and re-arms instead of throwing', async () => {
+    const {db, scheduler, timers} = setup();
+    appendSeries(db, 1, 10);
+    db.exec(/*sql*/ `DROP TABLE "${CHANGE_LOG_STREAM_TABLE}"`);
+
+    const result = await scheduler.purge(v(8));
+    expect(result.stopped).toBe('error');
+    expect(timers.delays()).toEqual([30_000]);
+  });
+
+  test('stop ends cycles and unparks a waiting batch', async () => {
+    const {db, scheduler} = setup();
+    appendSeries(db, 1, 10);
+    const writer = new ChangeLogStreamWriter(new StatementRunner(db));
+    writer.begin(
+      v(40),
+      serializeChangeStreamData([
+        'begin',
+        {tag: 'begin'},
+        {commitWatermark: v(40)},
+      ]),
+    );
+
+    const cycle = scheduler.purge(NO_FLOOR);
+    scheduler.stop();
+    const result = await cycle;
+    expect(result.stopped).toBe('stopped');
+    writer.rollback();
+
+    expect((await scheduler.purge(NO_FLOOR)).stopped).toBe('stopped');
+  });
+});

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-purge-scheduler.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-purge-scheduler.test.ts
@@ -236,6 +236,38 @@ describe('change-streamer/sqlite-change-log-purge-scheduler', () => {
     expect(result.probe).toBe('ahead');
   });
 
+  test('a floor ahead of the head stays armed for replayed commits', async () => {
+    const {db, scheduler} = setup();
+    appendSeries(db, 1, 5);
+
+    // The backup outran this log: the pass drains to the head cap but must
+    // stay deferred. The writer will replay commits below the unchanged
+    // floor, and neither those commits nor the backup monitor (which never
+    // resends an unchanged floor) re-arms cleanup — quiescence here would
+    // disarm it for good.
+    const ahead = await scheduler.purge(v(10));
+    expect(ahead.stopped).toBeUndefined();
+    expect(ahead.probe).toBe('ahead');
+    expect(watermarks(db)).toEqual([v(5)]);
+    expect(ahead.continuation).toBe('deferred');
+
+    // Mid-replay: the head is still behind the floor, so cleanup stays armed
+    // even though everything below the head has drained.
+    appendSeries(db, 6, 3);
+    const partial = await scheduler.purge(v(10));
+    expect(partial.stopped).toBeUndefined();
+    expect(watermarks(db)).toEqual([v(8)]);
+    expect(partial.continuation).toBe('deferred');
+
+    // Replay reaches the floor: the drain completes and cleanup disarms.
+    appendSeries(db, 9, 2);
+    const caughtUp = await scheduler.purge(v(10));
+    expect(caughtUp.stopped).toBeUndefined();
+    expect(watermarks(db)).toEqual([v(10)]);
+    expect(caughtUp.probe).toBe('retained');
+    expect(caughtUp.continuation).toBeUndefined();
+  });
+
   test('bounded batches per pass request an immediate continuation', async () => {
     const {db, scheduler} = setup({
       batchRows: 4,
@@ -1165,6 +1197,14 @@ describe('change-streamer/sqlite-change-log-purge-scheduler', () => {
 
               floorNum = snapFloor(finalFloorNum);
               const finalFloor = v(floorNum);
+              // Two terminal states: an undefined continuation, or — under a
+              // frozen floor the head can never reach — a stable no-progress
+              // 'deferred' that keeps cleanup armed for replayed rows.
+              const terminal = (r: PurgePassResult) =>
+                r.continuation === undefined ||
+                (r.stopped === undefined &&
+                  r.deletedRows === 0 &&
+                  r.continuation === 'deferred');
               let last: PurgePassResult;
               for (let passes = 0; ; passes++) {
                 // Termination: the drain reaches quiescence in bounded passes.
@@ -1172,17 +1212,25 @@ describe('change-streamer/sqlite-change-log-purge-scheduler', () => {
                 last = await scheduler.purge(finalFloor);
                 results.push(last);
                 checkResult(last);
-                if (last.continuation === undefined) {
+                if (terminal(last)) {
                   break;
                 }
               }
               expect(last.stopped).toBeUndefined();
 
+              // No lost floor: however the loop exited, nothing below both
+              // the final floor and the head survives.
+              const finalWms = [...rowCounts(db).keys()];
+              const finalHead = finalWms.reduce((a, b) => (a > b ? a : b));
+              for (const w of finalWms) {
+                expect(w >= finalFloor || w === finalHead).toBe(true);
+              }
+
               // Quiescence is stable, and no timer or yield is left parked.
               const extra = await scheduler.purge(finalFloor);
               results.push(extra);
               expect(extra.deletedRows).toBe(0);
-              expect(extra.continuation).toBeUndefined();
+              expect(extra.continuation).toBe(last.continuation);
               expect(timers.delays()).toEqual([]);
               expect(parkedYields).toEqual([]);
 

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-purge-scheduler.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-purge-scheduler.test.ts
@@ -162,8 +162,7 @@ function setup(
       retentionMs: 1_000,
       batchRows: 10,
       statementTargetMs: 1_000,
-      maxBatchesPerCycle: 100,
-      recheckIntervalMs: 30_000,
+      maxBatchesPerPass: 100,
       inTransactionPollMs: 1_000,
       now: () => nowMs,
       setTimeoutFn,
@@ -235,27 +234,29 @@ describe('change-streamer/sqlite-change-log-purge-scheduler', () => {
     expect(result.probe).toBe('ahead');
   });
 
-  test('bounded batches per cycle, with an immediate continuation', async () => {
-    const {db, scheduler, timers} = setup({
+  test('bounded batches per pass request an immediate continuation', async () => {
+    const {db, scheduler} = setup({
       batchRows: 4,
-      maxBatchesPerCycle: 2,
+      maxBatchesPerPass: 2,
     });
     appendSeries(db, 1, 20);
 
     const first = await scheduler.purge(v(15));
     expect(first.stopped).toBe('batch-limit');
     expect(first.batches).toBe(2);
+    expect(first.continuation).toBe('immediate');
     expect(minWatermark(db)).not.toBe(v(15));
-    // The continuation is scheduled immediately -- the limit bounds one
-    // cycle's bookkeeping, not the drain.
-    expect(timers.delays()).toEqual([0]);
 
-    // Repeated dispatches drain to the floor.
+    // The cleanup coordinator follows the result until the pass drains.
+    let result = first;
     for (let i = 0; i < 10; i++) {
-      timers.fire();
-      await scheduler.purge(v(15));
+      if (result.continuation === undefined) {
+        break;
+      }
+      result = await scheduler.purge(v(15));
     }
     expect(minWatermark(db)).toBe(v(15));
+    expect(result.continuation).toBeUndefined();
   });
 
   test('declines only when a connected subscriber ACK is behind the floor', async () => {
@@ -266,6 +267,7 @@ describe('change-streamer/sqlite-change-log-purge-scheduler', () => {
     let result = await scheduler.purge(v(8));
     expect(result.stopped).toBe('subscriber-behind');
     expect(result.deletedRows).toBe(0);
+    expect(result.continuation).toBe('deferred');
 
     setAcks([]);
     result = await scheduler.purge(v(8));
@@ -273,25 +275,21 @@ describe('change-streamer/sqlite-change-log-purge-scheduler', () => {
     expect(minWatermark(db)).toBe(v(8));
   });
 
-  test('a decline arms the recheck timer, which alone lifts it', async () => {
-    const {db, scheduler, timers, setAcks} = setup();
+  test('a deferred pass observes a subscriber that has caught up', async () => {
+    const {db, scheduler, setAcks} = setup();
     appendSeries(db, 1, 10);
 
     setAcks([v(3)]);
     const declined = await scheduler.purge(v(8));
     expect(declined.stopped).toBe('subscriber-behind');
-    // Nothing notifies when the lagging subscriber ACKs past the floor, so
-    // the recheck timer is the only thing that ever lifts a decline.
-    expect(timers.delays()).toEqual([30_000]);
+    expect(declined.continuation).toBe('deferred');
 
-    // The subscriber catches up; the timer alone — no new purge() dispatch —
-    // resumes the drain.
+    // Subscriber ACKs are level-triggered rather than notifications. The
+    // cleanup coordinator follows the deferred result with another pass.
     setAcks([v(20)]);
-    timers.fire();
-    await microtasks();
+    const result = await scheduler.purge(v(8));
     expect(minWatermark(db)).toBe(v(8));
-    // Drained to the floor with nothing below it: no timer left armed.
-    expect(timers.delays()).toEqual([]);
+    expect(result.continuation).toBeUndefined();
   });
 
   test('a registration mid-drain is honored by the very next batch', async () => {
@@ -299,7 +297,7 @@ describe('change-streamer/sqlite-change-log-purge-scheduler', () => {
       batchRows: 6,
       yieldFn: async () => {
         // Runs between batches, where the guard must be free: a guard held
-        // for the cycle would deadlock this registration.
+        // for the pass would deadlock this registration.
         if (!registered) {
           registered = true;
           await fixture.scheduler.cleanupGuard.runWhilePurgeBlocked(() => {
@@ -320,49 +318,6 @@ describe('change-streamer/sqlite-change-log-purge-scheduler', () => {
     expect(result.stopped).toBe('subscriber-behind');
     using reader = new SQLiteChangeLogReader(lc, changeLogFileName(file.path));
     expect(reader.plan(v(15)).kind).toBe('range');
-  });
-
-  test('a floor raised by a coalesced dispatch applies to the running drain', async () => {
-    const {db, scheduler} = setup({batchRows: 4});
-    appendSeries(db, 1, 30);
-
-    const first = scheduler.purge(v(10));
-    const second = scheduler.purge(v(20));
-    // The second dispatch coalesced into the running cycle...
-    expect(second).toBe(first);
-    await first;
-    // ...and raised its floor.
-    expect(minWatermark(db)).toBe(v(20));
-  });
-
-  test('a floor raised as the captured floor drains keeps the cycle running', async () => {
-    let scheduler!: SQLiteChangeLogPurgeScheduler;
-    let second: Promise<unknown> | undefined;
-    let raiseFloor = true;
-    const fixture = setup({
-      batchRows: 1_000,
-      now: () => {
-        if (raiseFloor) {
-          raiseFloor = false;
-          // Run after purgeBatch() has reported that floor 10 is drained but
-          // before #runCycle() resumes from awaiting the lock.
-          queueMicrotask(() => {
-            second = scheduler.purge(v(20));
-          });
-        }
-        return LONG_AGO;
-      },
-    });
-    ({scheduler} = fixture);
-    appendSeries(fixture.db, 1, 30);
-
-    const first = scheduler.purge(v(10));
-    const result = await first;
-
-    expect(second).toBe(first);
-    expect(result.floor).toBe(v(20));
-    expect(minWatermark(fixture.db)).toBe(v(20));
-    expect(fixture.timers.delays()).toEqual([]);
   });
 
   test("purges only between the writer's commits", async () => {
@@ -470,7 +425,7 @@ describe('change-streamer/sqlite-change-log-purge-scheduler', () => {
   });
 
   test('reservations pause purging and resume only when every one has ended', async () => {
-    const {db, scheduler, timers, setNow} = setup();
+    const {db, scheduler} = setup();
     appendSeries(db, 1, 10);
 
     await scheduler.pause('task-a');
@@ -479,17 +434,14 @@ describe('change-streamer/sqlite-change-log-purge-scheduler', () => {
     const paused = await scheduler.purge(v(8));
     expect(paused.stopped).toBe('paused');
     expect(paused.deletedRows).toBe(0);
+    expect(paused.continuation).toBe('deferred');
     expect(watermarks(db)).toContain(SEED_WATERMARK);
 
     scheduler.resume('task-a');
-    expect(timers.delays()).toEqual([]); // task-b still holds a reservation
     const stillPaused = await scheduler.purge(v(8));
     expect(stillPaused.stopped).toBe('paused');
 
     scheduler.resume('task-b');
-    expect(timers.delays()).toEqual([0]);
-    setNow(LONG_AGO + 1);
-    timers.fire();
     await scheduler.purge(v(8));
     expect(minWatermark(db)).toBe(v(8));
   });
@@ -517,7 +469,7 @@ describe('change-streamer/sqlite-change-log-purge-scheduler', () => {
     appendSeries(db, 1, 30);
 
     // Hold the purge mutex, as a catchup registration does, so that the
-    // cycle's first batch queues behind it: a batch "in flight" — dispatched
+    // pass's first batch queues behind it: a batch "in flight" — dispatched
     // but not yet run — at the moment the reservation arrives.
     let releaseGuard!: () => void;
     const registration = scheduler.cleanupGuard.runWhilePurgeBlocked(
@@ -607,7 +559,7 @@ describe('change-streamer/sqlite-change-log-purge-scheduler', () => {
   });
 
   test('a batch queued behind a registration skips a writer that failed soft', async () => {
-    const {db, scheduler, timers, setConnection} = setup();
+    const {db, scheduler, setConnection} = setup();
     appendSeries(db, 1, 10);
 
     let releaseGuard!: () => void;
@@ -630,8 +582,8 @@ describe('change-streamer/sqlite-change-log-purge-scheduler', () => {
     // loop then skipped rather than purging on the stale handle.
     expect(result.stopped).toBe('writer-unavailable');
     expect(result.deletedRows).toBe(0);
+    expect(result.continuation).toBe('deferred');
     expect(watermarks(db)).toContain(SEED_WATERMARK);
-    expect(timers.delays()).toEqual([30_000]);
   });
 
   test('a pause lands between batches and interrupts the drain', async () => {
@@ -645,7 +597,7 @@ describe('change-streamer/sqlite-change-log-purge-scheduler', () => {
       },
     });
     let paused = false;
-    const {db, scheduler, timers} = fixture;
+    const {db, scheduler} = fixture;
     appendSeries(db, 1, 30);
 
     const result = await scheduler.purge(v(25));
@@ -654,50 +606,50 @@ describe('change-streamer/sqlite-change-log-purge-scheduler', () => {
     const atPause = watermarks(db);
     expect(atPause.length).toBeGreaterThan(1); // the drain did not finish
 
-    // Ending the reservation resumes the interrupted drain.
+    // Ending the reservation lets the coordinator's next pass resume the
+    // interrupted drain.
     scheduler.resume('restorer');
-    timers.fire();
     await scheduler.purge(v(25));
     expect(minWatermark(db)).toBe(v(25));
   });
 
   test('skips at debug until the writer opens the log, then picks it up', async () => {
-    const {db, scheduler, timers, setConnection} = setup({connected: false});
+    const {db, scheduler, setConnection} = setup({connected: false});
     appendSeries(db, 1, 10);
 
     const skipped = await scheduler.purge(v(8));
     expect(skipped.stopped).toBe('writer-unavailable');
     expect(skipped.probe).toBeUndefined();
+    expect(skipped.continuation).toBe('deferred');
     expect(watermarks(db)).toContain(SEED_WATERMARK);
-    expect(timers.delays()).toEqual([30_000]);
 
     // The change-log file appears (the writer's first reconcile): the next
-    // cycle picks it up without a restart.
+    // pass picks it up without a restart.
     setConnection(db);
-    timers.fire();
     await scheduler.purge(v(8));
     expect(minWatermark(db)).toBe(v(8));
   });
 
   test('a quiet source still drains once young history ages out', async () => {
-    const {db, scheduler, timers, setNow} = setup();
+    const {db, scheduler, setNow} = setup();
     appendSeries(db, 1, 30);
     // Only transactions written before the cutoff are eligible on the first
-    // cycle; the rest are within the minimum retention window.
+    // pass; the rest are within the minimum retention window.
     setNow(SEED_WRITE_TIME_MS + 20 + 1_000);
 
     const first = await scheduler.purge(v(25));
     expect(first.stopped).toBeUndefined();
     expect(minWatermark(db)).toBe(v(20));
-    // History below the floor remains, so the recheck timer is armed.
-    expect(timers.delays()).toEqual([30_000]);
+    // History below the floor remains, so the coordinator gets a deferred
+    // continuation even though the source is quiet.
+    expect(first.continuation).toBe('deferred');
 
-    // No new cleanup watermark ever arrives; the clock alone releases the
-    // rest.
+    // No new cleanup watermark arrives; a later level-triggered pass observes
+    // the advanced clock and releases the rest.
     setNow(LONG_AGO);
-    timers.fire();
-    await scheduler.purge(v(25));
+    const second = await scheduler.purge(v(25));
     expect(minWatermark(db)).toBe(v(25));
+    expect(second.continuation).toBeUndefined();
   });
 
   test('a stale floor stalls purge; the boundary stays servable end to end', async () => {
@@ -770,7 +722,7 @@ describe('change-streamer/sqlite-change-log-purge-scheduler', () => {
         return Promise.resolve();
       },
     });
-    const {db, scheduler, timers} = fixture;
+    const {db, scheduler} = fixture;
     appendSeries(db, 1, 30);
 
     const result = await scheduler.purge(v(25));
@@ -779,20 +731,20 @@ describe('change-streamer/sqlite-change-log-purge-scheduler', () => {
     expect(result.batches).toBe(1);
     expect(result.deletedRows).toBeGreaterThan(0);
     expect(result.probe).toBe('retained');
-    expect(timers.delays()).toEqual([30_000]);
+    expect(result.continuation).toBe('deferred');
   });
 
-  test('a failed cycle reports an error and re-arms instead of throwing', async () => {
-    const {db, scheduler, timers} = setup();
+  test('a failed pass reports an error and requests a retry', async () => {
+    const {db, scheduler} = setup();
     appendSeries(db, 1, 10);
     db.exec(/*sql*/ `DROP TABLE "${CHANGE_LOG_STREAM_TABLE}"`);
 
     const result = await scheduler.purge(v(8));
     expect(result.stopped).toBe('error');
-    expect(timers.delays()).toEqual([30_000]);
+    expect(result.continuation).toBe('deferred');
   });
 
-  test('stop ends cycles and unparks a waiting batch', async () => {
+  test('stop ends passes and unparks a waiting batch', async () => {
     const {db, scheduler} = setup();
     appendSeries(db, 1, 10);
     const writer = new ChangeLogStreamWriter(new StatementRunner(db));

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-purge-scheduler.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-purge-scheduler.ts
@@ -412,81 +412,89 @@ export class SQLiteChangeLogPurgeScheduler {
     let stopped: PurgeStopReason | undefined;
     let db: Database | undefined;
 
-    for (;;) {
-      // The floor is re-read each batch: a coalesced dispatch may have raised
-      // it, and the gate below is evaluated against what is actually used.
-      floor = this.#pendingFloor ?? floor;
-      if (this.#stopped) {
-        stopped = 'stopped';
-        break;
-      }
-      if (this.#pausedBy.size > 0) {
-        stopped = 'paused';
-        break;
-      }
-      const connection = this.#connection();
-      if (connection === undefined) {
-        db = undefined;
-        this.#lc.debug?.(
-          'skipping SQLite change-log purge: the writer has not opened the log',
-        );
-        stopped = 'writer-unavailable';
-        break;
-      }
-      db = connection;
-      if (
-        batches >=
-        Math.max(
-          1,
-          this.#opts.maxBatchesPerCycle ?? DEFAULT_MAX_BATCHES_PER_CYCLE,
-        )
-      ) {
-        stopped = 'batch-limit';
-        break;
-      }
-      if (connection.inTransaction) {
-        // Purge windows exist only between the writer's commits (§3.3).
-        await this.#awaitWriterIdle();
-        continue;
-      }
+    try {
+      for (;;) {
+        // The floor is re-read each batch: a coalesced dispatch may have raised
+        // it, and the gate below is evaluated against what is actually used.
+        floor = this.#pendingFloor ?? floor;
+        if (this.#stopped) {
+          stopped = 'stopped';
+          break;
+        }
+        if (this.#pausedBy.size > 0) {
+          stopped = 'paused';
+          break;
+        }
+        const connection = this.#connection();
+        if (connection === undefined) {
+          db = undefined;
+          this.#lc.debug?.(
+            'skipping SQLite change-log purge: the writer has not opened the log',
+          );
+          stopped = 'writer-unavailable';
+          break;
+        }
+        db = connection;
+        if (
+          batches >=
+          Math.max(
+            1,
+            this.#opts.maxBatchesPerCycle ?? DEFAULT_MAX_BATCHES_PER_CYCLE,
+          )
+        ) {
+          stopped = 'batch-limit';
+          break;
+        }
+        if (connection.inTransaction) {
+          // Purge windows exist only between the writer's commits (§3.3).
+          await this.#awaitWriterIdle();
+          continue;
+        }
 
-      const batchFloor = floor;
-      const outcome = await this.#lock.withLock(() => {
-        // Everything the wait above established is re-checked under the lock:
-        // the writer may have begun another transaction or failed soft while
-        // this batch's acquisition was queued behind a registration.
-        if (this.#connection() !== connection || connection.inTransaction) {
-          return {kind: 'retry'} as const;
-        }
-        const declined = this.#gate(batchFloor);
-        if (declined !== undefined) {
-          return {kind: 'declined', reason: declined} as const;
-        }
-        const result = this.#cacheFor(connection).purger.purgeBatch({
-          externalFloor: batchFloor,
-          retentionCutoffMs: this.#now() - this.#opts.retentionMs,
-          maxRows: this.#opts.batchRows,
-          maxDurationMs:
-            this.#opts.statementTargetMs ?? DEFAULT_STATEMENT_TARGET_MS,
+        const batchFloor = floor;
+        const outcome = await this.#lock.withLock(() => {
+          // Everything the wait above established is re-checked under the lock:
+          // the writer may have begun another transaction or failed soft while
+          // this batch's acquisition was queued behind a registration.
+          if (this.#connection() !== connection || connection.inTransaction) {
+            return {kind: 'retry'} as const;
+          }
+          const declined = this.#gate(batchFloor);
+          if (declined !== undefined) {
+            return {kind: 'declined', reason: declined} as const;
+          }
+          const result = this.#cacheFor(connection).purger.purgeBatch({
+            externalFloor: batchFloor,
+            retentionCutoffMs: this.#now() - this.#opts.retentionMs,
+            maxRows: this.#opts.batchRows,
+            maxDurationMs:
+              this.#opts.statementTargetMs ?? DEFAULT_STATEMENT_TARGET_MS,
+          });
+          return {kind: 'purged', result} as const;
         });
-        return {kind: 'purged', result} as const;
-      });
 
-      if (outcome.kind === 'retry') {
-        continue;
+        if (outcome.kind === 'retry') {
+          continue;
+        }
+        if (outcome.kind === 'declined') {
+          stopped = outcome.reason;
+          break;
+        }
+        batches++;
+        deletedRows += outcome.result.deletedRows;
+        if (!outcome.result.moreEligible) {
+          break;
+        }
+        // Release the loop — and the guard, released above — so fan-out,
+        // catchup, and registrations make progress between batches.
+        await this.#yield();
       }
-      if (outcome.kind === 'declined') {
-        stopped = outcome.reason;
-        break;
-      }
-      batches++;
-      deletedRows += outcome.result.deletedRows;
-      if (!outcome.result.moreEligible) {
-        break;
-      }
-      // Release the loop — and the guard, released above — so fan-out,
-      // catchup, and registrations make progress between batches.
-      await this.#yield();
+    } catch (e) {
+      // Earlier batches committed independently and must remain visible in the
+      // result and metrics. Finalize the partial cycle, including its floor
+      // probe, rather than replacing it with an empty skipped result.
+      this.#lc.warn?.('error purging the SQLite change log', e);
+      stopped = 'error';
     }
 
     const probe = db === undefined ? undefined : this.#probeFloor(db, floor);

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-purge-scheduler.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-purge-scheduler.ts
@@ -58,9 +58,6 @@ export type PurgeStopReason =
   // The writer has not opened the change log (the file does not exist yet),
   // or has failed soft and deleted it.
   | 'writer-unavailable'
-  // No subscriber is connected to confirm the floor. Matches the PG arm's
-  // "No subscribers to confirm cleanup" bail.
-  | 'no-subscribers'
   // A connected subscriber's ACK is behind the floor. Matches the PG arm's
   // "behind backup" decline, re-checked before every batch so a registration
   // that lands mid-drain is honored by the very next batch.
@@ -541,7 +538,6 @@ export class SQLiteChangeLogPurgeScheduler {
       case 'stopped':
       case 'paused':
         break;
-      case 'no-subscribers':
       case 'subscriber-behind':
       case 'writer-unavailable':
       case 'error':
@@ -581,19 +577,18 @@ export class SQLiteChangeLogPurgeScheduler {
   }
 
   /**
-   * The decline gate, identical to the PG arm's: no purge unless at least one
-   * subscriber is connected and none is behind the floor. It is a gate, not a
-   * lower floor — more conservative than a `min()` over the ACKs.
+   * The decline gate, identical to the PG arm's: no purge while a connected
+   * subscriber is behind the floor. With no subscribers, the cleanup delay
+   * has already provided the reconnect grace period and the confirmed backup
+   * floor is safe to use.
    */
-  #gate(floor: string): 'no-subscribers' | 'subscriber-behind' | undefined {
-    let subscribers = 0;
+  #gate(floor: string): 'subscriber-behind' | undefined {
     for (const ack of this.#subscriberAcks()) {
-      subscribers++;
       if (ack < floor) {
         return 'subscriber-behind';
       }
     }
-    return subscribers === 0 ? 'no-subscribers' : undefined;
+    return undefined;
   }
 
   /**

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-purge-scheduler.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-purge-scheduler.ts
@@ -1,0 +1,681 @@
+import {Lock} from '@rocicorp/lock';
+import type {LogContext} from '@rocicorp/logger';
+import {assert} from '../../../../shared/src/asserts.ts';
+import type {Database, Statement} from '../../../../zqlite/src/db.ts';
+import {
+  getOrCreateCounter,
+  getOrCreateLatencyHistogram,
+  getOrCreateValueHistogram,
+} from '../../observability/metrics.ts';
+import {
+  CHANGE_LOG_STREAM_TABLE,
+  readChangeLogMeta,
+} from '../replicator/change-log-db.ts';
+import {SQLiteChangeLogPurger} from '../replicator/sqlite-change-log-purger.ts';
+import type {SQLiteChangeLogCleanupGuard} from './sqlite-change-log-catchup.ts';
+import {SQLITE_CHANGE_LOG_PLAN_SQL} from './sqlite-change-log-reader.ts';
+
+/**
+ * The hard bound on any one purge statement. Purge runs on the writer's own
+ * connection, in the stream loop's process, so a statement's duration stalls
+ * the appending path — and the fan-out behind it — directly. The bench's
+ * 100 ms bound was derived for the replicator's write worker; this budget is
+ * measured against an event loop that also owes progress to fan-out, catchup,
+ * and websocket keepalives, so it is deliberately tighter.
+ */
+const DEFAULT_STATEMENT_TARGET_MS = 20;
+
+/**
+ * Batches per cycle. This bounds one cycle's bookkeeping, not the drain:
+ * a cycle that hits the limit with history still eligible schedules its own
+ * continuation immediately.
+ */
+const DEFAULT_MAX_BATCHES_PER_CYCLE = 100;
+
+/**
+ * How long to wait before re-checking a log that is drained down to history
+ * that is not old enough to purge yet, or whose writer has not opened the
+ * file. This is what lets a quiet source still drain eligible history: the
+ * retention cutoff advances with the clock even when no new cleanup watermark
+ * arrives to dispatch a cycle.
+ */
+const DEFAULT_RECHECK_INTERVAL_MS = 30_000;
+
+/**
+ * The backstop poll while waiting for the writer's open transaction to
+ * commit. The commit notification normally arrives first; this covers an
+ * interrupted stream, whose rollback does not notify.
+ */
+const DEFAULT_IN_TRANSACTION_POLL_MS = 1_000;
+
+/** Why a cycle stopped before draining the eligible set. */
+export type PurgeStopReason =
+  // The scheduler was stopped.
+  | 'stopped'
+  // A snapshot reservation is open.
+  | 'paused'
+  // The writer has not opened the change log (the file does not exist yet),
+  // or has failed soft and deleted it.
+  | 'writer-unavailable'
+  // No subscriber is connected to confirm the floor. Matches the PG arm's
+  // "No subscribers to confirm cleanup" bail.
+  | 'no-subscribers'
+  // A connected subscriber's ACK is behind the floor. Matches the PG arm's
+  // "behind backup" decline, re-checked before every batch so a registration
+  // that lands mid-drain is honored by the very next batch.
+  | 'subscriber-behind'
+  // The per-cycle batch limit was reached with history still eligible.
+  | 'batch-limit'
+  // The cycle failed; the error was logged and counted.
+  | 'error';
+
+/**
+ * The invariant-14 probe's classification of `plan(floor)` after a cycle.
+ *
+ * `too-old` at the floor is not by itself a violation: a log that never held
+ * that history — routine at every fork, restore, and rolling restart — returns
+ * `too-old` without having purged anything. Only the seed point distinguishes
+ * the two, which is why `seedWatermark` is in the v2 meta row:
+ *
+ * ```
+ * violation  ⇔  plan(floor) is `too-old`  AND  seedWatermark <= floor
+ * ```
+ */
+export type FloorProbeOutcome =
+  // plan(floor) is `range`: the transaction at the floor survives as a
+  // restoring follower's catchup boundary.
+  | 'retained'
+  // The floor is above the log's head, i.e. the log is stale/frozen and the
+  // head cap is what held retention. Nothing at the floor was ever purged.
+  | 'ahead'
+  // plan(floor) is `too-old` but the log was seeded above the floor: it never
+  // held that history. Charted, and feeds the fork/resumption reach
+  // measurement; not an alert.
+  | 'cold-log'
+  // plan(floor) is `too-old` and the log demonstrably once held the floor.
+  // This is an invariant-14 violation: the only copy a restoring follower
+  // could catch up from was purged.
+  | 'violation';
+
+export type PurgeCycleResult = {
+  /** The external floor the cycle last used. */
+  readonly floor: string;
+  readonly batches: number;
+  readonly deletedRows: number;
+  /** Why the cycle ended before draining, if it did. */
+  readonly stopped: PurgeStopReason | undefined;
+  /** The invariant-14 probe's outcome, when the log was available to probe. */
+  readonly probe: FloorProbeOutcome | undefined;
+};
+
+export type SQLiteChangeLogPurgeSchedulerOptions = {
+  /**
+   * `sqliteChangeLogRetentionMs`: the minimum retention window, ANDed on top
+   * of the external floor. It can only make purge more conservative — the
+   * purger never accepts it as a standalone bound.
+   */
+  readonly retentionMs: number;
+  /**
+   * `sqliteChangeLogPurgeBatchRows`: the starting chunk size per batch. Not
+   * the bound — the statement duration target is.
+   */
+  readonly batchRows: number;
+  readonly statementTargetMs?: number | undefined;
+  readonly maxBatchesPerCycle?: number | undefined;
+  readonly recheckIntervalMs?: number | undefined;
+  readonly inTransactionPollMs?: number | undefined;
+  /** The clock the retention cutoff is measured against. Defaults to `Date.now`. */
+  readonly now?: (() => number) | undefined;
+  readonly setTimeoutFn?: typeof setTimeout | undefined;
+  readonly clearTimeoutFn?: typeof clearTimeout | undefined;
+  /**
+   * Awaited between batches so fan-out and catchup make progress. Defaults to
+   * a macrotask (`setImmediate`), so pending I/O runs before the next batch.
+   */
+  readonly yieldFn?: (() => Promise<void>) | undefined;
+};
+
+type ConnectionCache = {
+  readonly db: Database;
+  readonly purger: SQLiteChangeLogPurger;
+  readonly plan: Statement;
+  readonly belowFloorRemains: Statement;
+};
+
+type PlanRow = {
+  readonly headWatermark: string | null;
+  readonly minWatermark: string | null;
+  readonly boundaryExists: number;
+};
+
+/**
+ * Whether any row below both the floor and the head remains. Deliberately not
+ * the purger's eligibility query: rows younger than the retention cutoff are
+ * not eligible *yet*, but they will be, and their presence is what keeps the
+ * recheck timer armed on a quiet source.
+ */
+const BELOW_FLOOR_REMAINS_SQL = /*sql*/ `
+  SELECT EXISTS (
+    SELECT 1 FROM "${CHANGE_LOG_STREAM_TABLE}"
+    WHERE "watermark" < @floor
+      AND "watermark" < (SELECT max("watermark") FROM "${CHANGE_LOG_STREAM_TABLE}")
+  ) AS "remains"
+`;
+
+/**
+ * Schedules SQLite change-log purges from the change-streamer's own process,
+ * on the writer's own connection.
+ *
+ * The change-streamer dispatches a cycle from the same `#purgeOldChanges`
+ * pass that purges the PG change log, with the same floor, after the same
+ * decline gate — so the two logs cannot diverge in what they retain. Within a
+ * cycle the scheduler drains bounded batches, re-checking the gate before
+ * each one and releasing the cleanup guard between them, so a catchup
+ * registration or a snapshot reservation never waits longer than one batch.
+ *
+ * Purge windows exist only between the writer's commits: purge shares the
+ * writer's connection, so it cannot run inside the writer's open transaction,
+ * and a batch that finds one waits for the commit notification instead.
+ *
+ * The scheduler also re-arms itself: a cycle that hits its batch limit
+ * continues immediately, and a drained log that still holds history younger
+ * than the retention cutoff is re-checked on a timer — which is what lets a
+ * quiet source, whose backup watermark stops advancing, still drain eligible
+ * history.
+ */
+export class SQLiteChangeLogPurgeScheduler {
+  readonly #lc: LogContext;
+  readonly #connection: () => Database | undefined;
+  readonly #subscriberAcks: () => Iterable<string>;
+  readonly #opts: SQLiteChangeLogPurgeSchedulerOptions;
+  readonly #now: () => number;
+  readonly #setTimeoutFn: typeof setTimeout;
+  readonly #clearTimeoutFn: typeof clearTimeout;
+  readonly #yield: () => Promise<void>;
+
+  /**
+   * The mutex that serializes purge batches with catchup registration and
+   * reservation pauses. It is only ever held across a synchronous section —
+   * one batch, or one registration — never across a yield, which is what
+   * bounds any waiter to a single batch's duration.
+   */
+  readonly #lock = new Lock();
+
+  /**
+   * Open snapshot reservations, reference-counted by taskID. Purge pauses
+   * while any is open. Counted rather than a set so that a reservation retry
+   * -- whose cancel-then-recreate can resolve its old resume after its new
+   * suspend -- still nets out.
+   */
+  readonly #pausedBy = new Map<string, number>();
+
+  /** Waiters for the writer's next commit (or rollback). */
+  readonly #writerIdleWaiters = new Set<() => void>();
+
+  readonly #purgedRows = getOrCreateCounter(
+    'replica',
+    'sqlite_change_log.purged_rows',
+    'Rows removed from the SQLite change log by the purge scheduler.',
+  );
+  readonly #cycleDuration = getOrCreateLatencyHistogram(
+    'replica',
+    'sqlite_change_log.purge_cycle_duration',
+    'Duration of one SQLite change-log purge cycle, including the yields ' +
+      'between its batches.',
+  );
+  readonly #cycleBatches = getOrCreateValueHistogram(
+    'replica',
+    'sqlite_change_log.purge_cycle_batches',
+    {
+      description: 'Purge batches run per SQLite change-log purge cycle.',
+      unit: '{batch}',
+      bucketBoundaries: [1, 2, 5, 10, 25, 50, 100, 250],
+    },
+  );
+  readonly #declines = getOrCreateCounter(
+    'replica',
+    'sqlite_change_log.purge_declined',
+    'SQLite change-log purge cycles that ended before draining, by reason.',
+  );
+  readonly #floorProbes = getOrCreateCounter(
+    'replica',
+    'sqlite_change_log.purge_floor_probe',
+    'Invariant-14 probe outcomes: whether the transaction at the purge ' +
+      'floor is still servable after each cycle. "violation" means history ' +
+      'at or above the floor was purged and alerts; "cold-log" means the ' +
+      'log never held it, which is routine at every fork and resumption.',
+  );
+
+  /** The highest floor any cycle has been dispatched with. Floors only rise. */
+  #pendingFloor: string | undefined;
+  #running: Promise<PurgeCycleResult> | undefined;
+  #recheckTimer: ReturnType<typeof setTimeout> | undefined;
+  #cache: ConnectionCache | undefined;
+  #stopped = false;
+
+  /**
+   * The guard that brackets catchup registration: required-head capture and
+   * `Forwarder.add()` run under the same mutex as purge batches, so the
+   * registered ACK is visible to `Forwarder.getAcks()` before the next batch
+   * evaluates its gate.
+   */
+  readonly cleanupGuard: SQLiteChangeLogCleanupGuard = {
+    runWhilePurgeBlocked: register => this.#lock.withLock(register),
+  };
+
+  /**
+   * @param connection the writer's own connection (§3.3). `undefined` until
+   *     the writer's first reconcile creates the file, and again after the
+   *     writer fails soft and deletes it — both of which skip the cycle
+   *     rather than fail it, so the scheduler picks a late-appearing file up
+   *     without a restart.
+   * @param subscriberAcks the ACKs `#purgeOldChanges` gates the PG purge on,
+   *     re-read before every batch.
+   */
+  constructor(
+    lc: LogContext,
+    connection: () => Database | undefined,
+    subscriberAcks: () => Iterable<string>,
+    opts: SQLiteChangeLogPurgeSchedulerOptions,
+  ) {
+    assert(
+      Number.isSafeInteger(opts.retentionMs) && opts.retentionMs > 0,
+      'sqliteChangeLogRetentionMs must be a positive integer',
+    );
+    assert(
+      Number.isSafeInteger(opts.batchRows) && opts.batchRows > 0,
+      'sqliteChangeLogPurgeBatchRows must be a positive integer',
+    );
+    this.#lc = lc.withContext('component', 'sqlite-change-log-purge');
+    this.#connection = connection;
+    this.#subscriberAcks = subscriberAcks;
+    this.#opts = opts;
+    this.#now = opts.now ?? Date.now;
+    this.#setTimeoutFn = opts.setTimeoutFn ?? setTimeout;
+    this.#clearTimeoutFn = opts.clearTimeoutFn ?? clearTimeout;
+    this.#yield =
+      opts.yieldFn ??
+      (() => new Promise<void>(resolve => setImmediate(resolve)));
+  }
+
+  /**
+   * Dispatches a purge cycle for `floor` — the same floor, in the same cycle,
+   * behind the same decline gate as the PG purge. A cycle already running
+   * coalesces: the floor is raised for its next batch and its completion is
+   * returned.
+   *
+   * Never rejects; a failed cycle is logged and reported as `stopped: 'error'`.
+   */
+  purge(floor: string): Promise<PurgeCycleResult> {
+    this.#pendingFloor =
+      this.#pendingFloor === undefined || floor > this.#pendingFloor
+        ? floor
+        : this.#pendingFloor;
+    if (this.#stopped) {
+      return Promise.resolve(this.#skipped(floor, 'stopped'));
+    }
+    this.#clearRecheckTimer();
+    return this.#running ?? this.#dispatch();
+  }
+
+  /**
+   * Pauses purging while `taskID` holds a snapshot reservation. The returned
+   * promise resolves once no purge batch is in flight, i.e. once the bounds a
+   * backup monitor is about to advertise cannot be invalidated by a batch
+   * that had already been dispatched.
+   */
+  pause(taskID: string): Promise<void> {
+    this.#pausedBy.set(taskID, (this.#pausedBy.get(taskID) ?? 0) + 1);
+    this.#clearRecheckTimer();
+    return this.#lock.withLock(() => {});
+  }
+
+  /**
+   * Ends one of `taskID`'s pauses. Purging resumes only when every
+   * reservation has ended, picking up any drain the pauses interrupted.
+   * Unknown `taskID`s are ignored.
+   */
+  resume(taskID: string): void {
+    const count = this.#pausedBy.get(taskID);
+    if (count === undefined) {
+      return;
+    }
+    if (count > 1) {
+      this.#pausedBy.set(taskID, count - 1);
+      return;
+    }
+    this.#pausedBy.delete(taskID);
+    if (
+      this.#pausedBy.size === 0 &&
+      !this.#stopped &&
+      this.#pendingFloor !== undefined
+    ) {
+      this.#scheduleRecheck(0);
+    }
+  }
+
+  /**
+   * Notes that the writer's open transaction has ended, waking any batch
+   * waiting for a purge window. A missed notification costs one poll
+   * interval, never correctness.
+   */
+  onWriterIdle(): void {
+    for (const waiter of this.#writerIdleWaiters) {
+      waiter();
+    }
+    this.#writerIdleWaiters.clear();
+  }
+
+  stop(): void {
+    this.#stopped = true;
+    this.#clearRecheckTimer();
+    this.onWriterIdle();
+  }
+
+  #dispatch(): Promise<PurgeCycleResult> {
+    // One promise per cycle, stored and returned, so a dispatch that lands
+    // while a cycle is running coalesces into the identical completion.
+    const running = (async () => {
+      let result: PurgeCycleResult;
+      try {
+        result = await this.#runCycle();
+      } catch (e) {
+        const floor = this.#pendingFloor;
+        assert(floor !== undefined, 'a cycle cannot run without a floor');
+        this.#lc.warn?.('error purging the SQLite change log', e);
+        this.#declines.add(1, {reason: 'error'});
+        result = this.#skipped(floor, 'error');
+      }
+      try {
+        this.#finishCycle(result);
+      } catch (e) {
+        this.#lc.warn?.('error re-arming the SQLite change-log purge', e);
+      }
+      return result;
+    })().finally(() => {
+      this.#running = undefined;
+    });
+    this.#running = running;
+    return running;
+  }
+
+  async #runCycle(): Promise<PurgeCycleResult> {
+    const startedAt = performance.now();
+    assert(
+      this.#pendingFloor !== undefined,
+      'a cycle cannot run without a floor',
+    );
+    let floor: string = this.#pendingFloor;
+    let batches = 0;
+    let deletedRows = 0;
+    let stopped: PurgeStopReason | undefined;
+    let db: Database | undefined;
+
+    for (;;) {
+      // The floor is re-read each batch: a coalesced dispatch may have raised
+      // it, and the gate below is evaluated against what is actually used.
+      floor = this.#pendingFloor ?? floor;
+      if (this.#stopped) {
+        stopped = 'stopped';
+        break;
+      }
+      if (this.#pausedBy.size > 0) {
+        stopped = 'paused';
+        break;
+      }
+      const connection = this.#connection();
+      if (connection === undefined) {
+        db = undefined;
+        this.#lc.debug?.(
+          'skipping SQLite change-log purge: the writer has not opened the log',
+        );
+        stopped = 'writer-unavailable';
+        break;
+      }
+      db = connection;
+      if (
+        batches >=
+        Math.max(
+          1,
+          this.#opts.maxBatchesPerCycle ?? DEFAULT_MAX_BATCHES_PER_CYCLE,
+        )
+      ) {
+        stopped = 'batch-limit';
+        break;
+      }
+      if (connection.inTransaction) {
+        // Purge windows exist only between the writer's commits (§3.3).
+        await this.#awaitWriterIdle();
+        continue;
+      }
+
+      const batchFloor = floor;
+      const outcome = await this.#lock.withLock(() => {
+        // Everything the wait above established is re-checked under the lock:
+        // the writer may have begun another transaction or failed soft while
+        // this batch's acquisition was queued behind a registration.
+        if (this.#connection() !== connection || connection.inTransaction) {
+          return {kind: 'retry'} as const;
+        }
+        const declined = this.#gate(batchFloor);
+        if (declined !== undefined) {
+          return {kind: 'declined', reason: declined} as const;
+        }
+        const result = this.#cacheFor(connection).purger.purgeBatch({
+          externalFloor: batchFloor,
+          retentionCutoffMs: this.#now() - this.#opts.retentionMs,
+          maxRows: this.#opts.batchRows,
+          maxDurationMs:
+            this.#opts.statementTargetMs ?? DEFAULT_STATEMENT_TARGET_MS,
+        });
+        return {kind: 'purged', result} as const;
+      });
+
+      if (outcome.kind === 'retry') {
+        continue;
+      }
+      if (outcome.kind === 'declined') {
+        stopped = outcome.reason;
+        break;
+      }
+      batches++;
+      deletedRows += outcome.result.deletedRows;
+      if (!outcome.result.moreEligible) {
+        break;
+      }
+      // Release the loop — and the guard, released above — so fan-out,
+      // catchup, and registrations make progress between batches.
+      await this.#yield();
+    }
+
+    const probe = db === undefined ? undefined : this.#probeFloor(db, floor);
+    if (deletedRows > 0) {
+      this.#purgedRows.add(deletedRows);
+    }
+    if (batches > 0) {
+      this.#cycleBatches.record(batches);
+      this.#cycleDuration.recordMs(performance.now() - startedAt);
+    }
+    if (stopped !== undefined) {
+      this.#declines.add(1, {reason: stopped});
+    }
+    if (batches > 0 || stopped !== 'writer-unavailable') {
+      this.#lc.debug?.('SQLite change-log purge cycle', {
+        sqliteChangeLogPurge: {floor, batches, deletedRows, stopped, probe},
+      });
+    }
+    return {floor, batches, deletedRows, stopped, probe};
+  }
+
+  /**
+   * Re-arms the scheduler after a cycle. A cycle interrupted by its batch
+   * limit continues immediately; a decline or an unopened log is re-checked
+   * later (a decline lifts when the lagging subscriber ACKs past the floor,
+   * which nothing notifies); and a fully drained log is re-checked as long as
+   * it retains history below the floor, which the advancing retention cutoff
+   * will eventually release.
+   */
+  #finishCycle(result: PurgeCycleResult): void {
+    if (this.#stopped || this.#pausedBy.size > 0) {
+      return; // resume() re-arms.
+    }
+    switch (result.stopped) {
+      case 'batch-limit':
+        this.#scheduleRecheck(0);
+        break;
+      case 'stopped':
+      case 'paused':
+        break;
+      case 'no-subscribers':
+      case 'subscriber-behind':
+      case 'writer-unavailable':
+      case 'error':
+        this.#scheduleRecheck(
+          this.#opts.recheckIntervalMs ?? DEFAULT_RECHECK_INTERVAL_MS,
+        );
+        break;
+      case undefined: {
+        // A read is safe even inside the writer's open transaction; it just
+        // observes the uncommitted head, which is never below the floor.
+        const db = this.#connection();
+        if (db !== undefined) {
+          const {remains} = this.#cacheFor(db).belowFloorRemains.get<{
+            remains: number;
+          }>({floor: result.floor});
+          if (remains === 0) {
+            break;
+          }
+        }
+        this.#scheduleRecheck(
+          this.#opts.recheckIntervalMs ?? DEFAULT_RECHECK_INTERVAL_MS,
+        );
+        break;
+      }
+    }
+  }
+
+  /**
+   * The decline gate, identical to the PG arm's: no purge unless at least one
+   * subscriber is connected and none is behind the floor. It is a gate, not a
+   * lower floor — more conservative than a `min()` over the ACKs.
+   */
+  #gate(floor: string): 'no-subscribers' | 'subscriber-behind' | undefined {
+    let subscribers = 0;
+    for (const ack of this.#subscriberAcks()) {
+      subscribers++;
+      if (ack < floor) {
+        return 'subscriber-behind';
+      }
+    }
+    return subscribers === 0 ? 'no-subscribers' : undefined;
+  }
+
+  /**
+   * The live check on invariant 14 — what makes running this slice dark worth
+   * anything: in `write` mode nothing reads the log, so a wrong floor would
+   * otherwise stay invisible until the canary rollout two slices later.
+   */
+  #probeFloor(db: Database, floor: string): FloorProbeOutcome | undefined {
+    try {
+      const cache = this.#cacheFor(db);
+      const row = cache.plan.get<PlanRow>({fromWatermark: floor});
+      const {headWatermark, minWatermark} = row;
+      if (headWatermark === null || minWatermark === null) {
+        return undefined;
+      }
+      let outcome: FloorProbeOutcome;
+      if (floor > headWatermark) {
+        outcome = 'ahead';
+      } else if (floor < minWatermark || row.boundaryExists === 0) {
+        const {seedWatermark} = readChangeLogMeta(db);
+        outcome = seedWatermark <= floor ? 'violation' : 'cold-log';
+      } else {
+        outcome = 'retained';
+      }
+      this.#floorProbes.add(1, {outcome});
+      if (outcome === 'violation') {
+        this.#lc.error?.(
+          'SQLite change log purged history at or above the purge floor. A ' +
+            'follower restoring to that watermark would get `too-old` and ' +
+            'take a full restore.',
+          {sqliteChangeLogFloorProbe: {floor, ...row}},
+        );
+      }
+      return outcome;
+    } catch (e) {
+      this.#lc.warn?.('unable to probe the SQLite change-log purge floor', e);
+      return undefined;
+    }
+  }
+
+  /** Resolves once the writer's open transaction has committed or rolled back. */
+  #awaitWriterIdle(): Promise<void> {
+    return new Promise<void>(resolve => {
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const waiter = () => {
+        if (timer !== undefined) {
+          this.#clearTimeoutFn(timer);
+        }
+        this.#writerIdleWaiters.delete(waiter);
+        resolve();
+      };
+      this.#writerIdleWaiters.add(waiter);
+      timer = this.#setTimeoutFn(
+        waiter,
+        this.#opts.inTransactionPollMs ?? DEFAULT_IN_TRANSACTION_POLL_MS,
+      );
+    });
+  }
+
+  #scheduleRecheck(delayMs: number): void {
+    if (this.#stopped || this.#recheckTimer !== undefined) {
+      return;
+    }
+    this.#recheckTimer = this.#setTimeoutFn(() => {
+      this.#recheckTimer = undefined;
+      if (
+        this.#stopped ||
+        this.#running !== undefined ||
+        this.#pendingFloor === undefined ||
+        this.#pausedBy.size > 0
+      ) {
+        return;
+      }
+      void this.#dispatch();
+    }, delayMs);
+  }
+
+  #clearRecheckTimer(): void {
+    if (this.#recheckTimer !== undefined) {
+      this.#clearTimeoutFn(this.#recheckTimer);
+      this.#recheckTimer = undefined;
+    }
+  }
+
+  /**
+   * The per-connection statements, rebuilt if the writer's connection ever
+   * changes. The purger's prepared statements survive a reseed — SQLite
+   * re-prepares on schema change — but not a different `Database`.
+   */
+  #cacheFor(db: Database): ConnectionCache {
+    if (this.#cache?.db !== db) {
+      this.#cache = {
+        db,
+        purger: new SQLiteChangeLogPurger(db),
+        plan: db.prepare(SQLITE_CHANGE_LOG_PLAN_SQL),
+        belowFloorRemains: db.prepare(BELOW_FLOOR_REMAINS_SQL),
+      };
+    }
+    return this.#cache;
+  }
+
+  #skipped(floor: string, reason: PurgeStopReason): PurgeCycleResult {
+    return {
+      floor,
+      batches: 0,
+      deletedRows: 0,
+      stopped: reason,
+      probe: undefined,
+    };
+  }
+}

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-purge-scheduler.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-purge-scheduler.ts
@@ -146,17 +146,30 @@ type PlanRow = {
 };
 
 /**
- * Whether any row below both the floor and the head remains. Deliberately not
- * the purger's eligibility query: rows younger than the retention cutoff are
- * not eligible *yet*, but they will be, and their presence asks the cleanup
- * coordinator for a deferred pass even on a quiet source.
+ * Whether the cleanup coordinator still owes this floor a pass. Deliberately
+ * not the purger's eligibility query, in two ways:
+ *
+ * - `remains`: rows younger than the retention cutoff are not eligible *yet*,
+ *   but they will be, and their presence asks the cleanup coordinator for a
+ *   deferred pass even on a quiet source.
+ * - `headBehindFloor`: a head behind the floor means the writer is expected
+ *   to replay commits below it (e.g. after reconnecting while the backup
+ *   outran this log). Those rows do not exist to count yet, writer commits
+ *   only wake an in-flight waiter, and backup monitors never resend an
+ *   unchanged floor — so reporting quiescence here would disarm cleanup for
+ *   good. An empty log (no head) defers for the same reason.
  */
 const BELOW_FLOOR_REMAINS_SQL = /*sql*/ `
-  SELECT EXISTS (
-    SELECT 1 FROM "${CHANGE_LOG_STREAM_TABLE}"
-    WHERE "watermark" < @floor
-      AND "watermark" < (SELECT max("watermark") FROM "${CHANGE_LOG_STREAM_TABLE}")
-  ) AS "remains"
+  SELECT
+    EXISTS (
+      SELECT 1 FROM "${CHANGE_LOG_STREAM_TABLE}"
+      WHERE "watermark" < @floor
+        AND "watermark" < (SELECT max("watermark") FROM "${CHANGE_LOG_STREAM_TABLE}")
+    ) AS "remains",
+    coalesce(
+      (SELECT max("watermark") FROM "${CHANGE_LOG_STREAM_TABLE}") < @floor,
+      1
+    ) AS "headBehindFloor"
 `;
 
 /**
@@ -480,7 +493,9 @@ export class SQLiteChangeLogPurgeScheduler {
   /**
    * Reports whether the level-triggered cleanup coordinator should run again.
    * Rows below the floor but inside the retention window require a deferred
-   * pass even when no new backup watermark arrives.
+   * pass even when no new backup watermark arrives, and so does a head behind
+   * the floor: the rows the writer replays into that gap arrive after this
+   * check, with no other event armed to reap them.
    */
   #continuation(
     floor: string,
@@ -503,10 +518,13 @@ export class SQLiteChangeLogPurgeScheduler {
         if (db === undefined) {
           return 'deferred';
         }
-        const {remains} = this.#cacheFor(db).belowFloorRemains.get<{
+        const {remains, headBehindFloor} = this.#cacheFor(
+          db,
+        ).belowFloorRemains.get<{
           remains: number;
+          headBehindFloor: number;
         }>({floor});
-        return remains === 0 ? undefined : 'deferred';
+        return remains === 0 && headBehindFloor === 0 ? undefined : 'deferred';
       }
     }
   }

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-purge-scheduler.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-purge-scheduler.ts
@@ -482,11 +482,17 @@ export class SQLiteChangeLogPurgeScheduler {
         }
         batches++;
         deletedRows += outcome.result.deletedRows;
-        if (!outcome.result.moreEligible) {
+        // A purge() call can raise the pending floor while this batch is
+        // suspended on withLock(). `moreEligible` only describes the captured
+        // batch floor, so do not mistake a drain to that floor for a drain to
+        // the newer one.
+        const floorRaised =
+          this.#pendingFloor !== undefined && this.#pendingFloor > batchFloor;
+        if (!outcome.result.moreEligible && !floorRaised) {
           break;
         }
         // Release the loop — and the guard, released above — so fan-out,
-        // catchup, and registrations make progress between batches.
+        // catchup, and registrations make progress between batches or floors.
         await this.#yield();
       }
     } catch (e) {
@@ -544,6 +550,17 @@ export class SQLiteChangeLogPurgeScheduler {
         );
         break;
       case undefined: {
+        // Backstop the last-batch check above: a dispatch can land after
+        // #runCycle() returns but before this finalization runs. The coalesced
+        // floor must leave the scheduler armed even though the completed floor
+        // itself is fully drained.
+        if (
+          this.#pendingFloor !== undefined &&
+          this.#pendingFloor > result.floor
+        ) {
+          this.#scheduleRecheck(0);
+          break;
+        }
         // A read is safe even inside the writer's open transaction; it just
         // observes the uncommitted head, which is never below the floor.
         const db = this.#connection();

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-purge-scheduler.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-purge-scheduler.ts
@@ -16,7 +16,8 @@ import type {SQLiteChangeLogCleanupGuard} from './sqlite-change-log-catchup.ts';
 import {SQLITE_CHANGE_LOG_PLAN_SQL} from './sqlite-change-log-reader.ts';
 
 /**
- * The hard bound on any one purge statement. Purge runs on the writer's own
+ * The duration target for any one purge statement, enforced by the purger's
+ * measured-budget feedback. Purge runs on the writer's own
  * connection, in the stream loop's process, so a statement's duration stalls
  * the appending path — and the fan-out behind it — directly. The bench's
  * 100 ms bound was derived for the replicator's write worker; this budget is

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-purge-scheduler.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-purge-scheduler.ts
@@ -27,20 +27,10 @@ import {SQLITE_CHANGE_LOG_PLAN_SQL} from './sqlite-change-log-reader.ts';
 const DEFAULT_STATEMENT_TARGET_MS = 20;
 
 /**
- * Batches per cycle. This bounds one cycle's bookkeeping, not the drain:
- * a cycle that hits the limit with history still eligible schedules its own
- * continuation immediately.
+ * Batches per pass. This bounds one pass's bookkeeping, not the drain: a pass
+ * that hits the limit asks its caller for an immediate continuation.
  */
-const DEFAULT_MAX_BATCHES_PER_CYCLE = 100;
-
-/**
- * How long to wait before re-checking a log that is drained down to history
- * that is not old enough to purge yet, or whose writer has not opened the
- * file. This is what lets a quiet source still drain eligible history: the
- * retention cutoff advances with the clock even when no new cleanup watermark
- * arrives to dispatch a cycle.
- */
-const DEFAULT_RECHECK_INTERVAL_MS = 30_000;
+const DEFAULT_MAX_BATCHES_PER_PASS = 100;
 
 /**
  * The backstop poll while waiting for the writer's open transaction to
@@ -49,7 +39,7 @@ const DEFAULT_RECHECK_INTERVAL_MS = 30_000;
  */
 const DEFAULT_IN_TRANSACTION_POLL_MS = 1_000;
 
-/** Why a cycle stopped before draining the eligible set. */
+/** Why a pass stopped before draining the eligible set. */
 export type PurgeStopReason =
   // The scheduler was stopped.
   | 'stopped'
@@ -58,17 +48,17 @@ export type PurgeStopReason =
   // The writer has not opened the change log (the file does not exist yet),
   // or has failed soft and deleted it.
   | 'writer-unavailable'
-  // A connected subscriber's ACK is behind the floor. Matches the PG arm's
-  // "behind backup" decline, re-checked before every batch so a registration
-  // that lands mid-drain is honored by the very next batch.
+  // A connected subscriber's ACK is behind the floor. Re-checked before every
+  // batch so a registration that lands mid-drain is honored by the very next
+  // batch.
   | 'subscriber-behind'
-  // The per-cycle batch limit was reached with history still eligible.
+  // The per-pass batch limit was reached with history still eligible.
   | 'batch-limit'
-  // The cycle failed; the error was logged and counted.
+  // The pass failed; the error was logged and counted.
   | 'error';
 
 /**
- * The invariant-14 probe's classification of `plan(floor)` after a cycle.
+ * The invariant-14 probe's classification of `plan(floor)` after a pass.
  *
  * `too-old` at the floor is not by itself a violation: a log that never held
  * that history — routine at every fork, restore, and rolling restart — returns
@@ -95,15 +85,25 @@ export type FloorProbeOutcome =
   // could catch up from was purged.
   | 'violation';
 
-export type PurgeCycleResult = {
-  /** The external floor the cycle last used. */
+/** When the cleanup coordinator should run another pass. */
+export type PurgeContinuation =
+  // The pass hit its batch limit while eligible history remained.
+  | 'immediate'
+  // Progress depends on time or external state: retention, a subscriber ACK,
+  // a reservation, the writer becoming available, or a transient error.
+  | 'deferred';
+
+export type PurgePassResult = {
+  /** The external floor the pass used. */
   readonly floor: string;
   readonly batches: number;
   readonly deletedRows: number;
-  /** Why the cycle ended before draining, if it did. */
+  /** Why the pass ended before draining, if it did. */
   readonly stopped: PurgeStopReason | undefined;
   /** The invariant-14 probe's outcome, when the log was available to probe. */
   readonly probe: FloorProbeOutcome | undefined;
+  /** Whether, and how soon, the cleanup coordinator should run another pass. */
+  readonly continuation: PurgeContinuation | undefined;
 };
 
 export type SQLiteChangeLogPurgeSchedulerOptions = {
@@ -119,8 +119,7 @@ export type SQLiteChangeLogPurgeSchedulerOptions = {
    */
   readonly batchRows: number;
   readonly statementTargetMs?: number | undefined;
-  readonly maxBatchesPerCycle?: number | undefined;
-  readonly recheckIntervalMs?: number | undefined;
+  readonly maxBatchesPerPass?: number | undefined;
   readonly inTransactionPollMs?: number | undefined;
   /** The clock the retention cutoff is measured against. Defaults to `Date.now`. */
   readonly now?: (() => number) | undefined;
@@ -149,8 +148,8 @@ type PlanRow = {
 /**
  * Whether any row below both the floor and the head remains. Deliberately not
  * the purger's eligibility query: rows younger than the retention cutoff are
- * not eligible *yet*, but they will be, and their presence is what keeps the
- * recheck timer armed on a quiet source.
+ * not eligible *yet*, but they will be, and their presence asks the cleanup
+ * coordinator for a deferred pass even on a quiet source.
  */
 const BELOW_FLOOR_REMAINS_SQL = /*sql*/ `
   SELECT EXISTS (
@@ -161,25 +160,23 @@ const BELOW_FLOOR_REMAINS_SQL = /*sql*/ `
 `;
 
 /**
- * Schedules SQLite change-log purges from the change-streamer's own process,
- * on the writer's own connection.
+ * Runs bounded SQLite change-log purge passes on the writer's own connection.
  *
- * The change-streamer dispatches a cycle from the same `#purgeOldChanges`
- * pass that purges the PG change log, with the same floor, after the same
- * decline gate — so the two logs cannot diverge in what they retain. Within a
- * cycle the scheduler drains bounded batches, re-checking the gate before
- * each one and releasing the cleanup guard between them, so a catchup
- * registration or a snapshot reservation never waits longer than one batch.
+ * The caller supplies the current durable cleanup floor independently of any
+ * other change-log implementation and owns the timing of subsequent passes.
+ * Within a pass this class drains bounded batches, re-checking live subscriber
+ * ACKs before each one and releasing the cleanup guard between them, so a
+ * catchup registration or snapshot reservation never waits longer than one
+ * batch.
  *
  * Purge windows exist only between the writer's commits: purge shares the
  * writer's connection, so it cannot run inside the writer's open transaction,
  * and a batch that finds one waits for the commit notification instead.
  *
- * The scheduler also re-arms itself: a cycle that hits its batch limit
- * continues immediately, and a drained log that still holds history younger
- * than the retention cutoff is re-checked on a timer — which is what lets a
- * quiet source, whose backup watermark stops advancing, still drain eligible
- * history.
+ * The result tells the cleanup coordinator whether the next pass should be
+ * immediate or deferred. This class deliberately owns no cleanup timer: the
+ * same level-triggered coordinator continues a large drain, advances the
+ * retention clock on a quiet source, and retries changing external state.
  */
 export class SQLiteChangeLogPurgeScheduler {
   readonly #lc: LogContext;
@@ -215,17 +212,17 @@ export class SQLiteChangeLogPurgeScheduler {
     'sqlite_change_log.purged_rows',
     'Rows removed from the SQLite change log by the purge scheduler.',
   );
-  readonly #cycleDuration = getOrCreateLatencyHistogram(
+  readonly #passDuration = getOrCreateLatencyHistogram(
     'replica',
     'sqlite_change_log.purge_cycle_duration',
-    'Duration of one SQLite change-log purge cycle, including the yields ' +
+    'Duration of one SQLite change-log purge pass, including the yields ' +
       'between its batches.',
   );
-  readonly #cycleBatches = getOrCreateValueHistogram(
+  readonly #passBatches = getOrCreateValueHistogram(
     'replica',
     'sqlite_change_log.purge_cycle_batches',
     {
-      description: 'Purge batches run per SQLite change-log purge cycle.',
+      description: 'Purge batches run per SQLite change-log purge pass.',
       unit: '{batch}',
       bucketBoundaries: [1, 2, 5, 10, 25, 50, 100, 250],
     },
@@ -233,21 +230,17 @@ export class SQLiteChangeLogPurgeScheduler {
   readonly #declines = getOrCreateCounter(
     'replica',
     'sqlite_change_log.purge_declined',
-    'SQLite change-log purge cycles that ended before draining, by reason.',
+    'SQLite change-log purge passes that ended before draining, by reason.',
   );
   readonly #floorProbes = getOrCreateCounter(
     'replica',
     'sqlite_change_log.purge_floor_probe',
     'Invariant-14 probe outcomes: whether the transaction at the purge ' +
-      'floor is still servable after each cycle. "violation" means history ' +
+      'floor is still servable after each pass. "violation" means history ' +
       'at or above the floor was purged and alerts; "cold-log" means the ' +
       'log never held it, which is routine at every fork and resumption.',
   );
 
-  /** The highest floor any cycle has been dispatched with. Floors only rise. */
-  #pendingFloor: string | undefined;
-  #running: Promise<PurgeCycleResult> | undefined;
-  #recheckTimer: ReturnType<typeof setTimeout> | undefined;
   #cache: ConnectionCache | undefined;
   #stopped = false;
 
@@ -264,11 +257,11 @@ export class SQLiteChangeLogPurgeScheduler {
   /**
    * @param connection the writer's own connection (§3.3). `undefined` until
    *     the writer's first reconcile creates the file, and again after the
-   *     writer fails soft and deletes it — both of which skip the cycle
-   *     rather than fail it, so the scheduler picks a late-appearing file up
-   *     without a restart.
-   * @param subscriberAcks the ACKs `#purgeOldChanges` gates the PG purge on,
-   *     re-read before every batch.
+   *     writer fails soft and deletes it — both of which defer the pass rather
+   *     than fail it, so a later coordinator pass picks up a late-appearing
+   *     file without a restart.
+   * @param subscriberAcks live subscriber ACKs, re-read before every batch so
+   *     the supplied floor remains safe throughout an asynchronous drain.
    */
   constructor(
     lc: LogContext,
@@ -297,23 +290,20 @@ export class SQLiteChangeLogPurgeScheduler {
   }
 
   /**
-   * Dispatches a purge cycle for `floor` — the same floor, in the same cycle,
-   * behind the same decline gate as the PG purge. A cycle already running
-   * coalesces: the floor is raised for its next batch and its completion is
-   * returned.
-   *
-   * Never rejects; a failed cycle is logged and reported as `stopped: 'error'`.
+   * Runs one purge pass for the current durable cleanup `floor`.
+   * Never rejects; a failed pass is logged and reported as `stopped: 'error'`.
    */
-  purge(floor: string): Promise<PurgeCycleResult> {
-    this.#pendingFloor =
-      this.#pendingFloor === undefined || floor > this.#pendingFloor
-        ? floor
-        : this.#pendingFloor;
+  async purge(floor: string): Promise<PurgePassResult> {
     if (this.#stopped) {
-      return Promise.resolve(this.#skipped(floor, 'stopped'));
+      return this.#skipped(floor, 'stopped');
     }
-    this.#clearRecheckTimer();
-    return this.#running ?? this.#dispatch();
+    try {
+      return await this.#runPass(floor);
+    } catch (e) {
+      this.#lc.warn?.('error purging the SQLite change log', e);
+      this.#declines.add(1, {reason: 'error'});
+      return this.#skipped(floor, 'error', 'deferred');
+    }
   }
 
   /**
@@ -324,14 +314,12 @@ export class SQLiteChangeLogPurgeScheduler {
    */
   pause(taskID: string): Promise<void> {
     this.#pausedBy.set(taskID, (this.#pausedBy.get(taskID) ?? 0) + 1);
-    this.#clearRecheckTimer();
     return this.#lock.withLock(() => {});
   }
 
   /**
-   * Ends one of `taskID`'s pauses. Purging resumes only when every
-   * reservation has ended, picking up any drain the pauses interrupted.
-   * Unknown `taskID`s are ignored.
+   * Ends one of `taskID`'s pauses. A later coordinator pass can purge once
+   * every reservation has ended. Unknown `taskID`s are ignored.
    */
   resume(taskID: string): void {
     const count = this.#pausedBy.get(taskID);
@@ -343,13 +331,6 @@ export class SQLiteChangeLogPurgeScheduler {
       return;
     }
     this.#pausedBy.delete(taskID);
-    if (
-      this.#pausedBy.size === 0 &&
-      !this.#stopped &&
-      this.#pendingFloor !== undefined
-    ) {
-      this.#scheduleRecheck(0);
-    }
   }
 
   /**
@@ -366,44 +347,11 @@ export class SQLiteChangeLogPurgeScheduler {
 
   stop(): void {
     this.#stopped = true;
-    this.#clearRecheckTimer();
     this.onWriterIdle();
   }
 
-  #dispatch(): Promise<PurgeCycleResult> {
-    // One promise per cycle, stored and returned, so a dispatch that lands
-    // while a cycle is running coalesces into the identical completion.
-    const running = (async () => {
-      let result: PurgeCycleResult;
-      try {
-        result = await this.#runCycle();
-      } catch (e) {
-        const floor = this.#pendingFloor;
-        assert(floor !== undefined, 'a cycle cannot run without a floor');
-        this.#lc.warn?.('error purging the SQLite change log', e);
-        this.#declines.add(1, {reason: 'error'});
-        result = this.#skipped(floor, 'error');
-      }
-      try {
-        this.#finishCycle(result);
-      } catch (e) {
-        this.#lc.warn?.('error re-arming the SQLite change-log purge', e);
-      }
-      return result;
-    })().finally(() => {
-      this.#running = undefined;
-    });
-    this.#running = running;
-    return running;
-  }
-
-  async #runCycle(): Promise<PurgeCycleResult> {
+  async #runPass(floor: string): Promise<PurgePassResult> {
     const startedAt = performance.now();
-    assert(
-      this.#pendingFloor !== undefined,
-      'a cycle cannot run without a floor',
-    );
-    let floor: string = this.#pendingFloor;
     let batches = 0;
     let deletedRows = 0;
     let stopped: PurgeStopReason | undefined;
@@ -411,9 +359,6 @@ export class SQLiteChangeLogPurgeScheduler {
 
     try {
       for (;;) {
-        // The floor is re-read each batch: a coalesced dispatch may have raised
-        // it, and the gate below is evaluated against what is actually used.
-        floor = this.#pendingFloor ?? floor;
         if (this.#stopped) {
           stopped = 'stopped';
           break;
@@ -436,7 +381,7 @@ export class SQLiteChangeLogPurgeScheduler {
           batches >=
           Math.max(
             1,
-            this.#opts.maxBatchesPerCycle ?? DEFAULT_MAX_BATCHES_PER_CYCLE,
+            this.#opts.maxBatchesPerPass ?? DEFAULT_MAX_BATCHES_PER_PASS,
           )
         ) {
           stopped = 'batch-limit';
@@ -448,7 +393,6 @@ export class SQLiteChangeLogPurgeScheduler {
           continue;
         }
 
-        const batchFloor = floor;
         const outcome = await this.#lock.withLock(() => {
           // Everything the wait above established is re-checked under the lock:
           // the writer may have begun another transaction or failed soft while
@@ -456,12 +400,12 @@ export class SQLiteChangeLogPurgeScheduler {
           if (this.#connection() !== connection || connection.inTransaction) {
             return {kind: 'retry'} as const;
           }
-          const declined = this.#gate(batchFloor);
+          const declined = this.#gate(floor);
           if (declined !== undefined) {
             return {kind: 'declined', reason: declined} as const;
           }
           const result = this.#cacheFor(connection).purger.purgeBatch({
-            externalFloor: batchFloor,
+            externalFloor: floor,
             retentionCutoffMs: this.#now() - this.#opts.retentionMs,
             maxRows: this.#opts.batchRows,
             maxDurationMs:
@@ -479,108 +423,98 @@ export class SQLiteChangeLogPurgeScheduler {
         }
         batches++;
         deletedRows += outcome.result.deletedRows;
-        // A purge() call can raise the pending floor while this batch is
-        // suspended on withLock(). `moreEligible` only describes the captured
-        // batch floor, so do not mistake a drain to that floor for a drain to
-        // the newer one.
-        const floorRaised =
-          this.#pendingFloor !== undefined && this.#pendingFloor > batchFloor;
-        if (!outcome.result.moreEligible && !floorRaised) {
+        if (!outcome.result.moreEligible) {
           break;
         }
         // Release the loop — and the guard, released above — so fan-out,
-        // catchup, and registrations make progress between batches or floors.
+        // catchup, and registrations make progress between batches.
         await this.#yield();
       }
     } catch (e) {
       // Earlier batches committed independently and must remain visible in the
-      // result and metrics. Finalize the partial cycle, including its floor
+      // result and metrics. Finalize the partial pass, including its floor
       // probe, rather than replacing it with an empty skipped result.
       this.#lc.warn?.('error purging the SQLite change log', e);
       stopped = 'error';
     }
 
     const probe = db === undefined ? undefined : this.#probeFloor(db, floor);
+    let continuation: PurgeContinuation | undefined;
+    try {
+      continuation = this.#continuation(floor, stopped);
+    } catch (e) {
+      // A connection can fail soft between the pass and this level check. Keep
+      // completed batches visible and ask the coordinator to retry later.
+      this.#lc.warn?.(
+        'unable to determine whether SQLite change-log purge should continue',
+        e,
+      );
+      continuation = 'deferred';
+      stopped ??= 'error';
+    }
     if (deletedRows > 0) {
       this.#purgedRows.add(deletedRows);
     }
     if (batches > 0) {
-      this.#cycleBatches.record(batches);
-      this.#cycleDuration.recordMs(performance.now() - startedAt);
+      this.#passBatches.record(batches);
+      this.#passDuration.recordMs(performance.now() - startedAt);
     }
     if (stopped !== undefined) {
       this.#declines.add(1, {reason: stopped});
     }
     if (batches > 0 || stopped !== 'writer-unavailable') {
-      this.#lc.debug?.('SQLite change-log purge cycle', {
-        sqliteChangeLogPurge: {floor, batches, deletedRows, stopped, probe},
+      this.#lc.debug?.('SQLite change-log purge pass', {
+        sqliteChangeLogPurge: {
+          floor,
+          batches,
+          deletedRows,
+          stopped,
+          probe,
+          continuation,
+        },
       });
     }
-    return {floor, batches, deletedRows, stopped, probe};
+    return {floor, batches, deletedRows, stopped, probe, continuation};
   }
 
   /**
-   * Re-arms the scheduler after a cycle. A cycle interrupted by its batch
-   * limit continues immediately; a decline or an unopened log is re-checked
-   * later (a decline lifts when the lagging subscriber ACKs past the floor,
-   * which nothing notifies); and a fully drained log is re-checked as long as
-   * it retains history below the floor, which the advancing retention cutoff
-   * will eventually release.
+   * Reports whether the level-triggered cleanup coordinator should run again.
+   * Rows below the floor but inside the retention window require a deferred
+   * pass even when no new backup watermark arrives.
    */
-  #finishCycle(result: PurgeCycleResult): void {
-    if (this.#stopped || this.#pausedBy.size > 0) {
-      return; // resume() re-arms.
-    }
-    switch (result.stopped) {
+  #continuation(
+    floor: string,
+    stopped: PurgeStopReason | undefined,
+  ): PurgeContinuation | undefined {
+    switch (stopped) {
       case 'batch-limit':
-        this.#scheduleRecheck(0);
-        break;
+        return 'immediate';
       case 'stopped':
+        return undefined;
       case 'paused':
-        break;
       case 'subscriber-behind':
       case 'writer-unavailable':
       case 'error':
-        this.#scheduleRecheck(
-          this.#opts.recheckIntervalMs ?? DEFAULT_RECHECK_INTERVAL_MS,
-        );
-        break;
+        return 'deferred';
       case undefined: {
-        // Backstop the last-batch check above: a dispatch can land after
-        // #runCycle() returns but before this finalization runs. The coalesced
-        // floor must leave the scheduler armed even though the completed floor
-        // itself is fully drained.
-        if (
-          this.#pendingFloor !== undefined &&
-          this.#pendingFloor > result.floor
-        ) {
-          this.#scheduleRecheck(0);
-          break;
-        }
         // A read is safe even inside the writer's open transaction; it just
         // observes the uncommitted head, which is never below the floor.
         const db = this.#connection();
-        if (db !== undefined) {
-          const {remains} = this.#cacheFor(db).belowFloorRemains.get<{
-            remains: number;
-          }>({floor: result.floor});
-          if (remains === 0) {
-            break;
-          }
+        if (db === undefined) {
+          return 'deferred';
         }
-        this.#scheduleRecheck(
-          this.#opts.recheckIntervalMs ?? DEFAULT_RECHECK_INTERVAL_MS,
-        );
-        break;
+        const {remains} = this.#cacheFor(db).belowFloorRemains.get<{
+          remains: number;
+        }>({floor});
+        return remains === 0 ? undefined : 'deferred';
       }
     }
   }
 
   /**
-   * The decline gate, identical to the PG arm's: no purge while a connected
-   * subscriber is behind the floor. With no subscribers, the cleanup delay
-   * has already provided the reconnect grace period and the confirmed backup
-   * floor is safe to use.
+   * No purge while a connected subscriber is behind the supplied floor. The
+   * cleanup coordinator has already provided the reconnect grace period; an
+   * empty live set places no additional constraint on the durable floor.
    */
   #gate(floor: string): 'subscriber-behind' | undefined {
     for (const ack of this.#subscriberAcks()) {
@@ -648,31 +582,6 @@ export class SQLiteChangeLogPurgeScheduler {
     });
   }
 
-  #scheduleRecheck(delayMs: number): void {
-    if (this.#stopped || this.#recheckTimer !== undefined) {
-      return;
-    }
-    this.#recheckTimer = this.#setTimeoutFn(() => {
-      this.#recheckTimer = undefined;
-      if (
-        this.#stopped ||
-        this.#running !== undefined ||
-        this.#pendingFloor === undefined ||
-        this.#pausedBy.size > 0
-      ) {
-        return;
-      }
-      void this.#dispatch();
-    }, delayMs);
-  }
-
-  #clearRecheckTimer(): void {
-    if (this.#recheckTimer !== undefined) {
-      this.#clearTimeoutFn(this.#recheckTimer);
-      this.#recheckTimer = undefined;
-    }
-  }
-
   /**
    * The per-connection statements, rebuilt if the writer's connection ever
    * changes. The purger's prepared statements survive a reseed — SQLite
@@ -690,13 +599,18 @@ export class SQLiteChangeLogPurgeScheduler {
     return this.#cache;
   }
 
-  #skipped(floor: string, reason: PurgeStopReason): PurgeCycleResult {
+  #skipped(
+    floor: string,
+    reason: PurgeStopReason,
+    continuation?: PurgeContinuation | undefined,
+  ): PurgePassResult {
     return {
       floor,
       batches: 0,
       deletedRows: 0,
       stopped: reason,
       probe: undefined,
+      continuation,
     };
   }
 }

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-writer.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-writer.ts
@@ -98,6 +98,18 @@ export class SQLiteChangeLogWriter {
     return !this.#disabled;
   }
 
+  /**
+   * The writer's own connection, which is the one purge runs on (§3.3): one
+   * process appends *and* deletes, on one handle, with no second writable
+   * connection and no cross-process barrier. `undefined` until the stream
+   * loop's first reconcile creates the log, and again once the writer has
+   * failed soft and deleted the file — both of which a purge cycle treats as
+   * "skip", not as an error.
+   */
+  get connection(): Database | undefined {
+    return this.#db;
+  }
+
   /** Exposed for tests and for the integration assertions on the metrics. */
   state(): SQLiteChangeLogObservabilityState | undefined {
     return this.#observer?.state();

--- a/packages/zero-cache/src/services/replicator/change-log-db.ts
+++ b/packages/zero-cache/src/services/replicator/change-log-db.ts
@@ -20,13 +20,15 @@
  *
  * Disk sizing: a task that writes the log needs room for the replica *plus* the
  * retained change stream — the log's main file, its wal2 sidecars, and pages a
- * purge has freed but not yet reused. Nothing calls the purger yet (that is
- * slice 9), so with the writer enabled it currently grows with the entire
- * change stream since its last reseed, which is one more reason
- * `sqliteChangeLogMode` defaults to `off`. Once purge is scheduled, retention
- * is bounded by the confirmed backup watermark rather than by a constant, so it
- * is a function of the backup interval. The log is excluded from the litestream
- * backup, so this is local disk only and never S3.
+ * purge has freed but not yet returned to the OS. The change-streamer schedules
+ * purges against the same floor as the PG change log, so retention is bounded
+ * by the confirmed backup watermark ANDed with the minimum retention window —
+ * a function of the backup interval, not a constant: 15–30+ minutes behind an
+ * RMv1 sync interval, ~60 seconds once litestream v5 backs up every 15–30 s.
+ * A held snapshot reservation pins retention unboundedly for its duration, so
+ * peak retained bytes is set by the slowest concurrent restore rather than by
+ * the retention setting — size disk and alerts on that. The log is excluded
+ * from the litestream backup, so this is local disk only and never S3.
  */
 
 import type {LogContext} from '@rocicorp/logger';


### PR DESCRIPTION
Add the purger which deletes history when all of these are true:

  - The purge candidate is before the oldest backup watermark still needed.
  - Every connected subscriber has acknowledged at least that watermark.
  - It is older than the configured retention window—60 seconds by default.
  - It is not the newest transaction.
  - No backup/snapshot restore currently reserves that history.
  - The SQLite writer is between transactions.

  Cleanup happens in small batches so it doesn’t monopolize the change-streamer. It yields
  between batches and automatically checks again as retained rows grow old enough.


  Operationally:

  - Default mode is still off, so the branch changes nothing by default.
  - In write mode and above, SQLite logging is now disk-bounded (because we purge)
  - This branch still doesn’t serve normal catch-up traffic from SQLite; it prepares the infrastructure for slice 10’s comparison rollout.
  - PostgreSQL cleanup behavior is unchanged.
  - Rollback is simply setting sqliteChangeLogMode=off.
