### PR TITLE
fix(zql): skip view flush and React re-render when a change does not alter the view

### DIFF
--- a/packages/zero-react/src/use-query.test.tsx
+++ b/packages/zero-react/src/use-query.test.tsx
@@ -531,6 +531,163 @@ describe('ViewStore', () => {
       cleanup();
     });
   });
+
+  describe('unchanged data on flush', () => {
+    test('same data reference keeps snapshot identity and does not notify', () => {
+      const viewStore = new ViewStore();
+      const q = newMockQuery('query1');
+      const zero = newMockZero('client1');
+      const view = viewStore.getView(zero, q, true, 'forever');
+
+      const {listeners} = vi.mocked(zero.materialize).mock.results[0]
+        .value as unknown as {
+        listeners: Set<(...args: unknown[]) => void>;
+      };
+
+      const notify = vi.fn();
+      const cleanup = view.subscribeReactInternals(notify);
+
+      const rows = [{a: 1}];
+      listeners.forEach(cb => cb(rows, 'unknown'));
+      const snapshot1 = view.getSnapshot();
+      expect(snapshot1).toEqual([[{a: 1}], {type: 'unknown'}]);
+      expect(notify).toHaveBeenCalledTimes(1);
+
+      // Same data reference, resultType and error: the previous snapshot
+      // tuple is kept (so useSyncExternalStore's Object.is bailout works) and
+      // React is not notified.
+      listeners.forEach(cb => cb(rows, 'unknown'));
+      expect(view.getSnapshot()).toBe(snapshot1);
+      expect(notify).toHaveBeenCalledTimes(1);
+
+      // Same data reference but new resultType: new snapshot, notified.
+      listeners.forEach(cb => cb(rows, 'complete'));
+      const snapshot2 = view.getSnapshot();
+      expect(snapshot2).not.toBe(snapshot1);
+      expect(snapshot2).toEqual([[{a: 1}], {type: 'complete'}]);
+      expect(notify).toHaveBeenCalledTimes(2);
+
+      // New data reference: new snapshot, notified.
+      listeners.forEach(cb => cb([{a: 2}], 'complete'));
+      expect(view.getSnapshot()).toEqual([[{a: 2}], {type: 'complete'}]);
+      expect(notify).toHaveBeenCalledTimes(3);
+
+      cleanup();
+    });
+
+    test('same error reference keeps snapshot identity and does not notify', () => {
+      const viewStore = new ViewStore();
+      const q = newMockQuery('query1');
+      const zero = newMockZero('client1');
+      const view = viewStore.getView(zero, q, true, 'forever');
+
+      const {listeners} = vi.mocked(zero.materialize).mock.results[0]
+        .value as unknown as {
+        listeners: Set<(...args: unknown[]) => void>;
+      };
+
+      const notify = vi.fn();
+      const cleanup = view.subscribeReactInternals(notify);
+
+      const error: ErroredQuery = {
+        error: 'app',
+        id: 'query1',
+        name: 'query1',
+        details: 'boom',
+      };
+      const rows: unknown[] = [];
+      listeners.forEach(cb => cb(rows, 'error', error));
+      const snapshot1 = view.getSnapshot();
+      expect(snapshot1[1].type).toBe('error');
+      expect(notify).toHaveBeenCalledTimes(1);
+
+      listeners.forEach(cb => cb(rows, 'error', error));
+      expect(view.getSnapshot()).toBe(snapshot1);
+      expect(notify).toHaveBeenCalledTimes(1);
+
+      // A different error object produces a new snapshot and notifies.
+      const error2: ErroredQuery = {...error, details: 'boom again'};
+      listeners.forEach(cb => cb(rows, 'error', error2));
+      expect(view.getSnapshot()).not.toBe(snapshot1);
+      expect(notify).toHaveBeenCalledTimes(2);
+
+      cleanup();
+    });
+
+    test('resolvers resolve after re-materialize even when data is unchanged', async () => {
+      const viewStore = new ViewStore();
+      const q = newMockQuery('query1', true);
+      const zero = newMockZero('client1');
+      const view = viewStore.getView(zero, q, true, 'forever');
+
+      const {listeners} = vi.mocked(zero.materialize).mock.results[0]
+        .value as unknown as {
+        listeners: Set<(...args: unknown[]) => void>;
+      };
+
+      const cleanup = view.subscribeReactInternals(() => {});
+      const row = {a: 1};
+      listeners.forEach(cb => cb(row, 'complete'));
+      expect(view.complete).toBe(true);
+      await expect(view.waitForComplete()).resolves.toBeUndefined();
+      const snapshot = view.getSnapshot();
+
+      // Unsubscribing destroys the underlying view and resets the resolvers.
+      cleanup();
+      vi.advanceTimersByTime(20);
+      expect(view.complete).toBe(false);
+
+      // On re-materialization the new view delivers the same data reference
+      // and resultType as before the destroy. The snapshot keeps its identity
+      // and React is not notified, but completeness must still resolve.
+      const notify = vi.fn();
+      const cleanup2 = view.subscribeReactInternals(notify);
+      listeners.forEach(cb => cb(row, 'complete'));
+      expect(view.getSnapshot()).toBe(snapshot);
+      expect(notify).toHaveBeenCalledTimes(0);
+      expect(view.complete).toBe(true);
+      expect(view.nonEmpty).toBe(true);
+      await expect(view.waitForComplete()).resolves.toBeUndefined();
+      await expect(view.waitForNonEmpty()).resolves.toBeUndefined();
+
+      cleanup2();
+    });
+
+    test('empty singular query resolves after re-materialize without notifying', async () => {
+      // The realistic unchanged shape after a destroy/re-materialize cycle:
+      // an empty .one() query redelivers (undefined, 'complete'), which is
+      // reference-identical to the previous delivery.
+      const viewStore = new ViewStore();
+      const q = newMockQuery('query1', true);
+      const zero = newMockZero('client1');
+      const view = viewStore.getView(zero, q, true, 'forever');
+
+      const {listeners} = vi.mocked(zero.materialize).mock.results[0]
+        .value as unknown as {
+        listeners: Set<(...args: unknown[]) => void>;
+      };
+
+      const cleanup = view.subscribeReactInternals(() => {});
+      listeners.forEach(cb => cb(undefined, 'complete'));
+      const snapshot = view.getSnapshot();
+      expect(snapshot).toEqual([undefined, {type: 'complete'}]);
+      expect(view.complete).toBe(true);
+
+      cleanup();
+      vi.advanceTimersByTime(20);
+      expect(view.complete).toBe(false);
+
+      const notify = vi.fn();
+      const cleanup2 = view.subscribeReactInternals(notify);
+      listeners.forEach(cb => cb(undefined, 'complete'));
+      expect(view.getSnapshot()).toBe(snapshot);
+      expect(notify).toHaveBeenCalledTimes(0);
+      expect(view.complete).toBe(true);
+      await expect(view.waitForComplete()).resolves.toBeUndefined();
+
+      cleanup2();
+    });
+  });
 });
 
 describe('useSuspenseQuery', () => {

--- a/packages/zero-react/src/use-query.tsx
+++ b/packages/zero-react/src/use-query.tsx
@@ -515,6 +515,16 @@ class ViewWrapper<
   readonly #singular: boolean;
   #destroyTimer: ReturnType<typeof setTimeout> | undefined;
 
+  // Inputs of the previous #onData call. When a view flush delivers
+  // reference-identical data with the same resultType and error, the previous
+  // snapshot tuple is kept and React is not notified — building a fresh tuple
+  // would defeat useSyncExternalStore's Object.is bailout and re-render every
+  // subscriber with identical data. #lastResultType doubles as the "has fired
+  // before" sentinel (data and error may both legitimately be undefined).
+  #lastData: Immutable<HumanReadable<TReturn>> | undefined;
+  #lastResultType: ResultType | undefined;
+  #lastError: ErroredQuery | undefined;
+
   constructor(
     query: Query<TTable, TSchema, TReturn>,
     zero: Pick<Zero<TSchema, undefined, TContext>, 'materialize'>,
@@ -538,16 +548,31 @@ class ViewWrapper<
     resultType: ResultType,
     error?: ErroredQuery,
   ) => {
-    // applyChange now returns immutable data structures, so no deep clone needed.
-    // Unchanged rows preserve their object identity for React.memo optimization.
-    const data = snap as HumanReadable<TReturn>;
-    this.#snapshot = getSnapshot(
-      this.#singular,
-      data,
-      resultType,
-      this.#retry,
-      error,
-    );
+    const unchanged =
+      this.#lastResultType !== undefined &&
+      this.#lastData === snap &&
+      this.#lastResultType === resultType &&
+      this.#lastError === error;
+    this.#lastData = snap;
+    this.#lastResultType = resultType;
+    this.#lastError = error;
+
+    if (!unchanged) {
+      // applyChange now returns immutable data structures, so no deep clone needed.
+      // Unchanged rows preserve their object identity for React.memo optimization.
+      const data = snap as HumanReadable<TReturn>;
+      this.#snapshot = getSnapshot(
+        this.#singular,
+        data,
+        resultType,
+        this.#retry,
+        error,
+      );
+    }
+
+    // The resolver bookkeeping runs even when unchanged: after a
+    // destroy/re-materialize cycle the resolvers are fresh but the new view
+    // may deliver the same data/resultType as before the destroy.
     if (resultType === 'complete' || resultType === 'error') {
       this.#complete = true;
       this.#completeResolver.resolve();
@@ -562,6 +587,10 @@ class ViewWrapper<
     ) {
       this.#nonEmpty = true;
       this.#nonEmptyResolver.resolve();
+    }
+
+    if (unchanged) {
+      return;
     }
 
     for (const internals of this.#reactInternals) {

--- a/packages/zql/src/ivm/array-view.test.ts
+++ b/packages/zql/src/ivm/array-view.test.ts
@@ -2268,3 +2268,703 @@ test('unique relationship aliases work correctly', () => {
   const userAfter = data[0] as {all_applications: unknown[]};
   expect(userAfter.all_applications).toHaveLength(0);
 });
+
+/**
+ * Tests that a change flowing through the pipeline that does not alter the
+ * view output does not notify listeners.
+ *
+ * whereExists subqueries (zsubq_*) are present in the pipeline schema but not
+ * in the view format. Edits to rows matched by the subquery propagate to the
+ * view as child changes that alter nothing; the view must not flag itself
+ * dirty for them, otherwise every subscriber re-renders with identical data.
+ */
+test('whereExists subquery edit does not notify listeners', () => {
+  const issues = createSource(
+    lc,
+    testLogConfig,
+    'issues',
+    {id: {type: 'number'}, title: {type: 'string'}},
+    ['id'],
+  );
+  const labels = createSource(
+    lc,
+    testLogConfig,
+    'labels',
+    {
+      id: {type: 'number'},
+      issueID: {type: 'number'},
+      name: {type: 'string'},
+    },
+    ['id'],
+  );
+
+  consume(issues.push(makeSourceChangeAdd({id: 1, title: 'issue'})));
+  consume(labels.push(makeSourceChangeAdd({id: 1, issueID: 1, name: 'bug'})));
+
+  const delegate = new TestBuilderDelegate({issues, labels});
+
+  // issues.whereExists('labels')
+  const ast: AST = {
+    table: 'issues',
+    orderBy: [['id', 'asc']],
+    where: {
+      type: 'correlatedSubquery',
+      related: {
+        system: 'client',
+        correlation: {parentField: ['id'], childField: ['issueID']},
+        subquery: {
+          table: 'labels',
+          alias: 'zsubq_labels',
+          orderBy: [
+            ['issueID', 'asc'],
+            ['id', 'asc'],
+          ],
+        },
+      },
+      op: 'EXISTS',
+    },
+  };
+
+  const view = new ArrayView(
+    buildPipeline(ast, delegate, 'test-query'),
+    {singular: false, relationships: {}},
+    true,
+    () => {},
+  );
+
+  let callCount = 0;
+  let data: unknown;
+  view.addListener(entries => {
+    ++callCount;
+    data = entries;
+  });
+
+  expect(callCount).toBe(1);
+  expect(data).toEqual([{id: 1, title: 'issue', [refCountSymbol]: 1}]);
+  const snapshot = data;
+
+  // Edit a field of the matched label that affects neither the correlation
+  // nor the view output. The change reaches the view as a zsubq_labels child
+  // change but alters nothing: no notification, same data reference.
+  consume(
+    labels.push(
+      makeSourceChangeEdit(
+        {id: 1, issueID: 1, name: 'bug!'},
+        {id: 1, issueID: 1, name: 'bug'},
+      ),
+    ),
+  );
+  view.flush();
+  expect(callCount).toBe(1);
+  expect(view.data).toBe(snapshot);
+
+  // A change that does alter the view still notifies.
+  consume(
+    issues.push(
+      makeSourceChangeEdit({id: 1, title: 'issue!'}, {id: 1, title: 'issue'}),
+    ),
+  );
+  view.flush();
+  expect(callCount).toBe(2);
+  expect(data).not.toBe(snapshot);
+  expect(data).toEqual([{id: 1, title: 'issue!', [refCountSymbol]: 1}]);
+});
+
+test('no-op push does not dirty the view', () => {
+  // A child change for a relationship that is in the pipeline schema but not
+  // in the view format is a no-op for the view.
+  const schema: SourceSchema = {
+    tableName: 'issue',
+    primaryKey: ['id'],
+    system: 'client',
+    columns: {
+      id: {type: 'number'},
+      name: {type: 'string'},
+    },
+    sort: [['id', 'asc']],
+    isHidden: false,
+    compareRows: (r1, r2) => (r1.id as number) - (r2.id as number),
+    relationships: {
+      ['zsubq_labels']: {
+        tableName: 'label',
+        primaryKey: ['id'],
+        columns: {
+          id: {type: 'number'},
+          name: {type: 'string'},
+        },
+        isHidden: false,
+        sort: [['id', 'asc']],
+        system: 'client',
+        compareRows: (r1, r2) => (r1.id as number) - (r2.id as number),
+        relationships: {},
+      },
+    },
+  };
+
+  const input: Input = {
+    fetch() {
+      return [];
+    },
+    destroy() {},
+    getSchema() {
+      return schema;
+    },
+    setOutput() {},
+  };
+
+  const view = new ArrayView(
+    input,
+    // zsubq_labels is not part of the view format.
+    {singular: false, relationships: {}},
+    true,
+    () => {},
+  );
+
+  let callCount = 0;
+  let data: unknown;
+  view.addListener(entries => {
+    ++callCount;
+    data = entries;
+  });
+  expect(callCount).toBe(1);
+
+  const labelNode = {
+    row: {id: 1, name: 'label'},
+    relationships: {},
+  } as const;
+  consume(
+    view.push(
+      makeAddChange({
+        row: {id: 1, name: 'issue'},
+        relationships: {['zsubq_labels']: () => [labelNode]},
+      }),
+    ),
+  );
+  view.flush();
+  expect(callCount).toBe(2);
+  const snapshot = data;
+
+  const noopChange = makeChildChange(
+    {row: {id: 1, name: 'issue'}, relationships: {}},
+    {
+      relationshipName: 'zsubq_labels',
+      change: makeEditChange(
+        {row: {id: 1, name: 'label edited'}, relationships: {}},
+        labelNode,
+      ),
+    },
+  );
+  consume(view.push(noopChange));
+  view.flush();
+
+  // No notification, same data reference.
+  expect(callCount).toBe(2);
+  expect(data).toBe(snapshot);
+  expect(view.data).toBe(snapshot);
+
+  // A transaction mixing no-op and real changes still notifies once.
+  consume(view.push(noopChange));
+  consume(
+    view.push(
+      makeAddChange({
+        row: {id: 2, name: 'issue2'},
+        relationships: {['zsubq_labels']: () => []},
+      }),
+    ),
+  );
+  consume(view.push(noopChange));
+  view.flush();
+  expect(callCount).toBe(3);
+  expect(data).not.toBe(snapshot);
+  expect(data).toEqual([
+    {id: 1, name: 'issue', [refCountSymbol]: 1},
+    {id: 2, name: 'issue2', [refCountSymbol]: 1},
+  ]);
+});
+
+test('a listener throwing during flush does not freeze the view', () => {
+  const ms = createSource(
+    lc,
+    testLogConfig,
+    'table',
+    {a: {type: 'number'}, b: {type: 'string'}},
+    ['a'],
+  );
+
+  const view = new ArrayView(
+    ms.connect([['a', 'asc']]),
+    {singular: false, relationships: {}},
+    true,
+    () => {},
+  );
+
+  let throwOnce = false;
+  let callCount = 0;
+  let data: unknown;
+  view.addListener(entries => {
+    ++callCount;
+    data = entries;
+    if (throwOnce) {
+      throwOnce = false;
+      throw new Error('listener error');
+    }
+  });
+  expect(callCount).toBe(1);
+
+  consume(ms.push(makeSourceChangeAdd({a: 1, b: 'a'})));
+  throwOnce = true;
+  // In production the throw is swallowed by ZeroContext#endTransaction.
+  expect(() => view.flush()).toThrow('listener error');
+  expect(callCount).toBe(2);
+  const snapshot = data;
+
+  // The next transaction must still copy-on-write and notify. If the throw
+  // left the committed root marked as owned by the flushed transaction,
+  // applyChange would mutate it in place and return an identical reference,
+  // which push() would read as "no change" — silencing the view forever.
+  consume(ms.push(makeSourceChangeAdd({a: 2, b: 'b'})));
+  view.flush();
+  expect(callCount).toBe(3);
+  expect(data).not.toBe(snapshot);
+  expect(data).toEqual([
+    {a: 1, b: 'a', [refCountSymbol]: 1},
+    {a: 2, b: 'b', [refCountSymbol]: 1},
+  ]);
+  // The snapshot delivered before the throw was not mutated in place.
+  expect(snapshot).toEqual([{a: 1, b: 'a', [refCountSymbol]: 1}]);
+});
+
+test('a listener pushing synchronously during flush is not lost', () => {
+  const ms = createSource(
+    lc,
+    testLogConfig,
+    'table',
+    {a: {type: 'number'}, b: {type: 'string'}},
+    ['a'],
+  );
+
+  const view = new ArrayView(
+    ms.connect([['a', 'asc']]),
+    {singular: false, relationships: {}},
+    true,
+    () => {},
+  );
+
+  let pushOnce = false;
+  let callCount = 0;
+  let data: unknown;
+  view.addListener(entries => {
+    ++callCount;
+    data = entries;
+    if (pushOnce) {
+      pushOnce = false;
+      consume(ms.push(makeSourceChangeAdd({a: 2, b: 'b'})));
+    }
+  });
+  expect(callCount).toBe(1);
+
+  consume(ms.push(makeSourceChangeAdd({a: 1, b: 'a'})));
+  pushOnce = true;
+  view.flush();
+  expect(callCount).toBe(2);
+  const snapshot = data;
+  // The re-entrant push must not mutate the just-delivered snapshot in place;
+  // it belongs to the next transaction and is delivered by the next flush.
+  expect(snapshot).toEqual([{a: 1, b: 'a', [refCountSymbol]: 1}]);
+
+  view.flush();
+  expect(callCount).toBe(3);
+  expect(data).not.toBe(snapshot);
+  expect(data).toEqual([
+    {a: 1, b: 'a', [refCountSymbol]: 1},
+    {a: 2, b: 'b', [refCountSymbol]: 1},
+  ]);
+});
+
+// Schema for the nested no-op tests: comments is in the view format, its
+// zsubq_reactions sub-relationship (a whereExists subquery on the related
+// query) is not.
+function nestedNoopSchema(): SourceSchema {
+  return {
+    tableName: 'issue',
+    primaryKey: ['id'],
+    system: 'client',
+    columns: {
+      id: {type: 'number'},
+      name: {type: 'string'},
+    },
+    sort: [['id', 'asc']],
+    isHidden: false,
+    compareRows: (r1, r2) => (r1.id as number) - (r2.id as number),
+    relationships: {
+      comments: {
+        tableName: 'comment',
+        primaryKey: ['id'],
+        columns: {
+          id: {type: 'number'},
+          issueID: {type: 'number'},
+          text: {type: 'string'},
+        },
+        isHidden: false,
+        sort: [['id', 'asc']],
+        system: 'client',
+        compareRows: (r1, r2) => (r1.id as number) - (r2.id as number),
+        relationships: {
+          ['zsubq_reactions']: {
+            tableName: 'reaction',
+            primaryKey: ['id'],
+            columns: {
+              id: {type: 'number'},
+              commentID: {type: 'number'},
+              emoji: {type: 'string'},
+            },
+            isHidden: false,
+            sort: [['id', 'asc']],
+            system: 'client',
+            compareRows: (r1, r2) => (r1.id as number) - (r2.id as number),
+            relationships: {},
+          },
+        },
+      },
+    },
+  };
+}
+
+function nestedNoopIssueNode() {
+  return {
+    row: {id: 1, name: 'issue'},
+    relationships: {
+      comments: () => [
+        {
+          row: {id: 1, issueID: 1, text: 'comment'},
+          relationships: {
+            ['zsubq_reactions']: () => [
+              {
+                row: {id: 1, commentID: 1, emoji: 'up'},
+                relationships: {},
+              },
+            ],
+          },
+        },
+      ],
+    },
+  };
+}
+
+// issue.related('comments', q => q.whereExists('reactions', ...)): an edit of
+// a matched reaction arrives as a child change for the format-present
+// comments relationship wrapping a zsubq change one level down. Suppressing
+// the notification depends on applyChange's identity-propagation checks
+// (return parentEntry when the descendant did not change).
+function nestedNoopChange() {
+  return makeChildChange(
+    {row: {id: 1, name: 'issue'}, relationships: {}},
+    {
+      relationshipName: 'comments',
+      change: makeChildChange(
+        {row: {id: 1, issueID: 1, text: 'comment'}, relationships: {}},
+        {
+          relationshipName: 'zsubq_reactions',
+          change: makeEditChange(
+            {row: {id: 1, commentID: 1, emoji: 'down'}, relationships: {}},
+            {row: {id: 1, commentID: 1, emoji: 'up'}, relationships: {}},
+          ),
+        },
+      ),
+    },
+  );
+}
+
+test('nested no-op child change does not notify listeners', () => {
+  const schema = nestedNoopSchema();
+  const input: Input = {
+    fetch() {
+      return [nestedNoopIssueNode()];
+    },
+    destroy() {},
+    getSchema() {
+      return schema;
+    },
+    setOutput() {},
+  };
+
+  const view = new ArrayView(
+    input,
+    {
+      singular: false,
+      relationships: {comments: {singular: false, relationships: {}}},
+    },
+    true,
+    () => {},
+  );
+
+  let callCount = 0;
+  let data: unknown;
+  view.addListener(entries => {
+    ++callCount;
+    data = entries;
+  });
+  expect(callCount).toBe(1);
+  expect(data).toEqual([
+    {
+      id: 1,
+      name: 'issue',
+      comments: [{id: 1, issueID: 1, text: 'comment', [refCountSymbol]: 1}],
+      [refCountSymbol]: 1,
+    },
+  ]);
+  const snapshot = data;
+
+  consume(view.push(nestedNoopChange()));
+  view.flush();
+  expect(callCount).toBe(1);
+  expect(view.data).toBe(snapshot);
+});
+
+test('nested no-op child change does not notify listeners (singular root)', () => {
+  const schema = nestedNoopSchema();
+  const input: Input = {
+    fetch() {
+      return [nestedNoopIssueNode()];
+    },
+    destroy() {},
+    getSchema() {
+      return schema;
+    },
+    setOutput() {},
+  };
+
+  const view = new ArrayView(
+    input,
+    {
+      singular: true,
+      relationships: {comments: {singular: false, relationships: {}}},
+    },
+    true,
+    () => {},
+  );
+
+  let callCount = 0;
+  let data: unknown;
+  view.addListener(d => {
+    ++callCount;
+    data = d;
+  });
+  expect(callCount).toBe(1);
+  const snapshot = data;
+
+  consume(view.push(nestedNoopChange()));
+  view.flush();
+  expect(callCount).toBe(1);
+  expect(view.data).toBe(snapshot);
+});
+
+// Schema for the hidden junction edit tests, matching the 'collapse' tests:
+// issue -> issueLabel (hidden junction) -> label.
+function hiddenJunctionSchema(): SourceSchema {
+  return {
+    tableName: 'issue',
+    primaryKey: ['id'],
+    system: 'client',
+    columns: {
+      id: {type: 'number'},
+      name: {type: 'string'},
+    },
+    sort: [['id', 'asc']],
+    isHidden: false,
+    compareRows: (r1, r2) => (r1.id as number) - (r2.id as number),
+    relationships: {
+      labels: {
+        tableName: 'issueLabel',
+        primaryKey: ['id'],
+        sort: [['id', 'asc']],
+        system: 'client',
+        columns: {
+          id: {type: 'number'},
+          issueId: {type: 'number'},
+          labelId: {type: 'number'},
+          extra: {type: 'string'},
+        },
+        isHidden: true,
+        compareRows: (r1, r2) => (r1.id as number) - (r2.id as number),
+        relationships: {
+          labels: {
+            tableName: 'label',
+            primaryKey: ['id'],
+            columns: {
+              id: {type: 'number'},
+              name: {type: 'string'},
+            },
+            isHidden: false,
+            sort: [['id', 'asc']],
+            system: 'client',
+            compareRows: (r1, r2) => (r1.id as number) - (r2.id as number),
+            relationships: {},
+          },
+        },
+      },
+    },
+  };
+}
+
+function hiddenJunctionIssueNode() {
+  return {
+    row: {id: 1, name: 'issue'},
+    relationships: {
+      labels: () => [
+        {
+          row: {id: 1, issueId: 1, labelId: 1, extra: 'a'},
+          relationships: {
+            labels: () => [
+              {
+                row: {id: 1, name: 'label'},
+                relationships: {},
+              },
+            ],
+          },
+        },
+      ],
+    },
+  };
+}
+
+// Edit of a non-key column of the hidden junction row. The junction row is
+// collapsed out of the view, so this must not notify.
+function hiddenJunctionEditChange() {
+  return makeChildChange(
+    {row: {id: 1, name: 'issue'}, relationships: {}},
+    {
+      relationshipName: 'labels',
+      change: makeEditChange(
+        {row: {id: 1, issueId: 1, labelId: 1, extra: 'a2'}, relationships: {}},
+        {row: {id: 1, issueId: 1, labelId: 1, extra: 'a'}, relationships: {}},
+      ),
+    },
+  );
+}
+
+// Edit of the visible leaf label, which must notify.
+function hiddenJunctionLeafEditChange() {
+  return makeChildChange(
+    {row: {id: 1, name: 'issue'}, relationships: {}},
+    {
+      relationshipName: 'labels',
+      change: makeChildChange(
+        {row: {id: 1, issueId: 1, labelId: 1, extra: 'a2'}, relationships: {}},
+        {
+          relationshipName: 'labels',
+          change: makeEditChange(
+            {row: {id: 1, name: 'label2'}, relationships: {}},
+            {row: {id: 1, name: 'label'}, relationships: {}},
+          ),
+        },
+      ),
+    },
+  );
+}
+
+test('hidden junction row edit does not notify listeners', () => {
+  const schema = hiddenJunctionSchema();
+  const input: Input = {
+    fetch() {
+      return [hiddenJunctionIssueNode()];
+    },
+    destroy() {},
+    getSchema() {
+      return schema;
+    },
+    setOutput() {},
+  };
+
+  const view = new ArrayView(
+    input,
+    {
+      singular: false,
+      relationships: {labels: {singular: false, relationships: {}}},
+    },
+    true,
+    () => {},
+  );
+
+  let callCount = 0;
+  let data: unknown;
+  view.addListener(entries => {
+    ++callCount;
+    data = entries;
+  });
+  expect(callCount).toBe(1);
+  expect(data).toEqual([
+    {
+      id: 1,
+      name: 'issue',
+      labels: [{id: 1, name: 'label', [refCountSymbol]: 1}],
+      [refCountSymbol]: 1,
+    },
+  ]);
+  const snapshot = data;
+
+  consume(view.push(hiddenJunctionEditChange()));
+  view.flush();
+  expect(callCount).toBe(1);
+  expect(view.data).toBe(snapshot);
+
+  // An edit of the visible leaf still notifies with a new reference.
+  consume(view.push(hiddenJunctionLeafEditChange()));
+  view.flush();
+  expect(callCount).toBe(2);
+  expect(data).not.toBe(snapshot);
+  expect(data).toEqual([
+    {
+      id: 1,
+      name: 'issue',
+      labels: [{id: 1, name: 'label2', [refCountSymbol]: 1}],
+      [refCountSymbol]: 1,
+    },
+  ]);
+});
+
+test('hidden junction row edit does not notify listeners (singular child format)', () => {
+  const schema = hiddenJunctionSchema();
+  const input: Input = {
+    fetch() {
+      return [hiddenJunctionIssueNode()];
+    },
+    destroy() {},
+    getSchema() {
+      return schema;
+    },
+    setOutput() {},
+  };
+
+  const view = new ArrayView(
+    input,
+    {
+      singular: false,
+      relationships: {labels: {singular: true, relationships: {}}},
+    },
+    true,
+    () => {},
+  );
+
+  let callCount = 0;
+  let data: unknown;
+  view.addListener(entries => {
+    ++callCount;
+    data = entries;
+  });
+  expect(callCount).toBe(1);
+  expect(data).toEqual([
+    {
+      id: 1,
+      name: 'issue',
+      labels: {id: 1, name: 'label', [refCountSymbol]: 1},
+      [refCountSymbol]: 1,
+    },
+  ]);
+  const snapshot = data;
+
+  consume(view.push(hiddenJunctionEditChange()));
+  view.flush();
+  expect(callCount).toBe(1);
+  expect(view.data).toBe(snapshot);
+});

--- a/packages/zql/src/ivm/array-view.ts
+++ b/packages/zql/src/ivm/array-view.ts
@@ -157,8 +157,7 @@ export class ArrayView<V extends View> implements Output, TypedView<V> {
   }
 
   push(change: Change) {
-    this.#dirty = true;
-    this.#root = applyChange(
+    const newRoot = applyChange(
       this.#root,
       changeToViewChange(change),
       this.#schema,
@@ -167,6 +166,18 @@ export class ArrayView<V extends View> implements Output, TypedView<V> {
       false /* withIDs */,
       this.#txnDirty /* mutate: copy-on-write within this transaction */,
     );
+    // applyChange returns the same root when the change did not affect the
+    // view — e.g. a child change for a relationship that is not in the format,
+    // such as a whereExists subquery (zsubq_*). Only mark dirty when the root
+    // actually changed so flush() does not notify listeners with identical
+    // data. Within a transaction the root keeps its reference across a *real*
+    // change only if an earlier change in the same transaction already cloned
+    // it (copy-on-write) — and that earlier change set #dirty, so an unchanged
+    // reference here never hides a real change.
+    if (newRoot !== this.#root) {
+      this.#root = newRoot;
+      this.#dirty = true;
+    }
     return emptyArray;
   }
 
@@ -175,11 +186,17 @@ export class ArrayView<V extends View> implements Output, TypedView<V> {
       return;
     }
     this.#dirty = false;
-    this.#fireListeners();
-    // The snapshot just handed to listeners is now observed; the next
+    // The snapshot about to be handed to listeners becomes observed; the next
     // transaction must copy-on-write rather than mutate these objects. A fresh
     // WeakSet drops all "owned" marks (WeakSet has no clear()).
+    //
+    // Reset BEFORE notifying: a listener may throw (swallowed by
+    // ZeroContext#endTransaction) or re-enter push(). If the committed root
+    // kept its "owned" marks, a later transaction would mutate it in place and
+    // return an identical reference — which push() would read as "no change",
+    // permanently silencing the view.
     this.#txnDirty = new WeakSet();
+    this.#fireListeners();
   }
 
   updateTTL(ttl: TTL) {


### PR DESCRIPTION
## Problem

`ArrayView.push` set `#dirty = true` unconditionally, *before* calling `applyChange` — even when `applyChange` returned the identical root because the change didn't affect the view output.

This happens on a real, recurring path: `whereExists` subquery relationships (`zsubq_*`) are part of the pipeline schema but never part of the view format. Any edit to a row matched by the subquery propagates through the pipeline as a `child` change that alters nothing in the view — but the view still flagged itself dirty, `flush()` fired all listeners, and in React `ViewWrapper.#onData` built a fresh snapshot tuple. A fresh tuple defeats `useSyncExternalStore`'s `Object.is` bailout, so **every component subscribed to the query re-rendered with byte-identical data**. The same applies to edits of hidden junction rows (e.g. a many-to-many `issueLabel` row's non-key column) and to `whereExists` nested inside `related()` subqueries.

Repro (now a regression test): with `issue.whereExists('labels', …)` materialized, editing a matched label's `name` fired the listener with a `data` reference `===` the previous one.

## Fix

**1. `zql` — `ArrayView.push` only dirties the view when the root actually changed:**

```ts
const newRoot = applyChange(…);
if (newRoot !== this.#root) {
  this.#root = newRoot;
  this.#dirty = true;
}
```

This is safe against the transaction-scoped copy-on-write scheme (`#txnDirty`): within a transaction, the root keeps its reference across a *real* change only if an earlier change in the same transaction already cloned it — and that earlier change set `#dirty`. An unchanged reference therefore never hides a real change. (`applyChange` documents this contract: "Returns new Entry on change, same Entry if unchanged.")

**2. `zql` — `ArrayView.flush` resets `#txnDirty` *before* notifying listeners.**

Previously the reset ran after `#fireListeners()`. A listener that throws (which `ZeroContext#endTransaction` swallows in production) or re-enters `push()` would skip/predate the reset, leaving the committed, listener-observed root marked as transaction-owned. A later transaction would then mutate it in place and return an identical reference — which the new identity check in `push()` would read as "no change", permanently silencing the view (under the old unconditional-dirty code this window self-healed). Resetting first closes both holes and also stops the (pre-existing) in-place mutation of an already-delivered snapshot in that window.

**3. `zero-react` — `ViewWrapper.#onData` keeps the previous snapshot when nothing changed:**

When the incoming `(data, resultType, error)` triple is reference-identical to the previous call, the previous snapshot tuple is kept and React internals are not notified. This is belt-and-braces for the React binding: it also protects against any other `TypedView` implementation that notifies without a data change. Resolver bookkeeping (`complete` / `nonEmpty`) still runs unconditionally so `waitForComplete()` / `waitForNonEmpty()` resolve correctly after a destroy/re-materialize cycle delivers unchanged data (e.g. an empty `.one()` query redelivering `(undefined, 'complete')`).

## Not affected / out of scope

- **`zero-solid`**: `SolidView` batches changes into a Solid store `produce` draft; Solid's fine-grained store only notifies on actually-written leaves, so it doesn't share this bug.
- **refCount-only updates** (e.g. duplicate add via a second junction edge) still clone the entry and notify with byte-identical visible data. Detecting those requires deep comparison; unchanged behavior.
- `run()` / `preload()` completion signaling is unaffected: the `'complete'`/`'error'` transition fires through the `queryComplete` promise path, not through `flush()`.

## Tests

`array-view.test.ts` (8 new):
- **end-to-end**: a real `whereExists` pipeline (`EXISTS` correlated subquery, `zsubq_labels`) where editing the matched label does **not** notify listeners and preserves the `data` reference, while a real edit still notifies;
- **root-level no-op**: a `child` change for a relationship absent from the view format doesn't dirty the view; a transaction mixing no-op and real changes still notifies exactly once;
- **nested no-op** (plural + singular root): `related('comments', q => q.whereExists(…))`-shaped changes, pinning `applyChange`'s identity-propagation checks (`return parentEntry` when the descendant didn't change) which this change promotes from allocation optimizations to notification-correctness gates;
- **hidden junction edits** (plural + singular child format): editing a collapsed junction row's non-key column doesn't notify; editing the visible leaf still does;
- **throwing listener**: a listener that throws during `flush()` doesn't freeze the view — the next transaction still copies-on-write and notifies;
- **re-entrant push**: a listener that synchronously pushes during `flush()` neither mutates the just-delivered snapshot nor loses the change.

`use-query.test.tsx` (4 new, `unchanged data on flush`):
- same data reference + resultType keeps snapshot identity and does not notify React;
- same error reference keeps snapshot identity; a new error object notifies;
- resolvers re-resolve after unsubscribe → destroy → re-subscribe even when the re-materialized view delivers identical data (so `useSuspenseQuery` cannot hang);
- the realistic empty-`.one()` shape: `(undefined, 'complete')` redelivered after re-materialize keeps the predefined snapshot tuple, skips notification, and still resolves `waitForComplete()`.

All new tests were verified to fail without the specific part of the fix they pin (checked by reverting each part independently).
