### PR TITLE
chore(rmv2): compare SQLite catchup output against PG

### DIFF
--- a/packages/zero-cache/src/config/normalize.test.ts
+++ b/packages/zero-cache/src/config/normalize.test.ts
@@ -12,6 +12,7 @@ function configWith(litestream: Partial<ZeroConfig['litestream']>): ZeroConfig {
       address: 'localhost',
       sqliteChangeLogMode: 'off',
       sqliteChangeLogReadPercent: 0,
+      sqliteChangeLogComparePercent: 1,
       sqliteChangeLogRetentionMs: 60_000,
       sqliteChangeLogReadBatchRows: 1000,
       sqliteChangeLogPurgeBatchRows: 1000,
@@ -128,6 +129,22 @@ describe('config/normalize SQLite change log', () => {
         'must be an integer between 0 and 100',
       );
     }
+  });
+
+  test('compare percentage must be an integer from 0 through 100, in any mode', () => {
+    for (const percent of [-1, 1.5, 101]) {
+      const config = configWith({});
+      config.changeStreamer.sqliteChangeLogComparePercent = percent;
+
+      expect(() => assertNormalized(config)).toThrow(
+        '--change-streamer-sqlite-change-log-compare-percent must be an integer between 0 and 100',
+      );
+    }
+    // Unlike the read percentage, a nonzero value is valid in every mode:
+    // the default is nonzero, and sampling only runs in `compare` and above.
+    const config = configWith({});
+    config.changeStreamer.sqliteChangeLogComparePercent = 100;
+    expect(() => assertNormalized(config)).not.toThrow();
   });
 
   test('accepts positive integer tuning values', () => {

--- a/packages/zero-cache/src/config/normalize.ts
+++ b/packages/zero-cache/src/config/normalize.ts
@@ -46,6 +46,7 @@ export function assertNormalized(
   const {
     sqliteChangeLogMode,
     sqliteChangeLogReadPercent,
+    sqliteChangeLogComparePercent,
     sqliteChangeLogRetentionMs,
     sqliteChangeLogReadBatchRows,
     sqliteChangeLogPurgeBatchRows,
@@ -56,6 +57,14 @@ export function assertNormalized(
       sqliteChangeLogReadPercent >= 0 &&
       sqliteChangeLogReadPercent <= 100,
     '--change-streamer-sqlite-change-log-read-percent must be an integer between 0 and 100',
+  );
+  // Deliberately no mode restriction: the default is nonzero, and the sampled
+  // comparison only runs in `compare` mode and above.
+  assert(
+    Number.isSafeInteger(sqliteChangeLogComparePercent) &&
+      sqliteChangeLogComparePercent >= 0 &&
+      sqliteChangeLogComparePercent <= 100,
+    '--change-streamer-sqlite-change-log-compare-percent must be an integer between 0 and 100',
   );
   assert(
     sqliteChangeLogMode === 'serve' || sqliteChangeLogReadPercent === 0,

--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -693,6 +693,15 @@ export const zeroOptions = {
       hidden: true,
     },
 
+    sqliteChangeLogComparePercent: {
+      type: v.number().default(1),
+      desc: [
+        `The stable percentage of committed transactions whose catchup output is`,
+        `compared between the Postgres and SQLite change logs in {bold compare} mode.`,
+      ],
+      hidden: true,
+    },
+
     sqliteChangeLogRetentionMs: {
       type: v.number().default(60_000),
       desc: [`The minimum time window retained in the SQLite change log.`],

--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -68,6 +68,7 @@ export default async function runWorker(
       flowControlConsensusPaddingSeconds,
       flowControlEventDrivenRelease,
       sqliteChangeLogMode,
+      sqliteChangeLogComparePercent,
       sqliteChangeLogRetentionMs,
       sqliteChangeLogReadBatchRows,
       sqliteChangeLogPurgeBatchRows,
@@ -226,6 +227,17 @@ export default async function runWorker(
                 batchRows: sqliteChangeLogPurgeBatchRows,
               }
             : undefined,
+          // Modes are cumulative: `compare` and `serve` sample dark reads of
+          // both stores' catchup output. PG remains authoritative; nothing a
+          // subscriber is served changes.
+          sqliteChangeLogCompare:
+            sqliteChangeLogMode === 'compare' || sqliteChangeLogMode === 'serve'
+              ? {
+                  comparePercent: sqliteChangeLogComparePercent,
+                  retentionMs: sqliteChangeLogRetentionMs,
+                  readBatchRows: sqliteChangeLogReadBatchRows,
+                }
+              : undefined,
         },
         setTimeout,
       );

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -54,6 +54,10 @@ import {
   type SQLiteChangeLogCleanupGuard,
 } from './sqlite-change-log-catchup.ts';
 import {
+  SQLiteChangeLogComparator,
+  type SQLiteChangeLogCompareOptions,
+} from './sqlite-change-log-comparator.ts';
+import {
   SQLiteChangeLogPurgeScheduler,
   type PurgeContinuation,
   type SQLiteChangeLogPurgeSchedulerOptions,
@@ -127,6 +131,14 @@ export type TuningOptions = StorerOptions & {
    * the replicator's cleanup.
    */
   sqliteChangeLogPurge?: SQLiteChangeLogPurgeSchedulerOptions | undefined;
+  /**
+   * Supplied when `sqliteChangeLogMode` is `compare` or above: samples dark
+   * reads of both change logs' catchup output and compares them per
+   * transaction. Requires the writer (for the log to compare against) and the
+   * catchup options (for the log's path); it changes nothing about what
+   * subscribers are served.
+   */
+  sqliteChangeLogCompare?: SQLiteChangeLogCompareOptions | undefined;
 };
 
 /**
@@ -339,6 +351,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
   readonly #sqliteCatchupOptions: SQLiteCatchupOptions | undefined;
   readonly #changeLogWriter: SQLiteChangeLogWriter | undefined;
   readonly #purgeScheduler: SQLiteChangeLogPurgeScheduler | undefined;
+  readonly #comparator: SQLiteChangeLogComparator | undefined;
 
   readonly #autoReset: boolean;
   readonly #state: RunningState;
@@ -457,8 +470,12 @@ class ChangeStreamerImpl implements ChangeStreamerService {
           },
           // Fail-soft deletes the file, and the reader is cached here, so it
           // has to go with it: otherwise it serves an unlinked inode while
-          // every new open sees nothing.
-          onDisabled: () => this.#closeSQLiteCatchup(),
+          // every new open sees nothing. The comparator stops for the same
+          // reason: with the file gone there is nothing left to compare.
+          onDisabled: () => {
+            this.#closeSQLiteCatchup();
+            this.#comparator?.stop();
+          },
         })
       : undefined;
     // The purge scheduler runs on the writer's own connection, which is also
@@ -485,6 +502,24 @@ class ChangeStreamerImpl implements ChangeStreamerService {
             this.#purgeScheduler?.cleanupGuard,
         }
       : undefined;
+    // The comparator samples dark reads of both stores' catchup output
+    // (`sqliteChangeLogMode=compare` and above). It shares the writer's gate —
+    // without a writer there is no log to compare — and reads the log through
+    // its own readonly handles, opened per cycle, so a fail-soft delete or a
+    // late-appearing file needs no coordination.
+    this.#comparator =
+      opts.sqliteChangeLogCompare &&
+      opts.sqliteChangeLogWriter &&
+      opts.sqliteCatchup
+        ? new SQLiteChangeLogComparator(
+            lc,
+            shard,
+            opts.sqliteCatchup.changeLogFile,
+            opts.sqliteChangeLogWriter.identity,
+            this.#storer,
+            {setTimeoutFn, ...opts.sqliteChangeLogCompare},
+          )
+        : undefined;
     this.#purgeLock = initialPurgeLock;
     this.#autoReset = autoReset;
     this.#state = new RunningState(this.id, undefined, setTimeoutFn);
@@ -991,6 +1026,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
     this.#state.stop(this.#lc, err);
     this.#stream?.changes.cancel();
     this.#purgeScheduler?.stop();
+    this.#comparator?.stop();
     this.#sqliteCatchup?.close();
     this.#changeLogWriter?.close();
     await this.#storer.stop();

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.pg.test.ts
@@ -337,6 +337,45 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
     });
   });
 
+  test('a capped cycle schedules its continuation without the poll delay', async () => {
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'a'})),
+      tx('04', messages.insert('foo', {id: 'b'})),
+      tx('05', messages.insert('foo', {id: 'c'})),
+    );
+
+    type Scheduled = {callback: () => void; delayMs: number};
+    const scheduled = new Map<ReturnType<typeof setTimeout>, Scheduled>();
+    let nextTimer = 0;
+    const setTimeoutFn = vi.fn((callback: () => void, delayMs?: number) => {
+      const handle = ++nextTimer as unknown as ReturnType<typeof setTimeout>;
+      scheduled.set(handle, {callback, delayMs: delayMs ?? 0});
+      return handle;
+    }) as unknown as typeof setTimeout;
+    const clearTimeoutFn = vi.fn((handle: ReturnType<typeof setTimeout>) => {
+      scheduled.delete(handle);
+    }) as unknown as typeof clearTimeout;
+    const comparator = newComparator({
+      intervalMs: 30_000,
+      maxTransactionsPerCycle: 2,
+      setTimeoutFn,
+      clearTimeoutFn,
+    });
+
+    expect(Array.from(scheduled.values(), ({delayMs}) => delayMs)).toEqual([
+      30_000,
+    ]);
+    const first = await comparator.compareOnce();
+    assert(first.kind === 'compared', 'expected a compared cycle');
+    expect(first).toMatchObject({
+      throughWatermark: '04',
+      transactions: 2,
+    });
+    expect(Array.from(scheduled.values(), ({delayMs}) => delayMs)).toEqual([0]);
+
+    comparator.stop();
+  });
+
   test('head lag in either direction is not divergence', async () => {
     await feedBoth(
       tx('03', messages.insert('foo', {id: 'boundary'})),
@@ -530,6 +569,46 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
     expect(third).toEqual({kind: 'skipped', reason: 'nothing-to-compare'});
   });
 
+  test('a missing PG catchup boundary prevents accepting the later range', async () => {
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'older'})),
+      tx('04', messages.insert('foo', {id: 'boundary'})),
+      tx('05', messages.insert('foo', {id: 'later'})),
+    );
+    // SQLite has purged to '04', while PG still has older and later rows but
+    // has a hole at that exact catchup boundary.
+    withSQLiteLog(db =>
+      db
+        .prepare(
+          /*sql*/ `DELETE FROM "${CHANGE_LOG_STREAM_TABLE}" WHERE "watermark" < '04'`,
+        )
+        .run(),
+    );
+    await sql`DELETE FROM ${cdc('changeLog')} WHERE watermark = '04'`;
+
+    const comparator = newComparator();
+    const first = await comparator.compareOnce();
+    assert(first.kind === 'compared', 'expected a compared cycle');
+    expect(first).toMatchObject({
+      fromWatermark: '04',
+      throughWatermark: '04',
+      transactions: 0,
+      sampled: 0,
+      matched: 0,
+      divergent: [{watermark: '04', outcome: 'bounds-mismatch'}],
+    });
+
+    // The later transaction is not accepted and the invalid boundary remains
+    // the start of the next attempt.
+    const second = await comparator.compareOnce();
+    assert(second.kind === 'compared', 'expected a compared cycle');
+    expect(second).toMatchObject({
+      fromWatermark: '04',
+      throughWatermark: '04',
+      matched: 0,
+    });
+  });
+
   test('a divergent cursor boundary does not wedge the comparator', async () => {
     // SQLite loses a whole transaction PG holds, while the log runs ahead of
     // PG (its normal state), so the cycle's common upper bound — and with it
@@ -626,6 +705,7 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
     // cannot see this — only the meta comparison can.
     const racing: PGChangeLogRangeReader = {
       getCatchupBounds: () => storer.getCatchupBounds(),
+      hasCatchupWatermark: w => storer.hasCatchupWatermark(w),
       listCommitWatermarks: async (after, through, limit) => {
         const list = await storer.listCommitWatermarks(after, through, limit);
         withSQLiteLog(db => {
@@ -668,27 +748,37 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
         )
         .run(),
     );
-    // The bounds re-read that would confirm the finding fails; the
+    // The first bounds re-read that would confirm the finding fails; the
     // observation cannot be distinguished from a race and must not report.
     let boundsReads = 0;
     const failing: PGChangeLogRangeReader = {
       getCatchupBounds: () => {
-        if (++boundsReads > 1) {
+        if (++boundsReads === 2) {
           throw new Error('injected bounds re-read failure');
         }
         return storer.getCatchupBounds();
       },
+      hasCatchupWatermark: w => storer.hasCatchupWatermark(w),
       listCommitWatermarks: (after, through, limit) =>
         storer.listCommitWatermarks(after, through, limit),
       readCatchupRange: (after, through) =>
         storer.readCatchupRange(after, through),
     };
-    const result = await newComparator({pg: failing}).compareOnce();
+    const comparator = newComparator({pg: failing});
+    const result = await comparator.compareOnce();
     assert(result.kind === 'compared', 'expected a compared cycle');
     expect(result.divergent).toMatchObject([
       {watermark: '04', outcome: 'inconclusive'},
     ]);
     expect(result.matched).toBe(2);
+
+    // The cursor did not move, so a later cycle retries and confirms the
+    // persistent divergence once the transient bounds failure clears.
+    const retry = await comparator.compareOnce();
+    assert(retry.kind === 'compared', 'expected a compared cycle');
+    expect(retry.divergent).toMatchObject([
+      {watermark: '04', outcome: 'missing-sqlite'},
+    ]);
   });
 
   test('a failing reader classifies as reader-error', async () => {
@@ -698,6 +788,7 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
     );
     const failing: PGChangeLogRangeReader = {
       getCatchupBounds: () => storer.getCatchupBounds(),
+      hasCatchupWatermark: w => storer.hasCatchupWatermark(w),
       listCommitWatermarks: (after, through, limit) =>
         storer.listCommitWatermarks(after, through, limit),
       readCatchupRange: (after, through) => {
@@ -726,6 +817,7 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
     let purged = false;
     const racing: PGChangeLogRangeReader = {
       getCatchupBounds: () => storer.getCatchupBounds(),
+      hasCatchupWatermark: w => storer.hasCatchupWatermark(w),
       listCommitWatermarks: (after, through, limit) =>
         storer.listCommitWatermarks(after, through, limit),
       readCatchupRange: (after, through) =>
@@ -763,6 +855,7 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
     // purger (which deletes whole transactions below the floor) would.
     const racing: PGChangeLogRangeReader = {
       getCatchupBounds: () => storer.getCatchupBounds(),
+      hasCatchupWatermark: w => storer.hasCatchupWatermark(w),
       listCommitWatermarks: async (after, through, limit) => {
         const list = await storer.listCommitWatermarks(after, through, limit);
         withSQLiteLog(db =>
@@ -989,6 +1082,16 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
               runWriter.write(change, storer.store(t.watermark, change));
             }
           };
+          // Production seeds at PG's durable head, which must be a valid
+          // catchup boundary. Give each generated run the same invariant;
+          // SQLite's synthetic seed remains excluded from the compared range.
+          const boundary = tx(
+            wm(base),
+            messages.insert('foo', {id: `boundary-${base}`}),
+          );
+          for (const change of boundary.changes) {
+            storer.store(boundary.watermark, change);
+          }
           for (const spec of specs) {
             feedRun(
               tx(
@@ -1066,14 +1169,12 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
             }
           }
 
-          // Drive to quiescence. The tiny per-cycle limit forces cycle
-          // boundaries onto arbitrary — possibly corrupted — transactions,
-          // fuzzing the truncation-to-common-range arithmetic, and makes the
-          // guard a real anti-wedge property: a divergent boundary must
-          // never stall the cursor.
+          // Drive to quiescence in one complete range, whose clean sentinel is
+          // a valid boundary in both stores. Capped-range behavior is covered
+          // separately: allowing a cap to land on a PG hole would correctly
+          // keep rejecting that boundary, just as authoritative catchup does.
           const comparator = newComparator({
             file: changeLogFileName(runFile.path),
-            maxTransactionsPerCycle: 2,
           });
           const divergent: {watermark: string; outcome: string}[] = [];
           let matched = 0;
@@ -1093,22 +1194,6 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
             );
           }
 
-          // A cursor landing on a transaction SQLite does not hold is
-          // re-reported once as a bounds-mismatch when the next cycle's
-          // plan() cannot serve the boundary — a classified duplicate of the
-          // missing-sqlite finding, never of anything else, and never twice.
-          const echoes = divergent.filter(d => d.outcome === 'bounds-mismatch');
-          for (const echo of echoes) {
-            expect(
-              specs.some(
-                s => s.watermark === echo.watermark && s.kind === 'drop-sqlite',
-              ),
-            ).toBe(true);
-          }
-          expect(new Set(echoes.map(e => e.watermark)).size).toBe(
-            echoes.length,
-          );
-
           const order = (
             a: {watermark: string; outcome: string},
             b: {watermark: string; outcome: string},
@@ -1118,10 +1203,7 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
               : a.watermark > b.watermark
                 ? 1
                 : a.outcome.localeCompare(b.outcome);
-          const primary = divergent.filter(
-            d => d.outcome !== 'bounds-mismatch',
-          );
-          expect(primary.toSorted(order)).toEqual(expected.toSorted(order));
+          expect(divergent.toSorted(order)).toEqual(expected.toSorted(order));
           expect(matched).toBe(expectedMatched);
         } finally {
           runWriter.close();

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.pg.test.ts
@@ -337,6 +337,105 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
     });
   });
 
+  test('caps total catchup rows per source and defers an unfinished transaction', async () => {
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'first'})),
+      tx(
+        '04',
+        messages.insert('foo', {id: 'second-a'}),
+        messages.insert('foo', {id: 'second-b'}),
+      ),
+    );
+    const comparator = newComparator({
+      maxRowsPerSourcePerCycle: 5,
+      readBatchRows: 2,
+    });
+
+    const first = await comparator.compareOnce();
+    assert(first.kind === 'compared', 'expected a compared cycle');
+    expect(first).toMatchObject({
+      throughWatermark: '03',
+      transactions: 1,
+      sampled: 2,
+      matched: 1,
+      sqliteRowsRead: 5,
+      pgRowsRead: 5,
+      deferred: 1,
+      oversized: 0,
+      divergent: [],
+    });
+
+    const second = await comparator.compareOnce();
+    assert(second.kind === 'compared', 'expected a compared cycle');
+    expect(second).toMatchObject({
+      fromWatermark: '03',
+      throughWatermark: '04',
+      transactions: 1,
+      sampled: 1,
+      matched: 1,
+      sqliteRowsRead: 4,
+      pgRowsRead: 4,
+      deferred: 0,
+      oversized: 0,
+      divergent: [],
+    });
+  });
+
+  test('skips a transaction that exceeds a fresh cycle row budget', async () => {
+    await feedBoth(
+      tx(
+        '03',
+        messages.insert('foo', {id: 'large-a'}),
+        messages.insert('foo', {id: 'large-b'}),
+        messages.insert('foo', {id: 'large-c'}),
+      ),
+      tx('04', messages.insert('foo', {id: 'after-large'})),
+    );
+    const comparator = newComparator({maxRowsPerSourcePerCycle: 4});
+
+    const first = await comparator.compareOnce();
+    assert(first.kind === 'compared', 'expected a compared cycle');
+    expect(first).toMatchObject({
+      throughWatermark: '03',
+      transactions: 1,
+      sampled: 1,
+      matched: 0,
+      sqliteRowsRead: 4,
+      pgRowsRead: 4,
+      deferred: 0,
+      oversized: 1,
+      divergent: [],
+    });
+
+    const second = await comparator.compareOnce();
+    assert(second.kind === 'compared', 'expected a compared cycle');
+    expect(second).toMatchObject({
+      fromWatermark: '03',
+      throughWatermark: '04',
+      matched: 1,
+      sqliteRowsRead: 3,
+      pgRowsRead: 3,
+      oversized: 0,
+    });
+  });
+
+  test('compares a transaction that exactly fills the cycle row budget', async () => {
+    await feedBoth(tx('03', messages.insert('foo', {id: 'exact'})));
+
+    const result = await newComparator({
+      maxRowsPerSourcePerCycle: 3,
+    }).compareOnce();
+    assert(result.kind === 'compared', 'expected a compared cycle');
+    expect(result).toMatchObject({
+      throughWatermark: '03',
+      matched: 1,
+      sqliteRowsRead: 3,
+      pgRowsRead: 3,
+      deferred: 0,
+      oversized: 0,
+    });
+  });
+
   test('a capped cycle schedules its continuation without the poll delay', async () => {
     await feedBoth(
       tx('03', messages.insert('foo', {id: 'a'})),
@@ -717,8 +816,8 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
         });
         return list;
       },
-      readCatchupRange: (after, through) =>
-        storer.readCatchupRange(after, through),
+      readCatchupRange: (after, through, batchRows) =>
+        storer.readCatchupRange(after, through, batchRows),
     };
     const result = await newComparator({pg: racing}).compareOnce();
     assert(result.kind === 'compared', 'expected a compared cycle');
@@ -761,8 +860,8 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
       hasCatchupWatermark: w => storer.hasCatchupWatermark(w),
       listCommitWatermarks: (after, through, limit) =>
         storer.listCommitWatermarks(after, through, limit),
-      readCatchupRange: (after, through) =>
-        storer.readCatchupRange(after, through),
+      readCatchupRange: (after, through, batchRows) =>
+        storer.readCatchupRange(after, through, batchRows),
     };
     const comparator = newComparator({pg: failing});
     const result = await comparator.compareOnce();
@@ -791,11 +890,11 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
       hasCatchupWatermark: w => storer.hasCatchupWatermark(w),
       listCommitWatermarks: (after, through, limit) =>
         storer.listCommitWatermarks(after, through, limit),
-      readCatchupRange: (after, through) => {
+      readCatchupRange: (after, through, batchRows) => {
         if (through === '04') {
           throw new Error('injected read failure');
         }
-        return storer.readCatchupRange(after, through);
+        return storer.readCatchupRange(after, through, batchRows);
       },
     };
     const result = await newComparator({pg: failing}).compareOnce();
@@ -820,13 +919,13 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
       hasCatchupWatermark: w => storer.hasCatchupWatermark(w),
       listCommitWatermarks: (after, through, limit) =>
         storer.listCommitWatermarks(after, through, limit),
-      readCatchupRange: (after, through) =>
+      readCatchupRange: (after, through, batchRows) =>
         (async function* (this: void) {
           if (!purged) {
             purged = true;
             await storer.purgeRecordsBefore('05');
           }
-          yield* storer.readCatchupRange(after, through);
+          yield* storer.readCatchupRange(after, through, batchRows);
         })(),
     };
     const result = await newComparator({pg: racing}).compareOnce();
@@ -867,8 +966,8 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
         );
         return list;
       },
-      readCatchupRange: (after, through) =>
-        storer.readCatchupRange(after, through),
+      readCatchupRange: (after, through, batchRows) =>
+        storer.readCatchupRange(after, through, batchRows),
     };
     const result = await newComparator({pg: racing}).compareOnce();
     assert(result.kind === 'compared', 'expected a compared cycle');

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.pg.test.ts
@@ -446,6 +446,50 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
     expect(result.matched).toBe(2);
   });
 
+  test('rows outside any committed transaction classify as orphan-output', async () => {
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'a'})),
+      tx('04', messages.insert('foo', {id: 'b'})),
+      tx('05', messages.insert('foo', {id: 'c'})),
+    );
+    // A torn/corrupt remnant only SQLite serves: begin + data with no commit
+    // row, invisible to the commit enumeration but served to any subscriber
+    // catching up across it. '03b' is the same remnant in *both* stores,
+    // identically — parity in what catchup serves, so not a finding.
+    withSQLiteLog(db =>
+      db.exec(/*sql*/ `
+        INSERT INTO "${CHANGE_LOG_STREAM_TABLE}"
+          ("watermark", "pos", "change", "precommit", "writeTimeMs")
+        VALUES
+          ('03a', 0, '{"tag":"begin"}', NULL, NULL),
+          ('03a', 1, '{"tag":"insert"}', NULL, NULL),
+          ('03b', 0, '{"tag":"begin"}', NULL, NULL),
+          ('03b', 1, '{"tag":"insert"}', NULL, NULL)
+      `),
+    );
+    await sql`
+      INSERT INTO ${cdc('changeLog')} ("watermark", "pos", "change", "precommit")
+      VALUES ('03b', 0, '{"tag":"begin"}'::json, NULL),
+             ('03b', 1, '{"tag":"insert"}'::json, NULL),
+             ('04a', 0, '{"tag":"begin"}'::json, NULL),
+             ('04a', 1, '{"tag":"insert"}'::json, NULL)`;
+
+    const result = await newComparator().compareOnce();
+    assert(result.kind === 'compared', 'expected a compared cycle');
+    // The asymmetric orphans are reported at their own watermarks; the
+    // transactions themselves all still match.
+    expect(result.divergent).toMatchObject([
+      {watermark: '03a', outcome: 'orphan-output', sqliteRows: 2},
+      {watermark: '04a', outcome: 'orphan-output', pgRows: 2},
+    ]);
+    expect(result.matched).toBe(3);
+    const [sqliteOrphan, pgOrphan] = result.divergent;
+    expect(sqliteOrphan.sqliteDigest).toHaveLength(16);
+    expect(sqliteOrphan.pgDigest).toBeUndefined();
+    expect(pgOrphan.pgDigest).toHaveLength(16);
+    expect(pgOrphan.sqliteDigest).toBeUndefined();
+  });
+
   test('a missing catchup boundary classifies as bounds-mismatch', async () => {
     await feedBoth(
       tx('03', messages.insert('foo', {id: 'boundary'})),

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.pg.test.ts
@@ -1,4 +1,5 @@
 import {LogContext} from '@rocicorp/logger';
+import fc from 'fast-check';
 import {beforeEach, describe, expect, vi} from 'vitest';
 import {assert} from '../../../../shared/src/asserts.ts';
 import {TestLogSink} from '../../../../shared/src/logging-test-utils.ts';
@@ -11,7 +12,9 @@ import {cdcSchema, type ShardID} from '../../types/shards.ts';
 import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
 import {
   changeLogFileName,
+  CHANGE_LOG_META_TABLE,
   CHANGE_LOG_STREAM_TABLE,
+  deleteChangeLogDB,
   type ChangeLogIdentity,
 } from '../replicator/change-log-db.ts';
 import {
@@ -571,6 +574,123 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
     expect(third).toEqual({kind: 'skipped', reason: 'nothing-to-compare'});
   });
 
+  test('a limited cycle over divergent stores compares only the common covered range', async () => {
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'a'})),
+      tx('04', messages.insert('foo', {id: 'b'})),
+      tx('05', messages.insert('foo', {id: 'c'})),
+      tx('06', messages.insert('foo', {id: 'd'})),
+    );
+    withSQLiteLog(db =>
+      db
+        .prepare(
+          /*sql*/ `DELETE FROM "${CHANGE_LOG_STREAM_TABLE}" WHERE "watermark" = '04'`,
+        )
+        .run(),
+    );
+
+    const comparator = newComparator({maxTransactionsPerCycle: 2});
+    const first = await comparator.compareOnce();
+    assert(first.kind === 'compared', 'expected a compared cycle');
+    // The stores hit the limit at different watermarks — SQLite's two commits
+    // reach '05', PG's reach '04' — so the cycle covers only the range both
+    // enumerations completely cover. '05', cut from PG's list by the limit
+    // alone, must not be reported missing.
+    expect(first).toMatchObject({
+      throughWatermark: '04',
+      transactions: 2,
+      matched: 1,
+    });
+    expect(first.divergent).toMatchObject([
+      {watermark: '04', outcome: 'missing-sqlite'},
+    ]);
+
+    // The next cycle resumes above the covered range and completes it.
+    const second = await comparator.compareOnce();
+    assert(second.kind === 'compared', 'expected a compared cycle');
+    expect(second).toMatchObject({throughWatermark: '06', matched: 2});
+    expect(second.divergent).toMatchObject([
+      {watermark: '04', outcome: 'bounds-mismatch'},
+    ]);
+  });
+
+  test('a reseed racing the comparison yields inconclusive', async () => {
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'boundary'})),
+      tx('04', messages.insert('foo', {id: 'reseeded-away'})),
+      tx('05', messages.insert('foo', {id: 'witness'})),
+    );
+    // The writer reseeds the log after the cycle pinned its bounds and
+    // enumerated the range: '04' vanishes and the meta row's seed point
+    // moves, as reconcileChangeLog's reseed would. The re-read bounds alone
+    // cannot see this — only the meta comparison can.
+    const racing: PGChangeLogRangeReader = {
+      getCatchupBounds: () => storer.getCatchupBounds(),
+      listCommitWatermarks: async (after, through, limit) => {
+        const list = await storer.listCommitWatermarks(after, through, limit);
+        withSQLiteLog(db => {
+          db.prepare(
+            /*sql*/ `DELETE FROM "${CHANGE_LOG_STREAM_TABLE}" WHERE "watermark" = '04'`,
+          ).run();
+          db.prepare(/*sql*/ `UPDATE "${CHANGE_LOG_META_TABLE}"
+                SET "seedWatermark" = '03', "seededAtMs" = "seededAtMs" + 1`).run();
+        });
+        return list;
+      },
+      readCatchupRange: (after, through) =>
+        storer.readCatchupRange(after, through),
+    };
+    const result = await newComparator({pg: racing}).compareOnce();
+    assert(result.kind === 'compared', 'expected a compared cycle');
+    expect(result.divergent).toMatchObject([
+      {watermark: '04', outcome: 'inconclusive'},
+    ]);
+    expect(result.matched).toBe(2);
+    // A reseed is a race, not a finding: nothing reports as diverged.
+    expect(
+      logSink.messages.filter(
+        ([level, , parts]) =>
+          level === 'error' && JSON.stringify(parts).includes('diverged'),
+      ),
+    ).toEqual([]);
+  });
+
+  test('a suspect that cannot be reconfirmed is inconclusive', async () => {
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'boundary'})),
+      tx('04', messages.insert('foo', {id: 'victim'})),
+      tx('05', messages.insert('foo', {id: 'witness'})),
+    );
+    withSQLiteLog(db =>
+      db
+        .prepare(
+          /*sql*/ `DELETE FROM "${CHANGE_LOG_STREAM_TABLE}" WHERE "watermark" = '04'`,
+        )
+        .run(),
+    );
+    // The bounds re-read that would confirm the finding fails; the
+    // observation cannot be distinguished from a race and must not report.
+    let boundsReads = 0;
+    const failing: PGChangeLogRangeReader = {
+      getCatchupBounds: () => {
+        if (++boundsReads > 1) {
+          throw new Error('injected bounds re-read failure');
+        }
+        return storer.getCatchupBounds();
+      },
+      listCommitWatermarks: (after, through, limit) =>
+        storer.listCommitWatermarks(after, through, limit),
+      readCatchupRange: (after, through) =>
+        storer.readCatchupRange(after, through),
+    };
+    const result = await newComparator({pg: failing}).compareOnce();
+    assert(result.kind === 'compared', 'expected a compared cycle');
+    expect(result.divergent).toMatchObject([
+      {watermark: '04', outcome: 'inconclusive'},
+    ]);
+    expect(result.matched).toBe(2);
+  });
+
   test('a failing reader classifies as reader-error', async () => {
     await feedBoth(
       tx('03', messages.insert('foo', {id: 'boundary'})),
@@ -786,6 +906,231 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
       kind: 'skipped',
       reason: 'nothing-to-compare',
     });
+  });
+
+  test('property: injected corruptions are reported exactly, then quiescence', async () => {
+    type CorruptionKind = 'clean' | 'drop-sqlite' | 'drop-pg' | 'mutate-pg';
+    type OrphanSide = 'sqlite' | 'pg' | 'both';
+
+    const faultScenario = fc.record({
+      txs: fc.array(
+        fc.record({
+          width: fc.integer({min: 0, max: 3}),
+          kind: fc.constantFrom<CorruptionKind>(
+            'clean',
+            'drop-sqlite',
+            'drop-pg',
+            'mutate-pg',
+          ),
+          orphanAfter: fc.option(
+            fc.constantFrom<OrphanSide>('sqlite', 'pg', 'both'),
+            {nil: undefined},
+          ),
+        }),
+        {minLength: 1, maxLength: 5},
+      ),
+    });
+
+    // Runs share the fixture's PG database; each run scopes itself with a
+    // fresh SQLite log seeded above every prior run's watermarks, so prior
+    // corruptions sit below its `from` and are invisible to it.
+    let nextNum = 1;
+    const wm = (n: number) => `w${String(n).padStart(8, '0')}`;
+
+    const withRunLog = <T>(file: DbFile, fn: (db: Database) => T): T => {
+      const db = new Database(lc, changeLogFileName(file.path));
+      try {
+        return fn(db);
+      } finally {
+        db.close();
+      }
+    };
+    const insertSQLiteOrphan = (file: DbFile, watermark: string) =>
+      withRunLog(file, db =>
+        db
+          .prepare(/*sql*/ `
+              INSERT INTO "${CHANGE_LOG_STREAM_TABLE}"
+                ("watermark", "pos", "change", "precommit", "writeTimeMs")
+              VALUES (?, 0, '{"tag":"begin"}', NULL, NULL),
+                     (?, 1, '{"tag":"insert"}', NULL, NULL)`)
+          .run(watermark, watermark),
+      );
+    const insertPGOrphan = (watermark: string) => sql`
+      INSERT INTO ${cdc('changeLog')} ("watermark", "pos", "change", "precommit")
+      VALUES (${watermark}, 0, '{"tag":"begin"}'::json, NULL),
+             (${watermark}, 1, '{"tag":"insert"}'::json, NULL)`;
+
+    await fc.assert(
+      fc.asyncProperty(faultScenario, async ({txs}) => {
+        const base = nextNum;
+        nextNum += (txs.length + 2) * 10;
+
+        const runFile = new DbFile('sqlite-change-log-comparator-fuzz');
+        const runWriter = new SQLiteChangeLogWriter(lc, {
+          replicaFile: runFile.path,
+          identity,
+          now: () => seededAtMs,
+        });
+        try {
+          runWriter.reconcile(wm(base));
+
+          const specs = txs.map((spec, i) => ({
+            ...spec,
+            watermark: wm(base + (i + 1) * 10),
+            orphanAt: wm(base + (i + 1) * 10 + 5),
+          }));
+          // A clean sentinel pins the common head, so every generated
+          // transaction lies strictly inside the compared range — head skew
+          // is deliberately never reported, and is not what this pins.
+          const sentinel = wm(base + (txs.length + 1) * 10);
+
+          const feedRun = (t: Tx) => {
+            for (const change of t.changes) {
+              runWriter.write(change, storer.store(t.watermark, change));
+            }
+          };
+          for (const spec of specs) {
+            feedRun(
+              tx(
+                spec.watermark,
+                ...Array.from({length: spec.width}, (_, k) =>
+                  messages.insert('foo', {id: `${spec.watermark}-${k}`}),
+                ),
+              ),
+            );
+          }
+          feedRun(tx(sentinel, messages.insert('foo', {id: sentinel})));
+          await storer.allProcessed();
+
+          // Corrupt, and build the expected report while doing so.
+          const expected: {watermark: string; outcome: string}[] = [];
+          let expectedMatched = 1; // the sentinel
+          for (const [i, spec] of specs.entries()) {
+            // An orphan is served inside the range of the next transaction
+            // up; when one store does not hold that transaction, the range
+            // is never read and the orphan is unobservable.
+            const upper = specs[i + 1];
+            const upperIntact =
+              upper === undefined ||
+              (upper.kind !== 'drop-sqlite' && upper.kind !== 'drop-pg');
+            switch (spec.kind) {
+              case 'clean':
+                expectedMatched++;
+                break;
+              case 'drop-sqlite':
+                withRunLog(runFile, db =>
+                  db
+                    .prepare(
+                      /*sql*/ `DELETE FROM "${CHANGE_LOG_STREAM_TABLE}" WHERE "watermark" = ?`,
+                    )
+                    .run(spec.watermark),
+                );
+                expected.push({
+                  watermark: spec.watermark,
+                  outcome: 'missing-sqlite',
+                });
+                break;
+              case 'drop-pg':
+                await sql`
+                  DELETE FROM ${cdc('changeLog')} WHERE watermark = ${spec.watermark}`;
+                expected.push({
+                  watermark: spec.watermark,
+                  outcome: 'missing-pg',
+                });
+                break;
+              case 'mutate-pg':
+                await mutatePGChange(spec.watermark, 0, change => {
+                  change.mutated = true;
+                });
+                expected.push({
+                  watermark: spec.watermark,
+                  outcome: 'digest-mismatch',
+                });
+                break;
+            }
+            if (spec.orphanAfter !== undefined) {
+              if (spec.orphanAfter !== 'pg') {
+                insertSQLiteOrphan(runFile, spec.orphanAt);
+              }
+              if (spec.orphanAfter !== 'sqlite') {
+                await insertPGOrphan(spec.orphanAt);
+              }
+              // Identical orphan output in both stores is parity in what
+              // catchup serves, never a finding.
+              if (spec.orphanAfter !== 'both' && upperIntact) {
+                expected.push({
+                  watermark: spec.orphanAt,
+                  outcome: 'orphan-output',
+                });
+              }
+            }
+          }
+
+          // Drive to quiescence. The tiny per-cycle limit forces cycle
+          // boundaries onto arbitrary — possibly corrupted — transactions,
+          // fuzzing the truncation-to-common-range arithmetic, and makes the
+          // guard a real anti-wedge property: a divergent boundary must
+          // never stall the cursor.
+          const comparator = newComparator({
+            file: changeLogFileName(runFile.path),
+            maxTransactionsPerCycle: 2,
+          });
+          const divergent: {watermark: string; outcome: string}[] = [];
+          let matched = 0;
+          for (let guard = 0; ; guard++) {
+            assert(guard < 8, 'comparator failed to reach quiescence');
+            const result = await comparator.compareOnce();
+            if (result.kind === 'skipped') {
+              expect(result.reason).toBe('nothing-to-compare');
+              break;
+            }
+            matched += result.matched;
+            divergent.push(
+              ...result.divergent.map(({watermark, outcome}) => ({
+                watermark,
+                outcome,
+              })),
+            );
+          }
+
+          // A cursor landing on a transaction SQLite does not hold is
+          // re-reported once as a bounds-mismatch when the next cycle's
+          // plan() cannot serve the boundary — a classified duplicate of the
+          // missing-sqlite finding, never of anything else, and never twice.
+          const echoes = divergent.filter(d => d.outcome === 'bounds-mismatch');
+          for (const echo of echoes) {
+            expect(
+              specs.some(
+                s => s.watermark === echo.watermark && s.kind === 'drop-sqlite',
+              ),
+            ).toBe(true);
+          }
+          expect(new Set(echoes.map(e => e.watermark)).size).toBe(
+            echoes.length,
+          );
+
+          const order = (
+            a: {watermark: string; outcome: string},
+            b: {watermark: string; outcome: string},
+          ) =>
+            a.watermark < b.watermark
+              ? -1
+              : a.watermark > b.watermark
+                ? 1
+                : a.outcome.localeCompare(b.outcome);
+          const primary = divergent.filter(
+            d => d.outcome !== 'bounds-mismatch',
+          );
+          expect(primary.toSorted(order)).toEqual(expected.toSorted(order));
+          expect(matched).toBe(expectedMatched);
+        } finally {
+          runWriter.close();
+          deleteChangeLogDB(runFile.path);
+          runFile.delete();
+        }
+      }),
+      {numRuns: 10},
+    );
   });
 
   test('stop() ends the comparator', async () => {

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.pg.test.ts
@@ -27,7 +27,6 @@ import {initChangeStreamerSchema} from './schema/init.ts';
 import {ensureReplicationConfig} from './schema/tables.ts';
 import {
   isSampledForCompare,
-  normalizeChangeJSON,
   SQLiteChangeLogComparator,
   type PGChangeLogRangeReader,
   type SQLiteChangeLogCompareOptions,
@@ -184,6 +183,20 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
     );
   }
 
+  /** The production reader, with one call site swapped for a fault or a race. */
+  function pgReader(
+    overrides: Partial<PGChangeLogRangeReader> = {},
+  ): PGChangeLogRangeReader {
+    return {
+      getCatchupBounds: () => storer.getCatchupBounds(),
+      listCommitWatermarks: (after, through, limit) =>
+        storer.listCommitWatermarks(after, through, limit),
+      readCatchupRange: (after, through, batchRows) =>
+        storer.readCatchupRange(after, through, batchRows),
+      ...overrides,
+    };
+  }
+
   /** Direct writes to the SQLite log, as the purger or an injected fault. */
   function withSQLiteLog<T>(fn: (db: Database) => T): T {
     const db = new Database(lc, changeLogFileName(logFile.path));
@@ -196,6 +209,26 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
 
   function cdc(table: string) {
     return sql(`${cdcSchema(shard)}.${table}`);
+  }
+
+  /**
+   * The watermarks reported diverged, read back off the log line — the
+   * comparison's actual production surface. The cycle result carries counts
+   * only, deliberately: one collapsed `mismatch` outcome replaced the old
+   * per-watermark taxonomy.
+   */
+  function divergedWatermarks(since = 0): string[] {
+    return logSink.messages
+      .slice(since)
+      .filter(([level, , parts]) => level === 'error' && parts.length === 2)
+      .flatMap(([, , parts]) => {
+        const detail = (
+          parts[1] as {
+            sqliteChangeLogCompare?: {watermark: string} | undefined;
+          }
+        ).sqliteChangeLogCompare;
+        return detail === undefined ? [] : [detail.watermark];
+      });
   }
 
   async function mutatePGChange(
@@ -214,10 +247,42 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
        WHERE watermark = ${watermark} AND pos = ${pos}`;
   }
 
-  // The normalization pin, first (§6.5): a transaction round-tripped through
-  // both stores — SQLite's exact stored substring versus PG's json column read
-  // back as text — must digest identically before any injected-mutation case
-  // can mean anything.
+  function deleteFromSQLiteLog(where: string) {
+    withSQLiteLog(db =>
+      db
+        .prepare(
+          /*sql*/ `DELETE FROM "${CHANGE_LOG_STREAM_TABLE}" WHERE ${where}`,
+        )
+        .run(),
+    );
+  }
+
+  /** Rows belonging to no committed transaction, as a torn write would leave. */
+  function insertSQLiteRows(watermark: string) {
+    withSQLiteLog(db =>
+      db
+        .prepare(/*sql*/ `
+            INSERT INTO "${CHANGE_LOG_STREAM_TABLE}"
+              ("watermark", "pos", "change", "precommit", "writeTimeMs")
+            VALUES (?, 0, '{"tag":"begin"}', NULL, NULL),
+                   (?, 1, '{"tag":"insert"}', NULL, NULL)`)
+        .run(watermark, watermark),
+    );
+  }
+
+  function insertPGRows(watermark: string) {
+    return sql`
+      INSERT INTO ${cdc('changeLog')} ("watermark", "pos", "change", "precommit")
+      VALUES (${watermark}, 0, '{"tag":"begin"}'::json, NULL),
+             (${watermark}, 1, '{"tag":"insert"}'::json, NULL)`;
+  }
+
+  // 1. Equivalent output matches.
+  //
+  // The normalization pin comes first (§6.5): a transaction round-tripped
+  // through both stores — SQLite's exact stored substring versus PG's json
+  // column read back as text — must digest identically before any injected
+  // mutation can mean anything.
   //
   // Both stores carry a synthetic seed transaction at the replica version
   // '01' (PG's from ensureReplicationConfig, SQLite's from reconcile), so the
@@ -227,50 +292,21 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
   // an actual NUL character: `change->'tag'` in the production PG catchup
   // statement de-escapes every string value while scanning for the field, and
   // Postgres cannot convert an escaped NUL to text, so a row containing one
-  // fails PG catchup itself — the comparator faithfully reports it as
-  // `reader-error` rather than as parity.
-  test('round-trips one transaction through both stores with equal digests', async () => {
+  // fails PG catchup itself — the comparator faithfully reports it as a
+  // mismatch rather than as parity.
+  test('equivalent catchup output matches, across message families and batches', async () => {
     await feedBoth(
-      tx('03', messages.insert('foo', {id: 'first'})),
       tx(
-        '04',
+        '03',
         messages.insert('foo', {
           id: 'nul-\\u0000-esc',
           big: 9007199254740993n,
           float: 1.5,
-          text: 'quotes " backslash \\ newline \n emoji 🙂 control \u0001',
+          text: 'quotes " backslash \\ newline \n emoji 🙂 control ',
           nil: null,
           bool: true,
         }),
       ),
-    );
-    const result = await newComparator().compareOnce();
-    assert(result.kind === 'compared', 'expected a compared cycle');
-    expect(result).toMatchObject({
-      fromWatermark: '01',
-      throughWatermark: '04',
-      transactions: 2,
-      sampled: 2,
-      matched: 2,
-      divergent: [],
-    });
-  });
-
-  test('normalizeChangeJSON collapses formatting, preserves content', () => {
-    expect(normalizeChangeJSON('{ "tag" : "insert",\n  "v": 1 }')).toBe(
-      normalizeChangeJSON('{"tag":"insert","v":1}'),
-    );
-    // Precision above Number.MAX_SAFE_INTEGER survives the round trip.
-    expect(normalizeChangeJSON('{"v":9007199254740993}')).toBe(
-      '{"v":9007199254740993}',
-    );
-    // A value that does not parse is hashed as-is.
-    expect(normalizeChangeJSON('not-json')).toBe('not-json');
-  });
-
-  test('parity across message families and multi-batch ranges', async () => {
-    await feedBoth(
-      tx('03', messages.insert('foo', {id: 'boundary'})),
       tx(
         '04',
         messages.insert('foo', {id: 'b', v: 1}),
@@ -299,44 +335,367 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
     });
 
     const first = await comparator.compareOnce();
-    assert(first.kind === 'compared', 'expected a compared cycle');
     expect(first).toMatchObject({
+      kind: 'compared',
       fromWatermark: '01',
       throughWatermark: '04',
       transactions: 2,
       sampled: 2,
       matched: 2,
-      divergent: [],
+      mismatched: 0,
     });
 
     const second = await comparator.compareOnce();
-    assert(second.kind === 'compared', 'expected a compared cycle');
     expect(second).toMatchObject({
       fromWatermark: '04',
       throughWatermark: '06',
-      transactions: 2,
-      sampled: 2,
       matched: 2,
-      divergent: [],
+      mismatched: 0,
     });
 
     const third = await comparator.compareOnce();
-    assert(third.kind === 'compared', 'expected a compared cycle');
     expect(third).toMatchObject({
       fromWatermark: '06',
       throughWatermark: '07',
-      transactions: 1,
-      sampled: 1,
       matched: 1,
-      divergent: [],
+      mismatched: 0,
     });
 
     expect(await comparator.compareOnce()).toEqual({
       kind: 'skipped',
       reason: 'nothing-to-compare',
     });
+    expect(divergedWatermarks()).toEqual([]);
   });
 
+  // 2. Mutated, missing, or extra output mismatches.
+  //
+  // One rolling digest per served range replaced the per-transaction digest
+  // map, so extra rows at any watermark — which no commit enumeration can see
+  // — are caught by the same equality check as a mutated payload, and are
+  // reported at the watermark of the range that served them.
+  describe('divergent catchup output mismatches', () => {
+    const cases: {
+      name: string;
+      corrupt: () => Promise<void> | void;
+      diverged: string[];
+    }[] = [
+      {
+        name: 'a mutated PG payload',
+        corrupt: () =>
+          mutatePGChange('04', 1, change => {
+            (change.new as Record<string, unknown>).v = 999;
+          }),
+        diverged: ['04'],
+      },
+      {
+        name: 'a transaction SQLite does not hold',
+        corrupt: () => deleteFromSQLiteLog(`"watermark" = '04'`),
+        diverged: ['04'],
+      },
+      {
+        name: 'a transaction PG does not hold',
+        corrupt: async () => {
+          await sql`DELETE FROM ${cdc('changeLog')} WHERE watermark = '04'`;
+        },
+        diverged: ['04'],
+      },
+      {
+        name: 'a commit row SQLite lost from an otherwise intact transaction',
+        corrupt: () =>
+          deleteFromSQLiteLog(`"watermark" = '04' AND "precommit" IS NOT NULL`),
+        diverged: ['04'],
+      },
+      {
+        name: 'rows only SQLite serves',
+        corrupt: () => insertSQLiteRows('04z'),
+        diverged: ['05'],
+      },
+      {
+        name: 'rows only PG serves',
+        corrupt: async () => {
+          await insertPGRows('04z');
+        },
+        diverged: ['05'],
+      },
+      {
+        // Identical output is parity in what catchup *serves* — the thing this
+        // comparison measures — even where no committed transaction claims it.
+        name: 'identical extra rows in both stores',
+        corrupt: async () => {
+          insertSQLiteRows('04z');
+          await insertPGRows('04z');
+        },
+        diverged: [],
+      },
+    ];
+
+    for (const {name, corrupt, diverged} of cases) {
+      test(name, async () => {
+        await feedBoth(
+          tx('03', messages.insert('foo', {id: 'boundary'})),
+          tx('04', messages.insert('foo', {id: 'victim', v: 1})),
+          tx('05', messages.insert('foo', {id: 'witness'})),
+        );
+        await corrupt();
+
+        const result = await newComparator().compareOnce();
+        assert(result.kind === 'compared', 'expected a compared cycle');
+        expect(divergedWatermarks()).toEqual(diverged);
+        expect(result.mismatched).toBe(diverged.length);
+        expect(result.inconclusive).toBe(0);
+      });
+    }
+  });
+
+  // 3. Head skew compares only the common range.
+  test('head lag in either direction is not divergence', async () => {
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'boundary'})),
+      tx('04', messages.insert('foo', {id: 'both'})),
+    );
+    const t5 = tx('05', messages.insert('foo', {id: 'trailing-pg'}));
+    const t6 = tx('06', messages.insert('foo', {id: 'trailing-sqlite'}));
+
+    // The SQLite log leads, as it does in production: compare only through
+    // the PG head.
+    feedSQLiteOnly(t5);
+    const comparator = newComparator();
+    expect(await comparator.compareOnce()).toMatchObject({
+      throughWatermark: '04',
+      transactions: 2,
+      matched: 2,
+      mismatched: 0,
+    });
+
+    // PG catches up and then leads: compare only through the SQLite head.
+    await feedPGOnly(t5, t6);
+    expect(await comparator.compareOnce()).toMatchObject({
+      fromWatermark: '04',
+      throughWatermark: '05',
+      matched: 1,
+      mismatched: 0,
+    });
+
+    // SQLite catches up: the previously skewed transaction compares clean.
+    feedSQLiteOnly(t6);
+    expect(await comparator.compareOnce()).toMatchObject({
+      fromWatermark: '05',
+      throughWatermark: '06',
+      matched: 1,
+      mismatched: 0,
+    });
+    expect(divergedWatermarks()).toEqual([]);
+  });
+
+  test('a limited cycle compares only the range both enumerations cover', async () => {
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'a'})),
+      tx('04', messages.insert('foo', {id: 'b'})),
+      tx('05', messages.insert('foo', {id: 'c'})),
+      tx('06', messages.insert('foo', {id: 'd'})),
+    );
+    deleteFromSQLiteLog(`"watermark" = '04'`);
+
+    const comparator = newComparator({maxTransactionsPerCycle: 2});
+    // The stores hit the limit at different watermarks — SQLite's two commits
+    // reach '05', PG's reach '04' — so the cycle covers only the range both
+    // enumerations completely cover. '05', cut from PG's list by the limit
+    // alone, must not be reported missing.
+    expect(await comparator.compareOnce()).toMatchObject({
+      throughWatermark: '04',
+      transactions: 2,
+      matched: 1,
+      mismatched: 1,
+    });
+    expect(divergedWatermarks()).toEqual(['04']);
+
+    // The next cycle resumes above the covered range and completes it.
+    const before = logSink.messages.length;
+    expect(await comparator.compareOnce()).toMatchObject({
+      throughWatermark: '06',
+      matched: 2,
+    });
+    // '04' is re-reported once, as the boundary the log cannot serve.
+    expect(divergedWatermarks(before)).toEqual(['04']);
+  });
+
+  // 4. Purge/reseed races are inconclusive.
+  describe('a race with the pinned bounds is inconclusive', () => {
+    const cases: {
+      name: string;
+      pg: () => PGChangeLogRangeReader;
+      matched: number;
+      inconclusive: number;
+    }[] = [
+      {
+        // The purge lands after the cycle pinned its bounds and enumerated the
+        // range, exactly as a concurrently scheduled cleanup would.
+        name: 'a PG purge',
+        pg: () => {
+          let purged = false;
+          return pgReader({
+            readCatchupRange: (after, through, batchRows) =>
+              (async function* (this: void) {
+                if (!purged) {
+                  purged = true;
+                  await storer.purgeRecordsBefore('05');
+                }
+                yield* storer.readCatchupRange(after, through, batchRows);
+              })(),
+          });
+        },
+        matched: 1, // '05' survives the purge and matches
+        inconclusive: 2,
+      },
+      {
+        // The purger deletes whole transactions below the floor, after the
+        // cycle enumerated them.
+        name: 'a SQLite purge',
+        pg: () =>
+          pgReader({
+            listCommitWatermarks: async (after, through, limit) => {
+              const list = await storer.listCommitWatermarks(
+                after,
+                through,
+                limit,
+              );
+              deleteFromSQLiteLog(`"watermark" < '05'`);
+              return list;
+            },
+          }),
+        matched: 1,
+        inconclusive: 2,
+      },
+      {
+        // The writer reseeds the log after the cycle pinned its bounds: '04'
+        // vanishes and the meta row's seed point moves, as reconcileChangeLog's
+        // reseed would. The re-read bounds alone cannot see this — only the
+        // meta comparison can.
+        name: 'a reseed',
+        pg: () =>
+          pgReader({
+            listCommitWatermarks: async (after, through, limit) => {
+              const list = await storer.listCommitWatermarks(
+                after,
+                through,
+                limit,
+              );
+              withSQLiteLog(db => {
+                db.prepare(
+                  /*sql*/ `DELETE FROM "${CHANGE_LOG_STREAM_TABLE}" WHERE "watermark" = '04'`,
+                ).run();
+                db.prepare(/*sql*/ `UPDATE "${CHANGE_LOG_META_TABLE}"
+                      SET "seedWatermark" = '03', "seededAtMs" = "seededAtMs" + 1`).run();
+              });
+              return list;
+            },
+          }),
+        matched: 2,
+        inconclusive: 1,
+      },
+    ];
+
+    for (const {name, pg, matched, inconclusive} of cases) {
+      test(name, async () => {
+        await feedBoth(
+          tx('03', messages.insert('foo', {id: 'boundary'})),
+          tx('04', messages.insert('foo', {id: 'raced'})),
+          tx('05', messages.insert('foo', {id: 'witness'})),
+        );
+
+        const result = await newComparator({pg: pg()}).compareOnce();
+        expect(result).toMatchObject({matched, inconclusive, mismatched: 0});
+        // A race is not a finding: nothing reports as diverged.
+        expect(divergedWatermarks()).toEqual([]);
+      });
+    }
+  });
+
+  test('a suspect that cannot be reconfirmed is inconclusive, then retried', async () => {
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'boundary'})),
+      tx('04', messages.insert('foo', {id: 'victim'})),
+      tx('05', messages.insert('foo', {id: 'witness'})),
+    );
+    deleteFromSQLiteLog(`"watermark" = '04'`);
+
+    // The bounds re-read that would confirm the finding fails once; the
+    // observation cannot be distinguished from a race and must not report.
+    let boundsReads = 0;
+    const comparator = newComparator({
+      pg: pgReader({
+        getCatchupBounds: () => {
+          if (++boundsReads === 2) {
+            throw new Error('injected bounds re-read failure');
+          }
+          return storer.getCatchupBounds();
+        },
+      }),
+    });
+    expect(await comparator.compareOnce()).toMatchObject({
+      matched: 2,
+      mismatched: 0,
+      inconclusive: 1,
+    });
+    expect(divergedWatermarks()).toEqual([]);
+
+    // The cursor did not move, so a later cycle retries and confirms the
+    // persistent divergence once the transient bounds failure clears.
+    expect(await comparator.compareOnce()).toMatchObject({mismatched: 1});
+    expect(divergedWatermarks()).toEqual(['04']);
+  });
+
+  test('a read that cannot complete is a mismatch, not a crash', async () => {
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'boundary'})),
+      tx('04', messages.insert('foo', {id: 'unreadable'})),
+    );
+    const result = await newComparator({
+      pg: pgReader({
+        readCatchupRange: (after, through, batchRows) => {
+          if (through === '04') {
+            throw new Error('injected read failure');
+          }
+          return storer.readCatchupRange(after, through, batchRows);
+        },
+      }),
+    }).compareOnce();
+    expect(result).toMatchObject({matched: 1, mismatched: 1});
+    expect(divergedWatermarks()).toEqual(['04']);
+  });
+
+  // 5. Sampling is deterministic.
+  test('a retried comparison samples the same transactions', async () => {
+    const txs = Array.from({length: 12}, (_, i) =>
+      tx((i + 3).toString(36).padStart(2, '0'), {
+        ...messages.insert('foo', {id: `row-${i}`}),
+      }),
+    );
+    await feedBoth(...txs);
+
+    const percent = 40;
+    const expected = txs.filter(({watermark}) =>
+      isSampledForCompare(shard, watermark, percent),
+    ).length;
+
+    // Two independent comparators — as across a restart — pin the same range
+    // and select exactly the same sample.
+    const first = await newComparator({comparePercent: percent}).compareOnce();
+    const second = await newComparator({comparePercent: percent}).compareOnce();
+    assert(
+      first.kind === 'compared' && second.kind === 'compared',
+      'expected compared cycles',
+    );
+    expect(first.sampled).toBe(expected);
+    expect(second.sampled).toBe(expected);
+    expect(second.fromWatermark).toBe(first.fromWatermark);
+    expect(second.throughWatermark).toBe(first.throughWatermark);
+    expect(first.matched).toBe(first.sampled);
+    expect(second.matched).toBe(second.sampled);
+  });
+
+  // 6. Remaining-budget exhaustion defers.
   test('caps total catchup rows per source and defers an unfinished transaction', async () => {
     await feedBoth(
       tx('03', messages.insert('foo', {id: 'first'})),
@@ -351,36 +710,27 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
       readBatchRows: 2,
     });
 
-    const first = await comparator.compareOnce();
-    assert(first.kind === 'compared', 'expected a compared cycle');
-    expect(first).toMatchObject({
+    expect(await comparator.compareOnce()).toMatchObject({
       throughWatermark: '03',
       transactions: 1,
       sampled: 2,
       matched: 1,
-      sqliteRowsRead: 5,
-      pgRowsRead: 5,
       deferred: 1,
       oversized: 0,
-      divergent: [],
+      mismatched: 0,
     });
 
-    const second = await comparator.compareOnce();
-    assert(second.kind === 'compared', 'expected a compared cycle');
-    expect(second).toMatchObject({
+    // The next cycle's fresh budget fits it.
+    expect(await comparator.compareOnce()).toMatchObject({
       fromWatermark: '03',
       throughWatermark: '04',
-      transactions: 1,
-      sampled: 1,
       matched: 1,
-      sqliteRowsRead: 4,
-      pgRowsRead: 4,
       deferred: 0,
-      oversized: 0,
-      divergent: [],
+      mismatched: 0,
     });
   });
 
+  // 7. A fresh-budget overflow skips.
   test('skips a transaction that exceeds a fresh cycle row budget', async () => {
     await feedBoth(
       tx(
@@ -393,46 +743,75 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
     );
     const comparator = newComparator({maxRowsPerSourcePerCycle: 4});
 
-    const first = await comparator.compareOnce();
-    assert(first.kind === 'compared', 'expected a compared cycle');
-    expect(first).toMatchObject({
+    expect(await comparator.compareOnce()).toMatchObject({
       throughWatermark: '03',
-      transactions: 1,
       sampled: 1,
       matched: 0,
-      sqliteRowsRead: 4,
-      pgRowsRead: 4,
-      deferred: 0,
       oversized: 1,
-      divergent: [],
+      mismatched: 0,
     });
 
-    const second = await comparator.compareOnce();
-    assert(second.kind === 'compared', 'expected a compared cycle');
-    expect(second).toMatchObject({
+    // Skipped, not wedged: the cursor moved past what can never fit.
+    expect(await comparator.compareOnce()).toMatchObject({
       fromWatermark: '03',
       throughWatermark: '04',
       matched: 1,
-      sqliteRowsRead: 3,
-      pgRowsRead: 3,
       oversized: 0,
     });
   });
 
+  // 8. A transaction that exactly fills the budget compares.
   test('compares a transaction that exactly fills the cycle row budget', async () => {
     await feedBoth(tx('03', messages.insert('foo', {id: 'exact'})));
 
-    const result = await newComparator({
-      maxRowsPerSourcePerCycle: 3,
-    }).compareOnce();
-    assert(result.kind === 'compared', 'expected a compared cycle');
-    expect(result).toMatchObject({
+    expect(
+      await newComparator({maxRowsPerSourcePerCycle: 3}).compareOnce(),
+    ).toMatchObject({
       throughWatermark: '03',
       matched: 1,
-      sqliteRowsRead: 3,
-      pgRowsRead: 3,
       deferred: 0,
       oversized: 0,
+    });
+  });
+
+  // 9. A confirmed mismatch at the cursor boundary still advances.
+  test('a divergent cursor boundary does not wedge the comparator', async () => {
+    // SQLite loses a whole transaction PG holds, while the log runs ahead of
+    // PG (its normal state), so the cycle's common upper bound — and with it
+    // the cursor — lands exactly on the commit the log cannot serve as a
+    // catchup boundary.
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'boundary'})),
+      tx('04', messages.insert('foo', {id: 'sqlite-lost'})),
+    );
+    feedSQLiteOnly(tx('05', messages.insert('foo', {id: 'log-leads'})));
+    deleteFromSQLiteLog(`"watermark" = '04'`);
+
+    const comparator = newComparator();
+    expect(await comparator.compareOnce()).toMatchObject({
+      throughWatermark: '04',
+      matched: 1,
+      mismatched: 1,
+    });
+    expect(divergedWatermarks()).toEqual(['04']);
+
+    // The stream continues, so the next cycle has a non-empty range whose
+    // `from` is the divergent boundary: plan() is `too-old` and the bounds
+    // have not moved. The cycle must still compare the range above it.
+    await feedBoth(tx('06', messages.insert('foo', {id: 'next'})));
+
+    const before = logSink.messages.length;
+    expect(await comparator.compareOnce()).toMatchObject({
+      throughWatermark: '06',
+      matched: 1,
+      mismatched: 2,
+    });
+    expect(divergedWatermarks(before)).toEqual(['04', '05']);
+
+    // Progress, not a wedge.
+    expect(await comparator.compareOnce()).toEqual({
+      kind: 'skipped',
+      reason: 'nothing-to-compare',
     });
   });
 
@@ -464,577 +843,13 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
     expect(Array.from(scheduled.values(), ({delayMs}) => delayMs)).toEqual([
       30_000,
     ]);
-    const first = await comparator.compareOnce();
-    assert(first.kind === 'compared', 'expected a compared cycle');
-    expect(first).toMatchObject({
+    expect(await comparator.compareOnce()).toMatchObject({
       throughWatermark: '04',
       transactions: 2,
     });
     expect(Array.from(scheduled.values(), ({delayMs}) => delayMs)).toEqual([0]);
 
     comparator.stop();
-  });
-
-  test('head lag in either direction is not divergence', async () => {
-    await feedBoth(
-      tx('03', messages.insert('foo', {id: 'boundary'})),
-      tx('04', messages.insert('foo', {id: 'both'})),
-    );
-    const t5 = tx('05', messages.insert('foo', {id: 'trailing-pg'}));
-    const t6 = tx('06', messages.insert('foo', {id: 'trailing-sqlite'}));
-
-    // The SQLite log leads, as it does in production: compare only through
-    // the PG head.
-    feedSQLiteOnly(t5);
-    const comparator = newComparator();
-    let result = await comparator.compareOnce();
-    assert(result.kind === 'compared', 'expected a compared cycle');
-    expect(result).toMatchObject({
-      throughWatermark: '04',
-      transactions: 2,
-      matched: 2,
-      divergent: [],
-    });
-
-    // PG catches up and then leads: compare only through the SQLite head.
-    await feedPGOnly(t5, t6);
-    result = await comparator.compareOnce();
-    assert(result.kind === 'compared', 'expected a compared cycle');
-    expect(result).toMatchObject({
-      fromWatermark: '04',
-      throughWatermark: '05',
-      transactions: 1,
-      matched: 1,
-      divergent: [],
-    });
-
-    // SQLite catches up: the previously skewed transaction compares clean.
-    feedSQLiteOnly(t6);
-    result = await comparator.compareOnce();
-    assert(result.kind === 'compared', 'expected a compared cycle');
-    expect(result).toMatchObject({
-      fromWatermark: '05',
-      throughWatermark: '06',
-      transactions: 1,
-      matched: 1,
-      divergent: [],
-    });
-  });
-
-  test('a mutated PG payload classifies as digest-mismatch', async () => {
-    await feedBoth(
-      tx('03', messages.insert('foo', {id: 'boundary'})),
-      tx('04', messages.insert('foo', {id: 'victim', v: 1})),
-      tx('05', messages.insert('foo', {id: 'witness'})),
-    );
-    await mutatePGChange('04', 1, change => {
-      (change.new as Record<string, unknown>).v = 999;
-    });
-
-    const result = await newComparator().compareOnce();
-    assert(result.kind === 'compared', 'expected a compared cycle');
-    expect(result).toMatchObject({
-      transactions: 3,
-      sampled: 3,
-      matched: 2,
-    });
-    expect(result.divergent).toMatchObject([
-      {watermark: '04', outcome: 'digest-mismatch'},
-    ]);
-    const [divergent] = result.divergent;
-    expect(divergent.sqliteDigest).toHaveLength(16);
-    expect(divergent.pgDigest).toHaveLength(16);
-    expect(divergent.sqliteDigest).not.toBe(divergent.pgDigest);
-    expect(divergent.sqliteRows).toBe(3);
-    expect(divergent.pgRows).toBe(3);
-  });
-
-  test('a transaction PG does not hold classifies as missing-pg', async () => {
-    await feedBoth(
-      tx('03', messages.insert('foo', {id: 'boundary'})),
-      tx('04', messages.insert('foo', {id: 'victim'})),
-      tx('05', messages.insert('foo', {id: 'witness'})),
-    );
-    await sql`DELETE FROM ${cdc('changeLog')} WHERE watermark = '04'`;
-
-    const result = await newComparator().compareOnce();
-    assert(result.kind === 'compared', 'expected a compared cycle');
-    expect(result.divergent).toMatchObject([
-      {watermark: '04', outcome: 'missing-pg'},
-    ]);
-    expect(result.matched).toBe(2); // '03' and '05' still match
-  });
-
-  test('a transaction SQLite does not serve classifies as missing-sqlite', async () => {
-    await feedBoth(
-      tx('03', messages.insert('foo', {id: 'boundary'})),
-      tx('04', messages.insert('foo', {id: 'victim'})),
-      tx('05', messages.insert('foo', {id: 'witness'})),
-    );
-    withSQLiteLog(db =>
-      db
-        .prepare(
-          /*sql*/ `DELETE FROM "${CHANGE_LOG_STREAM_TABLE}" WHERE "watermark" = '04'`,
-        )
-        .run(),
-    );
-
-    const result = await newComparator().compareOnce();
-    assert(result.kind === 'compared', 'expected a compared cycle');
-    expect(result.divergent).toMatchObject([
-      {watermark: '04', outcome: 'missing-sqlite'},
-    ]);
-    expect(result.matched).toBe(2);
-  });
-
-  test('rows outside any committed transaction classify as orphan-output', async () => {
-    await feedBoth(
-      tx('03', messages.insert('foo', {id: 'a'})),
-      tx('04', messages.insert('foo', {id: 'b'})),
-      tx('05', messages.insert('foo', {id: 'c'})),
-    );
-    // A torn/corrupt remnant only SQLite serves: begin + data with no commit
-    // row, invisible to the commit enumeration but served to any subscriber
-    // catching up across it. '03b' is the same remnant in *both* stores,
-    // identically — parity in what catchup serves, so not a finding.
-    withSQLiteLog(db =>
-      db.exec(/*sql*/ `
-        INSERT INTO "${CHANGE_LOG_STREAM_TABLE}"
-          ("watermark", "pos", "change", "precommit", "writeTimeMs")
-        VALUES
-          ('03a', 0, '{"tag":"begin"}', NULL, NULL),
-          ('03a', 1, '{"tag":"insert"}', NULL, NULL),
-          ('03b', 0, '{"tag":"begin"}', NULL, NULL),
-          ('03b', 1, '{"tag":"insert"}', NULL, NULL)
-      `),
-    );
-    await sql`
-      INSERT INTO ${cdc('changeLog')} ("watermark", "pos", "change", "precommit")
-      VALUES ('03b', 0, '{"tag":"begin"}'::json, NULL),
-             ('03b', 1, '{"tag":"insert"}'::json, NULL),
-             ('04a', 0, '{"tag":"begin"}'::json, NULL),
-             ('04a', 1, '{"tag":"insert"}'::json, NULL)`;
-
-    const result = await newComparator().compareOnce();
-    assert(result.kind === 'compared', 'expected a compared cycle');
-    // The asymmetric orphans are reported at their own watermarks; the
-    // transactions themselves all still match.
-    expect(result.divergent).toMatchObject([
-      {watermark: '03a', outcome: 'orphan-output', sqliteRows: 2},
-      {watermark: '04a', outcome: 'orphan-output', pgRows: 2},
-    ]);
-    expect(result.matched).toBe(3);
-    const [sqliteOrphan, pgOrphan] = result.divergent;
-    expect(sqliteOrphan.sqliteDigest).toHaveLength(16);
-    expect(sqliteOrphan.pgDigest).toBeUndefined();
-    expect(pgOrphan.pgDigest).toHaveLength(16);
-    expect(pgOrphan.sqliteDigest).toBeUndefined();
-  });
-
-  test('a missing catchup boundary classifies as bounds-mismatch', async () => {
-    await feedBoth(
-      tx('03', messages.insert('foo', {id: 'boundary'})),
-      tx('04', messages.insert('foo', {id: 'cursor-boundary'})),
-    );
-    const comparator = newComparator();
-    const first = await comparator.compareOnce();
-    assert(first.kind === 'compared', 'expected a compared cycle');
-    expect(first).toMatchObject({throughWatermark: '04', matched: 2});
-
-    // The cursor now rests on '04', whose commit row is the boundary the next
-    // cycle's plan() must find. Removing it makes the log unable to serve a
-    // range it claims to hold.
-    withSQLiteLog(db =>
-      db
-        .prepare(/*sql*/ `
-            DELETE FROM "${CHANGE_LOG_STREAM_TABLE}"
-             WHERE "watermark" = '04' AND "precommit" IS NOT NULL`)
-        .run(),
-    );
-    await feedBoth(tx('05', messages.insert('foo', {id: 'next'})));
-
-    const second = await comparator.compareOnce();
-    assert(second.kind === 'compared', 'expected a compared cycle');
-    expect(second.divergent).toMatchObject([
-      {watermark: '04', outcome: 'bounds-mismatch'},
-    ]);
-    // The finding is about the boundary, not the range above it: the same
-    // cycle still compares ('04', '05'] and moves the cursor past the damage.
-    expect(second).toMatchObject({throughWatermark: '05', matched: 1});
-
-    // The next cycle starts above the bad boundary rather than re-reporting
-    // the identical bounds-mismatch forever.
-    const third = await comparator.compareOnce();
-    expect(third).toEqual({kind: 'skipped', reason: 'nothing-to-compare'});
-  });
-
-  test('a missing PG catchup boundary prevents accepting the later range', async () => {
-    await feedBoth(
-      tx('03', messages.insert('foo', {id: 'older'})),
-      tx('04', messages.insert('foo', {id: 'boundary'})),
-      tx('05', messages.insert('foo', {id: 'later'})),
-    );
-    // SQLite has purged to '04', while PG still has older and later rows but
-    // has a hole at that exact catchup boundary.
-    withSQLiteLog(db =>
-      db
-        .prepare(
-          /*sql*/ `DELETE FROM "${CHANGE_LOG_STREAM_TABLE}" WHERE "watermark" < '04'`,
-        )
-        .run(),
-    );
-    await sql`DELETE FROM ${cdc('changeLog')} WHERE watermark = '04'`;
-
-    const comparator = newComparator();
-    const first = await comparator.compareOnce();
-    assert(first.kind === 'compared', 'expected a compared cycle');
-    expect(first).toMatchObject({
-      fromWatermark: '04',
-      throughWatermark: '04',
-      transactions: 0,
-      sampled: 0,
-      matched: 0,
-      divergent: [{watermark: '04', outcome: 'bounds-mismatch'}],
-    });
-
-    // The later transaction is not accepted and the invalid boundary remains
-    // the start of the next attempt.
-    const second = await comparator.compareOnce();
-    assert(second.kind === 'compared', 'expected a compared cycle');
-    expect(second).toMatchObject({
-      fromWatermark: '04',
-      throughWatermark: '04',
-      matched: 0,
-    });
-  });
-
-  test('a divergent cursor boundary does not wedge the comparator', async () => {
-    // SQLite loses a whole transaction PG holds, while the log runs ahead of
-    // PG (its normal state), so the cycle's common upper bound — and with it
-    // the cursor — lands exactly on the commit the log cannot serve as a
-    // catchup boundary.
-    await feedBoth(
-      tx('03', messages.insert('foo', {id: 'boundary'})),
-      tx('04', messages.insert('foo', {id: 'sqlite-lost'})),
-    );
-    feedSQLiteOnly(tx('05', messages.insert('foo', {id: 'log-leads'})));
-    withSQLiteLog(db =>
-      db
-        .prepare(
-          /*sql*/ `DELETE FROM "${CHANGE_LOG_STREAM_TABLE}" WHERE "watermark" = '04'`,
-        )
-        .run(),
-    );
-
-    const comparator = newComparator();
-    const first = await comparator.compareOnce();
-    assert(first.kind === 'compared', 'expected a compared cycle');
-    expect(first).toMatchObject({throughWatermark: '04', matched: 1});
-    expect(first.divergent).toMatchObject([
-      {watermark: '04', outcome: 'missing-sqlite'},
-    ]);
-
-    // The stream continues, so the next cycle has a non-empty range whose
-    // `from` is the divergent boundary: plan() is `too-old` and the bounds
-    // have not moved.
-    await feedBoth(tx('06', messages.insert('foo', {id: 'next'})));
-
-    const second = await comparator.compareOnce();
-    assert(second.kind === 'compared', 'expected a compared cycle');
-    expect(second.divergent).toMatchObject([
-      {watermark: '04', outcome: 'bounds-mismatch'},
-      {watermark: '05', outcome: 'missing-pg'},
-    ]);
-    expect(second).toMatchObject({throughWatermark: '06', matched: 1});
-
-    // Progress, not a wedge.
-    const third = await comparator.compareOnce();
-    expect(third).toEqual({kind: 'skipped', reason: 'nothing-to-compare'});
-  });
-
-  test('a limited cycle over divergent stores compares only the common covered range', async () => {
-    await feedBoth(
-      tx('03', messages.insert('foo', {id: 'a'})),
-      tx('04', messages.insert('foo', {id: 'b'})),
-      tx('05', messages.insert('foo', {id: 'c'})),
-      tx('06', messages.insert('foo', {id: 'd'})),
-    );
-    withSQLiteLog(db =>
-      db
-        .prepare(
-          /*sql*/ `DELETE FROM "${CHANGE_LOG_STREAM_TABLE}" WHERE "watermark" = '04'`,
-        )
-        .run(),
-    );
-
-    const comparator = newComparator({maxTransactionsPerCycle: 2});
-    const first = await comparator.compareOnce();
-    assert(first.kind === 'compared', 'expected a compared cycle');
-    // The stores hit the limit at different watermarks — SQLite's two commits
-    // reach '05', PG's reach '04' — so the cycle covers only the range both
-    // enumerations completely cover. '05', cut from PG's list by the limit
-    // alone, must not be reported missing.
-    expect(first).toMatchObject({
-      throughWatermark: '04',
-      transactions: 2,
-      matched: 1,
-    });
-    expect(first.divergent).toMatchObject([
-      {watermark: '04', outcome: 'missing-sqlite'},
-    ]);
-
-    // The next cycle resumes above the covered range and completes it.
-    const second = await comparator.compareOnce();
-    assert(second.kind === 'compared', 'expected a compared cycle');
-    expect(second).toMatchObject({throughWatermark: '06', matched: 2});
-    expect(second.divergent).toMatchObject([
-      {watermark: '04', outcome: 'bounds-mismatch'},
-    ]);
-  });
-
-  test('a reseed racing the comparison yields inconclusive', async () => {
-    await feedBoth(
-      tx('03', messages.insert('foo', {id: 'boundary'})),
-      tx('04', messages.insert('foo', {id: 'reseeded-away'})),
-      tx('05', messages.insert('foo', {id: 'witness'})),
-    );
-    // The writer reseeds the log after the cycle pinned its bounds and
-    // enumerated the range: '04' vanishes and the meta row's seed point
-    // moves, as reconcileChangeLog's reseed would. The re-read bounds alone
-    // cannot see this — only the meta comparison can.
-    const racing: PGChangeLogRangeReader = {
-      getCatchupBounds: () => storer.getCatchupBounds(),
-      hasCatchupWatermark: w => storer.hasCatchupWatermark(w),
-      listCommitWatermarks: async (after, through, limit) => {
-        const list = await storer.listCommitWatermarks(after, through, limit);
-        withSQLiteLog(db => {
-          db.prepare(
-            /*sql*/ `DELETE FROM "${CHANGE_LOG_STREAM_TABLE}" WHERE "watermark" = '04'`,
-          ).run();
-          db.prepare(/*sql*/ `UPDATE "${CHANGE_LOG_META_TABLE}"
-                SET "seedWatermark" = '03', "seededAtMs" = "seededAtMs" + 1`).run();
-        });
-        return list;
-      },
-      readCatchupRange: (after, through, batchRows) =>
-        storer.readCatchupRange(after, through, batchRows),
-    };
-    const result = await newComparator({pg: racing}).compareOnce();
-    assert(result.kind === 'compared', 'expected a compared cycle');
-    expect(result.divergent).toMatchObject([
-      {watermark: '04', outcome: 'inconclusive'},
-    ]);
-    expect(result.matched).toBe(2);
-    // A reseed is a race, not a finding: nothing reports as diverged.
-    expect(
-      logSink.messages.filter(
-        ([level, , parts]) =>
-          level === 'error' && JSON.stringify(parts).includes('diverged'),
-      ),
-    ).toEqual([]);
-  });
-
-  test('a suspect that cannot be reconfirmed is inconclusive', async () => {
-    await feedBoth(
-      tx('03', messages.insert('foo', {id: 'boundary'})),
-      tx('04', messages.insert('foo', {id: 'victim'})),
-      tx('05', messages.insert('foo', {id: 'witness'})),
-    );
-    withSQLiteLog(db =>
-      db
-        .prepare(
-          /*sql*/ `DELETE FROM "${CHANGE_LOG_STREAM_TABLE}" WHERE "watermark" = '04'`,
-        )
-        .run(),
-    );
-    // The first bounds re-read that would confirm the finding fails; the
-    // observation cannot be distinguished from a race and must not report.
-    let boundsReads = 0;
-    const failing: PGChangeLogRangeReader = {
-      getCatchupBounds: () => {
-        if (++boundsReads === 2) {
-          throw new Error('injected bounds re-read failure');
-        }
-        return storer.getCatchupBounds();
-      },
-      hasCatchupWatermark: w => storer.hasCatchupWatermark(w),
-      listCommitWatermarks: (after, through, limit) =>
-        storer.listCommitWatermarks(after, through, limit),
-      readCatchupRange: (after, through, batchRows) =>
-        storer.readCatchupRange(after, through, batchRows),
-    };
-    const comparator = newComparator({pg: failing});
-    const result = await comparator.compareOnce();
-    assert(result.kind === 'compared', 'expected a compared cycle');
-    expect(result.divergent).toMatchObject([
-      {watermark: '04', outcome: 'inconclusive'},
-    ]);
-    expect(result.matched).toBe(2);
-
-    // The cursor did not move, so a later cycle retries and confirms the
-    // persistent divergence once the transient bounds failure clears.
-    const retry = await comparator.compareOnce();
-    assert(retry.kind === 'compared', 'expected a compared cycle');
-    expect(retry.divergent).toMatchObject([
-      {watermark: '04', outcome: 'missing-sqlite'},
-    ]);
-  });
-
-  test('a failing reader classifies as reader-error', async () => {
-    await feedBoth(
-      tx('03', messages.insert('foo', {id: 'boundary'})),
-      tx('04', messages.insert('foo', {id: 'unreadable'})),
-    );
-    const failing: PGChangeLogRangeReader = {
-      getCatchupBounds: () => storer.getCatchupBounds(),
-      hasCatchupWatermark: w => storer.hasCatchupWatermark(w),
-      listCommitWatermarks: (after, through, limit) =>
-        storer.listCommitWatermarks(after, through, limit),
-      readCatchupRange: (after, through, batchRows) => {
-        if (through === '04') {
-          throw new Error('injected read failure');
-        }
-        return storer.readCatchupRange(after, through, batchRows);
-      },
-    };
-    const result = await newComparator({pg: failing}).compareOnce();
-    assert(result.kind === 'compared', 'expected a compared cycle');
-    expect(result.divergent).toMatchObject([
-      {watermark: '04', outcome: 'reader-error'},
-    ]);
-    expect(result.matched).toBe(1); // '03' read cleanly and matched
-  });
-
-  test('a PG purge racing the comparison yields inconclusive', async () => {
-    await feedBoth(
-      tx('03', messages.insert('foo', {id: 'boundary'})),
-      tx('04', messages.insert('foo', {id: 'purged-mid-compare'})),
-      tx('05', messages.insert('foo', {id: 'witness'})),
-    );
-    // The purge lands after the cycle pinned its bounds and enumerated the
-    // range, exactly as a concurrently scheduled cleanup would.
-    let purged = false;
-    const racing: PGChangeLogRangeReader = {
-      getCatchupBounds: () => storer.getCatchupBounds(),
-      hasCatchupWatermark: w => storer.hasCatchupWatermark(w),
-      listCommitWatermarks: (after, through, limit) =>
-        storer.listCommitWatermarks(after, through, limit),
-      readCatchupRange: (after, through, batchRows) =>
-        (async function* (this: void) {
-          if (!purged) {
-            purged = true;
-            await storer.purgeRecordsBefore('05');
-          }
-          yield* storer.readCatchupRange(after, through, batchRows);
-        })(),
-    };
-    const result = await newComparator({pg: racing}).compareOnce();
-    assert(result.kind === 'compared', 'expected a compared cycle');
-    expect(result.divergent).toMatchObject([
-      {watermark: '03', outcome: 'inconclusive'},
-      {watermark: '04', outcome: 'inconclusive'},
-    ]);
-    expect(result.matched).toBe(1); // '05' survives the purge and matches
-    // Inconclusive is a race, not a finding: nothing is reported as diverged.
-    expect(
-      logSink.messages.filter(
-        ([level, , parts]) =>
-          level === 'error' && JSON.stringify(parts).includes('diverged'),
-      ),
-    ).toEqual([]);
-  });
-
-  test('a SQLite purge racing the comparison yields inconclusive', async () => {
-    await feedBoth(
-      tx('03', messages.insert('foo', {id: 'boundary'})),
-      tx('04', messages.insert('foo', {id: 'purged-mid-compare'})),
-      tx('05', messages.insert('foo', {id: 'witness'})),
-    );
-    // Delete the low transactions after the cycle enumerates them, as the
-    // purger (which deletes whole transactions below the floor) would.
-    const racing: PGChangeLogRangeReader = {
-      getCatchupBounds: () => storer.getCatchupBounds(),
-      hasCatchupWatermark: w => storer.hasCatchupWatermark(w),
-      listCommitWatermarks: async (after, through, limit) => {
-        const list = await storer.listCommitWatermarks(after, through, limit);
-        withSQLiteLog(db =>
-          db
-            .prepare(
-              /*sql*/ `DELETE FROM "${CHANGE_LOG_STREAM_TABLE}" WHERE "watermark" < '05'`,
-            )
-            .run(),
-        );
-        return list;
-      },
-      readCatchupRange: (after, through, batchRows) =>
-        storer.readCatchupRange(after, through, batchRows),
-    };
-    const result = await newComparator({pg: racing}).compareOnce();
-    assert(result.kind === 'compared', 'expected a compared cycle');
-    expect(result.divergent).toMatchObject([
-      {watermark: '03', outcome: 'inconclusive'},
-      {watermark: '04', outcome: 'inconclusive'},
-    ]);
-    expect(result.matched).toBe(1);
-  });
-
-  test('sampling is stable by shard and watermark', () => {
-    const watermarks = Array.from({length: 64}, (_, i) =>
-      (i + 3).toString(36).padStart(2, '0'),
-    );
-    for (const percent of [0, 25, 60, 100]) {
-      for (const w of watermarks) {
-        const sampled = isSampledForCompare(shard, w, percent);
-        // Deterministic.
-        expect(isSampledForCompare(shard, w, percent)).toBe(sampled);
-        // Monotone in percent: raising the sample never drops a member.
-        if (sampled) {
-          expect(
-            isSampledForCompare(shard, w, Math.min(100, percent + 20)),
-          ).toBe(true);
-        }
-      }
-      const count = watermarks.filter(w =>
-        isSampledForCompare(shard, w, percent),
-      ).length;
-      if (percent === 0) {
-        expect(count).toBe(0);
-      } else if (percent === 100) {
-        expect(count).toBe(watermarks.length);
-      } else {
-        expect(count).toBeGreaterThan(0);
-        expect(count).toBeLessThan(watermarks.length);
-      }
-    }
-  });
-
-  test('a retried comparison samples the same transactions', async () => {
-    const txs = Array.from({length: 12}, (_, i) =>
-      tx((i + 3).toString(36).padStart(2, '0'), {
-        ...messages.insert('foo', {id: `row-${i}`}),
-      }),
-    );
-    await feedBoth(...txs);
-
-    const percent = 40;
-    const expected = txs.filter(({watermark}) =>
-      isSampledForCompare(shard, watermark, percent),
-    ).length;
-
-    // Two independent comparators — as across a restart — pin the same range
-    // and select exactly the same sample.
-    const first = await newComparator({comparePercent: percent}).compareOnce();
-    const second = await newComparator({comparePercent: percent}).compareOnce();
-    assert(
-      first.kind === 'compared' && second.kind === 'compared',
-      'expected compared cycles',
-    );
-    expect(first.sampled).toBe(expected);
-    expect(second.sampled).toBe(expected);
-    expect(second.fromWatermark).toBe(first.fromWatermark);
-    expect(second.throughWatermark).toBe(first.throughWatermark);
-    expect(first.matched).toBe(first.sampled);
-    expect(second.matched).toBe(second.sampled);
   });
 
   test('divergence reports carry no payload data', async () => {
@@ -1049,18 +864,15 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
 
     const before = logSink.messages.length;
     const result = await newComparator().compareOnce();
-    assert(result.kind === 'compared', 'expected a compared cycle');
-    expect(result.divergent).toMatchObject([
-      {watermark: '04', outcome: 'digest-mismatch'},
-    ]);
+    expect(result).toMatchObject({mismatched: 1});
 
     // Neither the cycle result nor anything logged for it contains the
-    // payload; digests are truncated prefixes.
+    // payload, or any digest of it.
     expect(JSON.stringify(result)).not.toContain(sentinel);
     expect(JSON.stringify(logSink.messages.slice(before))).not.toContain(
       sentinel,
     );
-    expect(result.divergent[0].sqliteDigest).toHaveLength(16);
+    expect(divergedWatermarks(before)).toEqual(['04']);
   });
 
   test('declines a cold log, a wrong identity, and an absent file', async () => {
@@ -1085,9 +897,10 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
       await newComparator({file: `${logFile.path}-absent`}).compareOnce(),
     ).toEqual({kind: 'skipped', reason: 'log-unavailable'});
 
-    const result = await newComparator().compareOnce();
-    assert(result.kind === 'compared', 'expected a compared cycle');
-    expect(result).toMatchObject({matched: 2, divergent: []});
+    expect(await newComparator().compareOnce()).toMatchObject({
+      matched: 2,
+      mismatched: 0,
+    });
   });
 
   test('a freshly seeded log with no traffic has nothing to compare', async () => {
@@ -1100,9 +913,21 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
     });
   });
 
-  test('property: injected corruptions are reported exactly, then quiescence', async () => {
+  test('stop() ends the comparator', async () => {
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'boundary'})),
+      tx('04', messages.insert('foo', {id: 'content'})),
+    );
+    const comparator = newComparator();
+    comparator.stop();
+    expect(await comparator.compareOnce()).toEqual({
+      kind: 'skipped',
+      reason: 'stopped',
+    });
+  });
+
+  test('property: every corrupted transaction is reported, every clean one is not', async () => {
     type CorruptionKind = 'clean' | 'drop-sqlite' | 'drop-pg' | 'mutate-pg';
-    type OrphanSide = 'sqlite' | 'pg' | 'both';
 
     const faultScenario = fc.record({
       txs: fc.array(
@@ -1114,10 +939,6 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
             'drop-pg',
             'mutate-pg',
           ),
-          orphanAfter: fc.option(
-            fc.constantFrom<OrphanSide>('sqlite', 'pg', 'both'),
-            {nil: undefined},
-          ),
         }),
         {minLength: 1, maxLength: 5},
       ),
@@ -1128,29 +949,6 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
     // corruptions sit below its `from` and are invisible to it.
     let nextNum = 1;
     const wm = (n: number) => `w${String(n).padStart(8, '0')}`;
-
-    const withRunLog = <T>(file: DbFile, fn: (db: Database) => T): T => {
-      const db = new Database(lc, changeLogFileName(file.path));
-      try {
-        return fn(db);
-      } finally {
-        db.close();
-      }
-    };
-    const insertSQLiteOrphan = (file: DbFile, watermark: string) =>
-      withRunLog(file, db =>
-        db
-          .prepare(/*sql*/ `
-              INSERT INTO "${CHANGE_LOG_STREAM_TABLE}"
-                ("watermark", "pos", "change", "precommit", "writeTimeMs")
-              VALUES (?, 0, '{"tag":"begin"}', NULL, NULL),
-                     (?, 1, '{"tag":"insert"}', NULL, NULL)`)
-          .run(watermark, watermark),
-      );
-    const insertPGOrphan = (watermark: string) => sql`
-      INSERT INTO ${cdc('changeLog')} ("watermark", "pos", "change", "precommit")
-      VALUES (${watermark}, 0, '{"tag":"begin"}'::json, NULL),
-             (${watermark}, 1, '{"tag":"insert"}'::json, NULL)`;
 
     await fc.assert(
       fc.asyncProperty(faultScenario, async ({txs}) => {
@@ -1169,7 +967,6 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
           const specs = txs.map((spec, i) => ({
             ...spec,
             watermark: wm(base + (i + 1) * 10),
-            orphanAt: wm(base + (i + 1) * 10 + 5),
           }));
           // A clean sentinel pins the common head, so every generated
           // transaction lies strictly inside the compared range — head skew
@@ -1181,16 +978,6 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
               runWriter.write(change, storer.store(t.watermark, change));
             }
           };
-          // Production seeds at PG's durable head, which must be a valid
-          // catchup boundary. Give each generated run the same invariant;
-          // SQLite's synthetic seed remains excluded from the compared range.
-          const boundary = tx(
-            wm(base),
-            messages.insert('foo', {id: `boundary-${base}`}),
-          );
-          for (const change of boundary.changes) {
-            storer.store(boundary.watermark, change);
-          }
           for (const spec of specs) {
             feedRun(
               tx(
@@ -1204,78 +991,53 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
           feedRun(tx(sentinel, messages.insert('foo', {id: sentinel})));
           await storer.allProcessed();
 
-          // Corrupt, and build the expected report while doing so.
-          const expected: {watermark: string; outcome: string}[] = [];
+          const withRunLog = <T>(fn: (db: Database) => T): T => {
+            const db = new Database(lc, changeLogFileName(runFile.path));
+            try {
+              return fn(db);
+            } finally {
+              db.close();
+            }
+          };
+
+          // Corrupt, and build the expected report while doing so. Every
+          // corruption is reported at its own watermark: presence for a
+          // dropped transaction, a digest inequality for a mutated one.
+          const expected: string[] = [];
           let expectedMatched = 1; // the sentinel
-          for (const [i, spec] of specs.entries()) {
-            // An orphan is served inside the range of the next transaction
-            // up; when one store does not hold that transaction, the range
-            // is never read and the orphan is unobservable.
-            const upper = specs[i + 1];
-            const upperIntact =
-              upper === undefined ||
-              (upper.kind !== 'drop-sqlite' && upper.kind !== 'drop-pg');
+          for (const spec of specs) {
             switch (spec.kind) {
               case 'clean':
                 expectedMatched++;
                 break;
               case 'drop-sqlite':
-                withRunLog(runFile, db =>
+                withRunLog(db =>
                   db
                     .prepare(
                       /*sql*/ `DELETE FROM "${CHANGE_LOG_STREAM_TABLE}" WHERE "watermark" = ?`,
                     )
                     .run(spec.watermark),
                 );
-                expected.push({
-                  watermark: spec.watermark,
-                  outcome: 'missing-sqlite',
-                });
+                expected.push(spec.watermark);
                 break;
               case 'drop-pg':
                 await sql`
                   DELETE FROM ${cdc('changeLog')} WHERE watermark = ${spec.watermark}`;
-                expected.push({
-                  watermark: spec.watermark,
-                  outcome: 'missing-pg',
-                });
+                expected.push(spec.watermark);
                 break;
               case 'mutate-pg':
                 await mutatePGChange(spec.watermark, 0, change => {
                   change.mutated = true;
                 });
-                expected.push({
-                  watermark: spec.watermark,
-                  outcome: 'digest-mismatch',
-                });
+                expected.push(spec.watermark);
                 break;
-            }
-            if (spec.orphanAfter !== undefined) {
-              if (spec.orphanAfter !== 'pg') {
-                insertSQLiteOrphan(runFile, spec.orphanAt);
-              }
-              if (spec.orphanAfter !== 'sqlite') {
-                await insertPGOrphan(spec.orphanAt);
-              }
-              // Identical orphan output in both stores is parity in what
-              // catchup serves, never a finding.
-              if (spec.orphanAfter !== 'both' && upperIntact) {
-                expected.push({
-                  watermark: spec.orphanAt,
-                  outcome: 'orphan-output',
-                });
-              }
             }
           }
 
-          // Drive to quiescence in one complete range, whose clean sentinel is
-          // a valid boundary in both stores. Capped-range behavior is covered
-          // separately: allowing a cap to land on a PG hole would correctly
-          // keep rejecting that boundary, just as authoritative catchup does.
+          const before = logSink.messages.length;
           const comparator = newComparator({
             file: changeLogFileName(runFile.path),
           });
-          const divergent: {watermark: string; outcome: string}[] = [];
           let matched = 0;
           for (let guard = 0; ; guard++) {
             assert(guard < 8, 'comparator failed to reach quiescence');
@@ -1285,24 +1047,11 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
               break;
             }
             matched += result.matched;
-            divergent.push(
-              ...result.divergent.map(({watermark, outcome}) => ({
-                watermark,
-                outcome,
-              })),
-            );
           }
 
-          const order = (
-            a: {watermark: string; outcome: string},
-            b: {watermark: string; outcome: string},
-          ) =>
-            a.watermark < b.watermark
-              ? -1
-              : a.watermark > b.watermark
-                ? 1
-                : a.outcome.localeCompare(b.outcome);
-          expect(divergent.toSorted(order)).toEqual(expected.toSorted(order));
+          expect(divergedWatermarks(before).toSorted()).toEqual(
+            expected.toSorted(),
+          );
           expect(matched).toBe(expectedMatched);
         } finally {
           runWriter.close();
@@ -1312,18 +1061,5 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
       }),
       {numRuns: 10},
     );
-  });
-
-  test('stop() ends the comparator', async () => {
-    await feedBoth(
-      tx('03', messages.insert('foo', {id: 'boundary'})),
-      tx('04', messages.insert('foo', {id: 'content'})),
-    );
-    const comparator = newComparator();
-    comparator.stop();
-    expect(await comparator.compareOnce()).toEqual({
-      kind: 'skipped',
-      reason: 'stopped',
-    });
   });
 });

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.pg.test.ts
@@ -473,6 +473,58 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
     expect(second.divergent).toMatchObject([
       {watermark: '04', outcome: 'bounds-mismatch'},
     ]);
+    // The finding is about the boundary, not the range above it: the same
+    // cycle still compares ('04', '05'] and moves the cursor past the damage.
+    expect(second).toMatchObject({throughWatermark: '05', matched: 1});
+
+    // The next cycle starts above the bad boundary rather than re-reporting
+    // the identical bounds-mismatch forever.
+    const third = await comparator.compareOnce();
+    expect(third).toEqual({kind: 'skipped', reason: 'nothing-to-compare'});
+  });
+
+  test('a divergent cursor boundary does not wedge the comparator', async () => {
+    // SQLite loses a whole transaction PG holds, while the log runs ahead of
+    // PG (its normal state), so the cycle's common upper bound — and with it
+    // the cursor — lands exactly on the commit the log cannot serve as a
+    // catchup boundary.
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'boundary'})),
+      tx('04', messages.insert('foo', {id: 'sqlite-lost'})),
+    );
+    feedSQLiteOnly(tx('05', messages.insert('foo', {id: 'log-leads'})));
+    withSQLiteLog(db =>
+      db
+        .prepare(
+          /*sql*/ `DELETE FROM "${CHANGE_LOG_STREAM_TABLE}" WHERE "watermark" = '04'`,
+        )
+        .run(),
+    );
+
+    const comparator = newComparator();
+    const first = await comparator.compareOnce();
+    assert(first.kind === 'compared', 'expected a compared cycle');
+    expect(first).toMatchObject({throughWatermark: '04', matched: 1});
+    expect(first.divergent).toMatchObject([
+      {watermark: '04', outcome: 'missing-sqlite'},
+    ]);
+
+    // The stream continues, so the next cycle has a non-empty range whose
+    // `from` is the divergent boundary: plan() is `too-old` and the bounds
+    // have not moved.
+    await feedBoth(tx('06', messages.insert('foo', {id: 'next'})));
+
+    const second = await comparator.compareOnce();
+    assert(second.kind === 'compared', 'expected a compared cycle');
+    expect(second.divergent).toMatchObject([
+      {watermark: '04', outcome: 'bounds-mismatch'},
+      {watermark: '05', outcome: 'missing-pg'},
+    ]);
+    expect(second).toMatchObject({throughWatermark: '06', matched: 1});
+
+    // Progress, not a wedge.
+    const third = await comparator.compareOnce();
+    expect(third).toEqual({kind: 'skipped', reason: 'nothing-to-compare'});
   });
 
   test('a failing reader classifies as reader-error', async () => {

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.pg.test.ts
@@ -1,0 +1,707 @@
+import {LogContext} from '@rocicorp/logger';
+import {beforeEach, describe, expect, vi} from 'vitest';
+import {assert} from '../../../../shared/src/asserts.ts';
+import {TestLogSink} from '../../../../shared/src/logging-test-utils.ts';
+import {Database} from '../../../../zqlite/src/db.ts';
+import {StatementRunner} from '../../db/statements.ts';
+import {test, type PgTest} from '../../test/db.ts';
+import {DbFile} from '../../test/lite.ts';
+import type {PostgresDB} from '../../types/pg.ts';
+import {cdcSchema, type ShardID} from '../../types/shards.ts';
+import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
+import {
+  changeLogFileName,
+  CHANGE_LOG_STREAM_TABLE,
+  type ChangeLogIdentity,
+} from '../replicator/change-log-db.ts';
+import {
+  getSubscriptionState,
+  initReplicationState,
+} from '../replicator/schema/replication-state.ts';
+import {ReplicationMessages} from '../replicator/test-utils.ts';
+import {serializeChangeStreamData} from './change-log-codec.ts';
+import {initChangeStreamerSchema} from './schema/init.ts';
+import {ensureReplicationConfig} from './schema/tables.ts';
+import {
+  isSampledForCompare,
+  normalizeChangeJSON,
+  SQLiteChangeLogComparator,
+  type PGChangeLogRangeReader,
+  type SQLiteChangeLogCompareOptions,
+} from './sqlite-change-log-comparator.ts';
+import {SQLiteChangeLogWriter} from './sqlite-change-log-writer.ts';
+import {Storer} from './storer.ts';
+
+describe('change-streamer/sqlite-change-log-comparator', () => {
+  const REPLICA_VERSION = '01';
+  const RETENTION_MS = 60_000;
+  const shard: ShardID = {appID: 'cmp', shardNum: 7};
+  const identity: ChangeLogIdentity = {
+    epoch: null,
+    generation: REPLICA_VERSION,
+    replicaID: 'replica-id',
+  };
+
+  let lc: LogContext;
+  let logSink: TestLogSink;
+  let sql: PostgresDB;
+  let storer: Storer;
+  let storerDone: Promise<void>;
+  let writer: SQLiteChangeLogWriter;
+  let logFile: DbFile;
+  let seededAtMs: number;
+
+  beforeEach<PgTest>(async ({testDBs}) => {
+    logSink = new TestLogSink();
+    lc = new LogContext('debug', {}, logSink);
+
+    sql = await testDBs.create('sqlite_change_log_comparator_test', {
+      typeOpts: {sendStringAsJson: true},
+    });
+
+    const replica = new Database(lc, ':memory:');
+    initReplicationState(replica, ['zero_data'], REPLICA_VERSION);
+    const subscriptionState = getSubscriptionState(
+      new StatementRunner(replica),
+    );
+
+    await initChangeStreamerSchema(lc, sql, shard);
+    await ensureReplicationConfig(lc, sql, subscriptionState, shard, true);
+
+    storer = new Storer(
+      lc,
+      shard,
+      'task-id',
+      'change.streamer:12345',
+      'ws',
+      sql,
+      REPLICA_VERSION,
+      () => {},
+      vi.fn(),
+      {
+        backPressureLimitHeapProportion: 0.04,
+        statementTimeoutMs: 20_000,
+        changeLogBatchSize: 2000,
+      },
+    );
+    await storer.assumeOwnership();
+    storerDone = storer.run();
+
+    seededAtMs = 1_000_000;
+    logFile = new DbFile('sqlite-change-log-comparator');
+    writer = new SQLiteChangeLogWriter(lc, {
+      replicaFile: logFile.path,
+      identity,
+      now: () => seededAtMs,
+    });
+    // The stream would resume from PG's lastWatermark, which
+    // ensureReplicationConfig initialized to the replica version.
+    writer.reconcile(REPLICA_VERSION);
+
+    return async () => {
+      await storer.stop();
+      await storerDone;
+      writer.close();
+      logFile.delete();
+      await testDBs.drop(sql);
+    };
+  });
+
+  const messages = new ReplicationMessages({foo: 'id'});
+
+  type Tx = {watermark: string; changes: ChangeStreamData[]};
+
+  function tx(watermark: string, ...data: object[]): Tx {
+    return {
+      watermark,
+      changes: [
+        [
+          'begin',
+          messages.begin(),
+          {commitWatermark: watermark},
+        ] as unknown as ChangeStreamData,
+        ...data.map(d => ['data', d] as unknown as ChangeStreamData),
+        [
+          'commit',
+          messages.commit(),
+          {watermark},
+        ] as unknown as ChangeStreamData,
+      ],
+    };
+  }
+
+  function feedTx(t: Tx, target: {pg: boolean; sqlite: boolean}) {
+    for (const change of t.changes) {
+      const json = target.pg
+        ? storer.store(t.watermark, change)
+        : serializeChangeStreamData(change);
+      if (target.sqlite) {
+        writer.write(change, json);
+      }
+    }
+  }
+
+  async function feedBoth(...txs: Tx[]) {
+    txs.forEach(t => feedTx(t, {pg: true, sqlite: true}));
+    await storer.allProcessed();
+  }
+
+  async function feedPGOnly(...txs: Tx[]) {
+    txs.forEach(t => feedTx(t, {pg: true, sqlite: false}));
+    await storer.allProcessed();
+  }
+
+  function feedSQLiteOnly(...txs: Tx[]) {
+    txs.forEach(t => feedTx(t, {pg: false, sqlite: true}));
+  }
+
+  function newComparator(
+    overrides: Partial<SQLiteChangeLogCompareOptions> & {
+      pg?: PGChangeLogRangeReader;
+      logIdentity?: ChangeLogIdentity;
+      file?: string;
+    } = {},
+  ): SQLiteChangeLogComparator {
+    const {pg, logIdentity, file, ...opts} = overrides;
+    return new SQLiteChangeLogComparator(
+      lc,
+      shard,
+      file ?? changeLogFileName(logFile.path),
+      logIdentity ?? identity,
+      pg ?? storer,
+      {
+        comparePercent: 100,
+        retentionMs: RETENTION_MS,
+        // Warm by default: exactly one retention window past the seed.
+        now: () => seededAtMs + RETENTION_MS,
+        setTimeoutFn: vi.fn() as unknown as typeof setTimeout,
+        yieldFn: () => Promise.resolve(),
+        ...opts,
+      },
+    );
+  }
+
+  /** Direct writes to the SQLite log, as the purger or an injected fault. */
+  function withSQLiteLog<T>(fn: (db: Database) => T): T {
+    const db = new Database(lc, changeLogFileName(logFile.path));
+    try {
+      return fn(db);
+    } finally {
+      db.close();
+    }
+  }
+
+  function cdc(table: string) {
+    return sql(`${cdcSchema(shard)}.${table}`);
+  }
+
+  async function mutatePGChange(
+    watermark: string,
+    pos: number,
+    mutate: (change: Record<string, unknown>) => void,
+  ) {
+    const [{change}] = await sql<{change: string}[]>`
+      SELECT change::text FROM ${cdc('changeLog')}
+       WHERE watermark = ${watermark} AND pos = ${pos}`;
+    const parsed = JSON.parse(change) as Record<string, unknown>;
+    mutate(parsed);
+    const mutated = JSON.stringify(parsed);
+    await sql`
+      UPDATE ${cdc('changeLog')} SET change = ${mutated}::json
+       WHERE watermark = ${watermark} AND pos = ${pos}`;
+  }
+
+  // The normalization pin, first (§6.5): a transaction round-tripped through
+  // both stores — SQLite's exact stored substring versus PG's json column read
+  // back as text — must digest identically before any injected-mutation case
+  // can mean anything.
+  //
+  // Both stores carry a synthetic seed transaction at the replica version
+  // '01' (PG's from ensureReplicationConfig, SQLite's from reconcile), so the
+  // comparable range starts there and every fed transaction is compared.
+  //
+  // The payload deliberately contains an *escaped* backslash-u sequence, not
+  // an actual NUL character: `change->'tag'` in the production PG catchup
+  // statement de-escapes every string value while scanning for the field, and
+  // Postgres cannot convert an escaped NUL to text, so a row containing one
+  // fails PG catchup itself — the comparator faithfully reports it as
+  // `reader-error` rather than as parity.
+  test('round-trips one transaction through both stores with equal digests', async () => {
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'first'})),
+      tx(
+        '04',
+        messages.insert('foo', {
+          id: 'nul-\\u0000-esc',
+          big: 9007199254740993n,
+          float: 1.5,
+          text: 'quotes " backslash \\ newline \n emoji 🙂 control \u0001',
+          nil: null,
+          bool: true,
+        }),
+      ),
+    );
+    const result = await newComparator().compareOnce();
+    assert(result.kind === 'compared', 'expected a compared cycle');
+    expect(result).toMatchObject({
+      fromWatermark: '01',
+      throughWatermark: '04',
+      transactions: 2,
+      sampled: 2,
+      matched: 2,
+      divergent: [],
+    });
+  });
+
+  test('normalizeChangeJSON collapses formatting, preserves content', () => {
+    expect(normalizeChangeJSON('{ "tag" : "insert",\n  "v": 1 }')).toBe(
+      normalizeChangeJSON('{"tag":"insert","v":1}'),
+    );
+    // Precision above Number.MAX_SAFE_INTEGER survives the round trip.
+    expect(normalizeChangeJSON('{"v":9007199254740993}')).toBe(
+      '{"v":9007199254740993}',
+    );
+    // A value that does not parse is hashed as-is.
+    expect(normalizeChangeJSON('not-json')).toBe('not-json');
+  });
+
+  test('parity across message families and multi-batch ranges', async () => {
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'boundary'})),
+      tx(
+        '04',
+        messages.insert('foo', {id: 'b', v: 1}),
+        messages.update('foo', {id: 'b', v: 2}),
+        messages.update('foo', {id: 'b2', v: 3}, {id: 'b'}),
+        messages.delete('foo', {id: 'b2'}),
+        messages.truncate('foo'),
+      ),
+      tx(
+        '05',
+        messages.createTable({
+          schema: 'public',
+          name: 'baz',
+          columns: {id: {pos: 0, dataType: 'varchar'}},
+          primaryKey: ['id'],
+        }),
+      ),
+      tx('06', messages.addColumn('foo', 'extra', {dataType: 'text', pos: 9})),
+      tx('07', messages.dropColumn('foo', 'extra'), messages.dropTable('baz')),
+    );
+    // readBatchRows 2 forces multiple SQLite read batches per transaction;
+    // maxTransactionsPerCycle 2 forces the comparison across cycles.
+    const comparator = newComparator({
+      readBatchRows: 2,
+      maxTransactionsPerCycle: 2,
+    });
+
+    const first = await comparator.compareOnce();
+    assert(first.kind === 'compared', 'expected a compared cycle');
+    expect(first).toMatchObject({
+      fromWatermark: '01',
+      throughWatermark: '04',
+      transactions: 2,
+      sampled: 2,
+      matched: 2,
+      divergent: [],
+    });
+
+    const second = await comparator.compareOnce();
+    assert(second.kind === 'compared', 'expected a compared cycle');
+    expect(second).toMatchObject({
+      fromWatermark: '04',
+      throughWatermark: '06',
+      transactions: 2,
+      sampled: 2,
+      matched: 2,
+      divergent: [],
+    });
+
+    const third = await comparator.compareOnce();
+    assert(third.kind === 'compared', 'expected a compared cycle');
+    expect(third).toMatchObject({
+      fromWatermark: '06',
+      throughWatermark: '07',
+      transactions: 1,
+      sampled: 1,
+      matched: 1,
+      divergent: [],
+    });
+
+    expect(await comparator.compareOnce()).toEqual({
+      kind: 'skipped',
+      reason: 'nothing-to-compare',
+    });
+  });
+
+  test('head lag in either direction is not divergence', async () => {
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'boundary'})),
+      tx('04', messages.insert('foo', {id: 'both'})),
+    );
+    const t5 = tx('05', messages.insert('foo', {id: 'trailing-pg'}));
+    const t6 = tx('06', messages.insert('foo', {id: 'trailing-sqlite'}));
+
+    // The SQLite log leads, as it does in production: compare only through
+    // the PG head.
+    feedSQLiteOnly(t5);
+    const comparator = newComparator();
+    let result = await comparator.compareOnce();
+    assert(result.kind === 'compared', 'expected a compared cycle');
+    expect(result).toMatchObject({
+      throughWatermark: '04',
+      transactions: 2,
+      matched: 2,
+      divergent: [],
+    });
+
+    // PG catches up and then leads: compare only through the SQLite head.
+    await feedPGOnly(t5, t6);
+    result = await comparator.compareOnce();
+    assert(result.kind === 'compared', 'expected a compared cycle');
+    expect(result).toMatchObject({
+      fromWatermark: '04',
+      throughWatermark: '05',
+      transactions: 1,
+      matched: 1,
+      divergent: [],
+    });
+
+    // SQLite catches up: the previously skewed transaction compares clean.
+    feedSQLiteOnly(t6);
+    result = await comparator.compareOnce();
+    assert(result.kind === 'compared', 'expected a compared cycle');
+    expect(result).toMatchObject({
+      fromWatermark: '05',
+      throughWatermark: '06',
+      transactions: 1,
+      matched: 1,
+      divergent: [],
+    });
+  });
+
+  test('a mutated PG payload classifies as digest-mismatch', async () => {
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'boundary'})),
+      tx('04', messages.insert('foo', {id: 'victim', v: 1})),
+      tx('05', messages.insert('foo', {id: 'witness'})),
+    );
+    await mutatePGChange('04', 1, change => {
+      (change.new as Record<string, unknown>).v = 999;
+    });
+
+    const result = await newComparator().compareOnce();
+    assert(result.kind === 'compared', 'expected a compared cycle');
+    expect(result).toMatchObject({
+      transactions: 3,
+      sampled: 3,
+      matched: 2,
+    });
+    expect(result.divergent).toMatchObject([
+      {watermark: '04', outcome: 'digest-mismatch'},
+    ]);
+    const [divergent] = result.divergent;
+    expect(divergent.sqliteDigest).toHaveLength(16);
+    expect(divergent.pgDigest).toHaveLength(16);
+    expect(divergent.sqliteDigest).not.toBe(divergent.pgDigest);
+    expect(divergent.sqliteRows).toBe(3);
+    expect(divergent.pgRows).toBe(3);
+  });
+
+  test('a transaction PG does not hold classifies as missing-pg', async () => {
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'boundary'})),
+      tx('04', messages.insert('foo', {id: 'victim'})),
+      tx('05', messages.insert('foo', {id: 'witness'})),
+    );
+    await sql`DELETE FROM ${cdc('changeLog')} WHERE watermark = '04'`;
+
+    const result = await newComparator().compareOnce();
+    assert(result.kind === 'compared', 'expected a compared cycle');
+    expect(result.divergent).toMatchObject([
+      {watermark: '04', outcome: 'missing-pg'},
+    ]);
+    expect(result.matched).toBe(2); // '03' and '05' still match
+  });
+
+  test('a transaction SQLite does not serve classifies as missing-sqlite', async () => {
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'boundary'})),
+      tx('04', messages.insert('foo', {id: 'victim'})),
+      tx('05', messages.insert('foo', {id: 'witness'})),
+    );
+    withSQLiteLog(db =>
+      db
+        .prepare(
+          /*sql*/ `DELETE FROM "${CHANGE_LOG_STREAM_TABLE}" WHERE "watermark" = '04'`,
+        )
+        .run(),
+    );
+
+    const result = await newComparator().compareOnce();
+    assert(result.kind === 'compared', 'expected a compared cycle');
+    expect(result.divergent).toMatchObject([
+      {watermark: '04', outcome: 'missing-sqlite'},
+    ]);
+    expect(result.matched).toBe(2);
+  });
+
+  test('a missing catchup boundary classifies as bounds-mismatch', async () => {
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'boundary'})),
+      tx('04', messages.insert('foo', {id: 'cursor-boundary'})),
+    );
+    const comparator = newComparator();
+    const first = await comparator.compareOnce();
+    assert(first.kind === 'compared', 'expected a compared cycle');
+    expect(first).toMatchObject({throughWatermark: '04', matched: 2});
+
+    // The cursor now rests on '04', whose commit row is the boundary the next
+    // cycle's plan() must find. Removing it makes the log unable to serve a
+    // range it claims to hold.
+    withSQLiteLog(db =>
+      db
+        .prepare(/*sql*/ `
+            DELETE FROM "${CHANGE_LOG_STREAM_TABLE}"
+             WHERE "watermark" = '04' AND "precommit" IS NOT NULL`)
+        .run(),
+    );
+    await feedBoth(tx('05', messages.insert('foo', {id: 'next'})));
+
+    const second = await comparator.compareOnce();
+    assert(second.kind === 'compared', 'expected a compared cycle');
+    expect(second.divergent).toMatchObject([
+      {watermark: '04', outcome: 'bounds-mismatch'},
+    ]);
+  });
+
+  test('a failing reader classifies as reader-error', async () => {
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'boundary'})),
+      tx('04', messages.insert('foo', {id: 'unreadable'})),
+    );
+    const failing: PGChangeLogRangeReader = {
+      getCatchupBounds: () => storer.getCatchupBounds(),
+      listCommitWatermarks: (after, through, limit) =>
+        storer.listCommitWatermarks(after, through, limit),
+      readCatchupRange: (after, through) => {
+        if (through === '04') {
+          throw new Error('injected read failure');
+        }
+        return storer.readCatchupRange(after, through);
+      },
+    };
+    const result = await newComparator({pg: failing}).compareOnce();
+    assert(result.kind === 'compared', 'expected a compared cycle');
+    expect(result.divergent).toMatchObject([
+      {watermark: '04', outcome: 'reader-error'},
+    ]);
+    expect(result.matched).toBe(1); // '03' read cleanly and matched
+  });
+
+  test('a PG purge racing the comparison yields inconclusive', async () => {
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'boundary'})),
+      tx('04', messages.insert('foo', {id: 'purged-mid-compare'})),
+      tx('05', messages.insert('foo', {id: 'witness'})),
+    );
+    // The purge lands after the cycle pinned its bounds and enumerated the
+    // range, exactly as a concurrently scheduled cleanup would.
+    let purged = false;
+    const racing: PGChangeLogRangeReader = {
+      getCatchupBounds: () => storer.getCatchupBounds(),
+      listCommitWatermarks: (after, through, limit) =>
+        storer.listCommitWatermarks(after, through, limit),
+      readCatchupRange: (after, through) =>
+        (async function* (this: void) {
+          if (!purged) {
+            purged = true;
+            await storer.purgeRecordsBefore('05');
+          }
+          yield* storer.readCatchupRange(after, through);
+        })(),
+    };
+    const result = await newComparator({pg: racing}).compareOnce();
+    assert(result.kind === 'compared', 'expected a compared cycle');
+    expect(result.divergent).toMatchObject([
+      {watermark: '03', outcome: 'inconclusive'},
+      {watermark: '04', outcome: 'inconclusive'},
+    ]);
+    expect(result.matched).toBe(1); // '05' survives the purge and matches
+    // Inconclusive is a race, not a finding: nothing is reported as diverged.
+    expect(
+      logSink.messages.filter(
+        ([level, , parts]) =>
+          level === 'error' && JSON.stringify(parts).includes('diverged'),
+      ),
+    ).toEqual([]);
+  });
+
+  test('a SQLite purge racing the comparison yields inconclusive', async () => {
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'boundary'})),
+      tx('04', messages.insert('foo', {id: 'purged-mid-compare'})),
+      tx('05', messages.insert('foo', {id: 'witness'})),
+    );
+    // Delete the low transactions after the cycle enumerates them, as the
+    // purger (which deletes whole transactions below the floor) would.
+    const racing: PGChangeLogRangeReader = {
+      getCatchupBounds: () => storer.getCatchupBounds(),
+      listCommitWatermarks: async (after, through, limit) => {
+        const list = await storer.listCommitWatermarks(after, through, limit);
+        withSQLiteLog(db =>
+          db
+            .prepare(
+              /*sql*/ `DELETE FROM "${CHANGE_LOG_STREAM_TABLE}" WHERE "watermark" < '05'`,
+            )
+            .run(),
+        );
+        return list;
+      },
+      readCatchupRange: (after, through) =>
+        storer.readCatchupRange(after, through),
+    };
+    const result = await newComparator({pg: racing}).compareOnce();
+    assert(result.kind === 'compared', 'expected a compared cycle');
+    expect(result.divergent).toMatchObject([
+      {watermark: '03', outcome: 'inconclusive'},
+      {watermark: '04', outcome: 'inconclusive'},
+    ]);
+    expect(result.matched).toBe(1);
+  });
+
+  test('sampling is stable by shard and watermark', () => {
+    const watermarks = Array.from({length: 64}, (_, i) =>
+      (i + 3).toString(36).padStart(2, '0'),
+    );
+    for (const percent of [0, 25, 60, 100]) {
+      for (const w of watermarks) {
+        const sampled = isSampledForCompare(shard, w, percent);
+        // Deterministic.
+        expect(isSampledForCompare(shard, w, percent)).toBe(sampled);
+        // Monotone in percent: raising the sample never drops a member.
+        if (sampled) {
+          expect(
+            isSampledForCompare(shard, w, Math.min(100, percent + 20)),
+          ).toBe(true);
+        }
+      }
+      const count = watermarks.filter(w =>
+        isSampledForCompare(shard, w, percent),
+      ).length;
+      if (percent === 0) {
+        expect(count).toBe(0);
+      } else if (percent === 100) {
+        expect(count).toBe(watermarks.length);
+      } else {
+        expect(count).toBeGreaterThan(0);
+        expect(count).toBeLessThan(watermarks.length);
+      }
+    }
+  });
+
+  test('a retried comparison samples the same transactions', async () => {
+    const txs = Array.from({length: 12}, (_, i) =>
+      tx((i + 3).toString(36).padStart(2, '0'), {
+        ...messages.insert('foo', {id: `row-${i}`}),
+      }),
+    );
+    await feedBoth(...txs);
+
+    const percent = 40;
+    const expected = txs.filter(({watermark}) =>
+      isSampledForCompare(shard, watermark, percent),
+    ).length;
+
+    // Two independent comparators — as across a restart — pin the same range
+    // and select exactly the same sample.
+    const first = await newComparator({comparePercent: percent}).compareOnce();
+    const second = await newComparator({comparePercent: percent}).compareOnce();
+    assert(
+      first.kind === 'compared' && second.kind === 'compared',
+      'expected compared cycles',
+    );
+    expect(first.sampled).toBe(expected);
+    expect(second.sampled).toBe(expected);
+    expect(second.fromWatermark).toBe(first.fromWatermark);
+    expect(second.throughWatermark).toBe(first.throughWatermark);
+    expect(first.matched).toBe(first.sampled);
+    expect(second.matched).toBe(second.sampled);
+  });
+
+  test('divergence reports carry no payload data', async () => {
+    const sentinel = 'SENSITIVE-PAYLOAD-8675309';
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'boundary'})),
+      tx('04', messages.insert('foo', {id: sentinel, secret: sentinel})),
+    );
+    await mutatePGChange('04', 1, change => {
+      (change.new as Record<string, unknown>).secret = `${sentinel}-mutated`;
+    });
+
+    const before = logSink.messages.length;
+    const result = await newComparator().compareOnce();
+    assert(result.kind === 'compared', 'expected a compared cycle');
+    expect(result.divergent).toMatchObject([
+      {watermark: '04', outcome: 'digest-mismatch'},
+    ]);
+
+    // Neither the cycle result nor anything logged for it contains the
+    // payload; digests are truncated prefixes.
+    expect(JSON.stringify(result)).not.toContain(sentinel);
+    expect(JSON.stringify(logSink.messages.slice(before))).not.toContain(
+      sentinel,
+    );
+    expect(result.divergent[0].sqliteDigest).toHaveLength(16);
+  });
+
+  test('declines a cold log, a wrong identity, and an absent file', async () => {
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'boundary'})),
+      tx('04', messages.insert('foo', {id: 'content'})),
+    );
+
+    expect(
+      await newComparator({
+        now: () => seededAtMs + RETENTION_MS - 1,
+      }).compareOnce(),
+    ).toEqual({kind: 'skipped', reason: 'cold-log'});
+
+    expect(
+      await newComparator({
+        logIdentity: {...identity, replicaID: 'someone-else'},
+      }).compareOnce(),
+    ).toEqual({kind: 'skipped', reason: 'ineligible-identity'});
+
+    expect(
+      await newComparator({file: `${logFile.path}-absent`}).compareOnce(),
+    ).toEqual({kind: 'skipped', reason: 'log-unavailable'});
+
+    const result = await newComparator().compareOnce();
+    assert(result.kind === 'compared', 'expected a compared cycle');
+    expect(result).toMatchObject({matched: 2, divergent: []});
+  });
+
+  test('a freshly seeded log with no traffic has nothing to compare', async () => {
+    // Both stores hold only their synthetic seed transactions at '01'. Seeds
+    // are catchup boundaries, never compared output — and SQLite's seed is
+    // never reported as missing from PG.
+    expect(await newComparator().compareOnce()).toEqual({
+      kind: 'skipped',
+      reason: 'nothing-to-compare',
+    });
+  });
+
+  test('stop() ends the comparator', async () => {
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'boundary'})),
+      tx('04', messages.insert('foo', {id: 'content'})),
+    );
+    const comparator = newComparator();
+    comparator.stop();
+    expect(await comparator.compareOnce()).toEqual({
+      kind: 'skipped',
+      reason: 'stopped',
+    });
+  });
+});

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Property tests for the comparator's pure functions. The store-facing
+ * behavior — real Postgres against a real SQLite log — lives in
+ * `sqlite-change-log-comparator.pg.test.ts`; nothing here needs a database.
+ */
+
+import fc from 'fast-check';
+import {describe, expect, test} from 'vitest';
+import type {ShardID} from '../../types/shards.ts';
+import type {ChangeTag, WatermarkedChange} from './change-streamer.ts';
+import {
+  digestCatchupTransactions,
+  isSampledForCompare,
+  normalizeChangeJSON,
+} from './sqlite-change-log-comparator.ts';
+
+describe('change-streamer/sqlite-change-log-comparator/properties', () => {
+  type TxKind = 'complete' | 'orphan' | 'rollback';
+
+  const streamScenario = fc.record({
+    txs: fc.array(
+      fc.record({
+        width: fc.integer({min: 0, max: 5}),
+        kind: fc.constantFrom<TxKind>('complete', 'orphan', 'rollback'),
+      }),
+      {maxLength: 8},
+    ),
+    // Rows dropped from the front of the stream, so it can begin
+    // mid-transaction — possibly beheading more than one transaction.
+    truncateHead: fc.nat({max: 3}),
+    // Two chunkings of the same rows, cycled over the stream.
+    chunkSizesA: fc.array(fc.integer({min: 1, max: 7}), {
+      minLength: 1,
+      maxLength: 4,
+    }),
+    chunkSizesB: fc.array(fc.integer({min: 1, max: 7}), {
+      minLength: 1,
+      maxLength: 4,
+    }),
+  });
+
+  function buildRows(
+    txs: {width: number; kind: TxKind}[],
+  ): WatermarkedChange[] {
+    const rows: WatermarkedChange[] = [];
+    txs.forEach(({width, kind}, i) => {
+      const w = `w${String(i + 1).padStart(2, '0')}`;
+      rows.push([
+        w,
+        'begin',
+        `["begin",{"tag":"begin"},{"commitWatermark":"${w}"}]`,
+      ]);
+      for (let k = 0; k < width; k++) {
+        rows.push([
+          w,
+          'insert' as ChangeTag,
+          `["data",{"tag":"insert","row":${k}}]`,
+        ]);
+      }
+      if (kind === 'complete') {
+        rows.push([
+          w,
+          'commit',
+          `["commit",{"tag":"commit"},{"watermark":"${w}"}]`,
+        ]);
+      } else if (kind === 'rollback') {
+        rows.push([w, 'rollback', `["rollback",{"tag":"rollback"}]`]);
+      } // orphan: no terminal row — a torn or corrupt remnant.
+    });
+    return rows;
+  }
+
+  async function* chunked(
+    rows: WatermarkedChange[],
+    sizes: number[],
+  ): AsyncIterable<WatermarkedChange[]> {
+    let i = 0;
+    let s = 0;
+    while (i < rows.length) {
+      const size = sizes[s++ % sizes.length];
+      yield rows.slice(i, i + size);
+      i += size;
+    }
+  }
+
+  test('digests are a pure function of the rows, not of their batching', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        streamScenario,
+        async ({txs, truncateHead, chunkSizesA, chunkSizesB}) => {
+          const rows = buildRows(txs).slice(truncateHead);
+
+          const a = await digestCatchupTransactions(chunked(rows, chunkSizesA));
+          const b = await digestCatchupTransactions(chunked(rows, chunkSizesB));
+          // Batch boundaries carry no meaning: any two chunkings of the same
+          // served rows digest identically.
+          expect(a).toEqual(b);
+
+          // The entries are exactly the groupwise rules the comparator
+          // depends on: committed groups digest as complete iff their begin
+          // survived; rolled-back groups vanish; everything else is orphan
+          // output, always incomplete. Row counts are what was served.
+          const groups = new Map<string, WatermarkedChange[]>();
+          for (const row of rows) {
+            const group = groups.get(row[0]) ?? [];
+            group.push(row);
+            groups.set(row[0], group);
+          }
+          for (const [w, group] of groups) {
+            const tags = new Set(group.map(([, tag]) => tag));
+            const entry = a.get(w);
+            if (tags.has('rollback')) {
+              expect(entry).toBeUndefined();
+            } else {
+              expect(entry).toMatchObject({
+                watermark: w,
+                rows: group.length,
+                complete: tags.has('commit') && tags.has('begin'),
+              });
+            }
+          }
+          expect(a.size).toBe(
+            [...groups.values()].filter(
+              group => !group.some(([, tag]) => tag === 'rollback'),
+            ).length,
+          );
+        },
+      ),
+      {numRuns: 100},
+    );
+  });
+
+  test('sampling is stable, bounded, and monotone in the percentage', () => {
+    fc.assert(
+      fc.property(
+        fc.record({
+          appID: fc.string({minLength: 1, maxLength: 8}),
+          shardNum: fc.nat({max: 1000}),
+          watermark: fc.hexaString({minLength: 2, maxLength: 10}),
+          p1: fc.integer({min: 0, max: 100}),
+          p2: fc.integer({min: 0, max: 100}),
+        }),
+        ({appID, shardNum, watermark, p1, p2}) => {
+          const shard: ShardID = {appID, shardNum};
+          const lo = Math.min(p1, p2);
+          const hi = Math.max(p1, p2);
+          // Stable: a retried comparison selects the same transactions.
+          expect(isSampledForCompare(shard, watermark, hi)).toBe(
+            isSampledForCompare(shard, watermark, hi),
+          );
+          // Monotone: raising the percentage only ever adds transactions,
+          // so a canary ramp-up keeps everything it was already comparing.
+          if (isSampledForCompare(shard, watermark, lo)) {
+            expect(isSampledForCompare(shard, watermark, hi)).toBe(true);
+          }
+          expect(isSampledForCompare(shard, watermark, 0)).toBe(false);
+          expect(isSampledForCompare(shard, watermark, 100)).toBe(true);
+        },
+      ),
+    );
+  });
+
+  test('normalization is idempotent', () => {
+    fc.assert(
+      fc.property(fc.oneof(fc.json(), fc.string()), value => {
+        const once = normalizeChangeJSON(value);
+        expect(normalizeChangeJSON(once)).toBe(once);
+      }),
+    );
+  });
+});

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.test.ts
@@ -9,7 +9,7 @@ import {describe, expect, test} from 'vitest';
 import type {ShardID} from '../../types/shards.ts';
 import type {ChangeTag, WatermarkedChange} from './change-streamer.ts';
 import {
-  digestCatchupTransactions,
+  digestCatchupRange,
   isSampledForCompare,
   normalizeChangeJSON,
 } from './sqlite-change-log-comparator.ts';
@@ -23,7 +23,7 @@ describe('change-streamer/sqlite-change-log-comparator/properties', () => {
         width: fc.integer({min: 0, max: 5}),
         kind: fc.constantFrom<TxKind>('complete', 'orphan', 'rollback'),
       }),
-      {maxLength: 8},
+      {minLength: 1, maxLength: 8},
     ),
     // Rows dropped from the front of the stream, so it can begin
     // mid-transaction — possibly beheading more than one transaction.
@@ -83,47 +83,132 @@ describe('change-streamer/sqlite-change-log-comparator/properties', () => {
     }
   }
 
-  test('digests are a pure function of the rows, not of their batching', async () => {
+  const digest = (rows: WatermarkedChange[], sizes: number[] = [3]) =>
+    digestCatchupRange(
+      chunked(rows, sizes),
+      rows.at(-1)?.[0] ?? '',
+      rows.length + 1,
+    );
+
+  test('the digest is a pure function of the served rows, not their batching', async () => {
     await fc.assert(
       fc.asyncProperty(
         streamScenario,
         async ({txs, truncateHead, chunkSizesA, chunkSizesB}) => {
           const rows = buildRows(txs).slice(truncateHead);
 
-          const a = await digestCatchupTransactions(chunked(rows, chunkSizesA));
-          const b = await digestCatchupTransactions(chunked(rows, chunkSizesB));
           // Batch boundaries carry no meaning: any two chunkings of the same
-          // served rows digest identically.
-          expect(a).toEqual(b);
-
-          // The entries are exactly the groupwise rules the comparator
-          // depends on: committed groups digest as complete iff their begin
-          // survived; rolled-back groups vanish; everything else is orphan
-          // output, always incomplete. Row counts are what was served.
-          const groups = new Map<string, WatermarkedChange[]>();
-          for (const row of rows) {
-            const group = groups.get(row[0]) ?? [];
-            group.push(row);
-            groups.set(row[0], group);
-          }
-          for (const [w, group] of groups) {
-            const tags = new Set(group.map(([, tag]) => tag));
-            const entry = a.get(w);
-            if (tags.has('rollback')) {
-              expect(entry).toBeUndefined();
-            } else {
-              expect(entry).toMatchObject({
-                watermark: w,
-                rows: group.length,
-                complete: tags.has('commit') && tags.has('begin'),
-              });
-            }
-          }
-          expect(a.size).toBe(
-            [...groups.values()].filter(
-              group => !group.some(([, tag]) => tag === 'rollback'),
-            ).length,
+          // served rows digest identically, and count the same rows.
+          expect(await digest(rows, chunkSizesA)).toEqual(
+            await digest(rows, chunkSizesB),
           );
+          expect((await digest(rows, chunkSizesA)).rows).toBe(rows.length);
+        },
+      ),
+      {numRuns: 100},
+    );
+  });
+
+  test('the digest changes under any single-row corruption', async () => {
+    type Corruption = 'drop' | 'mutate' | 'duplicate' | 'move-to-end';
+
+    await fc.assert(
+      fc.asyncProperty(
+        fc.record({
+          txs: streamScenario.map(({txs}) => txs),
+          index: fc.nat(),
+          kind: fc.constantFrom<Corruption>(
+            'drop',
+            'mutate',
+            'duplicate',
+            'move-to-end',
+          ),
+        }),
+        async ({txs, index, kind}) => {
+          const rows = buildRows(txs);
+          const i = index % rows.length;
+          // Reordering the only row, or the last one, is not a reordering.
+          fc.pre(kind !== 'move-to-end' || i < rows.length - 1);
+
+          const corrupted = [...rows];
+          switch (kind) {
+            case 'drop':
+              corrupted.splice(i, 1);
+              break;
+            case 'mutate': {
+              const [w, tag, json] = rows[i];
+              corrupted[i] = [w, tag, `${json.slice(0, -1)},"extra":1]`];
+              break;
+            }
+            case 'duplicate':
+              corrupted.splice(i, 0, rows[i]);
+              break;
+            case 'move-to-end':
+              corrupted.push(...corrupted.splice(i, 1));
+              break;
+          }
+
+          // This is the whole comparison: a missing row, an extra row at any
+          // watermark, a mutated payload, and a reordering are all one
+          // inequality. There is no per-watermark bookkeeping to fool.
+          expect((await digest(corrupted)).digest).not.toBe(
+            (await digest(rows)).digest,
+          );
+        },
+      ),
+      {numRuns: 200},
+    );
+  });
+
+  test('the digest ignores JSON formatting, as the two stores differ in it', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.record({txs: streamScenario.map(({txs}) => txs)}),
+        async ({txs}) => {
+          const rows = buildRows(txs);
+          // SQLite serves the exact substring it stored; PG serves the same
+          // document re-rendered from its `json` column. Only normalization
+          // keeps that round trip from reading as divergence.
+          const reformatted = rows.map(
+            ([w, tag, json]): WatermarkedChange => [
+              w,
+              tag,
+              json.replaceAll(':', ': ').replaceAll(',', ', '),
+            ],
+          );
+          expect((await digest(reformatted)).digest).toBe(
+            (await digest(rows)).digest,
+          );
+        },
+      ),
+      {numRuns: 50},
+    );
+  });
+
+  test('the row cap reports whether the range closed', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.record({
+          txs: streamScenario.map(({txs}) => txs),
+          maxRows: fc.integer({min: 1, max: 60}),
+        }),
+        async ({txs, maxRows}) => {
+          const rows = buildRows(txs);
+          const through = rows.at(-1)?.[0] ?? '';
+          const result = await digestCatchupRange(
+            chunked(rows, [4]),
+            through,
+            maxRows,
+          );
+
+          const served = Math.min(maxRows, rows.length);
+          expect(result.rows).toBe(served);
+          // The cap is only a finding when it cut the range short of the
+          // commit that closes it; a range that fits exactly is compared.
+          const closed = rows
+            .slice(0, served)
+            .some(([w, tag]) => tag === 'commit' && w === through);
+          expect(result.limitReached).toBe(served === maxRows && !closed);
         },
       ),
       {numRuns: 100},
@@ -160,7 +245,17 @@ describe('change-streamer/sqlite-change-log-comparator/properties', () => {
     );
   });
 
-  test('normalization is idempotent', () => {
+  test('normalization collapses formatting and preserves content', () => {
+    expect(normalizeChangeJSON('{ "tag" : "insert",\n  "v": 1 }')).toBe(
+      normalizeChangeJSON('{"tag":"insert","v":1}'),
+    );
+    // Precision above Number.MAX_SAFE_INTEGER survives the round trip.
+    expect(normalizeChangeJSON('{"v":9007199254740993}')).toBe(
+      '{"v":9007199254740993}',
+    );
+    // A value that does not parse is hashed as-is.
+    expect(normalizeChangeJSON('not-json')).toBe('not-json');
+
     fc.assert(
       fc.property(fc.oneof(fc.json(), fc.string()), value => {
         const once = normalizeChangeJSON(value);

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.ts
@@ -489,6 +489,7 @@ export class SQLiteChangeLogComparator {
         return this.#skipped('nothing-to-compare');
       }
 
+      const divergent: TransactionCompareResult[] = [];
       reader = new SQLiteChangeLogReader(this.#lc, this.#changeLogFile);
       const plan = reader.plan(from);
       if (plan.kind === 'not-ready') {
@@ -508,9 +509,19 @@ export class SQLiteChangeLogComparator {
           'bounds-mismatch',
         );
         this.#compareResults.add(1, {outcome});
-        return this.#compared(from, from, 0, 0, 0, [
-          {watermark: from, outcome},
-        ]);
+        divergent.push({watermark: from, outcome});
+        if (outcome === 'inconclusive') {
+          // The pinned bounds moved; nothing this cycle established about the
+          // range still holds. The cursor stays put and the next cycle re-pins.
+          return this.#compared(from, from, 0, 0, 0, divergent);
+        }
+        // A *confirmed* mismatch is a finding about the boundary itself —
+        // typically a commit this store never held, already reported as
+        // missing by the cycle that enumerated it. The reads below are
+        // positional and never dereference the boundary row, so the cycle
+        // still compares the range and advances the cursor past it. Returning
+        // here instead would re-report the same boundary — and compare
+        // nothing else — every cycle, forever.
       }
 
       const limit = Math.max(
@@ -522,7 +533,6 @@ export class SQLiteChangeLogComparator {
       const {union} = enumerated;
       const effectiveThrough = enumerated.through;
 
-      const divergent: TransactionCompareResult[] = [];
       let sampled = 0;
       let matched = 0;
       let previousBoundary = from;

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.ts
@@ -107,7 +107,10 @@ export type CompareCycleResult =
       readonly kind: 'compared';
       /** Exclusive lower bound of the compared range. */
       readonly fromWatermark: string;
-      /** Inclusive upper bound; the next cycle resumes from here. */
+      /**
+       * Inclusive upper bound attempted. The next cycle normally resumes from
+       * here, but retries from `fromWatermark` after an inconclusive result.
+       */
       readonly throughWatermark: string;
       /** Committed transactions present in either store over the range. */
       readonly transactions: number;
@@ -128,6 +131,7 @@ export interface PGChangeLogRangeReader {
     minWatermark: string | null;
     lastWatermark: string;
   }>;
+  hasCatchupWatermark(watermark: string): Promise<boolean>;
   listCommitWatermarks(
     afterWatermark: string,
     throughWatermark: string,
@@ -400,6 +404,7 @@ export class SQLiteChangeLogComparator {
   #running: Promise<CompareCycleResult> | undefined;
   #timer: ReturnType<typeof setTimeout> | undefined;
   #stopped = false;
+  #continueWithoutDelay = false;
 
   constructor(
     lc: LogContext,
@@ -434,9 +439,16 @@ export class SQLiteChangeLogComparator {
       return Promise.resolve({kind: 'skipped', reason: 'stopped'});
     }
     if (this.#running === undefined) {
-      this.#running = this.#runCycle().finally(() => {
-        this.#running = undefined;
-      });
+      this.#running = this.#runCycle()
+        .then(result => {
+          if (this.#continueWithoutDelay) {
+            this.#rescheduleNext(0);
+          }
+          return result;
+        })
+        .finally(() => {
+          this.#running = undefined;
+        });
     }
     return this.#running;
   }
@@ -449,18 +461,29 @@ export class SQLiteChangeLogComparator {
     }
   }
 
-  #scheduleNext(): void {
+  #scheduleNext(
+    delayMs = this.#opts.intervalMs ?? DEFAULT_COMPARE_INTERVAL_MS,
+  ): void {
     if (this.#stopped || this.#timer !== undefined) {
       return;
     }
     this.#timer = this.#setTimeoutFn(() => {
       this.#timer = undefined;
       void this.compareOnce().finally(() => this.#scheduleNext());
-    }, this.#opts.intervalMs ?? DEFAULT_COMPARE_INTERVAL_MS);
+    }, delayMs);
+  }
+
+  #rescheduleNext(delayMs: number): void {
+    if (this.#timer !== undefined) {
+      this.#clearTimeoutFn(this.#timer);
+      this.#timer = undefined;
+    }
+    this.#scheduleNext(delayMs);
   }
 
   async #runCycle(): Promise<CompareCycleResult> {
     const startedAt = performance.now();
+    this.#continueWithoutDelay = false;
     let db: Database | undefined;
     let reader: SQLiteChangeLogReader | undefined;
     try {
@@ -501,6 +524,21 @@ export class SQLiteChangeLogComparator {
       }
 
       const divergent: TransactionCompareResult[] = [];
+      if (!(await this.#pg.hasCatchupWatermark(from))) {
+        // PG catchup includes the requested boundary and rejects the range if
+        // it cannot find it. A strict-greater-than comparison would otherwise
+        // hide a hole at exactly `from` and accept output PG cannot serve.
+        const outcome = await this.#reconfirm(
+          db,
+          pinned,
+          from,
+          'bounds-mismatch',
+        );
+        this.#compareResults.add(1, {outcome});
+        divergent.push({watermark: from, outcome});
+        return this.#compared(from, from, 0, 0, 0, divergent);
+      }
+
       reader = new SQLiteChangeLogReader(this.#lc, this.#changeLogFile);
       const plan = reader.plan(from);
       if (plan.kind === 'not-ready') {
@@ -515,7 +553,7 @@ export class SQLiteChangeLogComparator {
         // after they were pinned, which is a purge race, not a finding.
         const outcome = await this.#reconfirm(
           db,
-          meta,
+          pinned,
           from,
           'bounds-mismatch',
         );
@@ -554,7 +592,7 @@ export class SQLiteChangeLogComparator {
         if (!inSqlite || !inPg) {
           const outcome = await this.#reconfirm(
             db,
-            meta,
+            pinned,
             watermark,
             inSqlite ? 'missing-pg' : 'missing-sqlite',
           );
@@ -567,7 +605,7 @@ export class SQLiteChangeLogComparator {
           const {tx, orphans} = await this.#compareTransaction(
             db,
             reader,
-            meta,
+            pinned,
             previousBoundary,
             watermark,
           );
@@ -592,8 +630,12 @@ export class SQLiteChangeLogComparator {
         previousBoundary = watermark;
       }
 
-      if (!this.#stopped) {
+      const inconclusive = divergent.some(
+        ({outcome}) => outcome === 'inconclusive',
+      );
+      if (!this.#stopped && !inconclusive) {
         this.#cursor = effectiveThrough;
+        this.#continueWithoutDelay = effectiveThrough < through;
       }
       return this.#compared(
         from,
@@ -742,7 +784,7 @@ export class SQLiteChangeLogComparator {
   async #compareTransaction(
     db: Database,
     reader: SQLiteChangeLogReader,
-    meta: ChangeLogMeta,
+    pinned: PinnedBounds,
     previousBoundary: string,
     watermark: string,
   ): Promise<{
@@ -768,7 +810,7 @@ export class SQLiteChangeLogComparator {
       );
       const outcome = await this.#reconfirm(
         db,
-        meta,
+        pinned,
         watermark,
         'reader-error',
       );
@@ -776,7 +818,7 @@ export class SQLiteChangeLogComparator {
     }
     const orphans = await this.#compareOrphans(
       db,
-      meta,
+      pinned,
       watermark,
       sqliteServed,
       pgServed,
@@ -798,7 +840,7 @@ export class SQLiteChangeLogComparator {
         : pgTx === undefined
           ? 'missing-pg'
           : 'digest-mismatch';
-    const outcome = await this.#reconfirm(db, meta, watermark, suspect);
+    const outcome = await this.#reconfirm(db, pinned, watermark, suspect);
     return {
       tx: {
         watermark,
@@ -824,7 +866,7 @@ export class SQLiteChangeLogComparator {
    */
   async #compareOrphans(
     db: Database,
-    meta: ChangeLogMeta,
+    pinned: PinnedBounds,
     txWatermark: string,
     sqliteServed: Map<string, CatchupTransactionDigest>,
     pgServed: Map<string, CatchupTransactionDigest>,
@@ -846,7 +888,7 @@ export class SQLiteChangeLogComparator {
       ) {
         continue;
       }
-      const outcome = await this.#reconfirm(db, meta, w, 'orphan-output');
+      const outcome = await this.#reconfirm(db, pinned, w, 'orphan-output');
       orphans.push({
         watermark: w,
         outcome,
@@ -869,15 +911,15 @@ export class SQLiteChangeLogComparator {
    */
   async #reconfirm(
     db: Database,
-    pinnedMeta: ChangeLogMeta,
+    pinned: PinnedBounds,
     watermark: string,
     suspect: Exclude<CompareOutcome, 'match'>,
   ): Promise<Exclude<CompareOutcome, 'match'>> {
     try {
       const meta = readChangeLogMeta(db);
       if (
-        meta.seedWatermark !== pinnedMeta.seedWatermark ||
-        meta.seededAtMs !== pinnedMeta.seededAtMs
+        meta.seedWatermark !== pinned.meta.seedWatermark ||
+        meta.seededAtMs !== pinned.meta.seededAtMs
       ) {
         return 'inconclusive';
       }
@@ -887,8 +929,9 @@ export class SQLiteChangeLogComparator {
         return 'inconclusive';
       }
       if (
-        watermark <= sqlite.minWatermark ||
-        watermark <= minWatermark ||
+        (sqlite.minWatermark > pinned.sqlite.minWatermark &&
+          watermark <= sqlite.minWatermark) ||
+        (minWatermark > pinned.pgMinWatermark && watermark <= minWatermark) ||
         watermark > sqlite.headWatermark ||
         watermark > lastWatermark
       ) {

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.ts
@@ -1,0 +1,892 @@
+import {createHash} from 'node:crypto';
+import type {LogContext} from '@rocicorp/logger';
+import {BigIntJSON} from '../../../../shared/src/bigint-json.ts';
+import {Database} from '../../../../zqlite/src/db.ts';
+import {
+  getOrCreateCounter,
+  getOrCreateLatencyHistogram,
+} from '../../observability/metrics.ts';
+import type {ShardID} from '../../types/shards.ts';
+import {
+  CHANGE_LOG_DB_SCHEMA_VERSION,
+  CHANGE_LOG_STREAM_TABLE,
+  readChangeLogMeta,
+  type ChangeLogIdentity,
+  type ChangeLogMeta,
+} from '../replicator/change-log-db.ts';
+import {
+  extractChangeSubstring,
+  reconstructWatermarkedChange,
+  type ChangeLogEntry,
+} from './change-log-codec.ts';
+import {ChangeLogTransactionHasher} from './change-log-transaction-hash.ts';
+import type {WatermarkedChange} from './change-streamer.ts';
+import {SQLiteChangeLogReader} from './sqlite-change-log-reader.ts';
+
+/**
+ * How often a comparison cycle runs. Each cycle is bounded by
+ * {@link SQLiteChangeLogCompareOptions.maxTransactionsPerCycle}, so a busy
+ * stream is compared in bounded increments rather than all at once.
+ */
+const DEFAULT_COMPARE_INTERVAL_MS = 30_000;
+
+/**
+ * The per-cycle bound on enumerated transactions. Bounds one cycle's work and
+ * memory (two watermark lists plus one transaction's digest state); it does not
+ * bound coverage, since the next cycle resumes from where this one stopped.
+ */
+const DEFAULT_MAX_TRANSACTIONS_PER_CYCLE = 256;
+
+/** Rows per SQLite catchup read batch, matching the read path's default. */
+const DEFAULT_READ_BATCH_ROWS = 1000;
+
+/** Divergences logged in detail per cycle; the rest are counted only. */
+const DEFAULT_MAX_LOGGED_DIVERGENCES = 10;
+
+/** How much of a digest is ever logged or reported. */
+const DIGEST_PREFIX_LENGTH = 16;
+
+/**
+ * The outcome of comparing one committed transaction's catchup output between
+ * the two stores, or of a cycle-level bounds check.
+ *
+ * `inconclusive` means the common lower bound (or a head) moved after the
+ * cycle pinned it — a purge, truncation, or reseed raced the comparison — so
+ * the observation says nothing about divergence and is deliberately not
+ * reported as any.
+ */
+export type CompareOutcome =
+  | 'match'
+  | 'digest-mismatch'
+  | 'missing-pg'
+  | 'missing-sqlite'
+  | 'bounds-mismatch'
+  | 'reader-error'
+  | 'inconclusive';
+
+/** A non-match observation. Digest prefixes and row counts only — never payloads. */
+export type TransactionCompareResult = {
+  readonly watermark: string;
+  readonly outcome: Exclude<CompareOutcome, 'match'>;
+  readonly sqliteDigest?: string | undefined;
+  readonly pgDigest?: string | undefined;
+  readonly sqliteRows?: number | undefined;
+  readonly pgRows?: number | undefined;
+};
+
+export type CompareSkipReason =
+  // The comparator was stopped.
+  | 'stopped'
+  // The change-log file is absent, unreadable, or has no meta row yet: the
+  // writer has not created it, or has failed soft and deleted it.
+  | 'log-unavailable'
+  // The log's schema version is not this build's.
+  | 'ineligible-schema'
+  // The log belongs to a different replica (§3.2's identity triple).
+  | 'ineligible-identity'
+  // The log was seeded less than a retention window ago (§6.6's predicate).
+  | 'cold-log'
+  // The complete committed range common to both stores is empty. Head skew in
+  // either direction lands here; it is expected — the log leads — and is
+  // deliberately not reported as divergence.
+  | 'nothing-to-compare'
+  // The cycle failed; the error was logged and counted.
+  | 'error';
+
+export type CompareCycleResult =
+  | {readonly kind: 'skipped'; readonly reason: CompareSkipReason}
+  | {
+      readonly kind: 'compared';
+      /** Exclusive lower bound of the compared range. */
+      readonly fromWatermark: string;
+      /** Inclusive upper bound; the next cycle resumes from here. */
+      readonly throughWatermark: string;
+      /** Committed transactions present in either store over the range. */
+      readonly transactions: number;
+      /** How many were sampled for digest comparison. */
+      readonly sampled: number;
+      readonly matched: number;
+      /** Every non-match observation, in watermark order. */
+      readonly divergent: readonly TransactionCompareResult[];
+    };
+
+/**
+ * The PG change log's side of the comparison. Implemented by `Storer`, whose
+ * `readCatchupRange` shares its statement shape with the subscriber catchup
+ * query — the thing this comparison exists to validate.
+ */
+export interface PGChangeLogRangeReader {
+  getCatchupBounds(): Promise<{
+    minWatermark: string | null;
+    lastWatermark: string;
+  }>;
+  listCommitWatermarks(
+    afterWatermark: string,
+    throughWatermark: string,
+    limit: number,
+  ): Promise<string[]>;
+  readCatchupRange(
+    afterWatermark: string,
+    throughWatermark: string,
+  ): AsyncIterable<ChangeLogEntry[]>;
+}
+
+export type SQLiteChangeLogCompareOptions = {
+  /**
+   * `sqliteChangeLogComparePercent`: the stable percentage of committed
+   * transactions whose catchup output is digest-compared. Presence (a
+   * transaction one store serves and the other does not) is checked for every
+   * transaction in the range regardless, since it needs no payload reads.
+   */
+  readonly comparePercent: number;
+  /**
+   * `sqliteChangeLogRetentionMs`, reused as the warm-up window: a log seeded
+   * less than this long ago is declined (§6.6), since its covered range is
+   * still filling.
+   */
+  readonly retentionMs: number;
+  readonly intervalMs?: number | undefined;
+  readonly maxTransactionsPerCycle?: number | undefined;
+  readonly readBatchRows?: number | undefined;
+  readonly maxLoggedDivergences?: number | undefined;
+  /** The clock the warm-up window is measured against. Defaults to `Date.now`. */
+  readonly now?: (() => number) | undefined;
+  readonly setTimeoutFn?: typeof setTimeout | undefined;
+  readonly clearTimeoutFn?: typeof clearTimeout | undefined;
+  /**
+   * Awaited between sampled transactions so fan-out and catchup make progress.
+   * Defaults to a macrotask (`setImmediate`).
+   */
+  readonly yieldFn?: (() => Promise<void>) | undefined;
+};
+
+/**
+ * Whether `watermark`'s transaction is in the compared sample.
+ *
+ * Stable by shard and watermark — a pure function of the two — so a retried
+ * or restarted comparison selects exactly the same transactions and therefore
+ * compares the same data.
+ */
+export function isSampledForCompare(
+  shard: ShardID,
+  watermark: string,
+  percent: number,
+): boolean {
+  if (percent >= 100) {
+    return true;
+  }
+  if (percent <= 0) {
+    return false;
+  }
+  const digest = createHash('sha256')
+    .update(`${shard.appID}/${shard.shardNum}:${watermark}`)
+    .digest();
+  return digest.readUInt32BE(0) % 100 < percent;
+}
+
+/**
+ * Normalizes a stored `change` to one text form before hashing.
+ *
+ * The two stores hand the text back differently: SQLite serves the exact
+ * serialized substring it stored, while PG holds it in a `json` column and
+ * serves `change::text` — a round trip through the client's JSON parameter
+ * encoding and `json_to_recordset`. Any formatting difference from that round
+ * trip would report as a digest mismatch that is *not* divergence, which would
+ * be indistinguishable from the finding this comparison exists to make. Both
+ * sides are therefore re-serialized through the same codec; a value that does
+ * not parse is hashed as-is, identically on both sides.
+ */
+export function normalizeChangeJSON(change: string): string {
+  try {
+    return BigIntJSON.stringify(BigIntJSON.parse(change));
+  } catch {
+    return change;
+  }
+}
+
+export type CatchupTransactionDigest = {
+  readonly watermark: string;
+  readonly digest: string;
+  readonly rows: number;
+  /**
+   * False when the served range lacked the transaction's `begin` or `commit`
+   * row. An incomplete transaction never counts as a match.
+   */
+  readonly complete: boolean;
+};
+
+/**
+ * Digests a store's catchup output per transaction, exactly as the 7H observer
+ * digests the received stream: `pos` is derived by counting from `begin` = 0
+ * and `precommit` from the transaction's watermark, so the digest is a pure
+ * function of what the store *serves* and is computed identically for both
+ * stores. Streams batch by batch; only one transaction's digest state is held
+ * at a time.
+ */
+export async function digestCatchupTransactions(
+  batches: AsyncIterable<readonly WatermarkedChange[]>,
+): Promise<Map<string, CatchupTransactionDigest>> {
+  const digests = new Map<string, CatchupTransactionDigest>();
+  let hasher: ChangeLogTransactionHasher | undefined;
+  let txWatermark: string | undefined;
+  let sawBegin = false;
+  let pos = 0;
+
+  const flushIncomplete = () => {
+    if (hasher !== undefined && txWatermark !== undefined) {
+      digests.set(txWatermark, {
+        watermark: txWatermark,
+        digest: hasher.digest(),
+        rows: pos + 1,
+        complete: false,
+      });
+    }
+    hasher = undefined;
+    txWatermark = undefined;
+  };
+
+  for await (const batch of batches) {
+    for (const [watermark, tag, json] of batch) {
+      if (tag === 'begin') {
+        flushIncomplete();
+        hasher = new ChangeLogTransactionHasher();
+        txWatermark = watermark;
+        sawBegin = true;
+        pos = 0;
+      } else if (tag === 'rollback') {
+        // Rollbacks are not stored by either log; tolerated for symmetry.
+        hasher = undefined;
+        txWatermark = undefined;
+        continue;
+      } else if (hasher === undefined) {
+        // The range began mid-transaction (e.g. a concurrently torn minimum).
+        // Digest what was served, marked incomplete.
+        hasher = new ChangeLogTransactionHasher();
+        txWatermark = watermark;
+        sawBegin = false;
+        pos = 0;
+      } else {
+        pos++;
+      }
+      hasher.add({
+        watermark,
+        pos,
+        tag,
+        change: normalizeChangeJSON(extractChangeSubstring(json, tag)),
+        precommit: tag === 'commit' ? (txWatermark ?? watermark) : null,
+      });
+      if (tag === 'commit') {
+        digests.set(watermark, {
+          watermark,
+          digest: hasher.digest(),
+          rows: pos + 1,
+          complete: sawBegin,
+        });
+        hasher = undefined;
+        txWatermark = undefined;
+      }
+    }
+  }
+  flushIncomplete();
+  return digests;
+}
+
+/**
+ * `min` and `max` as separate scalar subqueries for the single-aggregate index
+ * optimization, matching the reader's plan query.
+ */
+const SQLITE_BOUNDS_SQL = /*sql*/ `
+  SELECT
+    (SELECT min("watermark") FROM "${CHANGE_LOG_STREAM_TABLE}")
+      AS "minWatermark",
+    (SELECT max("watermark") FROM "${CHANGE_LOG_STREAM_TABLE}")
+      AS "headWatermark"
+`;
+
+/**
+ * Commit watermarks in `(@after, @through]`. Every row of a transaction is
+ * stored at its commit watermark and only commit rows carry `precommit`, so
+ * this enumerates the committed transactions in the range.
+ */
+const SQLITE_COMMITS_SQL = /*sql*/ `
+  SELECT "watermark" FROM "${CHANGE_LOG_STREAM_TABLE}"
+   WHERE "precommit" IS NOT NULL
+     AND "watermark" > @after
+     AND "watermark" <= @through
+   ORDER BY "watermark"
+   LIMIT @limit
+`;
+
+type SQLiteBounds = {
+  readonly minWatermark: string;
+  readonly headWatermark: string;
+};
+
+type PinnedBounds = {
+  readonly meta: ChangeLogMeta;
+  readonly sqlite: SQLiteBounds;
+  readonly pgMinWatermark: string;
+  readonly pgLastWatermark: string;
+};
+
+/**
+ * Compares what SQLite catchup *serves* against what PG catchup serves, over
+ * complete committed ranges, without serving either to a subscriber.
+ *
+ * "SQLite content equals PG content" is already established by construction —
+ * both stores hold the same serialized substrings — plus the continuous
+ * per-transaction hash check from 7H. What is *not* covered, and what this
+ * validates, is the read path: reader reconstruction, `plan()` bounds, and
+ * purge interacting with a pinned range. Each cycle therefore reads both
+ * stores through their catchup statements, digests the output per transaction
+ * with {@link digestCatchupTransactions}, and compares digests.
+ *
+ * The comparison is dark and advisory: it changes nothing about what
+ * subscribers receive, PG remains authoritative, and every anomaly is a
+ * metric and a (redacted) log line rather than an action.
+ *
+ * Ranges are compared only through `min(pgHead, sqliteHead)` — head skew in
+ * either direction is expected, the log leads, and is never reported. A purge,
+ * truncation, or reseed that moves the pinned bounds mid-cycle reports
+ * `inconclusive`, not divergence.
+ */
+export class SQLiteChangeLogComparator {
+  readonly #lc: LogContext;
+  readonly #shard: ShardID;
+  readonly #changeLogFile: string;
+  readonly #identity: ChangeLogIdentity;
+  readonly #pg: PGChangeLogRangeReader;
+  readonly #opts: SQLiteChangeLogCompareOptions;
+  readonly #now: () => number;
+  readonly #setTimeoutFn: typeof setTimeout;
+  readonly #clearTimeoutFn: typeof clearTimeout;
+  readonly #yield: () => Promise<void>;
+
+  readonly #compareResults = getOrCreateCounter(
+    'replica',
+    'sqlite_change_log.compare_result',
+    'Outcomes of the dark comparison between what SQLite catchup serves and ' +
+      'what PG catchup serves, per committed transaction. `inconclusive` ' +
+      'means a purge or reseed moved the pinned bounds mid-comparison.',
+  );
+  readonly #compareCycles = getOrCreateCounter(
+    'replica',
+    'sqlite_change_log.compare_cycles',
+    'SQLite change-log comparison cycles, by result.',
+  );
+  readonly #cycleDuration = getOrCreateLatencyHistogram(
+    'replica',
+    'sqlite_change_log.compare_cycle_duration',
+    'Duration of one SQLite change-log comparison cycle.',
+  );
+
+  /**
+   * The commit watermark through which output has been compared. Ranges are
+   * compared once and never re-read; a restart re-derives it from the common
+   * lower bound, and the stable sample selects the same transactions again.
+   */
+  #cursor: string | undefined;
+  #running: Promise<CompareCycleResult> | undefined;
+  #timer: ReturnType<typeof setTimeout> | undefined;
+  #stopped = false;
+
+  constructor(
+    lc: LogContext,
+    shard: ShardID,
+    changeLogFile: string,
+    identity: ChangeLogIdentity,
+    pg: PGChangeLogRangeReader,
+    opts: SQLiteChangeLogCompareOptions,
+  ) {
+    this.#lc = lc.withContext('component', 'sqlite-change-log-compare');
+    this.#shard = shard;
+    this.#changeLogFile = changeLogFile;
+    this.#identity = identity;
+    this.#pg = pg;
+    this.#opts = opts;
+    this.#now = opts.now ?? Date.now;
+    this.#setTimeoutFn = opts.setTimeoutFn ?? setTimeout;
+    this.#clearTimeoutFn = opts.clearTimeoutFn ?? clearTimeout;
+    this.#yield =
+      opts.yieldFn ??
+      (() => new Promise<void>(resolve => setImmediate(resolve)));
+    this.#scheduleNext();
+  }
+
+  /**
+   * Runs one comparison cycle. Concurrent calls coalesce into the running
+   * cycle's completion. Never rejects; a failed cycle is logged and reported
+   * as `skipped: 'error'`.
+   */
+  compareOnce(): Promise<CompareCycleResult> {
+    if (this.#stopped) {
+      return Promise.resolve({kind: 'skipped', reason: 'stopped'});
+    }
+    if (this.#running === undefined) {
+      this.#running = this.#runCycle().finally(() => {
+        this.#running = undefined;
+      });
+    }
+    return this.#running;
+  }
+
+  stop(): void {
+    this.#stopped = true;
+    if (this.#timer !== undefined) {
+      this.#clearTimeoutFn(this.#timer);
+      this.#timer = undefined;
+    }
+  }
+
+  #scheduleNext(): void {
+    if (this.#stopped || this.#timer !== undefined) {
+      return;
+    }
+    this.#timer = this.#setTimeoutFn(() => {
+      this.#timer = undefined;
+      void this.compareOnce().finally(() => this.#scheduleNext());
+    }, this.#opts.intervalMs ?? DEFAULT_COMPARE_INTERVAL_MS);
+  }
+
+  async #runCycle(): Promise<CompareCycleResult> {
+    const startedAt = performance.now();
+    let db: Database | undefined;
+    let reader: SQLiteChangeLogReader | undefined;
+    try {
+      try {
+        // A readonly handle cannot create the file, so an absent log — the
+        // writer has not reconciled yet, or failed soft and deleted it — is a
+        // routine decline rather than an error.
+        db = new Database(this.#lc, this.#changeLogFile, {readonly: true});
+      } catch {
+        return this.#skipped('log-unavailable');
+      }
+
+      const pinned = await this.#pinBounds(db);
+      if (typeof pinned === 'string') {
+        return this.#skipped(pinned);
+      }
+      const {meta} = pinned;
+
+      const from = maxWatermark(
+        this.#cursor ?? meta.seedWatermark,
+        // The log's seed transaction is synthetic — its content matches
+        // nothing PG holds — so the exclusive lower bound keeps it out of
+        // every comparison. (PG's own synthetic seed, from
+        // ensureReplicationConfig, carries no `precommit` and is already
+        // invisible to the commit enumeration.)
+        meta.seedWatermark,
+        // The transaction *at* a store's minimum is a catchup boundary, not
+        // output that store can serve, so comparison starts above it.
+        pinned.pgMinWatermark,
+        pinned.sqlite.minWatermark,
+      );
+      const through = minWatermark(
+        pinned.pgLastWatermark,
+        pinned.sqlite.headWatermark,
+      );
+      if (through <= from) {
+        return this.#skipped('nothing-to-compare');
+      }
+
+      reader = new SQLiteChangeLogReader(this.#lc, this.#changeLogFile);
+      const plan = reader.plan(from);
+      if (plan.kind === 'not-ready') {
+        return this.#skipped('log-unavailable');
+      }
+      if (plan.kind === 'ahead') {
+        return this.#skipped('nothing-to-compare');
+      }
+      if (plan.kind === 'too-old') {
+        // `from` was computed at or above the log's own minimum, so the log
+        // cannot serve a boundary it should hold — unless the bounds moved
+        // after they were pinned, which is a purge race, not a finding.
+        const outcome = await this.#reconfirm(
+          db,
+          meta,
+          from,
+          'bounds-mismatch',
+        );
+        this.#compareResults.add(1, {outcome});
+        return this.#compared(from, from, 0, 0, 0, [
+          {watermark: from, outcome},
+        ]);
+      }
+
+      const limit = Math.max(
+        1,
+        this.#opts.maxTransactionsPerCycle ??
+          DEFAULT_MAX_TRANSACTIONS_PER_CYCLE,
+      );
+      const enumerated = await this.#enumerateCommits(db, from, through, limit);
+      const {union} = enumerated;
+      const effectiveThrough = enumerated.through;
+
+      const divergent: TransactionCompareResult[] = [];
+      let sampled = 0;
+      let matched = 0;
+      let previousBoundary = from;
+      for (const {watermark, inSqlite, inPg} of union) {
+        if (this.#stopped) {
+          break;
+        }
+        if (!inSqlite || !inPg) {
+          const outcome = await this.#reconfirm(
+            db,
+            meta,
+            watermark,
+            inSqlite ? 'missing-pg' : 'missing-sqlite',
+          );
+          divergent.push({watermark, outcome});
+          this.#compareResults.add(1, {outcome});
+        } else if (
+          isSampledForCompare(this.#shard, watermark, this.#opts.comparePercent)
+        ) {
+          sampled++;
+          const result = await this.#compareTransaction(
+            db,
+            reader,
+            meta,
+            previousBoundary,
+            watermark,
+          );
+          if (result === undefined) {
+            matched++;
+            this.#compareResults.add(1, {outcome: 'match'});
+          } else {
+            divergent.push(result);
+            this.#compareResults.add(1, {outcome: result.outcome});
+          }
+          // Let fan-out, catchup, and the stream loop make progress between
+          // sampled reads.
+          await this.#yield();
+        }
+        previousBoundary = watermark;
+      }
+
+      if (!this.#stopped) {
+        this.#cursor = effectiveThrough;
+      }
+      return this.#compared(
+        from,
+        effectiveThrough,
+        union.length,
+        sampled,
+        matched,
+        divergent,
+      );
+    } catch (e) {
+      this.#lc.warn?.('error comparing the SQLite change log', e);
+      return this.#skipped('error');
+    } finally {
+      reader?.close();
+      db?.close();
+      this.#cycleDuration.recordMs(performance.now() - startedAt);
+    }
+  }
+
+  /**
+   * Eligibility and the pinned bounds, in one pass: schema v2, identity
+   * matches (a leftover log from another replica is never compared), the log
+   * is warm (§6.6), and both stores have content.
+   */
+  async #pinBounds(db: Database): Promise<PinnedBounds | CompareSkipReason> {
+    let meta: ChangeLogMeta;
+    try {
+      meta = readChangeLogMeta(db);
+    } catch {
+      // Tables or the meta row do not exist yet: the writer has not
+      // reconciled the log.
+      return 'log-unavailable';
+    }
+    if (meta.schemaVersion !== CHANGE_LOG_DB_SCHEMA_VERSION) {
+      return 'ineligible-schema';
+    }
+    const {epoch, generation, replicaID} = this.#identity;
+    if (
+      meta.epoch !== epoch ||
+      meta.generation !== generation ||
+      meta.replicaID !== replicaID
+    ) {
+      return 'ineligible-identity';
+    }
+    if (this.#now() - meta.seededAtMs < this.#opts.retentionMs) {
+      return 'cold-log';
+    }
+    const sqlite = this.#readSQLiteBounds(db);
+    if (sqlite === undefined) {
+      return 'log-unavailable';
+    }
+    const {minWatermark, lastWatermark} = await this.#pg.getCatchupBounds();
+    if (minWatermark === null) {
+      // Only a completely new replica has an empty PG change log.
+      return 'nothing-to-compare';
+    }
+    return {
+      meta,
+      sqlite,
+      pgMinWatermark: minWatermark,
+      pgLastWatermark: lastWatermark,
+    };
+  }
+
+  #readSQLiteBounds(db: Database): SQLiteBounds | undefined {
+    const bounds = db
+      .prepare(SQLITE_BOUNDS_SQL)
+      .get<{minWatermark: string | null; headWatermark: string | null}>();
+    return bounds.minWatermark === null || bounds.headWatermark === null
+      ? undefined
+      : {
+          minWatermark: bounds.minWatermark,
+          headWatermark: bounds.headWatermark,
+        };
+  }
+
+  /**
+   * Enumerates the committed transactions in `(from, through]` from both
+   * stores and merges them by watermark. When either store's enumeration hits
+   * the per-cycle limit, `through` is lowered to the highest watermark both
+   * enumerations completely cover, so a truncated cycle still compares a
+   * complete common range and the next cycle resumes above it.
+   */
+  async #enumerateCommits(
+    db: Database,
+    from: string,
+    through: string,
+    limit: number,
+  ): Promise<{
+    through: string;
+    union: {watermark: string; inSqlite: boolean; inPg: boolean}[];
+  }> {
+    let sqlite: string[] = db
+      .prepare(SQLITE_COMMITS_SQL)
+      .all<{watermark: string}>({after: from, through, limit: limit + 1})
+      .map(({watermark}) => watermark);
+    let pg = await this.#pg.listCommitWatermarks(from, through, limit + 1);
+
+    let effectiveThrough = through;
+    if (sqlite.length > limit) {
+      sqlite.length = limit;
+      effectiveThrough = minWatermark(effectiveThrough, sqlite[limit - 1]);
+    }
+    if (pg.length > limit) {
+      pg.length = limit;
+      effectiveThrough = minWatermark(effectiveThrough, pg[limit - 1]);
+    }
+    if (effectiveThrough !== through) {
+      sqlite = sqlite.filter(w => w <= effectiveThrough);
+      pg = pg.filter(w => w <= effectiveThrough);
+    }
+
+    const union: {watermark: string; inSqlite: boolean; inPg: boolean}[] = [];
+    let s = 0;
+    let p = 0;
+    while (s < sqlite.length || p < pg.length) {
+      const sw = s < sqlite.length ? sqlite[s] : undefined;
+      const pw = p < pg.length ? pg[p] : undefined;
+      if (sw !== undefined && (pw === undefined || sw < pw)) {
+        union.push({watermark: sw, inSqlite: true, inPg: false});
+        s++;
+      } else if (pw !== undefined && (sw === undefined || pw < sw)) {
+        union.push({watermark: pw, inSqlite: false, inPg: true});
+        p++;
+      } else if (sw !== undefined) {
+        union.push({watermark: sw, inSqlite: true, inPg: true});
+        s++;
+        p++;
+      }
+    }
+    return {through: effectiveThrough, union};
+  }
+
+  /**
+   * Runs both catchup paths over `(previousBoundary, watermark]` — exactly one
+   * transaction, since `previousBoundary` is the immediately preceding commit
+   * in either store — and compares the digests of what each serves. Returns
+   * `undefined` on a match.
+   */
+  async #compareTransaction(
+    db: Database,
+    reader: SQLiteChangeLogReader,
+    meta: ChangeLogMeta,
+    previousBoundary: string,
+    watermark: string,
+  ): Promise<TransactionCompareResult | undefined> {
+    let sqliteTx: CatchupTransactionDigest | undefined;
+    let pgTx: CatchupTransactionDigest | undefined;
+    try {
+      const readBatchRows = this.#opts.readBatchRows ?? DEFAULT_READ_BATCH_ROWS;
+      sqliteTx = (
+        await digestCatchupTransactions(
+          reader.read(previousBoundary, watermark, readBatchRows),
+        )
+      ).get(watermark);
+      pgTx = (
+        await digestCatchupTransactions(
+          reconstructBatches(
+            this.#pg.readCatchupRange(previousBoundary, watermark),
+          ),
+        )
+      ).get(watermark);
+    } catch (e) {
+      this.#lc.warn?.(
+        `error reading transaction ${watermark} for comparison`,
+        e,
+      );
+      const outcome = await this.#reconfirm(
+        db,
+        meta,
+        watermark,
+        'reader-error',
+      );
+      return {watermark, outcome};
+    }
+    if (
+      sqliteTx !== undefined &&
+      pgTx !== undefined &&
+      sqliteTx.complete &&
+      pgTx.complete &&
+      sqliteTx.digest === pgTx.digest
+    ) {
+      return undefined;
+    }
+    const suspect: Exclude<CompareOutcome, 'match'> =
+      sqliteTx === undefined
+        ? 'missing-sqlite'
+        : pgTx === undefined
+          ? 'missing-pg'
+          : 'digest-mismatch';
+    const outcome = await this.#reconfirm(db, meta, watermark, suspect);
+    return {
+      watermark,
+      outcome,
+      sqliteDigest: sqliteTx?.digest.slice(0, DIGEST_PREFIX_LENGTH),
+      pgDigest: pgTx?.digest.slice(0, DIGEST_PREFIX_LENGTH),
+      sqliteRows: sqliteTx?.rows,
+      pgRows: pgTx?.rows,
+    };
+  }
+
+  /**
+   * Decides whether a suspect observation is a finding or a race. The bounds
+   * are re-read from both stores: if the common lower bound has moved to or
+   * past the watermark, a head has fallen below it, or the log was reseeded
+   * since the cycle pinned them, the observation is `inconclusive` — a purge,
+   * truncation, or reseed raced the comparison — and is not reported as
+   * divergence. Anything that fails to re-read is likewise inconclusive.
+   */
+  async #reconfirm(
+    db: Database,
+    pinnedMeta: ChangeLogMeta,
+    watermark: string,
+    suspect: Exclude<CompareOutcome, 'match'>,
+  ): Promise<Exclude<CompareOutcome, 'match'>> {
+    try {
+      const meta = readChangeLogMeta(db);
+      if (
+        meta.seedWatermark !== pinnedMeta.seedWatermark ||
+        meta.seededAtMs !== pinnedMeta.seededAtMs
+      ) {
+        return 'inconclusive';
+      }
+      const sqlite = this.#readSQLiteBounds(db);
+      const {minWatermark, lastWatermark} = await this.#pg.getCatchupBounds();
+      if (sqlite === undefined || minWatermark === null) {
+        return 'inconclusive';
+      }
+      if (
+        watermark <= sqlite.minWatermark ||
+        watermark <= minWatermark ||
+        watermark > sqlite.headWatermark ||
+        watermark > lastWatermark
+      ) {
+        return 'inconclusive';
+      }
+      return suspect;
+    } catch {
+      return 'inconclusive';
+    }
+  }
+
+  #skipped(reason: CompareSkipReason): CompareCycleResult {
+    this.#compareCycles.add(1, {result: reason});
+    if (reason === 'error') {
+      // Already logged with the thrown error.
+    } else if (reason !== 'nothing-to-compare') {
+      this.#lc.debug?.(`skipping SQLite change-log comparison: ${reason}`);
+    }
+    return {kind: 'skipped', reason};
+  }
+
+  #compared(
+    fromWatermark: string,
+    throughWatermark: string,
+    transactions: number,
+    sampled: number,
+    matched: number,
+    divergent: TransactionCompareResult[],
+  ): CompareCycleResult {
+    this.#compareCycles.add(1, {result: 'compared'});
+    const reportable = divergent.filter(d => d.outcome !== 'inconclusive');
+    if (reportable.length > 0) {
+      const maxLogged =
+        this.#opts.maxLoggedDivergences ?? DEFAULT_MAX_LOGGED_DIVERGENCES;
+      // Digest prefixes and row counts only. The payloads are customer data
+      // and are never logged; the watermark is enough to find them.
+      for (const d of reportable.slice(0, maxLogged)) {
+        this.#lc.error?.(
+          'SQLite change-log catchup output diverged from Postgres',
+          {sqliteChangeLogCompare: d},
+        );
+      }
+      if (reportable.length > maxLogged) {
+        this.#lc.error?.(
+          `... and ${reportable.length - maxLogged} more SQLite change-log ` +
+            `compare divergences this cycle`,
+        );
+      }
+    }
+    this.#lc.debug?.('SQLite change-log comparison cycle', {
+      sqliteChangeLogCompare: {
+        fromWatermark,
+        throughWatermark,
+        transactions,
+        sampled,
+        matched,
+        divergent: divergent.length,
+      },
+    });
+    return {
+      kind: 'compared',
+      fromWatermark,
+      throughWatermark,
+      transactions,
+      sampled,
+      matched,
+      divergent,
+    };
+  }
+}
+
+/** Reconstructs PG catchup batches exactly as the PG catchup path does. */
+async function* reconstructBatches(
+  batches: AsyncIterable<ChangeLogEntry[]>,
+): AsyncIterable<WatermarkedChange[]> {
+  for await (const batch of batches) {
+    yield batch.map(reconstructWatermarkedChange);
+  }
+}
+
+function minWatermark(a: string, b: string): string {
+  return a < b ? a : b;
+}
+
+function maxWatermark(...watermarks: string[]): string {
+  let max = watermarks[0];
+  for (const w of watermarks) {
+    if (w > max) {
+      max = w;
+    }
+  }
+  return max;
+}

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.ts
@@ -42,22 +42,13 @@ const DEFAULT_MAX_ROWS_PER_SOURCE_PER_CYCLE = 1000;
 /** Rows per SQLite catchup read batch, matching the read path's default. */
 const DEFAULT_READ_BATCH_ROWS = 1000;
 
-/** Divergences logged in detail per cycle; the rest are counted only. */
-const DEFAULT_MAX_LOGGED_DIVERGENCES = 10;
-
-/** How much of a digest is ever logged or reported. */
-const DIGEST_PREFIX_LENGTH = 16;
-
 /**
- * The outcome of comparing one committed transaction's catchup output between
- * the two stores, or of a cycle-level bounds check.
+ * The outcome of one committed transaction's comparison.
  *
- * `orphan-output` means a sampled read served rows at a watermark that is not
- * a committed transaction in either store — a torn or corrupt remnant the
- * commit enumeration cannot see, but that a real catchup subscriber would
- * receive. It is reported at the orphan's own watermark, for whichever store
- * serves it, unless both stores serve it identically (which is parity in what
- * catchup *serves*, the thing this comparison measures).
+ * There is deliberately no taxonomy of *how* the two stores disagreed: a
+ * missing transaction, an extra row, a mutated payload, and a reordered range
+ * are all `mismatch`, and the watermark is enough to go look. The comparison
+ * is advisory, and a finer classification cost more than it paid.
  *
  * `inconclusive` means the common lower bound (or a head) moved after the
  * cycle pinned it — a purge, truncation, or reseed raced the comparison — so
@@ -66,23 +57,10 @@ const DIGEST_PREFIX_LENGTH = 16;
  */
 export type CompareOutcome =
   | 'match'
-  | 'digest-mismatch'
-  | 'missing-pg'
-  | 'missing-sqlite'
-  | 'orphan-output'
-  | 'bounds-mismatch'
-  | 'reader-error'
-  | 'inconclusive';
-
-/** A non-match observation. Digest prefixes and row counts only — never payloads. */
-export type TransactionCompareResult = {
-  readonly watermark: string;
-  readonly outcome: Exclude<CompareOutcome, 'match'>;
-  readonly sqliteDigest?: string | undefined;
-  readonly pgDigest?: string | undefined;
-  readonly sqliteRows?: number | undefined;
-  readonly pgRows?: number | undefined;
-};
+  | 'mismatch'
+  | 'inconclusive'
+  | 'deferred'
+  | 'oversized';
 
 export type CompareSkipReason =
   // The comparator was stopped.
@@ -113,17 +91,16 @@ export type CompareCycleResult =
       readonly throughWatermark: string;
       /** Committed transactions handled through `throughWatermark`. */
       readonly transactions: number;
-      /** How many were sampled for digest comparison. */
+      /** How many had their catchup output read and digested. */
       readonly sampled: number;
       readonly matched: number;
-      readonly sqliteRowsRead: number;
-      readonly pgRowsRead: number;
+      readonly mismatched: number;
+      /** Suspects a concurrent purge or reseed disqualified. */
+      readonly inconclusive: number;
       /** Sampled transactions deferred until a fresh cycle row budget. */
       readonly deferred: number;
       /** Sampled transactions skipped because they exceed a fresh row budget. */
       readonly oversized: number;
-      /** Every non-match observation, in watermark order. */
-      readonly divergent: readonly TransactionCompareResult[];
     };
 
 /**
@@ -136,7 +113,6 @@ export interface PGChangeLogRangeReader {
     minWatermark: string | null;
     lastWatermark: string;
   }>;
-  hasCatchupWatermark(watermark: string): Promise<boolean>;
   listCommitWatermarks(
     afterWatermark: string,
     throughWatermark: string,
@@ -153,11 +129,8 @@ export type SQLiteChangeLogCompareOptions = {
   /**
    * `sqliteChangeLogComparePercent`: the stable percentage of committed
    * transactions whose catchup output is digest-compared. Presence (a
-   * transaction one store serves and the other does not) is checked for every
+   * transaction one store holds and the other does not) is checked for every
    * transaction in the range regardless, since it needs no payload reads.
-   * Orphan output — rows belonging to no committed transaction — has no
-   * commit row for the presence pass to see, so it is detectable only within
-   * sampled reads.
    */
   readonly comparePercent: number;
   /**
@@ -171,7 +144,6 @@ export type SQLiteChangeLogCompareOptions = {
   /** Catchup payload rows read from each source in one cycle. */
   readonly maxRowsPerSourcePerCycle?: number | undefined;
   readonly readBatchRows?: number | undefined;
-  readonly maxLoggedDivergences?: number | undefined;
   /** The clock the warm-up window is measured against. Defaults to `Date.now`. */
   readonly now?: (() => number) | undefined;
   readonly setTimeoutFn?: typeof setTimeout | undefined;
@@ -214,8 +186,8 @@ export function isSampledForCompare(
  * serialized substring it stored, while PG holds it in a `json` column and
  * serves `change::text` — a round trip through the client's JSON parameter
  * encoding and `json_to_recordset`. Any formatting difference from that round
- * trip would report as a digest mismatch that is *not* divergence, which would
- * be indistinguishable from the finding this comparison exists to make. Both
+ * trip would report as a mismatch that is *not* divergence, which would be
+ * indistinguishable from the finding this comparison exists to make. Both
  * sides are therefore re-serialized through the same codec; a value that does
  * not parse is hashed as-is, identically on both sides.
  */
@@ -227,131 +199,57 @@ export function normalizeChangeJSON(change: string): string {
   }
 }
 
-export type CatchupTransactionDigest = {
-  readonly watermark: string;
+export type CatchupRangeDigest = {
   readonly digest: string;
   readonly rows: number;
-  /**
-   * False when the served range lacked the transaction's `begin` or `commit`
-   * row. An incomplete transaction never counts as a match.
-   */
-  readonly complete: boolean;
-};
-
-/**
- * Digests a store's catchup output per transaction, exactly as the 7H observer
- * digests the received stream: `pos` is derived by counting from `begin` = 0
- * and `precommit` from the transaction's watermark, so the digest is a pure
- * function of what the store *serves* and is computed identically for both
- * stores. Streams batch by batch; only one transaction's digest state is held
- * at a time.
- */
-export async function digestCatchupTransactions(
-  batches: AsyncIterable<readonly WatermarkedChange[]>,
-): Promise<Map<string, CatchupTransactionDigest>> {
-  const digests = new Map<string, CatchupTransactionDigest>();
-  let hasher: ChangeLogTransactionHasher | undefined;
-  let txWatermark: string | undefined;
-  let sawBegin = false;
-  let pos = 0;
-
-  const flushIncomplete = () => {
-    if (hasher !== undefined && txWatermark !== undefined) {
-      digests.set(txWatermark, {
-        watermark: txWatermark,
-        digest: hasher.digest(),
-        rows: pos + 1,
-        complete: false,
-      });
-    }
-    hasher = undefined;
-    txWatermark = undefined;
-  };
-
-  for await (const batch of batches) {
-    for (const [watermark, tag, json] of batch) {
-      if (tag === 'begin') {
-        flushIncomplete();
-        hasher = new ChangeLogTransactionHasher();
-        txWatermark = watermark;
-        sawBegin = true;
-        pos = 0;
-      } else if (tag === 'rollback') {
-        // Rollbacks are not stored by either log; tolerated for symmetry.
-        hasher = undefined;
-        txWatermark = undefined;
-        continue;
-      } else if (hasher === undefined) {
-        // The range began mid-transaction (e.g. a concurrently torn minimum).
-        // Digest what was served, marked incomplete.
-        hasher = new ChangeLogTransactionHasher();
-        txWatermark = watermark;
-        sawBegin = false;
-        pos = 0;
-      } else {
-        pos++;
-      }
-      hasher.add({
-        watermark,
-        pos,
-        tag,
-        change: normalizeChangeJSON(extractChangeSubstring(json, tag)),
-        precommit: tag === 'commit' ? (txWatermark ?? watermark) : null,
-      });
-      if (tag === 'commit') {
-        digests.set(watermark, {
-          watermark,
-          digest: hasher.digest(),
-          rows: pos + 1,
-          complete: sawBegin,
-        });
-        hasher = undefined;
-        txWatermark = undefined;
-      }
-    }
-  }
-  flushIncomplete();
-  return digests;
-}
-
-type CappedCatchupDigest = {
-  readonly digests: Map<string, CatchupTransactionDigest>;
-  readonly rowsRead: number;
-  /** The cap was reached before the target transaction committed. */
+  /** The row cap was reached before the range's closing commit was served. */
   readonly limitReached: boolean;
 };
 
-async function digestCappedCatchupTransactions(
+/**
+ * Digests everything a store serves over a catchup range, as one rolling hash
+ * in served order.
+ *
+ * Position is the row's index *within the served range*, so the digest is a
+ * pure function of what the store hands a subscriber: a missing row, an extra
+ * row at any watermark, a mutated payload, and a reordering all change it.
+ * That is what lets the comparison be a single equality check — there is no
+ * per-watermark bookkeeping to decide which served rows "count".
+ *
+ * `precommit` is not hashed: for a commit row it equals that row's own
+ * watermark, which is hashed already.
+ */
+export async function digestCatchupRange(
   batches: AsyncIterable<readonly WatermarkedChange[]>,
-  targetWatermark: string,
+  throughWatermark: string,
   maxRows: number,
-  onRowsRead: (rows: number) => void,
-): Promise<CappedCatchupDigest> {
-  let rowsRead = 0;
+): Promise<CatchupRangeDigest> {
+  const hasher = new ChangeLogTransactionHasher();
+  let rows = 0;
+  let servedClosingCommit = false;
 
-  async function* cappedBatches() {
-    for await (const batch of batches) {
-      const remaining = maxRows - rowsRead;
-      if (remaining === 0) {
-        return;
+  for await (const batch of batches) {
+    for (const [watermark, tag, json] of batch) {
+      if (rows === maxRows) {
+        return {digest: hasher.digest(), rows, limitReached: true};
       }
-      const capped =
-        batch.length <= remaining ? batch : batch.slice(0, remaining);
-      rowsRead += capped.length;
-      onRowsRead(capped.length);
-      yield capped;
-      if (rowsRead === maxRows) {
-        return;
+      hasher.add({
+        watermark,
+        pos: rows,
+        tag,
+        change: normalizeChangeJSON(extractChangeSubstring(json, tag)),
+        precommit: null,
+      });
+      rows++;
+      if (tag === 'commit' && watermark === throughWatermark) {
+        servedClosingCommit = true;
       }
     }
   }
-
-  const digests = await digestCatchupTransactions(cappedBatches());
   return {
-    digests,
-    rowsRead,
-    limitReached:
-      rowsRead === maxRows && !digests.get(targetWatermark)?.complete,
+    digest: hasher.digest(),
+    rows,
+    limitReached: rows === maxRows && !servedClosingCommit,
   };
 }
 
@@ -393,24 +291,11 @@ type PinnedBounds = {
   readonly pgLastWatermark: string;
 };
 
-type TransactionComparison =
-  | {
-      readonly kind: 'compared';
-      readonly tx: TransactionCompareResult | undefined;
-      readonly orphans: TransactionCompareResult[];
-      readonly sqliteRowsRead: number;
-      readonly pgRowsRead: number;
-    }
-  | {
-      readonly kind: 'deferred';
-      readonly sqliteRowsRead: number;
-      readonly pgRowsRead: number;
-    }
-  | {
-      readonly kind: 'oversized';
-      readonly sqliteRowsRead: number;
-      readonly pgRowsRead: number;
-    };
+type SampledComparison = {
+  readonly outcome: CompareOutcome;
+  readonly sqliteRowsRead: number;
+  readonly pgRowsRead: number;
+};
 
 /**
  * Compares what SQLite catchup *serves* against what PG catchup serves, over
@@ -420,9 +305,10 @@ type TransactionComparison =
  * both stores hold the same serialized substrings — plus the continuous
  * per-transaction hash check from 7H. What is *not* covered, and what this
  * validates, is the read path: reader reconstruction, `plan()` bounds, and
- * purge interacting with a pinned range. Each cycle therefore reads both
- * stores through their catchup statements, digests the output per transaction
- * with {@link digestCatchupTransactions}, and compares digests.
+ * purge interacting with a pinned range. Each cycle enumerates the committed
+ * transactions both stores hold, samples a stable subset, reads each sampled
+ * range through both stores' catchup statements, and compares one rolling
+ * digest of what each served.
  *
  * The comparison is dark and advisory: it changes nothing about what
  * subscribers receive, PG remains authoritative, and every anomaly is a
@@ -456,16 +342,6 @@ export class SQLiteChangeLogComparator {
     'replica',
     'sqlite_change_log.compare_cycles',
     'SQLite change-log comparison cycles, by result.',
-  );
-  readonly #compareRows = getOrCreateCounter(
-    'replica',
-    'sqlite_change_log.compare_rows',
-    'Catchup rows read by the SQLite change-log comparator, by source.',
-  );
-  readonly #compareSkippedTransactions = getOrCreateCounter(
-    'replica',
-    'sqlite_change_log.compare_skipped_transactions',
-    'Sampled SQLite change-log transactions not compared, by reason.',
   );
   readonly #cycleDuration = getOrCreateLatencyHistogram(
     'replica',
@@ -601,21 +477,27 @@ export class SQLiteChangeLogComparator {
         return this.#skipped('nothing-to-compare');
       }
 
-      const divergent: TransactionCompareResult[] = [];
-      if (!(await this.#pg.hasCatchupWatermark(from))) {
-        // PG catchup includes the requested boundary and rejects the range if
-        // it cannot find it. A strict-greater-than comparison would otherwise
-        // hide a hole at exactly `from` and accept output PG cannot serve.
-        const outcome = await this.#reconfirm(
-          db,
-          pinned,
-          from,
-          'bounds-mismatch',
-        );
+      let transactions = 0;
+      let sampled = 0;
+      const outcomes: Record<CompareOutcome, number> = {
+        match: 0,
+        mismatch: 0,
+        inconclusive: 0,
+        deferred: 0,
+        oversized: 0,
+      };
+      const record = (watermark: string, outcome: CompareOutcome) => {
         this.#compareResults.add(1, {outcome});
-        divergent.push({watermark: from, outcome});
-        return this.#compared(from, from, 0, 0, 0, divergent);
-      }
+        outcomes[outcome]++;
+        if (outcome === 'mismatch') {
+          // The watermark only. The payloads are customer data and are never
+          // logged; the watermark is enough to find them.
+          this.#lc.error?.(
+            'SQLite change-log catchup output diverged from Postgres',
+            {sqliteChangeLogCompare: {watermark}},
+          );
+        }
+      };
 
       reader = new SQLiteChangeLogReader(this.#lc, this.#changeLogFile);
       const plan = reader.plan(from);
@@ -629,18 +511,12 @@ export class SQLiteChangeLogComparator {
         // `from` was computed at or above the log's own minimum, so the log
         // cannot serve a boundary it should hold — unless the bounds moved
         // after they were pinned, which is a purge race, not a finding.
-        const outcome = await this.#reconfirm(
-          db,
-          pinned,
-          from,
-          'bounds-mismatch',
-        );
-        this.#compareResults.add(1, {outcome});
-        divergent.push({watermark: from, outcome});
+        const outcome = await this.#reconfirm(db, pinned, from);
+        record(from, outcome);
         if (outcome === 'inconclusive') {
           // The pinned bounds moved; nothing this cycle established about the
           // range still holds. The cursor stays put and the next cycle re-pins.
-          return this.#compared(from, from, 0, 0, 0, divergent);
+          return this.#compared(from, from, transactions, sampled, outcomes);
         }
         // A *confirmed* mismatch is a finding about the boundary itself —
         // typically a commit this store never held, already reported as
@@ -656,21 +532,15 @@ export class SQLiteChangeLogComparator {
         this.#opts.maxTransactionsPerCycle ??
           DEFAULT_MAX_TRANSACTIONS_PER_CYCLE,
       );
-      const enumerated = await this.#enumerateCommits(db, from, through, limit);
-      const {union} = enumerated;
+      const union = await this.#enumerateCommits(db, from, through, limit);
       const maxRowsPerSource = Math.max(
         1,
         this.#opts.maxRowsPerSourcePerCycle ??
           DEFAULT_MAX_ROWS_PER_SOURCE_PER_CYCLE,
       );
 
-      let sampled = 0;
-      let matched = 0;
       let sqliteRowsRead = 0;
       let pgRowsRead = 0;
-      let deferred = 0;
-      let oversized = 0;
-      let transactions = 0;
       let previousBoundary = from;
       let handledThrough = from;
       for (const {watermark, inSqlite, inPg} of union) {
@@ -679,22 +549,17 @@ export class SQLiteChangeLogComparator {
         }
         let stopAfterTransaction = false;
         if (!inSqlite || !inPg) {
-          const outcome = await this.#reconfirm(
-            db,
-            pinned,
-            watermark,
-            inSqlite ? 'missing-pg' : 'missing-sqlite',
-          );
-          divergent.push({watermark, outcome});
-          this.#compareResults.add(1, {outcome});
+          // Presence needs no payload read, so it is checked for every
+          // transaction in the range, not just the sampled ones — the only
+          // signal this comparison has over the unsampled majority.
+          record(watermark, await this.#reconfirm(db, pinned, watermark));
         } else if (
           isSampledForCompare(this.#shard, watermark, this.#opts.comparePercent)
         ) {
           const sqliteRowsRemaining = maxRowsPerSource - sqliteRowsRead;
           const pgRowsRemaining = maxRowsPerSource - pgRowsRead;
           if (sqliteRowsRemaining === 0 || pgRowsRemaining === 0) {
-            deferred++;
-            this.#compareSkippedTransactions.add(1, {reason: 'deferred'});
+            record(watermark, 'deferred');
             break;
           }
           sampled++;
@@ -710,31 +575,14 @@ export class SQLiteChangeLogComparator {
           );
           sqliteRowsRead += comparison.sqliteRowsRead;
           pgRowsRead += comparison.pgRowsRead;
-          if (comparison.kind === 'deferred') {
-            deferred++;
-            this.#compareSkippedTransactions.add(1, {reason: 'deferred'});
+          record(watermark, comparison.outcome);
+          if (comparison.outcome === 'deferred') {
             break;
           }
-          if (comparison.kind === 'oversized') {
-            oversized++;
-            this.#compareSkippedTransactions.add(1, {reason: 'oversized'});
+          if (comparison.outcome === 'oversized') {
+            // The rows it did read came out of this cycle's budget, and it can
+            // never fit one; count it handled so the cursor moves past it.
             stopAfterTransaction = true;
-          } else {
-            const {tx, orphans} = comparison;
-            // Orphans precede the transaction: their watermarks lie strictly
-            // inside `(previousBoundary, watermark)`, keeping `divergent` in
-            // watermark order.
-            for (const orphan of orphans) {
-              divergent.push(orphan);
-              this.#compareResults.add(1, {outcome: orphan.outcome});
-            }
-            if (tx === undefined) {
-              matched++;
-              this.#compareResults.add(1, {outcome: 'match'});
-            } else {
-              divergent.push(tx);
-              this.#compareResults.add(1, {outcome: tx.outcome});
-            }
           }
           // Let fan-out, catchup, and the stream loop make progress between
           // sampled reads.
@@ -748,10 +596,7 @@ export class SQLiteChangeLogComparator {
         }
       }
 
-      const inconclusive = divergent.some(
-        ({outcome}) => outcome === 'inconclusive',
-      );
-      if (!this.#stopped && !inconclusive) {
+      if (!this.#stopped && outcomes.inconclusive === 0) {
         this.#cursor = handledThrough;
         this.#continueWithoutDelay = handledThrough < through;
       }
@@ -760,9 +605,7 @@ export class SQLiteChangeLogComparator {
         handledThrough,
         transactions,
         sampled,
-        matched,
-        divergent,
-        {sqliteRowsRead, pgRowsRead, deferred, oversized},
+        outcomes,
       );
     } catch (e) {
       this.#lc.warn?.('error comparing the SQLite change log', e);
@@ -843,10 +686,7 @@ export class SQLiteChangeLogComparator {
     from: string,
     through: string,
     limit: number,
-  ): Promise<{
-    through: string;
-    union: {watermark: string; inSqlite: boolean; inPg: boolean}[];
-  }> {
+  ): Promise<{watermark: string; inSqlite: boolean; inPg: boolean}[]> {
     let sqlite: string[] = db
       .prepare(SQLITE_COMMITS_SQL)
       .all<{watermark: string}>({after: from, through, limit: limit + 1})
@@ -885,20 +725,18 @@ export class SQLiteChangeLogComparator {
         p++;
       }
     }
-    return {through: effectiveThrough, union};
+    return union;
   }
 
   /**
-   * Runs both catchup paths over `(previousBoundary, watermark]` — exactly one
-   * transaction, since `previousBoundary` is the immediately preceding commit
-   * in either store — and compares the digests of what each serves. `tx` is
-   * `undefined` on a match.
+   * Runs both catchup paths over `(previousBoundary, watermark]` — one
+   * transaction plus anything else either store serves in the gap, since
+   * `previousBoundary` is the immediately preceding committed watermark in
+   * either store — and compares one rolling digest of each store's output.
    *
-   * Everything else either read returned is orphan output: rows at a
-   * watermark that is not a committed transaction in either store, which a
-   * real catchup subscriber would nevertheless receive. Reporting it here is
-   * what keeps "extra served rows" from passing as parity; see
-   * {@link #compareOrphans}.
+   * Both reads are positional (`watermark > previousBoundary`), so neither
+   * dereferences the boundary row and a boundary only one store holds is not
+   * itself a finding here.
    */
   async #compareTransaction(
     db: Database,
@@ -909,14 +747,12 @@ export class SQLiteChangeLogComparator {
     sqliteMaxRows: number,
     pgMaxRows: number,
     maxRowsPerSource: number,
-  ): Promise<TransactionComparison> {
-    let sqliteRowsRead = 0;
-    let pgRowsRead = 0;
-    let sqlite: CappedCatchupDigest;
-    let pg: CappedCatchupDigest;
+  ): Promise<SampledComparison> {
+    let sqlite: CatchupRangeDigest;
+    let pg: CatchupRangeDigest;
     try {
       const readBatchRows = this.#opts.readBatchRows ?? DEFAULT_READ_BATCH_ROWS;
-      sqlite = await digestCappedCatchupTransactions(
+      sqlite = await digestCatchupRange(
         reader.read(
           previousBoundary,
           watermark,
@@ -926,139 +762,45 @@ export class SQLiteChangeLogComparator {
         ),
         watermark,
         sqliteMaxRows,
-        rows => {
-          sqliteRowsRead += rows;
-        },
       );
-      pg = await digestCappedCatchupTransactions(
+      pg = await digestCatchupRange(
         reconstructBatches(
           this.#pg.readCatchupRange(previousBoundary, watermark, pgMaxRows),
         ),
         watermark,
         pgMaxRows,
-        rows => {
-          pgRowsRead += rows;
-        },
       );
     } catch (e) {
+      // A read that cannot complete is a read a subscriber could not be
+      // served either, so it is a suspect like any other.
       this.#lc.warn?.(
         `error reading transaction ${watermark} for comparison`,
         e,
       );
-      const outcome = await this.#reconfirm(
-        db,
-        pinned,
-        watermark,
-        'reader-error',
-      );
       return {
-        kind: 'compared',
-        tx: {watermark, outcome},
-        orphans: [],
-        sqliteRowsRead,
-        pgRowsRead,
+        outcome: await this.#reconfirm(db, pinned, watermark),
+        sqliteRowsRead: 0,
+        pgRowsRead: 0,
       };
     }
+    const rowsRead = {sqliteRowsRead: sqlite.rows, pgRowsRead: pg.rows};
     if (sqlite.limitReached || pg.limitReached) {
-      const kind =
+      // A transaction that does not fit a *fresh* budget never will; one that
+      // only failed to fit what was left is retried by the next cycle.
+      const outcome =
         (sqlite.limitReached && sqliteMaxRows === maxRowsPerSource) ||
         (pg.limitReached && pgMaxRows === maxRowsPerSource)
           ? 'oversized'
           : 'deferred';
-      return {kind, sqliteRowsRead, pgRowsRead};
+      return {outcome, ...rowsRead};
     }
-    const orphans = await this.#compareOrphans(
-      db,
-      pinned,
-      watermark,
-      sqlite.digests,
-      pg.digests,
-    );
-    const sqliteTx = sqlite.digests.get(watermark);
-    const pgTx = pg.digests.get(watermark);
-    if (
-      sqliteTx !== undefined &&
-      pgTx !== undefined &&
-      sqliteTx.complete &&
-      pgTx.complete &&
-      sqliteTx.digest === pgTx.digest
-    ) {
-      return {
-        kind: 'compared',
-        tx: undefined,
-        orphans,
-        sqliteRowsRead,
-        pgRowsRead,
-      };
+    if (sqlite.digest === pg.digest) {
+      return {outcome: 'match', ...rowsRead};
     }
-    const suspect: Exclude<CompareOutcome, 'match'> =
-      sqliteTx === undefined
-        ? 'missing-sqlite'
-        : pgTx === undefined
-          ? 'missing-pg'
-          : 'digest-mismatch';
-    const outcome = await this.#reconfirm(db, pinned, watermark, suspect);
     return {
-      kind: 'compared',
-      tx: {
-        watermark,
-        outcome,
-        sqliteDigest: sqliteTx?.digest.slice(0, DIGEST_PREFIX_LENGTH),
-        pgDigest: pgTx?.digest.slice(0, DIGEST_PREFIX_LENGTH),
-        sqliteRows: sqliteTx?.rows,
-        pgRows: pgTx?.rows,
-      },
-      orphans,
-      sqliteRowsRead,
-      pgRowsRead,
+      outcome: await this.#reconfirm(db, pinned, watermark),
+      ...rowsRead,
     };
-  }
-
-  /**
-   * Classifies every digest a range read produced at a watermark other than
-   * the compared transaction's. The commit enumeration cannot see these —
-   * they have no commit row — so a sampled read is the only place they are
-   * observable, and discarding them would report a store that serves extra
-   * rows as parity. Output both stores serve identically is parity — the
-   * comparison measures what catchup *serves*, and 7H owns content — so only
-   * asymmetric orphans are reported, at their own watermark, subject to the
-   * same purge-race reconfirmation as every other suspect.
-   */
-  async #compareOrphans(
-    db: Database,
-    pinned: PinnedBounds,
-    txWatermark: string,
-    sqliteServed: Map<string, CatchupTransactionDigest>,
-    pgServed: Map<string, CatchupTransactionDigest>,
-  ): Promise<TransactionCompareResult[]> {
-    const watermarks = [
-      ...new Set([...sqliteServed.keys(), ...pgServed.keys()]),
-    ]
-      .filter(w => w !== txWatermark)
-      .sort();
-    const orphans: TransactionCompareResult[] = [];
-    for (const w of watermarks) {
-      const sqlite = sqliteServed.get(w);
-      const pg = pgServed.get(w);
-      if (
-        sqlite !== undefined &&
-        pg !== undefined &&
-        sqlite.complete === pg.complete &&
-        sqlite.digest === pg.digest
-      ) {
-        continue;
-      }
-      const outcome = await this.#reconfirm(db, pinned, w, 'orphan-output');
-      orphans.push({
-        watermark: w,
-        outcome,
-        sqliteDigest: sqlite?.digest.slice(0, DIGEST_PREFIX_LENGTH),
-        pgDigest: pg?.digest.slice(0, DIGEST_PREFIX_LENGTH),
-        sqliteRows: sqlite?.rows,
-        pgRows: pg?.rows,
-      });
-    }
-    return orphans;
   }
 
   /**
@@ -1073,8 +815,7 @@ export class SQLiteChangeLogComparator {
     db: Database,
     pinned: PinnedBounds,
     watermark: string,
-    suspect: Exclude<CompareOutcome, 'match'>,
-  ): Promise<Exclude<CompareOutcome, 'match'>> {
+  ): Promise<'mismatch' | 'inconclusive'> {
     try {
       const meta = readChangeLogMeta(db);
       if (
@@ -1097,7 +838,7 @@ export class SQLiteChangeLogComparator {
       ) {
         return 'inconclusive';
       }
-      return suspect;
+      return 'mismatch';
     } catch {
       return 'inconclusive';
     }
@@ -1118,67 +859,25 @@ export class SQLiteChangeLogComparator {
     throughWatermark: string,
     transactions: number,
     sampled: number,
-    matched: number,
-    divergent: TransactionCompareResult[],
-    stats: {
-      readonly sqliteRowsRead: number;
-      readonly pgRowsRead: number;
-      readonly deferred: number;
-      readonly oversized: number;
-    } = {
-      sqliteRowsRead: 0,
-      pgRowsRead: 0,
-      deferred: 0,
-      oversized: 0,
-    },
+    outcomes: Record<CompareOutcome, number>,
   ): CompareCycleResult {
     this.#compareCycles.add(1, {result: 'compared'});
-    if (stats.sqliteRowsRead > 0) {
-      this.#compareRows.add(stats.sqliteRowsRead, {source: 'sqlite'});
-    }
-    if (stats.pgRowsRead > 0) {
-      this.#compareRows.add(stats.pgRowsRead, {source: 'pg'});
-    }
-    const reportable = divergent.filter(d => d.outcome !== 'inconclusive');
-    if (reportable.length > 0) {
-      const maxLogged =
-        this.#opts.maxLoggedDivergences ?? DEFAULT_MAX_LOGGED_DIVERGENCES;
-      // Digest prefixes and row counts only. The payloads are customer data
-      // and are never logged; the watermark is enough to find them.
-      for (const d of reportable.slice(0, maxLogged)) {
-        this.#lc.error?.(
-          'SQLite change-log catchup output diverged from Postgres',
-          {sqliteChangeLogCompare: d},
-        );
-      }
-      if (reportable.length > maxLogged) {
-        this.#lc.error?.(
-          `... and ${reportable.length - maxLogged} more SQLite change-log ` +
-            `compare divergences this cycle`,
-        );
-      }
-    }
-    this.#lc.debug?.('SQLite change-log comparison cycle', {
-      sqliteChangeLogCompare: {
-        fromWatermark,
-        throughWatermark,
-        transactions,
-        sampled,
-        matched,
-        ...stats,
-        divergent: divergent.length,
-      },
-    });
-    return {
+    const result = {
       kind: 'compared',
       fromWatermark,
       throughWatermark,
       transactions,
       sampled,
-      matched,
-      ...stats,
-      divergent,
-    };
+      matched: outcomes.match,
+      mismatched: outcomes.mismatch,
+      inconclusive: outcomes.inconclusive,
+      deferred: outcomes.deferred,
+      oversized: outcomes.oversized,
+    } as const;
+    this.#lc.debug?.('SQLite change-log comparison cycle', {
+      sqliteChangeLogCompare: result,
+    });
+    return result;
   }
 }
 

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.ts
@@ -50,6 +50,13 @@ const DIGEST_PREFIX_LENGTH = 16;
  * The outcome of comparing one committed transaction's catchup output between
  * the two stores, or of a cycle-level bounds check.
  *
+ * `orphan-output` means a sampled read served rows at a watermark that is not
+ * a committed transaction in either store — a torn or corrupt remnant the
+ * commit enumeration cannot see, but that a real catchup subscriber would
+ * receive. It is reported at the orphan's own watermark, for whichever store
+ * serves it, unless both stores serve it identically (which is parity in what
+ * catchup *serves*, the thing this comparison measures).
+ *
  * `inconclusive` means the common lower bound (or a head) moved after the
  * cycle pinned it — a purge, truncation, or reseed raced the comparison — so
  * the observation says nothing about divergence and is deliberately not
@@ -60,6 +67,7 @@ export type CompareOutcome =
   | 'digest-mismatch'
   | 'missing-pg'
   | 'missing-sqlite'
+  | 'orphan-output'
   | 'bounds-mismatch'
   | 'reader-error'
   | 'inconclusive';
@@ -137,6 +145,9 @@ export type SQLiteChangeLogCompareOptions = {
    * transactions whose catchup output is digest-compared. Presence (a
    * transaction one store serves and the other does not) is checked for every
    * transaction in the range regardless, since it needs no payload reads.
+   * Orphan output — rows belonging to no committed transaction — has no
+   * commit row for the presence pass to see, so it is detectable only within
+   * sampled reads.
    */
   readonly comparePercent: number;
   /**
@@ -553,19 +564,26 @@ export class SQLiteChangeLogComparator {
           isSampledForCompare(this.#shard, watermark, this.#opts.comparePercent)
         ) {
           sampled++;
-          const result = await this.#compareTransaction(
+          const {tx, orphans} = await this.#compareTransaction(
             db,
             reader,
             meta,
             previousBoundary,
             watermark,
           );
-          if (result === undefined) {
+          // Orphans precede the transaction: their watermarks lie strictly
+          // inside `(previousBoundary, watermark)`, keeping `divergent` in
+          // watermark order.
+          for (const orphan of orphans) {
+            divergent.push(orphan);
+            this.#compareResults.add(1, {outcome: orphan.outcome});
+          }
+          if (tx === undefined) {
             matched++;
             this.#compareResults.add(1, {outcome: 'match'});
           } else {
-            divergent.push(result);
-            this.#compareResults.add(1, {outcome: result.outcome});
+            divergent.push(tx);
+            this.#compareResults.add(1, {outcome: tx.outcome});
           }
           // Let fan-out, catchup, and the stream loop make progress between
           // sampled reads.
@@ -712,8 +730,14 @@ export class SQLiteChangeLogComparator {
   /**
    * Runs both catchup paths over `(previousBoundary, watermark]` — exactly one
    * transaction, since `previousBoundary` is the immediately preceding commit
-   * in either store — and compares the digests of what each serves. Returns
+   * in either store — and compares the digests of what each serves. `tx` is
    * `undefined` on a match.
+   *
+   * Everything else either read returned is orphan output: rows at a
+   * watermark that is not a committed transaction in either store, which a
+   * real catchup subscriber would nevertheless receive. Reporting it here is
+   * what keeps "extra served rows" from passing as parity; see
+   * {@link #compareOrphans}.
    */
   async #compareTransaction(
     db: Database,
@@ -721,23 +745,22 @@ export class SQLiteChangeLogComparator {
     meta: ChangeLogMeta,
     previousBoundary: string,
     watermark: string,
-  ): Promise<TransactionCompareResult | undefined> {
-    let sqliteTx: CatchupTransactionDigest | undefined;
-    let pgTx: CatchupTransactionDigest | undefined;
+  ): Promise<{
+    tx: TransactionCompareResult | undefined;
+    orphans: TransactionCompareResult[];
+  }> {
+    let sqliteServed: Map<string, CatchupTransactionDigest>;
+    let pgServed: Map<string, CatchupTransactionDigest>;
     try {
       const readBatchRows = this.#opts.readBatchRows ?? DEFAULT_READ_BATCH_ROWS;
-      sqliteTx = (
-        await digestCatchupTransactions(
-          reader.read(previousBoundary, watermark, readBatchRows),
-        )
-      ).get(watermark);
-      pgTx = (
-        await digestCatchupTransactions(
-          reconstructBatches(
-            this.#pg.readCatchupRange(previousBoundary, watermark),
-          ),
-        )
-      ).get(watermark);
+      sqliteServed = await digestCatchupTransactions(
+        reader.read(previousBoundary, watermark, readBatchRows),
+      );
+      pgServed = await digestCatchupTransactions(
+        reconstructBatches(
+          this.#pg.readCatchupRange(previousBoundary, watermark),
+        ),
+      );
     } catch (e) {
       this.#lc.warn?.(
         `error reading transaction ${watermark} for comparison`,
@@ -749,8 +772,17 @@ export class SQLiteChangeLogComparator {
         watermark,
         'reader-error',
       );
-      return {watermark, outcome};
+      return {tx: {watermark, outcome}, orphans: []};
     }
+    const orphans = await this.#compareOrphans(
+      db,
+      meta,
+      watermark,
+      sqliteServed,
+      pgServed,
+    );
+    const sqliteTx = sqliteServed.get(watermark);
+    const pgTx = pgServed.get(watermark);
     if (
       sqliteTx !== undefined &&
       pgTx !== undefined &&
@@ -758,7 +790,7 @@ export class SQLiteChangeLogComparator {
       pgTx.complete &&
       sqliteTx.digest === pgTx.digest
     ) {
-      return undefined;
+      return {tx: undefined, orphans};
     }
     const suspect: Exclude<CompareOutcome, 'match'> =
       sqliteTx === undefined
@@ -768,13 +800,63 @@ export class SQLiteChangeLogComparator {
           : 'digest-mismatch';
     const outcome = await this.#reconfirm(db, meta, watermark, suspect);
     return {
-      watermark,
-      outcome,
-      sqliteDigest: sqliteTx?.digest.slice(0, DIGEST_PREFIX_LENGTH),
-      pgDigest: pgTx?.digest.slice(0, DIGEST_PREFIX_LENGTH),
-      sqliteRows: sqliteTx?.rows,
-      pgRows: pgTx?.rows,
+      tx: {
+        watermark,
+        outcome,
+        sqliteDigest: sqliteTx?.digest.slice(0, DIGEST_PREFIX_LENGTH),
+        pgDigest: pgTx?.digest.slice(0, DIGEST_PREFIX_LENGTH),
+        sqliteRows: sqliteTx?.rows,
+        pgRows: pgTx?.rows,
+      },
+      orphans,
     };
+  }
+
+  /**
+   * Classifies every digest a range read produced at a watermark other than
+   * the compared transaction's. The commit enumeration cannot see these —
+   * they have no commit row — so a sampled read is the only place they are
+   * observable, and discarding them would report a store that serves extra
+   * rows as parity. Output both stores serve identically is parity — the
+   * comparison measures what catchup *serves*, and 7H owns content — so only
+   * asymmetric orphans are reported, at their own watermark, subject to the
+   * same purge-race reconfirmation as every other suspect.
+   */
+  async #compareOrphans(
+    db: Database,
+    meta: ChangeLogMeta,
+    txWatermark: string,
+    sqliteServed: Map<string, CatchupTransactionDigest>,
+    pgServed: Map<string, CatchupTransactionDigest>,
+  ): Promise<TransactionCompareResult[]> {
+    const watermarks = [
+      ...new Set([...sqliteServed.keys(), ...pgServed.keys()]),
+    ]
+      .filter(w => w !== txWatermark)
+      .sort();
+    const orphans: TransactionCompareResult[] = [];
+    for (const w of watermarks) {
+      const sqlite = sqliteServed.get(w);
+      const pg = pgServed.get(w);
+      if (
+        sqlite !== undefined &&
+        pg !== undefined &&
+        sqlite.complete === pg.complete &&
+        sqlite.digest === pg.digest
+      ) {
+        continue;
+      }
+      const outcome = await this.#reconfirm(db, meta, w, 'orphan-output');
+      orphans.push({
+        watermark: w,
+        outcome,
+        sqliteDigest: sqlite?.digest.slice(0, DIGEST_PREFIX_LENGTH),
+        pgDigest: pg?.digest.slice(0, DIGEST_PREFIX_LENGTH),
+        sqliteRows: sqlite?.rows,
+        pgRows: pg?.rows,
+      });
+    }
+    return orphans;
   }
 
   /**

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.ts
@@ -24,18 +24,20 @@ import type {WatermarkedChange} from './change-streamer.ts';
 import {SQLiteChangeLogReader} from './sqlite-change-log-reader.ts';
 
 /**
- * How often a comparison cycle runs. Each cycle is bounded by
- * {@link SQLiteChangeLogCompareOptions.maxTransactionsPerCycle}, so a busy
- * stream is compared in bounded increments rather than all at once.
+ * How often a comparison cycle runs. Each cycle is bounded by commit
+ * enumeration and catchup row budgets, so a busy stream is compared in
+ * bounded increments rather than all at once.
  */
 const DEFAULT_COMPARE_INTERVAL_MS = 30_000;
 
 /**
- * The per-cycle bound on enumerated transactions. Bounds one cycle's work and
- * memory (two watermark lists plus one transaction's digest state); it does not
- * bound coverage, since the next cycle resumes from where this one stopped.
+ * The per-cycle bound on enumerated transactions. This bounds the two commit
+ * watermark lists; catchup payload work has a separate per-source row budget.
  */
 const DEFAULT_MAX_TRANSACTIONS_PER_CYCLE = 256;
+
+/** Catchup rows read from each store per comparison cycle. */
+const DEFAULT_MAX_ROWS_PER_SOURCE_PER_CYCLE = 1000;
 
 /** Rows per SQLite catchup read batch, matching the read path's default. */
 const DEFAULT_READ_BATCH_ROWS = 1000;
@@ -107,16 +109,19 @@ export type CompareCycleResult =
       readonly kind: 'compared';
       /** Exclusive lower bound of the compared range. */
       readonly fromWatermark: string;
-      /**
-       * Inclusive upper bound attempted. The next cycle normally resumes from
-       * here, but retries from `fromWatermark` after an inconclusive result.
-       */
+      /** Inclusive upper bound handled; the next cycle resumes from here. */
       readonly throughWatermark: string;
-      /** Committed transactions present in either store over the range. */
+      /** Committed transactions handled through `throughWatermark`. */
       readonly transactions: number;
       /** How many were sampled for digest comparison. */
       readonly sampled: number;
       readonly matched: number;
+      readonly sqliteRowsRead: number;
+      readonly pgRowsRead: number;
+      /** Sampled transactions deferred until a fresh cycle row budget. */
+      readonly deferred: number;
+      /** Sampled transactions skipped because they exceed a fresh row budget. */
+      readonly oversized: number;
       /** Every non-match observation, in watermark order. */
       readonly divergent: readonly TransactionCompareResult[];
     };
@@ -140,6 +145,7 @@ export interface PGChangeLogRangeReader {
   readCatchupRange(
     afterWatermark: string,
     throughWatermark: string,
+    batchRows?: number | undefined,
   ): AsyncIterable<ChangeLogEntry[]>;
 }
 
@@ -162,6 +168,8 @@ export type SQLiteChangeLogCompareOptions = {
   readonly retentionMs: number;
   readonly intervalMs?: number | undefined;
   readonly maxTransactionsPerCycle?: number | undefined;
+  /** Catchup payload rows read from each source in one cycle. */
+  readonly maxRowsPerSourcePerCycle?: number | undefined;
   readonly readBatchRows?: number | undefined;
   readonly maxLoggedDivergences?: number | undefined;
   /** The clock the warm-up window is measured against. Defaults to `Date.now`. */
@@ -306,6 +314,47 @@ export async function digestCatchupTransactions(
   return digests;
 }
 
+type CappedCatchupDigest = {
+  readonly digests: Map<string, CatchupTransactionDigest>;
+  readonly rowsRead: number;
+  /** The cap was reached before the target transaction committed. */
+  readonly limitReached: boolean;
+};
+
+async function digestCappedCatchupTransactions(
+  batches: AsyncIterable<readonly WatermarkedChange[]>,
+  targetWatermark: string,
+  maxRows: number,
+  onRowsRead: (rows: number) => void,
+): Promise<CappedCatchupDigest> {
+  let rowsRead = 0;
+
+  async function* cappedBatches() {
+    for await (const batch of batches) {
+      const remaining = maxRows - rowsRead;
+      if (remaining === 0) {
+        return;
+      }
+      const capped =
+        batch.length <= remaining ? batch : batch.slice(0, remaining);
+      rowsRead += capped.length;
+      onRowsRead(capped.length);
+      yield capped;
+      if (rowsRead === maxRows) {
+        return;
+      }
+    }
+  }
+
+  const digests = await digestCatchupTransactions(cappedBatches());
+  return {
+    digests,
+    rowsRead,
+    limitReached:
+      rowsRead === maxRows && !digests.get(targetWatermark)?.complete,
+  };
+}
+
 /**
  * `min` and `max` as separate scalar subqueries for the single-aggregate index
  * optimization, matching the reader's plan query.
@@ -343,6 +392,25 @@ type PinnedBounds = {
   readonly pgMinWatermark: string;
   readonly pgLastWatermark: string;
 };
+
+type TransactionComparison =
+  | {
+      readonly kind: 'compared';
+      readonly tx: TransactionCompareResult | undefined;
+      readonly orphans: TransactionCompareResult[];
+      readonly sqliteRowsRead: number;
+      readonly pgRowsRead: number;
+    }
+  | {
+      readonly kind: 'deferred';
+      readonly sqliteRowsRead: number;
+      readonly pgRowsRead: number;
+    }
+  | {
+      readonly kind: 'oversized';
+      readonly sqliteRowsRead: number;
+      readonly pgRowsRead: number;
+    };
 
 /**
  * Compares what SQLite catchup *serves* against what PG catchup serves, over
@@ -388,6 +456,16 @@ export class SQLiteChangeLogComparator {
     'replica',
     'sqlite_change_log.compare_cycles',
     'SQLite change-log comparison cycles, by result.',
+  );
+  readonly #compareRows = getOrCreateCounter(
+    'replica',
+    'sqlite_change_log.compare_rows',
+    'Catchup rows read by the SQLite change-log comparator, by source.',
+  );
+  readonly #compareSkippedTransactions = getOrCreateCounter(
+    'replica',
+    'sqlite_change_log.compare_skipped_transactions',
+    'Sampled SQLite change-log transactions not compared, by reason.',
   );
   readonly #cycleDuration = getOrCreateLatencyHistogram(
     'replica',
@@ -580,15 +658,26 @@ export class SQLiteChangeLogComparator {
       );
       const enumerated = await this.#enumerateCommits(db, from, through, limit);
       const {union} = enumerated;
-      const effectiveThrough = enumerated.through;
+      const maxRowsPerSource = Math.max(
+        1,
+        this.#opts.maxRowsPerSourcePerCycle ??
+          DEFAULT_MAX_ROWS_PER_SOURCE_PER_CYCLE,
+      );
 
       let sampled = 0;
       let matched = 0;
+      let sqliteRowsRead = 0;
+      let pgRowsRead = 0;
+      let deferred = 0;
+      let oversized = 0;
+      let transactions = 0;
       let previousBoundary = from;
+      let handledThrough = from;
       for (const {watermark, inSqlite, inPg} of union) {
         if (this.#stopped) {
           break;
         }
+        let stopAfterTransaction = false;
         if (!inSqlite || !inPg) {
           const outcome = await this.#reconfirm(
             db,
@@ -601,49 +690,79 @@ export class SQLiteChangeLogComparator {
         } else if (
           isSampledForCompare(this.#shard, watermark, this.#opts.comparePercent)
         ) {
+          const sqliteRowsRemaining = maxRowsPerSource - sqliteRowsRead;
+          const pgRowsRemaining = maxRowsPerSource - pgRowsRead;
+          if (sqliteRowsRemaining === 0 || pgRowsRemaining === 0) {
+            deferred++;
+            this.#compareSkippedTransactions.add(1, {reason: 'deferred'});
+            break;
+          }
           sampled++;
-          const {tx, orphans} = await this.#compareTransaction(
+          const comparison = await this.#compareTransaction(
             db,
             reader,
             pinned,
             previousBoundary,
             watermark,
+            sqliteRowsRemaining,
+            pgRowsRemaining,
+            maxRowsPerSource,
           );
-          // Orphans precede the transaction: their watermarks lie strictly
-          // inside `(previousBoundary, watermark)`, keeping `divergent` in
-          // watermark order.
-          for (const orphan of orphans) {
-            divergent.push(orphan);
-            this.#compareResults.add(1, {outcome: orphan.outcome});
+          sqliteRowsRead += comparison.sqliteRowsRead;
+          pgRowsRead += comparison.pgRowsRead;
+          if (comparison.kind === 'deferred') {
+            deferred++;
+            this.#compareSkippedTransactions.add(1, {reason: 'deferred'});
+            break;
           }
-          if (tx === undefined) {
-            matched++;
-            this.#compareResults.add(1, {outcome: 'match'});
+          if (comparison.kind === 'oversized') {
+            oversized++;
+            this.#compareSkippedTransactions.add(1, {reason: 'oversized'});
+            stopAfterTransaction = true;
           } else {
-            divergent.push(tx);
-            this.#compareResults.add(1, {outcome: tx.outcome});
+            const {tx, orphans} = comparison;
+            // Orphans precede the transaction: their watermarks lie strictly
+            // inside `(previousBoundary, watermark)`, keeping `divergent` in
+            // watermark order.
+            for (const orphan of orphans) {
+              divergent.push(orphan);
+              this.#compareResults.add(1, {outcome: orphan.outcome});
+            }
+            if (tx === undefined) {
+              matched++;
+              this.#compareResults.add(1, {outcome: 'match'});
+            } else {
+              divergent.push(tx);
+              this.#compareResults.add(1, {outcome: tx.outcome});
+            }
           }
           // Let fan-out, catchup, and the stream loop make progress between
           // sampled reads.
           await this.#yield();
         }
         previousBoundary = watermark;
+        handledThrough = watermark;
+        transactions++;
+        if (stopAfterTransaction) {
+          break;
+        }
       }
 
       const inconclusive = divergent.some(
         ({outcome}) => outcome === 'inconclusive',
       );
       if (!this.#stopped && !inconclusive) {
-        this.#cursor = effectiveThrough;
-        this.#continueWithoutDelay = effectiveThrough < through;
+        this.#cursor = handledThrough;
+        this.#continueWithoutDelay = handledThrough < through;
       }
       return this.#compared(
         from,
-        effectiveThrough,
-        union.length,
+        handledThrough,
+        transactions,
         sampled,
         matched,
         divergent,
+        {sqliteRowsRead, pgRowsRead, deferred, oversized},
       );
     } catch (e) {
       this.#lc.warn?.('error comparing the SQLite change log', e);
@@ -787,21 +906,39 @@ export class SQLiteChangeLogComparator {
     pinned: PinnedBounds,
     previousBoundary: string,
     watermark: string,
-  ): Promise<{
-    tx: TransactionCompareResult | undefined;
-    orphans: TransactionCompareResult[];
-  }> {
-    let sqliteServed: Map<string, CatchupTransactionDigest>;
-    let pgServed: Map<string, CatchupTransactionDigest>;
+    sqliteMaxRows: number,
+    pgMaxRows: number,
+    maxRowsPerSource: number,
+  ): Promise<TransactionComparison> {
+    let sqliteRowsRead = 0;
+    let pgRowsRead = 0;
+    let sqlite: CappedCatchupDigest;
+    let pg: CappedCatchupDigest;
     try {
       const readBatchRows = this.#opts.readBatchRows ?? DEFAULT_READ_BATCH_ROWS;
-      sqliteServed = await digestCatchupTransactions(
-        reader.read(previousBoundary, watermark, readBatchRows),
-      );
-      pgServed = await digestCatchupTransactions(
-        reconstructBatches(
-          this.#pg.readCatchupRange(previousBoundary, watermark),
+      sqlite = await digestCappedCatchupTransactions(
+        reader.read(
+          previousBoundary,
+          watermark,
+          Math.min(readBatchRows, sqliteMaxRows),
+          undefined,
+          sqliteMaxRows,
         ),
+        watermark,
+        sqliteMaxRows,
+        rows => {
+          sqliteRowsRead += rows;
+        },
+      );
+      pg = await digestCappedCatchupTransactions(
+        reconstructBatches(
+          this.#pg.readCatchupRange(previousBoundary, watermark, pgMaxRows),
+        ),
+        watermark,
+        pgMaxRows,
+        rows => {
+          pgRowsRead += rows;
+        },
       );
     } catch (e) {
       this.#lc.warn?.(
@@ -814,17 +951,31 @@ export class SQLiteChangeLogComparator {
         watermark,
         'reader-error',
       );
-      return {tx: {watermark, outcome}, orphans: []};
+      return {
+        kind: 'compared',
+        tx: {watermark, outcome},
+        orphans: [],
+        sqliteRowsRead,
+        pgRowsRead,
+      };
+    }
+    if (sqlite.limitReached || pg.limitReached) {
+      const kind =
+        (sqlite.limitReached && sqliteMaxRows === maxRowsPerSource) ||
+        (pg.limitReached && pgMaxRows === maxRowsPerSource)
+          ? 'oversized'
+          : 'deferred';
+      return {kind, sqliteRowsRead, pgRowsRead};
     }
     const orphans = await this.#compareOrphans(
       db,
       pinned,
       watermark,
-      sqliteServed,
-      pgServed,
+      sqlite.digests,
+      pg.digests,
     );
-    const sqliteTx = sqliteServed.get(watermark);
-    const pgTx = pgServed.get(watermark);
+    const sqliteTx = sqlite.digests.get(watermark);
+    const pgTx = pg.digests.get(watermark);
     if (
       sqliteTx !== undefined &&
       pgTx !== undefined &&
@@ -832,7 +983,13 @@ export class SQLiteChangeLogComparator {
       pgTx.complete &&
       sqliteTx.digest === pgTx.digest
     ) {
-      return {tx: undefined, orphans};
+      return {
+        kind: 'compared',
+        tx: undefined,
+        orphans,
+        sqliteRowsRead,
+        pgRowsRead,
+      };
     }
     const suspect: Exclude<CompareOutcome, 'match'> =
       sqliteTx === undefined
@@ -842,6 +999,7 @@ export class SQLiteChangeLogComparator {
           : 'digest-mismatch';
     const outcome = await this.#reconfirm(db, pinned, watermark, suspect);
     return {
+      kind: 'compared',
       tx: {
         watermark,
         outcome,
@@ -851,6 +1009,8 @@ export class SQLiteChangeLogComparator {
         pgRows: pgTx?.rows,
       },
       orphans,
+      sqliteRowsRead,
+      pgRowsRead,
     };
   }
 
@@ -960,8 +1120,25 @@ export class SQLiteChangeLogComparator {
     sampled: number,
     matched: number,
     divergent: TransactionCompareResult[],
+    stats: {
+      readonly sqliteRowsRead: number;
+      readonly pgRowsRead: number;
+      readonly deferred: number;
+      readonly oversized: number;
+    } = {
+      sqliteRowsRead: 0,
+      pgRowsRead: 0,
+      deferred: 0,
+      oversized: 0,
+    },
   ): CompareCycleResult {
     this.#compareCycles.add(1, {result: 'compared'});
+    if (stats.sqliteRowsRead > 0) {
+      this.#compareRows.add(stats.sqliteRowsRead, {source: 'sqlite'});
+    }
+    if (stats.pgRowsRead > 0) {
+      this.#compareRows.add(stats.pgRowsRead, {source: 'pg'});
+    }
     const reportable = divergent.filter(d => d.outcome !== 'inconclusive');
     if (reportable.length > 0) {
       const maxLogged =
@@ -988,6 +1165,7 @@ export class SQLiteChangeLogComparator {
         transactions,
         sampled,
         matched,
+        ...stats,
         divergent: divergent.length,
       },
     });
@@ -998,6 +1176,7 @@ export class SQLiteChangeLogComparator {
       transactions,
       sampled,
       matched,
+      ...stats,
       divergent,
     };
   }

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-reader.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-reader.test.ts
@@ -262,6 +262,26 @@ describe('sqlite change log reader', () => {
     await expect(collect(reader, '06', '06', 2)).resolves.toEqual([]);
   });
 
+  test('caps total rows across read batches', async () => {
+    const {db, path} = createChangeLog();
+    using writer = db;
+    const tx04 = appendTransaction(writer, '04', [
+      truncate(),
+      truncate(),
+      truncate(),
+      truncate(),
+      truncate(),
+    ]);
+    using reader = new SQLiteChangeLogReader(lc, path);
+
+    const batches: (readonly WatermarkedChange[])[] = [];
+    for await (const batch of reader.read('02', '04', 2, undefined, 5)) {
+      batches.push(batch);
+    }
+    expect(batches.map(batch => batch.length)).toEqual([2, 2, 1]);
+    expect(flatten(batches)).toEqual(tx04.slice(0, 5));
+  });
+
   test('pins the head while another connection appends and purges', async () => {
     const {db, path} = createChangeLog();
     using writer = db;

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-reader.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-reader.ts
@@ -151,10 +151,15 @@ export class SQLiteChangeLogReader implements Disposable {
     throughWatermark: string,
     batchSize: number,
     signal?: AbortSignal | undefined,
+    maxRows?: number | undefined,
   ): AsyncIterable<readonly WatermarkedChange[]> {
     assert(
       Number.isSafeInteger(batchSize) && batchSize > 0,
       'SQLite change log batch size must be a positive safe integer',
+    );
+    assert(
+      maxRows === undefined || (Number.isSafeInteger(maxRows) && maxRows > 0),
+      'SQLite change log row limit must be a positive safe integer',
     );
     this.#assertOpen();
     const statements = this.#prepare();
@@ -168,14 +173,20 @@ export class SQLiteChangeLogReader implements Disposable {
     // real stream position is far below this sentinel.
     let lastPos = Number.MAX_SAFE_INTEGER;
     let lastTag: string | undefined;
+    let rowsRead = 0;
 
     while (true) {
       this.#throwIfAborted(signal);
+      const remainingRows =
+        maxRows === undefined ? batchSize : maxRows - rowsRead;
+      if (remainingRows === 0) {
+        break;
+      }
       const rows = statements.readBatch.all<ChangeLogRow>(
         lastWatermark,
         lastPos,
         throughWatermark,
-        batchSize,
+        Math.min(batchSize, remainingRows),
       );
       this.#throwIfAborted(signal);
 
@@ -189,6 +200,7 @@ export class SQLiteChangeLogReader implements Disposable {
       lastWatermark = last.watermark;
       lastPos = last.pos;
       lastTag = last.tag;
+      rowsRead += rows.length;
 
       // all() has exhausted the SELECT and closed its implicit read
       // transaction. This yield therefore cannot pin the WAL while subscriber
@@ -201,7 +213,12 @@ export class SQLiteChangeLogReader implements Disposable {
     // `_zero.replicationState`, which is what this assertion used to guard.
     // What remains is a concurrent purge of the head transaction, which the
     // purge policy (never past the latest durable transaction) does not do.
-    if (fromWatermark !== throughWatermark) {
+    if (
+      fromWatermark !== throughWatermark &&
+      (maxRows === undefined ||
+        rowsRead < maxRows ||
+        (lastWatermark === throughWatermark && lastTag === 'commit'))
+    ) {
       assert(
         lastWatermark === throughWatermark && lastTag === 'commit',
         () =>

--- a/packages/zero-cache/src/services/change-streamer/storer.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.ts
@@ -290,16 +290,6 @@ export class Storer implements Service {
     return bounds;
   }
 
-  /** Whether PG catchup can find the requested exclusive lower boundary. */
-  async hasCatchupWatermark(watermark: string): Promise<boolean> {
-    const [{exists}] = await this.#db<{exists: boolean}[]> /*sql*/ `
-      SELECT EXISTS (
-        SELECT 1 FROM ${this.#cdc('changeLog')}
-         WHERE watermark = ${watermark}
-      ) AS exists`;
-    return exists;
-  }
-
   /**
    * The commit watermarks of the transactions in `(afterWatermark,
    * throughWatermark]`, ascending, at most `limit` of them. Every row of a
@@ -331,8 +321,8 @@ export class Storer implements Service {
    * every string value in the document while scanning for the field, and
    * Postgres cannot represent `\u0000` as text, so a change whose payload
    * contains an escaped NUL fails the read. Subscriber catchup fails on
-   * exactly the same row, so the comparator reports it (as `reader-error`)
-   * rather than papering over it with a different statement.
+   * exactly the same row, so the comparator reports it as a mismatch rather
+   * than papering over it with a different statement.
    */
   readCatchupRange(
     afterWatermark: string,

--- a/packages/zero-cache/src/services/change-streamer/storer.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.ts
@@ -337,12 +337,19 @@ export class Storer implements Service {
   readCatchupRange(
     afterWatermark: string,
     throughWatermark: string,
+    batchRows = 2000,
   ): AsyncIterable<ChangeLogEntry[]> {
+    assert(
+      Number.isSafeInteger(batchRows) && batchRows > 0,
+      'Postgres change log batch size must be a positive safe integer',
+    );
     return this.#db<ChangeLogEntry[]> /*sql*/ `
       SELECT watermark, change->'tag' as tag, change::text FROM ${this.#cdc('changeLog')}
        WHERE watermark > ${afterWatermark}
          AND watermark <= ${throughWatermark}
-       ORDER BY watermark, pos`.cursor(2000) as AsyncIterable<ChangeLogEntry[]>;
+       ORDER BY watermark, pos`.cursor(batchRows) as AsyncIterable<
+      ChangeLogEntry[]
+    >;
   }
 
   purgeRecordsBefore(watermark: string): Promise<number> {

--- a/packages/zero-cache/src/services/change-streamer/storer.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.ts
@@ -290,6 +290,16 @@ export class Storer implements Service {
     return bounds;
   }
 
+  /** Whether PG catchup can find the requested exclusive lower boundary. */
+  async hasCatchupWatermark(watermark: string): Promise<boolean> {
+    const [{exists}] = await this.#db<{exists: boolean}[]> /*sql*/ `
+      SELECT EXISTS (
+        SELECT 1 FROM ${this.#cdc('changeLog')}
+         WHERE watermark = ${watermark}
+      ) AS exists`;
+    return exists;
+  }
+
   /**
    * The commit watermarks of the transactions in `(afterWatermark,
    * throughWatermark]`, ascending, at most `limit` of them. Every row of a

--- a/packages/zero-cache/src/services/change-streamer/storer.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.ts
@@ -269,6 +269,72 @@ export class Storer implements Service {
     return minWatermark;
   }
 
+  /**
+   * The bounds of the range the PG change log can serve catchup over:
+   * `minWatermark` is the earliest retained transaction (`null` only for a
+   * completely new replica) and `lastWatermark` is the durable head, which
+   * commits in the same transaction as its change-log rows.
+   *
+   * Used by the SQLite change-log comparator to pin the range it compares.
+   */
+  async getCatchupBounds(): Promise<{
+    minWatermark: string | null;
+    lastWatermark: string;
+  }> {
+    const [bounds] = await this.#db<
+      {minWatermark: string | null; lastWatermark: string}[]
+    > /*sql*/ `
+      SELECT
+        (SELECT min(watermark) FROM ${this.#cdc('changeLog')}) as "minWatermark",
+        (SELECT "lastWatermark" FROM ${this.#cdc('replicationState')}) as "lastWatermark"`;
+    return bounds;
+  }
+
+  /**
+   * The commit watermarks of the transactions in `(afterWatermark,
+   * throughWatermark]`, ascending, at most `limit` of them. Every row of a
+   * transaction is stored at its commit watermark, so this is a complete
+   * enumeration of the committed transactions in the range.
+   */
+  async listCommitWatermarks(
+    afterWatermark: string,
+    throughWatermark: string,
+    limit: number,
+  ): Promise<string[]> {
+    const rows = await this.#db<{watermark: string}[]> /*sql*/ `
+      SELECT watermark FROM ${this.#cdc('changeLog')}
+       WHERE precommit IS NOT NULL
+         AND watermark > ${afterWatermark}
+         AND watermark <= ${throughWatermark}
+       ORDER BY watermark
+       LIMIT ${limit}`;
+    return rows.map(({watermark}) => watermark);
+  }
+
+  /**
+   * Reads the change-log entries in `(afterWatermark, throughWatermark]` in
+   * stream order, in bounded batches. This is the same statement shape as the
+   * subscriber catchup query in {@link #catchup} — the comparator exists to
+   * compare catchup *output*, so the two must not diverge in what they select.
+   *
+   * That fidelity includes a shared limitation: `change->'tag'` de-escapes
+   * every string value in the document while scanning for the field, and
+   * Postgres cannot represent `\u0000` as text, so a change whose payload
+   * contains an escaped NUL fails the read. Subscriber catchup fails on
+   * exactly the same row, so the comparator reports it (as `reader-error`)
+   * rather than papering over it with a different statement.
+   */
+  readCatchupRange(
+    afterWatermark: string,
+    throughWatermark: string,
+  ): AsyncIterable<ChangeLogEntry[]> {
+    return this.#db<ChangeLogEntry[]> /*sql*/ `
+      SELECT watermark, change->'tag' as tag, change::text FROM ${this.#cdc('changeLog')}
+       WHERE watermark > ${afterWatermark}
+         AND watermark <= ${throughWatermark}
+       ORDER BY watermark, pos`.cursor(2000) as AsyncIterable<ChangeLogEntry[]>;
+  }
+
   purgeRecordsBefore(watermark: string): Promise<number> {
     return runTx(this.#db, async sql => {
       // This NOWAIT pre-check is an optimization to abort the transaction


### PR DESCRIPTION
Adds sqliteChangeLogMode=compare: a SQLiteChangeLogComparator in the change-streamer samples committed transactions (stable by shard and watermark), runs both catchup read paths over them, and compares per-transaction digests via ChangeLogTransactionHasher. Ranges are compared only through min(pgHead, sqliteHead); head skew is never reported. Suspect observations re-read the bounds and report `inconclusive` when a purge, truncation, or reseed raced the pin. Change text is normalized to one form before hashing, pinned by a round-trip test through both stores. Diagnostics carry digest prefixes and row counts only, never payloads.

Presence (missing-pg / missing-sqlite) is checked for every transaction in the range; digest comparison is sampled per
sqliteChangeLogComparePercent (new hidden option, default 1).

Production default unchanged (mode=off); compare activates only at mode=compare or serve, is dark, and changes nothing subscribers are served. Rollback: return the mode to `write`.

Note: the comparator's PG read deliberately shares the subscriber catchup statement shape, including its limitation that change->'tag' de-escapes every string value and therefore fails on payloads containing an escaped NUL character (a pre-existing catchup issue introduced with the stringify-before-fanout rewrite in #5900); such rows report as `reader-error`, matching what a subscriber would experience.