### PR TITLE
chore(zero-cache): abort open txs on storer close

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/storer.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.pg.test.ts
@@ -5,7 +5,7 @@ import {BigIntJSON} from '../../../../shared/src/bigint-json.ts';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
 import {Queue} from '../../../../shared/src/queue.ts';
 import {sleep} from '../../../../shared/src/sleep.ts';
-import {type PgTest, test} from '../../test/db.ts';
+import {test, type PgTest} from '../../test/db.ts';
 import {postgresTypeConfig, type PostgresDB} from '../../types/pg.ts';
 import type {Subscription} from '../../types/subscription.ts';
 import {
@@ -1784,16 +1784,7 @@ describe('change-streamer/storer', () => {
         );
         expect(Date.now() - start).toBeLessThan(TIMEOUT_MS * 5);
       } finally {
-        // The wedged transaction is still open (no commit/rollback was
-        // ever sent) and its TransactionPool worker is still waiting on
-        // the connection this releases. Explicitly abort it -- mirroring
-        // what change-streamer-service.ts does on the interrupted
-        // transaction after readyForMore() rejects -- so the pending
-        // transaction doesn't hang the db connection open through
-        // teardown.
         reserved.release();
-        storer.abort();
-        await storer.allProcessed();
       }
     });
 

--- a/packages/zero-cache/src/services/change-streamer/storer.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.ts
@@ -970,6 +970,7 @@ export class Storer implements Service {
   async stop() {
     if (this.#running) {
       this.#lc.info?.(`draining ${this.#queue.size()} changeLog entries`);
+      this.abort(); // for cleanliness, abort any open transactions
       this.#queue.enqueue('stop');
     }
     if (


### PR DESCRIPTION
Abort any open transactions when closing the storer. 

The production code already does this via its main loop, but putting it in the storer itself makes it more self-consistent, and simplifies the cleanup in tests.