### PR TITLE
chore(zero-cache): move watermark and snapshot tracking into the change-streamer

### DIFF
--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -56,7 +56,6 @@ export default async function runWorker(
   env: NodeJS.ProcessEnv,
   ...argv: string[]
 ): Promise<void> {
-  const workerStartTime = Date.now();
   const config = getNormalizedZeroConfig({env, argv});
   const {
     taskID,
@@ -185,6 +184,9 @@ export default async function runWorker(
         changeSource,
         replicationStatusPublisher,
         subscriptionState,
+        destinationBackupURL
+          ? {backupURL: destinationBackupURL, litestreamVersion: 'legacy'}
+          : null,
         purgeLock,
         autoReset ?? false,
         {
@@ -289,14 +291,6 @@ export default async function runWorker(
     config,
     replicaFile: replica.file,
     changeStreamer,
-    // The time between when the zero-cache was started to when the
-    // change-streamer is ready to start serves as the initial delay for
-    // watermark cleanup (as it either includes a similar replica
-    // restoration/preparation step, or an initial-sync, which
-    // generally takes longer).
-    //
-    // Consider: Also account for permanent volumes?
-    initialCleanupDelayMs: Date.now() - workerStartTime,
     env,
   });
   const monitor =
@@ -307,7 +301,6 @@ export default async function runWorker(
     {port, keepaliveTimeoutMs, startupDelayMs},
     parent,
     changeStreamer,
-    backupMonitor,
   );
 
   parent.send(['ready', {ready: true}]);

--- a/packages/zero-cache/src/services/change-streamer/backup-cleanup-monitor-factory.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/backup-cleanup-monitor-factory.test.ts
@@ -12,12 +12,8 @@ const changeStreamer = {
   run: () => Promise.resolve(),
   stop: () => Promise.resolve(),
   subscribe: () => Promise.resolve(Subscription.create<string>()),
-  scheduleCleanup: vi.fn(),
-  getChangeLogState: () =>
-    Promise.resolve({
-      replicaVersion: 'replica-version',
-      minWatermark: 'min-watermark',
-    }),
+  startSnapshotReservation: vi.fn(),
+  trackBackupWatermark: vi.fn(),
 } satisfies ChangeStreamerService;
 
 function configWithLitestream(
@@ -43,7 +39,6 @@ describe('createBackupCleanupMonitor', () => {
       config: configWithLitestream({backupURL: undefined}),
       replicaFile: '/tmp/replica.db',
       changeStreamer,
-      initialCleanupDelayMs: 0,
     });
 
     expect(monitor).toBeNull();
@@ -55,7 +50,6 @@ describe('createBackupCleanupMonitor', () => {
       config: configWithLitestream({backupURL: 's3://bucket/prefix'}),
       replicaFile: '/tmp/replica.db',
       changeStreamer,
-      initialCleanupDelayMs: 0,
       verifyBackupState: vi.fn().mockResolvedValue(new Date()),
     });
 
@@ -74,7 +68,6 @@ describe('createBackupCleanupMonitor', () => {
       }),
       replicaFile: '/tmp/replica.db',
       changeStreamer,
-      initialCleanupDelayMs: 0,
       vfsBackupWatermarkSource: {
         readWatermark: vi.fn(),
       },

--- a/packages/zero-cache/src/services/change-streamer/backup-cleanup-monitor-factory.ts
+++ b/packages/zero-cache/src/services/change-streamer/backup-cleanup-monitor-factory.ts
@@ -20,7 +20,6 @@ export type BackupCleanupMonitorFactoryOptions = {
   config: NormalizedZeroConfig;
   replicaFile: string;
   changeStreamer: ChangeStreamerService;
-  initialCleanupDelayMs: number;
   verifyBackupState?: BackupStateVerifier | undefined;
   vfsBackupWatermarkSource?: VfsBackupWatermarkSource | undefined;
   env?: NodeJS.ProcessEnv | undefined;
@@ -31,7 +30,6 @@ export function createBackupCleanupMonitor({
   config,
   replicaFile,
   changeStreamer,
-  initialCleanupDelayMs,
   verifyBackupState,
   vfsBackupWatermarkSource,
   env,
@@ -47,7 +45,6 @@ export function createBackupCleanupMonitor({
       lc,
       backupURL,
       changeStreamer,
-      initialCleanupDelayMs,
       config.litestream.vfsProbeIntervalMs,
       vfsBackupWatermarkSource ??
         new VfsBackupWatermarkWorkerSource(
@@ -65,7 +62,6 @@ export function createBackupCleanupMonitor({
     backupURL,
     `http://localhost:${metricsPort}/metrics`,
     changeStreamer,
-    initialCleanupDelayMs,
     verifyBackupState ??
       (() => getLastBackupTime(lc, litestream, replica.file)),
   );

--- a/packages/zero-cache/src/services/change-streamer/backup-monitor.ts
+++ b/packages/zero-cache/src/services/change-streamer/backup-monitor.ts
@@ -1,11 +1,6 @@
-import type {Subscription} from '../../types/subscription.ts';
 import type {SingletonService} from '../service.ts';
-import type {SnapshotMessage} from './snapshot.ts';
 
 export interface BackupMonitor extends SingletonService {
-  startSnapshotReservation(taskID: string): Subscription<SnapshotMessage>;
-  endReservation(
-    taskID: string,
-    updateCleanupDelay?: boolean | undefined,
-  ): void;
+  // TODO: Add a method for delaying readiness until a backup is available.
+  // backupAvailable(): Promise<void>;
 }

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-http.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-http.pg.test.ts
@@ -13,7 +13,6 @@ import type {Source} from '../../types/streams.ts';
 import {Subscription} from '../../types/subscription.ts';
 import {installWebSocketHandoff} from '../../types/websocket-handoff.ts';
 import {ReplicationMessages} from '../replicator/test-utils.ts';
-import type {BackupMonitor} from './backup-monitor.ts';
 import {
   ChangeStreamerHttpClient,
   ChangeStreamerHttpServer,
@@ -36,8 +35,9 @@ describe('change-streamer/http', () => {
   let subscribeFn: MockedFunction<
     (ctx: SubscriberContext) => Promise<Subscription<string>>
   >;
-  let snapshotFn: MockedFunction<(id: string) => Subscription<SnapshotMessage>>;
-  let endReservationFn: MockedFunction<(id: string) => void>;
+  let snapshotFn: MockedFunction<
+    (id: string) => Promise<Subscription<SnapshotMessage>>
+  >;
   let runFn: MockedFunction<() => Promise<void>>;
   let stopFn: MockedFunction<() => Promise<void>>;
 
@@ -71,7 +71,6 @@ describe('change-streamer/http', () => {
     snapshotStream = Subscription.create();
     subscribeFn = vi.fn();
     snapshotFn = vi.fn();
-    endReservationFn = vi.fn();
     runFn = vi.fn();
     stopFn = vi.fn();
 
@@ -99,21 +98,14 @@ describe('change-streamer/http', () => {
       {
         id: 'change-streamer',
         subscribe: subscribeFn.mockResolvedValue(downstream),
+        startSnapshotReservation: snapshotFn.mockResolvedValue(snapshotStream),
+        trackBackupWatermark: vi.fn(),
         run: runFn.mockImplementation(() => service.promise),
         stop: stopFn.mockImplementation(() => {
           service.resolve();
           return service.promise;
         }),
-        scheduleCleanup: vi.fn(),
-        getChangeLogState: vi.fn(),
       },
-      {
-        id: 'backup-monitor',
-        run: vi.fn(() => Promise.resolve()),
-        stop: vi.fn(() => Promise.resolve()),
-        startSnapshotReservation: snapshotFn.mockReturnValue(snapshotStream),
-        endReservation: endReservationFn,
-      } satisfies BackupMonitor,
     );
 
     const [dispatcherURL, serverURL] = await Promise.all([
@@ -162,15 +154,14 @@ describe('change-streamer/http', () => {
       {
         id: 'change-streamer',
         subscribe: subscribeFn.mockResolvedValue(downstream),
+        startSnapshotReservation: vi.fn(),
+        trackBackupWatermark: vi.fn(),
         run: runFn.mockImplementation(() => service.promise),
         stop: stopFn.mockImplementation(() => {
           service.resolve();
           return service.promise;
         }),
-        scheduleCleanup: vi.fn(),
-        getChangeLogState: vi.fn(),
       },
-      null,
     );
     const baseURL = await server.start();
 
@@ -297,8 +288,6 @@ describe('change-streamer/http', () => {
             `http://${addr()}`,
           );
       const sub = await client.subscribe(ctx);
-
-      expect(endReservationFn).toHaveBeenCalledWith('foo-task');
 
       const begin = JSON.stringify([
         'begin',

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-http.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-http.ts
@@ -3,7 +3,6 @@ import websocket from '@fastify/websocket';
 import type {LogContext} from '@rocicorp/logger';
 import WebSocket from 'ws';
 import {assert} from '../../../../shared/src/asserts.ts';
-import {must} from '../../../../shared/src/must.ts';
 import type {IncomingMessageSubset} from '../../types/http.ts';
 import {pgClient, type PostgresDB} from '../../types/pg.ts';
 import {type Worker} from '../../types/processes.ts';
@@ -19,7 +18,6 @@ import {URLParams} from '../../types/url-params.ts';
 import {installWebSocketReceiver} from '../../types/websocket-handoff.ts';
 import {closeWithError, PROTOCOL_ERROR} from '../../types/ws.ts';
 import {HttpService} from '../http-service.ts';
-import type {BackupMonitor} from './backup-monitor.ts';
 import {
   downstreamSchema,
   PROTOCOL_VERSION,
@@ -51,14 +49,12 @@ export class ChangeStreamerHttpServer extends HttpService {
   readonly #lc: LogContext;
   readonly #opts: Options;
   readonly #changeStreamer: ChangeStreamerService;
-  readonly #backupMonitor: BackupMonitor | null;
 
   constructor(
     lc: LogContext,
     opts: Options,
     parent: Worker,
     changeStreamer: ChangeStreamerService,
-    backupMonitor: BackupMonitor | null,
   ) {
     super('change-streamer-http-server', lc, opts, async fastify => {
       await fastify.register(websocket);
@@ -81,14 +77,6 @@ export class ChangeStreamerHttpServer extends HttpService {
     this.#lc = lc;
     this.#opts = opts;
     this.#changeStreamer = changeStreamer;
-    this.#backupMonitor = backupMonitor;
-  }
-
-  #getBackupMonitor() {
-    return must(
-      this.#backupMonitor,
-      'replication-manager is not configured with a ZERO_LITESTREAM_BACKUP_URL',
-    );
   }
 
   // Called when receiving a web socket via the main dispatcher handoff.
@@ -112,7 +100,8 @@ export class ChangeStreamerHttpServer extends HttpService {
     }
   };
 
-  readonly #reserveSnapshot = (ws: WebSocket, req: RequestHeaders) => {
+  readonly #reserveSnapshot = async (ws: WebSocket, req: RequestHeaders) => {
+    this.#ensureChangeStreamerStarted('incoming snapshot reservation');
     try {
       const url = new URL(
         req.url ?? '',
@@ -124,7 +113,7 @@ export class ChangeStreamerHttpServer extends HttpService {
         throw new Error('Missing taskID in snapshot request');
       }
       const downstream =
-        this.#getBackupMonitor().startSnapshotReservation(taskID);
+        await this.#changeStreamer.startSnapshotReservation(taskID);
       void streamOut(this._lc, downstream, ws);
     } catch (err) {
       closeWithError(this._lc, ws, err, PROTOCOL_ERROR);
@@ -139,11 +128,6 @@ export class ChangeStreamerHttpServer extends HttpService {
       }
 
       const downstream = await this.#changeStreamer.subscribe(ctx);
-      if (ctx.initial && ctx.taskID && this.#backupMonitor) {
-        // Now that the change-streamer knows about the subscriber and watermark,
-        // end the reservation to safely resume scheduling cleanup.
-        this.#backupMonitor.endReservation(ctx.taskID);
-      }
       void streamOutStringified(this._lc, downstream, ws);
     } catch (err) {
       closeWithError(this._lc, ws, err, PROTOCOL_ERROR);

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
@@ -37,8 +37,8 @@ import {ReplicationStatusPublisher} from '../replicator/replication-status.ts';
 import {
   getSubscriptionState,
   initReplicationState,
-  type SubscriptionState,
   updateReplicationWatermark,
+  type SubscriptionState,
 } from '../replicator/schema/replication-state.ts';
 import {ReplicationMessages} from '../replicator/test-utils.ts';
 import {serializeChangeStreamData} from './change-log-codec.ts';
@@ -56,6 +56,7 @@ import * as ErrorType from './error-type-enum.ts';
 import {Forwarder} from './forwarder.ts';
 import {initChangeStreamerSchema} from './schema/init.ts';
 import {AutoResetSignal, ensureReplicationConfig} from './schema/tables.ts';
+import type {SnapshotMessage} from './snapshot.ts';
 import {SQLiteChangeLogCatchup} from './sqlite-change-log-catchup.ts';
 import {SQLiteChangeLogReader} from './sqlite-change-log-reader.ts';
 import {SQLiteChangeLogWriter} from './sqlite-change-log-writer.ts';
@@ -123,6 +124,7 @@ describe('change-streamer/service', () => {
       ReplicationStatusPublisher.forTesting(),
       replicaConfig,
       null,
+      null,
       true,
       opts,
       setTimeoutFn as unknown as typeof setTimeout,
@@ -143,6 +145,56 @@ describe('change-streamer/service', () => {
       }
     })();
     return queue;
+  }
+
+  function drainSnapshotMessages(
+    sub: Source<SnapshotMessage>,
+  ): Queue<SnapshotMessage> {
+    const queue = new Queue<SnapshotMessage>();
+    void (async () => {
+      for await (const msg of sub) {
+        queue.enqueue(msg);
+      }
+    })();
+    return queue;
+  }
+
+  // Creates and runs a second ChangeStreamerImpl configured with a
+  // `backupURL`, i.e. with snapshot reservations enabled. Callers that use
+  // this must first `await streamer.stop()` to release the default
+  // (backup-less) streamer's ownership of the change DB.
+  async function newBackupStreamer(
+    backupURL: string,
+    source: Partial<ChangeSource> = {},
+  ): Promise<ChangeStreamerService> {
+    const backupStreamer = await initializeStreamer(
+      lc,
+      shard,
+      'task-id',
+      'change.streamer:12345',
+      'ws',
+      sql,
+      {
+        startStream: () =>
+          Promise.resolve({
+            initialWatermark: '02',
+            changes: Subscription.create(),
+            acks: {push: () => {}},
+          }),
+        startLagReporter: () => Promise.resolve(null),
+        stop: () => Promise.resolve(),
+        ...source,
+      } satisfies ChangeSource,
+      ReplicationStatusPublisher.forTesting(),
+      replicaConfig,
+      {backupURL, litestreamVersion: 'legacy'},
+      null,
+      true,
+      opts,
+      setTimeoutFn as unknown as typeof setTimeout,
+    );
+    void backupStreamer.run();
+    return backupStreamer;
   }
 
   async function nextChange(sub: Queue<Downstream>) {
@@ -258,6 +310,7 @@ describe('change-streamer/service', () => {
       ReplicationStatusPublisher.forTesting(),
       replicaConfig,
       null,
+      null,
       true,
       {...opts, sqliteCatchup},
       setTimeoutFn as unknown as typeof setTimeout,
@@ -298,6 +351,7 @@ describe('change-streamer/service', () => {
       },
       ReplicationStatusPublisher.forTesting(),
       replicaConfig,
+      null,
       null,
       true,
       {
@@ -606,6 +660,7 @@ describe('change-streamer/service', () => {
       ReplicationStatusPublisher.forTesting(),
       replicaConfig,
       null,
+      null,
       true,
       {
         ...opts,
@@ -714,6 +769,7 @@ describe('change-streamer/service', () => {
       },
       ReplicationStatusPublisher.forTesting(),
       replicaConfig,
+      null,
       null,
       true,
       {
@@ -1087,6 +1143,7 @@ describe('change-streamer/service', () => {
       ReplicationStatusPublisher.forTesting(),
       replicaConfig,
       null,
+      null,
       true,
       {
         ...opts,
@@ -1421,13 +1478,6 @@ describe('change-streamer/service', () => {
       deleteChangeLogDB(catchupReplicaFile.path);
       catchupReplicaFile.delete();
     }
-  });
-
-  test('get empty changelog state', async () => {
-    expect(await streamer.getChangeLogState()).toEqual({
-      minWatermark: '01',
-      replicaVersion: '01',
-    });
   });
 
   test('immediate forwarding, transaction storage', async () => {
@@ -2140,11 +2190,6 @@ describe('change-streamer/service', () => {
       UPDATE "zoro_3/cdc"."replicationState" SET "lastWatermark" = '08';
     `.simple();
 
-    expect(await streamer.getChangeLogState()).toEqual({
-      replicaVersion: '01',
-      minWatermark: '01',
-    });
-
     // Start two subscribers: one at 06 and one at 04
     const sub1 = await streamer.subscribe({
       protocolVersion: PROTOCOL_VERSION,
@@ -2172,9 +2217,9 @@ describe('change-streamer/service', () => {
       await sql`SELECT watermark FROM "zoro_3/cdc"."changeLog"`.values(),
     ).toEqual([['01'], ['01'], ['03'], ['04'], ['05'], ['06'], ['07'], ['08']]);
 
-    // schedule a cleanups at 04 and 06
-    streamer.scheduleCleanup('06');
-    streamer.scheduleCleanup('04');
+    // Report the backup watermark as '06'. The purge floor is
+    // min(backupWatermark, current subscriber acks), which is '04' (sub2).
+    streamer.trackBackupWatermark('06');
 
     expect(setTimeoutFn).toHaveBeenCalledTimes(1);
     expect(setTimeoutFn.mock.calls[0][1]).toBe(30000);
@@ -2221,13 +2266,8 @@ describe('change-streamer/service', () => {
       ],
     });
 
-    expect(await streamer.getChangeLogState()).toEqual({
-      replicaVersion: '01',
-      minWatermark: '06',
-    });
-
-    // No more timeouts should have been scheduled because both initialWatermarks
-    // were cleaned up.
+    // No more timeouts should have been scheduled because the purged
+    // watermark has caught up to the backup watermark.
     expect(setTimeoutFn).toHaveBeenCalledTimes(3);
 
     // New connections earlier than 06 should now be rejected.
@@ -2250,6 +2290,164 @@ describe('change-streamer/service', () => {
         message: 'earliest supported watermark is 06 (requested 04)',
       },
     ]);
+  });
+
+  test('startSnapshotReservation throws when backups are not configured', async () => {
+    // The default `streamer` fixture is initialized with a `null` backupURL.
+    await expect(
+      streamer.startSnapshotReservation('view-syncer-1'),
+    ).rejects.toThrow('backups are not configured');
+  });
+
+  test('startSnapshotReservation withholds status until a backup watermark is tracked', async () => {
+    await streamer.stop();
+    const backupStreamer = await newBackupStreamer('s3://foo/bar');
+
+    const reservation =
+      await backupStreamer.startSnapshotReservation('view-syncer-1');
+    const messages = drainSnapshotMessages(reservation);
+
+    // No backup watermark has been tracked yet, so the reservation stays
+    // open with no status pushed.
+    const NO_MESSAGE = Symbol('no-message');
+    expect(
+      await messages.dequeue(NO_MESSAGE as unknown as SnapshotMessage, 50),
+    ).toBe(NO_MESSAGE);
+
+    backupStreamer.trackBackupWatermark('05');
+
+    expect(await messages.dequeue()).toEqual([
+      'status',
+      {
+        tag: 'status',
+        backupURL: 's3://foo/bar',
+        replicaVersion: REPLICA_VERSION,
+        minWatermark: REPLICA_VERSION,
+      },
+    ]);
+
+    await backupStreamer.stop();
+  });
+
+  test('startSnapshotReservation immediately confirms once a backup watermark is known', async () => {
+    await streamer.stop();
+    const backupStreamer = await newBackupStreamer('s3://foo/bar');
+
+    backupStreamer.trackBackupWatermark('05');
+
+    const reservation =
+      await backupStreamer.startSnapshotReservation('view-syncer-1');
+    expect(await drainSnapshotMessages(reservation).dequeue()).toEqual([
+      'status',
+      {
+        tag: 'status',
+        backupURL: 's3://foo/bar',
+        replicaVersion: REPLICA_VERSION,
+        minWatermark: REPLICA_VERSION,
+      },
+    ]);
+
+    await backupStreamer.stop();
+  });
+
+  test('subscribe() closes a pending snapshot reservation for the same taskID', async () => {
+    await streamer.stop();
+    const backupStreamer = await newBackupStreamer('s3://foo/bar');
+
+    const reservation =
+      await backupStreamer.startSnapshotReservation('view-syncer-1');
+
+    await backupStreamer.subscribe({
+      protocolVersion: PROTOCOL_VERSION,
+      taskID: 'view-syncer-1',
+      id: 'myid1',
+      mode: 'serving',
+      watermark: '05',
+      replicaVersion: REPLICA_VERSION,
+      initial: true,
+      logsChangeStream: false,
+    });
+
+    // The reservation's connection is torn down once its taskID subscribes
+    // to the change stream: its iteration completes rather than hanging
+    // open.
+    const {done} = await reservation[Symbol.asyncIterator]().next();
+    expect(done).toBe(true);
+
+    await backupStreamer.stop();
+  });
+
+  test('a snapshot reservation limits the purge floor', async () => {
+    // Free up ownership of the change DB for the backup-enabled streamer
+    // that this test needs (the default `streamer` fixture has no backup).
+    await streamer.stop();
+
+    await sql`
+      INSERT INTO "zoro_3/cdc"."changeLog" (watermark, pos, change) VALUES ('03', 0, '{"tag":"begin"}'::json);
+      INSERT INTO "zoro_3/cdc"."changeLog" (watermark, pos, change) VALUES ('04', 0, '{"tag":"commit"}'::json);
+      INSERT INTO "zoro_3/cdc"."changeLog" (watermark, pos, change) VALUES ('05', 0, '{"tag":"begin"}'::json);
+      INSERT INTO "zoro_3/cdc"."changeLog" (watermark, pos, change) VALUES ('06', 0, '{"tag":"commit"}'::json);
+      UPDATE "zoro_3/cdc"."replicationState" SET "lastWatermark" = '06';
+    `.simple();
+
+    const backupStreamer = await newBackupStreamer('s3://foo/bar');
+
+    // A view-syncer reserves a snapshot while it downloads the backup.
+    const reservation =
+      await backupStreamer.startSnapshotReservation('view-syncer-1');
+    const reservationMessages = drainSnapshotMessages(reservation);
+
+    // A different subscriber is already fully caught up at '06'.
+    const sub1 = await backupStreamer.subscribe({
+      protocolVersion: PROTOCOL_VERSION,
+      taskID: 'other-task',
+      id: 'myid1',
+      mode: 'serving',
+      watermark: '06',
+      replicaVersion: REPLICA_VERSION,
+      initial: true,
+      logsChangeStream: false,
+    });
+    drainToQueue(sub1);
+
+    // Tracking the backup watermark confirms the reservation at the
+    // change-log's current minimum ('01', since nothing has been purged
+    // yet), even though the backup and the other subscriber are both at
+    // '06'.
+    backupStreamer.trackBackupWatermark('06');
+    expect(await reservationMessages.dequeue()).toEqual([
+      'status',
+      {
+        tag: 'status',
+        backupURL: 's3://foo/bar',
+        replicaVersion: REPLICA_VERSION,
+        minWatermark: '01',
+      },
+    ]);
+    expect(setTimeoutFn).toHaveBeenCalledTimes(1);
+
+    // The open reservation pins the purge floor at '01': nothing new is
+    // deleted even though the backup and the other subscriber are at '06'.
+    await (setTimeoutFn.mock.calls[0][0]() as unknown as Promise<void>);
+    expect(
+      await sql`SELECT watermark FROM "zoro_3/cdc"."changeLog"`.values(),
+    ).toEqual([['01'], ['01'], ['03'], ['04'], ['05'], ['06']]);
+    // Purging hasn't yet caught up to the backup watermark, so cleanup is
+    // rescheduled.
+    expect(setTimeoutFn).toHaveBeenCalledTimes(2);
+
+    // Releasing the reservation (e.g. the snapshot connection is dropped)
+    // lets the next purge proceed all the way to the backup watermark.
+    reservation.cancel();
+    await (setTimeoutFn.mock.calls[1][0]() as unknown as Promise<void>);
+    expect(
+      await sql`SELECT watermark FROM "zoro_3/cdc"."changeLog"`.values(),
+    ).toEqual([['06']]);
+    // The purged watermark now equals the backup watermark, so no further
+    // cleanup is scheduled.
+    expect(setTimeoutFn).toHaveBeenCalledTimes(2);
+
+    await backupStreamer.stop();
   });
 
   test('wrong replica version', async () => {
@@ -2298,6 +2496,7 @@ describe('change-streamer/service', () => {
       ReplicationStatusPublisher.forTesting(),
       replicaConfig,
       null,
+      null,
       true,
       opts,
     );
@@ -2339,6 +2538,7 @@ describe('change-streamer/service', () => {
       ReplicationStatusPublisher.forTesting(),
       replicaConfig,
       null,
+      null,
       true,
       opts,
     );
@@ -2362,6 +2562,7 @@ describe('change-streamer/service', () => {
       source,
       ReplicationStatusPublisher.forTesting(),
       replicaConfig,
+      null,
       null,
       true,
       opts,
@@ -2400,6 +2601,7 @@ describe('change-streamer/service', () => {
       },
       ReplicationStatusPublisher.forTesting(),
       replicaConfig,
+      null,
       lock,
       true,
       opts,
@@ -2444,6 +2646,7 @@ describe('change-streamer/service', () => {
       ReplicationStatusPublisher.forTesting(),
       replicaConfig,
       null,
+      null,
       true,
       opts,
     );
@@ -2485,6 +2688,7 @@ describe('change-streamer/service', () => {
       source,
       ReplicationStatusPublisher.forTesting(),
       replicaConfig,
+      null,
       null,
       true,
       opts,
@@ -2544,6 +2748,7 @@ describe('change-streamer/service', () => {
       source,
       ReplicationStatusPublisher.forTesting(),
       replicaConfig,
+      null,
       null,
       true,
       opts,
@@ -2620,6 +2825,7 @@ describe('change-streamer/service', () => {
       source,
       ReplicationStatusPublisher.forTesting(),
       replicaConfig,
+      null,
       null,
       true,
       opts,

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
@@ -2316,13 +2316,16 @@ describe('change-streamer/service', () => {
 
     backupStreamer.trackBackupWatermark('05');
 
+    // The confirmed minWatermark is the backup watermark itself ('05'),
+    // since it is later than the change-log's actual minimum (the initial
+    // watermark, REPLICA_VERSION) -- the normal, expected case.
     expect(await messages.dequeue()).toEqual([
       'status',
       {
         tag: 'status',
         backupURL: 's3://foo/bar',
         replicaVersion: REPLICA_VERSION,
-        minWatermark: REPLICA_VERSION,
+        minWatermark: '05',
       },
     ]);
 
@@ -2343,7 +2346,7 @@ describe('change-streamer/service', () => {
         tag: 'status',
         backupURL: 's3://foo/bar',
         replicaVersion: REPLICA_VERSION,
-        minWatermark: REPLICA_VERSION,
+        minWatermark: '05',
       },
     ]);
 
@@ -2377,7 +2380,7 @@ describe('change-streamer/service', () => {
     await backupStreamer.stop();
   });
 
-  test('a snapshot reservation limits the purge floor', async () => {
+  test('a confirmed snapshot reservation does not hold back purging below the backup watermark', async () => {
     // Free up ownership of the change DB for the backup-enabled streamer
     // that this test needs (the default `streamer` fixture has no backup).
     await streamer.stop();
@@ -2393,59 +2396,79 @@ describe('change-streamer/service', () => {
     const backupStreamer = await newBackupStreamer('s3://foo/bar');
 
     // A view-syncer reserves a snapshot while it downloads the backup.
+    // There are no other subscribers yet.
     const reservation =
       await backupStreamer.startSnapshotReservation('view-syncer-1');
-    const reservationMessages = drainSnapshotMessages(reservation);
+    const messages = drainSnapshotMessages(reservation);
 
-    // A different subscriber is already fully caught up at '06'.
-    const sub1 = await backupStreamer.subscribe({
-      protocolVersion: PROTOCOL_VERSION,
-      taskID: 'other-task',
-      id: 'myid1',
-      mode: 'serving',
-      watermark: '06',
-      replicaVersion: REPLICA_VERSION,
-      initial: true,
-      logsChangeStream: false,
-    });
-    drainToQueue(sub1);
-
-    // Tracking the backup watermark confirms the reservation at the
-    // change-log's current minimum ('01', since nothing has been purged
-    // yet), even though the backup and the other subscriber are both at
-    // '06'.
     backupStreamer.trackBackupWatermark('06');
-    expect(await reservationMessages.dequeue()).toEqual([
+
+    // Confirmed at the backup watermark ('06'), not the change-log's much
+    // older actual minimum ('01').
+    expect(await messages.dequeue()).toEqual([
       'status',
       {
         tag: 'status',
         backupURL: 's3://foo/bar',
         replicaVersion: REPLICA_VERSION,
-        minWatermark: '01',
+        minWatermark: '06',
       },
     ]);
     expect(setTimeoutFn).toHaveBeenCalledTimes(1);
 
-    // The open reservation pins the purge floor at '01': nothing new is
-    // deleted even though the backup and the other subscriber are at '06'.
+    // Even with no other subscribers, the confirmed reservation (rather
+    // than making `current` empty and bailing out) lets the purge proceed
+    // all the way to the backup watermark: it no longer pins the floor at
+    // a stale minWatermark.
     await (setTimeoutFn.mock.calls[0][0]() as unknown as Promise<void>);
     expect(
       await sql`SELECT watermark FROM "zoro_3/cdc"."changeLog"`.values(),
-    ).toEqual([['01'], ['01'], ['03'], ['04'], ['05'], ['06']]);
-    // Purging hasn't yet caught up to the backup watermark, so cleanup is
-    // rescheduled.
-    expect(setTimeoutFn).toHaveBeenCalledTimes(2);
-
-    // Releasing the reservation (e.g. the snapshot connection is dropped)
-    // lets the next purge proceed all the way to the backup watermark.
-    reservation.cancel();
-    await (setTimeoutFn.mock.calls[1][0]() as unknown as Promise<void>);
-    expect(
-      await sql`SELECT watermark FROM "zoro_3/cdc"."changeLog"`.values(),
     ).toEqual([['06']]);
-    // The purged watermark now equals the backup watermark, so no further
+
+    // Purging caught all the way up to the backup watermark, so no further
     // cleanup is scheduled.
-    expect(setTimeoutFn).toHaveBeenCalledTimes(2);
+    expect(setTimeoutFn).toHaveBeenCalledTimes(1);
+
+    await backupStreamer.stop();
+  });
+
+  test('does not confirm reservation if the change-log minWatermark has unexpectedly advanced past the backup watermark', async () => {
+    await streamer.stop();
+
+    // Simulate the change-log having been purged past what the (stale)
+    // reported backup watermark claims -- not expected if cleanup logic is
+    // correct, but handled defensively rather than confirming a watermark
+    // that is no longer available for catchup.
+    await sql`
+      DELETE FROM "zoro_3/cdc"."changeLog";
+      INSERT INTO "zoro_3/cdc"."changeLog" (watermark, pos, change) VALUES ('05', 0, '{"tag":"begin"}'::json);
+      INSERT INTO "zoro_3/cdc"."changeLog" (watermark, pos, change) VALUES ('06', 0, '{"tag":"commit"}'::json);
+    `.simple();
+
+    const backupStreamer = await newBackupStreamer('s3://foo/bar');
+
+    const reservation =
+      await backupStreamer.startSnapshotReservation('view-syncer-1');
+    const messages = drainSnapshotMessages(reservation);
+
+    // The reported backup watermark ('03') is older than the change-log's
+    // actual minimum ('05').
+    backupStreamer.trackBackupWatermark('03');
+
+    const NO_MESSAGE = Symbol('no-message');
+    expect(
+      await messages.dequeue(NO_MESSAGE as unknown as SnapshotMessage, 50),
+    ).toBe(NO_MESSAGE);
+
+    expect(
+      logSink.messages.some(
+        ([level, , args]) =>
+          level === 'error' &&
+          args.some(
+            arg => typeof arg === 'string' && arg.includes('is later than'),
+          ),
+      ),
+    ).toBe(true);
 
     await backupStreamer.stop();
   });

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -739,7 +739,18 @@ class ChangeStreamerImpl implements ChangeStreamerService {
   async #confirmReservations() {
     if (this.#backupWatermark && this.#reservations?.confirmationsRequired()) {
       const {replicaVersion, minWatermark} = await this.#getChangeLogState();
-      this.#reservations?.confirm(replicaVersion, minWatermark);
+      if (minWatermark <= this.#backupWatermark) {
+        this.#reservations?.confirm(replicaVersion, this.#backupWatermark);
+      } else {
+        // Something is wrong here ... the change-log should not have been
+        // purged past the backup watermark. If we confirm the reservation,
+        // we may not be able to catch up from the backup that the requester
+        // restores.
+        this.#lc.error?.(
+          `change-log minWatermark ${minWatermark} is later than backupWatermark ${this.#backupWatermark}. ` +
+            `Delaying confirmation of snapshot reservation until next backup.`,
+        );
+      }
     }
   }
 

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -22,10 +22,11 @@ import type {
   ChangeStream,
 } from '../change-source/change-source.ts';
 import {
-  type ChangeStreamData,
   type ChangeStreamControl,
+  type ChangeStreamData,
   type Rollback,
 } from '../change-source/protocol/current/downstream.ts';
+import type {LitestreamVersion} from '../litestream/metrics.ts';
 import {
   publishReplicationError,
   replicationStatusError,
@@ -38,10 +39,10 @@ import {
   UnrecoverableError,
 } from '../running-state.ts';
 import {
-  type WatermarkedChange,
   type ChangeStreamerService,
   type Status,
   type SubscriberContext,
+  type WatermarkedChange,
 } from './change-streamer.ts';
 import * as ErrorType from './error-type-enum.ts';
 import {Forwarder} from './forwarder.ts';
@@ -50,6 +51,8 @@ import {
   ensureReplicationConfig,
   markResetRequired,
 } from './schema/tables.ts';
+import {SnapshotReservations} from './snapshot-reservations.ts';
+import type {SnapshotMessage} from './snapshot.ts';
 import {
   SQLiteChangeLogCatchup,
   type SQLiteChangeLogCleanupGuard,
@@ -65,6 +68,11 @@ import {
   type TuningOptions as StorerOptions,
 } from './storer.ts';
 import {Subscriber} from './subscriber.ts';
+
+export type BackupConfig = {
+  backupURL: string;
+  litestreamVersion: LitestreamVersion;
+};
 
 export type SQLiteCatchupOptions = {
   /** The change-log database, i.e. `changeLogFileName(replicaFile)`. */
@@ -120,6 +128,7 @@ export async function initializeStreamer(
   changeSource: ChangeSource,
   replicationStatusPublisher: ReplicationStatusPublisher,
   subscriptionState: SubscriptionState,
+  backupConfig: BackupConfig | null,
   purgeLock: PurgeLock | null,
   autoReset: boolean,
   opts: TuningOptions,
@@ -146,6 +155,7 @@ export async function initializeStreamer(
     replicaVersion,
     changeSource,
     replicationStatusPublisher,
+    backupConfig,
     purgeLock,
     autoReset,
     opts,
@@ -310,13 +320,13 @@ class ChangeStreamerImpl implements ChangeStreamerService {
   readonly #source: ChangeSource;
   readonly #storer: Storer;
   readonly #forwarder: Forwarder;
+  readonly #reservations: SnapshotReservations | undefined;
   readonly #replicationStatusPublisher: ReplicationStatusPublisher;
   readonly #sqliteCatchupOptions: SQLiteCatchupOptions | undefined;
   readonly #changeLogWriter: SQLiteChangeLogWriter | undefined;
 
   readonly #autoReset: boolean;
   readonly #state: RunningState;
-  readonly #initialWatermarks = new Set<string>();
 
   // Starting the (Postgres) ChangeStream results in killing the previous
   // Postgres subscriber, potentially creating a gap in which the old
@@ -350,7 +360,10 @@ class ChangeStreamerImpl implements ChangeStreamerService {
 
   #latestStatus: Status;
   #latestLagReportCommitTimeMs = 0;
+  #backupWatermark: string | undefined;
+  #purgedWatermark: string = '';
   #purgeLock: PurgeLock | null;
+  #purgeTimer: NodeJS.Timeout | undefined;
   #stream: ChangeStream | undefined;
   #sqliteCatchup: SQLiteChangeLogCatchup | undefined;
   #changeLogUnavailableSince: number | undefined;
@@ -370,6 +383,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
     replicaVersion: string,
     source: ChangeSource,
     replicationStatusPublisher: ReplicationStatusPublisher,
+    backupConfig: BackupConfig | null,
     initialPurgeLock: PurgeLock | null,
     autoReset: boolean,
     opts: TuningOptions,
@@ -398,6 +412,9 @@ class ChangeStreamerImpl implements ChangeStreamerService {
         opts.flowControlConsensusPaddingSeconds,
       eventDrivenRelease: opts.flowControlEventDrivenRelease,
     });
+    this.#reservations = backupConfig
+      ? new SnapshotReservations(lc, backupConfig)
+      : undefined;
     this.#replicationStatusPublisher = replicationStatusPublisher;
     this.#sqliteCatchupOptions = opts.sqliteCatchup;
     this.#changeLogWriter = opts.sqliteChangeLogWriter
@@ -683,19 +700,63 @@ class ChangeStreamerImpl implements ChangeStreamerService {
         this.#storer.catchup(subscriber, mode);
       }
     }
+    // Any snapshot reservation held by this task can be closed now that
+    // it is subscribed to the change stream.
+    this.#reservations?.close(ctx.taskID);
     return downstream;
   }
 
-  scheduleCleanup(watermark: string) {
-    const origSize = this.#initialWatermarks.size;
-    this.#initialWatermarks.add(watermark);
+  async startSnapshotReservation(
+    taskID: string,
+  ): Promise<Source<SnapshotMessage>> {
+    if (!this.#reservations) {
+      throw new Error('backups are not configured');
+    }
+    const downstream = this.#reservations.open(taskID);
 
-    if (origSize === 0) {
-      this.#state.setTimeout(() => this.#purgeOldChanges(), CLEANUP_DELAY_MS);
+    // If a backup has been confirmed, immediately confirm the reservation.
+    await this.#confirmReservations();
+    return downstream;
+  }
+
+  trackBackupWatermark(watermark: string) {
+    this.#backupWatermark = watermark;
+    // TODO: in RMv2, the backup watermark immediately acks upstream
+    //       so that (in PG) the confirmed_flush_lsn can advance. The
+    //       cleanup of the change-log can trail that based on where
+    //       current subscribers are, and our policy for how much buffer
+    //       is kept around for reconnecting view-syncers.
+    this.#maybeScheduleCleanup();
+
+    // Confirm any waiting reservations now that a backup has been confirmed.
+    // Note that this is asynchronous and best effort; if it fails, the watermark
+    // is still "tracked" and the confirmation will be retried on the next backup.
+    void this.#confirmReservations().catch(e =>
+      this.#lc.warn?.(`error confirming snapshot reservation`, e),
+    );
+  }
+
+  async #confirmReservations() {
+    if (this.#backupWatermark && this.#reservations?.confirmationsRequired()) {
+      const {replicaVersion, minWatermark} = await this.#getChangeLogState();
+      this.#reservations?.confirm(replicaVersion, minWatermark);
     }
   }
 
-  async getChangeLogState(): Promise<{
+  #maybeScheduleCleanup() {
+    if (
+      this.#purgeTimer === undefined &&
+      this.#backupWatermark !== undefined &&
+      this.#purgedWatermark < this.#backupWatermark
+    ) {
+      this.#purgeTimer = this.#state.setTimeout(() => {
+        this.#purgeTimer = undefined;
+        return this.#purgeOldChanges();
+      }, CLEANUP_DELAY_MS);
+    }
+  }
+
+  async #getChangeLogState(): Promise<{
     replicaVersion: string;
     minWatermark: string;
   }> {
@@ -717,42 +778,45 @@ class ChangeStreamerImpl implements ChangeStreamerService {
    * to run in a timeout.
    */
   async #purgeOldChanges(): Promise<void> {
-    const initial = [...this.#initialWatermarks];
-    if (initial.length === 0) {
-      this.#lc.warn?.('No initial watermarks to check for cleanup'); // Not expected.
-      return;
-    }
-    const current = [...this.#forwarder.getAcks()];
-    if (current.length === 0) {
-      // Also not expected, but possible (e.g. subscriber connects, then disconnects).
-      // Bail to be safe.
-      this.#lc.warn?.('No subscribers to confirm cleanup');
+    if (!this.#backupWatermark) {
+      this.#lc.warn?.('No backup watermark tracked for cleanup'); // Not expected.
       return;
     }
     try {
-      const earliestInitial = min(...(initial as AtLeastOne<LexiVersion>));
-      const earliestCurrent = min(...(current as AtLeastOne<LexiVersion>));
-      if (earliestCurrent < earliestInitial) {
-        this.#lc.info?.(
-          `At least one client is behind backup (${earliestCurrent} < ${earliestInitial})`,
-        );
-      } else {
-        this.#lc.info?.(`Purging changes before ${earliestInitial} ...`);
+      const current = [
+        ...this.#forwarder.getAcks(),
+        ...(this.#reservations?.getReservedWatermarks() ?? []),
+      ];
+      if (current.length === 0) {
+        // Also not expected, but possible (e.g. subscriber connects, then disconnects).
+        // Bail to be safe.
+        this.#lc.warn?.('No subscribers to confirm cleanup');
+        return;
+      }
+      const purgeWatermark = min(
+        this.#backupWatermark,
+        ...(current as AtLeastOne<LexiVersion>),
+      );
+      if (purgeWatermark > this.#purgedWatermark) {
+        if (purgeWatermark < this.#backupWatermark) {
+          this.#lc.info?.(
+            `At least one client is behind backup ${this.#backupWatermark}`,
+            {watermarks: current},
+          );
+        }
+        this.#lc.info?.(`Purging changes before ${purgeWatermark} ...`);
         const start = performance.now();
-        const deleted = await this.#storer.purgeRecordsBefore(earliestInitial);
+        const deleted = await this.#storer.purgeRecordsBefore(purgeWatermark);
         const elapsed = (performance.now() - start).toFixed(2);
         this.#lc.info?.(
-          `Purged ${deleted} changes before ${earliestInitial} (${elapsed} ms)`,
+          `Purged ${deleted} changes before ${purgeWatermark} (${elapsed} ms)`,
         );
-        this.#initialWatermarks.delete(earliestInitial);
+        this.#purgedWatermark = purgeWatermark;
       }
     } catch (e) {
       this.#lc.warn?.(`error purging change log`, e);
     } finally {
-      if (this.#initialWatermarks.size) {
-        // If there are unpurged watermarks to check, schedule the next purge.
-        this.#state.setTimeout(() => this.#purgeOldChanges(), CLEANUP_DELAY_MS);
-      }
+      this.#maybeScheduleCleanup();
     }
   }
 

--- a/packages/zero-cache/src/services/change-streamer/change-streamer.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer.ts
@@ -9,6 +9,7 @@ import type {ReplicatorMode} from '../replicator/replicator.ts';
 import {changeSourceTimingsSchema} from '../replicator/reporter/report-schema.ts';
 import type {Service} from '../service.ts';
 import * as ErrorType from './error-type-enum.ts';
+import type {SnapshotMessage} from './snapshot.ts';
 
 type ErrorType = Enum<typeof ErrorType>;
 
@@ -239,14 +240,25 @@ export interface ChangeStreamerService
   subscribe(ctx: SubscriberContext): Promise<Source<string>>;
 
   /**
-   * Notifies the change streamer of a watermark that has been backed up,
-   * indicating that changes before the watermark can be purged if active
-   * subscribers have progressed beyond the watermark.
+   * Starts a snapshot reservation to preserve change-log entries while
+   * a soon-to-be-subscriber downloads the current replica backup. Once
+   * the change-streamer knows that a backup is available
+   * (via {@link trackBackupWatermark}), it sends a confirmation
+   * SnapshotMessage and reserves the corresponding entries in the change-log
+   * until the client with that `taskID` subscribes, or if the snapshot
+   * connection terminates.
    */
-  scheduleCleanup(watermark: string): void;
+  startSnapshotReservation(taskID: string): Promise<Source<SnapshotMessage>>;
 
-  getChangeLogState(): Promise<{
-    replicaVersion: string;
-    minWatermark: string;
-  }>;
+  /**
+   * Informs the change-streamer of the watermark up to which the replica has
+   * been backed up. This serves two purposes:
+   * - It serves as the maximum watermark up to which the change-log can be
+   *   purged. Note that the change-streamer also takes into account the
+   *   positions of its subscribers and snapshot reservations when purging
+   *   changes in the change-log.
+   * - In RMv2, this ACK's the upstream change-source to allow its buffer of
+   *   changes (e.g. the replication_slot) to advance.
+   */
+  trackBackupWatermark(watermark: string): void;
 }

--- a/packages/zero-cache/src/services/change-streamer/litestream3-backup-monitor.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/litestream3-backup-monitor.test.ts
@@ -3,26 +3,18 @@ import nock from 'nock';
 import {beforeAll, beforeEach, describe, expect, test, vi} from 'vitest';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
 import {DbFile} from '../../test/lite.ts';
-import type {Subscription} from '../../types/subscription.ts';
 import {initReplicationState} from '../replicator/schema/replication-state.ts';
 import type {ChangeStreamerService} from './change-streamer.ts';
 import {
   INITIAL_BACKUP_GRACE_MS_PER_UNIT,
   Litestream3BackupMonitor,
-  RESTORABLE_BACKUP_POLL_INTERVAL_MS,
   WEDGED_SHUTDOWN_GRACE_MS,
 } from './litestream3-backup-monitor.ts';
-import type {SnapshotMessage} from './snapshot.ts';
 
 describe('change-streamer/litestream3-backup-monitor', () => {
   const scheduled: string[] = [];
   const changeStreamer = {
-    scheduleCleanup: (watermark: string) => scheduled.push(watermark),
-    getChangeLogState: () =>
-      Promise.resolve({
-        replicaVersion: '123',
-        minWatermark: '1ab',
-      }),
+    trackBackupWatermark: (watermark: string) => scheduled.push(watermark),
   };
   let metricsResponse = 'unconfigured';
   let monitor: Litestream3BackupMonitor;
@@ -75,7 +67,6 @@ litestream_replica_validation_total{db="/tmp/zbugs-sync-replica.db",name="file",
       's3://foo/bar',
       'http://localhost:4850/metrics',
       changeStreamer as unknown as ChangeStreamerService,
-      100_000, // 100 seconds
       verifyBackupState,
     );
 
@@ -91,62 +82,22 @@ litestream_replica_validation_total{db="/tmp/zbugs-sync-replica.db",name="file",
     };
   });
 
-  function getFirstMessage(
-    sub: Subscription<SnapshotMessage>,
-  ): Promise<SnapshotMessage> {
-    const {promise, resolve} = resolver<SnapshotMessage>();
-    void (async function () {
-      for await (const msg of sub) {
-        resolve(msg);
-        // To simulate an open connection, do not exit the loop.
-      }
-    })();
-    return promise;
-  }
-
-  test('schedules overdue cleanup', async () => {
-    setMetricsResponse('618ocqq8', '1.74545644476593e+09');
-
-    await monitor.checkWatermarksAndScheduleCleanup();
-
-    expect(scheduled).toEqual(['618ocqq8']);
-  });
-
-  test('schedules new cleanup at the right time', async () => {
-    const time = Date.UTC(2025, 3, 24);
-    vi.setSystemTime(time);
-    const nowSeconds = (Date.now() / 1000).toPrecision(9);
-    setMetricsResponse('618p0bw8', nowSeconds);
-
-    await monitor.checkWatermarksAndScheduleCleanup();
-
-    vi.setSystemTime(time + 99_999);
-    await monitor.checkWatermarksAndScheduleCleanup();
-    expect(scheduled).toEqual([]);
-
-    vi.setSystemTime(time + 100_000);
-    await monitor.checkWatermarksAndScheduleCleanup();
-    expect(scheduled).toEqual(['618p0bw8']);
-  });
-
-  test('drops obsolete watermarks', async () => {
+  test('schedules cleanup', async () => {
     const time = Date.UTC(2025, 3, 24);
     vi.setSystemTime(time);
 
     const t1 = (Date.now() / 1000).toPrecision(9);
     setMetricsResponse('618ocqq8', t1);
+
     await monitor.checkWatermarksAndScheduleCleanup();
-    expect(scheduled).toEqual([]);
+    expect(scheduled).toEqual(['618ocqq8']);
 
     vi.setSystemTime(time + 10_000);
     const t2 = (Date.now() / 1000).toPrecision(9);
     setMetricsResponse('618p0bw8', t2);
-    await monitor.checkWatermarksAndScheduleCleanup();
-    expect(scheduled).toEqual([]);
 
-    vi.setSystemTime(time + 110_000);
     await monitor.checkWatermarksAndScheduleCleanup();
-    expect(scheduled).toEqual(['618p0bw8']);
+    expect(scheduled).toEqual(['618ocqq8', '618p0bw8']);
   });
 
   test('blocks purge when actual backup is older than claimed', async () => {
@@ -159,13 +110,6 @@ litestream_replica_validation_total{db="/tmp/zbugs-sync-replica.db",name="file",
     // object actually uploaded to the backup destination is 10 minutes old.
     lastActualBackupTime = () => Promise.resolve(new Date(time - 10 * 60_000));
 
-    await monitor.checkWatermarksAndScheduleCleanup();
-    expect(scheduled).toEqual([]);
-    expect(verifyBackupState).toHaveBeenCalledTimes(0);
-
-    // The cleanup delay has passed, but the purge must be blocked because
-    // the claimed backup time is not corroborated by an actual upload.
-    vi.setSystemTime(time + 100_000);
     await monitor.checkWatermarksAndScheduleCleanup();
     expect(scheduled).toEqual([]);
     expect(verifyBackupState).toHaveBeenCalledTimes(1);
@@ -193,20 +137,12 @@ litestream_replica_validation_total{db="/tmp/zbugs-sync-replica.db",name="file",
     const t1 = (Date.now() / 1000).toPrecision(9);
     setMetricsResponse('618ocqq8', t1);
     await monitor.checkWatermarksAndScheduleCleanup();
-    expect(scheduled).toEqual([]);
+    expect(scheduled).toEqual(['618ocqq8']);
 
-    // The first watermark (claimed at `time`) becomes eligible and is
-    // confirmed by the actual backup state.
+    // The second watermark is after the confirmed lastActualBackupTime.
     vi.setSystemTime(time + 10 * 60_000);
     const t2 = (Date.now() / 1000).toPrecision(9);
     setMetricsResponse('618p0bw8', t2);
-    await monitor.checkWatermarksAndScheduleCleanup();
-    expect(scheduled).toEqual(['618ocqq8']);
-
-    // Both watermarks have passed the cleanup delay, but the second one
-    // (claimed at time + 10 min) is not corroborated by the actual backup
-    // state (last actual upload at `time`), so it must not be purged.
-    vi.setSystemTime(time + 20 * 60_000);
     await monitor.checkWatermarksAndScheduleCleanup();
     expect(scheduled).toEqual(['618ocqq8']);
 
@@ -227,12 +163,13 @@ litestream_replica_validation_total{db="/tmp/zbugs-sync-replica.db",name="file",
 
     await monitor.checkWatermarksAndScheduleCleanup();
     expect(scheduled).toEqual([]);
+    expect(verifyBackupState).toHaveBeenCalledTimes(1);
 
     // Verification fails, so the purge is conservatively skipped.
     vi.setSystemTime(time + 100_000);
     await monitor.checkWatermarksAndScheduleCleanup();
     expect(scheduled).toEqual([]);
-    expect(verifyBackupState).toHaveBeenCalledTimes(1);
+    expect(verifyBackupState).toHaveBeenCalledTimes(2);
 
     // When verification recovers (and confirms the claim), the purge
     // proceeds.
@@ -245,20 +182,12 @@ litestream_replica_validation_total{db="/tmp/zbugs-sync-replica.db",name="file",
     const time = Date.UTC(2025, 3, 24);
     vi.setSystemTime(time);
 
-    const t1 = (Date.now() / 1000).toPrecision(9);
-    setMetricsResponse('618ocqq8', t1);
-    await monitor.checkWatermarksAndScheduleCleanup();
-
-    vi.setSystemTime(time + 10_000);
-    const t2 = (Date.now() / 1000).toPrecision(9);
-    setMetricsResponse('618p0bw8', t2);
-    await monitor.checkWatermarksAndScheduleCleanup();
-
     // The first purge verifies against the backup destination, which
     // reports a last actual upload time that also covers the second
     // watermark (within the clock-skew slack).
     lastActualBackupTime = () => Promise.resolve(new Date(time + 10_000));
-    vi.setSystemTime(time + 100_000);
+    const t1 = (Date.now() / 1000).toPrecision(9);
+    setMetricsResponse('618ocqq8', t1);
     await monitor.checkWatermarksAndScheduleCleanup();
     expect(scheduled).toEqual(['618ocqq8']);
     expect(verifyBackupState).toHaveBeenCalledTimes(1);
@@ -266,203 +195,12 @@ litestream_replica_validation_total{db="/tmp/zbugs-sync-replica.db",name="file",
     // The second watermark's claimed backup time is already confirmed by
     // the cached verification result, so the backup destination is not
     // consulted again.
-    vi.setSystemTime(time + 110_000);
+    vi.setSystemTime(time + 10_000);
+    const t2 = (Date.now() / 1000).toPrecision(9);
+    setMetricsResponse('618p0bw8', t2);
     await monitor.checkWatermarksAndScheduleCleanup();
     expect(scheduled).toEqual(['618ocqq8', '618p0bw8']);
     expect(verifyBackupState).toHaveBeenCalledTimes(1);
-  });
-
-  test('only keeps one reservation per id', async () => {
-    const sub1 = monitor.startSnapshotReservation('foo-bar');
-    expect(await getFirstMessage(sub1)).toEqual([
-      'status',
-      {
-        tag: 'status',
-        backupURL: 's3://foo/bar',
-        replicaVersion: '123',
-        minWatermark: '1ab',
-      },
-    ]);
-    expect(sub1.active).toBe(true);
-
-    const sub2 = monitor.startSnapshotReservation('bar-foo');
-    expect(await getFirstMessage(sub2)).toEqual([
-      'status',
-      {
-        tag: 'status',
-        backupURL: 's3://foo/bar',
-        replicaVersion: '123',
-        minWatermark: '1ab',
-      },
-    ]);
-    expect(sub1.active).toBe(true);
-    expect(sub2.active).toBe(true);
-
-    const sub3 = monitor.startSnapshotReservation('bar-foo');
-    expect(await getFirstMessage(sub3)).toEqual([
-      'status',
-      {
-        tag: 'status',
-        backupURL: 's3://foo/bar',
-        replicaVersion: '123',
-        minWatermark: '1ab',
-      },
-    ]);
-    expect(sub1.active).toBe(true);
-    expect(sub2.active).toBe(false);
-    expect(sub3.active).toBe(true);
-  });
-
-  test('withholds the snapshot status until a restorable backup exists', async () => {
-    // Cold start: no restorable backup yet, so verification rejects (as the
-    // litestream listing would while the initial snapshot is still uploading).
-    lastActualBackupTime = () =>
-      Promise.reject(new Error('no snapshots or WAL segments listed'));
-
-    const sub = monitor.startSnapshotReservation('view-syncer-1');
-    let status: SnapshotMessage | undefined;
-    void getFirstMessage(sub).then(m => (status = m));
-
-    // While no backup exists, the reservation is held open (still active) and
-    // no status is pushed, so the view-syncer stays unready instead of being
-    // told to restore a backup that does not yet exist.
-    await vi.advanceTimersByTimeAsync(RESTORABLE_BACKUP_POLL_INTERVAL_MS * 3);
-    expect(status).toBeUndefined();
-    expect(sub.active).toBe(true);
-    expect(verifyBackupState.mock.calls.length).toBeGreaterThan(1);
-
-    // The first backup lands; the next poll confirms it and the status is
-    // finally pushed.
-    lastActualBackupTime = () => Promise.resolve(new Date());
-    await vi.advanceTimersByTimeAsync(RESTORABLE_BACKUP_POLL_INTERVAL_MS);
-
-    expect(status).toEqual([
-      'status',
-      {
-        tag: 'status',
-        backupURL: 's3://foo/bar',
-        replicaVersion: '123',
-        minWatermark: '1ab',
-      },
-    ]);
-    expect(sub.active).toBe(true);
-  });
-
-  test('pushes the snapshot status immediately on a warm start', async () => {
-    // A restorable backup already exists (verification succeeds), so the
-    // status is pushed without waiting on any poll interval.
-    const sub = monitor.startSnapshotReservation('view-syncer-1');
-    expect(await getFirstMessage(sub)).toEqual([
-      'status',
-      {
-        tag: 'status',
-        backupURL: 's3://foo/bar',
-        replicaVersion: '123',
-        minWatermark: '1ab',
-      },
-    ]);
-  });
-
-  test('pauses cleanup during reservation', async () => {
-    const time = Date.UTC(2025, 3, 24);
-    vi.setSystemTime(time);
-    const nowSeconds = (Date.now() / 1000).toPrecision(9);
-    setMetricsResponse('618p0bw8', nowSeconds);
-
-    await monitor.checkWatermarksAndScheduleCleanup();
-
-    const sub = monitor.startSnapshotReservation('foo-bar');
-    expect(await getFirstMessage(sub)).toEqual([
-      'status',
-      {
-        tag: 'status',
-        backupURL: 's3://foo/bar',
-        replicaVersion: '123',
-        minWatermark: '1ab',
-      },
-    ]);
-
-    vi.setSystemTime(time + 100_000);
-    await monitor.checkWatermarksAndScheduleCleanup();
-    expect(scheduled).toEqual([]);
-
-    monitor.endReservation('foo-bar');
-    await monitor.checkWatermarksAndScheduleCleanup();
-    expect(scheduled).toEqual(['618p0bw8']);
-  });
-
-  test('extends cleanup delay due to reservation', async () => {
-    const time = Date.UTC(2025, 3, 24);
-    vi.setSystemTime(time);
-    const sub = monitor.startSnapshotReservation('boo-far');
-    expect(await getFirstMessage(sub)).toEqual([
-      'status',
-      {
-        tag: 'status',
-        backupURL: 's3://foo/bar',
-        replicaVersion: '123',
-        minWatermark: '1ab',
-      },
-    ]);
-
-    vi.setSystemTime(time + 50_000);
-    const nowSeconds = (Date.now() / 1000).toPrecision(9);
-    setMetricsResponse('618p0bw8', nowSeconds);
-
-    await monitor.checkWatermarksAndScheduleCleanup();
-    expect(scheduled).toEqual([]);
-
-    vi.setSystemTime(time + 125_000); // Reservation was held of 125 secs.
-    monitor.endReservation('boo-far');
-    await monitor.checkWatermarksAndScheduleCleanup();
-    expect(scheduled).toEqual([]);
-
-    // No cleanup should be scheduled, even though 100 seconds passed,
-    // as the delay should have been increased to 125 seconds.
-    vi.setSystemTime(time + 174_999);
-    await monitor.checkWatermarksAndScheduleCleanup();
-    expect(scheduled).toEqual([]);
-
-    vi.setSystemTime(time + 175_000);
-    await monitor.checkWatermarksAndScheduleCleanup();
-    expect(scheduled).toEqual(['618p0bw8']);
-  });
-
-  test('does not extend cleanup delay on prematurely terminated reservation', async () => {
-    const time = Date.UTC(2025, 3, 24);
-    vi.setSystemTime(time);
-    const sub = monitor.startSnapshotReservation('boo-far');
-    expect(await getFirstMessage(sub)).toEqual([
-      'status',
-      {
-        tag: 'status',
-        backupURL: 's3://foo/bar',
-        replicaVersion: '123',
-        minWatermark: '1ab',
-      },
-    ]);
-
-    vi.setSystemTime(time + 50_000);
-    const nowSeconds = (Date.now() / 1000).toPrecision(9);
-    setMetricsResponse('618p0bw8', nowSeconds);
-
-    await monitor.checkWatermarksAndScheduleCleanup();
-    expect(scheduled).toEqual([]);
-
-    // Hold the reservation for 125 secs but terminate unexpectedly.
-    // This should *not* result in increasing the cleanup delay.
-    vi.setSystemTime(time + 125_000);
-    sub.cancel();
-    await monitor.checkWatermarksAndScheduleCleanup();
-    expect(scheduled).toEqual([]);
-
-    vi.setSystemTime(time + 149_999);
-    await monitor.checkWatermarksAndScheduleCleanup();
-    expect(scheduled).toEqual([]);
-
-    vi.setSystemTime(time + 150_000); // delay should still be 100 secs
-    await monitor.checkWatermarksAndScheduleCleanup();
-    expect(scheduled).toEqual(['618p0bw8']);
   });
 
   test('aborts in-flight fetch on stop', async () => {
@@ -628,18 +366,8 @@ litestream_db_size{db="/tmp/zbugs-sync-replica.db"} 1e+06`;
     await Promise.resolve();
     expect(rejection).toBeUndefined();
 
-    // The first backup lands and a view-syncer reservation confirms it.
+    // The first backup lands.
     lastActualBackupTime = () => Promise.resolve(new Date());
-    const sub = monitor.startSnapshotReservation('view-syncer-1');
-    expect(await getFirstMessage(sub)).toEqual([
-      'status',
-      {
-        tag: 'status',
-        backupURL: 's3://foo/bar',
-        replicaVersion: '123',
-        minWatermark: '1ab',
-      },
-    ]);
 
     // Past the deadline, but since a restorable backup has been confirmed the
     // process keeps running.

--- a/packages/zero-cache/src/services/change-streamer/litestream3-backup-monitor.ts
+++ b/packages/zero-cache/src/services/change-streamer/litestream3-backup-monitor.ts
@@ -4,25 +4,20 @@ import {resolver} from '@rocicorp/resolver';
 import parsePrometheusTextFormat from 'parse-prometheus-text-format';
 import {must} from '../../../../shared/src/must.ts';
 import {promiseVoid} from '../../../../shared/src/resolved-promises.ts';
-import {sleep} from '../../../../shared/src/sleep.ts';
 import {Database} from '../../../../zqlite/src/db.ts';
 import {
   getOrCreateCounter,
   getOrCreateGauge,
 } from '../../observability/metrics.ts';
-import {Subscription} from '../../types/subscription.ts';
 import {
   litestreamBackupVerificationDuration,
   litestreamMonitorMetricAttrs,
-  litestreamSnapshotReservationDuration,
 } from '../litestream/metrics.ts';
 import {RunningState, UnrecoverableError} from '../running-state.ts';
 import type {BackupMonitor} from './backup-monitor.ts';
 import type {ChangeStreamerService} from './change-streamer.ts';
-import type {SnapshotMessage} from './snapshot.ts';
 
-export const CHECK_INTERVAL_MS = 60_000;
-const MIN_CLEANUP_DELAY_MS = 30_000;
+export const CHECK_INTERVAL_MS = 10_000;
 
 /**
  * Allowance for clock skew between the machine reporting litestream metrics
@@ -89,11 +84,6 @@ export const RESTORABLE_BACKUP_POLL_INTERVAL_MS = 10_000;
  */
 export type BackupStateVerifier = () => Promise<Date>;
 
-type Reservation = {
-  start: Date;
-  sub: Subscription<SnapshotMessage>;
-};
-
 /**
  * The Litestream3BackupMonitor polls the litestream "/metrics" endpoint to
  * track the watermark (label) value of the `litestream_replica_progress` gauge
@@ -143,7 +133,6 @@ export class Litestream3BackupMonitor implements BackupMonitor {
   readonly #changeStreamer: ChangeStreamerService;
   readonly #state = new RunningState(this.id);
 
-  readonly #reservations = new Map<string, Reservation>();
   readonly #watermarks = new Map<string, Date>();
 
   readonly #verifyBackupState: BackupStateVerifier;
@@ -177,7 +166,6 @@ export class Litestream3BackupMonitor implements BackupMonitor {
   // Epoch ms at which run() started, used to bound how long to wait for the
   // first restorable backup to appear. `null` until run() is called.
   #runStartTime: number | null = null;
-  #cleanupDelayMs: number;
   #checkMetricsTimer: NodeJS.Timeout | undefined;
 
   constructor(
@@ -186,7 +174,6 @@ export class Litestream3BackupMonitor implements BackupMonitor {
     backupURL: string,
     metricsEndpoint: string,
     changeStreamer: ChangeStreamerService,
-    initialCleanupDelayMs: number,
     verifyBackupState: BackupStateVerifier,
   ) {
     this.#lc = lc.withContext('component', this.id);
@@ -195,22 +182,11 @@ export class Litestream3BackupMonitor implements BackupMonitor {
     this.#metricsEndpoint = metricsEndpoint;
     this.#changeStreamer = changeStreamer;
     this.#verifyBackupState = verifyBackupState;
-    this.#cleanupDelayMs = Math.max(
-      initialCleanupDelayMs,
-      MIN_CLEANUP_DELAY_MS, // purely for peace of mind
-    );
-
-    this.#lc.info?.(
-      `backup monitor started ${initialCleanupDelayMs} ms after snapshot restore`,
-    );
   }
 
   run(): Promise<void> {
     this.#runStartTime = Date.now();
-    this.#lc.info?.(
-      `monitoring backups at ${this.#metricsEndpoint} with ` +
-        `${this.#cleanupDelayMs} ms cleanup delay`,
-    );
+    this.#lc.info?.(`monitoring backups at ${this.#metricsEndpoint}`);
     this.#checkMetricsTimer = setInterval(
       this.checkWatermarksAndScheduleCleanup,
       CHECK_INTERVAL_MS,
@@ -218,68 +194,6 @@ export class Litestream3BackupMonitor implements BackupMonitor {
     this.#initBackupLagMetric();
     // Resolves on a normal stop; rejects if the backup is found to be wedged.
     return Promise.race([this.#state.stopped(), this.#fatal.promise]);
-  }
-
-  startSnapshotReservation(taskID: string): Subscription<SnapshotMessage> {
-    this.#lc.info?.(`pausing change-log cleanup while ${taskID} snapshots`);
-    // In the case of retries, only track the last reservation.
-    this.#reservations.get(taskID)?.sub.cancel();
-
-    const sub = Subscription.create<SnapshotMessage>({
-      // If the reservation still exists when the connection closes
-      // (e.g. subscriber crashed), clean it up without updating the
-      // cleanup delay.
-      cleanup: () => this.endReservation(taskID, false),
-    });
-    this.#reservations.set(taskID, {start: new Date(), sub});
-    // Note: the Subscription must be returned immediately so that the
-    //       websocket can begin sending liveness pings. The `status` signal
-    //       (which tells the view-syncer to restore) is withheld until a
-    //       restorable backup actually exists; see #pushStatusWhenRestorable.
-    void this.#pushStatusWhenRestorable(taskID, sub);
-    return sub;
-  }
-
-  /**
-   * Pushes the `status` snapshot signal once a restorable backup is confirmed
-   * to exist in the backup destination. On a warm start this is immediate; on a
-   * cold start (a fresh stack whose first backup is still being produced) the
-   * reservation is held open — kept alive by websocket liveness pings — and the
-   * view-syncer stays unready until the first backup lands, rather than being
-   * told to restore a backup that does not yet exist.
-   */
-  async #pushStatusWhenRestorable(
-    taskID: string,
-    sub: Subscription<SnapshotMessage>,
-  ): Promise<void> {
-    try {
-      while (this.#lastVerifiedUploadTime === null) {
-        if (!sub.active) {
-          return; // subscriber disconnected, or a newer reservation took over
-        }
-        if (await this.#confirmRestorableBackup()) {
-          break;
-        }
-        this.#lc.info?.(
-          `no restorable backup at ${this.#backupURL} yet; ` +
-            `holding ${taskID}'s reservation open until it lands`,
-        );
-        await sleep(RESTORABLE_BACKUP_POLL_INTERVAL_MS, this.#state.signal);
-      }
-      const changeLogState = await this.#changeStreamer.getChangeLogState();
-      if (sub.active) {
-        sub.push([
-          'status',
-          {tag: 'status', backupURL: this.#backupURL, ...changeLogState},
-        ]);
-      }
-    } catch (e) {
-      if (this.#state.signal.aborted) {
-        return; // shutting down; not an error
-      }
-      this.#lc.warn?.(`failing snapshot reservation`, e);
-      sub.fail(e instanceof Error ? e : new Error(String(e)));
-    }
   }
 
   /**
@@ -297,29 +211,6 @@ export class Litestream3BackupMonitor implements BackupMonitor {
     } catch (e) {
       this.#lc.info?.(`backup not yet restorable at ${this.#backupURL}`, e);
       return false;
-    }
-  }
-
-  endReservation(taskID: string, updateCleanupDelay = true) {
-    const res = this.#reservations.get(taskID);
-    if (res === undefined) {
-      return;
-    }
-    this.#reservations.delete(taskID);
-    const {start, sub} = res;
-    sub.cancel(); // closes the connection if still open
-    const duration = Date.now() - start.getTime();
-    litestreamSnapshotReservationDuration().recordMs(duration, {
-      ...litestreamMonitorMetricAttrs(this.#backupURL, 'legacy', 'view_syncer'),
-      result: updateCleanupDelay ? 'success' : 'cancelled',
-    });
-
-    if (updateCleanupDelay) {
-      this.#lc.info?.(`snapshot initialized by ${taskID} in ${duration} ms`);
-      if (duration > this.#cleanupDelayMs) {
-        this.#cleanupDelayMs = duration;
-        this.#lc.info?.(`increased cleanup delay to ${duration} ms`);
-      }
     }
   }
 
@@ -403,14 +294,7 @@ export class Litestream3BackupMonitor implements BackupMonitor {
   }
 
   async #scheduleCleanup() {
-    if (this.#reservations.size > 0) {
-      this.#lc.info?.(
-        `watermark cleanup paused for snapshot(s): ${[...this.#reservations.keys()]}`,
-      );
-      return;
-    }
-    const latestCleanupTime = Date.now() - this.#cleanupDelayMs;
-    const maxWatermark = this.#maxWatermarkUpTo(latestCleanupTime);
+    const maxWatermark = this.#maxWatermarkUpTo(Date.now());
     if (maxWatermark.length === 0) {
       return;
     }
@@ -443,10 +327,7 @@ export class Litestream3BackupMonitor implements BackupMonitor {
     // map and are re-evaluated at the next check.
     const lastUpload = must(this.#lastVerifiedUploadTime);
     const verifiedWatermark = this.#maxWatermarkUpTo(
-      Math.min(
-        latestCleanupTime,
-        lastUpload.getTime() + BACKUP_VERIFICATION_SLACK_MS,
-      ),
+      lastUpload.getTime() + BACKUP_VERIFICATION_SLACK_MS,
     );
     if (verifiedWatermark.length === 0) {
       this.#purgesBlocked.add(1, {reason: 'backup-stale'});
@@ -471,7 +352,7 @@ export class Litestream3BackupMonitor implements BackupMonitor {
     // The cleanup watermark advanced past a real upload, so the backup is
     // keeping up: clear the staleness clock.
     this.#backupStaleSince = null;
-    this.#changeStreamer.scheduleCleanup(verifiedWatermark);
+    this.#changeStreamer.trackBackupWatermark(verifiedWatermark);
     for (const watermark of this.#watermarks.keys()) {
       if (watermark <= verifiedWatermark) {
         this.#watermarks.delete(watermark);
@@ -627,13 +508,6 @@ export class Litestream3BackupMonitor implements BackupMonitor {
 
   stop(): Promise<void> {
     clearInterval(this.#checkMetricsTimer);
-    for (const {sub} of this.#reservations.values()) {
-      // Close any pending reservations. This commonly happens when a new
-      // replication-manager makes a `/snapshot` reservation on the existing
-      // replication-manager, and then shuts it down when it takes over the
-      // replication slot.
-      sub.cancel();
-    }
     this.#state.stop(this.#lc);
     return promiseVoid;
   }

--- a/packages/zero-cache/src/services/change-streamer/replica-monitor.ts
+++ b/packages/zero-cache/src/services/change-streamer/replica-monitor.ts
@@ -7,7 +7,7 @@ import {RunningState} from '../running-state.ts';
 import type {Service} from '../service.ts';
 import type {ChangeStreamerService} from './change-streamer.ts';
 
-const CHECK_INTERVAL_MS = 30 * 1000;
+const CHECK_INTERVAL_MS = 10 * 1000;
 
 /**
  * The single-node equivalent of a backup monitor polls the replica file every
@@ -44,7 +44,7 @@ export class ReplicaMonitor implements Service {
         if (stateVersion !== this.#lastWatermark) {
           this.#lastWatermark = stateVersion;
           this.#lc.debug?.(`replicated up to watermark ${stateVersion}`);
-          this.#changeStreamer.scheduleCleanup(stateVersion);
+          this.#changeStreamer.trackBackupWatermark(stateVersion);
         }
       } catch (e) {
         this.#lc.error?.(`Unable to read watermark from replica`, e);

--- a/packages/zero-cache/src/services/change-streamer/snapshot-reservations.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/snapshot-reservations.test.ts
@@ -1,0 +1,166 @@
+import {resolver} from '@rocicorp/resolver';
+import {describe, expect, test} from 'vitest';
+import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
+import type {Source} from '../../types/streams.ts';
+import {SnapshotReservations} from './snapshot-reservations.ts';
+import type {SnapshotMessage} from './snapshot.ts';
+
+function getFirstMessage(
+  sub: Source<SnapshotMessage>,
+): Promise<SnapshotMessage> {
+  const {promise, resolve} = resolver<SnapshotMessage>();
+  void (async function () {
+    for await (const msg of sub) {
+      resolve(msg);
+      // Simulate an open connection; do not exit the loop.
+    }
+  })();
+  return promise;
+}
+
+// `open()` only exposes the `Source` interface (not the full `Subscription`),
+// so cancellation is observed the same way a real consumer would: a
+// cancelled subscription's iteration completes (`done: true`) immediately,
+// without hanging, since cancel() terminates any in-flight `next()` call.
+function isCancelled(sub: Source<SnapshotMessage>): Promise<boolean> {
+  return sub[Symbol.asyncIterator]()
+    .next()
+    .then(({done}) => !!done);
+}
+
+describe('change-streamer/snapshot-reservations', () => {
+  function newReservations() {
+    return new SnapshotReservations(createSilentLogContext(), {
+      backupURL: 's3://foo/bar',
+      litestreamVersion: 'v5',
+    });
+  }
+
+  test('confirmationsRequired() is false with no reservations', () => {
+    const reservations = newReservations();
+    expect(reservations.confirmationsRequired()).toBe(false);
+  });
+
+  test('open() creates an unconfirmed reservation', () => {
+    const reservations = newReservations();
+    reservations.open('task-1');
+
+    expect(reservations.confirmationsRequired()).toBe(true);
+    expect(reservations.getReservedWatermarks()).toEqual([]);
+  });
+
+  test('confirm() pushes a status message and confirms the reservation', async () => {
+    const reservations = newReservations();
+    const sub = reservations.open('task-1');
+    const message = getFirstMessage(sub);
+
+    reservations.confirm('replica-v1', 'watermark-1');
+
+    expect(await message).toEqual([
+      'status',
+      {
+        tag: 'status',
+        backupURL: 's3://foo/bar',
+        replicaVersion: 'replica-v1',
+        minWatermark: 'watermark-1',
+      },
+    ]);
+    expect(reservations.confirmationsRequired()).toBe(false);
+    expect(reservations.getReservedWatermarks()).toEqual(['watermark-1']);
+  });
+
+  test('confirm() is a no-op for an already-confirmed reservation', () => {
+    const reservations = newReservations();
+    reservations.open('task-1');
+
+    reservations.confirm('replica-v1', 'watermark-1');
+    reservations.confirm('replica-v1', 'watermark-2');
+
+    // The reservation stays pinned to the watermark from its first
+    // confirmation; the second confirm() call is a no-op for it.
+    expect(reservations.getReservedWatermarks()).toEqual(['watermark-1']);
+  });
+
+  test('a single confirm() call resolves all pending reservations at once', () => {
+    const reservations = newReservations();
+    reservations.open('task-1');
+    reservations.open('task-2');
+    expect(reservations.confirmationsRequired()).toBe(true);
+
+    reservations.confirm('replica-v1', 'watermark-1');
+
+    expect(reservations.confirmationsRequired()).toBe(false);
+    expect(reservations.getReservedWatermarks().sort()).toEqual([
+      'watermark-1',
+      'watermark-1',
+    ]);
+  });
+
+  test('confirm() only resolves reservations opened before it was called', () => {
+    const reservations = newReservations();
+    reservations.open('task-1');
+    reservations.confirm('replica-v1', 'watermark-1');
+
+    // Opened after the first confirm(); still unconfirmed.
+    reservations.open('task-2');
+    expect(reservations.confirmationsRequired()).toBe(true);
+    expect(reservations.getReservedWatermarks()).toEqual(['watermark-1']);
+
+    reservations.confirm('replica-v1', 'watermark-2');
+    expect(reservations.confirmationsRequired()).toBe(false);
+    expect(reservations.getReservedWatermarks().sort()).toEqual([
+      'watermark-1',
+      'watermark-2',
+    ]);
+  });
+
+  test('open() with the same taskID cancels the previous reservation', async () => {
+    const reservations = newReservations();
+    const sub1 = reservations.open('task-1');
+    const sub2 = reservations.open('task-1');
+
+    expect(await isCancelled(sub1)).toBe(true);
+
+    // Only one reservation is tracked for the taskID, and it's the new one:
+    // it still receives the confirm() push.
+    const message = getFirstMessage(sub2);
+    reservations.confirm('replica-v1', 'watermark-1');
+    await message;
+    expect(reservations.getReservedWatermarks()).toEqual(['watermark-1']);
+  });
+
+  test('close() cancels and removes the reservation', async () => {
+    const reservations = newReservations();
+    const sub = reservations.open('task-1');
+
+    reservations.close('task-1');
+
+    expect(await isCancelled(sub)).toBe(true);
+    expect(reservations.confirmationsRequired()).toBe(false);
+  });
+
+  test('close() is a no-op for an unknown taskID', () => {
+    const reservations = newReservations();
+    reservations.open('task-1');
+
+    expect(() => reservations.close('unknown-task')).not.toThrow();
+    expect(reservations.confirmationsRequired()).toBe(true);
+  });
+
+  test('cancelling a subscription closes its reservation via cleanup', () => {
+    const reservations = newReservations();
+    const sub = reservations.open('task-1');
+
+    sub.cancel();
+
+    expect(reservations.confirmationsRequired()).toBe(false);
+    expect(reservations.getReservedWatermarks()).toEqual([]);
+  });
+
+  test('confirm() with no reservations is a no-op', () => {
+    const reservations = newReservations();
+    expect(() =>
+      reservations.confirm('replica-v1', 'watermark-1'),
+    ).not.toThrow();
+  });
+});

--- a/packages/zero-cache/src/services/change-streamer/snapshot-reservations.ts
+++ b/packages/zero-cache/src/services/change-streamer/snapshot-reservations.ts
@@ -14,7 +14,7 @@ export class SnapshotReservations {
   readonly #reservations = new Map<string, Reservation>();
 
   constructor(lc: LogContext, backupConfig: BackupConfig) {
-    this.#lc = lc;
+    this.#lc = lc.withContext('component', 'snapshot-reserver');
     this.#backupConfig = backupConfig;
   }
 

--- a/packages/zero-cache/src/services/change-streamer/snapshot-reservations.ts
+++ b/packages/zero-cache/src/services/change-streamer/snapshot-reservations.ts
@@ -1,0 +1,130 @@
+import type {LogContext} from '@rocicorp/logger';
+import type {Source} from '../../types/streams.ts';
+import {Subscription} from '../../types/subscription.ts';
+import {
+  litestreamMonitorMetricAttrs,
+  litestreamSnapshotReservationDuration,
+} from '../litestream/metrics.ts';
+import type {BackupConfig} from './change-streamer-service.ts';
+import type {SnapshotMessage} from './snapshot.ts';
+
+export class SnapshotReservations {
+  readonly #lc: LogContext;
+  readonly #backupConfig: BackupConfig;
+  readonly #reservations = new Map<string, Reservation>();
+
+  constructor(lc: LogContext, backupConfig: BackupConfig) {
+    this.#lc = lc;
+    this.#backupConfig = backupConfig;
+  }
+
+  open(taskID: string): Source<SnapshotMessage> {
+    this.close(taskID);
+
+    const instanceID = {};
+    const downstream = Subscription.create<SnapshotMessage>({
+      cleanup: () => this.#close(taskID, instanceID),
+    });
+    this.#reservations.set(taskID, new Reservation(instanceID, downstream));
+    this.#lc.info?.(`created snasphot reservation for ${taskID}`);
+    return downstream;
+  }
+
+  close(taskID: string) {
+    this.#close(taskID, undefined);
+  }
+
+  #close(taskID: string, cancelledInstanceID: InstanceID | undefined) {
+    const res = this.#reservations.get(taskID);
+    if (
+      res &&
+      (!cancelledInstanceID || res.instanceID === cancelledInstanceID)
+    ) {
+      // Note: delete first, so that the reservation is gone when close() is called.
+      this.#reservations.delete(taskID);
+      res.close();
+
+      const duration = Date.now() - res.startTime.getTime();
+      this.#lc.info?.(
+        `ended snapshot reservation for ${taskID} (${duration} ms)`,
+      );
+      litestreamSnapshotReservationDuration().recordMs(duration, {
+        ...litestreamMonitorMetricAttrs(
+          this.#backupConfig.backupURL,
+          this.#backupConfig.litestreamVersion,
+          'view_syncer',
+        ),
+        result:
+          cancelledInstanceID || !res.confirmed() ? 'cancelled' : 'closed',
+      });
+    }
+  }
+
+  confirmationsRequired() {
+    for (const res of this.#reservations.values()) {
+      if (!res.confirmed()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  confirm(replicaVersion: string, minWatermark: string) {
+    for (const [taskID, res] of this.#reservations.entries()) {
+      if (!res.confirmed()) {
+        this.#lc.info?.(
+          `reserving change-log entries since ${minWatermark} for ${taskID}`,
+        );
+        res.confirm(this.#backupConfig.backupURL, replicaVersion, minWatermark);
+      }
+    }
+  }
+
+  getReservedWatermarks() {
+    return Array.from(
+      this.#reservations.values(),
+      ({reservedWatermark}) => reservedWatermark,
+    ).filter(watermark => watermark !== null);
+  }
+}
+
+type InstanceID = {};
+
+class Reservation {
+  readonly instanceID: InstanceID;
+  readonly startTime: Date = new Date();
+  readonly #downstream: Subscription<SnapshotMessage>;
+  #watermark: string | null = null;
+
+  constructor(
+    instanceID: InstanceID,
+    downstream: Subscription<SnapshotMessage>,
+  ) {
+    this.instanceID = instanceID;
+    this.#downstream = downstream;
+  }
+
+  get reservedWatermark() {
+    return this.#watermark;
+  }
+
+  confirmed() {
+    return this.#watermark !== null;
+  }
+
+  confirm(backupURL: string, replicaVersion: string, minWatermark: string) {
+    if (this.#watermark === null) {
+      if (this.#downstream.active) {
+        this.#downstream.push([
+          'status',
+          {tag: 'status', backupURL, replicaVersion, minWatermark},
+        ]);
+      }
+      this.#watermark = minWatermark;
+    }
+  }
+
+  close() {
+    this.#downstream.cancel();
+  }
+}

--- a/packages/zero-cache/src/services/change-streamer/vfs-backup-monitor.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/vfs-backup-monitor.test.ts
@@ -1,10 +1,7 @@
-import {resolver} from '@rocicorp/resolver';
 import {beforeEach, describe, expect, test, vi} from 'vitest';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
-import type {Subscription} from '../../types/subscription.ts';
 import type {VfsBackupWatermark} from '../litestream/vfs-watermark-reader.ts';
 import type {ChangeStreamerService} from './change-streamer.ts';
-import type {SnapshotMessage} from './snapshot.ts';
 import {
   VfsBackupMonitor,
   type VfsBackupWatermarkSource,
@@ -13,7 +10,7 @@ import {
 describe('change-streamer/vfs-backup-monitor', () => {
   const scheduled: string[] = [];
   const changeStreamer = {
-    scheduleCleanup: (watermark: string) => scheduled.push(watermark),
+    trackBackupWatermark: (watermark: string) => scheduled.push(watermark),
     getChangeLogState: () =>
       Promise.resolve({
         replicaVersion: '123',
@@ -41,7 +38,6 @@ describe('change-streamer/vfs-backup-monitor', () => {
       createSilentLogContext(),
       's3://foo/bar',
       changeStreamer,
-      100_000,
       30_000,
       source,
     );
@@ -51,18 +47,6 @@ describe('change-streamer/vfs-backup-monitor', () => {
       vi.useRealTimers();
     };
   });
-
-  function getFirstMessage(
-    sub: Subscription<SnapshotMessage>,
-  ): Promise<SnapshotMessage> {
-    const {promise, resolve} = resolver<SnapshotMessage>();
-    void (async function () {
-      for await (const msg of sub) {
-        resolve(msg);
-      }
-    })();
-    return promise;
-  }
 
   function backupWatermark(
     watermark: string,
@@ -77,19 +61,11 @@ describe('change-streamer/vfs-backup-monitor', () => {
     };
   }
 
-  test('schedules cleanup from the VFS-visible watermark after the cleanup delay', async () => {
+  test('schedules cleanup from the VFS-visible watermark', async () => {
     const time = Date.UTC(2025, 3, 24);
     vi.setSystemTime(time);
     readWatermark.mockResolvedValue(backupWatermark('04', time));
 
-    await monitor.checkWatermarkAndScheduleCleanup();
-    expect(scheduled).toEqual([]);
-
-    vi.setSystemTime(time + 99_999);
-    await monitor.checkWatermarkAndScheduleCleanup();
-    expect(scheduled).toEqual([]);
-
-    vi.setSystemTime(time + 100_000);
     await monitor.checkWatermarkAndScheduleCleanup();
     expect(scheduled).toEqual(['04']);
 
@@ -101,57 +77,13 @@ describe('change-streamer/vfs-backup-monitor', () => {
     const time = Date.UTC(2025, 3, 24);
     vi.setSystemTime(time);
     readWatermark
-      .mockResolvedValueOnce(backupWatermark('04', time))
       .mockRejectedValueOnce(new Error('boom'))
       .mockResolvedValueOnce(backupWatermark('04', time));
 
-    await monitor.checkWatermarkAndScheduleCleanup();
-
     vi.setSystemTime(time + 100_000);
     await monitor.checkWatermarkAndScheduleCleanup();
     expect(scheduled).toEqual([]);
 
-    await monitor.checkWatermarkAndScheduleCleanup();
-    expect(scheduled).toEqual(['04']);
-  });
-
-  test('does not schedule a cached watermark newer than the current VFS read', async () => {
-    const time = Date.UTC(2025, 3, 24);
-    vi.setSystemTime(time);
-    readWatermark
-      .mockResolvedValueOnce(backupWatermark('05', time))
-      .mockResolvedValueOnce(backupWatermark('04', time));
-
-    await monitor.checkWatermarkAndScheduleCleanup();
-
-    vi.setSystemTime(time + 100_000);
-    await monitor.checkWatermarkAndScheduleCleanup();
-    expect(scheduled).toEqual(['04']);
-  });
-
-  test('pauses cleanup during snapshot reservation', async () => {
-    const time = Date.UTC(2025, 3, 24);
-    vi.setSystemTime(time);
-    readWatermark.mockResolvedValue(backupWatermark('04', time));
-
-    await monitor.checkWatermarkAndScheduleCleanup();
-
-    const sub = monitor.startSnapshotReservation('foo-bar');
-    expect(await getFirstMessage(sub)).toEqual([
-      'status',
-      {
-        tag: 'status',
-        backupURL: 's3://foo/bar',
-        replicaVersion: '123',
-        minWatermark: '1ab',
-      },
-    ]);
-
-    vi.setSystemTime(time + 100_000);
-    await monitor.checkWatermarkAndScheduleCleanup();
-    expect(scheduled).toEqual([]);
-
-    monitor.endReservation('foo-bar');
     await monitor.checkWatermarkAndScheduleCleanup();
     expect(scheduled).toEqual(['04']);
   });

--- a/packages/zero-cache/src/services/change-streamer/vfs-backup-monitor.ts
+++ b/packages/zero-cache/src/services/change-streamer/vfs-backup-monitor.ts
@@ -4,24 +4,14 @@ import {
   getOrCreateCounter,
   getOrCreateGauge,
 } from '../../observability/metrics.ts';
-import {Subscription} from '../../types/subscription.ts';
 import {
   litestreamBackupVerificationDuration,
   litestreamMonitorMetricAttrs,
-  litestreamSnapshotReservationDuration,
 } from '../litestream/metrics.ts';
 import type {VfsBackupWatermark} from '../litestream/vfs-watermark-reader.ts';
 import {RunningState} from '../running-state.ts';
 import type {BackupMonitor} from './backup-monitor.ts';
 import type {ChangeStreamerService} from './change-streamer.ts';
-import type {SnapshotMessage} from './snapshot.ts';
-
-const MIN_CLEANUP_DELAY_MS = 30_000;
-
-type Reservation = {
-  start: Date;
-  sub: Subscription<SnapshotMessage>;
-};
 
 export interface VfsBackupWatermarkSource {
   readWatermark(): Promise<VfsBackupWatermark>;
@@ -41,7 +31,6 @@ export class VfsBackupMonitor implements BackupMonitor {
   readonly #probeIntervalMs: number;
   readonly #state = new RunningState(this.id);
 
-  readonly #reservations = new Map<string, Reservation>();
   readonly #watermarks = new Map<string, VfsBackupWatermark>();
 
   readonly #purgesBlocked = getOrCreateCounter('replica', 'purge_blocked', {
@@ -52,14 +41,12 @@ export class VfsBackupMonitor implements BackupMonitor {
 
   #lastWatermark: string = '';
   #latestBackupWatermark: VfsBackupWatermark | undefined;
-  #cleanupDelayMs: number;
   #checkWatermarkTimer: NodeJS.Timeout | undefined;
 
   constructor(
     lc: LogContext,
     backupURL: string,
     changeStreamer: ChangeStreamerService,
-    initialCleanupDelayMs: number,
     probeIntervalMs: number,
     source: VfsBackupWatermarkSource,
   ) {
@@ -68,70 +55,16 @@ export class VfsBackupMonitor implements BackupMonitor {
     this.#changeStreamer = changeStreamer;
     this.#source = source;
     this.#probeIntervalMs = probeIntervalMs;
-    this.#cleanupDelayMs = Math.max(
-      initialCleanupDelayMs,
-      MIN_CLEANUP_DELAY_MS,
-    );
   }
 
   run(): Promise<void> {
-    this.#lc.info?.(
-      `monitoring v5 backups at ${this.#backupURL} with ` +
-        `${this.#cleanupDelayMs} ms cleanup delay`,
-    );
+    this.#lc.info?.(`monitoring v5 backups at ${this.#backupURL} `);
     this.#checkWatermarkTimer = setInterval(
       this.checkWatermarkAndScheduleCleanup,
       this.#probeIntervalMs,
     );
     this.#initBackupLagMetric();
     return this.#state.stopped();
-  }
-
-  startSnapshotReservation(taskID: string): Subscription<SnapshotMessage> {
-    this.#lc.info?.(`pausing change-log cleanup while ${taskID} snapshots`);
-    this.#reservations.get(taskID)?.sub.cancel();
-
-    const sub = Subscription.create<SnapshotMessage>({
-      cleanup: () => this.endReservation(taskID, false),
-    });
-    this.#reservations.set(taskID, {start: new Date(), sub});
-
-    void this.#changeStreamer
-      .getChangeLogState()
-      .then(changeLogState => {
-        sub.push([
-          'status',
-          {tag: 'status', backupURL: this.#backupURL, ...changeLogState},
-        ]);
-      })
-      .catch(e => {
-        this.#lc.warn?.(`failing snapshot reservation`, e);
-        sub.fail(e);
-      });
-    return sub;
-  }
-
-  endReservation(taskID: string, updateCleanupDelay = true): void {
-    const res = this.#reservations.get(taskID);
-    if (res === undefined) {
-      return;
-    }
-    this.#reservations.delete(taskID);
-    const {start, sub} = res;
-    sub.cancel();
-    const duration = Date.now() - start.getTime();
-    litestreamSnapshotReservationDuration().recordMs(duration, {
-      ...litestreamMonitorMetricAttrs(this.#backupURL, 'v5', 'view_syncer'),
-      result: updateCleanupDelay ? 'success' : 'cancelled',
-    });
-
-    if (updateCleanupDelay) {
-      this.#lc.info?.(`snapshot initialized by ${taskID} in ${duration} ms`);
-      if (duration > this.#cleanupDelayMs) {
-        this.#cleanupDelayMs = duration;
-        this.#lc.info?.(`increased cleanup delay to ${duration} ms`);
-      }
-    }
   }
 
   // Exported for testing
@@ -194,27 +127,20 @@ export class VfsBackupMonitor implements BackupMonitor {
   }
 
   #scheduleCleanup(): void {
-    if (this.#reservations.size > 0) {
-      this.#lc.info?.(
-        `watermark cleanup paused for snapshot(s): ${[...this.#reservations.keys()]}`,
-      );
-      return;
-    }
-
     const latestConfirmedWatermark = this.#latestBackupWatermark?.watermark;
     if (latestConfirmedWatermark === undefined) {
       return;
     }
 
     const maxWatermark = this.#maxWatermarkUpTo(
-      Date.now() - this.#cleanupDelayMs,
+      Date.now(),
       latestConfirmedWatermark,
     );
     if (maxWatermark.length === 0) {
       return;
     }
 
-    this.#changeStreamer.scheduleCleanup(maxWatermark);
+    this.#changeStreamer.trackBackupWatermark(maxWatermark);
     for (const watermark of this.#watermarks.keys()) {
       if (watermark <= maxWatermark) {
         this.#watermarks.delete(watermark);
@@ -239,9 +165,6 @@ export class VfsBackupMonitor implements BackupMonitor {
 
   stop(): Promise<void> {
     clearInterval(this.#checkWatermarkTimer);
-    for (const {sub} of this.#reservations.values()) {
-      sub.cancel();
-    }
     this.#source.close?.();
     this.#state.stop(this.#lc);
     return promiseVoid;

--- a/packages/zero-cache/src/services/replicator/replication-resumption.pg.test.ts
+++ b/packages/zero-cache/src/services/replicator/replication-resumption.pg.test.ts
@@ -492,6 +492,7 @@ async function startHarness(testDBs: PgTest['testDBs']) {
       ReplicationStatusPublisher.forTesting(),
       subscriptionState,
       null,
+      null,
       true,
       streamerOptions,
     );

--- a/packages/zero-cache/src/services/replicator/replication-throughput.bench.pg.ts
+++ b/packages/zero-cache/src/services/replicator/replication-throughput.bench.pg.ts
@@ -162,6 +162,7 @@ async function startReplicationPipeline(testDBs: PgTest['testDBs']) {
     ),
     subscriptionState,
     null,
+    null,
     true,
     streamerOptions,
   );

--- a/packages/zero-cache/src/services/running-state.ts
+++ b/packages/zero-cache/src/services/running-state.ts
@@ -112,6 +112,7 @@ export class RunningState {
     }, timeoutMs);
 
     this.#pendingTimeouts.add(timeout);
+    return timeout;
   }
 
   /**

--- a/packages/zql-integration-tests/src/chinook/chinook-zero-cache-fuzzer.pg.test.ts
+++ b/packages/zql-integration-tests/src/chinook/chinook-zero-cache-fuzzer.pg.test.ts
@@ -29,8 +29,8 @@ import {
 } from '../../../zero-cache/src/services/view-syncer/schema/types.ts';
 import {Snapshotter} from '../../../zero-cache/src/services/view-syncer/snapshotter.ts';
 import {
-  type SyncContext,
   ViewSyncerService,
+  type SyncContext,
 } from '../../../zero-cache/src/services/view-syncer/view-syncer.ts';
 import {
   getConnectionURI,
@@ -64,8 +64,8 @@ import {
 import {getServerSchema} from '../../../zero-server/src/schema.ts';
 import {Transaction} from '../../../zero-server/src/test/util.ts';
 import type {
-  Schema as ZeroSchema,
   TableSchema,
+  Schema as ZeroSchema,
 } from '../../../zero-types/src/schema.ts';
 import {MemorySource} from '../../../zql/src/ivm/memory-source.ts';
 import {makeSourceChangeAdd} from '../../../zql/src/ivm/source.ts';
@@ -99,7 +99,7 @@ import {
 import {Data} from './fuzz/literals.ts';
 import {miniData, miniPgContent} from './fuzz/mini.ts';
 import {pushForSkeleton, type Mutation} from './fuzz/push.ts';
-import {label as skeletonLabel, lower, type Skeleton} from './fuzz/skeleton.ts';
+import {lower, label as skeletonLabel, type Skeleton} from './fuzz/skeleton.ts';
 import {builder, schema} from './schema.ts';
 
 const lc = createSilentLogContext();
@@ -347,6 +347,7 @@ async function startZeroCacheReplica(testDBs: PgTest['testDBs']) {
         Promise.resolve(),
       ),
       subscriptionState,
+      null,
       null,
       true,
       streamerOptions,


### PR DESCRIPTION
Moves the tracking of backup watermarks, as well as snapshot reservations, into the change-streamer.

### TL;DR

* change-streamer tracks both backup watermarks and snapshot reservations, the former for eventual upstream ACK-ing, and the latter for change-log cleanup
* the change-streamer-http server now just deals with a change-streamer, and doesn't need to know about a backup monitor

### More details

This backup and snapshot logic was previously in the v3 and v5 implementations of the BackupMonitor, which implemented a "reservation" by avoiding the reporting of backup progress while a backup was being restored (i.e. represented by the snapshot reservation).

For RMv2 this would be problematic because the backup watermark will be used to ACK the upstream replication slot, so the change-streamer (and upstream) need to know about this as soon as possible, regardless of whether a snapshot reservation is in progress. So the backupWatermark tracking is now in the change-streamer itself.

change-log cleanup, however, still need to take into account snapshot reservations, so these are moved into the change-streamer as well.

Other benefits to this reorganization:
* The change-streamer can return a more correct `minWatermark` for the snapshot reservation, based on what has been backed up, rather than what is in the change-log. The change-log is now only checked as a safety measure to ensure that it can be used to catch up from the backup watermark.
* The snapshot reservation watermark fits nicely within the existing logic of preserving change-log entries for change subscriptions.
* Duplicate logic from the two BackupMonitor implementations is consolidated.

### Tangential

Removed the squishy, complicated cleanup delay logic.