### PR TITLE
chore(rmv2): compare sqlite and pg change logs at a sampled rate

### DIFF
--- a/packages/zero-cache/src/config/normalize.test.ts
+++ b/packages/zero-cache/src/config/normalize.test.ts
@@ -140,8 +140,7 @@ describe('config/normalize SQLite change log', () => {
         '--change-streamer-sqlite-change-log-compare-percent must be an integer between 0 and 100',
       );
     }
-    // Unlike the read percentage, a nonzero value is valid in every mode:
-    // the default is nonzero, and sampling only runs in `compare` and above.
+    // A nonzero value is valid in every mode. Sampling starts in `compare` mode.
     const config = configWith({});
     config.changeStreamer.sqliteChangeLogComparePercent = 100;
     expect(() => assertNormalized(config)).not.toThrow();

--- a/packages/zero-cache/src/config/normalize.test.ts
+++ b/packages/zero-cache/src/config/normalize.test.ts
@@ -12,6 +12,7 @@ function configWith(litestream: Partial<ZeroConfig['litestream']>): ZeroConfig {
       address: 'localhost',
       sqliteChangeLogMode: 'off',
       sqliteChangeLogReadPercent: 0,
+      sqliteChangeLogComparePercent: 1,
       sqliteChangeLogRetentionMs: 60_000,
       sqliteChangeLogReadBatchRows: 1000,
       sqliteChangeLogPurgeBatchRows: 1000,
@@ -128,6 +129,22 @@ describe('config/normalize SQLite change log', () => {
         'must be an integer between 0 and 100',
       );
     }
+  });
+
+  test('compare percentage must be an integer from 0 through 100, in any mode', () => {
+    for (const percent of [-1, 1.5, 101]) {
+      const config = configWith({});
+      config.changeStreamer.sqliteChangeLogComparePercent = percent;
+
+      expect(() => assertNormalized(config)).toThrow(
+        '--change-streamer-sqlite-change-log-compare-percent must be an integer between 0 and 100',
+      );
+    }
+    // Unlike the read percentage, a nonzero value is valid in every mode:
+    // the default is nonzero, and sampling only runs in `compare` and above.
+    const config = configWith({});
+    config.changeStreamer.sqliteChangeLogComparePercent = 100;
+    expect(() => assertNormalized(config)).not.toThrow();
   });
 
   test('accepts positive integer tuning values', () => {

--- a/packages/zero-cache/src/config/normalize.ts
+++ b/packages/zero-cache/src/config/normalize.ts
@@ -58,8 +58,7 @@ export function assertNormalized(
       sqliteChangeLogReadPercent <= 100,
     '--change-streamer-sqlite-change-log-read-percent must be an integer between 0 and 100',
   );
-  // Deliberately no mode restriction: the default is nonzero, and the sampled
-  // comparison only runs in `compare` mode and above.
+  // This setting has no mode restriction. Comparison starts in `compare` mode.
   assert(
     Number.isSafeInteger(sqliteChangeLogComparePercent) &&
       sqliteChangeLogComparePercent >= 0 &&

--- a/packages/zero-cache/src/config/normalize.ts
+++ b/packages/zero-cache/src/config/normalize.ts
@@ -46,6 +46,7 @@ export function assertNormalized(
   const {
     sqliteChangeLogMode,
     sqliteChangeLogReadPercent,
+    sqliteChangeLogComparePercent,
     sqliteChangeLogRetentionMs,
     sqliteChangeLogReadBatchRows,
     sqliteChangeLogPurgeBatchRows,
@@ -56,6 +57,14 @@ export function assertNormalized(
       sqliteChangeLogReadPercent >= 0 &&
       sqliteChangeLogReadPercent <= 100,
     '--change-streamer-sqlite-change-log-read-percent must be an integer between 0 and 100',
+  );
+  // Deliberately no mode restriction: the default is nonzero, and the sampled
+  // comparison only runs in `compare` mode and above.
+  assert(
+    Number.isSafeInteger(sqliteChangeLogComparePercent) &&
+      sqliteChangeLogComparePercent >= 0 &&
+      sqliteChangeLogComparePercent <= 100,
+    '--change-streamer-sqlite-change-log-compare-percent must be an integer between 0 and 100',
   );
   assert(
     sqliteChangeLogMode === 'serve' || sqliteChangeLogReadPercent === 0,

--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -724,6 +724,15 @@ export const zeroOptions = {
       hidden: true,
     },
 
+    sqliteChangeLogComparePercent: {
+      type: v.number().default(1),
+      desc: [
+        `The stable percentage of committed transactions whose catchup output is`,
+        `compared between the Postgres and SQLite change logs in {bold compare} mode.`,
+      ],
+      hidden: true,
+    },
+
     sqliteChangeLogRetentionMs: {
       type: v.number().default(60_000),
       desc: [`The minimum time window retained in the SQLite change log.`],

--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -67,6 +67,7 @@ export default async function runWorker(
       flowControlConsensusTimeoutProportion,
       flowControlSlowSubscriberGracePeriodSeconds,
       sqliteChangeLogMode,
+      sqliteChangeLogComparePercent,
       sqliteChangeLogRetentionMs,
       sqliteChangeLogReadBatchRows,
       sqliteChangeLogPurgeBatchRows,
@@ -250,11 +251,14 @@ export default async function runWorker(
                 batchRows: sqliteChangeLogPurgeBatchRows,
               }
             : undefined,
-          // `compare` and above. The replica-derived initialization path runs
-          // at full rate and is checked against Postgres, which stays
-          // authoritative. Flipping authority to the replica comes later.
+          // Compare mode runs both advisory checks. Postgres remains authoritative.
           sqliteChangeLogCompare: sqliteChangeLogComparing
-            ? {replicaFile: replica.file}
+            ? {
+                replicaFile: replica.file,
+                comparePercent: sqliteChangeLogComparePercent,
+                retentionMs: sqliteChangeLogRetentionMs,
+                readBatchRows: sqliteChangeLogReadBatchRows,
+              }
             : undefined,
         },
         setTimeout,

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
@@ -340,6 +340,7 @@ describe('change-streamer/service', () => {
     sqliteCatchup?: Partial<SQLiteCatchupOptions>,
     sqliteChangeLogPurge?: TuningOptions['sqliteChangeLogPurge'],
     backupURL?: string,
+    sqliteChangeLogCompare?: TuningOptions['sqliteChangeLogCompare'],
   ): Promise<void> {
     await streamer.stop();
     await streamerDone;
@@ -381,6 +382,9 @@ describe('change-streamer/service', () => {
           },
         },
         ...(sqliteChangeLogPurge === undefined ? {} : {sqliteChangeLogPurge}),
+        ...(sqliteChangeLogCompare === undefined
+          ? {}
+          : {sqliteChangeLogCompare}),
         ...(sqliteCatchup === undefined
           ? {}
           : {
@@ -870,6 +874,125 @@ describe('change-streamer/service', () => {
       storeSpy.mockRestore();
       writeSpy.mockRestore();
       forwardSpy.mockRestore();
+      await streamer.stop();
+      await streamerDone;
+      deleteChangeLogDB(logFile.path);
+      logFile.delete();
+    }
+  });
+
+  /**
+   * Compare mode runs initialization and catchup checks independently.
+   * Failures do not stop replication.
+   * A warm log reports injected Postgres divergence.
+   */
+  test('compare mode: both checks run and fail independently', async () => {
+    const COLD_INTERVAL_MS = 777_001;
+    const WARM_INTERVAL_MS = 777_002;
+    const logFile = new DbFile('sqlite-change-log-compare-coexist');
+    const noSuchReplica = `${logFile.path}-no-such-replica`;
+
+    const fireCompareCycle = (intervalMs: number, fromIndex: number) => {
+      const call = setTimeoutFn.mock.calls
+        .slice(fromIndex)
+        .find(([, delay]) => delay === intervalMs);
+      assert(call, `no comparison cycle scheduled at ${intervalMs}ms`);
+      (call[0] as () => void)();
+    };
+    const logged = (level: string, message: string) =>
+      logSink.messages.some(
+        ([lvl, , parts]) => lvl === level && parts[0] === message,
+      );
+    // Read diverged watermarks from production error logs.
+    const divergedWatermarks = () =>
+      logSink.messages
+        .filter(([level, , parts]) => level === 'error' && parts.length === 2)
+        .flatMap(([, , parts]) => {
+          const detail = (
+            parts[1] as {
+              sqliteChangeLogCompare?: {watermark: string} | undefined;
+            }
+          ).sqliteChangeLogCompare;
+          return detail === undefined ? [] : [detail.watermark];
+        });
+
+    try {
+      // Start with a new log and a missing replica file.
+      await restartWithInlineChangeLogWriter(
+        logFile,
+        {},
+        undefined,
+        undefined,
+        {
+          replicaFile: noSuchReplica,
+          comparePercent: 100,
+          retentionMs: 60_000,
+          intervalMs: COLD_INTERVAL_MS,
+        },
+      );
+
+      // Both advisory checks leave replication active.
+      changes.push(['begin', messages.begin(), {commitWatermark: '06'}]);
+      changes.push(['data', messages.insert('foo', {id: 'compared'})]);
+      changes.push(['commit', messages.commit(), {watermark: '06'}]);
+      await expectAcks('06');
+
+      // The missing replica causes a warning, but startup continues.
+      await vi.waitFor(() =>
+        expect(
+          logged(
+            'warn',
+            'failed to derive change-log initialization from the replica',
+          ),
+        ).toBe(true),
+      );
+
+      // The comparator skips the new log without reporting divergence.
+      fireCompareCycle(COLD_INTERVAL_MS, 0);
+      await vi.waitFor(() =>
+        expect(
+          logged('debug', 'skipping SQLite change-log comparison: cold-log'),
+        ).toBe(true),
+      );
+      expect(divergedWatermarks()).toEqual([]);
+
+      // Restart with a clock that makes the log warm.
+      const warmStart = setTimeoutFn.mock.calls.length;
+      await restartWithInlineChangeLogWriter(
+        logFile,
+        {},
+        undefined,
+        undefined,
+        {
+          replicaFile: noSuchReplica,
+          comparePercent: 100,
+          retentionMs: 60_000,
+          intervalMs: WARM_INTERVAL_MS,
+          now: () => Date.now() + 3_600_000,
+        },
+      );
+
+      changes.push(['begin', messages.begin(), {commitWatermark: '08'}]);
+      changes.push(['data', messages.insert('foo', {id: 'diverged'})]);
+      changes.push(['commit', messages.commit(), {watermark: '08'}]);
+      await expectAcks('08');
+
+      // Change the stored Postgres row after commit.
+      const [{change}] = await sql<{change: string}[]>`
+        SELECT change::text FROM "zoro_3/cdc"."changeLog"
+         WHERE watermark = '08' AND pos = 1`;
+      const mutated = JSON.stringify({
+        ...(JSON.parse(change) as Record<string, unknown>),
+        divergence: true,
+      });
+      await sql`
+        UPDATE "zoro_3/cdc"."changeLog" SET change = ${mutated}::json
+         WHERE watermark = '08' AND pos = 1`;
+
+      // Transaction 06 matches. Transaction 08 diverges.
+      fireCompareCycle(WARM_INTERVAL_MS, warmStart);
+      await vi.waitFor(() => expect(divergedWatermarks()).toEqual(['08']));
+    } finally {
       await streamer.stop();
       await streamerDone;
       deleteChangeLogDB(logFile.path);

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -59,6 +59,10 @@ import {
   type SQLiteChangeLogCleanupGuard,
 } from './sqlite-change-log-catchup.ts';
 import {
+  SQLiteChangeLogComparator,
+  type SQLiteChangeLogCompareOptions,
+} from './sqlite-change-log-comparator.ts';
+import {
   SQLiteChangeLogPurgeScheduler,
   type PurgeContinuation,
   type SQLiteChangeLogPurgeSchedulerOptions,
@@ -137,14 +141,15 @@ export type TuningOptions = StorerOptions & {
    */
   sqliteChangeLogPurge?: SQLiteChangeLogPurgeSchedulerOptions | undefined;
   /**
-   * Supplied at `sqliteChangeLogMode >= compare`, and the gate on deriving the
-   * stream's initialization parameters from the replica as well as from
-   * Postgres. Postgres stays authoritative; the two are compared and the
-   * result is reported. Not a new configuration option -- the mode ladder
-   * carries it, because a state in which the log's buffer and its cookies were
-   * at different rollout stages is what invariant 15 exists to forbid.
+   * Supplied in `compare` mode and later modes.
+   * `replicaFile` enables the initialization comparison.
+   * The other fields configure sampled catchup comparisons.
+   * Both checks are advisory, and Postgres remains authoritative.
+   * The comparator also requires the writer and catchup options.
    */
-  sqliteChangeLogCompare?: {replicaFile: string} | undefined;
+  sqliteChangeLogCompare?:
+    | (SQLiteChangeLogCompareOptions & {replicaFile: string})
+    | undefined;
 };
 
 /**
@@ -357,6 +362,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
   readonly #sqliteCatchupOptions: SQLiteCatchupOptions | undefined;
   readonly #changeLogWriter: SQLiteChangeLogWriter | undefined;
   readonly #purgeScheduler: SQLiteChangeLogPurgeScheduler | undefined;
+  readonly #comparator: SQLiteChangeLogComparator | undefined;
   readonly #acker: UpstreamAcker;
   readonly #initializer: ChangeLogInitializer;
 
@@ -479,8 +485,15 @@ class ChangeStreamerImpl implements ChangeStreamerService {
           // Fail-soft deletes the file, and the reader is cached here, so it
           // has to go with it: otherwise it serves an unlinked inode while
           // every new open sees nothing.
-          onDisabled: () => this.#closeSQLiteCatchup(),
-          onRebuilt: () => this.#closeSQLiteCatchup(),
+          onDisabled: () => {
+            this.#closeSQLiteCatchup();
+            this.#comparator?.stop();
+          },
+          onRebuilt: () => {
+            this.#closeSQLiteCatchup();
+            // Invalidate cycles that can still read the replaced file.
+            this.#comparator?.invalidate();
+          },
         })
       : undefined;
     // The purge scheduler runs on the writer's own connection, which is also
@@ -535,6 +548,20 @@ class ChangeStreamerImpl implements ChangeStreamerService {
             this.#purgeScheduler?.cleanupGuard,
         }
       : undefined;
+    // Compare mode requires the writer and catchup configuration.
+    this.#comparator =
+      opts.sqliteChangeLogCompare &&
+      opts.sqliteChangeLogWriter &&
+      opts.sqliteCatchup
+        ? new SQLiteChangeLogComparator(
+            lc,
+            shard,
+            opts.sqliteCatchup.changeLogFile,
+            opts.sqliteChangeLogWriter.identity,
+            this.#storer,
+            {setTimeoutFn, ...opts.sqliteChangeLogCompare},
+          )
+        : undefined;
     this.#purgeLock = initialPurgeLock;
     this.#autoReset = autoReset;
     this.#state = new RunningState(this.id, undefined, setTimeoutFn);
@@ -1034,6 +1061,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
     this.#state.stop(this.#lc, err);
     this.#stream?.changes.cancel();
     this.#purgeScheduler?.stop();
+    this.#comparator?.stop();
     this.#sqliteCatchup?.close();
     this.#changeLogWriter?.close();
     await Promise.allSettled([this.#storer.stop(), this.#source.stop()]);

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.pg.test.ts
@@ -1,4 +1,5 @@
 import {LogContext} from '@rocicorp/logger';
+import {resolver} from '@rocicorp/resolver';
 import fc from 'fast-check';
 import {beforeEach, describe, expect, vi} from 'vitest';
 import {assert} from '../../../../shared/src/asserts.ts';
@@ -54,6 +55,7 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
   let writer: SQLiteChangeLogWriter;
   let logFile: DbFile;
   let seededAtMs: number;
+  let onWriterRebuilt: () => void;
 
   beforeEach<PgTest>(async ({testDBs}) => {
     logSink = new TestLogSink();
@@ -92,14 +94,15 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
     storerDone = storer.run();
 
     seededAtMs = 1_000_000;
+    onWriterRebuilt = () => {};
     logFile = new DbFile('sqlite-change-log-comparator');
     writer = new SQLiteChangeLogWriter(lc, {
       replicaFile: logFile.path,
       identity,
       now: () => seededAtMs,
+      onRebuilt: () => onWriterRebuilt(),
     });
-    // The stream would resume from PG's lastWatermark, which
-    // ensureReplicationConfig initialized to the replica version.
+    // Resume from the Postgres watermark at the replica version.
     writer.reconcile({
       resumeWatermark: REPLICA_VERSION,
       cookies: EMPTY_COOKIE_SET,
@@ -179,7 +182,7 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
       {
         comparePercent: 100,
         retentionMs: RETENTION_MS,
-        // Warm by default: exactly one retention window past the seed.
+        // Make the log exactly one retention period old.
         now: () => seededAtMs + RETENTION_MS,
         setTimeoutFn: vi.fn() as unknown as typeof setTimeout,
         yieldFn: () => Promise.resolve(),
@@ -188,7 +191,7 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
     );
   }
 
-  /** The production reader, with one call site swapped for a fault or a race. */
+  /** Returns the production reader with optional overrides. */
   function pgReader(
     overrides: Partial<PGChangeLogRangeReader> = {},
   ): PGChangeLogRangeReader {
@@ -202,7 +205,7 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
     };
   }
 
-  /** Direct writes to the SQLite log, as the purger or an injected fault. */
+  /** Opens the SQLite log for direct fault injection. */
   function withSQLiteLog<T>(fn: (db: Database) => T): T {
     const db = new Database(lc, changeLogFileName(logFile.path));
     try {
@@ -216,12 +219,7 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
     return sql(`${cdcSchema(shard)}.${table}`);
   }
 
-  /**
-   * The watermarks reported diverged, read back off the log line — the
-   * comparison's actual production surface. The cycle result carries counts
-   * only, deliberately: one collapsed `mismatch` outcome replaced the old
-   * per-watermark taxonomy.
-   */
+  /** Reads diverged watermarks from production error logs. */
   function divergedWatermarks(since = 0): string[] {
     return logSink.messages
       .slice(since)
@@ -262,7 +260,7 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
     );
   }
 
-  /** Rows belonging to no committed transaction, as a torn write would leave. */
+  /** Inserts rows that do not belong to a committed transaction. */
   function insertSQLiteRows(watermark: string) {
     withSQLiteLog(db => {
       const insert = db.prepare(/*sql*/ `
@@ -292,23 +290,7 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
              (${watermark}, 1, '{"tag":"insert"}'::json, NULL)`;
   }
 
-  // 1. Equivalent output matches.
-  //
-  // The normalization pin comes first (§6.5): a transaction round-tripped
-  // through both stores — SQLite's exact stored substring versus PG's json
-  // column read back as text — must digest identically before any injected
-  // mutation can mean anything.
-  //
-  // Both stores carry a synthetic seed transaction at the replica version
-  // '01' (PG's from ensureReplicationConfig, SQLite's from reconcile), so the
-  // comparable range starts there and every fed transaction is compared.
-  //
-  // The payload deliberately contains an *escaped* backslash-u sequence, not
-  // an actual NUL character: `change->'tag'` in the production PG catchup
-  // statement de-escapes every string value while scanning for the field, and
-  // Postgres cannot convert an escaped NUL to text, so a row containing one
-  // fails PG catchup itself — the comparator faithfully reports it as a
-  // mismatch rather than as parity.
+  // Use a literal backslash-u sequence. An escaped NUL makes Postgres catchup fail.
   test('equivalent catchup output matches, across message families and batches', async () => {
     await feedBoth(
       tx(
@@ -342,8 +324,7 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
       tx('06', messages.addColumn('foo', 'extra', {dataType: 'text', pos: 9})),
       tx('07', messages.dropColumn('foo', 'extra'), messages.dropTable('baz')),
     );
-    // readBatchRows 2 forces multiple SQLite read batches per transaction;
-    // maxTransactionsPerCycle 2 forces the comparison across cycles.
+    // Use small limits to require multiple batches and cycles.
     const comparator = newComparator({
       readBatchRows: 2,
       maxTransactionsPerCycle: 2,
@@ -383,12 +364,6 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
     expect(divergedWatermarks()).toEqual([]);
   });
 
-  // 2. Mutated, missing, or extra output mismatches.
-  //
-  // One rolling digest per served range replaced the per-transaction digest
-  // map, so extra rows at any watermark — which no commit enumeration can see
-  // — are caught by the same equality check as a mutated payload, and are
-  // reported at the watermark of the range that served them.
   describe('divergent catchup output mismatches', () => {
     const cases: {
       name: string;
@@ -434,8 +409,7 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
         diverged: ['05'],
       },
       {
-        // Identical output is parity in what catchup *serves* — the thing this
-        // comparison measures — even where no committed transaction claims it.
+        // Equal output matches even when no commit owns these rows.
         name: 'identical extra rows in both stores',
         corrupt: async () => {
           insertSQLiteRows('04z');
@@ -463,7 +437,6 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
     }
   });
 
-  // 3. Head skew compares only the common range.
   test('head lag in either direction is not divergence', async () => {
     await feedBoth(
       tx('03', messages.insert('foo', {id: 'boundary'})),
@@ -472,8 +445,7 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
     const t5 = tx('05', messages.insert('foo', {id: 'trailing-pg'}));
     const t6 = tx('06', messages.insert('foo', {id: 'trailing-sqlite'}));
 
-    // The SQLite log leads, as it does in production: compare only through
-    // the PG head.
+    // SQLite leads, so compare only through the Postgres head.
     feedSQLiteOnly(t5);
     const comparator = newComparator();
     expect(await comparator.compareOnce()).toMatchObject({
@@ -483,7 +455,7 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
       mismatched: 0,
     });
 
-    // PG catches up and then leads: compare only through the SQLite head.
+    // Postgres then leads, so compare only through the SQLite head.
     await feedPGOnly(t5, t6);
     expect(await comparator.compareOnce()).toMatchObject({
       fromWatermark: '04',
@@ -492,7 +464,7 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
       mismatched: 0,
     });
 
-    // SQLite catches up: the previously skewed transaction compares clean.
+    // SQLite catches up, and the earlier skew matches.
     feedSQLiteOnly(t6);
     expect(await comparator.compareOnce()).toMatchObject({
       fromWatermark: '05',
@@ -513,10 +485,7 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
     deleteFromSQLiteLog(`"watermark" = '04'`);
 
     const comparator = newComparator({maxTransactionsPerCycle: 2});
-    // The stores hit the limit at different watermarks — SQLite's two commits
-    // reach '05', PG's reach '04' — so the cycle covers only the range both
-    // enumerations completely cover. '05', cut from PG's list by the limit
-    // alone, must not be reported missing.
+    // The lower complete enumeration ends at 04, so 05 is not missing.
     expect(await comparator.compareOnce()).toMatchObject({
       throughWatermark: '04',
       transactions: 2,
@@ -525,17 +494,16 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
     });
     expect(divergedWatermarks()).toEqual(['04']);
 
-    // The next cycle resumes above the covered range and completes it.
+    // The next cycle completes the remaining range.
     const before = logSink.messages.length;
     expect(await comparator.compareOnce()).toMatchObject({
       throughWatermark: '06',
       matched: 2,
     });
-    // '04' is re-reported once, as the boundary the log cannot serve.
+    // Report 04 again because the log cannot serve that boundary.
     expect(divergedWatermarks(before)).toEqual(['04']);
   });
 
-  // 4. Purge/reseed races are inconclusive.
   describe('a race with the pinned bounds is inconclusive', () => {
     const cases: {
       name: string;
@@ -544,8 +512,7 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
       inconclusive: number;
     }[] = [
       {
-        // The purge lands after the cycle pinned its bounds and enumerated the
-        // range, exactly as a concurrently scheduled cleanup would.
+        // Purge Postgres after the cycle reads its initial bounds.
         name: 'a PG purge',
         pg: () => {
           let purged = false;
@@ -560,12 +527,11 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
               })(),
           });
         },
-        matched: 1, // '05' survives the purge and matches
+        matched: 1, // Transaction 05 survives the purge and matches.
         inconclusive: 2,
       },
       {
-        // The purger deletes whole transactions below the floor, after the
-        // cycle enumerated them.
+        // Purge SQLite after the cycle enumerates its transactions.
         name: 'a SQLite purge',
         pg: () =>
           pgReader({
@@ -583,10 +549,7 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
         inconclusive: 2,
       },
       {
-        // The writer reseeds the log after the cycle pinned its bounds: '04'
-        // vanishes and the meta row's seed point moves, as reconcileChangeLog's
-        // reseed would. The re-read bounds alone cannot see this — only the
-        // meta comparison can.
+        // Change the seed after the cycle reads its initial bounds.
         name: 'a reseed',
         pg: () =>
           pgReader({
@@ -621,10 +584,52 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
 
         const result = await newComparator({pg: pg()}).compareOnce();
         expect(result).toMatchObject({matched, inconclusive, mismatched: 0});
-        // A race is not a finding: nothing reports as diverged.
+        // Bounds races do not report divergence.
         expect(divergedWatermarks()).toEqual([]);
       });
     }
+  });
+
+  test('a file rebuild invalidates a cycle before it opens another reader', async () => {
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'removed-before-rebuild'})),
+      tx('04', messages.insert('foo', {id: 'old-head'})),
+    );
+
+    const boundsPinned = resolver();
+    const continueBounds = resolver();
+    let firstBoundsRead = true;
+    const comparator = newComparator({
+      pg: pgReader({
+        getCatchupBounds: async () => {
+          if (firstBoundsRead) {
+            firstBoundsRead = false;
+            boundsPinned.resolve();
+            await continueBounds.promise;
+          }
+          return storer.getCatchupBounds();
+        },
+      }),
+    });
+    onWriterRebuilt = () => comparator.invalidate();
+
+    const comparing = comparator.compareOnce();
+    await boundsPinned.promise;
+
+    // Rebuild while the comparator waits for Postgres bounds.
+    // The old database handle then points to the removed file.
+    deleteFromSQLiteLog(`"watermark" = '03'`);
+    writer.reconcile({
+      resumeWatermark: '03',
+      cookies: EMPTY_COOKIE_SET,
+    });
+    continueBounds.resolve();
+
+    expect(await comparing).toEqual({
+      kind: 'skipped',
+      reason: 'log-rebuilt',
+    });
+    expect(divergedWatermarks()).toEqual([]);
   });
 
   test('a suspect that cannot be reconfirmed is inconclusive, then retried', async () => {
@@ -635,8 +640,7 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
     );
     deleteFromSQLiteLog(`"watermark" = '04'`);
 
-    // The bounds re-read that would confirm the finding fails once; the
-    // observation cannot be distinguished from a race and must not report.
+    // Fail the bounds recheck once, so the first result is inconclusive.
     let boundsReads = 0;
     const comparator = newComparator({
       pg: pgReader({
@@ -655,8 +659,7 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
     });
     expect(divergedWatermarks()).toEqual([]);
 
-    // The cursor did not move, so a later cycle retries and confirms the
-    // persistent divergence once the transient bounds failure clears.
+    // The next cycle retries and reports the persistent mismatch.
     expect(await comparator.compareOnce()).toMatchObject({mismatched: 1});
     expect(divergedWatermarks()).toEqual(['04']);
   });
@@ -680,7 +683,6 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
     expect(divergedWatermarks()).toEqual(['04']);
   });
 
-  // 5. Sampling is deterministic.
   test('a retried comparison samples the same transactions', async () => {
     const txs = Array.from({length: 12}, (_, i) =>
       tx((i + 3).toString(36).padStart(2, '0'), {
@@ -694,8 +696,7 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
       isSampledForCompare(shard, watermark, percent),
     ).length;
 
-    // Two independent comparators — as across a restart — pin the same range
-    // and select exactly the same sample.
+    // Independent comparators select the same sample.
     const first = await newComparator({comparePercent: percent}).compareOnce();
     const second = await newComparator({comparePercent: percent}).compareOnce();
     assert(
@@ -710,7 +711,6 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
     expect(second.matched).toBe(second.sampled);
   });
 
-  // 6. Remaining-budget exhaustion defers.
   test('caps total catchup rows per source and defers an unfinished transaction', async () => {
     await feedBoth(
       tx('03', messages.insert('foo', {id: 'first'})),
@@ -735,7 +735,7 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
       mismatched: 0,
     });
 
-    // The next cycle's fresh budget fits it.
+    // The fresh budget in the next cycle fits the transaction.
     expect(await comparator.compareOnce()).toMatchObject({
       fromWatermark: '03',
       throughWatermark: '04',
@@ -745,7 +745,6 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
     });
   });
 
-  // 7. A fresh-budget overflow skips.
   test('skips a transaction that exceeds a fresh cycle row budget', async () => {
     await feedBoth(
       tx(
@@ -766,7 +765,7 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
       mismatched: 0,
     });
 
-    // Skipped, not wedged: the cursor moved past what can never fit.
+    // The cursor advances past the oversized transaction.
     expect(await comparator.compareOnce()).toMatchObject({
       fromWatermark: '03',
       throughWatermark: '04',
@@ -775,7 +774,6 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
     });
   });
 
-  // 8. A transaction that exactly fills the budget compares.
   test('compares a transaction that exactly fills the cycle row budget', async () => {
     await feedBoth(tx('03', messages.insert('foo', {id: 'exact'})));
 
@@ -789,12 +787,8 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
     });
   });
 
-  // 9. A confirmed mismatch at the cursor boundary still advances.
   test('a divergent cursor boundary does not wedge the comparator', async () => {
-    // SQLite loses a whole transaction PG holds, while the log runs ahead of
-    // PG (its normal state), so the cycle's common upper bound — and with it
-    // the cursor — lands exactly on the commit the log cannot serve as a
-    // catchup boundary.
+    // Remove the transaction at the common upper bound.
     await feedBoth(
       tx('03', messages.insert('foo', {id: 'boundary'})),
       tx('04', messages.insert('foo', {id: 'sqlite-lost'})),
@@ -810,9 +804,7 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
     });
     expect(divergedWatermarks()).toEqual(['04']);
 
-    // The stream continues, so the next cycle has a non-empty range whose
-    // `from` is the divergent boundary: plan() is `too-old` and the bounds
-    // have not moved. The cycle must still compare the range above it.
+    // The next cycle starts at the missing boundary and compares later rows.
     await feedBoth(tx('06', messages.insert('foo', {id: 'next'})));
 
     const before = logSink.messages.length;
@@ -823,7 +815,7 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
     });
     expect(divergedWatermarks(before)).toEqual(['04', '05']);
 
-    // Progress, not a wedge.
+    // The cursor advanced.
     expect(await comparator.compareOnce()).toEqual({
       kind: 'skipped',
       reason: 'nothing-to-compare',
@@ -881,8 +873,7 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
     const result = await newComparator().compareOnce();
     expect(result).toMatchObject({mismatched: 1});
 
-    // Neither the cycle result nor anything logged for it contains the
-    // payload, or any digest of it.
+    // Results and logs contain neither payloads nor digests.
     expect(JSON.stringify(result)).not.toContain(sentinel);
     expect(JSON.stringify(logSink.messages.slice(before))).not.toContain(
       sentinel,
@@ -919,9 +910,7 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
   });
 
   test('a freshly seeded log with no traffic has nothing to compare', async () => {
-    // Both stores hold only their synthetic seed transactions at '01'. Seeds
-    // are catchup boundaries, never compared output — and SQLite's seed is
-    // never reported as missing from PG.
+    // Synthetic seed transactions are boundaries, not compared output.
     expect(await newComparator().compareOnce()).toEqual({
       kind: 'skipped',
       reason: 'nothing-to-compare',
@@ -959,9 +948,7 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
       ),
     });
 
-    // Runs share the fixture's PG database; each run scopes itself with a
-    // fresh SQLite log seeded above every prior run's watermarks, so prior
-    // corruptions sit below its `from` and are invisible to it.
+    // Each run starts above the watermarks from earlier runs.
     let nextNum = 1;
     const wm = (n: number) => `w${String(n).padStart(8, '0')}`;
 
@@ -986,9 +973,7 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
             ...spec,
             watermark: wm(base + (i + 1) * 10),
           }));
-          // A clean sentinel pins the common head, so every generated
-          // transaction lies strictly inside the compared range — head skew
-          // is deliberately never reported, and is not what this pins.
+          // A clean sentinel keeps generated transactions below the common head.
           const sentinel = wm(base + (txs.length + 1) * 10);
 
           const feedRun = (t: Tx) => {
@@ -1018,11 +1003,9 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
             }
           };
 
-          // Corrupt, and build the expected report while doing so. Every
-          // corruption is reported at its own watermark: presence for a
-          // dropped transaction, a digest inequality for a mutated one.
+          // Apply each fault and record its expected watermark.
           const expected: string[] = [];
-          let expectedMatched = 1; // the sentinel
+          let expectedMatched = 1; // The sentinel matches.
           for (const spec of specs) {
             switch (spec.kind) {
               case 'clean':

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.pg.test.ts
@@ -1,0 +1,1083 @@
+import {LogContext} from '@rocicorp/logger';
+import fc from 'fast-check';
+import {beforeEach, describe, expect, vi} from 'vitest';
+import {assert} from '../../../../shared/src/asserts.ts';
+import {TestLogSink} from '../../../../shared/src/logging-test-utils.ts';
+import {Database} from '../../../../zqlite/src/db.ts';
+import {StatementRunner} from '../../db/statements.ts';
+import {test, type PgTest} from '../../test/db.ts';
+import {DbFile} from '../../test/lite.ts';
+import type {PostgresDB} from '../../types/pg.ts';
+import {cdcSchema, type ShardID} from '../../types/shards.ts';
+import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
+import {EMPTY_COOKIE_SET} from '../replicator/change-log-cookies.ts';
+import {
+  changeLogFileName,
+  CHANGE_LOG_META_TABLE,
+  CHANGE_LOG_STREAM_TABLE,
+  deleteChangeLogDB,
+  estimateChangeLogStreamRowBytes,
+  type ChangeLogIdentity,
+} from '../replicator/change-log-db.ts';
+import {
+  getSubscriptionState,
+  initReplicationState,
+} from '../replicator/schema/replication-state.ts';
+import {ReplicationMessages} from '../replicator/test-utils.ts';
+import {serializeChangeStreamData} from './change-log-codec.ts';
+import {initChangeStreamerSchema} from './schema/init.ts';
+import {ensureReplicationConfig} from './schema/tables.ts';
+import {
+  isSampledForCompare,
+  SQLiteChangeLogComparator,
+  type PGChangeLogRangeReader,
+  type SQLiteChangeLogCompareOptions,
+} from './sqlite-change-log-comparator.ts';
+import {SQLiteChangeLogWriter} from './sqlite-change-log-writer.ts';
+import {Storer} from './storer.ts';
+
+describe('change-streamer/sqlite-change-log-comparator', () => {
+  const REPLICA_VERSION = '01';
+  const RETENTION_MS = 60_000;
+  const shard: ShardID = {appID: 'cmp', shardNum: 7};
+  const identity: ChangeLogIdentity = {
+    epoch: null,
+    generation: REPLICA_VERSION,
+    replicaID: 'replica-id',
+  };
+
+  let lc: LogContext;
+  let logSink: TestLogSink;
+  let sql: PostgresDB;
+  let storer: Storer;
+  let storerDone: Promise<void>;
+  let writer: SQLiteChangeLogWriter;
+  let logFile: DbFile;
+  let seededAtMs: number;
+
+  beforeEach<PgTest>(async ({testDBs}) => {
+    logSink = new TestLogSink();
+    lc = new LogContext('debug', {}, logSink);
+
+    sql = await testDBs.create('sqlite_change_log_comparator_test', {
+      typeOpts: {sendStringAsJson: true},
+    });
+
+    const replica = new Database(lc, ':memory:');
+    initReplicationState(replica, ['zero_data'], REPLICA_VERSION);
+    const subscriptionState = getSubscriptionState(
+      new StatementRunner(replica),
+    );
+
+    await initChangeStreamerSchema(lc, sql, shard);
+    await ensureReplicationConfig(lc, sql, subscriptionState, shard, true);
+
+    storer = new Storer(
+      lc,
+      shard,
+      'task-id',
+      'change.streamer:12345',
+      'ws',
+      sql,
+      REPLICA_VERSION,
+      () => {},
+      vi.fn(),
+      {
+        backPressureLimitHeapProportion: 0.04,
+        statementTimeoutMs: 20_000,
+        changeLogBatchSize: 2000,
+      },
+    );
+    await storer.assumeOwnership();
+    storerDone = storer.run();
+
+    seededAtMs = 1_000_000;
+    logFile = new DbFile('sqlite-change-log-comparator');
+    writer = new SQLiteChangeLogWriter(lc, {
+      replicaFile: logFile.path,
+      identity,
+      now: () => seededAtMs,
+    });
+    // The stream would resume from PG's lastWatermark, which
+    // ensureReplicationConfig initialized to the replica version.
+    writer.reconcile({
+      resumeWatermark: REPLICA_VERSION,
+      cookies: EMPTY_COOKIE_SET,
+    });
+
+    return async () => {
+      await storer.stop();
+      await storerDone;
+      writer.close();
+      logFile.delete();
+      await testDBs.drop(sql);
+    };
+  });
+
+  const messages = new ReplicationMessages({foo: 'id'});
+
+  type Tx = {watermark: string; changes: ChangeStreamData[]};
+
+  function tx(watermark: string, ...data: object[]): Tx {
+    return {
+      watermark,
+      changes: [
+        [
+          'begin',
+          messages.begin(),
+          {commitWatermark: watermark},
+        ] as unknown as ChangeStreamData,
+        ...data.map(d => ['data', d] as unknown as ChangeStreamData),
+        [
+          'commit',
+          messages.commit(),
+          {watermark},
+        ] as unknown as ChangeStreamData,
+      ],
+    };
+  }
+
+  function feedTx(t: Tx, target: {pg: boolean; sqlite: boolean}) {
+    for (const change of t.changes) {
+      const json = target.pg
+        ? storer.store(t.watermark, change)
+        : serializeChangeStreamData(change);
+      if (target.sqlite) {
+        writer.write(change, json);
+      }
+    }
+  }
+
+  async function feedBoth(...txs: Tx[]) {
+    txs.forEach(t => feedTx(t, {pg: true, sqlite: true}));
+    await storer.allProcessed();
+  }
+
+  async function feedPGOnly(...txs: Tx[]) {
+    txs.forEach(t => feedTx(t, {pg: true, sqlite: false}));
+    await storer.allProcessed();
+  }
+
+  function feedSQLiteOnly(...txs: Tx[]) {
+    txs.forEach(t => feedTx(t, {pg: false, sqlite: true}));
+  }
+
+  function newComparator(
+    overrides: Partial<SQLiteChangeLogCompareOptions> & {
+      pg?: PGChangeLogRangeReader;
+      logIdentity?: ChangeLogIdentity;
+      file?: string;
+    } = {},
+  ): SQLiteChangeLogComparator {
+    const {pg, logIdentity, file, ...opts} = overrides;
+    return new SQLiteChangeLogComparator(
+      lc,
+      shard,
+      file ?? changeLogFileName(logFile.path),
+      logIdentity ?? identity,
+      pg ?? storer,
+      {
+        comparePercent: 100,
+        retentionMs: RETENTION_MS,
+        // Warm by default: exactly one retention window past the seed.
+        now: () => seededAtMs + RETENTION_MS,
+        setTimeoutFn: vi.fn() as unknown as typeof setTimeout,
+        yieldFn: () => Promise.resolve(),
+        ...opts,
+      },
+    );
+  }
+
+  /** The production reader, with one call site swapped for a fault or a race. */
+  function pgReader(
+    overrides: Partial<PGChangeLogRangeReader> = {},
+  ): PGChangeLogRangeReader {
+    return {
+      getCatchupBounds: () => storer.getCatchupBounds(),
+      listCommitWatermarks: (after, through, limit) =>
+        storer.listCommitWatermarks(after, through, limit),
+      readCatchupRange: (after, through, batchRows) =>
+        storer.readCatchupRange(after, through, batchRows),
+      ...overrides,
+    };
+  }
+
+  /** Direct writes to the SQLite log, as the purger or an injected fault. */
+  function withSQLiteLog<T>(fn: (db: Database) => T): T {
+    const db = new Database(lc, changeLogFileName(logFile.path));
+    try {
+      return fn(db);
+    } finally {
+      db.close();
+    }
+  }
+
+  function cdc(table: string) {
+    return sql(`${cdcSchema(shard)}.${table}`);
+  }
+
+  /**
+   * The watermarks reported diverged, read back off the log line — the
+   * comparison's actual production surface. The cycle result carries counts
+   * only, deliberately: one collapsed `mismatch` outcome replaced the old
+   * per-watermark taxonomy.
+   */
+  function divergedWatermarks(since = 0): string[] {
+    return logSink.messages
+      .slice(since)
+      .filter(([level, , parts]) => level === 'error' && parts.length === 2)
+      .flatMap(([, , parts]) => {
+        const detail = (
+          parts[1] as {
+            sqliteChangeLogCompare?: {watermark: string} | undefined;
+          }
+        ).sqliteChangeLogCompare;
+        return detail === undefined ? [] : [detail.watermark];
+      });
+  }
+
+  async function mutatePGChange(
+    watermark: string,
+    pos: number,
+    mutate: (change: Record<string, unknown>) => void,
+  ) {
+    const [{change}] = await sql<{change: string}[]>`
+      SELECT change::text FROM ${cdc('changeLog')}
+       WHERE watermark = ${watermark} AND pos = ${pos}`;
+    const parsed = JSON.parse(change) as Record<string, unknown>;
+    mutate(parsed);
+    const mutated = JSON.stringify(parsed);
+    await sql`
+      UPDATE ${cdc('changeLog')} SET change = ${mutated}::json
+       WHERE watermark = ${watermark} AND pos = ${pos}`;
+  }
+
+  function deleteFromSQLiteLog(where: string) {
+    withSQLiteLog(db =>
+      db
+        .prepare(
+          /*sql*/ `DELETE FROM "${CHANGE_LOG_STREAM_TABLE}" WHERE ${where}`,
+        )
+        .run(),
+    );
+  }
+
+  /** Rows belonging to no committed transaction, as a torn write would leave. */
+  function insertSQLiteRows(watermark: string) {
+    withSQLiteLog(db => {
+      const insert = db.prepare(/*sql*/ `
+          INSERT INTO "${CHANGE_LOG_STREAM_TABLE}"
+            ("watermark", "pos", "tag", "estimatedBytes", "change",
+             "precommit", "writeTimeMs")
+          VALUES (?, ?, ?, ?, ?, NULL, NULL)`);
+      for (const [pos, tag, change] of [
+        [0, 'begin', '{"tag":"begin"}'],
+        [1, 'insert', '{"tag":"insert"}'],
+      ] as const) {
+        insert.run(
+          watermark,
+          pos,
+          tag,
+          estimateChangeLogStreamRowBytes(watermark, tag, change),
+          change,
+        );
+      }
+    });
+  }
+
+  function insertPGRows(watermark: string) {
+    return sql`
+      INSERT INTO ${cdc('changeLog')} ("watermark", "pos", "change", "precommit")
+      VALUES (${watermark}, 0, '{"tag":"begin"}'::json, NULL),
+             (${watermark}, 1, '{"tag":"insert"}'::json, NULL)`;
+  }
+
+  // 1. Equivalent output matches.
+  //
+  // The normalization pin comes first (§6.5): a transaction round-tripped
+  // through both stores — SQLite's exact stored substring versus PG's json
+  // column read back as text — must digest identically before any injected
+  // mutation can mean anything.
+  //
+  // Both stores carry a synthetic seed transaction at the replica version
+  // '01' (PG's from ensureReplicationConfig, SQLite's from reconcile), so the
+  // comparable range starts there and every fed transaction is compared.
+  //
+  // The payload deliberately contains an *escaped* backslash-u sequence, not
+  // an actual NUL character: `change->'tag'` in the production PG catchup
+  // statement de-escapes every string value while scanning for the field, and
+  // Postgres cannot convert an escaped NUL to text, so a row containing one
+  // fails PG catchup itself — the comparator faithfully reports it as a
+  // mismatch rather than as parity.
+  test('equivalent catchup output matches, across message families and batches', async () => {
+    await feedBoth(
+      tx(
+        '03',
+        messages.insert('foo', {
+          id: 'nul-\\u0000-esc',
+          big: 9007199254740993n,
+          float: 1.5,
+          text: 'quotes " backslash \\ newline \n emoji 🙂 control ',
+          nil: null,
+          bool: true,
+        }),
+      ),
+      tx(
+        '04',
+        messages.insert('foo', {id: 'b', v: 1}),
+        messages.update('foo', {id: 'b', v: 2}),
+        messages.update('foo', {id: 'b2', v: 3}, {id: 'b'}),
+        messages.delete('foo', {id: 'b2'}),
+        messages.truncate('foo'),
+      ),
+      tx(
+        '05',
+        messages.createTable({
+          schema: 'public',
+          name: 'baz',
+          columns: {id: {pos: 0, dataType: 'varchar'}},
+          primaryKey: ['id'],
+        }),
+      ),
+      tx('06', messages.addColumn('foo', 'extra', {dataType: 'text', pos: 9})),
+      tx('07', messages.dropColumn('foo', 'extra'), messages.dropTable('baz')),
+    );
+    // readBatchRows 2 forces multiple SQLite read batches per transaction;
+    // maxTransactionsPerCycle 2 forces the comparison across cycles.
+    const comparator = newComparator({
+      readBatchRows: 2,
+      maxTransactionsPerCycle: 2,
+    });
+
+    const first = await comparator.compareOnce();
+    expect(first).toMatchObject({
+      kind: 'compared',
+      fromWatermark: '01',
+      throughWatermark: '04',
+      transactions: 2,
+      sampled: 2,
+      matched: 2,
+      mismatched: 0,
+    });
+
+    const second = await comparator.compareOnce();
+    expect(second).toMatchObject({
+      fromWatermark: '04',
+      throughWatermark: '06',
+      matched: 2,
+      mismatched: 0,
+    });
+
+    const third = await comparator.compareOnce();
+    expect(third).toMatchObject({
+      fromWatermark: '06',
+      throughWatermark: '07',
+      matched: 1,
+      mismatched: 0,
+    });
+
+    expect(await comparator.compareOnce()).toEqual({
+      kind: 'skipped',
+      reason: 'nothing-to-compare',
+    });
+    expect(divergedWatermarks()).toEqual([]);
+  });
+
+  // 2. Mutated, missing, or extra output mismatches.
+  //
+  // One rolling digest per served range replaced the per-transaction digest
+  // map, so extra rows at any watermark — which no commit enumeration can see
+  // — are caught by the same equality check as a mutated payload, and are
+  // reported at the watermark of the range that served them.
+  describe('divergent catchup output mismatches', () => {
+    const cases: {
+      name: string;
+      corrupt: () => Promise<void> | void;
+      diverged: string[];
+    }[] = [
+      {
+        name: 'a mutated PG payload',
+        corrupt: () =>
+          mutatePGChange('04', 1, change => {
+            (change.new as Record<string, unknown>).v = 999;
+          }),
+        diverged: ['04'],
+      },
+      {
+        name: 'a transaction SQLite does not hold',
+        corrupt: () => deleteFromSQLiteLog(`"watermark" = '04'`),
+        diverged: ['04'],
+      },
+      {
+        name: 'a transaction PG does not hold',
+        corrupt: async () => {
+          await sql`DELETE FROM ${cdc('changeLog')} WHERE watermark = '04'`;
+        },
+        diverged: ['04'],
+      },
+      {
+        name: 'a commit row SQLite lost from an otherwise intact transaction',
+        corrupt: () =>
+          deleteFromSQLiteLog(`"watermark" = '04' AND "precommit" IS NOT NULL`),
+        diverged: ['04'],
+      },
+      {
+        name: 'rows only SQLite serves',
+        corrupt: () => insertSQLiteRows('04z'),
+        diverged: ['05'],
+      },
+      {
+        name: 'rows only PG serves',
+        corrupt: async () => {
+          await insertPGRows('04z');
+        },
+        diverged: ['05'],
+      },
+      {
+        // Identical output is parity in what catchup *serves* — the thing this
+        // comparison measures — even where no committed transaction claims it.
+        name: 'identical extra rows in both stores',
+        corrupt: async () => {
+          insertSQLiteRows('04z');
+          await insertPGRows('04z');
+        },
+        diverged: [],
+      },
+    ];
+
+    for (const {name, corrupt, diverged} of cases) {
+      test(name, async () => {
+        await feedBoth(
+          tx('03', messages.insert('foo', {id: 'boundary'})),
+          tx('04', messages.insert('foo', {id: 'victim', v: 1})),
+          tx('05', messages.insert('foo', {id: 'witness'})),
+        );
+        await corrupt();
+
+        const result = await newComparator().compareOnce();
+        assert(result.kind === 'compared', 'expected a compared cycle');
+        expect(divergedWatermarks()).toEqual(diverged);
+        expect(result.mismatched).toBe(diverged.length);
+        expect(result.inconclusive).toBe(0);
+      });
+    }
+  });
+
+  // 3. Head skew compares only the common range.
+  test('head lag in either direction is not divergence', async () => {
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'boundary'})),
+      tx('04', messages.insert('foo', {id: 'both'})),
+    );
+    const t5 = tx('05', messages.insert('foo', {id: 'trailing-pg'}));
+    const t6 = tx('06', messages.insert('foo', {id: 'trailing-sqlite'}));
+
+    // The SQLite log leads, as it does in production: compare only through
+    // the PG head.
+    feedSQLiteOnly(t5);
+    const comparator = newComparator();
+    expect(await comparator.compareOnce()).toMatchObject({
+      throughWatermark: '04',
+      transactions: 2,
+      matched: 2,
+      mismatched: 0,
+    });
+
+    // PG catches up and then leads: compare only through the SQLite head.
+    await feedPGOnly(t5, t6);
+    expect(await comparator.compareOnce()).toMatchObject({
+      fromWatermark: '04',
+      throughWatermark: '05',
+      matched: 1,
+      mismatched: 0,
+    });
+
+    // SQLite catches up: the previously skewed transaction compares clean.
+    feedSQLiteOnly(t6);
+    expect(await comparator.compareOnce()).toMatchObject({
+      fromWatermark: '05',
+      throughWatermark: '06',
+      matched: 1,
+      mismatched: 0,
+    });
+    expect(divergedWatermarks()).toEqual([]);
+  });
+
+  test('a limited cycle compares only the range both enumerations cover', async () => {
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'a'})),
+      tx('04', messages.insert('foo', {id: 'b'})),
+      tx('05', messages.insert('foo', {id: 'c'})),
+      tx('06', messages.insert('foo', {id: 'd'})),
+    );
+    deleteFromSQLiteLog(`"watermark" = '04'`);
+
+    const comparator = newComparator({maxTransactionsPerCycle: 2});
+    // The stores hit the limit at different watermarks — SQLite's two commits
+    // reach '05', PG's reach '04' — so the cycle covers only the range both
+    // enumerations completely cover. '05', cut from PG's list by the limit
+    // alone, must not be reported missing.
+    expect(await comparator.compareOnce()).toMatchObject({
+      throughWatermark: '04',
+      transactions: 2,
+      matched: 1,
+      mismatched: 1,
+    });
+    expect(divergedWatermarks()).toEqual(['04']);
+
+    // The next cycle resumes above the covered range and completes it.
+    const before = logSink.messages.length;
+    expect(await comparator.compareOnce()).toMatchObject({
+      throughWatermark: '06',
+      matched: 2,
+    });
+    // '04' is re-reported once, as the boundary the log cannot serve.
+    expect(divergedWatermarks(before)).toEqual(['04']);
+  });
+
+  // 4. Purge/reseed races are inconclusive.
+  describe('a race with the pinned bounds is inconclusive', () => {
+    const cases: {
+      name: string;
+      pg: () => PGChangeLogRangeReader;
+      matched: number;
+      inconclusive: number;
+    }[] = [
+      {
+        // The purge lands after the cycle pinned its bounds and enumerated the
+        // range, exactly as a concurrently scheduled cleanup would.
+        name: 'a PG purge',
+        pg: () => {
+          let purged = false;
+          return pgReader({
+            readCatchupRange: (after, through, batchRows) =>
+              (async function* (this: void) {
+                if (!purged) {
+                  purged = true;
+                  await storer.purgeRecordsBefore('05');
+                }
+                yield* storer.readCatchupRange(after, through, batchRows);
+              })(),
+          });
+        },
+        matched: 1, // '05' survives the purge and matches
+        inconclusive: 2,
+      },
+      {
+        // The purger deletes whole transactions below the floor, after the
+        // cycle enumerated them.
+        name: 'a SQLite purge',
+        pg: () =>
+          pgReader({
+            listCommitWatermarks: async (after, through, limit) => {
+              const list = await storer.listCommitWatermarks(
+                after,
+                through,
+                limit,
+              );
+              deleteFromSQLiteLog(`"watermark" < '05'`);
+              return list;
+            },
+          }),
+        matched: 1,
+        inconclusive: 2,
+      },
+      {
+        // The writer reseeds the log after the cycle pinned its bounds: '04'
+        // vanishes and the meta row's seed point moves, as reconcileChangeLog's
+        // reseed would. The re-read bounds alone cannot see this — only the
+        // meta comparison can.
+        name: 'a reseed',
+        pg: () =>
+          pgReader({
+            listCommitWatermarks: async (after, through, limit) => {
+              const list = await storer.listCommitWatermarks(
+                after,
+                through,
+                limit,
+              );
+              withSQLiteLog(db => {
+                db.prepare(
+                  /*sql*/ `DELETE FROM "${CHANGE_LOG_STREAM_TABLE}" WHERE "watermark" = '04'`,
+                ).run();
+                db.prepare(/*sql*/ `UPDATE "${CHANGE_LOG_META_TABLE}"
+                      SET "seedWatermark" = '03', "seededAtMs" = "seededAtMs" + 1`).run();
+              });
+              return list;
+            },
+          }),
+        matched: 2,
+        inconclusive: 1,
+      },
+    ];
+
+    for (const {name, pg, matched, inconclusive} of cases) {
+      test(name, async () => {
+        await feedBoth(
+          tx('03', messages.insert('foo', {id: 'boundary'})),
+          tx('04', messages.insert('foo', {id: 'raced'})),
+          tx('05', messages.insert('foo', {id: 'witness'})),
+        );
+
+        const result = await newComparator({pg: pg()}).compareOnce();
+        expect(result).toMatchObject({matched, inconclusive, mismatched: 0});
+        // A race is not a finding: nothing reports as diverged.
+        expect(divergedWatermarks()).toEqual([]);
+      });
+    }
+  });
+
+  test('a suspect that cannot be reconfirmed is inconclusive, then retried', async () => {
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'boundary'})),
+      tx('04', messages.insert('foo', {id: 'victim'})),
+      tx('05', messages.insert('foo', {id: 'witness'})),
+    );
+    deleteFromSQLiteLog(`"watermark" = '04'`);
+
+    // The bounds re-read that would confirm the finding fails once; the
+    // observation cannot be distinguished from a race and must not report.
+    let boundsReads = 0;
+    const comparator = newComparator({
+      pg: pgReader({
+        getCatchupBounds: () => {
+          if (++boundsReads === 2) {
+            throw new Error('injected bounds re-read failure');
+          }
+          return storer.getCatchupBounds();
+        },
+      }),
+    });
+    expect(await comparator.compareOnce()).toMatchObject({
+      matched: 2,
+      mismatched: 0,
+      inconclusive: 1,
+    });
+    expect(divergedWatermarks()).toEqual([]);
+
+    // The cursor did not move, so a later cycle retries and confirms the
+    // persistent divergence once the transient bounds failure clears.
+    expect(await comparator.compareOnce()).toMatchObject({mismatched: 1});
+    expect(divergedWatermarks()).toEqual(['04']);
+  });
+
+  test('a read that cannot complete is a mismatch, not a crash', async () => {
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'boundary'})),
+      tx('04', messages.insert('foo', {id: 'unreadable'})),
+    );
+    const result = await newComparator({
+      pg: pgReader({
+        readCatchupRange: (after, through, batchRows) => {
+          if (through === '04') {
+            throw new Error('injected read failure');
+          }
+          return storer.readCatchupRange(after, through, batchRows);
+        },
+      }),
+    }).compareOnce();
+    expect(result).toMatchObject({matched: 1, mismatched: 1});
+    expect(divergedWatermarks()).toEqual(['04']);
+  });
+
+  // 5. Sampling is deterministic.
+  test('a retried comparison samples the same transactions', async () => {
+    const txs = Array.from({length: 12}, (_, i) =>
+      tx((i + 3).toString(36).padStart(2, '0'), {
+        ...messages.insert('foo', {id: `row-${i}`}),
+      }),
+    );
+    await feedBoth(...txs);
+
+    const percent = 40;
+    const expected = txs.filter(({watermark}) =>
+      isSampledForCompare(shard, watermark, percent),
+    ).length;
+
+    // Two independent comparators — as across a restart — pin the same range
+    // and select exactly the same sample.
+    const first = await newComparator({comparePercent: percent}).compareOnce();
+    const second = await newComparator({comparePercent: percent}).compareOnce();
+    assert(
+      first.kind === 'compared' && second.kind === 'compared',
+      'expected compared cycles',
+    );
+    expect(first.sampled).toBe(expected);
+    expect(second.sampled).toBe(expected);
+    expect(second.fromWatermark).toBe(first.fromWatermark);
+    expect(second.throughWatermark).toBe(first.throughWatermark);
+    expect(first.matched).toBe(first.sampled);
+    expect(second.matched).toBe(second.sampled);
+  });
+
+  // 6. Remaining-budget exhaustion defers.
+  test('caps total catchup rows per source and defers an unfinished transaction', async () => {
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'first'})),
+      tx(
+        '04',
+        messages.insert('foo', {id: 'second-a'}),
+        messages.insert('foo', {id: 'second-b'}),
+      ),
+    );
+    const comparator = newComparator({
+      maxRowsPerSourcePerCycle: 5,
+      readBatchRows: 2,
+    });
+
+    expect(await comparator.compareOnce()).toMatchObject({
+      throughWatermark: '03',
+      transactions: 1,
+      sampled: 2,
+      matched: 1,
+      deferred: 1,
+      oversized: 0,
+      mismatched: 0,
+    });
+
+    // The next cycle's fresh budget fits it.
+    expect(await comparator.compareOnce()).toMatchObject({
+      fromWatermark: '03',
+      throughWatermark: '04',
+      matched: 1,
+      deferred: 0,
+      mismatched: 0,
+    });
+  });
+
+  // 7. A fresh-budget overflow skips.
+  test('skips a transaction that exceeds a fresh cycle row budget', async () => {
+    await feedBoth(
+      tx(
+        '03',
+        messages.insert('foo', {id: 'large-a'}),
+        messages.insert('foo', {id: 'large-b'}),
+        messages.insert('foo', {id: 'large-c'}),
+      ),
+      tx('04', messages.insert('foo', {id: 'after-large'})),
+    );
+    const comparator = newComparator({maxRowsPerSourcePerCycle: 4});
+
+    expect(await comparator.compareOnce()).toMatchObject({
+      throughWatermark: '03',
+      sampled: 1,
+      matched: 0,
+      oversized: 1,
+      mismatched: 0,
+    });
+
+    // Skipped, not wedged: the cursor moved past what can never fit.
+    expect(await comparator.compareOnce()).toMatchObject({
+      fromWatermark: '03',
+      throughWatermark: '04',
+      matched: 1,
+      oversized: 0,
+    });
+  });
+
+  // 8. A transaction that exactly fills the budget compares.
+  test('compares a transaction that exactly fills the cycle row budget', async () => {
+    await feedBoth(tx('03', messages.insert('foo', {id: 'exact'})));
+
+    expect(
+      await newComparator({maxRowsPerSourcePerCycle: 3}).compareOnce(),
+    ).toMatchObject({
+      throughWatermark: '03',
+      matched: 1,
+      deferred: 0,
+      oversized: 0,
+    });
+  });
+
+  // 9. A confirmed mismatch at the cursor boundary still advances.
+  test('a divergent cursor boundary does not wedge the comparator', async () => {
+    // SQLite loses a whole transaction PG holds, while the log runs ahead of
+    // PG (its normal state), so the cycle's common upper bound — and with it
+    // the cursor — lands exactly on the commit the log cannot serve as a
+    // catchup boundary.
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'boundary'})),
+      tx('04', messages.insert('foo', {id: 'sqlite-lost'})),
+    );
+    feedSQLiteOnly(tx('05', messages.insert('foo', {id: 'log-leads'})));
+    deleteFromSQLiteLog(`"watermark" = '04'`);
+
+    const comparator = newComparator();
+    expect(await comparator.compareOnce()).toMatchObject({
+      throughWatermark: '04',
+      matched: 1,
+      mismatched: 1,
+    });
+    expect(divergedWatermarks()).toEqual(['04']);
+
+    // The stream continues, so the next cycle has a non-empty range whose
+    // `from` is the divergent boundary: plan() is `too-old` and the bounds
+    // have not moved. The cycle must still compare the range above it.
+    await feedBoth(tx('06', messages.insert('foo', {id: 'next'})));
+
+    const before = logSink.messages.length;
+    expect(await comparator.compareOnce()).toMatchObject({
+      throughWatermark: '06',
+      matched: 1,
+      mismatched: 2,
+    });
+    expect(divergedWatermarks(before)).toEqual(['04', '05']);
+
+    // Progress, not a wedge.
+    expect(await comparator.compareOnce()).toEqual({
+      kind: 'skipped',
+      reason: 'nothing-to-compare',
+    });
+  });
+
+  test('a capped cycle schedules its continuation without the poll delay', async () => {
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'a'})),
+      tx('04', messages.insert('foo', {id: 'b'})),
+      tx('05', messages.insert('foo', {id: 'c'})),
+    );
+
+    type Scheduled = {callback: () => void; delayMs: number};
+    const scheduled = new Map<ReturnType<typeof setTimeout>, Scheduled>();
+    let nextTimer = 0;
+    const setTimeoutFn = vi.fn((callback: () => void, delayMs?: number) => {
+      const handle = ++nextTimer as unknown as ReturnType<typeof setTimeout>;
+      scheduled.set(handle, {callback, delayMs: delayMs ?? 0});
+      return handle;
+    }) as unknown as typeof setTimeout;
+    const clearTimeoutFn = vi.fn((handle: ReturnType<typeof setTimeout>) => {
+      scheduled.delete(handle);
+    }) as unknown as typeof clearTimeout;
+    const comparator = newComparator({
+      intervalMs: 30_000,
+      maxTransactionsPerCycle: 2,
+      setTimeoutFn,
+      clearTimeoutFn,
+    });
+
+    expect(Array.from(scheduled.values(), ({delayMs}) => delayMs)).toEqual([
+      30_000,
+    ]);
+    expect(await comparator.compareOnce()).toMatchObject({
+      throughWatermark: '04',
+      transactions: 2,
+    });
+    expect(Array.from(scheduled.values(), ({delayMs}) => delayMs)).toEqual([0]);
+
+    comparator.stop();
+  });
+
+  test('divergence reports carry no payload data', async () => {
+    const sentinel = 'SENSITIVE-PAYLOAD-8675309';
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'boundary'})),
+      tx('04', messages.insert('foo', {id: sentinel, secret: sentinel})),
+    );
+    await mutatePGChange('04', 1, change => {
+      (change.new as Record<string, unknown>).secret = `${sentinel}-mutated`;
+    });
+
+    const before = logSink.messages.length;
+    const result = await newComparator().compareOnce();
+    expect(result).toMatchObject({mismatched: 1});
+
+    // Neither the cycle result nor anything logged for it contains the
+    // payload, or any digest of it.
+    expect(JSON.stringify(result)).not.toContain(sentinel);
+    expect(JSON.stringify(logSink.messages.slice(before))).not.toContain(
+      sentinel,
+    );
+    expect(divergedWatermarks(before)).toEqual(['04']);
+  });
+
+  test('declines a cold log, a wrong identity, and an absent file', async () => {
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'boundary'})),
+      tx('04', messages.insert('foo', {id: 'content'})),
+    );
+
+    expect(
+      await newComparator({
+        now: () => seededAtMs + RETENTION_MS - 1,
+      }).compareOnce(),
+    ).toEqual({kind: 'skipped', reason: 'cold-log'});
+
+    expect(
+      await newComparator({
+        logIdentity: {...identity, replicaID: 'someone-else'},
+      }).compareOnce(),
+    ).toEqual({kind: 'skipped', reason: 'ineligible-identity'});
+
+    expect(
+      await newComparator({file: `${logFile.path}-absent`}).compareOnce(),
+    ).toEqual({kind: 'skipped', reason: 'log-unavailable'});
+
+    expect(await newComparator().compareOnce()).toMatchObject({
+      matched: 2,
+      mismatched: 0,
+    });
+  });
+
+  test('a freshly seeded log with no traffic has nothing to compare', async () => {
+    // Both stores hold only their synthetic seed transactions at '01'. Seeds
+    // are catchup boundaries, never compared output — and SQLite's seed is
+    // never reported as missing from PG.
+    expect(await newComparator().compareOnce()).toEqual({
+      kind: 'skipped',
+      reason: 'nothing-to-compare',
+    });
+  });
+
+  test('stop() ends the comparator', async () => {
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'boundary'})),
+      tx('04', messages.insert('foo', {id: 'content'})),
+    );
+    const comparator = newComparator();
+    comparator.stop();
+    expect(await comparator.compareOnce()).toEqual({
+      kind: 'skipped',
+      reason: 'stopped',
+    });
+  });
+
+  test('property: every corrupted transaction is reported, every clean one is not', async () => {
+    type CorruptionKind = 'clean' | 'drop-sqlite' | 'drop-pg' | 'mutate-pg';
+
+    const faultScenario = fc.record({
+      txs: fc.array(
+        fc.record({
+          width: fc.integer({min: 0, max: 3}),
+          kind: fc.constantFrom<CorruptionKind>(
+            'clean',
+            'drop-sqlite',
+            'drop-pg',
+            'mutate-pg',
+          ),
+        }),
+        {minLength: 1, maxLength: 5},
+      ),
+    });
+
+    // Runs share the fixture's PG database; each run scopes itself with a
+    // fresh SQLite log seeded above every prior run's watermarks, so prior
+    // corruptions sit below its `from` and are invisible to it.
+    let nextNum = 1;
+    const wm = (n: number) => `w${String(n).padStart(8, '0')}`;
+
+    await fc.assert(
+      fc.asyncProperty(faultScenario, async ({txs}) => {
+        const base = nextNum;
+        nextNum += (txs.length + 2) * 10;
+
+        const runFile = new DbFile('sqlite-change-log-comparator-fuzz');
+        const runWriter = new SQLiteChangeLogWriter(lc, {
+          replicaFile: runFile.path,
+          identity,
+          now: () => seededAtMs,
+        });
+        try {
+          runWriter.reconcile({
+            resumeWatermark: wm(base),
+            cookies: EMPTY_COOKIE_SET,
+          });
+
+          const specs = txs.map((spec, i) => ({
+            ...spec,
+            watermark: wm(base + (i + 1) * 10),
+          }));
+          // A clean sentinel pins the common head, so every generated
+          // transaction lies strictly inside the compared range — head skew
+          // is deliberately never reported, and is not what this pins.
+          const sentinel = wm(base + (txs.length + 1) * 10);
+
+          const feedRun = (t: Tx) => {
+            for (const change of t.changes) {
+              runWriter.write(change, storer.store(t.watermark, change));
+            }
+          };
+          for (const spec of specs) {
+            feedRun(
+              tx(
+                spec.watermark,
+                ...Array.from({length: spec.width}, (_, k) =>
+                  messages.insert('foo', {id: `${spec.watermark}-${k}`}),
+                ),
+              ),
+            );
+          }
+          feedRun(tx(sentinel, messages.insert('foo', {id: sentinel})));
+          await storer.allProcessed();
+
+          const withRunLog = <T>(fn: (db: Database) => T): T => {
+            const db = new Database(lc, changeLogFileName(runFile.path));
+            try {
+              return fn(db);
+            } finally {
+              db.close();
+            }
+          };
+
+          // Corrupt, and build the expected report while doing so. Every
+          // corruption is reported at its own watermark: presence for a
+          // dropped transaction, a digest inequality for a mutated one.
+          const expected: string[] = [];
+          let expectedMatched = 1; // the sentinel
+          for (const spec of specs) {
+            switch (spec.kind) {
+              case 'clean':
+                expectedMatched++;
+                break;
+              case 'drop-sqlite':
+                withRunLog(db =>
+                  db
+                    .prepare(
+                      /*sql*/ `DELETE FROM "${CHANGE_LOG_STREAM_TABLE}" WHERE "watermark" = ?`,
+                    )
+                    .run(spec.watermark),
+                );
+                expected.push(spec.watermark);
+                break;
+              case 'drop-pg':
+                await sql`
+                  DELETE FROM ${cdc('changeLog')} WHERE watermark = ${spec.watermark}`;
+                expected.push(spec.watermark);
+                break;
+              case 'mutate-pg':
+                await mutatePGChange(spec.watermark, 0, change => {
+                  change.mutated = true;
+                });
+                expected.push(spec.watermark);
+                break;
+            }
+          }
+
+          const before = logSink.messages.length;
+          const comparator = newComparator({
+            file: changeLogFileName(runFile.path),
+          });
+          let matched = 0;
+          for (let guard = 0; ; guard++) {
+            assert(guard < 8, 'comparator failed to reach quiescence');
+            const result = await comparator.compareOnce();
+            if (result.kind === 'skipped') {
+              expect(result.reason).toBe('nothing-to-compare');
+              break;
+            }
+            matched += result.matched;
+          }
+
+          expect(divergedWatermarks(before).toSorted()).toEqual(
+            expected.toSorted(),
+          );
+          expect(matched).toBe(expectedMatched);
+        } finally {
+          runWriter.close();
+          deleteChangeLogDB(runFile.path);
+          runFile.delete();
+        }
+      }),
+      {numRuns: 10},
+    );
+  });
+});

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.pg.test.ts
@@ -774,6 +774,72 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
     });
   });
 
+  test('caps total catchup bytes per source and defers, then skips, a wide transaction', async () => {
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'narrow'})),
+      // One row wider than a whole cycle budget.
+      tx('04', messages.insert('foo', {id: 'wide', pad: 'x'.repeat(5000)})),
+    );
+    const comparator = newComparator({maxBytesPerSourcePerCycle: 2000});
+
+    // The narrow transaction fits and spends part of the budget. The wide one
+    // cannot fit in what remains, so it waits for a fresh budget.
+    expect(await comparator.compareOnce()).toMatchObject({
+      throughWatermark: '03',
+      transactions: 1,
+      sampled: 2,
+      matched: 1,
+      deferred: 1,
+      oversized: 0,
+      mismatched: 0,
+    });
+
+    // A fresh budget does not fit it either, so it is skipped rather than
+    // retried forever, and the cursor advances past it.
+    expect(await comparator.compareOnce()).toMatchObject({
+      fromWatermark: '03',
+      throughWatermark: '04',
+      sampled: 1,
+      matched: 0,
+      deferred: 0,
+      oversized: 1,
+      mismatched: 0,
+    });
+    // A byte limit is not divergence.
+    expect(divergedWatermarks()).toEqual([]);
+  });
+
+  test('a generous byte budget leaves the row budget binding', async () => {
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'first'})),
+      tx(
+        '04',
+        messages.insert('foo', {id: 'second-a'}),
+        messages.insert('foo', {id: 'second-b'}),
+      ),
+    );
+    // The same expectations as the row-budget test above.
+    const comparator = newComparator({
+      maxRowsPerSourcePerCycle: 5,
+      maxBytesPerSourcePerCycle: 1024 * 1024,
+      readBatchRows: 2,
+    });
+
+    expect(await comparator.compareOnce()).toMatchObject({
+      throughWatermark: '03',
+      matched: 1,
+      deferred: 1,
+      oversized: 0,
+    });
+    expect(await comparator.compareOnce()).toMatchObject({
+      fromWatermark: '03',
+      throughWatermark: '04',
+      matched: 1,
+      deferred: 0,
+      oversized: 0,
+    });
+  });
+
   test('compares a transaction that exactly fills the cycle row budget', async () => {
     await feedBoth(tx('03', messages.insert('foo', {id: 'exact'})));
 

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.test.ts
@@ -1,8 +1,4 @@
-/**
- * Property tests for the comparator's pure functions. The store-facing
- * behavior — real Postgres against a real SQLite log — lives in
- * `sqlite-change-log-comparator.pg.test.ts`; nothing here needs a database.
- */
+/** Tests pure comparator functions. Integration tests cover both stores. */
 
 import fc from 'fast-check';
 import {describe, expect, test} from 'vitest';
@@ -25,10 +21,9 @@ describe('change-streamer/sqlite-change-log-comparator/properties', () => {
       }),
       {minLength: 1, maxLength: 8},
     ),
-    // Rows dropped from the front of the stream, so it can begin
-    // mid-transaction — possibly beheading more than one transaction.
+    // Remove leading rows to start inside a transaction.
     truncateHead: fc.nat({max: 3}),
-    // Two chunkings of the same rows, cycled over the stream.
+    // Use two batch layouts for the same rows.
     chunkSizesA: fc.array(fc.integer({min: 1, max: 7}), {
       minLength: 1,
       maxLength: 4,
@@ -65,7 +60,7 @@ describe('change-streamer/sqlite-change-log-comparator/properties', () => {
         ]);
       } else if (kind === 'rollback') {
         rows.push([w, 'rollback', `["rollback",{"tag":"rollback"}]`]);
-      } // orphan: no terminal row — a torn or corrupt remnant.
+      } // Orphan transactions have no terminal row.
     });
     return rows;
   }
@@ -97,8 +92,7 @@ describe('change-streamer/sqlite-change-log-comparator/properties', () => {
         async ({txs, truncateHead, chunkSizesA, chunkSizesB}) => {
           const rows = buildRows(txs).slice(truncateHead);
 
-          // Batch boundaries carry no meaning: any two chunkings of the same
-          // served rows digest identically, and count the same rows.
+          // Batch boundaries do not change the digest or row count.
           expect(await digest(rows, chunkSizesA)).toEqual(
             await digest(rows, chunkSizesB),
           );
@@ -127,7 +121,7 @@ describe('change-streamer/sqlite-change-log-comparator/properties', () => {
         async ({txs, index, kind}) => {
           const rows = buildRows(txs);
           const i = index % rows.length;
-          // Reordering the only row, or the last one, is not a reordering.
+          // Moving the only or last row does not change its order.
           fc.pre(kind !== 'move-to-end' || i < rows.length - 1);
 
           const corrupted = [...rows];
@@ -148,9 +142,7 @@ describe('change-streamer/sqlite-change-log-comparator/properties', () => {
               break;
           }
 
-          // This is the whole comparison: a missing row, an extra row at any
-          // watermark, a mutated payload, and a reordering are all one
-          // inequality. There is no per-watermark bookkeeping to fool.
+          // Each corruption changes the ordered range digest.
           expect((await digest(corrupted)).digest).not.toBe(
             (await digest(rows)).digest,
           );
@@ -166,9 +158,7 @@ describe('change-streamer/sqlite-change-log-comparator/properties', () => {
         fc.record({txs: streamScenario.map(({txs}) => txs)}),
         async ({txs}) => {
           const rows = buildRows(txs);
-          // SQLite serves the exact substring it stored; PG serves the same
-          // document re-rendered from its `json` column. Only normalization
-          // keeps that round trip from reading as divergence.
+          // Both stores can return the same JSON with different formatting.
           const reformatted = rows.map(
             ([w, tag, json]): WatermarkedChange => [
               w,
@@ -203,8 +193,7 @@ describe('change-streamer/sqlite-change-log-comparator/properties', () => {
 
           const served = Math.min(maxRows, rows.length);
           expect(result.rows).toBe(served);
-          // The cap is only a finding when it cut the range short of the
-          // commit that closes it; a range that fits exactly is compared.
+          // The limit applies only when it omits the closing commit.
           const closed = rows
             .slice(0, served)
             .some(([w, tag]) => tag === 'commit' && w === through);
@@ -229,12 +218,11 @@ describe('change-streamer/sqlite-change-log-comparator/properties', () => {
           const shard: ShardID = {appID, shardNum};
           const lo = Math.min(p1, p2);
           const hi = Math.max(p1, p2);
-          // Stable: a retried comparison selects the same transactions.
+          // A retry selects the same transactions.
           expect(isSampledForCompare(shard, watermark, hi)).toBe(
             isSampledForCompare(shard, watermark, hi),
           );
-          // Monotone: raising the percentage only ever adds transactions,
-          // so a canary ramp-up keeps everything it was already comparing.
+          // A larger percentage keeps the transactions in a smaller sample.
           if (isSampledForCompare(shard, watermark, lo)) {
             expect(isSampledForCompare(shard, watermark, hi)).toBe(true);
           }
@@ -249,11 +237,11 @@ describe('change-streamer/sqlite-change-log-comparator/properties', () => {
     expect(normalizeChangeJSON('{ "tag" : "insert",\n  "v": 1 }')).toBe(
       normalizeChangeJSON('{"tag":"insert","v":1}'),
     );
-    // Precision above Number.MAX_SAFE_INTEGER survives the round trip.
+    // Values above Number.MAX_SAFE_INTEGER retain their precision.
     expect(normalizeChangeJSON('{"v":9007199254740993}')).toBe(
       '{"v":9007199254740993}',
     );
-    // A value that does not parse is hashed as-is.
+    // Invalid JSON remains unchanged.
     expect(normalizeChangeJSON('not-json')).toBe('not-json');
 
     fc.assert(

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Property tests for the comparator's pure functions. The store-facing
+ * behavior — real Postgres against a real SQLite log — lives in
+ * `sqlite-change-log-comparator.pg.test.ts`; nothing here needs a database.
+ */
+
+import fc from 'fast-check';
+import {describe, expect, test} from 'vitest';
+import type {ShardID} from '../../types/shards.ts';
+import type {ChangeTag, WatermarkedChange} from './change-streamer.ts';
+import {
+  digestCatchupRange,
+  isSampledForCompare,
+  normalizeChangeJSON,
+} from './sqlite-change-log-comparator.ts';
+
+describe('change-streamer/sqlite-change-log-comparator/properties', () => {
+  type TxKind = 'complete' | 'orphan' | 'rollback';
+
+  const streamScenario = fc.record({
+    txs: fc.array(
+      fc.record({
+        width: fc.integer({min: 0, max: 5}),
+        kind: fc.constantFrom<TxKind>('complete', 'orphan', 'rollback'),
+      }),
+      {minLength: 1, maxLength: 8},
+    ),
+    // Rows dropped from the front of the stream, so it can begin
+    // mid-transaction — possibly beheading more than one transaction.
+    truncateHead: fc.nat({max: 3}),
+    // Two chunkings of the same rows, cycled over the stream.
+    chunkSizesA: fc.array(fc.integer({min: 1, max: 7}), {
+      minLength: 1,
+      maxLength: 4,
+    }),
+    chunkSizesB: fc.array(fc.integer({min: 1, max: 7}), {
+      minLength: 1,
+      maxLength: 4,
+    }),
+  });
+
+  function buildRows(
+    txs: {width: number; kind: TxKind}[],
+  ): WatermarkedChange[] {
+    const rows: WatermarkedChange[] = [];
+    txs.forEach(({width, kind}, i) => {
+      const w = `w${String(i + 1).padStart(2, '0')}`;
+      rows.push([
+        w,
+        'begin',
+        `["begin",{"tag":"begin"},{"commitWatermark":"${w}"}]`,
+      ]);
+      for (let k = 0; k < width; k++) {
+        rows.push([
+          w,
+          'insert' as ChangeTag,
+          `["data",{"tag":"insert","row":${k}}]`,
+        ]);
+      }
+      if (kind === 'complete') {
+        rows.push([
+          w,
+          'commit',
+          `["commit",{"tag":"commit"},{"watermark":"${w}"}]`,
+        ]);
+      } else if (kind === 'rollback') {
+        rows.push([w, 'rollback', `["rollback",{"tag":"rollback"}]`]);
+      } // orphan: no terminal row — a torn or corrupt remnant.
+    });
+    return rows;
+  }
+
+  async function* chunked(
+    rows: WatermarkedChange[],
+    sizes: number[],
+  ): AsyncIterable<WatermarkedChange[]> {
+    let i = 0;
+    let s = 0;
+    while (i < rows.length) {
+      const size = sizes[s++ % sizes.length];
+      yield rows.slice(i, i + size);
+      i += size;
+    }
+  }
+
+  const digest = (rows: WatermarkedChange[], sizes: number[] = [3]) =>
+    digestCatchupRange(
+      chunked(rows, sizes),
+      rows.at(-1)?.[0] ?? '',
+      rows.length + 1,
+    );
+
+  test('the digest is a pure function of the served rows, not their batching', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        streamScenario,
+        async ({txs, truncateHead, chunkSizesA, chunkSizesB}) => {
+          const rows = buildRows(txs).slice(truncateHead);
+
+          // Batch boundaries carry no meaning: any two chunkings of the same
+          // served rows digest identically, and count the same rows.
+          expect(await digest(rows, chunkSizesA)).toEqual(
+            await digest(rows, chunkSizesB),
+          );
+          expect((await digest(rows, chunkSizesA)).rows).toBe(rows.length);
+        },
+      ),
+      {numRuns: 100},
+    );
+  });
+
+  test('the digest changes under any single-row corruption', async () => {
+    type Corruption = 'drop' | 'mutate' | 'duplicate' | 'move-to-end';
+
+    await fc.assert(
+      fc.asyncProperty(
+        fc.record({
+          txs: streamScenario.map(({txs}) => txs),
+          index: fc.nat(),
+          kind: fc.constantFrom<Corruption>(
+            'drop',
+            'mutate',
+            'duplicate',
+            'move-to-end',
+          ),
+        }),
+        async ({txs, index, kind}) => {
+          const rows = buildRows(txs);
+          const i = index % rows.length;
+          // Reordering the only row, or the last one, is not a reordering.
+          fc.pre(kind !== 'move-to-end' || i < rows.length - 1);
+
+          const corrupted = [...rows];
+          switch (kind) {
+            case 'drop':
+              corrupted.splice(i, 1);
+              break;
+            case 'mutate': {
+              const [w, tag, json] = rows[i];
+              corrupted[i] = [w, tag, `${json.slice(0, -1)},"extra":1]`];
+              break;
+            }
+            case 'duplicate':
+              corrupted.splice(i, 0, rows[i]);
+              break;
+            case 'move-to-end':
+              corrupted.push(...corrupted.splice(i, 1));
+              break;
+          }
+
+          // This is the whole comparison: a missing row, an extra row at any
+          // watermark, a mutated payload, and a reordering are all one
+          // inequality. There is no per-watermark bookkeeping to fool.
+          expect((await digest(corrupted)).digest).not.toBe(
+            (await digest(rows)).digest,
+          );
+        },
+      ),
+      {numRuns: 200},
+    );
+  });
+
+  test('the digest ignores JSON formatting, as the two stores differ in it', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.record({txs: streamScenario.map(({txs}) => txs)}),
+        async ({txs}) => {
+          const rows = buildRows(txs);
+          // SQLite serves the exact substring it stored; PG serves the same
+          // document re-rendered from its `json` column. Only normalization
+          // keeps that round trip from reading as divergence.
+          const reformatted = rows.map(
+            ([w, tag, json]): WatermarkedChange => [
+              w,
+              tag,
+              json.replaceAll(':', ': ').replaceAll(',', ', '),
+            ],
+          );
+          expect((await digest(reformatted)).digest).toBe(
+            (await digest(rows)).digest,
+          );
+        },
+      ),
+      {numRuns: 50},
+    );
+  });
+
+  test('the row cap reports whether the range closed', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.record({
+          txs: streamScenario.map(({txs}) => txs),
+          maxRows: fc.integer({min: 1, max: 60}),
+        }),
+        async ({txs, maxRows}) => {
+          const rows = buildRows(txs);
+          const through = rows.at(-1)?.[0] ?? '';
+          const result = await digestCatchupRange(
+            chunked(rows, [4]),
+            through,
+            maxRows,
+          );
+
+          const served = Math.min(maxRows, rows.length);
+          expect(result.rows).toBe(served);
+          // The cap is only a finding when it cut the range short of the
+          // commit that closes it; a range that fits exactly is compared.
+          const closed = rows
+            .slice(0, served)
+            .some(([w, tag]) => tag === 'commit' && w === through);
+          expect(result.limitReached).toBe(served === maxRows && !closed);
+        },
+      ),
+      {numRuns: 100},
+    );
+  });
+
+  test('sampling is stable, bounded, and monotone in the percentage', () => {
+    fc.assert(
+      fc.property(
+        fc.record({
+          appID: fc.string({minLength: 1, maxLength: 8}),
+          shardNum: fc.nat({max: 1000}),
+          watermark: fc.hexaString({minLength: 2, maxLength: 10}),
+          p1: fc.integer({min: 0, max: 100}),
+          p2: fc.integer({min: 0, max: 100}),
+        }),
+        ({appID, shardNum, watermark, p1, p2}) => {
+          const shard: ShardID = {appID, shardNum};
+          const lo = Math.min(p1, p2);
+          const hi = Math.max(p1, p2);
+          // Stable: a retried comparison selects the same transactions.
+          expect(isSampledForCompare(shard, watermark, hi)).toBe(
+            isSampledForCompare(shard, watermark, hi),
+          );
+          // Monotone: raising the percentage only ever adds transactions,
+          // so a canary ramp-up keeps everything it was already comparing.
+          if (isSampledForCompare(shard, watermark, lo)) {
+            expect(isSampledForCompare(shard, watermark, hi)).toBe(true);
+          }
+          expect(isSampledForCompare(shard, watermark, 0)).toBe(false);
+          expect(isSampledForCompare(shard, watermark, 100)).toBe(true);
+        },
+      ),
+    );
+  });
+
+  test('normalization collapses formatting and preserves content', () => {
+    expect(normalizeChangeJSON('{ "tag" : "insert",\n  "v": 1 }')).toBe(
+      normalizeChangeJSON('{"tag":"insert","v":1}'),
+    );
+    // Precision above Number.MAX_SAFE_INTEGER survives the round trip.
+    expect(normalizeChangeJSON('{"v":9007199254740993}')).toBe(
+      '{"v":9007199254740993}',
+    );
+    // A value that does not parse is hashed as-is.
+    expect(normalizeChangeJSON('not-json')).toBe('not-json');
+
+    fc.assert(
+      fc.property(fc.oneof(fc.json(), fc.string()), value => {
+        const once = normalizeChangeJSON(value);
+        expect(normalizeChangeJSON(once)).toBe(once);
+      }),
+    );
+  });
+});

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.test.ts
@@ -13,6 +13,9 @@ import {
 describe('change-streamer/sqlite-change-log-comparator/properties', () => {
   type TxKind = 'complete' | 'orphan' | 'rollback';
 
+  /** Isolates the row budget in tests that do not exercise the byte budget. */
+  const NO_BYTE_LIMIT = Number.MAX_SAFE_INTEGER;
+
   const streamScenario = fc.record({
     txs: fc.array(
       fc.record({
@@ -83,6 +86,7 @@ describe('change-streamer/sqlite-change-log-comparator/properties', () => {
       chunked(rows, sizes),
       rows.at(-1)?.[0] ?? '',
       rows.length + 1,
+      NO_BYTE_LIMIT,
     );
 
   test('the digest is a pure function of the served rows, not their batching', async () => {
@@ -189,6 +193,7 @@ describe('change-streamer/sqlite-change-log-comparator/properties', () => {
             chunked(rows, [4]),
             through,
             maxRows,
+            NO_BYTE_LIMIT,
           );
 
           const served = Math.min(maxRows, rows.length);
@@ -202,6 +207,65 @@ describe('change-streamer/sqlite-change-log-comparator/properties', () => {
       ),
       {numRuns: 100},
     );
+  });
+
+  test('the byte budget bounds the read', async () => {
+    const rows = buildRows([{width: 5, kind: 'complete'}]);
+    const through = rows.at(-1)?.[0] ?? '';
+    const read = (maxBytes: number) =>
+      digestCatchupRange(
+        chunked(rows, [4]),
+        through,
+        rows.length + 1,
+        maxBytes,
+      );
+
+    // A budget above the cost of the range serves all of it.
+    const full = await read(NO_BYTE_LIMIT);
+    expect(full.rows).toBe(rows.length);
+    expect(full.bytes).toBeGreaterThan(0);
+    expect(full.limitReached).toBe(false);
+
+    // A budget below that cost stops before the closing commit.
+    const cut = await read(Math.floor(full.bytes / 2));
+    expect(cut.limitReached).toBe(true);
+    expect(cut.rows).toBeLessThan(full.rows);
+    expect(cut.bytes).toBeLessThan(full.bytes);
+
+    // A row wider than the whole budget stops the read before it is parsed.
+    const none = await read(1);
+    expect(none.rows).toBe(0);
+    expect(none.bytes).toBe(0);
+    expect(none.limitReached).toBe(true);
+  });
+
+  test('the byte count measures normalized payloads, not stored text', async () => {
+    // The same logical rows, one store padding its JSON with whitespace.
+    const canonical = buildRows([{width: 3, kind: 'complete'}]);
+    const padded = canonical.map(
+      ([w, tag, json]) =>
+        [w, tag, json.replaceAll(',', ' ,\n  ')] as WatermarkedChange,
+    );
+    const through = canonical.at(-1)?.[0] ?? '';
+
+    const a = await digestCatchupRange(
+      chunked(canonical, [4]),
+      through,
+      canonical.length + 1,
+      NO_BYTE_LIMIT,
+    );
+    const b = await digestCatchupRange(
+      chunked(padded, [4]),
+      through,
+      padded.length + 1,
+      NO_BYTE_LIMIT,
+    );
+
+    // Both stores spend the same budget, so a limit falls in the same place
+    // for both and neither side is sampled less than the other.
+    expect(b.bytes).toBe(a.bytes);
+    expect(b.digest).toBe(a.digest);
+    expect(b.rows).toBe(a.rows);
   });
 
   test('sampling is stable, bounded, and monotone in the percentage', () => {

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.ts
@@ -32,6 +32,15 @@ const DEFAULT_MAX_TRANSACTIONS_PER_CYCLE = 256;
 /** Maximum catchup rows read from each store per cycle. */
 const DEFAULT_MAX_ROWS_PER_SOURCE_PER_CYCLE = 1000;
 
+/**
+ * Maximum normalized catchup bytes read from each store per cycle.
+ *
+ * Rows bound the per-row overhead. Bytes bound the parse and hash work,
+ * which scales with payload size instead of row count. Normal traffic
+ * reaches the row limit first. Wide payloads reach this one.
+ */
+const DEFAULT_MAX_BYTES_PER_SOURCE_PER_CYCLE = 32 * 1024 * 1024;
+
 /** Rows per SQLite catchup batch. */
 const DEFAULT_READ_BATCH_ROWS = 1000;
 
@@ -82,9 +91,9 @@ export type CompareCycleResult =
       readonly mismatched: number;
       /** Suspects rejected because store bounds changed. */
       readonly inconclusive: number;
-      /** Sampled transactions deferred to a fresh row budget. */
+      /** Sampled transactions deferred to a fresh budget. */
       readonly deferred: number;
-      /** Sampled transactions that exceed a fresh row budget. */
+      /** Sampled transactions that exceed a fresh budget. */
       readonly oversized: number;
     };
 
@@ -115,6 +124,8 @@ export type SQLiteChangeLogCompareOptions = {
   readonly maxTransactionsPerCycle?: number | undefined;
   /** Maximum catchup rows read from each store in one cycle. */
   readonly maxRowsPerSourcePerCycle?: number | undefined;
+  /** Maximum normalized catchup bytes read from each store in one cycle. */
+  readonly maxBytesPerSourcePerCycle?: number | undefined;
   readonly readBatchRows?: number | undefined;
   /** Clock for the warm-up period. Defaults to `Date.now`. */
   readonly now?: (() => number) | undefined;
@@ -159,7 +170,9 @@ export function normalizeChangeJSON(change: string): string {
 export type CatchupRangeDigest = {
   readonly digest: string;
   readonly rows: number;
-  /** The row limit was reached before the closing commit. */
+  /** Normalized bytes hashed. This is the payload cost of the range. */
+  readonly bytes: number;
+  /** A row or byte limit was reached before the closing commit. */
   readonly limitReached: boolean;
 };
 
@@ -168,29 +181,43 @@ export type CatchupRangeDigest = {
  *
  * The row position makes missing, extra, changed, and reordered rows change the digest.
  * The digest omits `precommit` because a commit already includes its watermark.
+ *
+ * The read stops at `maxRows` or at `maxBytes`, whichever comes first.
  */
 export async function digestCatchupRange(
   batches: AsyncIterable<readonly WatermarkedChange[]>,
   throughWatermark: string,
   maxRows: number,
+  maxBytes: number,
 ): Promise<CatchupRangeDigest> {
   const hasher = new ChangeLogTransactionHasher();
   let rows = 0;
+  let bytes = 0;
   let servedClosingCommit = false;
 
   for await (const batch of batches) {
     for (const [watermark, tag, json] of batch) {
-      if (rows === maxRows) {
-        return {digest: hasher.digest(), rows, limitReached: true};
+      if (rows === maxRows || bytes >= maxBytes) {
+        return {digest: hasher.digest(), rows, bytes, limitReached: true};
       }
+      // Measure the stored text before parsing it. A row wider than the
+      // whole budget never fits, and normalizing it first would pay the
+      // cost that this limit exists to avoid.
+      if (json.length > maxBytes) {
+        return {digest: hasher.digest(), rows, bytes, limitReached: true};
+      }
+      const change = normalizeChangeJSON(extractChangeSubstring(json, tag));
       hasher.add({
         watermark,
         pos: rows,
         tag,
-        change: normalizeChangeJSON(extractChangeSubstring(json, tag)),
+        change,
         precommit: null,
       });
       rows++;
+      // Count the normalized length so both stores measure the same logical
+      // payload. Stored encodings differ between them. Normalized ones do not.
+      bytes += change.length;
       if (tag === 'commit' && watermark === throughWatermark) {
         servedClosingCommit = true;
       }
@@ -199,7 +226,9 @@ export async function digestCatchupRange(
   return {
     digest: hasher.digest(),
     rows,
-    limitReached: rows === maxRows && !servedClosingCommit,
+    bytes,
+    limitReached:
+      (rows === maxRows || bytes >= maxBytes) && !servedClosingCommit,
   };
 }
 
@@ -238,6 +267,8 @@ type SampledComparison = {
   readonly outcome: CompareOutcome;
   readonly sqliteRowsRead: number;
   readonly pgRowsRead: number;
+  readonly sqliteBytesRead: number;
+  readonly pgBytesRead: number;
 };
 
 /**
@@ -467,9 +498,16 @@ export class SQLiteChangeLogComparator {
         this.#opts.maxRowsPerSourcePerCycle ??
           DEFAULT_MAX_ROWS_PER_SOURCE_PER_CYCLE,
       );
+      const maxBytesPerSource = Math.max(
+        1,
+        this.#opts.maxBytesPerSourcePerCycle ??
+          DEFAULT_MAX_BYTES_PER_SOURCE_PER_CYCLE,
+      );
 
       let sqliteRowsRead = 0;
       let pgRowsRead = 0;
+      let sqliteBytesRead = 0;
+      let pgBytesRead = 0;
       let previousBoundary = from;
       let handledThrough = from;
       for (const {watermark, inSqlite, inPg} of union) {
@@ -489,7 +527,16 @@ export class SQLiteChangeLogComparator {
         ) {
           const sqliteRowsRemaining = maxRowsPerSource - sqliteRowsRead;
           const pgRowsRemaining = maxRowsPerSource - pgRowsRead;
-          if (sqliteRowsRemaining === 0 || pgRowsRemaining === 0) {
+          // A read may pass the byte budget by its last row, so this
+          // compares against zero rather than checking for equality.
+          const sqliteBytesRemaining = maxBytesPerSource - sqliteBytesRead;
+          const pgBytesRemaining = maxBytesPerSource - pgBytesRead;
+          if (
+            sqliteRowsRemaining === 0 ||
+            pgRowsRemaining === 0 ||
+            sqliteBytesRemaining <= 0 ||
+            pgBytesRemaining <= 0
+          ) {
             record(watermark, 'deferred');
             break;
           }
@@ -502,10 +549,15 @@ export class SQLiteChangeLogComparator {
             watermark,
             sqliteRowsRemaining,
             pgRowsRemaining,
+            sqliteBytesRemaining,
+            pgBytesRemaining,
             maxRowsPerSource,
+            maxBytesPerSource,
           );
           sqliteRowsRead += comparison.sqliteRowsRead;
           pgRowsRead += comparison.pgRowsRead;
+          sqliteBytesRead += comparison.sqliteBytesRead;
+          pgBytesRead += comparison.pgBytesRead;
           const outcome =
             fileGeneration === this.#fileGeneration
               ? comparison.outcome
@@ -518,7 +570,7 @@ export class SQLiteChangeLogComparator {
             break;
           }
           if (outcome === 'oversized') {
-            // Advance past a transaction that cannot fit in a fresh row budget.
+            // Advance past a transaction that cannot fit in a fresh budget.
             stopAfterTransaction = true;
           }
           // Yield between sampled reads so other stream work can continue.
@@ -672,7 +724,10 @@ export class SQLiteChangeLogComparator {
     watermark: string,
     sqliteMaxRows: number,
     pgMaxRows: number,
+    sqliteMaxBytes: number,
+    pgMaxBytes: number,
     maxRowsPerSource: number,
+    maxBytesPerSource: number,
   ): Promise<SampledComparison> {
     let sqlite: CatchupRangeDigest;
     let pg: CatchupRangeDigest;
@@ -688,6 +743,7 @@ export class SQLiteChangeLogComparator {
         ),
         watermark,
         sqliteMaxRows,
+        sqliteMaxBytes,
       );
       pg = await digestCatchupRange(
         reconstructBatches(
@@ -695,6 +751,7 @@ export class SQLiteChangeLogComparator {
         ),
         watermark,
         pgMaxRows,
+        pgMaxBytes,
       );
     } catch (e) {
       // A failed catchup read makes the transaction suspect.
@@ -706,25 +763,37 @@ export class SQLiteChangeLogComparator {
         outcome: await this.#reconfirm(db, pinned, watermark),
         sqliteRowsRead: 0,
         pgRowsRead: 0,
+        sqliteBytesRead: 0,
+        pgBytesRead: 0,
       };
     }
-    const rowsRead = {sqliteRowsRead: sqlite.rows, pgRowsRead: pg.rows};
+    const read = {
+      sqliteRowsRead: sqlite.rows,
+      pgRowsRead: pg.rows,
+      sqliteBytesRead: sqlite.bytes,
+      pgBytesRead: pg.bytes,
+    };
     if (sqlite.limitReached || pg.limitReached) {
       // Skip a transaction that cannot fit in a fresh budget.
       // Defer one that does not fit only in the remaining budget.
+      // A budget is fresh when neither dimension has been spent.
+      const sqliteFresh =
+        sqliteMaxRows === maxRowsPerSource &&
+        sqliteMaxBytes === maxBytesPerSource;
+      const pgFresh =
+        pgMaxRows === maxRowsPerSource && pgMaxBytes === maxBytesPerSource;
       const outcome =
-        (sqlite.limitReached && sqliteMaxRows === maxRowsPerSource) ||
-        (pg.limitReached && pgMaxRows === maxRowsPerSource)
+        (sqlite.limitReached && sqliteFresh) || (pg.limitReached && pgFresh)
           ? 'oversized'
           : 'deferred';
-      return {outcome, ...rowsRead};
+      return {outcome, ...read};
     }
     if (sqlite.digest === pg.digest) {
-      return {outcome: 'match', ...rowsRead};
+      return {outcome: 'match', ...read};
     }
     return {
       outcome: await this.#reconfirm(db, pinned, watermark),
-      ...rowsRead,
+      ...read,
     };
   }
 

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.ts
@@ -23,37 +23,23 @@ import {ChangeLogTransactionHasher} from './change-log-transaction-hash.ts';
 import type {WatermarkedChange} from './change-streamer.ts';
 import {SQLiteChangeLogReader} from './sqlite-change-log-reader.ts';
 
-/**
- * How often a comparison cycle runs. Each cycle is bounded by commit
- * enumeration and catchup row budgets, so a busy stream is compared in
- * bounded increments rather than all at once.
- */
+/** Interval between comparison cycles. */
 const DEFAULT_COMPARE_INTERVAL_MS = 30_000;
 
-/**
- * The per-cycle bound on enumerated transactions. This bounds the two commit
- * watermark lists; catchup payload work has a separate per-source row budget.
- */
+/** Maximum transactions enumerated per cycle. */
 const DEFAULT_MAX_TRANSACTIONS_PER_CYCLE = 256;
 
-/** Catchup rows read from each store per comparison cycle. */
+/** Maximum catchup rows read from each store per cycle. */
 const DEFAULT_MAX_ROWS_PER_SOURCE_PER_CYCLE = 1000;
 
-/** Rows per SQLite catchup read batch, matching the read path's default. */
+/** Rows per SQLite catchup batch. */
 const DEFAULT_READ_BATCH_ROWS = 1000;
 
 /**
- * The outcome of one committed transaction's comparison.
+ * Result for one committed transaction.
  *
- * There is deliberately no taxonomy of *how* the two stores disagreed: a
- * missing transaction, an extra row, a mutated payload, and a reordered range
- * are all `mismatch`, and the watermark is enough to go look. The comparison
- * is advisory, and a finer classification cost more than it paid.
- *
- * `inconclusive` means the common lower bound (or a head) moved after the
- * cycle pinned it — a purge, truncation, or reseed raced the comparison — so
- * the observation says nothing about divergence and is deliberately not
- * reported as any.
+ * `mismatch` covers missing, extra, changed, or reordered rows.
+ * `inconclusive` means that store bounds changed during the comparison.
  */
 export type CompareOutcome =
   | 'match'
@@ -65,20 +51,19 @@ export type CompareOutcome =
 export type CompareSkipReason =
   // The comparator was stopped.
   | 'stopped'
-  // The change-log file is absent, unreadable, or has no meta row yet: the
-  // writer has not created it, or has failed soft and deleted it.
+  // The writer replaced the file during this cycle.
+  | 'log-rebuilt'
+  // The file is absent, unreadable, or uninitialized.
   | 'log-unavailable'
-  // The log's schema version is not this build's.
+  // The schema version does not match this build.
   | 'ineligible-schema'
-  // The log belongs to a different replica (§3.2's identity triple).
+  // The log belongs to a different replica.
   | 'ineligible-identity'
-  // The log was seeded less than a retention window ago (§6.6's predicate).
+  // The log is younger than the warm-up period.
   | 'cold-log'
-  // The complete committed range common to both stores is empty. Head skew in
-  // either direction lands here; it is expected — the log leads — and is
-  // deliberately not reported as divergence.
+  // The stores have no complete committed range in common.
   | 'nothing-to-compare'
-  // The cycle failed; the error was logged and counted.
+  // The cycle failed. The error was logged and counted.
   | 'error';
 
 export type CompareCycleResult =
@@ -87,27 +72,23 @@ export type CompareCycleResult =
       readonly kind: 'compared';
       /** Exclusive lower bound of the compared range. */
       readonly fromWatermark: string;
-      /** Inclusive upper bound handled; the next cycle resumes from here. */
+      /** Inclusive upper bound handled. The next cycle resumes from here. */
       readonly throughWatermark: string;
       /** Committed transactions handled through `throughWatermark`. */
       readonly transactions: number;
-      /** How many had their catchup output read and digested. */
+      /** Transactions with compared catchup output. */
       readonly sampled: number;
       readonly matched: number;
       readonly mismatched: number;
-      /** Suspects a concurrent purge or reseed disqualified. */
+      /** Suspects rejected because store bounds changed. */
       readonly inconclusive: number;
-      /** Sampled transactions deferred until a fresh cycle row budget. */
+      /** Sampled transactions deferred to a fresh row budget. */
       readonly deferred: number;
-      /** Sampled transactions skipped because they exceed a fresh row budget. */
+      /** Sampled transactions that exceed a fresh row budget. */
       readonly oversized: number;
     };
 
-/**
- * The PG change log's side of the comparison. Implemented by `Storer`, whose
- * `readCatchupRange` shares its statement shape with the subscriber catchup
- * query — the thing this comparison exists to validate.
- */
+/** Provides the Postgres side of the catchup comparison. */
 export interface PGChangeLogRangeReader {
   getCatchupBounds(): Promise<{
     minWatermark: string | null;
@@ -126,42 +107,24 @@ export interface PGChangeLogRangeReader {
 }
 
 export type SQLiteChangeLogCompareOptions = {
-  /**
-   * `sqliteChangeLogComparePercent`: the stable percentage of committed
-   * transactions whose catchup output is digest-compared. Presence (a
-   * transaction one store holds and the other does not) is checked for every
-   * transaction in the range regardless, since it needs no payload reads.
-   */
+  /** Stable percentage of transactions selected for payload comparison. */
   readonly comparePercent: number;
-  /**
-   * `sqliteChangeLogRetentionMs`, reused as the warm-up window: a log seeded
-   * less than this long ago is declined (§6.6), since its covered range is
-   * still filling.
-   */
+  /** Warm-up time after a seed. The comparator skips a younger log. */
   readonly retentionMs: number;
   readonly intervalMs?: number | undefined;
   readonly maxTransactionsPerCycle?: number | undefined;
-  /** Catchup payload rows read from each source in one cycle. */
+  /** Maximum catchup rows read from each store in one cycle. */
   readonly maxRowsPerSourcePerCycle?: number | undefined;
   readonly readBatchRows?: number | undefined;
-  /** The clock the warm-up window is measured against. Defaults to `Date.now`. */
+  /** Clock for the warm-up period. Defaults to `Date.now`. */
   readonly now?: (() => number) | undefined;
   readonly setTimeoutFn?: typeof setTimeout | undefined;
   readonly clearTimeoutFn?: typeof clearTimeout | undefined;
-  /**
-   * Awaited between sampled transactions so fan-out and catchup make progress.
-   * Defaults to a macrotask (`setImmediate`).
-   */
+  /** Yields between sampled transactions. Defaults to `setImmediate`. */
   readonly yieldFn?: (() => Promise<void>) | undefined;
 };
 
-/**
- * Whether `watermark`'s transaction is in the compared sample.
- *
- * Stable by shard and watermark — a pure function of the two — so a retried
- * or restarted comparison selects exactly the same transactions and therefore
- * compares the same data.
- */
+/** Selects a stable sample by shard and watermark. */
 export function isSampledForCompare(
   shard: ShardID,
   watermark: string,
@@ -180,16 +143,10 @@ export function isSampledForCompare(
 }
 
 /**
- * Normalizes a stored `change` to one text form before hashing.
+ * Normalizes JSON text before hashing.
  *
- * The two stores hand the text back differently: SQLite serves the exact
- * serialized substring it stored, while PG holds it in a `json` column and
- * serves `change::text` — a round trip through the client's JSON parameter
- * encoding and `json_to_recordset`. Any formatting difference from that round
- * trip would report as a mismatch that is *not* divergence, which would be
- * indistinguishable from the finding this comparison exists to make. Both
- * sides are therefore re-serialized through the same codec; a value that does
- * not parse is hashed as-is, identically on both sides.
+ * SQLite preserves the source text. Postgres can change its formatting.
+ * Invalid JSON remains unchanged.
  */
 export function normalizeChangeJSON(change: string): string {
   try {
@@ -202,22 +159,15 @@ export function normalizeChangeJSON(change: string): string {
 export type CatchupRangeDigest = {
   readonly digest: string;
   readonly rows: number;
-  /** The row cap was reached before the range's closing commit was served. */
+  /** The row limit was reached before the closing commit. */
   readonly limitReached: boolean;
 };
 
 /**
- * Digests everything a store serves over a catchup range, as one rolling hash
- * in served order.
+ * Builds one ordered digest for a catchup range.
  *
- * Position is the row's index *within the served range*, so the digest is a
- * pure function of what the store hands a subscriber: a missing row, an extra
- * row at any watermark, a mutated payload, and a reordering all change it.
- * That is what lets the comparison be a single equality check — there is no
- * per-watermark bookkeeping to decide which served rows "count".
- *
- * `precommit` is not hashed: for a commit row it equals that row's own
- * watermark, which is hashed already.
+ * The row position makes missing, extra, changed, and reordered rows change the digest.
+ * The digest omits `precommit` because a commit already includes its watermark.
  */
 export async function digestCatchupRange(
   batches: AsyncIterable<readonly WatermarkedChange[]>,
@@ -253,10 +203,7 @@ export async function digestCatchupRange(
   };
 }
 
-/**
- * `min` and `max` as separate scalar subqueries for the single-aggregate index
- * optimization, matching the reader's plan query.
- */
+/** Uses separate aggregates so SQLite can use an index for each value. */
 const SQLITE_BOUNDS_SQL = /*sql*/ `
   SELECT
     (SELECT min("watermark") FROM "${CHANGE_LOG_STREAM_TABLE}")
@@ -265,11 +212,7 @@ const SQLITE_BOUNDS_SQL = /*sql*/ `
       AS "headWatermark"
 `;
 
-/**
- * Commit watermarks in `(@after, @through]`. Every row of a transaction is
- * stored at its commit watermark and only commit rows carry `precommit`, so
- * this enumerates the committed transactions in the range.
- */
+/** Lists committed transaction watermarks in `(@after, @through]`. */
 const SQLITE_COMMITS_SQL = /*sql*/ `
   SELECT "watermark" FROM "${CHANGE_LOG_STREAM_TABLE}"
    WHERE "precommit" IS NOT NULL
@@ -298,26 +241,12 @@ type SampledComparison = {
 };
 
 /**
- * Compares what SQLite catchup *serves* against what PG catchup serves, over
- * complete committed ranges, without serving either to a subscriber.
+ * Compares SQLite and Postgres catchup output without affecting subscribers.
  *
- * "SQLite content equals PG content" is already established by construction —
- * both stores hold the same serialized substrings — plus the continuous
- * per-transaction hash check from 7H. What is *not* covered, and what this
- * validates, is the read path: reader reconstruction, `plan()` bounds, and
- * purge interacting with a pinned range. Each cycle enumerates the committed
- * transactions both stores hold, samples a stable subset, reads each sampled
- * range through both stores' catchup statements, and compares one rolling
- * digest of what each served.
- *
- * The comparison is dark and advisory: it changes nothing about what
- * subscribers receive, PG remains authoritative, and every anomaly is a
- * metric and a (redacted) log line rather than an action.
- *
- * Ranges are compared only through `min(pgHead, sqliteHead)` — head skew in
- * either direction is expected, the log leads, and is never reported. A purge,
- * truncation, or reseed that moves the pinned bounds mid-cycle reports
- * `inconclusive`, not divergence.
+ * Each cycle compares complete ranges through the lower store head.
+ * It checks every transaction for presence and samples payloads.
+ * A bounds change makes the affected result `inconclusive`.
+ * Postgres remains authoritative.
  */
 export class SQLiteChangeLogComparator {
   readonly #lc: LogContext;
@@ -349,16 +278,13 @@ export class SQLiteChangeLogComparator {
     'Duration of one SQLite change-log comparison cycle.',
   );
 
-  /**
-   * The commit watermark through which output has been compared. Ranges are
-   * compared once and never re-read; a restart re-derives it from the common
-   * lower bound, and the stable sample selects the same transactions again.
-   */
+  /** Last handled commit watermark. A restart derives it from current bounds. */
   #cursor: string | undefined;
   #running: Promise<CompareCycleResult> | undefined;
   #timer: ReturnType<typeof setTimeout> | undefined;
   #stopped = false;
   #continueWithoutDelay = false;
+  #fileGeneration = 0;
 
   constructor(
     lc: LogContext,
@@ -384,9 +310,8 @@ export class SQLiteChangeLogComparator {
   }
 
   /**
-   * Runs one comparison cycle. Concurrent calls coalesce into the running
-   * cycle's completion. Never rejects; a failed cycle is logged and reported
-   * as `skipped: 'error'`.
+   * Runs one cycle. Concurrent calls share the same promise.
+   * Errors produce `skipped: 'error'`.
    */
   compareOnce(): Promise<CompareCycleResult> {
     if (this.#stopped) {
@@ -415,6 +340,13 @@ export class SQLiteChangeLogComparator {
     }
   }
 
+  /** Invalidates cycles that can still read a replaced file. */
+  invalidate(): void {
+    this.#fileGeneration++;
+    this.#cursor = undefined;
+    this.#continueWithoutDelay = false;
+  }
+
   #scheduleNext(
     delayMs = this.#opts.intervalMs ?? DEFAULT_COMPARE_INTERVAL_MS,
   ): void {
@@ -437,20 +369,22 @@ export class SQLiteChangeLogComparator {
 
   async #runCycle(): Promise<CompareCycleResult> {
     const startedAt = performance.now();
+    const fileGeneration = this.#fileGeneration;
     this.#continueWithoutDelay = false;
     let db: Database | undefined;
     let reader: SQLiteChangeLogReader | undefined;
     try {
       try {
-        // A readonly handle cannot create the file, so an absent log — the
-        // writer has not reconciled yet, or failed soft and deleted it — is a
-        // routine decline rather than an error.
+        // A readonly handle does not create a missing file.
         db = new Database(this.#lc, this.#changeLogFile, {readonly: true});
       } catch {
         return this.#skipped('log-unavailable');
       }
 
       const pinned = await this.#pinBounds(db);
+      if (fileGeneration !== this.#fileGeneration) {
+        return this.#skipped('log-rebuilt');
+      }
       if (typeof pinned === 'string') {
         return this.#skipped(pinned);
       }
@@ -458,14 +392,10 @@ export class SQLiteChangeLogComparator {
 
       const from = maxWatermark(
         this.#cursor ?? meta.seedWatermark,
-        // The log's seed transaction is synthetic — its content matches
-        // nothing PG holds — so the exclusive lower bound keeps it out of
-        // every comparison. (PG's own synthetic seed, from
-        // ensureReplicationConfig, carries no `precommit` and is already
-        // invisible to the commit enumeration.)
+        // Exclude the synthetic SQLite seed transaction.
+        // The Postgres seed has no `precommit`, so enumeration also excludes it.
         meta.seedWatermark,
-        // The transaction *at* a store's minimum is a catchup boundary, not
-        // output that store can serve, so comparison starts above it.
+        // A store cannot serve the transaction at its minimum watermark.
         pinned.pgMinWatermark,
         pinned.sqlite.minWatermark,
       );
@@ -490,8 +420,7 @@ export class SQLiteChangeLogComparator {
         this.#compareResults.add(1, {outcome});
         outcomes[outcome]++;
         if (outcome === 'mismatch') {
-          // The watermark only. The payloads are customer data and are never
-          // logged; the watermark is enough to find them.
+          // Log only the watermark because payloads contain customer data.
           this.#lc.error?.(
             'SQLite change-log catchup output diverged from Postgres',
             {sqliteChangeLogCompare: {watermark}},
@@ -508,23 +437,20 @@ export class SQLiteChangeLogComparator {
         return this.#skipped('nothing-to-compare');
       }
       if (plan.kind === 'too-old') {
-        // `from` was computed at or above the log's own minimum, so the log
-        // cannot serve a boundary it should hold — unless the bounds moved
-        // after they were pinned, which is a purge race, not a finding.
-        const outcome = await this.#reconfirm(db, pinned, from);
+        // A fixed lower bound makes this result a mismatch.
+        // A changed lower bound makes it inconclusive.
+        const reconfirmed = await this.#reconfirm(db, pinned, from);
+        const outcome =
+          fileGeneration === this.#fileGeneration
+            ? reconfirmed
+            : 'inconclusive';
         record(from, outcome);
         if (outcome === 'inconclusive') {
-          // The pinned bounds moved; nothing this cycle established about the
-          // range still holds. The cursor stays put and the next cycle re-pins.
+          // Keep the cursor unchanged because the bounds moved.
           return this.#compared(from, from, transactions, sampled, outcomes);
         }
-        // A *confirmed* mismatch is a finding about the boundary itself —
-        // typically a commit this store never held, already reported as
-        // missing by the cycle that enumerated it. The reads below are
-        // positional and never dereference the boundary row, so the cycle
-        // still compares the range and advances the cursor past it. Returning
-        // here instead would re-report the same boundary — and compare
-        // nothing else — every cycle, forever.
+        // Positional reads can continue after a missing boundary.
+        // Advancing avoids reporting the same boundary in every cycle.
       }
 
       const limit = Math.max(
@@ -533,6 +459,9 @@ export class SQLiteChangeLogComparator {
           DEFAULT_MAX_TRANSACTIONS_PER_CYCLE,
       );
       const union = await this.#enumerateCommits(db, from, through, limit);
+      if (fileGeneration !== this.#fileGeneration) {
+        return this.#skipped('log-rebuilt');
+      }
       const maxRowsPerSource = Math.max(
         1,
         this.#opts.maxRowsPerSourcePerCycle ??
@@ -549,10 +478,12 @@ export class SQLiteChangeLogComparator {
         }
         let stopAfterTransaction = false;
         if (!inSqlite || !inPg) {
-          // Presence needs no payload read, so it is checked for every
-          // transaction in the range, not just the sampled ones — the only
-          // signal this comparison has over the unsampled majority.
-          record(watermark, await this.#reconfirm(db, pinned, watermark));
+          // Check every transaction for presence because this needs no payload read.
+          const outcome = await this.#reconfirm(db, pinned, watermark);
+          record(
+            watermark,
+            fileGeneration === this.#fileGeneration ? outcome : 'inconclusive',
+          );
         } else if (
           isSampledForCompare(this.#shard, watermark, this.#opts.comparePercent)
         ) {
@@ -575,17 +506,22 @@ export class SQLiteChangeLogComparator {
           );
           sqliteRowsRead += comparison.sqliteRowsRead;
           pgRowsRead += comparison.pgRowsRead;
-          record(watermark, comparison.outcome);
-          if (comparison.outcome === 'deferred') {
+          const outcome =
+            fileGeneration === this.#fileGeneration
+              ? comparison.outcome
+              : 'inconclusive';
+          record(watermark, outcome);
+          if (outcome === 'inconclusive') {
             break;
           }
-          if (comparison.outcome === 'oversized') {
-            // The rows it did read came out of this cycle's budget, and it can
-            // never fit one; count it handled so the cursor moves past it.
+          if (outcome === 'deferred') {
+            break;
+          }
+          if (outcome === 'oversized') {
+            // Advance past a transaction that cannot fit in a fresh row budget.
             stopAfterTransaction = true;
           }
-          // Let fan-out, catchup, and the stream loop make progress between
-          // sampled reads.
+          // Yield between sampled reads so other stream work can continue.
           await this.#yield();
         }
         previousBoundary = watermark;
@@ -596,7 +532,11 @@ export class SQLiteChangeLogComparator {
         }
       }
 
-      if (!this.#stopped && outcomes.inconclusive === 0) {
+      if (
+        !this.#stopped &&
+        fileGeneration === this.#fileGeneration &&
+        outcomes.inconclusive === 0
+      ) {
         this.#cursor = handledThrough;
         this.#continueWithoutDelay = handledThrough < through;
       }
@@ -617,18 +557,13 @@ export class SQLiteChangeLogComparator {
     }
   }
 
-  /**
-   * Eligibility and the pinned bounds, in one pass: schema v2, identity
-   * matches (a leftover log from another replica is never compared), the log
-   * is warm (§6.6), and both stores have content.
-   */
+  /** Checks log eligibility and reads the bounds from both stores. */
   async #pinBounds(db: Database): Promise<PinnedBounds | CompareSkipReason> {
     let meta: ChangeLogMeta;
     try {
       meta = readChangeLogMeta(db);
     } catch {
-      // Tables or the meta row do not exist yet: the writer has not
-      // reconciled the log.
+      // The writer has not initialized the log.
       return 'log-unavailable';
     }
     if (meta.schemaVersion !== CHANGE_LOG_DB_SCHEMA_VERSION) {
@@ -651,7 +586,7 @@ export class SQLiteChangeLogComparator {
     }
     const {minWatermark, lastWatermark} = await this.#pg.getCatchupBounds();
     if (minWatermark === null) {
-      // Only a completely new replica has an empty PG change log.
+      // Only a new replica has an empty Postgres change log.
       return 'nothing-to-compare';
     }
     return {
@@ -675,11 +610,8 @@ export class SQLiteChangeLogComparator {
   }
 
   /**
-   * Enumerates the committed transactions in `(from, through]` from both
-   * stores and merges them by watermark. When either store's enumeration hits
-   * the per-cycle limit, `through` is lowered to the highest watermark both
-   * enumerations completely cover, so a truncated cycle still compares a
-   * complete common range and the next cycle resumes above it.
+   * Merges committed transaction watermarks from both stores.
+   * If a list reaches the limit, the result ends at the last complete common range.
    */
   async #enumerateCommits(
     db: Database,
@@ -729,14 +661,8 @@ export class SQLiteChangeLogComparator {
   }
 
   /**
-   * Runs both catchup paths over `(previousBoundary, watermark]` — one
-   * transaction plus anything else either store serves in the gap, since
-   * `previousBoundary` is the immediately preceding committed watermark in
-   * either store — and compares one rolling digest of each store's output.
-   *
-   * Both reads are positional (`watermark > previousBoundary`), so neither
-   * dereferences the boundary row and a boundary only one store holds is not
-   * itself a finding here.
+   * Compares the output in `(previousBoundary, watermark]`.
+   * Positional reads do not require either store to contain the boundary row.
    */
   async #compareTransaction(
     db: Database,
@@ -771,8 +697,7 @@ export class SQLiteChangeLogComparator {
         pgMaxRows,
       );
     } catch (e) {
-      // A read that cannot complete is a read a subscriber could not be
-      // served either, so it is a suspect like any other.
+      // A failed catchup read makes the transaction suspect.
       this.#lc.warn?.(
         `error reading transaction ${watermark} for comparison`,
         e,
@@ -785,8 +710,8 @@ export class SQLiteChangeLogComparator {
     }
     const rowsRead = {sqliteRowsRead: sqlite.rows, pgRowsRead: pg.rows};
     if (sqlite.limitReached || pg.limitReached) {
-      // A transaction that does not fit a *fresh* budget never will; one that
-      // only failed to fit what was left is retried by the next cycle.
+      // Skip a transaction that cannot fit in a fresh budget.
+      // Defer one that does not fit only in the remaining budget.
       const outcome =
         (sqlite.limitReached && sqliteMaxRows === maxRowsPerSource) ||
         (pg.limitReached && pgMaxRows === maxRowsPerSource)
@@ -804,12 +729,8 @@ export class SQLiteChangeLogComparator {
   }
 
   /**
-   * Decides whether a suspect observation is a finding or a race. The bounds
-   * are re-read from both stores: if the common lower bound has moved to or
-   * past the watermark, a head has fallen below it, or the log was reseeded
-   * since the cycle pinned them, the observation is `inconclusive` — a purge,
-   * truncation, or reseed raced the comparison — and is not reported as
-   * divergence. Anything that fails to re-read is likewise inconclusive.
+   * Rechecks a suspect result against current store bounds.
+   * A moved bound, changed seed, failed read, or lower head makes the result inconclusive.
    */
   async #reconfirm(
     db: Database,
@@ -847,7 +768,7 @@ export class SQLiteChangeLogComparator {
   #skipped(reason: CompareSkipReason): CompareCycleResult {
     this.#compareCycles.add(1, {result: reason});
     if (reason === 'error') {
-      // Already logged with the thrown error.
+      // The caller logged the error.
     } else if (reason !== 'nothing-to-compare') {
       this.#lc.debug?.(`skipping SQLite change-log comparison: ${reason}`);
     }
@@ -881,7 +802,7 @@ export class SQLiteChangeLogComparator {
   }
 }
 
-/** Reconstructs PG catchup batches exactly as the PG catchup path does. */
+/** Applies the same reconstruction as Postgres catchup. */
 async function* reconstructBatches(
   batches: AsyncIterable<ChangeLogEntry[]>,
 ): AsyncIterable<WatermarkedChange[]> {

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.ts
@@ -1,0 +1,905 @@
+import {createHash} from 'node:crypto';
+import type {LogContext} from '@rocicorp/logger';
+import {BigIntJSON} from '../../../../shared/src/bigint-json.ts';
+import {Database} from '../../../../zqlite/src/db.ts';
+import {
+  getOrCreateCounter,
+  getOrCreateLatencyHistogram,
+} from '../../observability/metrics.ts';
+import type {ShardID} from '../../types/shards.ts';
+import {
+  CHANGE_LOG_DB_SCHEMA_VERSION,
+  CHANGE_LOG_STREAM_TABLE,
+  readChangeLogMeta,
+  type ChangeLogIdentity,
+  type ChangeLogMeta,
+} from '../replicator/change-log-db.ts';
+import {
+  extractChangeSubstring,
+  reconstructWatermarkedChange,
+  type ChangeLogEntry,
+} from './change-log-codec.ts';
+import {ChangeLogTransactionHasher} from './change-log-transaction-hash.ts';
+import type {WatermarkedChange} from './change-streamer.ts';
+import {SQLiteChangeLogReader} from './sqlite-change-log-reader.ts';
+
+/**
+ * How often a comparison cycle runs. Each cycle is bounded by commit
+ * enumeration and catchup row budgets, so a busy stream is compared in
+ * bounded increments rather than all at once.
+ */
+const DEFAULT_COMPARE_INTERVAL_MS = 30_000;
+
+/**
+ * The per-cycle bound on enumerated transactions. This bounds the two commit
+ * watermark lists; catchup payload work has a separate per-source row budget.
+ */
+const DEFAULT_MAX_TRANSACTIONS_PER_CYCLE = 256;
+
+/** Catchup rows read from each store per comparison cycle. */
+const DEFAULT_MAX_ROWS_PER_SOURCE_PER_CYCLE = 1000;
+
+/** Rows per SQLite catchup read batch, matching the read path's default. */
+const DEFAULT_READ_BATCH_ROWS = 1000;
+
+/**
+ * The outcome of one committed transaction's comparison.
+ *
+ * There is deliberately no taxonomy of *how* the two stores disagreed: a
+ * missing transaction, an extra row, a mutated payload, and a reordered range
+ * are all `mismatch`, and the watermark is enough to go look. The comparison
+ * is advisory, and a finer classification cost more than it paid.
+ *
+ * `inconclusive` means the common lower bound (or a head) moved after the
+ * cycle pinned it — a purge, truncation, or reseed raced the comparison — so
+ * the observation says nothing about divergence and is deliberately not
+ * reported as any.
+ */
+export type CompareOutcome =
+  | 'match'
+  | 'mismatch'
+  | 'inconclusive'
+  | 'deferred'
+  | 'oversized';
+
+export type CompareSkipReason =
+  // The comparator was stopped.
+  | 'stopped'
+  // The change-log file is absent, unreadable, or has no meta row yet: the
+  // writer has not created it, or has failed soft and deleted it.
+  | 'log-unavailable'
+  // The log's schema version is not this build's.
+  | 'ineligible-schema'
+  // The log belongs to a different replica (§3.2's identity triple).
+  | 'ineligible-identity'
+  // The log was seeded less than a retention window ago (§6.6's predicate).
+  | 'cold-log'
+  // The complete committed range common to both stores is empty. Head skew in
+  // either direction lands here; it is expected — the log leads — and is
+  // deliberately not reported as divergence.
+  | 'nothing-to-compare'
+  // The cycle failed; the error was logged and counted.
+  | 'error';
+
+export type CompareCycleResult =
+  | {readonly kind: 'skipped'; readonly reason: CompareSkipReason}
+  | {
+      readonly kind: 'compared';
+      /** Exclusive lower bound of the compared range. */
+      readonly fromWatermark: string;
+      /** Inclusive upper bound handled; the next cycle resumes from here. */
+      readonly throughWatermark: string;
+      /** Committed transactions handled through `throughWatermark`. */
+      readonly transactions: number;
+      /** How many had their catchup output read and digested. */
+      readonly sampled: number;
+      readonly matched: number;
+      readonly mismatched: number;
+      /** Suspects a concurrent purge or reseed disqualified. */
+      readonly inconclusive: number;
+      /** Sampled transactions deferred until a fresh cycle row budget. */
+      readonly deferred: number;
+      /** Sampled transactions skipped because they exceed a fresh row budget. */
+      readonly oversized: number;
+    };
+
+/**
+ * The PG change log's side of the comparison. Implemented by `Storer`, whose
+ * `readCatchupRange` shares its statement shape with the subscriber catchup
+ * query — the thing this comparison exists to validate.
+ */
+export interface PGChangeLogRangeReader {
+  getCatchupBounds(): Promise<{
+    minWatermark: string | null;
+    lastWatermark: string;
+  }>;
+  listCommitWatermarks(
+    afterWatermark: string,
+    throughWatermark: string,
+    limit: number,
+  ): Promise<string[]>;
+  readCatchupRange(
+    afterWatermark: string,
+    throughWatermark: string,
+    batchRows?: number | undefined,
+  ): AsyncIterable<ChangeLogEntry[]>;
+}
+
+export type SQLiteChangeLogCompareOptions = {
+  /**
+   * `sqliteChangeLogComparePercent`: the stable percentage of committed
+   * transactions whose catchup output is digest-compared. Presence (a
+   * transaction one store holds and the other does not) is checked for every
+   * transaction in the range regardless, since it needs no payload reads.
+   */
+  readonly comparePercent: number;
+  /**
+   * `sqliteChangeLogRetentionMs`, reused as the warm-up window: a log seeded
+   * less than this long ago is declined (§6.6), since its covered range is
+   * still filling.
+   */
+  readonly retentionMs: number;
+  readonly intervalMs?: number | undefined;
+  readonly maxTransactionsPerCycle?: number | undefined;
+  /** Catchup payload rows read from each source in one cycle. */
+  readonly maxRowsPerSourcePerCycle?: number | undefined;
+  readonly readBatchRows?: number | undefined;
+  /** The clock the warm-up window is measured against. Defaults to `Date.now`. */
+  readonly now?: (() => number) | undefined;
+  readonly setTimeoutFn?: typeof setTimeout | undefined;
+  readonly clearTimeoutFn?: typeof clearTimeout | undefined;
+  /**
+   * Awaited between sampled transactions so fan-out and catchup make progress.
+   * Defaults to a macrotask (`setImmediate`).
+   */
+  readonly yieldFn?: (() => Promise<void>) | undefined;
+};
+
+/**
+ * Whether `watermark`'s transaction is in the compared sample.
+ *
+ * Stable by shard and watermark — a pure function of the two — so a retried
+ * or restarted comparison selects exactly the same transactions and therefore
+ * compares the same data.
+ */
+export function isSampledForCompare(
+  shard: ShardID,
+  watermark: string,
+  percent: number,
+): boolean {
+  if (percent >= 100) {
+    return true;
+  }
+  if (percent <= 0) {
+    return false;
+  }
+  const digest = createHash('sha256')
+    .update(`${shard.appID}/${shard.shardNum}:${watermark}`)
+    .digest();
+  return digest.readUInt32BE(0) % 100 < percent;
+}
+
+/**
+ * Normalizes a stored `change` to one text form before hashing.
+ *
+ * The two stores hand the text back differently: SQLite serves the exact
+ * serialized substring it stored, while PG holds it in a `json` column and
+ * serves `change::text` — a round trip through the client's JSON parameter
+ * encoding and `json_to_recordset`. Any formatting difference from that round
+ * trip would report as a mismatch that is *not* divergence, which would be
+ * indistinguishable from the finding this comparison exists to make. Both
+ * sides are therefore re-serialized through the same codec; a value that does
+ * not parse is hashed as-is, identically on both sides.
+ */
+export function normalizeChangeJSON(change: string): string {
+  try {
+    return BigIntJSON.stringify(BigIntJSON.parse(change));
+  } catch {
+    return change;
+  }
+}
+
+export type CatchupRangeDigest = {
+  readonly digest: string;
+  readonly rows: number;
+  /** The row cap was reached before the range's closing commit was served. */
+  readonly limitReached: boolean;
+};
+
+/**
+ * Digests everything a store serves over a catchup range, as one rolling hash
+ * in served order.
+ *
+ * Position is the row's index *within the served range*, so the digest is a
+ * pure function of what the store hands a subscriber: a missing row, an extra
+ * row at any watermark, a mutated payload, and a reordering all change it.
+ * That is what lets the comparison be a single equality check — there is no
+ * per-watermark bookkeeping to decide which served rows "count".
+ *
+ * `precommit` is not hashed: for a commit row it equals that row's own
+ * watermark, which is hashed already.
+ */
+export async function digestCatchupRange(
+  batches: AsyncIterable<readonly WatermarkedChange[]>,
+  throughWatermark: string,
+  maxRows: number,
+): Promise<CatchupRangeDigest> {
+  const hasher = new ChangeLogTransactionHasher();
+  let rows = 0;
+  let servedClosingCommit = false;
+
+  for await (const batch of batches) {
+    for (const [watermark, tag, json] of batch) {
+      if (rows === maxRows) {
+        return {digest: hasher.digest(), rows, limitReached: true};
+      }
+      hasher.add({
+        watermark,
+        pos: rows,
+        tag,
+        change: normalizeChangeJSON(extractChangeSubstring(json, tag)),
+        precommit: null,
+      });
+      rows++;
+      if (tag === 'commit' && watermark === throughWatermark) {
+        servedClosingCommit = true;
+      }
+    }
+  }
+  return {
+    digest: hasher.digest(),
+    rows,
+    limitReached: rows === maxRows && !servedClosingCommit,
+  };
+}
+
+/**
+ * `min` and `max` as separate scalar subqueries for the single-aggregate index
+ * optimization, matching the reader's plan query.
+ */
+const SQLITE_BOUNDS_SQL = /*sql*/ `
+  SELECT
+    (SELECT min("watermark") FROM "${CHANGE_LOG_STREAM_TABLE}")
+      AS "minWatermark",
+    (SELECT max("watermark") FROM "${CHANGE_LOG_STREAM_TABLE}")
+      AS "headWatermark"
+`;
+
+/**
+ * Commit watermarks in `(@after, @through]`. Every row of a transaction is
+ * stored at its commit watermark and only commit rows carry `precommit`, so
+ * this enumerates the committed transactions in the range.
+ */
+const SQLITE_COMMITS_SQL = /*sql*/ `
+  SELECT "watermark" FROM "${CHANGE_LOG_STREAM_TABLE}"
+   WHERE "precommit" IS NOT NULL
+     AND "watermark" > @after
+     AND "watermark" <= @through
+   ORDER BY "watermark"
+   LIMIT @limit
+`;
+
+type SQLiteBounds = {
+  readonly minWatermark: string;
+  readonly headWatermark: string;
+};
+
+type PinnedBounds = {
+  readonly meta: ChangeLogMeta;
+  readonly sqlite: SQLiteBounds;
+  readonly pgMinWatermark: string;
+  readonly pgLastWatermark: string;
+};
+
+type SampledComparison = {
+  readonly outcome: CompareOutcome;
+  readonly sqliteRowsRead: number;
+  readonly pgRowsRead: number;
+};
+
+/**
+ * Compares what SQLite catchup *serves* against what PG catchup serves, over
+ * complete committed ranges, without serving either to a subscriber.
+ *
+ * "SQLite content equals PG content" is already established by construction —
+ * both stores hold the same serialized substrings — plus the continuous
+ * per-transaction hash check from 7H. What is *not* covered, and what this
+ * validates, is the read path: reader reconstruction, `plan()` bounds, and
+ * purge interacting with a pinned range. Each cycle enumerates the committed
+ * transactions both stores hold, samples a stable subset, reads each sampled
+ * range through both stores' catchup statements, and compares one rolling
+ * digest of what each served.
+ *
+ * The comparison is dark and advisory: it changes nothing about what
+ * subscribers receive, PG remains authoritative, and every anomaly is a
+ * metric and a (redacted) log line rather than an action.
+ *
+ * Ranges are compared only through `min(pgHead, sqliteHead)` — head skew in
+ * either direction is expected, the log leads, and is never reported. A purge,
+ * truncation, or reseed that moves the pinned bounds mid-cycle reports
+ * `inconclusive`, not divergence.
+ */
+export class SQLiteChangeLogComparator {
+  readonly #lc: LogContext;
+  readonly #shard: ShardID;
+  readonly #changeLogFile: string;
+  readonly #identity: ChangeLogIdentity;
+  readonly #pg: PGChangeLogRangeReader;
+  readonly #opts: SQLiteChangeLogCompareOptions;
+  readonly #now: () => number;
+  readonly #setTimeoutFn: typeof setTimeout;
+  readonly #clearTimeoutFn: typeof clearTimeout;
+  readonly #yield: () => Promise<void>;
+
+  readonly #compareResults = getOrCreateCounter(
+    'replica',
+    'sqlite_change_log.compare_result',
+    'Outcomes of the dark comparison between what SQLite catchup serves and ' +
+      'what PG catchup serves, per committed transaction. `inconclusive` ' +
+      'means a purge or reseed moved the pinned bounds mid-comparison.',
+  );
+  readonly #compareCycles = getOrCreateCounter(
+    'replica',
+    'sqlite_change_log.compare_cycles',
+    'SQLite change-log comparison cycles, by result.',
+  );
+  readonly #cycleDuration = getOrCreateLatencyHistogram(
+    'replica',
+    'sqlite_change_log.compare_cycle_duration',
+    'Duration of one SQLite change-log comparison cycle.',
+  );
+
+  /**
+   * The commit watermark through which output has been compared. Ranges are
+   * compared once and never re-read; a restart re-derives it from the common
+   * lower bound, and the stable sample selects the same transactions again.
+   */
+  #cursor: string | undefined;
+  #running: Promise<CompareCycleResult> | undefined;
+  #timer: ReturnType<typeof setTimeout> | undefined;
+  #stopped = false;
+  #continueWithoutDelay = false;
+
+  constructor(
+    lc: LogContext,
+    shard: ShardID,
+    changeLogFile: string,
+    identity: ChangeLogIdentity,
+    pg: PGChangeLogRangeReader,
+    opts: SQLiteChangeLogCompareOptions,
+  ) {
+    this.#lc = lc.withContext('component', 'sqlite-change-log-compare');
+    this.#shard = shard;
+    this.#changeLogFile = changeLogFile;
+    this.#identity = identity;
+    this.#pg = pg;
+    this.#opts = opts;
+    this.#now = opts.now ?? Date.now;
+    this.#setTimeoutFn = opts.setTimeoutFn ?? setTimeout;
+    this.#clearTimeoutFn = opts.clearTimeoutFn ?? clearTimeout;
+    this.#yield =
+      opts.yieldFn ??
+      (() => new Promise<void>(resolve => setImmediate(resolve)));
+    this.#scheduleNext();
+  }
+
+  /**
+   * Runs one comparison cycle. Concurrent calls coalesce into the running
+   * cycle's completion. Never rejects; a failed cycle is logged and reported
+   * as `skipped: 'error'`.
+   */
+  compareOnce(): Promise<CompareCycleResult> {
+    if (this.#stopped) {
+      return Promise.resolve({kind: 'skipped', reason: 'stopped'});
+    }
+    if (this.#running === undefined) {
+      this.#running = this.#runCycle()
+        .then(result => {
+          if (this.#continueWithoutDelay) {
+            this.#rescheduleNext(0);
+          }
+          return result;
+        })
+        .finally(() => {
+          this.#running = undefined;
+        });
+    }
+    return this.#running;
+  }
+
+  stop(): void {
+    this.#stopped = true;
+    if (this.#timer !== undefined) {
+      this.#clearTimeoutFn(this.#timer);
+      this.#timer = undefined;
+    }
+  }
+
+  #scheduleNext(
+    delayMs = this.#opts.intervalMs ?? DEFAULT_COMPARE_INTERVAL_MS,
+  ): void {
+    if (this.#stopped || this.#timer !== undefined) {
+      return;
+    }
+    this.#timer = this.#setTimeoutFn(() => {
+      this.#timer = undefined;
+      void this.compareOnce().finally(() => this.#scheduleNext());
+    }, delayMs);
+  }
+
+  #rescheduleNext(delayMs: number): void {
+    if (this.#timer !== undefined) {
+      this.#clearTimeoutFn(this.#timer);
+      this.#timer = undefined;
+    }
+    this.#scheduleNext(delayMs);
+  }
+
+  async #runCycle(): Promise<CompareCycleResult> {
+    const startedAt = performance.now();
+    this.#continueWithoutDelay = false;
+    let db: Database | undefined;
+    let reader: SQLiteChangeLogReader | undefined;
+    try {
+      try {
+        // A readonly handle cannot create the file, so an absent log — the
+        // writer has not reconciled yet, or failed soft and deleted it — is a
+        // routine decline rather than an error.
+        db = new Database(this.#lc, this.#changeLogFile, {readonly: true});
+      } catch {
+        return this.#skipped('log-unavailable');
+      }
+
+      const pinned = await this.#pinBounds(db);
+      if (typeof pinned === 'string') {
+        return this.#skipped(pinned);
+      }
+      const {meta} = pinned;
+
+      const from = maxWatermark(
+        this.#cursor ?? meta.seedWatermark,
+        // The log's seed transaction is synthetic — its content matches
+        // nothing PG holds — so the exclusive lower bound keeps it out of
+        // every comparison. (PG's own synthetic seed, from
+        // ensureReplicationConfig, carries no `precommit` and is already
+        // invisible to the commit enumeration.)
+        meta.seedWatermark,
+        // The transaction *at* a store's minimum is a catchup boundary, not
+        // output that store can serve, so comparison starts above it.
+        pinned.pgMinWatermark,
+        pinned.sqlite.minWatermark,
+      );
+      const through = minWatermark(
+        pinned.pgLastWatermark,
+        pinned.sqlite.headWatermark,
+      );
+      if (through <= from) {
+        return this.#skipped('nothing-to-compare');
+      }
+
+      let transactions = 0;
+      let sampled = 0;
+      const outcomes: Record<CompareOutcome, number> = {
+        match: 0,
+        mismatch: 0,
+        inconclusive: 0,
+        deferred: 0,
+        oversized: 0,
+      };
+      const record = (watermark: string, outcome: CompareOutcome) => {
+        this.#compareResults.add(1, {outcome});
+        outcomes[outcome]++;
+        if (outcome === 'mismatch') {
+          // The watermark only. The payloads are customer data and are never
+          // logged; the watermark is enough to find them.
+          this.#lc.error?.(
+            'SQLite change-log catchup output diverged from Postgres',
+            {sqliteChangeLogCompare: {watermark}},
+          );
+        }
+      };
+
+      reader = new SQLiteChangeLogReader(this.#lc, this.#changeLogFile);
+      const plan = reader.plan(from);
+      if (plan.kind === 'not-ready') {
+        return this.#skipped('log-unavailable');
+      }
+      if (plan.kind === 'ahead') {
+        return this.#skipped('nothing-to-compare');
+      }
+      if (plan.kind === 'too-old') {
+        // `from` was computed at or above the log's own minimum, so the log
+        // cannot serve a boundary it should hold — unless the bounds moved
+        // after they were pinned, which is a purge race, not a finding.
+        const outcome = await this.#reconfirm(db, pinned, from);
+        record(from, outcome);
+        if (outcome === 'inconclusive') {
+          // The pinned bounds moved; nothing this cycle established about the
+          // range still holds. The cursor stays put and the next cycle re-pins.
+          return this.#compared(from, from, transactions, sampled, outcomes);
+        }
+        // A *confirmed* mismatch is a finding about the boundary itself —
+        // typically a commit this store never held, already reported as
+        // missing by the cycle that enumerated it. The reads below are
+        // positional and never dereference the boundary row, so the cycle
+        // still compares the range and advances the cursor past it. Returning
+        // here instead would re-report the same boundary — and compare
+        // nothing else — every cycle, forever.
+      }
+
+      const limit = Math.max(
+        1,
+        this.#opts.maxTransactionsPerCycle ??
+          DEFAULT_MAX_TRANSACTIONS_PER_CYCLE,
+      );
+      const union = await this.#enumerateCommits(db, from, through, limit);
+      const maxRowsPerSource = Math.max(
+        1,
+        this.#opts.maxRowsPerSourcePerCycle ??
+          DEFAULT_MAX_ROWS_PER_SOURCE_PER_CYCLE,
+      );
+
+      let sqliteRowsRead = 0;
+      let pgRowsRead = 0;
+      let previousBoundary = from;
+      let handledThrough = from;
+      for (const {watermark, inSqlite, inPg} of union) {
+        if (this.#stopped) {
+          break;
+        }
+        let stopAfterTransaction = false;
+        if (!inSqlite || !inPg) {
+          // Presence needs no payload read, so it is checked for every
+          // transaction in the range, not just the sampled ones — the only
+          // signal this comparison has over the unsampled majority.
+          record(watermark, await this.#reconfirm(db, pinned, watermark));
+        } else if (
+          isSampledForCompare(this.#shard, watermark, this.#opts.comparePercent)
+        ) {
+          const sqliteRowsRemaining = maxRowsPerSource - sqliteRowsRead;
+          const pgRowsRemaining = maxRowsPerSource - pgRowsRead;
+          if (sqliteRowsRemaining === 0 || pgRowsRemaining === 0) {
+            record(watermark, 'deferred');
+            break;
+          }
+          sampled++;
+          const comparison = await this.#compareTransaction(
+            db,
+            reader,
+            pinned,
+            previousBoundary,
+            watermark,
+            sqliteRowsRemaining,
+            pgRowsRemaining,
+            maxRowsPerSource,
+          );
+          sqliteRowsRead += comparison.sqliteRowsRead;
+          pgRowsRead += comparison.pgRowsRead;
+          record(watermark, comparison.outcome);
+          if (comparison.outcome === 'deferred') {
+            break;
+          }
+          if (comparison.outcome === 'oversized') {
+            // The rows it did read came out of this cycle's budget, and it can
+            // never fit one; count it handled so the cursor moves past it.
+            stopAfterTransaction = true;
+          }
+          // Let fan-out, catchup, and the stream loop make progress between
+          // sampled reads.
+          await this.#yield();
+        }
+        previousBoundary = watermark;
+        handledThrough = watermark;
+        transactions++;
+        if (stopAfterTransaction) {
+          break;
+        }
+      }
+
+      if (!this.#stopped && outcomes.inconclusive === 0) {
+        this.#cursor = handledThrough;
+        this.#continueWithoutDelay = handledThrough < through;
+      }
+      return this.#compared(
+        from,
+        handledThrough,
+        transactions,
+        sampled,
+        outcomes,
+      );
+    } catch (e) {
+      this.#lc.warn?.('error comparing the SQLite change log', e);
+      return this.#skipped('error');
+    } finally {
+      reader?.close();
+      db?.close();
+      this.#cycleDuration.recordMs(performance.now() - startedAt);
+    }
+  }
+
+  /**
+   * Eligibility and the pinned bounds, in one pass: schema v2, identity
+   * matches (a leftover log from another replica is never compared), the log
+   * is warm (§6.6), and both stores have content.
+   */
+  async #pinBounds(db: Database): Promise<PinnedBounds | CompareSkipReason> {
+    let meta: ChangeLogMeta;
+    try {
+      meta = readChangeLogMeta(db);
+    } catch {
+      // Tables or the meta row do not exist yet: the writer has not
+      // reconciled the log.
+      return 'log-unavailable';
+    }
+    if (meta.schemaVersion !== CHANGE_LOG_DB_SCHEMA_VERSION) {
+      return 'ineligible-schema';
+    }
+    const {epoch, generation, replicaID} = this.#identity;
+    if (
+      meta.epoch !== epoch ||
+      meta.generation !== generation ||
+      meta.replicaID !== replicaID
+    ) {
+      return 'ineligible-identity';
+    }
+    if (this.#now() - meta.seededAtMs < this.#opts.retentionMs) {
+      return 'cold-log';
+    }
+    const sqlite = this.#readSQLiteBounds(db);
+    if (sqlite === undefined) {
+      return 'log-unavailable';
+    }
+    const {minWatermark, lastWatermark} = await this.#pg.getCatchupBounds();
+    if (minWatermark === null) {
+      // Only a completely new replica has an empty PG change log.
+      return 'nothing-to-compare';
+    }
+    return {
+      meta,
+      sqlite,
+      pgMinWatermark: minWatermark,
+      pgLastWatermark: lastWatermark,
+    };
+  }
+
+  #readSQLiteBounds(db: Database): SQLiteBounds | undefined {
+    const bounds = db
+      .prepare(SQLITE_BOUNDS_SQL)
+      .get<{minWatermark: string | null; headWatermark: string | null}>();
+    return bounds.minWatermark === null || bounds.headWatermark === null
+      ? undefined
+      : {
+          minWatermark: bounds.minWatermark,
+          headWatermark: bounds.headWatermark,
+        };
+  }
+
+  /**
+   * Enumerates the committed transactions in `(from, through]` from both
+   * stores and merges them by watermark. When either store's enumeration hits
+   * the per-cycle limit, `through` is lowered to the highest watermark both
+   * enumerations completely cover, so a truncated cycle still compares a
+   * complete common range and the next cycle resumes above it.
+   */
+  async #enumerateCommits(
+    db: Database,
+    from: string,
+    through: string,
+    limit: number,
+  ): Promise<{watermark: string; inSqlite: boolean; inPg: boolean}[]> {
+    let sqlite: string[] = db
+      .prepare(SQLITE_COMMITS_SQL)
+      .all<{watermark: string}>({after: from, through, limit: limit + 1})
+      .map(({watermark}) => watermark);
+    let pg = await this.#pg.listCommitWatermarks(from, through, limit + 1);
+
+    let effectiveThrough = through;
+    if (sqlite.length > limit) {
+      sqlite.length = limit;
+      effectiveThrough = minWatermark(effectiveThrough, sqlite[limit - 1]);
+    }
+    if (pg.length > limit) {
+      pg.length = limit;
+      effectiveThrough = minWatermark(effectiveThrough, pg[limit - 1]);
+    }
+    if (effectiveThrough !== through) {
+      sqlite = sqlite.filter(w => w <= effectiveThrough);
+      pg = pg.filter(w => w <= effectiveThrough);
+    }
+
+    const union: {watermark: string; inSqlite: boolean; inPg: boolean}[] = [];
+    let s = 0;
+    let p = 0;
+    while (s < sqlite.length || p < pg.length) {
+      const sw = s < sqlite.length ? sqlite[s] : undefined;
+      const pw = p < pg.length ? pg[p] : undefined;
+      if (sw !== undefined && (pw === undefined || sw < pw)) {
+        union.push({watermark: sw, inSqlite: true, inPg: false});
+        s++;
+      } else if (pw !== undefined && (sw === undefined || pw < sw)) {
+        union.push({watermark: pw, inSqlite: false, inPg: true});
+        p++;
+      } else if (sw !== undefined) {
+        union.push({watermark: sw, inSqlite: true, inPg: true});
+        s++;
+        p++;
+      }
+    }
+    return union;
+  }
+
+  /**
+   * Runs both catchup paths over `(previousBoundary, watermark]` — one
+   * transaction plus anything else either store serves in the gap, since
+   * `previousBoundary` is the immediately preceding committed watermark in
+   * either store — and compares one rolling digest of each store's output.
+   *
+   * Both reads are positional (`watermark > previousBoundary`), so neither
+   * dereferences the boundary row and a boundary only one store holds is not
+   * itself a finding here.
+   */
+  async #compareTransaction(
+    db: Database,
+    reader: SQLiteChangeLogReader,
+    pinned: PinnedBounds,
+    previousBoundary: string,
+    watermark: string,
+    sqliteMaxRows: number,
+    pgMaxRows: number,
+    maxRowsPerSource: number,
+  ): Promise<SampledComparison> {
+    let sqlite: CatchupRangeDigest;
+    let pg: CatchupRangeDigest;
+    try {
+      const readBatchRows = this.#opts.readBatchRows ?? DEFAULT_READ_BATCH_ROWS;
+      sqlite = await digestCatchupRange(
+        reader.read(
+          previousBoundary,
+          watermark,
+          Math.min(readBatchRows, sqliteMaxRows),
+          undefined,
+          sqliteMaxRows,
+        ),
+        watermark,
+        sqliteMaxRows,
+      );
+      pg = await digestCatchupRange(
+        reconstructBatches(
+          this.#pg.readCatchupRange(previousBoundary, watermark, pgMaxRows),
+        ),
+        watermark,
+        pgMaxRows,
+      );
+    } catch (e) {
+      // A read that cannot complete is a read a subscriber could not be
+      // served either, so it is a suspect like any other.
+      this.#lc.warn?.(
+        `error reading transaction ${watermark} for comparison`,
+        e,
+      );
+      return {
+        outcome: await this.#reconfirm(db, pinned, watermark),
+        sqliteRowsRead: 0,
+        pgRowsRead: 0,
+      };
+    }
+    const rowsRead = {sqliteRowsRead: sqlite.rows, pgRowsRead: pg.rows};
+    if (sqlite.limitReached || pg.limitReached) {
+      // A transaction that does not fit a *fresh* budget never will; one that
+      // only failed to fit what was left is retried by the next cycle.
+      const outcome =
+        (sqlite.limitReached && sqliteMaxRows === maxRowsPerSource) ||
+        (pg.limitReached && pgMaxRows === maxRowsPerSource)
+          ? 'oversized'
+          : 'deferred';
+      return {outcome, ...rowsRead};
+    }
+    if (sqlite.digest === pg.digest) {
+      return {outcome: 'match', ...rowsRead};
+    }
+    return {
+      outcome: await this.#reconfirm(db, pinned, watermark),
+      ...rowsRead,
+    };
+  }
+
+  /**
+   * Decides whether a suspect observation is a finding or a race. The bounds
+   * are re-read from both stores: if the common lower bound has moved to or
+   * past the watermark, a head has fallen below it, or the log was reseeded
+   * since the cycle pinned them, the observation is `inconclusive` — a purge,
+   * truncation, or reseed raced the comparison — and is not reported as
+   * divergence. Anything that fails to re-read is likewise inconclusive.
+   */
+  async #reconfirm(
+    db: Database,
+    pinned: PinnedBounds,
+    watermark: string,
+  ): Promise<'mismatch' | 'inconclusive'> {
+    try {
+      const meta = readChangeLogMeta(db);
+      if (
+        meta.seedWatermark !== pinned.meta.seedWatermark ||
+        meta.seededAtMs !== pinned.meta.seededAtMs
+      ) {
+        return 'inconclusive';
+      }
+      const sqlite = this.#readSQLiteBounds(db);
+      const {minWatermark, lastWatermark} = await this.#pg.getCatchupBounds();
+      if (sqlite === undefined || minWatermark === null) {
+        return 'inconclusive';
+      }
+      if (
+        (sqlite.minWatermark > pinned.sqlite.minWatermark &&
+          watermark <= sqlite.minWatermark) ||
+        (minWatermark > pinned.pgMinWatermark && watermark <= minWatermark) ||
+        watermark > sqlite.headWatermark ||
+        watermark > lastWatermark
+      ) {
+        return 'inconclusive';
+      }
+      return 'mismatch';
+    } catch {
+      return 'inconclusive';
+    }
+  }
+
+  #skipped(reason: CompareSkipReason): CompareCycleResult {
+    this.#compareCycles.add(1, {result: reason});
+    if (reason === 'error') {
+      // Already logged with the thrown error.
+    } else if (reason !== 'nothing-to-compare') {
+      this.#lc.debug?.(`skipping SQLite change-log comparison: ${reason}`);
+    }
+    return {kind: 'skipped', reason};
+  }
+
+  #compared(
+    fromWatermark: string,
+    throughWatermark: string,
+    transactions: number,
+    sampled: number,
+    outcomes: Record<CompareOutcome, number>,
+  ): CompareCycleResult {
+    this.#compareCycles.add(1, {result: 'compared'});
+    const result = {
+      kind: 'compared',
+      fromWatermark,
+      throughWatermark,
+      transactions,
+      sampled,
+      matched: outcomes.match,
+      mismatched: outcomes.mismatch,
+      inconclusive: outcomes.inconclusive,
+      deferred: outcomes.deferred,
+      oversized: outcomes.oversized,
+    } as const;
+    this.#lc.debug?.('SQLite change-log comparison cycle', {
+      sqliteChangeLogCompare: result,
+    });
+    return result;
+  }
+}
+
+/** Reconstructs PG catchup batches exactly as the PG catchup path does. */
+async function* reconstructBatches(
+  batches: AsyncIterable<ChangeLogEntry[]>,
+): AsyncIterable<WatermarkedChange[]> {
+  for await (const batch of batches) {
+    yield batch.map(reconstructWatermarkedChange);
+  }
+}
+
+function minWatermark(a: string, b: string): string {
+  return a < b ? a : b;
+}
+
+function maxWatermark(...watermarks: string[]): string {
+  let max = watermarks[0];
+  for (const w of watermarks) {
+    if (w > max) {
+      max = w;
+    }
+  }
+  return max;
+}

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-reader.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-reader.test.ts
@@ -267,6 +267,26 @@ describe('sqlite change log reader', () => {
     await expect(collect(reader, '06', '06', 2)).resolves.toEqual([]);
   });
 
+  test('caps total rows across read batches', async () => {
+    const {db, path} = createChangeLog();
+    using writer = db;
+    const tx04 = appendTransaction(writer, '04', [
+      truncate(),
+      truncate(),
+      truncate(),
+      truncate(),
+      truncate(),
+    ]);
+    using reader = new SQLiteChangeLogReader(lc, path);
+
+    const batches: (readonly WatermarkedChange[])[] = [];
+    for await (const batch of reader.read('02', '04', 2, undefined, 5)) {
+      batches.push(batch);
+    }
+    expect(batches.map(batch => batch.length)).toEqual([2, 2, 1]);
+    expect(flatten(batches)).toEqual(tx04.slice(0, 5));
+  });
+
   test('pins the head while another connection appends and purges', async () => {
     const {db, path} = createChangeLog();
     using writer = db;

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-reader.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-reader.ts
@@ -151,10 +151,15 @@ export class SQLiteChangeLogReader implements Disposable {
     throughWatermark: string,
     batchSize: number,
     signal?: AbortSignal | undefined,
+    maxRows?: number | undefined,
   ): AsyncIterable<readonly WatermarkedChange[]> {
     assert(
       Number.isSafeInteger(batchSize) && batchSize > 0,
       'SQLite change log batch size must be a positive safe integer',
+    );
+    assert(
+      maxRows === undefined || (Number.isSafeInteger(maxRows) && maxRows > 0),
+      'SQLite change log row limit must be a positive safe integer',
     );
     this.#assertOpen();
     const statements = this.#prepare();
@@ -168,14 +173,20 @@ export class SQLiteChangeLogReader implements Disposable {
     // real stream position is far below this sentinel.
     let lastPos = Number.MAX_SAFE_INTEGER;
     let lastTag: string | undefined;
+    let rowsRead = 0;
 
     while (true) {
       this.#throwIfAborted(signal);
+      const remainingRows =
+        maxRows === undefined ? batchSize : maxRows - rowsRead;
+      if (remainingRows === 0) {
+        break;
+      }
       const rows = statements.readBatch.all<ChangeLogRow>(
         lastWatermark,
         lastPos,
         throughWatermark,
-        batchSize,
+        Math.min(batchSize, remainingRows),
       );
       this.#throwIfAborted(signal);
 
@@ -189,6 +200,7 @@ export class SQLiteChangeLogReader implements Disposable {
       lastWatermark = last.watermark;
       lastPos = last.pos;
       lastTag = last.tag;
+      rowsRead += rows.length;
 
       // all() has exhausted the SELECT and closed its implicit read
       // transaction. This yield therefore cannot pin the WAL while subscriber
@@ -201,7 +213,12 @@ export class SQLiteChangeLogReader implements Disposable {
     // `_zero.replicationState`, which is what this assertion used to guard.
     // What remains is a concurrent purge of the head transaction, which the
     // purge policy (never past the latest durable transaction) does not do.
-    if (fromWatermark !== throughWatermark) {
+    if (
+      fromWatermark !== throughWatermark &&
+      (maxRows === undefined ||
+        rowsRead < maxRows ||
+        (lastWatermark === throughWatermark && lastTag === 'commit'))
+    ) {
       assert(
         lastWatermark === throughWatermark && lastTag === 'commit',
         () =>

--- a/packages/zero-cache/src/services/change-streamer/storer.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.ts
@@ -314,12 +314,9 @@ export class Storer implements Service {
   }
 
   /**
-   * The bounds of the range the PG change log can serve catchup over:
-   * `minWatermark` is the earliest retained transaction (`null` only for a
-   * completely new replica) and `lastWatermark` is the durable head, which
-   * commits in the same transaction as its change-log rows.
-   *
-   * Used by the SQLite change-log comparator to pin the range it compares.
+   * Returns the retained Postgres catchup bounds.
+   * `minWatermark` is the oldest transaction, or `null` for a new replica.
+   * `lastWatermark` is the durable head.
    */
   async getCatchupBounds(): Promise<{
     minWatermark: string | null;
@@ -335,10 +332,8 @@ export class Storer implements Service {
   }
 
   /**
-   * The commit watermarks of the transactions in `(afterWatermark,
-   * throughWatermark]`, ascending, at most `limit` of them. Every row of a
-   * transaction is stored at its commit watermark, so this is a complete
-   * enumeration of the committed transactions in the range.
+   * Lists at most `limit` committed transaction watermarks in
+   * `(afterWatermark, throughWatermark]`, in ascending order.
    */
   async listCommitWatermarks(
     afterWatermark: string,
@@ -356,17 +351,11 @@ export class Storer implements Service {
   }
 
   /**
-   * Reads the change-log entries in `(afterWatermark, throughWatermark]` in
-   * stream order, in bounded batches. This is the same statement shape as the
-   * subscriber catchup query in {@link #catchup} — the comparator exists to
-   * compare catchup *output*, so the two must not diverge in what they select.
+   * Reads `(afterWatermark, throughWatermark]` in stream order and bounded batches.
+   * This query matches the subscriber catchup query.
    *
-   * That fidelity includes a shared limitation: `change->'tag'` de-escapes
-   * every string value in the document while scanning for the field, and
-   * Postgres cannot represent `\u0000` as text, so a change whose payload
-   * contains an escaped NUL fails the read. Subscriber catchup fails on
-   * exactly the same row, so the comparator reports it as a mismatch rather
-   * than papering over it with a different statement.
+   * Both queries fail when an escaped NUL reaches `change->'tag'`.
+   * Postgres cannot convert that value to text.
    */
   readCatchupRange(
     afterWatermark: string,

--- a/packages/zero-cache/src/services/change-streamer/storer.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.ts
@@ -313,6 +313,79 @@ export class Storer implements Service {
     return minWatermark;
   }
 
+  /**
+   * The bounds of the range the PG change log can serve catchup over:
+   * `minWatermark` is the earliest retained transaction (`null` only for a
+   * completely new replica) and `lastWatermark` is the durable head, which
+   * commits in the same transaction as its change-log rows.
+   *
+   * Used by the SQLite change-log comparator to pin the range it compares.
+   */
+  async getCatchupBounds(): Promise<{
+    minWatermark: string | null;
+    lastWatermark: string;
+  }> {
+    const [bounds] = await this.#db<
+      {minWatermark: string | null; lastWatermark: string}[]
+    > /*sql*/ `
+      SELECT
+        (SELECT min(watermark) FROM ${this.#cdc('changeLog')}) as "minWatermark",
+        (SELECT "lastWatermark" FROM ${this.#cdc('replicationState')}) as "lastWatermark"`;
+    return bounds;
+  }
+
+  /**
+   * The commit watermarks of the transactions in `(afterWatermark,
+   * throughWatermark]`, ascending, at most `limit` of them. Every row of a
+   * transaction is stored at its commit watermark, so this is a complete
+   * enumeration of the committed transactions in the range.
+   */
+  async listCommitWatermarks(
+    afterWatermark: string,
+    throughWatermark: string,
+    limit: number,
+  ): Promise<string[]> {
+    const rows = await this.#db<{watermark: string}[]> /*sql*/ `
+      SELECT watermark FROM ${this.#cdc('changeLog')}
+       WHERE precommit IS NOT NULL
+         AND watermark > ${afterWatermark}
+         AND watermark <= ${throughWatermark}
+       ORDER BY watermark
+       LIMIT ${limit}`;
+    return rows.map(({watermark}) => watermark);
+  }
+
+  /**
+   * Reads the change-log entries in `(afterWatermark, throughWatermark]` in
+   * stream order, in bounded batches. This is the same statement shape as the
+   * subscriber catchup query in {@link #catchup} — the comparator exists to
+   * compare catchup *output*, so the two must not diverge in what they select.
+   *
+   * That fidelity includes a shared limitation: `change->'tag'` de-escapes
+   * every string value in the document while scanning for the field, and
+   * Postgres cannot represent `\u0000` as text, so a change whose payload
+   * contains an escaped NUL fails the read. Subscriber catchup fails on
+   * exactly the same row, so the comparator reports it as a mismatch rather
+   * than papering over it with a different statement.
+   */
+  readCatchupRange(
+    afterWatermark: string,
+    throughWatermark: string,
+    batchRows = 2000,
+  ): AsyncIterable<ChangeLogEntry[]> {
+    assert(
+      Number.isSafeInteger(batchRows) && batchRows > 0,
+      'Postgres change log batch size must be a positive safe integer',
+    );
+    return this.#db<ChangeLogEntry[]> /*sql*/ `
+      SELECT watermark, change->'tag' as tag, change::text FROM ${this.#cdc('changeLog')}
+       WHERE watermark > ${afterWatermark}
+         AND watermark <= ${throughWatermark}
+       ORDER BY watermark, pos`.cursor(batchRows) as AsyncIterable<
+      ChangeLogEntry[]
+    >;
+  }
+
   purgeRecordsBefore(watermark: string): Promise<number> {
     return runTx(this.#db, async sql => {
       // This NOWAIT pre-check is an optimization to abort the transaction


### PR DESCRIPTION
## What this does

Runs the SQLite change log's catchup **read path** against Postgres's, in production, without serving anything from it. On a 30-second cycle the change-streamer takes the range of committed transactions both logs hold, checks that every transaction present in one is present in the other, and — for a sampled percentage — reads the full catchup output through both stores' real read paths and compares a digest of what each would have served a subscriber. Postgres remains authoritative; nothing a subscriber receives changes.

## Rollout

- Default is `sqliteChangeLogMode=off`; **this PR has no production effect until enabled.**
- Enable per replication-manager with `--change-streamer-sqlite-change-log-mode=compare`. The sampling dial is `--change-streamer-sqlite-change-log-compare-percent` (default 1; presence checks always run at 100%).
- Roll back by returning the mode to `write` — both comparisons stop, the log keeps accumulating.
- Cost is bounded by construction: at most 256 transactions and 1,000 catchup rows per store per cycle, yielding to the event loop between sampled reads, so a busy shard is compared incrementally rather than all at once.


## Checking on it in production

- `zero_replica_sqlite_change_log_compare_result_total{outcome}` — per-transaction outcomes. `mismatch` is the finding. `inconclusive` means a purge or reseed moved the bounds mid-cycle and is deliberately not counted as divergence.
- `zero_replica_sqlite_change_log_compare_cycles_total{result}` — cycles and skip reasons. `cold-log` after a reseed is routine; persistent `log-unavailable` is not.
- `zero_replica_sqlite_change_log_compare_cycle_duration_seconds` — cycle cost on the serving process.
- A mismatch also logs one error line carrying **only the watermark** — payloads are customer data and are never logged. The watermark is enough to pull both stores' rows and diff them by hand.

No paging on divergence (standing decision): compare mode has no production impact, so mismatches are investigated via the dashboard at leisure.
