### PR TITLE
chore(zero-cache): delete a corrupted db before exiting

### DIFF
--- a/packages/zero-cache/src/services/replicator/write-worker.ts
+++ b/packages/zero-cache/src/services/replicator/write-worker.ts
@@ -3,6 +3,7 @@ import type {LogContext} from '@rocicorp/logger';
 import type {LogConfig} from '../../../../shared/src/logging.ts';
 import {must} from '../../../../shared/src/must.ts';
 import {Database} from '../../../../zqlite/src/db.ts';
+import {deleteLiteDB} from '../../db/delete-lite-db.ts';
 import {
   isSQLiteCorruption,
   logSQLiteCorruptionDiagnostics,
@@ -47,16 +48,18 @@ function createAPI(): API {
     unregisterCorruptionDiagnosticTargets = [];
   }
 
-  function logCorruptionDiagnostics(err: unknown) {
+  function handleCorruptedDb(err: unknown) {
     if (!lc || !replicaDbPath || !isSQLiteCorruption(err)) {
       return;
     }
     logSQLiteCorruptionDiagnostics(lc, 'write-worker', replicaDbPath, err);
+    lc.warn?.(`deleting corrupted db at ${replicaDbPath}`);
+    deleteLiteDB(replicaDbPath);
   }
 
   function createProcessor() {
     processor = new ChangeProcessor(must(runner), must(mode), (_lc, err) => {
-      logCorruptionDiagnostics(err);
+      handleCorruptedDb(err);
       port.postMessage({
         writeError: serializeError(err),
       } satisfies WriteError);
@@ -86,7 +89,7 @@ function createAPI(): API {
         mode = cpMode;
         createProcessor();
       } catch (e) {
-        logCorruptionDiagnostics(e);
+        handleCorruptedDb(e);
         throw e;
       }
     },
@@ -95,7 +98,7 @@ function createAPI(): API {
       try {
         return getSubscriptionState(must(runner));
       } catch (e) {
-        logCorruptionDiagnostics(e);
+        handleCorruptedDb(e);
         throw e;
       }
     },
@@ -104,7 +107,7 @@ function createAPI(): API {
       try {
         return must(processor).processMessage(must(lc), downstream);
       } catch (e) {
-        logCorruptionDiagnostics(e);
+        handleCorruptedDb(e);
         throw e;
       }
     },

--- a/packages/zero-cache/src/services/replicator/write-worker.ts
+++ b/packages/zero-cache/src/services/replicator/write-worker.ts
@@ -53,8 +53,12 @@ function createAPI(): API {
       return;
     }
     logSQLiteCorruptionDiagnostics(lc, 'write-worker', replicaDbPath, err);
-    lc.warn?.(`deleting corrupted db at ${replicaDbPath}`);
-    deleteLiteDB(replicaDbPath);
+    try {
+      lc.warn?.(`deleting corrupted db at ${replicaDbPath}`);
+      deleteLiteDB(replicaDbPath);
+    } catch (e) {
+      lc.warn?.(`error deleting corrupted db at ${replicaDbPath}`, e);
+    }
   }
 
   function createProcessor() {


### PR DESCRIPTION
Before exiting from an `SQLITE_CORRUPT*` error, delete the db file so that a restarted container has a clean slate and re-restores the replica.

This would allow the system to recover from certain types of corruption. Otherwise, the container on the same volume just crash loops on the same corruption error.

<img width="1153" height="1150" alt="Screenshot 2026-08-12 at 2 22 30 PM" src="https://github.com/user-attachments/assets/a7973697-b011-4090-9f69-7697d407efab" />
