### PR TITLE
fix(zero-client): Connection cleanup

### DIFF
--- a/packages/zero-client/src/client/zero.test.ts
+++ b/packages/zero-client/src/client/zero.test.ts
@@ -73,6 +73,7 @@ import {
 import {createBuilder} from '../../../zql/src/query/create-builder.ts';
 import type {Row} from '../../../zql/src/query/query.ts';
 import {nanoid} from '../util/nanoid.ts';
+import {ActiveClientsManager} from './active-clients-manager.ts';
 import {ClientErrorKind} from './client-error-kind.ts';
 import {ConnectionStatus} from './connection-status.ts';
 import type {ConnectionState} from './connection.ts';
@@ -2603,7 +2604,7 @@ test('Runtime pingTimeoutMs configuration', async () => {
   expect(z.connectionStatus).toBe(ConnectionStatus.Connecting);
 });
 
-const connectTimeoutMessage = 'Rejecting connect resolver due to timeout';
+const connectTimeoutMessage = 'Connection attempt timed out';
 
 function expectLogMessages(z: TestZero<Schema>) {
   return expect(
@@ -2611,6 +2612,16 @@ function expectLogMessages(z: TestZero<Schema>) {
       level === 'debug' ? msg : [],
     ),
   );
+}
+
+function connectTimeoutErrors(z: TestZero<Schema>): ClientError[] {
+  return z.testLogSink.messages
+    .flatMap(([_level, _context, messages]) => messages)
+    .filter(
+      (message): message is ClientError =>
+        message instanceof ClientError &&
+        message.kind === ClientErrorKind.ConnectTimeout,
+    );
 }
 
 test('Connect timeout', async () => {
@@ -2643,6 +2654,9 @@ test('Connect timeout', async () => {
     await vi.advanceTimersByTimeAsync(1);
     expect(z.connectionStatus).toBe(ConnectionStatus.Connecting);
     expectLogMessages(z).contain(connectTimeoutMessage);
+    expect(connectTimeoutErrors(z).at(-1)?.message).toContain(
+      'while waiting for the server acknowledgement',
+    );
     const nextSocketPromise = z.socket;
 
     // We stay in connecting state and sleep for RUN_LOOP_INTERVAL_MS before trying again
@@ -2684,6 +2698,51 @@ test('Connect timeout', async () => {
   ]);
 
   connectionStatusCleanup();
+});
+
+test('connect timeout during setup retries without an unhandled rejection', async () => {
+  const unhandledRejections: PromiseRejectionEvent[] = [];
+  const onUnhandled = (event: PromiseRejectionEvent) => {
+    unhandledRejections.push(event);
+    event.preventDefault();
+  };
+  window.addEventListener('unhandledrejection', onUnhandled);
+
+  vi.spyOn(ActiveClientsManager, 'create').mockReturnValue(
+    new Promise(() => {}),
+  );
+
+  try {
+    const z = zeroForTest({logLevel: 'debug'});
+    const connectAttempts = () =>
+      z.testLogSink.messages.filter(
+        ([level, _context, messages]) =>
+          level === 'info' && messages.includes('Connecting...'),
+      ).length;
+
+    await z.waitForConnectionStatus(ConnectionStatus.Connecting);
+    await tickAFewTimes(vi, 0);
+    expect(connectAttempts()).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(CONNECT_TIMEOUT_MS + 1);
+    await tickAFewTimes(vi);
+
+    expect(
+      unhandledRejections.filter(
+        event =>
+          event.reason instanceof ClientError &&
+          event.reason.kind === ClientErrorKind.ConnectTimeout,
+      ),
+    ).toEqual([]);
+    expect(connectTimeoutErrors(z).at(-1)?.message).toContain(
+      'while initializing active clients',
+    );
+
+    await tickAFewTimes(vi, RUN_LOOP_INTERVAL_MS);
+    expect(connectAttempts()).toBe(2);
+  } finally {
+    window.removeEventListener('unhandledrejection', onUnhandled);
+  }
 });
 
 test('socketOrigin', async () => {

--- a/packages/zero-client/src/client/zero.test.ts
+++ b/packages/zero-client/src/client/zero.test.ts
@@ -2624,6 +2624,16 @@ function connectTimeoutErrors(z: TestZero<Schema>): ClientError[] {
     );
 }
 
+function connectEvents(
+  error: ClientError | undefined,
+): [date: string, event: string][] {
+  assert(error);
+  const marker = 'Connect events: ';
+  const markerIndex = error.message.indexOf(marker);
+  assert(markerIndex >= 0, 'Expected timeout error to contain connect events');
+  return JSON.parse(error.message.slice(markerIndex + marker.length));
+}
+
 test('Connect timeout', async () => {
   const z = zeroForTest({logLevel: 'debug'});
 
@@ -2654,8 +2664,20 @@ test('Connect timeout', async () => {
     await vi.advanceTimersByTimeAsync(1);
     expect(z.connectionStatus).toBe(ConnectionStatus.Connecting);
     expectLogMessages(z).contain(connectTimeoutMessage);
-    expect(connectTimeoutErrors(z).at(-1)?.message).toContain(
-      'while waiting for the server acknowledgement',
+    const events = connectEvents(connectTimeoutErrors(z).at(-1));
+    expect(events.map(([_date, event]) => event)).toEqual([
+      'starting the connection',
+      'reading the cookie',
+      'reading the client group ID',
+      'initializing active clients',
+      'reading the profile ID',
+      'reading deleted clients',
+      'reading desired queries',
+      'creating the WebSocket',
+      'waiting for the server acknowledgement',
+    ]);
+    expect(events.every(([date]) => !Number.isNaN(Date.parse(date)))).toBe(
+      true,
     );
     const nextSocketPromise = z.socket;
 
@@ -2734,9 +2756,16 @@ test('connect timeout during setup retries without an unhandled rejection', asyn
           event.reason.kind === ClientErrorKind.ConnectTimeout,
       ),
     ).toEqual([]);
-    expect(connectTimeoutErrors(z).at(-1)?.message).toContain(
-      'while initializing active clients',
-    );
+    expect(
+      connectEvents(connectTimeoutErrors(z).at(-1)).map(
+        ([_date, event]) => event,
+      ),
+    ).toEqual([
+      'starting the connection',
+      'reading the cookie',
+      'reading the client group ID',
+      'initializing active clients',
+    ]);
 
     await tickAFewTimes(vi, RUN_LOOP_INTERVAL_MS);
     expect(connectAttempts()).toBe(2);

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -147,6 +147,7 @@ import {
   isAuthError,
   isClientError,
   isServerError,
+  isZeroError,
 } from './error.ts';
 import {
   type HTTPString,
@@ -211,6 +212,43 @@ interface TestZero {
     consoleLogLevel: LogLevel;
     server: string | null;
   }) => LogOptions;
+}
+
+type ConnectPhase =
+  | 'starting the connection'
+  | 'reading the cookie'
+  | 'reading the client group ID'
+  | 'initializing active clients'
+  | 'reading the profile ID'
+  | 'reading deleted clients'
+  | 'reading desired queries'
+  | 'creating the WebSocket'
+  | 'waiting for the server acknowledgement'
+  | 'processing the server acknowledgement';
+
+type ConnectAttemptControl = {
+  readonly controller: AbortController;
+  readonly connected: Resolver<void>;
+  phase: ConnectPhase;
+  phaseStartedAt: number;
+};
+
+function setConnectPhase(
+  attempt: ConnectAttemptControl,
+  phase: ConnectPhase,
+): void {
+  attempt.phase = phase;
+  attempt.phaseStartedAt = Date.now();
+}
+
+function connectionReadyResolver(): Resolver<void> {
+  const ready = resolver<void>();
+  // A connection attempt can fail without any push, pull, or inspector
+  // currently waiting on it. The run loop handles the corresponding attempt
+  // failure; this handler prevents the optional readiness listener from
+  // becoming an unhandled rejection.
+  void ready.promise.catch(() => {});
+  return ready;
 }
 
 function asTestZero<
@@ -415,12 +453,14 @@ export class Zero<
 
   #socket: WebSocket | undefined = undefined;
   #socketResolver = resolver<WebSocket>();
-  /**
-   * Utility promise that resolves when the socket transitions to connected.
-   * It rejects if we hit an error or timeout before the connected message.
-   * Used by push/pull helpers to queue work until the connection is usable.
-   */
-  #connectResolver = resolver<void>();
+
+  // Resolves when the run loop establishes a usable connection. The run loop
+  // replaces it if the attempt fails or the established connection disconnects.
+  #connectionReadyResolver = connectionReadyResolver();
+
+  // Installed and removed by the run loop so socket events and disconnects can
+  // deliver inputs to the active attempt without settling its returned promise.
+  #currentConnectAttempt: ConnectAttemptControl | undefined;
 
   #closeAbortController = new AbortController();
 
@@ -1433,7 +1473,6 @@ export class Zero<
             'large files to object storage and storing only the URL in Zero.' +
             recentMessagesInfo,
         });
-        this.#connectResolver.reject(messageTooLargeError);
         this.#disconnect(lc, messageTooLargeError);
 
         await this.#rep.disableClientGroup();
@@ -1453,7 +1492,6 @@ export class Zero<
                 message: 'WebSocket connection closed abruptly',
               },
         );
-        this.#connectResolver.reject(closeError);
         this.#disconnect(lc, closeError);
       }
     } catch (e) {
@@ -1465,7 +1503,6 @@ export class Zero<
         },
         {cause: e},
       );
-      this.#connectResolver.reject(internalError);
       this.#disconnect(lc, internalError);
     }
   };
@@ -1490,8 +1527,6 @@ export class Zero<
     const error = new ProtocolError(downMessage[1]);
     lc.error?.(`${error.kind}:\n\n${error.errorBody.message}`, error);
 
-    lc.debug?.('Rejecting connect resolver due to error', error);
-    this.#connectResolver.reject(error);
     this.#disconnect(lc, error);
 
     if (kind === ErrorKind.VersionNotSupported) {
@@ -1524,6 +1559,12 @@ export class Zero<
     lc: LogContext,
     connectedMessage: ConnectedMessage,
   ): Promise<void> {
+    const attempt = must(
+      this.#currentConnectAttempt,
+      'Connected message received without an active connection attempt',
+    );
+    setConnectPhase(attempt, 'processing the server acknowledgement');
+
     const now = Date.now();
     const [, connectBody] = connectedMessage;
     lc = addWebSocketIDToLogContext(connectBody.wsid, lc);
@@ -1626,42 +1667,40 @@ export class Zero<
     maybeSendDeletedClients();
 
     this.#connectionManager.connected();
-    this.#connectResolver.resolve();
+    attempt.connected.resolve();
   }
 
   /**
    * Starts a new connection. This will create the WebSocket that does the HTTP
    * request to the server.
    *
-   * {@link #connect} will throw an assertion error if the
+   * {@link #connectAttempt} will throw an assertion error if the
    * {@link #connectionManager} status is not {@link ConnectionManagerState.Disconnected}
    * or {@link ConnectionManagerState.Connecting}.
    * Callers MUST check the connection status before calling this method and log
    * an error as needed.
    *
-   * The function will resolve once the socket is connected. If you need to know
-   * when a connection has been established, as in we have received the
-   * {@link ConnectedMessage}, you should await the {@link #connectResolver}
-   * promise. The {@link #connectResolver} promise rejects if an error message
-   * is received before the connected message is received or if the connection
-   * attempt times out.
+   * The returned promise resolves after receiving the {@link ConnectedMessage}
+   * and rejects if setup, the socket, or the connection handshake fails.
    */
-  async #connect(
+  async #connectAttempt(
     lc: LogContext,
     additionalConnectParams: Record<string, string> | undefined,
+    attempt: ConnectAttemptControl,
   ): Promise<void> {
     if (this.closed) {
       return;
     }
 
     assert(this.#server, 'No server provided');
+    const socketOrigin = toWSString(this.#server);
 
     // can be called from both disconnected and connecting states.
     // connecting() handles incrementing attempt counter if already connecting.
     assert(
       this.#connectionManager.is(ConnectionStatus.Disconnected) ||
         this.#connectionManager.is(ConnectionStatus.Connecting),
-      'connect() called from invalid state: ' +
+      'connectAttempt() called from invalid state: ' +
         this.#connectionManager.state.name,
     );
 
@@ -1671,7 +1710,7 @@ export class Zero<
 
     this.#connectionManager.connecting();
 
-    // connect() called but connect start time is defined. This should not
+    // connectAttempt() called but connect start time is defined. This should not
     // happen.
     assert(this.#connectStart === undefined, 'connect start time is defined');
 
@@ -1681,42 +1720,32 @@ export class Zero<
       this.#totalToConnectStart = now;
     }
 
-    if (this.closed) {
-      return;
-    }
-    this.#connectCookie = valita.parse(
+    const {signal} = attempt.controller;
+    setConnectPhase(attempt, 'reading the cookie');
+    const connectCookie = valita.parse(
       await this.#rep.cookie,
       nullableVersionSchema,
       'passthrough',
     );
-    if (this.closed) {
-      return;
-    }
+    setConnectPhase(attempt, 'reading the client group ID');
+    const clientGroupID = await this.clientGroupID;
+    setConnectPhase(attempt, 'initializing active clients');
+    const activeClientsManager = await this.#activeClientsManager;
 
-    // Reject connect after a timeout.
-    const timeoutID = setTimeout(() => {
-      lc.debug?.('Rejecting connect resolver due to timeout');
-      const timeoutError = new ClientError({
-        kind: ClientErrorKind.ConnectTimeout,
-        message: `Connection attempt timed out after ${CONNECT_TIMEOUT_MS / 1000} seconds`,
-      });
-      this.#connectResolver.reject(timeoutError);
-      this.#disconnect(lc, timeoutError);
-    }, CONNECT_TIMEOUT_MS);
-    const abortHandler = () => {
-      clearTimeout(timeoutID);
-    };
-    // signal.aborted cannot be true here because we checked for `this.closed` above.
-    this.#closeAbortController.signal.addEventListener('abort', abortHandler);
+    // The run loop has already stopped waiting for this attempt if it was
+    // canceled. Do not let setup that completed late create a socket.
+    if (signal.aborted) {
+      throw signal.reason;
+    }
 
     const [ws, initConnectionQueries, deletedClients] = await createSocket(
       this.#rep,
       this.#queryManager,
       this.#deleteClientsManager,
-      toWSString(this.#server),
-      this.#connectCookie,
+      socketOrigin,
+      connectCookie,
       this.clientID,
-      await this.clientGroupID,
+      clientGroupID,
       this.#clientSchema,
       this.userID,
       fromReplicacheAuthToken(this.#rep.auth),
@@ -1729,14 +1758,25 @@ export class Zero<
       this.#options.queryURL ?? this.#options.getQueriesURL,
       this.#options.queryHeaders,
       additionalConnectParams,
-      await this.#activeClientsManager,
+      activeClientsManager,
       this.#options.maxHeaderLength,
+      phase => setConnectPhase(attempt, phase),
     );
 
+    // createSocket performs asynchronous preparation before constructing the
+    // WebSocket. If the attempt was canceled during that work, the late socket
+    // still belongs to this attempt and must be closed.
+    if (signal.aborted) {
+      ws.close();
+      throw signal.reason;
+    }
+
     if (this.closed) {
+      ws.close();
       return;
     }
 
+    this.#connectCookie = connectCookie;
     this.#initConnectionQueries = initConnectionQueries;
     this.#deletedClients = deletedClients;
     ws.addEventListener('message', this.#onMessage);
@@ -1745,22 +1785,20 @@ export class Zero<
     this.#socket = ws;
     this.#socketResolver.resolve(ws);
 
-    try {
-      lc.debug?.('Waiting for connection to be acknowledged');
-      await this.#connectResolver.promise;
-      this.#mutationTracker.onConnected(this.#lastMutationIDReceived);
-      // push any outstanding mutations on reconnect.
-      this.#rep.push().catch(() => {});
-    } finally {
-      clearTimeout(timeoutID);
-      this.#closeAbortController.signal.removeEventListener(
-        'abort',
-        abortHandler,
-      );
+    setConnectPhase(attempt, 'waiting for the server acknowledgement');
+    lc.debug?.('Waiting for connection to be acknowledged');
+    await attempt.connected.promise;
+    if (signal.aborted) {
+      throw signal.reason;
     }
+    this.#mutationTracker.onConnected(this.#lastMutationIDReceived);
+    // push any outstanding mutations on reconnect.
+    this.#rep.push().catch(() => {});
   }
 
   #disconnect(lc: LogContext, reason: ZeroError, closeCode?: CloseCode): void {
+    this.#currentConnectAttempt?.controller.abort(reason);
+
     if (shouldReportConnectError(reason)) {
       this.#connectErrorCount++;
       this.#metrics.lastConnectError.set(getLastConnectErrorValue(reason));
@@ -1814,8 +1852,6 @@ export class Zero<
     }
 
     this.#socketResolver = resolver();
-    lc.debug?.('Creating new connect resolver');
-    this.#connectResolver = resolver();
     this.#messageCount = 0;
     this.#connectStart = undefined; // don't reset this._totalToConnectStart
     this.#connectedAt = 0;
@@ -1922,7 +1958,7 @@ export class Zero<
     // The deprecation of pushVersion 0 predates zero-client
     assert(req.pushVersion === 1, 'Expected pushVersion 1');
     // If we are connecting we wait until we are connected.
-    await this.#connectResolver.promise;
+    await this.#connectionReadyResolver.promise;
     const lc = this.#lc.withContext('requestID', requestID);
     lc.debug?.(`pushing ${req.mutations.length} mutations`);
     assert(this.#socket, 'Expected socket to be connected for push');
@@ -2055,8 +2091,76 @@ export class Zero<
               break;
             }
 
-            await this.#connect(lc, additionalConnectParams);
-            additionalConnectParams = undefined;
+            const ready = this.#connectionReadyResolver;
+            assert(
+              this.#currentConnectAttempt === undefined,
+              'Connection attempt already active',
+            );
+            const attempt: ConnectAttemptControl = {
+              controller: new AbortController(),
+              connected: resolver(),
+              phase: 'starting the connection',
+              phaseStartedAt: Date.now(),
+            };
+            this.#currentConnectAttempt = attempt;
+            const canceled = resolver<never>();
+            const abortHandler = () =>
+              canceled.reject(attempt.controller.signal.reason);
+            attempt.controller.signal.addEventListener('abort', abortHandler, {
+              once: true,
+            });
+            const timeoutID = setTimeout(() => {
+              lc.debug?.('Connection attempt timed out');
+              const phaseDurationSeconds =
+                Math.round((Date.now() - attempt.phaseStartedAt) / 100) / 10;
+              this.#disconnect(
+                lc,
+                new ClientError({
+                  kind: ClientErrorKind.ConnectTimeout,
+                  message:
+                    `Connection attempt timed out after ${CONNECT_TIMEOUT_MS / 1000} seconds ` +
+                    `while ${attempt.phase} ` +
+                    `(${phaseDurationSeconds} seconds in this phase)`,
+                }),
+              );
+            }, CONNECT_TIMEOUT_MS);
+            try {
+              try {
+                await Promise.race([
+                  this.#connectAttempt(lc, additionalConnectParams, attempt),
+                  canceled.promise,
+                ]);
+              } catch (ex) {
+                const error = isZeroError(ex)
+                  ? ex
+                  : new ClientError(
+                      {
+                        kind: ClientErrorKind.Internal,
+                        message: getErrorMessage(ex),
+                      },
+                      {cause: ex},
+                    );
+                if (!attempt.controller.signal.aborted) {
+                  this.#disconnect(lc, error);
+                }
+                ready.reject(error);
+                if (this.#connectionReadyResolver === ready) {
+                  this.#connectionReadyResolver = connectionReadyResolver();
+                }
+                throw error;
+              }
+              ready.resolve();
+              additionalConnectParams = undefined;
+            } finally {
+              clearTimeout(timeoutID);
+              attempt.controller.signal.removeEventListener(
+                'abort',
+                abortHandler,
+              );
+              if (this.#currentConnectAttempt === attempt) {
+                this.#currentConnectAttempt = undefined;
+              }
+            }
 
             throwIfConnectionError(this.#connectionManager.state);
 
@@ -2069,6 +2173,7 @@ export class Zero<
           }
 
           case ConnectionStatus.Connected: {
+            const ready = this.#connectionReadyResolver;
             // When connected we wait for whatever happens first out of:
             // - After pingTimeoutMs we send a ping
             // - We get a message
@@ -2082,38 +2187,47 @@ export class Zero<
               controller.signal,
             );
 
-            const raceResult = await promiseRace({
-              waitForPing: pingTimeoutPromise,
-              waitForPingAborted: pingTimeoutAborted,
-              tabHidden: this.#visibilityWatcher.waitForHidden(),
-              stateChange: this.#connectionManager.waitForStateChange(),
-            });
+            try {
+              const raceResult = await promiseRace({
+                waitForPing: pingTimeoutPromise,
+                waitForPingAborted: pingTimeoutAborted,
+                tabHidden: this.#visibilityWatcher.waitForHidden(),
+                stateChange: this.#connectionManager.waitForStateChange(),
+              });
 
-            switch (raceResult.key) {
-              case 'waitForPing': {
-                await this.#ping(lc);
-                break;
+              switch (raceResult.key) {
+                case 'waitForPing': {
+                  await this.#ping(lc);
+                  break;
+                }
+
+                case 'waitForPingAborted':
+                  break;
+
+                case 'tabHidden': {
+                  const hiddenError = new ClientError({
+                    kind: ClientErrorKind.Hidden,
+                    message: 'Connection closed because tab was hidden',
+                  });
+                  this.#disconnect(lc, hiddenError);
+                  break;
+                }
+
+                case 'stateChange': {
+                  throwIfConnectionError(raceResult.result);
+                  break;
+                }
+
+                default:
+                  unreachable(raceResult);
               }
-
-              case 'waitForPingAborted':
-                break;
-
-              case 'tabHidden': {
-                const hiddenError = new ClientError({
-                  kind: ClientErrorKind.Hidden,
-                  message: 'Connection closed because tab was hidden',
-                });
-                this.#disconnect(lc, hiddenError);
-                break;
+            } finally {
+              if (
+                !this.#connectionManager.is(ConnectionStatus.Connected) &&
+                this.#connectionReadyResolver === ready
+              ) {
+                this.#connectionReadyResolver = connectionReadyResolver();
               }
-
-              case 'stateChange': {
-                throwIfConnectionError(raceResult.result);
-                break;
-              }
-
-              default:
-                unreachable(raceResult);
             }
 
             break;
@@ -2281,7 +2395,7 @@ export class Zero<
     }
 
     // If we are connecting we wait until we are connected.
-    await this.#connectResolver.promise;
+    await this.#connectionReadyResolver.promise;
     assert(
       this.#socket,
       'Expected socket to be connected for mutation recovery pull',
@@ -2499,7 +2613,7 @@ export class Zero<
         this.#queryManager,
         this.#zeroContext,
         async () => {
-          await this.#connectResolver.promise;
+          await this.#connectionReadyResolver.promise;
           return must(this.#socket);
         },
       ));
@@ -2604,6 +2718,7 @@ export async function createSocket(
   additionalConnectParams: Record<string, string> | undefined,
   activeClientsManager: Pick<ActiveClientsManager, 'activeClients'>,
   maxHeaderLength = 1024 * 8,
+  onPhase?: (phase: ConnectPhase) => void,
 ): Promise<
   [
     WebSocket,
@@ -2611,6 +2726,7 @@ export async function createSocket(
     DeleteClientsBody | undefined,
   ]
 > {
+  onPhase?.('reading the profile ID');
   const url = await createConnectionURL(
     socketOrigin,
     clientID,
@@ -2632,9 +2748,11 @@ export async function createSocket(
   // for a `protocol`.
   const WS = mustGetBrowserGlobal('WebSocket');
   const queriesPatchP = rep.query(tx => queryManager.getQueriesPatch(tx));
+  onPhase?.('reading deleted clients');
   const deletedClientsArray = await deleteClientsManager.getDeletedClients();
   let deletedClients: DeleteClientsBody | undefined =
     convertDeletedClientsToBody(deletedClientsArray, clientGroupID);
+  onPhase?.('reading desired queries');
   let queriesPatch: Map<string, UpQueriesPatchOp> | undefined =
     await queriesPatchP;
   const {activeClients} = activeClientsManager;
@@ -2670,6 +2788,7 @@ export async function createSocket(
   } else {
     deletedClients = undefined;
   }
+  onPhase?.('creating the WebSocket');
   return [
     new WS(
       // toString() required for RN URL polyfill.

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -214,32 +214,11 @@ interface TestZero {
   }) => LogOptions;
 }
 
-type ConnectPhase =
-  | 'starting the connection'
-  | 'reading the cookie'
-  | 'reading the client group ID'
-  | 'initializing active clients'
-  | 'reading the profile ID'
-  | 'reading deleted clients'
-  | 'reading desired queries'
-  | 'creating the WebSocket'
-  | 'waiting for the server acknowledgement'
-  | 'processing the server acknowledgement';
-
 type ConnectAttemptControl = {
   readonly controller: AbortController;
   readonly connected: Resolver<void>;
-  phase: ConnectPhase;
-  phaseStartedAt: number;
+  readonly events: [date: Date, event: string][];
 };
-
-function setConnectPhase(
-  attempt: ConnectAttemptControl,
-  phase: ConnectPhase,
-): void {
-  attempt.phase = phase;
-  attempt.phaseStartedAt = Date.now();
-}
 
 function connectionReadyResolver(): Resolver<void> {
   const ready = resolver<void>();
@@ -1563,11 +1542,10 @@ export class Zero<
       this.#currentConnectAttempt,
       'Connected message received without an active connection attempt',
     );
-    setConnectPhase(attempt, 'processing the server acknowledgement');
-
     const now = Date.now();
     const [, connectBody] = connectedMessage;
     lc = addWebSocketIDToLogContext(connectBody.wsid, lc);
+    this.#addConnectEvent(lc, attempt, 'processing the server acknowledgement');
 
     if (this.#connectedCount === 0) {
       this.#checkConnectivity('firstConnect');
@@ -1721,15 +1699,15 @@ export class Zero<
     }
 
     const {signal} = attempt.controller;
-    setConnectPhase(attempt, 'reading the cookie');
+    this.#addConnectEvent(lc, attempt, 'reading the cookie');
     const connectCookie = valita.parse(
       await this.#rep.cookie,
       nullableVersionSchema,
       'passthrough',
     );
-    setConnectPhase(attempt, 'reading the client group ID');
+    this.#addConnectEvent(lc, attempt, 'reading the client group ID');
     const clientGroupID = await this.clientGroupID;
-    setConnectPhase(attempt, 'initializing active clients');
+    this.#addConnectEvent(lc, attempt, 'initializing active clients');
     const activeClientsManager = await this.#activeClientsManager;
 
     // The run loop has already stopped waiting for this attempt if it was
@@ -1760,7 +1738,7 @@ export class Zero<
       additionalConnectParams,
       activeClientsManager,
       this.#options.maxHeaderLength,
-      phase => setConnectPhase(attempt, phase),
+      event => this.#addConnectEvent(lc, attempt, event),
     );
 
     // createSocket performs asynchronous preparation before constructing the
@@ -1785,7 +1763,11 @@ export class Zero<
     this.#socket = ws;
     this.#socketResolver.resolve(ws);
 
-    setConnectPhase(attempt, 'waiting for the server acknowledgement');
+    this.#addConnectEvent(
+      lc,
+      attempt,
+      'waiting for the server acknowledgement',
+    );
     lc.debug?.('Waiting for connection to be acknowledged');
     await attempt.connected.promise;
     if (signal.aborted) {
@@ -1794,6 +1776,15 @@ export class Zero<
     this.#mutationTracker.onConnected(this.#lastMutationIDReceived);
     // push any outstanding mutations on reconnect.
     this.#rep.push().catch(() => {});
+  }
+
+  #addConnectEvent(
+    lc: LogContext,
+    attempt: ConnectAttemptControl,
+    event: string,
+  ): void {
+    attempt.events.push([new Date(), event]);
+    lc.debug?.('Connect event', event);
   }
 
   #disconnect(lc: LogContext, reason: ZeroError, closeCode?: CloseCode): void {
@@ -2099,10 +2090,10 @@ export class Zero<
             const attempt: ConnectAttemptControl = {
               controller: new AbortController(),
               connected: resolver(),
-              phase: 'starting the connection',
-              phaseStartedAt: Date.now(),
+              events: [],
             };
             this.#currentConnectAttempt = attempt;
+            this.#addConnectEvent(lc, attempt, 'starting the connection');
             const canceled = resolver<never>();
             const abortHandler = () =>
               canceled.reject(attempt.controller.signal.reason);
@@ -2111,16 +2102,13 @@ export class Zero<
             });
             const timeoutID = setTimeout(() => {
               lc.debug?.('Connection attempt timed out');
-              const phaseDurationSeconds =
-                Math.round((Date.now() - attempt.phaseStartedAt) / 100) / 10;
               this.#disconnect(
                 lc,
                 new ClientError({
                   kind: ClientErrorKind.ConnectTimeout,
                   message:
-                    `Connection attempt timed out after ${CONNECT_TIMEOUT_MS / 1000} seconds ` +
-                    `while ${attempt.phase} ` +
-                    `(${phaseDurationSeconds} seconds in this phase)`,
+                    `Connection attempt timed out after ${CONNECT_TIMEOUT_MS / 1000} seconds. ` +
+                    `Connect events: ${JSON.stringify(attempt.events)}`,
                 }),
               );
             }, CONNECT_TIMEOUT_MS);
@@ -2718,7 +2706,7 @@ export async function createSocket(
   additionalConnectParams: Record<string, string> | undefined,
   activeClientsManager: Pick<ActiveClientsManager, 'activeClients'>,
   maxHeaderLength = 1024 * 8,
-  onPhase?: (phase: ConnectPhase) => void,
+  onEvent?: (event: string) => void,
 ): Promise<
   [
     WebSocket,
@@ -2726,7 +2714,7 @@ export async function createSocket(
     DeleteClientsBody | undefined,
   ]
 > {
-  onPhase?.('reading the profile ID');
+  onEvent?.('reading the profile ID');
   const url = await createConnectionURL(
     socketOrigin,
     clientID,
@@ -2748,11 +2736,11 @@ export async function createSocket(
   // for a `protocol`.
   const WS = mustGetBrowserGlobal('WebSocket');
   const queriesPatchP = rep.query(tx => queryManager.getQueriesPatch(tx));
-  onPhase?.('reading deleted clients');
+  onEvent?.('reading deleted clients');
   const deletedClientsArray = await deleteClientsManager.getDeletedClients();
   let deletedClients: DeleteClientsBody | undefined =
     convertDeletedClientsToBody(deletedClientsArray, clientGroupID);
-  onPhase?.('reading desired queries');
+  onEvent?.('reading desired queries');
   let queriesPatch: Map<string, UpQueriesPatchOp> | undefined =
     await queriesPatchP;
   const {activeClients} = activeClientsManager;
@@ -2788,7 +2776,7 @@ export async function createSocket(
   } else {
     deletedClients = undefined;
   }
-  onPhase?.('creating the WebSocket');
+  onEvent?.('creating the WebSocket');
   return [
     new WS(
       // toString() required for RN URL polyfill.


### PR DESCRIPTION
This started with [#6232](https://github.com/rocicorp/mono/pull/6232). A user was seeing `Connection attempt timed out after 10 seconds` as an unhandled promise rejection. That PR proposed adding a catch to the rejected promise to reduce the exception noise.

Looking at it more closely, the timeout was not actually timing out the connection.

`#connect()` did some asynchronous setup before it started waiting on `#connectResolver`. The timer started during that setup. If setup took longer than 10 seconds:

1. The timer rejected `#connectResolver` before anything was waiting on it, causing the unhandled rejection.
2. `#disconnect()` created a new resolver, but the run loop was still blocked waiting for the original `#connect()`.
3. If setup eventually finished, the original "timed out" connection continued and could still connect normally.
4. If setup never finished, the run loop never retried and the client was stuck until refresh.

So adding a catch would have hidden the reported error, but it would not have fixed the connection behavior.

This PR makes setup, socket creation, and waiting for the server acknowledgement one bounded connection attempt. The run loop owns the 10-second timeout and races the whole connection against cancellation. On timeout we disconnect, abandon that connection, and retry after the normal backoff. If abandoned setup later creates a socket, we close it instead of installing it.

The timeout is still reported through the normal connection error path. We are fixing the unhandled rejection without hiding the timeout or other legitimate connection failures.

We still do not know why connection setup sometimes takes longer than 10 seconds. Timeout errors now include a timestamped list of connection events so the next report should tell us where the connection was stuck.

Tests: `pnpm --filter zero-client run test` (644 tests)