### PR TITLE
chore(zero-cache): bump to litestream 0.5.16 (experimental)

### DIFF
--- a/packages/zero/Dockerfile
+++ b/packages/zero/Dockerfile
@@ -16,7 +16,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 	--mount=type=cache,target=/go/pkg \
 	go build -ldflags "-s -w -X 'main.Version=${LITESTREAM_VERSION}' -extldflags '-static'" -tags osusergo,netgo,sqlite_omit_load_extension -o /usr/local/bin/litestream ./cmd/litestream
 
-FROM litestream/litestream:0.5.15 AS litestream-v5
+FROM litestream/litestream:0.5.16 AS litestream-v5
 
 FROM node:22.23.1-alpine3.23@sha256:8516dce0483394d5708d4b2ee6cacb79fb1d617ea4e2787c2120bcca92ce372e
 


### PR DESCRIPTION
The latest [litestream v5 version](https://github.com/benbjohnson/litestream/releases#release-v0.5.16) has some goodies, like better LTX compression, and a newer sqlite3 runtime version (for VFS). Bumping now so that we can test with something closer to what we will release with. 