### PR TITLE
chore: add aboodman as lockfile code owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 .github/ @arv @0xcadams
-pnpm-lock.yaml @arv @0xcadams
+pnpm-lock.yaml @arv @0xcadams @aboodman


### PR DESCRIPTION
Adds @aboodman as a code owner for pnpm-lock.yaml so they can approve lockfile-only dependency updates.