### PR TITLE
fix(zero-cache): report oversized update binding context

### DIFF
--- a/packages/zero-cache/src/services/replicator/change-processor.test.ts
+++ b/packages/zero-cache/src/services/replicator/change-processor.test.ts
@@ -3824,6 +3824,44 @@ describe('replicator/change-processor-errors', () => {
     expect(replica.inTransaction).toBe(false);
   });
 
+  test('wraps oversized update binding errors with context', () => {
+    const failures: unknown[] = [];
+    const processor = new ChangeProcessor(
+      new StatementRunner(replica),
+      'backup',
+      (_, error) => failures.push(error),
+    );
+    const update = messages.update('foo', {id: 1, big: 1n << 63n});
+    const relation = {
+      ...update.relation,
+      relationOid: 42,
+    } as typeof update.relation & {relationOid: number};
+
+    processor.processMessage(lc, [
+      'begin',
+      messages.begin(),
+      {commitWatermark: '0e'},
+    ]);
+    processor.processMessage(lc, [
+      'data',
+      {
+        ...update,
+        relation,
+      },
+    ]);
+
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toMatchObject({
+      name: 'OversizedUpdateBindingError',
+      message:
+        'Oversized SQLite update binding: tx=0e relationOid=42 table=public.foo column=big valueType=bigint fitsInt64=false',
+      cause: {
+        name: 'RangeError',
+        message: 'The bound string, buffer, or bigint is too big',
+      },
+    });
+  });
+
   test('preserves original sqlite auto-rollback error', () => {
     const failures: unknown[] = [];
     const processor = createChangeProcessor(replica, (_, err) =>

--- a/packages/zero-cache/src/services/replicator/change-processor.ts
+++ b/packages/zero-cache/src/services/replicator/change-processor.ts
@@ -1,3 +1,4 @@
+import {constants as bufferConstants} from 'node:buffer';
 import type {LogContext} from '@rocicorp/logger';
 import {SqliteError} from '@rocicorp/zero-sqlite3';
 import {AbortError} from '../../../../shared/src/abort-error.ts';
@@ -66,6 +67,15 @@ import {
 import {TableMetadataTracker} from './schema/table-metadata.ts';
 
 export type ChangeProcessorMode = ReplicatorMode | 'initial-sync';
+
+const BIND_VALUE_TOO_BIG_ERROR =
+  'The bound string, buffer, or bigint is too big';
+const MAX_SQLITE_BIND_BYTES = Math.min(
+  bufferConstants.MAX_LENGTH,
+  bufferConstants.MAX_STRING_LENGTH,
+);
+const MIN_SQLITE_BIGINT = -(1n << 63n);
+const MAX_SQLITE_BIGINT = (1n << 63n) - 1n;
 
 export type CommitResult = {
   watermark: string;
@@ -509,19 +519,23 @@ class TransactionProcessor {
     const conds = Object.keys(currKey).map(col => `${id(col)}=?`);
     const setExprs = Object.keys(row).map(col => `${id(col)}=?`);
 
-    const {changes} = this.#db.run(
-      `
-      UPDATE ${id(table)}
-        SET ${setExprs.join(',')}
-        WHERE ${conds.join(' AND ')}
-      `,
-      [...Object.values(row), ...Object.values(currKey)],
-    );
+    try {
+      const {changes} = this.#db.run(
+        `
+        UPDATE ${id(table)}
+          SET ${setExprs.join(',')}
+          WHERE ${conds.join(' AND ')}
+        `,
+        [...Object.values(row), ...Object.values(currKey)],
+      );
 
-    // If the UPDATE did not affect any rows, perform an UPSERT of the
-    // new row for resumptive replication.
-    if (changes === 0) {
-      this.#upsert(table, row);
+      // If the UPDATE did not affect any rows, perform an UPSERT of the
+      // new row for resumptive replication.
+      if (changes === 0) {
+        this.#upsert(table, row);
+      }
+    } catch (e) {
+      throw wrapBindError(e, this.#version, update.relation, row, currKey);
     }
   }
 
@@ -959,6 +973,74 @@ function getBackfilledColumns(
     return undefined; // common case
   }
   return backfilling.filter(col => col in row);
+}
+
+class OversizedUpdateBindingError extends Error {
+  constructor(message: string, cause: RangeError) {
+    super(message, {cause});
+    this.name = 'OversizedUpdateBindingError';
+  }
+}
+
+function wrapBindError(
+  error: unknown,
+  tx: LexiVersion,
+  relation: MessageRelation,
+  row: LiteRow,
+  currKey: LiteRowKey,
+) {
+  if (
+    !(error instanceof RangeError) ||
+    error.message !== BIND_VALUE_TOO_BIG_ERROR
+  ) {
+    return error;
+  }
+
+  const binding = [...Object.entries(row), ...Object.entries(currKey)].find(
+    ([, value]) => oversizedValueDescription(value),
+  );
+  const relationOid = getRelationOid(relation);
+  const context = [
+    `tx=${tx}`,
+    relationOid === undefined ? undefined : `relationOid=${relationOid}`,
+    `table=${relation.schema}.${relation.name}`,
+    `column=${binding?.[0] ?? 'unknown'}`,
+    binding && oversizedValueDescription(binding[1]),
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return new OversizedUpdateBindingError(
+    `Oversized SQLite update binding: ${context}`,
+    error,
+  );
+}
+
+function getRelationOid(relation: MessageRelation): number | undefined {
+  return 'relationOid' in relation && typeof relation.relationOid === 'number'
+    ? relation.relationOid
+    : undefined;
+}
+
+function oversizedValueDescription(value: LiteValueType): string | undefined {
+  if (typeof value === 'bigint') {
+    return value < MIN_SQLITE_BIGINT || value > MAX_SQLITE_BIGINT
+      ? 'valueType=bigint fitsInt64=false'
+      : undefined;
+  }
+
+  if (typeof value === 'string') {
+    const sizeBytes = Buffer.byteLength(value);
+    return sizeBytes > MAX_SQLITE_BIND_BYTES
+      ? `valueType=string sizeBytes=${sizeBytes} limitBytes=${MAX_SQLITE_BIND_BYTES}`
+      : undefined;
+  }
+
+  if (value instanceof Uint8Array && value.byteLength > MAX_SQLITE_BIND_BYTES) {
+    return `valueType=buffer sizeBytes=${value.byteLength} limitBytes=${MAX_SQLITE_BIND_BYTES}`;
+  }
+
+  return undefined;
 }
 
 /** Runs `fn`, returning its error rather than throwing it. */


### PR DESCRIPTION
### What

Improve Zero replication diagnostics when a PostgreSQL update contains a value that SQLite cannot bind.

### Why

The existing `RangeError: The bound string, buffer, or bigint is too big` does not identify the affected relation or column. This can leave replication repeatedly crashing on a poison transaction without enough information to locate the upstream write.

### Changes

- Wrap oversized update-binding failures with transaction, relation, table, column, value type, and size context.
- Preserve the native SQLite `RangeError` and stack as the error cause.
- Avoid logging customer values.
- Add regression coverage for the enriched error.
- Leave the change-stream protocol and schema hash unchanged.