### PR TITLE
fix(zero-cache): retry failed Litestream restores

### DIFF
--- a/packages/zero-cache/src/services/change-source/common/replica-restore.test.ts
+++ b/packages/zero-cache/src/services/change-source/common/replica-restore.test.ts
@@ -1,0 +1,121 @@
+import {LogContext} from '@rocicorp/logger';
+import {afterEach, describe, expect, test, vi} from 'vitest';
+import {
+  createSilentLogContext,
+  TestLogSink,
+} from '../../../../../shared/src/logging-test-utils.ts';
+import type {LitestreamConfig} from '../../../config/normalize.ts';
+import * as LitestreamCommands from '../../litestream/commands.ts';
+import {restoreReplica} from './replica-restore.ts';
+
+vi.mock('../../litestream/commands.ts', async importOriginal => {
+  const actual = await importOriginal<typeof LitestreamCommands>();
+  return {...actual, tryRestore: vi.fn()};
+});
+
+const config = {
+  backupURL: 's3://backup-bucket/replica',
+  executable: 'litestream',
+  multipartConcurrency: 48,
+  multipartSize: 16 * 1024 * 1024,
+} as LitestreamConfig;
+
+const lc = createSilentLogContext();
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe('restoreReplica', () => {
+  test('retries a failed restore before using a successful restore', async () => {
+    vi.useFakeTimers();
+    vi.mocked(LitestreamCommands.tryRestore)
+      .mockRejectedValueOnce(
+        new Error('NoSuchKey: the specified key does not exist'),
+      )
+      .mockResolvedValueOnce({
+        restored: true,
+        backupURL: config.backupURL,
+        result: 'success',
+      });
+
+    const restored = restoreReplica(lc, config, '/tmp/replica.db', undefined);
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(5_000);
+    await restored;
+
+    expect(LitestreamCommands.tryRestore).toHaveBeenCalledTimes(2);
+  });
+
+  test('logs captured subprocess diagnostics while retrying', async () => {
+    vi.useFakeTimers();
+    const sink = new TestLogSink();
+    const retryLog = new LogContext('debug', undefined, sink);
+    const diagnostic =
+      'litestream exited with code 1\nrequest failed: 503 ServiceUnavailable';
+    const diagnosticError = new Error(diagnostic);
+    vi.mocked(LitestreamCommands.tryRestore)
+      .mockRejectedValueOnce(diagnosticError)
+      .mockResolvedValueOnce({
+        restored: true,
+        backupURL: config.backupURL,
+        result: 'success',
+      });
+
+    const restored = restoreReplica(
+      retryLog,
+      config,
+      '/tmp/replica.db',
+      undefined,
+    );
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(5_000);
+    await restored;
+
+    const retry = sink.messages.find(
+      ([level, , args]) =>
+        level === 'warn' && String(args[0]).includes('restore attempt 1'),
+    );
+    expect(retry?.[2][1]).toBe(diagnosticError);
+  });
+
+  test('makes at most three total attempts for any restore failure', async () => {
+    vi.useFakeTimers();
+    vi.mocked(LitestreamCommands.tryRestore).mockRejectedValue(
+      new Error('litestream exited with code 1'),
+    );
+
+    const restored = restoreReplica(lc, config, '/tmp/replica.db', undefined);
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(10_000);
+    await restored;
+
+    expect(LitestreamCommands.tryRestore).toHaveBeenCalledTimes(3);
+  });
+
+  test('does not retry the ordinary first-run no-backup result', async () => {
+    vi.mocked(LitestreamCommands.tryRestore).mockResolvedValue({
+      restored: false,
+      backupURL: config.backupURL,
+      result: 'no_backup',
+    });
+
+    await restoreReplica(lc, config, '/tmp/replica.db', undefined);
+
+    expect(LitestreamCommands.tryRestore).toHaveBeenCalledTimes(1);
+  });
+
+  test('immediately falls back for invalid replica data', async () => {
+    vi.mocked(LitestreamCommands.tryRestore).mockResolvedValue({
+      restored: false,
+      backupURL: config.backupURL,
+      result: 'invalid_replica',
+    });
+
+    await restoreReplica(lc, config, '/tmp/replica.db', undefined);
+
+    expect(LitestreamCommands.tryRestore).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/zero-cache/src/services/change-source/common/replica-restore.ts
+++ b/packages/zero-cache/src/services/change-source/common/replica-restore.ts
@@ -1,4 +1,5 @@
 import type {LogContext} from '@rocicorp/logger';
+import {sleep} from '../../../../../shared/src/sleep.ts';
 import type {LitestreamConfig} from '../../../config/normalize.ts';
 import {
   tryRestore,
@@ -44,6 +45,11 @@ export type InitializeResult = {
   waitForBackupBeforeServing: boolean;
 };
 
+// A short retry is much cheaper than an initial Postgres sync, while keeping a
+// persistent failure from delaying startup appreciably.
+const MAX_RESTORE_ATTEMPTS = 3;
+const RESTORE_RETRY_DELAY_MS = 5_000;
+
 export async function restoreReplica(
   lc: LogContext,
   config: LitestreamConfig,
@@ -53,16 +59,37 @@ export async function restoreReplica(
   const start = performance.now();
   let result: RestoreResult | undefined;
   try {
-    const attempt = await tryRestore(
-      lc,
-      config,
-      replicaFile,
-      replicaConstraints,
-      'replication_manager',
-    );
-    result = attempt.result;
-  } catch (e) {
-    lc.error?.(`error restoring backup. resyncing the replica`, e);
+    // `tryRestore` returns ordinary restore outcomes (no backup or an invalid
+    // replica) rather than throwing; preserve their existing immediate
+    // initial-sync fallback. Retry every thrown restore error twice before
+    // falling back to the initial Postgres sync.
+    for (let attemptNum = 1; attemptNum <= MAX_RESTORE_ATTEMPTS; attemptNum++) {
+      try {
+        const attempt = await tryRestore(
+          lc,
+          config,
+          replicaFile,
+          replicaConstraints,
+          'replication_manager',
+        );
+        result = attempt.result;
+        return;
+      } catch (e) {
+        if (attemptNum === MAX_RESTORE_ATTEMPTS) {
+          lc.error?.(
+            `litestream restore failed after ${attemptNum} attempts; resyncing the replica`,
+            e,
+          );
+          return;
+        }
+
+        lc.warn?.(
+          `litestream restore attempt ${attemptNum} failed; retrying in ${RESTORE_RETRY_DELAY_MS}ms (attempt ${attemptNum + 1} of ${MAX_RESTORE_ATTEMPTS})`,
+          e,
+        );
+        await sleep(RESTORE_RETRY_DELAY_MS);
+      }
+    }
   } finally {
     const attrs = litestreamRestoreMetricAttrs(config, 'replication_manager');
     const labels = {...attrs, result: result ?? 'error'};


### PR DESCRIPTION
## Problem

We have seen several errors restoring litestream with just generic `litestream exited with code 1` errors. We do not know why these errors are occurring.

## Solution

There is some theory that certain classes of transient errors (e.g., if a compaction to the s3 backup happens durning a restore) could cause this.

Adding a simple quick retry in case that is indeed happening.
