### PR TITLE
chore(zero-cache): include the "replicas" table in the metadata publication

### DIFF
--- a/packages/zero-cache/src/services/change-source/pg/change-source.end-to-mid.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.end-to-mid.pg.test.ts
@@ -120,6 +120,24 @@ describe('change-source/pg/end-to-mid-test', {timeout: 30000}, () => {
     return queue;
   }
 
+  // The "replicas" table is included in the metadata publication (see
+  // schema/shard.ts) so that the change-log and replica backups advance
+  // past the consistent_point_lsn of new replication slots. This means
+  // that the stream started from watermark '00' in beforeAll() replays,
+  // as its first transaction(s), bookkeeping changes to the replica's own
+  // row in that table (the INSERT from initial sync, and an UPDATE from
+  // starting the stream). None of the test.each cases below are concerned
+  // with those bookkeeping rows, so transactions consisting entirely of
+  // such changes are applied to the replica (to keep it consistent) but
+  // not surfaced to callers of nextTransaction().
+  function isReplicasBookkeepingChange(change: DataOrSchemaChange): boolean {
+    return (
+      'relation' in change &&
+      change.relation.name === 'replicas' &&
+      change.relation.schema === `${APP_ID}_0`
+    );
+  }
+
   async function nextTransaction(): Promise<DataOrSchemaChange[]> {
     const data: DataOrSchemaChange[] = [];
     for (;;) {
@@ -139,10 +157,11 @@ describe('change-source/pg/end-to-mid-test', {timeout: 30000}, () => {
           data.push(change[1]);
           break;
         case 'commit':
-          if (data.length) {
+          if (data.length && !data.every(isReplicasBookkeepingChange)) {
             return data;
           }
-          break; // skip empty transactions
+          data.length = 0; // skip empty or bookkeeping-only transactions
+          break;
         case 'rollback':
           throw new Error(`received rollback: ${JSON.stringify(change)}`);
         case 'control':

--- a/packages/zero-cache/src/services/change-source/pg/change-source.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.pg.test.ts
@@ -194,15 +194,101 @@ describe('change-source/pg', {timeout: 30000, retry: 3}, () => {
 
   const MAX_ATTEMPTS_IF_REPLICATION_SLOT_ACTIVE = 10;
 
+  // The "replicas" table is included in the metadata publication (see
+  // schema/shard.ts) so that the change-log and replica backups advance
+  // past the consistent_point_lsn of new replication slots. This means
+  // that a stream started from watermark '00' (i.e. replaying the entire
+  // history of the shard) will replay, as its first transaction(s), the
+  // bookkeeping INSERT of the replica's own row into that table (from
+  // initial sync) as well as an UPDATE to that row's subscriberContext
+  // (from starting the stream). None of the tests in this file are
+  // concerned with those bookkeeping rows, so transparently filter them
+  // out here to keep the rest of the tests agnostic to this
+  // implementation detail.
+  function skipReplicasBookkeepingInsert(
+    changes: Source<ChangeStreamMessage>,
+  ): Source<ChangeStreamMessage> {
+    const it = changes[Symbol.asyncIterator]();
+
+    // Reads one full transaction (or a single non-transactional message)
+    // starting from the next value. Returns the buffered messages, and
+    // whether the transaction consisted entirely of "replicas" table
+    // changes (and thus should be dropped).
+    async function readNext(): Promise<{
+      buffered: ChangeStreamMessage[];
+      done: boolean;
+      onlyReplicas: boolean;
+    }> {
+      const {value: first, done: firstDone} = await it.next();
+      if (firstDone) {
+        return {buffered: [], done: true, onlyReplicas: false};
+      }
+      if (first[0] !== 'begin') {
+        // A standalone 'status'/'control' message (e.g. a periodic lag
+        // report) arrives outside of any begin/commit transaction. Pass
+        // it through immediately rather than buffering it while waiting
+        // for a 'commit' that will never arrive.
+        return {buffered: [first], done: false, onlyReplicas: false};
+      }
+
+      const buffered: ChangeStreamMessage[] = [first];
+      let onlyReplicas = true;
+      let sawData = false;
+      for (;;) {
+        const {value, done} = await it.next();
+        if (done) {
+          return {buffered, done: true, onlyReplicas: false};
+        }
+        buffered.push(value);
+        if (value[0] === 'status') {
+          // A status/lag-report can be interleaved mid-transaction; it
+          // doesn't end the transaction and isn't itself a data change.
+          continue;
+        }
+        if (value[0] === 'data') {
+          sawData = true;
+          const change = value[1];
+          if (!('relation' in change) || change.relation.name !== 'replicas') {
+            onlyReplicas = false;
+          }
+          continue;
+        }
+        // 'commit' or 'rollback': end of this transaction.
+        break;
+      }
+      return {buffered, done: false, onlyReplicas: onlyReplicas && sawData};
+    }
+
+    async function* gen() {
+      for (;;) {
+        const {buffered, done, onlyReplicas} = await readNext();
+        if (!onlyReplicas) {
+          yield* buffered;
+        }
+        if (done) {
+          return;
+        }
+      }
+    }
+
+    return Object.assign(gen(), {
+      cancel: (err?: Error) => changes.cancel(err),
+    });
+  }
+
   async function startStream(watermark: string, src = source) {
     let err;
     for (let i = 0; i < MAX_ATTEMPTS_IF_REPLICATION_SLOT_ACTIVE; i++) {
       try {
         assert(src, 'ChangeSource not initialized');
         const stream = await src.startStream(watermark);
+        const wrapped = {
+          ...stream,
+          changes: skipReplicasBookkeepingInsert(stream.changes),
+        };
         // cleanup in afterEach() ensures that replication slots are released
-        streams.push(stream);
-        return stream;
+        streams.push(wrapped);
+        return wrapped;
       } catch (e) {
         if (e instanceof PostgresError && e.code === PG_OBJECT_IN_USE) {
           // Sometimes Postgres still considers the replication slot active

--- a/packages/zero-cache/src/services/change-source/pg/initial-sync.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync.pg.test.ts
@@ -132,6 +132,98 @@ const ZERO_CLIENTS_SPEC: PublishedTableSpec = {
   publications: {[`_${APP_ID}_metadata_${SHARD_NUM}`]: {rowFilter: null}},
 } as const;
 
+const ZERO_REPLICAS_SPEC: PublishedTableSpec = {
+  columns: {
+    id: {
+      pos: 1,
+      characterMaximumLength: null,
+      dataType: 'text',
+      typeOID: 25,
+      notNull: true,
+      dflt: "replace((gen_random_uuid())::text, '-'::text, ''::text)",
+      elemPgTypeClass: null,
+    },
+    rank: {
+      pos: 2,
+      characterMaximumLength: null,
+      dataType: 'int8',
+      typeOID: 20,
+      notNull: true,
+      dflt: `nextval('"${APP_ID}_${SHARD_NUM}".replicas_rank_seq'::regclass)`,
+      elemPgTypeClass: null,
+    },
+    slot: {
+      pos: 3,
+      characterMaximumLength: null,
+      dataType: 'text',
+      typeOID: 25,
+      notNull: true,
+      dflt: null,
+      elemPgTypeClass: null,
+    },
+    version: {
+      pos: 4,
+      characterMaximumLength: null,
+      dataType: 'text',
+      typeOID: 25,
+      notNull: true,
+      dflt: null,
+      elemPgTypeClass: null,
+    },
+    generation: {
+      pos: 5,
+      characterMaximumLength: null,
+      dataType: 'text',
+      typeOID: 25,
+      notNull: false,
+      dflt: null,
+      elemPgTypeClass: null,
+    },
+    backupPath: {
+      pos: 6,
+      characterMaximumLength: null,
+      dataType: 'text',
+      typeOID: 25,
+      notNull: false,
+      dflt: null,
+      elemPgTypeClass: null,
+    },
+    initialSchema: {
+      pos: 7,
+      characterMaximumLength: null,
+      dataType: 'json',
+      typeOID: 114,
+      notNull: false,
+      dflt: null,
+      elemPgTypeClass: null,
+    },
+    initialSyncContext: {
+      pos: 8,
+      characterMaximumLength: null,
+      dataType: 'json',
+      typeOID: 114,
+      notNull: false,
+      dflt: null,
+      elemPgTypeClass: null,
+    },
+    subscriberContext: {
+      pos: 9,
+      characterMaximumLength: null,
+      dataType: 'json',
+      typeOID: 114,
+      notNull: false,
+      dflt: null,
+      elemPgTypeClass: null,
+    },
+  },
+  oid: expect.any(Number),
+  name: 'replicas',
+  primaryKey: ['id'],
+  schema: `${APP_ID}_${SHARD_NUM}`,
+  schemaOID: expect.any(Number),
+  publications: {[`_${APP_ID}_metadata_${SHARD_NUM}`]: {rowFilter: null}},
+} as const;
+
 const ZERO_MUTATIONS_SPEC: PublishedTableSpec = {
   columns: {
     clientGroupID: {
@@ -285,6 +377,84 @@ const REPLICATED_ZERO_MUTATIONS_SPEC: LiteTableSpec = {
   name: `${APP_ID}_${SHARD_NUM}.mutations`,
 } as const;
 
+const REPLICATED_ZERO_REPLICAS_SPEC: LiteTableSpec = {
+  columns: {
+    id: {
+      pos: 1,
+      characterMaximumLength: null,
+      dataType: 'text|NOT_NULL',
+      notNull: false,
+      dflt: null,
+      elemPgTypeClass: null,
+    },
+    rank: {
+      pos: 2,
+      characterMaximumLength: null,
+      dataType: 'int8|NOT_NULL',
+      notNull: false,
+      dflt: null,
+      elemPgTypeClass: null,
+    },
+    slot: {
+      pos: 3,
+      characterMaximumLength: null,
+      dataType: 'text|NOT_NULL',
+      notNull: false,
+      dflt: null,
+      elemPgTypeClass: null,
+    },
+    version: {
+      pos: 4,
+      characterMaximumLength: null,
+      dataType: 'text|NOT_NULL',
+      notNull: false,
+      dflt: null,
+      elemPgTypeClass: null,
+    },
+    generation: {
+      pos: 5,
+      characterMaximumLength: null,
+      dataType: 'text',
+      notNull: false,
+      dflt: null,
+      elemPgTypeClass: null,
+    },
+    backupPath: {
+      pos: 6,
+      characterMaximumLength: null,
+      dataType: 'text',
+      notNull: false,
+      dflt: null,
+      elemPgTypeClass: null,
+    },
+    initialSchema: {
+      pos: 7,
+      characterMaximumLength: null,
+      dataType: 'json',
+      notNull: false,
+      dflt: null,
+      elemPgTypeClass: null,
+    },
+    initialSyncContext: {
+      pos: 8,
+      characterMaximumLength: null,
+      dataType: 'json',
+      notNull: false,
+      dflt: null,
+      elemPgTypeClass: null,
+    },
+    subscriberContext: {
+      pos: 9,
+      characterMaximumLength: null,
+      dataType: 'json',
+      notNull: false,
+      dflt: null,
+      elemPgTypeClass: null,
+    },
+  },
+  name: `${APP_ID}_${SHARD_NUM}.replicas`,
+} as const;
+
 const WATERMARK_REGEX = /[0-9a-z]{4,}/;
 
 describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
@@ -309,11 +479,13 @@ describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
         [`${APP_ID}_${SHARD_NUM}.clients`]: ZERO_CLIENTS_SPEC,
         [`${APP_ID}_${SHARD_NUM}.mutations`]: ZERO_MUTATIONS_SPEC,
         [`${APP_ID}.permissions`]: ZERO_PERMISSIONS_SPEC,
+        [`${APP_ID}_${SHARD_NUM}.replicas`]: ZERO_REPLICAS_SPEC,
       },
       replicatedSchema: {
         [`${APP_ID}_${SHARD_NUM}.clients`]: REPLICATED_ZERO_CLIENTS_SPEC,
         [`${APP_ID}_${SHARD_NUM}.mutations`]: REPLICATED_ZERO_MUTATIONS_SPEC,
         [`${APP_ID}.permissions`]: REPLICATED_ZERO_PERMISSIONS_SPEC,
+        [`${APP_ID}_${SHARD_NUM}.replicas`]: REPLICATED_ZERO_REPLICAS_SPEC,
       },
       replicatedIndexes: [
         {
@@ -342,6 +514,13 @@ describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
           name: 'mutations_pkey',
           schema: `${APP_ID}_${SHARD_NUM}`,
           tableName: 'mutations',
+          unique: true,
+        },
+        {
+          columns: {id: 'ASC'},
+          name: 'replicas_pkey',
+          schema: `${APP_ID}_${SHARD_NUM}`,
+          tableName: 'replicas',
           unique: true,
         },
       ],
@@ -455,6 +634,87 @@ describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
             table_name: '1_18.mutations',
             upstream_type: 'json',
           },
+          {
+            character_max_length: null,
+            column_name: 'backupPath',
+            is_array: 0n,
+            is_enum: 0n,
+            is_not_null: 0n,
+            table_name: '1_18.replicas',
+            upstream_type: 'text',
+          },
+          {
+            character_max_length: null,
+            column_name: 'generation',
+            is_array: 0n,
+            is_enum: 0n,
+            is_not_null: 0n,
+            table_name: '1_18.replicas',
+            upstream_type: 'text',
+          },
+          {
+            character_max_length: null,
+            column_name: 'id',
+            is_array: 0n,
+            is_enum: 0n,
+            is_not_null: 1n,
+            table_name: '1_18.replicas',
+            upstream_type: 'text',
+          },
+          {
+            character_max_length: null,
+            column_name: 'initialSchema',
+            is_array: 0n,
+            is_enum: 0n,
+            is_not_null: 0n,
+            table_name: '1_18.replicas',
+            upstream_type: 'json',
+          },
+          {
+            character_max_length: null,
+            column_name: 'initialSyncContext',
+            is_array: 0n,
+            is_enum: 0n,
+            is_not_null: 0n,
+            table_name: '1_18.replicas',
+            upstream_type: 'json',
+          },
+          {
+            character_max_length: null,
+            column_name: 'rank',
+            is_array: 0n,
+            is_enum: 0n,
+            is_not_null: 1n,
+            table_name: '1_18.replicas',
+            upstream_type: 'int8',
+          },
+          {
+            character_max_length: null,
+            column_name: 'slot',
+            is_array: 0n,
+            is_enum: 0n,
+            is_not_null: 1n,
+            table_name: '1_18.replicas',
+            upstream_type: 'text',
+          },
+          {
+            character_max_length: null,
+            column_name: 'subscriberContext',
+            is_array: 0n,
+            is_enum: 0n,
+            is_not_null: 0n,
+            table_name: '1_18.replicas',
+            upstream_type: 'json',
+          },
+          {
+            character_max_length: null,
+            column_name: 'version',
+            is_array: 0n,
+            is_enum: 0n,
+            is_not_null: 1n,
+            table_name: '1_18.replicas',
+            upstream_type: 'text',
+          },
         ],
       },
       resultingPublications: [
@@ -500,6 +760,7 @@ describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
         [`${APP_ID}_${SHARD_NUM}.clients`]: ZERO_CLIENTS_SPEC,
         [`${APP_ID}_${SHARD_NUM}.mutations`]: ZERO_MUTATIONS_SPEC,
         [`${APP_ID}.permissions`]: ZERO_PERMISSIONS_SPEC,
+        [`${APP_ID}_${SHARD_NUM}.replicas`]: ZERO_REPLICAS_SPEC,
         ['public.issues']: {
           columns: {
             'issueID': {
@@ -695,6 +956,7 @@ describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
       },
       replicatedSchema: {
         [`${APP_ID}_${SHARD_NUM}.clients`]: REPLICATED_ZERO_CLIENTS_SPEC,
+        [`${APP_ID}_${SHARD_NUM}.replicas`]: REPLICATED_ZERO_REPLICAS_SPEC,
         ['issues']: {
           columns: {
             'issueID': {
@@ -887,6 +1149,13 @@ describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
           name: 'mutations_pkey',
           schema: `${APP_ID}_${SHARD_NUM}`,
           tableName: 'mutations',
+          unique: true,
+        },
+        {
+          columns: {id: 'ASC'},
+          name: 'replicas_pkey',
+          schema: `${APP_ID}_${SHARD_NUM}`,
+          tableName: 'replicas',
           unique: true,
         },
         {
@@ -1116,6 +1385,87 @@ describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
           },
           {
             character_max_length: null,
+            column_name: 'backupPath',
+            is_array: 0n,
+            is_enum: 0n,
+            is_not_null: 0n,
+            table_name: '1_18.replicas',
+            upstream_type: 'text',
+          },
+          {
+            character_max_length: null,
+            column_name: 'generation',
+            is_array: 0n,
+            is_enum: 0n,
+            is_not_null: 0n,
+            table_name: '1_18.replicas',
+            upstream_type: 'text',
+          },
+          {
+            character_max_length: null,
+            column_name: 'id',
+            is_array: 0n,
+            is_enum: 0n,
+            is_not_null: 1n,
+            table_name: '1_18.replicas',
+            upstream_type: 'text',
+          },
+          {
+            character_max_length: null,
+            column_name: 'initialSchema',
+            is_array: 0n,
+            is_enum: 0n,
+            is_not_null: 0n,
+            table_name: '1_18.replicas',
+            upstream_type: 'json',
+          },
+          {
+            character_max_length: null,
+            column_name: 'initialSyncContext',
+            is_array: 0n,
+            is_enum: 0n,
+            is_not_null: 0n,
+            table_name: '1_18.replicas',
+            upstream_type: 'json',
+          },
+          {
+            character_max_length: null,
+            column_name: 'rank',
+            is_array: 0n,
+            is_enum: 0n,
+            is_not_null: 1n,
+            table_name: '1_18.replicas',
+            upstream_type: 'int8',
+          },
+          {
+            character_max_length: null,
+            column_name: 'slot',
+            is_array: 0n,
+            is_enum: 0n,
+            is_not_null: 1n,
+            table_name: '1_18.replicas',
+            upstream_type: 'text',
+          },
+          {
+            character_max_length: null,
+            column_name: 'subscriberContext',
+            is_array: 0n,
+            is_enum: 0n,
+            is_not_null: 0n,
+            table_name: '1_18.replicas',
+            upstream_type: 'json',
+          },
+          {
+            character_max_length: null,
+            column_name: 'version',
+            is_array: 0n,
+            is_enum: 0n,
+            is_not_null: 1n,
+            table_name: '1_18.replicas',
+            upstream_type: 'text',
+          },
+          {
+            character_max_length: null,
             column_name: 'bigint',
             is_array: 0n,
             is_enum: 0n,
@@ -1307,6 +1657,7 @@ describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
         [`${APP_ID}_${SHARD_NUM}.clients`]: ZERO_CLIENTS_SPEC,
         [`${APP_ID}_${SHARD_NUM}.mutations`]: ZERO_MUTATIONS_SPEC,
         [`${APP_ID}.permissions`]: ZERO_PERMISSIONS_SPEC,
+        [`${APP_ID}_${SHARD_NUM}.replicas`]: ZERO_REPLICAS_SPEC,
         ['public.foo']: {
           columns: {
             id: {
@@ -1365,6 +1716,7 @@ describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
       },
       replicatedSchema: {
         [`${APP_ID}_${SHARD_NUM}.clients`]: REPLICATED_ZERO_CLIENTS_SPEC,
+        [`${APP_ID}_${SHARD_NUM}.replicas`]: REPLICATED_ZERO_REPLICAS_SPEC,
         ['foo']: {
           columns: {
             id: {
@@ -1449,6 +1801,13 @@ describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
         },
         {
           columns: {id: 'ASC'},
+          name: 'replicas_pkey',
+          schema: `${APP_ID}_${SHARD_NUM}`,
+          tableName: 'replicas',
+          unique: true,
+        },
+        {
+          columns: {id: 'ASC'},
           name: 'foo_pkey',
           schema: 'public',
           tableName: 'foo',
@@ -1497,6 +1856,7 @@ describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
         [`${APP_ID}_${SHARD_NUM}.clients`]: ZERO_CLIENTS_SPEC,
         [`${APP_ID}_${SHARD_NUM}.mutations`]: ZERO_MUTATIONS_SPEC,
         [`${APP_ID}.permissions`]: ZERO_PERMISSIONS_SPEC,
+        [`${APP_ID}_${SHARD_NUM}.replicas`]: ZERO_REPLICAS_SPEC,
         ['public.users']: {
           columns: {
             userID: {
@@ -1531,6 +1891,7 @@ describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
         [`${APP_ID}_${SHARD_NUM}.clients`]: REPLICATED_ZERO_CLIENTS_SPEC,
         [`${APP_ID}_${SHARD_NUM}.mutations`]: REPLICATED_ZERO_MUTATIONS_SPEC,
         [`${APP_ID}.permissions`]: REPLICATED_ZERO_PERMISSIONS_SPEC,
+        [`${APP_ID}_${SHARD_NUM}.replicas`]: REPLICATED_ZERO_REPLICAS_SPEC,
         ['users']: {
           columns: {
             userID: {
@@ -1588,6 +1949,13 @@ describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
           name: 'mutations_pkey',
           schema: `${APP_ID}_${SHARD_NUM}`,
           tableName: 'mutations',
+          unique: true,
+        },
+        {
+          columns: {id: 'ASC'},
+          name: 'replicas_pkey',
+          schema: `${APP_ID}_${SHARD_NUM}`,
+          tableName: 'replicas',
           unique: true,
         },
         {
@@ -1637,6 +2005,7 @@ describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
         [`${APP_ID}_${SHARD_NUM}.clients`]: ZERO_CLIENTS_SPEC,
         [`${APP_ID}_${SHARD_NUM}.mutations`]: ZERO_MUTATIONS_SPEC,
         [`${APP_ID}.permissions`]: ZERO_PERMISSIONS_SPEC,
+        [`${APP_ID}_${SHARD_NUM}.replicas`]: ZERO_REPLICAS_SPEC,
         ['public.users']: {
           columns: {
             userID: {
@@ -1674,6 +2043,7 @@ describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
         [`${APP_ID}_${SHARD_NUM}.clients`]: REPLICATED_ZERO_CLIENTS_SPEC,
         [`${APP_ID}_${SHARD_NUM}.mutations`]: REPLICATED_ZERO_MUTATIONS_SPEC,
         [`${APP_ID}.permissions`]: REPLICATED_ZERO_PERMISSIONS_SPEC,
+        [`${APP_ID}_${SHARD_NUM}.replicas`]: REPLICATED_ZERO_REPLICAS_SPEC,
         ['users']: {
           columns: {
             userID: {
@@ -1731,6 +2101,13 @@ describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
           name: 'mutations_pkey',
           schema: `${APP_ID}_${SHARD_NUM}`,
           tableName: 'mutations',
+          unique: true,
+        },
+        {
+          columns: {id: 'ASC'},
+          name: 'replicas_pkey',
+          schema: `${APP_ID}_${SHARD_NUM}`,
+          tableName: 'replicas',
           unique: true,
         },
         {
@@ -1786,6 +2163,7 @@ describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
         [`${APP_ID}_${SHARD_NUM}.clients`]: ZERO_CLIENTS_SPEC,
         [`${APP_ID}_${SHARD_NUM}.mutations`]: ZERO_MUTATIONS_SPEC,
         [`${APP_ID}.permissions`]: ZERO_PERMISSIONS_SPEC,
+        [`${APP_ID}_${SHARD_NUM}.replicas`]: ZERO_REPLICAS_SPEC,
         ['public.users']: {
           columns: {
             userID: {
@@ -1828,6 +2206,7 @@ describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
         [`${APP_ID}_${SHARD_NUM}.clients`]: REPLICATED_ZERO_CLIENTS_SPEC,
         [`${APP_ID}_${SHARD_NUM}.mutations`]: REPLICATED_ZERO_MUTATIONS_SPEC,
         [`${APP_ID}.permissions`]: REPLICATED_ZERO_PERMISSIONS_SPEC,
+        [`${APP_ID}_${SHARD_NUM}.replicas`]: REPLICATED_ZERO_REPLICAS_SPEC,
         ['users']: {
           columns: {
             userID: {
@@ -1892,6 +2271,13 @@ describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
           name: 'mutations_pkey',
           schema: `${APP_ID}_${SHARD_NUM}`,
           tableName: 'mutations',
+          unique: true,
+        },
+        {
+          columns: {id: 'ASC'},
+          name: 'replicas_pkey',
+          schema: `${APP_ID}_${SHARD_NUM}`,
+          tableName: 'replicas',
           unique: true,
         },
         {
@@ -1956,6 +2342,7 @@ describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
         [`${APP_ID}_${SHARD_NUM}.clients`]: ZERO_CLIENTS_SPEC,
         [`${APP_ID}_${SHARD_NUM}.mutations`]: ZERO_MUTATIONS_SPEC,
         [`${APP_ID}.permissions`]: ZERO_PERMISSIONS_SPEC,
+        [`${APP_ID}_${SHARD_NUM}.replicas`]: ZERO_REPLICAS_SPEC,
         ['public.issues']: {
           columns: {
             issueID: {
@@ -2005,6 +2392,7 @@ describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
       },
       replicatedSchema: {
         [`${APP_ID}_${SHARD_NUM}.clients`]: REPLICATED_ZERO_CLIENTS_SPEC,
+        [`${APP_ID}_${SHARD_NUM}.replicas`]: REPLICATED_ZERO_REPLICAS_SPEC,
         ['issues']: {
           columns: {
             issueID: {
@@ -2085,6 +2473,13 @@ describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
           unique: true,
         },
         {
+          columns: {id: 'ASC'},
+          name: 'replicas_pkey',
+          schema: `${APP_ID}_${SHARD_NUM}`,
+          tableName: 'replicas',
+          unique: true,
+        },
+        {
           columns: {
             orgID: 'DESC',
             other: 'ASC',
@@ -2121,6 +2516,7 @@ describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
         [`${APP_ID}_${SHARD_NUM}.clients`]: ZERO_CLIENTS_SPEC,
         [`${APP_ID}_${SHARD_NUM}.mutations`]: ZERO_MUTATIONS_SPEC,
         [`${APP_ID}.permissions`]: ZERO_PERMISSIONS_SPEC,
+        [`${APP_ID}_${SHARD_NUM}.replicas`]: ZERO_REPLICAS_SPEC,
         ['public.giant']: {
           columns: {
             id: {
@@ -2145,6 +2541,7 @@ describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
         [`${APP_ID}_${SHARD_NUM}.clients`]: REPLICATED_ZERO_CLIENTS_SPEC,
         [`${APP_ID}_${SHARD_NUM}.mutations`]: REPLICATED_ZERO_MUTATIONS_SPEC,
         [`${APP_ID}.permissions`]: REPLICATED_ZERO_PERMISSIONS_SPEC,
+        [`${APP_ID}_${SHARD_NUM}.replicas`]: REPLICATED_ZERO_REPLICAS_SPEC,
         ['giant']: {
           columns: {
             id: {
@@ -2197,6 +2594,13 @@ describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
         },
         {
           columns: {id: 'ASC'},
+          name: 'replicas_pkey',
+          schema: `${APP_ID}_${SHARD_NUM}`,
+          tableName: 'replicas',
+          unique: true,
+        },
+        {
+          columns: {id: 'ASC'},
           name: 'giant_pkey',
           schema: 'public',
           tableName: 'giant',
@@ -2232,6 +2636,7 @@ describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
         [`${APP_ID}_${SHARD_NUM}.clients`]: ZERO_CLIENTS_SPEC,
         [`${APP_ID}_${SHARD_NUM}.mutations`]: ZERO_MUTATIONS_SPEC,
         [`${APP_ID}.permissions`]: ZERO_PERMISSIONS_SPEC,
+        [`${APP_ID}_${SHARD_NUM}.replicas`]: ZERO_REPLICAS_SPEC,
         ['public.funk']: {
           columns: {
             id: {
@@ -2287,6 +2692,7 @@ describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
       },
       replicatedSchema: {
         [`${APP_ID}_${SHARD_NUM}.clients`]: REPLICATED_ZERO_CLIENTS_SPEC,
+        [`${APP_ID}_${SHARD_NUM}.replicas`]: REPLICATED_ZERO_REPLICAS_SPEC,
         ['funk']: {
           columns: {
             id: {
@@ -2370,6 +2776,13 @@ describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
           unique: true,
         },
         {
+          columns: {id: 'ASC'},
+          name: 'replicas_pkey',
+          schema: `${APP_ID}_${SHARD_NUM}`,
+          tableName: 'replicas',
+          unique: true,
+        },
+        {
           columns: {name: 'ASC'},
           name: 'funk_name_unique',
           schema: 'public',
@@ -2445,6 +2858,7 @@ describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
         [`${APP_ID}_${SHARD_NUM}.clients`]: ZERO_CLIENTS_SPEC,
         [`${APP_ID}_${SHARD_NUM}.mutations`]: ZERO_MUTATIONS_SPEC,
         [`${APP_ID}.permissions`]: ZERO_PERMISSIONS_SPEC,
+        [`${APP_ID}_${SHARD_NUM}.replicas`]: ZERO_REPLICAS_SPEC,
         ...Object.fromEntries(
           Array.from({length: 10}, (_, i) => [
             `public.t${i}`,
@@ -2488,6 +2902,7 @@ describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
       },
       replicatedSchema: {
         [`${APP_ID}_${SHARD_NUM}.clients`]: REPLICATED_ZERO_CLIENTS_SPEC,
+        [`${APP_ID}_${SHARD_NUM}.replicas`]: REPLICATED_ZERO_REPLICAS_SPEC,
         ...Object.fromEntries(
           Array.from({length: 10}, (_, i) => [
             `t${i}`,
@@ -2553,6 +2968,13 @@ describe('change-source/pg/initial-sync', {timeout: 10000}, () => {
           name: 'mutations_pkey',
           schema: `${APP_ID}_${SHARD_NUM}`,
           tableName: 'mutations',
+          unique: true,
+        },
+        {
+          columns: {id: 'ASC'},
+          name: 'replicas_pkey',
+          schema: `${APP_ID}_${SHARD_NUM}`,
+          tableName: 'replicas',
           unique: true,
         },
         ...Array.from(

--- a/packages/zero-cache/src/services/change-source/pg/schema-change-differential.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema-change-differential.pg.test.ts
@@ -8,6 +8,7 @@ import {canonicalReplicaState} from '../../../test/replica-state.ts';
 import type {PostgresDB} from '../../../types/pg.ts';
 import type {Source} from '../../../types/streams.ts';
 import {createChangeProcessor} from '../../replicator/test-utils.ts';
+import {isSchemaChange} from '../protocol/current/data.ts';
 import type {ChangeStreamMessage} from '../protocol/current/downstream.ts';
 import {initializePostgresChangeSource} from './change-source.ts';
 import {initialSync} from './initial-sync.ts';
@@ -93,16 +94,16 @@ async function applyNextTransaction(
   processor: ReturnType<typeof createChangeProcessor>,
   changes: Source<ChangeStreamMessage>,
 ) {
-  let sawData = false;
+  let sawSchemaChange = false;
   for await (const change of changes) {
     const [type] = change;
     if (type === 'control' || type === 'status') {
       continue;
     }
     processor.processMessage(lc, change);
-    if (type === 'data') {
-      sawData = true;
-    } else if (type === 'commit' && sawData) {
+    if (type === 'data' && isSchemaChange(change[1])) {
+      sawSchemaChange = true;
+    } else if (type === 'commit' && sawSchemaChange) {
       return;
     }
   }

--- a/packages/zero-cache/src/services/change-source/pg/schema/init.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/init.ts
@@ -229,6 +229,24 @@ function getIncrementalMigrations(shard: ShardConfig): IncrementalMigrationMap {
         `;
       },
     },
+
+    // v25 (1.10.0):
+    // - adds the "replicas" table to the metadata publication to guarantee
+    //   that the change-log and backups advance past the consistent point of
+    //   new replication slots.
+    25: {
+      migrateSchema: async (_, sql) => {
+        const {appID, shardNum} = shard;
+        const metadataPublication = metadataPublicationName(appID, shardNum);
+        await sql`
+          ALTER PUBLICATION ${sql(metadataPublication)}
+            ADD TABLE ${sql(upstreamSchema(shard))}.replicas;`;
+
+        // Workaround Supabase's lack of ALTER PUBLICATION event triggers
+        await sql`
+          SELECT ${sql(upstreamSchema(shard))}.update_schemas();`;
+      },
+    },
   };
 }
 

--- a/packages/zero-cache/src/services/change-source/pg/schema/shard.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/shard.pg.test.ts
@@ -72,6 +72,7 @@ describe('change-source/pg', () => {
       [`_zro_metadata_0`, 'zro', 'permissions', null],
       [`_zro_metadata_0`, `zro_0`, 'clients', null],
       [`_zro_metadata_0`, `zro_0`, 'mutations', null],
+      [`_zro_metadata_0`, `zro_0`, 'replicas', null],
       ['_zro_public_0', null, null, null],
     ]);
 
@@ -123,6 +124,7 @@ describe('change-source/pg', () => {
       [`_zro_metadata_0`, 'zro', 'permissions', null],
       [`_zro_metadata_0`, `zro_0`, 'clients', null],
       [`_zro_metadata_0`, `zro_0`, 'mutations', null],
+      [`_zro_metadata_0`, `zro_0`, 'replicas', null],
       ['_zro_public_0', 'public', 'join_table', null],
     ]);
 
@@ -161,6 +163,7 @@ describe('change-source/pg', () => {
       [`_1_metadata_0`, '1', 'permissions', null],
       [`_1_metadata_0`, `1_0`, 'clients', null],
       [`_1_metadata_0`, `1_0`, 'mutations', null],
+      [`_1_metadata_0`, `1_0`, 'replicas', null],
       [`_1_public_0`, null, null, null],
     ]);
 
@@ -198,9 +201,11 @@ describe('change-source/pg', () => {
       [`_zro_metadata_0`, 'zro', 'permissions', null],
       [`_zro_metadata_0`, `zro_0`, 'clients', null],
       [`_zro_metadata_0`, `zro_0`, 'mutations', null],
+      [`_zro_metadata_0`, `zro_0`, 'replicas', null],
       [`_zro_metadata_1`, 'zro', 'permissions', null],
       [`_zro_metadata_1`, `zro_1`, 'clients', null],
       [`_zro_metadata_1`, `zro_1`, 'mutations', null],
+      [`_zro_metadata_1`, `zro_1`, 'replicas', null],
       ['_zro_public_0', null, null, null],
       ['_zro_public_1', null, null, null],
     ]);
@@ -288,6 +293,7 @@ describe('change-source/pg', () => {
       [`_zro_metadata_2`, 'zro', 'permissions', null],
       [`_zro_metadata_2`, `zro_2`, 'clients', null],
       [`_zro_metadata_2`, `zro_2`, 'mutations', null],
+      [`_zro_metadata_2`, `zro_2`, 'replicas', null],
       ['zero_bar', 'far', 'bar', null],
       ['zero_foo', 'public', 'foo', '(id > 1000)'],
     ]);
@@ -327,6 +333,7 @@ describe('change-source/pg', () => {
       [`_supaneon_metadata_0`, 'supaneon', 'permissions', null],
       [`_supaneon_metadata_0`, `supaneon_0`, 'clients', null],
       ['_supaneon_metadata_0', 'supaneon_0', 'mutations', null],
+      ['_supaneon_metadata_0', 'supaneon_0', 'replicas', null],
       ['zero_foo', 'public', 'foo', null],
     ]);
 

--- a/packages/zero-cache/src/services/change-source/pg/schema/shard.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/shard.ts
@@ -168,15 +168,17 @@ export function shardSetup(
     () => `Publications must include ${metadataPublication}`,
   );
 
+  // Note: the "replicas" table is included in the metadata publication
+  // to guarantee that the change-log and replica backups eventually
+  // advance past the consistent_point_lsn of new replication slots
+  // (when a new replica is added). It is not actually read from the
+  // replica itself, but the amount of data is small so including the
+  // table is a simple and reliable way to achieve this.
   return /*sql*/ `
   CREATE SCHEMA IF NOT EXISTS ${shard};
 
   ${getClientsTableDefinition(shard)}
   ${getMutationsTableDefinition(shard)}
-
-  DROP PUBLICATION IF EXISTS ${id(metadataPublication)};
-  CREATE PUBLICATION ${id(metadataPublication)}
-    FOR TABLE ${app}."permissions", TABLE ${shard}."clients", ${shard}."mutations";
 
   CREATE TABLE ${shard}."${SHARD_CONFIG_TABLE}" (
     "publications"  TEXT[] NOT NULL,
@@ -207,6 +209,11 @@ export function shardSetup(
     "initialSyncContext" JSON,
     "subscriberContext"  JSON
   );
+
+  DROP PUBLICATION IF EXISTS ${id(metadataPublication)};
+  CREATE PUBLICATION ${id(metadataPublication)}
+    FOR TABLE ${app}."permissions", 
+        TABLE ${shard}."clients", ${shard}."mutations", ${shard}."replicas";
   `;
 }
 


### PR DESCRIPTION
Include the "replicas" table (which contains metadata about a replica and its replication slot) in the zero metadata publication to guarantee that the LSN, change-log, and litestream backup all advance when a new replica is created. This will facilitate the per-RM replication slot initialization logic of RMv2.