### PR TITLE
fix(zero-cache): exit on replication source termination

### DIFF
--- a/packages/zero-cache/src/services/change-source/change-source.ts
+++ b/packages/zero-cache/src/services/change-source/change-source.ts
@@ -8,6 +8,9 @@ import type {
 export type ChangeStream = {
   changes: Source<ChangeStreamMessage>;
 
+  /** Resolves if the upstream source fails independently of change consumption. */
+  sourceTerminated?: Promise<Error>;
+
   /**
    * A Sink to push the {@link StatusMessage}s that reflect Commits
    * that have been successfully stored by the {@link Storer}, or

--- a/packages/zero-cache/src/services/change-source/pg/change-source.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.ts
@@ -449,7 +449,7 @@ class PostgresChangeSource implements ChangeSource {
     backfillRequests: BackfillRequest[],
   ): Promise<ChangeStream> {
     const clientStart = majorVersionFromString(clientWatermark) + 1n;
-    const {messages, acks} = await subscribe(
+    const {messages, acks, sourceTerminated} = await subscribe(
       this.#lc,
       this.#db,
       slot,
@@ -589,6 +589,7 @@ class PostgresChangeSource implements ChangeSource {
     return {
       changes: changes.asSource(),
       acks: {push: status => acker.ack(status[2].watermark)},
+      sourceTerminated: sourceTerminated.then(translateError),
     };
   }
 

--- a/packages/zero-cache/src/services/change-source/pg/logical-replication/stream.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/logical-replication/stream.pg.test.ts
@@ -301,6 +301,24 @@ describe('pg/logic-replication', {timeout: 30000}, () => {
     }
   });
 
+  test('reports unexpected source termination', async () => {
+    const {messages, sourceTerminated} = await subscribe(
+      lc,
+      db,
+      SLOT,
+      ['foo_pub', 'my_pub'],
+      0n,
+    );
+
+    await db`
+      SELECT pg_terminate_backend(active_pid)
+        FROM pg_replication_slots
+        WHERE slot_name = ${SLOT}`;
+
+    await expect(sourceTerminated).resolves.toBeInstanceOf(Error);
+    messages.cancel();
+  });
+
   // This fails with:
   //
   // FAIL   zero-cache/pg-17  src/services/change-source/pg/logical-replication/stream.pg.test.ts > pg/logic-replication > session resumption from confirmed flushes

--- a/packages/zero-cache/src/services/change-source/pg/logical-replication/stream.ts
+++ b/packages/zero-cache/src/services/change-source/pg/logical-replication/stream.ts
@@ -4,6 +4,7 @@ import {
   PG_OBJECT_NOT_IN_PREREQUISITE_STATE,
 } from '@drdgvhbh/postgres-error-codes';
 import type {LogContext} from '@rocicorp/logger';
+import {resolver} from '@rocicorp/resolver';
 import {defu} from 'defu';
 import postgres, {type Options, type PostgresType} from 'postgres';
 import {sleep} from '../../../../../../shared/src/sleep.ts';
@@ -42,6 +43,7 @@ export async function subscribe(
 ): Promise<{
   messages: SourceWithPendingQueue<StreamMessage>;
   acks: Sink<bigint>;
+  sourceTerminated: Promise<Error>;
 }> {
   const session = postgres(
     defu(
@@ -135,6 +137,7 @@ export async function subscribe(
     : undefined;
 
   let destroyed = false;
+  const sourceTerminated = resolver<Error>();
   const typeParsers = await getTypeParsers(db, {returnJsonAsString: true});
   const parser = new PgoutputParser(typeParsers);
   const messages = Subscription.create<StreamMessage>({
@@ -146,20 +149,24 @@ export async function subscribe(
     },
   });
 
-  readable.once(
-    'close',
-    () =>
-      // Only log a warning if the stream was not manually closed.
-      destroyed || lc.warn?.(`replication stream closed by ${db.options.host}`),
-  );
-  readable.once(
-    'error',
-    e =>
-      // Don't log the shutdown signal. This is the expected way for upstream
-      // to close the connection (and will be logged downstream).
-      (e instanceof postgres.PostgresError && e.code === PG_ADMIN_SHUTDOWN) ||
-      lc.warn?.(`error from ${db.options.host}`, e),
-  );
+  readable.once('close', () => {
+    if (!destroyed) {
+      const error = new Error(
+        `replication stream closed by ${db.options.host}`,
+      );
+      sourceTerminated.resolve(error);
+      lc.warn?.(error.message);
+    }
+  });
+  readable.once('error', e => {
+    if (!destroyed) {
+      sourceTerminated.resolve(e);
+    }
+    // Don't log the shutdown signal. This is the expected way for upstream
+    // to close the connection (and will be logged downstream).
+    (e instanceof postgres.PostgresError && e.code === PG_ADMIN_SHUTDOWN) ||
+      lc.warn?.(`error from ${db.options.host}`, e);
+  });
 
   pipe({
     source: readable,
@@ -177,6 +184,7 @@ export async function subscribe(
   return {
     messages,
     acks: {push: sendAck},
+    sourceTerminated: sourceTerminated.promise,
   };
 }
 

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
@@ -17,6 +17,7 @@ import {DbFile} from '../../test/lite.ts';
 import type {PostgresDB} from '../../types/pg.ts';
 import type {Source} from '../../types/streams.ts';
 import {Subscription, type Result} from '../../types/subscription.ts';
+import {orTimeout} from '../../types/timeout.ts';
 import type {ChangeSource} from '../change-source/change-source.ts';
 import type {
   ChangeStreamData,
@@ -3296,6 +3297,95 @@ describe('change-streamer/service', () => {
     changes.fail(new Error('doh'));
 
     expect(await hasRetried).toBe(true);
+  });
+
+  test('exit when source terminates behind storer backpressure', async () => {
+    await streamer.stop();
+    await streamerDone;
+
+    const firstStreamStarted = resolver<void>();
+    const sourceTerminated = resolver<Error>();
+    const firstChanges = Subscription.create<ChangeStreamMessage>();
+    const source = {
+      startStream: vi.fn().mockImplementation(() => {
+        firstStreamStarted.resolve();
+        return Promise.resolve({
+          initialWatermark: '01',
+          changes: firstChanges,
+          acks: {push: () => {}},
+          sourceTerminated: sourceTerminated.promise,
+        });
+      }),
+      startLagReporter: () => null,
+      stop: () => {
+        firstChanges.cancel();
+        return Promise.resolve();
+      },
+    } satisfies ChangeSource;
+
+    const incidentStreamer = await initializeStreamer(
+      lc,
+      shard,
+      'task-id',
+      'change.streamer:12345',
+      'ws',
+      sql,
+      source,
+      ReplicationStatusPublisher.forTesting(),
+      replicaConfig,
+      null,
+      null,
+      true,
+      {
+        ...opts,
+        backPressureLimitHeapProportion: 0.00001,
+        statementTimeoutMs: 20_000,
+      },
+    );
+    const incidentDone = incidentStreamer.run();
+    await firstStreamStarted.promise;
+
+    const lockAcquired = resolver<void>();
+    const releaseLock = resolver<void>();
+    const lockDone = sql.begin(async tx => {
+      await tx`SELECT owner FROM "zoro_3/cdc"."replicationState" FOR UPDATE`;
+      lockAcquired.resolve();
+      await releaseLock.promise;
+    });
+    void lockDone.catch(lockAcquired.reject);
+    await lockAcquired.promise;
+
+    firstChanges.push(['begin', messages.begin(), {commitWatermark: '05'}]);
+    firstChanges.push(['commit', messages.commit(), {watermark: '05'}]);
+    const nextBegin = firstChanges.push([
+      'begin',
+      messages.begin(),
+      {commitWatermark: '06'},
+    ]);
+
+    const nextBeginResult = await orTimeout(nextBegin.result, 300);
+    const blockedChange = firstChanges.push([
+      'data',
+      messages.insert('foo', {id: 'blocked', value: 'a'.repeat(1024 ** 2)}),
+    ]);
+    const backpressureResult = await orTimeout(blockedChange.result, 50);
+
+    const sourceError = new Error('source terminated');
+    sourceTerminated.resolve(sourceError);
+    const exitResult = await orTimeout(
+      incidentDone.catch(error => error),
+      300,
+    );
+    const stopResult = await orTimeout(incidentStreamer.stop(), 200);
+
+    releaseLock.resolve();
+    await lockDone;
+    await incidentDone.catch(() => {});
+
+    expect(nextBeginResult).toBe('consumed');
+    expect(backpressureResult).toBe('timed-out');
+    expect(exitResult).toBe(sourceError);
+    expect(stopResult).toBeUndefined();
   });
 
   test('retry on unexpected storage error', async () => {

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -14,6 +14,7 @@ import type {PostgresDB} from '../../types/pg.ts';
 import type {ShardID} from '../../types/shards.ts';
 import type {Source} from '../../types/streams.ts';
 import {Subscription} from '../../types/subscription.ts';
+import {orTimeout} from '../../types/timeout.ts';
 import type {
   ChangeSource,
   ChangeStream,
@@ -412,6 +413,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
   #pgPurgeRunning = false;
   #sqlitePurgeScheduled = false;
   #sqlitePurgeRunning = false;
+  #fatalSourceError: Error | undefined;
   #stream: ChangeStream | undefined;
   #sqliteCatchup: SQLiteChangeLogCatchup | undefined;
   #changeLogUnavailableSince: number | undefined;
@@ -596,6 +598,20 @@ class ChangeStreamerImpl implements ChangeStreamerService {
           lastWatermark,
           backfillRequests,
         );
+        const waitForFlowControl = async (wait: Promise<void>) => {
+          if (!stream.sourceTerminated) {
+            await wait;
+            return;
+          }
+          const sourceError = await Promise.race([
+            wait.then(() => undefined),
+            stream.sourceTerminated,
+          ]);
+          if (sourceError) {
+            this.#fatalSourceError = sourceError;
+            throw sourceError;
+          }
+        };
         this.#storer.run().catch(e => stream.changes.cancel(e));
 
         this.#stream = stream;
@@ -693,7 +709,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
             // control promise. Record the boundary before awaiting that promise
             // so registrations during the wait observe the forwarded state.
             this.#recordForwardedTransactionBoundary(type, entry[0]);
-            await forwarded;
+            await waitForFlowControl(forwarded);
             unflushedBytes = 0;
           }
 
@@ -704,7 +720,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
           // Allow the storer to exert back pressure.
           const readyForMore = this.#storer.readyForMore();
           if (readyForMore) {
-            await readyForMore;
+            await waitForFlowControl(readyForMore);
           }
         }
       } catch (e) {
@@ -712,6 +728,12 @@ class ChangeStreamerImpl implements ChangeStreamerService {
       } finally {
         this.#stream?.changes.cancel();
         this.#stream = undefined;
+      }
+
+      if (this.#fatalSourceError && err === this.#fatalSourceError) {
+        // A blocked flow-control wait may not drain; restart from durable state.
+        this.#forwarder.stopProgressMonitor();
+        throw err;
       }
 
       // When the change stream is interrupted, abort any pending transaction.
@@ -1047,6 +1069,15 @@ class ChangeStreamerImpl implements ChangeStreamerService {
     this.#purgeScheduler?.stop();
     this.#sqliteCatchup?.close();
     this.#changeLogWriter?.close();
+    if (this.#fatalSourceError) {
+      // Cleanup is best-effort before intentional process replacement. A
+      // wedged Storer may be unable to stop without the process exiting.
+      await orTimeout(
+        Promise.allSettled([this.#storer.stop(), this.#source.stop()]),
+        100,
+      );
+      return;
+    }
     await this.#storer.stop();
     await this.#source.stop();
   }


### PR DESCRIPTION
### What

Prevent Zero replication from remaining permanently wedged when the PostgreSQL logical replication connection terminates while the change-streamer is blocked by flow control.

The PostgreSQL change source now reports termination independently of change consumption. If termination occurs while waiting on Storer or subscriber backpressure, the change-streamer exits so its worker can be replaced and replication can resume from durable state.

### Why

During the incident, the Storer began applying backpressure and the change-streamer stopped requesting messages from the logical replication stream. After two missed PostgreSQL keepalive windows, the existing watchdog correctly destroyed the unresponsive replication connection.

However, the change-streamer was blocked in `readyForMore()` and could not observe the stream failure through normal iteration. It therefore never entered its reconnect path. Replication remained wedged for roughly 12 hours despite the watchdog firing after two minutes.

Normal in-process recovery is not reliable in this state because stopping the Storer may itself be queued behind the operation that is no longer making progress. Exiting the worker allows process replacement to force-abort that state and resume from the durable watermark.

This patch addresses the missing cancellation edge. It does not change watchdog behavior or attempt to diagnose the underlying reason the Storer stopped making progress.

### Changes

- Report unexpected PostgreSQL replication readable errors and closures through `sourceTerminated`.
- Exclude intentional local stream cancellation from fatal termination handling.
- Race source termination against both Storer and subscriber flow-control waits.
- Exit the change-streamer worker when termination interrupts a blocked flow-control wait.
- Bound cleanup before process replacement to 100ms and tolerate cleanup rejections.
- Add coverage for real PostgreSQL source termination and the incident’s Storer-backpressure failure mode.