### PR TITLE
fix(zero-cache): retry 5xx responses from API servers

### DIFF
--- a/packages/zero-cache/src/custom/fetch.test.ts
+++ b/packages/zero-cache/src/custom/fetch.test.ts
@@ -769,7 +769,7 @@ describe('fetchFromAPIServer', () => {
 
   test('wraps non-OK responses in ProtocolError with http type', async () => {
     mockFetch.mockResolvedValueOnce(
-      new Response('failure-body', {status: 503}),
+      new Response('failure-body', {status: 400}),
     );
 
     let caught: unknown;
@@ -792,9 +792,9 @@ describe('fetchFromAPIServer', () => {
       caught.errorBody.reason === ErrorReason.HTTP,
       'Expected zeroCache HTTP error',
     );
-    expect(caught.errorBody.status).toBe(503);
+    expect(caught.errorBody.status).toBe(400);
     expect(caught.errorBody.bodyPreview).toBe('failure-body');
-    expect(caught.errorBody.message).toMatch(/non-OK status 503/);
+    expect(caught.errorBody.message).toMatch(/non-OK status 400/);
   });
 
   test('wraps JSON parse failures in ProtocolError with parse type', async () => {
@@ -975,45 +975,26 @@ describe('fetchFromAPIServer', () => {
       vi.useFakeTimers();
     });
 
-    test('retries on 502 and succeeds', async () => {
-      mockFetch
-        .mockResolvedValueOnce(new Response('bad gateway', {status: 502}))
-        .mockResolvedValueOnce(new Response('bad gateway', {status: 502}))
-        .mockResolvedValueOnce(
-          new Response(JSON.stringify({success: true}), {status: 200}),
-        );
+    test.each([500, 502, 503, 504, 599])(
+      'retries on %i and succeeds',
+      async status => {
+        mockFetch
+          .mockResolvedValueOnce(new Response('server error', {status}))
+          .mockResolvedValueOnce(
+            new Response(JSON.stringify({success: true}), {status: 200}),
+          );
 
-      const promise = fetchWithContext(validator, 'push', {
-        operation: 'mutate',
-      });
+        const promise = fetchWithContext(validator, 'push', {
+          operation: 'mutate',
+        });
 
-      // 1st retry
-      await vi.advanceTimersByTimeAsync(1200);
-      // 2nd retry
-      await vi.advanceTimersByTimeAsync(1200);
+        await vi.advanceTimersByTimeAsync(1200);
 
-      const result = await promise;
-      expect(result).toEqual({success: true});
-      expect(mockFetch).toHaveBeenCalledTimes(3);
-    });
-
-    test('retries on 504 and succeeds', async () => {
-      mockFetch
-        .mockResolvedValueOnce(new Response('gateway timeout', {status: 504}))
-        .mockResolvedValueOnce(
-          new Response(JSON.stringify({success: true}), {status: 200}),
-        );
-
-      const promise = fetchWithContext(validator, 'push', {
-        operation: 'mutate',
-      });
-
-      await vi.advanceTimersByTimeAsync(1200);
-
-      const result = await promise;
-      expect(result).toEqual({success: true});
-      expect(mockFetch).toHaveBeenCalledTimes(2);
-    });
+        const result = await promise;
+        expect(result).toEqual({success: true});
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+      },
+    );
 
     test('retries on fetch failed and succeeds', async () => {
       mockFetch

--- a/packages/zero-cache/src/custom/fetch.ts
+++ b/packages/zero-cache/src/custom/fetch.ts
@@ -224,10 +224,10 @@ export async function fetchFromAPIServer<TValidator extends Type>(
             status: response.status,
             bodyPreview,
           });
-          // Bad Gateway or Gateway Timeout indicate the server was not reached
-          // We retry these if we have retries remaining.
+          // Server errors can be transient, so retry if attempts remain.
           const willRetry =
-            (response.status === 502 || response.status === 504) &&
+            response.status >= 500 &&
+            response.status < 600 &&
             attempt < MAX_ATTEMPTS;
           recordApiAttempt(performance.now() - attemptStart, metricAttrs, {
             attempt,


### PR DESCRIPTION
API servers can return `503 Service Unavailable` during brief overload or a deployment. Zero currently forwards that response to the client as `PushFailed` or `TransformFailed`, even though it retries nearby transient failures.

This PR treats `5xx` like the existing `502` and `504` cases. The retry count and exponential backoff remain unchanged.