### PR TITLE
chore(rmv2): seed sqlite's backfill cookies

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/change-log-cookies.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-log-cookies.pg.test.ts
@@ -27,7 +27,11 @@ import {
   type CookieSet,
   type TableMetadataCookie,
 } from '../replicator/change-log-cookies.ts';
-import {CREATE_CHANGE_LOG_STREAM_SCHEMA} from '../replicator/change-log-db.ts';
+import {
+  CREATE_CHANGE_LOG_STREAM_SCHEMA,
+  reconcileChangeLog,
+  type ChangeLogAnchor,
+} from '../replicator/change-log-db.ts';
 import {ChangeLogStreamWriter} from '../replicator/change-log-stream-writer.ts';
 import {serializeChangeStreamData} from './change-log-codec.ts';
 import {ensureReplicationConfig, setupCDCTables} from './schema/tables.ts';
@@ -418,6 +422,125 @@ describe('change-streamer/change-log cookie parity', () => {
       backfilling: [
         {schema: 'my', table: 'foo', column: 'a', backfill: {fooID: 1}},
       ],
+    });
+  });
+
+  /**
+   * Slice C2. Everything above proves the two stores fold alike; this proves
+   * that the log can be *handed* the Postgres set at a resume point and carry
+   * on folding from it — which is what invariant 17 requires of every
+   * reconciliation that moves the head, and what the C5 flip inverts.
+   */
+  describe('reseeding the log at the resume point', () => {
+    function anchorFrom({
+      lastWatermark,
+      cookies,
+    }: {
+      lastWatermark: string;
+      cookies: CookieSet;
+    }): ChangeLogAnchor {
+      return {
+        identity: {epoch: null, generation: REPLICA_VERSION, replicaID: null},
+        resumeWatermark: lastWatermark,
+        nowMs: 1_700_000_000_000,
+        cookies,
+      };
+    }
+
+    /** The anchor a stream connection would reconcile the log against. */
+    async function anchor(): Promise<ChangeLogAnchor> {
+      return anchorFrom(await storer.getStartStreamInitializationParameters());
+    }
+
+    test('a reseed lands the cookie set Postgres holds', async () => {
+      await transaction({
+        tag: 'create-table',
+        spec: {schema: 'my', name: 'foo', columns: {}},
+        metadata: {rowKey: {type: 'index', columns: ['a', 'b']}},
+        backfill: {a: {fooID: 987}, b: {fooID: 843}},
+      });
+      // A table whose metadata `backfillRequests` drops, since it has no
+      // in-flight backfill (§3.7). The raw cookie set is what carries it, and
+      // is why the reseed reads the tables rather than the request list.
+      await transaction({
+        tag: 'create-table',
+        spec: {schema: 'your', name: 'bar', columns: {}},
+        metadata: {rowKey: {type: 'default', columns: ['id']}},
+      });
+
+      // A log with no meta row of its own: what a task that has just restored a
+      // replica, or upgraded past a schema version, brings to its first stream
+      // connection. It is wiped and reseeded at the resume watermark.
+      const params = await storer.getStartStreamInitializationParameters();
+      expect(
+        reconcileChangeLog(lc, changeLog, anchorFrom(params)),
+      ).toMatchObject({
+        action: 'reseeded',
+        reason: 'created',
+        cookiesStale: true,
+      });
+
+      expect(readCookies(changeLog)).toEqual(await pgCookies());
+      // Not the same thing as the request list, and strictly more than it.
+      expect(params.backfillRequests).toHaveLength(1);
+      expect(readCookies(changeLog).tableMetadata).toHaveLength(2);
+    });
+
+    test('a truncation replaces the set rather than keeping its own', async () => {
+      await transaction({
+        tag: 'create-table',
+        spec: {schema: 'my', name: 'foo', columns: {}},
+        backfill: {a: {fooID: 1}},
+      });
+      // The resume point of the connection that is about to reconnect, captured
+      // before the log runs ahead of it.
+      const resumePoint = await anchor();
+      reconcileChangeLog(lc, changeLog, resumePoint);
+
+      // The log commits before anything that advances the resume watermark, so
+      // it can hold a transaction Postgres' watermark has not reached -- and
+      // that transaction's cookies with it.
+      await transaction({
+        tag: 'add-column',
+        table: {schema: 'my', name: 'foo'},
+        column: {name: 'b', spec: {pos: 2, dataType: 'text'}},
+        backfill: {fooID: 2},
+      });
+      expect(readCookies(changeLog).backfilling).toHaveLength(2);
+
+      // The reconnect truncates it away. Rolling the cookies back is not
+      // possible -- an `add-column`'s backfill is not undone by deleting the
+      // row that carried it -- so the set that belongs to the resume watermark
+      // replaces it wholesale.
+      expect(reconcileChangeLog(lc, changeLog, resumePoint)).toMatchObject({
+        action: 'truncated',
+        cookiesStale: true,
+      });
+      expect(readCookies(changeLog)).toEqual(resumePoint.cookies);
+      expect(readCookies(changeLog).backfilling).toEqual([
+        {schema: 'my', table: 'foo', column: 'a', backfill: {fooID: 1}},
+      ]);
+    });
+
+    test('the log folds onward from the set it was reseeded with', async () => {
+      await transaction({
+        tag: 'create-table',
+        spec: {schema: 'my', name: 'foo', columns: {}},
+        backfill: {a: {fooID: 1}, b: {fooID: 2}},
+      });
+      reconcileChangeLog(lc, changeLog, await anchor());
+
+      // The completion arrives on the resumed stream, against cookies this log
+      // never folded for itself. Both stores land in the same place, which is
+      // the property the whole reseed exists to preserve.
+      await transaction({
+        tag: 'backfill-completed',
+        relation: {schema: 'my', name: 'foo', rowKey: {columns: ['a']}},
+        columns: ['b'],
+        watermark: '09',
+      });
+
+      await expectCookies({tableMetadata: [], backfilling: []});
     });
   });
 

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
@@ -27,6 +27,10 @@ import type {UpstreamStatusMessage} from '../change-source/protocol/current/stat
 import {exitAfter} from '../life-cycle.ts';
 import type {LitestreamVersion} from '../litestream/metrics.ts';
 import {
+  EMPTY_COOKIE_SET,
+  readCookies,
+} from '../replicator/change-log-cookies.ts';
+import {
   CHANGE_LOG_DB_SCHEMA_VERSION,
   changeLogFileName,
   deleteChangeLogDB,
@@ -262,6 +266,9 @@ describe('change-streamer/service', () => {
       identity: {epoch: null, generation: replicaVersion, replicaID: null},
       resumeWatermark: stateVersion,
       nowMs: Date.now(),
+      // No backfill is in flight in any of these tests, which is the steady
+      // state: the cookie jar is empty and stays empty.
+      cookies: EMPTY_COOKIE_SET,
     };
   }
 
@@ -871,16 +878,15 @@ describe('change-streamer/service', () => {
   });
 
   /**
-   * The in-process form of truncate-above, driven by production machinery: a
-   * storer commit fails, the stream is re-established, and its resume watermark
-   * is behind the log's head. The writer inserts with a plain `INSERT`, so an
-   * un-truncated overlap is a constraint violation on the re-delivery.
+   * A streamer whose change source hands out two streams in turn, with the
+   * reconnect between them observable. This is the shape every in-process
+   * reconnect takes: the resume point is re-read from Postgres and the log is
+   * reconciled against it before the second stream starts.
    */
-  test('an in-process reconnect below the log head truncates rather than colliding', async () => {
+  async function startWithReconnect(logFile: DbFile) {
     await streamer.stop();
     await streamerDone;
 
-    const logFile = new DbFile('sqlite-change-log-reconnect');
     const first = Subscription.create<ChangeStreamMessage>();
     const second = Subscription.create<ChangeStreamMessage>();
     const {promise: reconnected, resolve: didReconnect} = resolver<true>();
@@ -929,19 +935,44 @@ describe('change-streamer/service', () => {
           },
         },
       },
-      // The real timer, because this test depends on the reconnect backoff
+      // The real timer, because these tests depend on the reconnect backoff
       // actually firing.
     );
     streamerDone = streamer.run();
 
-    const head = () => {
-      using changeLog = openChangeLogDB(lc, logFile.path, {readonly: true});
-      return changeLog
-        .prepare(
-          `SELECT max("watermark") AS "head" FROM "_zero.changeLogStream"`,
-        )
-        .get<{head: string | null}>().head;
+    return {
+      first,
+      second,
+      reconnected,
+      head: () => {
+        using changeLog = openChangeLogDB(lc, logFile.path, {readonly: true});
+        return readChangeLogHead(changeLog);
+      },
+      cookies: () => {
+        using changeLog = openChangeLogDB(lc, logFile.path, {readonly: true});
+        return readCookies(changeLog);
+      },
+      cleanup: async () => {
+        first.cancel();
+        second.cancel();
+        await streamer.stop();
+        await streamerDone;
+        deleteChangeLogDB(logFile.path);
+        logFile.delete();
+      },
     };
+  }
+
+  /**
+   * The in-process form of truncate-above, driven by production machinery: a
+   * storer commit fails, the stream is re-established, and its resume watermark
+   * is behind the log's head. The writer inserts with a plain `INSERT`, so an
+   * un-truncated overlap is a constraint violation on the re-delivery.
+   */
+  test('an in-process reconnect below the log head truncates rather than colliding', async () => {
+    const logFile = new DbFile('sqlite-change-log-reconnect');
+    const {first, second, reconnected, head, cleanup} =
+      await startWithReconnect(logFile);
 
     try {
       // Makes the storer's commit of '05' fail, so Postgres never records it
@@ -981,12 +1012,110 @@ describe('change-streamer/service', () => {
           .filter(m => m.includes('constraint')),
       ).toEqual([]);
     } finally {
-      first.cancel();
-      second.cancel();
-      await streamer.stop();
-      await streamerDone;
-      deleteChangeLogDB(logFile.path);
-      logFile.delete();
+      await cleanup();
+    }
+  });
+
+  /**
+   * The cookie half of the same reconnect (slice C2). The log folds the cookies
+   * of every schema change it appends, so a transaction it holds and Postgres
+   * does not leaves it holding a backfill Postgres never recorded — and
+   * deleting those rows does not undo the fold. The set that belongs to the
+   * resume watermark therefore replaces the log's wholesale, read from Postgres
+   * in the same snapshot as the watermark itself (invariants 15 and 17).
+   */
+  test('a reconnect replaces the log’s cookies with the resume point’s', async () => {
+    const logFile = new DbFile('sqlite-change-log-reconnect-cookies');
+    const {first, second, reconnected, head, cookies, cleanup} =
+      await startWithReconnect(logFile);
+
+    const foo = {
+      tag: 'create-table',
+      spec: {schema: 'my', name: 'foo', columns: {}},
+      metadata: {rowKey: {type: 'default', columns: ['id']}},
+      backfill: {a: {fooID: 1}},
+    } as const;
+    const bar = {
+      tag: 'create-table',
+      spec: {schema: 'my', name: 'bar', columns: {}},
+      backfill: {b: {barID: 2}},
+    } as const;
+
+    try {
+      // '03' commits in both stores: a table whose backfill is still in flight
+      // at the watermark the reconnect will resume from.
+      first.push(['begin', messages.begin(), {commitWatermark: '03'}]);
+      first.push(['data', foo]);
+      first.push(['commit', messages.commit(), {watermark: '03'}]);
+      await vi.waitFor(() => expect(head()).toBe('03'));
+      await vi.waitFor(async () =>
+        expect(
+          await sql`SELECT "lastWatermark" FROM "zoro_3/cdc"."replicationState"`.values(),
+        ).toEqual([['03']]),
+      );
+
+      // '05' reaches the log only: its commit row collides at `pos` 2, so the
+      // storer rolls the whole transaction back -- the schema-change row and
+      // the cookie DML it carried with it. The log's own write is synchronous
+      // and already done, cookies and all.
+      await sql`INSERT INTO "zoro_3/cdc"."changeLog" (watermark, pos, change)
+        VALUES ('05', 2, ${{conflicting: 'entry'}})`;
+      first.push(['begin', messages.begin(), {commitWatermark: '05'}]);
+      first.push(['data', bar]);
+      first.push(['commit', messages.commit(), {watermark: '05'}]);
+
+      expect(await reconnected).toBe(true);
+      // The truncation is what says the log had gone above '03', i.e. that it
+      // had folded `bar` into a jar Postgres knows nothing about.
+      expect(
+        logSink.messages
+          .map(([, , args]) => String(args[0]))
+          .filter(m => m.includes('truncated phantom transactions')),
+      ).toHaveLength(1);
+      expect(head()).toBe('03');
+
+      // Invariant 17: the set that belongs to '03', which is Postgres' -- not
+      // the one the log folded, and not an empty jar.
+      const atResumePoint = {
+        tableMetadata: [
+          {
+            schema: 'my',
+            table: 'foo',
+            metadata: {rowKey: {type: 'default', columns: ['id']}},
+          },
+        ],
+        backfilling: [
+          {schema: 'my', table: 'foo', column: 'a', backfill: {fooID: 1}},
+        ],
+      };
+      expect(cookies()).toEqual(atResumePoint);
+
+      // And the log folds onward from it: the resumed stream re-delivers '05',
+      // and both stores end up holding the same two tables.
+      await sql`DELETE FROM "zoro_3/cdc"."changeLog"
+                  WHERE watermark = '05' AND pos = 2`;
+      second.push(['begin', messages.begin(), {commitWatermark: '05'}]);
+      second.push(['data', bar]);
+      second.push(['commit', messages.commit(), {watermark: '05'}]);
+      await vi.waitFor(() => expect(head()).toBe('05'));
+
+      expect(cookies()).toEqual({
+        ...atResumePoint,
+        backfilling: [
+          {schema: 'my', table: 'bar', column: 'b', backfill: {barID: 2}},
+          ...atResumePoint.backfilling,
+        ],
+      });
+      expect(
+        await sql`SELECT "schema", "table", "column", "backfill"
+                    FROM "zoro_3/cdc"."backfilling"
+                    ORDER BY "schema", "table", "column"`.values(),
+      ).toEqual([
+        ['my', 'bar', 'b', {barID: 2}],
+        ['my', 'foo', 'a', {fooID: 1}],
+      ]);
+    } finally {
+      await cleanup();
     }
   });
 

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -528,7 +528,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
       let watermark: string | null = null;
       let unflushedBytes = 0;
       try {
-        const {lastWatermark, backfillRequests} =
+        const {lastWatermark, backfillRequests, cookies} =
           await this.#storer.getStartStreamInitializationParameters();
         // SQLite catchup must not be eligible until this has been initialized
         // from the durable PG head. Commits observed only since process startup
@@ -539,7 +539,15 @@ class ChangeStreamerImpl implements ChangeStreamerService {
         // above it -- a restarted backfill's abandoned ones, in bulk -- and the
         // writer's plain INSERT would collide with the first re-delivery.
         // Ordered before startStream so no change can arrive mid-reconcile.
-        this.#changeLogWriter?.reconcile(lastWatermark);
+        //
+        // The cookies come from the same read as the watermark, and go to the
+        // log with it: a reconcile that moves the head discards the set the log
+        // had folded, and only the set that belongs to this watermark can
+        // replace it (invariant 15).
+        this.#changeLogWriter?.reconcile({
+          resumeWatermark: lastWatermark,
+          cookies,
+        });
         const stream = await this.#source.startStream(
           lastWatermark,
           backfillRequests,

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-purge-scheduler.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-purge-scheduler.test.ts
@@ -9,6 +9,7 @@ import type {
   ChangeStreamData,
   Data,
 } from '../change-source/protocol/current/downstream.ts';
+import {EMPTY_COOKIE_SET} from '../replicator/change-log-cookies.ts';
 import {
   CHANGE_LOG_STREAM_TABLE,
   changeLogFileName,
@@ -140,6 +141,7 @@ function setup(
     identity: {epoch: null, generation: '01', replicaID: null},
     resumeWatermark: opts.resumeWatermark ?? SEED_WATERMARK,
     nowMs: SEED_WRITE_TIME_MS,
+    cookies: EMPTY_COOKIE_SET,
   };
   const {db} = openChangeLogDBForWriting(lc, file.path, anchor);
 

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-reader.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-reader.test.ts
@@ -10,6 +10,7 @@ import type {
   ChangeStreamData,
   Data,
 } from '../change-source/protocol/current/downstream.ts';
+import {EMPTY_COOKIE_SET} from '../replicator/change-log-cookies.ts';
 import {
   CHANGE_LOG_STREAM_TABLE,
   changeLogFileName,
@@ -46,6 +47,7 @@ const ANCHOR: ChangeLogAnchor = {
   identity: {epoch: null, generation: '01', replicaID: null},
   resumeWatermark: '02',
   nowMs: 1234567890,
+  cookies: EMPTY_COOKIE_SET,
 };
 
 /** The replica path whose `-change-log` sibling the fixtures build. */

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-writer.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-writer.test.ts
@@ -4,7 +4,11 @@ import {afterEach, describe, expect, test} from 'vitest';
 import {TestLogSink} from '../../../../shared/src/logging-test-utils.ts';
 import {DbFile} from '../../test/lite.ts';
 import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
-import {readCookies, type CookieSet} from '../replicator/change-log-cookies.ts';
+import {
+  EMPTY_COOKIE_SET,
+  readCookies,
+  type CookieSet,
+} from '../replicator/change-log-cookies.ts';
 import {
   CHANGE_LOG_STREAM_TABLE,
   changeLogFileName,
@@ -35,6 +39,17 @@ afterEach(() => {
   }
 });
 
+/**
+ * What the stream loop hands the writer: the watermark it resumes from and the
+ * cookie set that belongs to it, both read from Postgres in one snapshot.
+ */
+function resumeAt(
+  resumeWatermark: string,
+  cookies: CookieSet = EMPTY_COOKIE_SET,
+) {
+  return {resumeWatermark, cookies};
+}
+
 function setup(name: string, resumeWatermark = '02') {
   const sink = new TestLogSink();
   const lc = new LogContext('debug', undefined, sink);
@@ -49,7 +64,7 @@ function setup(name: string, resumeWatermark = '02') {
     onDisabled: () => disabled++,
     now: () => 1_700_000_000_000,
   });
-  writer.reconcile(resumeWatermark);
+  writer.reconcile(resumeAt(resumeWatermark));
   return {
     lc,
     sink,
@@ -164,7 +179,7 @@ describe('change-streamer/sqlite-change-log-writer', () => {
     // Replication continues: further writes are no-ops rather than throws, and
     // nothing recreates the file.
     expect(() => transaction(fixture.writer, '06')).not.toThrow();
-    fixture.writer.reconcile('06');
+    fixture.writer.reconcile(resumeAt('06'));
     expect(existsSync(changeLogFileName(fixture.file.path))).toBe(false);
     expect(fixture.writer.enabled).toBe(false);
   });
@@ -216,7 +231,7 @@ describe('change-streamer/sqlite-change-log-writer', () => {
 
     // The reconnected stream reconciles and re-delivers as if the interrupted
     // transaction had never arrived.
-    fixture.writer.reconcile('02');
+    fixture.writer.reconcile(resumeAt('02'));
     transaction(fixture.writer, '04');
     expect(fixture.head()).toBe('04');
     expect(fixture.commits).toEqual(['04']);
@@ -247,7 +262,7 @@ describe('change-streamer/sqlite-change-log-writer', () => {
       identity: IDENTITY,
     });
 
-    expect(() => writer.reconcile('02')).not.toThrow();
+    expect(() => writer.reconcile(resumeAt('02'))).not.toThrow();
     expect(writer.enabled).toBe(false);
     expect(
       sink.messages
@@ -271,7 +286,7 @@ describe('change-streamer/sqlite-change-log-writer', () => {
     expect(fixture.head()).toBe('06');
 
     // The stream reconnects and resumes below the head.
-    fixture.writer.reconcile('04');
+    fixture.writer.reconcile(resumeAt('04'));
     expect(fixture.head()).toBe('04');
 
     transaction(fixture.writer, '06', [
@@ -343,9 +358,30 @@ describe('change-streamer/sqlite-change-log-writer', () => {
       expect(fixture.writer.enabled).toBe(true);
     });
 
+    /**
+     * What Postgres holds at the watermark a reconnect resumes from: a backfill
+     * that is still in flight there, on a table the log's own head has never
+     * heard of. Deliberately disjoint from what {@link createTable} folds, so
+     * that "installed the anchor's set" and "kept its own" cannot both pass.
+     */
+    const pgCookies: CookieSet = {
+      tableMetadata: [
+        {
+          schema: 'my',
+          table: 'bar',
+          metadata: {rowKey: {columns: ['barID']}},
+        },
+      ],
+      backfilling: [
+        {schema: 'my', table: 'bar', column: 'z', backfill: {barID: 9}},
+      ],
+    };
+
     // Invariant 17: the cookie set is only meaningful paired with the watermark
-    // it was folded to, and a truncation moves that watermark.
-    test('a reconcile that truncates leaves no stale cookies behind', () => {
+    // it was folded to, and a truncation moves that watermark. What the log
+    // folded above the resume point is not rolled back by deleting those rows,
+    // so it is replaced wholesale rather than rewound.
+    test('a reconcile that truncates installs the resume point’s cookies', () => {
       using fixture = setup('change-log-writer-cookies-reconcile');
 
       transaction(fixture.writer, '04', createTable);
@@ -354,13 +390,59 @@ describe('change-streamer/sqlite-change-log-writer', () => {
       });
 
       // The stream reconnects below the head, so the transaction that carried
-      // the cookies is truncated away.
-      fixture.writer.reconcile('02');
+      // the cookies is truncated away and Postgres' set takes its place.
+      fixture.writer.reconcile(resumeAt('02', pgCookies));
 
-      expect(fixture.cookies()).toEqual({tableMetadata: [], backfilling: []});
+      expect(fixture.cookies()).toEqual(pgCookies);
       expect(fixture.writer.state()).toMatchObject({
-        cookieRows: {tableMetadata: 0, backfilling: 0},
+        cookieRows: {tableMetadata: 1, backfilling: 1},
       });
+
+      // And the log keeps folding onto it rather than from scratch: 'my.foo'
+      // is re-delivered by the resumed stream, 'my.bar' is still backfilling.
+      transaction(fixture.writer, '04', createTable);
+      expect(fixture.cookies()).toEqual({
+        tableMetadata: [
+          ...pgCookies.tableMetadata,
+          {schema: 'my', table: 'foo', metadata: {rowKey: {columns: ['id']}}},
+        ],
+        backfilling: [
+          ...pgCookies.backfilling,
+          {schema: 'my', table: 'foo', column: 'a', backfill: {fooID: 1}},
+        ],
+      });
+    });
+
+    // The other half of invariant 17: a wipe discards the cookie tables with
+    // the buffer, so the anchor's set is all that is left to seed them with.
+    test('a reconcile that reseeds installs the resume point’s cookies', () => {
+      using fixture = setup('change-log-writer-cookies-reseed');
+
+      transaction(fixture.writer, '04', createTable);
+
+      // A resume watermark the log neither holds nor can be truncated to, i.e.
+      // what a restored replica leaves behind. The log is wiped and reseeded.
+      fixture.writer.reconcile(resumeAt('08', pgCookies));
+
+      expect(fixture.head()).toBe('08');
+      expect(fixture.cookies()).toEqual(pgCookies);
+      expect(fixture.writer.state()).toMatchObject({
+        cookieRows: {tableMetadata: 1, backfilling: 1},
+      });
+    });
+
+    test('a reconcile that changes nothing leaves the cookies alone', () => {
+      using fixture = setup('change-log-writer-cookies-noop');
+
+      transaction(fixture.writer, '04', createTable);
+      const folded = fixture.cookies();
+
+      // The anchor's set is Postgres' as of '04', which the log has already
+      // folded for itself. Nothing moved, so nothing is replaced -- and the
+      // disjoint `pgCookies` proves it is not written on this path.
+      fixture.writer.reconcile(resumeAt('04', pgCookies));
+
+      expect(fixture.cookies()).toEqual(folded);
     });
   });
 });

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-writer.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-writer.ts
@@ -14,7 +14,9 @@ import {
   deleteChangeLogDB,
   openChangeLogDBForWriting,
   reconcileChangeLog,
+  type ChangeLogAnchor,
   type ChangeLogIdentity,
+  type ChangeLogResumePoint,
 } from '../replicator/change-log-db.ts';
 import {ChangeLogStreamWriter} from '../replicator/change-log-stream-writer.ts';
 import {
@@ -117,21 +119,30 @@ export class SQLiteChangeLogWriter {
   }
 
   /**
-   * Opens the log if necessary and reconciles it against the watermark this
-   * stream connection resumes from.
+   * Opens the log if necessary and reconciles it against the point this stream
+   * connection resumes from.
    *
    * This runs per connection rather than once per process: the stream loop
-   * re-reads its resume watermark on every reconnect, so a routine reconnect —
-   * not just a restart — can leave the log holding watermarks above the new
-   * resume point, and the writer's plain `INSERT` would collide with the first
+   * re-reads its resume point on every reconnect, so a routine reconnect — not
+   * just a restart — can leave the log holding watermarks above the new resume
+   * watermark, and the writer's plain `INSERT` would collide with the first
    * re-delivered transaction.
+   *
+   * The resume point is taken whole rather than as a bare watermark because its
+   * cookie set is not separable from it: a reconciliation that moves the head
+   * invalidates the cookies the log was holding, and only the set read at the
+   * same position (invariant 15) can replace them.
    */
-  reconcile(resumeWatermark: string): void {
+  reconcile(resumeFrom: ChangeLogResumePoint): void {
     if (this.#disabled) {
       return;
     }
     const {replicaFile, identity} = this.#opts;
-    const anchor = {identity, resumeWatermark, nowMs: this.#now()};
+    const anchor: ChangeLogAnchor = {
+      ...resumeFrom,
+      identity,
+      nowMs: this.#now(),
+    };
     try {
       const db = this.#db;
       if (db === undefined) {

--- a/packages/zero-cache/src/services/change-streamer/storer.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.pg.test.ts
@@ -29,6 +29,42 @@ const opts: TuningOptions = {
 
 const json = BigIntJSON.stringify;
 
+/**
+ * The initialization parameters as one line per row.
+ *
+ * Lossless -- every field of every row is here -- but flat, because the cookie
+ * set is cumulative and what each step below is actually asserting is its delta
+ * from the one before. Printed as objects, every step re-prints everything its
+ * predecessors established, which is most of the snapshot and none of the
+ * signal. The `metadata: null` step keeps its object snapshot, so the exact
+ * shape this flattens is still pinned somewhere.
+ */
+function summarize({
+  lastWatermark,
+  backfillRequests,
+  cookies,
+}: Awaited<
+  ReturnType<Storer['getStartStreamInitializationParameters']>
+>): string {
+  return [
+    `lastWatermark ${lastWatermark}`,
+    'tableMetadata',
+    ...cookies.tableMetadata.map(
+      m => `  ${m.schema}.${m.table} ${json(m.metadata)}`,
+    ),
+    'backfilling',
+    ...cookies.backfilling.map(
+      b => `  ${b.schema}.${b.table}.${b.column} ${json(b.backfill)}`,
+    ),
+    'backfillRequests',
+    ...backfillRequests.map(
+      r =>
+        `  ${r.table.schema}.${r.table.name} metadata=${json(r.table.metadata)} ` +
+        `columns=${json(r.columns)}`,
+    ),
+  ].join('\n');
+}
+
 describe('change-streamer/storer', () => {
   const lc = createSilentLogContext();
   let db: PostgresDB;
@@ -299,12 +335,13 @@ describe('change-streamer/storer', () => {
 
       // No backfillRequests should be present.
       await storer.allProcessed();
-      expect(await storer.getStartStreamInitializationParameters())
+      expect(summarize(await storer.getStartStreamInitializationParameters()))
         .toMatchInlineSnapshot(`
-        {
-          "backfillRequests": Result [],
-          "lastWatermark": "09",
-        }
+        "lastWatermark 09
+        tableMetadata
+          my.foo {"rowKey":{"type":"index","columns":["a","b"]}}
+        backfilling
+        backfillRequests"
       `);
 
       // Add a different table with backfill metadata only.
@@ -356,6 +393,52 @@ describe('change-streamer/storer', () => {
                 },
               },
             ],
+            "cookies": {
+              "backfilling": [
+                {
+                  "backfill": {
+                    "barID": "zoo",
+                    "fooID": 987,
+                  },
+                  "column": "a",
+                  "schema": "your",
+                  "table": "bar",
+                },
+                {
+                  "backfill": {
+                    "barID": "ozz",
+                    "fooID": 843,
+                  },
+                  "column": "b",
+                  "schema": "your",
+                  "table": "bar",
+                },
+                {
+                  "backfill": {
+                    "barID": "zoz",
+                    "fooID": 777,
+                  },
+                  "column": "d",
+                  "schema": "your",
+                  "table": "bar",
+                },
+              ],
+              "tableMetadata": [
+                {
+                  "metadata": {
+                    "rowKey": {
+                      "columns": [
+                        "a",
+                        "b",
+                      ],
+                      "type": "index",
+                    },
+                  },
+                  "schema": "my",
+                  "table": "foo",
+                },
+              ],
+            },
             "lastWatermark": "0a",
           }
         `);
@@ -379,56 +462,20 @@ describe('change-streamer/storer', () => {
       // Now the original table shows up in the backfillRequests, with its
       // table metadata.
       await storer.allProcessed();
-      expect(await storer.getStartStreamInitializationParameters())
+      expect(summarize(await storer.getStartStreamInitializationParameters()))
         .toMatchInlineSnapshot(`
-          {
-            "backfillRequests": Result [
-              {
-                "columns": {
-                  "a": {
-                    "barID": "zoo",
-                    "fooID": 987,
-                  },
-                  "b": {
-                    "barID": "ozz",
-                    "fooID": 843,
-                  },
-                  "d": {
-                    "barID": "zoz",
-                    "fooID": 777,
-                  },
-                },
-                "table": {
-                  "metadata": null,
-                  "name": "bar",
-                  "schema": "your",
-                },
-              },
-              {
-                "columns": {
-                  "c": {
-                    "barID": "baz",
-                    "fooID": 123,
-                  },
-                },
-                "table": {
-                  "metadata": {
-                    "rowKey": {
-                      "columns": [
-                        "a",
-                        "b",
-                      ],
-                      "type": "index",
-                    },
-                  },
-                  "name": "foo",
-                  "schema": "my",
-                },
-              },
-            ],
-            "lastWatermark": "0b",
-          }
-        `);
+        "lastWatermark 0b
+        tableMetadata
+          my.foo {"rowKey":{"type":"index","columns":["a","b"]}}
+        backfilling
+          my.foo.c {"barID":"baz","fooID":123}
+          your.bar.a {"barID":"zoo","fooID":987}
+          your.bar.b {"barID":"ozz","fooID":843}
+          your.bar.d {"barID":"zoz","fooID":777}
+        backfillRequests
+          your.bar metadata=null columns={"a":{"barID":"zoo","fooID":987},"b":{"barID":"ozz","fooID":843},"d":{"barID":"zoz","fooID":777}}
+          my.foo metadata={"rowKey":{"type":"index","columns":["a","b"]}} columns={"c":{"barID":"baz","fooID":123}}"
+      `);
 
       // Add another column to the same table with new table metadata.
       storer.store('0c', ['begin', messages.begin(), {commitWatermark: '0b'}]);
@@ -450,59 +497,21 @@ describe('change-streamer/storer', () => {
       storer.store('0c', ['commit', messages.commit(), {watermark: '0c'}]);
 
       await storer.allProcessed();
-      expect(await storer.getStartStreamInitializationParameters())
+      expect(summarize(await storer.getStartStreamInitializationParameters()))
         .toMatchInlineSnapshot(`
-          {
-            "backfillRequests": Result [
-              {
-                "columns": {
-                  "c": {
-                    "barID": "baz",
-                    "fooID": 123,
-                  },
-                  "d": {
-                    "barID": "boo",
-                    "fooID": 456,
-                  },
-                },
-                "table": {
-                  "metadata": {
-                    "rowKey": {
-                      "columns": [
-                        "b",
-                      ],
-                      "type": "default",
-                    },
-                  },
-                  "name": "foo",
-                  "schema": "my",
-                },
-              },
-              {
-                "columns": {
-                  "a": {
-                    "barID": "zoo",
-                    "fooID": 987,
-                  },
-                  "b": {
-                    "barID": "ozz",
-                    "fooID": 843,
-                  },
-                  "d": {
-                    "barID": "zoz",
-                    "fooID": 777,
-                  },
-                },
-                "table": {
-                  "metadata": null,
-                  "name": "bar",
-                  "schema": "your",
-                },
-              },
-            ],
-            "lastWatermark": "0c",
-          }
-        `);
+        "lastWatermark 0c
+        tableMetadata
+          my.foo {"rowKey":{"type":"default","columns":["b"]}}
+        backfilling
+          my.foo.c {"barID":"baz","fooID":123}
+          my.foo.d {"barID":"boo","fooID":456}
+          your.bar.a {"barID":"zoo","fooID":987}
+          your.bar.b {"barID":"ozz","fooID":843}
+          your.bar.d {"barID":"zoz","fooID":777}
+        backfillRequests
+          my.foo metadata={"rowKey":{"type":"default","columns":["b"]}} columns={"c":{"barID":"baz","fooID":123},"d":{"barID":"boo","fooID":456}}
+          your.bar metadata=null columns={"a":{"barID":"zoo","fooID":987},"b":{"barID":"ozz","fooID":843},"d":{"barID":"zoz","fooID":777}}"
+      `);
 
       // Update the table metadata of the new table.
       storer.store('0d', ['begin', messages.begin(), {commitWatermark: '0c'}]);
@@ -525,66 +534,22 @@ describe('change-streamer/storer', () => {
       storer.store('0d', ['commit', messages.commit(), {watermark: '0d'}]);
 
       await storer.allProcessed();
-      expect(await storer.getStartStreamInitializationParameters())
+      expect(summarize(await storer.getStartStreamInitializationParameters()))
         .toMatchInlineSnapshot(`
-          {
-            "backfillRequests": Result [
-              {
-                "columns": {
-                  "c": {
-                    "barID": "baz",
-                    "fooID": 123,
-                  },
-                  "d": {
-                    "barID": "boo",
-                    "fooID": 456,
-                  },
-                },
-                "table": {
-                  "metadata": {
-                    "rowKey": {
-                      "columns": [
-                        "b",
-                      ],
-                      "type": "default",
-                    },
-                  },
-                  "name": "foo",
-                  "schema": "my",
-                },
-              },
-              {
-                "columns": {
-                  "a": {
-                    "barID": "zoo",
-                    "fooID": 987,
-                  },
-                  "b": {
-                    "barID": "ozz",
-                    "fooID": 843,
-                  },
-                  "d": {
-                    "barID": "zoz",
-                    "fooID": 777,
-                  },
-                },
-                "table": {
-                  "metadata": {
-                    "rowKey": {
-                      "columns": [
-                        "a",
-                      ],
-                      "type": "default",
-                    },
-                  },
-                  "name": "bar",
-                  "schema": "your",
-                },
-              },
-            ],
-            "lastWatermark": "0d",
-          }
-        `);
+        "lastWatermark 0d
+        tableMetadata
+          my.foo {"rowKey":{"type":"default","columns":["b"]}}
+          your.bar {"rowKey":{"type":"default","columns":["a"]}}
+        backfilling
+          my.foo.c {"barID":"baz","fooID":123}
+          my.foo.d {"barID":"boo","fooID":456}
+          your.bar.a {"barID":"zoo","fooID":987}
+          your.bar.b {"barID":"ozz","fooID":843}
+          your.bar.d {"barID":"zoz","fooID":777}
+        backfillRequests
+          my.foo metadata={"rowKey":{"type":"default","columns":["b"]}} columns={"c":{"barID":"baz","fooID":123},"d":{"barID":"boo","fooID":456}}
+          your.bar metadata={"rowKey":{"type":"default","columns":["a"]}} columns={"a":{"barID":"zoo","fooID":987},"b":{"barID":"ozz","fooID":843},"d":{"barID":"zoz","fooID":777}}"
+      `);
 
       // Rename one of the backfilling columns
       storer.store('0e', ['begin', messages.begin(), {commitWatermark: '0e'}]);
@@ -609,66 +574,22 @@ describe('change-streamer/storer', () => {
       storer.store('0e', ['commit', messages.commit(), {watermark: '0e'}]);
 
       await storer.allProcessed();
-      expect(await storer.getStartStreamInitializationParameters())
+      expect(summarize(await storer.getStartStreamInitializationParameters()))
         .toMatchInlineSnapshot(`
-          {
-            "backfillRequests": Result [
-              {
-                "columns": {
-                  "c": {
-                    "barID": "baz",
-                    "fooID": 123,
-                  },
-                  "d": {
-                    "barID": "boo",
-                    "fooID": 456,
-                  },
-                },
-                "table": {
-                  "metadata": {
-                    "rowKey": {
-                      "columns": [
-                        "b",
-                      ],
-                      "type": "default",
-                    },
-                  },
-                  "name": "foo",
-                  "schema": "my",
-                },
-              },
-              {
-                "columns": {
-                  "a": {
-                    "barID": "zoo",
-                    "fooID": 987,
-                  },
-                  "d": {
-                    "barID": "zoz",
-                    "fooID": 777,
-                  },
-                  "newName": {
-                    "barID": "ozz",
-                    "fooID": 843,
-                  },
-                },
-                "table": {
-                  "metadata": {
-                    "rowKey": {
-                      "columns": [
-                        "a",
-                      ],
-                      "type": "default",
-                    },
-                  },
-                  "name": "bar",
-                  "schema": "your",
-                },
-              },
-            ],
-            "lastWatermark": "0e",
-          }
-        `);
+        "lastWatermark 0e
+        tableMetadata
+          my.foo {"rowKey":{"type":"default","columns":["b"]}}
+          your.bar {"rowKey":{"type":"default","columns":["a"]}}
+        backfilling
+          my.foo.c {"barID":"baz","fooID":123}
+          my.foo.d {"barID":"boo","fooID":456}
+          your.bar.a {"barID":"zoo","fooID":987}
+          your.bar.d {"barID":"zoz","fooID":777}
+          your.bar.newName {"barID":"ozz","fooID":843}
+        backfillRequests
+          my.foo metadata={"rowKey":{"type":"default","columns":["b"]}} columns={"c":{"barID":"baz","fooID":123},"d":{"barID":"boo","fooID":456}}
+          your.bar metadata={"rowKey":{"type":"default","columns":["a"]}} columns={"a":{"barID":"zoo","fooID":987},"d":{"barID":"zoz","fooID":777},"newName":{"barID":"ozz","fooID":843}}"
+      `);
 
       // Drop a backfilling column.
       storer.store('0f', ['begin', messages.begin(), {commitWatermark: '0f'}]);
@@ -686,62 +607,21 @@ describe('change-streamer/storer', () => {
       storer.store('0f', ['commit', messages.commit(), {watermark: '0f'}]);
 
       await storer.allProcessed();
-      expect(await storer.getStartStreamInitializationParameters())
+      expect(summarize(await storer.getStartStreamInitializationParameters()))
         .toMatchInlineSnapshot(`
-          {
-            "backfillRequests": Result [
-              {
-                "columns": {
-                  "c": {
-                    "barID": "baz",
-                    "fooID": 123,
-                  },
-                  "d": {
-                    "barID": "boo",
-                    "fooID": 456,
-                  },
-                },
-                "table": {
-                  "metadata": {
-                    "rowKey": {
-                      "columns": [
-                        "b",
-                      ],
-                      "type": "default",
-                    },
-                  },
-                  "name": "foo",
-                  "schema": "my",
-                },
-              },
-              {
-                "columns": {
-                  "a": {
-                    "barID": "zoo",
-                    "fooID": 987,
-                  },
-                  "d": {
-                    "barID": "zoz",
-                    "fooID": 777,
-                  },
-                },
-                "table": {
-                  "metadata": {
-                    "rowKey": {
-                      "columns": [
-                        "a",
-                      ],
-                      "type": "default",
-                    },
-                  },
-                  "name": "bar",
-                  "schema": "your",
-                },
-              },
-            ],
-            "lastWatermark": "0f",
-          }
-        `);
+        "lastWatermark 0f
+        tableMetadata
+          my.foo {"rowKey":{"type":"default","columns":["b"]}}
+          your.bar {"rowKey":{"type":"default","columns":["a"]}}
+        backfilling
+          my.foo.c {"barID":"baz","fooID":123}
+          my.foo.d {"barID":"boo","fooID":456}
+          your.bar.a {"barID":"zoo","fooID":987}
+          your.bar.d {"barID":"zoz","fooID":777}
+        backfillRequests
+          my.foo metadata={"rowKey":{"type":"default","columns":["b"]}} columns={"c":{"barID":"baz","fooID":123},"d":{"barID":"boo","fooID":456}}
+          your.bar metadata={"rowKey":{"type":"default","columns":["a"]}} columns={"a":{"barID":"zoo","fooID":987},"d":{"barID":"zoz","fooID":777}}"
+      `);
 
       // Set the other backfilling columns to completed
       storer.store('110', [
@@ -765,38 +645,18 @@ describe('change-streamer/storer', () => {
       storer.store('110', ['commit', messages.commit(), {watermark: '110'}]);
 
       await storer.allProcessed();
-      expect(await storer.getStartStreamInitializationParameters())
+      expect(summarize(await storer.getStartStreamInitializationParameters()))
         .toMatchInlineSnapshot(`
-          {
-            "backfillRequests": Result [
-              {
-                "columns": {
-                  "c": {
-                    "barID": "baz",
-                    "fooID": 123,
-                  },
-                  "d": {
-                    "barID": "boo",
-                    "fooID": 456,
-                  },
-                },
-                "table": {
-                  "metadata": {
-                    "rowKey": {
-                      "columns": [
-                        "b",
-                      ],
-                      "type": "default",
-                    },
-                  },
-                  "name": "foo",
-                  "schema": "my",
-                },
-              },
-            ],
-            "lastWatermark": "110",
-          }
-        `);
+        "lastWatermark 110
+        tableMetadata
+          my.foo {"rowKey":{"type":"default","columns":["b"]}}
+          your.bar {"rowKey":{"type":"default","columns":["a"]}}
+        backfilling
+          my.foo.c {"barID":"baz","fooID":123}
+          my.foo.d {"barID":"boo","fooID":456}
+        backfillRequests
+          my.foo metadata={"rowKey":{"type":"default","columns":["b"]}} columns={"c":{"barID":"baz","fooID":123},"d":{"barID":"boo","fooID":456}}"
+      `);
 
       // Rename the backfilling table, and a contained column in the same tx.
       storer.store('111', [
@@ -833,38 +693,18 @@ describe('change-streamer/storer', () => {
       storer.store('111', ['commit', messages.commit(), {watermark: '111'}]);
 
       await storer.allProcessed();
-      expect(await storer.getStartStreamInitializationParameters())
+      expect(summarize(await storer.getStartStreamInitializationParameters()))
         .toMatchInlineSnapshot(`
-          {
-            "backfillRequests": Result [
-              {
-                "columns": {
-                  "c": {
-                    "barID": "baz",
-                    "fooID": 123,
-                  },
-                  "deez": {
-                    "barID": "boo",
-                    "fooID": 456,
-                  },
-                },
-                "table": {
-                  "metadata": {
-                    "rowKey": {
-                      "columns": [
-                        "b",
-                      ],
-                      "type": "default",
-                    },
-                  },
-                  "name": "bloo",
-                  "schema": "your",
-                },
-              },
-            ],
-            "lastWatermark": "111",
-          }
-        `);
+        "lastWatermark 111
+        tableMetadata
+          your.bar {"rowKey":{"type":"default","columns":["a"]}}
+          your.bloo {"rowKey":{"type":"default","columns":["b"]}}
+        backfilling
+          your.bloo.c {"barID":"baz","fooID":123}
+          your.bloo.deez {"barID":"boo","fooID":456}
+        backfillRequests
+          your.bloo metadata={"rowKey":{"type":"default","columns":["b"]}} columns={"c":{"barID":"baz","fooID":123},"deez":{"barID":"boo","fooID":456}}"
+      `);
 
       // Drop the backfilling table
       storer.store('112', [
@@ -882,13 +722,14 @@ describe('change-streamer/storer', () => {
       storer.store('112', ['commit', messages.commit(), {watermark: '112'}]);
 
       await storer.allProcessed();
-      expect(await storer.getStartStreamInitializationParameters())
+      expect(summarize(await storer.getStartStreamInitializationParameters()))
         .toMatchInlineSnapshot(`
-          {
-            "backfillRequests": Result [],
-            "lastWatermark": "112",
-          }
-        `);
+        "lastWatermark 112
+        tableMetadata
+          your.bar {"rowKey":{"type":"default","columns":["a"]}}
+        backfilling
+        backfillRequests"
+      `);
     });
 
     test('non-owner purge prevented', async () => {

--- a/packages/zero-cache/src/services/change-streamer/storer.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.ts
@@ -29,7 +29,13 @@ import {
   type Commit,
 } from '../change-source/protocol/current/downstream.ts';
 import type {UpstreamStatusMessage} from '../change-source/protocol/current/status.ts';
-import {cookieOps, type CookieOp} from '../replicator/change-log-cookies.ts';
+import {
+  cookieOps,
+  type BackfillCookie,
+  type CookieOp,
+  type CookieSet,
+  type TableMetadataCookie,
+} from '../replicator/change-log-cookies.ts';
 import type {ReplicatorMode} from '../replicator/replicator.ts';
 import type {Service} from '../service.ts';
 import {
@@ -222,11 +228,29 @@ export class Storer implements Service {
     }
   }
 
+  /**
+   * The whole of what a stream connection starts from: where to resume, what to
+   * ask the change source to backfill, and the raw cookie set those requests
+   * were derived from.
+   *
+   * All four statements run in one REPEATABLE READ transaction, so they see one
+   * snapshot. That is invariant 15 — the resume watermark and the cookies must
+   * come from the same store, read at the same position — and it is why the
+   * cookies are read here rather than by a second call: a cookie set paired
+   * with a watermark it was not folded to loses every backfill that completed
+   * in the interval, and those rows are not replayable from the slot.
+   *
+   * `cookies` is not `backfillRequests` in another shape. The request list is
+   * driven off `backfilling`, so it drops the metadata of every table with no
+   * in-flight backfill — correct for starting a stream, lossy as the cookie
+   * snapshot that the SQLite change log continues folding onto.
+   */
   async getStartStreamInitializationParameters(): Promise<{
     lastWatermark: string;
     backfillRequests: BackfillRequest[];
+    cookies: CookieSet;
   }> {
-    const [[{lastWatermark}], result] = await runTx(
+    const [[{lastWatermark}], result, tableMetadata, backfilling] = await runTx(
       this.#db,
       sql => [
         sql<{lastWatermark: string}[]>`
@@ -236,19 +260,33 @@ export class Storer implements Service {
         // `columns` object. It is LEFT JOIN'ed with the `tableMetadata` table
         // to make it optional and possibly `null`.
         sql`
-        SELECT 
+        SELECT
             json_build_object(
               'schema', b."schema",
               'name', b."table",
               'metadata', t."metadata"
             ) as "table",
-            json_object_agg(b."column", b."backfill") 
+            json_object_agg(b."column", b."backfill")
               as "columns"
           FROM ${this.#cdc('backfilling')} as b
           LEFT JOIN ${this.#cdc('tableMetadata')} as t
           ON (b."schema" = t."schema" AND b."table" = t."table")
           GROUP BY b."schema", b."table", t."metadata"
         `,
+
+        // Ordered by primary key, so that this set and the SQLite change log's
+        // can be compared row for row. `COLLATE "C"` because that comparison is
+        // against a store whose TEXT columns sort by byte: a linguistic
+        // collation orders `foo-bar` and `foobar` differently than SQLite's
+        // BINARY does, which would read as a divergence rather than as the
+        // identical set it is.
+        sql<TableMetadataCookie[]>`
+        SELECT "schema", "table", "metadata" FROM ${this.#cdc('tableMetadata')}
+          ORDER BY "schema" COLLATE "C", "table" COLLATE "C"`,
+
+        sql<BackfillCookie[]>`
+        SELECT "schema", "table", "column", "backfill" FROM ${this.#cdc('backfilling')}
+          ORDER BY "schema" COLLATE "C", "table" COLLATE "C", "column" COLLATE "C"`,
       ],
       {mode: Mode.READONLY},
     );
@@ -256,6 +294,10 @@ export class Storer implements Service {
     return {
       lastWatermark,
       backfillRequests: v.parse(result, backfillRequestsSchema),
+      cookies: {
+        tableMetadata: [...tableMetadata],
+        backfilling: [...backfilling],
+      },
     };
   }
 

--- a/packages/zero-cache/src/services/replicator/change-log-crash-recovery.test.ts
+++ b/packages/zero-cache/src/services/replicator/change-log-crash-recovery.test.ts
@@ -32,6 +32,7 @@ import {DbFile} from '../../test/lite.ts';
 import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
 import {serializeChangeStreamData} from '../change-streamer/change-log-codec.ts';
 import {SQLiteChangeLogWriter} from '../change-streamer/sqlite-change-log-writer.ts';
+import {EMPTY_COOKIE_SET} from './change-log-cookies.ts';
 import {
   CHANGE_LOG_STREAM_TABLE,
   deleteChangeLogDB,
@@ -114,7 +115,12 @@ class Session {
   }
 
   reconcile() {
-    this.writer.reconcile(this.#resumeWatermark);
+    // No backfill is in flight in any of these cases: what is under test is the
+    // buffer's commit ordering, and the cookie set rides the same transaction.
+    this.writer.reconcile({
+      resumeWatermark: this.#resumeWatermark,
+      cookies: EMPTY_COOKIE_SET,
+    });
   }
 
   write(change: ChangeStreamData) {
@@ -447,7 +453,10 @@ describe('replicator/change-log crash recovery', () => {
 
       // The stream is re-established without a restart. Its resume watermark is
       // re-read, is behind the log's head, and reconciliation truncates '05'.
-      session.writer.reconcile('03');
+      session.writer.reconcile({
+        resumeWatermark: '03',
+        cookies: EMPTY_COOKIE_SET,
+      });
       expect(readChangeLogHead(observer)).toBe('03');
 
       // The resumed stream re-delivers '05' at the same watermark.

--- a/packages/zero-cache/src/services/replicator/change-log-db.test.ts
+++ b/packages/zero-cache/src/services/replicator/change-log-db.test.ts
@@ -12,7 +12,9 @@ import {
   CHANGE_LOG_BACKFILLING_TABLE,
   ChangeLogCookieWriter,
   DROP_CHANGE_LOG_COOKIE_TABLES,
+  EMPTY_COOKIE_SET,
   readCookies,
+  type CookieSet,
 } from './change-log-cookies.ts';
 import {
   applyChangeLogPragmas,
@@ -45,6 +47,7 @@ const ANCHOR: ChangeLogAnchor = {
   identity: {epoch: null, generation: '01', replicaID: '1777575698286'},
   resumeWatermark: '05',
   nowMs: NOW_MS,
+  cookies: EMPTY_COOKIE_SET,
 };
 
 /** The main file and the sidecars `deleteLiteDB` removes. */
@@ -989,7 +992,8 @@ describe('replicator/change-log-db', () => {
 
   // The cookies are unversioned point-in-time state: they are only meaningful
   // paired with the watermark they were folded to. So they are created with the
-  // buffer, dropped with it, and invalidated by anything that moves the head.
+  // buffer, dropped with it, and — whenever reconciliation moves the head —
+  // replaced with the set the anchor carries for the resume watermark.
   describe('the cookie jar', () => {
     /** Puts a cookie in the jar without going through the writer. */
     function seedCookie(db: Database) {
@@ -1001,43 +1005,80 @@ describe('replicator/change-log-db', () => {
       });
     }
 
+    /**
+     * The cookie set Postgres holds at the resume watermark, in the shape
+     * `Storer.getStartStreamInitializationParameters()` returns it. It is
+     * deliberately disjoint from what {@link seedCookie} folds, so that
+     * "installed the anchor's" and "kept the log's own" cannot both pass.
+     */
+    const ANCHOR_COOKIES: CookieSet = {
+      tableMetadata: [
+        {schema: 'my', table: 'bar', metadata: {rowKey: {columns: ['barID']}}},
+      ],
+      backfilling: [
+        {schema: 'my', table: 'bar', column: 'z', backfill: {barID: 9}},
+      ],
+    };
+
     test('a reseed creates the cookie tables, empty', () => {
       using db = createReconciledLog();
 
-      expect(readCookies(db)).toEqual({tableMetadata: [], backfilling: []});
+      expect(readCookies(db)).toEqual(EMPTY_COOKIE_SET);
     });
 
-    test('a wipe drops the cookies with the buffer', () => {
+    test('a reseed installs the cookie set the anchor carries', () => {
+      using db = createReconciledLog(anchorAt('05', {cookies: ANCHOR_COOKIES}));
+
+      expect(readCookies(db)).toEqual(ANCHOR_COOKIES);
+    });
+
+    test('a wipe drops the log’s cookies and installs the anchor’s', () => {
       using db = createReconciledLog();
       seedCookie(db);
       appendTransaction(db, '09', '05', 1, 100);
 
       // An identity mismatch: this file belongs to a different replica, so its
-      // cookie set describes a different stream.
+      // cookie set describes a different stream and none of it survives.
       const anchor = anchorAt('05', {
         identity: {epoch: null, generation: '02', replicaID: 'other'},
+        cookies: ANCHOR_COOKIES,
       });
       expect(reconcileChangeLog(lc, db, anchor)).toMatchObject({
         action: 'reseeded',
         reason: 'identity-mismatch',
         cookiesStale: true,
       });
-      expect(readCookies(db)).toEqual({tableMetadata: [], backfilling: []});
+      expect(readCookies(db)).toEqual(ANCHOR_COOKIES);
     });
 
-    test('a truncation clears the cookies it can no longer vouch for', () => {
+    // Invariant 17. The truncated transactions could have carried a
+    // `create-table`, an `add-column`, or a `backfill-completed`, none of which
+    // deleting their rows rolls back — so the set is replaced rather than
+    // rewound, and the replacement is the one that belongs to the resume point.
+    test('a truncation replaces the cookies it can no longer vouch for', () => {
       using db = createReconciledLog();
       seedCookie(db);
-      // The truncated transaction could itself have carried a `create-table`,
-      // an `add-column`, or a `backfill-completed`, none of which truncating
-      // the rows rolls back.
       appendTransaction(db, '09', '05', 2, 100);
 
+      expect(
+        reconcileChangeLog(lc, db, anchorAt('05', {cookies: ANCHOR_COOKIES})),
+      ).toMatchObject({action: 'truncated', cookiesStale: true});
+      expect(readCookies(db)).toEqual(ANCHOR_COOKIES);
+    });
+
+    test('a truncation with an empty anchor set clears the jar', () => {
+      using db = createReconciledLog();
+      seedCookie(db);
+      appendTransaction(db, '09', '05', 2, 100);
+
+      // The normal case: no backfill is in flight at the resume watermark, so
+      // the set that belongs there is empty. It is still installed rather than
+      // assumed — an emptied jar and an untouched one are not the same thing.
       expect(reconcileChangeLog(lc, db, ANCHOR)).toMatchObject({
         action: 'truncated',
         cookiesStale: true,
       });
-      expect(readCookies(db)).toEqual({tableMetadata: [], backfilling: []});
+      expect(readCookies(db)).toEqual(EMPTY_COOKIE_SET);
     });
 
     test('a reconcile that changes nothing leaves the cookies alone', () => {
@@ -1045,7 +1086,11 @@ describe('replicator/change-log-db', () => {
       seedCookie(db);
       const before = readCookies(db);
 
-      expect(reconcileChangeLog(lc, db, ANCHOR)).toEqual({
+      // The head is already the resume watermark, so the log's own set is the
+      // one that belongs to it and the anchor's is not written over it.
+      expect(
+        reconcileChangeLog(lc, db, anchorAt('05', {cookies: ANCHOR_COOKIES})),
+      ).toEqual({
         action: 'none',
         head: ANCHOR.resumeWatermark,
         cookiesStale: false,
@@ -1063,27 +1108,51 @@ describe('replicator/change-log-db', () => {
         UPDATE "${CHANGE_LOG_META_TABLE}" SET "schemaVersion" = 2
       `);
 
-      expect(reconcileChangeLog(lc, db, ANCHOR)).toEqual({
+      const anchor = anchorAt('05', {cookies: ANCHOR_COOKIES});
+      expect(reconcileChangeLog(lc, db, anchor)).toEqual({
         action: 'reseeded',
         head: ANCHOR.resumeWatermark,
         reason: 'schema-mismatch',
         cookiesStale: true,
       });
-      expectSeededAt(db, ANCHOR);
-      expect(readCookies(db)).toEqual({tableMetadata: [], backfilling: []});
+      expectSeededAt(db, anchor);
+      // The tables the upgrade creates are not merely present: they hold the
+      // set the resumed stream is about to fold onto.
+      expect(readCookies(db)).toEqual(ANCHOR_COOKIES);
     });
 
     test('a current-version file missing a cookie table is rebuilt', () => {
       using db = createReconciledLog();
       db.exec(/*sql*/ `DROP TABLE "${CHANGE_LOG_BACKFILLING_TABLE}"`);
 
-      expect(reconcileChangeLog(lc, db, ANCHOR)).toEqual({
+      expect(
+        reconcileChangeLog(lc, db, anchorAt('05', {cookies: ANCHOR_COOKIES})),
+      ).toEqual({
         action: 'reseeded',
         head: ANCHOR.resumeWatermark,
         reason: 'created',
         cookiesStale: true,
       });
-      expect(readCookies(db)).toEqual({tableMetadata: [], backfilling: []});
+      expect(readCookies(db)).toEqual(ANCHOR_COOKIES);
+    });
+
+    // The whole reconciliation is one transaction, so a failure cannot leave
+    // the log's head at one position and its cookie set at another.
+    test('a failed reconcile rolls the cookie replacement back with it', () => {
+      using db = createReconciledLog();
+      seedCookie(db);
+      const before = readCookies(db);
+      appendTransaction(db, '09', '05', 2, 100);
+      db.exec(/*sql*/ `
+        CREATE TRIGGER "no_deletes" BEFORE DELETE ON "${CHANGE_LOG_STREAM_TABLE}"
+        BEGIN SELECT RAISE(ABORT, 'boom'); END;
+      `);
+
+      expect(() =>
+        reconcileChangeLog(lc, db, anchorAt('05', {cookies: ANCHOR_COOKIES})),
+      ).toThrow('boom');
+      expect(readChangeLogHead(db)).toBe('09');
+      expect(readCookies(db)).toEqual(before);
     });
   });
 });

--- a/packages/zero-cache/src/services/replicator/change-log-db.ts
+++ b/packages/zero-cache/src/services/replicator/change-log-db.ts
@@ -13,8 +13,9 @@
  * Beside the buffer it holds the log's *cookie jar* — the backfill progress
  * state folded up to the same head. That is `change-log-cookies.ts`; this file
  * owns its tables' lifecycle, because a cookie set is only meaningful paired
- * with the watermark it was folded to, and so must be created, dropped, and
- * invalidated with the buffer rather than beside it.
+ * with the watermark it was folded to, and so must be created, dropped, and —
+ * whenever reconciliation moves the head — replaced with the anchor's, all with
+ * the buffer rather than beside it.
  *
  * Because it is disposable, it has no migration framework. Any inconsistency —
  * a schema change, a leftover file from a different replica, a gap left by a
@@ -49,8 +50,8 @@ import {
   CHANGE_LOG_TABLE_METADATA_TABLE,
   CREATE_CHANGE_LOG_COOKIE_SCHEMA,
   DROP_CHANGE_LOG_COOKIE_TABLES,
-  EMPTY_COOKIE_SET,
   replaceCookies,
+  type CookieSet,
 } from './change-log-cookies.ts';
 
 /**
@@ -185,11 +186,19 @@ export type ChangeLogIdentity = {
 };
 
 /**
- * What the log is reconciled against. Reconciliation runs once per stream
- * connection, since every reconnect can re-read a different resume watermark.
+ * Where the stream connection resumes, and everything the log's state at that
+ * position consists of.
+ *
+ * The two fields travel together because a cookie set is only meaningful paired
+ * with the watermark it was folded up to (invariant 15). They are read from one
+ * store, in one snapshot: `Storer.getStartStreamInitializationParameters()`
+ * reads both from Postgres in a single REPEATABLE READ transaction. Pairing one
+ * store's cookies with another's watermark would silently drop every backfill
+ * that completed in the interval, and those rows are unrecoverable — backfill
+ * transactions are synthesized by the change source rather than replayed from
+ * the slot.
  */
-export type ChangeLogAnchor = {
-  readonly identity: ChangeLogIdentity;
+export type ChangeLogResumePoint = {
   /**
    * The watermark this stream connection resumes from. The log's own head is
    * measured against it, and a reseed seeds a synthetic transaction at it.
@@ -200,6 +209,26 @@ export type ChangeLogAnchor = {
    * than a constraint on it.
    */
   readonly resumeWatermark: string;
+  /**
+   * The cookie set that belongs to {@link resumeWatermark}. Any reconciliation
+   * that moves the head invalidates the set the log was holding — the cookies
+   * are unversioned point-in-time state, and truncating the stream above `W`
+   * does not roll them back to `W` — so the same transaction installs this one
+   * in its place (invariant 17).
+   *
+   * Postgres supplies it while it remains the store the stream resumes from. At
+   * the C5 flip the log's own head *is* the resume point, phantoms cannot
+   * exist, and both this field and the truncate-above path become dead code.
+   */
+  readonly cookies: CookieSet;
+};
+
+/**
+ * What the log is reconciled against. Reconciliation runs once per stream
+ * connection, since every reconnect can re-read a different resume point.
+ */
+export type ChangeLogAnchor = ChangeLogResumePoint & {
+  readonly identity: ChangeLogIdentity;
   /**
    * The change-streamer's clock, at reconciliation time. Supplied rather than
    * read inline so that tests control it. Used for `seededAtMs` and for the
@@ -430,10 +459,11 @@ export type ReseedReason =
  * `cookiesStale` records that the cookie set the log held did not survive
  * reconciliation. The cookies are unversioned point-in-time state, so any
  * reconciliation that moves the head invalidates them, and the same transaction
- * clears them (see `change-log-cookies.ts`). It is `action !== 'none'` today;
- * it is a field rather than a derivation because the reseed that replaces the
- * clear reads as intent at the call site, and because it is what the
- * `cookie_reseed` counter is keyed on.
+ * replaces them with the anchor's — the set that belongs to the resume
+ * watermark (see `change-log-cookies.ts`). It is `action !== 'none'` today; it
+ * is a field rather than a derivation because the replacement reads as intent
+ * at the call site, and because it is what the `cookie_reseed` counter is keyed
+ * on.
  */
 export type ReconcileResult =
   | {action: 'none'; head: string; cookiesStale: false}
@@ -473,6 +503,10 @@ export type ReconcileResult =
  * disabled for a while, the replica was restored, power was lost with
  * `synchronous=NORMAL` — surfaces as a head that does not land on the resume
  * watermark, and is resolved by wiping and reseeding there.
+ *
+ * Whichever of the two moves the head also replaces the cookie set with the one
+ * the anchor carries, in the same transaction: the head and the cookies are one
+ * position, and nothing may observe them at two.
  */
 export function reconcileChangeLog(
   lc: LogContext,
@@ -520,13 +554,12 @@ function reconcile(
   if (rows > 0) {
     // The truncated transactions can have carried `create-table`,
     // `add-column`, and `backfill-completed`, none of which the truncate rolls
-    // back, so the cookie set no longer belongs to the head. Clearing it is
-    // correct but lossy; the anchor supplies the set that belongs to the resume
-    // watermark once there is one to supply. Nothing reads the cookies in the
-    // meantime.
-    replaceCookies(db, EMPTY_COOKIE_SET);
+    // back, so the cookie set no longer belongs to the head. The anchor's set
+    // does, and it lands in this same transaction: invariant 17 holds at every
+    // point another connection could observe the log.
+    replaceCookies(db, anchor.cookies);
     lc.info?.('truncated phantom transactions from the SQLite change log', {
-      sqliteChangeLogReconcile: {head, rows},
+      sqliteChangeLogReconcile: {head, rows, cookies: cookieCounts(anchor)},
     });
     return {action: 'truncated', head, rows, cookiesStale: true};
   }
@@ -615,6 +648,11 @@ function reseed(
     seedWatermark: resumeWatermark,
   });
   seedChangeLogStream(db, anchor);
+  // Into tables this statement just created, so the wholesale replacement is
+  // all insert. It is still the same call the truncate path makes: a reseed is
+  // the case where the log's cookie set was not merely moved but discarded, and
+  // the anchor's is equally what belongs at the head either way.
+  replaceCookies(db, anchor.cookies);
 
   lc.info?.('reseeded the SQLite change log', {
     sqliteChangeLogReconcile: {
@@ -623,6 +661,7 @@ function reseed(
       ...identity,
       schemaVersion: CHANGE_LOG_DB_SCHEMA_VERSION,
       seededAtMs: nowMs,
+      cookies: cookieCounts(anchor),
     },
   });
   return {
@@ -674,6 +713,17 @@ export function readChangeLogHead(db: Database): string | null {
     `)
     .get<{head: string | null}>();
   return head;
+}
+
+/**
+ * What was installed, for the reconcile log line. Normally `{0, 0}`: a nonzero
+ * `backfilling` means the resumed stream is being handed backfills to re-request.
+ */
+function cookieCounts({cookies}: ChangeLogAnchor) {
+  return {
+    tableMetadata: cookies.tableMetadata.length,
+    backfilling: cookies.backfilling.length,
+  };
 }
 
 function tableExists(db: Database, table: string): boolean {

--- a/packages/zero-cache/src/services/replicator/change-log-stream-writer.test.ts
+++ b/packages/zero-cache/src/services/replicator/change-log-stream-writer.test.ts
@@ -28,6 +28,7 @@ const ANCHOR: ChangeLogAnchor = {
   identity: {epoch: null, generation: '01', replicaID: null},
   resumeWatermark: '02',
   nowMs: 1_000,
+  cookies: EMPTY_COOKIE_SET,
 };
 
 const files: DbFile[] = [];

--- a/packages/zero-cache/src/services/replicator/sqlite-change-log-observability.test.ts
+++ b/packages/zero-cache/src/services/replicator/sqlite-change-log-observability.test.ts
@@ -10,6 +10,7 @@ import {
   serializeChangeStreamData,
 } from '../change-streamer/change-log-codec.ts';
 import {ChangeLogTransactionHasher} from '../change-streamer/change-log-transaction-hash.ts';
+import {EMPTY_COOKIE_SET} from './change-log-cookies.ts';
 import {
   CHANGE_LOG_DB_SCHEMA_VERSION,
   CHANGE_LOG_META_TABLE,
@@ -36,6 +37,7 @@ const ANCHOR: ChangeLogAnchor = {
   identity: {epoch: null, generation: '01', replicaID: '1777575698286'},
   resumeWatermark: '02',
   nowMs: 1_700_000_000_000,
+  cookies: EMPTY_COOKIE_SET,
 };
 
 /**

--- a/packages/zero-cache/src/services/replicator/sqlite-change-log-purger.test.ts
+++ b/packages/zero-cache/src/services/replicator/sqlite-change-log-purger.test.ts
@@ -12,6 +12,7 @@ import type {
 import {serializeChangeStreamData} from '../change-streamer/change-log-codec.ts';
 import type {WatermarkedChange} from '../change-streamer/change-streamer.ts';
 import {SQLiteChangeLogReader} from '../change-streamer/sqlite-change-log-reader.ts';
+import {EMPTY_COOKIE_SET} from './change-log-cookies.ts';
 import {
   CHANGE_LOG_STREAM_TABLE,
   CHANGE_LOG_STREAM_WRITE_TIME_INDEX,
@@ -44,6 +45,7 @@ const ANCHOR: ChangeLogAnchor = {
   identity: {epoch: null, generation: '01', replicaID: null},
   resumeWatermark: SEED_WATERMARK,
   nowMs: SEED_WRITE_TIME_MS,
+  cookies: EMPTY_COOKIE_SET,
 };
 
 /** A floor above every watermark any fixture writes. */


### PR DESCRIPTION
This is a temporary measure until SQLite's change log is the source of truth.

We seed the cookies from the existing PG change log if we end up reconciling to that log's watermark.

Mostly tests here.