### PR TITLE
chore(rmv2): initialize the backfill records from the replica

### DIFF
--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -123,6 +123,9 @@ export default async function runWorker(
 
   const context = getServerContext(config);
   const sqliteChangeLogEnabled = sqliteChangeLogMode !== 'off';
+  // The modes are cumulative, so `serve` implies `compare`.
+  const sqliteChangeLogComparing =
+    sqliteChangeLogMode === 'compare' || sqliteChangeLogMode === 'serve';
   if (sqliteChangeLogEnabled) {
     const changeLogFile = changeLogFileName(replica.file);
     registerSQLiteCorruptionDiagnosticTarget({
@@ -231,6 +234,12 @@ export default async function runWorker(
                 retentionMs: sqliteChangeLogRetentionMs,
                 batchRows: sqliteChangeLogPurgeBatchRows,
               }
+            : undefined,
+          // `compare` and above. The replica-derived initialization path runs
+          // at full rate and is checked against Postgres, which stays
+          // authoritative. Flipping authority to the replica comes later.
+          sqliteChangeLogCompare: sqliteChangeLogComparing
+            ? {replicaFile: replica.file}
             : undefined,
         },
         setTimeout,

--- a/packages/zero-cache/src/services/change-source/protocol/current/data.ts
+++ b/packages/zero-cache/src/services/change-source/protocol/current/data.ts
@@ -13,6 +13,7 @@ import * as v from '../../../../../../shared/src/valita.ts';
 import {columnSpec, indexSpec, tableSpec} from '../../../../db/specs.ts';
 import type {Satisfies} from '../../../../types/satisfies.ts';
 import {jsonObjectSchema} from './json.ts';
+import {schemaChangeTags} from './schema-change-tags.ts';
 
 export const beginSchema = v.object({
   tag: v.literal('begin'),
@@ -382,20 +383,6 @@ const schemaChanges = [
   createIndexSchema,
   dropIndexSchema,
   backfillCompletedSchema,
-] as const;
-
-// Note: keep in sync or the tag tests will fail
-const schemaChangeTags = [
-  'create-table',
-  'rename-table',
-  'update-table-metadata',
-  'add-column',
-  'update-column',
-  'drop-column',
-  'drop-table',
-  'create-index',
-  'drop-index',
-  'backfill-completed',
 ] as const;
 
 export const schemaChangeSchema = v.union(...schemaChanges);

--- a/packages/zero-cache/src/services/change-source/protocol/current/schema-change-tags.ts
+++ b/packages/zero-cache/src/services/change-source/protocol/current/schema-change-tags.ts
@@ -1,0 +1,16 @@
+/**
+ * Kept in a module that is not re-exported by the public change protocol so
+ * internal consumers can share the tag list without expanding the public API.
+ */
+export const schemaChangeTags = [
+  'create-table',
+  'rename-table',
+  'update-table-metadata',
+  'add-column',
+  'update-column',
+  'drop-column',
+  'drop-table',
+  'create-index',
+  'drop-index',
+  'backfill-completed',
+] as const;

--- a/packages/zero-cache/src/services/change-streamer/change-log-cookies.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-log-cookies.pg.test.ts
@@ -10,96 +10,50 @@
 
 import {beforeEach, describe, expect} from 'vitest';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
-import {Database} from '../../../../zqlite/src/db.ts';
+import type {Database} from '../../../../zqlite/src/db.ts';
 import {StatementRunner} from '../../db/statements.ts';
 import {type PgTest, test} from '../../test/db.ts';
-import type {PostgresDB} from '../../types/pg.ts';
 import type {SchemaChange} from '../change-source/protocol/current/data.ts';
-import type {
-  ChangeStreamData,
-  Commit,
-} from '../change-source/protocol/current/downstream.ts';
-import type {UpstreamStatusMessage} from '../change-source/protocol/current/status.ts';
+import {readCookies, type CookieSet} from '../replicator/change-log-cookies.ts';
 import {
-  CREATE_CHANGE_LOG_COOKIE_SCHEMA,
-  readCookies,
-  type BackfillCookie,
-  type CookieSet,
-  type TableMetadataCookie,
-} from '../replicator/change-log-cookies.ts';
-import {
-  CREATE_CHANGE_LOG_STREAM_SCHEMA,
   reconcileChangeLog,
   type ChangeLogAnchor,
 } from '../replicator/change-log-db.ts';
 import {ChangeLogStreamWriter} from '../replicator/change-log-stream-writer.ts';
 import {serializeChangeStreamData} from './change-log-codec.ts';
-import {ensureReplicationConfig, setupCDCTables} from './schema/tables.ts';
-import {Storer, type TuningOptions} from './storer.ts';
+import {
+  ChangeStreamDriver,
+  createChangeLog,
+  createShardStorer,
+  readPgCookies,
+  REPLICA_VERSION,
+  transactionMessages,
+  type ShardStorer,
+} from './change-log-test-utils.ts';
 
 const lc = createSilentLogContext();
 
-const APP_ID = 'cookies';
-const SHARD_NUM = 1;
-const CDC_SCHEMA = `${APP_ID}_${SHARD_NUM}/cdc`;
-const REPLICA_VERSION = '00';
-
-const opts: TuningOptions = {
-  backPressureLimitHeapProportion: 0.04,
-  statementTimeoutMs: 20_000,
-  changeLogBatchSize: 2000,
-};
-
 describe('change-streamer/change-log cookie parity', () => {
-  let db: PostgresDB;
-  let storer: Storer;
-  let done: Promise<void>;
+  let shard: ShardStorer;
   let changeLog: Database;
-  let watermark: number;
+  let driver: ChangeStreamDriver;
 
   beforeEach<PgTest>(async ({testDBs}) => {
-    db = await testDBs.create('change_log_cookie_parity', {
-      typeOpts: {sendStringAsJson: true},
+    shard = await createShardStorer(
+      lc,
+      testDBs,
+      'change_log_cookie_parity',
+      'cookies',
+    );
+    changeLog = createChangeLog(lc);
+    driver = new ChangeStreamDriver(lc, {
+      upstream: shard.storer,
+      changeLog,
     });
-    const shard = {appID: APP_ID, shardNum: SHARD_NUM};
-    await db.begin(tx => setupCDCTables(lc, tx, shard));
-    await ensureReplicationConfig(
-      lc,
-      db,
-      {
-        replicaVersion: REPLICA_VERSION,
-        publications: [],
-        watermark: REPLICA_VERSION,
-      },
-      shard,
-      true,
-    );
-
-    storer = new Storer(
-      lc,
-      shard,
-      'task-id',
-      'change-streamer:12345',
-      'ws',
-      db,
-      REPLICA_VERSION,
-      (_: Commit | UpstreamStatusMessage) => {},
-      () => {},
-      opts,
-    );
-    await storer.assumeOwnership();
-    done = storer.run();
-
-    changeLog = new Database(lc, ':memory:');
-    changeLog.exec(CREATE_CHANGE_LOG_STREAM_SCHEMA);
-    changeLog.exec(CREATE_CHANGE_LOG_COOKIE_SCHEMA);
-    watermark = 1;
 
     return async () => {
       changeLog.close();
-      await testDBs.drop(db);
-      void storer?.stop();
-      await done;
+      await shard.close();
     };
   });
 
@@ -107,41 +61,12 @@ describe('change-streamer/change-log cookie parity', () => {
    * Drives one transaction carrying `changes` through both writers, the way
    * their respective stream loops do.
    */
-  async function transaction(...changes: SchemaChange[]): Promise<void> {
-    const wm = String(++watermark).padStart(2, '0');
-    const messages: ChangeStreamData[] = [
-      ['begin', {tag: 'begin'}, {commitWatermark: wm}],
-      ...changes.map((change): ChangeStreamData => ['data', change]),
-      ['commit', {tag: 'commit'}, {watermark: wm}],
-    ];
-
-    messages.forEach(message => storer.store(wm, message));
-
-    const writer = new ChangeLogStreamWriter(new StatementRunner(changeLog));
-    writer.begin(wm, serializeChangeStreamData(messages[0]));
-    changes.forEach((change, i) =>
-      writer.append(serializeChangeStreamData(messages[i + 1]), change),
-    );
-    writer.commit(wm, serializeChangeStreamData(messages.at(-1)!), 1_000);
-
-    await storer.allProcessed();
-  }
+  const transaction = (...changes: SchemaChange[]) =>
+    driver.transaction(changes);
 
   /** The cookie set the Postgres change log holds, in the SQLite log's shape. */
-  async function pgCookies(): Promise<CookieSet> {
-    const [tableMetadata, backfilling] = await Promise.all([
-      db<TableMetadataCookie[]>`
-        SELECT "schema", "table", "metadata" FROM ${db(CDC_SCHEMA)}."tableMetadata"
-          ORDER BY "schema", "table"`,
-      db<BackfillCookie[]>`
-        SELECT "schema", "table", "column", "backfill" FROM ${db(CDC_SCHEMA)}."backfilling"
-          ORDER BY "schema", "table", "column"`,
-    ]);
-    return {
-      tableMetadata: [...tableMetadata],
-      backfilling: [...backfilling],
-    };
-  }
+  const pgCookies = (): Promise<CookieSet> =>
+    readPgCookies(shard.db, shard.cdcSchema);
 
   /**
    * Both stores agree, and the agreed-on set is what was expected. The second
@@ -392,30 +317,26 @@ describe('change-streamer/change-log cookie parity', () => {
 
     // The stream is interrupted after the schema change and before the commit:
     // Postgres aborts its transaction pool, SQLite rolls its transaction back.
-    const wm = String(++watermark).padStart(2, '0');
+    // Driven by hand rather than by the driver, which only commits.
     const change: SchemaChange = {
       tag: 'add-column',
       table: {schema: 'my', name: 'foo'},
       column: {name: 'b', spec: {pos: 2, dataType: 'text'}},
       backfill: {fooID: 2},
     };
-    storer.store(wm, ['begin', {tag: 'begin'}, {commitWatermark: wm}]);
-    storer.store(wm, ['data', change]);
+    const wm = driver.claimWatermark();
+    const [begin, data] = transactionMessages(wm, [change]);
+
+    shard.storer.store(wm, begin);
+    shard.storer.store(wm, data);
 
     const writer = new ChangeLogStreamWriter(new StatementRunner(changeLog));
-    writer.begin(
-      wm,
-      serializeChangeStreamData([
-        'begin',
-        {tag: 'begin'},
-        {commitWatermark: wm},
-      ]),
-    );
-    writer.append(serializeChangeStreamData(['data', change]), change);
+    writer.begin(wm, serializeChangeStreamData(begin));
+    writer.append(serializeChangeStreamData(data), change);
     writer.rollback();
 
-    storer.abort();
-    await storer.allProcessed();
+    shard.storer.abort();
+    await shard.storer.allProcessed();
 
     await expectCookies({
       tableMetadata: [],
@@ -449,7 +370,9 @@ describe('change-streamer/change-log cookie parity', () => {
 
     /** The anchor a stream connection would reconcile the log against. */
     async function anchor(): Promise<ChangeLogAnchor> {
-      return anchorFrom(await storer.getStartStreamInitializationParameters());
+      return anchorFrom(
+        await shard.storer.getStartStreamInitializationParameters(),
+      );
     }
 
     test('a reseed lands the cookie set Postgres holds', async () => {
@@ -471,7 +394,8 @@ describe('change-streamer/change-log cookie parity', () => {
       // A log with no meta row of its own: what a task that has just restored a
       // replica, or upgraded past a schema version, brings to its first stream
       // connection. It is wiped and reseeded at the resume watermark.
-      const params = await storer.getStartStreamInitializationParameters();
+      const params =
+        await shard.storer.getStartStreamInitializationParameters();
       expect(
         reconcileChangeLog(lc, changeLog, anchorFrom(params)),
       ).toMatchObject({

--- a/packages/zero-cache/src/services/change-streamer/change-log-initializer-metrics.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-log-initializer-metrics.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Asserts the exported value of the initialization comparison's classification
+ * counter, which
+ * `change-log-initializer.test.ts` cannot: `observability/metrics.ts` caches
+ * every instrument in module scope, so an instrument created against a previous
+ * test's meter provider would be handed back to the next one. Each test here
+ * therefore resets modules and imports through a fresh provider, matching
+ * `replicator/sqlite-change-log-metrics.test.ts`.
+ *
+ * `divergent` is the alerting series (`P§:10`) and `inconclusive` is the one
+ * that is charted rather than alerted, so the label has to be right on both.
+ */
+
+import {metrics} from '@opentelemetry/api';
+import {
+  AggregationTemporality,
+  InMemoryMetricExporter,
+  MeterProvider,
+  PeriodicExportingMetricReader,
+} from '@opentelemetry/sdk-metrics';
+import {afterEach, expect, test, vi} from 'vitest';
+import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
+import {EMPTY_COOKIE_SET} from '../replicator/change-log-cookies.ts';
+import type {InitializationParameters} from './change-log-initializer.ts';
+
+afterEach(() => {
+  metrics.disable();
+  vi.resetModules();
+});
+
+const METRIC = 'zero.replica.sqlite_change_log.init_compare_result';
+
+function withProvider() {
+  const exporter = new InMemoryMetricExporter(
+    AggregationTemporality.CUMULATIVE,
+  );
+  const provider = new MeterProvider({
+    readers: [
+      new PeriodicExportingMetricReader({
+        exporter,
+        exportIntervalMillis: 60_000,
+      }),
+    ],
+  });
+  expect(metrics.setGlobalMeterProvider(provider)).toBe(true);
+  return {
+    exporter,
+    provider,
+    [Symbol.asyncDispose]: () => provider.shutdown(),
+  };
+}
+
+/** The counter's value per `result` label. */
+function byResult(exporter: InMemoryMetricExporter) {
+  const points =
+    exporter
+      .getMetrics()
+      .flatMap(resource => resource.scopeMetrics)
+      .flatMap(scope => scope.metrics)
+      .find(metric => metric.descriptor.name === METRIC)?.dataPoints ?? [];
+  return Object.fromEntries(
+    points.map(point => [point.attributes.result, point.value as number]),
+  );
+}
+
+const AT = (lastWatermark: string): InitializationParameters => ({
+  lastWatermark,
+  backfillRequests: [],
+  cookies: EMPTY_COOKIE_SET,
+});
+
+async function compare(replica: () => InitializationParameters) {
+  const {ChangeLogInitializer} = await import('./change-log-initializer.ts');
+  const init = new ChangeLogInitializer(
+    createSilentLogContext(),
+    {initFromPgChangeLog: true, initFromReplica: true},
+    {
+      pgChangeLog: () => Promise.resolve(AT('02')),
+      replica,
+      // The fold is never reached: the two cases below are decided at the
+      // watermark, and the third never gets as far as a comparison.
+      changeLog: () => undefined,
+    },
+  );
+  await init.initialize();
+  return init.compare();
+}
+
+test('an agreement is counted as equal', async () => {
+  await using otel = withProvider();
+  expect(await compare(() => AT('02'))).toBe('equal');
+  await otel.provider.forceFlush();
+
+  expect(byResult(otel.exporter)).toEqual({equal: 1});
+});
+
+test('a log that cannot span the interval is counted as inconclusive', async () => {
+  await using otel = withProvider();
+  expect(await compare(() => AT('01'))).toBe('inconclusive');
+  await otel.provider.forceFlush();
+
+  expect(byResult(otel.exporter)).toEqual({inconclusive: 1});
+});
+
+test('a replica that cannot be read is counted as an error', async () => {
+  await using otel = withProvider();
+  expect(
+    await compare(() => {
+      throw new Error('replica is gone');
+    }),
+  ).toBeUndefined();
+  await otel.provider.forceFlush();
+
+  // Counted at the read rather than at the comparison, which never runs.
+  expect(byResult(otel.exporter)).toEqual({error: 1});
+});

--- a/packages/zero-cache/src/services/change-streamer/change-log-initializer.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-log-initializer.pg.test.ts
@@ -1,0 +1,194 @@
+/**
+ * The change log's initialization comparator against the two stores it actually
+ * compares.
+ *
+ * `change-log-initializer.test.ts` covers the classification and the fold with
+ * the change log standing in for Postgres. This covers what only a shard can:
+ * `Storer.getStartStreamInitializationParameters()` reading `cdc.*`, against a
+ * real replica, through the real {@link ChangeLogInitializer}.
+ *
+ * The specific thing it pins is that the two stores are allowed to differ in
+ * ways that are not differences. Postgres holds the cookie documents as `jsonb`,
+ * which does not preserve key order, and orders its rows under a collation the
+ * replica does not share -- so a comparator that compared the two renderings
+ * would report a divergence at the first cookie with more than one key. Every
+ * `backfill` below has two.
+ *
+ * The transitions themselves are not re-walked here: `change-log-cookies.pg.test.ts`
+ * pins all eight against Postgres, and `change-log-initializer.test.ts` pins
+ * them across an interval. What is left is the composition.
+ */
+
+import {beforeEach, describe, expect} from 'vitest';
+import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
+import type {Database} from '../../../../zqlite/src/db.ts';
+import {type PgTest, test} from '../../test/db.ts';
+import type {ChangeProcessor} from '../replicator/change-processor.ts';
+import {
+  ChangeLogInitializer,
+  readReplicaInitializationParameters,
+} from './change-log-initializer.ts';
+import {
+  ChangeStreamDriver,
+  createChangeLog,
+  createReplica,
+  createShardStorer,
+  type ShardStorer,
+} from './change-log-test-utils.ts';
+
+const lc = createSilentLogContext();
+
+describe('change-streamer/change-log-initializer against a shard', () => {
+  let shard: ShardStorer;
+  let changeLog: Database;
+  let replica: Database;
+  let processor: ChangeProcessor;
+  let initializer: ChangeLogInitializer;
+  let driver: ChangeStreamDriver;
+
+  beforeEach<PgTest>(async ({testDBs}) => {
+    shard = await createShardStorer(
+      lc,
+      testDBs,
+      'change_log_initializer',
+      'initializer',
+    );
+    changeLog = createChangeLog(lc);
+    ({replica, processor} = createReplica(lc));
+
+    initializer = new ChangeLogInitializer(
+      lc,
+      {initFromPgChangeLog: true, initFromReplica: true},
+      {
+        pgChangeLog: () =>
+          shard.storer.getStartStreamInitializationParameters(),
+        replica: () => readReplicaInitializationParameters(replica),
+        changeLog: () => changeLog,
+      },
+    );
+    // The stream loop's three stores, driven together.
+    driver = new ChangeStreamDriver(lc, {
+      upstream: shard.storer,
+      changeLog,
+      replica: processor,
+    });
+
+    return async () => {
+      replica.close();
+      changeLog.close();
+      await shard.close();
+    };
+  });
+
+  async function compare() {
+    await initializer.initialize();
+    return initializer.compare();
+  }
+
+  test('the two stores agree when the replica is caught up', async () => {
+    await driver.transaction([
+      {
+        tag: 'create-table',
+        spec: {
+          schema: 'my',
+          name: 'foo',
+          columns: {
+            id: {pos: 0, dataType: 'int8', notNull: true},
+            a: {pos: 1, dataType: 'text'},
+          },
+          primaryKey: ['id'],
+        },
+        metadata: {rowKey: {type: 'default', columns: ['id']}},
+        // Two keys, in an order `jsonb` does not preserve.
+        backfill: {a: {fooID: 987, barID: 'zoo'}},
+      },
+    ]);
+
+    expect(await compare()).toBe('equal');
+  });
+
+  test('and when it trails, over an interval that moves both cookies', async () => {
+    await driver.transaction([
+      {
+        tag: 'create-table',
+        spec: {
+          schema: 'my',
+          name: 'foo',
+          columns: {
+            id: {pos: 0, dataType: 'int8', notNull: true},
+            a: {pos: 1, dataType: 'text'},
+            b: {pos: 2, dataType: 'text'},
+          },
+          primaryKey: ['id'],
+        },
+        metadata: {rowKey: {type: 'default', columns: ['id']}},
+        backfill: {a: {fooID: 987, barID: 'zoo'}, b: {fooID: 843, barID: 'oz'}},
+      },
+      // A table with in-flight backfills and no metadata row: legal, and the
+      // case the replica could not name before `_zero.backfilling` existed.
+      {
+        tag: 'create-table',
+        spec: {
+          schema: 'your',
+          name: 'bar',
+          columns: {id: {pos: 0, dataType: 'int8', notNull: true}},
+          primaryKey: ['id'],
+        },
+        backfill: {c: {barID: 'zoo', fooID: 1}},
+      },
+    ]);
+
+    // Everything below reaches the change log and Postgres but not the replica,
+    // i.e. it is exactly what the fold has to carry the replica forward over.
+    await driver.transaction(
+      [
+        {
+          tag: 'add-column',
+          table: {schema: 'my', name: 'foo'},
+          tableMetadata: {rowKey: {type: 'index', columns: ['id']}},
+          column: {name: 'd', spec: {pos: 3, dataType: 'text'}},
+          backfill: {fooID: 123, barID: 'dd'},
+        },
+        {
+          tag: 'update-column',
+          table: {schema: 'my', name: 'foo'},
+          old: {name: 'a', spec: {pos: 1, dataType: 'text'}},
+          new: {name: 'z', spec: {pos: 1, dataType: 'text'}},
+        },
+      ],
+      {toReplica: false},
+    );
+    await driver.transaction(
+      [
+        // Clears the listed columns *and* the rowKey's, leaving `your.bar`.
+        {
+          tag: 'backfill-completed',
+          relation: {
+            schema: 'my',
+            name: 'foo',
+            rowKey: {type: 'default', columns: ['z']},
+          },
+          columns: ['b', 'd'],
+          watermark: '03',
+        },
+      ],
+      {toReplica: false},
+    );
+
+    const {cookies} =
+      await shard.storer.getStartStreamInitializationParameters();
+    // Non-vacuous: the interval really did move the cookie set, and what is
+    // left is not empty.
+    expect(cookies.tableMetadata).toHaveLength(1);
+    expect(cookies.backfilling).toEqual([
+      {
+        schema: 'your',
+        table: 'bar',
+        column: 'c',
+        backfill: {barID: 'zoo', fooID: 1},
+      },
+    ]);
+
+    expect(await compare()).toBe('equal-after-fold');
+  });
+});

--- a/packages/zero-cache/src/services/change-streamer/change-log-initializer.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-log-initializer.test.ts
@@ -1,0 +1,608 @@
+/**
+ * The change log's initialization comparator, driven the way the stream loop
+ * drives it.
+ *
+ * The replica-derived side is real: an actual {@link ChangeProcessor} folding an
+ * actual change stream into an actual replica, stopped short of the log's head
+ * so that the fold has something to do. The Postgres-derived side is the change
+ * log's own cookie set, which `change-log-cookies.pg.test.ts` pins as identical
+ * to Postgres's — so what is under test here is the third interpreter and the
+ * fold that joins the two positions, without needing a shard.
+ */
+
+import {beforeEach, describe, expect, test} from 'vitest';
+import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
+import {Database} from '../../../../zqlite/src/db.ts';
+import {StatementRunner} from '../../db/statements.ts';
+import {DbFile} from '../../test/lite.ts';
+import type {SchemaChange} from '../change-source/protocol/current/data.ts';
+import {readCookies} from '../replicator/change-log-cookies.ts';
+import {CHANGE_LOG_STREAM_TABLE} from '../replicator/change-log-db.ts';
+import {BACKFILLING_TABLE} from '../replicator/schema/backfilling.ts';
+import {
+  initReplicationState,
+  updateReplicationWatermark,
+} from '../replicator/schema/replication-state.ts';
+import {
+  ChangeLogInitializer,
+  readReplicaInitializationParameters,
+  replicaInitializationSource,
+  type InitializationParameters,
+} from './change-log-initializer.ts';
+import {
+  ChangeStreamDriver,
+  createChangeLog,
+  createReplica,
+  REPLICA_VERSION,
+} from './change-log-test-utils.ts';
+
+const lc = createSilentLogContext();
+
+describe('change-streamer/change-log-initializer', () => {
+  let changeLog: Database;
+  let replica: Database;
+  let driver: ChangeStreamDriver;
+
+  beforeEach(() => {
+    changeLog = createChangeLog(lc);
+    const {replica: db, processor} = createReplica(lc);
+    replica = db;
+    // No shard: the change log stands in for Postgres, per the header.
+    driver = new ChangeStreamDriver(lc, {changeLog, replica: processor});
+
+    return () => {
+      replica.close();
+      changeLog.close();
+    };
+  });
+
+  /**
+   * Drives one transaction into the change log, and -- unless the replica is
+   * being held back to simulate a replicator that trails -- into the replica.
+   */
+  const transaction = (changes: SchemaChange[], opts?: {toReplica?: boolean}) =>
+    driver.transaction(changes, opts);
+
+  /**
+   * What Postgres would have derived, taken from the change log's own fold of
+   * the same stream. `backfillRequests` is not part of the comparison -- the
+   * cookie set it is projected from is strictly more -- so it is left empty.
+   */
+  function pgParameters(): InitializationParameters {
+    const {head} = changeLog
+      .prepare(/*sql*/ `SELECT max("watermark") AS "head"
+                   FROM "${CHANGE_LOG_STREAM_TABLE}"`)
+      .get<{head: string}>();
+    return {
+      lastWatermark: head,
+      backfillRequests: [],
+      cookies: readCookies(changeLog),
+    };
+  }
+
+  function initializer(
+    opts: {
+      initFromPgChangeLog?: boolean;
+      initFromReplica?: boolean;
+      pg?: () => Promise<InitializationParameters>;
+      replica?: () => InitializationParameters;
+      changeLog?: () => Database | undefined;
+    } = {},
+  ) {
+    return new ChangeLogInitializer(
+      lc,
+      {
+        initFromPgChangeLog: opts.initFromPgChangeLog ?? true,
+        initFromReplica: opts.initFromReplica ?? true,
+      },
+      {
+        pgChangeLog: opts.pg ?? (() => Promise.resolve(pgParameters())),
+        replica:
+          opts.replica ?? (() => readReplicaInitializationParameters(replica)),
+        changeLog: opts.changeLog ?? (() => changeLog),
+      },
+    );
+  }
+
+  /** The stream loop's order: initialize, reconcile, then compare. */
+  async function compare(init = initializer()) {
+    await init.initialize();
+    return init.compare();
+  }
+
+  const CREATE_FOO: SchemaChange = {
+    tag: 'create-table',
+    spec: {
+      schema: 'my',
+      name: 'foo',
+      columns: {
+        id: {pos: 0, dataType: 'int8', notNull: true},
+        a: {pos: 1, dataType: 'text'},
+        b: {pos: 2, dataType: 'text'},
+      },
+      primaryKey: ['id'],
+    },
+    metadata: {rowKey: {type: 'default', columns: ['id']}},
+    backfill: {a: {fooID: 987}, b: {fooID: 843}},
+  };
+
+  test('both stores at the same watermark, holding the same cookies', async () => {
+    await transaction([CREATE_FOO]);
+
+    expect(await compare()).toBe('equal');
+  });
+
+  test('every transition the replica trails by is reproduced by the fold', async () => {
+    // Replicated: the replica's snapshot is taken here.
+    await transaction([CREATE_FOO]);
+    const replicated = readReplicaInitializationParameters(replica);
+
+    // Everything below lands in the change log only, i.e. it is exactly what
+    // the fold has to carry the replica's snapshot forward over.
+    await transaction(
+      [
+        // A second table, with in-flight backfills and no metadata at all.
+        {
+          tag: 'create-table',
+          spec: {
+            schema: 'your',
+            name: 'bar',
+            columns: {id: {pos: 0, dataType: 'int8', notNull: true}},
+            primaryKey: ['id'],
+          },
+          backfill: {c: {barID: 'zoo'}},
+        },
+        // add-column, carrying both halves.
+        {
+          tag: 'add-column',
+          table: {schema: 'my', name: 'foo'},
+          tableMetadata: {rowKey: {type: 'index', columns: ['id']}},
+          column: {name: 'd', spec: {pos: 3, dataType: 'text'}},
+          backfill: {fooID: 123},
+        },
+      ],
+      {toReplica: false},
+    );
+    await transaction(
+      [
+        // update-table-metadata.
+        {
+          tag: 'update-table-metadata',
+          table: {schema: 'your', name: 'bar'},
+          old: {rowKey: {type: 'default', columns: ['id']}},
+          new: {rowKey: {type: 'index', columns: ['id']}},
+        },
+        // A column rename moves the cookie; a spec-only update moves nothing.
+        {
+          tag: 'update-column',
+          table: {schema: 'my', name: 'foo'},
+          old: {name: 'a', spec: {pos: 1, dataType: 'text'}},
+          new: {name: 'z', spec: {pos: 1, dataType: 'text'}},
+        },
+        {
+          tag: 'update-column',
+          table: {schema: 'my', name: 'foo'},
+          old: {name: 'b', spec: {pos: 2, dataType: 'text'}},
+          new: {name: 'b', spec: {pos: 2, dataType: 'text', notNull: true}},
+        },
+        {tag: 'drop-column', table: {schema: 'my', name: 'foo'}, column: 'd'},
+        // Index changes carry no cookie state.
+        {
+          tag: 'create-index',
+          spec: {
+            schema: 'my',
+            tableName: 'foo',
+            name: 'foo_z',
+            columns: {z: 'ASC'},
+            unique: false,
+          },
+        },
+      ],
+      {toReplica: false},
+    );
+    await transaction(
+      [
+        {
+          tag: 'rename-table',
+          old: {schema: 'my', name: 'foo'},
+          new: {schema: 'renamed', name: 'foo'},
+        },
+        {tag: 'drop-table', id: {schema: 'your', name: 'bar'}},
+      ],
+      {toReplica: false},
+    );
+
+    const pg = pgParameters();
+    // The premise of the test: the two positions really are different, and the
+    // sets really do differ before the fold.
+    expect(replicated.lastWatermark).not.toBe(pg.lastWatermark);
+    expect(replicated.cookies).not.toEqual(pg.cookies);
+
+    expect(await compare()).toBe('equal-after-fold');
+  });
+
+  test('a backfill completed inside the interval is reproduced by the fold', async () => {
+    await transaction([CREATE_FOO]);
+    // `backfill-completed` clears the listed columns *and* the rowKey columns,
+    // which is the transition most easily got wrong in a second interpreter.
+    await transaction(
+      [
+        {
+          tag: 'backfill-completed',
+          relation: {
+            schema: 'my',
+            name: 'foo',
+            rowKey: {type: 'default', columns: ['b']},
+          },
+          columns: ['a'],
+          watermark: '03',
+        },
+      ],
+      {toReplica: false},
+    );
+
+    expect(pgParameters().cookies.backfilling).toEqual([]);
+    expect(await compare()).toBe('equal-after-fold');
+  });
+
+  test('a cookie the replica does not have is divergent', async () => {
+    await transaction([CREATE_FOO]);
+    await transaction(
+      [
+        {
+          tag: 'add-column',
+          table: {schema: 'my', name: 'foo'},
+          column: {name: 'd', spec: {pos: 3, dataType: 'text'}},
+          backfill: {fooID: 123},
+        },
+      ],
+      {toReplica: false},
+    );
+    // The replica drops a backfill the log's interval never mentions again, so
+    // the fold cannot restore it.
+    replica
+      .prepare(
+        /*sql*/ `DELETE FROM "${BACKFILLING_TABLE}" WHERE "column" = 'a'`,
+      )
+      .run();
+
+    expect(await compare()).toBe('divergent');
+  });
+
+  test('a cookie whose value differs at the same watermark is divergent', async () => {
+    await transaction([CREATE_FOO]);
+    replica
+      .prepare(/*sql*/ `UPDATE "${BACKFILLING_TABLE}"
+                   SET "backfill" = '{"fooID":1}' WHERE "column" = 'a'`)
+      .run();
+
+    expect(await compare()).toBe('divergent');
+  });
+
+  test('key order and row order are not divergences', async () => {
+    await transaction([
+      {
+        tag: 'create-table',
+        spec: {
+          schema: 'my',
+          name: 'foo',
+          columns: {id: {pos: 0, dataType: 'int8', notNull: true}},
+          primaryKey: ['id'],
+        },
+        backfill: {a: {fooID: 1, barID: 'z'}, b: {fooID: 2, barID: 'y'}},
+      },
+    ]);
+    const pg = pgParameters();
+
+    expect(
+      await compare(
+        initializer({
+          pg: () =>
+            Promise.resolve({
+              ...pg,
+              cookies: {
+                tableMetadata: pg.cookies.tableMetadata,
+                // Reversed rows, and reversed keys within each document.
+                backfilling: pg.cookies.backfilling.toReversed().map(c => ({
+                  ...c,
+                  backfill: {barID: c.backfill.barID, fooID: c.backfill.fooID},
+                })),
+              },
+            }),
+        }),
+      ),
+    ).toBe('equal');
+  });
+
+  test('a log that does not reach back to the replica is inconclusive', async () => {
+    await transaction([CREATE_FOO]);
+    const replicated = readReplicaInitializationParameters(replica);
+    await transaction([], {toReplica: false});
+
+    // What a restore leaves behind: the log was reseeded above the replica's
+    // state version, so the interval between them is not in it.
+    changeLog
+      .prepare(
+        /*sql*/ `DELETE FROM "${CHANGE_LOG_STREAM_TABLE}" WHERE "watermark" <= ?`,
+      )
+      .run(replicated.lastWatermark);
+
+    expect(await compare()).toBe('inconclusive');
+  });
+
+  test('a log with no boundary at the replica is inconclusive', async () => {
+    await transaction([CREATE_FOO]);
+    const replicated = readReplicaInitializationParameters(replica);
+    await transaction([], {toReplica: false});
+
+    // The log reaches back far enough, but not to a transaction boundary: it
+    // holds part of the replica's last transaction, so the next row is not the
+    // first change of the interval.
+    changeLog
+      .prepare(/*sql*/ `DELETE FROM "${CHANGE_LOG_STREAM_TABLE}"
+                   WHERE "watermark" = ? AND "pos" > 0`)
+      .run(replicated.lastWatermark);
+
+    expect(await compare()).toBe('inconclusive');
+  });
+
+  test('no change log at all is inconclusive', async () => {
+    await transaction([CREATE_FOO]);
+    await transaction([], {toReplica: false});
+
+    expect(await compare(initializer({changeLog: () => undefined}))).toBe(
+      'inconclusive',
+    );
+  });
+
+  test('a change log that has not been created yet is inconclusive', async () => {
+    await transaction([CREATE_FOO]);
+    await transaction([], {toReplica: false});
+    const empty = new Database(lc, ':memory:');
+
+    try {
+      expect(await compare(initializer({changeLog: () => empty}))).toBe(
+        'inconclusive',
+      );
+    } finally {
+      empty.close();
+    }
+  });
+
+  test('a replica ahead of Postgres is inconclusive', async () => {
+    const wm = await transaction([CREATE_FOO]);
+    // Transactions reach subscribers before the storer commits, so a replica
+    // read taken mid-transaction can be one ahead. The fold only runs forward.
+    const pg = pgParameters();
+
+    expect(
+      await compare(
+        initializer({
+          pg: () => Promise.resolve({...pg, lastWatermark: '0' + wm[1]}),
+          replica: () => ({
+            ...readReplicaInitializationParameters(replica),
+            lastWatermark: '99',
+          }),
+        }),
+      ),
+    ).toBe('inconclusive');
+  });
+
+  // `lastPos` is inclusive, and the transaction's own begin/commit already
+  // occupy positions 0 and 1, so the interval ends up `lastPos + 1` rows deep.
+  function padTransaction(watermark: string, lastPos: number) {
+    changeLog
+      .prepare(/*sql*/ `
+        INSERT INTO "${CHANGE_LOG_STREAM_TABLE}"
+          ("watermark", "pos", "tag", "estimatedBytes", "change")
+          WITH RECURSIVE n("i") AS (
+            SELECT 2 UNION ALL SELECT "i" + 1 FROM n WHERE "i" < ?
+          )
+          SELECT ?, "i", 'insert', 0, '{"tag":"insert"}' FROM n
+      `)
+      .run(lastPos, watermark);
+  }
+
+  test('an interval too large to scan is inconclusive', async () => {
+    await transaction([CREATE_FOO]);
+    const head = await transaction([], {toReplica: false});
+    // Above MAX_FOLD_SCAN_ROWS. A replicator that has been stalled can leave
+    // the interval arbitrarily large, and this runs between reconciliation and
+    // `startStream`, so the comparison declines rather than pays.
+    padTransaction(head, 100_002);
+
+    expect(await compare()).toBe('inconclusive');
+  });
+
+  test('an interval exactly at the cap is still folded', async () => {
+    await transaction([CREATE_FOO]);
+    const head = await transaction([], {toReplica: false});
+    // Exactly MAX_FOLD_SCAN_ROWS, i.e. the last interval that is scanned
+    // rather than declined. Pinned because the guard counts to one row *past*
+    // the cap in SQL so that an unbounded interval is not walked in full, and
+    // an off-by-one there would silently stop folding a legal interval.
+    padTransaction(head, 99_999);
+
+    expect(await compare()).toBe('equal-after-fold');
+  });
+
+  test('ordinary changes are filtered without parsing their payloads', async () => {
+    await transaction([CREATE_FOO]);
+    const head = await transaction([], {toReplica: false});
+
+    // A malformed ordinary payload stands in for an arbitrarily large data
+    // change. Filtering with json_extract() would parse it and fail; the stored
+    // tag lets the schema fold skip it without touching the payload.
+    changeLog.transaction(() => {
+      changeLog
+        .prepare(/*sql*/ `
+          UPDATE "${CHANGE_LOG_STREAM_TABLE}" SET "pos" = 2
+            WHERE "watermark" = ? AND "tag" = 'commit'
+        `)
+        .run(head);
+      changeLog
+        .prepare(/*sql*/ `
+          INSERT INTO "${CHANGE_LOG_STREAM_TABLE}"
+            ("watermark", "pos", "tag", "estimatedBytes", "change")
+            VALUES (?, 1, 'insert', 1, 'not-json')
+        `)
+        .run(head);
+    });
+
+    expect(await compare()).toBe('equal-after-fold');
+  });
+
+  test('a replica that cannot be read does not stop the stream', async () => {
+    const wm = await transaction([CREATE_FOO]);
+    const init = initializer({
+      replica: () => {
+        throw new Error('replica is gone');
+      },
+    });
+
+    // Postgres is authoritative, so the parameters still come back...
+    expect((await init.initialize()).lastWatermark).toBe(wm);
+    // ...and there is nothing to compare them against.
+    expect(init.compare()).toBeUndefined();
+  });
+
+  test('a replica that cannot be read *is* fatal once it is the only source', async () => {
+    await transaction([CREATE_FOO]);
+    const init = initializer({
+      initFromPgChangeLog: false,
+      replica: () => {
+        throw new Error('replica is gone');
+      },
+    });
+
+    await expect(init.initialize()).rejects.toThrow('replica is gone');
+  });
+
+  test('with Postgres alone there is nothing to compare', async () => {
+    const wm = await transaction([CREATE_FOO]);
+    const init = initializer({initFromReplica: false});
+
+    expect((await init.initialize()).lastWatermark).toBe(wm);
+    expect(init.compare()).toBeUndefined();
+  });
+
+  test('with the replica alone its parameters are the ones returned', async () => {
+    await transaction([CREATE_FOO]);
+    // What the flip produces. The replica's own state version, and the requests
+    // assembled from its own tables.
+    const init = initializer({
+      initFromPgChangeLog: false,
+      pg: () => Promise.reject(new Error('must not be read')),
+    });
+
+    const params = await init.initialize();
+    expect(params.lastWatermark).toBe(
+      readReplicaInitializationParameters(replica).lastWatermark,
+    );
+    expect(params.backfillRequests).toEqual([
+      {
+        table: {
+          schema: 'my',
+          name: 'foo',
+          metadata: {rowKey: {type: 'default', columns: ['id']}},
+        },
+        columns: {a: {fooID: 987}, b: {fooID: 843}},
+      },
+    ]);
+    expect(init.compare()).toBeUndefined();
+  });
+
+  test('a comparison is consumed, so a missed initialize cannot compare stale state', async () => {
+    await transaction([CREATE_FOO]);
+    const init = initializer();
+
+    await init.initialize();
+    expect(init.compare()).toBe('equal');
+    expect(init.compare()).toBeUndefined();
+  });
+
+  test('a fold that throws is reported rather than raised', async () => {
+    await transaction([CREATE_FOO]);
+    await transaction([], {toReplica: false});
+    const init = initializer({
+      changeLog: () => {
+        throw new Error('the change log is not readable');
+      },
+    });
+
+    await init.initialize();
+    // Nothing acts on the comparison, so nothing about it may reach the stream
+    // loop -- but it must not be silent either.
+    expect(init.compare()).toBe('error');
+  });
+
+  test('at least one source is required', () => {
+    expect(() =>
+      initializer({initFromPgChangeLog: false, initFromReplica: false}),
+    ).toThrow('At least one of initFromPgChangeLog or initFromReplica');
+  });
+
+  /**
+   * The source the change-streamer actually uses, against a real file in WAL
+   * mode -- which is the arrangement that makes a read-only handle non-obvious,
+   * since one still has to attach the WAL's `-shm`. Both cases are covered: the
+   * replicator holding the replica open, which is the steady state, and nothing
+   * holding it, which is what a change-streamer that starts first sees.
+   */
+  describe('the replica source, on a file', () => {
+    let file: DbFile;
+
+    beforeEach(() => {
+      file = new DbFile('change-log-initializer');
+      const db = file.connect(lc);
+      db.pragma('journal_mode = WAL');
+      initReplicationState(db, ['zero_data'], REPLICA_VERSION);
+      db.prepare(/*sql*/ `INSERT INTO "${BACKFILLING_TABLE}"
+                   ("schema", "table", "column", "backfill")
+                   VALUES ('my', 'foo', 'a', '{"fooID":987}')`).run();
+      db.close();
+
+      return () => file.delete();
+    });
+
+    test('reads it with no other connection open', () => {
+      const params = replicaInitializationSource(lc, file.path)();
+
+      expect(params.lastWatermark).toBe(REPLICA_VERSION);
+      expect(params.cookies.backfilling).toEqual([
+        {schema: 'my', table: 'foo', column: 'a', backfill: {fooID: 987}},
+      ]);
+    });
+
+    test('reads it while the replicator holds it', () => {
+      const writer = file.connect(lc);
+      try {
+        const source = replicaInitializationSource(lc, file.path);
+        expect(source().lastWatermark).toBe(REPLICA_VERSION);
+
+        // A snapshot, not a cached handle: the source re-opens per stream
+        // connection, so it sees what the replicator has committed since.
+        updateReplicationWatermark(new StatementRunner(writer), '09');
+        expect(source().lastWatermark).toBe('09');
+      } finally {
+        writer.close();
+      }
+    });
+  });
+
+  test('a minRowVersion-only table is not a metadata cookie', async () => {
+    await transaction([CREATE_FOO]);
+    // `_zero.tableMetadata` also carries `minRowVersion`, so a row exists for
+    // every table whose rows were ever force-re-downloaded. Neither cookie
+    // store can represent one: both `"metadata"` columns are NOT NULL.
+    replica
+      .prepare(/*sql*/ `INSERT INTO "_zero.tableMetadata" ("schema", "table", "minRowVersion")
+                   VALUES ('my', 'unrelated', '05')`)
+      .run();
+
+    expect(
+      readReplicaInitializationParameters(replica).cookies.tableMetadata,
+    ).toHaveLength(1);
+    expect(await compare()).toBe('equal');
+  });
+});

--- a/packages/zero-cache/src/services/change-streamer/change-log-initializer.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-log-initializer.ts
@@ -1,0 +1,486 @@
+/**
+ * Where a stream connection's initialization parameters come from.
+ *
+ * A change-streamer starts a stream from three things read at one position: the
+ * watermark to resume at, the {@link BackfillRequest}s to hand the change
+ * source, and the cookie set those requests were derived from. Postgres has
+ * always supplied all three (`Storer.getStartStreamInitializationParameters()`).
+ * The point of this workstream is that a restored replica can supply them
+ * instead, which is what lets the `cdc` schema be decommissioned.
+ *
+ * This is the two-source stage. Both are computed on every stream connection,
+ * compared, and Postgres's is used — so the replica-derived path runs in
+ * production, at full rate, before anything depends on it. The flip is
+ * `initFromPgChangeLog: false`, not a rewrite.
+ *
+ * The shape is {@link UpstreamAcker}'s, deliberately: two stores, one output, a
+ * flag per store, and the Postgres flag carrying the marker that retires it.
+ * That class solved the identical problem for upstream ACKs earlier in this
+ * workstream.
+ *
+ * ### Why the comparison is a fold and not an equality
+ *
+ * The replica is a subscriber downstream of the change-streamer's write loop,
+ * so its state version trails the log's head by however long the replicator is
+ * behind. A raw difference between the two cookie sets is therefore the normal
+ * case and says nothing. What is checked instead is that the replica's set,
+ * carried forward over exactly the schema changes the log holds in the interval,
+ * equals Postgres's set at Postgres's watermark. The log holds precisely those
+ * transactions, schema changes are rare, and the check is exact rather than
+ * approximate — so it also happens to be the strongest available test of the
+ * premise that three interpreters of one fold agree.
+ */
+
+import type {LogContext} from '@rocicorp/logger';
+import {assert} from '../../../../shared/src/asserts.ts';
+import {BigIntJSON} from '../../../../shared/src/bigint-json.ts';
+import {must} from '../../../../shared/src/must.ts';
+import {Database} from '../../../../zqlite/src/db.ts';
+import {StatementRunner} from '../../db/statements.ts';
+import {getOrCreateCounter} from '../../observability/metrics.ts';
+import type {SchemaChange} from '../change-source/protocol/current/data.ts';
+import {schemaChangeTags} from '../change-source/protocol/current/schema-change-tags.ts';
+import type {BackfillRequest} from '../change-source/protocol/current/upstream.ts';
+import {foldCookies, type CookieSet} from '../replicator/change-log-cookies.ts';
+import {CHANGE_LOG_STREAM_TABLE} from '../replicator/change-log-db.ts';
+import {
+  readBackfillRequests,
+  readReplicaCookies,
+} from '../replicator/schema/backfilling.ts';
+import {getReplicationState} from '../replicator/schema/replication-state.ts';
+import {SQLITE_CHANGE_LOG_BOUNDARY_SQL} from './sqlite-change-log-reader.ts';
+
+/** Everything one stream connection starts from, read at one position. */
+export type InitializationParameters = {
+  readonly lastWatermark: string;
+  readonly backfillRequests: BackfillRequest[];
+  readonly cookies: CookieSet;
+};
+
+/**
+ * - `equal` — the two stores were at the same watermark and held the same
+ *   cookies. Nothing had to be folded, which is the strongest of the four.
+ * - `equal-after-fold` — the replica trailed, and carrying its set forward over
+ *   the log's schema changes in the interval reproduced Postgres's exactly.
+ *   The expected steady-state result.
+ * - `divergent` — the two disagree at the same position. Alert; investigate
+ *   individually.
+ * - `inconclusive` — the log does not span the interval, so the fold cannot be
+ *   performed. Routine on a cold log, and not a finding.
+ * - `error` — the comparison itself failed: the replica could not be read, or
+ *   the fold threw. Not one of the four classifications, because it is a
+ *   statement about this process rather than about the two stores. Kept
+ *   separate rather than folded into `inconclusive` so that a change-streamer
+ *   that has silently stopped being able to read its replica is visible before
+ *   that read becomes the only source.
+ */
+export type InitComparisonResult =
+  | 'equal'
+  | 'equal-after-fold'
+  | 'divergent'
+  | 'inconclusive'
+  | 'error';
+
+export type ChangeLogInitializerSources = {
+  /** `Storer.getStartStreamInitializationParameters()`. */
+  readonly pgChangeLog: () => Promise<InitializationParameters>;
+  /** Typically {@link replicaInitializationSource}. */
+  readonly replica: () => InitializationParameters;
+  /**
+   * The change log, for the fold. `undefined` before the stream loop's first
+   * reconcile has created it, and again once the writer has failed soft and
+   * deleted it — both of which make the comparison `inconclusive` rather than
+   * an error, since neither says anything about the two stores.
+   */
+  readonly changeLog: () => Database | undefined;
+};
+
+type Opts = {
+  /**
+   * Read the resume point from the Postgres change log. It is authoritative
+   * whenever it is read.
+   */
+  // TODO: set false when retiring PG
+  readonly initFromPgChangeLog: boolean;
+  /**
+   * Read it from the replica as well. Until the flag above goes false this is
+   * computed and compared but not used, which is the whole of slice C4.
+   */
+  readonly initFromReplica: boolean;
+};
+
+/**
+ * The most change-log rows one comparison will scan.
+ *
+ * The interval is `(replicaWatermark, pgWatermark]`, so it is normally a
+ * handful of transactions — but a replicator that has been stalled can leave it
+ * arbitrarily large, and this runs on the stream loop between reconciliation and
+ * `startStream`, where latency delays the resumption of replication. Over the
+ * cap the comparison declines rather than pays: a chronically lagging replicator
+ * shows up as `inconclusive`, which is charted, and not as a stall.
+ */
+const MAX_FOLD_SCAN_ROWS = 100_000;
+
+export class ChangeLogInitializer {
+  readonly #lc: LogContext;
+  readonly #initFromPgChangeLog: boolean;
+  readonly #initFromReplica: boolean;
+  readonly #sources: ChangeLogInitializerSources;
+
+  readonly #resultCounter = getOrCreateCounter(
+    'replica',
+    'sqlite_change_log.init_compare_result',
+    'Comparisons of the replica-derived stream initialization parameters ' +
+      'against the Postgres-derived ones, by classification.',
+  );
+
+  /**
+   * Set by {@link initialize} when both sources ran, consumed by
+   * {@link compare}. The two are separate calls because the fold reads the
+   * change log and the change log is only in agreement with the resume
+   * watermark *after* it has been reconciled against it — before that it can
+   * hold phantom transactions, another replica's history, or nothing at all,
+   * none of which would be a divergence between the two stores.
+   */
+  #pending:
+    | {pg: InitializationParameters; replica: InitializationParameters}
+    | undefined;
+
+  constructor(
+    lc: LogContext,
+    {initFromPgChangeLog, initFromReplica}: Opts,
+    sources: ChangeLogInitializerSources,
+  ) {
+    assert(
+      initFromPgChangeLog || initFromReplica,
+      `At least one of initFromPgChangeLog or initFromReplica must be true`,
+    );
+    this.#lc = lc.withContext('component', 'change-log-initializer');
+    this.#initFromPgChangeLog = initFromPgChangeLog;
+    this.#initFromReplica = initFromReplica;
+    this.#sources = sources;
+  }
+
+  /**
+   * Reads every enabled source and returns the authoritative one. When both are
+   * enabled the replica's is held for {@link compare}, which the caller runs
+   * once the log has been reconciled against the returned watermark.
+   */
+  async initialize(): Promise<InitializationParameters> {
+    const pg = this.#initFromPgChangeLog
+      ? await this.#sources.pgChangeLog()
+      : undefined;
+    const replica = this.#initFromReplica
+      ? this.#readReplica(pg === undefined)
+      : undefined;
+    this.#pending = pg && replica ? {pg, replica} : undefined;
+    // `must` rather than an `assert` on the flags: the constructor already
+    // rejects the case where neither is enabled.
+    return pg ?? must(replica, 'no change-log initialization source');
+  }
+
+  /**
+   * Compares the two derivations of the last {@link initialize}, reports the
+   * classification, and discards them. A no-op unless both sources are enabled,
+   * so the caller does not have to know which stage of the rollout it is in.
+   *
+   * Must run after the change log has been reconciled against the watermark
+   * {@link initialize} returned. Nothing acts on the result: Postgres remains
+   * authoritative until C5.
+   */
+  compare(): InitComparisonResult | undefined {
+    const pending = this.#pending;
+    this.#pending = undefined;
+    if (pending === undefined) {
+      return undefined;
+    }
+    const {pg, replica} = pending;
+    let result: InitComparisonResult;
+    try {
+      result = this.#classify(pg, replica);
+    } catch (e) {
+      this.#lc.warn?.('failed to compare change-log initialization sources', e);
+      result = 'error';
+    }
+    this.#resultCounter.add(1, {result});
+    this.#lc.debug?.('compared change-log initialization sources', {
+      changeLogInitCompare: {
+        result,
+        pgWatermark: pg.lastWatermark,
+        replicaWatermark: replica.lastWatermark,
+      },
+    });
+    return result;
+  }
+
+  #readReplica(required: boolean): InitializationParameters | undefined {
+    try {
+      return this.#sources.replica();
+    } catch (e) {
+      if (required) {
+        throw e;
+      }
+      // Observational until the flip, so a replica that cannot be read must not
+      // stop replication -- but it must not be quiet either, since the flip
+      // makes this read the only source.
+      this.#lc.warn?.(
+        'failed to derive change-log initialization from the replica',
+        e,
+      );
+      this.#resultCounter.add(1, {result: 'error'});
+      return undefined;
+    }
+  }
+
+  #classify(
+    pg: InitializationParameters,
+    replica: InitializationParameters,
+  ): InitComparisonResult {
+    if (replica.lastWatermark > pg.lastWatermark) {
+      // Transactions reach subscribers before the storer's commit, so a replica
+      // read taken while one is in flight can be a transaction ahead. The fold
+      // only runs forward, so there is nothing to be said either way.
+      return 'inconclusive';
+    }
+    if (replica.lastWatermark === pg.lastWatermark) {
+      return this.#report(pg, replica, replica.cookies, 'equal');
+    }
+
+    const db = this.#sources.changeLog();
+    if (db === undefined || !spansInterval(db, replica.lastWatermark)) {
+      return 'inconclusive';
+    }
+    const changes = readSchemaChanges(
+      db,
+      replica.lastWatermark,
+      pg.lastWatermark,
+    );
+    if (changes === undefined) {
+      return 'inconclusive'; // over MAX_FOLD_SCAN_ROWS
+    }
+    return this.#report(
+      pg,
+      replica,
+      foldCookies(replica.cookies, changes),
+      'equal-after-fold',
+      changes.length,
+    );
+  }
+
+  #report(
+    pg: InitializationParameters,
+    replica: InitializationParameters,
+    derived: CookieSet,
+    whenEqual: InitComparisonResult,
+    foldedChanges = 0,
+  ): InitComparisonResult {
+    const expected = canonicalizeCookies(pg.cookies);
+    const actual = canonicalizeCookies(derived);
+    if (expected === actual) {
+      return whenEqual;
+    }
+    // Both sets are normally empty and are at most a handful of rows, so they
+    // are logged whole: a divergence is investigated individually (`P§:10`)
+    // and the two renderings are the whole of what there is to look at.
+    this.#lc.error?.(
+      'the replica-derived change-log cookies do not match Postgres',
+      {
+        changeLogInitCompare: {
+          pgWatermark: pg.lastWatermark,
+          replicaWatermark: replica.lastWatermark,
+          foldedChanges,
+          expected,
+          actual,
+        },
+      },
+    );
+    return 'divergent';
+  }
+}
+
+/**
+ * Reads the replica's initialization parameters in one snapshot, which is
+ * invariant 15 on the replica side: the state version and the cookies are only
+ * meaningful together.
+ */
+export function readReplicaInitializationParameters(
+  db: Database,
+): InitializationParameters {
+  const runner = new StatementRunner(db);
+  runner.begin(); // deferred, i.e. one read snapshot for the three statements
+  try {
+    return {
+      lastWatermark: getReplicationState(runner).stateVersion,
+      backfillRequests: readBackfillRequests(db),
+      cookies: readReplicaCookies(db),
+    };
+  } finally {
+    if (db.inTransaction) {
+      runner.rollback();
+    }
+  }
+}
+
+/**
+ * The replica source for {@link ChangeLogInitializer}, opening and closing the
+ * file per stream connection rather than holding a handle on a database another
+ * process owns.
+ *
+ * The handle is read-only, which is invariant 19 stated in the API: the
+ * replica's cookie tables are written by the change-processor and by nothing
+ * else. Note that a read-only SQLite connection still needs to attach the
+ * WAL's `-shm`, so this can fail if it opens at a moment when no writer holds
+ * the replica; that surfaces as the `error` classification, which is the point
+ * of running the path under observation before anything depends on it.
+ */
+export function replicaInitializationSource(
+  lc: LogContext,
+  replicaFile: string,
+): () => InitializationParameters {
+  return () => {
+    const db = new Database(
+      lc.withContext('component', 'change-log-initializer'),
+      replicaFile,
+      {readonly: true},
+    );
+    try {
+      return readReplicaInitializationParameters(db);
+    } finally {
+      db.close();
+    }
+  };
+}
+
+/**
+ * Whether the log holds the complete interval above `fromWatermark`, using the
+ * same predicate catchup uses to decide `too-old`: the log both reaches back
+ * that far and contains that transaction's `commit` row, so the next row after
+ * it is the first change of the interval rather than the middle of a
+ * transaction the log only partly holds.
+ */
+function spansInterval(db: Database, fromWatermark: string): boolean {
+  if (!streamTableExists(db)) {
+    return false;
+  }
+  const row = db
+    .prepare(/*sql*/ `
+      SELECT
+        (SELECT min("watermark") FROM "${CHANGE_LOG_STREAM_TABLE}")
+          AS "minWatermark",
+        coalesce((${SQLITE_CHANGE_LOG_BOUNDARY_SQL}), 0) AS "boundaryExists"
+    `)
+    .get<{minWatermark: string | null; boundaryExists: number}>({
+      fromWatermark,
+    });
+  return (
+    row.minWatermark !== null &&
+    fromWatermark >= row.minWatermark &&
+    row.boundaryExists === 1
+  );
+}
+
+const SCHEMA_CHANGE_TAG_LIST = schemaChangeTags
+  .map(tag => `'${tag}'`)
+  .join(', ');
+
+/**
+ * The log's schema changes over `(after, through]`, in stream order, or
+ * `undefined` if the interval is too large to scan (see
+ * {@link MAX_FOLD_SCAN_ROWS}).
+ *
+ * The tag is stored beside the verbatim change so this scan never parses the
+ * payloads of ordinary data changes. The row count is still checked first so a
+ * stalled replicator cannot make the range scan unbounded.
+ *
+ * The count is itself capped, at one row past the cap it is deciding. A bare
+ * `count(*)` over the interval is `O(interval)`, so the unbounded interval this
+ * exists to decline would still be walked in full before being declined —
+ * which is the latency the cap is here to avoid, not a cheaper form of it. The
+ * `LIMIT` makes the decision `O(MAX_FOLD_SCAN_ROWS)`, and the comparison is
+ * unaffected: the subquery returns the true count whenever it is within the
+ * cap, and `cap + 1` whenever it is not.
+ */
+function readSchemaChanges(
+  db: Database,
+  after: string,
+  through: string,
+): SchemaChange[] | undefined {
+  const {rows} = db
+    .prepare(/*sql*/ `
+      SELECT count(*) AS "rows" FROM (
+        SELECT 1 FROM "${CHANGE_LOG_STREAM_TABLE}"
+          WHERE "watermark" > ? AND "watermark" <= ?
+          LIMIT ${MAX_FOLD_SCAN_ROWS + 1}
+      )
+    `)
+    .get<{rows: number}>(after, through);
+  if (rows > MAX_FOLD_SCAN_ROWS) {
+    return undefined;
+  }
+  return db
+    .prepare(/*sql*/ `
+      SELECT "change" FROM "${CHANGE_LOG_STREAM_TABLE}"
+        WHERE "watermark" > ? AND "watermark" <= ?
+          AND "tag" IN (${SCHEMA_CHANGE_TAG_LIST})
+        ORDER BY "watermark", "pos"
+    `)
+    .all<{change: string}>(after, through)
+    .map(({change}) => BigIntJSON.parse(change) as SchemaChange);
+}
+
+function streamTableExists(db: Database): boolean {
+  return (
+    db
+      .prepare(/*sql*/ `
+        SELECT 1 FROM "sqlite_master" WHERE "type" = 'table' AND "name" = ?
+      `)
+      .get<{1: number} | undefined>(CHANGE_LOG_STREAM_TABLE) !== undefined
+  );
+}
+
+/**
+ * A canonical rendering of a whole cookie set: rows sorted by primary key,
+ * object keys sorted at every depth.
+ *
+ * Both the equality check and the `divergent` log line fall out of this one
+ * value, and neither can be defeated by a difference that is not a difference.
+ * Postgres stores the cookie documents as `jsonb`, which does not preserve key
+ * order, and the two readers order their rows in SQL in two engines under two
+ * collations -- `storer.ts` pins `COLLATE "C"` for exactly that reason. Sorting
+ * again here means an ordering or key-order regression can never be reported as
+ * a divergence, which is a class of false alert that would cost more than it
+ * caught.
+ */
+function canonicalizeCookies(cookies: CookieSet): string {
+  return BigIntJSON.stringify({
+    tableMetadata: byKey(cookies.tableMetadata, c => [c.schema, c.table]).map(
+      c => [c.schema, c.table, sortKeys(c.metadata)],
+    ),
+    backfilling: byKey(cookies.backfilling, c => [
+      c.schema,
+      c.table,
+      c.column,
+    ]).map(c => [c.schema, c.table, c.column, sortKeys(c.backfill)]),
+  });
+}
+
+function byKey<T>(rows: readonly T[], key: (row: T) => string[]): T[] {
+  return rows
+    .map(row => [JSON.stringify(key(row)), row] as const)
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    .map(([, row]) => row);
+}
+
+function sortKeys(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sortKeys);
+  }
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+  return Object.fromEntries(
+    Object.entries(value)
+      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+      .map(([k, v]) => [k, sortKeys(v)]),
+  );
+}

--- a/packages/zero-cache/src/services/change-streamer/change-log-test-utils.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-log-test-utils.ts
@@ -1,0 +1,235 @@
+/**
+ * The fixture the change-log parity tests share.
+ *
+ * Several tests drive one change stream into more than one store and require
+ * the stores to agree: `change-log-cookies.pg.test.ts` (the Postgres change log
+ * against the SQLite one), `change-log-initializer{,.pg}.test.ts` (the change
+ * log against the replica, through the comparator), and
+ * `replicator/schema/backfilling.pg.test.ts` (Postgres against the replica).
+ * They differ only in which stores they attach and in what they assert.
+ *
+ * The driver is shared so that "the same stream" stays literally the same. Two
+ * copies of it that drifted would show up as a difference between the stores,
+ * which is indistinguishable from the difference these tests exist to catch.
+ */
+
+import type {LogContext} from '@rocicorp/logger';
+import {Database} from '../../../../zqlite/src/db.ts';
+import {StatementRunner} from '../../db/statements.ts';
+import type {TestDBs} from '../../test/db.ts';
+import type {PostgresDB} from '../../types/pg.ts';
+import {cdcSchema} from '../../types/shards.ts';
+import type {SchemaChange} from '../change-source/protocol/current/data.ts';
+import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
+import {
+  CREATE_CHANGE_LOG_COOKIE_SCHEMA,
+  type BackfillCookie,
+  type CookieSet,
+  type TableMetadataCookie,
+} from '../replicator/change-log-cookies.ts';
+import {CREATE_CHANGE_LOG_STREAM_SCHEMA} from '../replicator/change-log-db.ts';
+import {ChangeLogStreamWriter} from '../replicator/change-log-stream-writer.ts';
+import {ChangeProcessor} from '../replicator/change-processor.ts';
+import {initReplicationState} from '../replicator/schema/replication-state.ts';
+import {serializeChangeStreamData} from './change-log-codec.ts';
+import {ensureReplicationConfig, setupCDCTables} from './schema/tables.ts';
+import {Storer, type TuningOptions} from './storer.ts';
+
+export const REPLICA_VERSION = '00';
+
+const TUNING_OPTIONS: TuningOptions = {
+  backPressureLimitHeapProportion: 0.04,
+  statementTimeoutMs: 20_000,
+  changeLogBatchSize: 2000,
+};
+
+/** An in-memory SQLite change log, holding both the stream and the cookies. */
+export function createChangeLog(lc: LogContext): Database {
+  const db = new Database(lc, ':memory:');
+  db.exec(CREATE_CHANGE_LOG_STREAM_SCHEMA);
+  db.exec(CREATE_CHANGE_LOG_COOKIE_SCHEMA);
+  return db;
+}
+
+/**
+ * An in-memory replica and the change-processor that writes it, in the
+ * replication-manager's `backup` mode -- i.e. the replica that a change log
+ * would eventually be initialized from.
+ */
+export function createReplica(lc: LogContext): {
+  replica: Database;
+  processor: ChangeProcessor;
+} {
+  const replica = new Database(lc, ':memory:');
+  initReplicationState(replica, ['zero_data'], REPLICA_VERSION);
+  const processor = new ChangeProcessor(
+    new StatementRunner(replica),
+    'backup',
+    (_, err: unknown) => {
+      throw err;
+    },
+  );
+  return {replica, processor};
+}
+
+export type ShardStorer = {
+  readonly db: PostgresDB;
+  readonly storer: Storer;
+  /** The shard's `cdc` schema, for tests that read the tables directly. */
+  readonly cdcSchema: string;
+  /** Stops the storer and drops the database. For the `beforeEach` teardown. */
+  close(): Promise<void>;
+};
+
+/** A shard's `cdc` schema, with a {@link Storer} running over it. */
+export async function createShardStorer(
+  lc: LogContext,
+  testDBs: TestDBs,
+  dbName: string,
+  appID: string,
+  shardNum = 1,
+): Promise<ShardStorer> {
+  const db = await testDBs.create(dbName, {
+    typeOpts: {sendStringAsJson: true},
+  });
+  const shard = {appID, shardNum};
+  await db.begin(tx => setupCDCTables(lc, tx, shard));
+  await ensureReplicationConfig(
+    lc,
+    db,
+    {
+      replicaVersion: REPLICA_VERSION,
+      publications: [],
+      watermark: REPLICA_VERSION,
+    },
+    shard,
+    true,
+  );
+
+  const storer = new Storer(
+    lc,
+    shard,
+    'task-id',
+    'change-streamer:12345',
+    'ws',
+    db,
+    REPLICA_VERSION,
+    () => {},
+    () => {},
+    TUNING_OPTIONS,
+  );
+  await storer.assumeOwnership();
+  const done = storer.run();
+
+  return {
+    db,
+    storer,
+    cdcSchema: cdcSchema(shard),
+    close: async () => {
+      await testDBs.drop(db);
+      void storer.stop();
+      await done;
+    },
+  };
+}
+
+/** The `ChangeStreamData` messages of one transaction, in stream order. */
+export function transactionMessages(
+  watermark: string,
+  changes: SchemaChange[],
+): ChangeStreamData[] {
+  return [
+    ['begin', {tag: 'begin'}, {commitWatermark: watermark}],
+    ...changes.map((change): ChangeStreamData => ['data', change]),
+    ['commit', {tag: 'commit'}, {watermark}],
+  ];
+}
+
+/**
+ * The subset of {@link Storer} the driver needs, so that a test which attaches
+ * no shard does not pull one in.
+ */
+export type UpstreamStore = {
+  store(watermark: string, msg: ChangeStreamData): void;
+  allProcessed(): Promise<unknown>;
+};
+
+export type ChangeStreamSinks = {
+  /** The Postgres change log, i.e. a {@link Storer}. */
+  readonly upstream?: UpstreamStore | undefined;
+  /** The SQLite change log. */
+  readonly changeLog?: Database | undefined;
+  /** The replica, via the change-processor that writes it. */
+  readonly replica?: ChangeProcessor | undefined;
+};
+
+/** Drives whole transactions into every attached store, as a stream loop does. */
+export class ChangeStreamDriver {
+  readonly #lc: LogContext;
+  readonly #sinks: ChangeStreamSinks;
+  #watermark = 1;
+
+  constructor(lc: LogContext, sinks: ChangeStreamSinks) {
+    this.#lc = lc;
+    this.#sinks = sinks;
+  }
+
+  /**
+   * Takes the next watermark without driving anything, for a test that drives
+   * a partial transaction itself.
+   */
+  claimWatermark(): string {
+    return String(++this.#watermark).padStart(2, '0');
+  }
+
+  /**
+   * Drives one transaction into every attached store and returns the watermark
+   * it committed at. `toReplica: false` holds the replica back, which is how a
+   * replicator trailing the log's head is simulated.
+   */
+  async transaction(
+    changes: SchemaChange[],
+    {toReplica = true}: {toReplica?: boolean} = {},
+  ): Promise<string> {
+    const wm = this.claimWatermark();
+    const messages = transactionMessages(wm, changes);
+    const {upstream, changeLog, replica} = this.#sinks;
+
+    messages.forEach(message => upstream?.store(wm, message));
+
+    if (changeLog) {
+      const writer = new ChangeLogStreamWriter(new StatementRunner(changeLog));
+      writer.begin(wm, serializeChangeStreamData(messages[0]));
+      changes.forEach((change, i) =>
+        writer.append(serializeChangeStreamData(messages[i + 1]), change),
+      );
+      writer.commit(wm, serializeChangeStreamData(messages.at(-1)!), 1_000);
+    }
+
+    if (replica && toReplica) {
+      messages.forEach(message => replica.processMessage(this.#lc, message));
+    }
+
+    await upstream?.allProcessed();
+    return wm;
+  }
+}
+
+/** The cookie set the Postgres change log holds, in the SQLite log's shape. */
+export async function readPgCookies(
+  db: PostgresDB,
+  cdcSchema: string,
+): Promise<CookieSet> {
+  const [tableMetadata, backfilling] = await Promise.all([
+    db<TableMetadataCookie[]>`
+      SELECT "schema", "table", "metadata" FROM ${db(cdcSchema)}."tableMetadata"
+        ORDER BY "schema", "table"`,
+    db<BackfillCookie[]>`
+      SELECT "schema", "table", "column", "backfill" FROM ${db(cdcSchema)}."backfilling"
+        ORDER BY "schema", "table", "column"`,
+  ]);
+  return {
+    tableMetadata: [...tableMetadata],
+    backfilling: [...backfilling],
+  };
+}

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
@@ -507,8 +507,7 @@ describe('change-streamer/service', () => {
       expect(
         changeLog
           .prepare(/*sql*/ `
-            SELECT "watermark", "pos", json_extract("change", '$.tag') AS "tag",
-                   "precommit"
+            SELECT "watermark", "pos", "tag", "precommit"
               FROM "_zero.changeLogStream" ORDER BY "watermark", "pos"
           `)
           .all(),

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -2,6 +2,7 @@ import {getDefaultHighWaterMark} from 'node:stream';
 import type {LogContext} from '@rocicorp/logger';
 import {resolver, type Resolver} from '@rocicorp/resolver';
 import {assert, unreachable} from '../../../../shared/src/asserts.ts';
+import {must} from '../../../../shared/src/must.ts';
 import {promiseVoid} from '../../../../shared/src/resolved-promises.ts';
 import {publishCriticalEvent} from '../../observability/events.ts';
 import {
@@ -34,6 +35,10 @@ import {
   RunningState,
   UnrecoverableError,
 } from '../running-state.ts';
+import {
+  ChangeLogInitializer,
+  replicaInitializationSource,
+} from './change-log-initializer.ts';
 import {
   type ChangeStreamerService,
   type Status,
@@ -117,7 +122,10 @@ export type TuningOptions = StorerOptions & {
    * change-log writer. Absent, nothing writes the log.
    */
   sqliteChangeLogWriter?:
-    | Omit<SQLiteChangeLogWriterOptions, 'onCommit' | 'onDisabled'>
+    | Omit<
+        SQLiteChangeLogWriterOptions,
+        'onCommit' | 'onDisabled' | 'onRebuilt'
+      >
     | undefined;
   /**
    * Also supplied when `sqliteChangeLogMode != off`, and deliberately not
@@ -128,6 +136,15 @@ export type TuningOptions = StorerOptions & {
    * the replicator's cleanup.
    */
   sqliteChangeLogPurge?: SQLiteChangeLogPurgeSchedulerOptions | undefined;
+  /**
+   * Supplied at `sqliteChangeLogMode >= compare`, and the gate on deriving the
+   * stream's initialization parameters from the replica as well as from
+   * Postgres. Postgres stays authoritative; the two are compared and the
+   * result is reported. Not a new configuration option -- the mode ladder
+   * carries it, because a state in which the log's buffer and its cookies were
+   * at different rollout stages is what invariant 15 exists to forbid.
+   */
+  sqliteChangeLogCompare?: {replicaFile: string} | undefined;
 };
 
 /**
@@ -341,6 +358,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
   readonly #changeLogWriter: SQLiteChangeLogWriter | undefined;
   readonly #purgeScheduler: SQLiteChangeLogPurgeScheduler | undefined;
   readonly #acker: UpstreamAcker;
+  readonly #initializer: ChangeLogInitializer;
 
   readonly #autoReset: boolean;
   readonly #state: RunningState;
@@ -461,6 +479,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
           // has to go with it: otherwise it serves an unlinked inode while
           // every new open sees nothing.
           onDisabled: () => this.#closeSQLiteCatchup(),
+          onRebuilt: () => this.#closeSQLiteCatchup(),
         })
       : undefined;
     // The purge scheduler runs on the writer's own connection, which is also
@@ -481,6 +500,24 @@ class ChangeStreamerImpl implements ChangeStreamerService {
       trackPgChangeLog: true, // TODO: set false when retiring PG
       trackBackup: backupConfig?.litestreamVersion === 'v5',
     });
+    const replicaSource = opts.sqliteChangeLogCompare
+      ? replicaInitializationSource(lc, opts.sqliteChangeLogCompare.replicaFile)
+      : undefined;
+    this.#initializer = new ChangeLogInitializer(
+      lc,
+      {
+        initFromPgChangeLog: true, // TODO: set false when retiring PG
+        initFromReplica: replicaSource !== undefined,
+      },
+      {
+        pgChangeLog: () =>
+          this.#storer.getStartStreamInitializationParameters(),
+        // Only reached when `initFromReplica` is set, i.e. when the option
+        // that supplies the file is present.
+        replica: () => must(replicaSource)(),
+        changeLog: () => this.#changeLogWriter?.connection,
+      },
+    );
     this.#sqliteCatchupOptions = opts.sqliteCatchup
       ? {
           ...opts.sqliteCatchup,
@@ -529,7 +566,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
       let unflushedBytes = 0;
       try {
         const {lastWatermark, backfillRequests, cookies} =
-          await this.#storer.getStartStreamInitializationParameters();
+          await this.#initializer.initialize();
         // SQLite catchup must not be eligible until this has been initialized
         // from the durable PG head. Commits observed only since process startup
         // are insufficient after a change-streamer restart.
@@ -548,6 +585,13 @@ class ChangeStreamerImpl implements ChangeStreamerService {
           resumeWatermark: lastWatermark,
           cookies,
         });
+        // After the reconcile, not before: the fold reads the log's schema
+        // changes over the interval the replica trails by, and only a
+        // reconciled log holds exactly the transactions at or below the resume
+        // watermark. An un-reconciled one can hold phantoms, another replica's
+        // history, or nothing -- none of which is a disagreement between the
+        // two stores, and all of which would be reported as one.
+        this.#initializer.compare();
         const stream = await this.#source.startStream(
           lastWatermark,
           backfillRequests,

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-reader.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-reader.ts
@@ -50,7 +50,7 @@ type PreparedStatements = {
 export const SQLITE_CHANGE_LOG_BOUNDARY_SQL = /*sql*/ `
   SELECT
     "precommit" = @fromWatermark AND
-      json_extract("change", '$.tag') = 'commit' AS "boundaryExists"
+      "tag" = 'commit' AS "boundaryExists"
   FROM "${CHANGE_LOG_STREAM_TABLE}"
   WHERE "watermark" = @fromWatermark
   ORDER BY "pos" DESC
@@ -84,7 +84,7 @@ export const SQLITE_CHANGE_LOG_READ_BATCH_SQL = /*sql*/ `
   SELECT
     "watermark",
     "pos",
-    json_extract("change", '$.tag') AS "tag",
+    "tag",
     "change"
   FROM "${CHANGE_LOG_STREAM_TABLE}"
   WHERE ("watermark", "pos") > (?, ?)

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-writer.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-writer.test.ts
@@ -11,6 +11,8 @@ import {
 } from '../replicator/change-log-cookies.ts';
 import {
   CHANGE_LOG_STREAM_TABLE,
+  MAX_RECONCILE_TRUNCATE_BYTES,
+  MAX_RECONCILE_TRUNCATE_ROWS,
   changeLogFileName,
   deleteChangeLogDB,
   openChangeLogDB,
@@ -57,11 +59,13 @@ function setup(name: string, resumeWatermark = '02') {
   files.push(file);
   const commits: string[] = [];
   let disabled = 0;
+  let rebuilt = 0;
   const writer = new SQLiteChangeLogWriter(lc, {
     replicaFile: file.path,
     identity: IDENTITY,
     onCommit: watermark => commits.push(watermark),
     onDisabled: () => disabled++,
+    onRebuilt: () => rebuilt++,
     now: () => 1_700_000_000_000,
   });
   writer.reconcile(resumeAt(resumeWatermark));
@@ -72,6 +76,7 @@ function setup(name: string, resumeWatermark = '02') {
     writer,
     commits,
     disabledCount: () => disabled,
+    rebuiltCount: () => rebuilt,
     head: () => {
       using db = openChangeLogDB(lc, file.path, {readonly: true});
       return readChangeLogHead(db);
@@ -198,7 +203,8 @@ describe('change-streamer/sqlite-change-log-writer', () => {
       other
         .prepare(/*sql*/ `
           INSERT INTO "${CHANGE_LOG_STREAM_TABLE}"
-            ("watermark", "pos", "change") VALUES ('04', 0, '{"tag":"begin"}')
+            ("watermark", "pos", "tag", "estimatedBytes", "change")
+            VALUES ('04', 0, 'begin', 0, '{"tag":"begin"}')
         `)
         .run();
     }
@@ -296,6 +302,43 @@ describe('change-streamer/sqlite-change-log-writer', () => {
     expect(fixture.head()).toBe('06');
     expect(fixture.writer.enabled).toBe(true);
     expect(fixture.writer.state()?.invariantFailures).toBe(0);
+  });
+
+  test('oversized reconciliation replaces the log instead of deleting synchronously', () => {
+    using fixture = setup('change-log-writer-bounded-reconcile');
+
+    const insertSuffix = (rows: number, estimatedBytes: number) => {
+      using other = openChangeLogDB(fixture.lc, fixture.file.path, {
+        readonly: false,
+      });
+      const insert = other.prepare(/*sql*/ `
+        INSERT INTO "${CHANGE_LOG_STREAM_TABLE}"
+          ("watermark", "pos", "tag", "estimatedBytes", "change")
+          VALUES ('04', ?, 'insert', ?, '{"tag":"insert"}')
+      `);
+      other.transaction(() => {
+        for (let pos = 0; pos < rows; pos++) {
+          insert.run(pos, estimatedBytes);
+        }
+      });
+    };
+
+    // Too many small rows: the decision scans at most one row past the cap.
+    insertSuffix(MAX_RECONCILE_TRUNCATE_ROWS + 1, 1);
+    fixture.writer.reconcile(resumeAt('02'));
+    expect(fixture.head()).toBe('02');
+    expect(fixture.rebuiltCount()).toBe(1);
+
+    // One enormous row is bounded independently of the row count.
+    insertSuffix(1, MAX_RECONCILE_TRUNCATE_BYTES + 1);
+    fixture.writer.reconcile(resumeAt('02'));
+    expect(fixture.head()).toBe('02');
+    expect(fixture.rebuiltCount()).toBe(2);
+
+    // Rebuilding the disposable cache does not disable the stream writer.
+    transaction(fixture.writer, '04');
+    expect(fixture.writer.enabled).toBe(true);
+    expect(fixture.head()).toBe('04');
   });
 
   describe('the cookie jar', () => {

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-writer.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-writer.ts
@@ -10,13 +10,16 @@ import {StatementRunner} from '../../db/statements.ts';
 import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
 import {readCookieRowCounts} from '../replicator/change-log-cookies.ts';
 import {
+  ChangeLogRebuildRequired,
   changeLogFileName,
   deleteChangeLogDB,
   openChangeLogDBForWriting,
+  rebuildChangeLogDBForWriting,
   reconcileChangeLog,
   type ChangeLogAnchor,
   type ChangeLogIdentity,
   type ChangeLogResumePoint,
+  type ReconcileResult,
 } from '../replicator/change-log-db.ts';
 import {ChangeLogStreamWriter} from '../replicator/change-log-stream-writer.ts';
 import {
@@ -46,6 +49,8 @@ export type SQLiteChangeLogWriterOptions = {
    * nothing.
    */
   onDisabled?: (() => void) | undefined;
+  /** Called when reconciliation replaces the file, to close cached readers. */
+  onRebuilt?: (() => void) | undefined;
   /** Overridable for tests. */
   now?: (() => number) | undefined;
 };
@@ -148,6 +153,9 @@ export class SQLiteChangeLogWriter {
       if (db === undefined) {
         const opened = openChangeLogDBForWriting(this.#lc, replicaFile, anchor);
         this.#db = opened.db;
+        if (opened.replacedFile) {
+          this.#opts.onRebuilt?.();
+        }
         recordSQLiteChangeLogReconcile(this.#lc, opened.result);
         const info = getSQLiteChangeLogInfo(opened.db);
         logSQLiteChangeLogStartup(
@@ -157,10 +165,37 @@ export class SQLiteChangeLogWriter {
         );
         this.#observer = new SQLiteChangeLogObserver(this.#lc, info);
       } else {
-        const result = reconcileChangeLog(this.#lc, db, anchor);
+        let result: ReconcileResult;
+        try {
+          result = reconcileChangeLog(this.#lc, db, anchor, {
+            rebuildInsteadOfUnboundedWork: true,
+          });
+        } catch (e) {
+          if (!(e instanceof ChangeLogRebuildRequired)) {
+            throw e;
+          }
+          // Close every handle to the old inode before unlinking it. The writer
+          // is reconstructed below against the replacement connection.
+          this.#writer = undefined;
+          this.#db = undefined;
+          db.close();
+          this.#opts.onRebuilt?.();
+          const rebuilt = rebuildChangeLogDBForWriting(
+            this.#lc,
+            replicaFile,
+            anchor,
+            e,
+          );
+          this.#db = rebuilt.db;
+          result = rebuilt.result;
+        }
         recordSQLiteChangeLogReconcile(this.#lc, result);
         if (result.action !== 'none') {
-          this.#observer?.reconciled(getSQLiteChangeLogInfo(db));
+          this.#observer?.reconciled(
+            getSQLiteChangeLogInfo(
+              must(this.#db, 'the SQLite change log is not open'),
+            ),
+          );
         }
       }
       // A reseed drops and recreates the stream table, so the append statements

--- a/packages/zero-cache/src/services/replicator/change-log-cookies.ts
+++ b/packages/zero-cache/src/services/replicator/change-log-cookies.ts
@@ -361,6 +361,143 @@ export class ChangeLogCookieWriter {
   }
 }
 
+const tableKey = (schema: string, table: string) =>
+  JSON.stringify([schema, table]);
+
+const columnKey = (schema: string, table: string, column: string) =>
+  JSON.stringify([schema, table, column]);
+
+const cmp = (a: string, b: string) => (a < b ? -1 : a > b ? 1 : 0);
+
+/**
+ * The in-memory interpreter of {@link cookieOps}: the third one, and the only
+ * one that is not a store.
+ *
+ * A replica-derived cookie set is a snapshot at the replica's state version,
+ * which trails the change log's head, so it cannot be compared with a
+ * Postgres-derived set directly. This carries it forward over the schema changes
+ * the log holds in between, which turns "the two stores disagree, but they are
+ * also at different positions" into an exact equality — and makes a
+ * disagreement between any two of the three interpreters visible as an
+ * inequality that neither store would have noticed on its own.
+ *
+ * `changes` must be the log's schema changes over `(from, to]` in stream order.
+ * Anything else produces a set that belongs to no watermark.
+ */
+export function foldCookies(
+  cookies: CookieSet,
+  changes: Iterable<SchemaChange>,
+): CookieSet {
+  const metadata = new Map<string, TableMetadataCookie>(
+    cookies.tableMetadata.map(c => [tableKey(c.schema, c.table), c]),
+  );
+  const backfilling = new Map<string, BackfillCookie>(
+    cookies.backfilling.map(c => [columnKey(c.schema, c.table, c.column), c]),
+  );
+  const dropColumn = ({schema, name}: Identifier, column: string) =>
+    backfilling.delete(columnKey(schema, name, column));
+
+  for (const change of changes) {
+    for (const op of cookieOps(change)) {
+      switch (op.op) {
+        case 'upsert-metadata':
+          metadata.set(tableKey(op.table.schema, op.table.name), {
+            schema: op.table.schema,
+            table: op.table.name,
+            metadata: op.metadata,
+          });
+          break;
+
+        case 'upsert-backfill':
+          backfilling.set(
+            columnKey(op.table.schema, op.table.name, op.column),
+            {
+              schema: op.table.schema,
+              table: op.table.name,
+              column: op.column,
+              backfill: op.backfill,
+            },
+          );
+          break;
+
+        case 'rename-table': {
+          const {old, new: renamed} = op;
+          const moved = metadata.get(tableKey(old.schema, old.name));
+          if (moved) {
+            metadata.delete(tableKey(old.schema, old.name));
+            metadata.set(tableKey(renamed.schema, renamed.name), {
+              ...moved,
+              schema: renamed.schema,
+              table: renamed.name,
+            });
+          }
+          // Snapshotted before mutating, since the rename both deletes and
+          // inserts into the map being scanned.
+          for (const [key, cookie] of [...backfilling]) {
+            if (cookie.schema === old.schema && cookie.table === old.name) {
+              backfilling.delete(key);
+              backfilling.set(
+                columnKey(renamed.schema, renamed.name, cookie.column),
+                {...cookie, schema: renamed.schema, table: renamed.name},
+              );
+            }
+          }
+          break;
+        }
+
+        case 'drop-table': {
+          const {schema, name} = op.table;
+          metadata.delete(tableKey(schema, name));
+          for (const [key, cookie] of [...backfilling]) {
+            if (cookie.schema === schema && cookie.table === name) {
+              backfilling.delete(key);
+            }
+          }
+          break;
+        }
+
+        case 'rename-column': {
+          const {schema, name} = op.table;
+          const moved = backfilling.get(columnKey(schema, name, op.old));
+          if (moved) {
+            backfilling.delete(columnKey(schema, name, op.old));
+            backfilling.set(columnKey(schema, name, op.new), {
+              ...moved,
+              column: op.new,
+            });
+          }
+          break;
+        }
+
+        case 'drop-column':
+          dropColumn(op.table, op.column);
+          break;
+
+        case 'complete-backfill':
+          for (const column of op.columns) {
+            dropColumn(op.table, column);
+          }
+          break;
+
+        default:
+          unreachable(op);
+      }
+    }
+  }
+
+  return {
+    tableMetadata: [...metadata.values()].toSorted(
+      (a, b) => cmp(a.schema, b.schema) || cmp(a.table, b.table),
+    ),
+    backfilling: [...backfilling.values()].toSorted(
+      (a, b) =>
+        cmp(a.schema, b.schema) ||
+        cmp(a.table, b.table) ||
+        cmp(a.column, b.column),
+    ),
+  };
+}
+
 /**
  * Reads the whole cookie set, ordered by primary key. This is what a
  * change-streamer would hand `startStream`, and what the Postgres-derived and

--- a/packages/zero-cache/src/services/replicator/change-log-crash-recovery.test.ts
+++ b/packages/zero-cache/src/services/replicator/change-log-crash-recovery.test.ts
@@ -165,8 +165,7 @@ type LogTransaction = {
 function readLog(db: Database): LogTransaction[] {
   const rows = db
     .prepare(/*sql*/ `
-      SELECT "watermark", "pos", json_extract("change", '$.tag') AS "tag",
-             "precommit"
+      SELECT "watermark", "pos", "tag", "precommit"
         FROM "${CHANGE_LOG_STREAM_TABLE}"
         ORDER BY "watermark", "pos"
     `)

--- a/packages/zero-cache/src/services/replicator/change-log-db.test.ts
+++ b/packages/zero-cache/src/services/replicator/change-log-db.test.ts
@@ -25,6 +25,7 @@ import {
   changeLogFileName,
   CREATE_CHANGE_LOG_STREAM_SCHEMA,
   deleteChangeLogDB,
+  estimateChangeLogStreamRowBytes,
   openChangeLogDB,
   openChangeLogDBForWriting,
   readChangeLogHead,
@@ -90,14 +91,37 @@ function appendTransaction(
 ) {
   const stmt = db.prepare(/*sql*/ `
     INSERT INTO "${CHANGE_LOG_STREAM_TABLE}"
-      ("watermark", "pos", "change", "precommit", "writeTimeMs")
-      VALUES (?, ?, ?, ?, ?)
+      ("watermark", "pos", "tag", "estimatedBytes", "change", "precommit",
+       "writeTimeMs")
+      VALUES (?, ?, ?, ?, ?, ?, ?)
   `);
-  stmt.run(watermark, 0, '{"tag":"begin"}', null, null);
+  const insert = (
+    pos: number,
+    tag: string,
+    change: string,
+    rowPrecommit: string | null,
+    rowWriteTimeMs: number | null,
+  ) =>
+    stmt.run(
+      watermark,
+      pos,
+      tag,
+      estimateChangeLogStreamRowBytes(
+        watermark,
+        tag,
+        change,
+        rowPrecommit ?? undefined,
+        rowWriteTimeMs !== null,
+      ),
+      change,
+      rowPrecommit,
+      rowWriteTimeMs,
+    );
+  insert(0, 'begin', '{"tag":"begin"}', null, null);
   for (let i = 1; i <= changes; i++) {
-    stmt.run(watermark, i, `{"tag":"insert","pos":${i}}`, null, null);
+    insert(i, 'insert', `{"tag":"insert","pos":${i}}`, null, null);
   }
-  stmt.run(watermark, changes + 1, '{"tag":"commit"}', precommit, writeTimeMs);
+  insert(changes + 1, 'commit', '{"tag":"commit"}', precommit, writeTimeMs);
 }
 
 function seedRows(anchor: ChangeLogAnchor) {
@@ -105,6 +129,12 @@ function seedRows(anchor: ChangeLogAnchor) {
     {
       watermark: anchor.resumeWatermark,
       pos: 0,
+      tag: 'begin',
+      estimatedBytes: estimateChangeLogStreamRowBytes(
+        anchor.resumeWatermark,
+        'begin',
+        '{"tag":"begin"}',
+      ),
       change: '{"tag":"begin"}',
       precommit: null,
       writeTimeMs: null,
@@ -112,6 +142,14 @@ function seedRows(anchor: ChangeLogAnchor) {
     {
       watermark: anchor.resumeWatermark,
       pos: 1,
+      tag: 'commit',
+      estimatedBytes: estimateChangeLogStreamRowBytes(
+        anchor.resumeWatermark,
+        'commit',
+        '{"tag":"commit"}',
+        anchor.resumeWatermark,
+        true,
+      ),
       change: '{"tag":"commit"}',
       precommit: anchor.resumeWatermark,
       writeTimeMs: anchor.nowMs,
@@ -202,7 +240,7 @@ describe('replicator/change-log-db', () => {
         },
         {
           cid: 2,
-          name: 'change',
+          name: 'tag',
           type: 'TEXT',
           notnull: 1,
           dflt_value: null,
@@ -210,6 +248,22 @@ describe('replicator/change-log-db', () => {
         },
         {
           cid: 3,
+          name: 'estimatedBytes',
+          type: 'INTEGER',
+          notnull: 1,
+          dflt_value: null,
+          pk: 0,
+        },
+        {
+          cid: 4,
+          name: 'change',
+          type: 'TEXT',
+          notnull: 1,
+          dflt_value: null,
+          pk: 0,
+        },
+        {
+          cid: 5,
           name: 'precommit',
           type: 'TEXT',
           notnull: 0,
@@ -217,7 +271,7 @@ describe('replicator/change-log-db', () => {
           pk: 0,
         },
         {
-          cid: 4,
+          cid: 6,
           name: 'writeTimeMs',
           type: 'INTEGER',
           notnull: 0,
@@ -244,27 +298,40 @@ describe('replicator/change-log-db', () => {
           .prepare(`PRAGMA index_info("${CHANGE_LOG_STREAM_WRITE_TIME_INDEX}")`)
           .all(),
       ).toEqual([
-        {seqno: 0, cid: 4, name: 'writeTimeMs'},
+        {seqno: 0, cid: 6, name: 'writeTimeMs'},
         {seqno: 1, cid: 0, name: 'watermark'},
       ]);
     });
 
-    // The replica carried this same table at schema v14. The two definitions
-    // describe different databases now and are deliberately not shared, so
-    // this is the check that the writer's table is still the one a v14 replica
-    // would have held — i.e. that the split did not silently change the shape.
-    test('matches the shape frozen in replica migration 14', () => {
+    // The replica's migration is history and must not acquire columns added to
+    // the separate, disposable change-log database after the split.
+    test('keeps the replica migration 14 shape frozen apart', () => {
       using changeLog = new Database(lc, ':memory:');
       changeLog.exec(CREATE_CHANGE_LOG_STREAM_SCHEMA);
       using replica = new Database(lc, ':memory:');
       replica.exec(CREATE_V14_CHANGE_LOG_STREAM);
 
-      const schema = (db: Database) =>
+      const columns = (db: Database) =>
         db
-          .prepare(/*sql*/ `SELECT "type", "name", "tbl_name", "sql" FROM "sqlite_master"
-                       ORDER BY "type", "name"`)
-          .all();
-      expect(schema(changeLog)).toEqual(schema(replica));
+          .prepare(`PRAGMA table_info("${CHANGE_LOG_STREAM_TABLE}")`)
+          .all<{name: string}>()
+          .map(({name}) => name);
+      expect(columns(replica)).toEqual([
+        'watermark',
+        'pos',
+        'change',
+        'precommit',
+        'writeTimeMs',
+      ]);
+      expect(columns(changeLog)).toEqual([
+        'watermark',
+        'pos',
+        'tag',
+        'estimatedBytes',
+        'change',
+        'precommit',
+        'writeTimeMs',
+      ]);
     });
 
     // The whole v2 shape lands in one bump, so that slice 8 can add the
@@ -456,13 +523,12 @@ describe('replicator/change-log-db', () => {
       const {db, result} = openChangeLogDBForWriting(lc, file.path, ANCHOR);
       using rebuilt = db;
 
-      // 'created' rather than 'schema-mismatch': a reseed cannot enable the
-      // pragma, so the whole file is replaced and the reconcile that follows
-      // runs against a database that does not exist yet.
+      // The file is replaced rather than dropped in place, but the original
+      // reason is retained for observability.
       expect(result).toEqual({
         action: 'reseeded',
         head: ANCHOR.resumeWatermark,
-        reason: 'created',
+        reason: 'schema-mismatch',
         cookiesStale: true,
       });
       expectSeededAt(rebuilt, ANCHOR);
@@ -781,6 +847,12 @@ describe('replicator/change-log-db', () => {
         {
           watermark: '05',
           pos: 0,
+          tag: 'begin',
+          estimatedBytes: estimateChangeLogStreamRowBytes(
+            '05',
+            'begin',
+            '{"tag":"begin"}',
+          ),
           change: '{"tag":"begin"}',
           precommit: null,
           writeTimeMs: null,
@@ -788,6 +860,12 @@ describe('replicator/change-log-db', () => {
         {
           watermark: '05',
           pos: 1,
+          tag: 'insert',
+          estimatedBytes: estimateChangeLogStreamRowBytes(
+            '05',
+            'insert',
+            '{"tag":"insert","pos":1}',
+          ),
           change: '{"tag":"insert","pos":1}',
           precommit: null,
           writeTimeMs: null,
@@ -795,6 +873,14 @@ describe('replicator/change-log-db', () => {
         {
           watermark: '05',
           pos: 2,
+          tag: 'commit',
+          estimatedBytes: estimateChangeLogStreamRowBytes(
+            '05',
+            'commit',
+            '{"tag":"commit"}',
+            '03',
+            true,
+          ),
           change: '{"tag":"commit"}',
           precommit: '03',
           writeTimeMs: 200,

--- a/packages/zero-cache/src/services/replicator/change-log-db.ts
+++ b/packages/zero-cache/src/services/replicator/change-log-db.ts
@@ -21,7 +21,7 @@
  * a schema change, a leftover file from a different replica, a gap left by a
  * crash or by running with the writer disabled, a corrupt file — is resolved by
  * {@link reconcileChangeLog} and {@link openChangeLogDBForWriting}, which
- * truncate the offending rows or wipe and reseed the log at the resume
+ * truncate a bounded suffix or replace and reseed the log at the resume
  * watermark. The worst outcome is a `too-old` for a lagging subscriber; a
  * silently delivered gap is not reachable.
  *
@@ -38,6 +38,7 @@
  * from the litestream backup, so this is local disk only and never S3.
  */
 
+import {existsSync} from 'node:fs';
 import type {LogContext} from '@rocicorp/logger';
 import {Database} from '../../../../zqlite/src/db.ts';
 import {deleteLiteDB} from '../../db/delete-lite-db.ts';
@@ -67,13 +68,17 @@ import {
  * second job. The reseed it costs on upgrade buys one retention window of
  * catchup reach on a log nothing reads yet.
  *
+ * v4 stores each row's tag and estimated retained bytes alongside its JSON.
+ * Readers can now filter without parsing arbitrary row payloads, and
+ * reconciliation can bound truncation by bytes as well as rows.
+ *
  * `auto_vacuum = INCREMENTAL` arrived within v2, deliberately without a bump:
  * it is a file-header property rather than a schema change, and the reseed a
  * version mismatch triggers cannot enable it (see
  * {@link applyChangeLogPragmas}), so {@link openChangeLogDBForWriting} guards
  * on the pragma itself instead of on this number.
  */
-export const CHANGE_LOG_DB_SCHEMA_VERSION = 3;
+export const CHANGE_LOG_DB_SCHEMA_VERSION = 4;
 
 /** https://www.sqlite.org/pragma.html#pragma_auto_vacuum */
 const AUTO_VACUUM_INCREMENTAL = 2;
@@ -82,20 +87,47 @@ export const CHANGE_LOG_STREAM_TABLE = '_zero.changeLogStream';
 export const CHANGE_LOG_STREAM_WRITE_TIME_INDEX =
   '_zero.changeLogStream_writeTimeMs';
 
+const INTEGER_BYTES = 8;
+
+/**
+ * Estimates the retained payload size of a stream row. This deliberately does
+ * not claim to measure SQLite b-tree/page overhead; it is stable across the
+ * write path, reconciliation, and the startup scan used by observability.
+ */
+export function estimateChangeLogStreamRowBytes(
+  watermark: string,
+  tag: string,
+  change: string,
+  precommit?: string,
+  hasWriteTime = false,
+): number {
+  return (
+    Buffer.byteLength(watermark) +
+    INTEGER_BYTES +
+    Buffer.byteLength(tag) +
+    Buffer.byteLength(change) +
+    (precommit === undefined ? 0 : Buffer.byteLength(precommit)) +
+    (hasWriteTime ? INTEGER_BYTES : 0)
+  );
+}
+
 // The index is partial because only commit rows carry a "writeTimeMs", so it
 // holds one entry per transaction rather than one per change. It is what the
 // purger scans to find transactions older than the retention window.
 //
-// The replica carried this same table through schema versions 14 and 15; see
-// `CREATE_V14_CHANGE_LOG_STREAM` in `change-source/common/replica-schema.ts`,
-// which is frozen at the v14 shape and must not be kept in sync with this one.
+// The replica carried this table's original shape through versions 14 and 15;
+// see `CREATE_V14_CHANGE_LOG_STREAM` in
+// `change-source/common/replica-schema.ts`, which is frozen at the v14 shape
+// and must not be kept in sync with this one.
 export const CREATE_CHANGE_LOG_STREAM_SCHEMA = /*sql*/ `
   CREATE TABLE "${CHANGE_LOG_STREAM_TABLE}" (
-    "watermark"   TEXT NOT NULL,
-    "pos"         INTEGER NOT NULL,
-    "change"      TEXT NOT NULL,
-    "precommit"   TEXT,
-    "writeTimeMs" INTEGER,
+    "watermark"      TEXT NOT NULL,
+    "pos"            INTEGER NOT NULL,
+    "tag"            TEXT NOT NULL,
+    "estimatedBytes"  INTEGER NOT NULL,
+    "change"          TEXT NOT NULL,
+    "precommit"       TEXT,
+    "writeTimeMs"     INTEGER,
     PRIMARY KEY ("watermark", "pos")
   );
 
@@ -112,10 +144,12 @@ export const CREATE_CHANGE_LOG_STREAM_SCHEMA = /*sql*/ `
  */
 const SEED_CHANGE_LOG_STREAM_SQL = /*sql*/ `
   INSERT INTO "${CHANGE_LOG_STREAM_TABLE}"
-    ("watermark", "pos", "change", "precommit", "writeTimeMs")
+    ("watermark", "pos", "tag", "estimatedBytes", "change", "precommit",
+     "writeTimeMs")
   VALUES
-    (@watermark, 0, '{"tag":"begin"}', NULL, NULL),
-    (@watermark, 1, '{"tag":"commit"}', @watermark, @writeTimeMs)
+    (@watermark, 0, 'begin', @beginBytes, @beginChange, NULL, NULL),
+    (@watermark, 1, 'commit', @commitBytes, @commitChange, @watermark,
+     @writeTimeMs)
   ON CONFLICT ("watermark", "pos") DO NOTHING
 `;
 
@@ -336,25 +370,30 @@ export function openChangeLogDBForWriting(
   lc: LogContext,
   replicaFile: string,
   anchor: ChangeLogAnchor,
-): {db: Database; result: ReconcileResult} {
-  const opened = openOrRebuildCorrupt(lc, replicaFile, anchor);
-  const {db, result} = ensureIncrementalAutoVacuum(
+): {db: Database; result: ReconcileResult; replacedFile: boolean} {
+  const existed = existsSync(changeLogFileName(replicaFile));
+  const opened = openOrRebuildCorrupt(lc, replicaFile, anchor, existed);
+  const {db, result, replacedFile} = ensureIncrementalAutoVacuum(
     lc,
     replicaFile,
     anchor,
     opened,
   );
-  return {db, result};
+  return {db, result, replacedFile};
 }
 
 function openOrRebuildCorrupt(
   lc: LogContext,
   replicaFile: string,
   anchor: ChangeLogAnchor,
+  boundReconciliation: boolean,
 ): OpenedChangeLog {
   try {
-    return openAndReconcile(lc, replicaFile, anchor);
+    return openAndReconcile(lc, replicaFile, anchor, boundReconciliation);
   } catch (e) {
+    if (e instanceof ChangeLogRebuildRequired) {
+      return rebuildChangeLog(lc, replicaFile, anchor, e);
+    }
     if (!isSQLiteCorruption(e)) {
       throw e;
     }
@@ -417,16 +456,52 @@ function rebuildChangeLog(
   lc: LogContext,
   replicaFile: string,
   anchor: ChangeLogAnchor,
+  required?: ChangeLogRebuildRequired | undefined,
 ): OpenedChangeLog {
+  if (required) {
+    lc.warn?.(
+      'rebuilding the SQLite change log instead of running an unbounded reconciliation',
+      {
+        sqliteChangeLogRebuild: {
+          reason: required.reason,
+          rows: required.rows,
+          estimatedBytes: required.estimatedBytes,
+        },
+      },
+    );
+  }
   deleteChangeLogDB(replicaFile);
-  // Reconciles a database that does not exist, i.e. reseeds with reason
-  // 'created'. A second failure is the environment's, not the file's.
-  return openAndReconcile(lc, replicaFile, anchor);
+  // The file is absent, so the reseed only drops empty/nonexistent tables. A
+  // second failure is the environment's, not the old file's.
+  const opened = openAndReconcile(
+    lc,
+    replicaFile,
+    anchor,
+    false,
+    required?.reason,
+  );
+  return {...opened, replacedFile: true};
+}
+
+/**
+ * Replaces an already-closed change-log file after bounded reconciliation
+ * declined its work. The caller closes cached readers before calling this so
+ * none can continue serving the unlinked inode.
+ */
+export function rebuildChangeLogDBForWriting(
+  lc: LogContext,
+  replicaFile: string,
+  anchor: ChangeLogAnchor,
+  required: ChangeLogRebuildRequired,
+): {db: Database; result: ReconcileResult; replacedFile: true} {
+  const {db, result} = rebuildChangeLog(lc, replicaFile, anchor, required);
+  return {db, result, replacedFile: true};
 }
 
 type OpenedChangeLog = {
   db: Database;
   result: ReconcileResult;
+  replacedFile: boolean;
   /** The file's persistent `auto_vacuum` mode, read back after the pragmas. */
   autoVacuum: number;
 };
@@ -435,12 +510,22 @@ function openAndReconcile(
   lc: LogContext,
   replicaFile: string,
   anchor: ChangeLogAnchor,
+  boundReconciliation: boolean,
+  reseedReason?: ReseedReason | undefined,
 ): OpenedChangeLog {
   const db = openChangeLogDB(lc, replicaFile, {readonly: false});
   try {
     applyChangeLogPragmas(db);
     const autoVacuum = readAutoVacuum(db);
-    return {db, result: reconcileChangeLog(lc, db, anchor), autoVacuum};
+    return {
+      db,
+      result: reconcileChangeLog(lc, db, anchor, {
+        rebuildInsteadOfUnboundedWork: boundReconciliation,
+        reseedReason,
+      }),
+      replacedFile: false,
+      autoVacuum,
+    };
   } catch (e) {
     // The caller never sees this handle, so it closes here or leaks — and it
     // must be closed before the corruption path deletes the file.
@@ -453,7 +538,42 @@ export type ReseedReason =
   | 'created' // file or table absent
   | 'schema-mismatch'
   | 'identity-mismatch'
-  | 'gap'; // head does not land on the resume watermark after truncation
+  | 'gap' // head does not land on the resume watermark after truncation
+  | 'oversized-truncate'; // preserving the prefix would require too much work
+
+/**
+ * Reconciliation runs synchronously on the change-streamer's event loop. A
+ * normal phantom is one transaction, so work above either limit is answered by
+ * unlinking and reseeding this disposable cache rather than deleting an
+ * arbitrarily large suffix in place.
+ */
+export const MAX_RECONCILE_TRUNCATE_ROWS = 10_000;
+export const MAX_RECONCILE_TRUNCATE_BYTES = 16 * 1024 * 1024;
+
+export class ChangeLogRebuildRequired extends Error {
+  override readonly name = 'ChangeLogRebuildRequired';
+  readonly reason: ReseedReason;
+  readonly rows?: number | undefined;
+  readonly estimatedBytes?: number | undefined;
+
+  constructor(
+    reason: ReseedReason,
+    rows?: number | undefined,
+    estimatedBytes?: number | undefined,
+  ) {
+    super(`SQLite change log requires a ${reason} rebuild`);
+    this.reason = reason;
+    this.rows = rows;
+    this.estimatedBytes = estimatedBytes;
+  }
+}
+
+type ReconcileOptions = {
+  /** Throw before an unbounded delete/drop so the file owner can unlink it. */
+  readonly rebuildInsteadOfUnboundedWork?: boolean | undefined;
+  /** Preserve the reason that caused an old file to be unlinked. */
+  readonly reseedReason?: ReseedReason | undefined;
+};
 
 /**
  * `cookiesStale` records that the cookie set the log held did not survive
@@ -512,10 +632,19 @@ export function reconcileChangeLog(
   lc: LogContext,
   db: Database,
   anchor: ChangeLogAnchor,
+  opts: ReconcileOptions = {},
 ): ReconcileResult {
   db.exec('BEGIN IMMEDIATE');
   try {
-    const result = reconcile(lc, db, anchor);
+    if (opts.rebuildInsteadOfUnboundedWork) {
+      const required = rebuildRequired(db, anchor);
+      if (required) {
+        throw required;
+      }
+    }
+    const result = opts.reseedReason
+      ? reseed(lc, db, anchor, opts.reseedReason)
+      : reconcile(lc, db, anchor);
     db.exec('COMMIT');
     return result;
   } catch (e) {
@@ -524,6 +653,57 @@ export function reconcileChangeLog(
     }
     throw e;
   }
+}
+
+/**
+ * Decides whether reconciliation can be performed within its synchronous work
+ * budget. Every query is either an index seek or a scan capped at one row past
+ * the delete limit. No state changes before the decision is complete.
+ */
+function rebuildRequired(
+  db: Database,
+  anchor: ChangeLogAnchor,
+): ChangeLogRebuildRequired | undefined {
+  const wipe = wipeReason(db, anchor);
+  if (wipe !== undefined) {
+    return new ChangeLogRebuildRequired(wipe);
+  }
+
+  const head = readChangeLogHead(db);
+  const {resumeWatermark} = anchor;
+  if (head === null || head < resumeWatermark) {
+    return new ChangeLogRebuildRequired('gap');
+  }
+  if (head === resumeWatermark) {
+    return undefined;
+  }
+
+  const boundary = db
+    .prepare(/*sql*/ `
+      SELECT 1 FROM "${CHANGE_LOG_STREAM_TABLE}"
+        WHERE "watermark" = ?
+        LIMIT 1
+    `)
+    .get<{1: number} | undefined>(resumeWatermark);
+  if (boundary === undefined) {
+    return new ChangeLogRebuildRequired('gap');
+  }
+
+  const {rows, estimatedBytes} = db
+    .prepare(/*sql*/ `
+      SELECT count(*) AS "rows",
+             coalesce(sum("estimatedBytes"), 0) AS "estimatedBytes"
+        FROM (
+          SELECT "estimatedBytes" FROM "${CHANGE_LOG_STREAM_TABLE}"
+            WHERE "watermark" > ?
+            LIMIT ${MAX_RECONCILE_TRUNCATE_ROWS + 1}
+        )
+    `)
+    .get<{rows: number; estimatedBytes: number}>(resumeWatermark);
+  return rows > MAX_RECONCILE_TRUNCATE_ROWS ||
+    estimatedBytes > MAX_RECONCILE_TRUNCATE_BYTES
+    ? new ChangeLogRebuildRequired('oversized-truncate', rows, estimatedBytes)
+    : undefined;
 }
 
 function reconcile(
@@ -593,7 +773,7 @@ function wipeReason(
   if (version.schemaVersion !== CHANGE_LOG_DB_SCHEMA_VERSION) {
     return 'schema-mismatch';
   }
-  // Checked *after* the version, so that every pre-v3 file — which is every
+  // Checked *after* the version, so that every pre-v4 file — which is every
   // file in the fleet at the upgrade — reports the `schema-mismatch` that
   // explains it rather than the `created` its absent cookie tables would
   // otherwise look like.
@@ -681,8 +861,24 @@ export function seedChangeLogStream(
   db: Database,
   anchor: ChangeLogAnchor,
 ): void {
+  const beginChange = '{"tag":"begin"}';
+  const commitChange = '{"tag":"commit"}';
   db.prepare(SEED_CHANGE_LOG_STREAM_SQL).run({
     watermark: anchor.resumeWatermark,
+    beginBytes: estimateChangeLogStreamRowBytes(
+      anchor.resumeWatermark,
+      'begin',
+      beginChange,
+    ),
+    beginChange,
+    commitBytes: estimateChangeLogStreamRowBytes(
+      anchor.resumeWatermark,
+      'commit',
+      commitChange,
+      anchor.resumeWatermark,
+      true,
+    ),
+    commitChange,
     writeTimeMs: anchor.nowMs,
   });
 }

--- a/packages/zero-cache/src/services/replicator/change-log-stream-writer.test.ts
+++ b/packages/zero-cache/src/services/replicator/change-log-stream-writer.test.ts
@@ -13,14 +13,12 @@ import {EMPTY_COOKIE_SET, readCookies} from './change-log-cookies.ts';
 import {
   CHANGE_LOG_STREAM_TABLE,
   deleteChangeLogDB,
+  estimateChangeLogStreamRowBytes,
   openChangeLogDB,
   reconcileChangeLog,
   type ChangeLogAnchor,
 } from './change-log-db.ts';
-import {
-  ChangeLogStreamWriter,
-  estimateChangeLogStreamRowBytes,
-} from './change-log-stream-writer.ts';
+import {ChangeLogStreamWriter} from './change-log-stream-writer.ts';
 
 const lc = createSilentLogContext();
 
@@ -46,6 +44,12 @@ const SEED_ROWS = [
   {
     watermark: ANCHOR.resumeWatermark,
     pos: 0,
+    tag: 'begin',
+    estimatedBytes: estimateChangeLogStreamRowBytes(
+      ANCHOR.resumeWatermark,
+      'begin',
+      '{"tag":"begin"}',
+    ),
     change: '{"tag":"begin"}',
     precommit: null,
     writeTimeMs: null,
@@ -53,6 +57,14 @@ const SEED_ROWS = [
   {
     watermark: ANCHOR.resumeWatermark,
     pos: 1,
+    tag: 'commit',
+    estimatedBytes: estimateChangeLogStreamRowBytes(
+      ANCHOR.resumeWatermark,
+      'commit',
+      '{"tag":"commit"}',
+      ANCHOR.resumeWatermark,
+      true,
+    ),
     change: '{"tag":"commit"}',
     precommit: ANCHOR.resumeWatermark,
     writeTimeMs: ANCHOR.nowMs,
@@ -133,16 +145,24 @@ describe('replicator/change-log-stream-writer', () => {
       // matches nothing.
       cookieMutations: ['rename-table'],
       estimatedBytes:
-        estimateChangeLogStreamRowBytes('06', '{"tag":"begin"}') +
+        estimateChangeLogStreamRowBytes('06', 'begin', '{"tag":"begin"}') +
         estimateChangeLogStreamRowBytes(
           '06',
+          'insert',
           '{"tag":"insert","relation":{"schema":"public","name":"issues","rowKey":{"columns":["id"],"type":"default"}},"new":{"id":9007199254740993,"text":"before\\u0000after"}}',
         ) +
         estimateChangeLogStreamRowBytes(
           '06',
+          'rename-table',
           '{"tag":"rename-table","old":{"schema":"public","name":"issues"},"new":{"schema":"public","name":"renamed"}}',
         ) +
-        estimateChangeLogStreamRowBytes('06', '{"tag":"commit"}', '06', true),
+        estimateChangeLogStreamRowBytes(
+          '06',
+          'commit',
+          '{"tag":"commit"}',
+          '06',
+          true,
+        ),
     });
 
     expectTableExact(
@@ -153,6 +173,12 @@ describe('replicator/change-log-stream-writer', () => {
         {
           watermark: '06',
           pos: 0,
+          tag: 'begin',
+          estimatedBytes: estimateChangeLogStreamRowBytes(
+            '06',
+            'begin',
+            '{"tag":"begin"}',
+          ),
           change: '{"tag":"begin"}',
           precommit: null,
           writeTimeMs: null,
@@ -160,6 +186,12 @@ describe('replicator/change-log-stream-writer', () => {
         {
           watermark: '06',
           pos: 1,
+          tag: 'insert',
+          estimatedBytes: estimateChangeLogStreamRowBytes(
+            '06',
+            'insert',
+            '{"tag":"insert","relation":{"schema":"public","name":"issues","rowKey":{"columns":["id"],"type":"default"}},"new":{"id":9007199254740993,"text":"before\\u0000after"}}',
+          ),
           change:
             '{"tag":"insert","relation":{"schema":"public","name":"issues","rowKey":{"columns":["id"],"type":"default"}},"new":{"id":9007199254740993,"text":"before\\u0000after"}}',
           precommit: null,
@@ -168,6 +200,12 @@ describe('replicator/change-log-stream-writer', () => {
         {
           watermark: '06',
           pos: 2,
+          tag: 'rename-table',
+          estimatedBytes: estimateChangeLogStreamRowBytes(
+            '06',
+            'rename-table',
+            '{"tag":"rename-table","old":{"schema":"public","name":"issues"},"new":{"schema":"public","name":"renamed"}}',
+          ),
           change:
             '{"tag":"rename-table","old":{"schema":"public","name":"issues"},"new":{"schema":"public","name":"renamed"}}',
           precommit: null,
@@ -176,6 +214,14 @@ describe('replicator/change-log-stream-writer', () => {
         {
           watermark: '06',
           pos: 3,
+          tag: 'commit',
+          estimatedBytes: estimateChangeLogStreamRowBytes(
+            '06',
+            'commit',
+            '{"tag":"commit"}',
+            '06',
+            true,
+          ),
           change: '{"tag":"commit"}',
           precommit: '06',
           writeTimeMs,

--- a/packages/zero-cache/src/services/replicator/change-log-stream-writer.ts
+++ b/packages/zero-cache/src/services/replicator/change-log-stream-writer.ts
@@ -7,7 +7,10 @@ import {
 import {extractChangeSubstring} from '../change-streamer/change-log-codec.ts';
 import {ChangeLogTransactionHasher} from '../change-streamer/change-log-transaction-hash.ts';
 import {ChangeLogCookieWriter, type CookieOpTag} from './change-log-cookies.ts';
-import {CHANGE_LOG_STREAM_TABLE} from './change-log-db.ts';
+import {
+  CHANGE_LOG_STREAM_TABLE,
+  estimateChangeLogStreamRowBytes,
+} from './change-log-db.ts';
 
 export type ChangeLogStreamTransactionStats = {
   readonly rows: number;
@@ -19,28 +22,6 @@ export type ChangeLogStreamTransactionStats = {
    */
   readonly cookieMutations: readonly CookieOpTag[];
 };
-
-const INTEGER_BYTES = 8;
-
-/**
- * Estimates the retained payload size of a stream row. This deliberately does
- * not claim to measure SQLite b-tree/page overhead; it is stable across the
- * write path and the startup scan used by observability.
- */
-export function estimateChangeLogStreamRowBytes(
-  watermark: string,
-  change: string,
-  precommit?: string,
-  hasWriteTime = false,
-): number {
-  return (
-    Buffer.byteLength(watermark) +
-    INTEGER_BYTES +
-    Buffer.byteLength(change) +
-    (precommit === undefined ? 0 : Buffer.byteLength(precommit)) +
-    (hasWriteTime ? INTEGER_BYTES : 0)
-  );
-}
 
 export class ChangeLogStreamInvariantError extends Error {
   override readonly name = 'ChangeLogStreamInvariantError';
@@ -86,13 +67,14 @@ export class ChangeLogStreamWriter {
     this.#db = db;
     this.#insertChange = db.db.prepare(/*sql*/ `
       INSERT INTO "${CHANGE_LOG_STREAM_TABLE}"
-        ("watermark", "pos", "change")
-        VALUES (?, ?, ?)
+        ("watermark", "pos", "tag", "estimatedBytes", "change")
+        VALUES (?, ?, ?, ?, ?)
     `);
     this.#insertCommit = db.db.prepare(/*sql*/ `
       INSERT INTO "${CHANGE_LOG_STREAM_TABLE}"
-        ("watermark", "pos", "change", "precommit", "writeTimeMs")
-        VALUES (?, ?, ?, ?, ?)
+        ("watermark", "pos", "tag", "estimatedBytes", "change", "precommit",
+         "writeTimeMs")
+        VALUES (?, ?, 'commit', ?, ?, ?, ?)
     `);
     this.#cookies = new ChangeLogCookieWriter(db.db);
   }
@@ -109,7 +91,18 @@ export class ChangeLogStreamWriter {
     this.#watermark = watermark;
     this.#pos = 0;
     const change = extractChangeSubstring(json, 'begin');
-    this.#insertChange.run(watermark, this.#pos, change);
+    const estimatedBytes = estimateChangeLogStreamRowBytes(
+      watermark,
+      'begin',
+      change,
+    );
+    this.#insertChange.run(
+      watermark,
+      this.#pos,
+      'begin',
+      estimatedBytes,
+      change,
+    );
     this.#hasher = new ChangeLogTransactionHasher();
     this.#hasher.add({
       watermark,
@@ -118,7 +111,7 @@ export class ChangeLogStreamWriter {
       change,
       precommit: null,
     });
-    this.#estimatedBytes = estimateChangeLogStreamRowBytes(watermark, change);
+    this.#estimatedBytes = estimatedBytes;
   }
 
   /**
@@ -135,7 +128,12 @@ export class ChangeLogStreamWriter {
     const watermark = this.#requireWatermark();
     const {tag} = change;
     const stored = extractChangeSubstring(json, tag);
-    this.#insertChange.run(watermark, ++this.#pos, stored);
+    const estimatedBytes = estimateChangeLogStreamRowBytes(
+      watermark,
+      tag,
+      stored,
+    );
+    this.#insertChange.run(watermark, ++this.#pos, tag, estimatedBytes, stored);
     this.#requireHasher().add({
       watermark,
       pos: this.#pos,
@@ -143,7 +141,7 @@ export class ChangeLogStreamWriter {
       change: stored,
       precommit: null,
     });
-    this.#estimatedBytes += estimateChangeLogStreamRowBytes(watermark, stored);
+    this.#estimatedBytes += estimatedBytes;
 
     if (isSchemaChange(change)) {
       for (const op of this.#cookies.apply(change)) {
@@ -163,9 +161,17 @@ export class ChangeLogStreamWriter {
       `change-log stream commit ${watermark} does not match begin ${precommit}`,
     );
     const change = extractChangeSubstring(json, 'commit');
+    const estimatedBytes = estimateChangeLogStreamRowBytes(
+      watermark,
+      'commit',
+      change,
+      precommit,
+      true,
+    );
     this.#insertCommit.run(
       watermark,
       ++this.#pos,
+      estimatedBytes,
       change,
       precommit,
       writeTimeMs,
@@ -180,9 +186,7 @@ export class ChangeLogStreamWriter {
     });
     const stats = {
       rows: this.#pos + 1,
-      estimatedBytes:
-        this.#estimatedBytes +
-        estimateChangeLogStreamRowBytes(watermark, change, precommit, true),
+      estimatedBytes: this.#estimatedBytes + estimatedBytes,
       hash: hasher.digest(),
       cookieMutations: this.#cookieMutations,
     };

--- a/packages/zero-cache/src/services/replicator/schema/backfilling.ts
+++ b/packages/zero-cache/src/services/replicator/schema/backfilling.ts
@@ -52,7 +52,11 @@ import {
   backfillRequestSchema,
   type BackfillRequest,
 } from '../../change-source/protocol/current/upstream.ts';
-import {cookieOps, type CookieOp} from '../change-log-cookies.ts';
+import {
+  cookieOps,
+  type CookieOp,
+  type CookieSet,
+} from '../change-log-cookies.ts';
 
 export const BACKFILLING_TABLE = '_zero.backfilling';
 
@@ -239,6 +243,53 @@ export function readBackfillRequests(db: Database): BackfillRequest[] {
     curr.columns[column] = BigIntJSON.parse(backfill) as BackfillID;
   }
   return v.parse(requests, backfillRequestsSchema);
+}
+
+/**
+ * The replica's whole cookie set, in the shape the change log holds it — the
+ * seed a change log would be initialized from, and the replica-derived half of
+ * the initialization comparison.
+ *
+ * The metadata half is filtered on `upstreamMetadata IS NOT NULL` because
+ * `_zero.tableMetadata` carries `minRowVersion` as well, so a row exists for
+ * every table whose rows were ever force-re-downloaded, whether or not upstream
+ * ever sent metadata for it. Neither cookie store can represent that row:
+ * `cdc.tableMetadata."metadata"` and `_zero.changeLogTableMetadata."metadata"`
+ * are both `NOT NULL`.
+ *
+ * Only meaningful paired with `_zero.replicationState.stateVersion`, read in
+ * the same snapshot (invariant 15).
+ */
+export function readReplicaCookies(db: Database): CookieSet {
+  const tableMetadata = db
+    .prepare(/*sql*/ `
+      SELECT "schema", "table", "upstreamMetadata" AS "metadata"
+        FROM "_zero.tableMetadata"
+        WHERE "upstreamMetadata" IS NOT NULL
+        ORDER BY "schema", "table"
+    `)
+    .all<{schema: string; table: string; metadata: string}>()
+    .map(({schema, table, metadata}) => ({
+      schema,
+      table,
+      metadata: BigIntJSON.parse(metadata) as TableMetadata,
+    }));
+
+  const backfilling = db
+    .prepare(/*sql*/ `
+      SELECT "schema", "table", "column", "backfill"
+        FROM "${BACKFILLING_TABLE}"
+        ORDER BY "schema", "table", "column"
+    `)
+    .all<{schema: string; table: string; column: string; backfill: string}>()
+    .map(({schema, table, column, backfill}) => ({
+      schema,
+      table,
+      column,
+      backfill: BigIntJSON.parse(backfill) as BackfillID,
+    }));
+
+  return {tableMetadata, backfilling};
 }
 
 /**

--- a/packages/zero-cache/src/services/replicator/sqlite-change-log-metrics.test.ts
+++ b/packages/zero-cache/src/services/replicator/sqlite-change-log-metrics.test.ts
@@ -106,6 +106,7 @@ test('each reseed reason increments reconcile_wipes with its own label', async (
     'schema-mismatch',
     'identity-mismatch',
     'gap',
+    'oversized-truncate',
   ];
 
   for (const reason of reasons) {
@@ -143,6 +144,7 @@ test('each reseed reason increments reconcile_wipes with its own label', async (
     'schema-mismatch': 1,
     'identity-mismatch': 1,
     'gap': 2,
+    'oversized-truncate': 1,
   });
   expect(counts(otel.exporter, `${METRIC}.reconcile_truncated_rows`)).toEqual({
     '': 27,

--- a/packages/zero-cache/src/services/replicator/sqlite-change-log-observability.test.ts
+++ b/packages/zero-cache/src/services/replicator/sqlite-change-log-observability.test.ts
@@ -465,7 +465,8 @@ describe('SQLite change-log observability on disk', () => {
     files.changeLog
       .prepare(/*sql*/ `
         INSERT INTO "${CHANGE_LOG_STREAM_TABLE}"
-          ("watermark", "pos", "change") VALUES ('03', 0, ?)
+          ("watermark", "pos", "tag", "estimatedBytes", "change")
+          VALUES ('03', 0, 'insert', 100000, ?)
       `)
       .run('x'.repeat(100_000));
 

--- a/packages/zero-cache/src/services/replicator/sqlite-change-log-observability.ts
+++ b/packages/zero-cache/src/services/replicator/sqlite-change-log-observability.ts
@@ -139,13 +139,7 @@ export function getSQLiteChangeLogInfo(
   const aggregate = changeLog
     .prepare(/*sql*/ `
       SELECT count(*) AS "rows",
-             coalesce(sum(
-               length(CAST("watermark" AS BLOB)) +
-               8 +
-               length(CAST("change" AS BLOB)) +
-               coalesce(length(CAST("precommit" AS BLOB)), 0) +
-               CASE WHEN "writeTimeMs" IS NULL THEN 0 ELSE 8 END
-             ), 0) AS "estimatedBytes"
+             coalesce(sum("estimatedBytes"), 0) AS "estimatedBytes"
         FROM "${CHANGE_LOG_STREAM_TABLE}"
     `)
     .get<{rows: number; estimatedBytes: number}>();

--- a/packages/zero-cache/src/services/replicator/sqlite-change-log-purger.test.ts
+++ b/packages/zero-cache/src/services/replicator/sqlite-change-log-purger.test.ts
@@ -193,7 +193,7 @@ function expectMinimumIsAValidBoundary(db: Database) {
   }
   const last = db
     .prepare(/*sql*/ `
-      SELECT "precommit", json_extract("change", '$.tag') AS "tag"
+      SELECT "precommit", "tag"
       FROM "${CHANGE_LOG_STREAM_TABLE}"
       WHERE "watermark" = ?
       ORDER BY "pos" DESC


### PR DESCRIPTION

  - Postgres has the official log saying, “We processed up to page 100, and these backfills remain.”
  - SQLite now keeps its own copy of that.
  - This branch reads both logs whenever the change stream connects.
  - Because SQLite may be behind, it replays the intervening schema changes before comparing them.
  - It records whether they agree.

Zero still uses Postgres’s answer. A mismatch or unreadable replica is logged and measured, but does not change or stop replication. This lets the new SQLite-derived path run in production before cutting over.

Logs five outcomes:

  - equal
  - equal-after-fold (SQLite was behind but agreed after log replay)
  - divergent
  - inconclusive (insufficient history or too much to scan safely)
  - error

