### PR TITLE
feat(zero-cache): canary SQLite catchup reads

### DIFF
--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -68,6 +68,7 @@ export default async function runWorker(
       flowControlConsensusPaddingSeconds,
       flowControlEventDrivenRelease,
       sqliteChangeLogMode,
+      sqliteChangeLogReadPercent,
       sqliteChangeLogComparePercent,
       sqliteChangeLogRetentionMs,
       sqliteChangeLogReadBatchRows,
@@ -236,6 +237,16 @@ export default async function runWorker(
                   comparePercent: sqliteChangeLogComparePercent,
                   retentionMs: sqliteChangeLogRetentionMs,
                   readBatchRows: sqliteChangeLogReadBatchRows,
+                }
+              : undefined,
+          // Slice 11 lands dark by default: serve mode constructs the stable
+          // router, while readPercent=0 keeps every catchup on PG and emits
+          // eligibility metrics before any canary traffic is enabled.
+          sqliteChangeLogServe:
+            sqliteChangeLogMode === 'serve'
+              ? {
+                  readPercent: sqliteChangeLogReadPercent,
+                  retentionMs: sqliteChangeLogRetentionMs,
                 }
               : undefined,
         },

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
@@ -328,6 +328,7 @@ describe('change-streamer/service', () => {
     sqliteCatchup?: Partial<SQLiteCatchupOptions>,
     sqliteChangeLogPurge?: TuningOptions['sqliteChangeLogPurge'],
     backupURL?: string,
+    sqliteChangeLogServe?: TuningOptions['sqliteChangeLogServe'],
   ): Promise<void> {
     await streamer.stop();
     await streamerDone;
@@ -369,6 +370,7 @@ describe('change-streamer/service', () => {
           },
         },
         ...(sqliteChangeLogPurge === undefined ? {} : {sqliteChangeLogPurge}),
+        ...(sqliteChangeLogServe === undefined ? {} : {sqliteChangeLogServe}),
         ...(sqliteCatchup === undefined
           ? {}
           : {
@@ -549,6 +551,160 @@ describe('change-streamer/service', () => {
     }
   });
 
+  test('serve mode at zero percent measures eligibility but keeps catchup on PG', async () => {
+    const readerRead = vi.spyOn(SQLiteChangeLogReader.prototype, 'read');
+    const logFile = new DbFile('sqlite-change-log-zero-percent');
+    await restartWithInlineChangeLogWriter(
+      logFile,
+      {barrierPollIntervalMs: 10},
+      undefined,
+      undefined,
+      {readPercent: 0, retentionMs: 0},
+    );
+
+    try {
+      changes.push(['begin', messages.begin(), {commitWatermark: '06'}]);
+      changes.push(['data', messages.insert('foo', {id: 'from-pg'})]);
+      changes.push(['commit', messages.commit(), {watermark: '06'}]);
+      await expectAcks('06');
+
+      const sub = await subscribeServing('zero-percent');
+      const output = drainToQueue(sub);
+      expect(await nextChange(output)).toMatchObject({tag: 'status'});
+      expect(await nextChange(output)).toMatchObject({tag: 'begin'});
+      expect(await nextChange(output)).toMatchObject({
+        tag: 'insert',
+        new: {id: 'from-pg'},
+      });
+      expect(await nextChange(output)).toMatchObject({tag: 'commit'});
+      expect(readerRead).not.toHaveBeenCalled();
+
+      // The route log carries the covered range even though the percentage
+      // gate kept this eligible subscriber on PG.
+      expect(logSink.messages).toContainEqual([
+        'debug',
+        expect.anything(),
+        [
+          expect.stringContaining('SQLite route percentage'),
+          expect.objectContaining({
+            sqliteChangeLogCoverage: expect.objectContaining({
+              minWatermark: REPLICA_VERSION,
+              headWatermark: '06',
+            }),
+          }),
+        ],
+      ]);
+      sub.cancel();
+    } finally {
+      readerRead.mockRestore();
+      await streamer.stop();
+      await streamerDone;
+      deleteChangeLogDB(logFile.path);
+      logFile.delete();
+    }
+  });
+
+  test('serve mode declines a freshly seeded log until its retention window elapses', async () => {
+    const readerRead = vi.spyOn(SQLiteChangeLogReader.prototype, 'read');
+    const logFile = new DbFile('sqlite-change-log-warmup');
+    const retentionMs = 60_000;
+    let now = Date.now();
+    await restartWithInlineChangeLogWriter(
+      logFile,
+      {barrierPollIntervalMs: 10},
+      undefined,
+      undefined,
+      {readPercent: 100, retentionMs, now: () => now},
+    );
+
+    try {
+      changes.push(['begin', messages.begin(), {commitWatermark: '06'}]);
+      changes.push(['data', messages.insert('foo', {id: 'warmup'})]);
+      changes.push(['commit', messages.commit(), {watermark: '06'}]);
+      await expectAcks('06');
+
+      const coldSub = await subscribeServing('cold-log');
+      const cold = drainToQueue(coldSub);
+      expect(await nextChange(cold)).toMatchObject({tag: 'status'});
+      expect(await nextChange(cold)).toMatchObject({tag: 'begin'});
+      expect(await nextChange(cold)).toMatchObject({tag: 'insert'});
+      expect(await nextChange(cold)).toMatchObject({tag: 'commit'});
+      expect(readerRead).not.toHaveBeenCalled();
+
+      now += retentionMs + 10_000;
+      const warmSub = await subscribeServing('warm-log');
+      const warm = drainToQueue(warmSub);
+      expect(await nextChange(warm)).toMatchObject({tag: 'status'});
+      expect(await nextChange(warm)).toMatchObject({tag: 'begin'});
+      expect(await nextChange(warm)).toMatchObject({tag: 'insert'});
+      expect(await nextChange(warm)).toMatchObject({tag: 'commit'});
+      expect(readerRead).toHaveBeenCalled();
+
+      coldSub.cancel();
+      warmSub.cancel();
+    } finally {
+      readerRead.mockRestore();
+      await streamer.stop();
+      await streamerDone;
+      deleteChangeLogDB(logFile.path);
+      logFile.delete();
+    }
+  });
+
+  test('a post-registration SQLite read failure sends the retry to PG', async () => {
+    const readerRead = vi
+      .spyOn(SQLiteChangeLogReader.prototype, 'read')
+      .mockImplementationOnce(async function* () {
+        throw new Error('injected SQLite read failure');
+      });
+    const logFile = new DbFile('sqlite-change-log-read-breaker');
+    await restartWithInlineChangeLogWriter(
+      logFile,
+      {barrierPollIntervalMs: 10},
+      undefined,
+      undefined,
+      {readPercent: 100, retentionMs: 0},
+    );
+
+    try {
+      changes.push(['begin', messages.begin(), {commitWatermark: '06'}]);
+      changes.push(['data', messages.insert('foo', {id: 'from-pg-retry'})]);
+      changes.push(['commit', messages.commit(), {watermark: '06'}]);
+      await expectAcks('06');
+
+      const failed = await subscribeServing('breaker-retry');
+      for await (const _ of failed) {
+        // The injected reader failure happens before SQLite emits catchup.
+      }
+      expect(readerRead).toHaveBeenCalledOnce();
+      expect(logSink.messages).toContainEqual([
+        'warn',
+        expect.anything(),
+        [expect.stringContaining('temporarily disabling SQLite catchup')],
+      ]);
+
+      // The same stable task would ordinarily select SQLite again. The open
+      // breaker sends this immediate reconnect through the complete PG path.
+      const retrySub = await subscribeServing('breaker-retry');
+      const retry = drainToQueue(retrySub);
+      expect(await nextChange(retry)).toMatchObject({tag: 'status'});
+      expect(await nextChange(retry)).toMatchObject({tag: 'begin'});
+      expect(await nextChange(retry)).toMatchObject({
+        tag: 'insert',
+        new: {id: 'from-pg-retry'},
+      });
+      expect(await nextChange(retry)).toMatchObject({tag: 'commit'});
+      expect(readerRead).toHaveBeenCalledOnce();
+      retrySub.cancel();
+    } finally {
+      readerRead.mockRestore();
+      await streamer.stop();
+      await streamerDone;
+      deleteChangeLogDB(logFile.path);
+      logFile.delete();
+    }
+  });
+
   test('SQLite cleanup continues independently after PG reaches the floor', async () => {
     const logFile = new DbFile('sqlite-change-log-independent-purge');
     await restartWithInlineChangeLogWriter(logFile, undefined, {
@@ -711,10 +867,11 @@ describe('change-streamer/service', () => {
    * pinned once the restore is over.
    */
   test('a snapshot reservation pauses the SQLite purge until it closes', async () => {
+    const readerRead = vi.spyOn(SQLiteChangeLogReader.prototype, 'read');
     const logFile = new DbFile('sqlite-change-log-reservation-pause');
     await restartWithInlineChangeLogWriter(
       logFile,
-      undefined,
+      {barrierPollIntervalMs: 10},
       {
         retentionMs: 1,
         batchRows: 100,
@@ -722,6 +879,7 @@ describe('change-streamer/service', () => {
         yieldFn: () => Promise.resolve(),
       },
       's3://foo/bar',
+      {readPercent: 100, retentionMs: 0},
     );
 
     const watermarks = ['03', '04', '05', '06', '07', '08'];
@@ -772,14 +930,32 @@ describe('change-streamer/service', () => {
       await fireNextTimer();
       expect(sqliteMinWatermark(logFile)).toBe(REPLICA_VERSION);
 
+      // The matching /changes request consumes the source pinned by
+      // /snapshot. Its ACK keeps protecting the same SQLite range while
+      // subscribe() closes the reservation and resumes purging.
+      const sub = await streamer.subscribe({
+        protocolVersion: PROTOCOL_VERSION,
+        taskID: 'view-syncer-1',
+        id: 'view-syncer-1',
+        mode: 'serving',
+        watermark: '08',
+        replicaVersion: REPLICA_VERSION,
+        initial: true,
+        logsChangeStream: false,
+      });
+      const output = drainToQueue(sub);
+      expect(await nextChange(output)).toMatchObject({tag: 'status'});
+      expect(readerRead).toHaveBeenCalled();
+
       // Closing the reservation resumes purging: the next armed pass drains
-      // the SQLite log to the floor.
-      reservation.cancel();
+      // the SQLite log to the floor protected by the subscriber ACK.
       await fireNextTimer();
       expect(sqliteMinWatermark(logFile)).toBe('08');
       // Cleanup reached the backup watermark: nothing further is armed.
       expect(setTimeoutFn).toHaveBeenCalledTimes(fired);
+      sub.cancel();
     } finally {
+      readerRead.mockRestore();
       await streamer.stop();
       await streamerDone;
       deleteChangeLogDB(logFile.path);
@@ -1263,10 +1439,19 @@ describe('change-streamer/service', () => {
   test('a mid-stream writer failure fails soft without stopping replication', async () => {
     const readerClose = vi.spyOn(SQLiteChangeLogReader.prototype, 'close');
     const logFile = new DbFile('sqlite-change-log-fail-soft');
-    await restartWithInlineChangeLogWriter(logFile, {
-      barrierPollIntervalMs: 10,
-      shouldUse: ctx => ctx.id.startsWith('from-sqlite'),
-    });
+    await restartWithInlineChangeLogWriter(
+      logFile,
+      {
+        barrierPollIntervalMs: 10,
+        shouldUse: ctx => ctx.id.startsWith('from-sqlite'),
+      },
+      undefined,
+      undefined,
+      {
+        readPercent: 100,
+        retentionMs: 0,
+      },
+    );
 
     const liveSub = await subscribeServing('live-observer');
     const live = drainToQueue(liveSub);
@@ -1355,10 +1540,7 @@ describe('change-streamer/service', () => {
     }
   });
 
-  // The exclusion outlives its original reason -- the writer is no longer a
-  // subscriber, so nothing can wait on its own ACK -- because a replicator that
-  // predates the writer's move still sets the parameter. Slice 11 lifts it.
-  test('backup subscribers and legacy change-log writers cannot select SQLite catchup', async () => {
+  test('backup subscribers stay on PG while the legacy writer hint can select SQLite', async () => {
     await streamer.stop();
     await streamerDone;
 
@@ -1457,39 +1639,34 @@ describe('change-streamer/service', () => {
       });
       expect(await nextChange(backed)).toMatchObject({tag: 'commit'});
 
+      appendSQLiteTransaction(catchupReplica, catchupChangeLog, '04', [
+        ['data', messages.insert('foo', {id: 'from-sqlite'})],
+      ]);
+
       shouldUse.mockClear();
       const writerSub = await streamer.subscribe({
         protocolVersion: PROTOCOL_VERSION,
         taskID: 'task-id',
         id: 'change-log-writer',
-        // A single-node canonical writer has serving mode, so the independent
-        // logsChangeStream guard remains necessary.
+        // Slice 11 deliberately ignores this legacy hint: the writer now lives
+        // in the change-streamer, and no subscriber ACK advances the log.
         mode: 'serving',
         watermark: REPLICA_VERSION,
         replicaVersion: REPLICA_VERSION,
         initial: true,
         logsChangeStream: true,
       });
-      expect(shouldUse).not.toHaveBeenCalled();
+      expect(shouldUse).toHaveBeenCalledOnce();
       const written = drainToQueue(writerSub);
 
-      // Served from PG instead of waiting on itself.
+      // Served from SQLite; the payload differs from PG only to pin routing.
       expect(await nextChange(written)).toMatchObject({tag: 'status'});
       expect(await nextChange(written)).toMatchObject({tag: 'begin'});
       expect(await nextChange(written)).toMatchObject({
         tag: 'insert',
-        new: {id: 'forwarded'},
+        new: {id: 'from-sqlite'},
       });
       expect(await nextChange(written)).toMatchObject({tag: 'commit'});
-      expect(logSink.messages).toContainEqual([
-        'warn',
-        expect.anything(),
-        [
-          expect.stringContaining(
-            'not serving legacy change-log writer change-log-writer',
-          ),
-        ],
-      ]);
 
       observerSub.cancel();
       backupSub.cancel();

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -62,6 +62,12 @@ import {
   type PurgeContinuation,
   type SQLiteChangeLogPurgeSchedulerOptions,
 } from './sqlite-change-log-purge-scheduler.ts';
+import {
+  inspectSQLiteChangeLog,
+  SQLiteChangeLogReadRouter,
+  type ChangeLogReadRoute,
+  type SQLiteChangeLogCoverage,
+} from './sqlite-change-log-read-router.ts';
 import {SQLiteChangeLogReader} from './sqlite-change-log-reader.ts';
 import {
   SQLiteChangeLogWriter,
@@ -90,11 +96,9 @@ export type SQLiteCatchupOptions = {
    */
   barrierPollIntervalMs?: number | undefined;
   /**
-   * Slice 11 supplies the production canary selector.
-   *
-   * It does not need to exclude backup subscribers or the change-log writer:
-   * eligibility checks reject both before invoking this selector. Serving a
-   * writer from SQLite would make it wait on its own ACK.
+   * Optional policy hook used by focused tests. Production canary selection is
+   * supplied by `sqliteChangeLogServe` and is stable by shard plus task ID.
+   * Backup subscribers are rejected before either selector is invoked.
    */
   shouldUse?: ((ctx: SubscriberContext) => boolean) | undefined;
   /**
@@ -109,6 +113,19 @@ export type SQLiteCatchupOptions = {
    * {@link DEFAULT_CHANGE_LOG_UNAVAILABLE_WARN_THRESHOLD_MS}.
    */
   notReadyWarnThresholdMs?: number | undefined;
+};
+
+export type SQLiteChangeLogServeOptions = {
+  /** Stable percentage of eligible serving tasks routed to SQLite. */
+  readPercent: number;
+  /** A reseeded log must age through this whole window before it can serve. */
+  retentionMs: number;
+  /** Injectable for deterministic breaker tests. */
+  failureCooldownMs?: number | undefined;
+  /** Injectable for deterministic warm-up and breaker tests. */
+  now?: (() => number) | undefined;
+  /** Injectable readiness inspection for service-level tests. */
+  inspect?: (() => SQLiteChangeLogCoverage | undefined) | undefined;
 };
 
 export type TuningOptions = StorerOptions & {
@@ -139,6 +156,8 @@ export type TuningOptions = StorerOptions & {
    * subscribers are served.
    */
   sqliteChangeLogCompare?: SQLiteChangeLogCompareOptions | undefined;
+  /** Supplied only in `serve` mode. A zero percentage keeps every read on PG. */
+  sqliteChangeLogServe?: SQLiteChangeLogServeOptions | undefined;
 };
 
 /**
@@ -352,6 +371,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
   readonly #changeLogWriter: SQLiteChangeLogWriter | undefined;
   readonly #purgeScheduler: SQLiteChangeLogPurgeScheduler | undefined;
   readonly #comparator: SQLiteChangeLogComparator | undefined;
+  readonly #readRouter: SQLiteChangeLogReadRouter | undefined;
 
   readonly #autoReset: boolean;
   readonly #state: RunningState;
@@ -384,6 +404,11 @@ class ChangeStreamerImpl implements ChangeStreamerService {
     'transaction_forward_duration',
     "Time from receiving a transaction's `begin` to forwarding its `commit`, " +
       'i.e. the change-streamer half of forward-to-subscriber latency.',
+  );
+  readonly #catchupRoutes = getOrCreateCounter(
+    'replication',
+    'sqlite_change_log.catchup_routes',
+    'Catchup subscriptions by selected source and low-cardinality reason.',
   );
 
   #latestStatus: Status;
@@ -453,10 +478,32 @@ class ChangeStreamerImpl implements ChangeStreamerService {
         opts.flowControlConsensusPaddingSeconds,
       eventDrivenRelease: opts.flowControlEventDrivenRelease,
     });
+    const serveOptions = opts.sqliteChangeLogServe;
+    const writerOptions = opts.sqliteChangeLogWriter;
+    const catchupOptions = opts.sqliteCatchup;
+    this.#readRouter =
+      serveOptions && writerOptions && catchupOptions
+        ? new SQLiteChangeLogReadRouter({
+            shard,
+            readPercent: serveOptions.readPercent,
+            retentionMs: serveOptions.retentionMs,
+            failureCooldownMs: serveOptions.failureCooldownMs,
+            now: serveOptions.now,
+            inspect:
+              serveOptions.inspect ??
+              (() =>
+                inspectSQLiteChangeLog(
+                  lc,
+                  catchupOptions.changeLogFile,
+                  writerOptions.identity,
+                )),
+          })
+        : undefined;
     this.#reservations = backupConfig
-      ? new SnapshotReservations(lc, backupConfig, taskID =>
-          this.#purgeScheduler?.resume(taskID),
-        )
+      ? new SnapshotReservations(lc, backupConfig, taskID => {
+          this.#readRouter?.release(taskID);
+          this.#purgeScheduler?.resume(taskID);
+        })
       : undefined;
     this.#replicationStatusPublisher = replicationStatusPublisher;
     this.#changeLogWriter = opts.sqliteChangeLogWriter
@@ -473,6 +520,10 @@ class ChangeStreamerImpl implements ChangeStreamerService {
           // every new open sees nothing. The comparator stops for the same
           // reason: with the file gone there is nothing left to compare.
           onDisabled: () => {
+            // The writer stays disabled and the file stays absent for the life
+            // of this process, so unlike a transient read/barrier failure this
+            // breaker never expires.
+            this.#readRouter?.trip(true);
             this.#closeSQLiteCatchup();
             this.#comparator?.stop();
           },
@@ -813,6 +864,16 @@ class ChangeStreamerImpl implements ChangeStreamerService {
       // Wait for an in-flight SQLite purge batch before reading and
       // advertising the reservation's bounds.
       await (this.#purgeScheduler?.pause(taskID) ?? promiseVoid);
+      // A concurrent retry for this task may have superseded and cancelled
+      // this reservation while its purge pause was settling. Only the current
+      // owner may replace the task's source pin.
+      if (!this.#reservations.isCurrent(taskID, downstream)) {
+        return downstream;
+      }
+      // Pin after the purge pause has settled, so the SQLite minimum captured
+      // by the router cannot move before it is advertised. #confirmReservations
+      // skips an unpinned task while this await is in flight.
+      this.#readRouter?.pin(taskID);
       // If a backup has been confirmed, immediately confirm the reservation.
       await this.#confirmReservations();
       return downstream;
@@ -851,18 +912,47 @@ class ChangeStreamerImpl implements ChangeStreamerService {
   }
 
   async #confirmReservations() {
-    if (this.#backupWatermark && this.#reservations?.confirmationsRequired()) {
-      const {replicaVersion, minWatermark} = await this.#getChangeLogState();
-      if (minWatermark <= this.#backupWatermark) {
-        this.#reservations?.confirm(replicaVersion, this.#backupWatermark);
+    const backupWatermark = this.#backupWatermark;
+    const reservations = this.#reservations;
+    if (
+      backupWatermark === undefined ||
+      !reservations?.confirmationsRequired()
+    ) {
+      return;
+    }
+
+    let pgState: {replicaVersion: string; minWatermark: string} | undefined;
+    for (const taskID of reservations.unconfirmedTaskIDs()) {
+      const route = this.#readRouter?.peek(taskID);
+      // startSnapshotReservation pins only after an in-flight purge has
+      // completed. Do not race that await by confirming with PG bounds and
+      // then switching the matching /changes request to SQLite.
+      if (this.#readRouter && route === undefined) {
+        continue;
+      }
+
+      let replicaVersion: string;
+      let minWatermark: string;
+      if (route?.source === 'sqlite') {
+        const coverage = route.coverage;
+        assert(coverage, 'a pinned SQLite route must carry its covered range');
+        replicaVersion = this.#replicaVersion;
+        minWatermark = coverage.minWatermark;
       } else {
-        // Something is wrong here ... the change-log should not have been
-        // purged past the backup watermark. If we confirm the reservation,
-        // we may not be able to catch up from the backup that the requester
-        // restores.
+        pgState ??= await this.#getChangeLogState();
+        ({replicaVersion, minWatermark} = pgState);
+      }
+
+      if (minWatermark <= backupWatermark) {
+        reservations.confirmFor(taskID, replicaVersion, backupWatermark);
+      } else {
+        // The selected source cannot catch a restored replica up from this
+        // backup yet. Keep the reservation pending until a later backup moves
+        // the durable watermark into its covered range.
         this.#lc.error?.(
-          `change-log minWatermark ${minWatermark} is later than backupWatermark ${this.#backupWatermark}. ` +
-            `Delaying confirmation of snapshot reservation until next backup.`,
+          `${route?.source ?? 'pg'} change-log minWatermark ${minWatermark} ` +
+            `is later than backupWatermark ${backupWatermark}. Delaying ` +
+            `confirmation of snapshot reservation until next backup.`,
         );
       }
     }
@@ -1103,10 +1193,8 @@ class ChangeStreamerImpl implements ChangeStreamerService {
     ctx: SubscriberContext,
   ): SQLiteChangeLogCatchup | undefined {
     const opts = this.#sqliteCatchupOptions;
-    // Slice 11 supplies a non-default selector. Until then, this keeps all
-    // production subscriptions on PG even though the complete SQLite handoff
-    // path is wired and testable.
     if (this.#lastForwardedCommitWatermark === undefined || !opts) {
+      this.#recordCatchupRoute('pg', 'not-ready');
       return undefined;
     }
     // SQLite catchup is only for disposable serving replicas. Backup
@@ -1117,24 +1205,64 @@ class ChangeStreamerImpl implements ChangeStreamerService {
       this.#lc.info?.(
         `not serving backup subscriber ${ctx.id} from SQLite catchup`,
       );
+      this.#recordCatchupRoute('pg', 'ineligible-mode');
       return undefined;
     }
-    if (ctx.logsChangeStream) {
-      // The reason for this exclusion is gone: the writer is no longer a
-      // subscriber, so nothing can wait on its own ACK, and no replicator this
-      // version ships sets the parameter. It stays until slice 11 lifts it
-      // deliberately, because a subscriber that predates the writer's move does
-      // set it, and serving one from SQLite is a change in behavior rather than
-      // a cleanup.
-      this.#lc.warn?.(
-        `not serving legacy change-log writer ${ctx.id} from SQLite catchup`,
+
+    let route: ChangeLogReadRoute | undefined;
+    if (this.#readRouter) {
+      route = this.#readRouter.consume(ctx.taskID);
+      if (route.source === 'pg') {
+        if (route.reason === 'cold-log') {
+          this.#lc.info?.(
+            `serving ${ctx.id} from PG catchup: SQLite change log is still warming`,
+            {sqliteChangeLogCoverage: route.coverage},
+          );
+        } else if (route.reason === 'log-unavailable') {
+          this.#declineSQLiteCatchup(
+            ctx,
+            opts,
+            `${opts.changeLogFile} is unavailable or incompatible`,
+          );
+        } else {
+          this.#lc.debug?.(
+            `serving ${ctx.id} from PG catchup: SQLite route ${route.reason}`,
+            ...(route.coverage
+              ? [{sqliteChangeLogCoverage: route.coverage}]
+              : []),
+          );
+        }
+        this.#recordCatchupRoute('pg', route.reason);
+        return undefined;
+      }
+    }
+
+    // `shouldUse` remains as a test hook and an optional extra policy gate.
+    // Production selection comes from #readRouter.
+    if (!this.#readRouter && !opts.shouldUse?.(ctx)) {
+      this.#recordCatchupRoute('pg', 'selector');
+      return undefined;
+    }
+    if (this.#readRouter && opts.shouldUse && !opts.shouldUse(ctx)) {
+      this.#recordCatchupRoute('pg', 'selector');
+      return undefined;
+    }
+
+    const catchup = this.#sqliteCatchup ?? this.#openSQLiteCatchup(opts, ctx);
+    if (catchup) {
+      this.#lc.debug?.(
+        `serving ${ctx.id} from SQLite catchup`,
+        ...(route?.coverage ? [{sqliteChangeLogCoverage: route.coverage}] : []),
       );
-      return undefined;
+      this.#recordCatchupRoute('sqlite', route?.reason ?? 'selector');
+    } else {
+      this.#recordCatchupRoute('pg', 'log-unavailable');
     }
-    if (!opts.shouldUse?.(ctx)) {
-      return undefined;
-    }
-    return this.#sqliteCatchup ?? this.#openSQLiteCatchup(opts, ctx);
+    return catchup;
+  }
+
+  #recordCatchupRoute(source: 'pg' | 'sqlite', reason: string): void {
+    this.#catchupRoutes.add(1, {source, reason});
   }
 
   /**
@@ -1197,6 +1325,15 @@ class ChangeStreamerImpl implements ChangeStreamerService {
         barrierTimeoutMs: opts.barrierTimeoutMs,
         barrierPollIntervalMs: opts.barrierPollIntervalMs,
         cleanupGuard: opts.cleanupGuard,
+        // Production routing only reaches this point after the warm-up gate.
+        // Legacy focused-test selection has no warm classification.
+        logWarm: this.#readRouter ? true : undefined,
+        onFailure: failure => {
+          this.#lc.warn?.(
+            `temporarily disabling SQLite catchup after ${failure}`,
+          );
+          this.#readRouter?.trip();
+        },
       },
     );
     return this.#sqliteCatchup;

--- a/packages/zero-cache/src/services/change-streamer/change-streamer.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer.ts
@@ -145,15 +145,9 @@ export type SubscriberContext = {
   initial: boolean;
 
   /**
-   * Whether the subscriber's replica writes the SQLite change log that the
-   * `change-streamer` reads for catchup.
-   *
-   * Always `false` from this version on: the change-streamer writes that log
-   * itself, from the stream loop, so no subscriber advances it and no
-   * subscriber's ACK releases the catchup barrier. The parameter stays on the
-   * wire because a subscriber that predates the writer's move still sets it,
-   * and such a subscriber is excluded from SQLite catchup until slice 11 lifts
-   * the exclusion deliberately.
+   * Legacy topology hint retained on the wire. It no longer affects local
+   * routing: the change-streamer writes the SQLite log itself, so no
+   * subscriber's ACK advances its head or releases its catchup barrier.
    */
   logsChangeStream: boolean;
 };

--- a/packages/zero-cache/src/services/change-streamer/snapshot-reservations.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/snapshot-reservations.test.ts
@@ -96,6 +96,25 @@ describe('change-streamer/snapshot-reservations', () => {
     ]);
   });
 
+  test('confirmFor() applies the pinned source bounds to one task only', async () => {
+    const reservations = newReservations();
+    const first = getFirstMessage(reservations.open('task-1'));
+    reservations.open('task-2');
+
+    expect(reservations.unconfirmedTaskIDs().sort()).toEqual([
+      'task-1',
+      'task-2',
+    ]);
+    reservations.confirmFor('task-1', 'replica-v1', 'sqlite-min');
+
+    expect(await first).toMatchObject([
+      'status',
+      {replicaVersion: 'replica-v1', minWatermark: 'sqlite-min'},
+    ]);
+    expect(reservations.unconfirmedTaskIDs()).toEqual(['task-2']);
+    expect(reservations.getReservedWatermarks()).toEqual(['sqlite-min']);
+  });
+
   test('confirm() only resolves reservations opened before it was called', () => {
     const reservations = newReservations();
     reservations.open('task-1');
@@ -120,6 +139,8 @@ describe('change-streamer/snapshot-reservations', () => {
     const sub2 = reservations.open('task-1');
 
     expect(await isCancelled(sub1)).toBe(true);
+    expect(reservations.isCurrent('task-1', sub1)).toBe(false);
+    expect(reservations.isCurrent('task-1', sub2)).toBe(true);
 
     // Only one reservation is tracked for the taskID, and it's the new one:
     // it still receives the confirm() push.

--- a/packages/zero-cache/src/services/change-streamer/snapshot-reservations.ts
+++ b/packages/zero-cache/src/services/change-streamer/snapshot-reservations.ts
@@ -40,6 +40,10 @@ export class SnapshotReservations {
     this.#close(taskID, undefined);
   }
 
+  isCurrent(taskID: string, source: Source<SnapshotMessage>): boolean {
+    return this.#reservations.get(taskID)?.owns(source) ?? false;
+  }
+
   #close(taskID: string, cancelledInstanceID: InstanceID | undefined) {
     const res = this.#reservations.get(taskID);
     if (
@@ -76,14 +80,30 @@ export class SnapshotReservations {
     return false;
   }
 
+  unconfirmedTaskIDs(): string[] {
+    return [...this.#reservations.entries()]
+      .filter(([, reservation]) => !reservation.confirmed())
+      .map(([taskID]) => taskID);
+  }
+
   confirm(replicaVersion: string, minWatermark: string) {
-    for (const [taskID, res] of this.#reservations.entries()) {
-      if (!res.confirmed()) {
-        this.#lc.info?.(
-          `reserving change-log entries since ${minWatermark} for ${taskID}`,
-        );
-        res.confirm(this.#backupConfig.backupURL, replicaVersion, minWatermark);
-      }
+    for (const taskID of this.unconfirmedTaskIDs()) {
+      this.confirmFor(taskID, replicaVersion, minWatermark);
+    }
+  }
+
+  /** Confirms one reservation with the bounds of its pinned read source. */
+  confirmFor(
+    taskID: string,
+    replicaVersion: string,
+    minWatermark: string,
+  ): void {
+    const res = this.#reservations.get(taskID);
+    if (res && !res.confirmed()) {
+      this.#lc.info?.(
+        `reserving change-log entries since ${minWatermark} for ${taskID}`,
+      );
+      res.confirm(this.#backupConfig.backupURL, replicaVersion, minWatermark);
     }
   }
 
@@ -117,6 +137,10 @@ class Reservation {
 
   confirmed() {
     return this.#watermark !== null;
+  }
+
+  owns(source: Source<SnapshotMessage>): boolean {
+    return this.#downstream === source;
   }
 
   confirm(backupURL: string, replicaVersion: string, minWatermark: string) {

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.test.ts
@@ -351,11 +351,13 @@ describe('SQLiteChangeLogCatchup', () => {
   });
 
   test('gives up the barrier once the subscriber backlog fills', async () => {
+    const onFailure = vi.fn();
     // Long enough that only the backlog can end this wait. Bytes, not time,
     // are the real bound; the deadline is only a backstop for an idle shard.
     const fixture = createFixture({
       barrierTimeoutMs: 60_000,
       barrierPollIntervalMs: 60_000,
+      onFailure,
     });
     fixture.reader.head = '01';
 
@@ -374,6 +376,7 @@ describe('SQLiteChangeLogCatchup', () => {
     // holding replication while the backlog grows.
     expect(fail).not.toHaveBeenCalled();
     expect(output.size()).toBe(0);
+    expect(onFailure).toHaveBeenCalledExactlyOnceWith('barrier-backlog');
     expect(fixture.logSink.messages).toContainEqual([
       'warn',
       expect.anything(),
@@ -387,7 +390,8 @@ describe('SQLiteChangeLogCatchup', () => {
   });
 
   test('ends only the selected subscription, cleanly, on barrier timeout', async () => {
-    const fixture = createFixture({barrierTimeoutMs: 5});
+    const onFailure = vi.fn();
+    const fixture = createFixture({barrierTimeoutMs: 5, onFailure});
     fixture.reader.head = '01';
     const {subscriber, done, output} = createSubscriber('01');
     const fail = vi.spyOn(subscriber, 'fail');
@@ -400,6 +404,7 @@ describe('SQLiteChangeLogCatchup', () => {
     // caught up yet" warrants.
     expect(fail).not.toHaveBeenCalled();
     expect(output.size()).toBe(0);
+    expect(onFailure).toHaveBeenCalledExactlyOnceWith('barrier-timeout');
     expect(fixture.logSink.messages).toContainEqual([
       'warn',
       expect.anything(),
@@ -461,7 +466,8 @@ describe('SQLiteChangeLogCatchup', () => {
   });
 
   test('fails closed on reader errors after registration', async () => {
-    const fixture = createFixture();
+    const onFailure = vi.fn();
+    const fixture = createFixture({onFailure});
     fixture.reader.head = '06';
     fixture.reader.boundaries.add('01');
     fixture.reader.readError = new Error('broken SQLite read');
@@ -473,6 +479,7 @@ describe('SQLiteChangeLogCatchup', () => {
     // operators through the log below, not through the subscriber.
     await done;
     expect(output.size()).toBe(0);
+    expect(onFailure).toHaveBeenCalledExactlyOnceWith('reader-error');
     expect(fixture.logSink.messages).toContainEqual([
       'error',
       expect.anything(),
@@ -526,6 +533,7 @@ function createFixture(
     barrierPollIntervalMs?: number | undefined;
     cleanupGuard?: SQLiteChangeLogCleanupGuard | undefined;
     now?: SQLiteChangeLogCatchupOptions['now'];
+    onFailure?: SQLiteChangeLogCatchupOptions['onFailure'];
     sleep?: SQLiteChangeLogCatchupOptions['sleep'];
   } = {},
 ) {
@@ -539,6 +547,7 @@ function createFixture(
     barrierPollIntervalMs: opts.barrierPollIntervalMs ?? 1,
     cleanupGuard: opts.cleanupGuard,
     now: opts.now,
+    onFailure: opts.onFailure,
     sleep: opts.sleep,
   });
   coordinators.push(coordinator);

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.ts
@@ -2,7 +2,11 @@ import type {LogContext} from '@rocicorp/logger';
 import {resolver} from '@rocicorp/resolver';
 import {AbortError} from '../../../../shared/src/abort-error.ts';
 import {sleep} from '../../../../shared/src/sleep.ts';
-import {getOrCreateCounter} from '../../observability/metrics.ts';
+import {
+  getOrCreateCounter,
+  getOrCreateLatencyHistogram,
+  getOrCreateValueHistogram,
+} from '../../observability/metrics.ts';
 import type {WatermarkedChange} from './change-streamer.ts';
 import * as ErrorType from './error-type-enum.ts';
 import type {Forwarder} from './forwarder.ts';
@@ -42,7 +46,16 @@ export type SQLiteChangeLogCatchupOptions = {
   cleanupGuard?: SQLiteChangeLogCleanupGuard | undefined;
   sleep?: typeof sleep | undefined;
   now?: (() => number) | undefined;
+  /** Whether the routing warm-up gate classified this log as warm. */
+  logWarm?: boolean | undefined;
+  /** Opens slice 11's process-local breaker after registration has committed. */
+  onFailure?: ((failure: SQLiteChangeLogCatchupFailure) => void) | undefined;
 };
+
+export type SQLiteChangeLogCatchupFailure =
+  | 'barrier-timeout'
+  | 'barrier-backlog'
+  | 'reader-error';
 
 const NOOP_CLEANUP_GUARD: SQLiteChangeLogCleanupGuard = {
   runWhilePurgeBlocked: register => Promise.resolve(register()),
@@ -67,6 +80,10 @@ export class SQLiteChangeLogCatchup implements Disposable {
   readonly #cleanupGuard: SQLiteChangeLogCleanupGuard;
   readonly #sleep: typeof sleep;
   readonly #now: () => number;
+  readonly #logWarm: boolean | undefined;
+  readonly #onFailure:
+    | ((failure: SQLiteChangeLogCatchupFailure) => void)
+    | undefined;
   readonly #barrierTimeouts = getOrCreateCounter(
     'replication',
     'sqlite_change_log.barrier_timeouts',
@@ -84,6 +101,46 @@ export class SQLiteChangeLogCatchup implements Disposable {
     'SQLite catchup barrier waits, labeled by what ended the wait. A ' +
       'population dominated by "poll" means the change-log writer\'s commit ' +
       'notification is not reaching the barrier.',
+  );
+  readonly #catchupResults = getOrCreateCounter(
+    'replication',
+    'sqlite_change_log.catchup_results',
+    'SQLite catchup subscriptions by outcome.',
+  );
+  readonly #catchupRows = getOrCreateCounter(
+    'replication',
+    'sqlite_change_log.catchup_rows',
+    'Rows served from the SQLite change log during catchup.',
+  );
+  readonly #catchupBytes = getOrCreateCounter(
+    'replication',
+    'sqlite_change_log.catchup_bytes',
+    {
+      description: 'Bytes served from the SQLite change log during catchup.',
+      unit: 'By',
+    },
+  );
+  readonly #catchupDuration = getOrCreateLatencyHistogram(
+    'replication',
+    'sqlite_change_log.catchup_duration',
+    'Duration of a SQLite change-log catchup.',
+  );
+  readonly #barrierWaitDuration = getOrCreateLatencyHistogram(
+    'replication',
+    'sqlite_change_log.barrier_wait_duration',
+    'Time SQLite catchup waits for its pinned required head.',
+  );
+  readonly #catchupBacklogPeak = getOrCreateValueHistogram(
+    'replication',
+    'sqlite_change_log.catchup_backlog_peak_bytes',
+    {
+      description:
+        'Peak live backlog bytes buffered while a subscriber catches up from SQLite.',
+      unit: 'By',
+      bucketBoundaries: [
+        0, 1024, 16_384, 65_536, 262_144, 1_048_576, 4_194_304, 16_777_216,
+      ],
+    },
   );
   readonly #catchups = new Map<Subscriber, AbortController>();
   readonly #commitWaiters = new Set<CommitWaiter>();
@@ -105,6 +162,8 @@ export class SQLiteChangeLogCatchup implements Disposable {
     this.#cleanupGuard = opts.cleanupGuard ?? NOOP_CLEANUP_GUARD;
     this.#sleep = opts.sleep ?? sleep;
     this.#now = opts.now ?? Date.now;
+    this.#logWarm = opts.logWarm;
+    this.#onFailure = opts.onFailure;
   }
 
   /**
@@ -192,6 +251,9 @@ export class SQLiteChangeLogCatchup implements Disposable {
     abort: AbortController,
   ): Promise<void> {
     const {signal} = abort;
+    const catchupStart = this.#now();
+    let outcome = 'aborted';
+    let backlogPeakBytes = 0;
     try {
       const requiredHeadStart = this.#now();
       const required = await this.#awaitRequiredHead(requiredHead, signal);
@@ -208,15 +270,19 @@ export class SQLiteChangeLogCatchup implements Disposable {
       // during a transaction longer than barrierTimeoutMs, however current
       // the replica is.
       const deadline = this.#now() + this.#barrierTimeoutMs;
-      const plan = await this.#waitForPlan(
-        subscriber,
-        required,
-        deadline,
-        signal,
-      );
+      const barrierStart = this.#now();
+      let plan: CatchupPlan;
+      try {
+        plan = await this.#waitForPlan(subscriber, required, deadline, signal);
+      } finally {
+        // Record failed and aborted barriers too; their wait distribution is
+        // at least as operationally important as the successful path.
+        this.#barrierWaitDuration.recordMs(this.#now() - barrierStart);
+      }
       this.#throwIfAborted(signal);
 
       if (plan.kind === 'too-old') {
+        outcome = 'too-old';
         const message =
           `earliest supported watermark is ${plan.minWatermark} ` +
           `(requested ${subscriber.watermark})`;
@@ -229,6 +295,7 @@ export class SQLiteChangeLogCatchup implements Disposable {
       }
 
       let count = 0;
+      let bytes = 0;
       const start = this.#now();
       if (plan.kind === 'range') {
         let lastBatchConsumed: Promise<unknown> | undefined;
@@ -251,10 +318,17 @@ export class SQLiteChangeLogCatchup implements Disposable {
           for (const change of changes) {
             lastBatchConsumed = subscriber.catchup(change);
             count++;
+            bytes += Buffer.byteLength(change[2]);
           }
+          backlogPeakBytes = Math.max(
+            backlogPeakBytes,
+            subscriber.getStats().backlogBytes,
+          );
         }
         await lastBatchConsumed;
+        outcome = 'range';
       } else {
+        outcome = 'ahead';
         this.#lc.warn?.(
           `subscriber ${subscriber.id} at watermark ${subscriber.watermark} ` +
             `is ahead of the SQLite change-log head ${plan.headWatermark}; ` +
@@ -267,6 +341,12 @@ export class SQLiteChangeLogCatchup implements Disposable {
         `caught up ${subscriber.id} from SQLite with ${count} changes ` +
           `(${this.#now() - start} ms)`,
       );
+      const attributes = {
+        classification: outcome,
+        log_warm: this.#logWarm ?? 'unknown',
+      };
+      this.#catchupRows.add(count, attributes);
+      this.#catchupBytes.add(bytes, attributes);
       // Keep buffering live sends until the asynchronous backlog drain has
       // established its ordering boundary.
       void subscriber.setCaughtUp();
@@ -277,6 +357,11 @@ export class SQLiteChangeLogCatchup implements Disposable {
       if (error instanceof SQLiteChangeLogBarrierError) {
         if (error instanceof SQLiteChangeLogBarrierTimeoutError) {
           this.#barrierTimeouts.add(1);
+          outcome = 'barrier-timeout';
+          this.#onFailure?.('barrier-timeout');
+        } else {
+          outcome = 'barrier-backlog';
+          this.#onFailure?.('barrier-backlog');
         }
         // Giving up on the barrier means the replica has not caught up *yet*,
         // not that it cannot serve this subscriber. End the subscription
@@ -293,12 +378,25 @@ export class SQLiteChangeLogCatchup implements Disposable {
         subscriber.close();
         return;
       }
+      outcome = 'reader-error';
+      this.#onFailure?.('reader-error');
       this.#lc.error?.(
         `error while catching up subscriber ${subscriber.id} from SQLite`,
         error,
       );
       subscriber.fail(error);
     } finally {
+      backlogPeakBytes = Math.max(
+        backlogPeakBytes,
+        subscriber.getStats().backlogBytes,
+      );
+      const attributes = {
+        classification: outcome,
+        log_warm: this.#logWarm ?? 'unknown',
+      };
+      this.#catchupResults.add(1, attributes);
+      this.#catchupDuration.recordMs(this.#now() - catchupStart, attributes);
+      this.#catchupBacklogPeak.record(backlogPeakBytes, attributes);
       if (this.#catchups.get(subscriber) === abort) {
         this.#catchups.delete(subscriber);
       }

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-read-router.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-read-router.test.ts
@@ -1,0 +1,182 @@
+import {describe, expect, test, vi} from 'vitest';
+import type {ShardID} from '../../types/shards.ts';
+import {
+  isSelectedForSQLiteRead,
+  SQLiteChangeLogReadRouter,
+  type SQLiteChangeLogCoverage,
+} from './sqlite-change-log-read-router.ts';
+
+describe('change-streamer/sqlite-change-log-read-router', () => {
+  const shard: ShardID = {appID: 'router', shardNum: 3};
+  const warm: SQLiteChangeLogCoverage = {
+    seededAtMs: 1_000,
+    seedWatermark: '01',
+    minWatermark: '02',
+    headWatermark: '09',
+  };
+
+  test('selection is stable by shard and task, and zero percent still inspects eligibility', () => {
+    const inspect = vi.fn(() => warm);
+    const zero = new SQLiteChangeLogReadRouter({
+      shard,
+      readPercent: 0,
+      retentionMs: 100,
+      now: () => 2_000,
+      inspect,
+    });
+    expect(zero.consume('task-a')).toMatchObject({
+      source: 'pg',
+      reason: 'percentage',
+      coverage: warm,
+    });
+    expect(inspect).toHaveBeenCalledOnce();
+
+    const selected = Array.from({length: 1_000}, (_, i) => `task-${i}`).find(
+      taskID => isSelectedForSQLiteRead(shard, taskID, 10),
+    );
+    const declined = Array.from({length: 1_000}, (_, i) => `task-${i}`).find(
+      taskID => !isSelectedForSQLiteRead(shard, taskID, 10),
+    );
+    expect(selected).toBeDefined();
+    expect(declined).toBeDefined();
+
+    const canary = new SQLiteChangeLogReadRouter({
+      shard,
+      readPercent: 10,
+      retentionMs: 100,
+      now: () => 2_000,
+      inspect: () => warm,
+    });
+    expect(canary.consume(selected as string).source).toBe('sqlite');
+    expect(canary.consume(selected as string).source).toBe('sqlite');
+    expect(canary.consume(declined as string).source).toBe('pg');
+  });
+
+  test('declines a cold log and reports its covered range', () => {
+    const router = new SQLiteChangeLogReadRouter({
+      shard,
+      readPercent: 100,
+      retentionMs: 1_000,
+      now: () => 1_999,
+      inspect: () => warm,
+    });
+    expect(router.consume('task')).toEqual({
+      source: 'pg',
+      reason: 'cold-log',
+      coverage: warm,
+    });
+  });
+
+  test('a reseed resets warm-up eligibility until retention elapses again', () => {
+    let now = 2_000;
+    let coverage = warm;
+    const router = new SQLiteChangeLogReadRouter({
+      shard,
+      readPercent: 100,
+      retentionMs: 1_000,
+      now: () => now,
+      inspect: () => coverage,
+    });
+    expect(router.consume('task').source).toBe('sqlite');
+
+    coverage = {
+      ...warm,
+      seededAtMs: now,
+      seedWatermark: warm.headWatermark,
+      minWatermark: warm.headWatermark,
+    };
+    expect(router.consume('task')).toEqual({
+      source: 'pg',
+      reason: 'cold-log',
+      coverage,
+    });
+
+    now += 1_000;
+    expect(router.consume('task').source).toBe('sqlite');
+  });
+
+  test('a snapshot pin is consumed once and cannot change source mid-restore', () => {
+    let available = true;
+    const router = new SQLiteChangeLogReadRouter({
+      shard,
+      readPercent: 100,
+      retentionMs: 100,
+      now: () => 2_000,
+      inspect: () => (available ? warm : undefined),
+    });
+
+    expect(router.pin('task')).toMatchObject({source: 'sqlite'});
+    available = false;
+    expect(router.peek('task')).toMatchObject({
+      source: 'sqlite',
+      reason: 'selected',
+      pinned: true,
+    });
+    expect(router.consume('task')).toMatchObject({
+      source: 'sqlite',
+      reason: 'selected',
+      pinned: true,
+    });
+    expect(router.peek('task')).toBeUndefined();
+    expect(router.consume('task')).toEqual({
+      source: 'pg',
+      reason: 'log-unavailable',
+    });
+  });
+
+  test('post-registration failures route retries to PG until a bounded probe succeeds', () => {
+    let now = 2_000;
+    let available = true;
+    const inspect = vi.fn(() => (available ? warm : undefined));
+    const router = new SQLiteChangeLogReadRouter({
+      shard,
+      readPercent: 100,
+      retentionMs: 100,
+      failureCooldownMs: 500,
+      now: () => now,
+      inspect,
+    });
+
+    expect(router.consume('task').source).toBe('sqlite');
+    router.trip();
+    expect(router.consume('task')).toEqual({
+      source: 'pg',
+      reason: 'breaker-open',
+    });
+    expect(inspect).toHaveBeenCalledTimes(1);
+
+    available = false;
+    now += 500;
+    expect(router.consume('task')).toEqual({
+      source: 'pg',
+      reason: 'log-unavailable',
+    });
+    // The failed probe rearms the cooldown.
+    available = true;
+    expect(router.consume('task')).toEqual({
+      source: 'pg',
+      reason: 'breaker-open',
+    });
+
+    now += 500;
+    expect(router.consume('task').source).toBe('sqlite');
+  });
+
+  test('writer failure keeps the breaker open for the process lifetime', () => {
+    let now = 2_000;
+    const router = new SQLiteChangeLogReadRouter({
+      shard,
+      readPercent: 100,
+      retentionMs: 100,
+      failureCooldownMs: 1,
+      now: () => now,
+      inspect: () => warm,
+    });
+    router.trip(true);
+    now += 1_000_000;
+    expect(router.consume('task')).toEqual({
+      source: 'pg',
+      reason: 'breaker-open',
+    });
+  });
+});

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-read-router.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-read-router.ts
@@ -1,0 +1,226 @@
+import type {LogContext} from '@rocicorp/logger';
+import {h32} from '../../../../shared/src/hash.ts';
+import {Database} from '../../../../zqlite/src/db.ts';
+import type {ShardID} from '../../types/shards.ts';
+import {
+  CHANGE_LOG_DB_SCHEMA_VERSION,
+  CHANGE_LOG_STREAM_TABLE,
+  readChangeLogMeta,
+  type ChangeLogIdentity,
+} from '../replicator/change-log-db.ts';
+
+export type ChangeLogReadSource = 'pg' | 'sqlite';
+
+export type SQLiteChangeLogCoverage = {
+  readonly seededAtMs: number;
+  readonly seedWatermark: string;
+  readonly minWatermark: string;
+  readonly headWatermark: string;
+};
+
+export type ChangeLogReadRouteReason =
+  | 'selected'
+  | 'percentage'
+  | 'cold-log'
+  | 'log-unavailable'
+  | 'breaker-open';
+
+export type ChangeLogReadRoute = {
+  readonly source: ChangeLogReadSource;
+  readonly reason: ChangeLogReadRouteReason;
+  readonly pinned?: boolean | undefined;
+  readonly coverage?: SQLiteChangeLogCoverage | undefined;
+};
+
+export type SQLiteChangeLogReadRouterOptions = {
+  readonly shard: ShardID;
+  readonly readPercent: number;
+  readonly retentionMs: number;
+  readonly inspect: () => SQLiteChangeLogCoverage | undefined;
+  readonly failureCooldownMs?: number | undefined;
+  readonly now?: (() => number) | undefined;
+};
+
+const DEFAULT_FAILURE_COOLDOWN_MS = 30_000;
+
+/** Stable canary selection keyed by shard and subscriber task identity. */
+export function isSelectedForSQLiteRead(
+  shard: ShardID,
+  taskID: string,
+  percent: number,
+): boolean {
+  if (percent >= 100) {
+    return true;
+  }
+  if (percent <= 0) {
+    return false;
+  }
+  return h32(`${shard.appID}/${shard.shardNum}:${taskID}`) % 100 < percent;
+}
+
+/**
+ * Selects and pins the catchup source shared by `/snapshot` and `/changes`.
+ *
+ * A post-registration SQLite failure opens a process-local breaker. Requests
+ * use PG during the cooldown; the first request after it expires is the
+ * bounded probe. A successful readiness inspection closes the breaker, while
+ * another unavailable result rearms it. A writer failure opens it permanently
+ * because the writer remains disabled and its file stays absent for the life
+ * of the process.
+ */
+export class SQLiteChangeLogReadRouter {
+  readonly #shard: ShardID;
+  readonly #readPercent: number;
+  readonly #retentionMs: number;
+  readonly #inspect: () => SQLiteChangeLogCoverage | undefined;
+  readonly #failureCooldownMs: number;
+  readonly #now: () => number;
+  readonly #pins = new Map<string, ChangeLogReadRoute>();
+
+  #breakerUntilMs: number | undefined;
+  #permanentlyDisabled = false;
+
+  constructor(opts: SQLiteChangeLogReadRouterOptions) {
+    this.#shard = opts.shard;
+    this.#readPercent = opts.readPercent;
+    this.#retentionMs = opts.retentionMs;
+    this.#inspect = opts.inspect;
+    this.#failureCooldownMs =
+      opts.failureCooldownMs ?? DEFAULT_FAILURE_COOLDOWN_MS;
+    this.#now = opts.now ?? Date.now;
+  }
+
+  /** Chooses and pins a source for a snapshot reservation. */
+  pin(taskID: string): ChangeLogReadRoute {
+    const route = this.#choose(taskID);
+    this.#pins.set(taskID, route);
+    return route;
+  }
+
+  /** Returns the source pinned by an active snapshot reservation. */
+  peek(taskID: string): ChangeLogReadRoute | undefined {
+    const route = this.#pins.get(taskID);
+    return route && this.#asPinned(route);
+  }
+
+  /** Consumes a snapshot pin, or makes the stable choice for a direct retry. */
+  consume(taskID: string): ChangeLogReadRoute {
+    const route = this.#pins.get(taskID);
+    if (route === undefined) {
+      return this.#choose(taskID);
+    }
+    this.#pins.delete(taskID);
+    return this.#asPinned(route);
+  }
+
+  /** Releases a pin whose snapshot reservation ended before subscribing. */
+  release(taskID: string): void {
+    this.#pins.delete(taskID);
+  }
+
+  /** Opens the post-registration failure breaker. */
+  trip(permanent = false): void {
+    if (permanent) {
+      this.#permanentlyDisabled = true;
+      this.#breakerUntilMs = undefined;
+      return;
+    }
+    if (!this.#permanentlyDisabled) {
+      this.#breakerUntilMs = this.#now() + this.#failureCooldownMs;
+    }
+  }
+
+  #choose(taskID: string): ChangeLogReadRoute {
+    const now = this.#now();
+    if (
+      this.#permanentlyDisabled ||
+      (this.#breakerUntilMs !== undefined && now < this.#breakerUntilMs)
+    ) {
+      return {source: 'pg', reason: 'breaker-open'};
+    }
+
+    // Inspect eligibility even at readPercent=0. Slice 11 starts its rollout
+    // at zero specifically so warm/cold/unavailable rates are visible before
+    // any subscriber is routed to SQLite.
+    let coverage: SQLiteChangeLogCoverage | undefined;
+    try {
+      coverage = this.#inspect();
+    } catch {
+      coverage = undefined;
+    }
+    if (coverage === undefined) {
+      // This was a breaker probe rather than ordinary startup unavailability.
+      // Rearm it so a busy retry loop does not turn into an open/read loop.
+      if (this.#breakerUntilMs !== undefined) {
+        this.#breakerUntilMs = now + this.#failureCooldownMs;
+      }
+      return {source: 'pg', reason: 'log-unavailable'};
+    }
+    if (now - coverage.seededAtMs < this.#retentionMs) {
+      return {source: 'pg', reason: 'cold-log', coverage};
+    }
+
+    // A successful probe restores eligibility.
+    this.#breakerUntilMs = undefined;
+    // Keeping the percentage decision after readiness makes zero-percent
+    // rollouts emit eligibility metrics without serving reads.
+    if (!isSelectedForSQLiteRead(this.#shard, taskID, this.#readPercent)) {
+      return {source: 'pg', reason: 'percentage', coverage};
+    }
+    return {source: 'sqlite', reason: 'selected', coverage};
+  }
+
+  #asPinned(route: ChangeLogReadRoute): ChangeLogReadRoute {
+    return {...route, pinned: true};
+  }
+}
+
+/**
+ * Reads the coverage and validates the v2 schema and RMv2 identity in one
+ * short-lived readonly connection. It never creates the log.
+ */
+export function inspectSQLiteChangeLog(
+  lc: LogContext,
+  changeLogFile: string,
+  identity: ChangeLogIdentity,
+): SQLiteChangeLogCoverage | undefined {
+  let db: Database | undefined;
+  try {
+    db = new Database(
+      lc.withContext('component', 'sqlite-change-log-read-router'),
+      changeLogFile,
+      {readonly: true},
+    );
+    const meta = readChangeLogMeta(db);
+    if (
+      meta.schemaVersion !== CHANGE_LOG_DB_SCHEMA_VERSION ||
+      meta.epoch !== identity.epoch ||
+      meta.generation !== identity.generation ||
+      meta.replicaID !== identity.replicaID
+    ) {
+      return undefined;
+    }
+    const bounds = db
+      .prepare(/*sql*/ `
+        SELECT
+          (SELECT min("watermark") FROM "${CHANGE_LOG_STREAM_TABLE}")
+            AS "minWatermark",
+          (SELECT max("watermark") FROM "${CHANGE_LOG_STREAM_TABLE}")
+            AS "headWatermark"
+      `)
+      .get<{minWatermark: string | null; headWatermark: string | null}>();
+    if (bounds.minWatermark === null || bounds.headWatermark === null) {
+      return undefined;
+    }
+    return {
+      seededAtMs: meta.seededAtMs,
+      seedWatermark: meta.seedWatermark,
+      minWatermark: bounds.minWatermark,
+      headWatermark: bounds.headWatermark,
+    };
+  } catch {
+    return undefined;
+  } finally {
+    db?.close();
+  }
+}

--- a/packages/zero-cache/src/services/replicator/sqlite-change-log-metrics.test.ts
+++ b/packages/zero-cache/src/services/replicator/sqlite-change-log-metrics.test.ts
@@ -170,6 +170,7 @@ const INFO: SQLiteChangeLogInfo = {
   schemaVersion: 2,
   seededAtMs: 1_700_000_000_000,
   seedWatermark: '02',
+  minWatermark: '02',
   headWatermark: '02',
   rows: 2,
   estimatedBytes: 100,

--- a/packages/zero-cache/src/services/replicator/sqlite-change-log-observability.test.ts
+++ b/packages/zero-cache/src/services/replicator/sqlite-change-log-observability.test.ts
@@ -113,6 +113,7 @@ describe('SQLite change-log observability', () => {
       schemaVersion: CHANGE_LOG_DB_SCHEMA_VERSION,
       seededAtMs: ANCHOR.nowMs,
       seedWatermark: '02',
+      minWatermark: '02',
       headWatermark: '02',
       rows: 2,
       estimatedBytes: expect.any(Number),
@@ -134,6 +135,7 @@ describe('SQLite change-log observability', () => {
             schemaVersion: CHANGE_LOG_DB_SCHEMA_VERSION,
             seedWatermark: '02',
             seededAtMs: ANCHOR.nowMs,
+            minWatermark: '02',
             headWatermark: '02',
           },
         },
@@ -153,6 +155,7 @@ describe('SQLite change-log observability', () => {
       schemaVersion: CHANGE_LOG_DB_SCHEMA_VERSION,
       seededAtMs: ANCHOR.nowMs,
       seedWatermark: '02',
+      minWatermark: '02',
       headWatermark: '02',
     });
     const {

--- a/packages/zero-cache/src/services/replicator/sqlite-change-log-observability.ts
+++ b/packages/zero-cache/src/services/replicator/sqlite-change-log-observability.ts
@@ -26,7 +26,6 @@ import {extractChangeSubstring} from '../change-streamer/change-log-codec.ts';
 import {ChangeLogTransactionHasher} from '../change-streamer/change-log-transaction-hash.ts';
 import {
   CHANGE_LOG_STREAM_TABLE,
-  readChangeLogHead,
   readChangeLogMeta,
   type ChangeLogMeta,
   type ReconcileResult,
@@ -82,6 +81,7 @@ export function recordSQLiteChangeLogReconcile(
  * consequence of this log rather than a fact about it.
  */
 export type SQLiteChangeLogStartupInfo = ChangeLogMeta & {
+  readonly minWatermark: string;
   readonly headWatermark: string;
 };
 
@@ -91,8 +91,9 @@ export type SQLiteChangeLogInfo = SQLiteChangeLogStartupInfo & {
 };
 
 /**
- * Reads the meta row and the head. The head is an index-optimized `max()`, so
- * unlike {@link getSQLiteChangeLogInfo} this does not scan the log.
+ * Reads the meta row and covered range. The scalar `min()` and `max()`
+ * subqueries each use the watermark index, so unlike
+ * {@link getSQLiteChangeLogInfo} this does not scan the log.
  *
  * Call this after reconciliation, which is the only point at which the head is
  * known to be the resume watermark.
@@ -101,11 +102,19 @@ export function getSQLiteChangeLogStartupInfo(
   changeLog: Database,
 ): SQLiteChangeLogStartupInfo {
   const meta = readChangeLogMeta(changeLog);
-  const head = readChangeLogHead(changeLog);
-  if (head === null) {
+  const {minWatermark, headWatermark} = changeLog
+    .prepare(/*sql*/ `
+      SELECT
+        (SELECT min("watermark") FROM "${CHANGE_LOG_STREAM_TABLE}")
+          AS "minWatermark",
+        (SELECT max("watermark") FROM "${CHANGE_LOG_STREAM_TABLE}")
+          AS "headWatermark"
+    `)
+    .get<{minWatermark: string | null; headWatermark: string | null}>();
+  if (minWatermark === null || headWatermark === null) {
     throw new Error('the SQLite change log must contain its seed transaction');
   }
-  return {...meta, headWatermark: head};
+  return {...meta, minWatermark, headWatermark};
 }
 
 /**
@@ -153,6 +162,7 @@ export function logSQLiteChangeLogStartup(
       schemaVersion: info.schemaVersion,
       seedWatermark: info.seedWatermark,
       seededAtMs: info.seededAtMs,
+      minWatermark: info.minWatermark,
       headWatermark: info.headWatermark,
     },
   });


### PR DESCRIPTION
Route eligible serving catchups through a stable shard-and-task selector while keeping the rollout at zero percent by default. Cold, unavailable, or failed SQLite logs fall back to Postgres.

Pin snapshot and change requests to the same source, add transient and permanent safety breakers, and report the coverage and catchup signals needed for rollout decisions.

Cover routing, warm-up, retries, writer failures, snapshot protection, and PostgreSQL parity with focused unit and integration tests.