### PR TITLE
fix(zero-cache): prevent orphaned backfill replication slots

### DIFF
--- a/packages/zero-cache/src/services/change-source/pg/backfill-stream.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/backfill-stream.pg.test.ts
@@ -8,6 +8,8 @@ import type {BackfillRequest} from '../protocol/current.ts';
 import {streamBackfill} from './backfill-stream.ts';
 import {getPublicationInfo} from './schema/published.ts';
 
+const SLOT_NAME = 'backfill_test_slot';
+
 describe('backfill-stream', () => {
   let lc: LogContext;
   let upstream: PostgresDB;
@@ -96,7 +98,14 @@ describe('backfill-stream', () => {
       },
     };
 
-    return () => testDBs.drop(upstream);
+    return async () => {
+      expect(
+        await upstream /*sql*/ `
+          SELECT slot_name FROM pg_replication_slots WHERE slot_name LIKE 'backfill_test_slot_%'`,
+      ).toEqual([]);
+
+      await testDBs.drop(upstream);
+    };
   });
 
   test.each([
@@ -106,7 +115,7 @@ describe('backfill-stream', () => {
     const stream = streamBackfill(
       lc,
       upstreamURI,
-      {slot: 'slot_name', publications: ['the_pub']},
+      {slot: SLOT_NAME, publications: ['the_pub']},
       columnBackfillRequest,
       {textCopy},
     );
@@ -163,7 +172,7 @@ describe('backfill-stream', () => {
     const stream = streamBackfill(
       lc,
       upstreamURI,
-      {slot: 'slot_name', publications: ['the_pub']},
+      {slot: SLOT_NAME, publications: ['the_pub']},
       tableBackfillRequest,
       {textCopy},
     );
@@ -226,7 +235,7 @@ describe('backfill-stream', () => {
     const stream = streamBackfill(
       lc,
       upstreamURI,
-      {slot: 'slot_name', publications: ['the_pub']},
+      {slot: SLOT_NAME, publications: ['the_pub']},
       columnBackfillRequest,
     );
     for await (const _ of stream) {
@@ -305,7 +314,7 @@ describe('backfill-stream', () => {
     const stream = streamBackfill(
       lc,
       upstreamURI,
-      {slot: 'slot_name', publications: ['the_pub']},
+      {slot: SLOT_NAME, publications: ['the_pub']},
       columnBackfillRequest,
     );
 

--- a/packages/zero-cache/src/services/change-source/pg/backfill-stream.ts
+++ b/packages/zero-cache/src/services/change-source/pg/backfill-stream.ts
@@ -302,25 +302,18 @@ async function createSnapshotTransaction(
   const slotName = `${slotNamePrefix}_bf_${Date.now()}`;
   try {
     const {snapshot_name: snapshot, consistent_point: lsn} =
-      await createReplicationSlot(lc, replicationSession, {slotName});
+      await createReplicationSlot(lc, replicationSession, {
+        slotName,
+        temporary: true, // deletes the slot when the replicationSession ends
+      });
 
     const {init, imported} = importSnapshot(snapshot);
     const tx = new TransactionPool(lc, {mode: READONLY, init}).run(db);
     await imported;
-    await replicationSession.unsafe(`DROP_REPLICATION_SLOT "${slotName}"`);
 
     const watermark = toStateVersionString(lsn);
     lc.info?.(`Opened snapshot transaction at LSN ${lsn} (${watermark})`);
     return {tx, watermark};
-  } catch (e) {
-    // In the event of a failure, clean up the replication slot if created.
-    await replicationSession.unsafe(
-      /*sql*/
-      `SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots
-         WHERE slot_name = '${slotName}'`,
-    );
-    lc.warn?.(`Failed to create backfill snapshot`, e);
-    throw e;
   } finally {
     await replicationSession.end();
   }

--- a/packages/zero-cache/src/services/change-source/pg/replication-slots.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/replication-slots.pg.test.ts
@@ -3,6 +3,7 @@ import postgres from 'postgres';
 import {beforeEach, describe, expect, vi} from 'vitest';
 import {createSilentLogContext} from '../../../../../shared/src/logging-test-utils.ts';
 import {getConnectionURI, type PgTest, test} from '../../../test/db.ts';
+import {PG_17} from '../../../types/pg-versions.ts';
 import {pgClient, type PostgresDB} from '../../../types/pg.ts';
 import type {ShardID} from '../../../types/shards.ts';
 import {
@@ -33,14 +34,67 @@ describe('createReplicationSlot', () => {
   const shard: ShardID = {appID: APP_ID, shardNum: SHARD_NUM};
 
   let upstream: PostgresDB;
+  let pgVersion: number;
 
   beforeEach<PgTest>(async ({testDBs}) => {
     upstream = await testDBs.create('replication_slots');
+    [{pgVersion}] =
+      await upstream`SELECT current_setting('server_version_num')::int as "pgVersion"`;
     await ensureGlobalTables(upstream, shard);
     await upstream.unsafe(
       shardSetup({...shard, publications: ['foo_pub', 'meta_pub']}, 'meta_pub'),
     );
     return () => testDBs.drop(upstream);
+  });
+
+  test('createReplicationSlot options', async () => {
+    const lc = createSilentLogContext();
+    const upstreamURI = getConnectionURI(upstream);
+    const session = pgClient(lc, upstreamURI, 'slot-pool', {
+      max: 1,
+      ['fetch_types']: false,
+      connection: {replication: 'database'},
+    });
+
+    await createReplicationSlot(lc, session, {slotName: 'zero_18_a'});
+    await createReplicationSlot(lc, session, {
+      slotName: 'zero_18_b',
+      temporary: true,
+    });
+    expect(
+      await upstream /*sql*/ `
+      SELECT slot_name, temporary FROM pg_replication_slots 
+        WHERE slot_name LIKE 'zero_18_%' ORDER BY slot_name`,
+    ).toMatchObject([
+      {
+        slot_name: 'zero_18_a',
+        temporary: false,
+      },
+      {
+        slot_name: 'zero_18_b',
+        temporary: true,
+      },
+    ]);
+
+    if (pgVersion >= PG_17) {
+      await createReplicationSlot(lc, session, {
+        slotName: 'zero_18_c',
+        failover: true,
+      });
+      // oxlint-disable-next-line jest/no-conditional-expect
+      expect(
+        await upstream`SELECT slot_name, temporary, failover FROM pg_replication_slots WHERE slot_name = 'zero_18_c'`,
+      ).toMatchObject([
+        {
+          slot_name: 'zero_18_c',
+          temporary: false,
+          failover: true,
+        },
+      ]);
+    }
+
+    // Cleanup
+    await dropOldReplicasAndSlots(lc, upstream, shard, 100n);
   });
 
   test('createReplicationSlot times out behind an older idle transaction', async () => {

--- a/packages/zero-cache/src/services/change-source/pg/replication-slots.ts
+++ b/packages/zero-cache/src/services/change-source/pg/replication-slots.ts
@@ -29,6 +29,10 @@ export type CreateSlotSpec = {
   // Note: must be false if pgVersion < PG_17. Caller must verify.
   failover?: boolean;
 
+  // Create a temporary slot (i.e. not persisted, and automatically
+  // cleaned up when the replication session ends).
+  temporary?: boolean;
+
   // For overriding in tests.
   lockTimeout?: number;
 };
@@ -54,7 +58,12 @@ const SERVER_LOCK_TIMEOUT_MS = CREATE_REPLICATION_SLOT_TIMEOUT_MS - 1_000;
 export async function createReplicationSlot(
   lc: LogContext,
   session: postgres.Sql,
-  {slotName, failover, lockTimeout = SERVER_LOCK_TIMEOUT_MS}: CreateSlotSpec,
+  {
+    slotName,
+    failover,
+    temporary,
+    lockTimeout = SERVER_LOCK_TIMEOUT_MS,
+  }: CreateSlotSpec,
 ): Promise<ReplicationSlot> {
   // CREATE_REPLICATION_SLOT can hang indefinitely waiting for long-running
   // transactions to finish: internally it calls SnapBuildWaitSnapshot →
@@ -73,13 +82,11 @@ export async function createReplicationSlot(
   // fires (~2h default) or the blocking transaction finishes.
   await session.unsafe(`SET lock_timeout = ${lockTimeout}`);
 
-  const createSlot = failover
-    ? session.unsafe<ReplicationSlot[]>(
-        /*sql*/ `CREATE_REPLICATION_SLOT "${slotName}" LOGICAL pgoutput (FAILOVER)`,
-      )
-    : session.unsafe<ReplicationSlot[]>(
-        /*sql*/ `CREATE_REPLICATION_SLOT "${slotName}" LOGICAL pgoutput`,
-      );
+  const maybeTemporary = temporary ? 'TEMPORARY' : '';
+  const options = failover ? '(FAILOVER)' : '';
+  const createSlot = session.unsafe<ReplicationSlot[]>(/*sql*/ `
+    CREATE_REPLICATION_SLOT "${slotName}" ${maybeTemporary} LOGICAL pgoutput ${options}`);
+
   const raced = await orTimeout(createSlot, CREATE_REPLICATION_SLOT_TIMEOUT_MS);
   if (raced === 'timed-out') {
     // Create slot can block indefinitely waiting for old transactions. End


### PR DESCRIPTION
Use `TEMPORARY` replication slots for backfill (since their only purpose is to link a snapshot with an lsn) to avoid the possibility of orphaning slots if the connection dies.

Reported in: https://bugs.rocicorp.dev/p/zero/issue/246773