### PR TITLE
chore(rmv2): extract backfill operations from the storer

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/storer.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.ts
@@ -3,7 +3,7 @@ import type {LogContext} from '@rocicorp/logger';
 import {resolver, type Resolver} from '@rocicorp/resolver';
 import {type PendingQuery, type Row} from 'postgres';
 import {AbortError} from '../../../../shared/src/abort-error.ts';
-import {assert} from '../../../../shared/src/asserts.ts';
+import {assert, unreachable} from '../../../../shared/src/asserts.ts';
 import {Queue} from '../../../../shared/src/queue.ts';
 import {promiseVoid} from '../../../../shared/src/resolved-promises.ts';
 import * as v from '../../../../shared/src/valita.ts';
@@ -29,6 +29,7 @@ import {
   type Commit,
 } from '../change-source/protocol/current/downstream.ts';
 import type {UpstreamStatusMessage} from '../change-source/protocol/current/status.ts';
+import {cookieOps, type CookieOp} from '../replicator/change-log-cookies.ts';
 import type {ReplicatorMode} from '../replicator/replicator.ts';
 import type {Service} from '../service.ts';
 import {
@@ -781,110 +782,76 @@ export class Storer implements Service {
   /**
    * Returns the db statements necessary to track backfill and table metadata
    * presented in the `change`, if any.
+   *
+   * This is the Postgres interpreter of {@link cookieOps}, which is also
+   * interpreted against the SQLite change log by `ChangeLogCookieWriter`. The
+   * two stores have to agree on every transition forever, and the failure mode
+   * if they drift is a backfill that is silently never re-requested — so the
+   * decision of what a schema change *means* lives in one place and only its
+   * transport lives here.
    */
   #trackBackfillMetadata(sql: PostgresTransaction, change: SchemaChange) {
-    const stmts: PendingQuery<Row[]>[] = [];
+    return cookieOps(change).flatMap(op => this.#cookieStmts(sql, op));
+  }
 
-    switch (change.tag) {
-      case 'update-table-metadata': {
-        const {table, new: metadata} = change;
-        stmts.push(this.#upsertTableMetadataStmt(sql, table, metadata));
-        break;
-      }
+  #cookieStmts(sql: PostgresTransaction, op: CookieOp): PendingQuery<Row[]>[] {
+    switch (op.op) {
+      case 'upsert-metadata':
+        return [this.#upsertTableMetadataStmt(sql, op.table, op.metadata)];
 
-      case 'create-table': {
-        const {spec, metadata, backfill} = change;
-        if (metadata) {
-          stmts.push(this.#upsertTableMetadataStmt(sql, spec, metadata));
-        }
-        if (backfill) {
-          Object.entries(backfill).forEach(([col, backfill]) => {
-            stmts.push(
-              this.#upsertColumnBackfillStmt(sql, spec, col, backfill),
-            );
-          });
-        }
-        break;
-      }
+      case 'upsert-backfill':
+        return [
+          this.#upsertColumnBackfillStmt(sql, op.table, op.column, op.backfill),
+        ];
 
       case 'rename-table': {
-        const {old} = change;
-        const row = {schema: change.new.schema, table: change.new.name};
-        stmts.push(
+        const {old} = op;
+        const row = {schema: op.new.schema, table: op.new.name};
+        return [
           sql`UPDATE ${this.#cdc('tableMetadata')} SET ${sql(row)}
                 WHERE "schema" = ${old.schema} AND "table" = ${old.name}`,
           sql`UPDATE ${this.#cdc('backfilling')} SET ${sql(row)}
                 WHERE "schema" = ${old.schema} AND "table" = ${old.name}`,
-        );
-        break;
+        ];
       }
 
       case 'drop-table': {
-        const {
-          id: {schema, name},
-        } = change;
-        stmts.push(
+        const {schema, name} = op.table;
+        return [
           sql`DELETE FROM ${this.#cdc('tableMetadata')}
                 WHERE "schema" = ${schema} AND "table" = ${name}`,
           sql`DELETE FROM ${this.#cdc('backfilling')}
                 WHERE "schema" = ${schema} AND "table" = ${name}`,
-        );
-        break;
+        ];
       }
 
-      case 'add-column': {
-        const {table, tableMetadata, column, backfill} = change;
-        if (tableMetadata) {
-          stmts.push(this.#upsertTableMetadataStmt(sql, table, tableMetadata));
-        }
-        if (backfill) {
-          stmts.push(
-            this.#upsertColumnBackfillStmt(sql, table, column.name, backfill),
-          );
-        }
-        break;
-      }
-
-      case 'update-column': {
-        const {
-          table: {schema, name: table},
-          old: {name: oldName},
-          new: {name: newName},
-        } = change;
-        if (oldName !== newName) {
-          stmts.push(
-            sql`UPDATE ${this.#cdc('backfilling')} SET "column" = ${newName}
-                WHERE "schema" = ${schema} AND "table" = ${table} AND "column" = ${oldName}`,
-          );
-        }
-        break;
+      case 'rename-column': {
+        const {schema, name: table} = op.table;
+        return [
+          sql`UPDATE ${this.#cdc('backfilling')} SET "column" = ${op.new}
+                WHERE "schema" = ${schema} AND "table" = ${table} AND "column" = ${op.old}`,
+        ];
       }
 
       case 'drop-column': {
-        const {
-          table: {schema, name},
-          column,
-        } = change;
-        stmts.push(
+        const {schema, name} = op.table;
+        return [
           sql`DELETE FROM ${this.#cdc('backfilling')}
-                WHERE "schema" = ${schema} AND "table" = ${name} AND "column" = ${column}`,
-        );
-        break;
+                WHERE "schema" = ${schema} AND "table" = ${name} AND "column" = ${op.column}`,
+        ];
       }
 
-      case 'backfill-completed': {
-        const {
-          relation: {schema, name: table, rowKey},
-          columns,
-        } = change;
-        const cols = [...rowKey.columns, ...columns];
-        stmts.push(
+      case 'complete-backfill': {
+        const {schema, name: table} = op.table;
+        return [
           sql`DELETE FROM ${this.#cdc('backfilling')}
-                WHERE "schema" = ${schema} AND "table" = ${table} AND "column" IN ${sql(cols)}`,
-        );
+                WHERE "schema" = ${schema} AND "table" = ${table} AND "column" IN ${sql([...op.columns])}`,
+        ];
       }
+
+      default:
+        unreachable(op);
     }
-    return stmts;
   }
 
   #upsertTableMetadataStmt(
@@ -895,7 +862,7 @@ export class Storer implements Service {
     const row: TableMetadataRow = {schema, table, metadata};
     return sql`
         INSERT INTO ${this.#cdc('tableMetadata')} ${sql(row)}
-          ON CONFLICT ("schema", "table") 
+          ON CONFLICT ("schema", "table")
           DO UPDATE SET ${sql(row)};
     `;
   }
@@ -909,7 +876,7 @@ export class Storer implements Service {
     const row: BackfillingColumn = {schema, table, column, backfill};
     return sql`
         INSERT INTO ${this.#cdc('backfilling')} ${sql(row)}
-          ON CONFLICT ("schema", "table", "column") 
+          ON CONFLICT ("schema", "table", "column")
           DO UPDATE SET ${sql(row)};
     `;
   }

--- a/packages/zero-cache/src/services/replicator/change-log-cookies.test.ts
+++ b/packages/zero-cache/src/services/replicator/change-log-cookies.test.ts
@@ -1,0 +1,492 @@
+import {describe, expect, test} from 'vitest';
+import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
+import {Database} from '../../../../zqlite/src/db.ts';
+import type {SchemaChange} from '../change-source/protocol/current/data.ts';
+import {
+  ChangeLogCookieWriter,
+  CREATE_CHANGE_LOG_COOKIE_SCHEMA,
+  cookieOps,
+  EMPTY_COOKIE_SET,
+  readCookieRowCounts,
+  readCookies,
+  replaceCookies,
+  type CookieOp,
+  type CookieSet,
+} from './change-log-cookies.ts';
+
+const lc = createSilentLogContext();
+
+function createCookieJar(): Database {
+  const db = new Database(lc, ':memory:');
+  db.exec(CREATE_CHANGE_LOG_COOKIE_SCHEMA);
+  return db;
+}
+
+/** Folds a change sequence through the SQLite interpreter. */
+function fold(db: Database, ...changes: SchemaChange[]): CookieSet {
+  const writer = new ChangeLogCookieWriter(db);
+  changes.forEach(change => writer.apply(change));
+  return readCookies(db);
+}
+
+const ROW_KEY: {columns: string[]; type: 'default'} = {
+  columns: ['id'],
+  type: 'default',
+};
+
+const CREATE_FOO: SchemaChange = {
+  tag: 'create-table',
+  spec: {schema: 'my', name: 'foo', columns: {}},
+  metadata: {rowKey: {type: 'index', columns: ['a', 'b']}},
+  backfill: {
+    a: {fooID: 987, barID: 'zoo'},
+    b: {fooID: 843, barID: 'ozz'},
+  },
+};
+
+describe('replicator/change-log-cookies', () => {
+  describe('cookieOps', () => {
+    // The fold is what keeps the Postgres and SQLite change logs from drifting,
+    // so each transition's ops are pinned rather than round-tripped.
+    const cases: [name: string, change: SchemaChange, ops: CookieOp[]][] = [
+      [
+        'create-table with metadata and backfills',
+        CREATE_FOO,
+        [
+          {
+            op: 'upsert-metadata',
+            table: {schema: 'my', name: 'foo'},
+            metadata: {rowKey: {type: 'index', columns: ['a', 'b']}},
+          },
+          {
+            op: 'upsert-backfill',
+            table: {schema: 'my', name: 'foo'},
+            column: 'a',
+            backfill: {fooID: 987, barID: 'zoo'},
+          },
+          {
+            op: 'upsert-backfill',
+            table: {schema: 'my', name: 'foo'},
+            column: 'b',
+            backfill: {fooID: 843, barID: 'ozz'},
+          },
+        ],
+      ],
+      [
+        // Both fields are optional in the protocol, and a change source that
+        // does not support backfill sends neither.
+        'create-table without metadata or backfills',
+        {
+          tag: 'create-table',
+          spec: {schema: 'my', name: 'foo', columns: {}},
+        },
+        [],
+      ],
+      [
+        'update-table-metadata',
+        {
+          tag: 'update-table-metadata',
+          table: {schema: 'my', name: 'foo'},
+          old: {rowKey: {type: 'index', columns: ['a']}},
+          new: {rowKey: {type: 'default', columns: ['b']}},
+        },
+        [
+          {
+            op: 'upsert-metadata',
+            table: {schema: 'my', name: 'foo'},
+            metadata: {rowKey: {type: 'default', columns: ['b']}},
+          },
+        ],
+      ],
+      [
+        'add-column with table metadata and a backfill',
+        {
+          tag: 'add-column',
+          table: {schema: 'my', name: 'foo'},
+          tableMetadata: {rowKey: {type: 'default', columns: ['b']}},
+          column: {name: 'c', spec: {pos: 3, dataType: 'text'}},
+          backfill: {fooID: 123, barID: 'baz'},
+        },
+        [
+          {
+            op: 'upsert-metadata',
+            table: {schema: 'my', name: 'foo'},
+            metadata: {rowKey: {type: 'default', columns: ['b']}},
+          },
+          {
+            op: 'upsert-backfill',
+            table: {schema: 'my', name: 'foo'},
+            column: 'c',
+            backfill: {fooID: 123, barID: 'baz'},
+          },
+        ],
+      ],
+      [
+        'add-column with neither',
+        {
+          tag: 'add-column',
+          table: {schema: 'my', name: 'foo'},
+          column: {name: 'c', spec: {pos: 3, dataType: 'text'}},
+        },
+        [],
+      ],
+      [
+        'rename-table',
+        {
+          tag: 'rename-table',
+          old: {schema: 'my', name: 'foo'},
+          new: {schema: 'your', name: 'bar'},
+        },
+        [
+          {
+            op: 'rename-table',
+            old: {schema: 'my', name: 'foo'},
+            new: {schema: 'your', name: 'bar'},
+          },
+        ],
+      ],
+      [
+        'drop-table',
+        {tag: 'drop-table', id: {schema: 'my', name: 'foo'}},
+        [{op: 'drop-table', table: {schema: 'my', name: 'foo'}}],
+      ],
+      [
+        'update-column that renames',
+        {
+          tag: 'update-column',
+          table: {schema: 'my', name: 'foo'},
+          old: {name: 'a', spec: {pos: 1, dataType: 'text'}},
+          new: {name: 'z', spec: {pos: 1, dataType: 'text'}},
+        },
+        [
+          {
+            op: 'rename-column',
+            table: {schema: 'my', name: 'foo'},
+            old: 'a',
+            new: 'z',
+          },
+        ],
+      ],
+      [
+        // A type change moves nothing: whether a column is backfilling is not a
+        // property of its spec.
+        'update-column that does not rename',
+        {
+          tag: 'update-column',
+          table: {schema: 'my', name: 'foo'},
+          old: {name: 'a', spec: {pos: 1, dataType: 'text'}},
+          new: {name: 'a', spec: {pos: 1, dataType: 'int4'}},
+        },
+        [],
+      ],
+      [
+        'drop-column',
+        {tag: 'drop-column', table: {schema: 'my', name: 'foo'}, column: 'a'},
+        [
+          {
+            op: 'drop-column',
+            table: {schema: 'my', name: 'foo'},
+            column: 'a',
+          },
+        ],
+      ],
+      [
+        // The rowKey columns are excluded from `columns` but are backfilled
+        // with them, so the op clears both.
+        'backfill-completed',
+        {
+          tag: 'backfill-completed',
+          relation: {schema: 'my', name: 'foo', rowKey: ROW_KEY},
+          columns: ['a', 'b'],
+          watermark: '07',
+        },
+        [
+          {
+            op: 'complete-backfill',
+            table: {schema: 'my', name: 'foo'},
+            columns: ['id', 'a', 'b'],
+          },
+        ],
+      ],
+      [
+        'create-index',
+        {
+          tag: 'create-index',
+          spec: {
+            schema: 'my',
+            name: 'foo_idx',
+            tableName: 'foo',
+            unique: false,
+            columns: {a: 'ASC'},
+          },
+        },
+        [],
+      ],
+      [
+        'drop-index',
+        {tag: 'drop-index', id: {schema: 'my', name: 'foo_idx'}},
+        [],
+      ],
+    ];
+
+    test.each(cases)('%s', (_name, change, ops) => {
+      expect(cookieOps(change)).toEqual(ops);
+    });
+
+    test('covers every schema-change tag', () => {
+      // The fold is exhaustive at compile time; this is the reminder that a new
+      // tag also needs a case above, including if its answer is "no ops".
+      expect(new Set(cases.map(([, change]) => change.tag)).size).toBe(10);
+    });
+  });
+
+  describe('the SQLite interpreter', () => {
+    test('create-table seeds both cookies', () => {
+      using db = createCookieJar();
+
+      expect(fold(db, CREATE_FOO)).toEqual({
+        tableMetadata: [
+          {
+            schema: 'my',
+            table: 'foo',
+            metadata: {rowKey: {type: 'index', columns: ['a', 'b']}},
+          },
+        ],
+        backfilling: [
+          {
+            schema: 'my',
+            table: 'foo',
+            column: 'a',
+            backfill: {fooID: 987, barID: 'zoo'},
+          },
+          {
+            schema: 'my',
+            table: 'foo',
+            column: 'b',
+            backfill: {fooID: 843, barID: 'ozz'},
+          },
+        ],
+      });
+    });
+
+    test('metadata and backfills upsert rather than collide', () => {
+      using db = createCookieJar();
+
+      const {tableMetadata, backfilling} = fold(
+        db,
+        CREATE_FOO,
+        {
+          tag: 'update-table-metadata',
+          table: {schema: 'my', name: 'foo'},
+          old: {rowKey: {type: 'index', columns: ['a', 'b']}},
+          new: {rowKey: {type: 'default', columns: ['id']}},
+        },
+        {
+          tag: 'add-column',
+          table: {schema: 'my', name: 'foo'},
+          column: {name: 'a', spec: {pos: 1, dataType: 'text'}},
+          backfill: {fooID: 111, barID: 'restarted'},
+        },
+      );
+
+      expect(tableMetadata).toEqual([
+        {
+          schema: 'my',
+          table: 'foo',
+          metadata: {rowKey: {type: 'default', columns: ['id']}},
+        },
+      ]);
+      expect(
+        backfilling.map(({column, backfill}) => [column, backfill]),
+      ).toEqual([
+        ['a', {fooID: 111, barID: 'restarted'}],
+        ['b', {fooID: 843, barID: 'ozz'}],
+      ]);
+    });
+
+    test('a rename moves both cookies, and only the renamed table', () => {
+      using db = createCookieJar();
+
+      const cookies = fold(
+        db,
+        CREATE_FOO,
+        {
+          tag: 'create-table',
+          spec: {schema: 'my', name: 'other', columns: {}},
+          backfill: {a: {fooID: 1}},
+        },
+        {
+          tag: 'rename-table',
+          old: {schema: 'my', name: 'foo'},
+          new: {schema: 'your', name: 'renamed'},
+        },
+      );
+
+      expect(
+        cookies.tableMetadata.map(({schema, table}) => [schema, table]),
+      ).toEqual([['your', 'renamed']]);
+      expect(
+        cookies.backfilling.map(({schema, table, column}) => [
+          schema,
+          table,
+          column,
+        ]),
+      ).toEqual([
+        ['my', 'other', 'a'],
+        ['your', 'renamed', 'a'],
+        ['your', 'renamed', 'b'],
+      ]);
+    });
+
+    test('a column rename moves only the named column', () => {
+      using db = createCookieJar();
+
+      const {backfilling} = fold(db, CREATE_FOO, {
+        tag: 'update-column',
+        table: {schema: 'my', name: 'foo'},
+        old: {name: 'a', spec: {pos: 1, dataType: 'text'}},
+        new: {name: 'z', spec: {pos: 1, dataType: 'text'}},
+      });
+
+      expect(
+        backfilling.map(({column, backfill}) => [column, backfill]),
+      ).toEqual([
+        ['b', {fooID: 843, barID: 'ozz'}],
+        ['z', {fooID: 987, barID: 'zoo'}],
+      ]);
+    });
+
+    test('drop-column and backfill-completed clear backfills, not metadata', () => {
+      using db = createCookieJar();
+
+      const dropped = fold(db, CREATE_FOO, {
+        tag: 'drop-column',
+        table: {schema: 'my', name: 'foo'},
+        column: 'a',
+      });
+      expect(dropped.backfilling.map(({column}) => column)).toEqual(['b']);
+      expect(dropped.tableMetadata).toHaveLength(1);
+
+      const completed = fold(db, {
+        tag: 'backfill-completed',
+        relation: {schema: 'my', name: 'foo', rowKey: ROW_KEY},
+        columns: ['b'],
+        watermark: '07',
+      });
+      // The table's metadata outlives its backfills: it is what the *next*
+      // BackfillRequest for the table has to carry.
+      expect(completed.backfilling).toEqual([]);
+      expect(completed.tableMetadata).toHaveLength(1);
+    });
+
+    test('drop-table clears both cookies', () => {
+      using db = createCookieJar();
+
+      expect(
+        fold(db, CREATE_FOO, {
+          tag: 'drop-table',
+          id: {schema: 'my', name: 'foo'},
+        }),
+      ).toEqual(EMPTY_COOKIE_SET);
+    });
+
+    test('a table with backfills and no metadata is legal', () => {
+      using db = createCookieJar();
+
+      const cookies = fold(db, {
+        tag: 'create-table',
+        spec: {schema: 'your', name: 'bar', columns: {}},
+        backfill: {a: {fooID: 987}},
+      });
+
+      expect(cookies.tableMetadata).toEqual([]);
+      expect(cookies.backfilling).toHaveLength(1);
+    });
+
+    test('apply reports the ops it ran', () => {
+      using db = createCookieJar();
+      const writer = new ChangeLogCookieWriter(db);
+
+      expect(writer.apply(CREATE_FOO).map(({op}) => op)).toEqual([
+        'upsert-metadata',
+        'upsert-backfill',
+        'upsert-backfill',
+      ]);
+      expect(
+        writer.apply({
+          tag: 'create-index',
+          spec: {
+            schema: 'my',
+            name: 'foo_idx',
+            tableName: 'foo',
+            unique: false,
+            columns: {a: 'ASC'},
+          },
+        }),
+      ).toEqual([]);
+    });
+  });
+
+  describe('readers', () => {
+    test('replaceCookies replaces the whole set', () => {
+      using db = createCookieJar();
+      fold(db, CREATE_FOO);
+
+      const replacement: CookieSet = {
+        tableMetadata: [
+          {
+            schema: 'your',
+            table: 'bar',
+            metadata: {rowKey: {type: 'default', columns: ['id']}},
+          },
+        ],
+        backfilling: [
+          {schema: 'your', table: 'bar', column: 'c', backfill: {fooID: 5}},
+        ],
+      };
+      replaceCookies(db, replacement);
+      expect(readCookies(db)).toEqual(replacement);
+
+      replaceCookies(db, EMPTY_COOKIE_SET);
+      expect(readCookies(db)).toEqual(EMPTY_COOKIE_SET);
+    });
+
+    test('round-trips values outside the safe integer range', () => {
+      using db = createCookieJar();
+
+      const cookies: CookieSet = {
+        tableMetadata: [
+          {
+            schema: 'my',
+            table: 'foo',
+            metadata: {rowKey: {columns: ['id']}, oid: 9007199254740993n},
+          },
+        ],
+        backfilling: [
+          {
+            schema: 'my',
+            table: 'foo',
+            column: 'a',
+            backfill: {snapshotID: '000003E8-1', xmin: 1000},
+          },
+        ],
+      };
+      replaceCookies(db, cookies);
+      expect(readCookies(db)).toEqual(cookies);
+    });
+
+    test('row counts are per cookie table', () => {
+      using db = createCookieJar();
+      expect(readCookieRowCounts(db)).toEqual({
+        tableMetadata: 0,
+        backfilling: 0,
+      });
+
+      fold(db, CREATE_FOO);
+      expect(readCookieRowCounts(db)).toEqual({
+        tableMetadata: 1,
+        backfilling: 2,
+      });
+    });
+  });
+});

--- a/packages/zero-cache/src/services/replicator/change-log-cookies.ts
+++ b/packages/zero-cache/src/services/replicator/change-log-cookies.ts
@@ -1,0 +1,449 @@
+/**
+ * The change log's *second* job.
+ *
+ * A change log is a buffer **and** a cookie jar. The buffer catches a
+ * reconnecting subscriber up to the head; the cookie jar holds the backfill
+ * progress state that the change-streamer hands the change-source on every
+ * `startStream`, so that the change source never has to persist backfill state
+ * upstream. See `change-log-db.ts` for the buffer.
+ *
+ * There are two cookies, mirroring the two `cdc` tables the Postgres change log
+ * has always carried (`change-streamer/schema/tables.ts`):
+ *
+ * - **table metadata**, the most current {@link TableMetadata} of a table, which
+ *   a {@link BackfillRequest} has to carry; and
+ * - **backfilling columns**, the opaque {@link BackfillID} of every column whose
+ *   backfill has not completed.
+ *
+ * Both are a *fold over the change stream*: the cookie set is only meaningful
+ * paired with the watermark it was folded up to. {@link cookieOps} is that fold,
+ * expressed transport-free so that the Postgres change log and the SQLite change
+ * log cannot drift from each other — they must agree on all eight transitions
+ * forever, and the failure mode if they disagree is a backfill that is silently
+ * never re-requested. The two interpreters are {@link ChangeLogCookieWriter}
+ * here and `Storer.#trackBackfillMetadata()` in
+ * `change-streamer/storer.ts`.
+ *
+ * The tables live in the change-log database rather than in the replica: the
+ * replicator is a subscriber *downstream* of the change-streamer's write loop,
+ * so its state version trails the log's head, and pairing its cookies with the
+ * log's resume watermark would lose every backfill that completed in between.
+ * The replica's own copies (`_zero.tableMetadata`, `_zero.column_metadata`) are
+ * the *seed* source; these are the *working* set.
+ */
+
+import {unreachable} from '../../../../shared/src/asserts.ts';
+import {BigIntJSON} from '../../../../shared/src/bigint-json.ts';
+import type {Database, Statement} from '../../../../zqlite/src/db.ts';
+import type {
+  BackfillID,
+  Identifier,
+  SchemaChange,
+  TableMetadata,
+} from '../change-source/protocol/current/data.ts';
+
+export const CHANGE_LOG_TABLE_METADATA_TABLE = '_zero.changeLogTableMetadata';
+export const CHANGE_LOG_BACKFILLING_TABLE = '_zero.changeLogBackfilling';
+
+// The names follow the file's existing convention, beside
+// "_zero.changeLogStream" and "_zero.changeLogMeta".
+//
+// `metadata` and `backfill` hold the JSON that the `cdc` tables hold as JSONB.
+// SQLite has no JSONB, and nothing here queries into the documents: they are
+// stored to be handed back to the change source verbatim.
+export const CREATE_CHANGE_LOG_COOKIE_SCHEMA = /*sql*/ `
+  CREATE TABLE "${CHANGE_LOG_TABLE_METADATA_TABLE}" (
+    "schema"   TEXT NOT NULL,
+    "table"    TEXT NOT NULL,
+    "metadata" TEXT NOT NULL,
+    PRIMARY KEY ("schema", "table")
+  );
+
+  CREATE TABLE "${CHANGE_LOG_BACKFILLING_TABLE}" (
+    "schema"   TEXT NOT NULL,
+    "table"    TEXT NOT NULL,
+    "column"   TEXT NOT NULL,
+    "backfill" TEXT NOT NULL,
+    PRIMARY KEY ("schema", "table", "column")
+  );
+`;
+
+export const DROP_CHANGE_LOG_COOKIE_TABLES = /*sql*/ `
+  DROP TABLE IF EXISTS "${CHANGE_LOG_TABLE_METADATA_TABLE}";
+  DROP TABLE IF EXISTS "${CHANGE_LOG_BACKFILLING_TABLE}";
+`;
+
+export type TableMetadataCookie = {
+  readonly schema: string;
+  readonly table: string;
+  readonly metadata: TableMetadata;
+};
+
+export type BackfillCookie = {
+  readonly schema: string;
+  readonly table: string;
+  readonly column: string;
+  readonly backfill: BackfillID;
+};
+
+/**
+ * The whole cookie set, as of the log's head. Both lists are ordered by their
+ * primary key so that two stores' sets can be compared directly.
+ */
+export type CookieSet = {
+  readonly tableMetadata: readonly TableMetadataCookie[];
+  readonly backfilling: readonly BackfillCookie[];
+};
+
+export const EMPTY_COOKIE_SET: CookieSet = {
+  tableMetadata: [],
+  backfilling: [],
+};
+
+/**
+ * A transport-free description of a cookie mutation. This is the whole of what
+ * a {@link SchemaChange} means to the cookie jar; everything else about the
+ * change belongs to the buffer.
+ */
+export type CookieOp =
+  | {op: 'upsert-metadata'; table: Identifier; metadata: TableMetadata}
+  | {
+      op: 'upsert-backfill';
+      table: Identifier;
+      column: string;
+      backfill: BackfillID;
+    }
+  | {op: 'rename-table'; old: Identifier; new: Identifier}
+  | {op: 'drop-table'; table: Identifier}
+  | {op: 'rename-column'; table: Identifier; old: string; new: string}
+  | {op: 'drop-column'; table: Identifier; column: string}
+  | {op: 'complete-backfill'; table: Identifier; columns: readonly string[]};
+
+export type CookieOpTag = CookieOp['op'];
+
+/**
+ * The fold, and the only place either store decides what a schema change means
+ * for the cookie set. Both interpreters are mechanical translations of what this
+ * returns, in the order it returns them.
+ *
+ * Changes that carry no cookie state — index changes, and the `create-table` /
+ * `add-column` variants whose optional `metadata` and `backfill` fields are
+ * absent — produce no ops.
+ */
+export function cookieOps(change: SchemaChange): CookieOp[] {
+  switch (change.tag) {
+    case 'update-table-metadata':
+      return [
+        {op: 'upsert-metadata', table: change.table, metadata: change.new},
+      ];
+
+    case 'create-table': {
+      const {spec, metadata, backfill} = change;
+      const table = {schema: spec.schema, name: spec.name};
+      const ops: CookieOp[] = [];
+      if (metadata) {
+        ops.push({op: 'upsert-metadata', table, metadata});
+      }
+      if (backfill) {
+        for (const [column, id] of Object.entries(backfill)) {
+          ops.push({op: 'upsert-backfill', table, column, backfill: id});
+        }
+      }
+      return ops;
+    }
+
+    case 'rename-table':
+      return [{op: 'rename-table', old: change.old, new: change.new}];
+
+    case 'drop-table':
+      return [{op: 'drop-table', table: change.id}];
+
+    case 'add-column': {
+      const {table, tableMetadata, column, backfill} = change;
+      const ops: CookieOp[] = [];
+      if (tableMetadata) {
+        ops.push({op: 'upsert-metadata', table, metadata: tableMetadata});
+      }
+      if (backfill) {
+        ops.push({
+          op: 'upsert-backfill',
+          table,
+          column: column.name,
+          backfill,
+        });
+      }
+      return ops;
+    }
+
+    case 'update-column': {
+      // Only a rename moves the cookie; the rest of a column update does not
+      // affect whether or how it is being backfilled.
+      const {table, old, new: updated} = change;
+      return old.name === updated.name
+        ? []
+        : [{op: 'rename-column', table, old: old.name, new: updated.name}];
+    }
+
+    case 'drop-column':
+      return [{op: 'drop-column', table: change.table, column: change.column}];
+
+    case 'backfill-completed': {
+      const {relation, columns} = change;
+      // The rowKey columns are excluded from `columns` but are backfilled with
+      // them, so both are cleared.
+      const cleared = [...relation.rowKey.columns, ...columns];
+      return cleared.length === 0
+        ? []
+        : [
+            {
+              op: 'complete-backfill',
+              table: {schema: relation.schema, name: relation.name},
+              columns: cleared,
+            },
+          ];
+    }
+
+    case 'create-index':
+    case 'drop-index':
+      return [];
+
+    default:
+      // Unreachable: `isSchemaChange()` gates on the same tag set this switch
+      // covers. It is exhaustive so that a new schema-change tag is a compile
+      // error here rather than a silently dropped backfill.
+      unreachable(change);
+  }
+}
+
+/**
+ * The SQLite interpreter of {@link cookieOps}, over prepared statements on the
+ * change-log database.
+ *
+ * The statements run inside the log's transaction, in stream order, at the point
+ * the schema change is appended (see `ChangeLogStreamWriter`). That is what
+ * makes the cookie set atomic with the head — a crash cannot leave cookies ahead
+ * of or behind the rows they were folded from — and what makes an aborted
+ * transaction discard its cookies with its rows, for free.
+ *
+ * Statements are prepared against the tables as they exist now, so an instance
+ * does not survive a reconcile that drops and recreates them.
+ */
+export class ChangeLogCookieWriter {
+  readonly #upsertMetadata: Statement;
+  readonly #upsertBackfill: Statement;
+  readonly #renameMetadataTable: Statement;
+  readonly #renameBackfillTable: Statement;
+  readonly #deleteMetadataTable: Statement;
+  readonly #deleteBackfillTable: Statement;
+  readonly #renameBackfillColumn: Statement;
+  readonly #deleteBackfillColumn: Statement;
+
+  constructor(db: Database) {
+    this.#upsertMetadata = db.prepare(/*sql*/ `
+      INSERT INTO "${CHANGE_LOG_TABLE_METADATA_TABLE}"
+        ("schema", "table", "metadata") VALUES (?, ?, ?)
+        ON CONFLICT ("schema", "table")
+        DO UPDATE SET "metadata" = excluded."metadata"
+    `);
+    this.#upsertBackfill = db.prepare(/*sql*/ `
+      INSERT INTO "${CHANGE_LOG_BACKFILLING_TABLE}"
+        ("schema", "table", "column", "backfill") VALUES (?, ?, ?, ?)
+        ON CONFLICT ("schema", "table", "column")
+        DO UPDATE SET "backfill" = excluded."backfill"
+    `);
+    this.#renameMetadataTable = db.prepare(/*sql*/ `
+      UPDATE "${CHANGE_LOG_TABLE_METADATA_TABLE}"
+        SET "schema" = ?, "table" = ? WHERE "schema" = ? AND "table" = ?
+    `);
+    this.#renameBackfillTable = db.prepare(/*sql*/ `
+      UPDATE "${CHANGE_LOG_BACKFILLING_TABLE}"
+        SET "schema" = ?, "table" = ? WHERE "schema" = ? AND "table" = ?
+    `);
+    this.#deleteMetadataTable = db.prepare(/*sql*/ `
+      DELETE FROM "${CHANGE_LOG_TABLE_METADATA_TABLE}"
+        WHERE "schema" = ? AND "table" = ?
+    `);
+    this.#deleteBackfillTable = db.prepare(/*sql*/ `
+      DELETE FROM "${CHANGE_LOG_BACKFILLING_TABLE}"
+        WHERE "schema" = ? AND "table" = ?
+    `);
+    this.#renameBackfillColumn = db.prepare(/*sql*/ `
+      UPDATE "${CHANGE_LOG_BACKFILLING_TABLE}" SET "column" = ?
+        WHERE "schema" = ? AND "table" = ? AND "column" = ?
+    `);
+    this.#deleteBackfillColumn = db.prepare(/*sql*/ `
+      DELETE FROM "${CHANGE_LOG_BACKFILLING_TABLE}"
+        WHERE "schema" = ? AND "table" = ? AND "column" = ?
+    `);
+  }
+
+  /** Applies the change's cookie ops, returning the ops that were applied. */
+  apply(change: SchemaChange): CookieOp[] {
+    const ops = cookieOps(change);
+    for (const op of ops) {
+      this.#run(op);
+    }
+    return ops;
+  }
+
+  #run(op: CookieOp): void {
+    switch (op.op) {
+      case 'upsert-metadata':
+        this.#upsertMetadata.run(
+          op.table.schema,
+          op.table.name,
+          BigIntJSON.stringify(op.metadata),
+        );
+        break;
+
+      case 'upsert-backfill':
+        this.#upsertBackfill.run(
+          op.table.schema,
+          op.table.name,
+          op.column,
+          BigIntJSON.stringify(op.backfill),
+        );
+        break;
+
+      case 'rename-table':
+        this.#renameMetadataTable.run(
+          op.new.schema,
+          op.new.name,
+          op.old.schema,
+          op.old.name,
+        );
+        this.#renameBackfillTable.run(
+          op.new.schema,
+          op.new.name,
+          op.old.schema,
+          op.old.name,
+        );
+        break;
+
+      case 'drop-table':
+        this.#deleteMetadataTable.run(op.table.schema, op.table.name);
+        this.#deleteBackfillTable.run(op.table.schema, op.table.name);
+        break;
+
+      case 'rename-column':
+        this.#renameBackfillColumn.run(
+          op.new,
+          op.table.schema,
+          op.table.name,
+          op.old,
+        );
+        break;
+
+      case 'drop-column':
+        this.#deleteBackfillColumn.run(
+          op.table.schema,
+          op.table.name,
+          op.column,
+        );
+        break;
+
+      case 'complete-backfill':
+        // A per-column delete rather than an `IN` list, which cannot be a
+        // single prepared statement across arities. The columns of one
+        // completed backfill are few, and this runs only on schema changes.
+        for (const column of op.columns) {
+          this.#deleteBackfillColumn.run(
+            op.table.schema,
+            op.table.name,
+            column,
+          );
+        }
+        break;
+
+      default:
+        unreachable(op);
+    }
+  }
+}
+
+/**
+ * Reads the whole cookie set, ordered by primary key. This is what a
+ * change-streamer would hand `startStream`, and what the Postgres-derived and
+ * replica-derived sets are compared against.
+ */
+export function readCookies(db: Database): CookieSet {
+  const tableMetadata = db
+    .prepare(/*sql*/ `
+      SELECT "schema", "table", "metadata"
+        FROM "${CHANGE_LOG_TABLE_METADATA_TABLE}"
+        ORDER BY "schema", "table"
+    `)
+    .all<{schema: string; table: string; metadata: string}>()
+    .map(({schema, table, metadata}) => ({
+      schema,
+      table,
+      metadata: BigIntJSON.parse(metadata) as TableMetadata,
+    }));
+
+  const backfilling = db
+    .prepare(/*sql*/ `
+      SELECT "schema", "table", "column", "backfill"
+        FROM "${CHANGE_LOG_BACKFILLING_TABLE}"
+        ORDER BY "schema", "table", "column"
+    `)
+    .all<{schema: string; table: string; column: string; backfill: string}>()
+    .map(({schema, table, column, backfill}) => ({
+      schema,
+      table,
+      column,
+      backfill: BigIntJSON.parse(backfill) as BackfillID,
+    }));
+
+  return {tableMetadata, backfilling};
+}
+
+/**
+ * Replaces the cookie set wholesale.
+ *
+ * The cookies are unversioned point-in-time state, so a reconciliation that
+ * moves the head invalidates them: truncating the stream above `W` does not roll
+ * the cookie set back to `W`, and the truncated transactions can contain
+ * `create-table`, `add-column`, and `backfill-completed`. The caller must run
+ * this in the same transaction as the reconciliation that invalidated them.
+ */
+export function replaceCookies(db: Database, cookies: CookieSet): void {
+  db.prepare(/*sql*/ `DELETE FROM "${CHANGE_LOG_TABLE_METADATA_TABLE}"`).run();
+  db.prepare(/*sql*/ `DELETE FROM "${CHANGE_LOG_BACKFILLING_TABLE}"`).run();
+
+  if (cookies.tableMetadata.length > 0) {
+    const insert = db.prepare(/*sql*/ `
+      INSERT INTO "${CHANGE_LOG_TABLE_METADATA_TABLE}"
+        ("schema", "table", "metadata") VALUES (?, ?, ?)
+    `);
+    for (const {schema, table, metadata} of cookies.tableMetadata) {
+      insert.run(schema, table, BigIntJSON.stringify(metadata));
+    }
+  }
+  if (cookies.backfilling.length > 0) {
+    const insert = db.prepare(/*sql*/ `
+      INSERT INTO "${CHANGE_LOG_BACKFILLING_TABLE}"
+        ("schema", "table", "column", "backfill") VALUES (?, ?, ?, ?)
+    `);
+    for (const {schema, table, column, backfill} of cookies.backfilling) {
+      insert.run(schema, table, column, BigIntJSON.stringify(backfill));
+    }
+  }
+}
+
+/** Retained cookie rows, by table. Both are normally zero. */
+export type CookieRowCounts = {
+  readonly tableMetadata: number;
+  readonly backfilling: number;
+};
+
+export function readCookieRowCounts(db: Database): CookieRowCounts {
+  return db
+    .prepare(/*sql*/ `
+      SELECT
+        (SELECT count(*) FROM "${CHANGE_LOG_TABLE_METADATA_TABLE}")
+          AS "tableMetadata",
+        (SELECT count(*) FROM "${CHANGE_LOG_BACKFILLING_TABLE}")
+          AS "backfilling"
+    `)
+    .get<CookieRowCounts>();
+}


### PR DESCRIPTION
SQLite needs to record backfill in its change log too.

The basic idea here:

We now create "cookie ops" rather than direct SQL statements. Then PG and SQLite implementations interpret these ops into their SQL dialects.