### PR TITLE
fix(zero-client): avoid slow query warnings on reconnect

### DIFF
--- a/packages/zero-client/src/client/query-materialization-metrics.test.ts
+++ b/packages/zero-client/src/client/query-materialization-metrics.test.ts
@@ -425,6 +425,35 @@ describe('query materialization metrics', () => {
       view2.destroy();
     });
 
+    test('records the metric only once when got is re-confirmed', () => {
+      mockPerformanceNow([
+        100,
+        125, // Initial client materialization
+        200, // Initial got: 100ms end-to-end
+        309_801, // Reconnect got would incorrectly report 309,701ms
+      ]);
+
+      const query = createTestQuery();
+      const view = queryDelegate.materialize(query) as unknown as MockView;
+
+      gotCallback!(true);
+      gotCallback!(true);
+
+      const endToEndCalls = addMetricSpy.mock.calls.filter(
+        call => call[0] === 'query-materialization-end-to-end',
+      );
+      expect(endToEndCalls).toEqual([
+        [
+          'query-materialization-end-to-end',
+          100,
+          expect.any(String),
+          expect.objectContaining({table: 'users'}),
+        ],
+      ]);
+
+      view.destroy();
+    });
+
     test('handles server responding with false (query not available)', () => {
       // Mock performance.now() for server failure scenario
       mockClientTiming(150, 200);

--- a/packages/zql/src/query/query-delegate-base.ts
+++ b/packages/zql/src/query/query-delegate-base.ts
@@ -352,6 +352,7 @@ export function materializeImpl<
     : queryHash;
   const queryCompleteResolver = resolver<true>();
   let queryComplete: boolean | ErroredQuery = delegate.defaultQueryComplete;
+  let endToEndMetricRecorded = false;
   const updateTTL = customQueryID
     ? (newTTL: TTL) => delegate.updateCustomQuery(customQueryID, newTTL)
     : (newTTL: TTL) => delegate.updateServerQuery(ast, newTTL);
@@ -364,12 +365,15 @@ export function materializeImpl<
     }
 
     if (got) {
-      delegate.addMetric(
-        'query-materialization-end-to-end',
-        performance.now() - t0,
-        queryID,
-        ast,
-      );
+      if (!endToEndMetricRecorded) {
+        delegate.addMetric(
+          'query-materialization-end-to-end',
+          performance.now() - t0,
+          queryID,
+          ast,
+        );
+        endToEndMetricRecorded = true;
+      }
       queryComplete = true;
       queryCompleteResolver.resolve(true);
     }


### PR DESCRIPTION
### What

Prevents long-lived Zero queries from reporting their age as end-to-end materialization latency when the client reconnects. Materialization timing now represents only the view's initial completion.

### Why

After reconnect, the first poke deliberately re-confirms existing queries with `got(true)`. The materialization callback treated every confirmation as a new metric but measured from the view's original start time. This produced false slow-query warnings and polluted materialization metrics whenever a connection was interrupted.

See https://github.com/tldraw/tldraw/issues/9808 for the original report.

### Changes

- Record the end-to-end materialization metric only once per materialized view.
- Preserve reconnect query-state reconciliation behavior.
- Add a regression test covering a repeated `got(true)` after 309.7 seconds.
