### PR TITLE
chore(zero-cache): default to higher frequency backups and snapshots

### DIFF
--- a/packages/zero-cache/src/config/zero-config.test.ts
+++ b/packages/zero-cache/src/config/zero-config.test.ts
@@ -582,7 +582,7 @@ test('zero-cache --help', () => {
                                                                         Path to the Litestream v0.5.x SQLite VFS loadable extension used by                                                        
                                                                         the backup watermark reader to query the backup directly.                                                                  
                                                                                                                                                                                                    
-     --litestream-vfs-probe-interval-ms number                          default: 30000                                                                                                             
+     --litestream-vfs-probe-interval-ms number                          default: 15000                                                                                                             
        ZERO_LITESTREAM_VFS_PROBE_INTERVAL_MS env                                                                                                                                                   
                                                                         Interval in milliseconds at which the standalone backup watermark reader                                                   
                                                                         logs the watermark when it is run without a parent worker. The integrated                                                  

--- a/packages/zero-cache/src/config/zero-config.test.ts
+++ b/packages/zero-cache/src/config/zero-config.test.ts
@@ -645,14 +645,14 @@ test('zero-cache --help', () => {
                                                                         blocks writers until complete. Defaults to minCheckpointPageCount * 10.                                                    
                                                                         Set to 0 to disable RESTART checkpoints entirely.                                                                          
                                                                                                                                                                                                    
-     --litestream-incremental-backup-interval-minutes number            default: 15                                                                                                                
+     --litestream-incremental-backup-interval-minutes number            default: 5                                                                                                                 
        ZERO_LITESTREAM_INCREMENTAL_BACKUP_INTERVAL_MINUTES env                                                                                                                                     
                                                                         The interval between incremental backups of the replica. Shorter intervals                                                 
                                                                         reduce the amount of change history that needs to be replayed when catching                                                
                                                                         up a new view-syncer, at the expense of increasing the number of files needed                                              
                                                                         to download for the initial litestream restore.                                                                            
                                                                                                                                                                                                    
-     --litestream-snapshot-backup-interval-hours number                 default: 12                                                                                                                
+     --litestream-snapshot-backup-interval-hours number                 default: 4                                                                                                                 
        ZERO_LITESTREAM_SNAPSHOT_BACKUP_INTERVAL_HOURS env                                                                                                                                          
                                                                         The interval between snapshot backups of the replica. Snapshot backups                                                     
                                                                         make a full copy of the database to a new litestream generation. This                                                      

--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -941,7 +941,7 @@ export const zeroOptions = {
     },
 
     vfsProbeIntervalMs: {
-      type: v.number().default(30 * 1000),
+      type: v.number().default(15 * 1000),
       desc: [
         `Interval in milliseconds at which the standalone backup watermark reader`,
         `logs the watermark when it is run without a parent worker. The integrated`,

--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -1035,7 +1035,7 @@ export const zeroOptions = {
     },
 
     incrementalBackupIntervalMinutes: {
-      type: v.number().default(15),
+      type: v.number().default(5),
       desc: [
         `The interval between incremental backups of the replica. Shorter intervals`,
         `reduce the amount of change history that needs to be replayed when catching`,
@@ -1045,7 +1045,7 @@ export const zeroOptions = {
     },
 
     snapshotBackupIntervalHours: {
-      type: v.number().default(12),
+      type: v.number().default(4),
       desc: [
         `The interval between snapshot backups of the replica. Snapshot backups`,
         `make a full copy of the database to a new litestream generation. This`,


### PR DESCRIPTION
Increase the incremental and full snapshot frequency of litestream v3 backups by 3x, to every 5 min and 4 hours, respectively.

The ratio of the two is the same, making the expected number of wal files equivalent. The shorter interval decreases the amount of catchup needed per RM/VS restart, and the expensive of more backups to s3, but the latter is cheap enough to it should not make a big difference in overall costs.

This will facilitate the migration to the per-RM replication slots scheme of RMv2.