### PR TITLE
fix(zero-cache): preserve litestream restore errors

### DIFF
--- a/packages/zero-cache/src/services/change-source/common/replica-restore.ts
+++ b/packages/zero-cache/src/services/change-source/common/replica-restore.ts
@@ -62,10 +62,7 @@ export async function restoreReplica(
     );
     result = attempt.result;
   } catch (e) {
-    lc.error?.(
-      `error restoring backup. resyncing the replica: ${String(e)}`,
-      e,
-    );
+    lc.error?.(`error restoring backup. resyncing the replica`, e);
   } finally {
     const attrs = litestreamRestoreMetricAttrs(config, 'replication_manager');
     const labels = {...attrs, result: result ?? 'error'};

--- a/packages/zero-cache/src/services/litestream/commands.test.ts
+++ b/packages/zero-cache/src/services/litestream/commands.test.ts
@@ -330,6 +330,33 @@ describe('litestream/commands restoreReplica', () => {
     expect(restoredDbBytesAdd).not.toHaveBeenCalled();
   });
 
+  test('includes captured output when restore fails', async () => {
+    const {litestream, replica} = configWithFakeLitestream(
+      `if [ "$1" = "restore" ]; then\n` +
+        `  echo "restore stdout"\n` +
+        `  echo "restore stderr" >&2\n` +
+        `  exit 1\n` +
+        `fi\n` +
+        `exit 1`,
+    );
+
+    const error = await tryRestore(
+      lc,
+      litestream,
+      replica.file,
+      {replicaVersion: '01', minWatermark: '01'},
+      'replication_manager',
+    ).then(
+      () => undefined,
+      (e: unknown) => e,
+    );
+
+    expect(error).toBeInstanceOf(Error);
+    expect(String(error)).toContain('litestream exited with code 1');
+    expect(String(error)).toContain('restore stdout');
+    expect(String(error)).toContain('restore stderr');
+  });
+
   test('deletes an incompatible restored replica', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'litestream-restore-test-'));
     const source = join(dir, 'source.db');

--- a/packages/zero-cache/src/services/litestream/commands.ts
+++ b/packages/zero-cache/src/services/litestream/commands.ts
@@ -151,10 +151,9 @@ export async function tryRestore(
     // Pipe (rather than inherit) litestream's stdout/stderr so that its own
     // `"level":"ERROR"` output on a failed restore does not go straight to the
     // pod's stdout — where a log-scraper alert would page on it — before our
-    // code has decided whether the failure is retriable. The captured output is
-    // re-surfaced through `lc` below with a distinct message per attempt, so a
-    // retriable failure is routed to a non-paging warning and only a post-retry
-    // failure pages. See INC-961.
+    // code has decided how to handle the failure. The captured output is
+    // included in the thrown error so the caller can log the final outcome.
+    // See INC-961.
     const proc = spawn(
       litestream,
       [
@@ -205,7 +204,13 @@ export async function tryRestore(
         performance.now() - processStart,
         {...attrs, result: 'error'},
       );
-      throw e;
+      const output = [stdout, stderr]
+        .map(value => value.trim())
+        .filter(Boolean)
+        .join('\n');
+      throw new Error(output ? `${String(e)}\n${output}` : String(e), {
+        cause: e,
+      });
     }
     if (!existsSync(replicaFile)) {
       result = 'no_backup';


### PR DESCRIPTION
### What

Preserve Litestream’s captured stdout and stderr when a replica restore fails, so Zero logs the underlying restore error instead of only the subprocess exit code.

### Why

PR #6245 changed Litestream restores to pipe stdout and stderr rather than inherit the pod streams. This prevented raw Litestream errors from bypassing Zero’s structured logging and alert classification. It also re-surfaced the captured output after determining whether a failure was retriable.

PR #6267 fixed snapshot retention and removed the restore-retry workaround, including its captured-output logging. The subprocess output remained piped, however, so failed restores silently discarded it. PR #6268 later refactored restore logic on `main` while preserving that behavior.

This surfaced during a prod replication incident. A replica restore ran for approximately 13 minutes before failing, but the only retained diagnostic was `litestream exited with code 1`. The underlying S3, WAL, filesystem, or Litestream error was lost.

### Changes

- Include captured Litestream stdout and stderr in the error propagated from a failed restore.
- Keep subprocess output piped so raw Litestream errors cannot bypass structured logging.
- Log the replication-manager restore failure once without duplicating the exit message.
- Add regression coverage proving both stdout and stderr survive a failed restore.