### PR TITLE
chore(zero-cache): fix e2e lag metric

### DIFF
--- a/packages/zero-cache/src/observability/metrics.ts
+++ b/packages/zero-cache/src/observability/metrics.ts
@@ -25,6 +25,7 @@ type HistogramOptions = Options & {bucketBoundaries: number[]};
 export const NATIVE_HISTOGRAM_INSTRUMENT_NAMES = [
   'zero.sync.view_syncer_lag',
   'zero.sync.view_syncer_hydration',
+  'zero.sync.e2e_serving_lag',
 ] as const;
 
 export const LONG_DURATION_HISTOGRAM_BOUNDARIES_S = [

--- a/packages/zero-cache/src/services/change-source/pg/change-source.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.ts
@@ -1162,7 +1162,10 @@ class ChangeMaker {
         return [
           [
             'commit',
-            msg,
+            // `commitTime` is microseconds since the unix epoch. Carrying it
+            // as milliseconds gives the ViewSyncer the origin timestamp for
+            // the end-to-end serving lag histogram.
+            {...msg, commitTimeMs: Number(msg.commitTime / 1000n)},
             {watermark: toStateVersionString(must(msg.commitLsn))},
           ],
         ];

--- a/packages/zero-cache/src/services/change-source/protocol/current/data.ts
+++ b/packages/zero-cache/src/services/change-source/protocol/current/data.ts
@@ -34,6 +34,19 @@ export const beginSchema = v.object({
 
 export const commitSchema = v.object({
   tag: v.literal('commit'),
+
+  // Millisecond epoch at which the transaction committed upstream, as reported
+  // by the upstream database (e.g. the `commitTime` of the Postgres logical
+  // replication Commit message).
+  //
+  // This is the origin timestamp of the end-to-end serving lag measurement:
+  // it is carried through the replication stream to the ViewSyncer, which
+  // records `now - commitTimeMs` once the change has been poked to clients.
+  //
+  // Optional because it is absent from changes written to the Change DB by
+  // older versions, which are replayed verbatim during catchup, and from
+  // ChangeSources that do not report a commit time.
+  commitTimeMs: v.number().optional(),
 });
 
 export const rollbackSchema = v.object({

--- a/packages/zero-cache/src/services/change-source/protocol/version.test.ts
+++ b/packages/zero-cache/src/services/change-source/protocol/version.test.ts
@@ -37,9 +37,13 @@ test('protocol versions', () => {
   // Then update the version number of the `CHANGE_SOURCE_PATH`
   // in current and export it appropriately as the new version
   // in `mod.ts`.
-  t(current, 'eodyqg15jkoa', '/changes/v0/stream');
+  // The hash last changed for the optional `commit.commitTimeMs` field, which
+  // is additive: the stream is parsed in 'passthrough' mode, so an older peer
+  // ignores the field and a newer peer treats its absence as "no commit time
+  // reported". No new version directory was needed.
+  t(current, '37sbudqm1hcbg', '/changes/v0/stream');
   // During initial development, we use v0 as a non-stable
   // version (i.e. breaking change are allowed). Once the
   // protocol graduates to v1, versions must be stable.
-  t(v0, 'eodyqg15jkoa', '/changes/v0/stream');
+  t(v0, '37sbudqm1hcbg', '/changes/v0/stream');
 });

--- a/packages/zero-cache/src/services/change-streamer/change-streamer.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer.ts
@@ -96,6 +96,12 @@ export interface ChangeStreamer {
 //   - Adds support for `backfill` messages
 // v6: v1.0.1  (backwards compatible, no version change)
 //   - Adds lag reporting to status messages
+// v6: (backwards compatible, no version change)
+//   - Adds the optional `commitTimeMs` field to `commit` messages, carrying
+//     the upstream commit timestamp for end-to-end serving lag measurement.
+//     The stream is parsed in 'passthrough' mode, so an older peer ignores the
+//     field, and a newer peer treats its absence (including in changes
+//     replayed from the Change DB) as "no commit time reported".
 
 export const PROTOCOL_VERSION = 6;
 

--- a/packages/zero-cache/src/services/replicator/change-processor.ts
+++ b/packages/zero-cache/src/services/replicator/change-processor.ts
@@ -72,6 +72,12 @@ export type CommitResult = {
   completedBackfill: DownloadStatus | undefined;
   schemaUpdated: boolean;
   changeLogUpdated: boolean;
+  /**
+   * Millisecond epoch at which the transaction committed upstream, if the
+   * ChangeSource reported one. Propagated to ViewSyncers as the origin
+   * timestamp of the end-to-end serving lag measurement.
+   */
+  upstreamCommitTimeMs?: number | undefined;
 };
 
 /**
@@ -945,6 +951,7 @@ class TransactionProcessor {
       completedBackfill: this.#completedBackfill,
       schemaUpdated: this.#schemaChanged,
       changeLogUpdated: this.#numChangeLogEntries > 0,
+      upstreamCommitTimeMs: commit.commitTimeMs,
     };
   }
 

--- a/packages/zero-cache/src/services/replicator/incremental-sync.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.ts
@@ -228,6 +228,7 @@ export class IncrementalSyncer {
         state: 'version-ready',
         watermark: result.watermark,
         replicaReadyTimeMs: Date.now(),
+        upstreamCommitTimeMs: result.upstreamCommitTimeMs,
       });
     }
   }

--- a/packages/zero-cache/src/services/replicator/notifier.test.ts
+++ b/packages/zero-cache/src/services/replicator/notifier.test.ts
@@ -81,4 +81,54 @@ describe('replicator/notifier', () => {
       replicaReadyTimeMs: 300,
     });
   });
+
+  test('coalesced notifications keep earliest upstream commit time', async () => {
+    const notifier = new Notifier();
+    const sub = notifier.subscribe();
+
+    void notifier.notifySubscribers({
+      state: 'version-ready',
+      watermark: '02',
+      replicaReadyTimeMs: 200,
+      upstreamCommitTimeMs: 100,
+    });
+    void notifier.notifySubscribers({
+      state: 'version-ready',
+      watermark: '03',
+      replicaReadyTimeMs: 300,
+      upstreamCommitTimeMs: 250,
+    });
+
+    // The oldest commit time survives, paired with the newest watermark: the
+    // subsumed commit is only delivered once '03' has been served.
+    await expectSingleMessage(sub, {
+      state: 'version-ready',
+      watermark: '03',
+      replicaReadyTimeMs: 200,
+      upstreamCommitTimeMs: 100,
+    });
+  });
+
+  test('coalescing tolerates a missing upstream commit time', async () => {
+    const notifier = new Notifier();
+    const sub = notifier.subscribe();
+
+    // A ChangeSource that reports no commit time must not erase one that a
+    // previous notification did carry, and vice versa.
+    void notifier.notifySubscribers({
+      state: 'version-ready',
+      watermark: '02',
+      upstreamCommitTimeMs: 100,
+    });
+    void notifier.notifySubscribers({
+      state: 'version-ready',
+      watermark: '03',
+    });
+
+    await expectSingleMessage(sub, {
+      state: 'version-ready',
+      watermark: '03',
+      upstreamCommitTimeMs: 100,
+    });
+  });
 });

--- a/packages/zero-cache/src/services/replicator/notifier.ts
+++ b/packages/zero-cache/src/services/replicator/notifier.ts
@@ -28,6 +28,19 @@ import type {ReplicaState, ReplicaStateNotifier} from './replicator.ts';
  * subscribe and unsubscribe traffic from View Syncers remains within each
  * Syncer Thread.
  */
+function oldest(
+  curr: number | undefined,
+  prev: number | undefined,
+): number | undefined {
+  if (curr === undefined) {
+    return prev;
+  }
+  if (prev === undefined) {
+    return curr;
+  }
+  return Math.min(curr, prev);
+}
+
 export class Notifier implements ReplicaStateNotifier {
   readonly #eventEmitter = new EventEmitter();
   #lastStateReceived: ReplicaState | undefined;
@@ -39,14 +52,20 @@ export class Notifier implements ReplicaStateNotifier {
   #newSubscription() {
     const notify = (state: ReplicaState) => subscription.push(state);
     const subscription = Subscription.create<ReplicaState>({
+      // A coalesced notification stands in for every notification it
+      // subsumed, so both timestamps keep the *oldest* value: they measure how
+      // long work has been outstanding, and the subsumed watermarks are still
+      // unserved.
       coalesce: (curr, prev) => ({
         ...curr,
-        replicaReadyTimeMs:
-          curr.replicaReadyTimeMs === undefined
-            ? prev.replicaReadyTimeMs
-            : prev.replicaReadyTimeMs === undefined
-              ? curr.replicaReadyTimeMs
-              : Math.min(curr.replicaReadyTimeMs, prev.replicaReadyTimeMs),
+        replicaReadyTimeMs: oldest(
+          curr.replicaReadyTimeMs,
+          prev.replicaReadyTimeMs,
+        ),
+        upstreamCommitTimeMs: oldest(
+          curr.upstreamCommitTimeMs,
+          prev.upstreamCommitTimeMs,
+        ),
       }),
       cleanup: () => this.#eventEmitter.off('version', notify),
     });

--- a/packages/zero-cache/src/services/replicator/replicator.ts
+++ b/packages/zero-cache/src/services/replicator/replicator.ts
@@ -21,6 +21,22 @@ export type ReplicaState = {
    */
   readonly replicaReadyTimeMs?: number | undefined;
 
+  /**
+   * Millisecond epoch at which the transaction behind `watermark` committed
+   * *upstream*, as reported by the ChangeSource. Unlike `replicaReadyTimeMs`,
+   * which is stamped locally when the change lands in the replica, this is the
+   * origin of the whole pipeline, so `now - upstreamCommitTimeMs` at the point
+   * the change is poked to clients is the end-to-end serving lag.
+   *
+   * Note that this crosses a clock domain: it comes from the upstream
+   * database, whereas it is subtracted from the local clock in the ViewSyncer.
+   * The existing `zero.replication.total_lag` metric spans the same boundary.
+   *
+   * Undefined when the ChangeSource does not report a commit time, and for the
+   * initial "current state is ready" notification.
+   */
+  readonly upstreamCommitTimeMs?: number | undefined;
+
   // Used in tests to verify behavior when additional information
   // is ferried in the future. Not set in production.
   readonly testSeqNum?: number | undefined;

--- a/packages/zero-cache/src/services/replicator/reporter/recorder.test.ts
+++ b/packages/zero-cache/src/services/replicator/reporter/recorder.test.ts
@@ -1,7 +1,10 @@
 import type {ObservableResult} from '@opentelemetry/api';
-import {expect, test} from 'vitest';
+import {describe, expect, test} from 'vitest';
 import {createSilentLogContext} from '../../../../../shared/src/logging-test-utils.ts';
-import {ReplicationReportRecorder} from './recorder.ts';
+import {
+  estimateUpstreamClockSkewMs,
+  ReplicationReportRecorder,
+} from './recorder.ts';
 
 test('replication report recorder', () => {
   const recorder = new ReplicationReportRecorder(createSilentLogContext());
@@ -59,6 +62,8 @@ test('replication report recorder', () => {
   expectObserved(recorder.reportReplicaLag, 400);
   expectObserved(recorder.reportTotalLag, 650);
   expectObserved(recorder.reportLastTotalLag, 650);
+  // commit at 11_123 vs a round-trip midpoint of 11_125.
+  expectObserved(recorder.reportUpstreamClockSkew, -2);
 });
 
 test('replication report recorder ignores pending report without timings', () => {
@@ -81,4 +86,53 @@ test('replication report recorder ignores pending report without timings', () =>
   expectObserved(recorder.reportReplicaLag, undefined);
   expectObserved(recorder.reportTotalLag, undefined);
   expectObserved(recorder.reportLastTotalLag, undefined);
+  expectObserved(recorder.reportUpstreamClockSkew, undefined);
+});
+
+describe('estimateUpstreamClockSkewMs', () => {
+  test('a commit landing at the round-trip midpoint reads as no skew', () => {
+    expect(
+      estimateUpstreamClockSkewMs({
+        sendTimeMs: 1_000,
+        commitTimeMs: 1_100,
+        receiveTimeMs: 1_200,
+      }),
+    ).toBe(0);
+  });
+
+  test('an upstream clock running ahead reads positive', () => {
+    // This is the direction that biases sync.e2e_serving_lag *low*, so it must
+    // not be mistaken for a healthy pipeline.
+    expect(
+      estimateUpstreamClockSkewMs({
+        sendTimeMs: 1_000,
+        commitTimeMs: 31_100,
+        receiveTimeMs: 1_200,
+      }),
+    ).toBe(30_000);
+  });
+
+  test('an upstream clock running behind reads negative', () => {
+    expect(
+      estimateUpstreamClockSkewMs({
+        sendTimeMs: 1_000,
+        commitTimeMs: -28_900,
+        receiveTimeMs: 1_200,
+      }),
+    ).toBe(-30_000);
+  });
+
+  test('a commit outside the round trip proves skew regardless of latency', () => {
+    // The commit genuinely happened between send and receive, so a commit
+    // timestamp before send can only be clock offset. The estimate stays
+    // conservative: it reports at least half the amount by which the commit
+    // falls outside the window.
+    const skew = estimateUpstreamClockSkewMs({
+      sendTimeMs: 1_000,
+      commitTimeMs: 900,
+      receiveTimeMs: 1_200,
+    });
+    expect(skew).toBeLessThan(0);
+    expect(skew).toBe(-200);
+  });
 });

--- a/packages/zero-cache/src/services/replicator/reporter/recorder.ts
+++ b/packages/zero-cache/src/services/replicator/reporter/recorder.ts
@@ -64,6 +64,20 @@ export class ReplicationReportRecorder {
           'want the non-extrapolated value.',
         unit: 'millisecond',
       }).addCallback(this.reportLastTotalLag);
+
+      getOrCreateGauge('replication', 'upstream_clock_skew', {
+        description:
+          'Estimated offset of the upstream database clock relative to ' +
+          "zero-cache's. Positive means upstream is running ahead. " +
+          'Derived from the lag report round-trip, whose send and receive ' +
+          'times are stamped on our clock either side of the upstream ' +
+          'commit timestamp. This matters because ' +
+          'sync.e2e_serving_lag subtracts an upstream commit timestamp from ' +
+          'a local clock, so a skewed upstream clock biases it directly -- ' +
+          'and an upstream clock running ahead biases it *low*, which looks ' +
+          'like healthy serving rather than a broken measurement.',
+        unit: 'millisecond',
+      }).addCallback(this.reportUpstreamClockSkew);
     }
   }
 
@@ -94,4 +108,44 @@ export class ReplicationReportRecorder {
       o.observe(last.replicateTimeMs - last.sendTimeMs);
     }
   };
+
+  readonly reportUpstreamClockSkew = (o: ObservableResult) => {
+    const last = this.#last?.lastTimings;
+    if (last) {
+      o.observe(estimateUpstreamClockSkewMs(last));
+    }
+  };
+}
+
+/**
+ * Estimates how far the upstream database's clock is from ours, in
+ * milliseconds, positive meaning upstream is ahead.
+ *
+ * `sendTimeMs` and `receiveTimeMs` are both stamped in the
+ * replication-manager, either side of `commitTimeMs`, which upstream stamps.
+ * Assuming the upstream commit fell midway through that round trip, the
+ * difference between where it actually landed and that midpoint is the clock
+ * offset -- the same round-trip estimate NTP uses.
+ *
+ * The estimate is biased by any asymmetry between the two legs: the outbound
+ * leg is a SQL round trip, while the return leg additionally waits on a WAL
+ * flush and the walsender (which the pre-PG-17 path notes can add 50~100ms on
+ * an idle database). So treat this as a detector of gross skew -- the kind
+ * that invalidates sync.e2e_serving_lag -- and not as a sub-100ms correction.
+ *
+ * The rigorous bound, if a tighter reading is ever needed: the commit
+ * genuinely happened between send and receive, so a `commitTimeMs` outside
+ * that window proves skew of at least the amount by which it falls outside,
+ * independent of any latency assumption.
+ */
+export function estimateUpstreamClockSkewMs({
+  sendTimeMs,
+  commitTimeMs,
+  receiveTimeMs,
+}: {
+  sendTimeMs: number;
+  commitTimeMs: number;
+  receiveTimeMs: number;
+}): number {
+  return commitTimeMs - (sendTimeMs + receiveTimeMs) / 2;
 }

--- a/packages/zero-cache/src/services/view-syncer/e2e-serving-lag.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/e2e-serving-lag.test.ts
@@ -1,0 +1,83 @@
+import {describe, expect, test} from 'vitest';
+import {E2EServingLagTracker} from './e2e-serving-lag.ts';
+
+describe('view-syncer/e2e-serving-lag', () => {
+  function ready(watermark: string, upstreamCommitTimeMs?: number) {
+    return {
+      state: 'version-ready',
+      watermark,
+      upstreamCommitTimeMs,
+    } as const;
+  }
+
+  test('records lag from upstream commit to serve', () => {
+    const tracker = new E2EServingLagTracker();
+
+    tracker.onVersionReady(ready('02', 1_000));
+    expect(tracker.onVersionServed('02', 1_350)).toBe(350);
+    // The pending commit is consumed, so serving again records nothing.
+    expect(tracker.onVersionServed('02', 1_400)).toBeNull();
+  });
+
+  test('serving a later version still covers the pending commit', () => {
+    const tracker = new E2EServingLagTracker();
+
+    tracker.onVersionReady(ready('02', 1_000));
+    expect(tracker.onVersionServed('05', 1_500)).toBe(500);
+  });
+
+  test('serving an earlier version does not record', () => {
+    const tracker = new E2EServingLagTracker();
+
+    tracker.onVersionReady(ready('05', 1_000));
+    expect(tracker.onVersionServed('02', 1_500)).toBeNull();
+    // Still outstanding: it is recorded once the version is actually served.
+    expect(tracker.pending).toEqual({watermark: '05', commitTimeMs: 1_000});
+    expect(tracker.onVersionServed('05', 1_800)).toBe(800);
+  });
+
+  test('coalesced notifications measure the oldest subsumed commit', () => {
+    const tracker = new E2EServingLagTracker();
+
+    // Three commits arrive before the ViewSyncer gets to serve any of them.
+    tracker.onVersionReady(ready('02', 1_000));
+    tracker.onVersionReady(ready('03', 1_100));
+    tracker.onVersionReady(ready('04', 1_250));
+
+    // The reported lag is that of the oldest, which is the worst latency any
+    // client actually experienced.
+    expect(tracker.onVersionServed('04', 2_000)).toBe(1_000);
+  });
+
+  test('notifications without a commit time are ignored', () => {
+    const tracker = new E2EServingLagTracker();
+
+    tracker.onVersionReady(ready('02', undefined));
+    expect(tracker.pending).toBeNull();
+    expect(tracker.onVersionServed('02', 1_500)).toBeNull();
+
+    // A ChangeSource reporting no commit time must not clear one that a
+    // previous notification did carry.
+    tracker.onVersionReady(ready('03', 1_000));
+    tracker.onVersionReady(ready('04', undefined));
+    expect(tracker.onVersionServed('04', 1_600)).toBe(600);
+  });
+
+  test('the initial version-ready notification is ignored', () => {
+    const tracker = new E2EServingLagTracker();
+
+    // Sent on startup with no watermark; it represents already-current state,
+    // not newly replicated work.
+    tracker.onVersionReady({state: 'version-ready'});
+    expect(tracker.pending).toBeNull();
+  });
+
+  test('clock skew is clamped instead of recording a negative duration', () => {
+    const tracker = new E2EServingLagTracker();
+
+    // The upstream commit time comes from the upstream database's clock, which
+    // may run ahead of the ViewSyncer's.
+    tracker.onVersionReady(ready('02', 5_000));
+    expect(tracker.onVersionServed('02', 4_000)).toBe(0);
+  });
+});

--- a/packages/zero-cache/src/services/view-syncer/e2e-serving-lag.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/e2e-serving-lag.test.ts
@@ -14,7 +14,10 @@ describe('view-syncer/e2e-serving-lag', () => {
     const tracker = new E2EServingLagTracker();
 
     tracker.onVersionReady(ready('02', 1_000));
-    expect(tracker.onVersionServed('02', 1_350)).toBe(350);
+    expect(tracker.onVersionServed('02', 1_350)).toEqual({
+      lagMs: 350,
+      clamped: false,
+    });
     // The pending commit is consumed, so serving again records nothing.
     expect(tracker.onVersionServed('02', 1_400)).toBeNull();
   });
@@ -23,7 +26,10 @@ describe('view-syncer/e2e-serving-lag', () => {
     const tracker = new E2EServingLagTracker();
 
     tracker.onVersionReady(ready('02', 1_000));
-    expect(tracker.onVersionServed('05', 1_500)).toBe(500);
+    expect(tracker.onVersionServed('05', 1_500)).toEqual({
+      lagMs: 500,
+      clamped: false,
+    });
   });
 
   test('serving an earlier version does not record', () => {
@@ -33,7 +39,10 @@ describe('view-syncer/e2e-serving-lag', () => {
     expect(tracker.onVersionServed('02', 1_500)).toBeNull();
     // Still outstanding: it is recorded once the version is actually served.
     expect(tracker.pending).toEqual({watermark: '05', commitTimeMs: 1_000});
-    expect(tracker.onVersionServed('05', 1_800)).toBe(800);
+    expect(tracker.onVersionServed('05', 1_800)).toEqual({
+      lagMs: 800,
+      clamped: false,
+    });
   });
 
   test('coalesced notifications measure the oldest subsumed commit', () => {
@@ -46,7 +55,10 @@ describe('view-syncer/e2e-serving-lag', () => {
 
     // The reported lag is that of the oldest, which is the worst latency any
     // client actually experienced.
-    expect(tracker.onVersionServed('04', 2_000)).toBe(1_000);
+    expect(tracker.onVersionServed('04', 2_000)).toEqual({
+      lagMs: 1_000,
+      clamped: false,
+    });
   });
 
   test('notifications without a commit time are ignored', () => {
@@ -60,7 +72,10 @@ describe('view-syncer/e2e-serving-lag', () => {
     // previous notification did carry.
     tracker.onVersionReady(ready('03', 1_000));
     tracker.onVersionReady(ready('04', undefined));
-    expect(tracker.onVersionServed('04', 1_600)).toBe(600);
+    expect(tracker.onVersionServed('04', 1_600)).toEqual({
+      lagMs: 600,
+      clamped: false,
+    });
   });
 
   test('the initial version-ready notification is ignored', () => {
@@ -72,12 +87,27 @@ describe('view-syncer/e2e-serving-lag', () => {
     expect(tracker.pending).toBeNull();
   });
 
-  test('clock skew is clamped instead of recording a negative duration', () => {
+  test('clock skew is clamped and reported rather than silently swallowed', () => {
     const tracker = new E2EServingLagTracker();
 
     // The upstream commit time comes from the upstream database's clock, which
-    // may run ahead of the ViewSyncer's.
+    // may run ahead of the ViewSyncer's. A negative duration would corrupt the
+    // histogram's sum, but it must not vanish either: skew in this direction
+    // biases the metric low, which reads as healthy serving.
     tracker.onVersionReady(ready('02', 5_000));
-    expect(tracker.onVersionServed('02', 4_000)).toBe(0);
+    expect(tracker.onVersionServed('02', 4_000)).toEqual({
+      lagMs: 0,
+      clamped: true,
+    });
+  });
+
+  test('a genuinely zero lag is not reported as a clamp', () => {
+    const tracker = new E2EServingLagTracker();
+
+    tracker.onVersionReady(ready('02', 1_000));
+    expect(tracker.onVersionServed('02', 1_000)).toEqual({
+      lagMs: 0,
+      clamped: false,
+    });
   });
 });

--- a/packages/zero-cache/src/services/view-syncer/e2e-serving-lag.ts
+++ b/packages/zero-cache/src/services/view-syncer/e2e-serving-lag.ts
@@ -1,0 +1,66 @@
+import type {ReplicaState} from '../replicator/replicator.ts';
+
+export type PendingUpstreamCommit = {
+  readonly watermark: string;
+  readonly commitTimeMs: number;
+};
+
+/**
+ * Pairs the upstream commit timestamps carried by `version-ready`
+ * notifications with the moment the corresponding change is poked to clients,
+ * yielding the end-to-end serving lag.
+ *
+ * This measures completion, not backlog: an observation is produced only when
+ * work actually reaches clients, so the resulting histogram is a latency
+ * distribution rather than a periodic snapshot of how far behind things are.
+ * A ViewSyncer that is stuck contributes nothing until it recovers, instead of
+ * re-reporting its age on every sample tick.
+ */
+export class E2EServingLagTracker {
+  #pending: PendingUpstreamCommit | null = null;
+
+  get pending(): PendingUpstreamCommit | null {
+    return this.#pending;
+  }
+
+  /**
+   * Records the upstream commit behind a `version-ready` notification.
+   *
+   * Notifications coalesce when the ViewSyncer is busy, so one state may stand
+   * in for several commits. The *oldest* commit time is kept, since it bounds
+   * the lag of everything the notification subsumed, while the watermark
+   * advances to the newest — that is the one that must be served for all of
+   * the subsumed commits to have been delivered.
+   */
+  onVersionReady({watermark, upstreamCommitTimeMs}: ReplicaState): void {
+    if (watermark === undefined || upstreamCommitTimeMs === undefined) {
+      return;
+    }
+    const pending = this.#pending;
+    this.#pending = {
+      watermark,
+      commitTimeMs:
+        pending === null
+          ? upstreamCommitTimeMs
+          : Math.min(pending.commitTimeMs, upstreamCommitTimeMs),
+    };
+  }
+
+  /**
+   * Called once a version has been poked to clients.
+   *
+   * @return the end-to-end lag in milliseconds to record, or `null` if the
+   *     served version does not yet cover an outstanding upstream commit.
+   */
+  onVersionServed(servedVersion: string, nowMs: number): number | null {
+    const pending = this.#pending;
+    if (pending === null || servedVersion < pending.watermark) {
+      return null;
+    }
+    this.#pending = null;
+    // The commit time comes from the upstream database's clock while `nowMs`
+    // is local, so clamp rather than let skew put a negative duration into the
+    // histogram's sum.
+    return Math.max(0, nowMs - pending.commitTimeMs);
+  }
+}

--- a/packages/zero-cache/src/services/view-syncer/e2e-serving-lag.ts
+++ b/packages/zero-cache/src/services/view-syncer/e2e-serving-lag.ts
@@ -49,18 +49,34 @@ export class E2EServingLagTracker {
   /**
    * Called once a version has been poked to clients.
    *
-   * @return the end-to-end lag in milliseconds to record, or `null` if the
-   *     served version does not yet cover an outstanding upstream commit.
+   * @return the observation to record, or `null` if the served version does
+   *     not yet cover an outstanding upstream commit.
    */
-  onVersionServed(servedVersion: string, nowMs: number): number | null {
+  onVersionServed(servedVersion: string, nowMs: number): Observation | null {
     const pending = this.#pending;
     if (pending === null || servedVersion < pending.watermark) {
       return null;
     }
     this.#pending = null;
-    // The commit time comes from the upstream database's clock while `nowMs`
-    // is local, so clamp rather than let skew put a negative duration into the
-    // histogram's sum.
-    return Math.max(0, nowMs - pending.commitTimeMs);
+
+    const lagMs = nowMs - pending.commitTimeMs;
+    if (lagMs >= 0) {
+      return {lagMs, clamped: false};
+    }
+    // The commit time is on the upstream database's clock while `nowMs` is
+    // local, so a negative duration means upstream's clock is running ahead of
+    // ours by more than the entire pipeline latency. Clamp, because a negative
+    // value would corrupt the histogram's sum -- but report the clamp, since
+    // it is proof of gross clock skew, and skew in this direction biases the
+    // metric *low*, which reads as healthy serving rather than as a broken
+    // measurement. See replication.upstream_clock_skew for the magnitude.
+    return {lagMs: 0, clamped: true};
   }
 }
+
+export type Observation = {
+  /** End-to-end lag in milliseconds, clamped to be non-negative. */
+  readonly lagMs: number;
+  /** Whether the clamp was applied, i.e. the raw measurement was negative. */
+  readonly clamped: boolean;
+};

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -93,6 +93,7 @@ import {
   type RowUpdate,
 } from './cvr.ts';
 import type {DrainCoordinator} from './drain-coordinator.ts';
+import {E2EServingLagTracker} from './e2e-serving-lag.ts';
 import {handleInspect} from './inspect-handler.ts';
 import type {PipelineDriver} from './pipeline-driver.ts';
 import {type RowChange} from './pipeline-driver.ts';
@@ -293,6 +294,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
   #cvr: CVRSnapshot | undefined;
   #pipelinesSynced = false;
   #servedVersion: string | null = null;
+  readonly #e2eServingLagTracker = new E2EServingLagTracker();
 
   #expiredQueriesTimer: ReturnType<SetTimeout> | 0 = 0;
   #authMaintenanceTimer: ReturnType<SetTimeout> | 0 = 0;
@@ -328,6 +330,19 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
         'Time from ViewSyncer query sync requiring hydration to output for a ' +
         'client group. Includes query transformation, query materialization, ' +
         'CVR flush, catchup, and pokeEnd.',
+      unit: 's',
+    },
+  );
+  readonly #e2eServingLag = getOrCreateNativeHistogram(
+    'sync',
+    'e2e_serving_lag',
+    {
+      description:
+        'End-to-end lag from upstream commit to ViewSyncer output. Spans the ' +
+        'whole pipeline: the upstream transaction commit, replication to the ' +
+        'replica, IVM advancement, CVR flush, and pokeEnd. Recorded once per ' +
+        'served version, not sampled, so each observation is the completion ' +
+        'latency of real replicated work.',
       unit: 's',
     },
   );
@@ -528,12 +543,14 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
         this.#lc.debug?.(`draining view-syncer ${this.id} before running`);
         void this.stop();
       }
-      for await (const {state} of this.#stateChanges) {
+      for await (const replicaState of this.#stateChanges) {
+        const {state} = replicaState;
         if (this.#drainCoordinator.shouldDrain()) {
           this.#lc.debug?.(`draining view-syncer ${this.id} (elective)`);
           break;
         }
         assert(state === 'version-ready', 'state should be version-ready'); // This is the only state change used.
+        this.#e2eServingLagTracker.onVersionReady(replicaState);
 
         await this.#runInLockWithCVR(async (lc, cvr) => {
           const clientSchema = must(
@@ -711,6 +728,13 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
 
   #markVersionServed(version: CVRVersion) {
     this.#servedVersion = version.stateVersion;
+    const lagMs = this.#e2eServingLagTracker.onVersionServed(
+      version.stateVersion,
+      Date.now(),
+    );
+    if (lagMs !== null) {
+      this.#e2eServingLag.recordMs(lagMs);
+    }
   }
 
   #keepAliveUntil: number = 0;

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -346,6 +346,19 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
       unit: 's',
     },
   );
+  readonly #e2eServingLagClamps = getOrCreateCounter(
+    'sync',
+    'e2e_serving_lag_clamps',
+    {
+      description:
+        'Observations of sync.e2e_serving_lag that came out negative and were ' +
+        'clamped to zero. Non-zero means the upstream database clock is ' +
+        'running ahead of this pod by more than the entire pipeline latency, ' +
+        'so sync.e2e_serving_lag is biased low and reads healthier than ' +
+        'reality. See replication.upstream_clock_skew for the magnitude.',
+      unit: '{observation}',
+    },
+  );
   readonly #transactionAdvanceTime = getOrCreateLatencyHistogram(
     'sync',
     'advance-time',
@@ -728,12 +741,15 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
 
   #markVersionServed(version: CVRVersion) {
     this.#servedVersion = version.stateVersion;
-    const lagMs = this.#e2eServingLagTracker.onVersionServed(
+    const observation = this.#e2eServingLagTracker.onVersionServed(
       version.stateVersion,
       Date.now(),
     );
-    if (lagMs !== null) {
-      this.#e2eServingLag.recordMs(lagMs);
+    if (observation !== null) {
+      this.#e2eServingLag.recordMs(observation.lagMs);
+      if (observation.clamped) {
+        this.#e2eServingLagClamps.add(1);
+      }
     }
   }
 

--- a/tools/tsnapi/__snapshots__/tsnapi/@rocicorp/zero-types/change-protocol/v0/data.snapshot.d.ts
+++ b/tools/tsnapi/__snapshots__/tsnapi/@rocicorp/zero-types/change-protocol/v0/data.snapshot.d.ts
@@ -107,6 +107,7 @@ export declare const beginSchema: v.ObjectType<{
 }, undefined>;
 export declare const commitSchema: v.ObjectType<{
     tag: v.Type<"commit">;
+    commitTimeMs: v.Optional<number>;
 }, undefined>;
 export declare const createIndexSchema: v.ObjectType<{
     tag: v.Type<"create-index">;

--- a/tools/tsnapi/__snapshots__/tsnapi/@rocicorp/zero-types/change-protocol/v0/downstream.snapshot.d.ts
+++ b/tools/tsnapi/__snapshots__/tsnapi/@rocicorp/zero-types/change-protocol/v0/downstream.snapshot.d.ts
@@ -235,6 +235,7 @@ export declare const changeStreamDataSchema: v.UnionType<[v.TupleType<[v.Type<"b
     }>;
 }, undefined>]>]>]>, v.TupleType<[v.Type<"commit">, v.ObjectType<{
     tag: v.Type<"commit">;
+    commitTimeMs: v.Optional<number>;
 }, undefined>, v.ObjectType<{
     watermark: v.Type<string>;
 }, undefined>]>, v.TupleType<[v.Type<"rollback">, v.ObjectType<{
@@ -461,6 +462,7 @@ export declare const changeStreamMessageSchema: v.UnionType<[v.UnionType<[v.Tupl
     }>;
 }, undefined>]>]>]>, v.TupleType<[v.Type<"commit">, v.ObjectType<{
     tag: v.Type<"commit">;
+    commitTimeMs: v.Optional<number>;
 }, undefined>, v.ObjectType<{
     watermark: v.Type<string>;
 }, undefined>]>, v.TupleType<[v.Type<"rollback">, v.ObjectType<{

--- a/tools/tsnapi/__snapshots__/tsnapi/@rocicorp/zero-types/change-protocol/v0/status.snapshot.d.ts
+++ b/tools/tsnapi/__snapshots__/tsnapi/@rocicorp/zero-types/change-protocol/v0/status.snapshot.d.ts
@@ -41,6 +41,7 @@ export declare const upstreamStatusMessageSchema: v.TupleType<[v.Type<"status">,
     }>;
 }, undefined>, v.ObjectType<{
     tag: v.Type<"commit">;
+    commitTimeMs: v.Optional<number>;
 }, undefined>]>, v.ObjectType<{
     watermark: v.Type<string>;
 }, undefined>]>;

--- a/tools/tsnapi/__snapshots__/tsnapi/@rocicorp/zero-types/change-protocol/v0/upstream.snapshot.d.ts
+++ b/tools/tsnapi/__snapshots__/tsnapi/@rocicorp/zero-types/change-protocol/v0/upstream.snapshot.d.ts
@@ -28,6 +28,7 @@ export declare const changeSourceUpstreamSchema: v.TupleType<[v.Type<"status">, 
     }>;
 }, undefined>, v.ObjectType<{
     tag: v.Type<"commit">;
+    commitTimeMs: v.Optional<number>;
 }, undefined>]>, v.ObjectType<{
     watermark: v.Type<string>;
 }, undefined>]>;


### PR DESCRIPTION
We were double counting old changes and missing changes that were only briefly present in the backlog.