### PR TITLE
fix(zero-cache): make sqlite corruption checks opt-in

### DIFF
--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -476,6 +476,15 @@ export const zeroOptions = {
     ],
   },
 
+  sqliteCorruptionChecks: {
+    type: v.boolean().default(false),
+    desc: [
+      `Run SQLite quick_check and integrity_check when corruption is detected.`,
+      `These checks scan the replica and can take a long time on large databases.`,
+    ],
+    hidden: true,
+  },
+
   enableQueryPlanner: {
     type: v.boolean().default(true),
     desc: [

--- a/packages/zero-cache/src/db/sqlite-corruption.test.ts
+++ b/packages/zero-cache/src/db/sqlite-corruption.test.ts
@@ -94,6 +94,7 @@ describe('sqlite-corruption', () => {
       Object.assign(new Error('database disk image is malformed'), {
         code: 'SQLITE_CORRUPT',
       }),
+      true,
     );
 
     const serializedLogs = JSON.stringify(sink.messages);
@@ -103,6 +104,24 @@ describe('sqlite-corruption', () => {
     expect(serializedLogs).toContain('"status":"ok"');
     expect(serializedLogs).toContain('"watermark":"01"');
     expect(serializedLogs).not.toContain('do-not-log');
+  });
+
+  test('skips full checks by default', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'sqlite-corruption-test-'));
+    const dbPath = join(dir, 'replica.db');
+    new Database(createSilentLogContext(), dbPath).close();
+    const sink = new TestLogSink();
+
+    logSQLiteCorruptionDiagnostics(
+      new LogContext('debug', undefined, sink),
+      'test-replica',
+      dbPath,
+      new Error('database disk image is malformed'),
+    );
+
+    const serializedLogs = JSON.stringify(sink.messages);
+    expect(serializedLogs).not.toContain('quick-check');
+    expect(serializedLogs).not.toContain('integrity-check');
   });
 
   test('logs file stats when readonly open fails', () => {

--- a/packages/zero-cache/src/db/sqlite-corruption.ts
+++ b/packages/zero-cache/src/db/sqlite-corruption.ts
@@ -40,8 +40,14 @@ type DiagnosticTarget = {
   readonly dbPath: string;
 };
 
-const diagnosticTargets = new Map<number, DiagnosticTarget>();
+type RegisteredDiagnosticTarget = DiagnosticTarget & {
+  readonly corruptionChecks: SQLiteCorruptionChecks;
+};
+
+const diagnosticTargets = new Map<number, RegisteredDiagnosticTarget>();
 let nextDiagnosticTargetID = 0;
+
+export type SQLiteCorruptionChecks = boolean;
 
 export function isSQLiteCorruption(e: unknown): boolean {
   return getSQLiteCorruptionCode(e) !== undefined;
@@ -49,9 +55,10 @@ export function isSQLiteCorruption(e: unknown): boolean {
 
 export function registerSQLiteCorruptionDiagnosticTarget(
   target: DiagnosticTarget,
+  corruptionChecks: SQLiteCorruptionChecks = false,
 ): () => void {
   const id = nextDiagnosticTargetID++;
-  diagnosticTargets.set(id, target);
+  diagnosticTargets.set(id, {...target, corruptionChecks});
   return () => diagnosticTargets.delete(id);
 }
 
@@ -62,8 +69,18 @@ export function logLastChanceSQLiteCorruptionDiagnostics(
   if (!isSQLiteCorruption(cause) || diagnosticTargets.size === 0) {
     return false;
   }
-  for (const {debugName, dbPath} of diagnosticTargets.values()) {
-    logSQLiteCorruptionDiagnostics(lc, debugName, dbPath, cause);
+  for (const {
+    debugName,
+    dbPath,
+    corruptionChecks,
+  } of diagnosticTargets.values()) {
+    logSQLiteCorruptionDiagnostics(
+      lc,
+      debugName,
+      dbPath,
+      cause,
+      corruptionChecks,
+    );
   }
   return true;
 }
@@ -73,6 +90,7 @@ export function logSQLiteCorruptionDiagnostics(
   debugName: string,
   dbPath: string,
   cause: unknown,
+  corruptionChecks: SQLiteCorruptionChecks = false,
 ): void {
   const start = Date.now();
   lc.error?.('SQLite replica corruption detected', {
@@ -106,12 +124,14 @@ export function logSQLiteCorruptionDiagnostics(
     logDiagnostic(lc, debugName, 'replica-metadata', () => ({
       metadata: getReplicaMetadata(db),
     }));
-    logDiagnostic(lc, debugName, 'quick-check', () => ({
-      check: runCheck(db, 'quick_check'),
-    }));
-    logDiagnostic(lc, debugName, 'integrity-check', () => ({
-      check: runCheck(db, 'integrity_check'),
-    }));
+    if (corruptionChecks) {
+      logDiagnostic(lc, debugName, 'quick-check', () => ({
+        check: runCheck(db, 'quick_check'),
+      }));
+      logDiagnostic(lc, debugName, 'integrity-check', () => ({
+        check: runCheck(db, 'integrity_check'),
+      }));
+    }
     lc.error?.('SQLite corruption diagnostics completed', {
       debugName,
       dbPath,

--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -80,6 +80,7 @@ export default async function runWorker(
     replica,
     initialSync,
     keepaliveTimeoutMs,
+    sqliteCorruptionChecks,
   } = config;
 
   startOtelAuto(
@@ -88,10 +89,13 @@ export default async function runWorker(
     0,
   );
   lc = createLogContext(config, 'change-streamer');
-  registerSQLiteCorruptionDiagnosticTarget({
-    debugName: 'change-streamer replica',
-    dbPath: replica.file,
-  });
+  registerSQLiteCorruptionDiagnosticTarget(
+    {
+      debugName: 'change-streamer replica',
+      dbPath: replica.file,
+    },
+    sqliteCorruptionChecks,
+  );
   initEventSink(lc, config);
 
   // Kick off DB connection warmup in the background.
@@ -128,10 +132,13 @@ export default async function runWorker(
     sqliteChangeLogMode === 'compare' || sqliteChangeLogMode === 'serve';
   if (sqliteChangeLogEnabled) {
     const changeLogFile = changeLogFileName(replica.file);
-    registerSQLiteCorruptionDiagnosticTarget({
-      debugName: 'change-streamer change-log',
-      dbPath: changeLogFile,
-    });
+    registerSQLiteCorruptionDiagnosticTarget(
+      {
+        debugName: 'change-streamer change-log',
+        dbPath: changeLogFile,
+      },
+      sqliteCorruptionChecks,
+    );
     // The log's bytes are accounted for in the process that writes them. This
     // is local disk only — the log is excluded from the litestream backup — and
     // it is a whole-database total, because a table that left the replica left

--- a/packages/zero-cache/src/server/logging.test.ts
+++ b/packages/zero-cache/src/server/logging.test.ts
@@ -20,10 +20,13 @@ describe('server/logging', () => {
     const dbPath = createSQLiteDB();
     const sink = new TestLogSink();
     const lc = new LogContext('debug', undefined, sink);
-    const unregister = registerSQLiteCorruptionDiagnosticTarget({
-      debugName: 'test-replica',
-      dbPath,
-    });
+    const unregister = registerSQLiteCorruptionDiagnosticTarget(
+      {
+        debugName: 'test-replica',
+        dbPath,
+      },
+      true,
+    );
 
     try {
       await logUncaughtException(

--- a/packages/zero-cache/src/server/main.ts
+++ b/packages/zero-cache/src/server/main.ts
@@ -55,10 +55,13 @@ export default async function runWorker(
     0,
   );
   lc = createLogContext(config, 'dispatcher');
-  registerSQLiteCorruptionDiagnosticTarget({
-    debugName: 'dispatcher replica',
-    dbPath: config.replica.file,
-  });
+  registerSQLiteCorruptionDiagnosticTarget(
+    {
+      debugName: 'dispatcher replica',
+      dbPath: config.replica.file,
+    },
+    config.sqliteCorruptionChecks,
+  );
   initEventSink(lc, config);
 
   const processes = new ProcessManager(lc, parent);

--- a/packages/zero-cache/src/server/replicator.ts
+++ b/packages/zero-cache/src/server/replicator.ts
@@ -69,10 +69,13 @@ export default async function runWorker(
   startOtelAuto(createLogContext(config, workerName, 0, false), workerName, 0);
   lc = createLogContext(config, workerName);
   const unregisterInitialCorruptionDiagnosticTarget =
-    registerSQLiteCorruptionDiagnosticTarget({
-      debugName: `${workerName} replica`,
-      dbPath: config.replica.file,
-    });
+    registerSQLiteCorruptionDiagnosticTarget(
+      {
+        debugName: `${workerName} replica`,
+        dbPath: config.replica.file,
+      },
+      config.sqliteCorruptionChecks,
+    );
   initEventSink(lc, config);
 
   if (
@@ -88,10 +91,13 @@ export default async function runWorker(
     config.replica,
   );
   unregisterInitialCorruptionDiagnosticTarget();
-  registerSQLiteCorruptionDiagnosticTarget({
-    debugName: `${workerName} replica`,
-    dbPath,
-  });
+  registerSQLiteCorruptionDiagnosticTarget(
+    {
+      debugName: `${workerName} replica`,
+      dbPath,
+    },
+    config.sqliteCorruptionChecks,
+  );
 
   // A file left behind by a run with the writer enabled would otherwise hold
   // local disk indefinitely. See `replicatorDeletesStaleChangeLog` for why

--- a/packages/zero-cache/src/server/syncer.ts
+++ b/packages/zero-cache/src/server/syncer.ts
@@ -92,10 +92,13 @@ export default async function runWorker(
   const {cvr, upstream, enableCrudMutations} = config;
 
   const replicaFile = replicaFileName(config.replica.file, fileMode);
-  registerSQLiteCorruptionDiagnosticTarget({
-    debugName: 'syncer replica',
-    dbPath: replicaFile,
-  });
+  registerSQLiteCorruptionDiagnosticTarget(
+    {
+      debugName: 'syncer replica',
+      dbPath: replicaFile,
+    },
+    config.sqliteCorruptionChecks,
+  );
   lc.debug?.(`running view-syncer on ${replicaFile}`);
 
   const cvrDB = await connectPgClient(lc, cvr.db, `sync-worker-${pid}-cvr`, {


### PR DESCRIPTION
### What

Make full SQLite corruption scans opt-in while preserving the lightweight diagnostics emitted when replica corruption is detected.

### Why

`PRAGMA quick_check` and `PRAGMA integrity_check` scan the replica synchronously and can block shutdown for a long time on large databases. A production incident involving a 179 GB replica spent approximately 38 minutes in corruption diagnostics before propagating the failure.

Cheap context such as file stats, SQLite pragmas, and replica metadata remains useful and should continue to be collected by default.

### Changes

- Add the hidden `ZERO_SQLITE_CORRUPTION_CHECKS` option, defaulting to `false`.
- Skip `quick_check` and `integrity_check` unless the option is enabled.
- Propagate the option to fatal last-chance diagnostic targets.
- Leave recoverable restore, migration, change-log, and write-worker diagnostics lightweight.
- Cover both default-skipped and explicitly enabled full checks.