### PR TITLE
fix(zero-cache): timeout stalled websocket sends

### DIFF
--- a/packages/zero-cache/src/workers/connection.test.ts
+++ b/packages/zero-cache/src/workers/connection.test.ts
@@ -9,7 +9,12 @@ import type {Downstream} from '../../../zero-protocol/src/down.ts';
 import {ErrorKind} from '../../../zero-protocol/src/error-kind.ts';
 import {ErrorOrigin} from '../../../zero-protocol/src/error-origin.ts';
 import {ProtocolErrorWithLevel} from '../types/error-with-level.ts';
-import {send, sendError, type WebSocketLike} from './connection.ts';
+import {
+  send,
+  sendError,
+  WEBSOCKET_SEND_TIMEOUT_MS,
+  type WebSocketLike,
+} from './connection.ts';
 
 class MockSocket implements WebSocketLike {
   readyState: WebSocket['readyState'] = WebSocket.OPEN;
@@ -46,7 +51,51 @@ describe('send', () => {
     const callback = () => {};
     ws.readyState = WebSocket.OPEN;
     send(lc, ws, data, callback);
-    expect(sendSpy).toHaveBeenCalledWith(JSON.stringify(data), callback);
+    expect(sendSpy).toHaveBeenCalledWith(
+      JSON.stringify(data),
+      expect.any(Function),
+    );
+  });
+
+  test('fails a stalled websocket send after the timeout', async () => {
+    vi.useFakeTimers();
+    try {
+      const callback = vi.fn();
+      send(lc, ws, data, callback);
+
+      await vi.advanceTimersByTimeAsync(WEBSOCKET_SEND_TIMEOUT_MS);
+
+      expect(callback).toHaveBeenCalledTimes(1);
+      const error = callback.mock.calls[0]![0] as ProtocolErrorWithLevel;
+      expect(error).toBeInstanceOf(ProtocolErrorWithLevel);
+      expect(error.errorBody).toEqual({
+        kind: ErrorKind.Internal,
+        message: `WebSocket send timed out after ${WEBSOCKET_SEND_TIMEOUT_MS} ms`,
+        origin: ErrorOrigin.ZeroCache,
+      });
+      expect(error.logLevel).toBe('info');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test('invokes the callback only once when a timed-out send later completes', async () => {
+    vi.useFakeTimers();
+    try {
+      let sendCallback: ((err?: Error) => void) | undefined;
+      ws.send = (_data, callback) => {
+        sendCallback = callback;
+      };
+      const callback = vi.fn();
+      send(lc, ws, data, callback);
+
+      await vi.advanceTimersByTimeAsync(WEBSOCKET_SEND_TIMEOUT_MS);
+      sendCallback?.();
+
+      expect(callback).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/packages/zero-cache/src/workers/connection.ts
+++ b/packages/zero-cache/src/workers/connection.ts
@@ -63,6 +63,7 @@ export interface MessageHandler {
 // replication stream (which can similarly be back-pressured):
 // https://github.com/rocicorp/mono/blob/f98cb369a2dbb15650328859c732db358f187ef0/packages/zero-cache/src/services/change-source/pg/logical-replication/stream.ts#L21
 const DOWNSTREAM_MSG_INTERVAL_MS = 6_000;
+export const WEBSOCKET_SEND_TIMEOUT_MS = 10_000;
 const PROTOCOL_VERSION_ATTRIBUTE = 'protocol.version';
 const EVENT_TYPE_ATTRIBUTE = 'event.type';
 
@@ -361,10 +362,37 @@ export function send(
   callback: ((err?: Error | null) => void) | 'ignore-backpressure',
 ) {
   if (ws.readyState === WebSocket.OPEN) {
-    ws.send(
-      JSON.stringify(data),
-      callback === 'ignore-backpressure' ? undefined : callback,
-    );
+    const serialized = JSON.stringify(data);
+    if (callback === 'ignore-backpressure') {
+      ws.send(serialized);
+      return;
+    }
+
+    let completed = false;
+    const timer = setTimeout(() => {
+      complete(
+        new ProtocolErrorWithLevel(
+          {
+            kind: ErrorKind.Internal,
+            message: `WebSocket send timed out after ${WEBSOCKET_SEND_TIMEOUT_MS} ms`,
+            origin: ErrorOrigin.ZeroCache,
+          },
+          'info',
+        ),
+      );
+    }, WEBSOCKET_SEND_TIMEOUT_MS);
+    timer.unref();
+
+    const complete = (error?: Error | null) => {
+      if (completed) {
+        return;
+      }
+      completed = true;
+      clearTimeout(timer);
+      callback(error);
+    };
+
+    ws.send(serialized, complete);
   } else {
     lc.debug?.(`Dropping outbound message on ws (state: ${ws.readyState})`, {
       dropped: data,


### PR DESCRIPTION
 Add a timeout on the send so a stalled client cannot hold a pipeline for 85+ seconds; 