### PR TITLE
fix(zero-cache): surface fatal replication errors

### DIFF
--- a/packages/zero-cache/src/services/life-cycle.test.ts
+++ b/packages/zero-cache/src/services/life-cycle.test.ts
@@ -287,6 +287,19 @@ describe('shutdown', () => {
     expect(events.sort()).toEqual(expectedEvents.sort());
   });
 
+  test('exits nonzero when the final worker stops before drain', async () => {
+    const testProc = new EventEmitter();
+    const {promise: exitCode, resolve} = resolver<number>();
+    testProc.on('exit', resolve);
+    const manager = new ProcessManager(lc, testProc);
+    const [worker] = inProcChannel();
+    manager.addWorker(worker, 'user-facing', 'zero-cache');
+
+    worker.emit('close', 0, null);
+
+    expect(await exitCode).toBe(-1);
+  });
+
   test('records worker startup duration when a worker is ready', () => {
     const [parentPort, childPort] = inProcChannel();
     processes.addWorker(parentPort, 'supporting', 'replicator.ts (backup)');

--- a/packages/zero-cache/src/services/life-cycle.ts
+++ b/packages/zero-cache/src/services/life-cycle.ts
@@ -308,7 +308,7 @@ export class ProcessManager {
             } ms)`
           : `all user-facing workers exited`,
       );
-      return this.#exit(0);
+      return this.#exit(this.#drainStart ? 0 : code || -1);
     }
 
     if (this.#drainStart === 0) {

--- a/packages/zero-cache/src/services/replicator/change-processor.ts
+++ b/packages/zero-cache/src/services/replicator/change-processor.ts
@@ -74,8 +74,6 @@ const MAX_SQLITE_BIND_BYTES = Math.min(
   bufferConstants.MAX_LENGTH,
   bufferConstants.MAX_STRING_LENGTH,
 );
-const MIN_SQLITE_BIGINT = -(1n << 63n);
-const MAX_SQLITE_BIGINT = (1n << 63n) - 1n;
 
 export type CommitResult = {
   watermark: string;
@@ -541,7 +539,30 @@ class TransactionProcessor {
         this.#upsert(table, row);
       }
     } catch (e) {
-      throw wrapBindError(e, this.#version, update.relation, row, currKey);
+      if (
+        !(e instanceof RangeError) ||
+        e.message !== BIND_VALUE_TOO_BIG_ERROR
+      ) {
+        throw e;
+      }
+
+      const binding = [...Object.entries(row), ...Object.entries(currKey)]
+        .map(
+          ([column, value]) =>
+            [column, oversizedValueDescription(value)] as const,
+        )
+        .find(([, description]) => description);
+      const relationOid =
+        'relationOid' in update.relation &&
+        typeof update.relation.relationOid === 'number'
+          ? ` relationOid=${update.relation.relationOid}`
+          : '';
+      const error = new Error(
+        `Oversized SQLite update binding: tx=${this.#version}${relationOid} table=${update.relation.schema}.${update.relation.name} column=${binding?.[0] ?? 'unknown'}${binding?.[1] ? ` ${binding[1]}` : ''}`,
+        {cause: e},
+      );
+      error.name = 'OversizedUpdateBindingError';
+      throw error;
     }
   }
 
@@ -982,69 +1003,22 @@ function getBackfilledColumns(
   return backfilling.filter(col => col in row);
 }
 
-class OversizedUpdateBindingError extends Error {
-  constructor(message: string, cause: RangeError) {
-    super(message, {cause});
-    this.name = 'OversizedUpdateBindingError';
-  }
-}
-
-function wrapBindError(
-  error: unknown,
-  tx: LexiVersion,
-  relation: MessageRelation,
-  row: LiteRow,
-  currKey: LiteRowKey,
-) {
-  if (
-    !(error instanceof RangeError) ||
-    error.message !== BIND_VALUE_TOO_BIG_ERROR
-  ) {
-    return error;
-  }
-
-  const binding = [...Object.entries(row), ...Object.entries(currKey)].find(
-    ([, value]) => oversizedValueDescription(value),
-  );
-  const relationOid = getRelationOid(relation);
-  const context = [
-    `tx=${tx}`,
-    relationOid === undefined ? undefined : `relationOid=${relationOid}`,
-    `table=${relation.schema}.${relation.name}`,
-    `column=${binding?.[0] ?? 'unknown'}`,
-    binding && oversizedValueDescription(binding[1]),
-  ]
-    .filter(Boolean)
-    .join(' ');
-
-  return new OversizedUpdateBindingError(
-    `Oversized SQLite update binding: ${context}`,
-    error,
-  );
-}
-
-function getRelationOid(relation: MessageRelation): number | undefined {
-  return 'relationOid' in relation && typeof relation.relationOid === 'number'
-    ? relation.relationOid
-    : undefined;
-}
-
 function oversizedValueDescription(value: LiteValueType): string | undefined {
   if (typeof value === 'bigint') {
-    return value < MIN_SQLITE_BIGINT || value > MAX_SQLITE_BIGINT
+    return BigInt.asIntN(64, value) !== value
       ? 'valueType=bigint fitsInt64=false'
       : undefined;
   }
 
-  if (typeof value === 'string') {
-    const sizeBytes = Buffer.byteLength(value);
-    return sizeBytes > MAX_SQLITE_BIND_BYTES
-      ? `valueType=string sizeBytes=${sizeBytes} limitBytes=${MAX_SQLITE_BIND_BYTES}`
-      : undefined;
-  }
-
-  if (value instanceof Uint8Array && value.byteLength > MAX_SQLITE_BIND_BYTES) {
-    return `valueType=buffer sizeBytes=${value.byteLength} limitBytes=${MAX_SQLITE_BIND_BYTES}`;
+  const sizeBytes =
+    typeof value === 'string'
+      ? Buffer.byteLength(value)
+      : value instanceof Uint8Array
+        ? value.byteLength
+        : undefined;
+  if (sizeBytes !== undefined && sizeBytes > MAX_SQLITE_BIND_BYTES) {
+    const valueType = typeof value === 'string' ? 'string' : 'buffer';
+    return `valueType=${valueType} sizeBytes=${sizeBytes} limitBytes=${MAX_SQLITE_BIND_BYTES}`;
   }
 
   return undefined;

--- a/packages/zero-cache/src/services/replicator/incremental-sync.test.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.test.ts
@@ -33,6 +33,7 @@ import * as ErrorType from '../change-streamer/error-type-enum.ts';
 import {deleteChangeLogDB} from './change-log-db.ts';
 import {IncrementalSyncer} from './incremental-sync.ts';
 import {ReplicationStatusPublisher} from './replication-status.ts';
+import {ReplicatorService} from './replicator.ts';
 import {
   createReplicationStateTables,
   getReplicationState,
@@ -642,6 +643,37 @@ describe('replicator/incremental-sync', () => {
         },
       ]
     `);
+  });
+
+  test('publishes and rejects fatal replication errors', async () => {
+    const issues = new ReplicationMessages({issues: ['issueID']});
+
+    initReplicationState(mainDb, ['zero_data'], '02', {}, false);
+    const replicator = new ReplicatorService(
+      lc,
+      TASK_ID,
+      REPLICA_ID,
+      'backup',
+      {subscribe: subscribeFn.mockResolvedValue(downstream)},
+      worker,
+      ReplicationStatusPublisher.forReplicaFile(dbFile.path),
+    );
+    syncing = replicator.run();
+    await vi.waitFor(() => expect(subscribeFn).toHaveBeenCalled());
+
+    downstream.push([
+      'data',
+      issues.insert('issues', {issueID: 123, big: 456}),
+    ]);
+
+    await expect(syncing).rejects.toThrow(
+      'Received message outside of transaction',
+    );
+    expect(eventSink.at(-1)).toMatchObject({
+      status: 'ERROR',
+      stage: 'Replicating',
+      description: 'Replication stopped because the replica writer failed',
+    });
   });
 
   async function noNotification(

--- a/packages/zero-cache/src/services/replicator/incremental-sync.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.ts
@@ -71,7 +71,11 @@ export class IncrementalSyncer {
 
   async run() {
     const lc = this.#lc;
-    this.#worker.onError(err => this.#state.stop(lc, err));
+    let workerError: Error | undefined;
+    this.#worker.onError(err => {
+      workerError ??= err;
+      this.#state.stop(lc, err);
+    });
     lc.info?.(`Starting IncrementalSyncer`);
     const {watermark: initialWatermark} =
       await this.#worker.getSubscriptionState();
@@ -204,6 +208,9 @@ export class IncrementalSyncer {
       await this.#state.backoff(lc, err);
     }
     lc.info?.('IncrementalSyncer stopped');
+    if (workerError) {
+      throw workerError;
+    }
   }
 
   #handleResult(lc: LogContext, result: CommitResult | null) {

--- a/packages/zero-cache/src/services/replicator/replicator.ts
+++ b/packages/zero-cache/src/services/replicator/replicator.ts
@@ -4,7 +4,10 @@ import type {Source} from '../../types/streams.ts';
 import type {ChangeStreamer} from '../change-streamer/change-streamer.ts';
 import type {Service} from '../service.ts';
 import {IncrementalSyncer} from './incremental-sync.ts';
-import type {ReplicationStatusPublisher} from './replication-status.ts';
+import {
+  publishReplicationError,
+  type ReplicationStatusPublisher,
+} from './replication-status.ts';
 import type {WriteWorkerClient} from './write-worker-client.ts';
 
 /** See {@link ReplicaStateNotifier.subscribe()}. */
@@ -82,6 +85,7 @@ export class ReplicatorService implements Replicator, Service {
   readonly id: string;
   readonly #lc: LogContext;
   readonly #incrementalSyncer: IncrementalSyncer;
+  readonly #shouldPublishErrors: boolean;
   readonly #worker: WriteWorkerClient;
   #runPromise: Promise<void> | undefined;
 
@@ -99,6 +103,7 @@ export class ReplicatorService implements Replicator, Service {
       .withContext('component', 'replicator')
       .withContext('serviceID', this.id);
     this.#worker = worker;
+    this.#shouldPublishErrors = statusPublisher !== null;
 
     this.#incrementalSyncer = new IncrementalSyncer(
       this.#lc,
@@ -116,7 +121,16 @@ export class ReplicatorService implements Replicator, Service {
   }
 
   run() {
-    this.#runPromise = this.#incrementalSyncer.run();
+    this.#runPromise = this.#incrementalSyncer.run().catch(async error => {
+      if (this.#shouldPublishErrors) {
+        await publishReplicationError(
+          this.#lc,
+          'Replicating',
+          'Replication stopped because the replica writer failed',
+        );
+      }
+      throw error;
+    });
     return this.#runPromise;
   }
 


### PR DESCRIPTION

### What

Surface fatal replica-writer failures through Zero’s existing replication status pipeline and ensure they terminate zero-cache with a failure exit code.

### Why

A production poison update caused SQLite binding to fail, but the failure only appeared in logs. Incremental replication stopped without rejecting, no replication error reached the Cloud Zero console, and the parent process ultimately exited successfully.

### Changes

- Simplify oversized binding diagnostics while preserving transaction, relation, table, column, value type, size, and original cause context without logging values.
- Propagate fatal write-worker errors out of incremental replication.
- Publish one generic, safe replication error from the authoritative replicator before rethrowing.
- Preserve nonzero exit codes when workers terminate outside graceful shutdown.