### PR TITLE
fix(zero-cache): bound poke parts by payload size

### DIFF
--- a/packages/zero-cache/src/integration/integration.pg.test.ts
+++ b/packages/zero-cache/src/integration/integration.pg.test.ts
@@ -605,7 +605,8 @@ describe('integration', {timeout: 30000}, () => {
 
     const downstream = new Queue<unknown>();
     const ws = new WebSocket(
-      `ws://localhost:${port}/zero/sync/v${PROTOCOL_VERSION}/connect` +
+      // This test asserts the legacy JSON pokePart representation.
+      `ws://localhost:${port}/zero/sync/v${PROTOCOL_VERSION - 1}/connect` +
         `?clientGroupID=abc&clientID=def&wsid=123&schemaVersion=1&baseCookie=&ts=123456789&lmid=1`,
       encodeURIComponent(btoa('{}')),
     );
@@ -806,7 +807,8 @@ describe('integration', {timeout: 30000}, () => {
 
       const downstream = new Queue<unknown>();
       const ws = new WebSocket(
-        `ws://localhost:${port}/zero/sync/v${PROTOCOL_VERSION}/connect` +
+        // This test asserts the legacy JSON pokePart representation.
+        `ws://localhost:${port}/zero/sync/v${PROTOCOL_VERSION - 1}/connect` +
           `?clientGroupID=abc&clientID=def&wsid=123&schemaVersion=1&baseCookie=&ts=123456789&lmid=1`,
         encodeURIComponent(btoa('{}')), // auth token
       );

--- a/packages/zero-cache/src/integration/integration.pg.test.ts
+++ b/packages/zero-cache/src/integration/integration.pg.test.ts
@@ -17,7 +17,12 @@ import {
 } from '../../../zero-permissions/src/permissions.ts';
 import type {AST} from '../../../zero-protocol/src/ast.ts';
 import type {InitConnectionMessage} from '../../../zero-protocol/src/connect.ts';
-import type {PokeStartMessage} from '../../../zero-protocol/src/poke.ts';
+import {
+  LAST_POKE_PART_PROTOCOL_VERSION,
+  POKE_CHUNK_MESSAGE_TYPE,
+  type PokePartBody,
+  type PokeStartMessage,
+} from '../../../zero-protocol/src/poke.ts';
 import {PROTOCOL_VERSION} from '../../../zero-protocol/src/protocol-version.ts';
 import {createSchema} from '../../../zero-schema/src/builder/schema-builder.ts';
 import {string, table} from '../../../zero-schema/src/builder/table-builder.ts';
@@ -606,7 +611,7 @@ describe('integration', {timeout: 30000}, () => {
     const downstream = new Queue<unknown>();
     const ws = new WebSocket(
       // This test asserts the legacy JSON pokePart representation.
-      `ws://localhost:${port}/zero/sync/v${PROTOCOL_VERSION - 1}/connect` +
+      `ws://localhost:${port}/zero/sync/v${LAST_POKE_PART_PROTOCOL_VERSION}/connect` +
         `?clientGroupID=abc&clientID=def&wsid=123&schemaVersion=1&baseCookie=&ts=123456789&lmid=1`,
       encodeURIComponent(btoa('{}')),
     );
@@ -691,6 +696,83 @@ describe('integration', {timeout: 30000}, () => {
     expect(await dequeueMessage(downstream)).toMatchObject([
       'pokeEnd',
       {pokeID: contentPokeID},
+    ]);
+  });
+
+  test('streams tagged binary poke chunks to current clients', async () => {
+    await upDB.unsafe(initialPGSetup());
+    await startZero([env]);
+
+    const downstream = new Queue<unknown>();
+    const ws = new WebSocket(
+      `ws://localhost:${port}/zero/sync/v${PROTOCOL_VERSION}/connect` +
+        `?clientGroupID=abc&clientID=def&wsid=123&schemaVersion=1&baseCookie=&ts=123456789&lmid=1`,
+      encodeURIComponent(btoa('{}')),
+    );
+    ws.on('message', (data, isBinary) =>
+      downstream.enqueue(
+        isBinary
+          ? new Uint8Array(data as Buffer)
+          : JSON.parse(data.toString('utf-8')),
+      ),
+    );
+    ws.on('open', () =>
+      ws.send(
+        JSON.stringify([
+          'initConnection',
+          {
+            desiredQueriesPatch: [
+              {op: 'put', hash: 'book-query-hash', ast: BOOK_QUERY},
+            ],
+            clientSchema: {
+              tables: {
+                book: {
+                  primaryKey: ['id'],
+                  columns: {
+                    id: {type: 'string'},
+                    ip: {type: 'string'},
+                    mac: {type: 'string'},
+                    title: {type: 'string'},
+                  },
+                },
+              },
+            },
+          },
+        ] satisfies InitConnectionMessage),
+      ),
+    );
+
+    expect(await dequeueMessage(downstream)).toMatchObject([
+      'connected',
+      {wsid: '123'},
+    ]);
+    expect(await dequeueMessage(downstream)).toMatchObject([
+      'pokeStart',
+      {pokeID: '00:01'},
+    ]);
+
+    const decoder = new TextDecoder('utf-8', {fatal: true});
+    const decoded: string[] = [];
+    for (;;) {
+      const message = await dequeueMessage(downstream);
+      if (message instanceof Uint8Array) {
+        expect(message[0]).toBe(POKE_CHUNK_MESSAGE_TYPE);
+        decoded.push(decoder.decode(message.subarray(1), {stream: true}));
+        continue;
+      }
+      decoded.push(decoder.decode());
+      expect(message).toMatchObject(['pokeEnd', {pokeID: '00:01'}]);
+      break;
+    }
+
+    const parts = JSON.parse(decoded.join('')) as PokePartBody[];
+    expect(parts).toMatchObject([
+      {
+        pokeID: '00:01',
+        desiredQueriesPatches: {
+          def: [{op: 'put', hash: 'book-query-hash'}],
+        },
+      },
     ]);
   });
 
@@ -808,7 +890,7 @@ describe('integration', {timeout: 30000}, () => {
       const downstream = new Queue<unknown>();
       const ws = new WebSocket(
         // This test asserts the legacy JSON pokePart representation.
-        `ws://localhost:${port}/zero/sync/v${PROTOCOL_VERSION - 1}/connect` +
+        `ws://localhost:${port}/zero/sync/v${LAST_POKE_PART_PROTOCOL_VERSION}/connect` +
           `?clientGroupID=abc&clientID=def&wsid=123&schemaVersion=1&baseCookie=&ts=123456789&lmid=1`,
         encodeURIComponent(btoa('{}')), // auth token
       );

--- a/packages/zero-cache/src/services/view-syncer/client-handler.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/client-handler.test.ts
@@ -412,7 +412,7 @@ describe('view-syncer/client-handler', () => {
     ]);
   });
 
-  test('flushes poke parts by payload size instead of row count', async () => {
+  test('flushes poke parts at the patch-count threshold', async () => {
     const {subscription, close} = createSubscription();
     const handler = new ClientHandler(
       lc,
@@ -440,13 +440,14 @@ describe('view-syncer/client-handler', () => {
 
     const {received} = await close();
     const pokeParts = received.filter(message => message[0] === 'pokePart');
-    expect(pokeParts).toHaveLength(1);
+    expect(pokeParts).toHaveLength(2);
     expect((pokeParts[0]![1] as PokePartMessage[1]).rowsPatch).toHaveLength(
-      101,
+      100,
     );
+    expect((pokeParts[1]![1] as PokePartMessage[1]).rowsPatch).toHaveLength(1);
   });
 
-  test('keeps large rows in separate size-bounded poke parts', async () => {
+  test('uses a soft serialized-row character threshold', async () => {
     const {subscription, close} = createSubscription();
     const handler = new ClientHandler(
       lc,
@@ -474,14 +475,16 @@ describe('view-syncer/client-handler', () => {
 
     const {received, serialized} = await close();
     const pokeParts = received.filter(message => message[0] === 'pokePart');
-    expect(pokeParts).toHaveLength(3);
+    expect(pokeParts).toHaveLength(2);
     for (const pokePart of pokeParts) {
       const encoded = serialized.get(pokePart);
       expect(encoded).toBe(JSON.stringify(pokePart));
-      expect(encoded?.length).toBeLessThanOrEqual(
-        POKE_PART_FLUSH_THRESHOLD_CHARS,
-      );
     }
+    expect((pokeParts[0]![1] as PokePartMessage[1]).rowsPatch).toHaveLength(2);
+    expect((pokeParts[1]![1] as PokePartMessage[1]).rowsPatch).toHaveLength(1);
+    expect(serialized.get(pokeParts[0]!)?.length).toBeGreaterThan(
+      POKE_PART_FLUSH_THRESHOLD_CHARS,
+    );
   });
 
   describe('mutation results', () => {

--- a/packages/zero-cache/src/services/view-syncer/client-handler.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/client-handler.test.ts
@@ -8,7 +8,7 @@ import type {
   PokePartMessage,
   PokeStartMessage,
 } from '../../../../zero-protocol/src/poke.ts';
-import {stringifyDownstream} from '../../types/downstream.ts';
+import type {ViewSyncerDownstream} from '../../types/downstream.ts';
 import {Subscription} from '../../types/subscription.ts';
 import {
   ClientHandler,
@@ -29,15 +29,19 @@ describe('view-syncer/client-handler', () => {
   function createSubscription() {
     const received: Downstream[] = [];
     const unconsumed: Downstream[] = [];
-    const subscription = Subscription.create<Downstream>({
-      cleanup: msgs => unconsumed.push(...msgs),
+    const serialized = new Map<Downstream, string>();
+    const subscription = Subscription.create<ViewSyncerDownstream>({
+      cleanup: msgs => unconsumed.push(...msgs.map(msg => msg.message)),
     });
     let err: Error | undefined;
     const {promise: loopDone, resolve: onDone} = resolver();
     void (async function () {
       try {
-        for await (const msg of subscription) {
-          received.push(msg);
+        for await (const {message, serialized: encoded} of subscription) {
+          received.push(message);
+          if (encoded !== undefined) {
+            serialized.set(message, encoded);
+          }
         }
       } catch (e) {
         err = e instanceof Error ? e : new Error(String(e));
@@ -51,7 +55,7 @@ describe('view-syncer/client-handler', () => {
       close: async () => {
         subscription.cancel();
         await loopDone;
-        return {received: [...received, ...unconsumed], err};
+        return {received: [...received, ...unconsumed], serialized, err};
       },
     };
   }
@@ -468,13 +472,13 @@ describe('view-syncer/client-handler', () => {
     }
     await poker.end({stateVersion: '123'});
 
-    const {received} = await close();
+    const {received, serialized} = await close();
     const pokeParts = received.filter(message => message[0] === 'pokePart');
     expect(pokeParts).toHaveLength(3);
     for (const pokePart of pokeParts) {
-      const serialized = stringifyDownstream(pokePart);
-      expect(serialized).toBe(JSON.stringify(pokePart));
-      expect(serialized.length).toBeLessThanOrEqual(
+      const encoded = serialized.get(pokePart);
+      expect(encoded).toBe(JSON.stringify(pokePart));
+      expect(encoded?.length).toBeLessThanOrEqual(
         POKE_PART_FLUSH_THRESHOLD_CHARS,
       );
     }

--- a/packages/zero-cache/src/services/view-syncer/client-handler.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/client-handler.test.ts
@@ -12,6 +12,7 @@ import {Subscription} from '../../types/subscription.ts';
 import {
   ClientHandler,
   ensureSafeJSON,
+  POKE_PART_FLUSH_THRESHOLD_BYTES,
   startPoke,
   type Patch,
   type PokeHandler,
@@ -404,6 +405,76 @@ describe('view-syncer/client-handler', () => {
       ] satisfies PokeStartMessage,
       ['pokeEnd', {pokeID: '123', cookie: '123'}] satisfies PokeEndMessage,
     ]);
+  });
+
+  test('flushes poke parts by payload size instead of row count', async () => {
+    const {subscription, close} = createSubscription();
+    const handler = new ClientHandler(
+      lc,
+      'g1',
+      'id1',
+      'ws1',
+      SHARD,
+      '121',
+      subscription,
+    );
+    const poker = handler.startPoke({stateVersion: '123'});
+
+    for (let i = 0; i < 101; i++) {
+      await poker.addPatch({
+        toVersion: {stateVersion: '123'},
+        patch: {
+          type: 'row',
+          op: 'put',
+          id: {schema: 'public', table: 'issues', rowKey: {id: `small-${i}`}},
+          contents: {id: `small-${i}`},
+        },
+      });
+    }
+    await poker.end({stateVersion: '123'});
+
+    const {received} = await close();
+    const pokeParts = received.filter(message => message[0] === 'pokePart');
+    expect(pokeParts).toHaveLength(1);
+    expect((pokeParts[0]![1] as PokePartMessage[1]).rowsPatch).toHaveLength(
+      101,
+    );
+  });
+
+  test('keeps large rows in separate size-bounded poke parts', async () => {
+    const {subscription, close} = createSubscription();
+    const handler = new ClientHandler(
+      lc,
+      'g1',
+      'id1',
+      'ws1',
+      SHARD,
+      '121',
+      subscription,
+    );
+    const poker = handler.startPoke({stateVersion: '123'});
+
+    for (let i = 0; i < 3; i++) {
+      await poker.addPatch({
+        toVersion: {stateVersion: '123'},
+        patch: {
+          type: 'row',
+          op: 'put',
+          id: {schema: 'public', table: 'issues', rowKey: {id: `large-${i}`}},
+          contents: {id: `large-${i}`, value: 'x'.repeat(600_000)},
+        },
+      });
+    }
+    await poker.end({stateVersion: '123'});
+
+    const {received} = await close();
+    const pokeParts = received.filter(message => message[0] === 'pokePart');
+    expect(pokeParts).toHaveLength(3);
+    for (const pokePart of pokeParts) {
+      expect(Buffer.byteLength(JSON.stringify(pokePart))).toBeLessThanOrEqual(
+        POKE_PART_FLUSH_THRESHOLD_BYTES,
+      );
+    }
   });
 
   describe('mutation results', () => {

--- a/packages/zero-cache/src/services/view-syncer/client-handler.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/client-handler.test.ts
@@ -8,11 +8,12 @@ import type {
   PokePartMessage,
   PokeStartMessage,
 } from '../../../../zero-protocol/src/poke.ts';
+import {stringifyDownstream} from '../../types/downstream.ts';
 import {Subscription} from '../../types/subscription.ts';
 import {
   ClientHandler,
   ensureSafeJSON,
-  POKE_PART_FLUSH_THRESHOLD_BYTES,
+  POKE_PART_FLUSH_THRESHOLD_CHARS,
   startPoke,
   type Patch,
   type PokeHandler,
@@ -471,8 +472,10 @@ describe('view-syncer/client-handler', () => {
     const pokeParts = received.filter(message => message[0] === 'pokePart');
     expect(pokeParts).toHaveLength(3);
     for (const pokePart of pokeParts) {
-      expect(Buffer.byteLength(JSON.stringify(pokePart))).toBeLessThanOrEqual(
-        POKE_PART_FLUSH_THRESHOLD_BYTES,
+      const serialized = stringifyDownstream(pokePart);
+      expect(serialized).toBe(JSON.stringify(pokePart));
+      expect(serialized.length).toBeLessThanOrEqual(
+        POKE_PART_FLUSH_THRESHOLD_CHARS,
       );
     }
   });

--- a/packages/zero-cache/src/services/view-syncer/client-handler.ts
+++ b/packages/zero-cache/src/services/view-syncer/client-handler.ts
@@ -20,6 +20,7 @@ import type {InspectDownBody} from '../../../../zero-protocol/src/inspect-down.t
 import {mutationResultSchema} from '../../../../zero-protocol/src/mutation.ts';
 import type {
   PokePartBody,
+  PokePartMessage,
   PokeStartBody,
 } from '../../../../zero-protocol/src/poke.ts';
 import {primaryKeyValueRecordSchema} from '../../../../zero-protocol/src/primary-key.ts';
@@ -105,9 +106,9 @@ export function startPoke(
   };
 }
 
-// Keep poke parts small enough that clients observe progress while syncing.
-// A single patch can exceed this limit because rows are atomic at the protocol
-// level, but it will be sent in a part by itself.
+// Soft limit on the serialized row characters accumulated in a poke part.
+// This bounds view-syncer memory and keeps legacy JSON messages reasonably
+// sized. PokeChunkEncoder separately enforces the binary frame limit in bytes.
 export const POKE_PART_FLUSH_THRESHOLD_CHARS = 1024 * 1024;
 const PART_COUNT_FLUSH_THRESHOLD = 100;
 
@@ -211,9 +212,6 @@ export class ClientHandler {
     let pokeStarted = false;
     let body: PokePartBody | undefined;
     let partCount = 0;
-    const emptySerializedBody = JSON.stringify(['pokePart', {pokeID}]);
-    let serializedBody = emptySerializedBody;
-    const serializedRows: string[] = [];
     let serializedRowsLength = 0;
 
     const ensureBody = async () => {
@@ -224,32 +222,14 @@ export class ClientHandler {
       return (body ??= {pokeID});
     };
 
-    const serializedLength = (rowsLength = serializedRowsLength) =>
-      rowsLength
-        ? serializedBody.length - 2 + ',"rowsPatch":[]}]'.length + rowsLength
-        : serializedBody.length;
-
     const flushBody = async () => {
       if (body) {
-        const serialized = serializedRows.length
-          ? `${serializedBody.slice(0, -2)},"rowsPatch":[${serializedRows.join(',')}]}]`
-          : serializedBody;
-        assert(
-          serialized.length === serializedLength(),
-          'serialized poke part length did not match the measured length',
-        );
-        await this.#push(['pokePart', body], serialized);
+        const message = ['pokePart', body] satisfies PokePartMessage;
+        await this.#push(message, JSON.stringify(message));
         body = undefined;
         partCount = 0;
-        serializedBody = emptySerializedBody;
-        serializedRows.length = 0;
         serializedRowsLength = 0;
       }
-    };
-
-    const updateSerializedBody = (body: PokePartBody) => {
-      const {rowsPatch: _, ...rest} = body;
-      serializedBody = JSON.stringify(['pokePart', rest]);
     };
 
     const addPatch = async (patchToVersion: PatchToVersion) => {
@@ -257,8 +237,7 @@ export class ClientHandler {
       if (cmpVersions(toVersion, this.#baseVersion) <= 0) {
         return;
       }
-      let target = await ensureBody();
-      let addedSerializedRow = false;
+      const target = await ensureBody();
 
       const {type, op} = patch;
       switch (type) {
@@ -311,36 +290,18 @@ export class ClientHandler {
             }
           } else {
             const rowPatch = makeRowPatch(patch);
-            const serialized = JSON.stringify(rowPatch);
-            const nextRowsLength =
-              serializedRowsLength +
-              (serializedRows.length ? 1 : 0) +
-              serialized.length;
-            if (
-              partCount > 0 &&
-              serializedLength(nextRowsLength) > POKE_PART_FLUSH_THRESHOLD_CHARS
-            ) {
-              await flushBody();
-              target = await ensureBody();
-            }
             (target.rowsPatch ??= []).push(rowPatch);
-            serializedRowsLength +=
-              (serializedRows.length ? 1 : 0) + serialized.length;
-            serializedRows.push(serialized);
-            addedSerializedRow = true;
+            serializedRowsLength += JSON.stringify(rowPatch).length;
           }
           break;
         default:
           unreachable(patch);
       }
 
-      if (!addedSerializedRow) {
-        updateSerializedBody(target);
-      }
       partCount++;
       if (
-        serializedLength() >= POKE_PART_FLUSH_THRESHOLD_CHARS ||
-        (!addedSerializedRow && partCount >= PART_COUNT_FLUSH_THRESHOLD)
+        serializedRowsLength >= POKE_PART_FLUSH_THRESHOLD_CHARS ||
+        partCount >= PART_COUNT_FLUSH_THRESHOLD
       ) {
         await flushBody();
       }

--- a/packages/zero-cache/src/services/view-syncer/client-handler.ts
+++ b/packages/zero-cache/src/services/view-syncer/client-handler.ts
@@ -29,6 +29,7 @@ import {
   getOrCreateCounter,
   getOrCreateLatencyHistogram,
 } from '../../observability/metrics.ts';
+import {setSerializedDownstream} from '../../types/downstream.ts';
 import {
   getLogLevel,
   wrapWithProtocolError,
@@ -108,10 +109,193 @@ export function startPoke(
 // Keep poke parts small enough that clients observe progress while syncing.
 // A single patch can exceed this limit because rows are atomic at the protocol
 // level, but it will be sent in a part by itself.
-export const POKE_PART_FLUSH_THRESHOLD_BYTES = 1024 * 1024;
+export const POKE_PART_FLUSH_THRESHOLD_CHARS = 1024 * 1024;
 
-function jsonByteLength(value: unknown): number {
-  return Buffer.byteLength(JSON.stringify(value));
+type QueryPatchOp = NonNullable<PokePartBody['gotQueriesPatch']>[number];
+
+type SerializedRecordValue = {
+  readonly key: string;
+  value: string;
+};
+
+type SerializedDesiredQueries = {
+  readonly key: string;
+  readonly patches: string[];
+};
+
+class PokePartBuilder {
+  readonly #body: PokePartBody;
+  readonly #pokeID: string;
+  readonly #lastMutationIDChanges = new Map<string, SerializedRecordValue>();
+  readonly #desiredQueriesPatches = new Map<string, SerializedDesiredQueries>();
+  readonly #gotQueriesPatch: string[] = [];
+  readonly #rowsPatch: string[] = [];
+  readonly #mutationsPatch: string[] = [];
+  #length: number;
+  #patchCount = 0;
+
+  constructor(pokeID: string) {
+    this.#body = {pokeID};
+    this.#pokeID = JSON.stringify(pokeID);
+    this.#length = `["pokePart",{"pokeID":${this.#pokeID}}]`.length;
+  }
+
+  get length(): number {
+    return this.#length;
+  }
+
+  trySetLastMutationID(
+    clientID: string,
+    lastMutationID: number,
+    maxChars: number,
+  ): boolean {
+    const value = JSON.stringify(lastMutationID);
+    const existing = this.#lastMutationIDChanges.get(clientID);
+    const key = existing?.key ?? JSON.stringify(clientID);
+    const additionalChars = existing
+      ? value.length - existing.value.length
+      : this.#lastMutationIDChanges.size === 0
+        ? `,"lastMutationIDChanges":{${key}:${value}}`.length
+        : `,${key}:${value}`.length;
+    return this.#tryAdd(additionalChars, maxChars, () => {
+      this.#lastMutationIDChanges.set(clientID, {key, value});
+      (this.#body.lastMutationIDChanges ??= {})[clientID] = lastMutationID;
+    });
+  }
+
+  tryAddDesiredQueryPatch(
+    clientID: string,
+    patch: QueryPatchOp,
+    serialized: string,
+    maxChars: number,
+  ): boolean {
+    const existing = this.#desiredQueriesPatches.get(clientID);
+    const key = existing?.key ?? JSON.stringify(clientID);
+    const additionalChars = existing
+      ? `,${serialized}`.length
+      : this.#desiredQueriesPatches.size === 0
+        ? `,"desiredQueriesPatches":{${key}:[${serialized}]}`.length
+        : `,${key}:[${serialized}]`.length;
+    return this.#tryAdd(additionalChars, maxChars, () => {
+      if (existing) {
+        existing.patches.push(serialized);
+      } else {
+        this.#desiredQueriesPatches.set(clientID, {
+          key,
+          patches: [serialized],
+        });
+      }
+      ((this.#body.desiredQueriesPatches ??= {})[clientID] ??= []).push(patch);
+    });
+  }
+
+  tryAddGotQueryPatch(
+    patch: QueryPatchOp,
+    serialized: string,
+    maxChars: number,
+  ): boolean {
+    return this.#tryAddArrayItem(
+      'gotQueriesPatch',
+      this.#gotQueriesPatch,
+      serialized,
+      maxChars,
+      () => (this.#body.gotQueriesPatch ??= []).push(patch),
+    );
+  }
+
+  tryAddRowPatch(
+    patch: RowPatchOp,
+    serialized: string,
+    maxChars: number,
+  ): boolean {
+    return this.#tryAddArrayItem(
+      'rowsPatch',
+      this.#rowsPatch,
+      serialized,
+      maxChars,
+      () => (this.#body.rowsPatch ??= []).push(patch),
+    );
+  }
+
+  tryAddMutationPatch(
+    patch: MutationPatch,
+    serialized: string,
+    maxChars: number,
+  ): boolean {
+    return this.#tryAddArrayItem(
+      'mutationsPatch',
+      this.#mutationsPatch,
+      serialized,
+      maxChars,
+      () => (this.#body.mutationsPatch ??= []).push(patch),
+    );
+  }
+
+  message(): Downstream {
+    const serialized = this.#serialize();
+    assert(
+      serialized.length === this.#length,
+      'serialized poke part length did not match the measured length',
+    );
+    return setSerializedDownstream(['pokePart', this.#body], serialized);
+  }
+
+  #tryAddArrayItem(
+    field: string,
+    items: string[],
+    serialized: string,
+    maxChars: number,
+    addToBody: () => void,
+  ): boolean {
+    const additionalChars =
+      items.length === 0
+        ? `,${JSON.stringify(field)}:[${serialized}]`.length
+        : `,${serialized}`.length;
+    return this.#tryAdd(additionalChars, maxChars, () => {
+      items.push(serialized);
+      addToBody();
+    });
+  }
+
+  #tryAdd(additionalChars: number, maxChars: number, add: () => void): boolean {
+    if (this.#patchCount > 0 && this.#length + additionalChars > maxChars) {
+      return false;
+    }
+    add();
+    this.#length += additionalChars;
+    this.#patchCount++;
+    return true;
+  }
+
+  #serialize(): string {
+    const fields = [`"pokeID":${this.#pokeID}`];
+    if (this.#lastMutationIDChanges.size > 0) {
+      fields.push(
+        `"lastMutationIDChanges":{${Array.from(
+          this.#lastMutationIDChanges.values(),
+          ({key, value}) => `${key}:${value}`,
+        ).join(',')}}`,
+      );
+    }
+    if (this.#desiredQueriesPatches.size > 0) {
+      fields.push(
+        `"desiredQueriesPatches":{${Array.from(
+          this.#desiredQueriesPatches.values(),
+          ({key, patches}) => `${key}:[${patches.join(',')}]`,
+        ).join(',')}}`,
+      );
+    }
+    this.#pushArrayField(fields, 'gotQueriesPatch', this.#gotQueriesPatch);
+    this.#pushArrayField(fields, 'rowsPatch', this.#rowsPatch);
+    this.#pushArrayField(fields, 'mutationsPatch', this.#mutationsPatch);
+    return `["pokePart",{${fields.join(',')}}]`;
+  }
+
+  #pushArrayField(fields: string[], field: string, items: string[]): void {
+    if (items.length > 0) {
+      fields.push(`${JSON.stringify(field)}:[${items.join(',')}]`);
+    }
+  }
 }
 
 /**
@@ -212,35 +396,30 @@ export class ClientHandler {
     const pokeStart: PokeStartBody = {pokeID, baseCookie};
 
     let pokeStarted = false;
-    let body: PokePartBody | undefined;
-    const emptyPartBytes = jsonByteLength(['pokePart', {pokeID}]);
-    let partBytes = emptyPartBytes;
-    const ensureBody = async () => {
+    let part: PokePartBuilder | undefined;
+    const ensurePart = async () => {
       if (!pokeStarted) {
         await this.#push(['pokeStart', pokeStart]);
         pokeStarted = true;
       }
-      return (body ??= {pokeID});
+      return (part ??= new PokePartBuilder(pokeID));
     };
-    const flushBody = async () => {
-      if (body) {
-        await this.#push(['pokePart', body]);
-        body = undefined;
-        partBytes = emptyPartBytes;
+    const flushPart = async () => {
+      if (part) {
+        await this.#push(part.message());
+        part = undefined;
       }
     };
 
-    const addToBody = async (
-      patchBytes: number,
-      add: (body: PokePartBody) => void,
-    ) => {
-      if (body && partBytes + patchBytes > POKE_PART_FLUSH_THRESHOLD_BYTES) {
-        await flushBody();
+    const addToPart = async (add: (part: PokePartBuilder) => boolean) => {
+      let target = await ensurePart();
+      if (!add(target)) {
+        await flushPart();
+        target = await ensurePart();
+        assert(add(target), 'failed to add patch to an empty poke part');
       }
-      add(await ensureBody());
-      partBytes += patchBytes;
-      if (partBytes >= POKE_PART_FLUSH_THRESHOLD_BYTES) {
-        await flushBody();
+      if (target.length >= POKE_PART_FLUSH_THRESHOLD_CHARS) {
+        await flushPart();
       }
     };
 
@@ -253,29 +432,36 @@ export class ClientHandler {
       switch (type) {
         case 'query': {
           const queryPatch = {op, hash: patch.id};
-          const contribution = patch.clientID
-            ? {desiredQueriesPatches: {[patch.clientID]: [queryPatch]}}
-            : {gotQueriesPatch: [queryPatch]};
-          await addToBody(jsonByteLength(contribution), body => {
-            const patches = patch.clientID
-              ? ((body.desiredQueriesPatches ??= {})[patch.clientID] ??= [])
-              : (body.gotQueriesPatch ??= []);
-            patches.push(queryPatch);
-          });
+          const serialized = JSON.stringify(queryPatch);
+          await addToPart(part =>
+            patch.clientID
+              ? part.tryAddDesiredQueryPatch(
+                  patch.clientID,
+                  queryPatch,
+                  serialized,
+                  POKE_PART_FLUSH_THRESHOLD_CHARS,
+                )
+              : part.tryAddGotQueryPatch(
+                  queryPatch,
+                  serialized,
+                  POKE_PART_FLUSH_THRESHOLD_CHARS,
+                ),
+          );
           break;
         }
         case 'row':
           if (patch.id.table === this.#zeroClientsTable) {
             const lmidChanges: Record<string, number> = {};
             this.#updateLMIDs(lmidChanges, patch);
-            if (Object.keys(lmidChanges).length > 0) {
-              await addToBody(
-                jsonByteLength({lastMutationIDChanges: lmidChanges}),
-                body =>
-                  Object.assign(
-                    (body.lastMutationIDChanges ??= {}),
-                    lmidChanges,
-                  ),
+            for (const [clientID, lastMutationID] of Object.entries(
+              lmidChanges,
+            )) {
+              await addToPart(part =>
+                part.trySetLastMutationID(
+                  clientID,
+                  lastMutationID,
+                  POKE_PART_FLUSH_THRESHOLD_CHARS,
+                ),
               );
             }
           } else if (patch.id.table === this.#zeroMutationsTable) {
@@ -315,14 +501,23 @@ export class ClientHandler {
                 },
               };
             }
-            await addToBody(
-              jsonByteLength({mutationsPatch: [mutationPatch]}),
-              body => (body.mutationsPatch ??= []).push(mutationPatch),
+            const serialized = JSON.stringify(mutationPatch);
+            await addToPart(part =>
+              part.tryAddMutationPatch(
+                mutationPatch,
+                serialized,
+                POKE_PART_FLUSH_THRESHOLD_CHARS,
+              ),
             );
           } else {
             const rowPatch = makeRowPatch(patch);
-            await addToBody(jsonByteLength({rowsPatch: [rowPatch]}), body =>
-              (body.rowsPatch ??= []).push(rowPatch),
+            const serialized = JSON.stringify(rowPatch);
+            await addToPart(part =>
+              part.tryAddRowPatch(
+                rowPatch,
+                serialized,
+                POKE_PART_FLUSH_THRESHOLD_CHARS,
+              ),
             );
           }
           break;
@@ -367,7 +562,7 @@ export class ClientHandler {
               `not greater than baseVersion ${this.#baseVersion}`,
           );
         }
-        await flushBody();
+        await flushPart();
         await this.#push(['pokeEnd', {pokeID, cookie}]);
         this.#baseVersion = finalVersion;
         this.#everPoked = true;

--- a/packages/zero-cache/src/services/view-syncer/client-handler.ts
+++ b/packages/zero-cache/src/services/view-syncer/client-handler.ts
@@ -18,6 +18,7 @@ import {
 } from '../../../../zero-protocol/src/error.ts';
 import type {InspectDownBody} from '../../../../zero-protocol/src/inspect-down.ts';
 import {mutationResultSchema} from '../../../../zero-protocol/src/mutation.ts';
+import type {MutationPatch} from '../../../../zero-protocol/src/mutations-patch.ts';
 import type {
   PokePartBody,
   PokeStartBody,
@@ -104,9 +105,14 @@ export function startPoke(
   };
 }
 
-// Semi-arbitrary threshold at which poke body parts are flushed.
-// When row size is being computed, that should be used as a threshold instead.
-const PART_COUNT_FLUSH_THRESHOLD = 100;
+// Keep poke parts small enough that clients observe progress while syncing.
+// A single patch can exceed this limit because rows are atomic at the protocol
+// level, but it will be sent in a part by itself.
+export const POKE_PART_FLUSH_THRESHOLD_BYTES = 1024 * 1024;
+
+function jsonByteLength(value: unknown): number {
+  return Buffer.byteLength(JSON.stringify(value));
+}
 
 /**
  * Handles a single `ViewSyncer` connection.
@@ -207,7 +213,8 @@ export class ClientHandler {
 
     let pokeStarted = false;
     let body: PokePartBody | undefined;
-    let partCount = 0;
+    const emptyPartBytes = jsonByteLength(['pokePart', {pokeID}]);
+    let partBytes = emptyPartBytes;
     const ensureBody = async () => {
       if (!pokeStarted) {
         await this.#push(['pokeStart', pokeStart]);
@@ -219,7 +226,21 @@ export class ClientHandler {
       if (body) {
         await this.#push(['pokePart', body]);
         body = undefined;
-        partCount = 0;
+        partBytes = emptyPartBytes;
+      }
+    };
+
+    const addToBody = async (
+      patchBytes: number,
+      add: (body: PokePartBody) => void,
+    ) => {
+      if (body && partBytes + patchBytes > POKE_PART_FLUSH_THRESHOLD_BYTES) {
+        await flushBody();
+      }
+      add(await ensureBody());
+      partBytes += patchBytes;
+      if (partBytes >= POKE_PART_FLUSH_THRESHOLD_BYTES) {
+        await flushBody();
       }
     };
 
@@ -228,33 +249,44 @@ export class ClientHandler {
       if (cmpVersions(toVersion, this.#baseVersion) <= 0) {
         return;
       }
-      const body = await ensureBody();
-
       const {type, op} = patch;
       switch (type) {
         case 'query': {
-          const patches = patch.clientID
-            ? ((body.desiredQueriesPatches ??= {})[patch.clientID] ??= [])
-            : (body.gotQueriesPatch ??= []);
-          if (op === 'put') {
-            patches.push({op, hash: patch.id});
-          } else {
-            patches.push({op, hash: patch.id});
-          }
+          const queryPatch = {op, hash: patch.id};
+          const contribution = patch.clientID
+            ? {desiredQueriesPatches: {[patch.clientID]: [queryPatch]}}
+            : {gotQueriesPatch: [queryPatch]};
+          await addToBody(jsonByteLength(contribution), body => {
+            const patches = patch.clientID
+              ? ((body.desiredQueriesPatches ??= {})[patch.clientID] ??= [])
+              : (body.gotQueriesPatch ??= []);
+            patches.push(queryPatch);
+          });
           break;
         }
         case 'row':
           if (patch.id.table === this.#zeroClientsTable) {
-            this.#updateLMIDs((body.lastMutationIDChanges ??= {}), patch);
+            const lmidChanges: Record<string, number> = {};
+            this.#updateLMIDs(lmidChanges, patch);
+            if (Object.keys(lmidChanges).length > 0) {
+              await addToBody(
+                jsonByteLength({lastMutationIDChanges: lmidChanges}),
+                body =>
+                  Object.assign(
+                    (body.lastMutationIDChanges ??= {}),
+                    lmidChanges,
+                  ),
+              );
+            }
           } else if (patch.id.table === this.#zeroMutationsTable) {
-            const patches = (body.mutationsPatch ??= []);
+            let mutationPatch: MutationPatch;
             if (op === 'put') {
               const row = v.parse(
                 ensureSafeJSON(patch.contents),
                 mutationRowSchema,
                 'passthrough',
               );
-              patches.push({
+              mutationPatch = {
                 op: 'put',
                 mutation: {
                   id: {
@@ -263,7 +295,7 @@ export class ClientHandler {
                   },
                   result: row.result,
                 },
-              });
+              };
             } else {
               const {clientID, mutationID} = patch.id.rowKey;
               assert(
@@ -275,24 +307,27 @@ export class ClientHandler {
                 !Number.isNaN(id) && Number.isFinite(id) && id >= 0,
                 'mutation id must be a finite number',
               );
-              patches.push({
+              mutationPatch = {
                 op: 'del',
                 id: {
                   clientID,
                   id,
                 },
-              });
+              };
             }
+            await addToBody(
+              jsonByteLength({mutationsPatch: [mutationPatch]}),
+              body => (body.mutationsPatch ??= []).push(mutationPatch),
+            );
           } else {
-            (body.rowsPatch ??= []).push(makeRowPatch(patch));
+            const rowPatch = makeRowPatch(patch);
+            await addToBody(jsonByteLength({rowsPatch: [rowPatch]}), body =>
+              (body.rowsPatch ??= []).push(rowPatch),
+            );
           }
           break;
         default:
           unreachable(patch);
-      }
-
-      if (++partCount >= PART_COUNT_FLUSH_THRESHOLD) {
-        await flushBody();
       }
     };
 

--- a/packages/zero-cache/src/services/view-syncer/client-handler.ts
+++ b/packages/zero-cache/src/services/view-syncer/client-handler.ts
@@ -28,7 +28,7 @@ import {
   getOrCreateCounter,
   getOrCreateLatencyHistogram,
 } from '../../observability/metrics.ts';
-import {setSerializedDownstream} from '../../types/downstream.ts';
+import type {ViewSyncerDownstream} from '../../types/downstream.ts';
 import {
   getLogLevel,
   wrapWithProtocolError,
@@ -121,7 +121,7 @@ export class ClientHandler {
   readonly #zeroClientsTable: string;
   readonly #zeroMutationsTable: string;
   readonly #lc: LogContext;
-  readonly #downstream: Subscription<Downstream>;
+  readonly #downstream: Subscription<ViewSyncerDownstream>;
   #baseVersion: NullableCVRVersion;
   // We will send a poke on connect even if the client is already caught up, so that it can learn its
   // got-queries state has been reconciled with the server. After that, we will only send a poke if
@@ -153,7 +153,7 @@ export class ClientHandler {
     wsID: string,
     shard: ShardID,
     baseCookie: string | null,
-    downstream: Subscription<Downstream>,
+    downstream: Subscription<ViewSyncerDownstream>,
   ) {
     lc.debug?.('new client handler');
     this.#clientGroupID = clientGroupID;
@@ -170,8 +170,8 @@ export class ClientHandler {
     return this.#baseVersion;
   }
 
-  async #push(msg: Downstream): Promise<void> {
-    const {result} = this.#downstream.push(msg);
+  async #push(msg: Downstream, serialized?: string | undefined): Promise<void> {
+    const {result} = this.#downstream.push({message: msg, serialized});
     await result;
   }
 
@@ -238,9 +238,7 @@ export class ClientHandler {
           serialized.length === serializedLength(),
           'serialized poke part length did not match the measured length',
         );
-        await this.#push(
-          setSerializedDownstream(['pokePart', body], serialized),
-        );
+        await this.#push(['pokePart', body], serialized);
         body = undefined;
         partCount = 0;
         serializedBody = emptySerializedBody;
@@ -422,7 +420,10 @@ export class ClientHandler {
 
   sendInspectResponse(lc: LogContext, response: InspectDownBody): void {
     lc.debug?.('sending inspect response', response);
-    this.#downstream.push(['inspect', response]);
+    this.#downstream.push({
+      message: ['inspect', response],
+      serialized: undefined,
+    });
   }
 
   #updateLMIDs(lmids: Record<string, number>, patch: RowPatch) {

--- a/packages/zero-cache/src/services/view-syncer/client-handler.ts
+++ b/packages/zero-cache/src/services/view-syncer/client-handler.ts
@@ -18,7 +18,6 @@ import {
 } from '../../../../zero-protocol/src/error.ts';
 import type {InspectDownBody} from '../../../../zero-protocol/src/inspect-down.ts';
 import {mutationResultSchema} from '../../../../zero-protocol/src/mutation.ts';
-import type {MutationPatch} from '../../../../zero-protocol/src/mutations-patch.ts';
 import type {
   PokePartBody,
   PokeStartBody,
@@ -110,193 +109,7 @@ export function startPoke(
 // A single patch can exceed this limit because rows are atomic at the protocol
 // level, but it will be sent in a part by itself.
 export const POKE_PART_FLUSH_THRESHOLD_CHARS = 1024 * 1024;
-
-type QueryPatchOp = NonNullable<PokePartBody['gotQueriesPatch']>[number];
-
-type SerializedRecordValue = {
-  readonly key: string;
-  value: string;
-};
-
-type SerializedDesiredQueries = {
-  readonly key: string;
-  readonly patches: string[];
-};
-
-class PokePartBuilder {
-  readonly #body: PokePartBody;
-  readonly #pokeID: string;
-  readonly #lastMutationIDChanges = new Map<string, SerializedRecordValue>();
-  readonly #desiredQueriesPatches = new Map<string, SerializedDesiredQueries>();
-  readonly #gotQueriesPatch: string[] = [];
-  readonly #rowsPatch: string[] = [];
-  readonly #mutationsPatch: string[] = [];
-  #length: number;
-  #patchCount = 0;
-
-  constructor(pokeID: string) {
-    this.#body = {pokeID};
-    this.#pokeID = JSON.stringify(pokeID);
-    this.#length = `["pokePart",{"pokeID":${this.#pokeID}}]`.length;
-  }
-
-  get length(): number {
-    return this.#length;
-  }
-
-  trySetLastMutationID(
-    clientID: string,
-    lastMutationID: number,
-    maxChars: number,
-  ): boolean {
-    const value = JSON.stringify(lastMutationID);
-    const existing = this.#lastMutationIDChanges.get(clientID);
-    const key = existing?.key ?? JSON.stringify(clientID);
-    const additionalChars = existing
-      ? value.length - existing.value.length
-      : this.#lastMutationIDChanges.size === 0
-        ? `,"lastMutationIDChanges":{${key}:${value}}`.length
-        : `,${key}:${value}`.length;
-    return this.#tryAdd(additionalChars, maxChars, () => {
-      this.#lastMutationIDChanges.set(clientID, {key, value});
-      (this.#body.lastMutationIDChanges ??= {})[clientID] = lastMutationID;
-    });
-  }
-
-  tryAddDesiredQueryPatch(
-    clientID: string,
-    patch: QueryPatchOp,
-    serialized: string,
-    maxChars: number,
-  ): boolean {
-    const existing = this.#desiredQueriesPatches.get(clientID);
-    const key = existing?.key ?? JSON.stringify(clientID);
-    const additionalChars = existing
-      ? `,${serialized}`.length
-      : this.#desiredQueriesPatches.size === 0
-        ? `,"desiredQueriesPatches":{${key}:[${serialized}]}`.length
-        : `,${key}:[${serialized}]`.length;
-    return this.#tryAdd(additionalChars, maxChars, () => {
-      if (existing) {
-        existing.patches.push(serialized);
-      } else {
-        this.#desiredQueriesPatches.set(clientID, {
-          key,
-          patches: [serialized],
-        });
-      }
-      ((this.#body.desiredQueriesPatches ??= {})[clientID] ??= []).push(patch);
-    });
-  }
-
-  tryAddGotQueryPatch(
-    patch: QueryPatchOp,
-    serialized: string,
-    maxChars: number,
-  ): boolean {
-    return this.#tryAddArrayItem(
-      'gotQueriesPatch',
-      this.#gotQueriesPatch,
-      serialized,
-      maxChars,
-      () => (this.#body.gotQueriesPatch ??= []).push(patch),
-    );
-  }
-
-  tryAddRowPatch(
-    patch: RowPatchOp,
-    serialized: string,
-    maxChars: number,
-  ): boolean {
-    return this.#tryAddArrayItem(
-      'rowsPatch',
-      this.#rowsPatch,
-      serialized,
-      maxChars,
-      () => (this.#body.rowsPatch ??= []).push(patch),
-    );
-  }
-
-  tryAddMutationPatch(
-    patch: MutationPatch,
-    serialized: string,
-    maxChars: number,
-  ): boolean {
-    return this.#tryAddArrayItem(
-      'mutationsPatch',
-      this.#mutationsPatch,
-      serialized,
-      maxChars,
-      () => (this.#body.mutationsPatch ??= []).push(patch),
-    );
-  }
-
-  message(): Downstream {
-    const serialized = this.#serialize();
-    assert(
-      serialized.length === this.#length,
-      'serialized poke part length did not match the measured length',
-    );
-    return setSerializedDownstream(['pokePart', this.#body], serialized);
-  }
-
-  #tryAddArrayItem(
-    field: string,
-    items: string[],
-    serialized: string,
-    maxChars: number,
-    addToBody: () => void,
-  ): boolean {
-    const additionalChars =
-      items.length === 0
-        ? `,${JSON.stringify(field)}:[${serialized}]`.length
-        : `,${serialized}`.length;
-    return this.#tryAdd(additionalChars, maxChars, () => {
-      items.push(serialized);
-      addToBody();
-    });
-  }
-
-  #tryAdd(additionalChars: number, maxChars: number, add: () => void): boolean {
-    if (this.#patchCount > 0 && this.#length + additionalChars > maxChars) {
-      return false;
-    }
-    add();
-    this.#length += additionalChars;
-    this.#patchCount++;
-    return true;
-  }
-
-  #serialize(): string {
-    const fields = [`"pokeID":${this.#pokeID}`];
-    if (this.#lastMutationIDChanges.size > 0) {
-      fields.push(
-        `"lastMutationIDChanges":{${Array.from(
-          this.#lastMutationIDChanges.values(),
-          ({key, value}) => `${key}:${value}`,
-        ).join(',')}}`,
-      );
-    }
-    if (this.#desiredQueriesPatches.size > 0) {
-      fields.push(
-        `"desiredQueriesPatches":{${Array.from(
-          this.#desiredQueriesPatches.values(),
-          ({key, patches}) => `${key}:[${patches.join(',')}]`,
-        ).join(',')}}`,
-      );
-    }
-    this.#pushArrayField(fields, 'gotQueriesPatch', this.#gotQueriesPatch);
-    this.#pushArrayField(fields, 'rowsPatch', this.#rowsPatch);
-    this.#pushArrayField(fields, 'mutationsPatch', this.#mutationsPatch);
-    return `["pokePart",{${fields.join(',')}}]`;
-  }
-
-  #pushArrayField(fields: string[], field: string, items: string[]): void {
-    if (items.length > 0) {
-      fields.push(`${JSON.stringify(field)}:[${items.join(',')}]`);
-    }
-  }
-}
+const PART_COUNT_FLUSH_THRESHOLD = 100;
 
 /**
  * Handles a single `ViewSyncer` connection.
@@ -396,31 +209,49 @@ export class ClientHandler {
     const pokeStart: PokeStartBody = {pokeID, baseCookie};
 
     let pokeStarted = false;
-    let part: PokePartBuilder | undefined;
-    const ensurePart = async () => {
+    let body: PokePartBody | undefined;
+    let partCount = 0;
+    const emptySerializedBody = JSON.stringify(['pokePart', {pokeID}]);
+    let serializedBody = emptySerializedBody;
+    const serializedRows: string[] = [];
+    let serializedRowsLength = 0;
+
+    const ensureBody = async () => {
       if (!pokeStarted) {
         await this.#push(['pokeStart', pokeStart]);
         pokeStarted = true;
       }
-      return (part ??= new PokePartBuilder(pokeID));
+      return (body ??= {pokeID});
     };
-    const flushPart = async () => {
-      if (part) {
-        await this.#push(part.message());
-        part = undefined;
+
+    const serializedLength = (rowsLength = serializedRowsLength) =>
+      rowsLength
+        ? serializedBody.length - 2 + ',"rowsPatch":[]}]'.length + rowsLength
+        : serializedBody.length;
+
+    const flushBody = async () => {
+      if (body) {
+        const serialized = serializedRows.length
+          ? `${serializedBody.slice(0, -2)},"rowsPatch":[${serializedRows.join(',')}]}]`
+          : serializedBody;
+        assert(
+          serialized.length === serializedLength(),
+          'serialized poke part length did not match the measured length',
+        );
+        await this.#push(
+          setSerializedDownstream(['pokePart', body], serialized),
+        );
+        body = undefined;
+        partCount = 0;
+        serializedBody = emptySerializedBody;
+        serializedRows.length = 0;
+        serializedRowsLength = 0;
       }
     };
 
-    const addToPart = async (add: (part: PokePartBuilder) => boolean) => {
-      let target = await ensurePart();
-      if (!add(target)) {
-        await flushPart();
-        target = await ensurePart();
-        assert(add(target), 'failed to add patch to an empty poke part');
-      }
-      if (target.length >= POKE_PART_FLUSH_THRESHOLD_CHARS) {
-        await flushPart();
-      }
+    const updateSerializedBody = (body: PokePartBody) => {
+      const {rowsPatch: _, ...rest} = body;
+      serializedBody = JSON.stringify(['pokePart', rest]);
     };
 
     const addPatch = async (patchToVersion: PatchToVersion) => {
@@ -428,51 +259,30 @@ export class ClientHandler {
       if (cmpVersions(toVersion, this.#baseVersion) <= 0) {
         return;
       }
+      let target = await ensureBody();
+      let addedSerializedRow = false;
+
       const {type, op} = patch;
       switch (type) {
         case 'query': {
-          const queryPatch = {op, hash: patch.id};
-          const serialized = JSON.stringify(queryPatch);
-          await addToPart(part =>
-            patch.clientID
-              ? part.tryAddDesiredQueryPatch(
-                  patch.clientID,
-                  queryPatch,
-                  serialized,
-                  POKE_PART_FLUSH_THRESHOLD_CHARS,
-                )
-              : part.tryAddGotQueryPatch(
-                  queryPatch,
-                  serialized,
-                  POKE_PART_FLUSH_THRESHOLD_CHARS,
-                ),
-          );
+          const patches = patch.clientID
+            ? ((target.desiredQueriesPatches ??= {})[patch.clientID] ??= [])
+            : (target.gotQueriesPatch ??= []);
+          patches.push({op, hash: patch.id});
           break;
         }
         case 'row':
           if (patch.id.table === this.#zeroClientsTable) {
-            const lmidChanges: Record<string, number> = {};
-            this.#updateLMIDs(lmidChanges, patch);
-            for (const [clientID, lastMutationID] of Object.entries(
-              lmidChanges,
-            )) {
-              await addToPart(part =>
-                part.trySetLastMutationID(
-                  clientID,
-                  lastMutationID,
-                  POKE_PART_FLUSH_THRESHOLD_CHARS,
-                ),
-              );
-            }
+            this.#updateLMIDs((target.lastMutationIDChanges ??= {}), patch);
           } else if (patch.id.table === this.#zeroMutationsTable) {
-            let mutationPatch: MutationPatch;
+            const patches = (target.mutationsPatch ??= []);
             if (op === 'put') {
               const row = v.parse(
                 ensureSafeJSON(patch.contents),
                 mutationRowSchema,
                 'passthrough',
               );
-              mutationPatch = {
+              patches.push({
                 op: 'put',
                 mutation: {
                   id: {
@@ -481,7 +291,7 @@ export class ClientHandler {
                   },
                   result: row.result,
                 },
-              };
+              });
             } else {
               const {clientID, mutationID} = patch.id.rowKey;
               assert(
@@ -493,36 +303,48 @@ export class ClientHandler {
                 !Number.isNaN(id) && Number.isFinite(id) && id >= 0,
                 'mutation id must be a finite number',
               );
-              mutationPatch = {
+              patches.push({
                 op: 'del',
                 id: {
                   clientID,
                   id,
                 },
-              };
+              });
             }
-            const serialized = JSON.stringify(mutationPatch);
-            await addToPart(part =>
-              part.tryAddMutationPatch(
-                mutationPatch,
-                serialized,
-                POKE_PART_FLUSH_THRESHOLD_CHARS,
-              ),
-            );
           } else {
             const rowPatch = makeRowPatch(patch);
             const serialized = JSON.stringify(rowPatch);
-            await addToPart(part =>
-              part.tryAddRowPatch(
-                rowPatch,
-                serialized,
-                POKE_PART_FLUSH_THRESHOLD_CHARS,
-              ),
-            );
+            const nextRowsLength =
+              serializedRowsLength +
+              (serializedRows.length ? 1 : 0) +
+              serialized.length;
+            if (
+              partCount > 0 &&
+              serializedLength(nextRowsLength) > POKE_PART_FLUSH_THRESHOLD_CHARS
+            ) {
+              await flushBody();
+              target = await ensureBody();
+            }
+            (target.rowsPatch ??= []).push(rowPatch);
+            serializedRowsLength +=
+              (serializedRows.length ? 1 : 0) + serialized.length;
+            serializedRows.push(serialized);
+            addedSerializedRow = true;
           }
           break;
         default:
           unreachable(patch);
+      }
+
+      if (!addedSerializedRow) {
+        updateSerializedBody(target);
+      }
+      partCount++;
+      if (
+        serializedLength() >= POKE_PART_FLUSH_THRESHOLD_CHARS ||
+        (!addedSerializedRow && partCount >= PART_COUNT_FLUSH_THRESHOLD)
+      ) {
+        await flushBody();
       }
     };
 
@@ -562,7 +384,7 @@ export class ClientHandler {
               `not greater than baseVersion ${this.#baseVersion}`,
           );
         }
-        await flushPart();
+        await flushBody();
         await this.#push(['pokeEnd', {pokeID, cookie}]);
         this.#baseVersion = finalVersion;
         this.#everPoked = true;

--- a/packages/zero-cache/src/services/view-syncer/view-syncer-inspect.pg.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer-inspect.pg.test.ts
@@ -17,6 +17,7 @@ import type {
 import type {InspectorDelegate} from '../../server/inspector-delegate.ts';
 import {type PgTest, test} from '../../test/db.ts';
 import type {DbFile} from '../../test/lite.ts';
+import type {ViewSyncerDownstream} from '../../types/downstream.ts';
 import type {PostgresDB} from '../../types/pg.ts';
 import type {Source} from '../../types/streams.ts';
 import type {Subscription} from '../../types/subscription.ts';
@@ -69,7 +70,7 @@ describe('view-syncer/service', () => {
     activeClients?: string[],
   ) => {
     queue: Queue<Downstream>;
-    source: Source<Downstream>;
+    source: Source<ViewSyncerDownstream>;
   };
 
   const SYNC_CONTEXT: SyncContext = {
@@ -689,7 +690,7 @@ describe('view-syncer/service', () => {
       activeClients?: string[],
     ) => {
       queue: Queue<Downstream>;
-      source: Source<Downstream>;
+      source: Source<ViewSyncerDownstream>;
     };
     let restrictiveDelegate: InspectorDelegate;
     let restrictiveClearMocks: () => void;

--- a/packages/zero-cache/src/services/view-syncer/view-syncer-test-util.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer-test-util.ts
@@ -42,6 +42,7 @@ import {CustomQueryTransformer} from '../../custom-queries/transform-query.ts';
 import {InspectorDelegate} from '../../server/inspector-delegate.ts';
 import type {TestDBs} from '../../test/db.ts';
 import {DbFile} from '../../test/lite.ts';
+import type {ViewSyncerDownstream} from '../../types/downstream.ts';
 import type {PostgresDB} from '../../types/pg.ts';
 import {upstreamSchema} from '../../types/shards.ts';
 import {id} from '../../types/sql.ts';
@@ -844,7 +845,7 @@ export async function setup(
     desiredQueriesPatch: UpQueriesPatch,
     clientSchema: ClientSchema | null = defaultClientSchema,
     activeClients?: string[],
-  ): {queue: Queue<Downstream>; source: Source<Downstream>} {
+  ): {queue: Queue<Downstream>; source: Source<ViewSyncerDownstream>} {
     const selector = {clientID: ctx.clientID, wsID: ctx.wsID};
     vs.connContextManager.registerConnection(
       selector,
@@ -883,8 +884,8 @@ export async function setup(
 
     void (async function () {
       try {
-        for await (const msg of source) {
-          queue.enqueue(msg);
+        for await (const {message} of source) {
+          queue.enqueue(message);
         }
       } catch (e) {
         queue.enqueueRejection(e);
@@ -1061,8 +1062,8 @@ export function restartViewSyncer(params: {
     const queue = new Queue<Downstream>();
     void (async function () {
       try {
-        for await (const msg of source) {
-          queue.enqueue(msg);
+        for await (const {message} of source) {
+          queue.enqueue(message);
         }
       } catch (e) {
         queue.enqueueRejection(e);

--- a/packages/zero-cache/src/services/view-syncer/view-syncer-ttl.pg.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer-ttl.pg.test.ts
@@ -8,6 +8,7 @@ import type {UpQueriesPatch} from '../../../../zero-protocol/src/queries-patch.t
 import type {InspectorDelegate} from '../../server/inspector-delegate.ts';
 import {type PgTest, test} from '../../test/db.ts';
 import type {DbFile} from '../../test/lite.ts';
+import type {ViewSyncerDownstream} from '../../types/downstream.ts';
 import type {PostgresDB} from '../../types/pg.ts';
 import type {Source} from '../../types/streams.ts';
 import type {Subscription} from '../../types/subscription.ts';
@@ -57,7 +58,7 @@ let connectWithQueueAndSource: (
   activeClients?: string[],
 ) => {
   queue: Queue<Downstream>;
-  source: Source<Downstream>;
+  source: Source<ViewSyncerDownstream>;
 };
 let setTimeoutFn: Mock<typeof setTimeout>;
 let inspectorDelegate: InspectorDelegate;

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg.test.ts
@@ -34,6 +34,7 @@ import type {
 import {StatementRunner} from '../../db/statements.ts';
 import {type PgTest, test} from '../../test/db.ts';
 import type {DbFile} from '../../test/lite.ts';
+import type {ViewSyncerDownstream} from '../../types/downstream.ts';
 import type {PostgresDB} from '../../types/pg.ts';
 import {cvrSchema} from '../../types/shards.ts';
 import type {Source} from '../../types/streams.ts';
@@ -126,7 +127,7 @@ describe('view-syncer/service', () => {
     activeClients?: string[],
   ) => {
     queue: Queue<Downstream>;
-    source: Source<Downstream>;
+    source: Source<ViewSyncerDownstream>;
   };
   let setTimeoutFn: Mock<typeof setTimeout>;
   let customQueryTransformer: CustomQueryTransformer | undefined;

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg.test.ts
@@ -1305,7 +1305,7 @@ describe('view-syncer/service', () => {
               "url": undefined,
             },
             "profileID": "p0000g00000003203",
-            "protocolVersion": 51,
+            "protocolVersion": 52,
             "queryContext": {
               "allowedUrlPatterns": [
                 URLPattern {},
@@ -1595,7 +1595,7 @@ describe('view-syncer/service', () => {
               "url": undefined,
             },
             "profileID": "p0000g00000003203",
-            "protocolVersion": 51,
+            "protocolVersion": 52,
             "queryContext": {
               "allowedUrlPatterns": [
                 URLPattern {},
@@ -2273,7 +2273,7 @@ describe('view-syncer/service', () => {
               "url": undefined,
             },
             "profileID": "p0000g00000003203",
-            "protocolVersion": 51,
+            "protocolVersion": 52,
             "queryContext": {
               "allowedUrlPatterns": [
                 URLPattern {},
@@ -2492,7 +2492,7 @@ describe('view-syncer/service', () => {
               "url": undefined,
             },
             "profileID": "p0000g00000003203",
-            "protocolVersion": 51,
+            "protocolVersion": 52,
             "queryContext": {
               "allowedUrlPatterns": [
                 URLPattern {},

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -25,7 +25,6 @@ import type {
 } from '../../../../zero-protocol/src/connect.ts';
 import type {ErroredQuery} from '../../../../zero-protocol/src/custom-queries.ts';
 import type {DeleteClientsMessage} from '../../../../zero-protocol/src/delete-clients.ts';
-import type {Downstream} from '../../../../zero-protocol/src/down.ts';
 import {ErrorKind} from '../../../../zero-protocol/src/error-kind.ts';
 import {ErrorOrigin} from '../../../../zero-protocol/src/error-origin.ts';
 import {
@@ -57,6 +56,7 @@ import {
   getOrCreateUpDownCounter,
 } from '../../observability/metrics.ts';
 import type {InspectorDelegate} from '../../server/inspector-delegate.ts';
+import type {ViewSyncerDownstream} from '../../types/downstream.ts';
 import {
   getLogLevel,
   ProtocolErrorWithLevel,
@@ -139,7 +139,7 @@ export interface ViewSyncer {
   initConnection(
     selector: ConnectionSelector,
     initConnectionMessage: InitConnectionMessage,
-  ): Source<Downstream>;
+  ): Source<ViewSyncerDownstream>;
 
   changeDesiredQueries(
     selector: ConnectionSelector,
@@ -953,7 +953,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
   initConnection(
     selector: ConnectionSelector,
     initConnectionMessage: InitConnectionMessage,
-  ): Source<Downstream> {
+  ): Source<ViewSyncerDownstream> {
     this.#lc.debug?.('viewSyncer.initConnection');
     return startSpan(tracer, 'vs.initConnection', () => {
       const connCtx =
@@ -964,7 +964,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
         .withContext('wsID', connCtx.wsID);
 
       // Setup the downstream connection.
-      const downstream = Subscription.create<Downstream>({
+      const downstream = Subscription.create<ViewSyncerDownstream>({
         cleanup: (_, err) => {
           err
             ? lc[getLogLevel(err)]?.(`client closed with error`, err)

--- a/packages/zero-cache/src/types/downstream.ts
+++ b/packages/zero-cache/src/types/downstream.ts
@@ -1,19 +1,6 @@
 import type {Downstream} from '../../../zero-protocol/src/down.ts';
 
-const serializedDownstreams = new WeakMap<object, string>();
-
-/**
- * Associates a downstream message with its already-computed JSON encoding.
- * The message remains structurally unchanged for in-process consumers.
- */
-export function setSerializedDownstream<T extends Downstream>(
-  message: T,
-  serialized: string,
-): T {
-  serializedDownstreams.set(message, serialized);
-  return message;
-}
-
-export function stringifyDownstream(message: Downstream): string {
-  return serializedDownstreams.get(message) ?? JSON.stringify(message);
-}
+export type ViewSyncerDownstream = {
+  readonly message: Downstream;
+  readonly serialized: string | undefined;
+};

--- a/packages/zero-cache/src/types/downstream.ts
+++ b/packages/zero-cache/src/types/downstream.ts
@@ -1,0 +1,19 @@
+import type {Downstream} from '../../../zero-protocol/src/down.ts';
+
+const serializedDownstreams = new WeakMap<object, string>();
+
+/**
+ * Associates a downstream message with its already-computed JSON encoding.
+ * The message remains structurally unchanged for in-process consumers.
+ */
+export function setSerializedDownstream<T extends Downstream>(
+  message: T,
+  serialized: string,
+): T {
+  serializedDownstreams.set(message, serialized);
+  return message;
+}
+
+export function stringifyDownstream(message: Downstream): string {
+  return serializedDownstreams.get(message) ?? JSON.stringify(message);
+}

--- a/packages/zero-cache/src/types/downstream.ts
+++ b/packages/zero-cache/src/types/downstream.ts
@@ -1,5 +1,10 @@
 import type {Downstream} from '../../../zero-protocol/src/down.ts';
 
+/**
+ * A logical view-syncer message and, when already available, its serialized
+ * wire representation. Keeping them together lets the connection reuse the
+ * view-syncer's serialization instead of stringifying large poke parts again.
+ */
 export type ViewSyncerDownstream = {
   readonly message: Downstream;
   readonly serialized: string | undefined;

--- a/packages/zero-cache/src/types/poke-chunk.test.ts
+++ b/packages/zero-cache/src/types/poke-chunk.test.ts
@@ -1,4 +1,5 @@
 import {describe, expect, test} from 'vitest';
+import {POKE_CHUNK_MESSAGE_TYPE} from '../../../zero-protocol/src/poke.ts';
 import {PokeChunkEncoder} from './poke-chunk.ts';
 
 describe('PokeChunkEncoder', () => {
@@ -56,7 +57,7 @@ describe('PokeChunkEncoder', () => {
     expect(chunkLengths).toHaveLength(11);
     expect(Math.max(...chunkLengths)).toBe(1024 * 1024);
     expect(chunkLengths.reduce((sum, length) => sum + length, 0)).toBe(
-      patch.length + 2,
+      patch.length + 2 + chunkLengths.length,
     );
   });
 
@@ -77,7 +78,8 @@ function joinAndDecode(chunks: Uint8Array[]): string {
   const decoder = new TextDecoder('utf-8', {fatal: true});
   const decoded: string[] = [];
   for (const chunk of chunks) {
-    decoded.push(decoder.decode(chunk, {stream: true}));
+    expect(chunk[0]).toBe(POKE_CHUNK_MESSAGE_TYPE);
+    decoded.push(decoder.decode(chunk.subarray(1), {stream: true}));
   }
   decoded.push(decoder.decode());
   return decoded.join('');

--- a/packages/zero-cache/src/types/poke-chunk.test.ts
+++ b/packages/zero-cache/src/types/poke-chunk.test.ts
@@ -1,0 +1,84 @@
+import {describe, expect, test} from 'vitest';
+import {PokeChunkEncoder} from './poke-chunk.ts';
+
+describe('PokeChunkEncoder', () => {
+  test('streams a JSON array in bounded chunks', async () => {
+    const encoder = new PokeChunkEncoder(16);
+    const chunks: Uint8Array[] = [];
+    const emit = (chunk: Uint8Array) => {
+      // The encoder deliberately reuses its output buffer.
+      chunks.push(chunk.slice());
+      return Promise.resolve();
+    };
+
+    await encoder.addPatch(JSON.stringify({a: '0123456789'}), emit);
+    await encoder.addPatch(JSON.stringify({b: 2}), emit);
+    await encoder.finish(emit);
+
+    expect(chunks.every(chunk => chunk.byteLength <= 16)).toBe(true);
+    expect(JSON.parse(joinAndDecode(chunks))).toEqual([
+      {a: '0123456789'},
+      {b: 2},
+    ]);
+  });
+
+  test('splits a single oversized patch without corrupting UTF-8', async () => {
+    const encoder = new PokeChunkEncoder(7);
+    const chunks: Uint8Array[] = [];
+    const emit = (chunk: Uint8Array) => {
+      chunks.push(chunk.slice());
+      return Promise.resolve();
+    };
+    const patch = {value: '🙂漢'.repeat(100)};
+
+    await encoder.addPatch(JSON.stringify(patch), emit);
+    await encoder.finish(emit);
+
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.every(chunk => chunk.byteLength <= 7)).toBe(true);
+    expect(JSON.parse(joinAndDecode(chunks))).toEqual([patch]);
+  });
+
+  test('bounds every frame for a ten-megabyte row', async () => {
+    const encoder = new PokeChunkEncoder();
+    const chunkLengths: number[] = [];
+    const patch = JSON.stringify({value: 'x'.repeat(10 * 1024 * 1024)});
+
+    await encoder.addPatch(patch, chunk => {
+      chunkLengths.push(chunk.byteLength);
+      return Promise.resolve();
+    });
+    await encoder.finish(chunk => {
+      chunkLengths.push(chunk.byteLength);
+      return Promise.resolve();
+    });
+
+    expect(chunkLengths).toHaveLength(11);
+    expect(Math.max(...chunkLengths)).toBe(1024 * 1024);
+    expect(chunkLengths.reduce((sum, length) => sum + length, 0)).toBe(
+      patch.length + 2,
+    );
+  });
+
+  test('encodes an empty poke as an empty array', async () => {
+    const encoder = new PokeChunkEncoder();
+    const chunks: Uint8Array[] = [];
+
+    await encoder.finish(chunk => {
+      chunks.push(chunk.slice());
+      return Promise.resolve();
+    });
+
+    expect(joinAndDecode(chunks)).toBe('[]');
+  });
+});
+
+function joinAndDecode(chunks: Uint8Array[]): string {
+  const decoder = new TextDecoder('utf-8', {fatal: true});
+  const decoded: string[] = [];
+  for (const chunk of chunks) {
+    decoded.push(decoder.decode(chunk, {stream: true}));
+  }
+  decoded.push(decoder.decode());
+  return decoded.join('');
+}

--- a/packages/zero-cache/src/types/poke-chunk.ts
+++ b/packages/zero-cache/src/types/poke-chunk.ts
@@ -1,0 +1,70 @@
+import {assert} from '../../../shared/src/asserts.ts';
+import type {PokeChunk} from '../../../zero-protocol/src/poke.ts';
+
+export const POKE_CHUNK_BYTES = 1024 * 1024;
+export const POKE_CHUNK_PROTOCOL_VERSION = 52;
+
+export type EmitPokeChunk = (chunk: PokeChunk) => Promise<void>;
+
+/**
+ * Streams a JSON array into fixed-size UTF-8 chunks.
+ *
+ * The emitter must finish consuming a chunk before its promise resolves. This
+ * lets the encoder reuse one fixed-size buffer for the entire poke. Memory is
+ * therefore O(chunk size), independent of poke size.
+ */
+export class PokeChunkEncoder {
+  readonly #encoder = new TextEncoder();
+  readonly #buffer: Uint8Array;
+  #bufferedBytes = 0;
+  #patchCount = 0;
+  #finished = false;
+
+  constructor(chunkBytes = POKE_CHUNK_BYTES) {
+    // Four bytes are required to encode the largest UTF-8 code point. A
+    // smaller buffer could make encodeInto() unable to make progress.
+    assert(chunkBytes >= 4, 'poke chunk size must be at least four bytes');
+    this.#buffer = new Uint8Array(chunkBytes);
+  }
+
+  async addPatch(serializedPatch: string, emit: EmitPokeChunk): Promise<void> {
+    assert(!this.#finished, 'cannot add a patch to a finished poke');
+    await this.#write(this.#patchCount++ === 0 ? '[' : ',', emit);
+    await this.#write(serializedPatch, emit);
+  }
+
+  async finish(emit: EmitPokeChunk): Promise<void> {
+    assert(!this.#finished, 'cannot finish a poke twice');
+    this.#finished = true;
+    await this.#write(this.#patchCount === 0 ? '[]' : ']', emit);
+    await this.#flush(emit);
+  }
+
+  cancel(): void {
+    this.#finished = true;
+    this.#bufferedBytes = 0;
+  }
+
+  async #write(value: string, emit: EmitPokeChunk): Promise<void> {
+    let read = 0;
+    while (read < value.length) {
+      const target = this.#buffer.subarray(this.#bufferedBytes);
+      const result = this.#encoder.encodeInto(value.slice(read), target);
+      read += result.read;
+      this.#bufferedBytes += result.written;
+
+      // A multi-byte code point may not fit in the remaining space.
+      if (this.#bufferedBytes === this.#buffer.length || result.read === 0) {
+        await this.#flush(emit);
+      }
+    }
+  }
+
+  async #flush(emit: EmitPokeChunk): Promise<void> {
+    if (this.#bufferedBytes === 0) {
+      return;
+    }
+    await emit(this.#buffer.subarray(0, this.#bufferedBytes));
+    this.#bufferedBytes = 0;
+  }
+}

--- a/packages/zero-cache/src/types/poke-chunk.ts
+++ b/packages/zero-cache/src/types/poke-chunk.ts
@@ -1,8 +1,10 @@
 import {assert} from '../../../shared/src/asserts.ts';
-import type {PokeChunk} from '../../../zero-protocol/src/poke.ts';
+import {
+  POKE_CHUNK_MESSAGE_TYPE,
+  type PokeChunk,
+} from '../../../zero-protocol/src/poke.ts';
 
 export const POKE_CHUNK_BYTES = 1024 * 1024;
-export const POKE_CHUNK_PROTOCOL_VERSION = 52;
 
 export type EmitPokeChunk = (chunk: PokeChunk) => Promise<void>;
 
@@ -16,15 +18,16 @@ export type EmitPokeChunk = (chunk: PokeChunk) => Promise<void>;
 export class PokeChunkEncoder {
   readonly #encoder = new TextEncoder();
   readonly #buffer: Uint8Array;
-  #bufferedBytes = 0;
+  #bufferedBytes = 1;
   #patchCount = 0;
   #finished = false;
 
   constructor(chunkBytes = POKE_CHUNK_BYTES) {
-    // Four bytes are required to encode the largest UTF-8 code point. A
-    // smaller buffer could make encodeInto() unable to make progress.
-    assert(chunkBytes >= 4, 'poke chunk size must be at least four bytes');
+    // One byte tags the binary message and four bytes are required to encode
+    // the largest UTF-8 code point. A smaller buffer could prevent progress.
+    assert(chunkBytes >= 5, 'poke chunk size must be at least five bytes');
     this.#buffer = new Uint8Array(chunkBytes);
+    this.#buffer[0] = POKE_CHUNK_MESSAGE_TYPE;
   }
 
   async addPatch(serializedPatch: string, emit: EmitPokeChunk): Promise<void> {
@@ -42,7 +45,7 @@ export class PokeChunkEncoder {
 
   cancel(): void {
     this.#finished = true;
-    this.#bufferedBytes = 0;
+    this.#bufferedBytes = 1;
   }
 
   async #write(value: string, emit: EmitPokeChunk): Promise<void> {
@@ -61,10 +64,10 @@ export class PokeChunkEncoder {
   }
 
   async #flush(emit: EmitPokeChunk): Promise<void> {
-    if (this.#bufferedBytes === 0) {
+    if (this.#bufferedBytes === 1) {
       return;
     }
     await emit(this.#buffer.subarray(0, this.#bufferedBytes));
-    this.#bufferedBytes = 0;
+    this.#bufferedBytes = 1;
   }
 }

--- a/packages/zero-cache/src/workers/connection.test.ts
+++ b/packages/zero-cache/src/workers/connection.test.ts
@@ -8,11 +8,13 @@ import {
 import type {Downstream} from '../../../zero-protocol/src/down.ts';
 import {ErrorKind} from '../../../zero-protocol/src/error-kind.ts';
 import {ErrorOrigin} from '../../../zero-protocol/src/error-origin.ts';
+import type {PokePartMessage} from '../../../zero-protocol/src/poke.ts';
 import {setSerializedDownstream} from '../types/downstream.ts';
 import {ProtocolErrorWithLevel} from '../types/error-with-level.ts';
 import {
   send,
   sendError,
+  serializedPokePatch,
   WEBSOCKET_SEND_TIMEOUT_MS,
   type WebSocketLike,
 } from './connection.ts';
@@ -107,6 +109,29 @@ describe('send', () => {
     send(lc, ws, setSerializedDownstream(data, serialized), callback);
 
     expect(sendSpy).toHaveBeenCalledWith(serialized, callback);
+  });
+});
+
+describe('serializedPokePatch', () => {
+  test('removes the legacy envelope and repeated pokeID', () => {
+    const message: PokePartMessage = [
+      'pokePart',
+      {pokeID: '01', rowsPatch: [{op: 'clear'}]},
+    ];
+    const serialized = JSON.stringify(message);
+
+    expect(
+      serializedPokePatch(setSerializedDownstream(message, serialized)),
+    ).toBe('{"rowsPatch":[{"op":"clear"}]}');
+  });
+
+  test('handles nonstandard property insertion order off the hot path', () => {
+    const message = [
+      'pokePart',
+      {rowsPatch: [{op: 'clear'}], pokeID: '01'},
+    ] as PokePartMessage;
+
+    expect(serializedPokePatch(message)).toBe('{"rowsPatch":[{"op":"clear"}]}');
   });
 });
 

--- a/packages/zero-cache/src/workers/connection.test.ts
+++ b/packages/zero-cache/src/workers/connection.test.ts
@@ -8,6 +8,7 @@ import {
 import type {Downstream} from '../../../zero-protocol/src/down.ts';
 import {ErrorKind} from '../../../zero-protocol/src/error-kind.ts';
 import {ErrorOrigin} from '../../../zero-protocol/src/error-origin.ts';
+import {setSerializedDownstream} from '../types/downstream.ts';
 import {ProtocolErrorWithLevel} from '../types/error-with-level.ts';
 import {
   send,
@@ -96,6 +97,16 @@ describe('send', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  test('reuses an already serialized downstream message', () => {
+    using sendSpy = vi.spyOn(ws, 'send');
+    const callback = () => {};
+    const serialized = '["pong", {"cached": true}]';
+
+    send(lc, ws, setSerializedDownstream(data, serialized), callback);
+
+    expect(sendSpy).toHaveBeenCalledWith(serialized, callback);
   });
 });
 

--- a/packages/zero-cache/src/workers/connection.test.ts
+++ b/packages/zero-cache/src/workers/connection.test.ts
@@ -8,9 +8,17 @@ import {
 import type {Downstream} from '../../../zero-protocol/src/down.ts';
 import {ErrorKind} from '../../../zero-protocol/src/error-kind.ts';
 import {ErrorOrigin} from '../../../zero-protocol/src/error-origin.ts';
-import type {PokePartMessage} from '../../../zero-protocol/src/poke.ts';
+import type {
+  PokeChunk,
+  PokeEndMessage,
+  PokePartMessage,
+  PokeStartMessage,
+} from '../../../zero-protocol/src/poke.ts';
+import {MIN_SERVER_SUPPORTED_SYNC_PROTOCOL} from '../../../zero-protocol/src/protocol-version.ts';
 import {ProtocolErrorWithLevel} from '../types/error-with-level.ts';
+import {POKE_CHUNK_PROTOCOL_VERSION} from '../types/poke-chunk.ts';
 import {
+  DownstreamSender,
   send,
   sendError,
   serializedPokePatch,
@@ -20,7 +28,19 @@ import {
 
 class MockSocket implements WebSocketLike {
   readyState: WebSocket['readyState'] = WebSocket.OPEN;
-  send(_data: string, _cb?: (err?: Error) => void) {}
+  readonly sent: (string | PokeChunk)[] = [];
+  readonly autoComplete: boolean;
+
+  constructor(autoComplete = false) {
+    this.autoComplete = autoComplete;
+  }
+
+  send(data: string | PokeChunk, cb?: (err?: Error) => void) {
+    this.sent.push(typeof data === 'string' ? data : data.slice());
+    if (this.autoComplete) {
+      cb?.();
+    }
+  }
 }
 
 describe('send', () => {
@@ -107,9 +127,72 @@ describe('send', () => {
 
     send(lc, ws, data, callback, serialized);
 
-    expect(sendSpy).toHaveBeenCalledWith(serialized, callback);
+    expect(sendSpy).toHaveBeenCalledWith(serialized, expect.any(Function));
   });
 });
+
+describe('DownstreamSender poke compatibility', () => {
+  const lc = createSilentLogContext();
+  const pokeStart = [
+    'pokeStart',
+    {pokeID: '01', baseCookie: null},
+  ] satisfies PokeStartMessage;
+  const pokePart = [
+    'pokePart',
+    {pokeID: '01', rowsPatch: [{op: 'clear'}]},
+  ] satisfies PokePartMessage;
+  const pokeEnd = [
+    'pokeEnd',
+    {pokeID: '01', cookie: '01'},
+  ] satisfies PokeEndMessage;
+
+  test.each([
+    MIN_SERVER_SUPPORTED_SYNC_PROTOCOL,
+    POKE_CHUNK_PROTOCOL_VERSION - 1,
+  ])(
+    'keeps sending JSON pokePart messages to protocol version %i',
+    async protocolVersion => {
+      const ws = new MockSocket(true);
+      const sender = new DownstreamSender(lc, ws, protocolVersion);
+
+      await sendWithBackpressure(sender, pokeStart);
+      await sendWithBackpressure(sender, pokePart);
+      await sendWithBackpressure(sender, pokeEnd);
+
+      expect(ws.sent).toEqual([
+        JSON.stringify(pokeStart),
+        JSON.stringify(pokePart),
+        JSON.stringify(pokeEnd),
+      ]);
+    },
+  );
+
+  test('sends binary poke chunks only to clients at the cutoff', async () => {
+    const ws = new MockSocket(true);
+    const sender = new DownstreamSender(lc, ws, POKE_CHUNK_PROTOCOL_VERSION);
+
+    await sendWithBackpressure(sender, pokeStart);
+    await sendWithBackpressure(sender, pokePart);
+    await sendWithBackpressure(sender, pokeEnd);
+
+    expect(ws.sent).toHaveLength(3);
+    expect(ws.sent[0]).toBe(JSON.stringify(pokeStart));
+    expect(ws.sent[1]).toBeInstanceOf(Uint8Array);
+    expect(new TextDecoder().decode(ws.sent[1] as PokeChunk)).toBe(
+      '[{"rowsPatch":[{"op":"clear"}]}]',
+    );
+    expect(ws.sent[2]).toBe(JSON.stringify(pokeEnd));
+  });
+});
+
+function sendWithBackpressure(
+  sender: DownstreamSender,
+  downstream: Downstream,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    sender.send(downstream, error => (error ? reject(error) : resolve()));
+  });
+}
 
 describe('serializedPokePatch', () => {
   test('removes the legacy envelope and repeated pokeID', () => {

--- a/packages/zero-cache/src/workers/connection.test.ts
+++ b/packages/zero-cache/src/workers/connection.test.ts
@@ -9,7 +9,6 @@ import type {Downstream} from '../../../zero-protocol/src/down.ts';
 import {ErrorKind} from '../../../zero-protocol/src/error-kind.ts';
 import {ErrorOrigin} from '../../../zero-protocol/src/error-origin.ts';
 import type {PokePartMessage} from '../../../zero-protocol/src/poke.ts';
-import {setSerializedDownstream} from '../types/downstream.ts';
 import {ProtocolErrorWithLevel} from '../types/error-with-level.ts';
 import {
   send,
@@ -106,7 +105,7 @@ describe('send', () => {
     const callback = () => {};
     const serialized = '["pong", {"cached": true}]';
 
-    send(lc, ws, setSerializedDownstream(data, serialized), callback);
+    send(lc, ws, data, callback, serialized);
 
     expect(sendSpy).toHaveBeenCalledWith(serialized, callback);
   });
@@ -120,9 +119,9 @@ describe('serializedPokePatch', () => {
     ];
     const serialized = JSON.stringify(message);
 
-    expect(
-      serializedPokePatch(setSerializedDownstream(message, serialized)),
-    ).toBe('{"rowsPatch":[{"op":"clear"}]}');
+    expect(serializedPokePatch(message, serialized)).toBe(
+      '{"rowsPatch":[{"op":"clear"}]}',
+    );
   });
 
   test('handles nonstandard property insertion order off the hot path', () => {

--- a/packages/zero-cache/src/workers/connection.test.ts
+++ b/packages/zero-cache/src/workers/connection.test.ts
@@ -8,20 +8,21 @@ import {
 import type {Downstream} from '../../../zero-protocol/src/down.ts';
 import {ErrorKind} from '../../../zero-protocol/src/error-kind.ts';
 import {ErrorOrigin} from '../../../zero-protocol/src/error-origin.ts';
-import type {
-  PokeChunk,
-  PokeEndMessage,
-  PokePartMessage,
-  PokeStartMessage,
+import {
+  LAST_POKE_PART_PROTOCOL_VERSION,
+  POKE_CHUNK_MESSAGE_TYPE,
+  POKE_CHUNK_PROTOCOL_VERSION,
+  type PokeChunk,
+  type PokeEndMessage,
+  type PokePartMessage,
+  type PokeStartMessage,
 } from '../../../zero-protocol/src/poke.ts';
 import {MIN_SERVER_SUPPORTED_SYNC_PROTOCOL} from '../../../zero-protocol/src/protocol-version.ts';
 import {ProtocolErrorWithLevel} from '../types/error-with-level.ts';
-import {POKE_CHUNK_PROTOCOL_VERSION} from '../types/poke-chunk.ts';
 import {
   DownstreamSender,
   send,
   sendError,
-  serializedPokePatch,
   WEBSOCKET_SEND_TIMEOUT_MS,
   type WebSocketLike,
 } from './connection.ts';
@@ -148,7 +149,7 @@ describe('DownstreamSender poke compatibility', () => {
 
   test.each([
     MIN_SERVER_SUPPORTED_SYNC_PROTOCOL,
-    POKE_CHUNK_PROTOCOL_VERSION - 1,
+    LAST_POKE_PART_PROTOCOL_VERSION,
   ])(
     'keeps sending JSON pokePart messages to protocol version %i',
     async protocolVersion => {
@@ -178,10 +179,37 @@ describe('DownstreamSender poke compatibility', () => {
     expect(ws.sent).toHaveLength(3);
     expect(ws.sent[0]).toBe(JSON.stringify(pokeStart));
     expect(ws.sent[1]).toBeInstanceOf(Uint8Array);
-    expect(new TextDecoder().decode(ws.sent[1] as PokeChunk)).toBe(
-      '[{"rowsPatch":[{"op":"clear"}]}]',
+    const chunk = ws.sent[1] as PokeChunk;
+    expect(chunk[0]).toBe(POKE_CHUNK_MESSAGE_TYPE);
+    expect(new TextDecoder().decode(chunk.subarray(1))).toBe(
+      '[{"pokeID":"01","rowsPatch":[{"op":"clear"}]}]',
     );
     expect(ws.sent[2]).toBe(JSON.stringify(pokeEnd));
+  });
+
+  test('fails a stalled binary send after the websocket timeout', async () => {
+    vi.useFakeTimers();
+    try {
+      const ws = new MockSocket();
+      const sender = new DownstreamSender(lc, ws, POKE_CHUNK_PROTOCOL_VERSION);
+
+      sender.send(pokeStart, 'ignore-backpressure');
+      await sendWithBackpressure(sender, pokePart);
+      const pokeEndPromise = sendWithBackpressure(sender, pokeEnd);
+      const rejection = expect(pokeEndPromise).rejects.toMatchObject({
+        errorBody: {
+          kind: ErrorKind.Internal,
+          message: `WebSocket send timed out after ${WEBSOCKET_SEND_TIMEOUT_MS} ms`,
+          origin: ErrorOrigin.ZeroCache,
+        },
+        logLevel: 'info',
+      });
+
+      await vi.advanceTimersByTimeAsync(WEBSOCKET_SEND_TIMEOUT_MS);
+      await rejection;
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 
@@ -193,29 +221,6 @@ function sendWithBackpressure(
     sender.send(downstream, error => (error ? reject(error) : resolve()));
   });
 }
-
-describe('serializedPokePatch', () => {
-  test('removes the legacy envelope and repeated pokeID', () => {
-    const message: PokePartMessage = [
-      'pokePart',
-      {pokeID: '01', rowsPatch: [{op: 'clear'}]},
-    ];
-    const serialized = JSON.stringify(message);
-
-    expect(serializedPokePatch(message, serialized)).toBe(
-      '{"rowsPatch":[{"op":"clear"}]}',
-    );
-  });
-
-  test('handles nonstandard property insertion order off the hot path', () => {
-    const message = [
-      'pokePart',
-      {rowsPatch: [{op: 'clear'}], pokeID: '01'},
-    ] as PokePartMessage;
-
-    expect(serializedPokePatch(message)).toBe('{"rowsPatch":[{"op":"clear"}]}');
-  });
-});
 
 describe('sendError', () => {
   let sink: TestLogSink;

--- a/packages/zero-cache/src/workers/connection.ts
+++ b/packages/zero-cache/src/workers/connection.ts
@@ -24,7 +24,7 @@ import {
 } from '../../../zero-protocol/src/protocol-version.ts';
 import {upstreamSchema, type Upstream} from '../../../zero-protocol/src/up.ts';
 import {getOrCreateCounter} from '../observability/metrics.ts';
-import {stringifyDownstream} from '../types/downstream.ts';
+import type {ViewSyncerDownstream} from '../types/downstream.ts';
 import {
   ProtocolErrorWithLevel,
   getLogLevel,
@@ -51,11 +51,17 @@ export type HandlerResult =
     }
   | StreamResult;
 
-export type StreamResult = {
-  type: 'stream';
-  source: 'viewSyncer' | 'pusher';
-  stream: Source<Downstream>;
-};
+export type StreamResult =
+  | {
+      type: 'stream';
+      source: 'viewSyncer';
+      stream: Source<ViewSyncerDownstream>;
+    }
+  | {
+      type: 'stream';
+      source: 'pusher';
+      stream: Source<Downstream>;
+    };
 
 export interface MessageHandler {
   handleMessage(msg: Upstream): Promise<HandlerResult[]>;
@@ -99,7 +105,7 @@ export class Connection {
     'Client WebSocket error events.',
   );
 
-  #viewSyncerOutboundStream: Source<Downstream> | undefined;
+  #viewSyncerOutboundStream: Source<ViewSyncerDownstream> | undefined;
   #pusherOutboundStream: Source<Downstream> | undefined;
   #pokeChunkEncoder: PokeChunkEncoder | undefined;
   #closed = false;
@@ -258,7 +264,15 @@ export class Connection {
             this.#pusherOutboundStream = result.stream;
             break;
         }
-        this.#proxyOutbound(result.stream);
+        if (result.source === 'viewSyncer') {
+          this.#proxyOutbound(result.stream, (downstream, callback) =>
+            this.send(downstream.message, callback, downstream.serialized),
+          );
+        } else {
+          this.#proxyOutbound(result.stream, (downstream, callback) =>
+            this.send(downstream, callback),
+          );
+        }
         break;
       }
       case 'transient': {
@@ -304,7 +318,13 @@ export class Connection {
     );
   }
 
-  #proxyOutbound(outboundStream: Source<Downstream>) {
+  #proxyOutbound<T>(
+    outboundStream: Source<T>,
+    sendMessage: (
+      downstream: T,
+      callback: (err?: Error | null) => void,
+    ) => void,
+  ) {
     // Note: createWebSocketStream() is avoided here in order to control
     //       exception handling with #closeWithThrown(). If the Writable
     //       from createWebSocketStream() were instead used, exceptions
@@ -314,8 +334,8 @@ export class Connection {
       Readable.from(outboundStream),
       new Writable({
         objectMode: true,
-        write: (downstream: Downstream, _encoding, callback) =>
-          this.send(downstream, callback),
+        write: (downstream: T, _encoding, callback) =>
+          sendMessage(downstream, callback),
       }),
       e =>
         e
@@ -351,6 +371,7 @@ export class Connection {
   send(
     data: Downstream,
     callback: ((err?: Error | null) => void) | 'ignore-backpressure',
+    serialized?: string | undefined,
   ) {
     this.#lastDownstreamMsgTime = Date.now();
     if (this.#protocolVersion >= POKE_CHUNK_PROTOCOL_VERSION) {
@@ -363,25 +384,26 @@ export class Connection {
           this.#pokeChunkEncoder = new PokeChunkEncoder();
           break;
         case 'pokePart':
-          this.#sendPokePart(data, callback);
+          this.#sendPokePart(data, callback, serialized);
           return;
         case 'pokeEnd':
           this.#sendPokeEnd(data, callback);
           return;
       }
     }
-    return send(this.#lc, this.#ws, data, callback);
+    return send(this.#lc, this.#ws, data, callback, serialized);
   }
 
   #sendPokePart(
     pokePart: PokePartMessage,
     callback: ((err?: Error | null) => void) | 'ignore-backpressure',
+    serialized?: string | undefined,
   ): void {
     const encoder = this.#pokeChunkEncoder;
     assert(encoder, 'pokePart received without a pokeStart');
 
     void encoder
-      .addPatch(serializedPokePatch(pokePart), chunk =>
+      .addPatch(serializedPokePatch(pokePart, serialized), chunk =>
         sendBinary(this.#lc, this.#ws, chunk),
       )
       .then(
@@ -428,9 +450,10 @@ export function send(
   ws: WebSocketLike,
   data: Downstream,
   callback: ((err?: Error | null) => void) | 'ignore-backpressure',
+  serialized?: string | undefined,
 ) {
   if (ws.readyState === WebSocket.OPEN) {
-    const serialized = stringifyDownstream(data);
+    serialized ??= JSON.stringify(data);
     if (callback === 'ignore-backpressure') {
       ws.send(serialized);
       return;
@@ -483,8 +506,10 @@ export function send(
 const POKE_PART_PREFIX = '["pokePart",';
 
 // Exported for testing the no-reserialization fast path.
-export function serializedPokePatch(pokePart: PokePartMessage): string {
-  const serialized = stringifyDownstream(pokePart);
+export function serializedPokePatch(
+  pokePart: PokePartMessage,
+  serialized = JSON.stringify(pokePart),
+): string {
   const bodyPrefix = `${POKE_PART_PREFIX}{"pokeID":${JSON.stringify(
     pokePart[1].pokeID,
   )}`;

--- a/packages/zero-cache/src/workers/connection.ts
+++ b/packages/zero-cache/src/workers/connection.ts
@@ -13,10 +13,11 @@ import {
   isProtocolError,
   type ProtocolError,
 } from '../../../zero-protocol/src/error.ts';
-import type {
-  PokeChunk,
-  PokeEndMessage,
-  PokePartMessage,
+import {
+  POKE_CHUNK_PROTOCOL_VERSION,
+  type PokeChunk,
+  type PokeEndMessage,
+  type PokePartMessage,
 } from '../../../zero-protocol/src/poke.ts';
 import {
   MIN_SERVER_SUPPORTED_SYNC_PROTOCOL,
@@ -30,10 +31,7 @@ import {
   getLogLevel,
   wrapWithProtocolError,
 } from '../types/error-with-level.ts';
-import {
-  POKE_CHUNK_PROTOCOL_VERSION,
-  PokeChunkEncoder,
-} from '../types/poke-chunk.ts';
+import {PokeChunkEncoder} from '../types/poke-chunk.ts';
 import type {Source} from '../types/streams.ts';
 import type {ConnectParams} from './connect-params.ts';
 
@@ -408,16 +406,7 @@ export function send(
 
     let completed = false;
     const timer = setTimeout(() => {
-      complete(
-        new ProtocolErrorWithLevel(
-          {
-            kind: ErrorKind.Internal,
-            message: `WebSocket send timed out after ${WEBSOCKET_SEND_TIMEOUT_MS} ms`,
-            origin: ErrorOrigin.ZeroCache,
-          },
-          'info',
-        ),
-      );
+      complete(webSocketSendTimeoutError());
     }, WEBSOCKET_SEND_TIMEOUT_MS);
     timer.unref();
 
@@ -502,8 +491,13 @@ export class DownstreamSender {
     const encoder = this.#pokeChunkEncoder;
     assert(encoder, 'pokePart received without a pokeStart');
 
+    serialized ??= JSON.stringify(pokePart);
+    assert(
+      serialized.startsWith(POKE_PART_PREFIX) && serialized.endsWith(']'),
+      'invalid serialized pokePart',
+    );
     void encoder
-      .addPatch(serializedPokePatch(pokePart, serialized), chunk =>
+      .addPatch(serialized.slice(POKE_PART_PREFIX.length, -1), chunk =>
         sendBinary(this.#lc, this.#ws, chunk),
       )
       .then(
@@ -538,29 +532,6 @@ export class DownstreamSender {
 
 const POKE_PART_PREFIX = '["pokePart",';
 
-// Exported for testing the no-reserialization fast path.
-export function serializedPokePatch(
-  pokePart: PokePartMessage,
-  serialized = JSON.stringify(pokePart),
-): string {
-  const bodyPrefix = `${POKE_PART_PREFIX}{"pokeID":${JSON.stringify(
-    pokePart[1].pokeID,
-  )}`;
-  assert(
-    serialized.startsWith(POKE_PART_PREFIX) && serialized.endsWith('}]'),
-    'invalid serialized pokePart',
-  );
-  if (serialized.startsWith(bodyPrefix)) {
-    const fields = serialized.slice(bodyPrefix.length, -2);
-    return fields ? `{${fields.slice(1)}}` : '{}';
-  }
-
-  // Non-production callers may construct a body whose pokeID was inserted
-  // after other fields. Preserve correctness without penalizing the hot path.
-  const {pokeID: _, ...patch} = pokePart[1];
-  return JSON.stringify(patch);
-}
-
 function sendAsync(
   lc: LogContext,
   ws: WebSocketLike,
@@ -585,7 +556,23 @@ function sendBinary(
       reject(error);
       return;
     }
-    ws.send(chunk, error => (error ? reject(error) : resolve()));
+    let completed = false;
+    const timer = setTimeout(
+      () => complete(webSocketSendTimeoutError()),
+      WEBSOCKET_SEND_TIMEOUT_MS,
+    );
+    timer.unref();
+
+    const complete = (error?: Error | null) => {
+      if (completed) {
+        return;
+      }
+      completed = true;
+      clearTimeout(timer);
+      error ? reject(error) : resolve();
+    };
+
+    ws.send(chunk, complete);
   });
 }
 
@@ -607,6 +594,17 @@ function webSocketClosedError(): ProtocolErrorWithLevel {
     {
       kind: ErrorKind.Internal,
       message: 'WebSocket closed',
+      origin: ErrorOrigin.ZeroCache,
+    },
+    'info',
+  );
+}
+
+function webSocketSendTimeoutError(): ProtocolErrorWithLevel {
+  return new ProtocolErrorWithLevel(
+    {
+      kind: ErrorKind.Internal,
+      message: `WebSocket send timed out after ${WEBSOCKET_SEND_TIMEOUT_MS} ms`,
       origin: ErrorOrigin.ZeroCache,
     },
     'info',

--- a/packages/zero-cache/src/workers/connection.ts
+++ b/packages/zero-cache/src/workers/connection.ts
@@ -19,6 +19,7 @@ import {
 } from '../../../zero-protocol/src/protocol-version.ts';
 import {upstreamSchema, type Upstream} from '../../../zero-protocol/src/up.ts';
 import {getOrCreateCounter} from '../observability/metrics.ts';
+import {stringifyDownstream} from '../types/downstream.ts';
 import {
   ProtocolErrorWithLevel,
   getLogLevel,
@@ -362,7 +363,7 @@ export function send(
   callback: ((err?: Error | null) => void) | 'ignore-backpressure',
 ) {
   if (ws.readyState === WebSocket.OPEN) {
-    const serialized = JSON.stringify(data);
+    const serialized = stringifyDownstream(data);
     if (callback === 'ignore-backpressure') {
       ws.send(serialized);
       return;

--- a/packages/zero-cache/src/workers/connection.ts
+++ b/packages/zero-cache/src/workers/connection.ts
@@ -98,6 +98,7 @@ export class Connection {
   readonly #lc: LogContext;
   readonly #onClose: () => void;
   readonly #messageHandler: MessageHandler;
+  readonly #downstreamSender: DownstreamSender;
   readonly #downstreamMsgTimer: NodeJS.Timeout | undefined;
   readonly #webSocketErrors = getOrCreateCounter(
     'sync',
@@ -107,7 +108,6 @@ export class Connection {
 
   #viewSyncerOutboundStream: Source<ViewSyncerDownstream> | undefined;
   #pusherOutboundStream: Source<Downstream> | undefined;
-  #pokeChunkEncoder: PokeChunkEncoder | undefined;
   #closed = false;
 
   constructor(
@@ -129,6 +129,11 @@ export class Connection {
       .withContext('clientID', clientID)
       .withContext('clientGroupID', clientGroupID)
       .withContext('wsID', wsID);
+    this.#downstreamSender = new DownstreamSender(
+      this.#lc,
+      ws,
+      protocolVersion,
+    );
     this.#lc.debug?.('new connection');
     this.#onClose = onClose;
 
@@ -374,65 +379,7 @@ export class Connection {
     serialized?: string | undefined,
   ) {
     this.#lastDownstreamMsgTime = Date.now();
-    if (this.#protocolVersion >= POKE_CHUNK_PROTOCOL_VERSION) {
-      switch (data[0]) {
-        case 'pokeStart':
-          assert(
-            this.#pokeChunkEncoder === undefined,
-            'cannot start a poke while another poke is in progress',
-          );
-          this.#pokeChunkEncoder = new PokeChunkEncoder();
-          break;
-        case 'pokePart':
-          this.#sendPokePart(data, callback, serialized);
-          return;
-        case 'pokeEnd':
-          this.#sendPokeEnd(data, callback);
-          return;
-      }
-    }
-    return send(this.#lc, this.#ws, data, callback, serialized);
-  }
-
-  #sendPokePart(
-    pokePart: PokePartMessage,
-    callback: ((err?: Error | null) => void) | 'ignore-backpressure',
-    serialized?: string | undefined,
-  ): void {
-    const encoder = this.#pokeChunkEncoder;
-    assert(encoder, 'pokePart received without a pokeStart');
-
-    void encoder
-      .addPatch(serializedPokePatch(pokePart, serialized), chunk =>
-        sendBinary(this.#lc, this.#ws, chunk),
-      )
-      .then(
-        () => invokeCallback(callback),
-        error => invokeCallback(callback, toError(error)),
-      );
-  }
-
-  #sendPokeEnd(
-    pokeEnd: PokeEndMessage,
-    callback: ((err?: Error | null) => void) | 'ignore-backpressure',
-  ): void {
-    const encoder = this.#pokeChunkEncoder;
-    assert(encoder, 'pokeEnd received without a pokeStart');
-    this.#pokeChunkEncoder = undefined;
-
-    if (pokeEnd[1].cancel) {
-      encoder.cancel();
-      send(this.#lc, this.#ws, pokeEnd, callback);
-      return;
-    }
-
-    void encoder
-      .finish(chunk => sendBinary(this.#lc, this.#ws, chunk))
-      .then(() => sendAsync(this.#lc, this.#ws, pokeEnd))
-      .then(
-        () => invokeCallback(callback),
-        error => invokeCallback(callback, toError(error)),
-      );
+    this.#downstreamSender.send(data, callback, serialized);
   }
 
   sendError(errorBody: ErrorBody, thrown?: unknown) {
@@ -500,6 +447,92 @@ export function send(
         ),
       );
     }
+  }
+}
+
+/**
+ * Sends downstream messages in the format supported by a connection's sync
+ * protocol version. Keep version forks contained here so the view-syncer can
+ * continue producing one canonical poke representation.
+ *
+ * Exported for compatibility testing.
+ */
+export class DownstreamSender {
+  readonly #lc: LogContext;
+  readonly #ws: WebSocketLike;
+  readonly #protocolVersion: number;
+  #pokeChunkEncoder: PokeChunkEncoder | undefined;
+
+  constructor(lc: LogContext, ws: WebSocketLike, protocolVersion: number) {
+    this.#lc = lc;
+    this.#ws = ws;
+    this.#protocolVersion = protocolVersion;
+  }
+
+  send(
+    data: Downstream,
+    callback: ((err?: Error | null) => void) | 'ignore-backpressure',
+    serialized?: string | undefined,
+  ): void {
+    if (this.#protocolVersion >= POKE_CHUNK_PROTOCOL_VERSION) {
+      switch (data[0]) {
+        case 'pokeStart':
+          assert(
+            this.#pokeChunkEncoder === undefined,
+            'cannot start a poke while another poke is in progress',
+          );
+          this.#pokeChunkEncoder = new PokeChunkEncoder();
+          break;
+        case 'pokePart':
+          this.#sendPokePart(data, callback, serialized);
+          return;
+        case 'pokeEnd':
+          this.#sendPokeEnd(data, callback);
+          return;
+      }
+    }
+    send(this.#lc, this.#ws, data, callback, serialized);
+  }
+
+  #sendPokePart(
+    pokePart: PokePartMessage,
+    callback: ((err?: Error | null) => void) | 'ignore-backpressure',
+    serialized?: string | undefined,
+  ): void {
+    const encoder = this.#pokeChunkEncoder;
+    assert(encoder, 'pokePart received without a pokeStart');
+
+    void encoder
+      .addPatch(serializedPokePatch(pokePart, serialized), chunk =>
+        sendBinary(this.#lc, this.#ws, chunk),
+      )
+      .then(
+        () => invokeCallback(callback),
+        error => invokeCallback(callback, toError(error)),
+      );
+  }
+
+  #sendPokeEnd(
+    pokeEnd: PokeEndMessage,
+    callback: ((err?: Error | null) => void) | 'ignore-backpressure',
+  ): void {
+    const encoder = this.#pokeChunkEncoder;
+    assert(encoder, 'pokeEnd received without a pokeStart');
+    this.#pokeChunkEncoder = undefined;
+
+    if (pokeEnd[1].cancel) {
+      encoder.cancel();
+      send(this.#lc, this.#ws, pokeEnd, callback);
+      return;
+    }
+
+    void encoder
+      .finish(chunk => sendBinary(this.#lc, this.#ws, chunk))
+      .then(() => sendAsync(this.#lc, this.#ws, pokeEnd))
+      .then(
+        () => invokeCallback(callback),
+        error => invokeCallback(callback, toError(error)),
+      );
   }
 }
 

--- a/packages/zero-cache/src/workers/connection.ts
+++ b/packages/zero-cache/src/workers/connection.ts
@@ -13,6 +13,11 @@ import {
   isProtocolError,
   type ProtocolError,
 } from '../../../zero-protocol/src/error.ts';
+import type {
+  PokeChunk,
+  PokeEndMessage,
+  PokePartMessage,
+} from '../../../zero-protocol/src/poke.ts';
 import {
   MIN_SERVER_SUPPORTED_SYNC_PROTOCOL,
   PROTOCOL_VERSION,
@@ -25,6 +30,10 @@ import {
   getLogLevel,
   wrapWithProtocolError,
 } from '../types/error-with-level.ts';
+import {
+  POKE_CHUNK_PROTOCOL_VERSION,
+  PokeChunkEncoder,
+} from '../types/poke-chunk.ts';
 import type {Source} from '../types/streams.ts';
 import type {ConnectParams} from './connect-params.ts';
 
@@ -92,6 +101,7 @@ export class Connection {
 
   #viewSyncerOutboundStream: Source<Downstream> | undefined;
   #pusherOutboundStream: Source<Downstream> | undefined;
+  #pokeChunkEncoder: PokeChunkEncoder | undefined;
   #closed = false;
 
   constructor(
@@ -343,7 +353,64 @@ export class Connection {
     callback: ((err?: Error | null) => void) | 'ignore-backpressure',
   ) {
     this.#lastDownstreamMsgTime = Date.now();
+    if (this.#protocolVersion >= POKE_CHUNK_PROTOCOL_VERSION) {
+      switch (data[0]) {
+        case 'pokeStart':
+          assert(
+            this.#pokeChunkEncoder === undefined,
+            'cannot start a poke while another poke is in progress',
+          );
+          this.#pokeChunkEncoder = new PokeChunkEncoder();
+          break;
+        case 'pokePart':
+          this.#sendPokePart(data, callback);
+          return;
+        case 'pokeEnd':
+          this.#sendPokeEnd(data, callback);
+          return;
+      }
+    }
     return send(this.#lc, this.#ws, data, callback);
+  }
+
+  #sendPokePart(
+    pokePart: PokePartMessage,
+    callback: ((err?: Error | null) => void) | 'ignore-backpressure',
+  ): void {
+    const encoder = this.#pokeChunkEncoder;
+    assert(encoder, 'pokePart received without a pokeStart');
+
+    void encoder
+      .addPatch(serializedPokePatch(pokePart), chunk =>
+        sendBinary(this.#lc, this.#ws, chunk),
+      )
+      .then(
+        () => invokeCallback(callback),
+        error => invokeCallback(callback, toError(error)),
+      );
+  }
+
+  #sendPokeEnd(
+    pokeEnd: PokeEndMessage,
+    callback: ((err?: Error | null) => void) | 'ignore-backpressure',
+  ): void {
+    const encoder = this.#pokeChunkEncoder;
+    assert(encoder, 'pokeEnd received without a pokeStart');
+    this.#pokeChunkEncoder = undefined;
+
+    if (pokeEnd[1].cancel) {
+      encoder.cancel();
+      send(this.#lc, this.#ws, pokeEnd, callback);
+      return;
+    }
+
+    void encoder
+      .finish(chunk => sendBinary(this.#lc, this.#ws, chunk))
+      .then(() => sendAsync(this.#lc, this.#ws, pokeEnd))
+      .then(
+        () => invokeCallback(callback),
+        error => invokeCallback(callback, toError(error)),
+      );
   }
 
   sendError(errorBody: ErrorBody, thrown?: unknown) {
@@ -352,7 +419,7 @@ export class Connection {
 }
 
 export type WebSocketLike = Pick<WebSocket, 'readyState'> & {
-  send(data: string, cb?: (err?: Error) => void): void;
+  send(data: string | PokeChunk, cb?: (err?: Error) => void): void;
 };
 
 // Exported for testing purposes.
@@ -411,6 +478,81 @@ export function send(
       );
     }
   }
+}
+
+const POKE_PART_PREFIX = '["pokePart",';
+
+// Exported for testing the no-reserialization fast path.
+export function serializedPokePatch(pokePart: PokePartMessage): string {
+  const serialized = stringifyDownstream(pokePart);
+  const bodyPrefix = `${POKE_PART_PREFIX}{"pokeID":${JSON.stringify(
+    pokePart[1].pokeID,
+  )}`;
+  assert(
+    serialized.startsWith(POKE_PART_PREFIX) && serialized.endsWith('}]'),
+    'invalid serialized pokePart',
+  );
+  if (serialized.startsWith(bodyPrefix)) {
+    const fields = serialized.slice(bodyPrefix.length, -2);
+    return fields ? `{${fields.slice(1)}}` : '{}';
+  }
+
+  // Non-production callers may construct a body whose pokeID was inserted
+  // after other fields. Preserve correctness without penalizing the hot path.
+  const {pokeID: _, ...patch} = pokePart[1];
+  return JSON.stringify(patch);
+}
+
+function sendAsync(
+  lc: LogContext,
+  ws: WebSocketLike,
+  data: Downstream,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    send(lc, ws, data, error => (error ? reject(error) : resolve()));
+  });
+}
+
+function sendBinary(
+  lc: LogContext,
+  ws: WebSocketLike,
+  chunk: PokeChunk,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (ws.readyState !== WebSocket.OPEN) {
+      const error = webSocketClosedError();
+      lc.debug?.(
+        `Dropping outbound binary message on ws (state: ${ws.readyState})`,
+      );
+      reject(error);
+      return;
+    }
+    ws.send(chunk, error => (error ? reject(error) : resolve()));
+  });
+}
+
+function invokeCallback(
+  callback: ((err?: Error | null) => void) | 'ignore-backpressure',
+  error?: Error,
+): void {
+  if (callback !== 'ignore-backpressure') {
+    callback(error);
+  }
+}
+
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+function webSocketClosedError(): ProtocolErrorWithLevel {
+  return new ProtocolErrorWithLevel(
+    {
+      kind: ErrorKind.Internal,
+      message: 'WebSocket closed',
+      origin: ErrorOrigin.ZeroCache,
+    },
+    'info',
+  );
 }
 
 export function sendError(

--- a/packages/zero-client/src/client/protocol-version-url.test.ts
+++ b/packages/zero-client/src/client/protocol-version-url.test.ts
@@ -35,5 +35,5 @@ test('When the URL changes we need to update the protocol version', async () => 
   // might not understand it. You may need to bump the PROTOCOL_VERSION and
   // update the expected values.
   expect(hash).toBe('10r2tfvet9a3s');
-  expect(PROTOCOL_VERSION).toBe(51);
+  expect(PROTOCOL_VERSION).toBe(52);
 });

--- a/packages/zero-client/src/client/test-utils.ts
+++ b/packages/zero-client/src/client/test-utils.ts
@@ -216,6 +216,21 @@ export class TestZero<
     return this.triggerMessage(msg);
   }
 
+  async triggerPokeChunks(pokeParts: PokePartBody[]): Promise<void> {
+    const socket = await this.socket;
+    assert(!socket.closed, 'Expected socket to be open');
+    const patches = pokeParts.map(({pokeID: _, ...patch}) => patch);
+    const bytes = new TextEncoder().encode(JSON.stringify(patches));
+    socket.dispatchEvent(
+      new MessageEvent('message', {
+        data: bytes.buffer.slice(
+          bytes.byteOffset,
+          bytes.byteOffset + bytes.byteLength,
+        ),
+      }),
+    );
+  }
+
   triggerPokeEnd(pokeEnd: PokeEndBody): Promise<void> {
     const msg: PokeEndMessage = ['pokeEnd', pokeEnd];
     return this.triggerMessage(msg);
@@ -229,10 +244,7 @@ export class TestZero<
       pokeID: id,
       baseCookie: baseCookieStr,
     });
-    await this.triggerPokePart({
-      ...pokePart,
-      pokeID: id,
-    });
+    await this.triggerPokeChunks([{...pokePart, pokeID: id}]);
     if (this.#cookie === null) {
       this.#cookie = 1;
     } else {

--- a/packages/zero-client/src/client/test-utils.ts
+++ b/packages/zero-client/src/client/test-utils.ts
@@ -12,13 +12,14 @@ import type {
   ErrorBody,
   ErrorMessage,
 } from '../../../zero-protocol/src/error.ts';
-import type {
-  PokeEndBody,
-  PokeEndMessage,
-  PokePartBody,
-  PokePartMessage,
-  PokeStartBody,
-  PokeStartMessage,
+import {
+  POKE_CHUNK_MESSAGE_TYPE,
+  type PokeEndBody,
+  type PokeEndMessage,
+  type PokePartBody,
+  type PokePartMessage,
+  type PokeStartBody,
+  type PokeStartMessage,
 } from '../../../zero-protocol/src/poke.ts';
 import type {PongMessage} from '../../../zero-protocol/src/pong.ts';
 import type {
@@ -219,8 +220,10 @@ export class TestZero<
   async triggerPokeChunks(pokeParts: PokePartBody[]): Promise<void> {
     const socket = await this.socket;
     assert(!socket.closed, 'Expected socket to be open');
-    const patches = pokeParts.map(({pokeID: _, ...patch}) => patch);
-    const bytes = new TextEncoder().encode(JSON.stringify(patches));
+    const payload = new TextEncoder().encode(JSON.stringify(pokeParts));
+    const bytes = new Uint8Array(payload.byteLength + 1);
+    bytes[0] = POKE_CHUNK_MESSAGE_TYPE;
+    bytes.set(payload, 1);
     socket.dispatchEvent(
       new MessageEvent('message', {
         data: bytes.buffer.slice(

--- a/packages/zero-client/src/client/zero-idb.test.ts
+++ b/packages/zero-client/src/client/zero-idb.test.ts
@@ -166,7 +166,7 @@ test('logged-out client uses a private storage sentinel for idb naming', async (
   });
 
   expect(zero.idbName).toEqual(
-    `rep:zero-${LOGGED_OUT_STORAGE_USER_ID}-o92aeop6ci3f:7:51.32bj126fs2e3f`,
+    `rep:zero-${LOGGED_OUT_STORAGE_USER_ID}-o92aeop6ci3f:7:52.32bj126fs2e3f`,
   );
 
   await zero.close();

--- a/packages/zero-client/src/client/zero-poke-handler.test.ts
+++ b/packages/zero-client/src/client/zero-poke-handler.test.ts
@@ -799,6 +799,7 @@ describe('poke handler', () => {
     );
     const parts = [
       {
+        pokeID: 'poke1',
         lastMutationIDChanges: {c1: 7},
         rowsPatch: [
           {

--- a/packages/zero-client/src/client/zero-poke-handler.test.ts
+++ b/packages/zero-client/src/client/zero-poke-handler.test.ts
@@ -785,6 +785,64 @@ describe('poke handler', () => {
     expect(setTimeoutStub).toHaveBeenCalledTimes(3);
   });
 
+  test('reassembles and decodes binary chunks at pokeEnd', async () => {
+    const onPokeErrorStub = vi.fn();
+    const replicachePokeStub = vi.fn();
+    const logContext = new LogContext('error');
+    const pokeHandler = new PokeHandler(
+      replicachePokeStub,
+      onPokeErrorStub,
+      'c1',
+      schema,
+      logContext,
+      new MutationTracker(logContext, ackMutationResponses, onFatalError),
+    );
+    const parts = [
+      {
+        lastMutationIDChanges: {c1: 7},
+        rowsPatch: [
+          {
+            op: 'put' as const,
+            tableName: 'issues',
+            value: {issue_id: 'issue1', title: '🙂 binary chunks'},
+          },
+        ],
+      },
+    ];
+    const encoded = new TextEncoder().encode(JSON.stringify(parts));
+
+    pokeHandler.handlePokeStart({pokeID: 'poke1', baseCookie: '1'});
+    // Seven-byte slices force some UTF-8 code points across chunk boundaries.
+    for (let i = 0; i < encoded.length; i += 7) {
+      pokeHandler.handlePokeChunk(encoded.subarray(i, i + 7));
+    }
+    const result = pokeHandler.handlePokeEnd({pokeID: 'poke1', cookie: '2'});
+
+    expect(result).toEqual({
+      lastMutationIDChangeForSelf: 7,
+      hasRows: true,
+    });
+    expect(onPokeErrorStub).not.toHaveBeenCalled();
+    expect(setTimeoutStub).toHaveBeenCalledTimes(1);
+
+    const playback = setTimeoutStub.mock.calls[0][0] as () => Promise<void>;
+    await playback();
+    expect(replicachePokeStub).toHaveBeenCalledWith({
+      baseCookie: '1',
+      pullResponse: {
+        cookie: '2',
+        lastMutationIDChanges: {c1: 7},
+        patch: [
+          {
+            op: 'put',
+            key: 'e/issue/issue1',
+            value: {id: 'issue1', title: '🙂 binary chunks'},
+          },
+        ],
+      },
+    });
+  });
+
   suite('onPokeErrors', () => {
     const cases: {
       name: string;
@@ -797,8 +855,22 @@ describe('poke handler', () => {
         },
       },
       {
+        name: 'pokeChunk before pokeStart',
+        causeError: pokeHandler => {
+          pokeHandler.handlePokeChunk(new Uint8Array([0]));
+        },
+      },
+      {
         name: 'pokeEnd before pokeStart',
         causeError: pokeHandler => {
+          pokeHandler.handlePokeEnd({pokeID: 'poke1', cookie: '2'});
+        },
+      },
+      {
+        name: 'invalid UTF-8 pokeChunk',
+        causeError: pokeHandler => {
+          pokeHandler.handlePokeStart({pokeID: 'poke1', baseCookie: '1'});
+          pokeHandler.handlePokeChunk(new Uint8Array([0xff]));
           pokeHandler.handlePokeEnd({pokeID: 'poke1', cookie: '2'});
         },
       },

--- a/packages/zero-client/src/client/zero-poke-handler.ts
+++ b/packages/zero-client/src/client/zero-poke-handler.ts
@@ -10,11 +10,10 @@ import {unreachable} from '../../../shared/src/asserts.ts';
 import * as v from '../../../shared/src/valita.ts';
 import type {MutationPatch} from '../../../zero-protocol/src/mutations-patch.ts';
 import {
-  pokePatchesSchema,
-  type PokeChunk,
+  pokePartsSchema,
   type PokeEndBody,
   type PokePartBody,
-  type PokePatches,
+  type PokeParts,
   type PokeStartBody,
 } from '../../../zero-protocol/src/poke.ts';
 import type {QueriesPatchOp} from '../../../zero-protocol/src/queries-patch.ts';
@@ -41,7 +40,7 @@ type PokeAccumulator = {
 type ReceivingPoke = {
   readonly pokeStart: PokeStartBody;
   readonly parts: PokePartBody[];
-  readonly chunks: PokeChunk[];
+  readonly chunks: Uint8Array[];
 };
 
 export type PokeEndResult = {
@@ -126,7 +125,7 @@ export class PokeHandler {
     return pokePart.lastMutationIDChanges?.[this.#clientID];
   }
 
-  handlePokeChunk(chunk: PokeChunk): void {
+  handlePokeChunk(chunk: Uint8Array): void {
     if (!this.#receivingPoke) {
       this.#handlePokeError('received a binary poke chunk without pokeStart');
       return;
@@ -152,32 +151,20 @@ export class PokeHandler {
       return;
     }
     const receivingPoke = this.#receivingPoke;
+    let parts = receivingPoke.parts;
     if (receivingPoke.chunks.length > 0) {
       try {
-        receivingPoke.parts.push(
-          ...decodePokeChunks(receivingPoke.chunks).map(patch => ({
-            ...patch,
-            pokeID: pokeEnd.pokeID,
-          })),
-        );
+        parts = decodePokeChunks(receivingPoke.chunks);
       } catch (e) {
         this.#handlePokeError(e);
         return;
       }
     }
-    for (const part of receivingPoke.parts) {
-      if (part.pokeID !== pokeEnd.pokeID) {
-        this.#handlePokeError(
-          `poke patch for ${part.pokeID}, when receiving ${pokeEnd.pokeID}`,
-        );
-        return;
-      }
-    }
 
-    const result = summarizePoke(receivingPoke.parts, this.#clientID);
+    const result = summarizePoke(parts, this.#clientID);
     this.#pokeBuffer.push({
       pokeStart: receivingPoke.pokeStart,
-      parts: receivingPoke.parts,
+      parts,
       pokeEnd,
     });
     this.#receivingPoke = undefined;
@@ -272,7 +259,7 @@ export class PokeHandler {
   }
 }
 
-function decodePokeChunks(chunks: PokeChunk[]): PokePatches {
+function decodePokeChunks(chunks: Uint8Array[]): PokeParts {
   const decoder = new TextDecoder('utf-8', {fatal: true});
   const decoded = new Array<string>(chunks.length + 1);
   for (let i = 0; i < chunks.length; i++) {
@@ -280,11 +267,7 @@ function decodePokeChunks(chunks: PokeChunk[]): PokePatches {
   }
   decoded[chunks.length] = decoder.decode();
   chunks.length = 0;
-  return v.parse(
-    JSON.parse(decoded.join('')),
-    pokePatchesSchema,
-    'passthrough',
-  );
+  return v.parse(JSON.parse(decoded.join('')), pokePartsSchema, 'passthrough');
 }
 
 function summarizePoke(

--- a/packages/zero-client/src/client/zero-poke-handler.ts
+++ b/packages/zero-client/src/client/zero-poke-handler.ts
@@ -7,11 +7,15 @@ import type {
 import type {PatchOperation} from '../../../replicache/src/patch-operation.ts';
 import type {ClientID} from '../../../replicache/src/sync/ids.ts';
 import {unreachable} from '../../../shared/src/asserts.ts';
+import * as v from '../../../shared/src/valita.ts';
 import type {MutationPatch} from '../../../zero-protocol/src/mutations-patch.ts';
-import type {
-  PokeEndBody,
-  PokePartBody,
-  PokeStartBody,
+import {
+  pokePatchesSchema,
+  type PokeChunk,
+  type PokeEndBody,
+  type PokePartBody,
+  type PokePatches,
+  type PokeStartBody,
 } from '../../../zero-protocol/src/poke.ts';
 import type {QueriesPatchOp} from '../../../zero-protocol/src/queries-patch.ts';
 import type {RowPatchOp} from '../../../zero-protocol/src/row-patch.ts';
@@ -34,6 +38,17 @@ type PokeAccumulator = {
   readonly pokeEnd: PokeEndBody;
 };
 
+type ReceivingPoke = {
+  readonly pokeStart: PokeStartBody;
+  readonly parts: PokePartBody[];
+  readonly chunks: PokeChunk[];
+};
+
+export type PokeEndResult = {
+  readonly lastMutationIDChangeForSelf: number | undefined;
+  readonly hasRows: boolean;
+};
+
 /**
  * Handles the multi-part format of zero pokes.
  * As an optimization it also debounces pokes, only poking Replicache with a
@@ -48,7 +63,7 @@ export class PokeHandler {
   readonly #onPokeError: (error: unknown) => void;
   readonly #clientID: ClientID;
   readonly #lc: LogContext;
-  #receivingPoke: Omit<PokeAccumulator, 'pokeEnd'> | undefined = undefined;
+  #receivingPoke: ReceivingPoke | undefined = undefined;
   readonly #pokeBuffer: PokeAccumulator[] = [];
   #pokePlaybackLoopRunning = false;
   #lastScheduledTimestamp = 0;
@@ -90,6 +105,7 @@ export class PokeHandler {
     this.#receivingPoke = {
       pokeStart,
       parts: [],
+      chunks: [],
     };
   }
 
@@ -102,11 +118,27 @@ export class PokeHandler {
       );
       return;
     }
+    if (this.#receivingPoke.chunks.length > 0) {
+      this.#handlePokeError('received both pokePart and binary poke chunks');
+      return;
+    }
     this.#receivingPoke.parts.push(pokePart);
     return pokePart.lastMutationIDChanges?.[this.#clientID];
   }
 
-  handlePokeEnd(pokeEnd: PokeEndBody): void {
+  handlePokeChunk(chunk: PokeChunk): void {
+    if (!this.#receivingPoke) {
+      this.#handlePokeError('received a binary poke chunk without pokeStart');
+      return;
+    }
+    if (this.#receivingPoke.parts.length > 0) {
+      this.#handlePokeError('received both pokePart and binary poke chunks');
+      return;
+    }
+    this.#receivingPoke.chunks.push(chunk);
+  }
+
+  handlePokeEnd(pokeEnd: PokeEndBody): PokeEndResult | undefined {
     if (pokeEnd.pokeID !== this.#receivingPoke?.pokeStart.pokeID) {
       this.#handlePokeError(
         `pokeEnd for ${pokeEnd.pokeID}, when receiving ${
@@ -119,11 +151,40 @@ export class PokeHandler {
       this.#receivingPoke = undefined;
       return;
     }
-    this.#pokeBuffer.push({...this.#receivingPoke, pokeEnd});
+    const receivingPoke = this.#receivingPoke;
+    if (receivingPoke.chunks.length > 0) {
+      try {
+        receivingPoke.parts.push(
+          ...decodePokeChunks(receivingPoke.chunks).map(patch => ({
+            ...patch,
+            pokeID: pokeEnd.pokeID,
+          })),
+        );
+      } catch (e) {
+        this.#handlePokeError(e);
+        return;
+      }
+    }
+    for (const part of receivingPoke.parts) {
+      if (part.pokeID !== pokeEnd.pokeID) {
+        this.#handlePokeError(
+          `poke patch for ${part.pokeID}, when receiving ${pokeEnd.pokeID}`,
+        );
+        return;
+      }
+    }
+
+    const result = summarizePoke(receivingPoke.parts, this.#clientID);
+    this.#pokeBuffer.push({
+      pokeStart: receivingPoke.pokeStart,
+      parts: receivingPoke.parts,
+      pokeEnd,
+    });
     this.#receivingPoke = undefined;
     if (!this.#pokePlaybackLoopRunning) {
       this.#startPlaybackLoop();
     }
+    return result;
   }
 
   handleDisconnect(): void {
@@ -209,6 +270,37 @@ export class PokeHandler {
     this.#receivingPoke = undefined;
     this.#pokeBuffer.length = 0;
   }
+}
+
+function decodePokeChunks(chunks: PokeChunk[]): PokePatches {
+  const decoder = new TextDecoder('utf-8', {fatal: true});
+  const decoded = new Array<string>(chunks.length + 1);
+  for (let i = 0; i < chunks.length; i++) {
+    decoded[i] = decoder.decode(chunks[i], {stream: true});
+  }
+  decoded[chunks.length] = decoder.decode();
+  chunks.length = 0;
+  return v.parse(
+    JSON.parse(decoded.join('')),
+    pokePatchesSchema,
+    'passthrough',
+  );
+}
+
+function summarizePoke(
+  parts: PokePartBody[],
+  clientID: ClientID,
+): PokeEndResult {
+  let lastMutationIDChangeForSelf: number | undefined;
+  let hasRows = false;
+  for (const part of parts) {
+    const lmid = part.lastMutationIDChanges?.[clientID];
+    if (lmid !== undefined) {
+      lastMutationIDChangeForSelf = lmid;
+    }
+    hasRows ||= Boolean(part.rowsPatch?.length);
+  }
+  return {lastMutationIDChangeForSelf, hasRows};
 }
 
 export function mergePokes(

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -62,6 +62,7 @@ import {
 } from '../../../zero-protocol/src/mutation.ts';
 import type {PingMessage} from '../../../zero-protocol/src/ping.ts';
 import type {
+  PokeChunk,
   PokeEndMessage,
   PokePartMessage,
   PokeStartMessage,
@@ -1298,16 +1299,36 @@ export class Zero<
     }
   }
 
-  #onMessage = (e: MessageEvent<string>) => {
+  #onMessage = (e: MessageEvent<string | ArrayBuffer>) => {
     const lc = this.#lc;
-    lc.debug?.('received message', e.data);
+    const {data} = e;
+    lc.debug?.(
+      'received message',
+      data instanceof ArrayBuffer
+        ? {type: 'binary', byteLength: data.byteLength}
+        : data,
+    );
     if (this.closed) {
       lc.debug?.('ignoring message because already closed');
       return;
     }
 
     let downMessage: Downstream;
-    const {data} = e;
+    if (data instanceof ArrayBuffer) {
+      this.#messageCount++;
+      this.#handlePokeChunk(new Uint8Array(data));
+      return;
+    }
+    if (typeof data !== 'string') {
+      this.#disconnect(
+        lc,
+        new ClientError({
+          kind: ClientErrorKind.InvalidMessage,
+          message: 'Invalid binary message received from server',
+        }),
+      );
+      return;
+    }
     try {
       downMessage = valita.parse(
         JSON.parse(data),
@@ -1914,9 +1935,22 @@ export class Zero<
     }
   }
 
+  #handlePokeChunk(chunk: PokeChunk): void {
+    this.#abortPingTimeout();
+    this.#pokeHandler.handlePokeChunk(chunk);
+  }
+
   #handlePokeEnd(_lc: LogContext, pokeMessage: PokeEndMessage): void {
     this.#abortPingTimeout();
-    this.#pokeHandler.handlePokeEnd(pokeMessage[1]);
+    const result = this.#pokeHandler.handlePokeEnd(pokeMessage[1]);
+    if (result?.hasRows) {
+      // Receiving row data indicates that the client is in a good state and
+      // can reset the reload backoff state.
+      resetBackoff();
+    }
+    if (result?.lastMutationIDChangeForSelf !== undefined) {
+      this.#lastMutationIDReceived = result.lastMutationIDChangeForSelf;
+    }
   }
 
   #onPokeError(error: unknown): void {
@@ -2795,15 +2829,13 @@ export async function createSocket(
     deletedClients = undefined;
   }
   onEvent?.('creating the WebSocket');
-  return [
-    new WS(
-      // toString() required for RN URL polyfill.
-      url.toString(),
-      secProtocol,
-    ),
-    queriesPatch,
-    skipEmptyDeletedClients(deletedClients),
-  ];
+  const socket = new WS(
+    // toString() required for RN URL polyfill.
+    url.toString(),
+    secProtocol,
+  );
+  socket.binaryType = 'arraybuffer';
+  return [socket, queriesPatch, skipEmptyDeletedClients(deletedClients)];
 }
 
 export async function createConnectionURL(

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -61,11 +61,11 @@ import {
   mapCRUD,
 } from '../../../zero-protocol/src/mutation.ts';
 import type {PingMessage} from '../../../zero-protocol/src/ping.ts';
-import type {
-  PokeChunk,
-  PokeEndMessage,
-  PokePartMessage,
-  PokeStartMessage,
+import {
+  POKE_CHUNK_MESSAGE_TYPE,
+  type PokeEndMessage,
+  type PokePartMessage,
+  type PokeStartMessage,
 } from '../../../zero-protocol/src/poke.ts';
 import {PROTOCOL_VERSION} from '../../../zero-protocol/src/protocol-version.ts';
 import type {
@@ -1316,7 +1316,18 @@ export class Zero<
     let downMessage: Downstream;
     if (data instanceof ArrayBuffer) {
       this.#messageCount++;
-      this.#handlePokeChunk(new Uint8Array(data));
+      const message = new Uint8Array(data);
+      if (message[0] !== POKE_CHUNK_MESSAGE_TYPE) {
+        this.#disconnect(
+          lc,
+          new ClientError({
+            kind: ClientErrorKind.InvalidMessage,
+            message: `Unknown binary message type: ${String(message[0])}`,
+          }),
+        );
+        return;
+      }
+      this.#handlePokeChunk(message.subarray(1));
       return;
     }
     if (typeof data !== 'string') {
@@ -1935,7 +1946,7 @@ export class Zero<
     }
   }
 
-  #handlePokeChunk(chunk: PokeChunk): void {
+  #handlePokeChunk(chunk: Uint8Array): void {
     this.#abortPingTimeout();
     this.#pokeHandler.handlePokeChunk(chunk);
   }

--- a/packages/zero-protocol/src/ast.test.ts
+++ b/packages/zero-protocol/src/ast.test.ts
@@ -691,5 +691,5 @@ test('protocol version', () => {
   // old code will not understand the new schema, bump the
   // PROTOCOL_VERSION and update the expected values.
   expect(hash).toEqual('1dsf0svqtvyhv');
-  expect(PROTOCOL_VERSION).toBe(51);
+  expect(PROTOCOL_VERSION).toBe(52);
 });

--- a/packages/zero-protocol/src/poke.ts
+++ b/packages/zero-protocol/src/poke.ts
@@ -16,12 +16,13 @@ import {nullableVersionSchema, versionSchema} from './version.ts';
  * A poke begins with a `poke-start` message which contains the `baseCookie`
  * the poke is updating from and the `cookie` the poke is updating to.
  *
- * The poke continues with zero to many `poke-part` messages, each of which
- * can contain patch parts.  These patch parts should be merged in the order
- * received.
+ * Through protocol version 51, the poke continues with zero to many
+ * `poke-part` JSON messages. Starting in version 52, it continues with zero to
+ * many binary `pokeChunk` messages. Concatenating and decoding the pokeChunks
+ * produces a PokePatch array. pokeChunk boundaries have no semantic meaning.
  *
- * Finally, the poke ends with a `poke-end` message.  The merged `poke-parts`
- * can now be applied as a whole to update from `baseCookie` to `cookie`.
+ * Finally, the poke ends with a `poke-end` message. The decoded patches can
+ * now be applied as a whole to update from `baseCookie` to `cookie`.
  *
  * Poke messages can be intermingled with other `down` messages, but cannot be
  * intermingled with poke messages for a different `pokeID`. If this is
@@ -48,8 +49,7 @@ export const pokeStartBodySchema = v.object({
   timestamp: v.number().optional(),
 });
 
-export const pokePartBodySchema = v.object({
-  pokeID: v.string(),
+export const pokePatchSchema = v.object({
   // Changes to last mutation id by client id.
   lastMutationIDChanges: v.record(v.number()).optional(),
   // Patches to the desired query sets by client id.
@@ -62,6 +62,20 @@ export const pokePartBodySchema = v.object({
   // Mutation results patch
   mutationsPatch: mutationsPatchSchema.optional(),
 });
+
+export const pokePartBodySchema = pokePatchSchema.extend({
+  pokeID: v.string(),
+});
+
+/**
+ * The logical payload carried by binary poke chunks. Chunk boundaries are
+ * arbitrary; concatenating and decoding all chunks for a poke produces this
+ * array.
+ *
+ * PokePatch retains the grouped fields from PokePartBody, but omits pokeID:
+ * pokeStart and pokeEnd already delimit a single poke on the ordered stream.
+ */
+export const pokePatchesSchema = v.array(pokePatchSchema);
 
 export const pokeEndBodySchema = v.object({
   pokeID: v.string(),
@@ -86,8 +100,13 @@ export const pokeEndMessageSchema = v.tuple([
 ]);
 
 export type PokeStartBody = v.Infer<typeof pokeStartBodySchema>;
+export type PokePatch = v.Infer<typeof pokePatchSchema>;
 export type PokePartBody = v.Infer<typeof pokePartBodySchema>;
+export type PokePatches = v.Infer<typeof pokePatchesSchema>;
 export type PokeEndBody = v.Infer<typeof pokeEndBodySchema>;
+
+/** A raw binary WebSocket message. It has no JSON envelope. */
+export type PokeChunk = Uint8Array;
 
 export type PokeStartMessage = v.Infer<typeof pokeStartMessageSchema>;
 export type PokePartMessage = v.Infer<typeof pokePartMessageSchema>;

--- a/packages/zero-protocol/src/poke.ts
+++ b/packages/zero-protocol/src/poke.ts
@@ -18,8 +18,9 @@ import {nullableVersionSchema, versionSchema} from './version.ts';
  *
  * Through protocol version 51, the poke continues with zero to many
  * `poke-part` JSON messages. Starting in version 52, it continues with zero to
- * many binary `pokeChunk` messages. Concatenating and decoding the pokeChunks
- * produces a PokePatch array. pokeChunk boundaries have no semantic meaning.
+ * many binary `pokeChunk` messages. Each binary message starts with a message
+ * type byte. Concatenating and decoding the payload after that byte produces a
+ * PokePartBody array. pokeChunk boundaries have no semantic meaning.
  *
  * Finally, the poke ends with a `poke-end` message. The decoded patches can
  * now be applied as a whole to update from `baseCookie` to `cookie`.
@@ -49,7 +50,7 @@ export const pokeStartBodySchema = v.object({
   timestamp: v.number().optional(),
 });
 
-export const pokePatchSchema = v.object({
+export const pokePartBodySchema = v.object({
   // Changes to last mutation id by client id.
   lastMutationIDChanges: v.record(v.number()).optional(),
   // Patches to the desired query sets by client id.
@@ -61,9 +62,6 @@ export const pokePatchSchema = v.object({
   rowsPatch: rowsPatchSchema.optional(),
   // Mutation results patch
   mutationsPatch: mutationsPatchSchema.optional(),
-});
-
-export const pokePartBodySchema = pokePatchSchema.extend({
   pokeID: v.string(),
 });
 
@@ -71,11 +69,8 @@ export const pokePartBodySchema = pokePatchSchema.extend({
  * The logical payload carried by binary poke chunks. Chunk boundaries are
  * arbitrary; concatenating and decoding all chunks for a poke produces this
  * array.
- *
- * PokePatch retains the grouped fields from PokePartBody, but omits pokeID:
- * pokeStart and pokeEnd already delimit a single poke on the ordered stream.
  */
-export const pokePatchesSchema = v.array(pokePatchSchema);
+export const pokePartsSchema = v.array(pokePartBodySchema);
 
 export const pokeEndBodySchema = v.object({
   pokeID: v.string(),
@@ -100,12 +95,20 @@ export const pokeEndMessageSchema = v.tuple([
 ]);
 
 export type PokeStartBody = v.Infer<typeof pokeStartBodySchema>;
-export type PokePatch = v.Infer<typeof pokePatchSchema>;
 export type PokePartBody = v.Infer<typeof pokePartBodySchema>;
-export type PokePatches = v.Infer<typeof pokePatchesSchema>;
+export type PokeParts = v.Infer<typeof pokePartsSchema>;
 export type PokeEndBody = v.Infer<typeof pokeEndBodySchema>;
 
-/** A raw binary WebSocket message. It has no JSON envelope. */
+/** The first byte identifying a binary WebSocket message as a poke chunk. */
+export const POKE_CHUNK_MESSAGE_TYPE = 0x00;
+
+/** The first protocol version that receives binary poke chunks. */
+export const POKE_CHUNK_PROTOCOL_VERSION = 52;
+
+/** The last protocol version that receives JSON pokePart messages. */
+export const LAST_POKE_PART_PROTOCOL_VERSION = 51;
+
+/** A tagged binary poke chunk WebSocket message. */
 export type PokeChunk = Uint8Array;
 
 export type PokeStartMessage = v.Infer<typeof pokeStartMessageSchema>;

--- a/packages/zero-protocol/src/protocol-version.test.ts
+++ b/packages/zero-protocol/src/protocol-version.test.ts
@@ -2,6 +2,10 @@ import {expect, test} from 'vitest';
 import {h64} from '../../shared/src/hash.ts';
 import {downstreamSchema} from './down.ts';
 import {
+  LAST_POKE_PART_PROTOCOL_VERSION,
+  POKE_CHUNK_PROTOCOL_VERSION,
+} from './poke.ts';
+import {
   MIN_SERVER_SUPPORTED_SYNC_PROTOCOL,
   PROTOCOL_VERSION,
 } from './protocol-version.ts';
@@ -16,6 +20,8 @@ test('protocol version', () => {
   // PROTOCOL_VERSION and update the expected values.
   expect(hash).toEqual('24niurwt66lah');
   expect(PROTOCOL_VERSION).toBe(52);
+  expect(LAST_POKE_PART_PROTOCOL_VERSION).toBe(51);
+  expect(POKE_CHUNK_PROTOCOL_VERSION).toBe(52);
 });
 
 test('server support retains the CloudZero protocol floor', () => {

--- a/packages/zero-protocol/src/protocol-version.test.ts
+++ b/packages/zero-protocol/src/protocol-version.test.ts
@@ -1,7 +1,10 @@
 import {expect, test} from 'vitest';
 import {h64} from '../../shared/src/hash.ts';
 import {downstreamSchema} from './down.ts';
-import {PROTOCOL_VERSION} from './protocol-version.ts';
+import {
+  MIN_SERVER_SUPPORTED_SYNC_PROTOCOL,
+  PROTOCOL_VERSION,
+} from './protocol-version.ts';
 import {upstreamSchema} from './up.ts';
 
 test('protocol version', () => {
@@ -13,4 +16,9 @@ test('protocol version', () => {
   // PROTOCOL_VERSION and update the expected values.
   expect(hash).toEqual('24niurwt66lah');
   expect(PROTOCOL_VERSION).toBe(52);
+});
+
+test('server support retains the CloudZero protocol floor', () => {
+  // CloudZero may continue serving clients at this version indefinitely.
+  expect(MIN_SERVER_SUPPORTED_SYNC_PROTOCOL).toBe(30);
 });

--- a/packages/zero-protocol/src/protocol-version.test.ts
+++ b/packages/zero-protocol/src/protocol-version.test.ts
@@ -11,6 +11,6 @@ test('protocol version', () => {
   // If this test fails upstream or downstream schema has changed such that
   // old code will not understand the new schema, bump the
   // PROTOCOL_VERSION and update the expected values.
-  expect(hash).toEqual('zu84kgjqlxbm');
-  expect(PROTOCOL_VERSION).toBe(51);
+  expect(hash).toEqual('24niurwt66lah');
+  expect(PROTOCOL_VERSION).toBe(52);
 });

--- a/packages/zero-protocol/src/protocol-version.ts
+++ b/packages/zero-protocol/src/protocol-version.ts
@@ -57,7 +57,8 @@ import {assert} from '../../shared/src/asserts.ts';
 // -- version 49 adds `scalar` to CorrelatedSubqueryCondition, removes scalarSubquery
 // -- version 50 adds OTEL headers to push and query messages
 // -- version 51 changes inspector metrics fields
-export const PROTOCOL_VERSION = 51;
+// -- version 52 replaces JSON pokePart messages with binary poke chunks
+export const PROTOCOL_VERSION = 52;
 
 /**
  * The minimum server-supported sync protocol version (i.e. the version

--- a/packages/zero-protocol/src/protocol-version.ts
+++ b/packages/zero-protocol/src/protocol-version.ts
@@ -57,17 +57,23 @@ import {assert} from '../../shared/src/asserts.ts';
 // -- version 49 adds `scalar` to CorrelatedSubqueryCondition, removes scalarSubquery
 // -- version 50 adds OTEL headers to push and query messages
 // -- version 51 changes inspector metrics fields
-// -- version 52 replaces JSON pokePart messages with binary poke chunks
+// -- version 52 replaces JSON pokePart messages with binary poke chunks for
+//    clients using protocol version 52 or newer. Older clients retain pokePart.
 export const PROTOCOL_VERSION = 52;
 
 /**
  * The minimum server-supported sync protocol version (i.e. the version
- * declared in the "/sync/v{#}/connect" URL). The contract for
- * backwards compatibility is that a `zero-cache` supports the current
- * `PROTOCOL_VERSION` and at least the previous one (i.e. `PROTOCOL_VERSION - 1`)
- * if not earlier ones as well. This corresponds to supporting clients running
- * the current release and the previous (major) release. Any client connections
- * from protocol versions before `MIN_SERVER_SUPPORTED_PROTOCOL_VERSION` are
+ * declared in the "/sync/v{#}/connect" URL).
+ *
+ * CloudZero can serve applications running old client releases indefinitely.
+ * Consequently, this value must never be increased: `zero-cache` must continue
+ * to support every sync protocol from this version through `PROTOCOL_VERSION`.
+ * A wire change that an old client cannot ignore must branch on the client's
+ * protocol version and retain the old behavior. Keep each compatibility fork
+ * isolated at the boundary that owns the changed behavior and test both sides
+ * of its version cutoff.
+ *
+ * Client connections from protocol versions before this historical floor are
  * closed with a `VersionNotSupported` error.
  */
 export const MIN_SERVER_SUPPORTED_SYNC_PROTOCOL = 30;

--- a/packages/zql-integration-tests/src/chinook/chinook-zero-cache-fuzzer.pg.test.ts
+++ b/packages/zql-integration-tests/src/chinook/chinook-zero-cache-fuzzer.pg.test.ts
@@ -696,8 +696,8 @@ class ProtocolFuzzerClient {
 
     void (async () => {
       try {
-        for await (const msg of source) {
-          queue.enqueue(msg);
+        for await (const {message} of source) {
+          queue.enqueue(message);
         }
       } catch (e) {
         queue.enqueueRejection(e);


### PR DESCRIPTION
Zero flushes a chunk every 100 rows regardless of how large those rows are, so a single chunk can be arbitrarily big. Sizing by bytes keeps each message inside the client's timeout, and makes fat-row schemas degrade slowly instead of failing completely.