### PR TITLE
fix(zero-react): `useSuspenseQuery` should default `suspendUntil` to `'partial'`

### DIFF
--- a/packages/zero-react/src/use-query.test.tsx
+++ b/packages/zero-react/src/use-query.test.tsx
@@ -764,6 +764,62 @@ describe('useSuspenseQuery', () => {
     await expect.poll(() => element.textContent).toBe('singularUndefined');
   });
 
+  test('suspendUntil defaults to partial when no options are passed', async () => {
+    const q = newMockQuery('query' + unique);
+    const zero = newMockZero('client' + unique);
+
+    function Comp() {
+      const [data] = useSuspenseQuery(q);
+      return <div>{JSON.stringify(data)}</div>;
+    }
+
+    root.render(
+      <ZeroProvider zero={zero}>
+        <Suspense fallback={<>loading</>}>
+          <Comp />
+        </Suspense>
+      </ZeroProvider>,
+    );
+
+    await expect.poll(() => element.textContent).toBe('loading');
+
+    const view = vi.mocked(zero.materialize).mock.results[0].value as {
+      listeners: Set<(snap: unknown, resultType: ResultType) => void>;
+    };
+
+    // A partial (non-complete) result must unsuspend the component.
+    view.listeners.forEach(cb => cb([{a: 1}], 'unknown'));
+    await expect.poll(() => element.textContent).toBe('[{"a":1}]');
+  });
+
+  test('suspendUntil defaults to partial when options omit it', async () => {
+    const q = newMockQuery('query' + unique);
+    const zero = newMockZero('client' + unique);
+
+    function Comp() {
+      const [data] = useSuspenseQuery(q, {ttl: '1m'});
+      return <div>{JSON.stringify(data)}</div>;
+    }
+
+    root.render(
+      <ZeroProvider zero={zero}>
+        <Suspense fallback={<>loading</>}>
+          <Comp />
+        </Suspense>
+      </ZeroProvider>,
+    );
+
+    await expect.poll(() => element.textContent).toBe('loading');
+
+    const view = vi.mocked(zero.materialize).mock.results[0].value as {
+      listeners: Set<(snap: unknown, resultType: ResultType) => void>;
+    };
+
+    // A partial (non-complete) result must unsuspend the component.
+    view.listeners.forEach(cb => cb([{a: 1}], 'unknown'));
+    await expect.poll(() => element.textContent).toBe('[{"a":1}]');
+  });
+
   describe('error handling', () => {
     const getErroredQuery = (
       message: string,

--- a/packages/zero-react/src/use-query.tsx
+++ b/packages/zero-react/src/use-query.tsx
@@ -209,7 +209,7 @@ export function useSuspenseQuery<
     ({
       enabled = true,
       ttl = DEFAULT_TTL_MS,
-      suspendUntil = 'complete',
+      suspendUntil = 'partial',
     } = options);
   }
 


### PR DESCRIPTION
## Problem

`useSuspenseQuery` documents (and implements, when called with no options) a default of `suspendUntil: 'partial'`. But when *any* options object is passed, the destructuring default silently switches to `'complete'`:

```ts
let suspendUntil: 'complete' | 'partial' = 'partial';   // no-options default
...
({
  enabled = true,
  ttl = DEFAULT_TTL_MS,
  suspendUntil = 'complete',                            // options-object default — mismatch
} = options);
```

So `useSuspenseQuery(q, {ttl: '5m'})` suspends on `waitForComplete()` — a full server round trip of Suspense fallback on every mount instead of resuming synchronously with local replica data — and hangs the subtree indefinitely while offline, since the query can never reach `complete` without a server connection.

It appears the outer default was changed to `'partial'` in 9765c1c9a and this spot was missed. Every existing test passed `suspendUntil` explicitly, so neither default path was covered.

## Fix

One line: change the destructuring default from `'complete'` to `'partial'`, matching the no-options default and the `UseSuspenseQueryOptions.suspendUntil` JSDoc ("Default is 'partial'.").

## Tests

Two regression tests lock in both default paths:

- `suspendUntil defaults to partial when no options are passed`
- `suspendUntil defaults to partial when options omit it` (passes `{ttl: '1m'}`)

Both assert that a partial (`resultType: 'unknown'`) result unsuspends the component. Verified the second test fails against the old code (42 passed, 1 failed with the `'complete'` default) and both pass with the fix. Full `zero-react` suite: 76/76 passing; lint, format, and `check-types` clean.

## Note for reviewers

Behavior change: apps that passed an options object without `suspendUntil` (e.g. only `ttl` or `enabled`) were getting `'complete'` semantics and will now get the documented `'partial'` semantics — typically rendering sooner with local data. Anyone relying on the buggy behavior should pass `suspendUntil: 'complete'` explicitly.
