### PR TITLE
fix(zero-cache): avoid rebuilds for nullability changes

### DIFF
--- a/packages/zero-cache/src/services/replicator/change-processor.test.ts
+++ b/packages/zero-cache/src/services/replicator/change-processor.test.ts
@@ -14,7 +14,7 @@ import {StatementRunner} from '../../db/statements.ts';
 import {expectTables, initDB} from '../../test/lite.ts';
 import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
 import {ChangeProcessor} from './change-processor.ts';
-import {DEL_OP, SET_OP} from './schema/change-log.ts';
+import {DEL_OP, RESET_OP, SET_OP} from './schema/change-log.ts';
 import {ColumnMetadataStore} from './schema/column-metadata.ts';
 import {
   getSubscriptionState,
@@ -1679,6 +1679,9 @@ describe('replicator/change-processor', () => {
       setup: `
         CREATE TABLE foo(id INT8, nolz TEXT, _0_version TEXT);
         CREATE UNIQUE INDEX foo_pkey ON foo (id ASC);
+        INSERT INTO "_zero.column_metadata"
+          (table_name, column_name, upstream_type, is_not_null, is_enum, is_array)
+          VALUES ('foo', 'nolz', 'TEXT', 0, 0, 0);
         INSERT INTO foo(id, nolz, _0_version) VALUES (1, 'hel', '00');
         INSERT INTO foo(id, nolz, _0_version) VALUES (2, 'low', '00');
         INSERT INTO foo(id, nolz, _0_version) VALUES (3, 'orl', '00');
@@ -1787,6 +1790,9 @@ describe('replicator/change-processor', () => {
       setup: `
         CREATE TABLE foo(id INT8, nolz TEXT, _0_version TEXT);
         CREATE UNIQUE INDEX foo_pkey ON foo (id ASC);
+        INSERT INTO "_zero.column_metadata"
+          (table_name, column_name, upstream_type, is_not_null, is_enum, is_array)
+          VALUES ('foo', 'nolz', 'TEXT', 0, 0, 0);
         INSERT INTO foo(id, nolz, _0_version) VALUES (1, 'hel', '00');
         INSERT INTO foo(id, nolz, _0_version) VALUES (2, 'low', '00');
         INSERT INTO foo(id, nolz, _0_version) VALUES (3, 'orl', '00');
@@ -3610,49 +3616,6 @@ describe('replicator/change-processor', () => {
     },
   ];
 
-  test('SET NOT NULL preserves compound index column order', () => {
-    initDB(
-      backupReplica,
-      `
-        CREATE TABLE foo(
-          id INT8,
-          tenant_id TEXT,
-          _0_version TEXT
-        );
-        CREATE UNIQUE INDEX foo_pkey ON foo(id);
-        CREATE INDEX foo_tenant_id_id ON foo(tenant_id, id);
-      `,
-    );
-
-    const messages = new ReplicationMessages({foo: 'id'});
-    backupProcessor.processMessage(lc, [
-      'begin',
-      messages.begin(),
-      {commitWatermark: '03'},
-    ]);
-    backupProcessor.processMessage(lc, [
-      'data',
-      messages.updateColumn(
-        'foo',
-        {name: 'tenant_id', spec: {pos: 2, dataType: 'TEXT'}},
-        {
-          name: 'tenant_id',
-          spec: {pos: 2, dataType: 'TEXT', notNull: true},
-        },
-      ),
-    ]);
-    backupProcessor.processMessage(lc, [
-      'commit',
-      messages.commit(),
-      {watermark: '03'},
-    ]);
-
-    const index = must(
-      listIndexes(backupReplica).find(({name}) => name === 'foo_tenant_id_id'),
-    );
-    expect(Object.keys(index.columns)).toEqual(['tenant_id', 'id']);
-  });
-
   for (const c of cases) {
     test(c.name, () => {
       for (const [replica, processor, log] of [
@@ -4231,6 +4194,97 @@ describe('replicator/column-metadata-integration', () => {
       isBackfilling: false,
     });
   });
+
+  test.each([
+    {from: false, to: true},
+    {from: true, to: false},
+  ])(
+    'update column nullability from $from to $to without rebuilding the SQLite schema',
+    ({from, to}) => {
+      const messages = new ReplicationMessages({foo: 'id'});
+
+      processor.processMessage(lc, [
+        'begin',
+        messages.begin(),
+        {commitWatermark: '0d'},
+      ]);
+      processor.processMessage(lc, [
+        'data',
+        messages.createTable({
+          schema: 'public',
+          name: 'foo',
+          columns: {
+            id: {pos: 0, dataType: 'int8'},
+            value: {pos: 1, dataType: 'text', notNull: from},
+          },
+          primaryKey: ['id'],
+        }),
+      ]);
+      processor.processMessage(lc, [
+        'data',
+        messages.createIndex({
+          schema: 'public',
+          tableName: 'foo',
+          name: 'foo_value_id_idx',
+          columns: {value: 'ASC', id: 'ASC'},
+          unique: false,
+        }),
+      ]);
+      processor.processMessage(lc, [
+        'data',
+        messages.insert('foo', {id: 1, value: 'one'}),
+      ]);
+      processor.processMessage(lc, [
+        'commit',
+        messages.commit(),
+        {watermark: '0d'},
+      ]);
+
+      const sqliteSchema = replica.prepare(
+        `SELECT name, rootpage, sql FROM sqlite_master
+         WHERE name IN ('foo', 'foo_value_id_idx') ORDER BY name`,
+      );
+      const schemaBeforeUpdate = sqliteSchema.all();
+
+      processor.processMessage(lc, [
+        'begin',
+        messages.begin(),
+        {commitWatermark: '0e'},
+      ]);
+      processor.processMessage(lc, [
+        'data',
+        messages.updateColumn(
+          'foo',
+          {name: 'value', spec: {pos: 1, dataType: 'text', notNull: from}},
+          {name: 'value', spec: {pos: 1, dataType: 'text', notNull: to}},
+        ),
+      ]);
+      processor.processMessage(lc, [
+        'commit',
+        messages.commit(),
+        {watermark: '0e'},
+      ]);
+
+      expect(sqliteSchema.all()).toEqual(schemaBeforeUpdate);
+      expect(replica.prepare('SELECT id, value FROM foo').all()).toEqual([
+        {id: 1, value: 'one'},
+      ]);
+      expect(
+        must(ColumnMetadataStore.getInstance(replica)).getColumn(
+          'foo',
+          'value',
+        ),
+      ).toMatchObject({isNotNull: to});
+      expect(
+        replica
+          .prepare(
+            `SELECT stateVersion, "table", op FROM "_zero.changeLog2"
+             WHERE stateVersion = '0e'`,
+          )
+          .all(),
+      ).toContainEqual({stateVersion: '0e', table: 'foo', op: RESET_OP});
+    },
+  );
 
   test('drop column deletes metadata', () => {
     const messages = new ReplicationMessages({foo: 'id'});

--- a/packages/zero-cache/src/services/replicator/change-processor.ts
+++ b/packages/zero-cache/src/services/replicator/change-processor.ts
@@ -19,10 +19,13 @@ import {
   type LiteTableSpecWithReplicationStatus,
 } from '../../db/lite-tables.ts';
 import {
+  isArrayColumn,
+  isEnumColumn,
   mapPostgresToLite,
   mapPostgresToLiteColumn,
   mapPostgresToLiteIndex,
 } from '../../db/pg-to-lite.ts';
+import type {ColumnSpec} from '../../db/specs.ts';
 import type {StatementRunner} from '../../db/statements.ts';
 import type {LexiVersion} from '../../types/lexi-version.ts';
 import {
@@ -697,36 +700,46 @@ class TransactionProcessor {
     let oldName = msg.old.name;
     const newName = msg.new.name;
 
-    // update-column can ignore defaults because it does not change the values
-    // in existing rows.
-    //
-    // https://www.postgresql.org/docs/current/sql-altertable.html#SQL-ALTERTABLE-DESC-SET-DROP-DEFAULT
-    //
-    // "The new default value will only apply in subsequent INSERT or UPDATE
-    //  commands; it does not cause rows already in the table to change."
-    //
-    // This allows support for _changing_ column defaults to any expression,
-    // since it does not affect what the replica needs to do.
-    const oldSpec = mapPostgresToLiteColumn(table, msg.old, 'ignore-default');
-    const newSpec = mapPostgresToLiteColumn(table, msg.new, 'ignore-default');
+    const storageTypesDiffer = differentStorageTypes(
+      msg.old.spec,
+      msg.new.spec,
+    );
 
     // If neither the column name nor the SQLite data type changes, only the
     // upstream metadata needs to be updated. This includes changes such as a
-    // varchar character limit, which SQLite does not enforce but a freshly
-    // built replica still records.
-    if (oldName === newName && oldSpec.dataType === newSpec.dataType) {
+    // varchar character limit and nullability, which SQLite does not enforce
+    // but a freshly built replica still records.
+    if (oldName === newName && !storageTypesDiffer) {
       this.#columnMetadata.update(
         table,
         msg.old.name,
         msg.new.name,
         msg.new.spec,
       );
-      this.#lc.info?.(msg.tag, 'updated metadata only', oldSpec, newSpec);
+      if (Boolean(msg.old.spec.notNull) !== Boolean(msg.new.spec.notNull)) {
+        this.#bumpVersions(msg.table);
+      }
+      this.#lc.info?.(msg.tag, 'updated metadata only', msg.old, msg.new);
       return;
     }
-    // If the data type changes, we have to make a new column with the new data type
-    // and copy the values over.
-    if (oldSpec.dataType !== newSpec.dataType) {
+    // Storage type changes require a new column so that SQLite uses the new
+    // representation for existing and future values.
+    if (storageTypesDiffer) {
+      // update-column can ignore defaults because it does not change the values
+      // in existing rows.
+      //
+      // https://www.postgresql.org/docs/current/sql-altertable.html#SQL-ALTERTABLE-DESC-SET-DROP-DEFAULT
+      //
+      // "The new default value will only apply in subsequent INSERT or UPDATE
+      //  commands; it does not cause rows already in the table to change."
+      //
+      // This allows support for _changing_ column defaults to any expression,
+      // since it does not affect what the replica needs to do.
+      const newLiteSpec = mapPostgresToLiteColumn(
+        table,
+        msg.new,
+        'ignore-default',
+      );
       const tableSpec = must(
         listTables(this.#db.db, false, false).find(
           tableSpec => tableSpec.name === table,
@@ -738,7 +751,7 @@ class TransactionProcessor {
       const tmpTable = `tmp.${table}`;
       const newColumns = mapEntries(tableSpec.columns, (column, spec) => [
         column === oldName ? newName : column,
-        column === oldName ? {...newSpec, pos: spec.pos} : spec,
+        column === oldName ? {...newLiteSpec, pos: spec.pos} : spec,
       ]);
       const sourceColumns = Object.keys(tableSpec.columns);
       const destinationColumns = Object.keys(newColumns);
@@ -1016,6 +1029,17 @@ class TransactionProcessor {
     lc.info?.(`aborting transaction ${this.#version}`);
     this.#db.rollback();
   }
+}
+
+function differentStorageTypes(
+  oldSpec: ColumnSpec,
+  newSpec: ColumnSpec,
+): boolean {
+  return (
+    oldSpec.dataType !== newSpec.dataType ||
+    isEnumColumn(oldSpec) !== isEnumColumn(newSpec) ||
+    isArrayColumn(oldSpec) !== isArrayColumn(newSpec)
+  );
 }
 
 function getBackfilledColumns(

--- a/packages/zero-cache/src/test/replica-state.ts
+++ b/packages/zero-cache/src/test/replica-state.ts
@@ -24,7 +24,12 @@ export function canonicalReplicaState(db: Database) {
       name,
       columns: Object.entries(columns)
         .filter(([column]) => column !== ZERO_VERSION_COLUMN_NAME)
-        .map(([column, spec], pos) => ({column, ...spec, pos: pos + 1})),
+        .map(([column, spec], pos) => ({
+          column,
+          ...spec,
+          dataType: canonicalPhysicalDataType(spec.dataType),
+          pos: pos + 1,
+        })),
     }))
     .sort(byName);
 
@@ -83,6 +88,11 @@ export function canonicalReplicaState(db: Database) {
 
 function byName<T extends {name: string}>(a: T, b: T) {
   return a.name.localeCompare(b.name);
+}
+
+function canonicalPhysicalDataType(dataType: string) {
+  // Nullability is logical metadata, and SQLite type names are case-insensitive.
+  return dataType.replace('|NOT_NULL', '').toLowerCase();
 }
 
 function canonicalizeRow(row: Record<string, unknown>) {


### PR DESCRIPTION
### What

Treat PostgreSQL column nullability updates as logical metadata changes in zero-cache replicas instead of rebuilding the physical SQLite table and its indexes. Replica versioning still occurs so clients observe the schema change.

### Why

Zero records nullability with a `|NOT_NULL` marker in SQLite's declared type, even though SQLite does not enforce that constraint. The change processor interpreted changes to this marker as physical storage-type changes, causing unnecessary table and index rebuilds for `SET NOT NULL` and `DROP NOT NULL`.

These rebuilds create substantial write pressure on large replicas and can cause replication transactions to fail.

### Changes

- Compare column storage types without the logical `|NOT_NULL` marker before deciding to rebuild.
- Update column metadata and bump replica versions for nullability-only changes.
- Add regression coverage for both setting and dropping `NOT NULL`, including assertions that table and index storage remains unchanged.
- Normalize logical nullability markers in schema-change fuzz comparisons.
