### PR TITLE
chore(rmv2): track backfill records in the SQLite change log

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/change-log-cookies.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-log-cookies.pg.test.ts
@@ -1,0 +1,458 @@
+/**
+ * The Postgres and SQLite change logs interpret one fold
+ * (`replicator/change-log-cookies.ts`), and they have to agree on every
+ * transition forever: the failure mode when they drift is a backfill that is
+ * silently never re-requested, on a column that is then silently never
+ * populated. This drives the same change sequence through both writers and
+ * requires the resulting cookie sets to be identical.
+ *
+ */
+
+import {beforeEach, describe, expect} from 'vitest';
+import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
+import {Database} from '../../../../zqlite/src/db.ts';
+import {StatementRunner} from '../../db/statements.ts';
+import {type PgTest, test} from '../../test/db.ts';
+import type {PostgresDB} from '../../types/pg.ts';
+import type {SchemaChange} from '../change-source/protocol/current/data.ts';
+import type {
+  ChangeStreamData,
+  Commit,
+} from '../change-source/protocol/current/downstream.ts';
+import type {UpstreamStatusMessage} from '../change-source/protocol/current/status.ts';
+import {
+  CREATE_CHANGE_LOG_COOKIE_SCHEMA,
+  readCookies,
+  type BackfillCookie,
+  type CookieSet,
+  type TableMetadataCookie,
+} from '../replicator/change-log-cookies.ts';
+import {CREATE_CHANGE_LOG_STREAM_SCHEMA} from '../replicator/change-log-db.ts';
+import {ChangeLogStreamWriter} from '../replicator/change-log-stream-writer.ts';
+import {serializeChangeStreamData} from './change-log-codec.ts';
+import {ensureReplicationConfig, setupCDCTables} from './schema/tables.ts';
+import {Storer, type TuningOptions} from './storer.ts';
+
+const lc = createSilentLogContext();
+
+const APP_ID = 'cookies';
+const SHARD_NUM = 1;
+const CDC_SCHEMA = `${APP_ID}_${SHARD_NUM}/cdc`;
+const REPLICA_VERSION = '00';
+
+const opts: TuningOptions = {
+  backPressureLimitHeapProportion: 0.04,
+  statementTimeoutMs: 20_000,
+  changeLogBatchSize: 2000,
+};
+
+describe('change-streamer/change-log cookie parity', () => {
+  let db: PostgresDB;
+  let storer: Storer;
+  let done: Promise<void>;
+  let changeLog: Database;
+  let watermark: number;
+
+  beforeEach<PgTest>(async ({testDBs}) => {
+    db = await testDBs.create('change_log_cookie_parity', {
+      typeOpts: {sendStringAsJson: true},
+    });
+    const shard = {appID: APP_ID, shardNum: SHARD_NUM};
+    await db.begin(tx => setupCDCTables(lc, tx, shard));
+    await ensureReplicationConfig(
+      lc,
+      db,
+      {
+        replicaVersion: REPLICA_VERSION,
+        publications: [],
+        watermark: REPLICA_VERSION,
+      },
+      shard,
+      true,
+    );
+
+    storer = new Storer(
+      lc,
+      shard,
+      'task-id',
+      'change-streamer:12345',
+      'ws',
+      db,
+      REPLICA_VERSION,
+      (_: Commit | UpstreamStatusMessage) => {},
+      () => {},
+      opts,
+    );
+    await storer.assumeOwnership();
+    done = storer.run();
+
+    changeLog = new Database(lc, ':memory:');
+    changeLog.exec(CREATE_CHANGE_LOG_STREAM_SCHEMA);
+    changeLog.exec(CREATE_CHANGE_LOG_COOKIE_SCHEMA);
+    watermark = 1;
+
+    return async () => {
+      changeLog.close();
+      await testDBs.drop(db);
+      void storer?.stop();
+      await done;
+    };
+  });
+
+  /**
+   * Drives one transaction carrying `changes` through both writers, the way
+   * their respective stream loops do.
+   */
+  async function transaction(...changes: SchemaChange[]): Promise<void> {
+    const wm = String(++watermark).padStart(2, '0');
+    const messages: ChangeStreamData[] = [
+      ['begin', {tag: 'begin'}, {commitWatermark: wm}],
+      ...changes.map((change): ChangeStreamData => ['data', change]),
+      ['commit', {tag: 'commit'}, {watermark: wm}],
+    ];
+
+    messages.forEach(message => storer.store(wm, message));
+
+    const writer = new ChangeLogStreamWriter(new StatementRunner(changeLog));
+    writer.begin(wm, serializeChangeStreamData(messages[0]));
+    changes.forEach((change, i) =>
+      writer.append(serializeChangeStreamData(messages[i + 1]), change),
+    );
+    writer.commit(wm, serializeChangeStreamData(messages.at(-1)!), 1_000);
+
+    await storer.allProcessed();
+  }
+
+  /** The cookie set the Postgres change log holds, in the SQLite log's shape. */
+  async function pgCookies(): Promise<CookieSet> {
+    const [tableMetadata, backfilling] = await Promise.all([
+      db<TableMetadataCookie[]>`
+        SELECT "schema", "table", "metadata" FROM ${db(CDC_SCHEMA)}."tableMetadata"
+          ORDER BY "schema", "table"`,
+      db<BackfillCookie[]>`
+        SELECT "schema", "table", "column", "backfill" FROM ${db(CDC_SCHEMA)}."backfilling"
+          ORDER BY "schema", "table", "column"`,
+    ]);
+    return {
+      tableMetadata: [...tableMetadata],
+      backfilling: [...backfilling],
+    };
+  }
+
+  /**
+   * Both stores agree, and the agreed-on set is what was expected. The second
+   * half matters: two interpreters of the same fold agree vacuously if the fold
+   * itself does nothing.
+   */
+  async function expectCookies(expected: CookieSet) {
+    const pg = await pgCookies();
+    expect(pg).toEqual(readCookies(changeLog));
+    expect(pg).toEqual(expected);
+  }
+
+  test('all eight transitions', async () => {
+    // 1. create-table, carrying metadata and two in-flight backfills.
+    await transaction({
+      tag: 'create-table',
+      spec: {schema: 'my', name: 'foo', columns: {}},
+      metadata: {rowKey: {type: 'index', columns: ['a', 'b']}},
+      backfill: {
+        a: {fooID: 987, barID: 'zoo'},
+        b: {fooID: 843, barID: 'ozz'},
+      },
+    });
+    await expectCookies({
+      tableMetadata: [
+        {
+          schema: 'my',
+          table: 'foo',
+          metadata: {rowKey: {type: 'index', columns: ['a', 'b']}},
+        },
+      ],
+      backfilling: [
+        {
+          schema: 'my',
+          table: 'foo',
+          column: 'a',
+          backfill: {fooID: 987, barID: 'zoo'},
+        },
+        {
+          schema: 'my',
+          table: 'foo',
+          column: 'b',
+          backfill: {fooID: 843, barID: 'ozz'},
+        },
+      ],
+    });
+
+    // A table on a non-`public` schema with backfills and *no* metadata row:
+    // legal, since `metadata` is optional, and the case the replica-derived
+    // path (C3) cannot reconstruct without an identity of its own.
+    await transaction({
+      tag: 'create-table',
+      spec: {schema: 'your', name: 'bar', columns: {}},
+      backfill: {c: {fooID: 5}},
+    });
+
+    // 2. update-table-metadata.
+    // 3. add-column, carrying both a metadata update and a backfill.
+    await transaction(
+      {
+        tag: 'update-table-metadata',
+        table: {schema: 'my', name: 'foo'},
+        old: {rowKey: {type: 'index', columns: ['a', 'b']}},
+        new: {rowKey: {type: 'default', columns: ['id']}},
+      },
+      {
+        tag: 'add-column',
+        table: {schema: 'my', name: 'foo'},
+        tableMetadata: {rowKey: {type: 'default', columns: ['id']}},
+        column: {name: 'd', spec: {pos: 4, dataType: 'text'}},
+        backfill: {fooID: 123, barID: 'baz'},
+      },
+    );
+    await expectCookies({
+      tableMetadata: [
+        {
+          schema: 'my',
+          table: 'foo',
+          metadata: {rowKey: {type: 'default', columns: ['id']}},
+        },
+      ],
+      backfilling: [
+        {
+          schema: 'my',
+          table: 'foo',
+          column: 'a',
+          backfill: {fooID: 987, barID: 'zoo'},
+        },
+        {
+          schema: 'my',
+          table: 'foo',
+          column: 'b',
+          backfill: {fooID: 843, barID: 'ozz'},
+        },
+        {
+          schema: 'my',
+          table: 'foo',
+          column: 'd',
+          backfill: {fooID: 123, barID: 'baz'},
+        },
+        {schema: 'your', table: 'bar', column: 'c', backfill: {fooID: 5}},
+      ],
+    });
+
+    // 4. update-column (a rename), and a spec-only update that must move
+    //    nothing. 5. drop-column.
+    await transaction(
+      {
+        tag: 'update-column',
+        table: {schema: 'my', name: 'foo'},
+        old: {name: 'a', spec: {pos: 1, dataType: 'text'}},
+        new: {name: 'z', spec: {pos: 1, dataType: 'text'}},
+      },
+      {
+        tag: 'update-column',
+        table: {schema: 'my', name: 'foo'},
+        old: {name: 'b', spec: {pos: 2, dataType: 'text'}},
+        new: {name: 'b', spec: {pos: 2, dataType: 'int4'}},
+      },
+      {
+        tag: 'drop-column',
+        table: {schema: 'my', name: 'foo'},
+        column: 'd',
+      },
+    );
+    await expectCookies({
+      tableMetadata: [
+        {
+          schema: 'my',
+          table: 'foo',
+          metadata: {rowKey: {type: 'default', columns: ['id']}},
+        },
+      ],
+      backfilling: [
+        {
+          schema: 'my',
+          table: 'foo',
+          column: 'b',
+          backfill: {fooID: 843, barID: 'ozz'},
+        },
+        {
+          schema: 'my',
+          table: 'foo',
+          column: 'z',
+          backfill: {fooID: 987, barID: 'zoo'},
+        },
+        {schema: 'your', table: 'bar', column: 'c', backfill: {fooID: 5}},
+      ],
+    });
+
+    // 6. backfill-completed. `rowKey` columns are excluded from `columns` but
+    //    are backfilled with them, so both are cleared; the table's metadata is
+    //    not, since it is what the table's *next* BackfillRequest must carry.
+    await transaction({
+      tag: 'backfill-completed',
+      relation: {
+        schema: 'my',
+        name: 'foo',
+        rowKey: {columns: ['b'], type: 'index'},
+      },
+      columns: ['z'],
+      watermark: '07',
+    });
+    await expectCookies({
+      tableMetadata: [
+        {
+          schema: 'my',
+          table: 'foo',
+          metadata: {rowKey: {type: 'default', columns: ['id']}},
+        },
+      ],
+      backfilling: [
+        {schema: 'your', table: 'bar', column: 'c', backfill: {fooID: 5}},
+      ],
+    });
+
+    // 7. rename-table, which moves both cookies and only the renamed table's.
+    await transaction({
+      tag: 'rename-table',
+      old: {schema: 'my', name: 'foo'},
+      new: {schema: 'renamed', name: 'foo'},
+    });
+    await expectCookies({
+      tableMetadata: [
+        {
+          schema: 'renamed',
+          table: 'foo',
+          metadata: {rowKey: {type: 'default', columns: ['id']}},
+        },
+      ],
+      backfilling: [
+        {schema: 'your', table: 'bar', column: 'c', backfill: {fooID: 5}},
+      ],
+    });
+
+    // 8. drop-table, which clears both.
+    await transaction(
+      {tag: 'drop-table', id: {schema: 'renamed', name: 'foo'}},
+      {tag: 'drop-table', id: {schema: 'your', name: 'bar'}},
+    );
+    await expectCookies({tableMetadata: [], backfilling: []});
+  });
+
+  test('index changes and metadata-free schema changes move nothing', async () => {
+    await transaction({
+      tag: 'create-table',
+      spec: {schema: 'my', name: 'foo', columns: {}},
+      metadata: {rowKey: {type: 'default', columns: ['id']}},
+    });
+    await transaction(
+      {
+        tag: 'create-index',
+        spec: {
+          schema: 'my',
+          name: 'foo_idx',
+          tableName: 'foo',
+          unique: false,
+          columns: {id: 'ASC'},
+        },
+      },
+      {tag: 'drop-index', id: {schema: 'my', name: 'foo_idx'}},
+      // A change source that does not support backfill sends neither field.
+      {
+        tag: 'add-column',
+        table: {schema: 'my', name: 'foo'},
+        column: {name: 'e', spec: {pos: 5, dataType: 'text'}},
+      },
+    );
+
+    await expectCookies({
+      tableMetadata: [
+        {
+          schema: 'my',
+          table: 'foo',
+          metadata: {rowKey: {type: 'default', columns: ['id']}},
+        },
+      ],
+      backfilling: [],
+    });
+  });
+
+  test('an aborted transaction leaves neither store holding its cookies', async () => {
+    await transaction({
+      tag: 'create-table',
+      spec: {schema: 'my', name: 'foo', columns: {}},
+      backfill: {a: {fooID: 1}},
+    });
+
+    // The stream is interrupted after the schema change and before the commit:
+    // Postgres aborts its transaction pool, SQLite rolls its transaction back.
+    const wm = String(++watermark).padStart(2, '0');
+    const change: SchemaChange = {
+      tag: 'add-column',
+      table: {schema: 'my', name: 'foo'},
+      column: {name: 'b', spec: {pos: 2, dataType: 'text'}},
+      backfill: {fooID: 2},
+    };
+    storer.store(wm, ['begin', {tag: 'begin'}, {commitWatermark: wm}]);
+    storer.store(wm, ['data', change]);
+
+    const writer = new ChangeLogStreamWriter(new StatementRunner(changeLog));
+    writer.begin(
+      wm,
+      serializeChangeStreamData([
+        'begin',
+        {tag: 'begin'},
+        {commitWatermark: wm},
+      ]),
+    );
+    writer.append(serializeChangeStreamData(['data', change]), change);
+    writer.rollback();
+
+    storer.abort();
+    await storer.allProcessed();
+
+    await expectCookies({
+      tableMetadata: [],
+      backfilling: [
+        {schema: 'my', table: 'foo', column: 'a', backfill: {fooID: 1}},
+      ],
+    });
+  });
+
+  test('several cookie moves in one transaction stay in stream order', async () => {
+    // The storer flushes its buffered changeLog batch before a schema change so
+    // that the cookie DML stays in stream order relative to the rows; SQLite
+    // gets that from statement order. Several cookie-moving changes in one
+    // transaction is what would catch either one losing it.
+    await transaction(
+      {
+        tag: 'create-table',
+        spec: {schema: 'my', name: 'foo', columns: {}},
+        backfill: {a: {fooID: 1}, b: {fooID: 2}},
+      },
+      {
+        tag: 'backfill-completed',
+        relation: {schema: 'my', name: 'foo', rowKey: {columns: ['a']}},
+        columns: [],
+        watermark: '07',
+      },
+      {
+        tag: 'add-column',
+        table: {schema: 'my', name: 'foo'},
+        column: {name: 'c', spec: {pos: 3, dataType: 'text'}},
+        backfill: {fooID: 3},
+      },
+    );
+
+    // `a` completed, `b` never did, `c` started after the completion.
+    await expectCookies({
+      tableMetadata: [],
+      backfilling: [
+        {schema: 'my', table: 'foo', column: 'b', backfill: {fooID: 2}},
+        {schema: 'my', table: 'foo', column: 'c', backfill: {fooID: 3}},
+      ],
+    });
+  });
+});

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
@@ -21,11 +21,13 @@ import type {ChangeSource} from '../change-source/change-source.ts';
 import type {
   ChangeStreamData,
   ChangeStreamMessage,
+  Data,
 } from '../change-source/protocol/current/downstream.ts';
 import type {UpstreamStatusMessage} from '../change-source/protocol/current/status.ts';
 import {exitAfter} from '../life-cycle.ts';
 import type {LitestreamVersion} from '../litestream/metrics.ts';
 import {
+  CHANGE_LOG_DB_SCHEMA_VERSION,
   changeLogFileName,
   deleteChangeLogDB,
   openChangeLogDB,
@@ -421,7 +423,7 @@ describe('change-streamer/service', () => {
     replica: Database,
     changeLog: Database,
     watermark: string,
-    data: readonly ChangeStreamData[],
+    data: readonly Data[],
   ): void {
     const runner = new StatementRunner(replica);
     const writer = new ChangeLogStreamWriter(new StatementRunner(changeLog));
@@ -436,7 +438,7 @@ describe('change-streamer/service', () => {
     try {
       writer.begin(watermark, serializeChangeStreamData(begin));
       for (const message of data) {
-        writer.append(serializeChangeStreamData(message), message[1].tag);
+        writer.append(serializeChangeStreamData(message), message[1]);
       }
       writer.commit(watermark, serializeChangeStreamData(commit), Date.now());
       updateReplicationWatermark(runner, watermark);
@@ -522,7 +524,7 @@ describe('change-streamer/service', () => {
         epoch: null,
         generation: REPLICA_VERSION,
         replicaID: 'replica-id',
-        schemaVersion: 2,
+        schemaVersion: CHANGE_LOG_DB_SCHEMA_VERSION,
         seedWatermark: REPLICA_VERSION,
       });
 

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-purge-scheduler.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-purge-scheduler.test.ts
@@ -5,7 +5,10 @@ import type {Database} from '../../../../zqlite/src/db.ts';
 import {StatementRunner} from '../../db/statements.ts';
 import {DbFile} from '../../test/lite.ts';
 import {versionToLexi} from '../../types/lexi-version.ts';
-import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
+import type {
+  ChangeStreamData,
+  Data,
+} from '../change-source/protocol/current/downstream.ts';
 import {
   CHANGE_LOG_STREAM_TABLE,
   changeLogFileName,
@@ -60,12 +63,12 @@ function append(
     {tag: 'begin'},
     {commitWatermark: watermark},
   ];
-  const truncate: ChangeStreamData = ['data', {tag: 'truncate', relations: []}];
+  const truncate: Data = ['data', {tag: 'truncate', relations: []}];
   const commit: ChangeStreamData = ['commit', {tag: 'commit'}, {watermark}];
   try {
     writer.begin(watermark, serializeChangeStreamData(begin));
     for (let i = 0; i < changes; i++) {
-      writer.append(serializeChangeStreamData(truncate), 'truncate');
+      writer.append(serializeChangeStreamData(truncate), truncate[1]);
     }
     writer.commit(watermark, serializeChangeStreamData(commit), writeTimeMs);
   } catch (e) {
@@ -1037,7 +1040,7 @@ describe('change-streamer/sqlite-change-log-purge-scheduler', () => {
                               'data',
                               {tag: 'truncate', relations: []},
                             ]),
-                            'truncate',
+                            {tag: 'truncate', relations: []},
                           );
                         }
                       });

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-reader.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-reader.test.ts
@@ -6,7 +6,10 @@ import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.
 import type {Database, Statement} from '../../../../zqlite/src/db.ts';
 import {StatementRunner} from '../../db/statements.ts';
 import {DbFile} from '../../test/lite.ts';
-import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
+import type {
+  ChangeStreamData,
+  Data,
+} from '../change-source/protocol/current/downstream.ts';
 import {
   CHANGE_LOG_STREAM_TABLE,
   changeLogFileName,
@@ -61,14 +64,14 @@ function createChangeLog(): {db: Database; file: DbFile; path: string} {
   return {db, file, path: changeLogFileName(file.path)};
 }
 
-function truncate(): ChangeStreamData {
+function truncate(): Data {
   return ['data', {tag: 'truncate', relations: []}];
 }
 
 function appendTransaction(
   db: Database,
   watermark: string,
-  data: readonly ChangeStreamData[],
+  data: readonly Data[],
 ): readonly WatermarkedChange[] {
   const writer = new ChangeLogStreamWriter(new StatementRunner(db));
   const begin: ChangeStreamData = [
@@ -81,7 +84,7 @@ function appendTransaction(
   try {
     writer.begin(watermark, serializeChangeStreamData(begin));
     for (const message of data) {
-      writer.append(serializeChangeStreamData(message), message[1].tag);
+      writer.append(serializeChangeStreamData(message), message[1]);
     }
     writer.commit(watermark, serializeChangeStreamData(commit), Date.now());
   } catch (e) {
@@ -367,7 +370,7 @@ describe('sqlite change log reader', () => {
   test('reconstructs canonical bigint, NUL, schema, backfill, and truncate messages byte-for-byte', async () => {
     const {db, path} = createChangeLog();
     using writer = db;
-    const messages: ChangeStreamData[] = [
+    const messages: Data[] = [
       [
         'data',
         {

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-writer.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-writer.test.ts
@@ -4,6 +4,7 @@ import {afterEach, describe, expect, test} from 'vitest';
 import {TestLogSink} from '../../../../shared/src/logging-test-utils.ts';
 import {DbFile} from '../../test/lite.ts';
 import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
+import {readCookies, type CookieSet} from '../replicator/change-log-cookies.ts';
 import {
   CHANGE_LOG_STREAM_TABLE,
   changeLogFileName,
@@ -59,6 +60,11 @@ function setup(name: string, resumeWatermark = '02') {
     head: () => {
       using db = openChangeLogDB(lc, file.path, {readonly: true});
       return readChangeLogHead(db);
+    },
+    /** Read through a second connection, i.e. what is durable. */
+    cookies: (): CookieSet => {
+      using db = openChangeLogDB(lc, file.path, {readonly: true});
+      return readCookies(db);
     },
     errors: () =>
       sink.messages
@@ -275,5 +281,86 @@ describe('change-streamer/sqlite-change-log-writer', () => {
     expect(fixture.head()).toBe('06');
     expect(fixture.writer.enabled).toBe(true);
     expect(fixture.writer.state()?.invariantFailures).toBe(0);
+  });
+
+  describe('the cookie jar', () => {
+    const createTable: ChangeStreamData = [
+      'data',
+      {
+        tag: 'create-table',
+        spec: {schema: 'my', name: 'foo', columns: {}},
+        metadata: {rowKey: {columns: ['id']}},
+        backfill: {a: {fooID: 1}},
+      },
+    ];
+
+    test('a schema change moves the cookies and is counted', () => {
+      using fixture = setup('change-log-writer-cookies');
+
+      expect(fixture.writer.state()).toMatchObject({
+        cookieMutations: 0,
+        cookieRows: {tableMetadata: 0, backfilling: 0},
+      });
+
+      transaction(fixture.writer, '04', createTable);
+
+      expect(fixture.cookies()).toEqual({
+        tableMetadata: [
+          {schema: 'my', table: 'foo', metadata: {rowKey: {columns: ['id']}}},
+        ],
+        backfilling: [
+          {schema: 'my', table: 'foo', column: 'a', backfill: {fooID: 1}},
+        ],
+      });
+      expect(fixture.writer.state()).toMatchObject({
+        cookieMutations: 2,
+        cookieRows: {tableMetadata: 1, backfilling: 1},
+      });
+
+      // A transaction with no schema change neither moves nor re-counts them.
+      transaction(fixture.writer, '06', [
+        'data',
+        messages.insert('foo', {id: 'one'}),
+      ]);
+      expect(fixture.writer.state()).toMatchObject({cookieMutations: 2});
+    });
+
+    test('an interrupted transaction discards its cookies with its rows', () => {
+      using fixture = setup('change-log-writer-cookies-abort');
+
+      const begin: ChangeStreamData = [
+        'begin',
+        messages.begin(),
+        {commitWatermark: '04'},
+      ];
+      fixture.writer.write(begin, serializeChangeStreamData(begin));
+      fixture.writer.write(createTable, serializeChangeStreamData(createTable));
+      fixture.writer.abort();
+
+      expect(fixture.head()).toBe('02');
+      expect(fixture.cookies()).toEqual({tableMetadata: [], backfilling: []});
+      expect(fixture.writer.state()).toMatchObject({cookieMutations: 0});
+      expect(fixture.writer.enabled).toBe(true);
+    });
+
+    // Invariant 17: the cookie set is only meaningful paired with the watermark
+    // it was folded to, and a truncation moves that watermark.
+    test('a reconcile that truncates leaves no stale cookies behind', () => {
+      using fixture = setup('change-log-writer-cookies-reconcile');
+
+      transaction(fixture.writer, '04', createTable);
+      expect(fixture.writer.state()).toMatchObject({
+        cookieRows: {tableMetadata: 1, backfilling: 1},
+      });
+
+      // The stream reconnects below the head, so the transaction that carried
+      // the cookies is truncated away.
+      fixture.writer.reconcile('02');
+
+      expect(fixture.cookies()).toEqual({tableMetadata: [], backfilling: []});
+      expect(fixture.writer.state()).toMatchObject({
+        cookieRows: {tableMetadata: 0, backfilling: 0},
+      });
+    });
   });
 });

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-writer.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-writer.ts
@@ -8,6 +8,7 @@ import {
 } from '../../db/sqlite-corruption.ts';
 import {StatementRunner} from '../../db/statements.ts';
 import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
+import {readCookieRowCounts} from '../replicator/change-log-cookies.ts';
 import {
   changeLogFileName,
   deleteChangeLogDB,
@@ -169,7 +170,8 @@ export class SQLiteChangeLogWriter {
    */
   write(change: ChangeStreamData, json: string): void {
     const writer = this.#writer;
-    if (this.#disabled || writer === undefined) {
+    const db = this.#db;
+    if (this.#disabled || writer === undefined || db === undefined) {
       return;
     }
     const observer = this.#observer;
@@ -197,10 +199,20 @@ export class SQLiteChangeLogWriter {
           writer.rollback();
           break;
         default:
-          writer.append(json, msg.tag);
+          writer.append(json, msg);
           break;
       }
       observer?.messageProcessed(change, commit, performance.now() - startedAt);
+      if (commit !== null && commit.stats.cookieMutations.length > 0) {
+        // Only re-counted when a schema change actually moved the cookie jar,
+        // which keeps the count off the forward path of every other
+        // transaction. The counts are read after the commit, so they are what
+        // a reader of the file would see.
+        observer?.cookiesMutated(
+          commit.stats.cookieMutations,
+          readCookieRowCounts(db),
+        );
+      }
       if (commit !== null) {
         // The head advanced, and it is durable. Releasing the barrier here is
         // what makes its poll interval a backstop rather than the mechanism.

--- a/packages/zero-cache/src/services/replicator/change-log-db.test.ts
+++ b/packages/zero-cache/src/services/replicator/change-log-db.test.ts
@@ -9,6 +9,12 @@ import {Database} from '../../../../zqlite/src/db.ts';
 import {DbFile, expectTableExact} from '../../test/lite.ts';
 import {CREATE_V14_CHANGE_LOG_STREAM} from '../change-source/common/replica-schema.ts';
 import {
+  CHANGE_LOG_BACKFILLING_TABLE,
+  ChangeLogCookieWriter,
+  DROP_CHANGE_LOG_COOKIE_TABLES,
+  readCookies,
+} from './change-log-cookies.ts';
+import {
   applyChangeLogPragmas,
   CHANGE_LOG_DB_SCHEMA_VERSION,
   CHANGE_LOG_META_TABLE,
@@ -267,7 +273,7 @@ describe('replicator/change-log-db', () => {
         epoch: null,
         generation: '01',
         replicaID: '1777575698286',
-        schemaVersion: 2,
+        schemaVersion: CHANGE_LOG_DB_SCHEMA_VERSION,
         seededAtMs: NOW_MS,
         seedWatermark: '05',
       });
@@ -405,6 +411,7 @@ describe('replicator/change-log-db', () => {
           action: 'reseeded',
           head: ANCHOR.resumeWatermark,
           reason: 'created',
+          cookiesStale: true,
         });
         expect(open.pragma('journal_mode')).toEqual([{journal_mode: 'wal2'}]);
         expect(readChangeLogHead(open)).toBe(ANCHOR.resumeWatermark);
@@ -415,6 +422,7 @@ describe('replicator/change-log-db', () => {
       expect(reopened.result).toEqual({
         action: 'none',
         head: ANCHOR.resumeWatermark,
+        cookiesStale: false,
       });
       expect(readChangeLogHead(db)).toBe(ANCHOR.resumeWatermark);
     });
@@ -432,6 +440,7 @@ describe('replicator/change-log-db', () => {
         action: 'reseeded',
         head: ANCHOR.resumeWatermark,
         reason: 'created',
+        cookiesStale: true,
       });
       expectSeededAt(rebuilt, ANCHOR);
       expect(rebuilt.pragma('journal_mode')).toEqual([{journal_mode: 'wal2'}]);
@@ -451,6 +460,7 @@ describe('replicator/change-log-db', () => {
         action: 'reseeded',
         head: ANCHOR.resumeWatermark,
         reason: 'created',
+        cookiesStale: true,
       });
       expectSeededAt(rebuilt, ANCHOR);
       expect(autoVacuum(rebuilt)).toBe(2);
@@ -478,6 +488,7 @@ describe('replicator/change-log-db', () => {
         action: 'reseeded',
         head: ANCHOR.resumeWatermark,
         reason: 'created',
+        cookiesStale: true,
       });
       expect(autoVacuum(rebuilt)).toBe(2);
     });
@@ -512,6 +523,7 @@ describe('replicator/change-log-db', () => {
           action: 'reseeded',
           head: ANCHOR.resumeWatermark,
           reason: 'created',
+          cookiesStale: true,
         });
         expect(readChangeLogHead(opened)).toBe(ANCHOR.resumeWatermark);
         // One read for the initial open and one for the rebuild: no third.
@@ -557,6 +569,7 @@ describe('replicator/change-log-db', () => {
         action: 'reseeded',
         head: ANCHOR.resumeWatermark,
         reason: 'created',
+        cookiesStale: true,
       });
       expectSeededAt(db, ANCHOR);
     });
@@ -570,6 +583,7 @@ describe('replicator/change-log-db', () => {
         action: 'reseeded',
         head: ANCHOR.resumeWatermark,
         reason: 'created',
+        cookiesStale: true,
       });
       // The pre-existing rows are wiped, not retained.
       expectSeededAt(db, ANCHOR);
@@ -583,6 +597,7 @@ describe('replicator/change-log-db', () => {
         action: 'reseeded',
         head: ANCHOR.resumeWatermark,
         reason: 'created',
+        cookiesStale: true,
       });
       expectSeededAt(db, ANCHOR);
     });
@@ -595,6 +610,7 @@ describe('replicator/change-log-db', () => {
         action: 'reseeded',
         head: ANCHOR.resumeWatermark,
         reason: 'created',
+        cookiesStale: true,
       });
       expect(readChangeLogHead(db)).toBe(ANCHOR.resumeWatermark);
     });
@@ -611,6 +627,7 @@ describe('replicator/change-log-db', () => {
         action: 'reseeded',
         head: ANCHOR.resumeWatermark,
         reason: 'schema-mismatch',
+        cookiesStale: true,
       });
       expectSeededAt(db, ANCHOR);
     });
@@ -637,6 +654,7 @@ describe('replicator/change-log-db', () => {
         action: 'reseeded',
         head: ANCHOR.resumeWatermark,
         reason: 'schema-mismatch',
+        cookiesStale: true,
       });
       expectSeededAt(db, ANCHOR);
     });
@@ -661,6 +679,7 @@ describe('replicator/change-log-db', () => {
         action: 'reseeded',
         head: '05',
         reason: 'identity-mismatch',
+        cookiesStale: true,
       });
       expectSeededAt(db, anchor);
     });
@@ -672,6 +691,7 @@ describe('replicator/change-log-db', () => {
       expect(reconcileChangeLog(lc, db, anchorAt('05', {identity}))).toEqual({
         action: 'none',
         head: '05',
+        cookiesStale: false,
       });
       expect(
         reconcileChangeLog(
@@ -690,6 +710,7 @@ describe('replicator/change-log-db', () => {
         action: 'reseeded',
         head: ANCHOR.resumeWatermark,
         reason: 'gap',
+        cookiesStale: true,
       });
       expect(readChangeLogHead(db)).toBe(ANCHOR.resumeWatermark);
     });
@@ -705,6 +726,7 @@ describe('replicator/change-log-db', () => {
         action: 'reseeded',
         head: ANCHOR.resumeWatermark,
         reason: 'gap',
+        cookiesStale: true,
       });
       expectSeededAt(db, ANCHOR);
     });
@@ -717,6 +739,7 @@ describe('replicator/change-log-db', () => {
         action: 'reseeded',
         head: ANCHOR.resumeWatermark,
         reason: 'gap',
+        cookiesStale: true,
       });
       expect(readChangeLogHead(db)).toBe(ANCHOR.resumeWatermark);
     });
@@ -735,6 +758,7 @@ describe('replicator/change-log-db', () => {
         action: 'truncated',
         head: ANCHOR.resumeWatermark,
         rows: 7,
+        cookiesStale: true,
       });
       expect(readChangeLogHead(db)).toBe(ANCHOR.resumeWatermark);
       expect(
@@ -785,6 +809,7 @@ describe('replicator/change-log-db', () => {
         action: 'truncated',
         head: ANCHOR.resumeWatermark,
         rows: 27,
+        cookiesStale: true,
       });
       expect(
         db
@@ -812,10 +837,12 @@ describe('replicator/change-log-db', () => {
       expect(reconcileChangeLog(lc, db, ANCHOR)).toEqual({
         action: 'none',
         head: ANCHOR.resumeWatermark,
+        cookiesStale: false,
       });
       expect(reconcileChangeLog(lc, db, ANCHOR)).toEqual({
         action: 'none',
         head: ANCHOR.resumeWatermark,
+        cookiesStale: false,
       });
     });
 
@@ -834,6 +861,7 @@ describe('replicator/change-log-db', () => {
         action: 'truncated',
         head: '05',
         rows: 4,
+        cookiesStale: true,
       });
       // The log did not start over, so its warm-up clock does not restart.
       expect(readChangeLogMeta(db)).toMatchObject({seededAtMs: NOW_MS});
@@ -843,6 +871,7 @@ describe('replicator/change-log-db', () => {
         action: 'reseeded',
         head: '07',
         reason: 'gap',
+        cookiesStale: true,
       });
       expect(readChangeLogMeta(db)).toMatchObject({
         seededAtMs: NOW_MS + 60_000,
@@ -862,6 +891,7 @@ describe('replicator/change-log-db', () => {
         action: 'truncated',
         head: '03',
         rows: 3,
+        cookiesStale: true,
       });
       // Re-appending what was truncated no longer violates the primary key.
       expect(() => appendTransaction(db, '05', '03', 1, 300)).not.toThrow();
@@ -875,6 +905,7 @@ describe('replicator/change-log-db', () => {
       expect(reconcileChangeLog(lc, db, ANCHOR)).toEqual({
         action: 'none',
         head: ANCHOR.resumeWatermark,
+        cookiesStale: false,
       });
       expectSeededAt(db, ANCHOR);
     });
@@ -893,6 +924,7 @@ describe('replicator/change-log-db', () => {
       expect(reconcileChangeLog(lc, db, anchorAt('07'))).toEqual({
         action: 'none',
         head: '07',
+        cookiesStale: false,
       });
       expect(dataVersion()).toEqual(before);
 
@@ -952,6 +984,106 @@ describe('replicator/change-log-db', () => {
 
       expect(() => reconcileChangeLog(lc, db, ANCHOR)).toThrow(cause);
       expect(executed).toEqual(['BEGIN IMMEDIATE']);
+    });
+  });
+
+  // The cookies are unversioned point-in-time state: they are only meaningful
+  // paired with the watermark they were folded to. So they are created with the
+  // buffer, dropped with it, and invalidated by anything that moves the head.
+  describe('the cookie jar', () => {
+    /** Puts a cookie in the jar without going through the writer. */
+    function seedCookie(db: Database) {
+      new ChangeLogCookieWriter(db).apply({
+        tag: 'create-table',
+        spec: {schema: 'my', name: 'foo', columns: {}},
+        metadata: {rowKey: {columns: ['id']}},
+        backfill: {a: {fooID: 1}},
+      });
+    }
+
+    test('a reseed creates the cookie tables, empty', () => {
+      using db = createReconciledLog();
+
+      expect(readCookies(db)).toEqual({tableMetadata: [], backfilling: []});
+    });
+
+    test('a wipe drops the cookies with the buffer', () => {
+      using db = createReconciledLog();
+      seedCookie(db);
+      appendTransaction(db, '09', '05', 1, 100);
+
+      // An identity mismatch: this file belongs to a different replica, so its
+      // cookie set describes a different stream.
+      const anchor = anchorAt('05', {
+        identity: {epoch: null, generation: '02', replicaID: 'other'},
+      });
+      expect(reconcileChangeLog(lc, db, anchor)).toMatchObject({
+        action: 'reseeded',
+        reason: 'identity-mismatch',
+        cookiesStale: true,
+      });
+      expect(readCookies(db)).toEqual({tableMetadata: [], backfilling: []});
+    });
+
+    test('a truncation clears the cookies it can no longer vouch for', () => {
+      using db = createReconciledLog();
+      seedCookie(db);
+      // The truncated transaction could itself have carried a `create-table`,
+      // an `add-column`, or a `backfill-completed`, none of which truncating
+      // the rows rolls back.
+      appendTransaction(db, '09', '05', 2, 100);
+
+      expect(reconcileChangeLog(lc, db, ANCHOR)).toMatchObject({
+        action: 'truncated',
+        cookiesStale: true,
+      });
+      expect(readCookies(db)).toEqual({tableMetadata: [], backfilling: []});
+    });
+
+    test('a reconcile that changes nothing leaves the cookies alone', () => {
+      using db = createReconciledLog();
+      seedCookie(db);
+      const before = readCookies(db);
+
+      expect(reconcileChangeLog(lc, db, ANCHOR)).toEqual({
+        action: 'none',
+        head: ANCHOR.resumeWatermark,
+        cookiesStale: false,
+      });
+      expect(readCookies(db)).toEqual(before);
+      expect(before.backfilling).toHaveLength(1);
+    });
+
+    // Every file in the fleet at the v3 upgrade is a v2 file, and the reason it
+    // is wiped should be the version it is at rather than the tables it lacks.
+    test('a v2 file reseeds as schema-mismatch, not as created', () => {
+      using db = createReconciledLog();
+      db.exec(/*sql*/ `
+        ${DROP_CHANGE_LOG_COOKIE_TABLES}
+        UPDATE "${CHANGE_LOG_META_TABLE}" SET "schemaVersion" = 2
+      `);
+
+      expect(reconcileChangeLog(lc, db, ANCHOR)).toEqual({
+        action: 'reseeded',
+        head: ANCHOR.resumeWatermark,
+        reason: 'schema-mismatch',
+        cookiesStale: true,
+      });
+      expectSeededAt(db, ANCHOR);
+      expect(readCookies(db)).toEqual({tableMetadata: [], backfilling: []});
+    });
+
+    test('a current-version file missing a cookie table is rebuilt', () => {
+      using db = createReconciledLog();
+      db.exec(/*sql*/ `DROP TABLE "${CHANGE_LOG_BACKFILLING_TABLE}"`);
+
+      expect(reconcileChangeLog(lc, db, ANCHOR)).toEqual({
+        action: 'reseeded',
+        head: ANCHOR.resumeWatermark,
+        reason: 'created',
+        cookiesStale: true,
+      });
+      expect(readCookies(db)).toEqual({tableMetadata: [], backfilling: []});
     });
   });
 });

--- a/packages/zero-cache/src/services/replicator/change-log-db.ts
+++ b/packages/zero-cache/src/services/replicator/change-log-db.ts
@@ -10,6 +10,12 @@
  * message. Its head is therefore always at or above the watermark the stream
  * would resume from, which is what {@link reconcileChangeLog} anchors on.
  *
+ * Beside the buffer it holds the log's *cookie jar* — the backfill progress
+ * state folded up to the same head. That is `change-log-cookies.ts`; this file
+ * owns its tables' lifecycle, because a cookie set is only meaningful paired
+ * with the watermark it was folded to, and so must be created, dropped, and
+ * invalidated with the buffer rather than beside it.
+ *
  * Because it is disposable, it has no migration framework. Any inconsistency —
  * a schema change, a leftover file from a different replica, a gap left by a
  * crash or by running with the writer disabled, a corrupt file — is resolved by
@@ -38,6 +44,14 @@ import {
   isSQLiteCorruption,
   logSQLiteCorruptionDiagnostics,
 } from '../../db/sqlite-corruption.ts';
+import {
+  CHANGE_LOG_BACKFILLING_TABLE,
+  CHANGE_LOG_TABLE_METADATA_TABLE,
+  CREATE_CHANGE_LOG_COOKIE_SCHEMA,
+  DROP_CHANGE_LOG_COOKIE_TABLES,
+  EMPTY_COOKIE_SET,
+  replaceCookies,
+} from './change-log-cookies.ts';
 
 /**
  * Bumped whenever the change-log database's schema changes. Since the file is a
@@ -48,13 +62,17 @@ import {
  * state version, and its meta row carries the replica's identity triple plus
  * the seed point.
  *
+ * v3 added the cookie tables (see `change-log-cookies.ts`), i.e. the log's
+ * second job. The reseed it costs on upgrade buys one retention window of
+ * catchup reach on a log nothing reads yet.
+ *
  * `auto_vacuum = INCREMENTAL` arrived within v2, deliberately without a bump:
  * it is a file-header property rather than a schema change, and the reseed a
  * version mismatch triggers cannot enable it (see
  * {@link applyChangeLogPragmas}), so {@link openChangeLogDBForWriting} guards
  * on the pragma itself instead of on this number.
  */
-export const CHANGE_LOG_DB_SCHEMA_VERSION = 2;
+export const CHANGE_LOG_DB_SCHEMA_VERSION = 3;
 
 /** https://www.sqlite.org/pragma.html#pragma_auto_vacuum */
 const AUTO_VACUUM_INCREMENTAL = 2;
@@ -408,10 +426,24 @@ export type ReseedReason =
   | 'identity-mismatch'
   | 'gap'; // head does not land on the resume watermark after truncation
 
+/**
+ * `cookiesStale` records that the cookie set the log held did not survive
+ * reconciliation. The cookies are unversioned point-in-time state, so any
+ * reconciliation that moves the head invalidates them, and the same transaction
+ * clears them (see `change-log-cookies.ts`). It is `action !== 'none'` today;
+ * it is a field rather than a derivation because the reseed that replaces the
+ * clear reads as intent at the call site, and because it is what the
+ * `cookie_reseed` counter is keyed on.
+ */
 export type ReconcileResult =
-  | {action: 'none'; head: string}
-  | {action: 'truncated'; head: string; rows: number}
-  | {action: 'reseeded'; head: string; reason: ReseedReason};
+  | {action: 'none'; head: string; cookiesStale: false}
+  | {action: 'truncated'; head: string; rows: number; cookiesStale: true}
+  | {
+      action: 'reseeded';
+      head: string;
+      reason: ReseedReason;
+      cookiesStale: true;
+    };
 
 /**
  * Brings the change log into agreement with the watermark its stream connection
@@ -486,15 +518,22 @@ function reconcile(
     return reseed(lc, db, anchor, 'gap');
   }
   if (rows > 0) {
+    // The truncated transactions can have carried `create-table`,
+    // `add-column`, and `backfill-completed`, none of which the truncate rolls
+    // back, so the cookie set no longer belongs to the head. Clearing it is
+    // correct but lossy; the anchor supplies the set that belongs to the resume
+    // watermark once there is one to supply. Nothing reads the cookies in the
+    // meantime.
+    replaceCookies(db, EMPTY_COOKIE_SET);
     lc.info?.('truncated phantom transactions from the SQLite change log', {
       sqliteChangeLogReconcile: {head, rows},
     });
-    return {action: 'truncated', head, rows};
+    return {action: 'truncated', head, rows, cookiesStale: true};
   }
   lc.debug?.('SQLite change log is at the resume watermark', {
     sqliteChangeLogReconcile: {head},
   });
-  return {action: 'none', head};
+  return {action: 'none', head, cookiesStale: false};
 }
 
 function wipeReason(
@@ -521,6 +560,16 @@ function wipeReason(
   if (version.schemaVersion !== CHANGE_LOG_DB_SCHEMA_VERSION) {
     return 'schema-mismatch';
   }
+  // Checked *after* the version, so that every pre-v3 file — which is every
+  // file in the fleet at the upgrade — reports the `schema-mismatch` that
+  // explains it rather than the `created` its absent cookie tables would
+  // otherwise look like.
+  if (
+    !tableExists(db, CHANGE_LOG_TABLE_METADATA_TABLE) ||
+    !tableExists(db, CHANGE_LOG_BACKFILLING_TABLE)
+  ) {
+    return 'created';
+  }
   const {epoch, generation, replicaID} = readChangeLogMeta(db);
   const identity = anchor.identity;
   if (
@@ -540,12 +589,16 @@ function reseed(
   reason: ReseedReason,
 ): ReconcileResult {
   const {identity, resumeWatermark, nowMs} = anchor;
-  // Dropping the table drops its partial index with it.
+  // Dropping the table drops its partial index with it. The cookie tables go
+  // with the buffer: a cookie set without the transactions it was folded from
+  // is not a smaller cookie set, it is a wrong one.
   db.exec(/*sql*/ `
     DROP TABLE IF EXISTS "${CHANGE_LOG_STREAM_TABLE}";
     DROP TABLE IF EXISTS "${CHANGE_LOG_META_TABLE}";
+    ${DROP_CHANGE_LOG_COOKIE_TABLES}
     ${CREATE_CHANGE_LOG_STREAM_SCHEMA}
     ${CREATE_CHANGE_LOG_META_SCHEMA}
+    ${CREATE_CHANGE_LOG_COOKIE_SCHEMA}
   `);
   db.prepare(/*sql*/ `
     INSERT INTO "${CHANGE_LOG_META_TABLE}"
@@ -572,7 +625,12 @@ function reseed(
       seededAtMs: nowMs,
     },
   });
-  return {action: 'reseeded', head: resumeWatermark, reason};
+  return {
+    action: 'reseeded',
+    head: resumeWatermark,
+    reason,
+    cookiesStale: true,
+  };
 }
 
 /**

--- a/packages/zero-cache/src/services/replicator/change-log-stream-writer.test.ts
+++ b/packages/zero-cache/src/services/replicator/change-log-stream-writer.test.ts
@@ -3,8 +3,13 @@ import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.
 import {Database} from '../../../../zqlite/src/db.ts';
 import {StatementRunner} from '../../db/statements.ts';
 import {DbFile, expectTableExact} from '../../test/lite.ts';
+import type {
+  DataChange,
+  SchemaChange,
+} from '../change-source/protocol/current/data.ts';
 import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
 import {serializeChangeStreamData} from '../change-streamer/change-log-codec.ts';
+import {EMPTY_COOKIE_SET, readCookies} from './change-log-cookies.ts';
 import {
   CHANGE_LOG_STREAM_TABLE,
   deleteChangeLogDB,
@@ -91,7 +96,8 @@ function rowCount(db: Database): number {
 
 const BEGIN = json(['begin', {tag: 'begin'}, {commitWatermark: '06'}]);
 const COMMIT = json(['commit', {tag: 'commit'}, {watermark: '06'}]);
-const TRUNCATE = json(['data', {tag: 'truncate', relations: []}]);
+const TRUNCATE_CHANGE: DataChange = {tag: 'truncate', relations: []};
+const TRUNCATE = json(['data', TRUNCATE_CHANGE]);
 
 describe('replicator/change-log-stream-writer', () => {
   test('writes contiguous positions and commit-only metadata', () => {
@@ -99,33 +105,32 @@ describe('replicator/change-log-stream-writer', () => {
     const writer = new ChangeLogStreamWriter(new StatementRunner(db));
     const writeTimeMs = 1_234_567;
 
-    const insert = json([
-      'data',
-      {
-        tag: 'insert',
-        relation: {
-          schema: 'public',
-          name: 'issues',
-          rowKey: {columns: ['id'], type: 'default'},
-        },
-        new: {id: 9007199254740993n, text: 'before\0after'},
+    const insertChange: DataChange = {
+      tag: 'insert',
+      relation: {
+        schema: 'public',
+        name: 'issues',
+        rowKey: {columns: ['id'], type: 'default'},
       },
-    ]);
-    const rename = json([
-      'data',
-      {
-        tag: 'rename-table',
-        old: {schema: 'public', name: 'issues'},
-        new: {schema: 'public', name: 'renamed'},
-      },
-    ]);
+      new: {id: 9007199254740993n, text: 'before\0after'},
+    };
+    const renameChange: SchemaChange = {
+      tag: 'rename-table',
+      old: {schema: 'public', name: 'issues'},
+      new: {schema: 'public', name: 'renamed'},
+    };
+    const insert = json(['data', insertChange]);
+    const rename = json(['data', renameChange]);
     writer.begin('06', BEGIN);
-    writer.append(insert, 'insert');
-    writer.append(rename, 'rename-table');
+    writer.append(insert, insertChange);
+    writer.append(rename, renameChange);
     const stats = writer.commit('06', COMMIT, writeTimeMs);
     expect(stats).toEqual({
       rows: 4,
       hash: expect.stringMatching(/^[0-9a-f]{64}$/),
+      // A rename of a table with no cookies still folds: the mutation runs and
+      // matches nothing.
+      cookieMutations: ['rename-table'],
       estimatedBytes:
         estimateChangeLogStreamRowBytes('06', '{"tag":"begin"}') +
         estimateChangeLogStreamRowBytes(
@@ -190,7 +195,7 @@ describe('replicator/change-log-stream-writer', () => {
     expect(db.inTransaction).toBe(false);
     writer.begin('06', BEGIN);
     expect(db.inTransaction).toBe(true);
-    writer.append(TRUNCATE, 'truncate');
+    writer.append(TRUNCATE, TRUNCATE_CHANGE);
     // Nothing is visible to another connection until the writer commits.
     expect(head(observer)).toBe(ANCHOR.resumeWatermark);
 
@@ -204,7 +209,7 @@ describe('replicator/change-log-stream-writer', () => {
     const writer = new ChangeLogStreamWriter(new StatementRunner(db));
 
     writer.begin('06', BEGIN);
-    writer.append(TRUNCATE, 'truncate');
+    writer.append(TRUNCATE, TRUNCATE_CHANGE);
     writer.rollback();
 
     expect(db.inTransaction).toBe(false);
@@ -228,7 +233,7 @@ describe('replicator/change-log-stream-writer', () => {
     const writer = new ChangeLogStreamWriter(new StatementRunner(db));
 
     writer.begin('06', BEGIN);
-    writer.append(TRUNCATE, 'truncate');
+    writer.append(TRUNCATE, TRUNCATE_CHANGE);
     writer.rollback();
 
     expect(head(observer)).toBe(ANCHOR.resumeWatermark);
@@ -242,7 +247,7 @@ describe('replicator/change-log-stream-writer', () => {
     const rows = 2500;
     writer.begin('06', BEGIN);
     for (let i = 0; i < rows; i++) {
-      writer.append(TRUNCATE, 'truncate');
+      writer.append(TRUNCATE, TRUNCATE_CHANGE);
     }
     writer.commit('06', COMMIT, 789);
 
@@ -268,5 +273,72 @@ describe('replicator/change-log-stream-writer', () => {
     // The open transaction is the first one, not a nested second.
     writer.rollback();
     expect(db.inTransaction).toBe(false);
+  });
+
+  // The cookies are written in the stream's own transaction, which is what
+  // makes them atomic with the head and what makes an interrupted stream need
+  // no cookie handling of its own.
+  describe('the cookie jar', () => {
+    const CREATE_TABLE: SchemaChange = {
+      tag: 'create-table',
+      spec: {schema: 'my', name: 'foo', columns: {}},
+      metadata: {rowKey: {columns: ['id']}},
+      backfill: {a: {fooID: 1}},
+    };
+    const createTable = json(['data', CREATE_TABLE]);
+
+    test('cookies are durable with the transaction that carried them', () => {
+      const {db, observer} = createChangeLogFile();
+      using _db = db;
+      using _observer = observer;
+      const writer = new ChangeLogStreamWriter(new StatementRunner(db));
+
+      writer.begin('06', BEGIN);
+      writer.append(createTable, CREATE_TABLE);
+      // Written, but not yet visible to another connection — the cookie set and
+      // the rows it was folded from become durable together.
+      expect(readCookies(db).backfilling).toHaveLength(1);
+      expect(readCookies(observer)).toEqual(EMPTY_COOKIE_SET);
+
+      const stats = writer.commit('06', COMMIT, 789);
+      expect(stats.cookieMutations).toEqual([
+        'upsert-metadata',
+        'upsert-backfill',
+      ]);
+      expect(readCookies(observer)).toEqual({
+        tableMetadata: [
+          {schema: 'my', table: 'foo', metadata: {rowKey: {columns: ['id']}}},
+        ],
+        backfilling: [
+          {schema: 'my', table: 'foo', column: 'a', backfill: {fooID: 1}},
+        ],
+      });
+    });
+
+    test('a rollback discards the cookies with the rows', () => {
+      using db = createChangeLog();
+      const writer = new ChangeLogStreamWriter(new StatementRunner(db));
+
+      writer.begin('06', BEGIN);
+      writer.append(createTable, CREATE_TABLE);
+      writer.rollback();
+
+      expect(readCookies(db)).toEqual(EMPTY_COOKIE_SET);
+      expect(rowCount(db)).toBe(SEED_ROWS.length);
+
+      // ...and the discarded mutations are not reported by the next commit.
+      writer.begin('06', BEGIN);
+      expect(writer.commit('06', COMMIT, 789).cookieMutations).toEqual([]);
+    });
+
+    test('a transaction with no schema change reports no mutations', () => {
+      using db = createChangeLog();
+      const writer = new ChangeLogStreamWriter(new StatementRunner(db));
+
+      writer.begin('06', BEGIN);
+      writer.append(TRUNCATE, TRUNCATE_CHANGE);
+      expect(writer.commit('06', COMMIT, 789).cookieMutations).toEqual([]);
+      expect(readCookies(db)).toEqual(EMPTY_COOKIE_SET);
+    });
   });
 });

--- a/packages/zero-cache/src/services/replicator/change-log-stream-writer.ts
+++ b/packages/zero-cache/src/services/replicator/change-log-stream-writer.ts
@@ -1,16 +1,23 @@
 import type {Statement} from '../../../../zqlite/src/db.ts';
 import type {StatementRunner} from '../../db/statements.ts';
-import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
+import {
+  isSchemaChange,
+  type DataOrSchemaChange,
+} from '../change-source/protocol/current/data.ts';
 import {extractChangeSubstring} from '../change-streamer/change-log-codec.ts';
 import {ChangeLogTransactionHasher} from '../change-streamer/change-log-transaction-hash.ts';
+import {ChangeLogCookieWriter, type CookieOpTag} from './change-log-cookies.ts';
 import {CHANGE_LOG_STREAM_TABLE} from './change-log-db.ts';
-
-type ChangeTag = ChangeStreamData[1]['tag'];
 
 export type ChangeLogStreamTransactionStats = {
   readonly rows: number;
   readonly estimatedBytes: number;
   readonly hash: string;
+  /**
+   * The cookie mutations this transaction's schema changes folded in, in stream
+   * order. Empty for the overwhelming majority of transactions.
+   */
+  readonly cookieMutations: readonly CookieOpTag[];
 };
 
 const INTEGER_BYTES = 8;
@@ -50,23 +57,30 @@ function assertInvariant(
 
 /**
  * Appends the canonical downstream stream to the change-log database, which is
- * a separate file from the replica.
+ * a separate file from the replica, and folds its schema changes into the log's
+ * cookie jar (`change-log-cookies.ts`) as it goes.
  *
  * This class owns the change log's transaction, and its transaction alone. It is
  * driven from the change-streamer's stream loop, which commits it before
  * forwarding a transaction's `commit` message; see `SQLiteChangeLogWriter` in
  * `change-streamer/sqlite-change-log-writer.ts` for the ordering that makes a
  * hole unreachable, and for the fail-soft policy that wraps every call here.
+ *
+ * Because the cookies are written in that same transaction, they are atomic with
+ * the head and {@link rollback} discards them with the rows they were folded
+ * from. Neither needs any handling of its own.
  */
 export class ChangeLogStreamWriter {
   readonly #db: StatementRunner;
   readonly #insertChange: Statement;
   readonly #insertCommit: Statement;
+  readonly #cookies: ChangeLogCookieWriter;
 
   #watermark: string | undefined;
   #pos = 0;
   #estimatedBytes = 0;
   #hasher: ChangeLogTransactionHasher | undefined;
+  #cookieMutations: CookieOpTag[] = [];
 
   constructor(db: StatementRunner) {
     this.#db = db;
@@ -80,6 +94,7 @@ export class ChangeLogStreamWriter {
         ("watermark", "pos", "change", "precommit", "writeTimeMs")
         VALUES (?, ?, ?, ?, ?)
     `);
+    this.#cookies = new ChangeLogCookieWriter(db.db);
   }
 
   begin(watermark: string, json: string): void {
@@ -106,18 +121,35 @@ export class ChangeLogStreamWriter {
     this.#estimatedBytes = estimateChangeLogStreamRowBytes(watermark, change);
   }
 
-  append(json: string, tag: ChangeTag): void {
+  /**
+   * Appends one data or schema change. The parsed message is taken rather than
+   * just its tag because a schema change also mutates the cookie jar, and the
+   * caller already holds it — so the fold costs no re-parse.
+   *
+   * The cookie statements run here, i.e. inside this transaction and in stream
+   * order relative to the rows they were folded from. The Postgres change log
+   * has to flush its buffered batch to get the same ordering
+   * (`Storer.#processQueue()`); SQLite gets it from statement order.
+   */
+  append(json: string, change: DataOrSchemaChange): void {
     const watermark = this.#requireWatermark();
-    const change = extractChangeSubstring(json, tag);
-    this.#insertChange.run(watermark, ++this.#pos, change);
+    const {tag} = change;
+    const stored = extractChangeSubstring(json, tag);
+    this.#insertChange.run(watermark, ++this.#pos, stored);
     this.#requireHasher().add({
       watermark,
       pos: this.#pos,
       tag,
-      change,
+      change: stored,
       precommit: null,
     });
-    this.#estimatedBytes += estimateChangeLogStreamRowBytes(watermark, change);
+    this.#estimatedBytes += estimateChangeLogStreamRowBytes(watermark, stored);
+
+    if (isSchemaChange(change)) {
+      for (const op of this.#cookies.apply(change)) {
+        this.#cookieMutations.push(op.op);
+      }
+    }
   }
 
   commit(
@@ -152,6 +184,7 @@ export class ChangeLogStreamWriter {
         this.#estimatedBytes +
         estimateChangeLogStreamRowBytes(watermark, change, precommit, true),
       hash: hasher.digest(),
+      cookieMutations: this.#cookieMutations,
     };
     // The log is durable at `watermark` from here on, and nothing that can
     // advance the watermark the stream would resume from has run yet. A crash in
@@ -180,6 +213,9 @@ export class ChangeLogStreamWriter {
     this.#pos = 0;
     this.#estimatedBytes = 0;
     this.#hasher = undefined;
+    // A fresh array rather than a truncation: the committed stats hold a
+    // reference to the previous one.
+    this.#cookieMutations = [];
   }
 
   #requireWatermark(): string {

--- a/packages/zero-cache/src/services/replicator/sqlite-change-log-metrics.test.ts
+++ b/packages/zero-cache/src/services/replicator/sqlite-change-log-metrics.test.ts
@@ -17,7 +17,10 @@ import {
 import {afterEach, expect, test, vi} from 'vitest';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
 import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
-import type {ReseedReason} from './change-log-db.ts';
+import {
+  CHANGE_LOG_DB_SCHEMA_VERSION,
+  type ReseedReason,
+} from './change-log-db.ts';
 import type {
   ChangeLogCommit,
   SQLiteChangeLogInfo,
@@ -59,14 +62,22 @@ function dataPoints(exporter: InMemoryMetricExporter, name: string) {
   return metric?.dataPoints;
 }
 
-function counts(exporter: InMemoryMetricExporter, name: string) {
+function counts(
+  exporter: InMemoryMetricExporter,
+  name: string,
+  label: string = 'reason',
+) {
   return Object.fromEntries(
     (dataPoints(exporter, name) ?? []).map(point => [
-      // Every counter here is either unlabeled or labeled by `reason`.
-      point.attributes.reason ?? '',
+      point.attributes[label] ?? '',
       point.value,
     ]),
   );
+}
+
+/** Observable gauges report per label set, like the counters above. */
+function gauges(exporter: InMemoryMetricExporter, name: string, label: string) {
+  return counts(exporter, name, label);
 }
 
 function histogram(
@@ -102,6 +113,7 @@ test('each reseed reason increments reconcile_wipes with its own label', async (
       action: 'reseeded',
       head: '05',
       reason,
+      cookiesStale: true,
     });
   }
   // Twice, to show the `gap` series counts rather than latches. A nonzero rate
@@ -111,13 +123,19 @@ test('each reseed reason increments reconcile_wipes with its own label', async (
     action: 'reseeded',
     head: '05',
     reason: 'gap',
+    cookiesStale: true,
   });
   recordSQLiteChangeLogReconcile(lc, {
     action: 'truncated',
     head: '05',
     rows: 27,
+    cookiesStale: true,
   });
-  recordSQLiteChangeLogReconcile(lc, {action: 'none', head: '05'});
+  recordSQLiteChangeLogReconcile(lc, {
+    action: 'none',
+    head: '05',
+    cookiesStale: false,
+  });
   await otel.provider.forceFlush();
 
   expect(counts(otel.exporter, `${METRIC}.reconcile_wipes`)).toEqual({
@@ -139,6 +157,7 @@ test('a consistent log emits no wipe or truncation series at all', async () => {
   recordSQLiteChangeLogReconcile(createSilentLogContext(), {
     action: 'none',
     head: '05',
+    cookiesStale: false,
   });
   await otel.provider.forceFlush();
 
@@ -159,7 +178,12 @@ const COMMIT: ChangeStreamData = ['commit', {tag: 'commit'}, {watermark: '06'}];
 
 const COMMIT_RESULT: ChangeLogCommit = {
   watermark: '06',
-  stats: {rows: 2, estimatedBytes: 100, hash: '0'.repeat(64)},
+  stats: {
+    rows: 2,
+    estimatedBytes: 100,
+    hash: '0'.repeat(64),
+    cookieMutations: [],
+  },
   logCommitMs: 4,
 };
 
@@ -167,12 +191,13 @@ const INFO: SQLiteChangeLogInfo = {
   epoch: null,
   generation: '01',
   replicaID: null,
-  schemaVersion: 2,
+  schemaVersion: CHANGE_LOG_DB_SCHEMA_VERSION,
   seededAtMs: 1_700_000_000_000,
   seedWatermark: '02',
   headWatermark: '02',
   rows: 2,
   estimatedBytes: 100,
+  cookieRows: {tableMetadata: 0, backfilling: 0},
 };
 
 test('records the commit that sits on the forward path', async () => {
@@ -222,4 +247,70 @@ test('a failed commit times the attempt but not the commit', async () => {
       outcome: 'error',
     }),
   ).toMatchObject({count: 1, sum: 0.02});
+});
+
+test('every reconcile that moves the head counts a cookie reseed', async () => {
+  await using otel = withProvider();
+  const {recordSQLiteChangeLogReconcile} =
+    await import('./sqlite-change-log-observability.ts');
+  const lc = createSilentLogContext();
+
+  recordSQLiteChangeLogReconcile(lc, {
+    action: 'truncated',
+    head: '05',
+    rows: 27,
+    cookiesStale: true,
+  });
+  recordSQLiteChangeLogReconcile(lc, {
+    action: 'reseeded',
+    head: '05',
+    reason: 'gap',
+    cookiesStale: true,
+  });
+  // A reconcile that changed nothing did not invalidate the cookie set, so it
+  // must not appear in the series at all.
+  recordSQLiteChangeLogReconcile(lc, {
+    action: 'none',
+    head: '05',
+    cookiesStale: false,
+  });
+  await otel.provider.forceFlush();
+
+  expect(counts(otel.exporter, `${METRIC}.cookie_reseed`, 'action')).toEqual({
+    truncated: 1,
+    reseeded: 1,
+  });
+});
+
+test('cookie mutations are counted by op, and the rows they leave gauged', async () => {
+  await using otel = withProvider();
+  const {SQLiteChangeLogObserver} =
+    await import('./sqlite-change-log-observability.ts');
+  const observer = new SQLiteChangeLogObserver(createSilentLogContext(), INFO);
+
+  observer.cookiesMutated(['upsert-metadata', 'upsert-backfill'], {
+    tableMetadata: 1,
+    backfilling: 1,
+  });
+  observer.cookiesMutated(['upsert-backfill'], {
+    tableMetadata: 1,
+    backfilling: 2,
+  });
+  observer.cookiesMutated(['complete-backfill'], {
+    tableMetadata: 1,
+    backfilling: 0,
+  });
+  await otel.provider.forceFlush();
+
+  expect(counts(otel.exporter, `${METRIC}.cookie_mutations`, 'op')).toEqual({
+    'upsert-metadata': 1,
+    'upsert-backfill': 2,
+    'complete-backfill': 1,
+  });
+  // A retained cookie row with no backfill in flight is a backfill that will be
+  // re-requested forever, so the gauge is per table rather than a total.
+  expect(gauges(otel.exporter, `${METRIC}.cookie_rows`, 'table')).toEqual({
+    tableMetadata: 1,
+    backfilling: 0,
+  });
 });

--- a/packages/zero-cache/src/services/replicator/sqlite-change-log-observability.test.ts
+++ b/packages/zero-cache/src/services/replicator/sqlite-change-log-observability.test.ts
@@ -71,7 +71,7 @@ function commitResult(
 ): ChangeLogCommit {
   return {
     watermark,
-    stats: {rows: 2, estimatedBytes, hash},
+    stats: {rows: 2, estimatedBytes, hash, cookieMutations: []},
     logCommitMs: 0.009,
   };
 }
@@ -116,6 +116,7 @@ describe('SQLite change-log observability', () => {
       headWatermark: '02',
       rows: 2,
       estimatedBytes: expect.any(Number),
+      cookieRows: {tableMetadata: 0, backfilling: 0},
     });
     expect(info.estimatedBytes).toBeGreaterThan(0);
 
@@ -158,6 +159,7 @@ describe('SQLite change-log observability', () => {
     const {
       rows: _rows,
       estimatedBytes: _bytes,
+      cookieRows: _cookieRows,
       ...head
     } = getSQLiteChangeLogInfo(fixture.changeLog);
     expect(startupInfo).toEqual(head);
@@ -513,18 +515,37 @@ describe('replicator/sqlite-change-log reconcile reporting', () => {
   // means the log did not lead the resume watermark, and is the one on the
   // alert list.
   const cases: [name: string, result: ReconcileResult][] = [
-    ['consistent', {action: 'none', head: '05'}],
-    ['phantom truncation', {action: 'truncated', head: '05', rows: 27}],
-    ['wipe: created', {action: 'reseeded', head: '05', reason: 'created'}],
+    ['consistent', {action: 'none', head: '05', cookiesStale: false}],
+    [
+      'phantom truncation',
+      {action: 'truncated', head: '05', rows: 27, cookiesStale: true},
+    ],
+    [
+      'wipe: created',
+      {action: 'reseeded', head: '05', reason: 'created', cookiesStale: true},
+    ],
     [
       'wipe: schema-mismatch',
-      {action: 'reseeded', head: '05', reason: 'schema-mismatch'},
+      {
+        action: 'reseeded',
+        head: '05',
+        reason: 'schema-mismatch',
+        cookiesStale: true,
+      },
     ],
     [
       'wipe: identity-mismatch',
-      {action: 'reseeded', head: '05', reason: 'identity-mismatch'},
+      {
+        action: 'reseeded',
+        head: '05',
+        reason: 'identity-mismatch',
+        cookiesStale: true,
+      },
     ],
-    ['wipe: gap', {action: 'reseeded', head: '05', reason: 'gap'}],
+    [
+      'wipe: gap',
+      {action: 'reseeded', head: '05', reason: 'gap', cookiesStale: true},
+    ],
   ];
 
   test.each(cases)('%s', (_name, result) => {

--- a/packages/zero-cache/src/services/replicator/sqlite-change-log-observability.ts
+++ b/packages/zero-cache/src/services/replicator/sqlite-change-log-observability.ts
@@ -25,6 +25,11 @@ import type {ChangeStreamData} from '../change-source/protocol/current/downstrea
 import {extractChangeSubstring} from '../change-streamer/change-log-codec.ts';
 import {ChangeLogTransactionHasher} from '../change-streamer/change-log-transaction-hash.ts';
 import {
+  readCookieRowCounts,
+  type CookieOpTag,
+  type CookieRowCounts,
+} from './change-log-cookies.ts';
+import {
   CHANGE_LOG_STREAM_TABLE,
   readChangeLogHead,
   readChangeLogMeta,
@@ -71,6 +76,18 @@ export function recordSQLiteChangeLogReconcile(
     default:
       unreachable(result);
   }
+  if (result.cookiesStale) {
+    // The invariant-17 counter: after any reconcile that moved the head, the
+    // log's cookie set has to be replaced with the one that belongs to the
+    // resume watermark. A nonzero `truncated` series in steady state means
+    // phantom truncation is happening on a shard where it should not.
+    getOrCreateCounter(
+      'replica',
+      'sqlite_change_log.cookie_reseed',
+      'Change-log cookie sets invalidated at reconciliation, by the ' +
+        'reconcile action that invalidated them.',
+    ).add(1, {action: result.action});
+  }
   lc.debug?.('SQLite change-log reconciliation', {
     sqliteChangeLogReconcile: result,
   });
@@ -88,6 +105,7 @@ export type SQLiteChangeLogStartupInfo = ChangeLogMeta & {
 export type SQLiteChangeLogInfo = SQLiteChangeLogStartupInfo & {
   readonly rows: number;
   readonly estimatedBytes: number;
+  readonly cookieRows: CookieRowCounts;
 };
 
 /**
@@ -136,6 +154,7 @@ export function getSQLiteChangeLogInfo(
     ...startup,
     rows: aggregate.rows,
     estimatedBytes: aggregate.estimatedBytes,
+    cookieRows: readCookieRowCounts(changeLog),
   };
 }
 
@@ -203,6 +222,8 @@ export type SQLiteChangeLogObservabilityState = {
   readonly headLag: number | undefined;
   readonly rows: number;
   readonly estimatedBytes: number;
+  readonly cookieRows: CookieRowCounts;
+  readonly cookieMutations: number;
   readonly rollbacks: number;
   readonly invariantFailures: number;
   readonly hashMatches: number;
@@ -266,11 +287,19 @@ export class SQLiteChangeLogObserver {
     'sqlite_change_log.hash_unpaired',
     'Committed change-log transactions without both ephemeral hashes available for comparison.',
   );
+  // Near zero at steady state: cookie state only moves on schema changes.
+  readonly #cookieMutationCounter = getOrCreateCounter(
+    'replica',
+    'sqlite_change_log.cookie_mutations',
+    'Change-log cookie mutations folded from schema changes, by operation.',
+  );
 
   #receivedHead: string;
   #sqliteHead: string;
   #rows: number;
   #estimatedBytes: number;
+  #cookieRows: CookieRowCounts;
+  #cookieMutations = 0;
   #transactionWatermark: string | undefined;
   #sourceHasher: ChangeLogTransactionHasher | undefined;
   #sourcePos = 0;
@@ -289,12 +318,23 @@ export class SQLiteChangeLogObserver {
     this.#sqliteHead = info.headWatermark;
     this.#rows = info.rows;
     this.#estimatedBytes = info.estimatedBytes;
+    this.#cookieRows = info.cookieRows;
 
     getOrCreateGauge(
       'replica',
       'sqlite_change_log.rows',
       'Rows retained in the SQLite change log.',
     ).addCallback(result => result.observe(this.#rows));
+    // Nonzero with no backfill in flight is a leaked cookie, i.e. a backfill
+    // that will be re-requested forever.
+    getOrCreateGauge(
+      'replica',
+      'sqlite_change_log.cookie_rows',
+      'Cookie rows retained in the SQLite change log, by cookie table.',
+    ).addCallback(result => {
+      result.observe(this.#cookieRows.tableMetadata, {table: 'tableMetadata'});
+      result.observe(this.#cookieRows.backfilling, {table: 'backfilling'});
+    });
     getOrCreateGauge('replica', 'sqlite_change_log.retained_bytes', {
       description:
         'Estimated UTF-8 payload bytes retained in the SQLite change log.',
@@ -482,6 +522,19 @@ export class SQLiteChangeLogObserver {
   }
 
   /**
+   * A committed transaction folded schema changes into the cookie jar. Reported
+   * separately from {@link messageProcessed} because it costs a read of the
+   * cookie tables, which is only worth taking when they actually moved.
+   */
+  cookiesMutated(ops: readonly CookieOpTag[], rows: CookieRowCounts): void {
+    for (const op of ops) {
+      this.#cookieMutations++;
+      this.#cookieMutationCounter.add(1, {op});
+    }
+    this.#cookieRows = rows;
+  }
+
+  /**
    * A missed truncate-above surfaces as a constraint violation on the writer's
    * plain `INSERT`, which the fail-soft policy would otherwise absorb quietly.
    * Classifying it as an invariant failure is what keeps a reconciliation bug
@@ -506,6 +559,7 @@ export class SQLiteChangeLogObserver {
     this.#sqliteHead = info.headWatermark;
     this.#rows = info.rows;
     this.#estimatedBytes = info.estimatedBytes;
+    this.#cookieRows = info.cookieRows;
     this.#transactionWatermark = undefined;
     this.#resetSourceHash();
   }
@@ -517,6 +571,8 @@ export class SQLiteChangeLogObserver {
       headLag: watermarkDistance(this.#receivedHead, this.#sqliteHead),
       rows: this.#rows,
       estimatedBytes: this.#estimatedBytes,
+      cookieRows: this.#cookieRows,
+      cookieMutations: this.#cookieMutations,
       rollbacks: this.#rollbacks,
       invariantFailures: this.#invariantFailures,
       hashMatches: this.#hashMatches,

--- a/packages/zero-cache/src/services/replicator/sqlite-change-log-purger.test.ts
+++ b/packages/zero-cache/src/services/replicator/sqlite-change-log-purger.test.ts
@@ -5,7 +5,10 @@ import type {Database} from '../../../../zqlite/src/db.ts';
 import {StatementRunner} from '../../db/statements.ts';
 import {DbFile} from '../../test/lite.ts';
 import {versionToLexi} from '../../types/lexi-version.ts';
-import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
+import type {
+  ChangeStreamData,
+  Data,
+} from '../change-source/protocol/current/downstream.ts';
 import {serializeChangeStreamData} from '../change-streamer/change-log-codec.ts';
 import type {WatermarkedChange} from '../change-streamer/change-streamer.ts';
 import {SQLiteChangeLogReader} from '../change-streamer/sqlite-change-log-reader.ts';
@@ -86,12 +89,12 @@ function append(
     {tag: 'begin'},
     {commitWatermark: watermark},
   ];
-  const truncate: ChangeStreamData = ['data', {tag: 'truncate', relations: []}];
+  const truncate: Data = ['data', {tag: 'truncate', relations: []}];
   const commit: ChangeStreamData = ['commit', {tag: 'commit'}, {watermark}];
   try {
     writer.begin(watermark, serializeChangeStreamData(begin));
     for (let i = 0; i < changes; i++) {
-      writer.append(serializeChangeStreamData(truncate), 'truncate');
+      writer.append(serializeChangeStreamData(truncate), truncate[1]);
     }
     writer.commit(watermark, serializeChangeStreamData(commit), writeTimeMs);
   } catch (e) {
@@ -789,7 +792,11 @@ describe('replicator/sqlite-change-log-purger', () => {
           {...ANCHOR, resumeWatermark: v(4)},
         );
         try {
-          expect(result).toEqual({action: 'none', head: v(4)});
+          expect(result).toEqual({
+            action: 'none',
+            head: v(4),
+            cookiesStale: false,
+          });
           expect(rowCount(reopened, v(1))).toBe(remaining);
 
           drain(new SQLiteChangeLogPurger(reopened), {maxRows: MAX_ROWS});


### PR DESCRIPTION
Updates `change-log-stream-writer.ts` create `ChangeLogCookieWriter` and use it as schema changes come through.

 
- Schema changes write "cookies" to the change log so we can resume a backfill
- Those cookies are eventually persisted in the replica

---

If we lose the log before the cookie makes it to the replica, that's fine. We resume from PG (upstream DB, not pg change log) from the replica's watermark. PG will send us the DDL again.