### PR TITLE
[WIP] fix(zero-cache): replicate CREATE TABLE AS

### DIFF
--- a/packages/zero-cache/src/services/change-source/pg/change-source.backfill.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.backfill.pg.test.ts
@@ -178,7 +178,84 @@ describe.each([
     }
   }
 
+  test.each([
+    [
+      'CREATE TABLE AS',
+      `CREATE TABLE published.scratch AS SELECT 1::INT AS id`,
+    ],
+    ['SELECT INTO', `SELECT 1::INT AS id INTO published.scratch`],
+  ])(
+    '%s scratch table created and dropped in one transaction',
+    async (_, ddl) => {
+      await upstream.unsafe(/*sql*/ `
+      ${ddl};
+      INSERT INTO published.scratch VALUES (2);
+      DROP TABLE published.scratch;
+    `);
+
+      expect((await nextTransaction()).map(({tag}) => tag)).toEqual([
+        'create-table',
+        'insert',
+        'drop-table',
+      ]);
+    },
+  );
+
   test.for([
+    [
+      'table created with CREATE TABLE AS',
+      PG_15_UP,
+      /*sql*/ `
+      CREATE TABLE published.ctas_table AS
+        SELECT * FROM (VALUES (1, 'one'::TEXT), (2, 'two'::TEXT)) AS rows(id, value);
+      ALTER TABLE published.ctas_table ADD PRIMARY KEY (id);
+      INSERT INTO published.ctas_table VALUES (3, 'three');
+      `,
+      null,
+      {
+        ['published.ctas_table']: [
+          {id: 3n, value: 'three'},
+          {id: 1n, value: 'one'},
+          {id: 2n, value: 'two'},
+        ],
+      },
+      [
+        {
+          name: 'published.ctas_table',
+          columns: {
+            id: {dataType: 'int4|NOT_NULL', pos: 1},
+            value: {dataType: 'text', pos: 2},
+          },
+        },
+      ],
+    ],
+    [
+      'table created with SELECT INTO',
+      PG_15_UP,
+      /*sql*/ `
+      SELECT * INTO published.select_into_table
+        FROM (VALUES (1, 'one'::TEXT), (2, 'two'::TEXT)) AS rows(id, value);
+      ALTER TABLE published.select_into_table ADD PRIMARY KEY (id);
+      INSERT INTO published.select_into_table VALUES (3, 'three');
+      `,
+      null,
+      {
+        ['published.select_into_table']: [
+          {id: 3n, value: 'three'},
+          {id: 1n, value: 'one'},
+          {id: 2n, value: 'two'},
+        ],
+      },
+      [
+        {
+          name: 'published.select_into_table',
+          columns: {
+            id: {dataType: 'int4|NOT_NULL', pos: 1},
+            value: {dataType: 'text', pos: 2},
+          },
+        },
+      ],
+    ],
     [
       'table added to published schema',
       PG_15_UP,

--- a/packages/zero-cache/src/services/change-source/pg/change-source.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.ts
@@ -1011,6 +1011,7 @@ type ReplicationError = {
 };
 
 const SET_REPLICA_IDENTITY_DELAY_MS = 50;
+const PRE_SCHEMA_DATA_TAGS = new Set(['CREATE TABLE AS', 'SELECT INTO']);
 
 class ChangeMaker {
   readonly #shardPrefix: string;
@@ -1020,6 +1021,8 @@ class ChangeMaker {
 
   #replicaIdentityTimer: NodeJS.Timeout | undefined;
   #error: ReplicationError | undefined;
+  readonly #knownRelationOIDs: Set<number>;
+  #preSchemaData: {tag: string; relationOID?: number} | undefined;
 
   constructor(
     {appID, shardNum}: ShardID,
@@ -1032,6 +1035,7 @@ class ChangeMaker {
     this.#shardConfig = shardConfig;
     this.#initialSchema = initialSchema;
     this.#db = db;
+    this.#knownRelationOIDs = new Set(initialSchema.tables.map(({oid}) => oid));
   }
 
   async makeChanges(
@@ -1111,6 +1115,9 @@ class ChangeMaker {
         ];
 
       case 'delete': {
+        if (this.#isPreSchemaData(msg.relation)) {
+          return [];
+        }
         if (!(msg.key ?? msg.old)) {
           throw new Error(
             `Invalid DELETE msg (missing key): ${stringify(msg)}`,
@@ -1130,6 +1137,9 @@ class ChangeMaker {
       }
 
       case 'update': {
+        if (this.#isPreSchemaData(msg.relation)) {
+          return [];
+        }
         return [
           [
             'data',
@@ -1144,9 +1154,18 @@ class ChangeMaker {
       }
 
       case 'insert':
+        if (this.#isPreSchemaData(msg.relation)) {
+          return [];
+        }
         return [['data', {...msg, relation: makeRelation(msg.relation)}]];
-      case 'truncate':
-        return [['data', {...msg, relations: msg.relations.map(makeRelation)}]];
+      case 'truncate': {
+        const relations = msg.relations.filter(
+          relation => !this.#isPreSchemaData(relation),
+        );
+        return relations.length
+          ? [['data', {...msg, relations: relations.map(makeRelation)}]]
+          : [];
+      }
 
       case 'message':
         if (!msg.prefix.startsWith(this.#shardPrefix)) {
@@ -1163,6 +1182,7 @@ class ChangeMaker {
         }
 
       case 'commit':
+        this.#preSchemaData = undefined;
         return [
           [
             'commit',
@@ -1218,6 +1238,15 @@ class ChangeMaker {
         return [];
     }
 
+    if (type === 'ddlStart' && PRE_SCHEMA_DATA_TAGS.has(event.event.tag)) {
+      this.#preSchemaData = {tag: event.event.tag};
+    } else if (
+      type === 'ddlUpdate' &&
+      this.#preSchemaData?.tag === event.event.tag
+    ) {
+      this.#preSchemaData = undefined;
+    }
+
     const prevEvent = this.#lastReplicationEvent;
     // Store the new event to understand the context of the next event.
     this.#lastReplicationEvent = event;
@@ -1231,6 +1260,11 @@ class ChangeMaker {
         event: summarizeReplicationEventForLog(event),
       });
       return [];
+    }
+
+    this.#knownRelationOIDs.clear();
+    for (const {oid} of schema.tables) {
+      this.#knownRelationOIDs.add(oid);
     }
 
     const prevSchema =
@@ -1392,7 +1426,9 @@ class ChangeMaker {
           spec,
           metadata: getMetadata(spec),
         };
-        // Only tables introduced by a `CREATE` statement can skip backfill.
+        // Only tables introduced by a plain `CREATE TABLE` statement can skip
+        // backfill. CREATE TABLE AS and SELECT INTO emit their row changes
+        // before the schema change, so those rows are suppressed and backfilled.
         // All other scenarios in which tables are introduced into the
         // schema, e.g.
         // * ALTER PUBLICATION statements
@@ -1400,7 +1436,7 @@ class ChangeMaker {
         // * MANUAL snapshots
         // * UNKNOWN command tags
         // must be backfilled.
-        if (!tag.startsWith('CREATE')) {
+        if (tag !== 'CREATE TABLE') {
           createTable.backfill = mapValues(spec.columns, ({pos: attNum}) => ({
             attNum,
           })) satisfies Record<string, ColumnMetadata>;
@@ -1549,6 +1585,13 @@ class ChangeMaker {
    * However, they serve the purpose determining if schemas have changed.
    */
   async #handleRelation(rel: PostgresRelation): Promise<ChangeStreamData[]> {
+    if (
+      this.#preSchemaData &&
+      this.#preSchemaData.relationOID === undefined &&
+      !this.#knownRelationOIDs.has(rel.relationOid)
+    ) {
+      this.#preSchemaData.relationOID = rel.relationOid;
+    }
     const {publications, ddlDetection} = this.#shardConfig;
     if (ddlDetection) {
       return [];
@@ -1577,6 +1620,10 @@ class ChangeMaker {
       );
     }
     return [];
+  }
+
+  #isPreSchemaData(relation: PostgresRelation): boolean {
+    return this.#preSchemaData?.relationOID === relation.relationOid;
   }
 }
 

--- a/packages/zero-cache/src/services/change-source/pg/schema/ddl.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/ddl.pg.test.ts
@@ -1353,6 +1353,48 @@ describe('change-source/tables/ddl', () => {
 
   test.each([
     [
+      'CREATE TABLE AS',
+      `CREATE TABLE pub.ctas_table AS SELECT 1::INT8 AS id, 'one'::TEXT AS value`,
+      'ctas_table',
+      'CREATE TABLE AS',
+    ],
+    [
+      'SELECT INTO',
+      `SELECT 1::INT8 AS id, 'one'::TEXT AS value INTO pub.select_into_table`,
+      'select_into_table',
+      'SELECT INTO',
+    ],
+  ])('%s emits a schema update', async (endTag, query, tableName, startTag) => {
+    await upstream.unsafe(query);
+
+    const messages = await expectReplicationMessagesToMatchObject([
+      {tag: 'begin'},
+      {tag: 'message', prefix: 'zap/0/ddl'},
+      {tag: 'relation'},
+      {tag: 'insert'},
+      {tag: 'message', prefix: 'zap/0/ddl'},
+      {tag: 'commit'},
+    ]);
+
+    expect(parseDDLStartEvent(messages[1] as MessageMessage)).toMatchObject({
+      type: 'ddlStart',
+      event: {tag: startTag},
+      context: {query},
+    });
+
+    const update = parseDDLUpdateEvent(messages[4] as MessageMessage);
+    expect(update).toMatchObject({
+      type: 'ddlUpdate',
+      event: {tag: endTag},
+      context: {query},
+    });
+    expect(update.schema.tables).toContainEqual(
+      expect.objectContaining({schema: 'pub', name: tableName}),
+    );
+  });
+
+  test.each([
+    [
       'COMMENT',
       /*sql*/ `
       ALTER PUBLICATION zero_sum DROP TABLE pub.boo;

--- a/packages/zero-cache/src/services/change-source/pg/schema/ddl.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/ddl.ts
@@ -373,6 +373,8 @@ $$ LANGUAGE plpgsql;
 // Exported for testing.
 export const TAGS = [
   'CREATE TABLE',
+  'CREATE TABLE AS',
+  'SELECT INTO',
   'ALTER TABLE',
   'CREATE INDEX',
   'DROP TABLE',
@@ -413,7 +415,7 @@ CREATE EVENT TRIGGER ${sharded(`${appID}_ddl_end`)}
     `DROP FUNCTION IF EXISTS ${schema}.notice_ignore(text, record);`,
   );
   for (const tag of [...TAGS, 'COMMENT']) {
-    const tagID = tag.toLowerCase().replace(' ', '_');
+    const tagID = tag.toLowerCase().replaceAll(' ', '_');
     triggers.push(`DROP FUNCTION IF EXISTS ${schema}.emit_${tagID}() CASCADE;`);
   }
   return triggers.join('');

--- a/packages/zero-cache/src/services/change-source/pg/schema/init.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/init.pg.test.ts
@@ -23,7 +23,7 @@ const SHARD_NUM = 23;
 const CURRENT_SCHEMA_VERSIONS = {
   dataVersion: CURRENT_SCHEMA_VERSION,
   schemaVersion: CURRENT_SCHEMA_VERSION,
-  minSafeVersion: 1,
+  minSafeVersion: 25,
   lock: 'v',
 } as const;
 
@@ -228,4 +228,51 @@ describe('change-streamer/pg/schema/init', () => {
       await expectTablesToMatch(upstream, c.upstreamPostState);
     });
   }
+
+  test('upgrades DDL event triggers from v24', async () => {
+    const shard = {
+      appID: APP_ID,
+      shardNum: SHARD_NUM,
+      publications: [],
+    };
+    await ensureShardSchema(lc, upstream, shard);
+
+    await upstream.unsafe(/*sql*/ `
+      DROP EVENT TRIGGER ${APP_ID}_ddl_start_${SHARD_NUM};
+      DROP EVENT TRIGGER ${APP_ID}_ddl_end_${SHARD_NUM};
+
+      CREATE EVENT TRIGGER ${APP_ID}_ddl_start_${SHARD_NUM}
+        ON ddl_command_start
+        WHEN TAG IN ('CREATE TABLE')
+        EXECUTE PROCEDURE ${APP_ID}_${SHARD_NUM}.emit_ddl_start();
+
+      CREATE EVENT TRIGGER ${APP_ID}_ddl_end_${SHARD_NUM}
+        ON ddl_command_end
+        WHEN TAG IN ('CREATE TABLE')
+        EXECUTE PROCEDURE ${APP_ID}_${SHARD_NUM}.emit_ddl_end();
+    `);
+
+    const schema = `${APP_ID}_${SHARD_NUM}`;
+    await upstream`
+      UPDATE ${upstream(schema)}."versionHistory"
+      SET "dataVersion" = ${CURRENT_SCHEMA_VERSION - 1},
+          "schemaVersion" = ${CURRENT_SCHEMA_VERSION - 1}
+    `;
+
+    await ensureShardSchema(lc, upstream, shard);
+
+    const triggers = await upstream<{tags: string[]}[]>`
+      SELECT evttags AS tags
+      FROM pg_event_trigger
+      WHERE evtname IN (
+        ${`${APP_ID}_ddl_start_${SHARD_NUM}`},
+        ${`${APP_ID}_ddl_end_${SHARD_NUM}`}
+      )
+    `;
+    expect(triggers).toHaveLength(2);
+    for (const {tags} of triggers) {
+      expect(tags).toContain('CREATE TABLE AS');
+      expect(tags).toContain('SELECT INTO');
+    }
+  });
 });

--- a/packages/zero-cache/src/services/change-source/pg/schema/init.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/init.ts
@@ -29,7 +29,7 @@ export async function ensureShardSchema(
 ): Promise<void> {
   const initialSetup: Migration = {
     migrateSchema: (lc, tx) => setupTablesAndReplication(lc, tx, shard),
-    minSafeVersion: 1,
+    minSafeVersion: 25,
   };
   await runSchemaMigrations(
     lc,
@@ -228,6 +228,18 @@ function getIncrementalMigrations(shard: ShardConfig): IncrementalMigrationMap {
           UPDATE ${sql(upstreamSchema(shard))}.replicas SET "generation" = "version";
         `;
       },
+    },
+
+    // v25: Upgrade DDL triggers to detect CREATE TABLE AS and SELECT INTO.
+    25: {
+      migrateSchema: async (lc, sql) => {
+        const [{publications}] = await sql<{publications: string[]}[]>`
+          SELECT publications FROM ${sql(shardConfigTable)}`;
+        await setupTriggers(lc, sql, {...shard, publications});
+        lc.info?.(`Upgraded DDL event triggers`);
+      },
+      // Older change sources process CTAS rows before the table schema.
+      minSafeVersion: 25,
     },
   };
 }


### PR DESCRIPTION
 
### What

Support replicating tables created and populated with `CREATE TABLE AS` or `SELECT INTO`. This covers both durable tables and transient scratch-table workflows in schema-level publications.

### Why

Postgres emits the rows populated by these commands before the `ddl_command_end` event that exposes the new table schema. Zero did not monitor either command tag, so the replicator could receive an insert before receiving a `create-table` change and fail with `Unknown table`.

### Changes

- Register `CREATE TABLE AS` and `SELECT INTO` with Zero's DDL event triggers.
- Suppress creation-time row changes until the schema arrives, then recover those rows through table backfill without buffering large transactions.
- Preserve subsequent inserts and drops in the same transaction.
- Add shard schema migration v25 to upgrade existing event triggers and prevent rollback to change sources that cannot process this ordering.
- Cover DDL ordering, durable-table backfills, and transient create/insert/drop workflows across PostgreSQL 15 through 18.
