### PR TITLE
perf(zero-react): memoize the useQuery render path

### DIFF
--- a/packages/zero-react/src/use-query.test.tsx
+++ b/packages/zero-react/src/use-query.test.tsx
@@ -191,6 +191,33 @@ describe('ViewStore', () => {
 
       expect(getAllViewsSizeForTesting(viewStore)).toBe(1);
     });
+
+    test('getView with an unchanged TTL does not call updateTTL on the underlying view', () => {
+      const viewStore = new ViewStore();
+
+      const zero = newMockZero('client1');
+      viewStore.getView(zero, newMockQuery('query1'), true, '1m');
+
+      const underlyingView = vi.mocked(zero.materialize).mock.results[0]
+        .value as {updateTTL: (ttl: unknown) => void};
+      const updateTTLSpy = vi.spyOn(underlyingView, 'updateTTL');
+
+      viewStore.getView(
+        newMockZero('client1'),
+        newMockQuery('query1'),
+        true,
+        '1m',
+      );
+      expect(updateTTLSpy).not.toHaveBeenCalled();
+
+      viewStore.getView(
+        newMockZero('client1'),
+        newMockQuery('query1'),
+        true,
+        '5m',
+      );
+      expect(updateTTLSpy).toHaveBeenCalledExactlyOnceWith('5m');
+    });
   });
 
   describe('destruction', () => {
@@ -1587,5 +1614,269 @@ describe('maybe queries', () => {
       expect(container.textContent).toBe('Has query');
     });
     expect(zero.materialize).toHaveBeenCalled();
+  });
+});
+
+describe('render-path memoization', () => {
+  let element: HTMLDivElement;
+  let root: Root;
+  let unique = 0;
+
+  beforeEach(() => {
+    vi.useRealTimers();
+    element = document.createElement('div');
+    document.body.appendChild(element);
+    root = createRoot(element);
+    unique++;
+  });
+
+  afterEach(() => {
+    root.unmount();
+    document.body.removeChild(element);
+  });
+
+  const testSchema = createSchema({
+    tables: [
+      table('item').columns({id: number(), name: string()}).primaryKey('id'),
+    ],
+  });
+
+  function newMockQueryRequest(name: string, fn: Mock) {
+    const query = (args: ReadonlyJSONValue) =>
+      ({
+        args,
+        'query': query,
+        '~': 'QueryRequest',
+      }) as unknown as Query<'item', typeof testSchema>;
+    return Object.assign(query, {'queryName': name, fn, '~': 'Query'});
+  }
+
+  test('re-rendering with an equivalent query request does not re-run the query builder', async () => {
+    const zero = newMockZero('client-request-' + unique);
+    const builderFn = vi.fn(({args}: {args: {id: number}}) =>
+      newQuery(testSchema, 'item').where('id', args.id),
+    );
+    const request = newMockQueryRequest('myQuery', builderFn);
+
+    function Comp({id, tick}: {id: number; tick: number}) {
+      const [data] = useQuery(request({id}));
+      return <div>{`${tick}:${JSON.stringify(data)}`}</div>;
+    }
+
+    root.render(
+      <ZeroProvider zero={zero}>
+        <Comp id={1} tick={1} />
+      </ZeroProvider>,
+    );
+    await expect.poll(() => element.textContent).toBe('1:[]');
+    expect(builderFn).toHaveBeenCalledTimes(1);
+    expect(zero.materialize).toHaveBeenCalledTimes(1);
+
+    // A fresh but equivalent request does not re-run validation/builder.
+    root.render(
+      <ZeroProvider zero={zero}>
+        <Comp id={1} tick={2} />
+      </ZeroProvider>,
+    );
+    await expect.poll(() => element.textContent).toBe('2:[]');
+    expect(builderFn).toHaveBeenCalledTimes(1);
+    expect(zero.materialize).toHaveBeenCalledTimes(1);
+
+    // Changing args re-runs the builder and creates a new view.
+    root.render(
+      <ZeroProvider zero={zero}>
+        <Comp id={2} tick={3} />
+      </ZeroProvider>,
+    );
+    await expect.poll(() => element.textContent).toBe('3:[]');
+    expect(builderFn).toHaveBeenCalledTimes(2);
+    expect(builderFn).toHaveBeenLastCalledWith({ctx: undefined, args: {id: 2}});
+    expect(zero.materialize).toHaveBeenCalledTimes(2);
+  });
+
+  test('re-rendering with a deep-equal query reuses the previously resolved query', async () => {
+    const zero = newMockZero('client-builder-' + unique);
+    const makeQuery = (id: number) =>
+      newQuery(testSchema, 'item').where('id', id);
+    const q1 = makeQuery(1);
+    const q2 = makeQuery(1);
+    const q3 = makeQuery(2);
+    const hashSpy1 = vi.spyOn(q1 as unknown as {hash: () => string}, 'hash');
+    const hashSpy2 = vi.spyOn(q2 as unknown as {hash: () => string}, 'hash');
+
+    function Comp({
+      q,
+      tick,
+    }: {
+      q: Query<'item', typeof testSchema>;
+      tick: number;
+    }) {
+      const [data] = useQuery(q);
+      return <div>{`${tick}:${JSON.stringify(data)}`}</div>;
+    }
+
+    root.render(
+      <ZeroProvider zero={zero}>
+        <Comp q={q1} tick={1} />
+      </ZeroProvider>,
+    );
+    await expect.poll(() => element.textContent).toBe('1:[]');
+    expect(zero.materialize).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(zero.materialize).mock.calls[0][0]).toBe(q1);
+
+    // A distinct but deep-equal query object is never hashed; the previously
+    // resolved query keeps being used.
+    root.render(
+      <ZeroProvider zero={zero}>
+        <Comp q={q2} tick={2} />
+      </ZeroProvider>,
+    );
+    await expect.poll(() => element.textContent).toBe('2:[]');
+    expect(zero.materialize).toHaveBeenCalledTimes(1);
+    expect(hashSpy1).toHaveBeenCalledTimes(1);
+    expect(hashSpy2).not.toHaveBeenCalled();
+
+    // A query with a different AST creates a new view.
+    root.render(
+      <ZeroProvider zero={zero}>
+        <Comp q={q3} tick={3} />
+      </ZeroProvider>,
+    );
+    await expect.poll(() => element.textContent).toBe('3:[]');
+    expect(zero.materialize).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(zero.materialize).mock.calls[1][0]).toBe(q3);
+  });
+
+  test('changing the Zero instance re-resolves the query', async () => {
+    const zero1 = newMockZero('client-z1-' + unique);
+    const zero2 = newMockZero('client-z2-' + unique);
+    const builderFn = vi.fn(() => newQuery(testSchema, 'item'));
+    const request = newMockQueryRequest('zQuery', builderFn);
+
+    function Comp({tick}: {tick: number}) {
+      const [data] = useQuery(request({id: 1}));
+      return <div>{`${tick}:${JSON.stringify(data)}`}</div>;
+    }
+
+    root.render(
+      <ZeroProvider zero={zero1}>
+        <Comp tick={1} />
+      </ZeroProvider>,
+    );
+    await expect.poll(() => element.textContent).toBe('1:[]');
+    expect(builderFn).toHaveBeenCalledTimes(1);
+    expect(zero1.materialize).toHaveBeenCalledTimes(1);
+
+    root.render(
+      <ZeroProvider zero={zero2}>
+        <Comp tick={2} />
+      </ZeroProvider>,
+    );
+    await expect.poll(() => element.textContent).toBe('2:[]');
+    expect(builderFn).toHaveBeenCalledTimes(2);
+    expect(zero2.materialize).toHaveBeenCalledTimes(1);
+  });
+
+  test('toggling a query off and back on reuses the resolved query', async () => {
+    const zero = newMockZero('client-toggle-' + unique);
+    const builderFn = vi.fn(() => newQuery(testSchema, 'item'));
+    const request = newMockQueryRequest('tQuery', builderFn);
+
+    function Comp({on, tick}: {on: boolean; tick: number}) {
+      const [data] = useQuery(on && request({id: 1}));
+      return <div>{`${tick}:${JSON.stringify(data)}`}</div>;
+    }
+
+    root.render(
+      <ZeroProvider zero={zero}>
+        <Comp on={true} tick={1} />
+      </ZeroProvider>,
+    );
+    await expect.poll(() => element.textContent).toBe('1:[]');
+    expect(builderFn).toHaveBeenCalledTimes(1);
+
+    root.render(
+      <ZeroProvider zero={zero}>
+        <Comp on={false} tick={2} />
+      </ZeroProvider>,
+    );
+    await expect.poll(() => element.textContent).toBe('2:undefined');
+
+    root.render(
+      <ZeroProvider zero={zero}>
+        <Comp on={true} tick={3} />
+      </ZeroProvider>,
+    );
+    await expect.poll(() => element.textContent).toBe('3:[]');
+    expect(builderFn).toHaveBeenCalledTimes(1);
+  });
+
+  test('changed args are detected even when an undefined-valued key masks a new key', async () => {
+    const zero = newMockZero('client-mask-' + unique);
+    const builderFn = vi.fn(() => newQuery(testSchema, 'item'));
+    const request = newMockQueryRequest('mQuery', builderFn);
+
+    function Comp({args, tick}: {args: ReadonlyJSONValue; tick: number}) {
+      const [data] = useQuery(request(args));
+      return <div>{`${tick}:${JSON.stringify(data)}`}</div>;
+    }
+
+    root.render(
+      <ZeroProvider zero={zero}>
+        <Comp args={{q: undefined, page: 1}} tick={1} />
+      </ZeroProvider>,
+    );
+    await expect.poll(() => element.textContent).toBe('1:[]');
+    expect(builderFn).toHaveBeenCalledTimes(1);
+
+    // Equal args, reordered, with the same explicitly-undefined key still
+    // memoize.
+    root.render(
+      <ZeroProvider zero={zero}>
+        <Comp args={{page: 1, q: undefined}} tick={2} />
+      </ZeroProvider>,
+    );
+    await expect.poll(() => element.textContent).toBe('2:[]');
+    expect(builderFn).toHaveBeenCalledTimes(1);
+
+    // Same own-key count, but a defined key replaces the undefined-valued
+    // one. deepEqual alone reports these as equal; the builder must re-run.
+    root.render(
+      <ZeroProvider zero={zero}>
+        <Comp args={{page: 1, sort: 'x'}} tick={3} />
+      </ZeroProvider>,
+    );
+    await expect.poll(() => element.textContent).toBe('3:[]');
+    expect(builderFn).toHaveBeenCalledTimes(2);
+    expect(builderFn).toHaveBeenLastCalledWith({
+      ctx: undefined,
+      args: {page: 1, sort: 'x'},
+    });
+  });
+
+  test('enabled: false returns the default snapshot shape without materializing', async () => {
+    const zero = newMockZero('client-disabled-' + unique);
+    const pluralQuery = newQuery(testSchema, 'item');
+    const singularQuery = pluralQuery.one();
+
+    let pluralData: unknown = 'unset';
+    let singularData: unknown = 'unset';
+
+    function Comp() {
+      [pluralData] = useQuery(pluralQuery, {enabled: false});
+      [singularData] = useQuery(singularQuery, {enabled: false});
+      return <div>done</div>;
+    }
+
+    root.render(
+      <ZeroProvider zero={zero}>
+        <Comp />
+      </ZeroProvider>,
+    );
+    await expect.poll(() => element.textContent).toBe('done');
+
+    expect(pluralData).toEqual([]);
+    expect(singularData).toBe(undefined);
+    expect(zero.materialize).not.toHaveBeenCalled();
   });
 });

--- a/packages/zero-react/src/use-query.tsx
+++ b/packages/zero-react/src/use-query.tsx
@@ -1,6 +1,10 @@
 import {resolver} from '@rocicorp/resolver';
-import React, {useSyncExternalStore} from 'react';
+import React, {useRef, useSyncExternalStore} from 'react';
+import {deepEqual} from '../../shared/src/json.ts';
 import {TESTING} from '../../shared/src/testing.ts';
+import type {AST} from '../../zero-protocol/src/ast.ts';
+import type {Format} from '../../zero-types/src/format.ts';
+import type {CustomQueryID} from '../../zql/src/query/named.ts';
 import {
   type Immutable,
   addContextToQuery,
@@ -77,6 +81,153 @@ const suspend: (p: Promise<unknown>) => void = reactUse
       throw p;
     };
 
+type ResolvedQueryCacheEntry = {
+  zero: unknown;
+  context: unknown;
+  rawQuery: object;
+  customQuery: unknown;
+  args: ReadonlyJSONValue | undefined;
+  ast: AST | undefined;
+  format: Format | undefined;
+  customQueryID: CustomQueryID | undefined;
+  // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+  q: Query<any, any, any>;
+};
+
+/**
+ * deepEqual only value-compares the keys of its first argument and then
+ * compares own-key counts, so an explicitly-undefined key on one side can
+ * absorb a differently-named defined key on the other:
+ * `deepEqual({q: undefined, page: 1}, {page: 1, sort: 'x'})` is true.
+ * Comparing in both directions closes that hole — a defined key present on
+ * only one side is always caught by the pass iterating that side.
+ */
+function symmetricDeepEqual(
+  a: ReadonlyJSONValue | undefined,
+  b: ReadonlyJSONValue | undefined,
+): boolean {
+  return deepEqual(a, b) && deepEqual(b, a);
+}
+
+function equalCustomQueryID(
+  a: CustomQueryID | undefined,
+  b: CustomQueryID | undefined,
+): boolean {
+  if (a === b) {
+    return true;
+  }
+  if (a === undefined || b === undefined) {
+    return false;
+  }
+  return a.name === b.name && symmetricDeepEqual(a.args, b.args);
+}
+
+/**
+ * Resolves the query (applying the context to query requests) while keeping
+ * the resolved query object identity-stable across re-renders.
+ *
+ * Queries are typically rebuilt inline on every render
+ * (`useQuery(queries.issue({id}))` or `useQuery(z.query.issue.where(...))`),
+ * and all the caches downstream of here (`QueryImpl`'s hash, AST
+ * normalization, the view store key) are keyed on object identity. Without
+ * this, every render re-runs argument validation, the query builder chain,
+ * and AST hashing even though nothing changed.
+ *
+ * A query request resolves to the previous query when it has the same query
+ * function, the same context, and deep-equal args. A plain query is reused
+ * when its AST and format are deep-equal to the previous one.
+ *
+ * The ref is written during render, which is safe because it is a pure
+ * memoization cache: entries are derived only from the inputs, so re-renders
+ * and discarded concurrent renders always leave it in a valid state.
+ */
+function useStableQuery<
+  TTable extends keyof TSchema['tables'] & string,
+  TInput extends ReadonlyJSONValue | undefined,
+  TOutput extends ReadonlyJSONValue | undefined,
+  TSchema extends BaseDefaultSchema,
+  TReturn,
+  TContext extends BaseDefaultContext,
+>(
+  query:
+    | QueryOrQueryRequest<TTable, TInput, TOutput, TSchema, TReturn, TContext>
+    | Falsy,
+  zero: Zero<TSchema, undefined, TContext>,
+): Query<TTable, TSchema, TReturn> | undefined {
+  const cacheRef = useRef<ResolvedQueryCacheEntry | undefined>(undefined);
+
+  // Keep the cache when the query is falsy so a query that is toggled off
+  // and back on is still reused.
+  if (!query) {
+    return undefined;
+  }
+
+  const cache = cacheRef.current;
+  if (cache && cache.zero === zero) {
+    if (cache.rawQuery === query) {
+      return cache.q as Query<TTable, TSchema, TReturn>;
+    }
+    if ('query' in query) {
+      if (
+        cache.customQuery === query.query &&
+        cache.context === zero.context &&
+        symmetricDeepEqual(cache.args, query.args)
+      ) {
+        cache.rawQuery = query;
+        return cache.q as Query<TTable, TSchema, TReturn>;
+      }
+    } else if (cache.ast !== undefined) {
+      const qi = asQueryInternals(query);
+      // Mocked queries may lack an AST; those never match and fall through
+      // to a rebuild.
+      if (
+        (qi.ast as AST | undefined) !== undefined &&
+        symmetricDeepEqual(
+          qi.format as unknown as ReadonlyJSONValue,
+          cache.format as unknown as ReadonlyJSONValue,
+        ) &&
+        equalCustomQueryID(qi.customQueryID, cache.customQueryID) &&
+        symmetricDeepEqual(
+          qi.ast as unknown as ReadonlyJSONValue,
+          cache.ast as unknown as ReadonlyJSONValue,
+        )
+      ) {
+        cache.rawQuery = query;
+        return cache.q as Query<TTable, TSchema, TReturn>;
+      }
+    }
+  }
+
+  const q = addContextToQuery(query, zero.context);
+  if ('query' in query) {
+    cacheRef.current = {
+      zero,
+      context: zero.context,
+      rawQuery: query,
+      customQuery: query.query,
+      args: query.args,
+      ast: undefined,
+      format: undefined,
+      customQueryID: undefined,
+      q,
+    };
+  } else {
+    const qi = asQueryInternals(q);
+    cacheRef.current = {
+      zero,
+      context: zero.context,
+      rawQuery: query,
+      customQuery: undefined,
+      args: undefined,
+      ast: qi.ast,
+      format: qi.format,
+      customQueryID: qi.customQueryID,
+      q,
+    };
+  }
+  return q;
+}
+
 // Overload 1: Query
 export function useQuery<
   TTable extends keyof TSchema['tables'] & string,
@@ -137,7 +288,7 @@ export function useQuery<
   const zero = useZero<TSchema, undefined, TContext>();
 
   // When query is falsy, use disabled subscriber/snapshot to maintain hook order
-  const q = query ? addContextToQuery(query, zero.context) : undefined;
+  const q = useStableQuery(query, zero);
   const view = q ? viewStore.getView(zero, q, enabled, ttl) : undefined;
 
   // https://react.dev/reference/react/useSyncExternalStore
@@ -216,7 +367,7 @@ export function useSuspenseQuery<
   const zero = useZero<TSchema, undefined, TContext>();
 
   // When query is falsy, use disabled subscriber/snapshot to maintain hook order
-  const q = query ? addContextToQuery(query, zero.context) : undefined;
+  const q = useStableQuery(query, zero);
   const view = q ? viewStore.getView(zero, q, enabled, ttl) : undefined;
 
   // https://react.dev/reference/react/useSyncExternalStore
@@ -348,6 +499,12 @@ function makeError(retry: () => void, error: ErroredQuery): QueryErrorDetails {
 // oxlint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyViewWrapper = ViewWrapper<any, any, any, any, any>;
 
+// Caches `hash + format` per query object so renders that reuse the same
+// resolved query (see useStableQuery) skip re-hashing. The client ID is
+// appended per call because a query object may be used with multiple Zero
+// instances.
+const queryKeyCache = new WeakMap<object, string>();
+
 const allViews = new WeakMap<ViewStore, Map<string, AnyViewWrapper>>();
 
 export function getAllViewsSizeForTesting(store: ViewStore): number {
@@ -448,7 +605,12 @@ export class ViewStore {
       };
     }
 
-    const hash = qi.hash() + JSON.stringify(qi.format) + zero.clientID;
+    let queryKey = queryKeyCache.get(qi);
+    if (queryKey === undefined) {
+      queryKey = qi.hash() + JSON.stringify(qi.format);
+      queryKeyCache.set(qi, queryKey);
+    }
+    const hash = queryKey + zero.clientID;
     let existing = this.#views.get(hash);
     if (!existing) {
       existing = new ViewWrapper(q, zero, ttl, view => {
@@ -635,6 +797,9 @@ class ViewWrapper<
   };
 
   updateTTL(ttl: TTL): void {
+    if (this.#ttl === ttl) {
+      return;
+    }
     this.#ttl = ttl;
     this.#view?.updateTTL(ttl);
   }


### PR DESCRIPTION
### Problem

Every render of every `useQuery`/`useSuspenseQuery` — including re-renders for unrelated reasons — redoes O(query-size) work:

1. `addContextToQuery` re-runs argument validation and the full query builder chain (a query like zbugs' `issueDetail` allocates ~20 intermediate `QueryImpl`s).
2. `ViewStore.getView` recomputes the view key: `qi.hash()` (normalize AST → `JSON.stringify` → xxHash-based `h64`) plus `JSON.stringify(format)`.

All the caches on that path (`QueryImpl#hash`, AST normalization, hash cache) are keyed on **object identity**, and the query is rebuilt inline on every render (`useQuery(queries.issue({id}))`, `useQuery(z.query.issue.where(...))`) — so every cache misses on every render. Micro-benchmarks: ~21μs/render for a mid-size AST, ~117μs/render for an `issueDetail`-shaped request with validation, vs ~0.04μs when identity is stable. Multiply by hooks-per-screen × render frequency (typing, pokes re-rendering parents) and this is real main-thread time. The Solid binding already memoizes this exact computation with `createMemo`; React had no equivalent.

### Changes

- **`useStableQuery`** (new, internal): a per-hook cache that keeps the resolved query identity-stable across renders.
  - A **query request** reuses the previous resolved query when the query function, Zero instance, context, and deep-equal args match — skipping validation and the builder chain entirely.
  - A **plain builder query** is reused when its AST + format + customQueryID are deep-equal — a ~4μs compare instead of ~17μs of normalize/stringify/hash.
  - Falsy renders keep the cache, so a toggled-off query is reused when it comes back. Changing the Zero instance invalidates.
  - The ref is written during render; this is safe because it's a pure memoization cache — entries are derived only from the inputs, so StrictMode double-renders and discarded concurrent renders always leave it valid.
- **View-store key cache**: `getView` caches the `hash + format` string per query object in a `WeakMap` (clientID appended per call, since one query object can serve multiple Zero instances). With a stable query identity the per-render key cost drops to a `WeakMap.get` + concat.
- **`ViewWrapper.updateTTL` guard**: early-return when the TTL value is unchanged, avoiding a per-render re-hash in the query manager. Value changes (including representation changes like `'60s'` → `60000`) still propagate as before.

### Deliberately unchanged

- The view store stays keyed by **AST hash**, not `name:args` — divergent ASTs for the same query name must not collapse (see `query-internals.ts`).
- `enabled: false` still builds the query (once, memoized) rather than never: the disabled snapshot's shape (`undefined` vs `[]`) depends on `format.singular`.
- View lifecycle (subscribe refcounts, 10ms deferred destroy) is untouched; `getView` still runs every render.

### A subtlety worth knowing about

Equality checks run `deepEqual` in **both directions**. `deepEqual` only value-compares keys of its first argument and then compares own-key counts, so an explicitly-undefined key on one side can absorb a differently-named defined key on the other: `deepEqual({q: undefined, page: 1}, {page: 1, sort: 'x'})` is `true`. One-directional comparison would serve a stale query when a call site's args change shape like that (e.g. `{q: searchText || undefined, page}`). The symmetric compare closes the hole; a regression test covers the exact scenario.

### Testing

- 7 new tests: builder fn runs once across equivalent re-renders (and re-runs on args change); a distinct-but-deep-equal query object is never re-hashed and reuses the existing view; changing the Zero instance re-resolves; falsy toggle reuses the cache; the undefined-key masking scenario re-runs the builder; `enabled: false` returns `[]`/`undefined` per plurality without materializing; unchanged TTL doesn't call `updateTTL` on the underlying view. Each fails against the pre-change code.
- Full `zero-react` suite: 81/81. `lint`, `format`, `check-types` clean (including the `zero` umbrella package).
