### PR TITLE
fix(zero-cache)!: raise a type error when `scalar: true` is applied in a place it is not allowed

### DIFF
--- a/apps/zbugs/shared/queries.ts
+++ b/apps/zbugs/shared/queries.ts
@@ -450,17 +450,22 @@ export function buildListQuery(args: ListQueryArgs) {
         : undefined,
       ...(labels ?? []).map(label =>
         exists('issueLabels', q =>
-          // No `{scalar: true}` on this gate: `label`'s unique keys are `(id)`
-          // and `(projectID, name)`, and pinning `name` alone covers neither,
-          // so the server would ignore the hint and run a plain EXISTS anyway.
-          q.whereExists('label', q =>
-            q
-              .where('name', label)
-              .whereExists(
-                'project',
-                q => q.where('lowerCaseName', projectName.toLocaleLowerCase()),
-                {scalar: true},
-              ),
+          // `label`'s unique key is `(projectID, name)` and only `name` is
+          // pinned here — but the inner `project` gate is itself scalar, so it
+          // rewrites to `label.projectID = <literal>` before this gate is
+          // tested, completing the key. Both gates are honored.
+          q.whereExists(
+            'label',
+            q =>
+              q
+                .where('name', label)
+                .whereExists(
+                  'project',
+                  q =>
+                    q.where('lowerCaseName', projectName.toLocaleLowerCase()),
+                  {scalar: true},
+                ),
+            {scalar: true},
           ),
         ),
       ),

--- a/apps/zbugs/shared/queries.ts
+++ b/apps/zbugs/shared/queries.ts
@@ -450,18 +450,17 @@ export function buildListQuery(args: ListQueryArgs) {
         : undefined,
       ...(labels ?? []).map(label =>
         exists('issueLabels', q =>
-          q.whereExists(
-            'label',
-            q =>
-              q
-                .where('name', label)
-                .whereExists(
-                  'project',
-                  q =>
-                    q.where('lowerCaseName', projectName.toLocaleLowerCase()),
-                  {scalar: true},
-                ),
-            {scalar: true},
+          // No `{scalar: true}` on this gate: `label`'s unique keys are `(id)`
+          // and `(projectID, name)`, and pinning `name` alone covers neither,
+          // so the server would ignore the hint and run a plain EXISTS anyway.
+          q.whereExists('label', q =>
+            q
+              .where('name', label)
+              .whereExists(
+                'project',
+                q => q.where('lowerCaseName', projectName.toLocaleLowerCase()),
+                {scalar: true},
+              ),
           ),
         ),
       ),

--- a/apps/zbugs/shared/schema.ts
+++ b/apps/zbugs/shared/schema.ts
@@ -19,7 +19,9 @@ const user = table('user')
     avatar: string(),
     role: enumeration<Role>(),
   })
-  .primaryKey('id');
+  .primaryKey('id')
+  // CREATE UNIQUE INDEX "user_login_idx" ON "user" ("login")
+  .unique('login');
 
 const project = table('project')
   .columns({
@@ -31,7 +33,11 @@ const project = table('project')
     markURL: string().optional(),
     logoURL: string().optional(),
   })
-  .primaryKey('id');
+  .primaryKey('id')
+  // CREATE UNIQUE INDEX "project_name_idx" ON "project" ("name")
+  .unique('name')
+  // CREATE UNIQUE INDEX "project_lower_case_name_idx" ON "project" ("lowerCaseName")
+  .unique('lowerCaseName');
 
 const issue = table('issue')
   .columns({
@@ -73,7 +79,9 @@ const label = table('label')
     name: string(),
     projectID: string(),
   })
-  .primaryKey('id');
+  .primaryKey('id')
+  // CREATE UNIQUE INDEX "label_name_project_idx" ON "label" ("projectID","name")
+  .unique('projectID', 'name');
 
 const issueLabel = table('issueLabel')
   .columns({

--- a/packages/zero-cache/src/services/run-ast.ts
+++ b/packages/zero-cache/src/services/run-ast.ts
@@ -109,11 +109,20 @@ export async function runAst(
     return node ? ((node.row[childField] as LiteralValue) ?? null) : undefined;
   };
 
-  const {ast: resolvedAst} = resolveSimpleScalarSubqueries(
+  const {ast: resolvedAst, ignoredScalarHints} = resolveSimpleScalarSubqueries(
     ast,
     options.tableSpecs,
     executor,
   );
+  for (const {table, uniqueKeys} of ignoredScalarHints) {
+    lc.warn?.(
+      `Ignoring {scalar: true} on the "${table}" subquery: it does not ` +
+        `constrain every column of any unique key ` +
+        `[${uniqueKeys.map(k => `(${k.join(', ')})`).join(', ')}] to a ` +
+        `literal with "=", so it is not provably limited to one row. ` +
+        `The gate runs as a plain EXISTS.`,
+    );
+  }
 
   const pipeline = buildPipeline(
     resolvedAst,

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
@@ -2409,6 +2409,98 @@ describe('view-syncer/pipeline-driver', () => {
     });
   });
 
+  describe('unhonored scalar hints are reported', () => {
+    // The driver is built at 'error' by default, which swallows warnings.
+    function warningsFrom(query: AST): string[] {
+      logSink.messages.length = 0;
+      const warnLc = new LogContext('warn', undefined, logSink);
+      const storage = new Database(warnLc, ':memory:');
+      storage.prepare(CREATE_STORAGE_TABLE).run();
+      pipelines = new PipelineDriver(
+        warnLc,
+        testLogConfig,
+        new Snapshotter(warnLc, dbFile.path, {appID: shardID.appID}),
+        shardID,
+        new DatabaseStorage(storage).createClientGroupStorage(
+          'foo-client-group',
+        ),
+        'pipeline-driver.test.ts',
+        new InspectorDelegate(undefined),
+        () => 200 /** yield threshold */,
+      );
+      pipelines.init(clientSchema);
+      [...pipelines.addQuery('hash-warn', 'queryWarn', query, startTimer())];
+      return logSink.messages
+        .filter(([level]) => level === 'warn')
+        .map(([, , args]) => String(args[0]));
+    }
+
+    test('an unpinned subquery warns, naming the table and its unique keys', () => {
+      const warnings = warningsFrom({
+        ...ISSUES_WITH_SCALAR_SUBQUERY,
+        where: {
+          ...(ISSUES_WITH_SCALAR_SUBQUERY.where as CorrelatedSubqueryCondition),
+          related: {
+            correlation: {parentField: ['id'], childField: ['issueID']},
+            subquery: {
+              table: 'comments',
+              // The gate survives as a real EXISTS, which needs an alias —
+              // the builder always emits one.
+              alias: 'zsubq_comments',
+              orderBy: [['id', 'asc']],
+              // `upvotes` is not unique, so this pins nothing.
+              where: {
+                type: 'simple',
+                op: '=',
+                left: {type: 'column', name: 'upvotes'},
+                right: {type: 'literal', value: 0},
+              },
+            },
+          },
+        },
+      });
+
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toMatchInlineSnapshot(
+        `"Ignoring {scalar: true} on the "comments" subquery of query queryWarn: it does not constrain every column of any unique key [(id)] to a literal with "=", so it is not provably limited to one row. The gate runs as a plain EXISTS."`,
+      );
+    });
+
+    test('a subquery pinned on the primary key is silent', () => {
+      expect(warningsFrom(ISSUES_WITH_SCALAR_SUBQUERY)).toEqual([]);
+    });
+
+    test('a subquery pinned on a non-primary unique index is silent', () => {
+      // `uniques` has unique indexes on both `id` and `name`. Pinning `name`
+      // is honored, which the client schema — primary keys only — could not
+      // have known. This is why the check lives here and not in the builder.
+      expect(
+        warningsFrom({
+          table: 'issues',
+          orderBy: [['id', 'asc']],
+          where: {
+            type: 'correlatedSubquery',
+            op: 'EXISTS',
+            scalar: true,
+            related: {
+              correlation: {parentField: ['id'], childField: ['id']},
+              subquery: {
+                table: 'uniques',
+                orderBy: [['id', 'asc']],
+                where: {
+                  type: 'simple',
+                  op: '=',
+                  left: {type: 'column', name: 'name'},
+                  right: {type: 'literal', value: 'bar'},
+                },
+              },
+            },
+          },
+        }),
+      ).toEqual([]);
+    });
+  });
+
   test('scalar subquery in AND with other conditions', () => {
     pipelines.init(clientSchema);
 

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
@@ -40,6 +40,7 @@ import type {Database} from '../../../../zqlite/src/db.ts';
 import {
   resolveSimpleScalarSubqueries,
   type CompanionSubquery,
+  type IgnoredScalarHint,
 } from '../../../../zqlite/src/resolve-scalar-subqueries.ts';
 import {createSQLiteCostModel} from '../../../../zqlite/src/sqlite-cost-model.ts';
 import {TableSource} from '../../../../zqlite/src/table-source.ts';
@@ -505,11 +506,32 @@ export class PipelineDriver {
     lc.info?.('query pipeline lifecycle');
   }
 
+  /**
+   * A `{scalar: true}` that cannot be honored degrades silently to a plain
+   * EXISTS, so the author gets none of the plan they asked for and no signal
+   * that they didn't. Say so, with the unique keys that were actually
+   * available — the client schema knows only primary keys, so this is the only
+   * place the advice can be correct.
+   */
+  #warnIgnoredScalarHints(queryID: string, hints: IgnoredScalarHint[]): void {
+    for (const {table, uniqueKeys} of hints) {
+      const keys = uniqueKeys.map(k => `(${k.join(', ')})`).join(', ');
+      this.#lc.warn?.(
+        `Ignoring {scalar: true} on the "${table}" subquery of query ` +
+          `${queryID}: it does not constrain every column of any unique key ` +
+          `${keys.length > 0 ? `[${keys}]` : '(none on this table)'} to a ` +
+          `literal with "=", so it is not provably limited to one row. ` +
+          `The gate runs as a plain EXISTS.`,
+      );
+    }
+  }
+
   #resolveScalarSubqueries(ast: AST): {
     ast: AST;
     companionRows: {table: string; row: Row}[];
     companions: CompanionSubquery[];
     companionInputs: Input[];
+    ignoredScalarHints: IgnoredScalarHint[];
   } {
     const companionRows: {table: string; row: Row}[] = [];
     const companionInputs: Input[] = [];
@@ -548,12 +570,18 @@ export class PipelineDriver {
       return (node.row[childField] as LiteralValue) ?? null;
     };
 
-    const {ast: resolved, companions} = resolveSimpleScalarSubqueries(
-      ast,
-      this.#tableSpecs,
-      executor,
-    );
-    return {ast: resolved, companionRows, companions, companionInputs};
+    const {
+      ast: resolved,
+      companions,
+      ignoredScalarHints,
+    } = resolveSimpleScalarSubqueries(ast, this.#tableSpecs, executor);
+    return {
+      ast: resolved,
+      companionRows,
+      companions,
+      companionInputs,
+      ignoredScalarHints,
+    };
   }
 
   /**
@@ -637,7 +665,10 @@ export class PipelineDriver {
         companionRows,
         companions: companionMeta,
         companionInputs,
+        ignoredScalarHints,
       } = this.#resolveScalarSubqueries(query);
+
+      this.#warnIgnoredScalarHints(queryID, ignoredScalarHints);
 
       const input = buildPipeline(
         resolvedQuery,

--- a/packages/zero-schema/src/builder/table-builder.ts
+++ b/packages/zero-schema/src/builder/table-builder.ts
@@ -109,6 +109,43 @@ export class TableBuilderWithColumns<TShape extends TableSchema> {
     });
   }
 
+  /**
+   * Declares that `columnNames` together are unique — mirroring a unique index
+   * that already exists upstream. Call once per index.
+   *
+   * Zero neither creates nor enforces the constraint; declaring it tells the
+   * type checker what the server already knows from the replica, which is what
+   * lets a `{scalar: true}` subquery pinned on these columns typecheck.
+   *
+   * The return type is spelled out so the column names stay literal — spreading
+   * the accumulated keys widens them to `PrimaryKey`, which loses exactly the
+   * information the check needs.
+   */
+  unique<
+    const TUniqueColNames extends [
+      keyof TShape['columns'] & string,
+      ...(keyof TShape['columns'] & string)[],
+    ],
+  >(
+    ...columnNames: TUniqueColNames
+  ): TableBuilderWithColumns<
+    Omit<TShape, 'uniqueKeys'> & {
+      uniqueKeys: [
+        ...(TShape extends {
+          uniqueKeys: infer TExisting extends readonly PrimaryKey[];
+        }
+          ? TExisting
+          : []),
+        TUniqueColNames,
+      ];
+    }
+  > {
+    return new TableBuilderWithColumns({
+      ...this.#schema,
+      uniqueKeys: [...(this.#schema.uniqueKeys ?? []), columnNames],
+    }) as any;
+  }
+
   get schema() {
     return this.#schema;
   }

--- a/packages/zero-solid/src/use-query.test.tsx
+++ b/packages/zero-solid/src/use-query.test.tsx
@@ -297,7 +297,9 @@ test('useQuery query deps change', async () => {
 test('useQuery query deps change, reconcile minimizes reactive updates', async () => {
   const {tableQuery, queryDelegate} = setupTestEnvironment();
 
-  const [querySignal, setQuery] = createSignal(tableQuery.where('a', 1));
+  const [querySignal, setQuery] = createSignal<typeof tableQuery>(
+    tableQuery.where('a', 1),
+  );
 
   const zero = newMockZero('useQuery-deps-change-id-min', queryDelegate);
   const renderHookResult = useQueryWithZeroProvider(zero, querySignal);
@@ -415,9 +417,9 @@ test('useQuery query deps change, reconcile minimizes reactive updates, tree', a
   });
   const issueQuery = newQuery(schema, 'issue');
 
-  const [querySignal, setQuery] = createSignal(
-    issueQuery.where('id', 'i1').related('comments'),
-  );
+  const [querySignal, setQuery] = createSignal<
+    ReturnType<typeof issueQuery.related<'comments'>>
+  >(issueQuery.where('id', 'i1').related('comments'));
 
   const zero = newMockZero('useQuery-deps-change-id-min-tree', queryDelegate);
   const renderHookResult = useQueryWithZeroProvider(zero, querySignal);

--- a/packages/zero-types/src/schema.ts
+++ b/packages/zero-types/src/schema.ts
@@ -11,6 +11,17 @@ export type TableSchema = {
   readonly serverName?: string | undefined;
   readonly columns: Record<string, SchemaValue>;
   readonly primaryKey: PrimaryKey;
+  /**
+   * Additional unique keys on the table, beyond the primary key — one entry
+   * per unique index, each listing every column the index covers.
+   *
+   * This is metadata for the type checker, not a constraint Zero creates or
+   * enforces: it mirrors unique indexes that already exist upstream. The
+   * server reads the real indexes off the replica, so declaring these only
+   * affects what the client-side types can prove — notably whether a
+   * `{scalar: true}` subquery is provably limited to one row.
+   */
+  readonly uniqueKeys?: readonly PrimaryKey[] | undefined;
 };
 
 export type RelationshipsSchema = {

--- a/packages/zql-integration-tests/src/chinook/chinook.pg.test.ts
+++ b/packages/zql-integration-tests/src/chinook/chinook.pg.test.ts
@@ -146,7 +146,11 @@ describe(
           },
           {
             name: 'Scalar subquery: tracks for album by title',
+            // `title` is not unique on `album`, so the server ignores the hint
+            // and runs a plain EXISTS. The type says so; the case stays to
+            // prove the results are correct either way.
             createQuery: q =>
+              // @ts-expect-error deliberately unpinned
               q.track.whereExists('album', a => a.where('title', 'Riot Act'), {
                 scalar: true,
               }),
@@ -157,6 +161,7 @@ describe(
             name: 'Scalar subquery: with and combinator',
             createQuery: q =>
               q.track
+                // @ts-expect-error deliberately unpinned, as above
                 .whereExists('album', a => a.where('title', 'Riot Act'), {
                   scalar: true,
                 })

--- a/packages/zql-integration-tests/src/scalar-nested-exists.pg.test.ts
+++ b/packages/zql-integration-tests/src/scalar-nested-exists.pg.test.ts
@@ -153,9 +153,13 @@ test.each(
         // The user's query, verbatim in shape. z2s returns [], IVM returns
         // event2.
         name: 'scalar exists nesting a many-relation exists',
+        // The reported bug, verbatim — and the static check now rejects it at
+        // authoring time, since the callback pins no unique key of `post`.
+        // Kept as a runtime case to prove the compiled SQL is correct.
         createQuery: q =>
           q.event
             .where('rootPostId', '=', 'post2')
+            // @ts-expect-error deliberately unpinned
             .whereExists(
               'rootPost',
               p =>
@@ -246,6 +250,7 @@ test.each(
         createQuery: q =>
           q.event
             .where('rootPostId', '=', 'post2')
+            // @ts-expect-error deliberately unpinned — `title` pins no unique key
             .whereExists('rootPost', p => p.where('title', 'LIKE', 'Post%'), {
               scalar: true,
             })

--- a/packages/zql-integration-tests/src/school-access/schema.ts
+++ b/packages/zql-integration-tests/src/school-access/schema.ts
@@ -29,7 +29,9 @@ const teacher = table('teacher')
     role: string(),
     schoolId: number().from('school_id'),
   })
-  .primaryKey('id');
+  .primaryKey('id')
+  // CREATE UNIQUE INDEX teacher_user_id_unique ON teacher (user_id)
+  .unique('userId');
 
 const teacherToCoTeacher = table('teacherToCoTeacher')
   .from('teacher_to_co_teacher')

--- a/packages/zql-integration-tests/src/school-access/school-access-profile.pg.test.ts
+++ b/packages/zql-integration-tests/src/school-access/school-access-profile.pg.test.ts
@@ -73,6 +73,11 @@ function buildNormalizedQuery(
                       t.whereExists(
                         'school',
                         s =>
+                          // Known limitation: the expression-builder form of
+                          // `where` pins `userId` at runtime — the server does
+                          // honor this hint — but the type cannot see through
+                          // `ExpressionFactory`, so it reads as unpinned.
+                          // @ts-expect-error see above
                           s.whereExists(
                             'teachers',
                             st =>
@@ -105,6 +110,8 @@ function buildNormalizedQuery(
                               g.whereExists(
                                 'schools',
                                 ds =>
+                                  // @ts-expect-error expression-builder form is
+                                  // not tracked; see above
                                   ds.whereExists(
                                     'teachers',
                                     dt =>

--- a/packages/zql/src/query/query-impl.ast.test.ts
+++ b/packages/zql/src/query/query-impl.ast.test.ts
@@ -742,7 +742,9 @@ test('where expressions', () => {
 // mutate the AST itself.
 test('where to dnf', () => {
   const issueQuery = newQuery(schema, 'issue');
-  let flatten = issueQuery.where('id', '=', '1').where('closed', true);
+  let flatten: AnyQuery = issueQuery
+    .where('id', '=', '1')
+    .where('closed', true);
   expect(ast(flatten).where).toMatchInlineSnapshot(`
     {
       "conditions": [
@@ -2112,7 +2114,7 @@ test('scalar option on two-hop relationship applies to inner condition', () => {
 
   expect(
     ast(
-      issueQuery.whereExists('labels', q => q.where('name', 'foo'), {
+      issueQuery.whereExists('labels', q => q.where('id', '=', 'l1'), {
         scalar: true,
         flip: true,
       }),
@@ -2152,13 +2154,13 @@ test('scalar option on two-hop relationship applies to inner condition', () => {
                   "table": "label",
                   "where": {
                     "left": {
-                      "name": "name",
+                      "name": "id",
                       "type": "column",
                     },
                     "op": "=",
                     "right": {
                       "type": "literal",
-                      "value": "foo",
+                      "value": "l1",
                     },
                     "type": "simple",
                   },
@@ -2181,40 +2183,9 @@ describe('whereExists with scalar option', () => {
   test('basic scalar exists', () => {
     const issueQuery = newQuery(schema, 'issue');
 
-    expect(ast(issueQuery.whereExists('owner', {scalar: true})))
-      .toMatchInlineSnapshot(`
-      {
-        "table": "issue",
-        "where": {
-          "op": "EXISTS",
-          "related": {
-            "correlation": {
-              "childField": [
-                "id",
-              ],
-              "parentField": [
-                "ownerId",
-              ],
-            },
-            "subquery": {
-              "alias": "zsubq_owner",
-              "table": "user",
-            },
-            "system": "client",
-          },
-          "scalar": true,
-          "type": "correlatedSubquery",
-        },
-      }
-    `);
-  });
-
-  test('scalar with where condition on subquery', () => {
-    const issueQuery = newQuery(schema, 'issue');
-
     expect(
       ast(
-        issueQuery.whereExists('owner', q => q.where('name', 'Alice'), {
+        issueQuery.whereExists('owner', q => q.where('id', '=', 'u1'), {
           scalar: true,
         }),
       ),
@@ -2237,13 +2208,61 @@ describe('whereExists with scalar option', () => {
               "table": "user",
               "where": {
                 "left": {
-                  "name": "name",
+                  "name": "id",
                   "type": "column",
                 },
                 "op": "=",
                 "right": {
                   "type": "literal",
-                  "value": "Alice",
+                  "value": "u1",
+                },
+                "type": "simple",
+              },
+            },
+            "system": "client",
+          },
+          "scalar": true,
+          "type": "correlatedSubquery",
+        },
+      }
+    `);
+  });
+
+  test('scalar with where condition on subquery', () => {
+    const issueQuery = newQuery(schema, 'issue');
+
+    expect(
+      ast(
+        issueQuery.whereExists('owner', q => q.where('id', '=', 'u1'), {
+          scalar: true,
+        }),
+      ),
+    ).toMatchInlineSnapshot(`
+      {
+        "table": "issue",
+        "where": {
+          "op": "EXISTS",
+          "related": {
+            "correlation": {
+              "childField": [
+                "id",
+              ],
+              "parentField": [
+                "ownerId",
+              ],
+            },
+            "subquery": {
+              "alias": "zsubq_owner",
+              "table": "user",
+              "where": {
+                "left": {
+                  "name": "id",
+                  "type": "column",
+                },
+                "op": "=",
+                "right": {
+                  "type": "literal",
+                  "value": "u1",
                 },
                 "type": "simple",
               },
@@ -2263,7 +2282,7 @@ describe('whereExists with scalar option', () => {
     expect(
       ast(
         issueQuery
-          .whereExists('owner', q => q.where('name', 'Alice'), {scalar: true})
+          .whereExists('owner', q => q.where('id', '=', 'u1'), {scalar: true})
           .where('title', 'LIKE', '%bug%'),
       ).where,
     ).toMatchObject({
@@ -2334,7 +2353,7 @@ describe('whereExists with scalar option', () => {
     const issueQuery = newQuery(schema, 'issue');
 
     const q = issueQuery
-      .whereExists('owner', q => q.where('name', 'Alice'), {scalar: true})
+      .whereExists('owner', q => q.where('id', '=', 'u1'), {scalar: true})
       .where('closed', false);
 
     expect(ast(q).where).toMatchObject({

--- a/packages/zql/src/query/query-impl.ts
+++ b/packages/zql/src/query/query-impl.ts
@@ -354,12 +354,16 @@ export class QueryImpl<
     throw new Error(`Invalid relationship ${relationship}`);
   };
 
+  // The declared return is the *bottom* of the pinned dimension, which is
+  // assignable to every `where` overload's declared return. The overloads
+  // refine `TPinned` for callers only; a single non-generic implementation
+  // signature cannot express that refinement.
   where = function (
     this: QueryImpl<TTable, TSchema, TReturn>,
     fieldOrExpressionFactory: string | ExpressionFactory<TTable, TSchema>,
     opOrValue?: SimpleOperator | GetFilterTypeAny | Parameter,
     value?: GetFilterTypeAny | Parameter,
-  ): Query<TTable, TSchema, TReturn> {
+  ): Query<TTable, TSchema, TReturn, any> {
     let cond: Condition;
 
     if (typeof fieldOrExpressionFactory === 'function') {
@@ -391,7 +395,7 @@ export class QueryImpl<
       this.format,
       this.customQueryID,
       this.#currentJunction,
-    );
+    ) as unknown as Query<TTable, TSchema, TReturn, any>;
   }.bind(this);
 
   start = (

--- a/packages/zql/src/query/query.ts
+++ b/packages/zql/src/query/query.ts
@@ -126,6 +126,33 @@ type ScalarRequirement<
 
 declare const scalarNeedsUniqueKey: unique symbol;
 
+/**
+ * The columns an honored `{scalar: true}` gate pins on the *parent* query.
+ *
+ * The server rewrites such a gate to `parentField = <literal>`, and it does so
+ * bottom-up: an inner gate's rewrite is already in place when the outer gate is
+ * tested for single-row-ness. So an inner scalar can supply the very column an
+ * outer key was missing — which is how a `label` subquery pinning only `name`
+ * ends up covering `(projectID, name)`.
+ *
+ * Only one-hop relationships qualify. On a junction the flag lands on the inner
+ * hop, and the outer wrapper stays a plain EXISTS over the junction table, so
+ * nothing is pinned on the parent.
+ */
+type ScalarPins<
+  TTable extends string,
+  TSchema extends ZeroSchema,
+  TRelationship extends string,
+> = TSchema['relationships'][TTable][TRelationship] extends readonly [
+  infer TOnly,
+]
+  ? TOnly extends {
+      readonly sourceField: infer TSource extends readonly string[];
+    }
+    ? TSource[number]
+    : never
+  : never;
+
 export type GetFilterType<
   TSchema extends TableSchema,
   TColumn extends keyof TSchema['columns'],
@@ -405,7 +432,12 @@ export interface Query<
         TSubPinned
       >,
     options: ExistsOptions<boolean> & {scalar: true},
-  ): Query<TTable, TSchema, TReturn, TPinned>;
+  ): Query<
+    TTable,
+    TSchema,
+    TReturn,
+    TPinned | ScalarPins<TTable, TSchema, TRelationship>
+  >;
   whereExists<TRelationship extends AvailableRelationships<TTable, TSchema>>(
     relationship: TRelationship,
     cb: (

--- a/packages/zql/src/query/query.ts
+++ b/packages/zql/src/query/query.ts
@@ -39,7 +39,7 @@ export type QueryReturn<Q> = Q extends Query<any, any, infer R> ? R : never;
 
 export type QueryTable<Q> = Q extends Query<infer T, any, any> ? T : never;
 
-export type ExistsOptions = {
+export type ExistsOptions<TScalar extends boolean = boolean> = {
   /**
    * Controls the join direction.
    * - `true`: Force the join to be flipped (child drives the join).
@@ -61,11 +61,70 @@ export type ExistsOptions = {
    * frequently, as the query will need to be rehydrated whenever the
    * subquery's result changes.
    *
+   * The server only honors this when the subquery is *provably* limited to one
+   * row: every column of the table's primary key, or of one of its
+   * {@linkcode unique} keys, constrained to a literal by `=`. A subquery that
+   * does not do so silently falls back to a plain `EXISTS`, so the type rejects
+   * `scalar: true` there rather than letting the hint go quietly unused.
+   *
    * Only supported for one-hop relationships. Throws if used with
    * junction (two-hop) relationships.
    */
-  scalar?: boolean;
+  scalar?: TScalar;
 };
+
+declare const pinnedColumns: unique symbol;
+
+/**
+ * The keys that make a subquery over `TTable` provably single-row: its primary
+ * key, plus any {@linkcode unique} keys the schema declares.
+ */
+type UniqueKeysOf<
+  TTable extends string,
+  TSchema extends ZeroSchema,
+> = TSchema['tables'][TTable] extends {
+  readonly uniqueKeys: infer TUnique extends readonly (readonly string[])[];
+}
+  ? [PullTableSchema<TTable, TSchema>['primaryKey'], ...TUnique]
+  : [PullTableSchema<TTable, TSchema>['primaryKey']];
+
+/** Whether every column of at least one key in `TKeys` is in `TPinned`. */
+type CoversSomeKey<
+  TKeys extends readonly unknown[],
+  TPinned extends string,
+> = TKeys extends readonly [infer THead, ...infer TRest]
+  ? THead extends readonly string[]
+    ? [THead[number]] extends [TPinned]
+      ? true
+      : CoversSomeKey<TRest, TPinned>
+    : CoversSomeKey<TRest, TPinned>
+  : false;
+
+/**
+ * Intersected into the `whereExists` callback's declared return type on the
+ * `{scalar: true}` overload: `unknown` (a no-op) when the subquery pins a
+ * unique key, and otherwise an object the returned query does not have, so
+ * that overload stops matching and the call falls through to the general one —
+ * where `scalar` may only be `false`.
+ *
+ * The requirement rides on the callback's return type rather than on the
+ * options parameter because TypeScript fixes `TSubPinned` to its default
+ * before evaluating a parameter type that depends on it through a type alias.
+ * The callback is checked in a later inference pass, after `TSubPinned` is
+ * known, so the requirement is only enforceable there.
+ */
+type ScalarRequirement<
+  TTable extends string,
+  TSchema extends ZeroSchema,
+  TPinned extends string,
+> =
+  CoversSomeKey<UniqueKeysOf<TTable, TSchema>, TPinned> extends true
+    ? unknown
+    : {
+        readonly [scalarNeedsUniqueKey]: 'To use {scalar: true}, the subquery must constrain every column of the primary key — or of a key declared with .unique() — to a literal with `=`. Otherwise the server ignores the hint and runs a plain EXISTS.';
+      };
+
+declare const scalarNeedsUniqueKey: unique symbol;
 
 export type GetFilterType<
   TSchema extends TableSchema,
@@ -230,7 +289,22 @@ export interface Query<
   TTable extends keyof TSchema['tables'] & string,
   TSchema extends ZeroSchema = DefaultSchema,
   TReturn = PullRow<TTable, TSchema>,
+  TPinned extends string = never,
 > {
+  /**
+   * Phantom: the columns this query has constrained to a literal with `=`.
+   * Never present at runtime — it exists so `TPinned` has a direct inference
+   * site, since otherwise the parameter appears only in nested method return
+   * types, which `whereExists` cannot infer through.
+   *
+   * It is a function type so the parameter is *contravariant*: a query that
+   * pinned more stays assignable to one that pinned less. That keeps the
+   * default (`never`, i.e. "pinned nothing known") the most permissive
+   * annotation, so existing `Query<Table, Schema>` signatures still accept a
+   * `.where('id', '=', x)` result.
+   */
+  readonly [pinnedColumns]?: ((pinned: TPinned) => void) | undefined;
+
   related<TRelationship extends AvailableRelationships<TTable, TSchema>>(
     relationship: TRelationship,
   ): Query<
@@ -240,7 +314,8 @@ export interface Query<
       TReturn,
       DestRow<TTable, TSchema, TRelationship>,
       TRelationship
-    >
+    >,
+    TPinned
   >;
   related<
     TRelationship extends AvailableRelationships<TTable, TSchema>,
@@ -263,9 +338,27 @@ export interface Query<
         ? TSubReturn
         : never,
       TRelationship
-    >
+    >,
+    TPinned
   >;
 
+  // The `=` forms come first and are the only ones that record a pinned
+  // column: a `ParameterReference` compiles to a static param rather than a
+  // literal, which the server's scalar rewrite does not accept, so those fall
+  // through to the general overloads below and pin nothing.
+  where<
+    TSelector extends NoCompoundTypeSelector<PullTableSchema<TTable, TSchema>>,
+  >(
+    field: TSelector,
+    op: '=',
+    value: GetFilterType<PullTableSchema<TTable, TSchema>, TSelector, '='>,
+  ): Query<TTable, TSchema, TReturn, TPinned | (TSelector & string)>;
+  where<
+    TSelector extends NoCompoundTypeSelector<PullTableSchema<TTable, TSchema>>,
+  >(
+    field: TSelector,
+    value: GetFilterType<PullTableSchema<TTable, TSchema>, TSelector, '='>,
+  ): Query<TTable, TSchema, TReturn, TPinned | (TSelector & string)>;
   where<
     TSelector extends NoCompoundTypeSelector<PullTableSchema<TTable, TSchema>>,
     TOperator extends SimpleOperator,
@@ -276,7 +369,7 @@ export interface Query<
       | GetFilterType<PullTableSchema<TTable, TSchema>, TSelector, TOperator>
       | ParameterReference
       | undefined,
-  ): Query<TTable, TSchema, TReturn>;
+  ): Query<TTable, TSchema, TReturn, TPinned>;
   where<
     TSelector extends NoCompoundTypeSelector<PullTableSchema<TTable, TSchema>>,
   >(
@@ -285,36 +378,55 @@ export interface Query<
       | GetFilterType<PullTableSchema<TTable, TSchema>, TSelector, '='>
       | ParameterReference
       | undefined,
-  ): Query<TTable, TSchema, TReturn>;
+  ): Query<TTable, TSchema, TReturn, TPinned>;
   where(
     expressionFactory: ExpressionFactory<TTable, TSchema>,
-  ): Query<TTable, TSchema, TReturn>;
+  ): Query<TTable, TSchema, TReturn, TPinned>;
 
+  // With no callback the subquery pins nothing, so `scalar` can never be
+  // honored here.
   whereExists(
     relationship: AvailableRelationships<TTable, TSchema>,
-    options?: ExistsOptions,
-  ): Query<TTable, TSchema, TReturn>;
+    options?: ExistsOptions<false>,
+  ): Query<TTable, TSchema, TReturn, TPinned>;
+  // The `{scalar: true}` overload, tried first: it matches only when the
+  // callback returns a query that pins a unique key of the destination table.
+  whereExists<
+    TRelationship extends AvailableRelationships<TTable, TSchema>,
+    TSubPinned extends string = never,
+  >(
+    relationship: TRelationship,
+    cb: (
+      q: Query<DestTableName<TTable, TSchema, TRelationship>, TSchema>,
+    ) => Query<string, TSchema, any, TSubPinned> &
+      ScalarRequirement<
+        DestTableName<TTable, TSchema, TRelationship>,
+        TSchema,
+        TSubPinned
+      >,
+    options: ExistsOptions<boolean> & {scalar: true},
+  ): Query<TTable, TSchema, TReturn, TPinned>;
   whereExists<TRelationship extends AvailableRelationships<TTable, TSchema>>(
     relationship: TRelationship,
     cb: (
       q: Query<DestTableName<TTable, TSchema, TRelationship>, TSchema>,
-    ) => Query<string, TSchema>,
-    options?: ExistsOptions,
-  ): Query<TTable, TSchema, TReturn>;
+    ) => Query<string, TSchema, any>,
+    options?: ExistsOptions<false>,
+  ): Query<TTable, TSchema, TReturn, TPinned>;
 
   start(
     row: Partial<PullRow<TTable, TSchema>>,
     opts?: {inclusive: boolean},
-  ): Query<TTable, TSchema, TReturn>;
+  ): Query<TTable, TSchema, TReturn, TPinned>;
 
-  limit(limit: number): Query<TTable, TSchema, TReturn>;
+  limit(limit: number): Query<TTable, TSchema, TReturn, TPinned>;
 
   orderBy<TSelector extends Selector<PullTableSchema<TTable, TSchema>>>(
     field: TSelector,
     direction: 'asc' | 'desc',
-  ): Query<TTable, TSchema, TReturn>;
+  ): Query<TTable, TSchema, TReturn, TPinned>;
 
-  one(): Query<TTable, TSchema, TReturn | undefined>;
+  one(): Query<TTable, TSchema, TReturn | undefined, TPinned>;
 
   /**
    * @deprecated Use {@linkcode RunOptions} with {@linkcode zero.run} instead.

--- a/packages/zql/src/query/scalar-typing.test.ts
+++ b/packages/zql/src/query/scalar-typing.test.ts
@@ -217,3 +217,31 @@ test('rejected shapes are type errors but still build at runtime', () => {
   });
   expect(asQueryInternals(noCallback).ast.where).toMatchObject({scalar: true});
 });
+
+test('the rejections above are attributable to `scalar`, not to the query', () => {
+  // Controls for each rejected shape: the identical call *without* the option
+  // must compile. `@ts-expect-error` swallows whatever error lands on its line,
+  // so without these a case could go on "passing" after it started failing for
+  // an unrelated reason — a renamed column, a dropped relationship.
+  const q = newQuery(schema, 'issue');
+  expect(q.whereExists('project', p => p)).toBeDefined();
+  expect(
+    q.whereExists('project', p => p.where('name', '=', 'Zero')),
+  ).toBeDefined();
+  expect(
+    q.whereExists('project', p => p.where('id', 'LIKE', 'p%')),
+  ).toBeDefined();
+  expect(
+    newQuery(schema, 'label').whereExists('project', p =>
+      p.where('name', '=', 'zero'),
+    ),
+  ).toBeDefined();
+  expect(q.whereExists('project')).toBeDefined();
+  expect(
+    newQuery(schema, 'issueLabel').whereExists('label', l =>
+      l
+        .where('name', '=', 'bug')
+        .whereExists('project', p => p.where('lowerCaseName', '=', 'zero')),
+    ),
+  ).toBeDefined();
+});

--- a/packages/zql/src/query/scalar-typing.test.ts
+++ b/packages/zql/src/query/scalar-typing.test.ts
@@ -1,0 +1,165 @@
+import {expect, test} from 'vitest';
+import {relationships} from '../../../zero-schema/src/builder/relationship-builder.ts';
+import {createSchema} from '../../../zero-schema/src/builder/schema-builder.ts';
+import {string, table} from '../../../zero-schema/src/builder/table-builder.ts';
+import {newQuery} from './query-impl.ts';
+import {asQueryInternals} from './query-internals.ts';
+
+/**
+ * `{scalar: true}` is only honored by the server when the subquery is provably
+ * limited to one row — every column of the primary key, or of a declared
+ * {@linkcode TableBuilderWithColumns.unique} key, constrained to a literal by
+ * `=`. Anything else silently degrades to a plain `EXISTS`, so the type
+ * rejects it. These cases pin down where that line falls.
+ */
+
+const project = table('project')
+  .columns({
+    id: string(),
+    name: string(),
+    lowerCaseName: string(),
+  })
+  .primaryKey('id')
+  // Mirrors `CREATE UNIQUE INDEX ... ON project (lowerCaseName)` upstream.
+  .unique('lowerCaseName');
+
+const label = table('label')
+  .columns({
+    id: string(),
+    projectID: string(),
+    name: string(),
+  })
+  .primaryKey('id')
+  .unique('projectID', 'name');
+
+const issue = table('issue')
+  .columns({
+    id: string(),
+    projectID: string(),
+    title: string(),
+  })
+  .primaryKey('id');
+
+const issueRelationships = relationships(issue, ({one}) => ({
+  project: one({
+    sourceField: ['projectID'],
+    destField: ['id'],
+    destSchema: project,
+  }),
+}));
+
+const labelRelationships = relationships(label, ({one}) => ({
+  project: one({
+    sourceField: ['projectID'],
+    destField: ['id'],
+    destSchema: project,
+  }),
+}));
+
+const schema = createSchema({
+  tables: [issue, label, project],
+  relationships: [issueRelationships, labelRelationships],
+});
+
+test('primary key pinned by = is accepted', () => {
+  const q = newQuery(schema, 'issue').whereExists(
+    'project',
+    p => p.where('id', '=', 'p1'),
+    {scalar: true},
+  );
+  expect(asQueryInternals(q).ast.where).toMatchObject({scalar: true});
+});
+
+test('the implicit-= form pins too', () => {
+  const q = newQuery(schema, 'issue').whereExists(
+    'project',
+    p => p.where('id', 'p1'),
+    {scalar: true},
+  );
+  expect(asQueryInternals(q).ast.where).toMatchObject({scalar: true});
+});
+
+test('a declared unique key is accepted', () => {
+  // `lowerCaseName` is not the primary key; only the `.unique()` declaration
+  // makes this provable on the client. This is the zbugs shape.
+  const q = newQuery(schema, 'issue').whereExists(
+    'project',
+    p => p.where('lowerCaseName', '=', 'zero'),
+    {scalar: true},
+  );
+  expect(asQueryInternals(q).ast.where).toMatchObject({scalar: true});
+});
+
+test('a compound unique key needs every column', () => {
+  const q = newQuery(schema, 'label').whereExists(
+    'project',
+    p => p.where('id', '=', 'p1'),
+    {scalar: true},
+  );
+  expect(asQueryInternals(q).ast.where).toMatchObject({scalar: true});
+});
+
+test('pinning survives chaining in any order', () => {
+  const q = newQuery(schema, 'issue').whereExists(
+    'project',
+    p => p.where('name', 'LIKE', 'z%').where('id', '=', 'p1').limit(5),
+    {scalar: true},
+  );
+  expect(asQueryInternals(q).ast.where).toMatchObject({scalar: true});
+});
+
+test('scalar: false is always allowed', () => {
+  const q = newQuery(schema, 'issue').whereExists('project', p => p, {
+    scalar: false,
+  });
+  expect(asQueryInternals(q).ast.where).toMatchObject({scalar: false});
+});
+
+test('flip is unaffected by pinning', () => {
+  const q = newQuery(schema, 'issue').whereExists('project', p => p, {
+    flip: true,
+  });
+  expect(asQueryInternals(q).ast.where).toMatchObject({flip: true});
+});
+
+test('rejected shapes are type errors but still build at runtime', () => {
+  // The directive sits on the statement because the overload mismatch is
+  // reported at the call expression, not at the argument that caused it.
+  // Runtime behavior is unchanged — the server simply ignores the hint.
+
+  // @ts-expect-error the subquery pins nothing
+  const unpinned = newQuery(schema, 'issue').whereExists('project', p => p, {
+    scalar: true,
+  });
+  expect(asQueryInternals(unpinned).ast.where).toMatchObject({scalar: true});
+
+  // @ts-expect-error `name` is not unique on `project`
+  const nonUnique = newQuery(schema, 'issue').whereExists(
+    'project',
+    p => p.where('name', '=', 'Zero'),
+    {scalar: true},
+  );
+  expect(asQueryInternals(nonUnique).ast.where).toMatchObject({scalar: true});
+
+  // @ts-expect-error LIKE does not pin `id` to a literal
+  const nonEquality = newQuery(schema, 'issue').whereExists(
+    'project',
+    p => p.where('id', 'LIKE', 'p%'),
+    {scalar: true},
+  );
+  expect(asQueryInternals(nonEquality).ast.where).toMatchObject({scalar: true});
+
+  // @ts-expect-error `name` covers no unique key of `project`
+  const partial = newQuery(schema, 'label').whereExists(
+    'project',
+    p => p.where('name', '=', 'zero'),
+    {scalar: true},
+  );
+  expect(asQueryInternals(partial).ast.where).toMatchObject({scalar: true});
+
+  const noCallback = newQuery(schema, 'issue').whereExists('project', {
+    // @ts-expect-error with no callback nothing can be pinned
+    scalar: true,
+  });
+  expect(asQueryInternals(noCallback).ast.where).toMatchObject({scalar: true});
+});

--- a/packages/zql/src/query/scalar-typing.test.ts
+++ b/packages/zql/src/query/scalar-typing.test.ts
@@ -32,6 +32,13 @@ const label = table('label')
   .primaryKey('id')
   .unique('projectID', 'name');
 
+const issueLabel = table('issueLabel')
+  .columns({
+    issueID: string(),
+    labelID: string(),
+  })
+  .primaryKey('issueID', 'labelID');
+
 const issue = table('issue')
   .columns({
     id: string(),
@@ -48,6 +55,14 @@ const issueRelationships = relationships(issue, ({one}) => ({
   }),
 }));
 
+const issueLabelRelationships = relationships(issueLabel, ({one}) => ({
+  label: one({
+    sourceField: ['labelID'],
+    destField: ['id'],
+    destSchema: label,
+  }),
+}));
+
 const labelRelationships = relationships(label, ({one}) => ({
   project: one({
     sourceField: ['projectID'],
@@ -57,8 +72,12 @@ const labelRelationships = relationships(label, ({one}) => ({
 }));
 
 const schema = createSchema({
-  tables: [issue, label, project],
-  relationships: [issueRelationships, labelRelationships],
+  tables: [issue, issueLabel, label, project],
+  relationships: [
+    issueRelationships,
+    issueLabelRelationships,
+    labelRelationships,
+  ],
 });
 
 test('primary key pinned by = is accepted', () => {
@@ -103,6 +122,41 @@ test('pinning survives chaining in any order', () => {
   const q = newQuery(schema, 'issue').whereExists(
     'project',
     p => p.where('name', 'LIKE', 'z%').where('id', '=', 'p1').limit(5),
+    {scalar: true},
+  );
+  expect(asQueryInternals(q).ast.where).toMatchObject({scalar: true});
+});
+
+test('an inner scalar gate completes an outer compound key', () => {
+  // `label`'s unique key is (projectID, name) and only `name` is pinned here.
+  // The inner `project` gate is itself scalar, so the server rewrites it to
+  // `label.projectID = <literal>` before testing this gate — completing the
+  // key. The type follows the same rule.
+  // (Regression-tested end to end in
+  // zqlite/src/resolve-nested-scalar.test.ts.)
+  const q = newQuery(schema, 'issueLabel').whereExists(
+    'label',
+    l =>
+      l
+        .where('name', '=', 'bug')
+        .whereExists('project', p => p.where('lowerCaseName', '=', 'zero'), {
+          scalar: true,
+        }),
+    {scalar: true},
+  );
+  expect(asQueryInternals(q).ast.where).toMatchObject({scalar: true});
+});
+
+test('a non-scalar inner gate does not complete the key', () => {
+  // Same shape without the inner hint: nothing supplies `projectID`, so the
+  // outer gate is genuinely unpinned.
+  // @ts-expect-error `name` alone does not cover (projectID, name)
+  const q = newQuery(schema, 'issueLabel').whereExists(
+    'label',
+    l =>
+      l
+        .where('name', '=', 'bug')
+        .whereExists('project', p => p.where('lowerCaseName', '=', 'zero')),
     {scalar: true},
   );
   expect(asQueryInternals(q).ast.where).toMatchObject({scalar: true});

--- a/packages/zql/src/query/test/test-schemas.ts
+++ b/packages/zql/src/query/test/test-schemas.ts
@@ -57,7 +57,11 @@ const label = table('label')
     id: string(),
     name: string(),
   })
-  .primaryKey('id');
+  .primaryKey('id')
+  // Matches the unique keys the zqlite resolver tests hand the server
+  // (`label: [['id'], ['name']]`), so a scalar gate pinned on `name` is
+  // provable on the client too.
+  .unique('name');
 
 const revision = table('revision')
   .columns({

--- a/packages/zqlite/src/resolve-nested-scalar.test.ts
+++ b/packages/zqlite/src/resolve-nested-scalar.test.ts
@@ -1,0 +1,91 @@
+import {expect, test} from 'vitest';
+import type {AST, LiteralValue} from '../../zero-protocol/src/ast.ts';
+import type {PrimaryKey} from '../../zero-protocol/src/primary-key.ts';
+import {resolveSimpleScalarSubqueries} from './resolve-scalar-subqueries.ts';
+
+/**
+ * Nested scalar gates resolve bottom-up, and the outer gate's "is it pinned?"
+ * test runs on the *already-resolved* subquery. So a gate that looks unpinned
+ * syntactically can still be honored, because an inner scalar contributed the
+ * missing key column as a literal.
+ *
+ * This is the zbugs list-query shape: `issueLabel -> label` pins only `name`,
+ * but `label`'s unique key is `(projectID, name)`; the inner `label -> project`
+ * gate — pinned on the unique `lowerCaseName` — rewrites to
+ * `label.projectID = <literal>`, which completes the key.
+ */
+const specs = new Map<string, {tableSpec: {uniqueKeys: PrimaryKey[]}}>([
+  ['label', {tableSpec: {uniqueKeys: [['id'], ['projectID', 'name']]}}],
+  ['project', {tableSpec: {uniqueKeys: [['id'], ['lowerCaseName']]}}],
+]);
+
+const ast: AST = {
+  table: 'issueLabel',
+  where: {
+    type: 'correlatedSubquery',
+    op: 'EXISTS',
+    scalar: true,
+    related: {
+      correlation: {parentField: ['labelID'], childField: ['id']},
+      subquery: {
+        table: 'label',
+        alias: 'zsubq_label',
+        where: {
+          type: 'and',
+          conditions: [
+            {
+              type: 'simple',
+              op: '=',
+              left: {type: 'column', name: 'name'},
+              right: {type: 'literal', value: 'bug'},
+            },
+            {
+              type: 'correlatedSubquery',
+              op: 'EXISTS',
+              scalar: true,
+              related: {
+                correlation: {parentField: ['projectID'], childField: ['id']},
+                subquery: {
+                  table: 'project',
+                  alias: 'zsubq_project',
+                  where: {
+                    type: 'simple',
+                    op: '=',
+                    left: {type: 'column', name: 'lowerCaseName'},
+                    right: {type: 'literal', value: 'zero'},
+                  },
+                },
+              },
+            },
+          ],
+        },
+      },
+    },
+  },
+};
+
+test("an inner scalar completes the outer gate's unique key", () => {
+  const executed: string[] = [];
+  const execute = (sub: AST, childField: string): LiteralValue | undefined => {
+    executed.push(`${sub.table}.${childField}`);
+    return sub.table === 'project' ? 'proj1' : 'label1';
+  };
+
+  const {ast: resolved, ignoredScalarHints} = resolveSimpleScalarSubqueries(
+    ast,
+    specs,
+    execute,
+  );
+
+  // Innermost first, then the outer gate over the rewritten subquery.
+  expect(executed).toEqual(['project.id', 'label.id']);
+  // Nothing was declined: both gates were honored.
+  expect(ignoredScalarHints).toEqual([]);
+  // The whole chain collapsed to a single literal comparison.
+  expect(resolved.where).toEqual({
+    type: 'simple',
+    op: '=',
+    left: {type: 'column', name: 'labelID'},
+    right: {type: 'literal', value: 'label1'},
+  });
+});

--- a/packages/zqlite/src/resolve-scalar-subqueries.ts
+++ b/packages/zqlite/src/resolve-scalar-subqueries.ts
@@ -23,9 +23,31 @@ export type CompanionSubquery = {
   resolvedValue: LiteralValue | null | undefined;
 };
 
+/**
+ * A `scalar` hint that could not be honored: the subquery was not provably
+ * limited to one row, so the gate was left as a plain EXISTS.
+ */
+export type IgnoredScalarHint = {
+  /** The subquery's table. */
+  table: string;
+  /** The unique keys that were available to pin it. */
+  uniqueKeys: readonly PrimaryKey[];
+};
+
 export type ResolveResult = {
   ast: AST;
   companions: CompanionSubquery[];
+  /**
+   * Hints the caller may want to surface: each one is a `{scalar: true}` the
+   * author asked for and did not get. See {@link IgnoredScalarHint}.
+   */
+  ignoredScalarHints: IgnoredScalarHint[];
+};
+
+/** Accumulators threaded through the recursion. */
+type Out = {
+  companions: CompanionSubquery[];
+  ignoredScalarHints: IgnoredScalarHint[];
 };
 
 /**
@@ -56,24 +78,24 @@ export function resolveSimpleScalarSubqueries(
   tableSpecs: Map<string, TableSpecWithUniqueKeys>,
   execute: ScalarExecutor,
 ): ResolveResult {
-  const companions: CompanionSubquery[] = [];
-  const resolved = resolveASTRecursive(ast, tableSpecs, execute, companions);
-  return {ast: resolved, companions};
+  const out: Out = {companions: [], ignoredScalarHints: []};
+  const resolved = resolveASTRecursive(ast, tableSpecs, execute, out);
+  return {ast: resolved, ...out};
 }
 
 function resolveASTRecursive(
   ast: AST,
   tableSpecs: Map<string, TableSpecWithUniqueKeys>,
   execute: ScalarExecutor,
-  companions: CompanionSubquery[],
+  out: Out,
 ): AST {
   const where = ast.where
-    ? resolveCondition(ast.where, tableSpecs, execute, companions)
+    ? resolveCondition(ast.where, tableSpecs, execute, out)
     : undefined;
 
   const related = ast.related?.map(r => ({
     ...r,
-    subquery: resolveASTRecursive(r.subquery, tableSpecs, execute, companions),
+    subquery: resolveASTRecursive(r.subquery, tableSpecs, execute, out),
   }));
 
   if (where !== ast.where || related !== ast.related) {
@@ -86,17 +108,12 @@ function resolveCondition(
   condition: Condition,
   tableSpecs: Map<string, TableSpecWithUniqueKeys>,
   execute: ScalarExecutor,
-  companions: CompanionSubquery[],
+  out: Out,
 ): Condition {
   switch (condition.type) {
     case 'correlatedSubquery':
       if (condition.scalar) {
-        return resolveScalarSubquery(
-          condition,
-          tableSpecs,
-          execute,
-          companions,
-        );
+        return resolveScalarSubquery(condition, tableSpecs, execute, out);
       }
       // Non-scalar correlated subquery: recurse into its subquery
       {
@@ -104,7 +121,7 @@ function resolveCondition(
           condition.related.subquery,
           tableSpecs,
           execute,
-          companions,
+          out,
         );
         if (resolvedSubquery !== condition.related.subquery) {
           return {
@@ -117,7 +134,7 @@ function resolveCondition(
     case 'and':
     case 'or': {
       const resolved = condition.conditions.map(c =>
-        resolveCondition(c, tableSpecs, execute, companions),
+        resolveCondition(c, tableSpecs, execute, out),
       );
       if (resolved.every((c, i) => c === condition.conditions[i])) {
         return condition;
@@ -133,7 +150,7 @@ function resolveScalarSubquery(
   condition: CorrelatedSubqueryCondition,
   tableSpecs: Map<string, TableSpecWithUniqueKeys>,
   execute: ScalarExecutor,
-  companions: CompanionSubquery[],
+  out: Out,
 ): Condition {
   const parentField = condition.related.correlation.parentField[0];
   const childField = condition.related.correlation.childField[0];
@@ -144,10 +161,17 @@ function resolveScalarSubquery(
     condition.related.subquery,
     tableSpecs,
     execute,
-    companions,
+    out,
   );
 
   if (!isSimpleSubquery(subquery, tableSpecs)) {
+    // The author asked for a scalar rewrite and is not getting one. Record it
+    // so the caller can say so — silently falling back is the whole reason the
+    // hint is easy to get wrong.
+    out.ignoredScalarHints.push({
+      table: subquery.table,
+      uniqueKeys: tableSpecs.get(subquery.table)?.tableSpec.uniqueKeys ?? [],
+    });
     // Return with the (possibly partially-resolved) subquery.
     if (subquery !== condition.related.subquery) {
       return {
@@ -162,7 +186,7 @@ function resolveScalarSubquery(
 
   // Record the companion subquery AST so its rows are synced to the client.
   // The client rewrites scalar subqueries to EXISTS and needs those rows.
-  companions.push({
+  out.companions.push({
     ast: subquery,
     childField,
     resolvedValue: value,


### PR DESCRIPTION
do not allow the user to put `scalar: true` on things where it has no effect.

https://rocicorp.slack.com/archives/C0AKHBR6DT7/p1785857478901319?thread_ts=1785780527.387249&cid=C0AKHBR6DT7