### PR TITLE
chore(zero-cache): improve detection of wedged PG when back pressure kicks in

### DIFF
--- a/packages/zero-cache/src/services/change-source/pg/logical-replication/stream.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/logical-replication/stream.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, test} from 'vitest';
-import {computeLivenessTimings} from './stream.ts';
+import {computeLivenessTimings, evaluateInboundLiveness} from './stream.ts';
 
 describe('computeLivenessTimings', () => {
   // Regression test for https://github.com/rocicorp/mono/pull/6047, which
@@ -43,5 +43,88 @@ describe('computeLivenessTimings', () => {
       expect(t.inboundTimeoutMs).toBeGreaterThan(0);
       expect(t.manualKeepaliveTimeout).toBeGreaterThan(0);
     }
+  });
+});
+
+describe('evaluateInboundLiveness', () => {
+  const inboundTimeoutMs = 120_000; // 2x a default 60s wal_sender_timeout
+
+  // The whole point of the watchdog: when consumption has caught up (queue
+  // empty) and we still haven't heard from upstream past the threshold, the
+  // inbound half is dead and we must force a reconnect.
+  test('times out when the queue is empty and the gap exceeds the threshold', () => {
+    expect(
+      evaluateInboundLiveness({
+        sinceLastReceived: inboundTimeoutMs + 1,
+        inboundTimeoutMs,
+        queued: 0,
+      }),
+    ).toEqual({resetWindow: false, timedOut: true});
+  });
+
+  test('does not time out at or below the threshold with an empty queue', () => {
+    expect(
+      evaluateInboundLiveness({
+        sinceLastReceived: inboundTimeoutMs, // exactly at threshold: not yet
+        inboundTimeoutMs,
+        queued: 0,
+      }),
+    ).toEqual({resetWindow: false, timedOut: false});
+    expect(
+      evaluateInboundLiveness({
+        sinceLastReceived: inboundTimeoutMs - 1,
+        inboundTimeoutMs,
+        queued: 0,
+      }),
+    ).toEqual({resetWindow: false, timedOut: false});
+  });
+
+  // Steady-state back-pressure: a non-empty downstream queue means the silence
+  // is our own flow control, not upstream death. Never time out; instead signal
+  // the caller to refresh the inbound window.
+  test('suppresses the timeout while messages are queued, even far past the threshold', () => {
+    for (const queued of [1, 5, 100]) {
+      expect(
+        evaluateInboundLiveness({
+          sinceLastReceived: inboundTimeoutMs * 10,
+          inboundTimeoutMs,
+          queued,
+        }),
+      ).toEqual({resetWindow: true, timedOut: false});
+    }
+  });
+
+  // Regression test for the drain-transition race. During a long back-pressure
+  // stall the queue stays non-empty, so every tick resets the window (below).
+  // The tick that observes the queue finally drained to 0 must NOT immediately
+  // fire against the pre-stall timestamp — the window was kept fresh, so
+  // `sinceLastReceived` is small and the connection is granted a full
+  // inboundTimeoutMs to deliver the next message.
+  test('a non-empty queue resets the window so the post-drain tick has a fresh gap', () => {
+    // While stalled, every tick sees queued > 0 and resets the window.
+    const duringStall = evaluateInboundLiveness({
+      sinceLastReceived: inboundTimeoutMs * 5,
+      inboundTimeoutMs,
+      queued: 6,
+    });
+    expect(duringStall.resetWindow).toBe(true);
+    expect(duringStall.timedOut).toBe(false);
+
+    // The first tick after the queue drains sees only the small gap accumulated
+    // since the last (reset) tick — well under the threshold — so it holds.
+    const justAfterDrain = evaluateInboundLiveness({
+      sinceLastReceived: 200, // ~one polling interval since the window was reset
+      inboundTimeoutMs,
+      queued: 0,
+    });
+    expect(justAfterDrain).toEqual({resetWindow: false, timedOut: false});
+
+    // Only if upstream then stays silent past the full threshold do we act.
+    const stillSilent = evaluateInboundLiveness({
+      sinceLastReceived: inboundTimeoutMs + 1,
+      inboundTimeoutMs,
+      queued: 0,
+    });
+    expect(stillSilent).toEqual({resetWindow: false, timedOut: true});
   });
 });

--- a/packages/zero-cache/src/services/change-source/pg/logical-replication/stream.ts
+++ b/packages/zero-cache/src/services/change-source/pg/logical-replication/stream.ts
@@ -119,7 +119,20 @@ export async function subscribe(
           lc.debug?.(`sent manual keepalive`);
         }
         const sinceLastReceived = now - lastReceivedTime;
-        if (sinceLastReceived > inboundTimeoutMs && !readable.destroyed) {
+        const {resetWindow, timedOut} = evaluateInboundLiveness({
+          sinceLastReceived,
+          inboundTimeoutMs,
+          queued: messages.queued,
+        });
+        if (resetWindow) {
+          // Downstream back-pressure is preventing us from consuming (and thus
+          // receiving) upstream messages. Keep the inbound window fresh so that
+          // when the backlog finally drains we grant a full inboundTimeoutMs
+          // before concluding the connection is dead — otherwise a long stall
+          // would leave lastReceivedTime stale and fire this watchdog on the
+          // first post-drain tick, tearing down a healthy connection.
+          lastReceivedTime = now;
+        } else if (timedOut && !readable.destroyed) {
           lc.warn?.(
             `no message received from ${db.options.host} in ${sinceLastReceived}ms ` +
               `(> 2x wal_sender_timeout ${walSenderTimeoutMs}ms). Destroying ` +
@@ -225,6 +238,39 @@ export function computeLivenessTimings(walSenderTimeoutMs: number): {
     // Poll at 1/5th of the manual keepalive interval.
     timerIntervalMs: manualKeepaliveTimeout / 5,
   };
+}
+
+/**
+ * Pure decision for the inbound-liveness watchdog, given the time since the
+ * last inbound message, the timeout threshold, and the number of messages
+ * currently queued downstream (see {@link SourceWithPendingQueue.queued}).
+ *
+ * A non-empty downstream queue means we have received data we haven't yet
+ * consumed: the reason we aren't receiving *more* is our own back-pressure, not
+ * upstream silence. In that case we `resetWindow` (treat the backlog as
+ * liveness evidence) rather than counting the stall against the connection.
+ * This both suppresses false timeouts during back-pressure and — crucially —
+ * keeps `lastReceivedTime` fresh so the drain transition (queue emptying after
+ * a long stall) doesn't fire the watchdog against a stale timestamp on the very
+ * next tick.
+ *
+ * Only when the queue is empty (consumption has caught up, so reading — and
+ * thus keepalives — should be flowing again) does an over-threshold gap
+ * indicate a genuinely dead inbound half.
+ */
+export function evaluateInboundLiveness({
+  sinceLastReceived,
+  inboundTimeoutMs,
+  queued,
+}: {
+  sinceLastReceived: number;
+  inboundTimeoutMs: number;
+  queued: number;
+}): {resetWindow: boolean; timedOut: boolean} {
+  if (queued > 0) {
+    return {resetWindow: true, timedOut: false};
+  }
+  return {resetWindow: false, timedOut: sinceLastReceived > inboundTimeoutMs};
 }
 
 /**

--- a/packages/zero-cache/src/services/change-streamer/storer.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.pg.test.ts
@@ -1,12 +1,12 @@
 import {PG_LOCK_NOT_AVAILABLE} from '@drdgvhbh/postgres-error-codes';
 import postgres from 'postgres';
-import {beforeEach, describe, expect} from 'vitest';
+import {afterEach, beforeEach, describe, expect} from 'vitest';
 import {BigIntJSON} from '../../../../shared/src/bigint-json.ts';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
 import {Queue} from '../../../../shared/src/queue.ts';
 import {sleep} from '../../../../shared/src/sleep.ts';
 import {type PgTest, test} from '../../test/db.ts';
-import type {PostgresDB} from '../../types/pg.ts';
+import {postgresTypeConfig, type PostgresDB} from '../../types/pg.ts';
 import type {Subscription} from '../../types/subscription.ts';
 import {
   type ChangeStreamData,
@@ -1693,6 +1693,123 @@ describe('change-streamer/storer', () => {
       expect(
         await db`SELECT "ownerAddress" FROM "xero_5/cdc"."replicationState" WHERE owner = 'task-id'`,
       ).toEqual([{ownerAddress: 'wss://change-streamer:12345'}]);
+    });
+  });
+
+  describe('back pressure timeout', () => {
+    // Small enough that any nonzero backlog counts as "applying back
+    // pressure", and short enough to keep the test fast.
+    const TINY_BACKPRESSURE_PROPORTION = 1e-9;
+    const TIMEOUT_MS = 100;
+
+    let singleConnDb: PostgresDB;
+
+    beforeEach(async () => {
+      const {host, port, database, user: username, pass} = db.options;
+      // A dedicated, single-connection pool to the same test database, so
+      // that reserving its one connection deterministically blocks the
+      // storer from ever acquiring a connection for its next transaction --
+      // simulating a wedge that happens *before* any statement is sent to
+      // PG. This is the gap that TransactionPool's own
+      // statementResponseTimeout cannot see, since it only tracks
+      // statements that have already been dispatched.
+      singleConnDb = postgres({
+        host: host[0],
+        port: port[0],
+        username,
+        password: pass ?? undefined,
+        database,
+        max: 1,
+        ...postgresTypeConfig({sendStringAsJson: true}),
+      });
+
+      storer = new Storer(
+        lc,
+        shard,
+        'task-id',
+        'change-streamer:12345',
+        'ws',
+        singleConnDb,
+        REPLICA_VERSION,
+        msg => consumed.enqueue(msg),
+        err => fatalErrors.enqueue(err),
+        {
+          ...opts,
+          statementTimeoutMs: TIMEOUT_MS,
+          backPressureLimitHeapProportion: TINY_BACKPRESSURE_PROPORTION,
+          // Flush every change immediately, so that the *second* flush of
+          // the backlog blocks awaiting the still-pending first flush (which
+          // itself can never complete: the sole connection is reserved, so
+          // TransactionPool can't even start its `BEGIN`). This is what
+          // stalls #processQueue's loop mid-message, before it reaches the
+          // per-message #maybeReleaseBackPressure() call for that message,
+          // leaving the still-unprocessed backlog behind it counted against
+          // approximateQueuedBytes -- which is what keeps back pressure
+          // (and the watchdog timer) engaged instead of self-releasing.
+          changeLogBatchSize: 1,
+        },
+      );
+      await storer.assumeOwnership();
+      done = storer.run();
+    });
+
+    afterEach(async () => {
+      await storer.stop();
+      await singleConnDb.end();
+    });
+
+    // Queues a 'begin' plus enough data changes that #processQueue gets
+    // stuck (per the note above) with some of the backlog still undrained,
+    // and returns the resulting readyForMore() promise.
+    function storeUntilWedged() {
+      storer.store('20', ['begin', messages.begin(), {commitWatermark: '20'}]);
+      for (let i = 0; i < 4; i++) {
+        storer.store('20', ['data', messages.insert('issues', {id: `${i}`})]);
+      }
+      // Called synchronously with the store()s above (no intervening
+      // `await`) so that the async queue-processing loop has not yet had a
+      // chance to run and decrement approximateQueuedBytes.
+      return storer.readyForMore();
+    }
+
+    test('rejects with AbortError when the connection cannot be acquired within the timeout', async () => {
+      const reserved = await singleConnDb.reserve();
+      try {
+        const readyForMore = storeUntilWedged();
+        expect(readyForMore).toBeDefined();
+
+        const start = Date.now();
+        await expect(readyForMore).rejects.toThrow(
+          /Considering the change-log to be wedged/,
+        );
+        expect(Date.now() - start).toBeLessThan(TIMEOUT_MS * 5);
+      } finally {
+        // The wedged transaction is still open (no commit/rollback was
+        // ever sent) and its TransactionPool worker is still waiting on
+        // the connection this releases. Explicitly abort it -- mirroring
+        // what change-streamer-service.ts does on the interrupted
+        // transaction after readyForMore() rejects -- so the pending
+        // transaction doesn't hang the db connection open through
+        // teardown.
+        reserved.release();
+        storer.abort();
+        await storer.allProcessed();
+      }
+    });
+
+    test('recovers after a timeout once the backlog can drain again', async () => {
+      const reserved = await singleConnDb.reserve();
+      const firstReadyForMore = storeUntilWedged();
+      await expect(firstReadyForMore).rejects.toThrow(/wedged/);
+
+      // Release the connection so the storer can make progress again.
+      reserved.release();
+      storer.store('20', ['commit', messages.commit(), {watermark: '20'}]);
+      await expectConsumed('20');
+
+      // A stale, already-rejected resolver must not be reused: with nothing
+      // queued, back pressure should no longer be in effect.
+      expect(storer.readyForMore()).toBeUndefined();
     });
   });
 

--- a/packages/zero-cache/src/services/change-streamer/storer.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.ts
@@ -384,6 +384,7 @@ export class Storer implements Service {
   }
 
   #readyForMore: Resolver<void> | null = null;
+  #backpressureTimeout: NodeJS.Timeout | undefined;
 
   readyForMore(): Promise<void> | undefined {
     if (!this.#running) {
@@ -407,21 +408,41 @@ export class Storer implements Service {
           `  LIMIT 20;`,
       );
       this.#readyForMore = resolver();
+      this.#resetBackpressureTimeout(true);
     }
     return this.#readyForMore?.promise;
   }
 
+  #resetBackpressureTimeout(reschedule: boolean) {
+    clearTimeout(this.#backpressureTimeout);
+    this.#backpressureTimeout = reschedule
+      ? setTimeout(() => {
+          this.#readyForMore?.reject(
+            new AbortError(
+              `No statement processed within the last ${this.#statementTimeoutMs}ms. Considering the change-log to be wedged.`,
+            ),
+          );
+          this.#readyForMore = null;
+        }, this.#statementTimeoutMs)
+      : undefined;
+  }
+
   #maybeReleaseBackPressure() {
-    if (
-      this.#readyForMore !== null &&
+    if (this.#readyForMore !== null) {
       // Wait for at least 20% of the threshold to free up.
-      this.#approximateQueuedBytes < this.#backPressureThresholdBytes * 0.8
-    ) {
-      this.#lc.info?.(
-        `releasing back pressure with ${this.#queue.size()} queued changes (~${(this.#approximateQueuedBytes / 1024 ** 2).toFixed(2)} MB)`,
-      );
-      this.#readyForMore.resolve();
-      this.#readyForMore = null;
+      if (
+        this.#approximateQueuedBytes <
+        this.#backPressureThresholdBytes * 0.8
+      ) {
+        this.#lc.info?.(
+          `releasing back pressure with ${this.#queue.size()} queued changes (~${(this.#approximateQueuedBytes / 1024 ** 2).toFixed(2)} MB)`,
+        );
+        this.#readyForMore.resolve();
+        this.#readyForMore = null;
+        this.#resetBackpressureTimeout(false);
+      } else {
+        this.#resetBackpressureTimeout(true);
+      }
     }
   }
 
@@ -482,6 +503,7 @@ export class Storer implements Service {
         this.#readyForMore.resolve();
         this.#readyForMore = null;
       }
+      this.#resetBackpressureTimeout(false);
       this.#cancelQueueEntries(
         this.#queue.drain().filter(entry => entry !== undefined),
         err,


### PR DESCRIPTION
Two related changes that should go together:

1. Avoid considering an upstream connection dead if we are experiencing downstream backpressure

This mirrors the intent of https://github.com/rocicorp/mono/pull/6344 by taking back-pressure into account as the reason for not receiving upstream pings, using the `Subscription.queue` as the back-pressure signal.

2. Add a high-level statement timeout when back-pressure kicks in in the Storer. 

This mirrors the behavior of the TransactionPool's statement timeout for detecting an unresponsive PG, but at a higher level since it does not always catch all scenarios.


The two changes are bundled together because the watch dog in [1] currently serves as an abort mechanism when the storer is wedged, even though it is not the intent of the watch dog. "Fixing" the watch dog should thus be accompanied by corresponding logic to explicitly unwedge a server that is stuck on back pressure. 