### PR TITLE
chore(zero-cache): respond to upstream disconnects even if waiting for back-pressure

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
@@ -17,6 +17,7 @@ import {DbFile} from '../../test/lite.ts';
 import type {PostgresDB} from '../../types/pg.ts';
 import type {Source} from '../../types/streams.ts';
 import {Subscription, type Result} from '../../types/subscription.ts';
+import {orTimeout} from '../../types/timeout.ts';
 import type {ChangeSource} from '../change-source/change-source.ts';
 import type {
   ChangeStreamData,
@@ -3296,6 +3297,186 @@ describe('change-streamer/service', () => {
     changes.fail(new Error('doh'));
 
     expect(await hasRetried).toBe(true);
+  });
+
+  /**
+   * Drives a streamer into the incident state: the change stream terminates
+   * while the change-streamer is blocked in a flow-control await, behind a
+   * storer that is wedged on the `replicationState` row lock (as when PG or the
+   * connection to it stalls). Returns once the interrupted transaction's
+   * `rollback` has been observed by a subscriber -- i.e. once `doneOr()` has
+   * aborted the flow-control await -- with the streamer now in its backoff,
+   * calling `storer.stop()` to drain.
+   *
+   * The storer stays wedged until `releaseLock()` is called, which lets the
+   * caller choose whether the storer drains within `drainTimeoutMs` or not.
+   */
+  async function wedgeStreamerBehindStorerBackpressure(drainTimeoutMs: number) {
+    await streamer.stop();
+    await streamerDone;
+
+    const firstChanges = Subscription.create<ChangeStreamMessage>();
+    const reconnected = resolver<void>();
+    const startStream = vi
+      .fn()
+      .mockImplementationOnce(() =>
+        Promise.resolve({
+          initialWatermark: '01',
+          changes: firstChanges,
+          acks: {push: () => {}},
+        }),
+      )
+      // On in-process recovery the streamer reconnects; signal it and park so
+      // run() stays alive until the test tears it down.
+      .mockImplementation(() => {
+        reconnected.resolve();
+        return resolver().promise;
+      });
+    const source = {
+      startStream,
+      startLagReporter: () => null,
+      stop: () => {
+        firstChanges.cancel();
+        return Promise.resolve();
+      },
+    } satisfies ChangeSource;
+
+    const incidentStreamer = await initializeStreamer(
+      lc,
+      shard,
+      'task-id',
+      'change.streamer:12345',
+      'ws',
+      sql,
+      source,
+      ReplicationStatusPublisher.forTesting(),
+      replicaConfig,
+      null,
+      null,
+      true,
+      {
+        ...opts,
+        backPressureLimitHeapProportion: 0.00001,
+        statementTimeoutMs: 20_000,
+        drainTimeoutMs,
+      },
+    );
+    const incidentDone = incidentStreamer.run();
+
+    const sub = await incidentStreamer.subscribe({
+      protocolVersion: PROTOCOL_VERSION,
+      taskID: 'task-id',
+      id: 'myid1',
+      mode: 'serving',
+      watermark: '01',
+      replicaVersion: REPLICA_VERSION,
+      initial: true,
+      logsChangeStream: false,
+    });
+    const msgs = drainToQueue(sub);
+    expect(await nextChange(msgs)).toMatchObject({tag: 'status'});
+
+    // Wedge the storer: hold the replicationState row lock it acquires at the
+    // start of every transaction, so it cannot drain and backpressure never
+    // clears.
+    const lockAcquired = resolver<void>();
+    const releaseLock = resolver<void>();
+    const lockDone = sql.begin(async tx => {
+      await tx`SELECT owner FROM "zoro_3/cdc"."replicationState" FOR UPDATE`;
+      lockAcquired.resolve();
+      await releaseLock.promise;
+    });
+    void lockDone.catch(lockAcquired.reject);
+    await lockAcquired.promise;
+
+    // Commit one transaction so the storer parks at its commit (blocked on the
+    // held lock) and stops dequeuing. Then open a new transaction and push a
+    // large change: it stays queued behind the parked storer, keeping
+    // `approximateQueuedBytes` over the tiny backpressure threshold so
+    // `readyForMore()` never resolves. The change-streamer is now blocked in the
+    // flow-control await, mid-transaction (watermark '06').
+    firstChanges.push(['begin', messages.begin(), {commitWatermark: '05'}]);
+    firstChanges.push(['commit', messages.commit(), {watermark: '05'}]);
+    const nextBegin = firstChanges.push([
+      'begin',
+      messages.begin(),
+      {commitWatermark: '06'},
+    ]);
+    const blockedChange = firstChanges.push([
+      'data',
+      messages.insert('foo', {id: 'blocked', value: 'a'.repeat(1024 ** 2)}),
+    ]);
+
+    expect(await nextChange(msgs)).toMatchObject({tag: 'begin'});
+    expect(await nextChange(msgs)).toMatchObject({tag: 'commit'});
+    expect(await nextChange(msgs)).toMatchObject({tag: 'begin'});
+    expect(await nextChange(msgs)).toMatchObject({tag: 'insert'});
+
+    // The '06' begin was consumed, but the large change is not: the streamer is
+    // parked awaiting flow control before it can request the next message.
+    expect(await orTimeout(nextBegin.result, 300)).toBe('consumed');
+    expect(await orTimeout(blockedChange.result, 50)).toBe('timed-out');
+
+    // The source terminates independently of change consumption. doneOr() must
+    // abort the blocked flow-control await so the interrupted '06' transaction
+    // is rolled back immediately -- WITHOUT waiting for the wedged storer to
+    // drain (which cannot happen until the lock is released, ~12h in the
+    // incident).
+    firstChanges.fail(new Error('source terminated'));
+
+    const rollback = await msgs.dequeue(
+      ['error', {type: 0, message: 'timed-out'}],
+      1000,
+    );
+    expect(rollback).toMatchObject([expect.anything(), {tag: 'rollback'}]);
+
+    return {
+      incidentStreamer,
+      incidentDone,
+      startStream,
+      reconnected: reconnected.promise,
+      releaseLock: () => releaseLock.resolve(),
+      lockDone,
+    };
+  }
+
+  test('recover when source terminates behind storer backpressure that drains', async () => {
+    const {
+      incidentStreamer,
+      incidentDone,
+      startStream,
+      reconnected,
+      releaseLock,
+      lockDone,
+    } = await wedgeStreamerBehindStorerBackpressure(5_000);
+
+    // The storer drains before the timeout, so the streamer recovers in-process
+    // and reconnects rather than exiting.
+    releaseLock();
+    await lockDone.catch(() => {});
+
+    expect(await orTimeout(reconnected, 2_000)).toBeUndefined();
+    expect(startStream).toHaveBeenCalledTimes(2);
+
+    await orTimeout(incidentStreamer.stop(), 2_000);
+    void incidentDone.catch(() => {});
+  });
+
+  test('exit when source terminates behind storer backpressure that does not drain', async () => {
+    const {incidentDone, startStream, releaseLock, lockDone} =
+      await wedgeStreamerBehindStorerBackpressure(200);
+
+    // The storer never drains (the lock is still held), so `storer.stop()`
+    // times out and run() exits with the drain-timeout error instead of
+    // reconnecting -- allowing the worker to be replaced.
+    await expect(orTimeout(incidentDone, 3_000)).rejects.toThrow(
+      'changeLog did not drain within 200ms',
+    );
+    expect(startStream).toHaveBeenCalledTimes(1);
+
+    // Release the lock so the wedged storer transaction unwinds during teardown.
+    releaseLock();
+    await lockDone.catch(() => {});
   });
 
   test('retry on unexpected storage error', async () => {

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -693,7 +693,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
             // control promise. Record the boundary before awaiting that promise
             // so registrations during the wait observe the forwarded state.
             this.#recordForwardedTransactionBoundary(type, entry[0]);
-            await forwarded;
+            await stream.changes.doneOr(forwarded);
             unflushedBytes = 0;
           }
 
@@ -704,7 +704,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
           // Allow the storer to exert back pressure.
           const readyForMore = this.#storer.readyForMore();
           if (readyForMore) {
-            await readyForMore;
+            await stream.changes.doneOr(readyForMore);
           }
         }
       } catch (e) {
@@ -1047,8 +1047,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
     this.#purgeScheduler?.stop();
     this.#sqliteCatchup?.close();
     this.#changeLogWriter?.close();
-    await this.#storer.stop();
-    await this.#source.stop();
+    await Promise.allSettled([this.#storer.stop(), this.#source.stop()]);
   }
 
   #recordForwardedTransactionBoundary(

--- a/packages/zero-cache/src/services/change-streamer/storer.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.ts
@@ -12,6 +12,7 @@ import {runTx} from '../../db/run-transaction.ts';
 import {TransactionPool} from '../../db/transaction-pool.ts';
 import {type PostgresDB, type PostgresTransaction} from '../../types/pg.ts';
 import {cdcSchema, type ShardID} from '../../types/shards.ts';
+import {orTimeout} from '../../types/timeout.ts';
 import {
   backfillRequestSchema,
   isDataChange,
@@ -93,6 +94,7 @@ export type TuningOptions = {
   backPressureLimitHeapProportion: number;
   statementTimeoutMs: number;
   changeLogBatchSize: number;
+  drainTimeoutMs?: number | undefined;
 };
 
 /**
@@ -151,6 +153,7 @@ export class Storer implements Service {
   readonly #backPressureThresholdBytes: number;
   readonly #statementTimeoutMs: number;
   readonly #changeLogBatchSize: number;
+  readonly #drainTimeoutMs: number;
 
   #approximateQueuedBytes = 0;
   #running = false;
@@ -169,6 +172,7 @@ export class Storer implements Service {
       backPressureLimitHeapProportion,
       statementTimeoutMs,
       changeLogBatchSize,
+      drainTimeoutMs = 30_000,
     }: TuningOptions,
   ) {
     this.#lc = lc.withContext('component', 'change-log');
@@ -182,6 +186,7 @@ export class Storer implements Service {
     this.#onFatal = onFatal;
     this.#statementTimeoutMs = statementTimeoutMs;
     this.#changeLogBatchSize = Math.max(1, changeLogBatchSize);
+    this.#drainTimeoutMs = drainTimeoutMs;
 
     const heapStats = getHeapStatistics();
     this.#backPressureThresholdBytes =
@@ -935,12 +940,23 @@ export class Storer implements Service {
     }
   }
 
-  stop() {
+  /**
+   * Stops the storer and waits up to a drain timeout for entries to drain,
+   * throwing an exception if it doesn't drain in time, in order to abort
+   * the server when PG (or the connection to it) appears to be wedged.
+   */
+  async stop() {
     if (this.#running) {
       this.#lc.info?.(`draining ${this.#queue.size()} changeLog entries`);
       this.#queue.enqueue('stop');
     }
-    return this.#stopped;
+    if (
+      (await orTimeout(this.#stopped, this.#drainTimeoutMs)) === 'timed-out'
+    ) {
+      throw new AbortError(
+        `changeLog did not drain within ${this.#drainTimeoutMs}ms`,
+      );
+    }
   }
 }
 

--- a/packages/zero-cache/src/services/replicator/replication-resumption-child.test.ts
+++ b/packages/zero-cache/src/services/replicator/replication-resumption-child.test.ts
@@ -1,12 +1,13 @@
 import {EventEmitter} from 'node:events';
 import {describe, expect, test, vi} from 'vitest';
+import type * as processes from '../../types/processes.ts';
 import type {Worker} from '../../types/processes.ts';
 
 // The module self-starts its worker loop on import when `parentWorker` is set
 // (i.e. `process.send` exists, which is true under vitest's forked pool). Mock
 // it to null so importing the module for unit tests has no side effects.
 vi.mock('../../types/processes.ts', async importOriginal => ({
-  ...(await importOriginal<typeof import('../../types/processes.ts')>()),
+  ...(await importOriginal<typeof processes>()),
   parentWorker: null,
 }));
 

--- a/packages/zero-cache/src/services/replicator/replication-resumption-child.test.ts
+++ b/packages/zero-cache/src/services/replicator/replication-resumption-child.test.ts
@@ -1,0 +1,92 @@
+import {EventEmitter} from 'node:events';
+import {describe, expect, test, vi} from 'vitest';
+import type {Worker} from '../../types/processes.ts';
+
+// The module self-starts its worker loop on import when `parentWorker` is set
+// (i.e. `process.send` exists, which is true under vitest's forked pool). Mock
+// it to null so importing the module for unit tests has no side effects.
+vi.mock('../../types/processes.ts', async importOriginal => ({
+  ...(await importOriginal<typeof import('../../types/processes.ts')>()),
+  parentWorker: null,
+}));
+
+const {IPCDownstreamSource} = await import('./replication-resumption-child.ts');
+
+/**
+ * A minimal stand-in for the parent {@link Worker} that only supports the
+ * `on`/`off`/`send` surface used by {@link IPCDownstreamSource}.
+ */
+function fakeWorker(): Worker & {sent: unknown[]} {
+  const ee = new EventEmitter() as EventEmitter & {sent: unknown[]};
+  ee.sent = [];
+  (ee as unknown as {send: (msg: unknown) => boolean}).send = msg => {
+    ee.sent.push(msg);
+    return true;
+  };
+  return ee as unknown as Worker & {sent: unknown[]};
+}
+
+describe('replication-resumption-child/doneOr', () => {
+  const never = () => new Promise<string>(() => {});
+
+  test('other resolves first', async () => {
+    const source = new IPCDownstreamSource(fakeWorker());
+    expect(await source.doneOr(Promise.resolve('foo'))).toBe('foo');
+  });
+
+  test('local cancel() resolves doneOr', async () => {
+    const source = new IPCDownstreamSource(fakeWorker());
+    const raced = source.doneOr(never());
+    source.cancel();
+    expect(await raced).toBeUndefined();
+  });
+
+  test('producer source-end resolves doneOr', async () => {
+    const worker = fakeWorker();
+    const source = new IPCDownstreamSource(worker);
+    const raced = source.doneOr(never());
+    worker.emit('message', ['replication-resumption:source-end', {}]);
+    expect(await raced).toBeUndefined();
+  });
+
+  test('producer source-error rejects doneOr with the error', async () => {
+    const worker = fakeWorker();
+    const source = new IPCDownstreamSource(worker);
+    const raced = source.doneOr(never());
+    worker.emit('message', [
+      'replication-resumption:source-error',
+      {message: 'upstream-boom'},
+    ]);
+    await expect(raced).rejects.toThrow('upstream-boom');
+  });
+
+  test('doneOr after source-error rejects immediately', async () => {
+    const worker = fakeWorker();
+    const source = new IPCDownstreamSource(worker);
+    worker.emit('message', [
+      'replication-resumption:source-error',
+      {message: 'upstream-boom'},
+    ]);
+    await expect(source.doneOr(never())).rejects.toThrow('upstream-boom');
+  });
+
+  test('doneOr after source-end resolves immediately', async () => {
+    const worker = fakeWorker();
+    const source = new IPCDownstreamSource(worker);
+    worker.emit('message', ['replication-resumption:source-end', {}]);
+    expect(await source.doneOr(never())).toBeUndefined();
+  });
+
+  test('unrecognized messages do not terminate doneOr', async () => {
+    const worker = fakeWorker();
+    const source = new IPCDownstreamSource(worker);
+    const resolveWith = vi.fn();
+    const raced = source.doneOr(never()).then(resolveWith);
+    worker.emit('message', ['some-other-message', {}]);
+    worker.emit('message', 'not-even-an-array');
+    await Promise.resolve();
+    expect(resolveWith).not.toHaveBeenCalled();
+    source.cancel(); // settle the outstanding race so the test ends cleanly.
+    await raced;
+  });
+});

--- a/packages/zero-cache/src/services/replicator/replication-resumption-child.ts
+++ b/packages/zero-cache/src/services/replicator/replication-resumption-child.ts
@@ -77,10 +77,14 @@ type QueueEntry =
   | {type: 'message'; seq: number; msg: SerializedDownstream}
   | {type: 'end'};
 
-class IPCDownstreamSource implements Source<SerializedDownstream> {
+export class IPCDownstreamSource implements Source<SerializedDownstream> {
   readonly #parent: Worker;
   readonly #queue = new Queue<QueueEntry>();
+  readonly #abortController = new AbortController();
   #canceled = false;
+  // Set when the source is terminated by a producer-side error, so that
+  // doneOr() rejects (rather than resolves) like Subscription.doneOr().
+  #error: Error | undefined;
 
   constructor(parent: Worker) {
     this.#parent = parent;
@@ -97,10 +101,13 @@ class IPCDownstreamSource implements Source<SerializedDownstream> {
         this.#queue.enqueue({type: 'message', ...msg[1]});
         break;
       case 'replication-resumption:source-error':
-        this.#queue.enqueueRejection(new Error(msg[1].message));
+        this.#error = new Error(msg[1].message);
+        this.#queue.enqueueRejection(this.#error);
+        this.#abortController.abort();
         break;
       case 'replication-resumption:source-end':
         this.#queue.enqueue({type: 'end'});
+        this.#abortController.abort();
         break;
     }
   };
@@ -113,6 +120,25 @@ class IPCDownstreamSource implements Source<SerializedDownstream> {
     this.#parent.off('message', this.#onMessage);
     send(this.#parent, ['replication-resumption:cancel', {}]);
     this.#queue.enqueue({type: 'end'});
+    this.#abortController.abort();
+  }
+
+  async doneOr<R>(other: Promise<R>) {
+    const result = resolver();
+    const {signal} = this.#abortController;
+    const handler = () =>
+      this.#error ? result.reject(this.#error) : result.resolve();
+    if (signal.aborted) {
+      handler();
+    } else {
+      signal.addEventListener('abort', handler);
+    }
+
+    try {
+      return await Promise.race([other, result.promise]);
+    } finally {
+      signal.removeEventListener('abort', handler);
+    }
   }
 
   [Symbol.asyncIterator](): AsyncIterator<SerializedDownstream> {

--- a/packages/zero-cache/src/services/replicator/replication-throughput.bench.pg.ts
+++ b/packages/zero-cache/src/services/replicator/replication-throughput.bench.pg.ts
@@ -83,6 +83,7 @@ function parseStringifiedSource(
 ): Source<SerializedDownstream> {
   return {
     cancel: err => source.cancel(err),
+    doneOr: other => source.doneOr(other),
     async *[Symbol.asyncIterator]() {
       for await (const json of source) {
         yield {data: BigIntJSON.parse(json) as Downstream, json};

--- a/packages/zero-cache/src/types/streams.ts
+++ b/packages/zero-cache/src/types/streams.ts
@@ -40,6 +40,18 @@ export type Source<T> = AsyncIterable<T> & {
   cancel: (err?: Error) => void;
 
   /**
+   * Resolves the result of the specified `other` Promise, or a
+   * resolved/rejected Promise when the Source is terminated or
+   * rejects.
+   *
+   * This is similar to using `Promise.race([other, sourceDone])`, but
+   * in a memory safe way, as repeatedly calling `Promise.race([ ... ])` with
+   * a long-lived Promise results in leaking memory via a growing list of
+   * `then()` callbacks (https://github.com/nodejs/node/issues/17469).
+   */
+  doneOr<R>(other: Promise<R>): Promise<void | R>;
+
+  /**
    * The presence of a `pipeline` iterable allows the usual "consumed-on-iterate" semantics
    * to be overridden.
    *

--- a/packages/zero-cache/src/types/subscription.test.ts
+++ b/packages/zero-cache/src/types/subscription.test.ts
@@ -1,3 +1,4 @@
+import {resolver} from '@rocicorp/resolver';
 import {describe, expect, test, vi} from 'vitest';
 import {assert} from '../../../shared/src/asserts.ts';
 import {sleep} from '../../../shared/src/sleep.ts';
@@ -627,5 +628,95 @@ describe('types/subscription', () => {
       pipeline: true,
     });
     expect(subWithCoalesceAndPipeline.pipeline).not.toBeUndefined();
+  });
+
+  describe('doneOr', () => {
+    test('other resolves first, subscription remains active', async () => {
+      const sub = Subscription.create<number>();
+      const other = resolver<string>();
+
+      const raced = sub.doneOr(other.promise);
+      other.resolve('foo');
+
+      expect(await raced).toBe('foo');
+      expect(sub.active).toBe(true);
+    });
+
+    test('other rejects first', async () => {
+      const sub = Subscription.create<number>();
+      const other = resolver<string>();
+
+      const raced = sub.doneOr(other.promise);
+      other.reject(new Error('other-boom'));
+
+      await expect(raced).rejects.toThrow('other-boom');
+      expect(sub.active).toBe(true);
+    });
+
+    test('cancel wins over a never-settling other', async () => {
+      const sub = Subscription.create<number>();
+      const never = new Promise<string>(() => {});
+
+      const raced = sub.doneOr(never);
+      sub.cancel();
+
+      expect(await raced).toBeUndefined();
+    });
+
+    test('fail wins over a never-settling other, rejecting with the error', async () => {
+      const sub = Subscription.create<number>();
+      const never = new Promise<string>(() => {});
+
+      const raced = sub.doneOr(never);
+      sub.fail(new Error('sub-boom'));
+
+      await expect(raced).rejects.toThrow('sub-boom');
+    });
+
+    test('end (with no queued messages) resolves doneOr', async () => {
+      const sub = Subscription.create<number>();
+      const never = new Promise<string>(() => {});
+
+      const raced = sub.doneOr(never);
+      sub.end(); // no queued messages => immediate cancel
+
+      expect(await raced).toBeUndefined();
+    });
+
+    test('already-canceled subscription resolves immediately', async () => {
+      const sub = Subscription.create<number>();
+      sub.cancel();
+
+      const never = new Promise<string>(() => {});
+      expect(await sub.doneOr(never)).toBeUndefined();
+    });
+
+    test('already-failed subscription rejects immediately', async () => {
+      const sub = Subscription.create<number>();
+      sub.fail(new Error('already-boom'));
+
+      const never = new Promise<string>(() => {});
+      await expect(sub.doneOr(never)).rejects.toThrow('already-boom');
+    });
+
+    test('repeated races do not accumulate abort listeners', async () => {
+      const sub = Subscription.create<number>();
+
+      // Each race resolves via `other`; the abort listener must be removed in
+      // the `finally` so listeners don't accumulate on the shared signal
+      // (the whole point of doneOr over Promise.race with a long-lived done
+      // promise, see https://github.com/nodejs/node/issues/17469).
+      for (let i = 0; i < 100; i++) {
+        const other = resolver<number>();
+        const raced = sub.doneOr(other.promise);
+        other.resolve(i);
+        expect(await raced).toBe(i);
+      }
+
+      // The subscription still terminates cleanly afterwards.
+      const raced = sub.doneOr(new Promise<number>(() => {}));
+      sub.cancel();
+      expect(await raced).toBeUndefined();
+    });
   });
 });

--- a/packages/zero-cache/src/types/subscription.ts
+++ b/packages/zero-cache/src/types/subscription.ts
@@ -74,6 +74,7 @@ export class Subscription<T, M = T> implements Source<T>, Sink<M> {
     return new Subscription(options, publish);
   }
 
+  readonly #abortController = new AbortController();
   // Consumers waiting to consume messages (i.e. an async iteration awaiting the next message).
   readonly #consumers: Resolver<Entry<M> | null>[] = [];
   // Messages waiting to be dequeued.
@@ -227,6 +228,41 @@ export class Subscription<T, M = T> implements Source<T>, Sink<M> {
     this.#terminate(err);
   }
 
+  /**
+   * Resolves the result of the specified `other` Promise, or a
+   * resolved/rejected Promise when the Subscription {@link end}s,
+   * is {@link cancel}ed, or {@link fail}s.
+   *
+   * This is similar to using `Promise.race([other, subscriptionDone])`, but
+   * in a memory safe way, as repeatedly calling `Promise.race([ ... ])` with
+   * a long-lived Promise results in leaking memory via a growing list of
+   * `then()` callbacks (https://github.com/nodejs/node/issues/17469).
+   */
+  async doneOr<R>(other: Promise<R>): Promise<void | R> {
+    const result = resolver();
+    const handler = () => {
+      if (this.#sentinel instanceof Error) {
+        result.reject(this.#sentinel);
+      } else {
+        result.resolve();
+      }
+    };
+    const {signal} = this.#abortController;
+    if (signal.aborted) {
+      // The subscription is already terminated. `addEventListener('abort')`
+      // would never fire on an already-aborted signal, so settle eagerly.
+      handler();
+    } else {
+      signal.addEventListener('abort', handler);
+    }
+
+    try {
+      return await Promise.race([other, result.promise]);
+    } finally {
+      signal.removeEventListener('abort', handler);
+    }
+  }
+
   #terminate(sentinel: 'canceled' | Error) {
     if (!this.#sentinel) {
       this.#sentinel = sentinel;
@@ -245,6 +281,7 @@ export class Subscription<T, M = T> implements Source<T>, Sink<M> {
           ? consumer.resolve(null)
           : consumer.reject(sentinel);
       }
+      this.#abortController.abort(sentinel);
     }
   }
 

--- a/packages/zql-integration-tests/src/chinook/chinook-zero-cache-fuzzer.pg.test.ts
+++ b/packages/zql-integration-tests/src/chinook/chinook-zero-cache-fuzzer.pg.test.ts
@@ -253,6 +253,7 @@ function parseStringifiedSource(
 ): Source<SerializedDownstream> {
   return {
     cancel: err => source.cancel(err),
+    doneOr: other => source.doneOr(other),
     async *[Symbol.asyncIterator]() {
       for await (const json of source) {
         yield {data: BigIntJSON.parse(json) as Downstream, json};


### PR DESCRIPTION
Avoid wedging the change-streamer if back-pressure never clears.

(Partial, alternate strategy to https://github.com/rocicorp/mono/pull/6338)

The implementation of the policy has two parts:

### Part 1
* Add a memory-safe way to race the short-lived flow-control promises within the change-streamer loop, with the (long) lifetime of the change stream (i.e. the change-source `Source`), leveraging an AbortController with short-lived promises to avoid the [problematic memory behavior of Promise.race()](https://github.com/nodejs/node/issues/17469).
* This ensures that we stop waiting on flow-control if the upstream connection has ended, as opposed to hanging indefinitely (observed during the incident that back-pressure never clears even after many hours).

### Part 2
* Add a timeout when waiting for the storer to drain its entries before the usual reconnect to the change-source. 
* If the timeout fires, the service aborts and the process exits.