### PR TITLE
chore(zero-cache): avoid an sqlite_master lookup in the common case

### DIFF
--- a/packages/zero-cache/src/services/replicator/schema/column-metadata.ts
+++ b/packages/zero-cache/src/services/replicator/schema/column-metadata.ts
@@ -142,19 +142,19 @@ export class ColumnMetadataStore {
    * Returns `undefined` if the metadata table doesn't exist yet.
    */
   static getInstance(db: Database): ColumnMetadataStore | undefined {
-    // Check if table exists
-    const tableExists = db
-      .prepare(
-        `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = '_zero.column_metadata'`,
-      )
-      .get();
-
-    if (!tableExists) {
-      return undefined;
-    }
-
     let instance = ColumnMetadataStore.#instances.get(db);
     if (!instance) {
+      // Check if table exists
+      const tableExists = db
+        .prepare(
+          `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = '_zero.column_metadata'`,
+        )
+        .get();
+
+      if (!tableExists) {
+        return undefined;
+      }
+
       instance = new ColumnMetadataStore(db);
       ColumnMetadataStore.#instances.set(db, instance);
     }


### PR DESCRIPTION
Avoid a lookup on sqlite_master in the common case of ColumnMetadata.getInstance().