### PR TITLE
fix(zero-cache): suppress watchdog during backpressure

### DIFF
--- a/packages/zero-cache/src/services/change-source/pg/logical-replication/stream.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/logical-replication/stream.test.ts
@@ -1,5 +1,13 @@
 import {describe, expect, test} from 'vitest';
-import {computeLivenessTimings} from './stream.ts';
+import {
+  computeLivenessTimings,
+  shouldDestroyForInboundTimeout,
+} from './stream.ts';
+
+test('inbound timeout is suppressed during local backpressure', () => {
+  expect(shouldDestroyForInboundTimeout(120_001, 120_000, false)).toBe(true);
+  expect(shouldDestroyForInboundTimeout(120_001, 120_000, true)).toBe(false);
+});
 
 describe('computeLivenessTimings', () => {
   // Regression test for https://github.com/rocicorp/mono/pull/6047, which

--- a/packages/zero-cache/src/services/change-source/pg/logical-replication/stream.ts
+++ b/packages/zero-cache/src/services/change-source/pg/logical-replication/stream.ts
@@ -112,6 +112,7 @@ export async function subscribe(
   // thresholds — and why the whole timer is disabled when wal_sender_timeout
   // is 0.
   let lastReceivedTime = Date.now();
+  let locallyBackpressured = false;
 
   const livenessTimer = livenessEnabled
     ? setInterval(() => {
@@ -121,7 +122,14 @@ export async function subscribe(
           lc.debug?.(`sent manual keepalive`);
         }
         const sinceLastReceived = now - lastReceivedTime;
-        if (sinceLastReceived > inboundTimeoutMs && !readable.destroyed) {
+        if (
+          shouldDestroyForInboundTimeout(
+            sinceLastReceived,
+            inboundTimeoutMs,
+            locallyBackpressured,
+          ) &&
+          !readable.destroyed
+        ) {
           lc.warn?.(
             `no message received from ${db.options.host} in ${sinceLastReceived}ms ` +
               `(> 2x wal_sender_timeout ${walSenderTimeoutMs}ms). Destroying ` +
@@ -179,6 +187,12 @@ export async function subscribe(
     // that the change-source loop can check the queue to determine if more
     // messages are immediately available.
     bufferMessages: 5,
+    onBackpressureChange: backpressured => {
+      locallyBackpressured = backpressured;
+      if (!backpressured) {
+        lastReceivedTime = Date.now();
+      }
+    },
   });
 
   return {
@@ -186,6 +200,14 @@ export async function subscribe(
     acks: {push: sendAck},
     sourceTerminated: sourceTerminated.promise,
   };
+}
+
+export function shouldDestroyForInboundTimeout(
+  sinceLastReceived: number,
+  inboundTimeoutMs: number,
+  locallyBackpressured: boolean,
+) {
+  return !locallyBackpressured && sinceLastReceived > inboundTimeoutMs;
 }
 
 /**

--- a/packages/zero-cache/src/types/streams.test.ts
+++ b/packages/zero-cache/src/types/streams.test.ts
@@ -1,4 +1,4 @@
-import {getDefaultHighWaterMark} from 'stream';
+import {getDefaultHighWaterMark, Readable} from 'stream';
 import websocket from '@fastify/websocket';
 import {LogContext} from '@rocicorp/logger';
 import {resolver} from '@rocicorp/resolver';
@@ -20,6 +20,7 @@ import {
   streamInStringified,
   streamOut,
   streamOutStringified,
+  pipe,
   type Sink,
   type Source,
 } from './streams.ts';
@@ -32,6 +33,25 @@ const messageSchema = v.object({
 });
 
 type Message = v.Infer<typeof messageSchema>;
+
+test('pipe reports backpressure while waiting for consumption', async () => {
+  const sink = Subscription.create<string>();
+  const changes: boolean[] = [];
+  pipe({
+    source: Readable.from([Buffer.from('one'), Buffer.from('two')]),
+    sink,
+    parse: chunk => chunk.toString(),
+    onBackpressureChange: backpressured => changes.push(backpressured),
+  });
+
+  await vi.waitFor(() => expect(changes).toEqual([true]));
+
+  const iterator = sink[Symbol.asyncIterator]();
+  expect(await iterator.next()).toEqual({value: 'one'});
+  expect(await iterator.next()).toEqual({value: 'two'});
+  expect(await iterator.next()).toEqual({done: true});
+  expect(changes).toEqual([true, false, true, false]);
+});
 
 describe('streams with flow control', () => {
   let logSink: TestLogSink;

--- a/packages/zero-cache/src/types/streams.ts
+++ b/packages/zero-cache/src/types/streams.ts
@@ -150,9 +150,16 @@ type PipeOptions<T> = {
   sink: Subscription<T>;
   parse: (buffer: Buffer) => T | null;
   bufferMessages?: number;
+  onBackpressureChange?: ((backpressured: boolean) => void) | undefined;
 };
 
-export function pipe<T>({source, sink, parse, bufferMessages}: PipeOptions<T>) {
+export function pipe<T>({
+  source,
+  sink,
+  parse,
+  bufferMessages,
+  onBackpressureChange,
+}: PipeOptions<T>) {
   bufferMessages ??= 0;
   assert(bufferMessages >= 0, 'bufferMessages must be non-negative');
   const pending: Promise<unknown>[] = [];
@@ -186,9 +193,16 @@ export function pipe<T>({source, sink, parse, bufferMessages}: PipeOptions<T>) {
           callback();
         } else {
           // wait for the oldest result in the pending queue
+          onBackpressureChange?.(true);
           pending[0].then(
-            () => callback(),
-            err => callback(ensureError(err)),
+            () => {
+              onBackpressureChange?.(false);
+              callback();
+            },
+            err => {
+              onBackpressureChange?.(false);
+              callback(ensureError(err));
+            },
           );
         }
       },


### PR DESCRIPTION
### What

Make replication liveness and source-termination handling safe during change-streamer flow control.

### Why

When the Storer or subscriber forwarding applies backpressure, the change-streamer intentionally stops consuming the PostgreSQL replication stream. The inbound watchdog measured activity after that flow-control boundary, so a local stall lasting longer than `2x wal_sender_timeout` looked like an unresponsive upstream connection and caused an unnecessary task restart.

Source-termination handling also raced every flow-control wait against the same pending termination promise. Completed waits left their losing promise reactions attached until the source terminated, causing memory usage to grow with replicated traffic.

### Changes

- Report when the replication pipe is blocked waiting for local consumption.
- Suppress inbound watchdog timeouts during local backpressure.
- Reset the inbound liveness window when consumption resumes.
- Attach one source-termination handler per replication stream.
- Wake only the currently active flow-control waiter when the source terminates.
- Add focused coverage for backpressure transitions, watchdog suppression, and constant source-termination handler usage.