### PR TITLE
chore(zero-cache): bump min protocol version between vs/rm to v4

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/change-streamer-http.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-http.pg.test.ts
@@ -196,22 +196,26 @@ describe('change-streamer/http', () => {
         `/replication/v${PROTOCOL_VERSION}/changes`,
       ],
       [
+        'invalid querystring - missing taskID',
+        `/replication/v${PROTOCOL_VERSION}/changes?id=foo`,
+      ],
+      [
         'Missing taskID in snapshot request',
         `/replication/v${PROTOCOL_VERSION}/snapshot`,
       ],
       [
         'invalid querystring - missing watermark',
-        `/replication/v${PROTOCOL_VERSION}/changes?id=foo&replicaVersion=bar&initial=true`,
+        `/replication/v${PROTOCOL_VERSION}/changes?id=foo&replicaVersion=bar&initial=true&taskID=foo`,
       ],
       [
         // Change the error message as necessary
-        `Cannot service client at protocol v7. Supported protocols: [v1 ... v6]`,
+        `Cannot service client at protocol v7. Supported protocols: [v4 ... v6]`,
         `/replication/v${PROTOCOL_VERSION + 1}/changes` +
-          `?id=foo&replicaVersion=bar&watermark=123&initial=true`,
+          `?id=foo&replicaVersion=bar&watermark=123&initial=true&id=foo`,
       ],
       [
         // Change the error message as necessary
-        `Cannot service client at protocol v7. Supported protocols: [v1 ... v6]`,
+        `Cannot service client at protocol v7. Supported protocols: [v4 ... v6]`,
         `/replication/v${PROTOCOL_VERSION + 1}/snapshot` +
           `?id=foo&replicaVersion=bar&watermark=123&initial=true`,
       ],

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-http.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-http.ts
@@ -31,7 +31,7 @@ import {
 import {discoverChangeStreamerAddress} from './schema/tables.ts';
 import {snapshotMessageSchema, type SnapshotMessage} from './snapshot.ts';
 
-const MIN_SUPPORTED_PROTOCOL_VERSION = 1;
+const MIN_SUPPORTED_PROTOCOL_VERSION = 4;
 
 const SNAPSHOT_PATH_PATTERN = '/replication/:version/snapshot';
 const CHANGES_PATH_PATTERN = '/replication/:version/changes';
@@ -255,7 +255,7 @@ export function getSubscriberContext(req: RequestHeaders): SubscriberContext {
   return {
     protocolVersion,
     id: params.get('id', true),
-    taskID: params.get('taskID', false),
+    taskID: params.get('taskID', true),
     mode: params.get('mode', false) === 'backup' ? 'backup' : 'serving',
     replicaVersion: params.get('replicaVersion', true),
     watermark: params.get('watermark', true),
@@ -296,7 +296,6 @@ function getParams(ctx: SubscriberContext): URLSearchParams {
   );
   return new URLSearchParams({
     ...stringParams,
-    taskID: ctx.taskID ? ctx.taskID : '',
     initial: ctx.initial ? 'true' : 'false',
     logsChangeStream: ctx.logsChangeStream ? 'true' : 'false',
   });

--- a/packages/zero-cache/src/services/change-streamer/change-streamer.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer.ts
@@ -108,7 +108,7 @@ export type SubscriberContext = {
    * Task ID. This is used to link the request with a preceding snapshot
    * reservation.
    */
-  taskID: string; // TODO: Make required when v3 is min.
+  taskID: string;
 
   /**
    * Subscriber id. This is only used for debugging.

--- a/packages/zero-cache/src/services/change-streamer/change-streamer.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer.ts
@@ -108,7 +108,7 @@ export type SubscriberContext = {
    * Task ID. This is used to link the request with a preceding snapshot
    * reservation.
    */
-  taskID: string | null; // TODO: Make required when v3 is min.
+  taskID: string; // TODO: Make required when v3 is min.
 
   /**
    * Subscriber id. This is only used for debugging.

--- a/packages/zero-cache/src/services/change-streamer/subscriber.ts
+++ b/packages/zero-cache/src/services/change-streamer/subscriber.ts
@@ -153,7 +153,7 @@ export class Subscriber {
   }
 
   sendStatus(status: Status) {
-    if (this.#protocolVersion >= 2 && this.#initialized) {
+    if (this.#initialized) {
       void this.#sendDownstream(['status', status]);
     }
   }


### PR DESCRIPTION
Bump the min supported protcol version between the view-syncers and replication-manager to v4. This was released in zero@0.25, available since Dec 2025.

Associated cleanup will facilitate upcoming refactoring of the snapshot / change protocol.