### PR TITLE
feat(zero-cache): allow overriding the replication-stream inbound timeout

### DIFF
--- a/packages/zero-cache/src/config/zero-config.test.ts
+++ b/packages/zero-cache/src/config/zero-config.test.ts
@@ -53,6 +53,25 @@ test('zero-cache --help', () => {
                                                                                                                                                                                                    
                                                                         (Note that this option has no effect for Postgres versions before 17.)                                                     
                                                                                                                                                                                                    
+     --upstream-pg-stream-inbound-timeout-ms number                     optional                                                                                                                   
+       ZERO_UPSTREAM_PG_STREAM_INBOUND_TIMEOUT_MS env                                                                                                                                              
+                                                                        The time (in milliseconds) without any inbound message from the upstream                                                   
+                                                                        wal sender after which the replication stream is considered unresponsive                                                   
+                                                                        and torn down to force a reconnect.                                                                                        
+                                                                                                                                                                                                   
+                                                                        Defaults to 2x the server's wal_sender_timeout. That suits idle                                                            
+                                                                        streams, but a busy wal sender can be legitimately silent for longer —                                                     
+                                                                        e.g. while decoding through WAL from unpublished tables, or assembling a                                                   
+                                                                        large transaction that is only sent at commit. If the server's                                                             
+                                                                        wal_sender_timeout is aggressive (some managed environments                                                                
+                                                                        default it as low as 5 seconds), the resulting teardown aborts and                                                         
+                                                                        replays the in-flight transaction, which can prevent replication from                                                      
+                                                                        ever catching up on a large backlog. Set this option to widen the                                                          
+                                                                        client-side threshold without changing the server setting.                                                                 
+                                                                                                                                                                                                   
+                                                                        (This option has no effect when wal_sender_timeout is 0, which                                                             
+                                                                        disables inbound liveness detection entirely.)                                                                             
+                                                                                                                                                                                                   
      --mutate-url string[]                                              optional                                                                                                                   
        ZERO_MUTATE_URL env                                                                                                                                                                         
                                                                         The URL of the API server to which zero-cache will push mutations.                                                         

--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -393,6 +393,28 @@ export const zeroOptions = {
         `(Note that this option has no effect for Postgres versions before 17.)`,
       ],
     },
+
+    pgStreamInboundTimeoutMs: {
+      type: v.number().optional(),
+      desc: [
+        `The time (in milliseconds) without any inbound message from the upstream`,
+        `wal sender after which the replication stream is considered unresponsive`,
+        `and torn down to force a reconnect.`,
+        ``,
+        `Defaults to 2x the server's {bold wal_sender_timeout}. That suits idle`,
+        `streams, but a busy wal sender can be legitimately silent for longer —`,
+        `e.g. while decoding through WAL from unpublished tables, or assembling a`,
+        `large transaction that is only sent at commit. If the server's`,
+        `{bold wal_sender_timeout} is aggressive (some managed environments`,
+        `default it as low as 5 seconds), the resulting teardown aborts and`,
+        `replays the in-flight transaction, which can prevent replication from`,
+        `ever catching up on a large backlog. Set this option to widen the`,
+        `client-side threshold without changing the server setting.`,
+        ``,
+        `(This option has no effect when {bold wal_sender_timeout} is 0, which`,
+        `disables inbound liveness detection entirely.)`,
+      ],
+    },
   },
 
   /** @deprecated */

--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -179,6 +179,7 @@ export default async function runWorker(
               replicationLag.reportIntervalMs,
               restoreOptions,
               purgeLock,
+              upstream.pgStreamInboundTimeoutMs,
             )
           : await initializeCustomChangeSource(
               lc,

--- a/packages/zero-cache/src/services/change-source/pg/change-source.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.ts
@@ -139,6 +139,7 @@ export async function initializePostgresChangeSource(
   lagReportIntervalMs = 0,
   restoreOptions: RestoreOptions = {},
   purgeLock?: PurgeLock | null,
+  streamInboundTimeoutMs?: number | undefined,
 ): Promise<InitializeResult> {
   const db = await connectPgClient(lc, upstreamURI, 'change-source-init');
   try {
@@ -197,6 +198,7 @@ export async function initializePostgresChangeSource(
       context,
       lagReportIntervalMs,
       syncOptions.textCopy,
+      streamInboundTimeoutMs,
     );
 
     const backupPath = must(initialSyncedReplica ?? restoredReplica).backupPath;
@@ -358,6 +360,7 @@ class PostgresChangeSource implements ChangeSource {
   readonly #context: ServerContext;
   readonly #lagReporter: LagReporter | null;
   readonly #textCopy: boolean;
+  readonly #streamInboundTimeoutMs: number | undefined;
   #stopped = false;
 
   constructor(
@@ -368,6 +371,7 @@ class PostgresChangeSource implements ChangeSource {
     context: ServerContext,
     lagReportIntervalMs: number,
     textCopy?: boolean | undefined,
+    streamInboundTimeoutMs?: number | undefined,
   ) {
     this.#lc = lc.withContext('component', 'change-source');
     this.#db = pgClient(lc, upstreamUri, 'replication-monitor', {
@@ -380,6 +384,7 @@ class PostgresChangeSource implements ChangeSource {
     this.#replica = replica;
     this.#context = context;
     this.#textCopy = textCopy ?? false;
+    this.#streamInboundTimeoutMs = streamInboundTimeoutMs;
     this.#lagReporter =
       lagReportIntervalMs > 0
         ? new LagReporter(
@@ -455,6 +460,9 @@ class PostgresChangeSource implements ChangeSource {
       slot,
       [...shardConfig.publications],
       clientStart,
+      undefined,
+      undefined,
+      this.#streamInboundTimeoutMs,
     );
     const acker = new Acker(acks);
 

--- a/packages/zero-cache/src/services/change-source/pg/logical-replication/stream.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/logical-replication/stream.test.ts
@@ -44,6 +44,38 @@ describe('computeLivenessTimings', () => {
       expect(t.manualKeepaliveTimeout).toBeGreaterThan(0);
     }
   });
+
+  test('a positive override replaces only the inbound threshold', () => {
+    // An aggressive server-side wal_sender_timeout (e.g. CloudNativePG
+    // defaults 5s cluster-wide) yields a 10s inbound fuse, which a busy wal
+    // sender can trip while silently decoding — the override widens the
+    // client-side threshold without touching the keepalive contract, which
+    // genuinely belongs to the server setting.
+    expect(computeLivenessTimings(5_000, 120_000)).toEqual({
+      enabled: true,
+      manualKeepaliveTimeout: 3_750, // still 75% of wal_sender_timeout
+      inboundTimeoutMs: 120_000, // the override
+      timerIntervalMs: 750, // still manualKeepaliveTimeout / 5
+    });
+  });
+
+  test('non-positive / non-finite overrides fall back to 2x wal_sender_timeout', () => {
+    for (const override of [0, -1, NaN]) {
+      expect(computeLivenessTimings(60_000, override).inboundTimeoutMs).toBe(
+        120_000,
+      );
+    }
+    expect(computeLivenessTimings(60_000, undefined).inboundTimeoutMs).toBe(
+      120_000,
+    );
+  });
+
+  test('the override does not re-enable liveness when wal_sender_timeout is disabled', () => {
+    // With wal_sender_timeout = 0 the server sends no periodic keepalives, so
+    // inbound silence is normal on an idle healthy connection — an inbound
+    // watchdog would false-positive regardless of its threshold.
+    expect(computeLivenessTimings(0, 120_000).enabled).toBe(false);
+  });
 });
 
 describe('evaluateInboundLiveness', () => {

--- a/packages/zero-cache/src/services/change-source/pg/logical-replication/stream.ts
+++ b/packages/zero-cache/src/services/change-source/pg/logical-replication/stream.ts
@@ -39,6 +39,7 @@ export async function subscribe(
   lsn: bigint,
   retriesIfReplicationSlotActive = DEFAULT_RETRIES_IF_REPLICATION_SLOT_ACTIVE,
   applicationName = 'zero-replicator',
+  inboundTimeoutOverrideMs?: number | undefined,
 ): Promise<{
   messages: SourceWithPendingQueue<StreamMessage>;
   acks: Sink<bigint>;
@@ -79,11 +80,15 @@ export async function subscribe(
     manualKeepaliveTimeout,
     inboundTimeoutMs,
     timerIntervalMs,
-  } = computeLivenessTimings(walSenderTimeoutMs);
+  } = computeLivenessTimings(walSenderTimeoutMs, inboundTimeoutOverrideMs);
   lc.info?.(
     livenessEnabled
       ? `wal_sender_timeout: ${walSenderTimeoutMs}ms. ` +
-          `Ensuring manual keepalives at least every ${manualKeepaliveTimeout}ms`
+          `Ensuring manual keepalives at least every ${manualKeepaliveTimeout}ms. ` +
+          `Inbound timeout: ${inboundTimeoutMs}ms` +
+          (inboundTimeoutMs === walSenderTimeoutMs * 2
+            ? ''
+            : ' (configured override)')
       : `wal_sender_timeout is disabled (0); skipping manual keepalives and ` +
           `inbound liveness detection.`,
   );
@@ -135,7 +140,7 @@ export async function subscribe(
         } else if (timedOut && !readable.destroyed) {
           lc.warn?.(
             `no message received from ${db.options.host} in ${sinceLastReceived}ms ` +
-              `(> 2x wal_sender_timeout ${walSenderTimeoutMs}ms). Destroying ` +
+              `(> inbound timeout ${inboundTimeoutMs}ms). Destroying ` +
               `replication stream to force reconnect.`,
           );
           readable.destroy(
@@ -206,9 +211,29 @@ export async function subscribe(
  * first tick and destroy the stream, while the timer itself would busy-spin at
  * a 0ms interval — together producing a continuous reconnect storm.
  *
+ * An `inboundTimeoutOverrideMs` (when positive) replaces the default
+ * `2x wal_sender_timeout` inbound threshold. The two timeouts protect
+ * different parties with asymmetric false-positive costs: `wal_sender_timeout`
+ * is the server reaping dead clients (a false positive there costs a cheap
+ * reconnect), while the inbound watchdog tears down the stream and replays the
+ * in-flight transaction — expensive, and self-defeating when the wal sender is
+ * legitimately silent for long stretches (e.g. decoding through WAL from
+ * unpublished tables, or assembling a large transaction that pgoutput only
+ * sends at commit). Operators who don't own the server setting (e.g. managed
+ * or operator-provisioned Postgres with an aggressive cluster-wide
+ * `wal_sender_timeout`) can widen the client-side fuse independently.
+ *
+ * The override has no effect when `wal_sender_timeout` is disabled (0): the
+ * server then sends no periodic keepalives, so inbound silence is normal even
+ * on an idle healthy connection and any silence-based watchdog would
+ * false-positive.
+ *
  * https://www.postgresql.org/docs/current/runtime-config-replication.html#GUC-WAL-SENDER-TIMEOUT
  */
-export function computeLivenessTimings(walSenderTimeoutMs: number): {
+export function computeLivenessTimings(
+  walSenderTimeoutMs: number,
+  inboundTimeoutOverrideMs?: number | undefined,
+): {
   enabled: boolean;
   manualKeepaliveTimeout: number;
   inboundTimeoutMs: number;
@@ -233,8 +258,12 @@ export function computeLivenessTimings(walSenderTimeoutMs: number): {
     // Force a reconnect after 2x wal_sender_timeout — i.e. two consecutive
     // missed keepalives — without any inbound message, to avoid spurious
     // reconnects from a single delayed keepalive (PG scheduling jitter under
-    // load, our own event-loop stalls, etc.).
-    inboundTimeoutMs: walSenderTimeoutMs * 2,
+    // load, our own event-loop stalls, etc.). A 0 / negative / NaN override
+    // falls back to the default rather than degenerating the threshold.
+    inboundTimeoutMs:
+      inboundTimeoutOverrideMs !== undefined && inboundTimeoutOverrideMs > 0
+        ? inboundTimeoutOverrideMs
+        : walSenderTimeoutMs * 2,
     // Poll at 1/5th of the manual keepalive interval.
     timerIntervalMs: manualKeepaliveTimeout / 5,
   };


### PR DESCRIPTION
### What

Adds `ZERO_UPSTREAM_PG_STREAM_INBOUND_TIMEOUT_MS` (`upstream.pgStreamInboundTimeoutMs`), an optional override for the replication-stream inbound-liveness threshold, which is otherwise hard-derived as `2x wal_sender_timeout`. Defaults are unchanged. Filing as a PR directly since issues are disabled on this repo — happy to adjust naming/plumbing.

### Why

The two timeouts protect opposite parties with asymmetric false-positive costs. `wal_sender_timeout` is the **server** reaping dead clients; operators tune it low for their own reasons (CloudNativePG hard-defaults it to `5s` cluster-wide for fast standby-failover detection), and a false positive there costs a cheap reconnect. The inbound watchdog is the **client** detecting a dead server, and its false positive is expensive: destroy stream → abort the partially-decoded transaction → replay from the confirmed watermark.

A busy wal sender can be legitimately silent for longer than `2x wal_sender_timeout`: decoding through long stretches of WAL that is filtered out (changes on unpublished tables — including zero-cache's own changeLog churn when the change-db is co-located with upstream), or assembling a large transaction that pgoutput v1 only sends at commit. #6348's back-pressure suppression doesn't cover this case — `queued === 0` because nothing is arriving at all — so the watchdog fires against a healthy, progressing connection.

**Production incident that motivated this** (zero-cache 1.8.0, PG 17 / CloudNativePG, `wal_sender_timeout = 5s` → 10s fuse): a ~900 MB backlog of large TOASTed-row transactions produced repeated decode silences of 10.1–10.5s. Each tripped the watchdog: destroy → `aborting interrupted transaction` → replay → stall, every 60–90s; net catch-up ≈ 0 for over an hour. Confirming the mechanism: `ALTER ROLE <zero-user> SET wal_sender_timeout = '60s'` (fuse → 120s), with nothing else changed, drained the same backlog in ~2 minutes. We had to change a server-side setting we didn't want to touch — per-role, to preserve the operator's 5s for physical standbys — purely to move a client-side threshold that has no knob. Logs available if useful.

### Changes

- `computeLivenessTimings(walSenderTimeoutMs, inboundTimeoutOverrideMs?)`: a positive override replaces `inboundTimeoutMs` only. Manual-keepalive timing stays derived from `wal_sender_timeout` (that half genuinely belongs to the server contract). `wal_sender_timeout = 0` still disables liveness entirely, override or not — without server keepalives, inbound silence is normal on an idle healthy connection, so any silence-based watchdog would false-positive (#6244 semantics preserved). Non-positive/NaN overrides fall back to the default.
- Plumbed `upstream.pgStreamInboundTimeoutMs` → `initializePostgresChangeSource` → `PostgresChangeSource` → `subscribe()`, following the `lagReportIntervalMs` pattern.
- Teardown warning now reports the actual threshold instead of hard-coding "2x wal_sender_timeout".
- Tests for override honored / fallback / disabled-stays-disabled; updated the config `--help` snapshot.

### Testing

- `stream.test.ts` and `zero-config.test.ts`: all pass.
- Full `src/services/change-source/pg` suite: 1037 passed, 1 pre-existing flake (`change-source.backfill.pg.test.ts` "column renamed while being backfilled") which passes in isolation and is untouched by this change.
- `tsc` clean, `oxlint` no errors, `oxfmt` applied.

Related: #6047, #6244, #6348.

Made with [Cursor](https://cursor.com)