### PR TITLE
chore(rmv2): allow SQLite to be the authoritative change log source

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/change-log-initializer-metrics.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-log-initializer-metrics.test.ts
@@ -77,13 +77,14 @@ async function compare(replica: () => InitializationParameters) {
     {
       pgChangeLog: () => Promise.resolve(AT('02')),
       replica,
+      reconcileChangeLog: resumeFrom => resumeFrom,
       // The fold is never reached: the two cases below are decided at the
       // watermark, and the third never gets as far as a comparison.
       changeLog: () => undefined,
     },
   );
   await init.initialize();
-  return init.compare();
+  return init.lastComparison();
 }
 
 test('an agreement is counted as equal', async () => {

--- a/packages/zero-cache/src/services/change-streamer/change-log-initializer.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-log-initializer.pg.test.ts
@@ -23,6 +23,9 @@ import {beforeEach, describe, expect} from 'vitest';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
 import type {Database} from '../../../../zqlite/src/db.ts';
 import {type PgTest, test} from '../../test/db.ts';
+import type {BackfillRequest} from '../change-source/protocol/current/upstream.ts';
+import {readCookies} from '../replicator/change-log-cookies.ts';
+import {readChangeLogHead} from '../replicator/change-log-db.ts';
 import type {ChangeProcessor} from '../replicator/change-processor.ts';
 import {
   ChangeLogInitializer,
@@ -56,16 +59,7 @@ describe('change-streamer/change-log-initializer against a shard', () => {
     changeLog = createChangeLog(lc);
     ({replica, processor} = createReplica(lc));
 
-    initializer = new ChangeLogInitializer(
-      lc,
-      {initFromPgChangeLog: true, initFromReplica: true},
-      {
-        pgChangeLog: () =>
-          shard.storer.getStartStreamInitializationParameters(),
-        replica: () => readReplicaInitializationParameters(replica),
-        changeLog: () => changeLog,
-      },
-    );
+    initializer = makeInitializer(true);
     // The stream loop's three stores, driven together.
     driver = new ChangeStreamDriver(lc, {
       upstream: shard.storer,
@@ -80,9 +74,66 @@ describe('change-streamer/change-log-initializer against a shard', () => {
     };
   });
 
+  /**
+   * `initFromPgChangeLog` is the flip, and the only difference between the two
+   * configurations under test.
+   */
+  function makeInitializer(initFromPgChangeLog: boolean) {
+    return new ChangeLogInitializer(
+      lc,
+      {initFromPgChangeLog, initFromReplica: true},
+      {
+        pgChangeLog: () =>
+          shard.storer.getStartStreamInitializationParameters(),
+        replica: () => readReplicaInitializationParameters(replica),
+        // Stands in for the writer. The log here is driven directly, so it is
+        // always already in agreement: Postgres's point passes through, and
+        // without one the log's own head is the resume point.
+        reconcileChangeLog: (resumeFrom, seed) => {
+          if (resumeFrom) {
+            return resumeFrom;
+          }
+          const head = readChangeLogHead(changeLog);
+          return head === null
+            ? seed()
+            : {resumeWatermark: head, cookies: readCookies(changeLog)};
+        },
+        changeLog: () => changeLog,
+      },
+    );
+  }
+
   async function compare() {
     await initializer.initialize();
-    return initializer.compare();
+    return initializer.lastComparison();
+  }
+
+  /**
+   * The cutover, asserted directly: the two configurations produce the same
+   * parameters from the same stream. Everything else here says the SQLite side
+   * *agrees* with Postgres; this says the flip is a no-op, which is the claim
+   * it actually makes.
+   *
+   * Ordered against Postgres's list rather than compared position-for-position,
+   * because the two are ordered in two engines under two collations.
+   */
+  async function expectFlipIsANoOp() {
+    const withPg = await makeInitializer(true).initialize();
+    const withoutPg = await makeInitializer(false).initialize();
+
+    expect(withoutPg.lastWatermark).toBe(withPg.lastWatermark);
+    expect(sorted(withoutPg.backfillRequests)).toEqual(
+      sorted(withPg.backfillRequests),
+    );
+    expect(withoutPg.cookies).toEqual(withPg.cookies);
+  }
+
+  function sorted(requests: BackfillRequest[]): BackfillRequest[] {
+    return requests.toSorted((a, b) =>
+      `${a.table.schema}.${a.table.name}`.localeCompare(
+        `${b.table.schema}.${b.table.name}`,
+      ),
+    );
   }
 
   test('the two stores agree when the replica is caught up', async () => {
@@ -105,6 +156,7 @@ describe('change-streamer/change-log-initializer against a shard', () => {
     ]);
 
     expect(await compare()).toBe('equal');
+    await expectFlipIsANoOp();
   });
 
   test('and when it trails, over an interval that moves both cookies', async () => {
@@ -190,5 +242,6 @@ describe('change-streamer/change-log-initializer against a shard', () => {
     ]);
 
     expect(await compare()).toBe('equal-after-fold');
+    await expectFlipIsANoOp();
   });
 });

--- a/packages/zero-cache/src/services/change-streamer/change-log-initializer.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-log-initializer.pg.test.ts
@@ -75,8 +75,8 @@ describe('change-streamer/change-log-initializer against a shard', () => {
   });
 
   /**
-   * `initFromPgChangeLog` is the flip, and the only difference between the two
-   * configurations under test.
+   * Creates an initializer with or without Postgres as an initialization
+   * source.
    */
   function makeInitializer(initFromPgChangeLog: boolean) {
     return new ChangeLogInitializer(
@@ -86,9 +86,9 @@ describe('change-streamer/change-log-initializer against a shard', () => {
         pgChangeLog: () =>
           shard.storer.getStartStreamInitializationParameters(),
         replica: () => readReplicaInitializationParameters(replica),
-        // Stands in for the writer. The log here is driven directly, so it is
-        // always already in agreement: Postgres's point passes through, and
-        // without one the log's own head is the resume point.
+        // This test writes directly to the log, so writer reconciliation is not
+        // necessary. Use the Postgres point when present. Otherwise, use the
+        // current log head.
         reconcileChangeLog: (resumeFrom, seed) => {
           if (resumeFrom) {
             return resumeFrom;
@@ -109,13 +109,10 @@ describe('change-streamer/change-log-initializer against a shard', () => {
   }
 
   /**
-   * The cutover, asserted directly: the two configurations produce the same
-   * parameters from the same stream. Everything else here says the SQLite side
-   * *agrees* with Postgres; this says the flip is a no-op, which is the claim
-   * it actually makes.
+   * Makes sure that both configurations produce the same initialization
+   * parameters from the same stream.
    *
-   * Ordered against Postgres's list rather than compared position-for-position,
-   * because the two are ordered in two engines under two collations.
+   * Sorts the requests because Postgres and SQLite use different collations.
    */
   async function expectFlipIsANoOp() {
     const withPg = await makeInitializer(true).initialize();

--- a/packages/zero-cache/src/services/change-streamer/change-log-initializer.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-log-initializer.test.ts
@@ -435,7 +435,7 @@ describe('change-streamer/change-log-initializer', () => {
     // Above MAX_FOLD_SCAN_ROWS. A replicator that has been stalled can leave
     // the interval arbitrarily large, and this runs between reconciliation and
     // `startStream`, so the comparison declines rather than pays.
-    padTransaction(head, 100_002);
+    padTransaction(head, 10_002);
 
     expect(await compare()).toBe('inconclusive');
   });
@@ -447,7 +447,7 @@ describe('change-streamer/change-log-initializer', () => {
     // rather than declined. Pinned because the guard counts to one row *past*
     // the cap in SQL so that an unbounded interval is not walked in full, and
     // an off-by-one there would silently stop folding a legal interval.
-    padTransaction(head, 99_999);
+    padTransaction(head, 9_999);
 
     expect(await compare()).toBe('equal-after-fold');
   });

--- a/packages/zero-cache/src/services/change-streamer/change-log-initializer.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-log-initializer.test.ts
@@ -86,11 +86,11 @@ describe('change-streamer/change-log-initializer', () => {
   }
 
   /**
-   * Stands in for `SQLiteChangeLogWriter.reconcile` / `.reconcileFromLog`. The
-   * log here is driven directly, so it is always already in agreement and there
-   * is nothing to truncate: Postgres's point passes through, and without one
-   * the log's own head is the resume point -- which is what the writer's
-   * resolution reduces to for a log it may keep.
+   * Replaces writer reconciliation in these tests. The tests write directly to
+   * the log, so the log is already consistent.
+   *
+   * Uses the Postgres point when present. Otherwise, it uses the current log
+   * head or the supplied seed.
    */
   function reconcileChangeLog(
     resumeFrom: ChangeLogResumePoint | undefined,
@@ -513,9 +513,8 @@ describe('change-streamer/change-log-initializer', () => {
   });
 
   /**
-   * Postgres is not a source, so the resume point is the log's own head with
-   * its own cookies, and the requests are projected from those rather than
-   * queried from anywhere.
+   * When Postgres is disabled, the log supplies its own head and cookies. The
+   * initializer derives the backfill requests from those cookies.
    */
   describe('with Postgres retired', () => {
     const withoutPg = (
@@ -529,8 +528,8 @@ describe('change-streamer/change-log-initializer', () => {
 
     test('the log supplies the resume point, and it is the one Postgres would have', async () => {
       await transaction([CREATE_FOO]);
-      // The replica is held back, which after the flip is routine rather than
-      // interesting: nothing pairs its watermark with anything.
+      // The replica intentionally trails the log. Its watermark is not used
+      // because this configuration does not compare two sources.
       const head = await transaction(
         [
           {
@@ -564,7 +563,7 @@ describe('change-streamer/change-log-initializer', () => {
       await transaction([CREATE_FOO]);
       const replicated = readReplicaInitializationParameters(replica);
 
-      // What the writer returns for a wiped log: the seed it was handed.
+      // A recreated log starts from the supplied replica seed.
       const params = await withoutPg({
         reconcileChangeLog: (_, seed) => seed(),
       }).initialize();
@@ -579,8 +578,8 @@ describe('change-streamer/change-log-initializer', () => {
       await transaction([], {toReplica: false});
       const replicated = readReplicaInitializationParameters(replica);
 
-      // No log at all -- `sqliteChangeLogMode=off`, or a writer that deleted
-      // its file. The replica is the floor: there is always a resume point.
+      // When the log is unavailable, initialization uses the replica resume
+      // point.
       const params = await withoutPg({
         reconcileChangeLog: () => undefined,
       }).initialize();
@@ -606,8 +605,8 @@ describe('change-streamer/change-log-initializer', () => {
 
   test('with the replica alone its parameters are the ones returned', async () => {
     await transaction([CREATE_FOO]);
-    // What the flip produces. The replica's own state version, and the requests
-    // assembled from its own tables.
+    // With Postgres disabled, the replica supplies the state version and the
+    // backfill requests.
     const init = initializer({
       initFromPgChangeLog: false,
       pg: () => Promise.reject(new Error('must not be read')),
@@ -637,8 +636,8 @@ describe('change-streamer/change-log-initializer', () => {
     await init.initialize();
     expect(init.lastComparison()).toBe('equal');
 
-    // The next connection re-derives both sides, so a stale classification must
-    // not be reported for it -- this one has nothing to compare.
+    // The next initialization clears the previous result. This initializer has
+    // only one source, so it has no comparison result.
     const withoutReplica = initializer({initFromReplica: false});
     await withoutReplica.initialize();
     expect(withoutReplica.lastComparison()).toBeUndefined();

--- a/packages/zero-cache/src/services/change-streamer/change-log-initializer.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-log-initializer.test.ts
@@ -86,8 +86,8 @@ describe('change-streamer/change-log-initializer', () => {
   }
 
   /**
-   * Replaces writer reconciliation in these tests. The tests write directly to
-   * the log, so the log is already consistent.
+   * Simulates change-log reconciliation without creating a writer. These tests
+   * write directly to the log, so the log is already consistent.
    *
    * Uses the Postgres point when present. Otherwise, it uses the current log
    * head or the supplied seed.

--- a/packages/zero-cache/src/services/change-streamer/change-log-initializer.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-log-initializer.test.ts
@@ -17,7 +17,11 @@ import {StatementRunner} from '../../db/statements.ts';
 import {DbFile} from '../../test/lite.ts';
 import type {SchemaChange} from '../change-source/protocol/current/data.ts';
 import {readCookies} from '../replicator/change-log-cookies.ts';
-import {CHANGE_LOG_STREAM_TABLE} from '../replicator/change-log-db.ts';
+import {
+  CHANGE_LOG_STREAM_TABLE,
+  readChangeLogHead,
+  type ChangeLogResumePoint,
+} from '../replicator/change-log-db.ts';
 import {BACKFILLING_TABLE} from '../replicator/schema/backfilling.ts';
 import {
   initReplicationState,
@@ -27,6 +31,7 @@ import {
   ChangeLogInitializer,
   readReplicaInitializationParameters,
   replicaInitializationSource,
+  type ChangeLogInitializerSources,
   type InitializationParameters,
 } from './change-log-initializer.ts';
 import {
@@ -80,12 +85,33 @@ describe('change-streamer/change-log-initializer', () => {
     };
   }
 
+  /**
+   * Stands in for `SQLiteChangeLogWriter.reconcile` / `.reconcileFromLog`. The
+   * log here is driven directly, so it is always already in agreement and there
+   * is nothing to truncate: Postgres's point passes through, and without one
+   * the log's own head is the resume point -- which is what the writer's
+   * resolution reduces to for a log it may keep.
+   */
+  function reconcileChangeLog(
+    resumeFrom: ChangeLogResumePoint | undefined,
+    seed: () => ChangeLogResumePoint,
+  ): ChangeLogResumePoint | undefined {
+    if (resumeFrom) {
+      return resumeFrom;
+    }
+    const head = readChangeLogHead(changeLog);
+    return head === null
+      ? seed()
+      : {resumeWatermark: head, cookies: readCookies(changeLog)};
+  }
+
   function initializer(
     opts: {
       initFromPgChangeLog?: boolean;
       initFromReplica?: boolean;
       pg?: () => Promise<InitializationParameters>;
       replica?: () => InitializationParameters;
+      reconcileChangeLog?: ChangeLogInitializerSources['reconcileChangeLog'];
       changeLog?: () => Database | undefined;
     } = {},
   ) {
@@ -99,15 +125,15 @@ describe('change-streamer/change-log-initializer', () => {
         pgChangeLog: opts.pg ?? (() => Promise.resolve(pgParameters())),
         replica:
           opts.replica ?? (() => readReplicaInitializationParameters(replica)),
+        reconcileChangeLog: opts.reconcileChangeLog ?? reconcileChangeLog,
         changeLog: opts.changeLog ?? (() => changeLog),
       },
     );
   }
 
-  /** The stream loop's order: initialize, reconcile, then compare. */
   async function compare(init = initializer()) {
     await init.initialize();
-    return init.compare();
+    return init.lastComparison();
   }
 
   const CREATE_FOO: SchemaChange = {
@@ -463,7 +489,7 @@ describe('change-streamer/change-log-initializer', () => {
     // Postgres is authoritative, so the parameters still come back...
     expect((await init.initialize()).lastWatermark).toBe(wm);
     // ...and there is nothing to compare them against.
-    expect(init.compare()).toBeUndefined();
+    expect(init.lastComparison()).toBeUndefined();
   });
 
   test('a replica that cannot be read *is* fatal once it is the only source', async () => {
@@ -483,7 +509,99 @@ describe('change-streamer/change-log-initializer', () => {
     const init = initializer({initFromReplica: false});
 
     expect((await init.initialize()).lastWatermark).toBe(wm);
-    expect(init.compare()).toBeUndefined();
+    expect(init.lastComparison()).toBeUndefined();
+  });
+
+  /**
+   * Postgres is not a source, so the resume point is the log's own head with
+   * its own cookies, and the requests are projected from those rather than
+   * queried from anywhere.
+   */
+  describe('with Postgres retired', () => {
+    const withoutPg = (
+      opts: Parameters<typeof initializer>[0] = {},
+    ): ReturnType<typeof initializer> =>
+      initializer({
+        ...opts,
+        initFromPgChangeLog: false,
+        pg: () => Promise.reject(new Error('Postgres must not be read')),
+      });
+
+    test('the log supplies the resume point, and it is the one Postgres would have', async () => {
+      await transaction([CREATE_FOO]);
+      // The replica is held back, which after the flip is routine rather than
+      // interesting: nothing pairs its watermark with anything.
+      const head = await transaction(
+        [
+          {
+            tag: 'add-column',
+            table: {schema: 'my', name: 'foo'},
+            column: {name: 'd', spec: {pos: 3, dataType: 'text'}},
+            backfill: {fooID: 123},
+          },
+        ],
+        {toReplica: false},
+      );
+
+      const pg = pgParameters();
+      const params = await withoutPg().initialize();
+
+      expect(params.lastWatermark).toBe(head);
+      expect(params.cookies).toEqual(pg.cookies);
+      expect(params.backfillRequests).toEqual([
+        {
+          table: {
+            schema: 'my',
+            name: 'foo',
+            metadata: {rowKey: {type: 'default', columns: ['id']}},
+          },
+          columns: {a: {fooID: 987}, b: {fooID: 843}, d: {fooID: 123}},
+        },
+      ]);
+    });
+
+    test('a log that cannot be kept falls back to the replica', async () => {
+      await transaction([CREATE_FOO]);
+      const replicated = readReplicaInitializationParameters(replica);
+
+      // What the writer returns for a wiped log: the seed it was handed.
+      const params = await withoutPg({
+        reconcileChangeLog: (_, seed) => seed(),
+      }).initialize();
+
+      expect(params.lastWatermark).toBe(replicated.lastWatermark);
+      expect(params.cookies).toEqual(replicated.cookies);
+      expect(params.backfillRequests).toEqual(replicated.backfillRequests);
+    });
+
+    test('a writer that has failed soft falls back to the replica', async () => {
+      await transaction([CREATE_FOO]);
+      await transaction([], {toReplica: false});
+      const replicated = readReplicaInitializationParameters(replica);
+
+      // No log at all -- `sqliteChangeLogMode=off`, or a writer that deleted
+      // its file. The replica is the floor: there is always a resume point.
+      const params = await withoutPg({
+        reconcileChangeLog: () => undefined,
+      }).initialize();
+
+      expect(params.lastWatermark).toBe(replicated.lastWatermark);
+      expect(params.backfillRequests).toEqual(replicated.backfillRequests);
+    });
+
+    test('nothing is compared, because there is nothing to compare against', async () => {
+      await transaction([CREATE_FOO]);
+      const init = withoutPg();
+
+      await init.initialize();
+      expect(init.lastComparison()).toBeUndefined();
+    });
+
+    test('the replica is required, since it is the floor', () => {
+      expect(() => withoutPg({initFromReplica: false})).toThrow(
+        'At least one of initFromPgChangeLog or initFromReplica',
+      );
+    });
   });
 
   test('with the replica alone its parameters are the ones returned', async () => {
@@ -509,16 +627,21 @@ describe('change-streamer/change-log-initializer', () => {
         columns: {a: {fooID: 987}, b: {fooID: 843}},
       },
     ]);
-    expect(init.compare()).toBeUndefined();
+    expect(init.lastComparison()).toBeUndefined();
   });
 
-  test('a comparison is consumed, so a missed initialize cannot compare stale state', async () => {
+  test('a classification does not outlive the initialize that produced it', async () => {
     await transaction([CREATE_FOO]);
     const init = initializer();
 
     await init.initialize();
-    expect(init.compare()).toBe('equal');
-    expect(init.compare()).toBeUndefined();
+    expect(init.lastComparison()).toBe('equal');
+
+    // The next connection re-derives both sides, so a stale classification must
+    // not be reported for it -- this one has nothing to compare.
+    const withoutReplica = initializer({initFromReplica: false});
+    await withoutReplica.initialize();
+    expect(withoutReplica.lastComparison()).toBeUndefined();
   });
 
   test('a fold that throws is reported rather than raised', async () => {
@@ -533,7 +656,7 @@ describe('change-streamer/change-log-initializer', () => {
     await init.initialize();
     // Nothing acts on the comparison, so nothing about it may reach the stream
     // loop -- but it must not be silent either.
-    expect(init.compare()).toBe('error');
+    expect(init.lastComparison()).toBe('error');
   });
 
   test('at least one source is required', () => {

--- a/packages/zero-cache/src/services/change-streamer/change-log-initializer.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-log-initializer.ts
@@ -149,7 +149,7 @@ type Opts = {
  * cap the comparison declines rather than pays: a chronically lagging replicator
  * shows up as `inconclusive`, which is charted, and not as a stall.
  */
-const MAX_FOLD_SCAN_ROWS = 100_000;
+const MAX_FOLD_SCAN_ROWS = 10_000;
 
 export class ChangeLogInitializer {
   readonly #lc: LogContext;

--- a/packages/zero-cache/src/services/change-streamer/change-log-initializer.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-log-initializer.ts
@@ -41,8 +41,15 @@ import {getOrCreateCounter} from '../../observability/metrics.ts';
 import type {SchemaChange} from '../change-source/protocol/current/data.ts';
 import {schemaChangeTags} from '../change-source/protocol/current/schema-change-tags.ts';
 import type {BackfillRequest} from '../change-source/protocol/current/upstream.ts';
-import {foldCookies, type CookieSet} from '../replicator/change-log-cookies.ts';
-import {CHANGE_LOG_STREAM_TABLE} from '../replicator/change-log-db.ts';
+import {
+  backfillRequestsFrom,
+  foldCookies,
+  type CookieSet,
+} from '../replicator/change-log-cookies.ts';
+import {
+  CHANGE_LOG_STREAM_TABLE,
+  type ChangeLogResumePoint,
+} from '../replicator/change-log-db.ts';
 import {
   readBackfillRequests,
   readReplicaCookies,
@@ -87,6 +94,19 @@ export type ChangeLogInitializerSources = {
   /** Typically {@link replicaInitializationSource}. */
   readonly replica: () => InitializationParameters;
   /**
+   * `SQLiteChangeLogWriter.reconcile()`: brings the log into agreement with
+   * `resumeFrom` — Postgres's, while Postgres supplies one — and returns the
+   * point the log is actually at. With no `resumeFrom` the log's own head is
+   * that point, and `seed` is where a log that cannot be kept starts instead.
+   *
+   * `undefined` when there is no log at all (`sqliteChangeLogMode=off`) or the
+   * writer has failed soft.
+   */
+  readonly reconcileChangeLog: (
+    resumeFrom: ChangeLogResumePoint | undefined,
+    seed: () => ChangeLogResumePoint,
+  ) => ChangeLogResumePoint | undefined;
+  /**
    * The change log, for the fold. `undefined` before the stream loop's first
    * reconcile has created it, and again once the writer has failed soft and
    * deleted it — both of which make the comparison `inconclusive` rather than
@@ -98,13 +118,23 @@ export type ChangeLogInitializerSources = {
 type Opts = {
   /**
    * Read the resume point from the Postgres change log. It is authoritative
-   * whenever it is read.
+   * whenever it is read, and its cookies are what a reseed installs.
+   *
+   * False is the flip, and the whole of it: the change log then resumes from
+   * its own head, and a log that has to be wiped is seeded from the replica
+   * rather than from Postgres. Those are `P§:6.8`'s two gate items, and they
+   * are one flag because they are one fact — a store that no longer owns the
+   * resume point has nothing to seed with.
    */
   // TODO: set false when retiring PG
   readonly initFromPgChangeLog: boolean;
   /**
-   * Read it from the replica as well. Until the flag above goes false this is
-   * computed and compared but not used, which is the whole of slice C4.
+   * Derive the parameters from the replica as well.
+   *
+   * While Postgres is a source this is computed, compared, and not used.
+   * Once Postgres is not, it is required — the replica is the floor under the
+   * change log, both as the seed for a cold one and as the fallback when the
+   * writer has failed soft.
    */
   readonly initFromReplica: boolean;
 };
@@ -134,17 +164,7 @@ export class ChangeLogInitializer {
       'against the Postgres-derived ones, by classification.',
   );
 
-  /**
-   * Set by {@link initialize} when both sources ran, consumed by
-   * {@link compare}. The two are separate calls because the fold reads the
-   * change log and the change log is only in agreement with the resume
-   * watermark *after* it has been reconciled against it — before that it can
-   * hold phantom transactions, another replica's history, or nothing at all,
-   * none of which would be a divergence between the two stores.
-   */
-  #pending:
-    | {pg: InitializationParameters; replica: InitializationParameters}
-    | undefined;
+  #lastComparison: InitComparisonResult | undefined;
 
   constructor(
     lc: LogContext,
@@ -162,39 +182,77 @@ export class ChangeLogInitializer {
   }
 
   /**
-   * Reads every enabled source and returns the authoritative one. When both are
-   * enabled the replica's is held for {@link compare}, which the caller runs
-   * once the log has been reconciled against the returned watermark.
+   * How the last {@link initialize}'s two derivations compared, or `undefined`
+   * when only one source was consulted. Exposed for tests and for the
+   * integration assertions on the metrics; nothing acts on it.
    */
-  async initialize(): Promise<InitializationParameters> {
-    const pg = this.#initFromPgChangeLog
-      ? await this.#sources.pgChangeLog()
-      : undefined;
-    const replica = this.#initFromReplica
-      ? this.#readReplica(pg === undefined)
-      : undefined;
-    this.#pending = pg && replica ? {pg, replica} : undefined;
-    // `must` rather than an `assert` on the flags: the constructor already
-    // rejects the case where neither is enabled.
-    return pg ?? must(replica, 'no change-log initialization source');
+  lastComparison(): InitComparisonResult | undefined {
+    return this.#lastComparison;
   }
 
   /**
-   * Compares the two derivations of the last {@link initialize}, reports the
-   * classification, and discards them. A no-op unless both sources are enabled,
-   * so the caller does not have to know which stage of the rollout it is in.
+   * Everything one stream connection starts from, with the change log
+   * reconciled against it.
    *
-   * Must run after the change log has been reconciled against the watermark
-   * {@link initialize} returned. Nothing acts on the result: Postgres remains
-   * authoritative until C5.
+   * Reconciliation happens here rather than at the call site because the two
+   * are not separable in either direction. While Postgres owns the resume
+   * point, reconciliation is what brings the log into agreement with it; once
+   * the log owns it, reconciliation is where it *comes from*. Ordering them at
+   * the call site would mean the call site knowing which of those two worlds it
+   * is in, which is the one thing this class exists to hide.
    */
-  compare(): InitComparisonResult | undefined {
-    const pending = this.#pending;
-    this.#pending = undefined;
-    if (pending === undefined) {
-      return undefined;
+  async initialize(): Promise<InitializationParameters> {
+    this.#lastComparison = undefined;
+    const pg = this.#initFromPgChangeLog
+      ? await this.#sources.pgChangeLog()
+      : undefined;
+    // Required rather than observational once Postgres is gone: it is both the
+    // seed for a cold log and the fallback for a writer that has failed soft.
+    const replica = this.#initFromReplica
+      ? this.#readReplica(pg === undefined)
+      : undefined;
+
+    const reconciled = this.#sources.reconcileChangeLog(
+      pg && {resumeWatermark: pg.lastWatermark, cookies: pg.cookies},
+      () => resumePointOf(must(replica, 'no seed for the SQLite change log')),
+    );
+
+    if (pg) {
+      if (replica) {
+        // After the reconcile, never before: the fold reads the log's schema
+        // changes over the interval the replica trails by, and only a
+        // reconciled log holds exactly the transactions at or below the resume
+        // watermark. An un-reconciled one can hold phantoms, another replica's
+        // history, or nothing -- none of which is a disagreement between the
+        // two stores, and all of which would be reported as one.
+        this.#lastComparison = this.#compare(pg, replica);
+      }
+      return pg;
     }
-    const {pg, replica} = pending;
+
+    // The log's own head, or -- when there is no log to have one -- the
+    // replica's, which is the floor.
+    const resumePoint =
+      reconciled ?? resumePointOf(must(replica, 'no initialization source'));
+    return {
+      lastWatermark: resumePoint.resumeWatermark,
+      cookies: resumePoint.cookies,
+      // Projected rather than read: `BackfillRequest[]` is a view of the cookie
+      // set, and deriving it here is what keeps the requests and the watermark
+      // at one position without a second query that could see another.
+      backfillRequests: backfillRequestsFrom(resumePoint.cookies),
+    };
+  }
+
+  /**
+   * Compares the two derivations, reports the classification, and returns it.
+   * Nothing acts on the result: Postgres remains authoritative until the flip,
+   * and after it there is no second store to compare against.
+   */
+  #compare(
+    pg: InitializationParameters,
+    replica: InitializationParameters,
+  ): InitComparisonResult {
     let result: InitComparisonResult;
     try {
       result = this.#classify(pg, replica);
@@ -297,6 +355,14 @@ export class ChangeLogInitializer {
     return 'divergent';
   }
 }
+
+const resumePointOf = ({
+  lastWatermark,
+  cookies,
+}: InitializationParameters): ChangeLogResumePoint => ({
+  resumeWatermark: lastWatermark,
+  cookies,
+});
 
 /**
  * Reads the replica's initialization parameters in one snapshot, which is

--- a/packages/zero-cache/src/services/change-streamer/change-log-initializer.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-log-initializer.ts
@@ -94,13 +94,12 @@ export type ChangeLogInitializerSources = {
   /** Typically {@link replicaInitializationSource}. */
   readonly replica: () => InitializationParameters;
   /**
-   * `SQLiteChangeLogWriter.reconcile()`: brings the log into agreement with
-   * `resumeFrom` — Postgres's, while Postgres supplies one — and returns the
-   * point the log is actually at. With no `resumeFrom` the log's own head is
-   * that point, and `seed` is where a log that cannot be kept starts instead.
+   * Reconciles the SQLite change log and returns its current resume point.
    *
-   * `undefined` when there is no log at all (`sqliteChangeLogMode=off`) or the
-   * writer has failed soft.
+   * When `resumeFrom` is present, it supplies the resume point. Otherwise, a
+   * valid log uses its own head. A new or invalid log uses `seed`.
+   *
+   * Returns `undefined` when the writer is disabled or unavailable.
    */
   readonly reconcileChangeLog: (
     resumeFrom: ChangeLogResumePoint | undefined,
@@ -117,24 +116,20 @@ export type ChangeLogInitializerSources = {
 
 type Opts = {
   /**
-   * Read the resume point from the Postgres change log. It is authoritative
-   * whenever it is read, and its cookies are what a reseed installs.
+   * When true, Postgres supplies the resume point and the cookies for a new
+   * change log.
    *
-   * False is the flip, and the whole of it: the change log then resumes from
-   * its own head, and a log that has to be wiped is seeded from the replica
-   * rather than from Postgres. Those are `P§:6.8`'s two gate items, and they
-   * are one flag because they are one fact — a store that no longer owns the
-   * resume point has nothing to seed with.
+   * When false, a valid log resumes from its own head. The replica supplies the
+   * resume point for a new or invalid log.
    */
   // TODO: set false when retiring PG
   readonly initFromPgChangeLog: boolean;
   /**
-   * Derive the parameters from the replica as well.
+   * Derive the parameters from the replica. When Postgres is enabled, these
+   * parameters are used only for comparison.
    *
-   * While Postgres is a source this is computed, compared, and not used.
-   * Once Postgres is not, it is required — the replica is the floor under the
-   * change log, both as the seed for a cold one and as the fallback when the
-   * writer has failed soft.
+   * When Postgres is disabled, the replica supplies the seed and the fallback
+   * resume point.
    */
   readonly initFromReplica: boolean;
 };
@@ -182,32 +177,29 @@ export class ChangeLogInitializer {
   }
 
   /**
-   * How the last {@link initialize}'s two derivations compared, or `undefined`
-   * when only one source was consulted. Exposed for tests and for the
-   * integration assertions on the metrics; nothing acts on it.
+   * Returns the comparison result from the most recent {@link initialize}
+   * call. Returns `undefined` when that call used only one source.
+   *
+   * Tests and metrics use this result. It does not affect initialization.
    */
   lastComparison(): InitComparisonResult | undefined {
     return this.#lastComparison;
   }
 
   /**
-   * Everything one stream connection starts from, with the change log
-   * reconciled against it.
+   * Returns the initialization parameters for one stream connection after it
+   * reconciles the change log.
    *
-   * Reconciliation happens here rather than at the call site because the two
-   * are not separable in either direction. While Postgres owns the resume
-   * point, reconciliation is what brings the log into agreement with it; once
-   * the log owns it, reconciliation is where it *comes from*. Ordering them at
-   * the call site would mean the call site knowing which of those two worlds it
-   * is in, which is the one thing this class exists to hide.
+   * The selected source determines how reconciliation works. Keeping both
+   * operations here hides that choice from the caller.
    */
   async initialize(): Promise<InitializationParameters> {
     this.#lastComparison = undefined;
     const pg = this.#initFromPgChangeLog
       ? await this.#sources.pgChangeLog()
       : undefined;
-    // Required rather than observational once Postgres is gone: it is both the
-    // seed for a cold log and the fallback for a writer that has failed soft.
+    // The replica is required when Postgres is disabled. It seeds a new log and
+    // supplies a resume point when the writer is unavailable.
     const replica = this.#initFromReplica
       ? this.#readReplica(pg === undefined)
       : undefined;
@@ -219,35 +211,30 @@ export class ChangeLogInitializer {
 
     if (pg) {
       if (replica) {
-        // After the reconcile, never before: the fold reads the log's schema
-        // changes over the interval the replica trails by, and only a
-        // reconciled log holds exactly the transactions at or below the resume
-        // watermark. An un-reconciled one can hold phantoms, another replica's
-        // history, or nothing -- none of which is a disagreement between the
-        // two stores, and all of which would be reported as one.
+        // Compare only after reconciliation. The fold must read the schema
+        // changes from the replica watermark through the Postgres watermark.
+        // Reconciliation makes sure that the log contains that interval.
         this.#lastComparison = this.#compare(pg, replica);
       }
       return pg;
     }
 
-    // The log's own head, or -- when there is no log to have one -- the
-    // replica's, which is the floor.
+    // Use the reconciled log position. If the writer is unavailable, use the
+    // replica position.
     const resumePoint =
       reconciled ?? resumePointOf(must(replica, 'no initialization source'));
     return {
       lastWatermark: resumePoint.resumeWatermark,
       cookies: resumePoint.cookies,
-      // Projected rather than read: `BackfillRequest[]` is a view of the cookie
-      // set, and deriving it here is what keeps the requests and the watermark
-      // at one position without a second query that could see another.
+      // Derive the requests from these cookies so that the requests and the
+      // watermark describe the same position.
       backfillRequests: backfillRequestsFrom(resumePoint.cookies),
     };
   }
 
   /**
-   * Compares the two derivations, reports the classification, and returns it.
-   * Nothing acts on the result: Postgres remains authoritative until the flip,
-   * and after it there is no second store to compare against.
+   * Compares both sources and records the result. Postgres remains
+   * authoritative when both sources are enabled.
    */
   #compare(
     pg: InitializationParameters,

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -515,6 +515,11 @@ class ChangeStreamerImpl implements ChangeStreamerService {
         // Only reached when `initFromReplica` is set, i.e. when the option
         // that supplies the file is present.
         replica: () => must(replicaSource)(),
+        // The first arm goes with Postgres in `P§:6.9`, leaving the second.
+        reconcileChangeLog: (resumeFrom, seed) =>
+          resumeFrom
+            ? this.#changeLogWriter?.reconcile(resumeFrom)
+            : this.#changeLogWriter?.reconcileFromLog(seed),
         changeLog: () => this.#changeLogWriter?.connection,
       },
     );
@@ -565,33 +570,17 @@ class ChangeStreamerImpl implements ChangeStreamerService {
       let watermark: string | null = null;
       let unflushedBytes = 0;
       try {
-        const {lastWatermark, backfillRequests, cookies} =
+        // Reconciling the change log is part of this, and happens inside: it is
+        // what brings the log into agreement with the resume point while
+        // Postgres owns it, and it is where the resume point *comes from* once
+        // the log does. It runs per stream connection rather than once per
+        // process, and before startStream so no change can arrive mid-reconcile.
+        const {lastWatermark, backfillRequests} =
           await this.#initializer.initialize();
         // SQLite catchup must not be eligible until this has been initialized
         // from the durable PG head. Commits observed only since process startup
         // are insufficient after a change-streamer restart.
         this.#lastForwardedCommitWatermark = lastWatermark;
-        // Per stream connection, not once per process: the resume watermark is
-        // re-read on every reconnect, so the log can be holding transactions
-        // above it -- a restarted backfill's abandoned ones, in bulk -- and the
-        // writer's plain INSERT would collide with the first re-delivery.
-        // Ordered before startStream so no change can arrive mid-reconcile.
-        //
-        // The cookies come from the same read as the watermark, and go to the
-        // log with it: a reconcile that moves the head discards the set the log
-        // had folded, and only the set that belongs to this watermark can
-        // replace it (invariant 15).
-        this.#changeLogWriter?.reconcile({
-          resumeWatermark: lastWatermark,
-          cookies,
-        });
-        // After the reconcile, not before: the fold reads the log's schema
-        // changes over the interval the replica trails by, and only a
-        // reconciled log holds exactly the transactions at or below the resume
-        // watermark. An un-reconciled one can hold phantoms, another replica's
-        // history, or nothing -- none of which is a disagreement between the
-        // two stores, and all of which would be reported as one.
-        this.#initializer.compare();
         const stream = await this.#source.startStream(
           lastWatermark,
           backfillRequests,

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -515,7 +515,8 @@ class ChangeStreamerImpl implements ChangeStreamerService {
         // Only reached when `initFromReplica` is set, i.e. when the option
         // that supplies the file is present.
         replica: () => must(replicaSource)(),
-        // The first arm goes with Postgres in `P§:6.9`, leaving the second.
+        // Use the Postgres resume point when it is present. Otherwise, let the
+        // SQLite change log supply its own resume point.
         reconcileChangeLog: (resumeFrom, seed) =>
           resumeFrom
             ? this.#changeLogWriter?.reconcile(resumeFrom)
@@ -570,11 +571,9 @@ class ChangeStreamerImpl implements ChangeStreamerService {
       let watermark: string | null = null;
       let unflushedBytes = 0;
       try {
-        // Reconciling the change log is part of this, and happens inside: it is
-        // what brings the log into agreement with the resume point while
-        // Postgres owns it, and it is where the resume point *comes from* once
-        // the log does. It runs per stream connection rather than once per
-        // process, and before startStream so no change can arrive mid-reconcile.
+        // Initialization reconciles the change log for every stream
+        // connection. It completes before `startStream`, so no change can
+        // arrive during reconciliation.
         const {lastWatermark, backfillRequests} =
           await this.#initializer.initialize();
         // SQLite catchup must not be eligible until this has been initialized

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-purge-scheduler.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-purge-scheduler.test.ts
@@ -143,7 +143,7 @@ function setup(
     nowMs: SEED_WRITE_TIME_MS,
     cookies: EMPTY_COOKIE_SET,
   };
-  const {db} = openChangeLogDBForWriting(lc, file.path, anchor);
+  const {db} = openChangeLogDBForWriting(lc, file.path, () => anchor);
 
   let connection: Database | undefined =
     (opts.connected ?? true) ? db : undefined;

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-writer.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-writer.test.ts
@@ -490,12 +490,10 @@ describe('change-streamer/sqlite-change-log-writer', () => {
     });
 
     /**
-     * Nothing supplies a resume point, so the log's own head is one -- and a
-     * log that cannot be kept falls back to the replica's, never to Postgres's.
+     * When Postgres is disabled, a valid log supplies its own resume point. A
+     * new or invalid log uses the replica seed.
      *
-     * `seed` throws wherever it must not be called, which is the load-bearing
-     * half of these assertions: a warm log that consulted its seed would be
-     * resuming from a position it had already passed.
+     * `noSeed` throws if a valid log incorrectly reads the replica seed.
      */
     describe('resuming from the log itself', () => {
       const replicaSeed = resumeAt('03', pgCookies);
@@ -513,8 +511,8 @@ describe('change-streamer/sqlite-change-log-writer', () => {
           resumeWatermark: '04',
           cookies: folded,
         });
-        // Nothing was truncated and nothing was reseeded: the head *is* the
-        // anchor, so there is nothing above it to remove.
+        // The log already uses its own head and cookies, so reconciliation does
+        // not change it.
         expect(fixture.head()).toBe('04');
         expect(fixture.cookies()).toEqual(folded);
       });
@@ -524,7 +522,7 @@ describe('change-streamer/sqlite-change-log-writer', () => {
         transaction(fixture.writer, '04', createTable);
         fixture.writer.close();
 
-        // Same file, different replica: what a reused volume leaves behind.
+        // A reused volume can contain a log from a different replica.
         const other = new SQLiteChangeLogWriter(fixture.lc, {
           replicaFile: fixture.file.path,
           identity: {...IDENTITY, replicaID: 'a-different-replica'},
@@ -534,8 +532,8 @@ describe('change-streamer/sqlite-change-log-writer', () => {
           expect(other.reconcileFromLog(() => replicaSeed)).toEqual(
             replicaSeed,
           );
-          // Postgres' set is here because the fixture reuses it as the
-          // replica's; what matters is that it came from the seed.
+          // The fixture uses `pgCookies` as the replica seed. This assertion
+          // makes sure that the seed supplied the cookies.
           expect(fixture.cookies()).toEqual(pgCookies);
           expect(fixture.head()).toBe('03');
         } finally {
@@ -554,8 +552,8 @@ describe('change-streamer/sqlite-change-log-writer', () => {
           now: () => 1_700_000_000_000,
         });
         try {
-          // The first reconcile of a process whose file does not exist yet,
-          // which is every restore.
+          // A restore starts without a log, so reconciliation uses the replica
+          // seed.
           expect(writer.reconcileFromLog(() => replicaSeed)).toEqual(
             replicaSeed,
           );
@@ -567,8 +565,8 @@ describe('change-streamer/sqlite-change-log-writer', () => {
       test('a disabled writer supplies no resume point at all', () => {
         using fixture = setup('change-log-writer-from-log-disabled');
 
-        // Fail soft, which deletes the file and disables the writer. The
-        // caller falls back to the replica rather than resuming from nothing.
+        // A write failure deletes the log and disables the writer. The caller
+        // then uses the replica resume point.
         fixture.writer.write(
           ['data', {tag: 'insert'} as never],
           'not a transaction',

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-writer.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-writer.test.ts
@@ -18,6 +18,7 @@ import {
   openChangeLogDB,
   readChangeLogHead,
   type ChangeLogIdentity,
+  type ChangeLogResumePoint,
 } from '../replicator/change-log-db.ts';
 import {ReplicationMessages} from '../replicator/test-utils.ts';
 import {serializeChangeStreamData} from './change-log-codec.ts';
@@ -486,6 +487,96 @@ describe('change-streamer/sqlite-change-log-writer', () => {
       fixture.writer.reconcile(resumeAt('04', pgCookies));
 
       expect(fixture.cookies()).toEqual(folded);
+    });
+
+    /**
+     * Nothing supplies a resume point, so the log's own head is one -- and a
+     * log that cannot be kept falls back to the replica's, never to Postgres's.
+     *
+     * `seed` throws wherever it must not be called, which is the load-bearing
+     * half of these assertions: a warm log that consulted its seed would be
+     * resuming from a position it had already passed.
+     */
+    describe('resuming from the log itself', () => {
+      const replicaSeed = resumeAt('03', pgCookies);
+      const noSeed = (): ChangeLogResumePoint => {
+        throw new Error('the seed must not be consulted');
+      };
+
+      test('a log it may keep resumes from its own head and cookies', () => {
+        using fixture = setup('change-log-writer-from-log-warm');
+
+        transaction(fixture.writer, '04', createTable);
+        const folded = fixture.cookies();
+
+        expect(fixture.writer.reconcileFromLog(noSeed)).toEqual({
+          resumeWatermark: '04',
+          cookies: folded,
+        });
+        // Nothing was truncated and nothing was reseeded: the head *is* the
+        // anchor, so there is nothing above it to remove.
+        expect(fixture.head()).toBe('04');
+        expect(fixture.cookies()).toEqual(folded);
+      });
+
+      test('a log left by another replica is seeded from the replica', () => {
+        using fixture = setup('change-log-writer-from-log-identity');
+        transaction(fixture.writer, '04', createTable);
+        fixture.writer.close();
+
+        // Same file, different replica: what a reused volume leaves behind.
+        const other = new SQLiteChangeLogWriter(fixture.lc, {
+          replicaFile: fixture.file.path,
+          identity: {...IDENTITY, replicaID: 'a-different-replica'},
+          now: () => 1_700_000_000_000,
+        });
+        try {
+          expect(other.reconcileFromLog(() => replicaSeed)).toEqual(
+            replicaSeed,
+          );
+          // Postgres' set is here because the fixture reuses it as the
+          // replica's; what matters is that it came from the seed.
+          expect(fixture.cookies()).toEqual(pgCookies);
+          expect(fixture.head()).toBe('03');
+        } finally {
+          other.close();
+        }
+      });
+
+      test('a log created here and now is seeded from the replica', () => {
+        const sink = new TestLogSink();
+        const lc = new LogContext('debug', undefined, sink);
+        const file = new DbFile('change-log-writer-from-log-cold');
+        files.push(file);
+        const writer = new SQLiteChangeLogWriter(lc, {
+          replicaFile: file.path,
+          identity: IDENTITY,
+          now: () => 1_700_000_000_000,
+        });
+        try {
+          // The first reconcile of a process whose file does not exist yet,
+          // which is every restore.
+          expect(writer.reconcileFromLog(() => replicaSeed)).toEqual(
+            replicaSeed,
+          );
+        } finally {
+          writer.close();
+        }
+      });
+
+      test('a disabled writer supplies no resume point at all', () => {
+        using fixture = setup('change-log-writer-from-log-disabled');
+
+        // Fail soft, which deletes the file and disables the writer. The
+        // caller falls back to the replica rather than resuming from nothing.
+        fixture.writer.write(
+          ['data', {tag: 'insert'} as never],
+          'not a transaction',
+        );
+        expect(fixture.disabledCount()).toBe(1);
+
+        expect(fixture.writer.reconcileFromLog(noSeed)).toBeUndefined();
+      });
     });
   });
 });

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-writer.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-writer.ts
@@ -129,26 +129,18 @@ export class SQLiteChangeLogWriter {
   }
 
   /**
-   * Opens the log if necessary, brings it into agreement with the point
-   * Postgres says this stream connection resumes from, and returns the point
-   * the log ends up at. `undefined` when the writer is disabled, i.e. when
-   * there is no log to resume from and the caller has to fall back.
+   * Opens the log if necessary and reconciles it with the Postgres resume
+   * point. Returns the resume point stored in the log.
    *
-   * This runs per connection rather than once per process: the stream loop
-   * re-derives its resume point on every reconnect, so a routine reconnect —
-   * not just a restart — can leave the log holding watermarks above the new
-   * resume watermark, and the writer's plain `INSERT` would collide with the
-   * first re-delivered transaction.
+   * Returns `undefined` when the writer is disabled. The caller must then use
+   * another source.
    *
-   * `resumeFrom` is taken whole rather than as a bare watermark because a
-   * cookie set is not separable from the watermark it was folded to: a
-   * reconciliation that moves the head invalidates the cookies the log was
-   * holding, and only the set read at the same position (invariant 15) can
-   * replace them.
+   * This runs for every connection because Postgres supplies a new resume point
+   * after each reconnect. The log can contain transactions above that point.
+   * Reconciliation removes them before Postgres sends them again.
    *
-   * This is the transitional half of a pair — {@link reconcileFromLog} is the
-   * other — and `P§:6.9` deletes this method along with truncate-above and the
-   * reseed it feeds.
+   * `resumeFrom` includes cookies because the cookies must match the resume
+   * watermark.
    */
   reconcile(
     resumeFrom: ChangeLogResumePoint,
@@ -157,15 +149,10 @@ export class SQLiteChangeLogWriter {
   }
 
   /**
-   * The same, with the log itself supplying the resume point.
+   * Reconciles the log without a Postgres resume point.
    *
-   * A log this task may keep appending to is anchored on its own head, so
-   * there is nothing above it, nothing to truncate, and nothing to reseed —
-   * reconciliation degenerates to the rollback the stream loop already did on
-   * the interrupted transaction. `seed` is where a log that *cannot* be kept
-   * starts instead: the replica's state version and its cookies, read in one
-   * snapshot, which is the only other pairing of both halves at one position
-   * (invariant 15).
+   * A valid log uses its own head and cookies. A new or invalid log uses the
+   * replica values returned by `seed`.
    */
   reconcileFromLog(
     seed: () => ChangeLogResumePoint,
@@ -241,10 +228,8 @@ export class SQLiteChangeLogWriter {
       // are prepared fresh against whatever the reconciliation left behind.
       const db2 = must(this.#db, 'the SQLite change log is not open');
       this.#writer = new ChangeLogStreamWriter(new StatementRunner(db2));
-      // Read back rather than returned by reconciliation, and the same in every
-      // branch, because invariant 17 is exactly the statement that makes it
-      // valid: whichever of truncate or reseed moved the head also replaced the
-      // cookie set with the one that belongs there, in the same transaction.
+      // Read both values after reconciliation. A truncate or reseed updates the
+      // head and cookies in the same transaction.
       return {
         resumeWatermark: must(
           readChangeLogHead(db2),
@@ -259,14 +244,10 @@ export class SQLiteChangeLogWriter {
   }
 
   /**
-   * The resume point a log supplies for itself, once nothing else supplies one.
+   * Returns the resume point supplied by the log.
    *
-   * A log this task may keep appending to resumes from its own head — which is
-   * the whole of it: the head *is* the anchor, so phantoms cannot exist and
-   * reconciliation degenerates to the rollback the stream loop already did. A
-   * log that has to be wiped has no head worth having, and takes the replica's
-   * state version and cookies, which is the only other pairing of the two
-   * halves at one position (invariant 15).
+   * A valid log uses its own head and cookies. A log that must be recreated uses
+   * the replica values returned by `seed`.
    */
   #resumeFromLog(
     db: Database,
@@ -276,8 +257,7 @@ export class SQLiteChangeLogWriter {
       return seed();
     }
     const head = readChangeLogHead(db);
-    // An empty but otherwise valid log is `gap`'s case: there is no head to
-    // resume from, so it is seeded like any other wipe.
+    // An empty log has no resume point, so use the replica seed.
     return head === null
       ? seed()
       : {resumeWatermark: head, cookies: readCookies(db)};

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-writer.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-writer.ts
@@ -8,12 +8,17 @@ import {
 } from '../../db/sqlite-corruption.ts';
 import {StatementRunner} from '../../db/statements.ts';
 import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
-import {readCookieRowCounts} from '../replicator/change-log-cookies.ts';
+import {
+  readCookieRowCounts,
+  readCookies,
+} from '../replicator/change-log-cookies.ts';
 import {
   ChangeLogRebuildRequired,
   changeLogFileName,
+  changeLogWipeReason,
   deleteChangeLogDB,
   openChangeLogDBForWriting,
+  readChangeLogHead,
   rebuildChangeLogDBForWriting,
   reconcileChangeLog,
   type ChangeLogAnchor,
@@ -124,30 +129,63 @@ export class SQLiteChangeLogWriter {
   }
 
   /**
-   * Opens the log if necessary and reconciles it against the point this stream
-   * connection resumes from.
+   * Opens the log if necessary, brings it into agreement with the point
+   * Postgres says this stream connection resumes from, and returns the point
+   * the log ends up at. `undefined` when the writer is disabled, i.e. when
+   * there is no log to resume from and the caller has to fall back.
    *
    * This runs per connection rather than once per process: the stream loop
-   * re-reads its resume point on every reconnect, so a routine reconnect — not
-   * just a restart — can leave the log holding watermarks above the new resume
-   * watermark, and the writer's plain `INSERT` would collide with the first
-   * re-delivered transaction.
+   * re-derives its resume point on every reconnect, so a routine reconnect —
+   * not just a restart — can leave the log holding watermarks above the new
+   * resume watermark, and the writer's plain `INSERT` would collide with the
+   * first re-delivered transaction.
    *
-   * The resume point is taken whole rather than as a bare watermark because its
-   * cookie set is not separable from it: a reconciliation that moves the head
-   * invalidates the cookies the log was holding, and only the set read at the
-   * same position (invariant 15) can replace them.
+   * `resumeFrom` is taken whole rather than as a bare watermark because a
+   * cookie set is not separable from the watermark it was folded to: a
+   * reconciliation that moves the head invalidates the cookies the log was
+   * holding, and only the set read at the same position (invariant 15) can
+   * replace them.
+   *
+   * This is the transitional half of a pair — {@link reconcileFromLog} is the
+   * other — and `P§:6.9` deletes this method along with truncate-above and the
+   * reseed it feeds.
    */
-  reconcile(resumeFrom: ChangeLogResumePoint): void {
+  reconcile(
+    resumeFrom: ChangeLogResumePoint,
+  ): ChangeLogResumePoint | undefined {
+    return this.#reconcile(() => resumeFrom);
+  }
+
+  /**
+   * The same, with the log itself supplying the resume point.
+   *
+   * A log this task may keep appending to is anchored on its own head, so
+   * there is nothing above it, nothing to truncate, and nothing to reseed —
+   * reconciliation degenerates to the rollback the stream loop already did on
+   * the interrupted transaction. `seed` is where a log that *cannot* be kept
+   * starts instead: the replica's state version and its cookies, read in one
+   * snapshot, which is the only other pairing of both halves at one position
+   * (invariant 15).
+   */
+  reconcileFromLog(
+    seed: () => ChangeLogResumePoint,
+  ): ChangeLogResumePoint | undefined {
+    return this.#reconcile(db => this.#resumeFromLog(db, seed));
+  }
+
+  #reconcile(
+    resolve: (db: Database) => ChangeLogResumePoint,
+  ): ChangeLogResumePoint | undefined {
     if (this.#disabled) {
-      return;
+      return undefined;
     }
     const {replicaFile, identity} = this.#opts;
-    const anchor: ChangeLogAnchor = {
-      ...resumeFrom,
+    const nowMs = this.#now();
+    const anchor = (db: Database): ChangeLogAnchor => ({
+      ...resolve(db),
       identity,
-      nowMs: this.#now(),
-    };
+      nowMs,
+    });
     try {
       const db = this.#db;
       if (db === undefined) {
@@ -165,9 +203,10 @@ export class SQLiteChangeLogWriter {
         );
         this.#observer = new SQLiteChangeLogObserver(this.#lc, info);
       } else {
+        const resolved = anchor(db);
         let result: ReconcileResult;
         try {
-          result = reconcileChangeLog(this.#lc, db, anchor, {
+          result = reconcileChangeLog(this.#lc, db, resolved, {
             rebuildInsteadOfUnboundedWork: true,
           });
         } catch (e) {
@@ -183,7 +222,7 @@ export class SQLiteChangeLogWriter {
           const rebuilt = rebuildChangeLogDBForWriting(
             this.#lc,
             replicaFile,
-            anchor,
+            resolved,
             e,
           );
           this.#db = rebuilt.db;
@@ -200,14 +239,48 @@ export class SQLiteChangeLogWriter {
       }
       // A reseed drops and recreates the stream table, so the append statements
       // are prepared fresh against whatever the reconciliation left behind.
-      this.#writer = new ChangeLogStreamWriter(
-        new StatementRunner(
-          must(this.#db, 'the SQLite change log is not open'),
+      const db2 = must(this.#db, 'the SQLite change log is not open');
+      this.#writer = new ChangeLogStreamWriter(new StatementRunner(db2));
+      // Read back rather than returned by reconciliation, and the same in every
+      // branch, because invariant 17 is exactly the statement that makes it
+      // valid: whichever of truncate or reseed moved the head also replaced the
+      // cookie set with the one that belongs there, in the same transaction.
+      return {
+        resumeWatermark: must(
+          readChangeLogHead(db2),
+          'the SQLite change log has no head after reconciliation',
         ),
-      );
+        cookies: readCookies(db2),
+      };
     } catch (e) {
       this.#failSoft('reconciling the SQLite change log', e);
+      return undefined;
     }
+  }
+
+  /**
+   * The resume point a log supplies for itself, once nothing else supplies one.
+   *
+   * A log this task may keep appending to resumes from its own head — which is
+   * the whole of it: the head *is* the anchor, so phantoms cannot exist and
+   * reconciliation degenerates to the rollback the stream loop already did. A
+   * log that has to be wiped has no head worth having, and takes the replica's
+   * state version and cookies, which is the only other pairing of the two
+   * halves at one position (invariant 15).
+   */
+  #resumeFromLog(
+    db: Database,
+    seed: () => ChangeLogResumePoint,
+  ): ChangeLogResumePoint {
+    if (changeLogWipeReason(db, this.#opts.identity) !== undefined) {
+      return seed();
+    }
+    const head = readChangeLogHead(db);
+    // An empty but otherwise valid log is `gap`'s case: there is no head to
+    // resume from, so it is seeded like any other wipe.
+    return head === null
+      ? seed()
+      : {resumeWatermark: head, cookies: readCookies(db)};
   }
 
   /**

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-writer.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-writer.ts
@@ -226,16 +226,18 @@ export class SQLiteChangeLogWriter {
       }
       // A reseed drops and recreates the stream table, so the append statements
       // are prepared fresh against whatever the reconciliation left behind.
-      const db2 = must(this.#db, 'the SQLite change log is not open');
-      this.#writer = new ChangeLogStreamWriter(new StatementRunner(db2));
+      const reconciledDB = must(this.#db, 'the SQLite change log is not open');
+      this.#writer = new ChangeLogStreamWriter(
+        new StatementRunner(reconciledDB),
+      );
       // Read both values after reconciliation. A truncate or reseed updates the
       // head and cookies in the same transaction.
       return {
         resumeWatermark: must(
-          readChangeLogHead(db2),
+          readChangeLogHead(reconciledDB),
           'the SQLite change log has no head after reconciliation',
         ),
-        cookies: readCookies(db2),
+        cookies: readCookies(reconciledDB),
       };
     } catch (e) {
       this.#failSoft('reconciling the SQLite change log', e);

--- a/packages/zero-cache/src/services/replicator/change-log-cookies.ts
+++ b/packages/zero-cache/src/services/replicator/change-log-cookies.ts
@@ -34,6 +34,7 @@
 
 import {unreachable} from '../../../../shared/src/asserts.ts';
 import {BigIntJSON} from '../../../../shared/src/bigint-json.ts';
+import * as v from '../../../../shared/src/valita.ts';
 import type {Database, Statement} from '../../../../zqlite/src/db.ts';
 import type {
   BackfillID,
@@ -41,6 +42,10 @@ import type {
   SchemaChange,
   TableMetadata,
 } from '../change-source/protocol/current/data.ts';
+import {
+  backfillRequestSchema,
+  type BackfillRequest,
+} from '../change-source/protocol/current/upstream.ts';
 
 export const CHANGE_LOG_TABLE_METADATA_TABLE = '_zero.changeLogTableMetadata';
 export const CHANGE_LOG_BACKFILLING_TABLE = '_zero.changeLogBackfilling';
@@ -496,6 +501,48 @@ export function foldCookies(
         cmp(a.column, b.column),
     ),
   };
+}
+
+const backfillRequestsSchema = v.array(backfillRequestSchema);
+
+/**
+ * Projects a cookie set into the {@link BackfillRequest}s a stream connection
+ * hands the change source.
+ *
+ * The projection is lossy in one direction and that is deliberate (§3.7): it is
+ * driven off the *backfilling* half, so a table with no in-flight backfill
+ * contributes no request even when its metadata is held. Which is why the two
+ * are not interchangeable, and why a change log has to hold the whole cookie
+ * set rather than the requests it last sent.
+ *
+ * One implementation, shared by every store, for the same reason
+ * {@link cookieOps} is: `Storer.getStartStreamInitializationParameters()` does
+ * this join in SQL, and a second hand-written grouping is a second thing that
+ * can be wrong about `metadata: null`.
+ */
+export function backfillRequestsFrom(cookies: CookieSet): BackfillRequest[] {
+  const metadata = new Map(
+    cookies.tableMetadata.map(c => [tableKey(c.schema, c.table), c.metadata]),
+  );
+  const requests: BackfillRequest[] = [];
+  let curr: BackfillRequest | undefined;
+  for (const {schema, table, column, backfill} of cookies.backfilling) {
+    if (curr?.table.schema !== schema || curr.table.name !== table) {
+      curr = {
+        table: {
+          schema,
+          name: table,
+          // `null`, not absent: a table can be backfilling with no metadata of
+          // its own, which is the LEFT half of the join Postgres does in SQL.
+          metadata: metadata.get(tableKey(schema, table)) ?? null,
+        },
+        columns: {},
+      };
+      requests.push(curr);
+    }
+    curr.columns[column] = backfill;
+  }
+  return v.parse(requests, backfillRequestsSchema);
 }
 
 /**

--- a/packages/zero-cache/src/services/replicator/change-log-cookies.ts
+++ b/packages/zero-cache/src/services/replicator/change-log-cookies.ts
@@ -506,14 +506,8 @@ export function foldCookies(
 const backfillRequestsSchema = v.array(backfillRequestSchema);
 
 /**
- * Builds the {@link BackfillRequest}s for a stream connection from a cookie
- * set.
- *
- * Only tables with an active backfill produce requests. A table with metadata
- * but no active backfill does not produce a request. Therefore, the change log
- * stores the complete cookie set instead of only the generated requests.
- *
- * All stores use this function so they handle `metadata: null` in the same way.
+ * Returns one {@link BackfillRequest} for each table with an active backfill.
+ * Each request contains the stored table metadata, if available.
  */
 export function backfillRequestsFrom(cookies: CookieSet): BackfillRequest[] {
   const metadata = new Map(

--- a/packages/zero-cache/src/services/replicator/change-log-cookies.ts
+++ b/packages/zero-cache/src/services/replicator/change-log-cookies.ts
@@ -506,19 +506,14 @@ export function foldCookies(
 const backfillRequestsSchema = v.array(backfillRequestSchema);
 
 /**
- * Projects a cookie set into the {@link BackfillRequest}s a stream connection
- * hands the change source.
+ * Builds the {@link BackfillRequest}s for a stream connection from a cookie
+ * set.
  *
- * The projection is lossy in one direction and that is deliberate (§3.7): it is
- * driven off the *backfilling* half, so a table with no in-flight backfill
- * contributes no request even when its metadata is held. Which is why the two
- * are not interchangeable, and why a change log has to hold the whole cookie
- * set rather than the requests it last sent.
+ * Only tables with an active backfill produce requests. A table with metadata
+ * but no active backfill does not produce a request. Therefore, the change log
+ * stores the complete cookie set instead of only the generated requests.
  *
- * One implementation, shared by every store, for the same reason
- * {@link cookieOps} is: `Storer.getStartStreamInitializationParameters()` does
- * this join in SQL, and a second hand-written grouping is a second thing that
- * can be wrong about `metadata: null`.
+ * All stores use this function so they handle `metadata: null` in the same way.
  */
 export function backfillRequestsFrom(cookies: CookieSet): BackfillRequest[] {
   const metadata = new Map(
@@ -532,8 +527,8 @@ export function backfillRequestsFrom(cookies: CookieSet): BackfillRequest[] {
         table: {
           schema,
           name: table,
-          // `null`, not absent: a table can be backfilling with no metadata of
-          // its own, which is the LEFT half of the join Postgres does in SQL.
+          // Use `null` when a backfilling table has no metadata. This matches
+          // the result of the Postgres left join.
           metadata: metadata.get(tableKey(schema, table)) ?? null,
         },
         columns: {},

--- a/packages/zero-cache/src/services/replicator/change-log-db.test.ts
+++ b/packages/zero-cache/src/services/replicator/change-log-db.test.ts
@@ -475,7 +475,11 @@ describe('replicator/change-log-db', () => {
     test('creates and seeds the log, then leaves it alone', () => {
       const file = newDbFile();
       {
-        const {db, result} = openChangeLogDBForWriting(lc, file.path, ANCHOR);
+        const {db, result} = openChangeLogDBForWriting(
+          lc,
+          file.path,
+          () => ANCHOR,
+        );
         using open = db;
         expect(result).toEqual({
           action: 'reseeded',
@@ -487,7 +491,7 @@ describe('replicator/change-log-db', () => {
         expect(readChangeLogHead(open)).toBe(ANCHOR.resumeWatermark);
       }
 
-      const reopened = openChangeLogDBForWriting(lc, file.path, ANCHOR);
+      const reopened = openChangeLogDBForWriting(lc, file.path, () => ANCHOR);
       using db = reopened.db;
       expect(reopened.result).toEqual({
         action: 'none',
@@ -503,7 +507,11 @@ describe('replicator/change-log-db', () => {
       const file = newDbFile();
       writeFileSync(changeLogFileName(file.path), 'this is not a database');
 
-      const {db, result} = openChangeLogDBForWriting(lc, file.path, ANCHOR);
+      const {db, result} = openChangeLogDBForWriting(
+        lc,
+        file.path,
+        () => ANCHOR,
+      );
       using rebuilt = db;
 
       expect(result).toEqual({
@@ -520,7 +528,11 @@ describe('replicator/change-log-db', () => {
       const file = newDbFile();
       createV1Log(file.path);
 
-      const {db, result} = openChangeLogDBForWriting(lc, file.path, ANCHOR);
+      const {db, result} = openChangeLogDBForWriting(
+        lc,
+        file.path,
+        () => ANCHOR,
+      );
       using rebuilt = db;
 
       // The file is replaced rather than dropped in place, but the original
@@ -550,7 +562,11 @@ describe('replicator/change-log-db', () => {
         expect(autoVacuum(db)).toBe(0);
       }
 
-      const {db, result} = openChangeLogDBForWriting(lc, file.path, ANCHOR);
+      const {db, result} = openChangeLogDBForWriting(
+        lc,
+        file.path,
+        () => ANCHOR,
+      );
       using rebuilt = db;
 
       expect(result).toEqual({
@@ -584,7 +600,7 @@ describe('replicator/change-log-db', () => {
         const {db, result} = openChangeLogDBForWriting(
           logger,
           file.path,
-          ANCHOR,
+          () => ANCHOR,
         );
         using opened = db;
 
@@ -620,9 +636,9 @@ describe('replicator/change-log-db', () => {
       const dir = changeLogFileName(file.path);
       mkdirSync(dir);
       try {
-        expect(() => openChangeLogDBForWriting(lc, file.path, ANCHOR)).toThrow(
-          /unable to open database file/,
-        );
+        expect(() =>
+          openChangeLogDBForWriting(lc, file.path, () => ANCHOR),
+        ).toThrow(/unable to open database file/);
         expect(statSync(dir).isDirectory()).toBe(true);
       } finally {
         rmSync(dir, {recursive: true, force: true});

--- a/packages/zero-cache/src/services/replicator/change-log-db.ts
+++ b/packages/zero-cache/src/services/replicator/change-log-db.ts
@@ -367,14 +367,11 @@ function readAutoVacuum(db: Database): number {
  * tolerated rather than thrown — see {@link ensureIncrementalAutoVacuum}.
  */
 /**
- * Produces the anchor for a database that is now open.
+ * Returns an anchor after the database opens.
  *
- * A function rather than a value because the anchor can depend on what the file
- * turns out to contain: once the log owns the resume point, a log this
- * task may keep appending to is anchored on its *own* head, and only one that
- * has to be wiped falls back to the replica's state version. It is called
- * again after a rebuild, against the fresh empty file, which is the answer
- * those paths need rather than a complication for them.
+ * The resolver can inspect the existing file before it selects the anchor. A
+ * valid log can use its own head. A new or invalid log uses the replica seed.
+ * The rebuild path calls the resolver again for the new file.
  */
 export type AnchorResolver = (db: Database) => ChangeLogAnchor;
 
@@ -767,14 +764,11 @@ function reconcile(
 }
 
 /**
- * Whether the log's contents can be kept, and if not, why.
+ * Returns the reason that the log must be recreated. Returns `undefined` when
+ * the writer can continue to use the log.
  *
- * Exported because it is also the question "can this log supply a resume point
- * of its own": once the log owns the resume point, its head is only usable
- * if the file is one this task may keep appending to, and that is exactly this
- * predicate. Taking the identity rather than a whole anchor is what makes that
- * call possible — at that moment there is no anchor yet, because the anchor is
- * what the answer produces.
+ * This function takes only the expected identity because callers use the result
+ * to select the anchor.
  */
 export function changeLogWipeReason(
   db: Database,

--- a/packages/zero-cache/src/services/replicator/change-log-db.ts
+++ b/packages/zero-cache/src/services/replicator/change-log-db.ts
@@ -366,10 +366,22 @@ function readAutoVacuum(db: Database): number {
  * so a reseed cannot enable it. Unlike corruption, a *second* failure there is
  * tolerated rather than thrown — see {@link ensureIncrementalAutoVacuum}.
  */
+/**
+ * Produces the anchor for a database that is now open.
+ *
+ * A function rather than a value because the anchor can depend on what the file
+ * turns out to contain: once the log owns the resume point, a log this
+ * task may keep appending to is anchored on its *own* head, and only one that
+ * has to be wiped falls back to the replica's state version. It is called
+ * again after a rebuild, against the fresh empty file, which is the answer
+ * those paths need rather than a complication for them.
+ */
+export type AnchorResolver = (db: Database) => ChangeLogAnchor;
+
 export function openChangeLogDBForWriting(
   lc: LogContext,
   replicaFile: string,
-  anchor: ChangeLogAnchor,
+  anchor: AnchorResolver,
 ): {db: Database; result: ReconcileResult; replacedFile: boolean} {
   const existed = existsSync(changeLogFileName(replicaFile));
   const opened = openOrRebuildCorrupt(lc, replicaFile, anchor, existed);
@@ -385,7 +397,7 @@ export function openChangeLogDBForWriting(
 function openOrRebuildCorrupt(
   lc: LogContext,
   replicaFile: string,
-  anchor: ChangeLogAnchor,
+  anchor: AnchorResolver,
   boundReconciliation: boolean,
 ): OpenedChangeLog {
   try {
@@ -429,7 +441,7 @@ function openOrRebuildCorrupt(
 function ensureIncrementalAutoVacuum(
   lc: LogContext,
   replicaFile: string,
-  anchor: ChangeLogAnchor,
+  anchor: AnchorResolver,
   opened: OpenedChangeLog,
 ): OpenedChangeLog {
   if (opened.autoVacuum === AUTO_VACUUM_INCREMENTAL) {
@@ -455,7 +467,7 @@ function ensureIncrementalAutoVacuum(
 function rebuildChangeLog(
   lc: LogContext,
   replicaFile: string,
-  anchor: ChangeLogAnchor,
+  anchor: AnchorResolver,
   required?: ChangeLogRebuildRequired | undefined,
 ): OpenedChangeLog {
   if (required) {
@@ -494,7 +506,12 @@ export function rebuildChangeLogDBForWriting(
   anchor: ChangeLogAnchor,
   required: ChangeLogRebuildRequired,
 ): {db: Database; result: ReconcileResult; replacedFile: true} {
-  const {db, result} = rebuildChangeLog(lc, replicaFile, anchor, required);
+  const {db, result} = rebuildChangeLog(
+    lc,
+    replicaFile,
+    () => anchor,
+    required,
+  );
   return {db, result, replacedFile: true};
 }
 
@@ -509,7 +526,7 @@ type OpenedChangeLog = {
 function openAndReconcile(
   lc: LogContext,
   replicaFile: string,
-  anchor: ChangeLogAnchor,
+  anchor: AnchorResolver,
   boundReconciliation: boolean,
   reseedReason?: ReseedReason | undefined,
 ): OpenedChangeLog {
@@ -519,7 +536,7 @@ function openAndReconcile(
     const autoVacuum = readAutoVacuum(db);
     return {
       db,
-      result: reconcileChangeLog(lc, db, anchor, {
+      result: reconcileChangeLog(lc, db, anchor(db), {
         rebuildInsteadOfUnboundedWork: boundReconciliation,
         reseedReason,
       }),
@@ -664,7 +681,7 @@ function rebuildRequired(
   db: Database,
   anchor: ChangeLogAnchor,
 ): ChangeLogRebuildRequired | undefined {
-  const wipe = wipeReason(db, anchor);
+  const wipe = changeLogWipeReason(db, anchor.identity);
   if (wipe !== undefined) {
     return new ChangeLogRebuildRequired(wipe);
   }
@@ -711,7 +728,7 @@ function reconcile(
   db: Database,
   anchor: ChangeLogAnchor,
 ): ReconcileResult {
-  const wipe = wipeReason(db, anchor);
+  const wipe = changeLogWipeReason(db, anchor.identity);
   if (wipe !== undefined) {
     return reseed(lc, db, anchor, wipe);
   }
@@ -749,9 +766,19 @@ function reconcile(
   return {action: 'none', head, cookiesStale: false};
 }
 
-function wipeReason(
+/**
+ * Whether the log's contents can be kept, and if not, why.
+ *
+ * Exported because it is also the question "can this log supply a resume point
+ * of its own": once the log owns the resume point, its head is only usable
+ * if the file is one this task may keep appending to, and that is exactly this
+ * predicate. Taking the identity rather than a whole anchor is what makes that
+ * call possible — at that moment there is no anchor yet, because the anchor is
+ * what the answer produces.
+ */
+export function changeLogWipeReason(
   db: Database,
-  anchor: ChangeLogAnchor,
+  identity: ChangeLogIdentity,
 ): ReseedReason | undefined {
   if (
     !tableExists(db, CHANGE_LOG_STREAM_TABLE) ||
@@ -784,7 +811,6 @@ function wipeReason(
     return 'created';
   }
   const {epoch, generation, replicaID} = readChangeLogMeta(db);
-  const identity = anchor.identity;
   if (
     epoch !== identity.epoch ||
     generation !== identity.generation ||

--- a/packages/zero-cache/src/services/replicator/schema/backfilling.ts
+++ b/packages/zero-cache/src/services/replicator/schema/backfilling.ts
@@ -38,7 +38,6 @@
 import type {LogContext} from '@rocicorp/logger';
 import {unreachable} from '../../../../../shared/src/asserts.ts';
 import {BigIntJSON} from '../../../../../shared/src/bigint-json.ts';
-import * as v from '../../../../../shared/src/valita.ts';
 import type {Database, Statement} from '../../../../../zqlite/src/db.ts';
 import {getOrCreateCounter} from '../../../observability/metrics.ts';
 import {liteTableName} from '../../../types/names.ts';
@@ -48,11 +47,9 @@ import type {
   SchemaChange,
   TableMetadata,
 } from '../../change-source/protocol/current/data.ts';
+import type {BackfillRequest} from '../../change-source/protocol/current/upstream.ts';
 import {
-  backfillRequestSchema,
-  type BackfillRequest,
-} from '../../change-source/protocol/current/upstream.ts';
-import {
+  backfillRequestsFrom,
   cookieOps,
   type CookieOp,
   type CookieSet,
@@ -186,63 +183,18 @@ export class BackfillingTracker {
   }
 }
 
-const backfillRequestsSchema = v.array(backfillRequestSchema);
-
-type BackfillRequestRow = {
-  schema: string;
-  table: string;
-  metadata: string | null;
-  column: string;
-  backfill: string;
-};
-
 /**
- * Assembles the {@link BackfillRequest}s that the replica's state implies, in
- * the shape `Storer.getStartStreamInitializationParameters()` produces them
- * from `cdc.backfilling` LEFT JOIN `cdc.tableMetadata`.
+ * The {@link BackfillRequest}s the replica's state implies, in the shape
+ * `Storer.getStartStreamInitializationParameters()` produces them from
+ * `cdc.backfilling` LEFT JOIN `cdc.tableMetadata`.
  *
- * The join is `LEFT` for the same reason it is there: a table can be
- * backfilling with no metadata of its own, in which case the request carries
- * `metadata: null`. Rows are ordered by primary key so that this list and the
- * Postgres-derived one can be compared position for position.
- *
- * This is a snapshot of the replica at its `_zero.replicationState.stateVersion`
- * and is only meaningful paired with it. It trails the change log's head, which
- * is why C4 folds the log's own schema changes onto it before comparing rather
- * than expecting raw equality.
+ * A snapshot of the replica at its `_zero.replicationState.stateVersion`, only
+ * meaningful paired with it. It trails the change log's head, which is why the
+ * comparison folds the log's own schema changes onto it first rather than
+ * expecting raw equality.
  */
 export function readBackfillRequests(db: Database): BackfillRequest[] {
-  const rows = db
-    .prepare(/*sql*/ `
-      SELECT b."schema", b."table", b."column", b."backfill",
-             t."upstreamMetadata" AS "metadata"
-        FROM "${BACKFILLING_TABLE}" AS b
-        LEFT JOIN "_zero.tableMetadata" AS t
-          ON b."schema" = t."schema" AND b."table" = t."table"
-        ORDER BY b."schema", b."table", b."column"
-    `)
-    .all<BackfillRequestRow>();
-
-  const requests: BackfillRequest[] = [];
-  let curr: BackfillRequest | undefined;
-  for (const {schema, table, metadata, column, backfill} of rows) {
-    if (curr?.table.schema !== schema || curr.table.name !== table) {
-      curr = {
-        table: {
-          schema,
-          name: table,
-          metadata:
-            metadata === null
-              ? null
-              : (BigIntJSON.parse(metadata) as TableMetadata),
-        },
-        columns: {},
-      };
-      requests.push(curr);
-    }
-    curr.columns[column] = BigIntJSON.parse(backfill) as BackfillID;
-  }
-  return v.parse(requests, backfillRequestsSchema);
+  return backfillRequestsFrom(readReplicaCookies(db));
 }
 
 /**

--- a/packages/zero-cache/src/services/replicator/schema/backfilling.ts
+++ b/packages/zero-cache/src/services/replicator/schema/backfilling.ts
@@ -184,14 +184,12 @@ export class BackfillingTracker {
 }
 
 /**
- * The {@link BackfillRequest}s the replica's state implies, in the shape
- * `Storer.getStartStreamInitializationParameters()` produces them from
- * `cdc.backfilling` LEFT JOIN `cdc.tableMetadata`.
+ * Returns the {@link BackfillRequest}s from the current replica cookies. The
+ * result has the same shape as the Postgres initialization result.
  *
- * A snapshot of the replica at its `_zero.replicationState.stateVersion`, only
- * meaningful paired with it. It trails the change log's head, which is why the
- * comparison folds the log's own schema changes onto it first rather than
- * expecting raw equality.
+ * The caller must pair this snapshot with the replica state version. When the
+ * replica trails the change log, the comparison applies the missing schema
+ * changes before it compares the results.
  */
 export function readBackfillRequests(db: Database): BackfillRequest[] {
   return backfillRequestsFrom(readReplicaCookies(db));

--- a/packages/zero-cache/src/services/replicator/sqlite-change-log-observability.test.ts
+++ b/packages/zero-cache/src/services/replicator/sqlite-change-log-observability.test.ts
@@ -425,7 +425,11 @@ describe('SQLite change-log observability on disk', () => {
     const sink = new TestLogSink();
     const lc = new LogContext('debug', undefined, sink);
     dbFile = new DbFile('sqlite-change-log-observability');
-    const {db: changeLog} = openChangeLogDBForWriting(lc, dbFile.path, ANCHOR);
+    const {db: changeLog} = openChangeLogDBForWriting(
+      lc,
+      dbFile.path,
+      () => ANCHOR,
+    );
     return {
       lc,
       sink,

--- a/packages/zero-cache/src/services/replicator/sqlite-change-log-purger.test.ts
+++ b/packages/zero-cache/src/services/replicator/sqlite-change-log-purger.test.ts
@@ -74,7 +74,7 @@ type Log = {
 function createLog(): Log {
   const file = new DbFile('sqlite-change-log-purger');
   files.push(file);
-  const {db} = openChangeLogDBForWriting(lc, file.path, ANCHOR);
+  const {db} = openChangeLogDBForWriting(lc, file.path, () => ANCHOR);
   return {db, path: changeLogFileName(file.path), close: () => db.close()};
 }
 
@@ -723,10 +723,10 @@ describe('replicator/sqlite-change-log-purger', () => {
       // The seed's writeTimeMs is the change-streamer's own clock at
       // reconciliation, which can sit ahead of the upstream commit times the
       // transactions that follow carry.
-      const {db} = openChangeLogDBForWriting(lc, file.path, {
+      const {db} = openChangeLogDBForWriting(lc, file.path, () => ({
         ...ANCHOR,
         nowMs: 5_000,
-      });
+      }));
       try {
         append(db, v(1), 400, 2_000);
         appendSeries(db, 2, 1);
@@ -791,7 +791,7 @@ describe('replicator/sqlite-change-log-purger', () => {
         const {db: reopened, result} = openChangeLogDBForWriting(
           lc,
           replicaFile,
-          {...ANCHOR, resumeWatermark: v(4)},
+          () => ({...ANCHOR, resumeWatermark: v(4)}),
         );
         try {
           expect(result).toEqual({


### PR DESCRIPTION
  This adds the cutover path for making the SQLite change log authoritative for change-stream
  initialization.

  The cutover is **not enabled in this PR**: `initFromPgChangeLog` remains `true`, so
  Postgres continues to supply the resume point.

  Once that flag is changed to `false`:

  - A valid SQLite change log resumes from its own head and cookie set.
  - A missing, empty, or incompatible log is seeded from the replica’s state version and
  cookies.
  - A disabled or failed-soft change-log writer falls back to the replica.
  - Backfill requests are projected from the same cookie set as the selected resume
  watermark.

  Reconciliation now lives inside `ChangeLogInitializer`, where it can support both
  orderings:

  - Today: read the Postgres resume point, reconcile SQLite to it, then compare the Postgres-
  and replica-derived initialization state.
  - After cutover: reconcile SQLite first and use the resulting log head and cookies as the
  resume point.