### PR TITLE
fix(zero-cache): allow serving transactions to spill

### DIFF
--- a/packages/zero-cache/src/db/begin-concurrent.test.ts
+++ b/packages/zero-cache/src/db/begin-concurrent.test.ts
@@ -19,6 +19,34 @@ describe('db/begin-concurrent', () => {
     dbFile.delete();
   });
 
+  const startSpillingWriter = () => {
+    const writer = dbFile.connect(lc);
+    writer.pragma('journal_mode = DELETE');
+    writer.pragma('journal_mode = WAL2');
+    writer.pragma('cache_size = 10');
+    writer.pragma('cache_spill = ON');
+    writer.exec('CREATE TABLE large(id INTEGER PRIMARY KEY, value BLOB)');
+
+    const journalBytes = () =>
+      [`${dbFile.path}-wal`, `${dbFile.path}-wal2`].reduce(
+        (total, path) => total + (existsSync(path) ? statSync(path).size : 0),
+        0,
+      );
+    const before = journalBytes();
+
+    writer.prepare('BEGIN IMMEDIATE').run();
+    writer.exec(`
+      WITH RECURSIVE rows(id) AS (
+        VALUES(1)
+        UNION ALL
+        SELECT id + 1 FROM rows WHERE id < 2000
+      )
+      INSERT INTO large SELECT id, randomblob(4000) FROM rows;
+    `);
+
+    return {writer, spilledBytes: journalBytes() - before};
+  };
+
   test('independent, concurrent actions before commit', () => {
     const conn1 = dbFile.connect(lc);
     conn1.pragma('journal_mode = WAL');
@@ -161,39 +189,72 @@ describe('db/begin-concurrent', () => {
     current.close();
   });
 
-  test('immediate writer spills dirty pages before commit', () => {
+  test('concurrent snapshot proceeds alongside an immediate writer', () => {
     const writer = dbFile.connect(lc);
     writer.pragma('journal_mode = DELETE');
     writer.pragma('journal_mode = WAL2');
-    writer.pragma('cache_size = 10');
-    writer.pragma('cache_spill = ON');
-    writer.exec('CREATE TABLE large(id INTEGER PRIMARY KEY, value BLOB)');
-
-    const journalBytes = () =>
-      [`${dbFile.path}-wal`, `${dbFile.path}-wal2`].reduce(
-        (total, path) => total + (existsSync(path) ? statSync(path).size : 0),
-        0,
-      );
-    const before = journalBytes();
-
     writer.prepare('BEGIN IMMEDIATE').run();
-    writer.exec(`
-      WITH RECURSIVE rows(id) AS (
-        VALUES(1)
-        UNION ALL
-        SELECT id + 1 FROM rows WHERE id < 2000
-      )
-      INSERT INTO large SELECT id, randomblob(4000) FROM rows;
-    `);
+    writer.prepare('INSERT INTO foo(id) VALUES(1)').run();
+
+    const snapshot = dbFile.connect(lc);
+    snapshot.pragma('journal_mode = WAL2');
+    snapshot.prepare('BEGIN CONCURRENT').run();
+
+    // The snapshot can progress while the writer has an uncommitted change.
+    expect(snapshot.prepare('SELECT * FROM foo').all()).toEqual([]);
+    snapshot.prepare('INSERT INTO foo(id) VALUES(2)').run();
+    expect(snapshot.prepare('SELECT * FROM foo').all()).toEqual([{id: 2}]);
+
+    snapshot.prepare('ROLLBACK').run();
+    writer.prepare('COMMIT').run();
+    expect(writer.prepare('SELECT * FROM foo').all()).toEqual([{id: 1}]);
+
+    snapshot.close();
+    writer.close();
+  });
+
+  test('immediate writer spills dirty pages before commit', () => {
+    const {writer, spilledBytes} = startSpillingWriter();
 
     // Spilled pages are written as uncommitted WAL frames. A concurrent
     // transaction would retain them in memory until commit instead.
-    expect(journalBytes() - before).toBeGreaterThan(1024 * 1024);
+    expect(spilledBytes).toBeGreaterThan(1024 * 1024);
 
     writer.prepare('ROLLBACK').run();
     expect(writer.prepare('SELECT count(*) AS count FROM large').get()).toEqual(
       {count: 0},
     );
+    writer.close();
+  });
+
+  test('concurrent snapshot proceeds alongside spilled immediate writes', () => {
+    const {writer, spilledBytes} = startSpillingWriter();
+    expect(spilledBytes).toBeGreaterThan(1024 * 1024);
+
+    const snapshot = dbFile.connect(lc);
+    snapshot.pragma('journal_mode = WAL2');
+    snapshot.prepare('BEGIN CONCURRENT').run();
+
+    // The snapshot ignores the writer's uncommitted WAL frames and can make a
+    // private change of its own.
+    expect(
+      snapshot.prepare('SELECT count(*) AS count FROM large').get(),
+    ).toEqual({count: 0});
+    snapshot.prepare('INSERT INTO large VALUES(2001, randomblob(4000))').run();
+    expect(
+      snapshot.prepare('SELECT count(*) AS count FROM large').get(),
+    ).toEqual({count: 1});
+
+    writer.prepare('COMMIT').run();
+    expect(
+      snapshot.prepare('SELECT count(*) AS count FROM large').get(),
+    ).toEqual({count: 1});
+    expect(writer.prepare('SELECT count(*) AS count FROM large').get()).toEqual(
+      {count: 2000},
+    );
+
+    snapshot.prepare('ROLLBACK').run();
+    snapshot.close();
     writer.close();
   });
 });

--- a/packages/zero-cache/src/db/begin-concurrent.test.ts
+++ b/packages/zero-cache/src/db/begin-concurrent.test.ts
@@ -1,3 +1,4 @@
+import {existsSync, statSync} from 'node:fs';
 import {afterEach, beforeEach, describe, expect, test} from 'vitest';
 import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
 import {DbFile} from '../test/lite.ts';
@@ -129,5 +130,70 @@ describe('db/begin-concurrent', () => {
 
     conn1.close();
     conn2.close();
+  });
+
+  test('immediate writer commits alongside a concurrent snapshot', () => {
+    const snapshot = dbFile.connect(lc);
+    snapshot.pragma('journal_mode = DELETE');
+    snapshot.pragma('journal_mode = WAL2');
+    snapshot.prepare('BEGIN CONCURRENT').run();
+    expect(snapshot.prepare('SELECT * FROM foo').all()).toEqual([]);
+    snapshot.prepare('INSERT INTO foo(id) VALUES(2)').run();
+
+    const writer = dbFile.connect(lc);
+    writer.pragma('journal_mode = WAL2');
+    writer.prepare('BEGIN IMMEDIATE').run();
+    writer.prepare('INSERT INTO foo(id) VALUES(1)').run();
+    writer.prepare('COMMIT').run();
+
+    // The snapshot retains its historic view and private change.
+    expect(snapshot.prepare('SELECT * FROM foo').all()).toEqual([{id: 2}]);
+
+    const current = dbFile.connect(lc);
+    current.pragma('journal_mode = WAL2');
+    expect(current.prepare('SELECT * FROM foo').all()).toEqual([{id: 1}]);
+
+    snapshot.prepare('ROLLBACK').run();
+    expect(current.prepare('SELECT * FROM foo').all()).toEqual([{id: 1}]);
+
+    snapshot.close();
+    writer.close();
+    current.close();
+  });
+
+  test('immediate writer spills dirty pages before commit', () => {
+    const writer = dbFile.connect(lc);
+    writer.pragma('journal_mode = DELETE');
+    writer.pragma('journal_mode = WAL2');
+    writer.pragma('cache_size = 10');
+    writer.pragma('cache_spill = ON');
+    writer.exec('CREATE TABLE large(id INTEGER PRIMARY KEY, value BLOB)');
+
+    const journalBytes = () =>
+      [`${dbFile.path}-wal`, `${dbFile.path}-wal2`].reduce(
+        (total, path) => total + (existsSync(path) ? statSync(path).size : 0),
+        0,
+      );
+    const before = journalBytes();
+
+    writer.prepare('BEGIN IMMEDIATE').run();
+    writer.exec(`
+      WITH RECURSIVE rows(id) AS (
+        VALUES(1)
+        UNION ALL
+        SELECT id + 1 FROM rows WHERE id < 2000
+      )
+      INSERT INTO large SELECT id, randomblob(4000) FROM rows;
+    `);
+
+    // Spilled pages are written as uncommitted WAL frames. A concurrent
+    // transaction would retain them in memory until commit instead.
+    expect(journalBytes() - before).toBeGreaterThan(1024 * 1024);
+
+    writer.prepare('ROLLBACK').run();
+    expect(writer.prepare('SELECT count(*) AS count FROM large').get()).toEqual(
+      {count: 0},
+    );
+    writer.close();
   });
 });

--- a/packages/zero-cache/src/services/replicator/change-processor.test.ts
+++ b/packages/zero-cache/src/services/replicator/change-processor.test.ts
@@ -1,5 +1,5 @@
 import type {LogContext} from '@rocicorp/logger';
-import {beforeEach, describe, expect, test} from 'vitest';
+import {beforeEach, describe, expect, test, vi} from 'vitest';
 import type {JSONObject} from '../../../../shared/src/bigint-json.ts';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
 import {must} from '../../../../shared/src/must.ts';
@@ -25,6 +25,7 @@ import {createChangeProcessor, ReplicationMessages} from './test-utils.ts';
 describe('replicator/change-processor', () => {
   let lc: LogContext;
   let servingReplica: Database;
+  let servingRunner: StatementRunner;
   let servingProcessor: ChangeProcessor;
   let backupReplica: Database;
   let backupProcessor: ChangeProcessor;
@@ -33,8 +34,9 @@ describe('replicator/change-processor', () => {
     lc = createSilentLogContext();
     servingReplica = new Database(lc, ':memory:');
     initReplicationState(servingReplica, ['zero_data'], '02');
+    servingRunner = new StatementRunner(servingReplica);
     servingProcessor = new ChangeProcessor(
-      new StatementRunner(servingReplica),
+      servingRunner,
       'serving',
       (_, err: unknown) => {
         throw err;
@@ -73,6 +75,25 @@ describe('replicator/change-processor', () => {
   const fooBarBaz = new ReplicationMessages({foo: 'id', bar: 'id', baz: 'id'});
   const tables = new ReplicationMessages({transaction: 'column'});
   const bff = new ReplicationMessages({bff: ['b', 'a', 'c']});
+
+  test('starts serving transactions with BEGIN IMMEDIATE', () => {
+    const beginImmediate = vi.spyOn(servingRunner, 'beginImmediate');
+    const beginConcurrent = vi.spyOn(servingRunner, 'beginConcurrent');
+
+    servingProcessor.processMessage(lc, [
+      'begin',
+      issues.begin(),
+      {commitWatermark: '03'},
+    ]);
+    servingProcessor.processMessage(lc, [
+      'commit',
+      issues.commit(),
+      {watermark: '03'},
+    ]);
+
+    expect(beginImmediate).toHaveBeenCalledOnce();
+    expect(beginConcurrent).not.toHaveBeenCalled();
+  });
 
   const cases: Case[] = [
     {

--- a/packages/zero-cache/src/services/replicator/change-processor.ts
+++ b/packages/zero-cache/src/services/replicator/change-processor.ts
@@ -355,14 +355,11 @@ class TransactionProcessor {
 
     switch (mode) {
       case 'serving':
-        // Although the Replicator / Incremental Syncer is the only writer of the replica,
-        // a `BEGIN CONCURRENT` transaction is used to allow View Syncers to simulate
-        // (i.e. and `ROLLBACK`) changes on historic snapshots of the database for the
-        // purpose of IVM).
-        //
-        // This TransactionProcessor is the only logic that will actually
-        // `COMMIT` any transactions to the replica.
-        db.beginConcurrent();
+        // This is the only transaction that commits to the serving replica.
+        // Snapshotters use BEGIN CONCURRENT for private changes that are
+        // always rolled back, while BEGIN IMMEDIATE lets this writer spill
+        // dirty pages during large transactions.
+        db.beginImmediate();
         break;
       case 'backup':
         // For the backup-replicator (i.e. replication-manager), there are no View Syncers

--- a/packages/zero-cache/src/services/view-syncer/snapshotter.ts
+++ b/packages/zero-cache/src/services/view-syncer/snapshotter.ts
@@ -287,9 +287,10 @@ class Snapshot {
     const [{journal_mode: mode}] = conn.pragma('journal_mode') as [
       {journal_mode: string},
     ];
-    // The Snapshotter operates on the replica file with BEGIN CONCURRENT,
-    // which must be used in concert with the replicator using BEGIN CONCURRENT
-    // on a db in the wal2 journal_mode.
+    // BEGIN CONCURRENT lets the Snapshotter simulate changes on a historic
+    // snapshot without taking the WAL writer lock. These private changes are
+    // always rolled back; the replicator is the only committer and can use
+    // BEGIN IMMEDIATE on the same WAL2 database.
     assert(
       mode === 'wal2',
       `replica db must be in wal2 mode (current: ${mode})`,


### PR DESCRIPTION

### What

Use `BEGIN IMMEDIATE` for the serving replica's durable writer while retaining `BEGIN CONCURRENT` for snapshotters that simulate changes against historical snapshots and always roll them back.

This allows SQLite to spill dirty pages into WAL during large serving-replica transactions instead of retaining the complete write set in native memory until commit.

### Why

A production PostgreSQL migration changed several UUID columns to `NOT NULL`. Zero encoded the nullability change in SQLite's declared type and interpreted it as a physical type change, causing each serving replica to copy the complete table and rebuild its indexes.

The largest affected table repeatedly OOM-killed the view-syncers. The serving writer used `BEGIN CONCURRENT`, for which our SQLite build explicitly prohibits dirty-page spilling. As the replacement table and indexes were built, every dirty page remained in SQLite's native page cache until commit.

The Node `--max-old-space-size` setting did not protect against this because it limits V8's managed heap, not SQLite's native allocations. Native SQLite memory eventually pushed the process beyond its Kubernetes memory limit.

Avoiding rebuilds for nullability-only changes addresses this incident's immediate trigger (see https://github.com/rocicorp/mono/pull/6309), but it does not address the systemic problem. A legitimate type conversion, index rebuild, backfill, or large DML transaction could produce the same unspillable write set.

The serving replicator is the only connection that commits to the replica. Snapshotters use `BEGIN CONCURRENT` only to stage private changes against historical snapshots before rolling them back. The durable writer can therefore use `BEGIN IMMEDIATE`, acquire the WAL writer lock, and spill pages without changing snapshot isolation.

### Changes

- Start serving-replica transactions with `BEGIN IMMEDIATE`.
- Keep snapshotter transactions on `BEGIN CONCURRENT` and clarify the mixed-mode transaction model.
- Add coverage for an immediate writer committing while a concurrent WAL2 snapshot holds private changes.
- Add a regression test proving that a large immediate transaction spills uncommitted dirty pages into WAL and remains fully rollback-safe.
- Add direct coverage that the serving `ChangeProcessor` selects `BEGIN IMMEDIATE`.
