### PR TITLE
chore(rmv2): track backfill state in the SQLite Replica

### DIFF
--- a/packages/zero-cache/src/services/change-source/common/replica-schema.test.ts
+++ b/packages/zero-cache/src/services/change-source/common/replica-schema.test.ts
@@ -1,11 +1,14 @@
 import {beforeEach, describe, expect, test} from 'vitest';
 import {createSilentLogContext} from '../../../../../shared/src/logging-test-utils.ts';
 import {promiseVoid} from '../../../../../shared/src/resolved-promises.ts';
+import {runSchemaMigrations} from '../../../db/migration-lite.ts';
 import {
   DbFile,
   expectMatchingObjectsInTables,
   initDB as initLiteDB,
 } from '../../../test/lite.ts';
+import {BACKFILLING_TABLE} from '../../replicator/schema/backfilling.ts';
+import {CREATE_COLUMN_METADATA_TABLE} from '../../replicator/schema/column-metadata.ts';
 import {initReplicationState} from '../../replicator/schema/replication-state.ts';
 import {CREATE_TABLE_METADATA_TABLE} from '../../replicator/schema/table-metadata.ts';
 import {
@@ -15,6 +18,7 @@ import {
   CREATE_V14_CHANGE_LOG_STREAM,
   CURRENT_SCHEMA_VERSION,
   initReplica,
+  schemaVersionMigrationMap,
   V14_CHANGE_LOG_STREAM_TABLE,
 } from './replica-schema.ts';
 
@@ -55,6 +59,36 @@ const CREATE_V11_TABLE_METADATA_TABLE = /*sql*/ `
     PRIMARY KEY ("schema", "table")
   );
 `;
+
+// `_zero.replicationState` as of v15, i.e. with writeTimeMs NOT NULL.
+const CREATE_V15_REPLICATION_STATE_TABLE = /*sql*/ `
+  CREATE TABLE "_zero.replicationState" (
+    stateVersion TEXT NOT NULL,
+    writeTimeMs INTEGER NOT NULL,
+    lock INTEGER PRIMARY KEY DEFAULT 1 CHECK (lock=1)
+  );
+`;
+
+const V15_REPLICATION_STATE = [
+  {stateVersion: '123', writeTimeMs: 12345, lock: 1},
+];
+
+function columnMetadata(
+  tableName: string,
+  columnName: string,
+  backfill: string | null,
+) {
+  return {
+    table_name: tableName,
+    column_name: columnName,
+    upstream_type: 'text',
+    is_not_null: 0,
+    is_enum: 0,
+    is_array: 0,
+    character_max_length: null,
+    backfill,
+  };
+}
 
 describe('replica-schema-migrations', () => {
   type Case = {
@@ -304,7 +338,7 @@ describe('replica-schema-migrations', () => {
         CREATE TABLE users("userID" "INTEGER|NOT_NULL", password TEXT, handle TEXT);
       ` +
         CREATE_V1_REPLICATION_CONFIG_TABLE +
-        CREATE_V6_COLUMN_METADATA_TABLE +
+        CREATE_COLUMN_METADATA_TABLE +
         CREATE_V7_CHANGE_LOG +
         CREATE_V9_TABLE_METADATA_TABLE,
       replicaPreState: {
@@ -336,7 +370,7 @@ describe('replica-schema-migrations', () => {
         CREATE TABLE users("userID" "INTEGER|NOT_NULL", password TEXT, handle TEXT);
       ` +
         CREATE_V1_REPLICATION_CONFIG_TABLE +
-        CREATE_V6_COLUMN_METADATA_TABLE +
+        CREATE_COLUMN_METADATA_TABLE +
         CREATE_V7_CHANGE_LOG +
         CREATE_V11_TABLE_METADATA_TABLE,
       replicaPreState: {
@@ -369,7 +403,7 @@ describe('replica-schema-migrations', () => {
         CREATE TABLE users("userID" "INTEGER|NOT_NULL", password TEXT, handle TEXT);
       ` +
         CREATE_V1_REPLICATION_CONFIG_TABLE +
-        CREATE_V6_COLUMN_METADATA_TABLE +
+        CREATE_COLUMN_METADATA_TABLE +
         CREATE_V7_CHANGE_LOG +
         CREATE_TABLE_METADATA_TABLE,
       replicaPreState: {
@@ -399,7 +433,7 @@ describe('replica-schema-migrations', () => {
       desc: 'backfill writeTimeMs column',
       replicaSetup:
         CREATE_V1_REPLICATION_CONFIG_TABLE +
-        CREATE_V6_COLUMN_METADATA_TABLE +
+        CREATE_COLUMN_METADATA_TABLE +
         CREATE_V7_CHANGE_LOG +
         CREATE_TABLE_METADATA_TABLE,
       replicaPreState: {
@@ -432,7 +466,7 @@ describe('replica-schema-migrations', () => {
           writeTimeMs INTEGER,
           lock INTEGER PRIMARY KEY DEFAULT 1 CHECK (lock=1)
         );` +
-        CREATE_V6_COLUMN_METADATA_TABLE +
+        CREATE_COLUMN_METADATA_TABLE +
         CREATE_V7_CHANGE_LOG +
         CREATE_TABLE_METADATA_TABLE,
       replicaPreState: {
@@ -465,7 +499,10 @@ describe('replica-schema-migrations', () => {
           stateVersion TEXT NOT NULL,
           writeTimeMs INTEGER,
           lock INTEGER PRIMARY KEY DEFAULT 1 CHECK (lock=1)
-        );` + CREATE_V14_CHANGE_LOG_STREAM,
+        );` +
+        CREATE_COLUMN_METADATA_TABLE +
+        CREATE_TABLE_METADATA_TABLE +
+        CREATE_V14_CHANGE_LOG_STREAM,
       replicaPreState: {
         ['_zero.replicationState']: [
           {
@@ -509,11 +546,10 @@ describe('replica-schema-migrations', () => {
       fromDataVersion: 14,
       desc: 'stays dropped after rollback and rollforward',
       // writeTimeMs is NOT NULL because a v16 schema has been through v15.
-      replicaSetup: /*sql*/ `CREATE TABLE "_zero.replicationState" (
-          stateVersion TEXT NOT NULL,
-          writeTimeMs INTEGER NOT NULL,
-          lock INTEGER PRIMARY KEY DEFAULT 1 CHECK (lock=1)
-        );`,
+      replicaSetup:
+        CREATE_V15_REPLICATION_STATE_TABLE +
+        CREATE_COLUMN_METADATA_TABLE +
+        CREATE_TABLE_METADATA_TABLE,
       replicaPreState: {
         ['_zero.replicationState']: [
           {
@@ -529,6 +565,98 @@ describe('replica-schema-migrations', () => {
             stateVersion: '123',
             writeTimeMs: 12345,
             lock: 1,
+          },
+        ],
+      },
+    },
+    {
+      // The identity that `_zero.column_metadata` cannot supply: it is keyed by
+      // lite table name, which collapses the `public` schema and has no
+      // inverse. A metadata row resolves the schema exactly; a name with no dot
+      // in it is exactly `public`; anything else is a best-effort split.
+      fromSchemaVersion: 16,
+      desc: 'seeds the backfilling table from column metadata',
+      replicaSetup:
+        CREATE_V15_REPLICATION_STATE_TABLE +
+        CREATE_COLUMN_METADATA_TABLE +
+        CREATE_TABLE_METADATA_TABLE,
+      replicaPreState: {
+        ['_zero.replicationState']: V15_REPLICATION_STATE,
+        ['_zero.tableMetadata']: [
+          {
+            schema: 'my',
+            table: 'foo',
+            minRowVersion: '00',
+            upstreamMetadata: '{"rowKey":{"type":"default","columns":["id"]}}',
+            metadata: null,
+          },
+        ],
+        ['_zero.column_metadata']: [
+          columnMetadata('my.foo', 'a', '{"fooID":1}'),
+          columnMetadata('my.foo', 'b', null), // not backfilling
+          columnMetadata('bar', 'c', '{"fooID":2}'),
+          columnMetadata('your.baz', 'd', '{"fooID":3}'), // unresolvable
+        ],
+      },
+      replicaPostState: {
+        [BACKFILLING_TABLE]: [
+          {
+            schema: 'public',
+            table: 'bar',
+            column: 'c',
+            backfill: '{"fooID":2}',
+          },
+          {schema: 'my', table: 'foo', column: 'a', backfill: '{"fooID":1}'},
+          {
+            schema: 'your',
+            table: 'baz',
+            column: 'd',
+            backfill: '{"fooID":3}',
+          },
+        ],
+      },
+    },
+    {
+      // Rolled back to v16 code, which does not know the table exists and
+      // therefore maintains only `column_metadata.backfill` while it runs, then
+      // rolled forward. Migration 17 re-runs with its schema step skipped, so
+      // `migrateData` has to rebuild the table rather than merge into it.
+      fromSchemaVersion: 17,
+      fromDataVersion: 16,
+      desc: 're-seeds the backfilling table after rollback and rollforward',
+      replicaSetup:
+        CREATE_V15_REPLICATION_STATE_TABLE +
+        CREATE_COLUMN_METADATA_TABLE +
+        CREATE_TABLE_METADATA_TABLE +
+        /*sql*/ `CREATE TABLE "${BACKFILLING_TABLE}" (
+          "schema"   TEXT NOT NULL,
+          "table"    TEXT NOT NULL,
+          "column"   TEXT NOT NULL,
+          "backfill" TEXT NOT NULL,
+          PRIMARY KEY ("schema", "table", "column")
+        );`,
+      replicaPreState: {
+        ['_zero.replicationState']: V15_REPLICATION_STATE,
+        ['_zero.column_metadata']: [
+          columnMetadata('foo', 'a', null), // completed while rolled back
+          columnMetadata('foo', 'z', '{"fooID":9}'), // started while rolled back
+        ],
+        [BACKFILLING_TABLE]: [
+          {
+            schema: 'public',
+            table: 'foo',
+            column: 'a',
+            backfill: '{"fooID":1}',
+          },
+        ],
+      },
+      replicaPostState: {
+        [BACKFILLING_TABLE]: [
+          {
+            schema: 'public',
+            table: 'foo',
+            column: 'z',
+            backfill: '{"fooID":9}',
           },
         ],
       },
@@ -587,6 +715,62 @@ describe('replica-schema-migrations', () => {
                        WHERE "tbl_name" = ?`)
           .all(V14_CHANGE_LOG_STREAM_TABLE),
       ).toEqual([]);
+
+      // Conversely, every replica at CURRENT_SCHEMA_VERSION carries the
+      // backfilling table: a fresh sync creates it with the rest of the
+      // replication state, and every incremental path runs migration 17.
+      expect(
+        replica
+          .prepare(/*sql*/ `SELECT "name" FROM "sqlite_master"
+                       WHERE "type" = 'table' AND "tbl_name" = ?`)
+          .all(BACKFILLING_TABLE),
+      ).toEqual([{name: BACKFILLING_TABLE}]);
     });
   }
+
+  // Migration 17 sets no `minSafeVersion`, which is what makes this legal, and
+  // the reason it can: nothing at v16 reads "_zero.backfilling", and what a v16
+  // zero-cache does write — "_zero.column_metadata.backfill" — is what
+  // migration 17's `migrateData` rebuilds the table from on the way forward.
+  test('a v16 zero-cache runs against a v17 replica', async () => {
+    const replica = replicaFile.connect(lc);
+    initLiteDB(replica, CREATE_VERSION_HISTORY, {});
+    await initReplica(lc, 'test', replicaFile.path, (_, db) => {
+      initReplicationState(db, ['foo_publication'], '123');
+      return promiseVoid;
+    });
+    replica
+      .prepare(/*sql*/ `INSERT INTO "${BACKFILLING_TABLE}"
+                 ("schema", "table", "column", "backfill") VALUES (?, ?, ?, ?)`)
+      .run('my', 'foo', 'a', '{"fooID":1}');
+
+    const v16MigrationMap = Object.fromEntries(
+      Object.entries(schemaVersionMigrationMap).filter(
+        ([version]) => Number(version) <= 16,
+      ),
+    );
+    await runSchemaMigrations(
+      lc,
+      'test',
+      replicaFile.path,
+      {
+        migrateSchema: () => {
+          throw new Error('the replica is already synced');
+        },
+      },
+      v16MigrationMap,
+    );
+
+    expectMatchingObjectsInTables(replica, {
+      // The data version rolls back; the schema version never moves backwards.
+      ['_zero.versionHistory']: [
+        {dataVersion: 16, schemaVersion: 17, minSafeVersion: 1},
+      ],
+      // The table is left alone rather than dropped, so rolling forward does
+      // not have to recreate it.
+      [BACKFILLING_TABLE]: [
+        {schema: 'my', table: 'foo', column: 'a', backfill: '{"fooID":1}'},
+      ],
+    });
+  });
 });

--- a/packages/zero-cache/src/services/change-source/common/replica-schema.ts
+++ b/packages/zero-cache/src/services/change-source/common/replica-schema.ts
@@ -12,6 +12,10 @@ import {
   logSQLiteCorruptionDiagnostics,
 } from '../../../db/sqlite-corruption.ts';
 import {AutoResetSignal} from '../../change-streamer/schema/tables.ts';
+import {
+  CREATE_BACKFILLING_TABLE,
+  populateBackfillingFromColumnMetadata,
+} from '../../replicator/schema/backfilling.ts';
 import {populateFromExistingTables} from '../../replicator/schema/column-metadata.ts';
 import {
   CREATE_RUNTIME_EVENTS_TABLE,
@@ -354,6 +358,26 @@ export const schemaVersionMigrationMap: IncrementalMigrationMap = {
         DROP INDEX IF EXISTS "${V14_CHANGE_LOG_STREAM_WRITE_TIME_INDEX}";
         DROP TABLE IF EXISTS "${V14_CHANGE_LOG_STREAM_TABLE}";
       `);
+    },
+  },
+
+  // `_zero.column_metadata.backfill` records which columns are backfilling but
+  // is keyed by lite table name, which has no inverse: it cannot be turned back
+  // into the `BackfillRequest`s that a change log initialized from this replica
+  // would have to send. This table carries the upstream identity alongside the
+  // same state. See `replicator/schema/backfilling.ts`.
+  //
+  // No `minSafeVersion`: an older zero-cache runs fine against a v17 replica,
+  // since nothing at v16 reads the new table. Its writes to
+  // `column_metadata.backfill` are what `migrateData` rebuilds from when rolling
+  // forward again, so a rollback costs nothing but the re-seed.
+  17: {
+    migrateSchema: (_, db) => {
+      db.exec(CREATE_BACKFILLING_TABLE);
+    },
+
+    migrateData: (lc, db) => {
+      populateBackfillingFromColumnMetadata(lc, db);
     },
   },
 };

--- a/packages/zero-cache/src/services/replicator/change-processor.ts
+++ b/packages/zero-cache/src/services/replicator/change-processor.ts
@@ -58,6 +58,7 @@ import type {
 } from '../change-source/protocol/current/data.ts';
 import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
 import type {ReplicatorMode} from './replicator.ts';
+import {BackfillingTracker} from './schema/backfilling.ts';
 import {ChangeLog, DEL_OP, SET_OP} from './schema/change-log.ts';
 import {ColumnMetadataStore} from './schema/column-metadata.ts';
 import {
@@ -103,6 +104,7 @@ export class ChangeProcessor {
   readonly #db: StatementRunner;
   readonly #changeLog: ChangeLog;
   readonly #tableMetadata: TableMetadataTracker;
+  readonly #backfilling: BackfillingTracker;
   readonly #mode: ChangeProcessorMode;
   readonly #failService: (lc: LogContext, err: unknown) => void;
 
@@ -123,6 +125,7 @@ export class ChangeProcessor {
     this.#db = db;
     this.#changeLog = new ChangeLog(db.db);
     this.#tableMetadata = new TableMetadataTracker(db.db);
+    this.#backfilling = new BackfillingTracker(db.db);
     this.#mode = mode;
     this.#failService = failService;
   }
@@ -202,6 +205,7 @@ export class ChangeProcessor {
           this.#mode,
           this.#changeLog,
           this.#tableMetadata,
+          this.#backfilling,
           this.#tableSpecs,
           commitVersion,
           jsonFormat,
@@ -345,6 +349,7 @@ class TransactionProcessor {
   readonly #version: LexiVersion;
   readonly #changeLog: ChangeLog;
   readonly #tableMetadata: TableMetadataTracker;
+  readonly #backfilling: BackfillingTracker;
   readonly #tableSpecs: Map<string, LiteTableSpecWithReplicationStatus>;
   readonly #jsonFormat: JSONFormat;
   readonly #columnMetadata: ColumnMetadataStore;
@@ -359,6 +364,7 @@ class TransactionProcessor {
     mode: ChangeProcessorMode,
     changeLog: ChangeLog,
     tableMetadata: TableMetadataTracker,
+    backfilling: BackfillingTracker,
     tableSpecs: Map<string, LiteTableSpecWithReplicationStatus>,
     commitVersion: LexiVersion,
     jsonFormat: JSONFormat,
@@ -394,6 +400,7 @@ class TransactionProcessor {
     this.#lc = lc.withContext('version', commitVersion);
     this.#changeLog = changeLog;
     this.#tableMetadata = tableMetadata;
+    this.#backfilling = backfilling;
     this.#tableSpecs = tableSpecs;
     // The column_metadata table is guaranteed to exist since the
     // replica-schema.ts migration to v8.
@@ -601,6 +608,7 @@ class TransactionProcessor {
     if (create.metadata) {
       this.#tableMetadata.setUpstreamMetadata(create.spec, create.metadata);
     }
+    this.#backfilling.apply(create);
     const table = mapPostgresToLite(create.spec);
     this.#db.db.exec(createLiteTableStatement(table));
 
@@ -630,10 +638,18 @@ class TransactionProcessor {
 
   processTableMetadata(msg: TableUpdateMetadata) {
     this.#tableMetadata.setUpstreamMetadata(msg.table, msg.new);
+    // Inert today: the fold's only op for this tag is `upsert-metadata`, which
+    // the line above is the replica's interpreter of. Called anyway so that
+    // every site that hands a schema change to one cookie tracker hands it to
+    // both -- an exception here would be a schema change the shared fold has an
+    // opinion about and this store never sees, which is the drift the fold
+    // exists to make impossible.
+    this.#backfilling.apply(msg);
   }
 
   processRenameTable(rename: TableRename) {
     this.#tableMetadata.rename(rename.old, rename.new);
+    this.#backfilling.apply(rename);
 
     const oldName = liteTableName(rename.old);
     const newName = liteTableName(rename.new);
@@ -651,6 +667,7 @@ class TransactionProcessor {
     if (msg.tableMetadata) {
       this.#tableMetadata.setUpstreamMetadata(msg.table, msg.tableMetadata);
     }
+    this.#backfilling.apply(msg);
     const table = liteTableName(msg.table);
     const {name} = msg.column;
     const spec = mapPostgresToLiteColumn(table, msg.column);
@@ -672,6 +689,10 @@ class TransactionProcessor {
   }
 
   processUpdateColumn(msg: ColumnUpdate) {
+    // A no-op unless this is a rename, which is the only part of a column
+    // update that moves the backfill cookie.
+    this.#backfilling.apply(msg);
+
     const table = liteTableName(msg.table);
     let oldName = msg.old.name;
     const newName = msg.new.name;
@@ -769,6 +790,7 @@ class TransactionProcessor {
 
     // Delete from metadata table
     this.#columnMetadata.deleteColumn(table, column);
+    this.#backfilling.apply(msg);
 
     this.#bumpVersions(msg.table);
     this.#lc.info?.(msg.tag, table, column);
@@ -776,6 +798,7 @@ class TransactionProcessor {
 
   processDropTable(drop: TableDrop) {
     this.#tableMetadata.drop(drop.id);
+    this.#backfilling.apply(drop);
 
     const name = liteTableName(drop.id);
     this.#db.db.exec(`DROP TABLE IF EXISTS ${id(name)}`);
@@ -925,7 +948,8 @@ class TransactionProcessor {
 
   #completedBackfill: DownloadStatus | undefined;
 
-  processBackfillCompleted({relation, columns, status}: BackfillCompleted) {
+  processBackfillCompleted(msg: BackfillCompleted) {
+    const {relation, columns, status} = msg;
     const tableName = liteTableName(relation);
     const rowKeyCols = relation.rowKey.columns;
     const cols = [...rowKeyCols, ...columns];
@@ -934,6 +958,7 @@ class TransactionProcessor {
     for (const col of cols) {
       columnMetadata.clearBackfilling(tableName, col);
     }
+    this.#backfilling.apply(msg);
     // Given that new columns are being exposed for every row in the table, bump the
     // row version for all rows.
     this.#bumpVersions(relation);

--- a/packages/zero-cache/src/services/replicator/incremental-sync.test.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.test.ts
@@ -401,7 +401,7 @@ describe('replicator/incremental-sync', () => {
                 "unique": true,
               },
             ],
-            "replicaSize": 57344,
+            "replicaSize": 65536,
             "tables": [
               {
                 "columns": [
@@ -549,7 +549,7 @@ describe('replicator/incremental-sync', () => {
                 "unique": true,
               },
             ],
-            "replicaSize": 57344,
+            "replicaSize": 65536,
             "tables": [
               {
                 "columns": [
@@ -603,7 +603,7 @@ describe('replicator/incremental-sync', () => {
                 "unique": true,
               },
             ],
-            "replicaSize": 65536,
+            "replicaSize": 73728,
             "tables": [
               {
                 "columns": [

--- a/packages/zero-cache/src/services/replicator/schema/backfilling-metrics.test.ts
+++ b/packages/zero-cache/src/services/replicator/schema/backfilling-metrics.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Asserts the exported value of the v17 migration's unresolvable-row counter,
+ * which `backfilling.test.ts` cannot: `observability/metrics.ts` caches every
+ * instrument in module scope, so an instrument created against a previous
+ * test's meter provider would be handed back to the next one. Each test here
+ * therefore resets modules and imports through a fresh provider, matching
+ * `replicator/sqlite-change-log-metrics.test.ts`.
+ */
+
+import {metrics} from '@opentelemetry/api';
+import {
+  AggregationTemporality,
+  InMemoryMetricExporter,
+  MeterProvider,
+  PeriodicExportingMetricReader,
+} from '@opentelemetry/sdk-metrics';
+import {afterEach, expect, test, vi} from 'vitest';
+import {createSilentLogContext} from '../../../../../shared/src/logging-test-utils.ts';
+import {Database} from '../../../../../zqlite/src/db.ts';
+import {CREATE_COLUMN_METADATA_TABLE} from './column-metadata.ts';
+import {CREATE_TABLE_METADATA_TABLE} from './table-metadata.ts';
+
+afterEach(() => {
+  metrics.disable();
+  vi.resetModules();
+});
+
+const METRIC = 'zero.replica.backfilling_unresolvable_rows';
+
+function withProvider() {
+  const exporter = new InMemoryMetricExporter(
+    AggregationTemporality.CUMULATIVE,
+  );
+  const provider = new MeterProvider({
+    readers: [
+      new PeriodicExportingMetricReader({
+        exporter,
+        exportIntervalMillis: 60_000,
+      }),
+    ],
+  });
+  expect(metrics.setGlobalMeterProvider(provider)).toBe(true);
+  return {
+    exporter,
+    provider,
+    [Symbol.asyncDispose]: () => provider.shutdown(),
+  };
+}
+
+function total(exporter: InMemoryMetricExporter, name: string) {
+  const points = exporter
+    .getMetrics()
+    .flatMap(resource => resource.scopeMetrics)
+    .flatMap(scope => scope.metrics)
+    .find(metric => metric.descriptor.name === name)?.dataPoints;
+  return points?.reduce((sum, point) => sum + (point.value as number), 0);
+}
+
+async function migrate(columnMetadata: [string, string, string | null][]) {
+  const {CREATE_BACKFILLING_TABLE, populateBackfillingFromColumnMetadata} =
+    await import('./backfilling.ts');
+  const lc = createSilentLogContext();
+  const db = new Database(lc, ':memory:');
+  db.exec(
+    CREATE_BACKFILLING_TABLE +
+      CREATE_TABLE_METADATA_TABLE +
+      CREATE_COLUMN_METADATA_TABLE,
+  );
+  const insert = db.prepare(/*sql*/ `
+    INSERT INTO "_zero.column_metadata"
+      (table_name, column_name, upstream_type, is_not_null, is_enum, is_array,
+       backfill)
+      VALUES (?, ?, 'text', 0, 0, 0, ?)
+  `);
+  columnMetadata.forEach(row => insert.run(...row));
+  populateBackfillingFromColumnMetadata(lc, db);
+  db.close();
+}
+
+test('the counter reports zero when every identity is recoverable', async () => {
+  await using otel = withProvider();
+  await migrate([
+    // No dot in the lite name: `liteTableName()` only omits the schema for
+    // `public`, so this is exact.
+    ['foo', 'a', '{"fooID":1}'],
+    // Not backfilling, so not copied at all.
+    ['my.bar', 'b', null],
+  ]);
+  await otel.provider.forceFlush();
+
+  // Published rather than absent, so that the alert has a series to watch.
+  expect(total(otel.exporter, METRIC)).toBe(0);
+});
+
+test('the counter reports a dotted table with no metadata row', async () => {
+  await using otel = withProvider();
+  await migrate([
+    ['my.foo', 'a', '{"fooID":1}'],
+    ['your.bar', 'b', '{"fooID":2}'],
+    ['baz', 'c', '{"fooID":3}'],
+  ]);
+  await otel.provider.forceFlush();
+
+  expect(total(otel.exporter, METRIC)).toBe(2);
+});

--- a/packages/zero-cache/src/services/replicator/schema/backfilling.pg.test.ts
+++ b/packages/zero-cache/src/services/replicator/schema/backfilling.pg.test.ts
@@ -1,0 +1,309 @@
+/**
+ * The point of `_zero.backfilling` is that a change log can be initialized from
+ * a restored replica instead of from the Postgres change DB. That is only true
+ * if the two derive the *same* {@link BackfillRequest}s from the same change
+ * stream, so this drives one sequence through both the storer and the
+ * change-processor and requires their request lists to be identical.
+ *
+ * It covers the two cases `_zero.column_metadata` alone cannot express, and
+ * which are the whole reason this table exists: a table on a non-`public`
+ * schema, whose lite name is ambiguous, and a table with in-flight backfills
+ * and no metadata row at all.
+ *
+ * The change log's initializer runs this comparison in production, against a
+ * replica that trails the log's head. Here they are driven in lockstep, so
+ * equality is exact.
+ */
+
+import {beforeEach, describe, expect} from 'vitest';
+import {createSilentLogContext} from '../../../../../shared/src/logging-test-utils.ts';
+import {Database} from '../../../../../zqlite/src/db.ts';
+import {StatementRunner} from '../../../db/statements.ts';
+import {type PgTest, test} from '../../../test/db.ts';
+import type {PostgresDB} from '../../../types/pg.ts';
+import type {SchemaChange} from '../../change-source/protocol/current/data.ts';
+import type {
+  ChangeStreamData,
+  Commit,
+} from '../../change-source/protocol/current/downstream.ts';
+import type {UpstreamStatusMessage} from '../../change-source/protocol/current/status.ts';
+import type {BackfillRequest} from '../../change-source/protocol/current/upstream.ts';
+import {
+  ensureReplicationConfig,
+  setupCDCTables,
+} from '../../change-streamer/schema/tables.ts';
+import {Storer, type TuningOptions} from '../../change-streamer/storer.ts';
+import {ChangeProcessor} from '../change-processor.ts';
+import {readBackfillRequests} from './backfilling.ts';
+import {initReplicationState} from './replication-state.ts';
+
+const lc = createSilentLogContext();
+
+const APP_ID = 'backfilling';
+const SHARD_NUM = 1;
+const REPLICA_VERSION = '00';
+
+const opts: TuningOptions = {
+  backPressureLimitHeapProportion: 0.04,
+  statementTimeoutMs: 20_000,
+  changeLogBatchSize: 2000,
+};
+
+describe('replicator/schema/backfill request parity', () => {
+  let db: PostgresDB;
+  let storer: Storer;
+  let done: Promise<void>;
+  let replica: Database;
+  let processor: ChangeProcessor;
+  let watermark: number;
+
+  beforeEach<PgTest>(async ({testDBs}) => {
+    db = await testDBs.create('backfill_request_parity', {
+      typeOpts: {sendStringAsJson: true},
+    });
+    const shard = {appID: APP_ID, shardNum: SHARD_NUM};
+    await db.begin(tx => setupCDCTables(lc, tx, shard));
+    await ensureReplicationConfig(
+      lc,
+      db,
+      {
+        replicaVersion: REPLICA_VERSION,
+        publications: [],
+        watermark: REPLICA_VERSION,
+      },
+      shard,
+      true,
+    );
+
+    storer = new Storer(
+      lc,
+      shard,
+      'task-id',
+      'change-streamer:12345',
+      'ws',
+      db,
+      REPLICA_VERSION,
+      (_: Commit | UpstreamStatusMessage) => {},
+      () => {},
+      opts,
+    );
+    await storer.assumeOwnership();
+    done = storer.run();
+
+    replica = new Database(lc, ':memory:');
+    initReplicationState(replica, ['zero_data'], REPLICA_VERSION);
+    // The replication-manager's replica, which is the one a change log would
+    // eventually be initialized from.
+    processor = new ChangeProcessor(
+      new StatementRunner(replica),
+      'backup',
+      (_, err: unknown) => {
+        throw err;
+      },
+    );
+    watermark = 1;
+
+    return async () => {
+      replica.close();
+      await testDBs.drop(db);
+      void storer?.stop();
+      await done;
+    };
+  });
+
+  /** Drives one transaction carrying `changes` through both stores. */
+  async function transaction(...changes: SchemaChange[]): Promise<void> {
+    const wm = String(++watermark).padStart(2, '0');
+    const messages: ChangeStreamData[] = [
+      ['begin', {tag: 'begin'}, {commitWatermark: wm}],
+      ...changes.map((change): ChangeStreamData => ['data', change]),
+      ['commit', {tag: 'commit'}, {watermark: wm}],
+    ];
+
+    messages.forEach(message => storer.store(wm, message));
+    messages.forEach(message => processor.processMessage(lc, message));
+
+    await storer.allProcessed();
+  }
+
+  /** Requests are grouped per table, so the table's identity orders them. */
+  function sorted(requests: BackfillRequest[]): BackfillRequest[] {
+    return requests.toSorted((a, b) =>
+      `${a.table.schema}.${a.table.name}`.localeCompare(
+        `${b.table.schema}.${b.table.name}`,
+      ),
+    );
+  }
+
+  /**
+   * The `your.bar` request, which no transition below touches until the final
+   * drop. Named rather than repeated so that each step's expectation is its own
+   * delta, and so that "bar did not move" is something the reader can see
+   * instead of having to diff two literals.
+   */
+  const BAR: BackfillRequest = {
+    table: {schema: 'your', name: 'bar', metadata: null},
+    columns: {c: {barID: 'zoo'}},
+  };
+
+  /** The `my.foo` request: the two halves every step below moves. */
+  function foo(
+    rowKey: 'default' | 'index',
+    columns: BackfillRequest['columns'],
+    schema = 'my',
+  ): BackfillRequest {
+    return {
+      table: {
+        schema,
+        name: 'foo',
+        metadata: {rowKey: {type: rowKey, columns: ['id']}},
+      },
+      columns,
+    };
+  }
+
+  /**
+   * Both stores agree, and the agreed-on list is what was expected. The second
+   * half matters: two derivations agree vacuously if neither derives anything.
+   */
+  async function expectRequests(expected: BackfillRequest[]) {
+    const {backfillRequests} =
+      await storer.getStartStreamInitializationParameters();
+    const pg = sorted(backfillRequests);
+    expect(pg).toEqual(sorted(readBackfillRequests(replica)));
+    expect(pg).toEqual(sorted(expected));
+  }
+
+  test('every transition that moves a backfill request', async () => {
+    // A table on a non-`public` schema. Its lite name, "my.foo", is ambiguous
+    // against a `public` table named "my.foo", which is what the identity in
+    // "_zero.backfilling" resolves.
+    await transaction({
+      tag: 'create-table',
+      spec: {
+        schema: 'my',
+        name: 'foo',
+        columns: {
+          id: {pos: 0, dataType: 'int8', notNull: true},
+          a: {pos: 1, dataType: 'text'},
+          b: {pos: 2, dataType: 'text'},
+        },
+        primaryKey: ['id'],
+      },
+      metadata: {rowKey: {type: 'default', columns: ['id']}},
+      backfill: {a: {fooID: 987}, b: {fooID: 843}},
+    });
+
+    // A table with in-flight backfills and *no* metadata row: legal, since a
+    // change source need not send one, and the case the replica could not
+    // reconstruct before this table existed.
+    await transaction({
+      tag: 'create-table',
+      spec: {
+        schema: 'your',
+        name: 'bar',
+        columns: {
+          id: {pos: 0, dataType: 'int8', notNull: true},
+          c: {pos: 1, dataType: 'text'},
+        },
+        primaryKey: ['id'],
+      },
+      backfill: {c: {barID: 'zoo'}},
+    });
+
+    await expectRequests([
+      foo('default', {a: {fooID: 987}, b: {fooID: 843}}),
+      BAR,
+    ]);
+
+    // add-column, carrying both a metadata update and a backfill.
+    await transaction({
+      tag: 'add-column',
+      table: {schema: 'my', name: 'foo'},
+      tableMetadata: {rowKey: {type: 'index', columns: ['id']}},
+      column: {name: 'd', spec: {pos: 3, dataType: 'text'}},
+      backfill: {fooID: 123},
+    });
+    await expectRequests([
+      foo('index', {a: {fooID: 987}, b: {fooID: 843}, d: {fooID: 123}}),
+      BAR,
+    ]);
+
+    // update-column: a rename moves the request's column, a spec-only update
+    // moves nothing. Then drop-column removes one.
+    await transaction(
+      {
+        tag: 'update-column',
+        table: {schema: 'my', name: 'foo'},
+        old: {name: 'a', spec: {pos: 1, dataType: 'text'}},
+        new: {name: 'z', spec: {pos: 1, dataType: 'text'}},
+      },
+      {
+        tag: 'update-column',
+        table: {schema: 'my', name: 'foo'},
+        old: {name: 'b', spec: {pos: 2, dataType: 'text'}},
+        new: {name: 'b', spec: {pos: 2, dataType: 'text', notNull: true}},
+      },
+      {
+        tag: 'drop-column',
+        table: {schema: 'my', name: 'foo'},
+        column: 'd',
+      },
+    );
+    await expectRequests([
+      foo('index', {b: {fooID: 843}, z: {fooID: 987}}),
+      BAR,
+    ]);
+
+    // backfill-completed clears the rowKey columns along with the listed ones,
+    // but not the table's metadata: that is what the table's *next* request
+    // would have to carry.
+    await transaction({
+      tag: 'backfill-completed',
+      relation: {
+        schema: 'my',
+        name: 'foo',
+        rowKey: {type: 'default', columns: ['id']},
+      },
+      columns: ['z'],
+      watermark: '05',
+    });
+    await expectRequests([foo('index', {b: {fooID: 843}}), BAR]);
+
+    // rename-table moves the request, and only the renamed table's.
+    await transaction({
+      tag: 'rename-table',
+      old: {schema: 'my', name: 'foo'},
+      new: {schema: 'renamed', name: 'foo'},
+    });
+    await expectRequests([foo('index', {b: {fooID: 843}}, 'renamed'), BAR]);
+
+    // drop-table clears both halves.
+    await transaction(
+      {tag: 'drop-table', id: {schema: 'renamed', name: 'foo'}},
+      {tag: 'drop-table', id: {schema: 'your', name: 'bar'}},
+    );
+    await expectRequests([]);
+  });
+
+  test('a table with no in-flight backfill produces no request', async () => {
+    await transaction({
+      tag: 'create-table',
+      spec: {
+        schema: 'public',
+        name: 'foo',
+        columns: {id: {pos: 0, dataType: 'int8', notNull: true}},
+        primaryKey: ['id'],
+      },
+      metadata: {rowKey: {type: 'default', columns: ['id']}},
+    });
+    // A change source that does not support backfill sends neither field.
+    await transaction({
+      tag: 'add-column',
+      table: {schema: 'public', name: 'foo'},
+      column: {name: 'a', spec: {pos: 1, dataType: 'text'}},
+    });
+
+    await expectRequests([]);
+  });
+});

--- a/packages/zero-cache/src/services/replicator/schema/backfilling.test.ts
+++ b/packages/zero-cache/src/services/replicator/schema/backfilling.test.ts
@@ -1,0 +1,372 @@
+import {beforeEach, describe, expect, test} from 'vitest';
+import {createSilentLogContext} from '../../../../../shared/src/logging-test-utils.ts';
+import {Database} from '../../../../../zqlite/src/db.ts';
+import {expectTables} from '../../../test/lite.ts';
+import type {SchemaChange} from '../../change-source/protocol/current/data.ts';
+import {
+  BACKFILLING_TABLE,
+  BackfillingTracker,
+  CREATE_BACKFILLING_TABLE,
+  populateBackfillingFromColumnMetadata,
+  readBackfillRequests,
+} from './backfilling.ts';
+import {CREATE_COLUMN_METADATA_TABLE} from './column-metadata.ts';
+import {CREATE_TABLE_METADATA_TABLE} from './table-metadata.ts';
+
+const lc = createSilentLogContext();
+
+describe('replicator/schema/backfilling', () => {
+  let db: Database;
+
+  beforeEach(() => {
+    db = new Database(lc, ':memory:');
+    db.exec(
+      CREATE_BACKFILLING_TABLE +
+        CREATE_TABLE_METADATA_TABLE +
+        CREATE_COLUMN_METADATA_TABLE,
+    );
+    return () => db.close();
+  });
+
+  /** Every assertion below is about this one table's rows. */
+  function expectBackfilling(rows: Record<string, unknown>[]) {
+    expectTables(db, {[BACKFILLING_TABLE]: rows});
+  }
+
+  describe('BackfillingTracker', () => {
+    function apply(...changes: SchemaChange[]) {
+      const tracker = new BackfillingTracker(db);
+      changes.forEach(change => tracker.apply(change));
+    }
+
+    test('create-table records one row per backfilling column', () => {
+      apply({
+        tag: 'create-table',
+        spec: {schema: 'my', name: 'foo', columns: {}},
+        metadata: {rowKey: {type: 'default', columns: ['id']}},
+        backfill: {a: {fooID: 987}, b: {fooID: 843}},
+      });
+
+      expectBackfilling([
+        {schema: 'my', table: 'foo', column: 'a', backfill: '{"fooID":987}'},
+        {schema: 'my', table: 'foo', column: 'b', backfill: '{"fooID":843}'},
+      ]);
+    });
+
+    test('changes carrying no backfill record nothing', () => {
+      apply(
+        // A change source that does not support backfill sends neither field.
+        {
+          tag: 'create-table',
+          spec: {schema: 'public', name: 'foo', columns: {}},
+        },
+        {
+          tag: 'add-column',
+          table: {schema: 'public', name: 'foo'},
+          column: {name: 'a', spec: {pos: 1, dataType: 'text'}},
+        },
+        // Metadata-only changes move the metadata cookie, which lives in
+        // "_zero.tableMetadata".
+        {
+          tag: 'update-table-metadata',
+          table: {schema: 'public', name: 'foo'},
+          old: {rowKey: {type: 'default', columns: ['id']}},
+          new: {rowKey: {type: 'index', columns: ['a']}},
+        },
+        {
+          tag: 'create-index',
+          spec: {
+            schema: 'public',
+            name: 'foo_idx',
+            tableName: 'foo',
+            unique: false,
+            columns: {a: 'ASC'},
+          },
+        },
+        {tag: 'drop-index', id: {schema: 'public', name: 'foo_idx'}},
+      );
+
+      expectBackfilling([]);
+    });
+
+    test('add-column upserts, update-column renames only on a rename', () => {
+      apply(
+        {
+          tag: 'add-column',
+          table: {schema: 'my', name: 'foo'},
+          column: {name: 'a', spec: {pos: 1, dataType: 'text'}},
+          backfill: {fooID: 1},
+        },
+        // A spec-only update must move nothing.
+        {
+          tag: 'update-column',
+          table: {schema: 'my', name: 'foo'},
+          old: {name: 'a', spec: {pos: 1, dataType: 'text'}},
+          new: {name: 'a', spec: {pos: 1, dataType: 'int4'}},
+        },
+      );
+      expectBackfilling([
+        {schema: 'my', table: 'foo', column: 'a', backfill: '{"fooID":1}'},
+      ]);
+
+      apply({
+        tag: 'update-column',
+        table: {schema: 'my', name: 'foo'},
+        old: {name: 'a', spec: {pos: 1, dataType: 'int4'}},
+        new: {name: 'z', spec: {pos: 1, dataType: 'int4'}},
+      });
+      expectBackfilling([
+        {schema: 'my', table: 'foo', column: 'z', backfill: '{"fooID":1}'},
+      ]);
+    });
+
+    test('rename-table moves only the renamed table, drop-table clears it', () => {
+      apply(
+        {
+          tag: 'create-table',
+          spec: {schema: 'my', name: 'foo', columns: {}},
+          backfill: {a: {fooID: 1}},
+        },
+        {
+          tag: 'create-table',
+          spec: {schema: 'your', name: 'bar', columns: {}},
+          backfill: {c: {fooID: 2}},
+        },
+        {
+          tag: 'rename-table',
+          old: {schema: 'my', name: 'foo'},
+          new: {schema: 'renamed', name: 'foo'},
+        },
+      );
+      expectBackfilling([
+        {
+          schema: 'renamed',
+          table: 'foo',
+          column: 'a',
+          backfill: '{"fooID":1}',
+        },
+        {schema: 'your', table: 'bar', column: 'c', backfill: '{"fooID":2}'},
+      ]);
+
+      apply({tag: 'drop-table', id: {schema: 'renamed', name: 'foo'}});
+      expectBackfilling([
+        {schema: 'your', table: 'bar', column: 'c', backfill: '{"fooID":2}'},
+      ]);
+    });
+
+    test('drop-column and backfill-completed clear columns', () => {
+      apply({
+        tag: 'create-table',
+        spec: {schema: 'my', name: 'foo', columns: {}},
+        backfill: {id: {fooID: 0}, a: {fooID: 1}, b: {fooID: 2}},
+      });
+
+      apply({
+        tag: 'drop-column',
+        table: {schema: 'my', name: 'foo'},
+        column: 'b',
+      });
+      expectBackfilling([
+        {schema: 'my', table: 'foo', column: 'a', backfill: '{"fooID":1}'},
+        {schema: 'my', table: 'foo', column: 'id', backfill: '{"fooID":0}'},
+      ]);
+
+      // The rowKey columns are excluded from `columns` but are backfilled with
+      // them, so both are cleared.
+      apply({
+        tag: 'backfill-completed',
+        relation: {
+          schema: 'my',
+          name: 'foo',
+          rowKey: {type: 'default', columns: ['id']},
+        },
+        columns: ['a'],
+        watermark: '07',
+      });
+      expectBackfilling([]);
+    });
+  });
+
+  describe('readBackfillRequests', () => {
+    test('empty', () => {
+      expect(readBackfillRequests(db)).toEqual([]);
+    });
+
+    test('groups by table, with metadata from "_zero.tableMetadata"', () => {
+      const tracker = new BackfillingTracker(db);
+      tracker.apply({
+        tag: 'create-table',
+        spec: {schema: 'my', name: 'foo', columns: {}},
+        backfill: {b: {fooID: 2}, a: {fooID: 1}},
+      });
+      tracker.apply({
+        tag: 'create-table',
+        spec: {schema: 'public', name: 'bar', columns: {}},
+        backfill: {c: {barID: 'three'}},
+      });
+      db.prepare(/*sql*/ `INSERT INTO "_zero.tableMetadata"
+                   ("schema", "table", "upstreamMetadata") VALUES (?, ?, ?)`).run(
+        'my',
+        'foo',
+        '{"rowKey":{"type":"default","columns":["id"]}}',
+      );
+
+      expect(readBackfillRequests(db)).toEqual([
+        {
+          table: {
+            schema: 'my',
+            name: 'foo',
+            metadata: {rowKey: {type: 'default', columns: ['id']}},
+          },
+          columns: {a: {fooID: 1}, b: {fooID: 2}},
+        },
+        // A table can be backfilling with no metadata of its own.
+        {
+          table: {schema: 'public', name: 'bar', metadata: null},
+          columns: {c: {barID: 'three'}},
+        },
+      ]);
+    });
+
+    test('a "_zero.tableMetadata" row without metadata reads as null', () => {
+      new BackfillingTracker(db).apply({
+        tag: 'add-column',
+        table: {schema: 'public', name: 'foo'},
+        column: {name: 'a', spec: {pos: 1, dataType: 'text'}},
+        backfill: {fooID: 1},
+      });
+      // "_zero.tableMetadata" also tracks minRowVersion, so a row can exist
+      // with a null upstreamMetadata.
+      db.prepare(/*sql*/ `INSERT INTO "_zero.tableMetadata"
+                   ("schema", "table", "minRowVersion") VALUES (?, ?, ?)`).run(
+        'public',
+        'foo',
+        '03',
+      );
+
+      expect(readBackfillRequests(db)).toEqual([
+        {
+          table: {schema: 'public', name: 'foo', metadata: null},
+          columns: {a: {fooID: 1}},
+        },
+      ]);
+    });
+  });
+
+  describe('populateBackfillingFromColumnMetadata', () => {
+    function addColumnMetadata(
+      liteTable: string,
+      column: string,
+      backfill: string | null,
+    ) {
+      db.prepare(/*sql*/ `INSERT INTO "_zero.column_metadata"
+          (table_name, column_name, upstream_type, is_not_null, is_enum,
+           is_array, backfill)
+          VALUES (?, ?, 'text', 0, 0, 0, ?)`).run(liteTable, column, backfill);
+    }
+
+    function addTableMetadata(schema: string, table: string) {
+      db.prepare(/*sql*/ `INSERT INTO "_zero.tableMetadata"
+                   ("schema", "table", "upstreamMetadata") VALUES (?, ?, ?)`).run(
+        schema,
+        table,
+        '{"rowKey":{"type":"default","columns":["id"]}}',
+      );
+    }
+
+    test('nothing to copy, which is the expected case', () => {
+      addColumnMetadata('foo', 'a', null);
+
+      populateBackfillingFromColumnMetadata(lc, db);
+
+      expectBackfilling([]);
+    });
+
+    test('copies only in-flight backfills', () => {
+      addColumnMetadata('foo', 'a', '{"fooID":1}');
+      addColumnMetadata('foo', 'b', null);
+
+      populateBackfillingFromColumnMetadata(lc, db);
+
+      expectBackfilling([
+        {
+          schema: 'public',
+          table: 'foo',
+          column: 'a',
+          backfill: '{"fooID":1}',
+        },
+      ]);
+    });
+
+    test('resolves the schema through "_zero.tableMetadata"', () => {
+      addTableMetadata('my', 'foo');
+      addColumnMetadata('my.foo', 'a', '{"fooID":1}');
+
+      populateBackfillingFromColumnMetadata(lc, db);
+
+      expectBackfilling([
+        {schema: 'my', table: 'foo', column: 'a', backfill: '{"fooID":1}'},
+      ]);
+    });
+
+    test('a dotted table name is resolved even when the dot is in the name', () => {
+      // `liteTableName({schema: 'public', name: 'a.b'})` and
+      // `liteTableName({schema: 'a', name: 'b'})` are the same string, so the
+      // metadata row is the only thing that tells them apart.
+      addTableMetadata('public', 'a.b');
+      addColumnMetadata('a.b', 'c', '{"fooID":1}');
+
+      populateBackfillingFromColumnMetadata(lc, db);
+
+      expectBackfilling([
+        {
+          schema: 'public',
+          table: 'a.b',
+          column: 'c',
+          backfill: '{"fooID":1}',
+        },
+      ]);
+    });
+
+    test('an unresolvable row falls back to the first-dot split', () => {
+      addColumnMetadata('my.foo', 'a', '{"fooID":1}');
+      // Not unresolvable: liteTableName() only omits the schema for `public`,
+      // so a name with no dot in it is exactly `public`.
+      addColumnMetadata('bar', 'b', '{"fooID":2}');
+
+      populateBackfillingFromColumnMetadata(lc, db);
+
+      expectBackfilling([
+        {
+          schema: 'public',
+          table: 'bar',
+          column: 'b',
+          backfill: '{"fooID":2}',
+        },
+        {schema: 'my', table: 'foo', column: 'a', backfill: '{"fooID":1}'},
+      ]);
+    });
+
+    test('replaces rather than merges, so a re-run after a rollback is correct', () => {
+      addTableMetadata('my', 'foo');
+      addColumnMetadata('my.foo', 'a', '{"fooID":1}');
+      populateBackfillingFromColumnMetadata(lc, db);
+
+      // What an older zero-cache, which does not know about this table, does
+      // to the replica while it is rolled back: the backfill completes and is
+      // cleared from column_metadata, and a new one starts.
+      db.prepare(/*sql*/ `UPDATE "_zero.column_metadata" SET backfill = NULL
+                   WHERE table_name = ? AND column_name = ?`).run(
+        'my.foo',
+        'a',
+      );
+      addColumnMetadata('my.foo', 'z', '{"fooID":9}');
+
+      populateBackfillingFromColumnMetadata(lc, db);
+
+      expectBackfilling([
+        {schema: 'my', table: 'foo', column: 'z', backfill: '{"fooID":9}'},
+      ]);
+    });
+  });
+});

--- a/packages/zero-cache/src/services/replicator/schema/backfilling.ts
+++ b/packages/zero-cache/src/services/replicator/schema/backfilling.ts
@@ -1,0 +1,326 @@
+/**
+ * The replica's backfill cookie, keyed by upstream identity.
+ *
+ * `_zero.column_metadata.backfill` already records which columns are being
+ * backfilled, and it stays authoritative for `isBackfilling`, which is what the
+ * replica's own read paths use. What it cannot do is name the table an upstream
+ * would recognize: it is keyed by *lite* table name, and `liteTableName()`
+ * collapses the `public` schema and has no inverse anywhere in the tree. A lite
+ * name containing a dot is ambiguous — `{public, "a.b"}` and `{a, b}` produce
+ * the same string — and a table with backfilling columns and no
+ * `_zero.tableMetadata` row (legal, since its metadata is optional) cannot be
+ * resolved at all.
+ *
+ * That is the whole of what blocks a change log from being initialized out of a
+ * restored replica, so this table carries the identity the reconstruction needs:
+ * a straight row copy into the change log's own cookie tables, with nothing to
+ * reconstruct and nothing to guess. The replica's copy is the *seed* source; the
+ * change log's copy (`replicator/change-log-cookies.ts`) is the *working* set,
+ * folded forward from the seed as the log's head advances.
+ *
+ * The cost is a second copy of `backfill` inside the replica, taken
+ * deliberately — though not to save writes: `_zero.column_metadata` is written
+ * only by initial sync, the DDL handlers, and backfill completion, so two more
+ * columns on it would be free. It is a matter of shape. That table is keyed by
+ * lite table name, so `schema`/`table` would be non-key duplicates of its own
+ * key, to be held in sync with it across every rename with no answer to which
+ * encoding is authoritative. This one is keyed exactly as `cdc.backfilling` and
+ * `_zero.changeLogBackfilling` are, which is what makes the change log's
+ * initialization comparison a row-set diff rather than a translation, and what
+ * lets all three stores interpret the same fold. It also holds in-flight backfills and nothing else,
+ * where the same query against `column_metadata` is an unindexed scan over a row
+ * per column of every table.
+ *
+ * This table is write-only from the replica's perspective. Nothing in the
+ * replicator reads it; it exists to be read by the change-streamer.
+ */
+
+import type {LogContext} from '@rocicorp/logger';
+import {unreachable} from '../../../../../shared/src/asserts.ts';
+import {BigIntJSON} from '../../../../../shared/src/bigint-json.ts';
+import * as v from '../../../../../shared/src/valita.ts';
+import type {Database, Statement} from '../../../../../zqlite/src/db.ts';
+import {getOrCreateCounter} from '../../../observability/metrics.ts';
+import {liteTableName} from '../../../types/names.ts';
+import type {
+  BackfillID,
+  Identifier,
+  SchemaChange,
+  TableMetadata,
+} from '../../change-source/protocol/current/data.ts';
+import {
+  backfillRequestSchema,
+  type BackfillRequest,
+} from '../../change-source/protocol/current/upstream.ts';
+import {cookieOps, type CookieOp} from '../change-log-cookies.ts';
+
+export const BACKFILLING_TABLE = '_zero.backfilling';
+
+// `backfill` holds the JSON that `cdc.backfilling` holds as JSONB. SQLite has
+// no JSONB, and nothing here queries into the document: it is stored to be
+// handed back to the change source verbatim.
+export const CREATE_BACKFILLING_TABLE = /*sql*/ `
+  CREATE TABLE "${BACKFILLING_TABLE}" (
+    "schema"   TEXT NOT NULL,
+    "table"    TEXT NOT NULL,
+    "column"   TEXT NOT NULL,
+    "backfill" TEXT NOT NULL,
+    PRIMARY KEY ("schema", "table", "column")
+  );
+`;
+
+/**
+ * The replica's interpreter of the cookie fold in
+ * `replicator/change-log-cookies.ts`.
+ *
+ * The fold is shared rather than re-implemented for the same reason the
+ * Postgres and SQLite change logs share it: the three stores must agree on every
+ * transition forever, and the failure mode when they drift is a backfill that is
+ * silently never re-requested, on a column that is then silently never
+ * populated. Sharing it makes the replica-versus-Postgres comparison a
+ * regression test on the interpreters rather than on three implementations of
+ * the same switch.
+ *
+ * Only the backfill half of the fold is interpreted here. The replica's metadata
+ * cookie is `_zero.tableMetadata.upstreamMetadata`, which `TableMetadataTracker`
+ * already maintains at the same sites, so an `upsert-metadata` op is inert.
+ *
+ * Statements are lazily prepared, matching `TableMetadataTracker`: a replica
+ * that never sees a schema change never prepares any of them.
+ */
+export class BackfillingTracker {
+  readonly #db: Database;
+
+  #upsert: Statement | undefined;
+  #renameTable: Statement | undefined;
+  #dropTable: Statement | undefined;
+  #renameColumn: Statement | undefined;
+  #dropColumn: Statement | undefined;
+
+  constructor(db: Database) {
+    this.#db = db;
+  }
+
+  /**
+   * Applies the change's backfill-cookie ops, returning the ops that were
+   * applied. Changes that carry no backfill state — index changes, metadata-only
+   * updates, and the `create-table` / `add-column` variants from a change source
+   * that does not support backfill — apply nothing.
+   */
+  apply(change: SchemaChange): CookieOp[] {
+    const ops = cookieOps(change);
+    for (const op of ops) {
+      this.#run(op);
+    }
+    return ops;
+  }
+
+  #run(op: CookieOp): void {
+    switch (op.op) {
+      case 'upsert-metadata':
+        // Maintained by TableMetadataTracker in "_zero.tableMetadata".
+        break;
+
+      case 'upsert-backfill':
+        (this.#upsert ??= this.#db.prepare(/*sql*/ `
+          INSERT INTO "${BACKFILLING_TABLE}"
+            ("schema", "table", "column", "backfill") VALUES (?, ?, ?, ?)
+            ON CONFLICT ("schema", "table", "column")
+            DO UPDATE SET "backfill" = excluded."backfill"
+        `)).run(
+          op.table.schema,
+          op.table.name,
+          op.column,
+          BigIntJSON.stringify(op.backfill),
+        );
+        break;
+
+      case 'rename-table':
+        (this.#renameTable ??= this.#db.prepare(/*sql*/ `
+          UPDATE "${BACKFILLING_TABLE}"
+            SET "schema" = ?, "table" = ? WHERE "schema" = ? AND "table" = ?
+        `)).run(op.new.schema, op.new.name, op.old.schema, op.old.name);
+        break;
+
+      case 'drop-table':
+        (this.#dropTable ??= this.#db.prepare(/*sql*/ `
+          DELETE FROM "${BACKFILLING_TABLE}"
+            WHERE "schema" = ? AND "table" = ?
+        `)).run(op.table.schema, op.table.name);
+        break;
+
+      case 'rename-column':
+        (this.#renameColumn ??= this.#db.prepare(/*sql*/ `
+          UPDATE "${BACKFILLING_TABLE}" SET "column" = ?
+            WHERE "schema" = ? AND "table" = ? AND "column" = ?
+        `)).run(op.new, op.table.schema, op.table.name, op.old);
+        break;
+
+      case 'drop-column':
+        this.#deleteColumn(op.table, op.column);
+        break;
+
+      case 'complete-backfill':
+        // A per-column delete rather than an `IN` list, which cannot be a
+        // single prepared statement across arities. The columns of one
+        // completed backfill are few, and this runs only on schema changes.
+        for (const column of op.columns) {
+          this.#deleteColumn(op.table, column);
+        }
+        break;
+
+      default:
+        unreachable(op);
+    }
+  }
+
+  #deleteColumn(table: Identifier, column: string): void {
+    (this.#dropColumn ??= this.#db.prepare(/*sql*/ `
+      DELETE FROM "${BACKFILLING_TABLE}"
+        WHERE "schema" = ? AND "table" = ? AND "column" = ?
+    `)).run(table.schema, table.name, column);
+  }
+}
+
+const backfillRequestsSchema = v.array(backfillRequestSchema);
+
+type BackfillRequestRow = {
+  schema: string;
+  table: string;
+  metadata: string | null;
+  column: string;
+  backfill: string;
+};
+
+/**
+ * Assembles the {@link BackfillRequest}s that the replica's state implies, in
+ * the shape `Storer.getStartStreamInitializationParameters()` produces them
+ * from `cdc.backfilling` LEFT JOIN `cdc.tableMetadata`.
+ *
+ * The join is `LEFT` for the same reason it is there: a table can be
+ * backfilling with no metadata of its own, in which case the request carries
+ * `metadata: null`. Rows are ordered by primary key so that this list and the
+ * Postgres-derived one can be compared position for position.
+ *
+ * This is a snapshot of the replica at its `_zero.replicationState.stateVersion`
+ * and is only meaningful paired with it. It trails the change log's head, which
+ * is why C4 folds the log's own schema changes onto it before comparing rather
+ * than expecting raw equality.
+ */
+export function readBackfillRequests(db: Database): BackfillRequest[] {
+  const rows = db
+    .prepare(/*sql*/ `
+      SELECT b."schema", b."table", b."column", b."backfill",
+             t."upstreamMetadata" AS "metadata"
+        FROM "${BACKFILLING_TABLE}" AS b
+        LEFT JOIN "_zero.tableMetadata" AS t
+          ON b."schema" = t."schema" AND b."table" = t."table"
+        ORDER BY b."schema", b."table", b."column"
+    `)
+    .all<BackfillRequestRow>();
+
+  const requests: BackfillRequest[] = [];
+  let curr: BackfillRequest | undefined;
+  for (const {schema, table, metadata, column, backfill} of rows) {
+    if (curr?.table.schema !== schema || curr.table.name !== table) {
+      curr = {
+        table: {
+          schema,
+          name: table,
+          metadata:
+            metadata === null
+              ? null
+              : (BigIntJSON.parse(metadata) as TableMetadata),
+        },
+        columns: {},
+      };
+      requests.push(curr);
+    }
+    curr.columns[column] = BigIntJSON.parse(backfill) as BackfillID;
+  }
+  return v.parse(requests, backfillRequestsSchema);
+}
+
+/**
+ * Seeds {@link BACKFILLING_TABLE} from `_zero.column_metadata`, resolving each
+ * lite table name back to its upstream identity. Used by the v17 migration.
+ *
+ * The resolution is exact for a table that has a `_zero.tableMetadata` row, and
+ * exact for a lite name with no dot in it — `liteTableName()` only omits the
+ * schema for `public`. What is left over is an in-flight backfill, on a
+ * non-`public` schema, on a table with no metadata row, at the instant of
+ * upgrade. Those get the best-effort first-dot split and are counted, because a
+ * wrong identity produces a `BackfillRequest` the change source will reject
+ * rather than a silently wrong one, and because the initialization comparison
+ * surfaces it before anything depends on it. The expected count is zero.
+ *
+ * A full replace rather than an insert-if-absent: `migrateData` re-runs after a
+ * rollback and roll-forward, during which a v16 zero-cache advanced the replica
+ * without knowing this table existed. Rebuilding it from `column_metadata` —
+ * which that zero-cache *did* maintain — is what makes the re-run both
+ * idempotent and correct.
+ */
+export function populateBackfillingFromColumnMetadata(
+  lc: LogContext,
+  db: Database,
+): void {
+  db.prepare(/*sql*/ `DELETE FROM "${BACKFILLING_TABLE}"`).run();
+
+  const backfilling = db
+    .prepare(/*sql*/ `
+      SELECT table_name, column_name, backfill FROM "_zero.column_metadata"
+        WHERE backfill IS NOT NULL
+        ORDER BY table_name, column_name
+    `)
+    .all<{table_name: string; column_name: string; backfill: string}>();
+
+  const unresolvable = getOrCreateCounter(
+    'replica',
+    'backfilling_unresolvable_rows',
+    'In-flight backfills whose upstream table identity could not be recovered ' +
+      'from the replica when "' +
+      BACKFILLING_TABLE +
+      '" was created. A best-effort identity is stored; the expected count is 0.',
+  );
+  if (backfilling.length === 0) {
+    unresolvable.add(0); // the common case: publish the series anyway
+    return;
+  }
+
+  const byLiteName = new Map<string, Identifier>(
+    db
+      .prepare(/*sql*/ `SELECT "schema", "table" FROM "_zero.tableMetadata"`)
+      .all<{schema: string; table: string}>()
+      .map(({schema, table}) => [
+        liteTableName({schema, name: table}),
+        {schema, name: table},
+      ]),
+  );
+
+  const insert = db.prepare(/*sql*/ `
+    INSERT INTO "${BACKFILLING_TABLE}"
+      ("schema", "table", "column", "backfill") VALUES (?, ?, ?, ?)
+  `);
+  let unresolved = 0;
+  for (const {table_name: liteName, column_name, backfill} of backfilling) {
+    const known = byLiteName.get(liteName);
+    const dot = known ? -1 : liteName.indexOf('.');
+    const table = known ?? {
+      schema: dot < 0 ? 'public' : liteName.slice(0, dot),
+      name: dot < 0 ? liteName : liteName.slice(dot + 1),
+    };
+    if (!known && dot >= 0) {
+      unresolved++;
+      lc.warn?.(
+        `no metadata for backfilling table "${liteName}"; ` +
+          `assuming {schema: "${table.schema}", name: "${table.name}"}`,
+      );
+    }
+    insert.run(table.schema, table.name, column_name, backfill);
+  }
+  unresolvable.add(unresolved);
+  lc.info?.(
+    `seeded "${BACKFILLING_TABLE}" with ${backfilling.length} in-flight ` +
+      `backfill(s), ${unresolved} of which could not be resolved`,
+  );
+}

--- a/packages/zero-cache/src/services/replicator/schema/replication-state.ts
+++ b/packages/zero-cache/src/services/replicator/schema/replication-state.ts
@@ -13,6 +13,7 @@ import {
 import * as v from '../../../../../shared/src/valita.ts';
 import type {Database} from '../../../../../zqlite/src/db.ts';
 import type {StatementRunner} from '../../../db/statements.ts';
+import {CREATE_BACKFILLING_TABLE} from './backfilling.ts';
 import {CREATE_CHANGELOG_SCHEMA} from './change-log.ts';
 import {CREATE_COLUMN_METADATA_TABLE} from './column-metadata.ts';
 import {ZERO_VERSION_COLUMN_NAME} from './constants.ts';
@@ -69,7 +70,8 @@ const CREATE_REPLICATION_STATE_SCHEMA =
   CREATE_CHANGELOG_SCHEMA +
   CREATE_RUNTIME_EVENTS_TABLE +
   CREATE_COLUMN_METADATA_TABLE +
-  CREATE_TABLE_METADATA_TABLE;
+  CREATE_TABLE_METADATA_TABLE +
+  CREATE_BACKFILLING_TABLE;
 
 const stringArray = v.array(v.string());
 


### PR DESCRIPTION
Adds a new `_zero.backfilling(schema, table, column, backfill)` table at replica schema v17.

This will let us get backfill state from SQLite only and retire dependence on PG.


Why not just use the existing table keyed on `liteTableName`? Well a PG table could have a `.` in it, which breaks the mapping. E.g., `foo.bar`. Is that `schema foo table bar` or `table "foo.bar"`?