### PR TITLE
chore(zero-cache): upstream ACK logic for RMv2

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
@@ -24,6 +24,7 @@ import type {
 } from '../change-source/protocol/current/downstream.ts';
 import type {UpstreamStatusMessage} from '../change-source/protocol/current/status.ts';
 import {exitAfter} from '../life-cycle.ts';
+import type {LitestreamVersion} from '../litestream/metrics.ts';
 import {
   changeLogFileName,
   deleteChangeLogDB,
@@ -166,6 +167,7 @@ describe('change-streamer/service', () => {
   async function newBackupStreamer(
     backupURL: string,
     source: Partial<ChangeSource> = {},
+    litestreamVersion: LitestreamVersion = 'legacy',
   ): Promise<ChangeStreamerService> {
     const backupStreamer = await initializeStreamer(
       lc,
@@ -187,7 +189,7 @@ describe('change-streamer/service', () => {
       } satisfies ChangeSource,
       ReplicationStatusPublisher.forTesting(),
       replicaConfig,
-      {backupURL, litestreamVersion: 'legacy'},
+      {backupURL, litestreamVersion},
       null,
       true,
       opts,
@@ -1945,8 +1947,11 @@ describe('change-streamer/service', () => {
       more: 'stuff',
     });
 
-    // Two commits with intervening status messages
-    await expectAcks('09', '0a', '0b', '0d');
+    // Two commits with intervening status messages. Note that the '0a'
+    // status is superseded by '0d' (the latest known status watermark) before
+    // the pg change-log persists up through '0b', so it is coalesced into
+    // the '0d' ack rather than being acked on its own.
+    await expectAcks('09', '0b', '0d');
 
     expect(
       await sql`SELECT watermark, change->'tag' FROM "zoro_3/cdc"."changeLog"`.values(),
@@ -2849,6 +2854,111 @@ describe('change-streamer/service', () => {
     ).toBe(true);
 
     await backupStreamer.stop();
+  });
+
+  describe('upstream acks with a v5 backup', () => {
+    // With `litestreamVersion: 'v5'`, the UpstreamAcker tracks both the pg
+    // change-log (via the Storer, which persists to the real `sql` db) and
+    // the backup watermark (reported via `trackBackupWatermark()`). An
+    // upstream ack should only be sent once *both* have reached a watermark.
+    async function newV5BackupStreamer() {
+      await streamer.stop();
+      const v5Changes = Subscription.create<ChangeStreamMessage>();
+      const v5Acks = new Queue<UpstreamStatusMessage>();
+      const backupStreamer = await newBackupStreamer(
+        's3://foo/bar',
+        {
+          startStream: () =>
+            Promise.resolve({
+              initialWatermark: '02',
+              changes: v5Changes,
+              acks: {push: status => v5Acks.enqueue(status)},
+            }),
+        },
+        'v5',
+      );
+      return {backupStreamer, v5Changes, v5Acks};
+    }
+
+    // Polls the real change db (rather than a mock) since the pg change-log
+    // side of the ack gating is driven by the actual Storer flushing to it.
+    async function waitForChangeLog(watermark: string) {
+      for (let i = 0; i < 100; i++) {
+        const rows = await sql`
+          SELECT 1 FROM "zoro_3/cdc"."changeLog" WHERE watermark = ${watermark}`;
+        if (rows.length) {
+          return;
+        }
+        await sleep(10);
+      }
+      throw new Error(`changeLog never reached watermark ${watermark}`);
+    }
+
+    const NO_ACK = Symbol('no-ack');
+    async function expectNoAck(v5Acks: Queue<UpstreamStatusMessage>) {
+      expect(
+        await v5Acks.dequeue(NO_ACK as unknown as UpstreamStatusMessage, 50),
+      ).toBe(NO_ACK);
+    }
+
+    test('withholds the ack until the backup catches up to an already-persisted commit', async () => {
+      const {backupStreamer, v5Changes, v5Acks} = await newV5BackupStreamer();
+
+      v5Changes.push(['begin', messages.begin(), {commitWatermark: '09'}]);
+      v5Changes.push(['data', messages.insert('foo', {id: 'hello'})]);
+      v5Changes.push(['commit', messages.commit(), {watermark: '09'}]);
+
+      // The pg change-log persists the commit on its own, but the backup
+      // hasn't reported reaching '09' yet, so nothing should be acked.
+      await waitForChangeLog('09');
+      await expectNoAck(v5Acks);
+
+      backupStreamer.trackBackupWatermark('09');
+      expect((await v5Acks.dequeue())[2].watermark).toBe('09');
+
+      await backupStreamer.stop();
+    });
+
+    test('withholds the ack until the pg change-log catches up to an already-reported backup watermark', async () => {
+      const {backupStreamer, v5Changes, v5Acks} = await newV5BackupStreamer();
+
+      // The backup races ahead of the pg change-log.
+      backupStreamer.trackBackupWatermark('09');
+      await expectNoAck(v5Acks);
+
+      v5Changes.push(['begin', messages.begin(), {commitWatermark: '09'}]);
+      v5Changes.push(['data', messages.insert('foo', {id: 'hello'})]);
+      v5Changes.push(['commit', messages.commit(), {watermark: '09'}]);
+
+      // Even though the backup already reported '09', the ack should wait
+      // for the pg change-log to persist the commit itself.
+      await waitForChangeLog('09');
+      expect((await v5Acks.dequeue())[2].watermark).toBe('09');
+
+      await backupStreamer.stop();
+    });
+
+    test('acks the min of the two watermarks across multiple commits', async () => {
+      const {backupStreamer, v5Changes, v5Acks} = await newV5BackupStreamer();
+
+      v5Changes.push(['begin', messages.begin(), {commitWatermark: '09'}]);
+      v5Changes.push(['commit', messages.commit(), {watermark: '09'}]);
+      v5Changes.push(['begin', messages.begin(), {commitWatermark: '0a'}]);
+      v5Changes.push(['commit', messages.commit(), {watermark: '0a'}]);
+
+      // The pg change-log races ahead to '0a', but the backup only reports
+      // up through '09': the ack should stop there.
+      await waitForChangeLog('0a');
+      backupStreamer.trackBackupWatermark('09');
+      expect((await v5Acks.dequeue())[2].watermark).toBe('09');
+      await expectNoAck(v5Acks);
+
+      // Once the backup catches up to '0a', the second commit is acked too.
+      backupStreamer.trackBackupWatermark('0a');
+      expect((await v5Acks.dequeue())[2].watermark).toBe('0a');
+
+      await backupStreamer.stop();
+    });
   });
 
   test('wrong replica version', async () => {

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -69,6 +69,7 @@ import {
   type TuningOptions as StorerOptions,
 } from './storer.ts';
 import {Subscriber} from './subscriber.ts';
+import {UpstreamAcker} from './upstream-acker.ts';
 
 export type BackupConfig = {
   backupURL: string;
@@ -339,6 +340,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
   readonly #sqliteCatchupOptions: SQLiteCatchupOptions | undefined;
   readonly #changeLogWriter: SQLiteChangeLogWriter | undefined;
   readonly #purgeScheduler: SQLiteChangeLogPurgeScheduler | undefined;
+  readonly #acker: UpstreamAcker;
 
   readonly #autoReset: boolean;
   readonly #state: RunningState;
@@ -431,7 +433,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
       discoveryProtocol,
       changeDB,
       replicaVersion,
-      consumed => this.#stream?.acks.push(['status', consumed[1], consumed[2]]),
+      consumed => this.#acker.trackPgChangeLog(consumed[2].watermark),
       err => this.stop(err),
       opts,
     );
@@ -475,6 +477,10 @@ class ChangeStreamerImpl implements ChangeStreamerService {
             opts.sqliteChangeLogPurge,
           )
         : undefined;
+    this.#acker = new UpstreamAcker({
+      trackPgChangeLog: true, // TODO: set false when retiring PG
+      trackBackup: backupConfig?.litestreamVersion === 'v5',
+    });
     this.#sqliteCatchupOptions = opts.sqliteCatchup
       ? {
           ...opts.sqliteCatchup,
@@ -555,13 +561,13 @@ class ChangeStreamerImpl implements ChangeStreamerService {
         }
         watermark = null;
 
+        this.#acker.reset(stream.acks);
         for await (const change of stream.changes) {
+          this.#acker.trackDownstream(change);
+
           const [type, msg] = change;
           switch (type) {
             case 'status':
-              if (msg.ack) {
-                this.#storer.status(change); // storer acks once it gets through its queue
-              }
               if (
                 msg.lagReport &&
                 msg.lagReport.lastTimings.commitTimeMs >=
@@ -795,11 +801,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
 
   trackBackupWatermark(watermark: string) {
     this.#backupWatermark = watermark;
-    // TODO: in RMv2, the backup watermark immediately acks upstream
-    //       so that (in PG) the confirmed_flush_lsn can advance. The
-    //       cleanup of the change-log can trail that based on where
-    //       current subscribers are, and our policy for how much buffer
-    //       is kept around for reconnecting view-syncers.
+    this.#acker.trackBackup(watermark);
     // The durable backup floor is an independent input to each change-log
     // implementation. SQLite receives it even when the PG log has already
     // reached this watermark.

--- a/packages/zero-cache/src/services/change-streamer/storer.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.pg.test.ts
@@ -1279,9 +1279,6 @@ describe('change-streamer/storer', () => {
         {watermark: '08'},
       ]);
 
-      storer.status(['status', {ack: true}, {watermark: '0e'}]);
-      storer.status(['status', {ack: true}, {watermark: '0f'}]);
-
       // Catchup should wait for the transaction to complete before querying
       // the database, and start after watermark '03'.
       expect(await drain(stream1, '0a')).toMatchInlineSnapshot(`
@@ -1502,7 +1499,7 @@ describe('change-streamer/storer', () => {
         ]
       `);
 
-      await expectConsumed('08', '0e', '0f');
+      await expectConsumed('08');
     });
 
     // Similar to "queued if transaction is in progress" but tests rollback.
@@ -1539,9 +1536,6 @@ describe('change-streamer/storer', () => {
       storer.catchup(sub2, 'serving');
       // Rollback the transaction.
       storer.store('08', ['rollback', messages.rollback()]);
-
-      storer.status(['status', {ack: true}, {watermark: '0a'}]);
-      storer.status(['status', {ack: true}, {watermark: '0c'}]);
 
       // Catchup should wait for the transaction to complete before querying
       // the database, and start after watermark '03'.
@@ -1708,7 +1702,8 @@ describe('change-streamer/storer', () => {
         ]
       `);
 
-      await expectConsumed('0a', '0c');
+      // The transaction was rolled back, so nothing should be acked.
+      expect(consumed.size()).toBe(0);
     });
 
     test('catchup does not include subsequent transactions', async () => {
@@ -1742,9 +1737,6 @@ describe('change-streamer/storer', () => {
       // catchup doesn't include the next transaction.
       storer.store('09', ['begin', messages.begin(), {commitWatermark: '0a'}]);
       storer.store('0a', ['commit', messages.commit(), {watermark: '0a'}]);
-
-      storer.status(['status', {ack: true}, {watermark: '0d'}]);
-      storer.status(['status', {ack: true}, {watermark: '0e'}]);
 
       // Wait for the storer to commit that transaction.
       for (let i = 0; i < 10; i++) {
@@ -1834,7 +1826,7 @@ describe('change-streamer/storer', () => {
         ],
       ]
     `);
-      await expectConsumed('08', '0a', '0d', '0e');
+      await expectConsumed('08', '0a');
     });
   });
 

--- a/packages/zero-cache/src/services/change-streamer/storer.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.ts
@@ -28,10 +28,7 @@ import {
   type ChangeStreamData,
   type Commit,
 } from '../change-source/protocol/current/downstream.ts';
-import type {
-  DownstreamStatusMessage,
-  UpstreamStatusMessage,
-} from '../change-source/protocol/current/status.ts';
+import type {UpstreamStatusMessage} from '../change-source/protocol/current/status.ts';
 import type {ReplicatorMode} from '../replicator/replicator.ts';
 import type {Service} from '../service.ts';
 import {
@@ -63,7 +60,6 @@ type QueueEntry =
     ]
   | ['ready', callback: () => void]
   | ['subscriber', SubscriberAndMode]
-  | DownstreamStatusMessage
   | ['abort']
   | 'stop';
 
@@ -142,7 +138,7 @@ export class Storer implements Service {
   readonly #discoveryProtocol: string;
   readonly #db: PostgresDB;
   readonly #replicaVersion: string;
-  readonly #onConsumed: (c: Commit | UpstreamStatusMessage) => void;
+  readonly #onCommitted: (c: Commit) => void;
   readonly #onFatal: (err: Error) => void;
   readonly #queue = new Queue<QueueEntry>();
   readonly #backPressureThresholdBytes: number;
@@ -160,7 +156,7 @@ export class Storer implements Service {
     discoveryProtocol: string,
     db: PostgresDB,
     replicaVersion: string,
-    onConsumed: (c: Commit | UpstreamStatusMessage) => void,
+    onCommitted: (c: Commit | UpstreamStatusMessage) => void,
     onFatal: (err: Error) => void,
     {
       backPressureLimitHeapProportion,
@@ -175,7 +171,7 @@ export class Storer implements Service {
     this.#discoveryProtocol = discoveryProtocol;
     this.#db = db;
     this.#replicaVersion = replicaVersion;
-    this.#onConsumed = onConsumed;
+    this.#onCommitted = onCommitted;
     this.#onFatal = onFatal;
     this.#statementTimeoutMs = statementTimeoutMs;
     this.#changeLogBatchSize = Math.max(1, changeLogBatchSize);
@@ -333,10 +329,6 @@ export class Storer implements Service {
 
   abort() {
     this.#queue.enqueue(['abort']);
-  }
-
-  status(s: DownstreamStatusMessage) {
-    this.#queue.enqueue(s);
   }
 
   catchup(subscriber: Subscriber, mode: ReplicatorMode) {
@@ -501,9 +493,6 @@ export class Storer implements Service {
             }
             continue;
           }
-          case 'status':
-            this.#onConsumed(msg);
-            continue;
           case 'abort': {
             if (tx) {
               tx.pool.abort();
@@ -620,7 +609,7 @@ export class Storer implements Service {
 
           // ACK the LSN to the upstream Postgres.
           if (tx.ack) {
-            this.#onConsumed(['commit', change, {watermark}]);
+            this.#onCommitted(['commit', change, {watermark}]);
           }
           tx = null;
 

--- a/packages/zero-cache/src/services/change-streamer/upstream-acker.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/upstream-acker.test.ts
@@ -1,0 +1,212 @@
+import {describe, expect, test} from 'vitest';
+import type {Sink} from '../../types/streams.ts';
+import type {
+  ChangeSourceUpstream,
+  ChangeStreamMessage,
+} from '../change-source/protocol/current.ts';
+import {UpstreamAcker} from './upstream-acker.ts';
+
+function sink(): {
+  sink: Sink<ChangeSourceUpstream>;
+  acked: ChangeSourceUpstream[];
+} {
+  const acked: ChangeSourceUpstream[] = [];
+  return {sink: {push: msg => acked.push(msg)}, acked};
+}
+
+function commit(watermark: string): ChangeStreamMessage {
+  return ['commit', {tag: 'commit'}, {watermark}];
+}
+
+function status(watermark: string, ack = true): ChangeStreamMessage {
+  return ['status', {ack}, {watermark}];
+}
+
+describe('change-streamer/upstream-acker', () => {
+  test('requires at least one store to be tracked', () => {
+    expect(
+      () => new UpstreamAcker({trackPgChangeLog: false, trackBackup: false}),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `[Error: At least one of trackPgChangeLog or trackBackup must be true]`,
+    );
+  });
+
+  test('acks only once the (sole) tracked pg change-log catches up', () => {
+    const acker = new UpstreamAcker({
+      trackPgChangeLog: true,
+      trackBackup: false,
+    });
+    const {sink: upstream, acked} = sink();
+    acker.reset(upstream);
+
+    acker.trackDownstream(commit('05'));
+    expect(acked).toEqual([]);
+
+    acker.trackPgChangeLog('05');
+    expect(acked).toEqual([['status', {tag: 'commit'}, {watermark: '05'}]]);
+  });
+
+  test('acks only once the (sole) tracked backup catches up', () => {
+    const acker = new UpstreamAcker({
+      trackPgChangeLog: false,
+      trackBackup: true,
+    });
+    const {sink: upstream, acked} = sink();
+    acker.reset(upstream);
+
+    acker.trackDownstream(commit('05'));
+    expect(acked).toEqual([]);
+
+    acker.trackBackup('05');
+    expect(acked).toEqual([['status', {tag: 'commit'}, {watermark: '05'}]]);
+  });
+
+  test('when tracking both stores, acks are gated by the slower of the two', () => {
+    const acker = new UpstreamAcker({
+      trackPgChangeLog: true,
+      trackBackup: true,
+    });
+    const {sink: upstream, acked} = sink();
+    acker.reset(upstream);
+
+    acker.trackDownstream(commit('05'));
+
+    // The pg change-log races ahead of the backup: nothing should be acked
+    // yet, since the backup (the slower store) has not persisted '05'.
+    acker.trackPgChangeLog('05');
+    expect(acked).toEqual([]);
+
+    // Once the backup (the slower store) catches up, the watermark is acked.
+    acker.trackBackup('05');
+    expect(acked).toEqual([['status', {tag: 'commit'}, {watermark: '05'}]]);
+  });
+
+  test('when tracking both stores, the ack watermark is the min of the two', () => {
+    const acker = new UpstreamAcker({
+      trackPgChangeLog: true,
+      trackBackup: true,
+    });
+    const {sink: upstream, acked} = sink();
+    acker.reset(upstream);
+
+    acker.trackDownstream(commit('05'));
+    acker.trackDownstream(commit('0a'));
+
+    acker.trackBackup('0a'); // backup races ahead
+    expect(acked).toEqual([]);
+
+    acker.trackPgChangeLog('05'); // pg change-log catches up to '05' only
+    expect(acked).toEqual([['status', {tag: 'commit'}, {watermark: '05'}]]);
+
+    acker.trackPgChangeLog('0a'); // pg change-log catches up to '0a'
+    expect(acked).toEqual([
+      ['status', {tag: 'commit'}, {watermark: '05'}],
+      ['status', {tag: 'commit'}, {watermark: '0a'}],
+    ]);
+  });
+
+  test('does not re-ack a watermark that has already been acked', () => {
+    const acker = new UpstreamAcker({
+      trackPgChangeLog: true,
+      trackBackup: false,
+    });
+    const {sink: upstream, acked} = sink();
+    acker.reset(upstream);
+
+    acker.trackDownstream(commit('05'));
+    acker.trackPgChangeLog('05');
+    acker.trackPgChangeLog('05'); // redundant notification
+    expect(acked).toEqual([['status', {tag: 'commit'}, {watermark: '05'}]]);
+  });
+
+  test('acks a non-transactional status watermark once preceding commits are persisted', () => {
+    const acker = new UpstreamAcker({
+      trackPgChangeLog: true,
+      trackBackup: false,
+    });
+    const {sink: upstream, acked} = sink();
+    acker.reset(upstream);
+
+    acker.trackDownstream(commit('05'));
+    acker.trackDownstream(status('06'));
+    // The status watermark should not be acked before '05' is persisted.
+    expect(acked).toEqual([]);
+
+    acker.trackPgChangeLog('05');
+    expect(acked).toEqual([
+      ['status', {tag: 'commit'}, {watermark: '05'}],
+      ['status', {ack: true}, {watermark: '06'}],
+    ]);
+  });
+
+  test('acks a status watermark immediately if there are no outstanding commits', () => {
+    const acker = new UpstreamAcker({
+      trackPgChangeLog: true,
+      trackBackup: false,
+    });
+    const {sink: upstream, acked} = sink();
+    acker.reset(upstream);
+
+    acker.trackDownstream(status('06'));
+    expect(acked).toEqual([['status', {ack: true}, {watermark: '06'}]]);
+  });
+
+  test('ignores status messages that do not request an ack', () => {
+    const acker = new UpstreamAcker({
+      trackPgChangeLog: true,
+      trackBackup: false,
+    });
+    const {sink: upstream, acked} = sink();
+    acker.reset(upstream);
+
+    acker.trackDownstream(status('06', false));
+    expect(acked).toEqual([]);
+  });
+
+  test('a replayed commit is acked immediately if already covered by a persisted watermark from before a reconnect', () => {
+    const acker = new UpstreamAcker({
+      trackPgChangeLog: true,
+      trackBackup: false,
+    });
+    const {sink: upstream1, acked: acked1} = sink();
+    acker.reset(upstream1);
+
+    acker.trackDownstream(commit('0a'));
+    acker.trackPgChangeLog('0a');
+    expect(acked1).toEqual([['status', {tag: 'commit'}, {watermark: '0a'}]]);
+
+    // Simulate a reconnect (e.g. a temporarily dropped replication slot)
+    // where the change-source resumes from an earlier watermark ('05'),
+    // replaying a commit that was already persisted before the disconnect.
+    // This should be acked immediately -- from the store watermark alone,
+    // without waiting for another trackPgChangeLog() call, which may never
+    // come for a watermark that was already processed.
+    const {sink: upstream2, acked: acked2} = sink();
+    acker.reset(upstream2);
+    acker.trackDownstream(commit('05'));
+    expect(acked2).toEqual([['status', {tag: 'commit'}, {watermark: '0a'}]]);
+  });
+
+  test('reset() re-acks the current watermark to a new upstream sink', () => {
+    const acker = new UpstreamAcker({
+      trackPgChangeLog: true,
+      trackBackup: false,
+    });
+    const {sink: upstream1, acked: acked1} = sink();
+    acker.reset(upstream1);
+
+    acker.trackDownstream(commit('05'));
+    acker.trackPgChangeLog('05');
+    expect(acked1).toEqual([['status', {tag: 'commit'}, {watermark: '05'}]]);
+
+    // Simulate a reconnect: a new upstream sink should be re-informed of the
+    // watermark once persisted, since the store watermarks (unlike the
+    // per-connection tracking) survive the reset.
+    const {sink: upstream2, acked: acked2} = sink();
+    acker.reset(upstream2);
+    expect(acked2).toEqual([]);
+
+    acker.trackPgChangeLog('05');
+    expect(acked2).toEqual([['status', {tag: 'commit'}, {watermark: '05'}]]);
+  });
+});

--- a/packages/zero-cache/src/services/change-streamer/upstream-acker.ts
+++ b/packages/zero-cache/src/services/change-streamer/upstream-acker.ts
@@ -13,9 +13,10 @@ type Opts = {
 
 /**
  * Tracks the progress (watermark) of multiple streams:
- * - downstream transactinos and status messages (status messages
- *   indicate wal LSNs that are not relevant to the publication)
- * - PG change-log
+ * - downstream transactions and status messages (the latter
+ *   indicating LSNs that are not relevant to the publication
+ *   but nevertheless need to be ACKed)
+ * - PG change-log commits
  * - backup watermarks
  *
  * and sends upstream ACKs accordingly. When both the PG change-log
@@ -25,7 +26,7 @@ type Opts = {
  *
  * The UpstreamAcker also takes into account that an upstream
  * connection can be disconnected and {@link reset()}. In this case,
- * the progress of the persistent stores are retained and the acks
+ * the progress of the persistent stores is retained and the acks
  * are resent on the new upstream connection as necessary.
  */
 export class UpstreamAcker {

--- a/packages/zero-cache/src/services/change-streamer/upstream-acker.ts
+++ b/packages/zero-cache/src/services/change-streamer/upstream-acker.ts
@@ -1,0 +1,115 @@
+import {assert} from '../../../../shared/src/asserts.ts';
+import {max, min} from '../../types/lexi-version.ts';
+import type {Sink} from '../../types/streams.ts';
+import type {
+  ChangeSourceUpstream,
+  ChangeStreamMessage,
+} from '../change-source/protocol/current.ts';
+
+type Opts = {
+  trackPgChangeLog: boolean;
+  trackBackup: boolean;
+};
+
+/**
+ * Tracks the progress (watermark) of multiple streams:
+ * - downstream transactinos and status messages (status messages
+ *   indicate wal LSNs that are not relevant to the publication)
+ * - PG change-log
+ * - backup watermarks
+ *
+ * and sends upstream ACKs accordingly. When both the PG change-log
+ * and backup watermarks are being considered for upstream ACKs
+ * (i.e. RMv1.5), only watermarks that have been reached by both
+ * stores are acked.
+ *
+ * The UpstreamAcker also takes into account that an upstream
+ * connection can be disconnected and {@link reset()}. In this case,
+ * the progress of the persistent stores are retained and the acks
+ * are resent on the new upstream connection as necessary.
+ */
+export class UpstreamAcker {
+  readonly #trackPgChangeLog: boolean;
+  readonly #trackBackup: boolean;
+
+  #pgChangeLogWatermark = '';
+  #backupWatermark = '';
+
+  #upstream: Sink<ChangeSourceUpstream> | undefined;
+  #lastTx = '';
+  #lastStatus = '';
+  #lastAck = '';
+
+  constructor({trackPgChangeLog, trackBackup}: Opts) {
+    assert(
+      trackPgChangeLog || trackBackup,
+      `At least one of trackPgChangeLog or trackBackup must be true`,
+    );
+    this.#trackPgChangeLog = trackPgChangeLog;
+    this.#trackBackup = trackBackup;
+  }
+
+  reset(upstream: Sink<ChangeSourceUpstream>) {
+    this.#upstream = upstream;
+    this.#lastTx = '';
+    this.#lastStatus = '';
+    this.#lastAck = '';
+  }
+
+  trackDownstream(downstream: ChangeStreamMessage) {
+    const [tag, msg] = downstream;
+    switch (tag) {
+      case 'status':
+        if (msg.ack) {
+          this.#lastStatus = downstream[2].watermark;
+        }
+        this.#maybeAck();
+        break;
+      case 'commit':
+        this.#lastTx = downstream[2].watermark;
+        this.#maybeAck();
+        break;
+    }
+  }
+
+  trackPgChangeLog(committedWatermark: string) {
+    // Watermarks should never move backwards, but use max() defensively.
+    this.#pgChangeLogWatermark = max(
+      committedWatermark,
+      this.#pgChangeLogWatermark,
+    );
+    this.#maybeAck();
+  }
+
+  trackBackup(backedUpWatermark: string) {
+    // Watermarks should never move backwards, but use max() defensively.
+    this.#backupWatermark = max(backedUpWatermark, this.#backupWatermark);
+    this.#maybeAck();
+  }
+
+  #maybeAck() {
+    const currentWatermark = !this.#trackBackup
+      ? this.#pgChangeLogWatermark
+      : !this.#trackPgChangeLog
+        ? this.#backupWatermark
+        : min(this.#pgChangeLogWatermark, this.#backupWatermark);
+    if (currentWatermark > this.#lastAck) {
+      this.#upstream?.push([
+        'status',
+        {tag: 'commit'},
+        {watermark: currentWatermark},
+      ]);
+      this.#lastAck = currentWatermark;
+    }
+    // If all committed transactions have been acked, ack any outstanding
+    // status LSN's thereafter (i.e. non-publication upstream changes).
+    if (this.#lastAck >= this.#lastTx && this.#lastStatus > this.#lastAck) {
+      this.#upstream?.push([
+        'status',
+        {ack: true},
+        {watermark: this.#lastStatus},
+      ]);
+      this.#lastAck = this.#lastStatus;
+    }
+  }
+}


### PR DESCRIPTION
`UpstreamAcker` encapsulates the upstream ACK logic for RMv2. Whereas previously, all acks were mediated by the (progress of) the PG change-log `Storer`, the new UpstreamAcker:
* tracks the progress of either or both of the PG change-log and the replica backup
* sends upstream ACKs for the minimum of the two if both are being tracked (i.e. RMv1.5)
* tracks and automatically acks non-publication LSNs (commits that are not relevant to the replication slot) when all relevant transactions have been acked

The last type of ack is represented in the change-source protocol as `status` messages with `ack: true`. That logic has been removed from the PG storer implementation and subsumed by the UpstreamAcker to facilitate sunsetting the PG change-log.