### PR TITLE
fix(zero-client): fix out of order mutations

### DIFF
--- a/packages/zero-client/src/client/zero.test.ts
+++ b/packages/zero-client/src/client/zero.test.ts
@@ -1749,116 +1749,125 @@ test('pusher sends one mutation per push message', async () => {
   ]);
 });
 
-test('pusher does not skip mutations when the pending list is reordered', async () => {
-  // The pending list is the client group's local commit chain, so it
-  // interleaves mutations from every client (tab) in the group. `persist`
-  // rebases this client's unpersisted mutations onto the current perdag head
-  // and `refresh` then rebuilds memdag as `perdagChain ++ ownUnpersisted`, so
-  // another client's mutation can move *ahead* of a mutation we already sent.
-  // We must still send it, and we must never send a gap in a client's mutation
-  // ID sequence (the server rejects that with an out of order mutation error).
-  const z = zeroForTest();
-  await z.triggerConnected();
-
-  const mockSocket = await z.socket;
-  const clientGroupID = await z.clientGroupID;
-
-  const mut = (clientID: string, id: number): Mutation => ({
-    type: MutationType.Custom,
-    clientID,
-    id,
-    name: 'mut1',
-    args: [{}],
-    timestamp: id,
-  });
-
-  const push = async (mutations: Mutation[]) => {
-    mockSocket.messages.length = 0;
-    await z.pusher(
-      {
-        profileID: 'p1',
-        clientGroupID,
-        pushVersion: 1,
-        schemaVersion: '1',
-        mutations,
-      },
-      'test-request-id',
-    );
-    return mockSocket.messages.map(raw => {
-      const [, {mutations}] = valita.parse(JSON.parse(raw), pushMessageSchema);
-      return `${mutations[0].clientID}:${mutations[0].id}`;
-    });
-  };
-
-  expect(await push([mut('c2', 1), mut('c1', 1)])).toEqual(['c2:1', 'c1:1']);
-
-  // c2:2 lands *before* c1:1, the last mutation we sent.
-  expect(await push([mut('c2', 1), mut('c2', 2), mut('c1', 1)])).toEqual([
-    'c2:2',
-  ]);
-
-  // c2:3 must not be sent without c2:2 having been sent first.
-  expect(
-    await push([mut('c2', 1), mut('c2', 2), mut('c1', 1), mut('c2', 3)]),
-  ).toEqual(['c2:3']);
+const pushMutation = (clientID: string, id: number): Mutation => ({
+  type: MutationType.Custom,
+  clientID,
+  id,
+  name: 'mut1',
+  args: [{}],
+  timestamp: id,
 });
 
-test('pusher sends the pending mutations of a closed client', async () => {
-  // Mutation recovery skips our own client group, so when another tab in the
-  // group goes away its pending mutations are only ever sent by a surviving
-  // tab, as part of that tab's ordinary push of the client group's chain. Those
-  // mutations sit *before* our own unpersisted ones in the chain, so they must
-  // not be filtered out by what we have already sent for ourselves.
+// Pushes the given mutations as if they were the client group's pending
+// mutations and returns what actually went out on the socket, as
+// "clientID:mutationID" strings.
+const pushAndReadSocket = async (
+  z: TestZero<Schema>,
+  mutations: Mutation[],
+) => {
+  const mockSocket = await z.socket;
+  mockSocket.messages.length = 0;
+  await z.pusher(
+    {
+      profileID: 'p1',
+      clientGroupID: await z.clientGroupID,
+      pushVersion: 1,
+      schemaVersion: '1',
+      mutations,
+    },
+    'test-request-id',
+  );
+  return mockSocket.messages.map(raw => {
+    const [, {mutations}] = valita.parse(JSON.parse(raw), pushMessageSchema);
+    return `${mutations[0].clientID}:${mutations[0].id}`;
+  });
+};
+
+test('pusher does not skip mutations when the pending list is reordered', async () => {
+  // A client pushes the whole client group's commit chain, so the mutations it
+  // sends include ones made by the other tabs in the group. The order of that
+  // chain changes from one push to the next: when this tab persists its own
+  // mutations they move to the end of the chain, behind whatever the other tabs
+  // persisted in the meantime. So a mutation from another tab can show up in
+  // front of one we already sent. We still have to send it, and we must never
+  // leave a hole in a client's run of mutation IDs, because the server rejects
+  // a hole as an invalid push.
   const z = zeroForTest();
   await z.triggerConnected();
 
-  const clientGroupID = await z.clientGroupID;
+  // Our own mutations are the ones that get moved to the end of the chain, so
+  // use this client's real ID for them.
+  const self = z.clientID;
+  const other = 'other-tab';
+  const push = (mutations: Mutation[]) => pushAndReadSocket(z, mutations);
 
-  const mut = (clientID: string, id: number): Mutation => ({
-    type: MutationType.Custom,
-    clientID,
-    id,
-    name: 'mut1',
-    args: [{}],
-    timestamp: id,
-  });
+  expect(await push([pushMutation(other, 1), pushMutation(self, 1)])).toEqual([
+    `${other}:1`,
+    `${self}:1`,
+  ]);
 
-  const push = async (mutations: Mutation[]) => {
-    const mockSocket = await z.socket;
-    mockSocket.messages.length = 0;
-    await z.pusher(
-      {
-        profileID: 'p1',
-        clientGroupID,
-        pushVersion: 1,
-        schemaVersion: '1',
-        mutations,
-      },
-      'test-request-id',
-    );
-    return mockSocket.messages.map(raw => {
-      const [, {mutations}] = valita.parse(JSON.parse(raw), pushMessageSchema);
-      return `${mutations[0].clientID}:${mutations[0].id}`;
-    });
-  };
-
-  expect(await push([mut('a', 1), mut('b', 1)])).toEqual(['a:1', 'b:1']);
-
-  // Tab a closed with a:2 and a:3 persisted but unsent. We are the only client
-  // left that can push them.
+  // The other tab's second mutation now sits in front of our own, which was the
+  // last mutation we sent.
   expect(
-    await push([mut('a', 1), mut('a', 2), mut('a', 3), mut('b', 1)]),
-  ).toEqual(['a:2', 'a:3']);
+    await push([
+      pushMutation(other, 1),
+      pushMutation(other, 2),
+      pushMutation(self, 1),
+    ]),
+  ).toEqual([`${other}:2`]);
 
-  // After a reconnect the server has forgotten what it saw on the old socket,
-  // so everything still pending is sent again.
+  // The other tab's third mutation must not go out unless its second one
+  // already did.
+  expect(
+    await push([
+      pushMutation(other, 1),
+      pushMutation(other, 2),
+      pushMutation(self, 1),
+      pushMutation(other, 3),
+    ]),
+  ).toEqual([`${other}:3`]);
+});
+
+test('pusher resends every pending mutation after a reconnect', async () => {
+  // We track what we have sent per connection. On a new connection we don't
+  // know how much of what we sent on the old socket actually got there, so we
+  // send everything still pending again and let the server ignore the ones it
+  // has already applied.
+  const z = zeroForTest();
+  await z.triggerConnected();
+
+  const self = z.clientID;
+  const other = 'other-tab';
+  const push = (mutations: Mutation[]) => pushAndReadSocket(z, mutations);
+
+  expect(await push([pushMutation(other, 1), pushMutation(self, 1)])).toEqual([
+    `${other}:1`,
+    `${self}:1`,
+  ]);
+
+  // Still on the same connection, so only the mutations we haven't sent go out.
+  expect(
+    await push([
+      pushMutation(other, 1),
+      pushMutation(other, 2),
+      pushMutation(other, 3),
+      pushMutation(self, 1),
+    ]),
+  ).toEqual([`${other}:2`, `${other}:3`]);
+
   await z.triggerClose();
   await z.waitForConnectionStatus(ConnectionStatus.Connecting);
   await vi.advanceTimersByTimeAsync(RUN_LOOP_INTERVAL_MS);
   await z.triggerConnected();
+
   expect(
-    await push([mut('a', 1), mut('a', 2), mut('a', 3), mut('b', 1)]),
-  ).toEqual(['a:1', 'a:2', 'a:3', 'b:1']);
+    await push([
+      pushMutation(other, 1),
+      pushMutation(other, 2),
+      pushMutation(other, 3),
+      pushMutation(self, 1),
+    ]),
+  ).toEqual([`${other}:1`, `${other}:2`, `${other}:3`, `${self}:1`]);
 });
 
 test('pusher maps CRUD mutation names', async () => {

--- a/packages/zero-client/src/client/zero.test.ts
+++ b/packages/zero-client/src/client/zero.test.ts
@@ -1803,6 +1803,64 @@ test('pusher does not skip mutations when the pending list is reordered', async 
   ).toEqual(['c2:3']);
 });
 
+test('pusher sends the pending mutations of a closed client', async () => {
+  // Mutation recovery skips our own client group, so when another tab in the
+  // group goes away its pending mutations are only ever sent by a surviving
+  // tab, as part of that tab's ordinary push of the client group's chain. Those
+  // mutations sit *before* our own unpersisted ones in the chain, so they must
+  // not be filtered out by what we have already sent for ourselves.
+  const z = zeroForTest();
+  await z.triggerConnected();
+
+  const clientGroupID = await z.clientGroupID;
+
+  const mut = (clientID: string, id: number): Mutation => ({
+    type: MutationType.Custom,
+    clientID,
+    id,
+    name: 'mut1',
+    args: [{}],
+    timestamp: id,
+  });
+
+  const push = async (mutations: Mutation[]) => {
+    const mockSocket = await z.socket;
+    mockSocket.messages.length = 0;
+    await z.pusher(
+      {
+        profileID: 'p1',
+        clientGroupID,
+        pushVersion: 1,
+        schemaVersion: '1',
+        mutations,
+      },
+      'test-request-id',
+    );
+    return mockSocket.messages.map(raw => {
+      const [, {mutations}] = valita.parse(JSON.parse(raw), pushMessageSchema);
+      return `${mutations[0].clientID}:${mutations[0].id}`;
+    });
+  };
+
+  expect(await push([mut('a', 1), mut('b', 1)])).toEqual(['a:1', 'b:1']);
+
+  // Tab a closed with a:2 and a:3 persisted but unsent. We are the only client
+  // left that can push them.
+  expect(
+    await push([mut('a', 1), mut('a', 2), mut('a', 3), mut('b', 1)]),
+  ).toEqual(['a:2', 'a:3']);
+
+  // After a reconnect the server has forgotten what it saw on the old socket,
+  // so everything still pending is sent again.
+  await z.triggerClose();
+  await z.waitForConnectionStatus(ConnectionStatus.Connecting);
+  await vi.advanceTimersByTimeAsync(RUN_LOOP_INTERVAL_MS);
+  await z.triggerConnected();
+  expect(
+    await push([mut('a', 1), mut('a', 2), mut('a', 3), mut('b', 1)]),
+  ).toEqual(['a:1', 'a:2', 'a:3', 'b:1']);
+});
+
 test('pusher maps CRUD mutation names', async () => {
   const t = async (
     pushes: {

--- a/packages/zero-client/src/client/zero.test.ts
+++ b/packages/zero-client/src/client/zero.test.ts
@@ -1749,6 +1749,60 @@ test('pusher sends one mutation per push message', async () => {
   ]);
 });
 
+test('pusher does not skip mutations when the pending list is reordered', async () => {
+  // The pending list is the client group's local commit chain, so it
+  // interleaves mutations from every client (tab) in the group. `persist`
+  // rebases this client's unpersisted mutations onto the current perdag head
+  // and `refresh` then rebuilds memdag as `perdagChain ++ ownUnpersisted`, so
+  // another client's mutation can move *ahead* of a mutation we already sent.
+  // We must still send it, and we must never send a gap in a client's mutation
+  // ID sequence (the server rejects that with an out of order mutation error).
+  const z = zeroForTest();
+  await z.triggerConnected();
+
+  const mockSocket = await z.socket;
+  const clientGroupID = await z.clientGroupID;
+
+  const mut = (clientID: string, id: number): Mutation => ({
+    type: MutationType.Custom,
+    clientID,
+    id,
+    name: 'mut1',
+    args: [{}],
+    timestamp: id,
+  });
+
+  const push = async (mutations: Mutation[]) => {
+    mockSocket.messages.length = 0;
+    await z.pusher(
+      {
+        profileID: 'p1',
+        clientGroupID,
+        pushVersion: 1,
+        schemaVersion: '1',
+        mutations,
+      },
+      'test-request-id',
+    );
+    return mockSocket.messages.map(raw => {
+      const [, {mutations}] = valita.parse(JSON.parse(raw), pushMessageSchema);
+      return `${mutations[0].clientID}:${mutations[0].id}`;
+    });
+  };
+
+  expect(await push([mut('c2', 1), mut('c1', 1)])).toEqual(['c2:1', 'c1:1']);
+
+  // c2:2 lands *before* c1:1, the last mutation we sent.
+  expect(await push([mut('c2', 1), mut('c2', 2), mut('c1', 1)])).toEqual([
+    'c2:2',
+  ]);
+
+  // c2:3 must not be sent without c2:2 having been sent first.
+  expect(
+    await push([mut('c2', 1), mut('c2', 2), mut('c1', 1), mut('c2', 3)]),
+  ).toEqual(['c2:3']);
+});
+
 test('pusher maps CRUD mutation names', async () => {
   const t = async (
     pushes: {

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -269,8 +269,6 @@ export const CONNECT_TIMEOUT_MS = 10_000;
 
 const CHECK_CONNECTIVITY_ON_ERROR_FREQUENCY = 6;
 
-const NULL_LAST_MUTATION_ID_SENT = {clientID: '', id: -1} as const;
-
 const DEFAULT_QUERY_CHANGE_THROTTLE_MS = 10;
 
 export const LOGGED_OUT_STORAGE_USER_ID = '__anonymous__';
@@ -383,8 +381,25 @@ export class Zero<
    */
   #deletedClients: DeleteClientsBody | undefined;
 
-  #lastMutationIDSent: {clientID: string; id: number} =
-    NULL_LAST_MUTATION_ID_SENT;
+  /**
+   * The highest mutation ID we have sent over the current connection, per
+   * client.
+   *
+   * The pending mutations we push come from the client group's local commit
+   * chain, so they interleave mutations from every client (tab) in the group,
+   * and the *cross-client* order of that chain is not stable between pushes:
+   * `persist` rebases this client's unpersisted mutations onto the current
+   * perdag head, and `refresh` then rebuilds memdag as
+   * `perdagChain ++ ownUnpersistedMutations`. So another client's mutation can
+   * move ahead of a mutation we have already sent. Tracking what was sent per
+   * client (rather than a single position in the chain) keeps the decision
+   * independent of that ordering, so we never skip a mutation and never send a
+   * gap in a client's mutation ID sequence.
+   *
+   * Cleared whenever the connection is (re)established or torn down, since the
+   * server forgets what it has seen on a socket.
+   */
+  readonly #lastMutationIDsSent: Map<ClientID, number> = new Map();
 
   #onPong: () => void = () => undefined;
 
@@ -1496,7 +1511,7 @@ export class Zero<
     // We really don't want to disconnect and reconnect a rate limited user as
     // it'll use more resources on the server
     if (kind === ErrorKind.MutationRateLimited) {
-      this.#lastMutationIDSent = NULL_LAST_MUTATION_ID_SENT;
+      this.#lastMutationIDsSent.clear();
       lc.error?.(kind, 'Mutation rate limited', {message});
       return;
     }
@@ -1590,7 +1605,7 @@ export class Zero<
       connectedCount: this.#connectedCount,
       proceedingConnectErrorCount,
     });
-    this.#lastMutationIDSent = NULL_LAST_MUTATION_ID_SENT;
+    this.#lastMutationIDsSent.clear();
 
     lc.debug?.('Resolving connect resolver');
     must(this.#socket);
@@ -1850,7 +1865,7 @@ export class Zero<
     this.#socket?.removeEventListener('close', this.#onClose);
     this.#socket?.close(closeCode);
     this.#socket = undefined;
-    this.#lastMutationIDSent = NULL_LAST_MUTATION_ID_SENT;
+    this.#lastMutationIDsSent.clear();
     this.#pokeHandler.handleDisconnect();
     this.#queryManager.clearGotQueriesAuthoritative();
 
@@ -1955,23 +1970,22 @@ export class Zero<
 
     const isMutationRecoveryPush =
       req.clientGroupID !== (await this.clientGroupID);
-    const start = isMutationRecoveryPush
-      ? 0
-      : req.mutations.findIndex(
-          m =>
-            m.clientID === this.#lastMutationIDSent.clientID &&
-            m.id === this.#lastMutationIDSent.id,
-        ) + 1;
+    // A recovery push is for a different client group, so nothing has been sent
+    // for it on this connection.
+    const toSend = isMutationRecoveryPush
+      ? req.mutations
+      : req.mutations.filter(
+          m => m.id > (this.#lastMutationIDsSent.get(m.clientID) ?? 0),
+        );
     lc.debug?.(
       isMutationRecoveryPush ? 'pushing for recovery' : 'pushing',
-      req.mutations.length - start,
+      toSend.length,
       'mutations of',
       req.mutations.length,
       'mutations.',
     );
     const now = Date.now();
-    for (let i = start; i < req.mutations.length; i++) {
-      const m = req.mutations[i];
+    for (const m of toSend) {
       const timestamp = now - Math.round(performance.now() - m.timestamp);
       const zeroM =
         m.name === CRUD_MUTATION_NAME
@@ -2004,7 +2018,7 @@ export class Zero<
       ];
       this.#send(msg);
       if (!isMutationRecoveryPush) {
-        this.#lastMutationIDSent = {clientID: m.clientID, id: m.id};
+        this.#lastMutationIDsSent.set(m.clientID, m.id);
       }
     }
     return {

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -382,22 +382,27 @@ export class Zero<
   #deletedClients: DeleteClientsBody | undefined;
 
   /**
-   * The highest mutation ID we have sent over the current connection, per
-   * client.
+   * The highest mutation ID we have sent on the current connection, for each
+   * client in our client group.
    *
-   * The pending mutations we push come from the client group's local commit
-   * chain, so they interleave mutations from every client (tab) in the group,
-   * and the *cross-client* order of that chain is not stable between pushes:
-   * `persist` rebases this client's unpersisted mutations onto the current
-   * perdag head, and `refresh` then rebuilds memdag as
-   * `perdagChain ++ ownUnpersistedMutations`. So another client's mutation can
-   * move ahead of a mutation we have already sent. Tracking what was sent per
-   * client (rather than a single position in the chain) keeps the decision
-   * independent of that ordering, so we never skip a mutation and never send a
-   * gap in a client's mutation ID sequence.
+   * The mutations we push are the client group's local commit chain, so they
+   * include mutations made by every tab in the group, not just this one. The
+   * order of that chain changes from one push to the next: when we persist our
+   * own mutations they move to the end of the chain, behind whatever the other
+   * tabs persisted in the meantime. So a mutation from another tab can end up
+   * in front of one we already sent, which means we cannot decide what to send
+   * next by remembering a single position in the chain. Remembering the last ID
+   * we sent for each client works no matter how the chain is ordered: we never
+   * skip a mutation, and we never leave a hole in a client's run of mutation
+   * IDs (the server rejects a hole as an invalid push).
    *
-   * Cleared whenever the connection is (re)established or torn down, since the
-   * server forgets what it has seen on a socket.
+   * Cleared whenever the connection is established or torn down. The server
+   * does remember what it has processed, in a last mutation ID per client, and
+   * it ignores anything it has already applied. But we don't know which of our
+   * sends actually made it across before the socket died, so we start over and
+   * let the server drop the duplicates. The only mutations we don't resend are
+   * the ones the server has acknowledged in a poke, because those have already
+   * been rebased out of the commit chain.
    */
   readonly #lastMutationIDsSent: Map<ClientID, number> = new Map();
 


### PR DESCRIPTION
see user report: https://rocicorp.slack.com/archives/C0AQDEA9N10/p1786539945269819

tldr:

Tabs sending mutations for other tabs would end up skipping mutations, causing mutations to arrive out of order.

The fix is to pull all mutations out of the array that we have not sent rather than indexing into the array. Indexing into the array doesn't work because the tab always puts its own mutations last.