### PR TITLE
fix(d2s): `scalar` incorrectly compiled when the user incorrectly used `scalar`

### DIFF
--- a/packages/z2s/src/compiler.output.test.ts
+++ b/packages/z2s/src/compiler.output.test.ts
@@ -1449,7 +1449,12 @@ test('related w/o junction edge', () => {
   `);
 });
 
-test('scalar subquery with EXISTS generates = operator', () => {
+// `scalar` is an IVM planner hint; z2s ignores it and emits a plain
+// correlated EXISTS, which Postgres decorrelates on its own. Honoring it as
+// `parentField = (SELECT childField … LIMIT 1)` was only sound when the
+// subquery matched at most one row globally (here `name = 'Alice'` does not),
+// and silently dropped rows otherwise.
+test('scalar subquery with EXISTS is compiled as a plain EXISTS', () => {
   expect(
     formatPgInternalConvert(
       compile(serverSchema, schema, {
@@ -1484,7 +1489,12 @@ test('scalar subquery with EXISTS generates = operator', () => {
         COALESCE(json_agg(row_to_json("zql_root")), '[]'::json)::text AS "zql_result"
         FROM (SELECT "issue_0"."id" as "id","issue_0"."title" as "title","issue_0"."description" as "description","issue_0"."closed" as "closed","issue_0"."ownerId" as "ownerId",EXTRACT(EPOCH FROM "issue_0"."created") * 1000 as "created"
         FROM "issue" AS "issue_0"
-        WHERE "issue_0"."ownerId" = (SELECT "user_1"."id" FROM "user" AS "user_1" WHERE "user_1"."name" = $1::text ORDER BY "user_1"."id" ASC NULLS FIRST LIMIT 1)
+        WHERE EXISTS (SELECT "user_1"."id" as "id","user_1"."name" as "name","user_1"."nameArray" as "nameArray","user_1"."age" as "age","user_1"."ageArray" as "ageArray"
+        FROM "user" AS "user_1"
+        WHERE "user_1"."name" = $1::text
+        AND "issue_0"."ownerId" = "user_1"."id"
+        ORDER BY "user_1"."id" ASC NULLS FIRST
+        )
          
         ORDER BY "issue_0"."id" ASC NULLS FIRST
         ) "zql_root"",
@@ -1495,7 +1505,10 @@ test('scalar subquery with EXISTS generates = operator', () => {
   `);
 });
 
-test('scalar subquery with NOT EXISTS generates IS NOT operator', () => {
+// The NOT EXISTS form additionally used to emit `x IS NOT (SELECT …)`, which
+// Postgres cannot parse at all — this snapshot asserted invalid SQL because it
+// was never executed against a database.
+test('scalar subquery with NOT EXISTS is compiled as a plain NOT EXISTS', () => {
   expect(
     formatPgInternalConvert(
       compile(serverSchema, schema, {
@@ -1530,7 +1543,12 @@ test('scalar subquery with NOT EXISTS generates IS NOT operator', () => {
         COALESCE(json_agg(row_to_json("zql_root")), '[]'::json)::text AS "zql_result"
         FROM (SELECT "issue_0"."id" as "id","issue_0"."title" as "title","issue_0"."description" as "description","issue_0"."closed" as "closed","issue_0"."ownerId" as "ownerId",EXTRACT(EPOCH FROM "issue_0"."created") * 1000 as "created"
         FROM "issue" AS "issue_0"
-        WHERE "issue_0"."ownerId" IS NOT (SELECT "user_1"."id" FROM "user" AS "user_1" WHERE "user_1"."name" = $1::text ORDER BY "user_1"."id" ASC NULLS FIRST LIMIT 1)
+        WHERE NOT EXISTS (SELECT "user_1"."id" as "id","user_1"."name" as "name","user_1"."nameArray" as "nameArray","user_1"."age" as "age","user_1"."ageArray" as "ageArray"
+        FROM "user" AS "user_1"
+        WHERE "user_1"."name" = $1::text
+        AND "issue_0"."ownerId" = "user_1"."id"
+        ORDER BY "user_1"."id" ASC NULLS FIRST
+        )
          
         ORDER BY "issue_0"."id" ASC NULLS FIRST
         ) "zql_root"",

--- a/packages/z2s/src/compiler.ts
+++ b/packages/z2s/src/compiler.ts
@@ -352,9 +352,15 @@ function where(
         ' OR ',
       )})`;
     case 'correlatedSubquery':
-      if (condition.scalar) {
-        return scalarSubquery(spec, condition, table);
-      }
+      // `scalar` is deliberately ignored here. It is a planner hint for the
+      // IVM engines, which have no cost-based planner and benefit from
+      // pre-resolving an at-most-one-row subquery to a literal comparison
+      // (see zqlite's `resolveSimpleScalarSubqueries`). Postgres decorrelates
+      // EXISTS into a semi-join on its own, so the hint buys nothing here —
+      // and honoring it as `parentField = (SELECT childField … LIMIT 1)` is
+      // only sound when the subquery matches at most one row *globally*.
+      // Applying it unconditionally silently dropped rows whenever the
+      // subquery was not pinned to a unique key.
       return exists(spec, condition, table);
     case 'simple':
       return simple(spec, condition, table);
@@ -396,47 +402,6 @@ function exists(
         ),
       )})`;
   }
-}
-
-function scalarSubquery(
-  spec: Spec,
-  condition: CorrelatedSubqueryCondition,
-  parentTable: Table,
-): SQLQuery {
-  const parentField = condition.related.correlation.parentField[0];
-  const childField = condition.related.correlation.childField[0];
-  const subqueryAST = condition.related.subquery;
-
-  const parentCol = colIdent(spec.server, {
-    table: parentTable,
-    zql: parentField,
-  });
-
-  const subqueryTable = makeTable(spec, subqueryAST.table);
-  const childCol = colIdent(spec.server, {
-    table: subqueryTable,
-    zql: childField,
-  });
-
-  const op = sql.__dangerous__rawValue(
-    condition.op === 'EXISTS' ? '=' : 'IS NOT',
-  );
-
-  const subqueryConditions = subqueryAST.where
-    ? [where(spec, subqueryAST.where, subqueryTable)]
-    : [];
-  if (subqueryAST.start) {
-    subqueryConditions.push(
-      start(spec, subqueryAST.start, subqueryAST.orderBy, subqueryTable),
-    );
-  }
-  const subqueryOrderBy = orderBy(spec, subqueryAST.orderBy, subqueryTable);
-
-  return sql`${parentCol} ${op} (SELECT ${childCol} FROM ${fromIdent(spec.server, subqueryTable)} ${
-    subqueryConditions.length > 0
-      ? sql`WHERE ${sql.join(subqueryConditions, ' AND ')}`
-      : sql``
-  } ${subqueryOrderBy} LIMIT 1)`;
 }
 
 export function makeCorrelator(

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
@@ -2,7 +2,10 @@ import {LogContext} from '@rocicorp/logger';
 import {afterEach, beforeEach, describe, expect, test} from 'vitest';
 import {testLogConfig} from '../../../../otel/src/test-log-config.ts';
 import {TestLogSink} from '../../../../shared/src/logging-test-utils.ts';
-import type {AST} from '../../../../zero-protocol/src/ast.ts';
+import type {
+  AST,
+  CorrelatedSubqueryCondition,
+} from '../../../../zero-protocol/src/ast.ts';
 import {createSchema} from '../../../../zero-schema/src/builder/schema-builder.ts';
 import {
   boolean,
@@ -2367,6 +2370,42 @@ describe('view-syncer/pipeline-driver', () => {
       op: '=',
       left: {type: 'literal', value: 1},
       right: {type: 'literal', value: 0},
+    });
+  });
+
+  test('scalar NOT EXISTS subquery with no matching rows', () => {
+    pipelines.init(clientSchema);
+
+    // No comment has id='nonexistent', so nothing can satisfy the correlated
+    // EXISTS — its negation holds for every issue.
+    const results = [
+      ...pipelines.addQuery(
+        'hash-scalar-not-none',
+        'queryScalarNotNone',
+        {
+          ...ISSUES_WITH_NONEXISTENT_SCALAR_SUBQUERY,
+          where: {
+            ...(ISSUES_WITH_NONEXISTENT_SCALAR_SUBQUERY.where as CorrelatedSubqueryCondition),
+            op: 'NOT EXISTS',
+          },
+        },
+        startTimer(),
+      ),
+    ];
+
+    expect(results.filter(r => r !== 'yield').map(r => r.rowKey)).toEqual([
+      {id: '1'},
+      {id: '2'},
+      {id: '3'},
+    ]);
+
+    expect(
+      pipelines.queries().get('queryScalarNotNone')?.transformedAst.where,
+    ).toEqual({
+      type: 'simple',
+      op: '=',
+      left: {type: 'literal', value: 1},
+      right: {type: 'literal', value: 1},
     });
   });
 

--- a/packages/zql-integration-tests/src/chinook/chinook-fuzz-scalar.pg.test.ts
+++ b/packages/zql-integration-tests/src/chinook/chinook-fuzz-scalar.pg.test.ts
@@ -1,32 +1,38 @@
 /* oxlint-disable no-console */
 
 /**
- * The **scalar-subquery lane** of the coverage-driven fuzzer — the one phase-7 axis deferred
- * at first. A `whereExists(rel, …, {scalar: true})` gate compiles to a different shape on
- * each side of the differential:
+ * The **scalar-subquery lane** of the coverage-driven fuzzer.
  *
- * - **Postgres (z2s)** compiles the original `scalar: true` AST to
- *   `parentField = (SELECT childField … LIMIT 1)`.
- * - **The IVM** does not natively resolve scalars; zero-cache's pipeline-driver pre-resolves
- *   *simple* (unique-key-constrained) ones to a literal `parentField = <value>` before
- *   hydration. The driver's `checkScalar` applies that exact transform
- *   ({@link resolveSimpleScalarSubqueries}) and runs the IVM over the resolved AST.
+ * `{scalar: true}` on an EXISTS gate is a plan hint, not a semantic one: it asserts the
+ * subquery matches at most one row so an engine *may* decorrelate the gate. Every engine in
+ * this differential is free to ignore it — z2s does (Postgres decorrelates EXISTS on its
+ * own) and the base IVM does; only zero-cache's pipeline-driver acts on it, pre-resolving a
+ * *simple* (unique-key-pinned) subquery, and that transform is unit-tested directly in
+ * `zqlite/src/resolve-scalar-subqueries.test.ts`.
  *
- * So this is a true production mirror: original-through-z2s vs resolved-through-IVM must
- * agree. Every one-hop relationship in the schema yields one PK-constrained (hence simple)
- * scalar gate; a candidate that fails to resolve is reported (a generation regression), not
- * silently passed. Over the small, self-contained {@link miniPgContent mini} fixture, runs
- * per-PR.
+ * So the property here is **scalar-invariance**: marking gates scalar must not change
+ * results. Every `2^k` scalar assignment of an EXISTS-bearing skeleton is pinned to the same
+ * Postgres oracle, so any assignment that diverges surfaces.
+ *
+ * This replaces a lane that generated only PK-pinned gates and ran the *resolved* AST
+ * through the IVM against the *original* through z2s. That mirrored production but assumed
+ * the rewrite valid on both sides, so it could not observe a wrong one — and it missed a z2s
+ * bug that dropped rows for every scalar gate not pinned to a unique key. Skeleton gates are
+ * undecorated, hence unpinned, so that space is now the lane's default.
+ *
+ * Runs per-PR over the small, self-contained {@link miniPgContent mini} fixture.
  */
 
 import {expect, test} from 'vitest';
 import '../helpers/comparePg.ts';
 import {bootstrap} from '../helpers/runner.ts';
-import {pkOf} from './fuzz/axes.ts';
-import {checkScalar, panicIfFailed} from './fuzz/driver.ts';
-import {Data} from './fuzz/literals.ts';
-import {miniData, miniPgContent} from './fuzz/mini.ts';
-import {scalarCandidates} from './fuzz/scalar.ts';
+import {
+  checkScalarInvariance,
+  panicIfFailed,
+  scalarQueryCases,
+} from './fuzz/driver.ts';
+import {miniPgContent} from './fuzz/mini.ts';
+import {enumerate} from './fuzz/skeleton.ts';
 import {schema} from './schema.ts';
 
 const TIMEOUT_MS = 120_000;
@@ -37,22 +43,22 @@ const harness = await bootstrap({
   pgContent: miniPgContent(),
 });
 
-const data = new Data(miniData, pkOf);
-
 test(
-  'Scalar — simple scalar subqueries: resolved-IVM vs z2s parity over mini',
+  'Scalar-invariance — every scalar plan of an EXISTS query hydrate-equal over mini',
   async () => {
-    const report = await checkScalar(harness.delegates, miniData, data);
+    // D≤2 so a scalar gate can nest a further EXISTS — the shape of the reported bug
+    // (`src/scalar-nested-exists.pg.test.ts`), and one the old candidate list could not
+    // express. Deeper scalar×scalar nesting rides the nightly sweep.
+    const skels = enumerate({depth: 2, related: 1, exists: 2});
+    // Non-vacuous: the corpus must actually contain markable gates.
+    const cases = scalarQueryCases(skels);
+    expect(cases.length).toBeGreaterThan(0);
+
+    const report = await checkScalarInvariance(harness.delegates, skels);
     console.log(
-      `Scalar: ${report.total} one-hop gates, ${report.failures.length} failures`,
+      `Scalar: ${report.total} scalar-variants, ${report.failures.length} failures`,
     );
-    // Every non-junction, single-col-PK-child relationship with a present child PK in mini
-    // yields exactly one gate — a non-vacuous, exhaustive sweep over the relationship graph.
-    const expected = scalarCandidates().filter(
-      c => data.pkMid(c.child) !== undefined,
-    ).length;
-    expect(expected).toBeGreaterThan(0);
-    expect(report.total).toBe(expected);
+    expect(report.total).toBe(cases.length);
     panicIfFailed(report, 12);
   },
   TIMEOUT_MS,

--- a/packages/zql-integration-tests/src/chinook/fuzz/driver.ts
+++ b/packages/zql-integration-tests/src/chinook/fuzz/driver.ts
@@ -53,12 +53,7 @@ import {mutate} from './mutate.ts';
 import {type Mutation, pushForSkeleton} from './push.ts';
 import type {Regression} from './regressions.ts';
 import {rng} from './rng.ts';
-import {
-  buildScalar,
-  hasScalarSubquery,
-  resolveScalarForIvm,
-  scalarCandidates,
-} from './scalar.ts';
+import {scalarizableExistsCount, setScalars} from './scalar.ts';
 import {constructCount, shrinkAst} from './shrink.ts';
 import {enumerate, label, lower, type Skeleton} from './skeleton.ts';
 import {Mask, swarmGen} from './swarm.ts';
@@ -275,6 +270,29 @@ export function flipQueryCases(
       cases.push({
         label: `flip|${label(s)}|${bits.map(b => (b ? 1 : 0)).join('')}`,
         query: wrapAst(setFlips(base, bits)),
+      });
+    }
+  }
+  return cases;
+}
+
+/** Scalar-invariance variants as target-independent query cases. */
+export function scalarQueryCases(
+  skels: readonly Skeleton[],
+  maxScalars = 4,
+): readonly QueryCase[] {
+  const cases: QueryCase[] = [];
+  for (const s of skels) {
+    const base = asQueryInternals(lower(s)).ast;
+    const k = scalarizableExistsCount(base);
+    if (k === 0 || k > maxScalars) {
+      continue;
+    }
+    // The same `{false, true}^k` enumeration flip-invariance uses.
+    for (const bits of flipAssignments(k)) {
+      cases.push({
+        label: `scalar|${label(s)}|${bits.map(b => (b ? 1 : 0)).join('')}`,
+        query: wrapAst(setScalars(base, bits)),
       });
     }
   }
@@ -737,57 +755,21 @@ export async function checkYieldTail(
 }
 
 /**
- * **Scalar-subquery sweep:** for every one-hop relationship, build a PK-constrained (hence
- * *simple*) scalar subquery and check that the production split agrees with the oracle — the
- * original `scalar: true` AST through z2s (`parentField = (SELECT childField … LIMIT 1)`)
- * vs the IVM over the **pre-resolved** AST (`parentField = <literal>`, the transform
- * zero-cache's pipeline-driver applies via {@link resolveSimpleScalarSubqueries}).
- *
- * `rawRows` (client-named) backs the synchronous scalar executor; it must match the data
- * loaded into the oracle so both sides pick the same row. A candidate whose subquery fails
- * to resolve (would leave the base IVM treating `scalar` as a plain EXISTS — a generation
- * regression, not an engine bug) is reported, not silently passed.
+ * **Scalar-invariance sweep:** `scalar` is a plan hint every engine in the differential is
+ * free to ignore, so all `2^k` scalar assignments of an EXISTS-bearing skeleton must agree
+ * with the oracle — hence with each other. Unlike the old lane, gates are *not* pinned to a
+ * unique key first: an undecorated skeleton gate is unpinned, which is exactly the space
+ * where z2s used to decorrelate unsoundly.
  */
-export async function checkScalar(
+export async function checkScalarInvariance(
   delegates: Delegates,
-  rawRows: Record<string, readonly Row[]>,
-  data: Data,
+  skels: readonly Skeleton[],
+  maxScalars = 4,
 ): Promise<Report> {
-  const failures: Array<[string, string]> = [];
-  let total = 0;
-  for (const cand of scalarCandidates()) {
-    const q = buildScalar(cand, data);
-    if (!q) {
-      continue; // empty child table — no present PK to constrain
-    }
-    total += 1;
-    const lbl = `scalar|${cand.table}.${cand.rel}`;
-    const msg = await capture(async () => {
-      const ast = asQueryInternals(q).ast;
-      const resolved = resolveScalarForIvm(ast, rawRows);
-      if (hasScalarSubquery(resolved)) {
-        throw new Error(
-          `scalar subquery did not resolve (would diverge spuriously) for ${lbl}`,
-        );
-      }
-      const resolvedQuery = wrapAst(resolved);
-      // Oracle runs the ORIGINAL scalar AST (z2s); the IVM runs the RESOLVED one.
-      const pgResult = await delegates.pg.run(q);
-      const sqliteResult = mapResultToClientNames(
-        await delegates.sqlite.run(resolvedQuery),
-        schema,
-        // oxlint-disable-next-line @typescript-eslint/no-explicit-any
-        ast.table as any,
-      );
-      const memoryResult = await delegates.memory.run(resolvedQuery);
-      expect(memoryResult).toEqualPg(pgResult);
-      expect(sqliteResult).toEqualPg(pgResult);
-    });
-    if (msg) {
-      failures.push([lbl, msg]);
-    }
-  }
-  return {total, failures};
+  return await checkHydrateCases(
+    delegates,
+    scalarQueryCases(skels, maxScalars),
+  );
 }
 
 /**

--- a/packages/zql-integration-tests/src/chinook/fuzz/fuzz.test.ts
+++ b/packages/zql-integration-tests/src/chinook/fuzz/fuzz.test.ts
@@ -16,6 +16,7 @@ import {consume} from '../../../../zql/src/ivm/stream.ts';
 import {RandomYieldSource} from '../../../../zql/src/ivm/test/random-yield-source.ts';
 import {asQueryInternals} from '../../../../zql/src/query/query-internals.ts';
 import type {AnyQuery} from '../../../../zql/src/query/query.ts';
+import {newStaticQuery} from '../../../../zql/src/query/static-query.ts';
 import {QueryDelegateImpl as TestMemoryQueryDelegate} from '../../../../zql/src/query/test/query-delegate.ts';
 import {schema} from '../schema.ts';
 import {AXES, hasText, pkOf, relsOf, tables} from './axes.ts';
@@ -42,11 +43,9 @@ import {
 } from './regressions.ts';
 import {rng} from './rng.ts';
 import {
-  buildScalar,
   hasScalarSubquery,
-  makeScalarExecutor,
-  resolveScalarForIvm,
-  scalarCandidates,
+  scalarizableExistsCount,
+  setScalars,
 } from './scalar.ts';
 import {constructCount, shrinkAst} from './shrink.ts';
 import {
@@ -714,64 +713,87 @@ describe('regressions', () => {
   });
 });
 
-// ── scalar subqueries (production resolve mirror) ─────────────────────────────────────
+// ── scalar subqueries (scalar-invariance axis) ────────────────────────────────────────
 
 describe('scalar subqueries', () => {
-  test('candidates are one-hop (no junctions) with a single-col-PK child', () => {
-    const cands = scalarCandidates();
-    expect(cands.length).toBeGreaterThan(0);
-    for (const c of cands) {
-      expect(relsOf(c.table).find(r => r.name === c.rel)?.junction).toBe(false);
-      expect(pkOf(c.child)).toEqual([c.childPk]);
-    }
-  });
-
-  test('a built gate carries scalar:true and the resolver rewrites it to a literal =', async () => {
-    const delegate = memoryDelegate();
-    let checked = 0;
-    for (const c of scalarCandidates()) {
-      const q = buildScalar(c, data);
-      if (!q) {
+  test('the count matches the gates setScalars actually marks', () => {
+    let covered = 0;
+    for (const s of enumerate({depth: 2, related: 1, exists: 2})) {
+      const ast = asQueryInternals(lower(s)).ast;
+      const k = scalarizableExistsCount(ast);
+      if (k === 0) {
+        expect(hasScalarSubquery(setScalars(ast, []))).toBe(false);
         continue;
       }
-      const ast = asQueryInternals(q).ast;
-      // The raw gate is a scalar correlated subquery …
-      expect(hasScalarSubquery(ast), `${c.table}.${c.rel} not scalar`).toBe(
-        true,
-      );
-      // … which the production resolver rewrites away to a plain comparison …
-      const resolved = resolveScalarForIvm(ast, miniData);
+      covered += 1;
+      // All-on marks every gate; all-off leaves none set.
       expect(
-        hasScalarSubquery(resolved),
-        `unresolved scalar for ${c.table}.${c.rel}`,
-      ).toBe(false);
-      expect(resolved.where?.type).toBe('simple');
-      // … and the resolved query hydrates through the IVM.
-      await hydrates(delegate, wrapAst(resolved));
-      checked += 1;
+        hasScalarSubquery(setScalars(ast, Array(k).fill(true))),
+        `${label(s)} not marked`,
+      ).toBe(true);
+      expect(hasScalarSubquery(setScalars(ast, Array(k).fill(false)))).toBe(
+        false,
+      );
     }
-    expect(checked).toBeGreaterThan(0);
+    expect(covered).toBeGreaterThan(0);
   });
 
-  test('the executor returns the childField of the constrained row', () => {
-    // album.tracks: SELECT track.albumId WHERE track.id = <mid> ⇒ that track's albumId
-    // (childField ≠ the constrained PK — the non-trivial direction).
-    const c = must(
-      scalarCandidates().find(x => x.table === 'album' && x.rel === 'tracks'),
-      'album.tracks candidate missing',
+  test('junction wrappers are not marked — the builder puts scalar on the inner hop', () => {
+    // `playlist.tracks` is a two-hop junction. `{scalar: true}` through the builder lands
+    // on the second hop, so the wrapper must not be counted as a markable gate.
+    const junctionRel = must(
+      relsOf('playlist').find(r => r.junction),
+      'playlist has no junction relationship',
     );
-    const mid = data.pkMid('track');
-    const wantRow = must(miniData.track.find(r => r.id === mid));
-    const gate = must(asQueryInternals(must(buildScalar(c, data))).ast.where);
+    const viaBuilder = asQueryInternals(
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+      (newStaticQuery(schema, 'playlist') as any).whereExists(
+        junctionRel.name,
+        // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+        (q: any) => q,
+        {scalar: true},
+      ),
+    ).ast;
+    const gate = must(viaBuilder.where);
     expect(gate.type).toBe('correlatedSubquery');
     if (gate.type !== 'correlatedSubquery') {
       return;
     }
-    const childField = gate.related.correlation.childField[0];
-    expect(childField).toBe('albumId');
-    expect(
-      makeScalarExecutor(miniData)(gate.related.subquery, childField),
-    ).toBe(wantRow.albumId);
+    // The wrapper itself is unmarked by the builder …
+    expect(gate.scalar).toBeUndefined();
+    // … and setScalars agrees: one markable gate (the inner hop), not two.
+    const bare = asQueryInternals(
+      lower({
+        table: 'playlist',
+        children: [
+          {
+            rel: junctionRel.name,
+            kind: 'exists',
+            sub: {table: junctionRel.child, children: []},
+          },
+        ],
+      }),
+    ).ast;
+    expect(scalarizableExistsCount(bare)).toBe(1);
+  });
+
+  test('marking a gate scalar leaves hydration unchanged', async () => {
+    const delegate = memoryDelegate();
+    let checked = 0;
+    for (const s of enumerate({depth: 1, related: 0, exists: 1})) {
+      const ast = asQueryInternals(lower(s)).ast;
+      const k = scalarizableExistsCount(ast);
+      if (k === 0) {
+        continue;
+      }
+      const marked = setScalars(ast, Array(k).fill(true));
+      expect(hasScalarSubquery(marked)).toBe(true);
+      const before = await delegate.run(wrapAst(ast));
+      const after = await delegate.run(wrapAst(marked));
+      expect(after, `${label(s)} changed under scalar`).toEqual(before);
+      checked += 1;
+    }
+    expect(checked).toBeGreaterThan(0);
   });
 });
 

--- a/packages/zql-integration-tests/src/chinook/fuzz/scalar.ts
+++ b/packages/zql-integration-tests/src/chinook/fuzz/scalar.ts
@@ -1,162 +1,116 @@
 /**
- * **Scalar subqueries** (the one phase-7 axis deferred at first): a `whereExists(rel, …,
- * {scalar: true})` gate that z2s compiles to `parentField = (SELECT childField … LIMIT 1)`
- * but the base IVM does **not** natively resolve — only zero-cache's pipeline-driver does,
- * by pre-resolving "simple" (unique-key-constrained, ≤1-row) scalar subqueries to a literal
- * `parentField = <value>` condition via {@link resolveSimpleScalarSubqueries}.
+ * **Scalar-invariance** (design §6, shaped like {@link flippableExistsCount flip.ts}).
  *
- * So a faithful differential mirrors production: run the **original** scalar AST through the
- * Postgres oracle (z2s), and run the IVM (memory + sqlite) over the **pre-resolved** AST —
- * the exact transform the pipeline-driver applies. To keep the subquery simple (so it
- * actually resolves), we constrain the child's single-column **primary key** to one present
- * value; the resolver then rewrites the gate to the literal it would in production.
+ * `{scalar: true}` on an EXISTS gate is a **plan hint, not a semantic one**: it asserts the
+ * subquery matches at most one row, so an engine *may* decorrelate the gate into a literal
+ * comparison. z2s ignores it (Postgres decorrelates EXISTS on its own) and the base IVM
+ * ignores it; only zero-cache's pipeline-driver acts on it, pre-resolving a *simple*
+ * (unique-key-pinned) subquery through `resolveSimpleScalarSubqueries` — a transform whose
+ * own soundness is unit-tested in `zqlite/src/resolve-scalar-subqueries.test.ts`.
  *
- * This module is PG-free (the generator + the IVM-side resolve). The differential itself —
- * original-through-PG vs resolved-through-IVM — lives in `driver.ts`'s `checkScalar`.
+ * So the property is: **marking gates scalar must not change results.** Every
+ * `{false, true}^k` scalar assignment of an EXISTS-bearing query MUST hydrate to the same
+ * rows — and the differential pins each one to the same Postgres oracle, so if any
+ * assignment diverges it surfaces here.
+ *
+ * This lane used to generate only PK-pinned (hence provably decorrelatable) gates, and ran
+ * the *resolved* AST through the IVM against the *original* through z2s. That mirrored
+ * production, but it assumed the rewrite valid on both sides and so could not observe a
+ * wrong one: it missed a z2s bug that dropped rows for every scalar gate not pinned to a
+ * unique key (repro: `src/scalar-nested-exists.pg.test.ts`). Generating the unpinned space
+ * is the whole point — an undecorated skeleton gate is already unpinned.
+ *
+ * Both `EXISTS` and `NOT EXISTS` gates are marked (`not()` carries the flag through), at
+ * any nesting depth, so the shapes the old one-hop candidate list could not express — a
+ * scalar gate whose body nests a further EXISTS — are now in range.
+ *
+ * Junction (two-hop) wrappers are skipped: the builder lands `{scalar: true}` on the
+ * *inner* hop of a junction, so marking the wrapper would generate an AST no builder call
+ * can produce.
  */
 
-import type {AST, LiteralValue} from '../../../../zero-protocol/src/ast.ts';
-import type {Row, Value} from '../../../../zero-protocol/src/data.ts';
-import type {PrimaryKey} from '../../../../zero-protocol/src/primary-key.ts';
-import type {AnyQuery} from '../../../../zql/src/query/query.ts';
 import {
-  extractLiteralEqualityConstraints,
-  resolveSimpleScalarSubqueries,
-  type ScalarExecutor,
-} from '../../../../zqlite/src/resolve-scalar-subqueries.ts';
-import {pkOf, relsOf, tables} from './axes.ts';
-import type {Data} from './literals.ts';
-import {lower} from './skeleton.ts';
-
-/** A scalar-subquery candidate: a one-hop relationship a simple scalar gate can sit on. */
-export type ScalarCandidate = {
-  readonly table: string;
-  readonly rel: string;
-  readonly child: string;
-  readonly childPk: string;
-};
+  SUBQ_PREFIX,
+  type AST,
+  type Condition,
+  type CorrelatedSubqueryCondition,
+} from '../../../../zero-protocol/src/ast.ts';
 
 /**
- * Every `(table, one-hop relationship)` pair a *simple* scalar subquery can be built on:
- * non-junction (the builder throws on two-hop junctions) and a single-column-PK child (so
- * the subquery is made simple by constraining that PK to one present value). Deterministic
- * in schema-declaration order.
+ * Whether `c` is the outer wrapper the builder emits for a junction (two-hop)
+ * relationship — recognized, as in `ast-to-zql`, by the hidden alias on the second hop.
  */
-export function scalarCandidates(): ScalarCandidate[] {
-  const out: ScalarCandidate[] = [];
-  for (const table of tables()) {
-    for (const rel of relsOf(table)) {
-      if (rel.junction) {
-        continue; // scalar is unsupported on two-hop junctions (the builder throws)
-      }
-      const pk = pkOf(rel.child);
-      if (pk.length !== 1) {
-        continue; // need a single-column PK to constrain the subquery to one row
-      }
-      out.push({table, rel: rel.name, child: rel.child, childPk: pk[0]});
-    }
-  }
-  return out;
-}
-
-/**
- * Build the scalar-subquery query for `cand`:
- * `table.whereExists(rel, child ⇒ child.where(childPk = <present value>), {scalar: true})`.
- *
- * PK-constrained ⇒ the subquery returns ≤1 row, so it is *simple* and the production
- * resolver rewrites the gate to `parentField = <selected childField>`. `null` if the child
- * has no present PK value in `data` (an empty table).
- */
-export function buildScalar(
-  cand: ScalarCandidate,
-  data: Data,
-): AnyQuery | null {
-  const pkVal = data.pkMid(cand.child);
-  if (pkVal === undefined) {
-    return null;
-  }
-  const base = lower({table: cand.table, children: []});
+function isJunctionWrapper(c: CorrelatedSubqueryCondition): boolean {
+  const secondHop = c.related.subquery.where;
   return (
-    base as unknown as {
-      whereExists(
-        rel: string,
-        cb: (q: AnyQuery) => AnyQuery,
-        opts: {scalar: boolean},
-      ): AnyQuery;
-    }
-  ).whereExists(
-    cand.rel,
-    // oxlint-disable-next-line @typescript-eslint/no-explicit-any
-    (q: any) => q.where(cand.childPk, '=', pkVal),
-    {scalar: true},
+    secondHop?.type === 'correlatedSubquery' &&
+    (secondHop.related.subquery.alias?.includes(SUBQ_PREFIX + 'zhidden_') ??
+      false)
   );
 }
 
-/**
- * The `tableSpecs` map {@link resolveSimpleScalarSubqueries} needs, derived from the client
- * {@link schema}: each table's primary key is treated as a unique key — the subset of unique
- * keys the client schema records, and enough to make a PK-constrained subquery simple. Keyed
- * by **client** table name (matching the client-named subquery ASTs the builder produces).
- */
-export function scalarTableSpecs(): Map<
-  string,
-  {tableSpec: {uniqueKeys: PrimaryKey[]}}
-> {
-  const m = new Map<string, {tableSpec: {uniqueKeys: PrimaryKey[]}}>();
-  for (const t of tables()) {
-    m.set(t, {tableSpec: {uniqueKeys: [pkOf(t) as unknown as PrimaryKey]}});
-  }
-  return m;
-}
-
-/**
- * A synchronous {@link ScalarExecutor} backed by the raw fixture rows. For a *simple*
- * subquery the equality constraints pin a unique-key row, so a direct lookup returns the
- * same `childField` value the IVM pipeline (or Postgres `… LIMIT 1`) would. Returns
- * `undefined` when no row matches (→ the resolver yields an always-false gate, matching
- * Postgres's empty `(SELECT …)`).
- */
-export function makeScalarExecutor(
-  rawRows: Record<string, readonly Row[]>,
-): ScalarExecutor {
-  return (subqueryAST: AST, childField: string) => {
-    if (!subqueryAST.where) {
-      return undefined;
+/** The number of gates in `ast` that {@link setScalars} will mark. */
+export function scalarizableExistsCount(ast: AST): number {
+  let n = 0;
+  const countCond = (c: Condition): void => {
+    switch (c.type) {
+      case 'simple':
+        return;
+      case 'and':
+      case 'or':
+        c.conditions.forEach(countCond);
+        return;
+      case 'correlatedSubquery':
+        if (!isJunctionWrapper(c)) {
+          n += 1;
+        }
+        countAst(c.related.subquery);
     }
-    const constraints = extractLiteralEqualityConstraints(subqueryAST.where);
-    const rows = rawRows[subqueryAST.table] ?? [];
-    const match = rows.find(r =>
-      [...constraints].every(([col, val]) => eq(r[col], val)),
-    );
-    if (!match) {
-      return undefined;
-    }
-    return (match[childField] ?? null) as LiteralValue | null;
   };
-}
-
-function eq(a: Value | undefined, b: LiteralValue): boolean {
-  return a === b;
+  const countAst = (a: AST): void => {
+    if (a.where) {
+      countCond(a.where);
+    }
+    for (const r of a.related ?? []) {
+      countAst(r.subquery);
+    }
+  };
+  countAst(ast);
+  return n;
 }
 
 /**
- * Pre-resolve every simple scalar subquery in `ast` to a literal condition — the exact
- * transform zero-cache's pipeline-driver applies before running the IVM. The returned AST
- * has the scalar gate replaced by a plain `parentField = <value>` (or an always-false
- * condition), so the base IVM runs it as an ordinary filter.
+ * Set the `scalar` flag of each markable gate from `bits` (one boolean per gate, in a fixed
+ * pre-order). `bits.length` must equal {@link scalarizableExistsCount}. Pure.
  */
-export function resolveScalarForIvm(
-  ast: AST,
-  rawRows: Record<string, readonly Row[]>,
-): AST {
-  return resolveSimpleScalarSubqueries(
-    ast,
-    scalarTableSpecs(),
-    makeScalarExecutor(rawRows),
-  ).ast;
+export function setScalars(ast: AST, bits: readonly boolean[]): AST {
+  let i = 0;
+  const visitCond = (c: Condition): Condition => {
+    switch (c.type) {
+      case 'simple':
+        return c;
+      case 'and':
+      case 'or':
+        return {...c, conditions: c.conditions.map(visitCond)};
+      case 'correlatedSubquery': {
+        const mark = !isJunctionWrapper(c);
+        // Consume this gate's bit before descending, so the pre-order matches the count.
+        const scalar = mark ? bits[i++] : undefined;
+        const subquery = visitAst(c.related.subquery);
+        const withSub: Condition = {...c, related: {...c.related, subquery}};
+        return scalar === undefined ? withSub : {...withSub, scalar};
+      }
+    }
+  };
+  const visitAst = (a: AST): AST => ({
+    ...a,
+    where: a.where ? visitCond(a.where) : undefined,
+    related: a.related?.map(r => ({...r, subquery: visitAst(r.subquery)})),
+  });
+  return visitAst(ast);
 }
 
-/** Whether `ast` still contains a `scalar: true` correlated subquery (unresolved). */
+/** Whether `ast` carries any `scalar: true` correlated subquery. */
 export function hasScalarSubquery(ast: AST): boolean {
   const inCond = (c: AST['where']): boolean => {
     if (!c) {

--- a/packages/zql-integration-tests/src/scalar-nested-exists.pg.test.ts
+++ b/packages/zql-integration-tests/src/scalar-nested-exists.pg.test.ts
@@ -1,0 +1,261 @@
+import {test} from 'vitest';
+import {relationships} from '../../zero-schema/src/builder/relationship-builder.ts';
+import {createSchema} from '../../zero-schema/src/builder/schema-builder.ts';
+import {string, table} from '../../zero-schema/src/builder/table-builder.ts';
+import {createVitests} from './helpers/runner.ts';
+
+/**
+ * Repro for a user report: a `whereExists(oneRel, cb, {scalar: true})` whose
+ * callback contains a *non-scalar* exists over a many-relation silently
+ * returns the wrong rows (usually zero) through z2s, while the IVM paths
+ * (memory + zqlite) return the correct rows.
+ *
+ * The scalar rewrite replaces the EXISTS with
+ *
+ *   parentField = (SELECT childField FROM child WHERE <cb> ORDER BY <pk> LIMIT 1)
+ *
+ * which is only equivalent to the EXISTS when the subquery matches at most one
+ * row *globally* — i.e. when the callback pins a unique key with literal
+ * equalities. That is the contract zqlite's `resolveSimpleScalarSubqueries`
+ * enforces (`isSimpleSubquery`) before applying the same rewrite on the IVM
+ * side; when the subquery is not "simple" the IVM leaves the condition as a
+ * plain EXISTS. z2s applies the rewrite unconditionally, so for a non-simple
+ * subquery it compares against an arbitrary (lowest-pk) matching child row and
+ * drops every parent that points at a different one.
+ *
+ * Schema mirrors the report: event → post (many-to-one), post → team
+ * (many-to-one), team ← teamMember (one-to-many).
+ */
+
+const team = table('team')
+  .columns({
+    id: string(),
+    name: string(),
+  })
+  .primaryKey('id');
+
+const teamMember = table('teamMember')
+  .columns({
+    id: string(),
+    teamId: string(),
+    memberId: string(),
+  })
+  .primaryKey('id');
+
+const post = table('post')
+  .columns({
+    id: string(),
+    teamId: string(),
+    title: string(),
+  })
+  .primaryKey('id');
+
+const event = table('event')
+  .columns({
+    id: string(),
+    rootPostId: string(),
+    sortPath: string(),
+  })
+  .primaryKey('id');
+
+const teamRelationships = relationships(team, ({many}) => ({
+  teamMembers: many({
+    sourceField: ['id'],
+    destField: ['teamId'],
+    destSchema: teamMember,
+  }),
+}));
+
+const postRelationships = relationships(post, ({one}) => ({
+  team: one({
+    sourceField: ['teamId'],
+    destField: ['id'],
+    destSchema: team,
+  }),
+}));
+
+const eventRelationships = relationships(event, ({one}) => ({
+  rootPost: one({
+    sourceField: ['rootPostId'],
+    destField: ['id'],
+    destSchema: post,
+  }),
+}));
+
+const schema = createSchema({
+  tables: [team, teamMember, post, event],
+  relationships: [teamRelationships, postRelationships, eventRelationships],
+});
+
+const pgContent = /*sql*/ `
+CREATE TABLE "team" (
+  "id" TEXT PRIMARY KEY,
+  "name" TEXT NOT NULL
+);
+
+CREATE TABLE "teamMember" (
+  "id" TEXT PRIMARY KEY,
+  "teamId" TEXT NOT NULL,
+  "memberId" TEXT NOT NULL
+);
+
+CREATE TABLE "post" (
+  "id" TEXT PRIMARY KEY,
+  "teamId" TEXT NOT NULL,
+  "title" TEXT NOT NULL
+);
+
+CREATE TABLE "event" (
+  "id" TEXT PRIMARY KEY,
+  "rootPostId" TEXT NOT NULL,
+  "sortPath" TEXT NOT NULL
+);
+`;
+
+const MEMBER_ID = 'member1';
+
+/**
+ * `member1` belongs to both teams, so both posts pass the access chain.
+ * `post1` sorts first, which is the row the scalar rewrite's `LIMIT 1`
+ * latches onto — so every event rooted at `post2` is silently dropped.
+ */
+const testData = () => ({
+  team: [
+    {id: 'team1', name: 'Team 1'},
+    {id: 'team2', name: 'Team 2'},
+  ],
+  teamMember: [
+    {id: 'tm1', teamId: 'team1', memberId: MEMBER_ID},
+    {id: 'tm2', teamId: 'team2', memberId: MEMBER_ID},
+  ],
+  post: [
+    {id: 'post1', teamId: 'team1', title: 'Post 1'},
+    {id: 'post2', teamId: 'team2', title: 'Post 2'},
+  ],
+  event: [
+    {id: 'event1', rootPostId: 'post1', sortPath: 'a'},
+    {id: 'event2', rootPostId: 'post2', sortPath: 'b'},
+  ],
+});
+
+// oxlint-disable-next-line expect-expect
+test.each(
+  await createVitests(
+    {
+      suiteName: 'scalar_nested_exists',
+      pgContent,
+      zqlSchema: schema,
+      testData,
+      push: 0,
+    },
+    [
+      {
+        // The user's query, verbatim in shape. z2s returns [], IVM returns
+        // event2.
+        name: 'scalar exists nesting a many-relation exists',
+        createQuery: q =>
+          q.event
+            .where('rootPostId', '=', 'post2')
+            .whereExists(
+              'rootPost',
+              p =>
+                p.whereExists('team', t =>
+                  t.whereExists('teamMembers', m =>
+                    m.where('memberId', '=', MEMBER_ID),
+                  ),
+                ),
+              {scalar: true},
+            )
+            .orderBy('sortPath', 'asc')
+            .limit(20),
+        manualVerification: [
+          {id: 'event2', rootPostId: 'post2', sortPath: 'b'},
+        ],
+      },
+      {
+        // Identical, minus `{scalar: true}` — the user's workaround. Correct
+        // everywhere.
+        name: 'non-scalar exists nesting a many-relation exists',
+        createQuery: q =>
+          q.event
+            .where('rootPostId', '=', 'post2')
+            .whereExists('rootPost', p =>
+              p.whereExists('team', t =>
+                t.whereExists('teamMembers', m =>
+                  m.where('memberId', '=', MEMBER_ID),
+                ),
+              ),
+            )
+            .orderBy('sortPath', 'asc')
+            .limit(20),
+        manualVerification: [
+          {id: 'event2', rootPostId: 'post2', sortPath: 'b'},
+        ],
+      },
+      {
+        // The user's second data point: an inner primary-key equality makes
+        // the subquery "simple", so the scalar rewrite is sound and z2s
+        // agrees with IVM.
+        name: 'scalar exists with an inner primary-key equality',
+        createQuery: q =>
+          q.event
+            .where('rootPostId', '=', 'post2')
+            .whereExists(
+              'rootPost',
+              p =>
+                p
+                  .where('id', '=', 'post2')
+                  .whereExists('team', t =>
+                    t.whereExists('teamMembers', m =>
+                      m.where('memberId', '=', MEMBER_ID),
+                    ),
+                  ),
+              {scalar: true},
+            )
+            .orderBy('sortPath', 'asc')
+            .limit(20),
+        manualVerification: [
+          {id: 'event2', rootPostId: 'post2', sortPath: 'b'},
+        ],
+      },
+      {
+        // `NOT EXISTS` + scalar, with a "simple" (pk-pinned) subquery. z2s
+        // emits `x IS NOT (SELECT …)`, which is not valid Postgres syntax —
+        // a separate bug from the one above, and one the existing
+        // compiler.output snapshot bakes in without ever executing it.
+        name: 'scalar not-exists with an inner primary-key equality',
+        createQuery: q =>
+          q.event
+            .where(({not, exists}) =>
+              not(
+                exists('rootPost', p => p.where('id', '=', 'post1'), {
+                  scalar: true,
+                }),
+              ),
+            )
+            .orderBy('sortPath', 'asc'),
+        manualVerification: [
+          {id: 'event2', rootPostId: 'post2', sortPath: 'b'},
+        ],
+      },
+      {
+        // The nested exists is not the only trigger: any callback that fails
+        // to pin a unique key breaks the same way. Both posts match the LIKE,
+        // and the rewrite latches onto post1.
+        name: 'scalar exists with a non-unique simple filter',
+        createQuery: q =>
+          q.event
+            .where('rootPostId', '=', 'post2')
+            .whereExists('rootPost', p => p.where('title', 'LIKE', 'Post%'), {
+              scalar: true,
+            })
+            .orderBy('sortPath', 'asc'),
+        manualVerification: [
+          {id: 'event2', rootPostId: 'post2', sortPath: 'b'},
+        ],
+      },
+    ],
+  ),
+)('$name', async ({fn}) => {
+  await fn();
+});

--- a/packages/zqlite/src/resolve-scalar-subqueries.test.ts
+++ b/packages/zqlite/src/resolve-scalar-subqueries.test.ts
@@ -37,6 +37,13 @@ const ALWAYS_FALSE: SimpleCondition = {
   right: {type: 'literal', value: 0},
 };
 
+const ALWAYS_TRUE: SimpleCondition = {
+  type: 'simple',
+  op: '=',
+  left: {type: 'literal', value: 1},
+  right: {type: 'literal', value: 1},
+};
+
 // ---------- extractLiteralEqualityConstraints ----------
 
 test('extractLiteralEqualityConstraints: simple column = literal', () => {
@@ -363,6 +370,77 @@ test('returns ALWAYS_FALSE when executor returns null', () => {
   const {ast: resolved} = resolveSimpleScalarSubqueries(ast, specs, () => null);
 
   expect(resolved.where).toEqual(ALWAYS_FALSE);
+});
+
+// NOT EXISTS is the negation, so an unresolvable subquery makes it always
+// *true*: if no child row matches the subquery's WHERE, none can satisfy the
+// correlation either, so the EXISTS is false for every parent row.
+test('NOT EXISTS returns ALWAYS_TRUE when executor returns undefined', () => {
+  const specs = makeTableSpecs({users: [['id']]});
+  const ast: AST = {
+    table: 'issues',
+    where: {
+      type: 'correlatedSubquery',
+      op: 'NOT EXISTS',
+      scalar: true,
+      related: {
+        correlation: {
+          parentField: ['ownerId'],
+          childField: ['name'],
+        },
+        subquery: {
+          table: 'users',
+          where: {
+            type: 'simple',
+            op: '=',
+            left: {type: 'column', name: 'id'},
+            right: {type: 'literal', value: 'nonexistent'},
+          },
+        },
+      },
+    },
+  };
+
+  const {ast: resolved, companions} = resolveSimpleScalarSubqueries(
+    ast,
+    specs,
+    () => undefined,
+  );
+
+  expect(resolved.where).toEqual(ALWAYS_TRUE);
+  // Still recorded, so the pipeline re-resolves if a matching row appears.
+  expect(companions).toHaveLength(1);
+});
+
+test('NOT EXISTS returns ALWAYS_TRUE when executor returns null', () => {
+  const specs = makeTableSpecs({users: [['id']]});
+  const ast: AST = {
+    table: 'issues',
+    where: {
+      type: 'correlatedSubquery',
+      op: 'NOT EXISTS',
+      scalar: true,
+      related: {
+        correlation: {
+          parentField: ['ownerId'],
+          childField: ['name'],
+        },
+        subquery: {
+          table: 'users',
+          where: {
+            type: 'simple',
+            op: '=',
+            left: {type: 'column', name: 'id'},
+            right: {type: 'literal', value: '0001'},
+          },
+        },
+      },
+    },
+  };
+
+  const {ast: resolved} = resolveSimpleScalarSubqueries(ast, specs, () => null);
+
+  expect(resolved.where).toEqual(ALWAYS_TRUE);
 });
 
 test('leaves non-simple scalar subquery untouched', () => {

--- a/packages/zqlite/src/resolve-scalar-subqueries.ts
+++ b/packages/zqlite/src/resolve-scalar-subqueries.ts
@@ -169,8 +169,12 @@ function resolveScalarSubquery(
   });
 
   if (value === undefined || value === null) {
-    // No rows or NULL value — both x = NULL and x != NULL are false in SQL
-    return ALWAYS_FALSE;
+    // No row matched, or the matched row's `childField` is NULL (which can
+    // never satisfy the correlation, since `parentField = NULL` is never
+    // true). Either way the correlated EXISTS is false for *every* parent
+    // row, so the gate collapses to a constant: false for EXISTS, and its
+    // negation — true — for NOT EXISTS.
+    return condition.op === 'EXISTS' ? ALWAYS_FALSE : ALWAYS_TRUE;
   }
 
   const op = condition.op === 'EXISTS' ? '=' : 'IS NOT';
@@ -187,6 +191,13 @@ const ALWAYS_FALSE: SimpleCondition = {
   op: '=',
   left: {type: 'literal', value: 1},
   right: {type: 'literal', value: 0},
+};
+
+const ALWAYS_TRUE: SimpleCondition = {
+  type: 'simple',
+  op: '=',
+  left: {type: 'literal', value: 1},
+  right: {type: 'literal', value: 1},
 };
 
 /**


### PR DESCRIPTION
`scalar: true` is only allowed if the thing it is applied to constraints over a primary key.

E.g.,

```ts
issue.whereExists('owner', o => o.whereName('foo'))
```

`scalar: true` is applicable if there is a unique index on `name` and not applicable otherwise.

When `scalar:true` was used in the inapplicable case, d2s would compile incorrectly.

---

This also fixes the fuzzer so it would have found these bugs. The fuzzer only produced valid `scalar: true` queries now it can produce invalid ones like the user can.

Maybe there's a type level fix here so the user cannot even create invalid ones.... tbd