### PR TITLE
feat(rmv2): allow moving traffic to the SQLite change log

### DIFF
--- a/packages/zero-cache/src/config/normalize.test.ts
+++ b/packages/zero-cache/src/config/normalize.test.ts
@@ -12,6 +12,7 @@ function configWith(litestream: Partial<ZeroConfig['litestream']>): ZeroConfig {
       address: 'localhost',
       sqliteChangeLogMode: 'off',
       sqliteChangeLogReadPercent: 0,
+      sqliteChangeLogComparePercent: 1,
       sqliteChangeLogRetentionMs: 60_000,
       sqliteChangeLogReadBatchRows: 1000,
       sqliteChangeLogPurgeBatchRows: 1000,
@@ -128,6 +129,21 @@ describe('config/normalize SQLite change log', () => {
         'must be an integer between 0 and 100',
       );
     }
+  });
+
+  test('compare percentage must be an integer from 0 through 100, in any mode', () => {
+    for (const percent of [-1, 1.5, 101]) {
+      const config = configWith({});
+      config.changeStreamer.sqliteChangeLogComparePercent = percent;
+
+      expect(() => assertNormalized(config)).toThrow(
+        '--change-streamer-sqlite-change-log-compare-percent must be an integer between 0 and 100',
+      );
+    }
+    // A nonzero value is valid in every mode. Sampling starts in `compare` mode.
+    const config = configWith({});
+    config.changeStreamer.sqliteChangeLogComparePercent = 100;
+    expect(() => assertNormalized(config)).not.toThrow();
   });
 
   test('accepts positive integer tuning values', () => {

--- a/packages/zero-cache/src/config/normalize.ts
+++ b/packages/zero-cache/src/config/normalize.ts
@@ -46,6 +46,7 @@ export function assertNormalized(
   const {
     sqliteChangeLogMode,
     sqliteChangeLogReadPercent,
+    sqliteChangeLogComparePercent,
     sqliteChangeLogRetentionMs,
     sqliteChangeLogReadBatchRows,
     sqliteChangeLogPurgeBatchRows,
@@ -56,6 +57,13 @@ export function assertNormalized(
       sqliteChangeLogReadPercent >= 0 &&
       sqliteChangeLogReadPercent <= 100,
     '--change-streamer-sqlite-change-log-read-percent must be an integer between 0 and 100',
+  );
+  // This setting has no mode restriction. Comparison starts in `compare` mode.
+  assert(
+    Number.isSafeInteger(sqliteChangeLogComparePercent) &&
+      sqliteChangeLogComparePercent >= 0 &&
+      sqliteChangeLogComparePercent <= 100,
+    '--change-streamer-sqlite-change-log-compare-percent must be an integer between 0 and 100',
   );
   assert(
     sqliteChangeLogMode === 'serve' || sqliteChangeLogReadPercent === 0,

--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -724,6 +724,15 @@ export const zeroOptions = {
       hidden: true,
     },
 
+    sqliteChangeLogComparePercent: {
+      type: v.number().default(1),
+      desc: [
+        `The stable percentage of committed transactions whose catchup output is`,
+        `compared between the Postgres and SQLite change logs in {bold compare} mode.`,
+      ],
+      hidden: true,
+    },
+
     sqliteChangeLogRetentionMs: {
       type: v.number().default(60_000),
       desc: [`The minimum time window retained in the SQLite change log.`],

--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -67,6 +67,7 @@ export default async function runWorker(
       flowControlConsensusTimeoutProportion,
       flowControlSlowSubscriberGracePeriodSeconds,
       sqliteChangeLogMode,
+      sqliteChangeLogComparePercent,
       sqliteChangeLogRetentionMs,
       sqliteChangeLogReadBatchRows,
       sqliteChangeLogPurgeBatchRows,
@@ -250,11 +251,14 @@ export default async function runWorker(
                 batchRows: sqliteChangeLogPurgeBatchRows,
               }
             : undefined,
-          // `compare` and above. The replica-derived initialization path runs
-          // at full rate and is checked against Postgres, which stays
-          // authoritative. Flipping authority to the replica comes later.
+          // Compare mode runs both advisory checks. Postgres remains authoritative.
           sqliteChangeLogCompare: sqliteChangeLogComparing
-            ? {replicaFile: replica.file}
+            ? {
+                replicaFile: replica.file,
+                comparePercent: sqliteChangeLogComparePercent,
+                retentionMs: sqliteChangeLogRetentionMs,
+                readBatchRows: sqliteChangeLogReadBatchRows,
+              }
             : undefined,
         },
         setTimeout,

--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -67,6 +67,7 @@ export default async function runWorker(
       flowControlConsensusTimeoutProportion,
       flowControlSlowSubscriberGracePeriodSeconds,
       sqliteChangeLogMode,
+      sqliteChangeLogReadPercent,
       sqliteChangeLogComparePercent,
       sqliteChangeLogRetentionMs,
       sqliteChangeLogReadBatchRows,
@@ -260,6 +261,16 @@ export default async function runWorker(
                 readBatchRows: sqliteChangeLogReadBatchRows,
               }
             : undefined,
+          // Slice 11 lands dark by default: serve mode constructs the stable
+          // router, while readPercent=0 keeps every catchup on PG and emits
+          // eligibility metrics before any canary traffic is enabled.
+          sqliteChangeLogServe:
+            sqliteChangeLogMode === 'serve'
+              ? {
+                  readPercent: sqliteChangeLogReadPercent,
+                  retentionMs: sqliteChangeLogRetentionMs,
+                }
+              : undefined,
         },
         setTimeout,
       );

--- a/packages/zero-cache/src/services/change-streamer/change-log-compare-digest.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-log-compare-digest.test.ts
@@ -1,0 +1,318 @@
+/** Tests the pure compare primitives. Integration tests cover both stores. */
+
+import fc from 'fast-check';
+import {describe, expect, test} from 'vitest';
+import type {ShardID} from '../../types/shards.ts';
+import {
+  digestCatchupRange,
+  isSampledForCompare,
+  normalizeChangeJSON,
+} from './change-log-compare-digest.ts';
+import type {ChangeTag, WatermarkedChange} from './change-streamer.ts';
+
+describe('change-streamer/change-log-compare-digest', () => {
+  type TxKind = 'complete' | 'orphan' | 'rollback';
+
+  /** Isolates the row budget in tests that do not exercise the byte budget. */
+  const NO_BYTE_LIMIT = Number.MAX_SAFE_INTEGER;
+
+  const streamScenario = fc.record({
+    txs: fc.array(
+      fc.record({
+        width: fc.integer({min: 0, max: 5}),
+        kind: fc.constantFrom<TxKind>('complete', 'orphan', 'rollback'),
+      }),
+      {minLength: 1, maxLength: 8},
+    ),
+    // Remove leading rows to start inside a transaction.
+    truncateHead: fc.nat({max: 3}),
+    // Use two batch layouts for the same rows.
+    chunkSizesA: fc.array(fc.integer({min: 1, max: 7}), {
+      minLength: 1,
+      maxLength: 4,
+    }),
+    chunkSizesB: fc.array(fc.integer({min: 1, max: 7}), {
+      minLength: 1,
+      maxLength: 4,
+    }),
+  });
+
+  function buildRows(
+    txs: {width: number; kind: TxKind}[],
+  ): WatermarkedChange[] {
+    const rows: WatermarkedChange[] = [];
+    txs.forEach(({width, kind}, i) => {
+      const w = `w${String(i + 1).padStart(2, '0')}`;
+      rows.push([
+        w,
+        'begin',
+        `["begin",{"tag":"begin"},{"commitWatermark":"${w}"}]`,
+      ]);
+      for (let k = 0; k < width; k++) {
+        rows.push([
+          w,
+          'insert' as ChangeTag,
+          `["data",{"tag":"insert","row":${k}}]`,
+        ]);
+      }
+      if (kind === 'complete') {
+        rows.push([
+          w,
+          'commit',
+          `["commit",{"tag":"commit"},{"watermark":"${w}"}]`,
+        ]);
+      } else if (kind === 'rollback') {
+        rows.push([w, 'rollback', `["rollback",{"tag":"rollback"}]`]);
+      } // Orphan transactions have no terminal row.
+    });
+    return rows;
+  }
+
+  async function* chunked(
+    rows: WatermarkedChange[],
+    sizes: number[],
+  ): AsyncIterable<WatermarkedChange[]> {
+    let i = 0;
+    let s = 0;
+    while (i < rows.length) {
+      const size = sizes[s++ % sizes.length];
+      yield rows.slice(i, i + size);
+      i += size;
+    }
+  }
+
+  const digest = (rows: WatermarkedChange[], sizes: number[] = [3]) =>
+    digestCatchupRange(
+      chunked(rows, sizes),
+      rows.at(-1)?.[0] ?? '',
+      rows.length + 1,
+      NO_BYTE_LIMIT,
+    );
+
+  test('the digest is a pure function of the served rows, not their batching', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        streamScenario,
+        async ({txs, truncateHead, chunkSizesA, chunkSizesB}) => {
+          const rows = buildRows(txs).slice(truncateHead);
+
+          // Batch boundaries do not change the digest or row count.
+          expect(await digest(rows, chunkSizesA)).toEqual(
+            await digest(rows, chunkSizesB),
+          );
+          expect((await digest(rows, chunkSizesA)).rows).toBe(rows.length);
+        },
+      ),
+      {numRuns: 100},
+    );
+  });
+
+  test('the digest changes under any single-row corruption', async () => {
+    type Corruption = 'drop' | 'mutate' | 'duplicate' | 'move-to-end';
+
+    await fc.assert(
+      fc.asyncProperty(
+        fc.record({
+          txs: streamScenario.map(({txs}) => txs),
+          index: fc.nat(),
+          kind: fc.constantFrom<Corruption>(
+            'drop',
+            'mutate',
+            'duplicate',
+            'move-to-end',
+          ),
+        }),
+        async ({txs, index, kind}) => {
+          const rows = buildRows(txs);
+          const i = index % rows.length;
+          // Moving the only or last row does not change its order.
+          fc.pre(kind !== 'move-to-end' || i < rows.length - 1);
+
+          const corrupted = [...rows];
+          switch (kind) {
+            case 'drop':
+              corrupted.splice(i, 1);
+              break;
+            case 'mutate': {
+              const [w, tag, json] = rows[i];
+              corrupted[i] = [w, tag, `${json.slice(0, -1)},"extra":1]`];
+              break;
+            }
+            case 'duplicate':
+              corrupted.splice(i, 0, rows[i]);
+              break;
+            case 'move-to-end':
+              corrupted.push(...corrupted.splice(i, 1));
+              break;
+          }
+
+          // Each corruption changes the ordered range digest.
+          expect((await digest(corrupted)).digest).not.toBe(
+            (await digest(rows)).digest,
+          );
+        },
+      ),
+      {numRuns: 200},
+    );
+  });
+
+  test('the digest ignores JSON formatting, as the two stores differ in it', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.record({txs: streamScenario.map(({txs}) => txs)}),
+        async ({txs}) => {
+          const rows = buildRows(txs);
+          // Both stores can return the same JSON with different formatting.
+          const reformatted = rows.map(
+            ([w, tag, json]): WatermarkedChange => [
+              w,
+              tag,
+              json.replaceAll(':', ': ').replaceAll(',', ', '),
+            ],
+          );
+          expect((await digest(reformatted)).digest).toBe(
+            (await digest(rows)).digest,
+          );
+        },
+      ),
+      {numRuns: 50},
+    );
+  });
+
+  test('the row cap reports whether the range closed', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.record({
+          txs: streamScenario.map(({txs}) => txs),
+          maxRows: fc.integer({min: 1, max: 60}),
+        }),
+        async ({txs, maxRows}) => {
+          const rows = buildRows(txs);
+          const through = rows.at(-1)?.[0] ?? '';
+          const result = await digestCatchupRange(
+            chunked(rows, [4]),
+            through,
+            maxRows,
+            NO_BYTE_LIMIT,
+          );
+
+          const served = Math.min(maxRows, rows.length);
+          expect(result.rows).toBe(served);
+          // The limit applies only when it omits the closing commit.
+          const closed = rows
+            .slice(0, served)
+            .some(([w, tag]) => tag === 'commit' && w === through);
+          expect(result.limitReached).toBe(served === maxRows && !closed);
+        },
+      ),
+      {numRuns: 100},
+    );
+  });
+
+  test('the byte budget bounds the read', async () => {
+    const rows = buildRows([{width: 5, kind: 'complete'}]);
+    const through = rows.at(-1)?.[0] ?? '';
+    const read = (maxBytes: number) =>
+      digestCatchupRange(
+        chunked(rows, [4]),
+        through,
+        rows.length + 1,
+        maxBytes,
+      );
+
+    // A budget above the cost of the range serves all of it.
+    const full = await read(NO_BYTE_LIMIT);
+    expect(full.rows).toBe(rows.length);
+    expect(full.bytes).toBeGreaterThan(0);
+    expect(full.limitReached).toBe(false);
+
+    // A budget below that cost stops before the closing commit.
+    const cut = await read(Math.floor(full.bytes / 2));
+    expect(cut.limitReached).toBe(true);
+    expect(cut.rows).toBeLessThan(full.rows);
+    expect(cut.bytes).toBeLessThan(full.bytes);
+
+    // A row wider than the whole budget stops the read before it is parsed.
+    const none = await read(1);
+    expect(none.rows).toBe(0);
+    expect(none.bytes).toBe(0);
+    expect(none.limitReached).toBe(true);
+  });
+
+  test('the byte count measures normalized payloads, not stored text', async () => {
+    // The same logical rows, one store padding its JSON with whitespace.
+    const canonical = buildRows([{width: 3, kind: 'complete'}]);
+    const padded = canonical.map(
+      ([w, tag, json]) =>
+        [w, tag, json.replaceAll(',', ' ,\n  ')] as WatermarkedChange,
+    );
+    const through = canonical.at(-1)?.[0] ?? '';
+
+    const a = await digestCatchupRange(
+      chunked(canonical, [4]),
+      through,
+      canonical.length + 1,
+      NO_BYTE_LIMIT,
+    );
+    const b = await digestCatchupRange(
+      chunked(padded, [4]),
+      through,
+      padded.length + 1,
+      NO_BYTE_LIMIT,
+    );
+
+    // Both stores spend the same budget, so a limit falls in the same place
+    // for both and neither side is sampled less than the other.
+    expect(b.bytes).toBe(a.bytes);
+    expect(b.digest).toBe(a.digest);
+    expect(b.rows).toBe(a.rows);
+  });
+
+  test('sampling is stable, bounded, and monotone in the percentage', () => {
+    fc.assert(
+      fc.property(
+        fc.record({
+          appID: fc.string({minLength: 1, maxLength: 8}),
+          shardNum: fc.nat({max: 1000}),
+          watermark: fc.hexaString({minLength: 2, maxLength: 10}),
+          p1: fc.integer({min: 0, max: 100}),
+          p2: fc.integer({min: 0, max: 100}),
+        }),
+        ({appID, shardNum, watermark, p1, p2}) => {
+          const shard: ShardID = {appID, shardNum};
+          const lo = Math.min(p1, p2);
+          const hi = Math.max(p1, p2);
+          // A retry selects the same transactions.
+          expect(isSampledForCompare(shard, watermark, hi)).toBe(
+            isSampledForCompare(shard, watermark, hi),
+          );
+          // A larger percentage keeps the transactions in a smaller sample.
+          if (isSampledForCompare(shard, watermark, lo)) {
+            expect(isSampledForCompare(shard, watermark, hi)).toBe(true);
+          }
+          expect(isSampledForCompare(shard, watermark, 0)).toBe(false);
+          expect(isSampledForCompare(shard, watermark, 100)).toBe(true);
+        },
+      ),
+    );
+  });
+
+  test('normalization collapses formatting and preserves content', () => {
+    expect(normalizeChangeJSON('{ "tag" : "insert",\n  "v": 1 }')).toBe(
+      normalizeChangeJSON('{"tag":"insert","v":1}'),
+    );
+    // Values above Number.MAX_SAFE_INTEGER retain their precision.
+    expect(normalizeChangeJSON('{"v":9007199254740993}')).toBe(
+      '{"v":9007199254740993}',
+    );
+    // Invalid JSON remains unchanged.
+    expect(normalizeChangeJSON('not-json')).toBe('not-json');
+
+    fc.assert(
+      fc.property(fc.oneof(fc.json(), fc.string()), value => {
+        const once = normalizeChangeJSON(value);
+        expect(normalizeChangeJSON(once)).toBe(once);
+      }),
+    );
+  });
+});

--- a/packages/zero-cache/src/services/change-streamer/change-log-compare-digest.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-log-compare-digest.ts
@@ -1,0 +1,112 @@
+/**
+ * Pure building blocks for comparing catchup output between the Postgres and
+ * SQLite change logs: which transactions to sample, and how to reduce a
+ * catchup range to a single comparable digest.
+ *
+ * Nothing here touches either store. The comparator service supplies the
+ * batches.
+ */
+
+import {createHash} from 'node:crypto';
+import {BigIntJSON} from '../../../../shared/src/bigint-json.ts';
+import type {ShardID} from '../../types/shards.ts';
+import {extractChangeSubstring} from './change-log-codec.ts';
+import {ChangeLogTransactionHasher} from './change-log-transaction-hash.ts';
+import type {WatermarkedChange} from './change-streamer.ts';
+
+/** Selects a stable sample by shard and watermark. */
+export function isSampledForCompare(
+  shard: ShardID,
+  watermark: string,
+  percent: number,
+): boolean {
+  if (percent >= 100) {
+    return true;
+  }
+  if (percent <= 0) {
+    return false;
+  }
+  const digest = createHash('sha256')
+    .update(`${shard.appID}/${shard.shardNum}:${watermark}`)
+    .digest();
+  return digest.readUInt32BE(0) % 100 < percent;
+}
+
+/**
+ * Normalizes JSON text before hashing.
+ *
+ * SQLite preserves the source text. Postgres can change its formatting.
+ * Invalid JSON remains unchanged.
+ */
+export function normalizeChangeJSON(change: string): string {
+  try {
+    return BigIntJSON.stringify(BigIntJSON.parse(change));
+  } catch {
+    return change;
+  }
+}
+
+export type CatchupRangeDigest = {
+  readonly digest: string;
+  readonly rows: number;
+  /** Normalized bytes hashed. This is the payload cost of the range. */
+  readonly bytes: number;
+  /** A row or byte limit was reached before the closing commit. */
+  readonly limitReached: boolean;
+};
+
+/**
+ * Builds one ordered digest for a catchup range.
+ *
+ * The row position makes missing, extra, changed, and reordered rows change the digest.
+ * The digest omits `precommit` because a commit already includes its watermark.
+ *
+ * The read stops at `maxRows` or at `maxBytes`, whichever comes first.
+ */
+export async function digestCatchupRange(
+  batches: AsyncIterable<readonly WatermarkedChange[]>,
+  throughWatermark: string,
+  maxRows: number,
+  maxBytes: number,
+): Promise<CatchupRangeDigest> {
+  const hasher = new ChangeLogTransactionHasher();
+  let rows = 0;
+  let bytes = 0;
+  let servedClosingCommit = false;
+
+  for await (const batch of batches) {
+    for (const [watermark, tag, json] of batch) {
+      if (rows === maxRows || bytes >= maxBytes) {
+        return {digest: hasher.digest(), rows, bytes, limitReached: true};
+      }
+      // Measure the stored text before parsing it. A row wider than the
+      // whole budget never fits, and normalizing it first would pay the
+      // cost that this limit exists to avoid.
+      if (json.length > maxBytes) {
+        return {digest: hasher.digest(), rows, bytes, limitReached: true};
+      }
+      const change = normalizeChangeJSON(extractChangeSubstring(json, tag));
+      hasher.add({
+        watermark,
+        pos: rows,
+        tag,
+        change,
+        precommit: null,
+      });
+      rows++;
+      // Count the normalized length so both stores measure the same logical
+      // payload. Stored encodings differ between them. Normalized ones do not.
+      bytes += change.length;
+      if (tag === 'commit' && watermark === throughWatermark) {
+        servedClosingCommit = true;
+      }
+    }
+  }
+  return {
+    digest: hasher.digest(),
+    rows,
+    bytes,
+    limitReached:
+      (rows === maxRows || bytes >= maxBytes) && !servedClosingCommit,
+  };
+}

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
@@ -340,6 +340,7 @@ describe('change-streamer/service', () => {
     sqliteCatchup?: Partial<SQLiteCatchupOptions>,
     sqliteChangeLogPurge?: TuningOptions['sqliteChangeLogPurge'],
     backupURL?: string,
+    sqliteChangeLogCompare?: TuningOptions['sqliteChangeLogCompare'],
   ): Promise<void> {
     await streamer.stop();
     await streamerDone;
@@ -381,6 +382,9 @@ describe('change-streamer/service', () => {
           },
         },
         ...(sqliteChangeLogPurge === undefined ? {} : {sqliteChangeLogPurge}),
+        ...(sqliteChangeLogCompare === undefined
+          ? {}
+          : {sqliteChangeLogCompare}),
         ...(sqliteCatchup === undefined
           ? {}
           : {
@@ -870,6 +874,125 @@ describe('change-streamer/service', () => {
       storeSpy.mockRestore();
       writeSpy.mockRestore();
       forwardSpy.mockRestore();
+      await streamer.stop();
+      await streamerDone;
+      deleteChangeLogDB(logFile.path);
+      logFile.delete();
+    }
+  });
+
+  /**
+   * Compare mode runs initialization and catchup checks independently.
+   * Failures do not stop replication.
+   * A warm log reports injected Postgres divergence.
+   */
+  test('compare mode: both checks run and fail independently', async () => {
+    const COLD_INTERVAL_MS = 777_001;
+    const WARM_INTERVAL_MS = 777_002;
+    const logFile = new DbFile('sqlite-change-log-compare-coexist');
+    const noSuchReplica = `${logFile.path}-no-such-replica`;
+
+    const fireCompareCycle = (intervalMs: number, fromIndex: number) => {
+      const call = setTimeoutFn.mock.calls
+        .slice(fromIndex)
+        .find(([, delay]) => delay === intervalMs);
+      assert(call, `no comparison cycle scheduled at ${intervalMs}ms`);
+      (call[0] as () => void)();
+    };
+    const logged = (level: string, message: string) =>
+      logSink.messages.some(
+        ([lvl, , parts]) => lvl === level && parts[0] === message,
+      );
+    // Read diverged watermarks from production error logs.
+    const divergedWatermarks = () =>
+      logSink.messages
+        .filter(([level, , parts]) => level === 'error' && parts.length === 2)
+        .flatMap(([, , parts]) => {
+          const detail = (
+            parts[1] as {
+              sqliteChangeLogCompare?: {watermark: string} | undefined;
+            }
+          ).sqliteChangeLogCompare;
+          return detail === undefined ? [] : [detail.watermark];
+        });
+
+    try {
+      // Start with a new log and a missing replica file.
+      await restartWithInlineChangeLogWriter(
+        logFile,
+        {},
+        undefined,
+        undefined,
+        {
+          replicaFile: noSuchReplica,
+          comparePercent: 100,
+          retentionMs: 60_000,
+          intervalMs: COLD_INTERVAL_MS,
+        },
+      );
+
+      // Both advisory checks leave replication active.
+      changes.push(['begin', messages.begin(), {commitWatermark: '06'}]);
+      changes.push(['data', messages.insert('foo', {id: 'compared'})]);
+      changes.push(['commit', messages.commit(), {watermark: '06'}]);
+      await expectAcks('06');
+
+      // The missing replica causes a warning, but startup continues.
+      await vi.waitFor(() =>
+        expect(
+          logged(
+            'warn',
+            'failed to derive change-log initialization from the replica',
+          ),
+        ).toBe(true),
+      );
+
+      // The comparator skips the new log without reporting divergence.
+      fireCompareCycle(COLD_INTERVAL_MS, 0);
+      await vi.waitFor(() =>
+        expect(
+          logged('debug', 'skipping SQLite change-log comparison: cold-log'),
+        ).toBe(true),
+      );
+      expect(divergedWatermarks()).toEqual([]);
+
+      // Restart with a clock that makes the log warm.
+      const warmStart = setTimeoutFn.mock.calls.length;
+      await restartWithInlineChangeLogWriter(
+        logFile,
+        {},
+        undefined,
+        undefined,
+        {
+          replicaFile: noSuchReplica,
+          comparePercent: 100,
+          retentionMs: 60_000,
+          intervalMs: WARM_INTERVAL_MS,
+          now: () => Date.now() + 3_600_000,
+        },
+      );
+
+      changes.push(['begin', messages.begin(), {commitWatermark: '08'}]);
+      changes.push(['data', messages.insert('foo', {id: 'diverged'})]);
+      changes.push(['commit', messages.commit(), {watermark: '08'}]);
+      await expectAcks('08');
+
+      // Change the stored Postgres row after commit.
+      const [{change}] = await sql<{change: string}[]>`
+        SELECT change::text FROM "zoro_3/cdc"."changeLog"
+         WHERE watermark = '08' AND pos = 1`;
+      const mutated = JSON.stringify({
+        ...(JSON.parse(change) as Record<string, unknown>),
+        divergence: true,
+      });
+      await sql`
+        UPDATE "zoro_3/cdc"."changeLog" SET change = ${mutated}::json
+         WHERE watermark = '08' AND pos = 1`;
+
+      // Transaction 06 matches. Transaction 08 diverges.
+      fireCompareCycle(WARM_INTERVAL_MS, warmStart);
+      await vi.waitFor(() => expect(divergedWatermarks()).toEqual(['08']));
+    } finally {
       await streamer.stop();
       await streamerDone;
       deleteChangeLogDB(logFile.path);

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
@@ -791,6 +791,197 @@ describe('change-streamer/service', () => {
     }
   });
 
+  /**
+   * §6.6's rollback drill. At readPercent=100, with a subscriber served from
+   * SQLite and a snapshot reservation confirmed while SQLite was the pinned
+   * source, a restart back to un-flipped routing keeps every promise on PG:
+   * everything SQLite can promise, PG can serve.
+   */
+  test('rollback drill: a restart out of serve mode keeps every subscriber on PG range', async () => {
+    const readerRead = vi.spyOn(SQLiteChangeLogReader.prototype, 'read');
+    const logFile = new DbFile('sqlite-change-log-rollback-drill');
+    await restartWithInlineChangeLogWriter(
+      logFile,
+      {barrierPollIntervalMs: 10},
+      undefined,
+      's3://foo/bar',
+      undefined,
+      {readPercent: 100, retentionMs: 0},
+    );
+
+    try {
+      changes.push(['begin', messages.begin(), {commitWatermark: '06'}]);
+      changes.push(['data', messages.insert('foo', {id: 'pre-rollback'})]);
+      changes.push(['commit', messages.commit(), {watermark: '06'}]);
+      await expectAcks('06');
+
+      // Flipped: a serving subscriber reads from SQLite.
+      const flipped = await subscribeServing('flipped');
+      const flippedOut = drainToQueue(flipped);
+      expect(await nextChange(flippedOut)).toMatchObject({tag: 'status'});
+      expect(await nextChange(flippedOut)).toMatchObject({tag: 'begin'});
+      expect(await nextChange(flippedOut)).toMatchObject({
+        tag: 'insert',
+        new: {id: 'pre-rollback'},
+      });
+      expect(await nextChange(flippedOut)).toMatchObject({tag: 'commit'});
+      expect(readerRead).toHaveBeenCalled();
+      flipped.cancel();
+
+      // A follower's reservation, confirmed while SQLite is the pinned
+      // source. The advertised bounds are the promise the rollback must keep.
+      streamer.trackBackupWatermark('06');
+      const reservation = await streamer.startSnapshotReservation('follower');
+      const [, status] = await drainSnapshotMessages(reservation).dequeue();
+      const promisedMin = (status as {minWatermark: string}).minWatermark;
+      expect(promisedMin).toBe('06');
+
+      // The rollback deploy: same log and stores, no serve option, so no
+      // router is constructed and routing reverts to PG.
+      readerRead.mockClear();
+      await restartWithInlineChangeLogWriter(
+        logFile,
+        {barrierPollIntervalMs: 10},
+        undefined,
+        's3://foo/bar',
+      );
+
+      changes.push(['begin', messages.begin(), {commitWatermark: '08'}]);
+      changes.push(['data', messages.insert('foo', {id: 'post-rollback'})]);
+      changes.push(['commit', messages.commit(), {watermark: '08'}]);
+      await expectAcks('08');
+
+      // The pre-rollback subscriber reconnects where it left off and gets
+      // range from PG -- not too-old, not a reset.
+      const reconnected = await streamer.subscribe({
+        protocolVersion: PROTOCOL_VERSION,
+        taskID: 'flipped-task',
+        id: 'flipped',
+        mode: 'serving',
+        watermark: '06',
+        replicaVersion: REPLICA_VERSION,
+        initial: true,
+        logsChangeStream: false,
+      });
+      const reconnectedOut = drainToQueue(reconnected);
+      expect(await nextChange(reconnectedOut)).toMatchObject({tag: 'status'});
+      expect(await nextChange(reconnectedOut)).toMatchObject({tag: 'begin'});
+      expect(await nextChange(reconnectedOut)).toMatchObject({
+        tag: 'insert',
+        new: {id: 'post-rollback'},
+      });
+      expect(await nextChange(reconnectedOut)).toMatchObject({tag: 'commit'});
+      reconnected.cancel();
+
+      // The follower restores at the bounds advertised under SQLite pinning
+      // and catches up from PG.
+      const follower = await streamer.subscribe({
+        protocolVersion: PROTOCOL_VERSION,
+        taskID: 'follower',
+        id: 'follower',
+        mode: 'serving',
+        watermark: promisedMin,
+        replicaVersion: REPLICA_VERSION,
+        initial: true,
+        logsChangeStream: false,
+      });
+      const followerOut = drainToQueue(follower);
+      expect(await nextChange(followerOut)).toMatchObject({tag: 'status'});
+      expect(await nextChange(followerOut)).toMatchObject({tag: 'begin'});
+      expect(await nextChange(followerOut)).toMatchObject({
+        tag: 'insert',
+        new: {id: 'post-rollback'},
+      });
+      expect(readerRead).not.toHaveBeenCalled();
+      follower.cancel();
+    } finally {
+      readerRead.mockRestore();
+      await streamer.stop();
+      await streamerDone;
+      deleteChangeLogDB(logFile.path);
+      logFile.delete();
+    }
+  });
+
+  /**
+   * §6.6's flip-forward drill. A restart from un-flipped routing into serve
+   * mode at 100 percent, against a log that survived the restart, moves
+   * catchup to SQLite with no reset and the same committed sequence.
+   */
+  test('flip-forward drill: a restart into serve mode moves catchup to SQLite', async () => {
+    const readerRead = vi.spyOn(SQLiteChangeLogReader.prototype, 'read');
+    const logFile = new DbFile('sqlite-change-log-flip-drill');
+    // Un-flipped: the writer runs, catchup is served from PG.
+    await restartWithInlineChangeLogWriter(logFile, {
+      barrierPollIntervalMs: 10,
+    });
+
+    try {
+      changes.push(['begin', messages.begin(), {commitWatermark: '06'}]);
+      changes.push(['data', messages.insert('foo', {id: 'pre-flip'})]);
+      changes.push(['commit', messages.commit(), {watermark: '06'}]);
+      await expectAcks('06');
+
+      const before = await subscribeServing('pre-flip');
+      const beforeOut = drainToQueue(before);
+      expect(await nextChange(beforeOut)).toMatchObject({tag: 'status'});
+      expect(await nextChange(beforeOut)).toMatchObject({tag: 'begin'});
+      expect(await nextChange(beforeOut)).toMatchObject({
+        tag: 'insert',
+        new: {id: 'pre-flip'},
+      });
+      expect(await nextChange(beforeOut)).toMatchObject({tag: 'commit'});
+      expect(readerRead).not.toHaveBeenCalled();
+      before.cancel();
+
+      // The flip deploy. The log's head equals the resume watermark, so
+      // reconciliation keeps it -- the flip serves from the same log the
+      // un-flipped process wrote, with no reseed and no warm-up hole.
+      await restartWithInlineChangeLogWriter(
+        logFile,
+        {barrierPollIntervalMs: 10},
+        undefined,
+        undefined,
+        undefined,
+        {readPercent: 100, retentionMs: 0},
+      );
+
+      changes.push(['begin', messages.begin(), {commitWatermark: '08'}]);
+      changes.push(['data', messages.insert('foo', {id: 'post-flip'})]);
+      changes.push(['commit', messages.commit(), {watermark: '08'}]);
+      await expectAcks('08');
+
+      // A subscriber reconnecting across the flip is served the same
+      // committed sequence, now from SQLite.
+      const after = await streamer.subscribe({
+        protocolVersion: PROTOCOL_VERSION,
+        taskID: 'pre-flip-task',
+        id: 'pre-flip',
+        mode: 'serving',
+        watermark: '06',
+        replicaVersion: REPLICA_VERSION,
+        initial: true,
+        logsChangeStream: false,
+      });
+      const afterOut = drainToQueue(after);
+      expect(await nextChange(afterOut)).toMatchObject({tag: 'status'});
+      expect(await nextChange(afterOut)).toMatchObject({tag: 'begin'});
+      expect(await nextChange(afterOut)).toMatchObject({
+        tag: 'insert',
+        new: {id: 'post-flip'},
+      });
+      expect(await nextChange(afterOut)).toMatchObject({tag: 'commit'});
+      expect(readerRead).toHaveBeenCalled();
+      after.cancel();
+    } finally {
+      readerRead.mockRestore();
+      await streamer.stop();
+      await streamerDone;
+      deleteChangeLogDB(logFile.path);
+      logFile.delete();
+    }
+  });
+
   test('SQLite cleanup continues independently after PG reaches the floor', async () => {
     const logFile = new DbFile('sqlite-change-log-independent-purge');
     await restartWithInlineChangeLogWriter(logFile, undefined, {

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
@@ -341,6 +341,7 @@ describe('change-streamer/service', () => {
     sqliteChangeLogPurge?: TuningOptions['sqliteChangeLogPurge'],
     backupURL?: string,
     sqliteChangeLogCompare?: TuningOptions['sqliteChangeLogCompare'],
+    sqliteChangeLogServe?: TuningOptions['sqliteChangeLogServe'],
   ): Promise<void> {
     await streamer.stop();
     await streamerDone;
@@ -385,6 +386,7 @@ describe('change-streamer/service', () => {
         ...(sqliteChangeLogCompare === undefined
           ? {}
           : {sqliteChangeLogCompare}),
+        ...(sqliteChangeLogServe === undefined ? {} : {sqliteChangeLogServe}),
         ...(sqliteCatchup === undefined
           ? {}
           : {
@@ -564,6 +566,231 @@ describe('change-streamer/service', () => {
     }
   });
 
+  test('serve mode at zero percent measures eligibility but keeps catchup on PG', async () => {
+    const readerRead = vi.spyOn(SQLiteChangeLogReader.prototype, 'read');
+    const logFile = new DbFile('sqlite-change-log-zero-percent');
+    await restartWithInlineChangeLogWriter(
+      logFile,
+      {barrierPollIntervalMs: 10},
+      undefined,
+      undefined,
+      undefined,
+      {readPercent: 0, retentionMs: 0},
+    );
+
+    try {
+      changes.push(['begin', messages.begin(), {commitWatermark: '06'}]);
+      changes.push(['data', messages.insert('foo', {id: 'from-pg'})]);
+      changes.push(['commit', messages.commit(), {watermark: '06'}]);
+      await expectAcks('06');
+
+      const sub = await subscribeServing('zero-percent');
+      const output = drainToQueue(sub);
+      expect(await nextChange(output)).toMatchObject({tag: 'status'});
+      expect(await nextChange(output)).toMatchObject({tag: 'begin'});
+      expect(await nextChange(output)).toMatchObject({
+        tag: 'insert',
+        new: {id: 'from-pg'},
+      });
+      expect(await nextChange(output)).toMatchObject({tag: 'commit'});
+      expect(readerRead).not.toHaveBeenCalled();
+
+      // The route log carries the covered range even though the percentage
+      // gate kept this eligible subscriber on PG.
+      expect(logSink.messages).toContainEqual([
+        'debug',
+        expect.anything(),
+        [
+          expect.stringContaining('SQLite route percentage'),
+          expect.objectContaining({
+            sqliteChangeLogCoverage: expect.objectContaining({
+              minWatermark: REPLICA_VERSION,
+              headWatermark: '06',
+            }),
+          }),
+        ],
+      ]);
+      sub.cancel();
+    } finally {
+      readerRead.mockRestore();
+      await streamer.stop();
+      await streamerDone;
+      deleteChangeLogDB(logFile.path);
+      logFile.delete();
+    }
+  });
+
+  test('serve mode declines a freshly seeded log until its retention window elapses', async () => {
+    const readerRead = vi.spyOn(SQLiteChangeLogReader.prototype, 'read');
+    const logFile = new DbFile('sqlite-change-log-warmup');
+    const retentionMs = 60_000;
+    let now = Date.now();
+    await restartWithInlineChangeLogWriter(
+      logFile,
+      {barrierPollIntervalMs: 10},
+      undefined,
+      undefined,
+      undefined,
+      {readPercent: 100, retentionMs, now: () => now},
+    );
+
+    try {
+      changes.push(['begin', messages.begin(), {commitWatermark: '06'}]);
+      changes.push(['data', messages.insert('foo', {id: 'warmup'})]);
+      changes.push(['commit', messages.commit(), {watermark: '06'}]);
+      await expectAcks('06');
+
+      const coldSub = await subscribeServing('cold-log');
+      const cold = drainToQueue(coldSub);
+      expect(await nextChange(cold)).toMatchObject({tag: 'status'});
+      expect(await nextChange(cold)).toMatchObject({tag: 'begin'});
+      expect(await nextChange(cold)).toMatchObject({tag: 'insert'});
+      expect(await nextChange(cold)).toMatchObject({tag: 'commit'});
+      expect(readerRead).not.toHaveBeenCalled();
+
+      now += retentionMs + 10_000;
+      const warmSub = await subscribeServing('warm-log');
+      const warm = drainToQueue(warmSub);
+      expect(await nextChange(warm)).toMatchObject({tag: 'status'});
+      expect(await nextChange(warm)).toMatchObject({tag: 'begin'});
+      expect(await nextChange(warm)).toMatchObject({tag: 'insert'});
+      expect(await nextChange(warm)).toMatchObject({tag: 'commit'});
+      expect(readerRead).toHaveBeenCalled();
+
+      coldSub.cancel();
+      warmSub.cancel();
+    } finally {
+      readerRead.mockRestore();
+      await streamer.stop();
+      await streamerDone;
+      deleteChangeLogDB(logFile.path);
+      logFile.delete();
+    }
+  });
+
+  test('serve mode sends a subscriber below the SQLite floor to PG', async () => {
+    const readerRead = vi.spyOn(SQLiteChangeLogReader.prototype, 'read');
+    const pgCatchup = vi.spyOn(Storer.prototype, 'catchup');
+    const logFile = new DbFile('sqlite-change-log-uncovered-watermark');
+    await restartWithInlineChangeLogWriter(
+      logFile,
+      {barrierPollIntervalMs: 10},
+      undefined,
+      undefined,
+      undefined,
+      {
+        readPercent: 100,
+        retentionMs: 0,
+        // The route inspection raced the purge and still saw the old floor.
+        inspect: () => ({
+          seededAtMs: 0,
+          seedWatermark: REPLICA_VERSION,
+          minWatermark: REPLICA_VERSION,
+          headWatermark: '06',
+        }),
+      },
+    );
+
+    try {
+      changes.push(['begin', messages.begin(), {commitWatermark: '06'}]);
+      changes.push(['data', messages.insert('foo', {id: 'from-pg'})]);
+      changes.push(['commit', messages.commit(), {watermark: '06'}]);
+      await expectAcks('06');
+
+      // Model a SQLite purge that has moved past a still-retained PG boundary.
+      using changeLog = openChangeLogDB(lc, logFile.path, {readonly: false});
+      changeLog
+        .prepare(/*sql*/ `DELETE FROM "_zero.changeLogStream"
+                            WHERE "watermark" < '06'`)
+        .run();
+      expect(sqliteMinWatermark(logFile)).toBe('06');
+
+      const sub = await subscribeServing('below-sqlite-floor');
+      const output = drainToQueue(sub);
+      expect(await nextChange(output)).toMatchObject({tag: 'status'});
+      expect(await nextChange(output)).toMatchObject({tag: 'begin'});
+      expect(await nextChange(output)).toMatchObject({
+        tag: 'insert',
+        new: {id: 'from-pg'},
+      });
+      expect(await nextChange(output)).toMatchObject({tag: 'commit'});
+      expect(pgCatchup).toHaveBeenCalled();
+      expect(readerRead).not.toHaveBeenCalled();
+      expect(logSink.messages).toContainEqual([
+        'info',
+        expect.anything(),
+        [
+          expect.stringContaining(
+            'subscriber watermark 01 is below the SQLite change-log minimum 06',
+          ),
+        ],
+      ]);
+      sub.cancel();
+    } finally {
+      readerRead.mockRestore();
+      pgCatchup.mockRestore();
+      await streamer.stop();
+      await streamerDone;
+      deleteChangeLogDB(logFile.path);
+      logFile.delete();
+    }
+  });
+
+  test('a post-registration SQLite read failure sends the retry to PG', async () => {
+    const readerRead = vi
+      .spyOn(SQLiteChangeLogReader.prototype, 'read')
+      .mockImplementationOnce(async function* () {
+        throw new Error('injected SQLite read failure');
+      });
+    const logFile = new DbFile('sqlite-change-log-read-breaker');
+    await restartWithInlineChangeLogWriter(
+      logFile,
+      {barrierPollIntervalMs: 10},
+      undefined,
+      undefined,
+      undefined,
+      {readPercent: 100, retentionMs: 0},
+    );
+
+    try {
+      changes.push(['begin', messages.begin(), {commitWatermark: '06'}]);
+      changes.push(['data', messages.insert('foo', {id: 'from-pg-retry'})]);
+      changes.push(['commit', messages.commit(), {watermark: '06'}]);
+      await expectAcks('06');
+
+      const failed = await subscribeServing('breaker-retry');
+      for await (const _ of failed) {
+        // The injected reader failure happens before SQLite emits catchup.
+      }
+      expect(readerRead).toHaveBeenCalledOnce();
+      expect(logSink.messages).toContainEqual([
+        'warn',
+        expect.anything(),
+        [expect.stringContaining('temporarily disabling SQLite catchup')],
+      ]);
+
+      // The same stable task would ordinarily select SQLite again. The open
+      // breaker sends this immediate reconnect through the complete PG path.
+      const retrySub = await subscribeServing('breaker-retry');
+      const retry = drainToQueue(retrySub);
+      expect(await nextChange(retry)).toMatchObject({tag: 'status'});
+      expect(await nextChange(retry)).toMatchObject({tag: 'begin'});
+      expect(await nextChange(retry)).toMatchObject({
+        tag: 'insert',
+        new: {id: 'from-pg-retry'},
+      });
+      expect(await nextChange(retry)).toMatchObject({tag: 'commit'});
+      expect(readerRead).toHaveBeenCalledOnce();
+      retrySub.cancel();
+    } finally {
+      readerRead.mockRestore();
+      await streamer.stop();
+      await streamerDone;
+      deleteChangeLogDB(logFile.path);
+      logFile.delete();
+    }
+  });
+
   test('SQLite cleanup continues independently after PG reaches the floor', async () => {
     const logFile = new DbFile('sqlite-change-log-independent-purge');
     await restartWithInlineChangeLogWriter(logFile, undefined, {
@@ -726,10 +953,11 @@ describe('change-streamer/service', () => {
    * pinned once the restore is over.
    */
   test('a snapshot reservation pauses the SQLite purge until it closes', async () => {
+    const readerRead = vi.spyOn(SQLiteChangeLogReader.prototype, 'read');
     const logFile = new DbFile('sqlite-change-log-reservation-pause');
     await restartWithInlineChangeLogWriter(
       logFile,
-      undefined,
+      {barrierPollIntervalMs: 10},
       {
         retentionMs: 1,
         batchRows: 100,
@@ -737,6 +965,8 @@ describe('change-streamer/service', () => {
         yieldFn: () => Promise.resolve(),
       },
       's3://foo/bar',
+      undefined,
+      {readPercent: 100, retentionMs: 0},
     );
 
     const watermarks = ['03', '04', '05', '06', '07', '08'];
@@ -787,14 +1017,32 @@ describe('change-streamer/service', () => {
       await fireNextTimer();
       expect(sqliteMinWatermark(logFile)).toBe(REPLICA_VERSION);
 
+      // The matching /changes request consumes the source pinned by
+      // /snapshot. Its ACK keeps protecting the same SQLite range while
+      // subscribe() closes the reservation and resumes purging.
+      const sub = await streamer.subscribe({
+        protocolVersion: PROTOCOL_VERSION,
+        taskID: 'view-syncer-1',
+        id: 'view-syncer-1',
+        mode: 'serving',
+        watermark: '08',
+        replicaVersion: REPLICA_VERSION,
+        initial: true,
+        logsChangeStream: false,
+      });
+      const output = drainToQueue(sub);
+      expect(await nextChange(output)).toMatchObject({tag: 'status'});
+      expect(readerRead).toHaveBeenCalled();
+
       // Closing the reservation resumes purging: the next armed pass drains
-      // the SQLite log to the floor.
-      reservation.cancel();
+      // the SQLite log to the floor protected by the subscriber ACK.
       await fireNextTimer();
       expect(sqliteMinWatermark(logFile)).toBe('08');
       // Cleanup reached the backup watermark: nothing further is armed.
       expect(setTimeoutFn).toHaveBeenCalledTimes(fired);
+      sub.cancel();
     } finally {
+      readerRead.mockRestore();
       await streamer.stop();
       await streamerDone;
       deleteChangeLogDB(logFile.path);
@@ -1519,10 +1767,20 @@ describe('change-streamer/service', () => {
   test('a mid-stream writer failure fails soft without stopping replication', async () => {
     const readerClose = vi.spyOn(SQLiteChangeLogReader.prototype, 'close');
     const logFile = new DbFile('sqlite-change-log-fail-soft');
-    await restartWithInlineChangeLogWriter(logFile, {
-      barrierPollIntervalMs: 10,
-      shouldUse: ctx => ctx.id.startsWith('from-sqlite'),
-    });
+    await restartWithInlineChangeLogWriter(
+      logFile,
+      {
+        barrierPollIntervalMs: 10,
+        shouldUse: ctx => ctx.id.startsWith('from-sqlite'),
+      },
+      undefined,
+      undefined,
+      undefined,
+      {
+        readPercent: 100,
+        retentionMs: 0,
+      },
+    );
 
     const liveSub = await subscribeServing('live-observer');
     const live = drainToQueue(liveSub);
@@ -1611,10 +1869,7 @@ describe('change-streamer/service', () => {
     }
   });
 
-  // The exclusion outlives its original reason -- the writer is no longer a
-  // subscriber, so nothing can wait on its own ACK -- because a replicator that
-  // predates the writer's move still sets the parameter. Slice 11 lifts it.
-  test('backup subscribers and legacy change-log writers cannot select SQLite catchup', async () => {
+  test('backup subscribers stay on PG while the legacy writer hint can select SQLite', async () => {
     await streamer.stop();
     await streamerDone;
 
@@ -1713,39 +1968,34 @@ describe('change-streamer/service', () => {
       });
       expect(await nextChange(backed)).toMatchObject({tag: 'commit'});
 
+      appendSQLiteTransaction(catchupReplica, catchupChangeLog, '04', [
+        ['data', messages.insert('foo', {id: 'from-sqlite'})],
+      ]);
+
       shouldUse.mockClear();
       const writerSub = await streamer.subscribe({
         protocolVersion: PROTOCOL_VERSION,
         taskID: 'task-id',
         id: 'change-log-writer',
-        // A single-node canonical writer has serving mode, so the independent
-        // logsChangeStream guard remains necessary.
+        // Slice 11 deliberately ignores this legacy hint: the writer now lives
+        // in the change-streamer, and no subscriber ACK advances the log.
         mode: 'serving',
         watermark: REPLICA_VERSION,
         replicaVersion: REPLICA_VERSION,
         initial: true,
         logsChangeStream: true,
       });
-      expect(shouldUse).not.toHaveBeenCalled();
+      expect(shouldUse).toHaveBeenCalledOnce();
       const written = drainToQueue(writerSub);
 
-      // Served from PG instead of waiting on itself.
+      // Served from SQLite; the payload differs from PG only to pin routing.
       expect(await nextChange(written)).toMatchObject({tag: 'status'});
       expect(await nextChange(written)).toMatchObject({tag: 'begin'});
       expect(await nextChange(written)).toMatchObject({
         tag: 'insert',
-        new: {id: 'forwarded'},
+        new: {id: 'from-sqlite'},
       });
       expect(await nextChange(written)).toMatchObject({tag: 'commit'});
-      expect(logSink.messages).toContainEqual([
-        'warn',
-        expect.anything(),
-        [
-          expect.stringContaining(
-            'not serving legacy change-log writer change-log-writer',
-          ),
-        ],
-      ]);
 
       observerSub.cancel();
       backupSub.cancel();

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -59,6 +59,10 @@ import {
   type SQLiteChangeLogCleanupGuard,
 } from './sqlite-change-log-catchup.ts';
 import {
+  SQLiteChangeLogComparator,
+  type SQLiteChangeLogCompareOptions,
+} from './sqlite-change-log-comparator.ts';
+import {
   SQLiteChangeLogPurgeScheduler,
   type PurgeContinuation,
   type SQLiteChangeLogPurgeSchedulerOptions,
@@ -137,14 +141,15 @@ export type TuningOptions = StorerOptions & {
    */
   sqliteChangeLogPurge?: SQLiteChangeLogPurgeSchedulerOptions | undefined;
   /**
-   * Supplied at `sqliteChangeLogMode >= compare`, and the gate on deriving the
-   * stream's initialization parameters from the replica as well as from
-   * Postgres. Postgres stays authoritative; the two are compared and the
-   * result is reported. Not a new configuration option -- the mode ladder
-   * carries it, because a state in which the log's buffer and its cookies were
-   * at different rollout stages is what invariant 15 exists to forbid.
+   * Supplied in `compare` mode and later modes.
+   * `replicaFile` enables the initialization comparison.
+   * The other fields configure sampled catchup comparisons.
+   * Both checks are advisory, and Postgres remains authoritative.
+   * The comparator also requires the writer and catchup options.
    */
-  sqliteChangeLogCompare?: {replicaFile: string} | undefined;
+  sqliteChangeLogCompare?:
+    | (SQLiteChangeLogCompareOptions & {replicaFile: string})
+    | undefined;
 };
 
 /**
@@ -357,6 +362,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
   readonly #sqliteCatchupOptions: SQLiteCatchupOptions | undefined;
   readonly #changeLogWriter: SQLiteChangeLogWriter | undefined;
   readonly #purgeScheduler: SQLiteChangeLogPurgeScheduler | undefined;
+  readonly #comparator: SQLiteChangeLogComparator | undefined;
   readonly #acker: UpstreamAcker;
   readonly #initializer: ChangeLogInitializer;
 
@@ -479,8 +485,15 @@ class ChangeStreamerImpl implements ChangeStreamerService {
           // Fail-soft deletes the file, and the reader is cached here, so it
           // has to go with it: otherwise it serves an unlinked inode while
           // every new open sees nothing.
-          onDisabled: () => this.#closeSQLiteCatchup(),
-          onRebuilt: () => this.#closeSQLiteCatchup(),
+          onDisabled: () => {
+            this.#closeSQLiteCatchup();
+            this.#comparator?.stop();
+          },
+          onRebuilt: () => {
+            this.#closeSQLiteCatchup();
+            // Invalidate cycles that can still read the replaced file.
+            this.#comparator?.invalidate();
+          },
         })
       : undefined;
     // The purge scheduler runs on the writer's own connection, which is also
@@ -535,6 +548,20 @@ class ChangeStreamerImpl implements ChangeStreamerService {
             this.#purgeScheduler?.cleanupGuard,
         }
       : undefined;
+    // Compare mode requires the writer and catchup configuration.
+    this.#comparator =
+      opts.sqliteChangeLogCompare &&
+      opts.sqliteChangeLogWriter &&
+      opts.sqliteCatchup
+        ? new SQLiteChangeLogComparator(
+            lc,
+            shard,
+            opts.sqliteCatchup.changeLogFile,
+            opts.sqliteChangeLogWriter.identity,
+            this.#storer,
+            {setTimeoutFn, ...opts.sqliteChangeLogCompare},
+          )
+        : undefined;
     this.#purgeLock = initialPurgeLock;
     this.#autoReset = autoReset;
     this.#state = new RunningState(this.id, undefined, setTimeoutFn);
@@ -1034,6 +1061,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
     this.#state.stop(this.#lc, err);
     this.#stream?.changes.cancel();
     this.#purgeScheduler?.stop();
+    this.#comparator?.stop();
     this.#sqliteCatchup?.close();
     this.#changeLogWriter?.close();
     await Promise.allSettled([this.#storer.stop(), this.#source.stop()]);

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -67,6 +67,12 @@ import {
   type PurgeContinuation,
   type SQLiteChangeLogPurgeSchedulerOptions,
 } from './sqlite-change-log-purge-scheduler.ts';
+import {
+  inspectSQLiteChangeLog,
+  SQLiteChangeLogReadRouter,
+  type ChangeLogReadRoute,
+  type SQLiteChangeLogCoverage,
+} from './sqlite-change-log-read-router.ts';
 import {SQLiteChangeLogReader} from './sqlite-change-log-reader.ts';
 import {
   SQLiteChangeLogWriter,
@@ -96,11 +102,9 @@ export type SQLiteCatchupOptions = {
    */
   barrierPollIntervalMs?: number | undefined;
   /**
-   * Slice 11 supplies the production canary selector.
-   *
-   * It does not need to exclude backup subscribers or the change-log writer:
-   * eligibility checks reject both before invoking this selector. Serving a
-   * writer from SQLite would make it wait on its own ACK.
+   * Optional policy hook used by focused tests. Production canary selection is
+   * supplied by `sqliteChangeLogServe` and is stable by shard plus task ID.
+   * Backup subscribers are rejected before either selector is invoked.
    */
   shouldUse?: ((ctx: SubscriberContext) => boolean) | undefined;
   /**
@@ -115,6 +119,19 @@ export type SQLiteCatchupOptions = {
    * {@link DEFAULT_CHANGE_LOG_UNAVAILABLE_WARN_THRESHOLD_MS}.
    */
   notReadyWarnThresholdMs?: number | undefined;
+};
+
+export type SQLiteChangeLogServeOptions = {
+  /** Stable percentage of eligible serving tasks routed to SQLite. */
+  readPercent: number;
+  /** A reseeded log must age through this whole window before it can serve. */
+  retentionMs: number;
+  /** Injectable for deterministic breaker tests. */
+  failureCooldownMs?: number | undefined;
+  /** Injectable for deterministic warm-up and breaker tests. */
+  now?: (() => number) | undefined;
+  /** Injectable readiness inspection for service-level tests. */
+  inspect?: (() => SQLiteChangeLogCoverage | undefined) | undefined;
 };
 
 export type TuningOptions = StorerOptions & {
@@ -150,6 +167,8 @@ export type TuningOptions = StorerOptions & {
   sqliteChangeLogCompare?:
     | (SQLiteChangeLogCompareOptions & {replicaFile: string})
     | undefined;
+  /** Supplied only in `serve` mode. A zero percentage keeps every read on PG. */
+  sqliteChangeLogServe?: SQLiteChangeLogServeOptions | undefined;
 };
 
 /**
@@ -365,6 +384,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
   readonly #comparator: SQLiteChangeLogComparator | undefined;
   readonly #acker: UpstreamAcker;
   readonly #initializer: ChangeLogInitializer;
+  readonly #readRouter: SQLiteChangeLogReadRouter | undefined;
 
   readonly #autoReset: boolean;
   readonly #state: RunningState;
@@ -397,6 +417,11 @@ class ChangeStreamerImpl implements ChangeStreamerService {
     'transaction_forward_duration',
     "Time from receiving a transaction's `begin` to forwarding its `commit`, " +
       'i.e. the change-streamer half of forward-to-subscriber latency.',
+  );
+  readonly #catchupRoutes = getOrCreateCounter(
+    'replication',
+    'sqlite_change_log.catchup_routes',
+    'Catchup subscriptions by selected source and low-cardinality reason.',
   );
 
   #latestStatus: Status;
@@ -467,10 +492,32 @@ class ChangeStreamerImpl implements ChangeStreamerService {
       flowControlSlowSubscriberGracePeriodMs:
         opts.flowControlSlowSubscriberGracePeriodMs,
     });
+    const serveOptions = opts.sqliteChangeLogServe;
+    const writerOptions = opts.sqliteChangeLogWriter;
+    const catchupOptions = opts.sqliteCatchup;
+    this.#readRouter =
+      serveOptions && writerOptions && catchupOptions
+        ? new SQLiteChangeLogReadRouter({
+            shard,
+            readPercent: serveOptions.readPercent,
+            retentionMs: serveOptions.retentionMs,
+            failureCooldownMs: serveOptions.failureCooldownMs,
+            now: serveOptions.now,
+            inspect:
+              serveOptions.inspect ??
+              (() =>
+                inspectSQLiteChangeLog(
+                  lc,
+                  catchupOptions.changeLogFile,
+                  writerOptions.identity,
+                )),
+          })
+        : undefined;
     this.#reservations = backupConfig
-      ? new SnapshotReservations(lc, backupConfig, taskID =>
-          this.#purgeScheduler?.resume(taskID),
-        )
+      ? new SnapshotReservations(lc, backupConfig, taskID => {
+          this.#readRouter?.release(taskID);
+          this.#purgeScheduler?.resume(taskID);
+        })
       : undefined;
     this.#replicationStatusPublisher = replicationStatusPublisher;
     this.#changeLogWriter = opts.sqliteChangeLogWriter
@@ -486,6 +533,10 @@ class ChangeStreamerImpl implements ChangeStreamerService {
           // has to go with it: otherwise it serves an unlinked inode while
           // every new open sees nothing.
           onDisabled: () => {
+            // The writer stays disabled and the file stays absent for the life
+            // of this process, so unlike a transient read/barrier failure this
+            // breaker never expires.
+            this.#readRouter?.trip(true);
             this.#closeSQLiteCatchup();
             this.#comparator?.stop();
           },
@@ -821,12 +872,30 @@ class ChangeStreamerImpl implements ChangeStreamerService {
     } else {
       lc.info?.(`adding subscriber ${subscriber.id}`);
 
-      const sqliteCatchup = this.#selectSQLiteCatchup(ctx);
-      if (sqliteCatchup) {
-        cleanupSubscriber = () => sqliteCatchup.remove(subscriber);
-        await sqliteCatchup.catchup(subscriber, () =>
+      const sqliteSelection = this.#selectSQLiteCatchup(ctx);
+      if (sqliteSelection) {
+        const {catchup, reason, coverage} = sqliteSelection;
+        cleanupSubscriber = () => catchup.remove(subscriber);
+        const registration = await catchup.catchup(subscriber, () =>
           this.#captureRequiredHead(),
         );
+        if (registration.kind === 'registered') {
+          this.#lc.debug?.(
+            `serving ${ctx.id} from SQLite catchup`,
+            ...(coverage ? [{sqliteChangeLogCoverage: coverage}] : []),
+          );
+          this.#recordCatchupRoute('sqlite', reason);
+        } else if (registration.kind === 'uncovered') {
+          this.#lc.info?.(
+            `serving ${ctx.id} from PG catchup: subscriber watermark ` +
+              `${ctx.watermark} is below the SQLite change-log minimum ` +
+              registration.minWatermark,
+          );
+          this.#recordCatchupRoute('pg', 'watermark-uncovered');
+          cleanupSubscriber = () => this.#forwarder.remove(subscriber);
+          this.#forwarder.add(subscriber);
+          this.#storer.catchup(subscriber, mode);
+        }
       } else {
         // Keep the existing PG registration/catchup lockstep unchanged when
         // SQLite was not selected before Forwarder.add().
@@ -852,6 +921,16 @@ class ChangeStreamerImpl implements ChangeStreamerService {
       // Wait for an in-flight SQLite purge batch before reading and
       // advertising the reservation's bounds.
       await (this.#purgeScheduler?.pause(taskID) ?? promiseVoid);
+      // A concurrent retry for this task may have superseded and cancelled
+      // this reservation while its purge pause was settling. Only the current
+      // owner may replace the task's source pin.
+      if (!this.#reservations.isCurrent(taskID, downstream)) {
+        return downstream;
+      }
+      // Pin after the purge pause has settled, so the SQLite minimum captured
+      // by the router cannot move before it is advertised. #confirmReservations
+      // skips an unpinned task while this await is in flight.
+      this.#readRouter?.pin(taskID);
       // If a backup has been confirmed, immediately confirm the reservation.
       await this.#confirmReservations();
       return downstream;
@@ -886,18 +965,47 @@ class ChangeStreamerImpl implements ChangeStreamerService {
   }
 
   async #confirmReservations() {
-    if (this.#backupWatermark && this.#reservations?.confirmationsRequired()) {
-      const {replicaVersion, minWatermark} = await this.#getChangeLogState();
-      if (minWatermark <= this.#backupWatermark) {
-        this.#reservations?.confirm(replicaVersion, this.#backupWatermark);
+    const backupWatermark = this.#backupWatermark;
+    const reservations = this.#reservations;
+    if (
+      backupWatermark === undefined ||
+      !reservations?.confirmationsRequired()
+    ) {
+      return;
+    }
+
+    let pgState: {replicaVersion: string; minWatermark: string} | undefined;
+    for (const taskID of reservations.unconfirmedTaskIDs()) {
+      const route = this.#readRouter?.peek(taskID);
+      // startSnapshotReservation pins only after an in-flight purge has
+      // completed. Do not race that await by confirming with PG bounds and
+      // then switching the matching /changes request to SQLite.
+      if (this.#readRouter && route === undefined) {
+        continue;
+      }
+
+      let replicaVersion: string;
+      let minWatermark: string;
+      if (route?.source === 'sqlite') {
+        const coverage = route.coverage;
+        assert(coverage, 'a pinned SQLite route must carry its covered range');
+        replicaVersion = this.#replicaVersion;
+        minWatermark = coverage.minWatermark;
       } else {
-        // Something is wrong here ... the change-log should not have been
-        // purged past the backup watermark. If we confirm the reservation,
-        // we may not be able to catch up from the backup that the requester
-        // restores.
+        pgState ??= await this.#getChangeLogState();
+        ({replicaVersion, minWatermark} = pgState);
+      }
+
+      if (minWatermark <= backupWatermark) {
+        reservations.confirmFor(taskID, replicaVersion, backupWatermark);
+      } else {
+        // The selected source cannot catch a restored replica up from this
+        // backup yet. Keep the reservation pending until a later backup moves
+        // the durable watermark into its covered range.
         this.#lc.error?.(
-          `change-log minWatermark ${minWatermark} is later than backupWatermark ${this.#backupWatermark}. ` +
-            `Delaying confirmation of snapshot reservation until next backup.`,
+          `${route?.source ?? 'pg'} change-log minWatermark ${minWatermark} ` +
+            `is later than backupWatermark ${backupWatermark}. Delaying ` +
+            `confirmation of snapshot reservation until next backup.`,
         );
       }
     }
@@ -1135,12 +1243,10 @@ class ChangeStreamerImpl implements ChangeStreamerService {
 
   #selectSQLiteCatchup(
     ctx: SubscriberContext,
-  ): SQLiteChangeLogCatchup | undefined {
+  ): SQLiteCatchupSelection | undefined {
     const opts = this.#sqliteCatchupOptions;
-    // Slice 11 supplies a non-default selector. Until then, this keeps all
-    // production subscriptions on PG even though the complete SQLite handoff
-    // path is wired and testable.
     if (this.#lastForwardedCommitWatermark === undefined || !opts) {
+      this.#recordCatchupRoute('pg', 'not-ready');
       return undefined;
     }
     // SQLite catchup is only for disposable serving replicas. Backup
@@ -1151,24 +1257,76 @@ class ChangeStreamerImpl implements ChangeStreamerService {
       this.#lc.info?.(
         `not serving backup subscriber ${ctx.id} from SQLite catchup`,
       );
+      this.#recordCatchupRoute('pg', 'ineligible-mode');
       return undefined;
     }
-    if (ctx.logsChangeStream) {
-      // The reason for this exclusion is gone: the writer is no longer a
-      // subscriber, so nothing can wait on its own ACK, and no replicator this
-      // version ships sets the parameter. It stays until slice 11 lifts it
-      // deliberately, because a subscriber that predates the writer's move does
-      // set it, and serving one from SQLite is a change in behavior rather than
-      // a cleanup.
-      this.#lc.warn?.(
-        `not serving legacy change-log writer ${ctx.id} from SQLite catchup`,
-      );
+
+    let route: ChangeLogReadRoute | undefined;
+    if (this.#readRouter) {
+      route = this.#readRouter.consume(ctx.taskID);
+      if (route.source === 'pg') {
+        if (route.reason === 'cold-log') {
+          this.#lc.info?.(
+            `serving ${ctx.id} from PG catchup: SQLite change log is still warming`,
+            {sqliteChangeLogCoverage: route.coverage},
+          );
+        } else if (route.reason === 'log-unavailable') {
+          this.#declineSQLiteCatchup(
+            ctx,
+            opts,
+            `${opts.changeLogFile} is unavailable or incompatible`,
+          );
+        } else {
+          this.#lc.debug?.(
+            `serving ${ctx.id} from PG catchup: SQLite route ${route.reason}`,
+            ...(route.coverage
+              ? [{sqliteChangeLogCoverage: route.coverage}]
+              : []),
+          );
+        }
+        this.#recordCatchupRoute('pg', route.reason);
+        return undefined;
+      }
+      const coverage = route.coverage;
+      assert(coverage, 'a SQLite route must carry its covered range');
+      if (ctx.watermark < coverage.minWatermark) {
+        this.#lc.info?.(
+          `serving ${ctx.id} from PG catchup: subscriber watermark ` +
+            `${ctx.watermark} is below the SQLite change-log minimum ` +
+            coverage.minWatermark,
+          {sqliteChangeLogCoverage: coverage},
+        );
+        this.#recordCatchupRoute('pg', 'watermark-uncovered');
+        return undefined;
+      }
+    }
+
+    // `shouldUse` remains as a test hook and an optional extra policy gate.
+    // Production selection comes from #readRouter.
+    if (!this.#readRouter && !opts.shouldUse?.(ctx)) {
+      this.#recordCatchupRoute('pg', 'selector');
       return undefined;
     }
-    if (!opts.shouldUse?.(ctx)) {
+    if (this.#readRouter && opts.shouldUse && !opts.shouldUse(ctx)) {
+      this.#recordCatchupRoute('pg', 'selector');
       return undefined;
     }
-    return this.#sqliteCatchup ?? this.#openSQLiteCatchup(opts, ctx);
+
+    const catchup = this.#sqliteCatchup ?? this.#openSQLiteCatchup(opts, ctx);
+    if (catchup) {
+      return {
+        catchup,
+        reason: route?.reason ?? 'selector',
+        coverage: route?.coverage,
+      };
+    } else {
+      this.#recordCatchupRoute('pg', 'log-unavailable');
+    }
+    return undefined;
+  }
+
+  #recordCatchupRoute(source: 'pg' | 'sqlite', reason: string): void {
+    this.#catchupRoutes.add(1, {source, reason});
   }
 
   /**
@@ -1231,6 +1389,15 @@ class ChangeStreamerImpl implements ChangeStreamerService {
         barrierTimeoutMs: opts.barrierTimeoutMs,
         barrierPollIntervalMs: opts.barrierPollIntervalMs,
         cleanupGuard: opts.cleanupGuard,
+        // Production routing only reaches this point after the warm-up gate.
+        // Legacy focused-test selection has no warm classification.
+        logWarm: this.#readRouter ? true : undefined,
+        onFailure: failure => {
+          this.#lc.warn?.(
+            `temporarily disabling SQLite catchup after ${failure}`,
+          );
+          this.#readRouter?.trip();
+        },
       },
     );
     return this.#sqliteCatchup;
@@ -1264,6 +1431,12 @@ class ChangeStreamerImpl implements ChangeStreamerService {
 type ForwardedTransactionCompletion =
   | {kind: 'committed'; watermark: string}
   | {kind: 'rolled-back'; watermark: string};
+
+type SQLiteCatchupSelection = {
+  readonly catchup: SQLiteChangeLogCatchup;
+  readonly reason: string;
+  readonly coverage: SQLiteChangeLogCoverage | undefined;
+};
 
 // The delay between receiving an initial, backup-based watermark
 // and performing a check of whether to purge records before it.

--- a/packages/zero-cache/src/services/change-streamer/change-streamer.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer.ts
@@ -151,15 +151,9 @@ export type SubscriberContext = {
   initial: boolean;
 
   /**
-   * Whether the subscriber's replica writes the SQLite change log that the
-   * `change-streamer` reads for catchup.
-   *
-   * Always `false` from this version on: the change-streamer writes that log
-   * itself, from the stream loop, so no subscriber advances it and no
-   * subscriber's ACK releases the catchup barrier. The parameter stays on the
-   * wire because a subscriber that predates the writer's move still sets it,
-   * and such a subscriber is excluded from SQLite catchup until slice 11 lifts
-   * the exclusion deliberately.
+   * Legacy topology hint retained on the wire. It no longer affects local
+   * routing: the change-streamer writes the SQLite log itself, so no
+   * subscriber's ACK advances its head or releases its catchup barrier.
    */
   logsChangeStream: boolean;
 };

--- a/packages/zero-cache/src/services/change-streamer/snapshot-reservations.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/snapshot-reservations.test.ts
@@ -96,6 +96,25 @@ describe('change-streamer/snapshot-reservations', () => {
     ]);
   });
 
+  test('confirmFor() applies the pinned source bounds to one task only', async () => {
+    const reservations = newReservations();
+    const first = getFirstMessage(reservations.open('task-1'));
+    reservations.open('task-2');
+
+    expect(reservations.unconfirmedTaskIDs().sort()).toEqual([
+      'task-1',
+      'task-2',
+    ]);
+    reservations.confirmFor('task-1', 'replica-v1', 'sqlite-min');
+
+    expect(await first).toMatchObject([
+      'status',
+      {replicaVersion: 'replica-v1', minWatermark: 'sqlite-min'},
+    ]);
+    expect(reservations.unconfirmedTaskIDs()).toEqual(['task-2']);
+    expect(reservations.getReservedWatermarks()).toEqual(['sqlite-min']);
+  });
+
   test('confirm() only resolves reservations opened before it was called', () => {
     const reservations = newReservations();
     reservations.open('task-1');
@@ -120,6 +139,8 @@ describe('change-streamer/snapshot-reservations', () => {
     const sub2 = reservations.open('task-1');
 
     expect(await isCancelled(sub1)).toBe(true);
+    expect(reservations.isCurrent('task-1', sub1)).toBe(false);
+    expect(reservations.isCurrent('task-1', sub2)).toBe(true);
 
     // Only one reservation is tracked for the taskID, and it's the new one:
     // it still receives the confirm() push.

--- a/packages/zero-cache/src/services/change-streamer/snapshot-reservations.ts
+++ b/packages/zero-cache/src/services/change-streamer/snapshot-reservations.ts
@@ -40,6 +40,10 @@ export class SnapshotReservations {
     this.#close(taskID, undefined);
   }
 
+  isCurrent(taskID: string, source: Source<SnapshotMessage>): boolean {
+    return this.#reservations.get(taskID)?.owns(source) ?? false;
+  }
+
   #close(taskID: string, cancelledInstanceID: InstanceID | undefined) {
     const res = this.#reservations.get(taskID);
     if (
@@ -76,14 +80,30 @@ export class SnapshotReservations {
     return false;
   }
 
+  unconfirmedTaskIDs(): string[] {
+    return [...this.#reservations.entries()]
+      .filter(([, reservation]) => !reservation.confirmed())
+      .map(([taskID]) => taskID);
+  }
+
   confirm(replicaVersion: string, minWatermark: string) {
-    for (const [taskID, res] of this.#reservations.entries()) {
-      if (!res.confirmed()) {
-        this.#lc.info?.(
-          `reserving change-log entries since ${minWatermark} for ${taskID}`,
-        );
-        res.confirm(this.#backupConfig.backupURL, replicaVersion, minWatermark);
-      }
+    for (const taskID of this.unconfirmedTaskIDs()) {
+      this.confirmFor(taskID, replicaVersion, minWatermark);
+    }
+  }
+
+  /** Confirms one reservation with the bounds of its pinned read source. */
+  confirmFor(
+    taskID: string,
+    replicaVersion: string,
+    minWatermark: string,
+  ): void {
+    const res = this.#reservations.get(taskID);
+    if (res && !res.confirmed()) {
+      this.#lc.info?.(
+        `reserving change-log entries since ${minWatermark} for ${taskID}`,
+      );
+      res.confirm(this.#backupConfig.backupURL, replicaVersion, minWatermark);
     }
   }
 
@@ -117,6 +137,10 @@ class Reservation {
 
   confirmed() {
     return this.#watermark !== null;
+  }
+
+  owns(source: Source<SnapshotMessage>): boolean {
+    return this.#downstream === source;
   }
 
   confirm(backupURL: string, replicaVersion: string, minWatermark: string) {

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.test.ts
@@ -255,7 +255,7 @@ describe('SQLiteChangeLogCatchup', () => {
     const plan = vi.spyOn(fixture.reader, 'plan');
     const {subscriber, output} = createSubscriber('01');
     await fixture.coordinator.catchup(subscriber, () => '06');
-    await vi.waitFor(() => expect(plan).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(plan).toHaveBeenCalledTimes(2));
 
     fixture.reader.entries.push(...transaction('06'));
     fixture.reader.boundaries.add('06');
@@ -279,13 +279,13 @@ describe('SQLiteChangeLogCatchup', () => {
     const plan = vi.spyOn(fixture.reader, 'plan');
     const {subscriber, output} = createSubscriber('01');
     await fixture.coordinator.catchup(subscriber, () => '06');
-    await vi.waitFor(() => expect(plan).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(plan).toHaveBeenCalledTimes(2));
 
     // The writer is still behind the required head. Waking on every commit
     // would re-read the log at the writer's commit rate for no reason.
     fixture.coordinator.onChangeLogCommit('04');
     await sleep(20);
-    expect(plan).toHaveBeenCalledOnce();
+    expect(plan).toHaveBeenCalledTimes(2);
     expect(output.size()).toBe(0);
 
     fixture.reader.entries.push(...transaction('06'));
@@ -313,12 +313,12 @@ describe('SQLiteChangeLogCatchup', () => {
     const cancelBacklogWait = vi.spyOn(backlogFull, 'cancel');
     vi.spyOn(subscriber, 'whenBacklogFull').mockReturnValue(backlogFull);
     await fixture.coordinator.catchup(subscriber, () => '06');
-    await vi.waitFor(() => expect(plan).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(plan).toHaveBeenCalledTimes(2));
 
     // An ACK that the reader cannot yet corroborate wakes the barrier but does
     // not release it: plan() decides what is readable.
     fixture.coordinator.onChangeLogCommit('06');
-    await vi.waitFor(() => expect(plan).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() => expect(plan).toHaveBeenCalledTimes(3));
     expect(output.size()).toBe(0);
 
     fixture.reader.entries.push(...transaction('06'));
@@ -340,6 +340,17 @@ describe('SQLiteChangeLogCatchup', () => {
     fixture.reader.head = '06';
     fixture.reader.boundaries.add('04');
     const {output, subscriber} = createSubscriber('01');
+    vi.spyOn(fixture.reader, 'plan')
+      .mockReturnValueOnce({
+        kind: 'range',
+        minWatermark: '01',
+        headWatermark: '06',
+      })
+      .mockReturnValueOnce({
+        kind: 'too-old',
+        minWatermark: '04',
+        headWatermark: '06',
+      });
     await fixture.coordinator.catchup(subscriber, () => '06');
     expect(await output.dequeue()).toEqual([
       'error',
@@ -350,12 +361,29 @@ describe('SQLiteChangeLogCatchup', () => {
     ]);
   });
 
+  test('declines an uncovered watermark before registering', async () => {
+    const fixture = createFixture();
+    fixture.reader.min = '04';
+    fixture.reader.head = '06';
+    fixture.reader.boundaries.add('04');
+    const {output, subscriber} = createSubscriber('01');
+
+    expect(await fixture.coordinator.catchup(subscriber, () => '06')).toEqual({
+      kind: 'uncovered',
+      minWatermark: '04',
+    });
+    expect(fixture.forwarder.getAcks()).toEqual(new Set());
+    expect(output.size()).toBe(0);
+  });
+
   test('gives up the barrier once the subscriber backlog fills', async () => {
+    const onFailure = vi.fn();
     // Long enough that only the backlog can end this wait. Bytes, not time,
     // are the real bound; the deadline is only a backstop for an idle shard.
     const fixture = createFixture({
       barrierTimeoutMs: 60_000,
       barrierPollIntervalMs: 60_000,
+      onFailure,
     });
     fixture.reader.head = '01';
 
@@ -374,6 +402,7 @@ describe('SQLiteChangeLogCatchup', () => {
     // holding replication while the backlog grows.
     expect(fail).not.toHaveBeenCalled();
     expect(output.size()).toBe(0);
+    expect(onFailure).toHaveBeenCalledExactlyOnceWith('barrier-backlog');
     expect(fixture.logSink.messages).toContainEqual([
       'warn',
       expect.anything(),
@@ -387,7 +416,8 @@ describe('SQLiteChangeLogCatchup', () => {
   });
 
   test('ends only the selected subscription, cleanly, on barrier timeout', async () => {
-    const fixture = createFixture({barrierTimeoutMs: 5});
+    const onFailure = vi.fn();
+    const fixture = createFixture({barrierTimeoutMs: 5, onFailure});
     fixture.reader.head = '01';
     const {subscriber, done, output} = createSubscriber('01');
     const fail = vi.spyOn(subscriber, 'fail');
@@ -400,6 +430,7 @@ describe('SQLiteChangeLogCatchup', () => {
     // caught up yet" warrants.
     expect(fail).not.toHaveBeenCalled();
     expect(output.size()).toBe(0);
+    expect(onFailure).toHaveBeenCalledExactlyOnceWith('barrier-timeout');
     expect(fixture.logSink.messages).toContainEqual([
       'warn',
       expect.anything(),
@@ -461,7 +492,8 @@ describe('SQLiteChangeLogCatchup', () => {
   });
 
   test('fails closed on reader errors after registration', async () => {
-    const fixture = createFixture();
+    const onFailure = vi.fn();
+    const fixture = createFixture({onFailure});
     fixture.reader.head = '06';
     fixture.reader.boundaries.add('01');
     fixture.reader.readError = new Error('broken SQLite read');
@@ -473,6 +505,7 @@ describe('SQLiteChangeLogCatchup', () => {
     // operators through the log below, not through the subscriber.
     await done;
     expect(output.size()).toBe(0);
+    expect(onFailure).toHaveBeenCalledExactlyOnceWith('reader-error');
     expect(fixture.logSink.messages).toContainEqual([
       'error',
       expect.anything(),
@@ -526,6 +559,7 @@ function createFixture(
     barrierPollIntervalMs?: number | undefined;
     cleanupGuard?: SQLiteChangeLogCleanupGuard | undefined;
     now?: SQLiteChangeLogCatchupOptions['now'];
+    onFailure?: SQLiteChangeLogCatchupOptions['onFailure'];
     sleep?: SQLiteChangeLogCatchupOptions['sleep'];
   } = {},
 ) {
@@ -539,6 +573,7 @@ function createFixture(
     barrierPollIntervalMs: opts.barrierPollIntervalMs ?? 1,
     cleanupGuard: opts.cleanupGuard,
     now: opts.now,
+    onFailure: opts.onFailure,
     sleep: opts.sleep,
   });
   coordinators.push(coordinator);

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.ts
@@ -2,7 +2,11 @@ import type {LogContext} from '@rocicorp/logger';
 import {resolver} from '@rocicorp/resolver';
 import {AbortError} from '../../../../shared/src/abort-error.ts';
 import {sleep} from '../../../../shared/src/sleep.ts';
-import {getOrCreateCounter} from '../../observability/metrics.ts';
+import {
+  getOrCreateCounter,
+  getOrCreateLatencyHistogram,
+  getOrCreateValueHistogram,
+} from '../../observability/metrics.ts';
 import type {WatermarkedChange} from './change-streamer.ts';
 import * as ErrorType from './error-type-enum.ts';
 import type {Forwarder} from './forwarder.ts';
@@ -42,7 +46,22 @@ export type SQLiteChangeLogCatchupOptions = {
   cleanupGuard?: SQLiteChangeLogCleanupGuard | undefined;
   sleep?: typeof sleep | undefined;
   now?: (() => number) | undefined;
+  /** Whether the routing warm-up gate classified this log as warm. */
+  logWarm?: boolean | undefined;
+  /** Opens slice 11's process-local breaker after registration has committed. */
+  onFailure?: ((failure: SQLiteChangeLogCatchupFailure) => void) | undefined;
 };
+
+export type SQLiteChangeLogCatchupFailure =
+  | 'barrier-timeout'
+  | 'barrier-backlog'
+  | 'reader-error';
+
+export type SQLiteChangeLogCatchupRegistration =
+  | {readonly kind: 'registered'}
+  | {readonly kind: 'uncovered'; readonly minWatermark: string}
+  // The coordinator closed or failed the subscriber itself.
+  | {readonly kind: 'handled'};
 
 const NOOP_CLEANUP_GUARD: SQLiteChangeLogCleanupGuard = {
   runWhilePurgeBlocked: register => Promise.resolve(register()),
@@ -67,6 +86,10 @@ export class SQLiteChangeLogCatchup implements Disposable {
   readonly #cleanupGuard: SQLiteChangeLogCleanupGuard;
   readonly #sleep: typeof sleep;
   readonly #now: () => number;
+  readonly #logWarm: boolean | undefined;
+  readonly #onFailure:
+    | ((failure: SQLiteChangeLogCatchupFailure) => void)
+    | undefined;
   readonly #barrierTimeouts = getOrCreateCounter(
     'replication',
     'sqlite_change_log.barrier_timeouts',
@@ -84,6 +107,46 @@ export class SQLiteChangeLogCatchup implements Disposable {
     'SQLite catchup barrier waits, labeled by what ended the wait. A ' +
       'population dominated by "poll" means the change-log writer\'s commit ' +
       'notification is not reaching the barrier.',
+  );
+  readonly #catchupResults = getOrCreateCounter(
+    'replication',
+    'sqlite_change_log.catchup_results',
+    'SQLite catchup subscriptions by outcome.',
+  );
+  readonly #catchupRows = getOrCreateCounter(
+    'replication',
+    'sqlite_change_log.catchup_rows',
+    'Rows served from the SQLite change log during catchup.',
+  );
+  readonly #catchupBytes = getOrCreateCounter(
+    'replication',
+    'sqlite_change_log.catchup_bytes',
+    {
+      description: 'Bytes served from the SQLite change log during catchup.',
+      unit: 'By',
+    },
+  );
+  readonly #catchupDuration = getOrCreateLatencyHistogram(
+    'replication',
+    'sqlite_change_log.catchup_duration',
+    'Duration of a SQLite change-log catchup.',
+  );
+  readonly #barrierWaitDuration = getOrCreateLatencyHistogram(
+    'replication',
+    'sqlite_change_log.barrier_wait_duration',
+    'Time SQLite catchup waits for its pinned required head.',
+  );
+  readonly #catchupBacklogPeak = getOrCreateValueHistogram(
+    'replication',
+    'sqlite_change_log.catchup_backlog_peak_bytes',
+    {
+      description:
+        'Peak live backlog bytes buffered while a subscriber catches up from SQLite.',
+      unit: 'By',
+      bucketBoundaries: [
+        0, 1024, 16_384, 65_536, 262_144, 1_048_576, 4_194_304, 16_777_216,
+      ],
+    },
   );
   readonly #catchups = new Map<Subscriber, AbortController>();
   readonly #commitWaiters = new Set<CommitWaiter>();
@@ -105,6 +168,8 @@ export class SQLiteChangeLogCatchup implements Disposable {
     this.#cleanupGuard = opts.cleanupGuard ?? NOOP_CLEANUP_GUARD;
     this.#sleep = opts.sleep ?? sleep;
     this.#now = opts.now ?? Date.now;
+    this.#logWarm = opts.logWarm;
+    this.#onFailure = opts.onFailure;
   }
 
   /**
@@ -115,18 +180,29 @@ export class SQLiteChangeLogCatchup implements Disposable {
   async catchup(
     subscriber: Subscriber,
     captureRequiredHead: () => string | Promise<string>,
-  ): Promise<void> {
+  ): Promise<SQLiteChangeLogCatchupRegistration> {
     if (this.#closed) {
       subscriber.fail(new AbortError('SQLite change-log catchup is closed'));
-      return;
+      return {kind: 'handled'};
     }
 
     const abort = new AbortController();
     this.#catchups.set(subscriber, abort);
     let requiredHead: string | Promise<string> | undefined;
+    let uncoveredMinWatermark: string | undefined;
     try {
       await this.#cleanupGuard.runWhilePurgeBlocked(() => {
         this.#throwIfAborted(abort.signal);
+        // The router's eligibility inspection happens before this async guard
+        // is acquired. Recheck the exact boundary here: an in-flight purge can
+        // have advanced the minimum while registration waited. Once added to
+        // the Forwarder, the subscriber's ACK prevents any later purge from
+        // crossing this boundary.
+        const plan = this.#reader.plan(subscriber.watermark);
+        if (plan.kind === 'too-old') {
+          uncoveredMinWatermark = plan.minWatermark;
+          return;
+        }
         requiredHead = captureRequiredHead();
         this.#forwarder.add(subscriber);
       });
@@ -139,10 +215,15 @@ export class SQLiteChangeLogCatchup implements Disposable {
         );
         subscriber.fail(error);
       }
-      return;
+      return {kind: 'handled'};
+    }
+    if (uncoveredMinWatermark !== undefined) {
+      this.#catchups.delete(subscriber);
+      return {kind: 'uncovered', minWatermark: uncoveredMinWatermark};
     }
 
     void this.#run(subscriber, requiredHead as string | Promise<string>, abort);
+    return {kind: 'registered'};
   }
 
   /**
@@ -192,6 +273,9 @@ export class SQLiteChangeLogCatchup implements Disposable {
     abort: AbortController,
   ): Promise<void> {
     const {signal} = abort;
+    const catchupStart = this.#now();
+    let outcome = 'aborted';
+    let backlogPeakBytes = 0;
     try {
       const requiredHeadStart = this.#now();
       const required = await this.#awaitRequiredHead(requiredHead, signal);
@@ -208,15 +292,19 @@ export class SQLiteChangeLogCatchup implements Disposable {
       // during a transaction longer than barrierTimeoutMs, however current
       // the replica is.
       const deadline = this.#now() + this.#barrierTimeoutMs;
-      const plan = await this.#waitForPlan(
-        subscriber,
-        required,
-        deadline,
-        signal,
-      );
+      const barrierStart = this.#now();
+      let plan: CatchupPlan;
+      try {
+        plan = await this.#waitForPlan(subscriber, required, deadline, signal);
+      } finally {
+        // Record failed and aborted barriers too; their wait distribution is
+        // at least as operationally important as the successful path.
+        this.#barrierWaitDuration.recordMs(this.#now() - barrierStart);
+      }
       this.#throwIfAborted(signal);
 
       if (plan.kind === 'too-old') {
+        outcome = 'too-old';
         const message =
           `earliest supported watermark is ${plan.minWatermark} ` +
           `(requested ${subscriber.watermark})`;
@@ -229,6 +317,7 @@ export class SQLiteChangeLogCatchup implements Disposable {
       }
 
       let count = 0;
+      let bytes = 0;
       const start = this.#now();
       if (plan.kind === 'range') {
         let lastBatchConsumed: Promise<unknown> | undefined;
@@ -251,10 +340,17 @@ export class SQLiteChangeLogCatchup implements Disposable {
           for (const change of changes) {
             lastBatchConsumed = subscriber.catchup(change);
             count++;
+            bytes += Buffer.byteLength(change[2]);
           }
+          backlogPeakBytes = Math.max(
+            backlogPeakBytes,
+            subscriber.getStats().backlogBytes,
+          );
         }
         await lastBatchConsumed;
+        outcome = 'range';
       } else {
+        outcome = 'ahead';
         this.#lc.warn?.(
           `subscriber ${subscriber.id} at watermark ${subscriber.watermark} ` +
             `is ahead of the SQLite change-log head ${plan.headWatermark}; ` +
@@ -267,6 +363,12 @@ export class SQLiteChangeLogCatchup implements Disposable {
         `caught up ${subscriber.id} from SQLite with ${count} changes ` +
           `(${this.#now() - start} ms)`,
       );
+      const attributes = {
+        classification: outcome,
+        log_warm: this.#logWarm ?? 'unknown',
+      };
+      this.#catchupRows.add(count, attributes);
+      this.#catchupBytes.add(bytes, attributes);
       // Keep buffering live sends until the asynchronous backlog drain has
       // established its ordering boundary.
       void subscriber.setCaughtUp();
@@ -277,6 +379,11 @@ export class SQLiteChangeLogCatchup implements Disposable {
       if (error instanceof SQLiteChangeLogBarrierError) {
         if (error instanceof SQLiteChangeLogBarrierTimeoutError) {
           this.#barrierTimeouts.add(1);
+          outcome = 'barrier-timeout';
+          this.#onFailure?.('barrier-timeout');
+        } else {
+          outcome = 'barrier-backlog';
+          this.#onFailure?.('barrier-backlog');
         }
         // Giving up on the barrier means the replica has not caught up *yet*,
         // not that it cannot serve this subscriber. End the subscription
@@ -293,12 +400,25 @@ export class SQLiteChangeLogCatchup implements Disposable {
         subscriber.close();
         return;
       }
+      outcome = 'reader-error';
+      this.#onFailure?.('reader-error');
       this.#lc.error?.(
         `error while catching up subscriber ${subscriber.id} from SQLite`,
         error,
       );
       subscriber.fail(error);
     } finally {
+      backlogPeakBytes = Math.max(
+        backlogPeakBytes,
+        subscriber.getStats().backlogBytes,
+      );
+      const attributes = {
+        classification: outcome,
+        log_warm: this.#logWarm ?? 'unknown',
+      };
+      this.#catchupResults.add(1, attributes);
+      this.#catchupDuration.recordMs(this.#now() - catchupStart, attributes);
+      this.#catchupBacklogPeak.record(backlogPeakBytes, attributes);
       if (this.#catchups.get(subscriber) === abort) {
         this.#catchups.delete(subscriber);
       }

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.pg.test.ts
@@ -1,0 +1,1132 @@
+import {LogContext} from '@rocicorp/logger';
+import {resolver} from '@rocicorp/resolver';
+import fc from 'fast-check';
+import {beforeEach, describe, expect, vi} from 'vitest';
+import {assert} from '../../../../shared/src/asserts.ts';
+import {TestLogSink} from '../../../../shared/src/logging-test-utils.ts';
+import {Database} from '../../../../zqlite/src/db.ts';
+import {StatementRunner} from '../../db/statements.ts';
+import {test, type PgTest} from '../../test/db.ts';
+import {DbFile} from '../../test/lite.ts';
+import type {PostgresDB} from '../../types/pg.ts';
+import {cdcSchema, type ShardID} from '../../types/shards.ts';
+import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
+import {EMPTY_COOKIE_SET} from '../replicator/change-log-cookies.ts';
+import {
+  changeLogFileName,
+  CHANGE_LOG_META_TABLE,
+  CHANGE_LOG_STREAM_TABLE,
+  deleteChangeLogDB,
+  estimateChangeLogStreamRowBytes,
+  type ChangeLogIdentity,
+} from '../replicator/change-log-db.ts';
+import {
+  getSubscriptionState,
+  initReplicationState,
+} from '../replicator/schema/replication-state.ts';
+import {ReplicationMessages} from '../replicator/test-utils.ts';
+import {serializeChangeStreamData} from './change-log-codec.ts';
+import {isSampledForCompare} from './change-log-compare-digest.ts';
+import {initChangeStreamerSchema} from './schema/init.ts';
+import {ensureReplicationConfig} from './schema/tables.ts';
+import {
+  SQLiteChangeLogComparator,
+  type PGChangeLogRangeReader,
+  type SQLiteChangeLogCompareOptions,
+} from './sqlite-change-log-comparator.ts';
+import {SQLiteChangeLogWriter} from './sqlite-change-log-writer.ts';
+import {Storer} from './storer.ts';
+
+describe('change-streamer/sqlite-change-log-comparator', () => {
+  const REPLICA_VERSION = '01';
+  const RETENTION_MS = 60_000;
+  const shard: ShardID = {appID: 'cmp', shardNum: 7};
+  const identity: ChangeLogIdentity = {
+    epoch: null,
+    generation: REPLICA_VERSION,
+    replicaID: 'replica-id',
+  };
+
+  let lc: LogContext;
+  let logSink: TestLogSink;
+  let sql: PostgresDB;
+  let storer: Storer;
+  let storerDone: Promise<void>;
+  let writer: SQLiteChangeLogWriter;
+  let logFile: DbFile;
+  let seededAtMs: number;
+  let onWriterRebuilt: () => void;
+
+  beforeEach<PgTest>(async ({testDBs}) => {
+    logSink = new TestLogSink();
+    lc = new LogContext('debug', {}, logSink);
+
+    sql = await testDBs.create('sqlite_change_log_comparator_test', {
+      typeOpts: {sendStringAsJson: true},
+    });
+
+    const replica = new Database(lc, ':memory:');
+    initReplicationState(replica, ['zero_data'], REPLICA_VERSION);
+    const subscriptionState = getSubscriptionState(
+      new StatementRunner(replica),
+    );
+
+    await initChangeStreamerSchema(lc, sql, shard);
+    await ensureReplicationConfig(lc, sql, subscriptionState, shard, true);
+
+    storer = new Storer(
+      lc,
+      shard,
+      'task-id',
+      'change.streamer:12345',
+      'ws',
+      sql,
+      REPLICA_VERSION,
+      () => {},
+      vi.fn(),
+      {
+        backPressureLimitHeapProportion: 0.04,
+        statementTimeoutMs: 20_000,
+        changeLogBatchSize: 2000,
+      },
+    );
+    await storer.assumeOwnership();
+    storerDone = storer.run();
+
+    seededAtMs = 1_000_000;
+    onWriterRebuilt = () => {};
+    logFile = new DbFile('sqlite-change-log-comparator');
+    writer = new SQLiteChangeLogWriter(lc, {
+      replicaFile: logFile.path,
+      identity,
+      now: () => seededAtMs,
+      onRebuilt: () => onWriterRebuilt(),
+    });
+    // Resume from the Postgres watermark at the replica version.
+    writer.reconcile({
+      resumeWatermark: REPLICA_VERSION,
+      cookies: EMPTY_COOKIE_SET,
+    });
+
+    return async () => {
+      await storer.stop();
+      await storerDone;
+      writer.close();
+      logFile.delete();
+      await testDBs.drop(sql);
+    };
+  });
+
+  const messages = new ReplicationMessages({foo: 'id'});
+
+  type Tx = {watermark: string; changes: ChangeStreamData[]};
+
+  function tx(watermark: string, ...data: object[]): Tx {
+    return {
+      watermark,
+      changes: [
+        [
+          'begin',
+          messages.begin(),
+          {commitWatermark: watermark},
+        ] as unknown as ChangeStreamData,
+        ...data.map(d => ['data', d] as unknown as ChangeStreamData),
+        [
+          'commit',
+          messages.commit(),
+          {watermark},
+        ] as unknown as ChangeStreamData,
+      ],
+    };
+  }
+
+  function feedTx(t: Tx, target: {pg: boolean; sqlite: boolean}) {
+    for (const change of t.changes) {
+      const json = target.pg
+        ? storer.store(t.watermark, change)
+        : serializeChangeStreamData(change);
+      if (target.sqlite) {
+        writer.write(change, json);
+      }
+    }
+  }
+
+  async function feedBoth(...txs: Tx[]) {
+    txs.forEach(t => feedTx(t, {pg: true, sqlite: true}));
+    await storer.allProcessed();
+  }
+
+  async function feedPGOnly(...txs: Tx[]) {
+    txs.forEach(t => feedTx(t, {pg: true, sqlite: false}));
+    await storer.allProcessed();
+  }
+
+  function feedSQLiteOnly(...txs: Tx[]) {
+    txs.forEach(t => feedTx(t, {pg: false, sqlite: true}));
+  }
+
+  function newComparator(
+    overrides: Partial<SQLiteChangeLogCompareOptions> & {
+      pg?: PGChangeLogRangeReader;
+      logIdentity?: ChangeLogIdentity;
+      file?: string;
+    } = {},
+  ): SQLiteChangeLogComparator {
+    const {pg, logIdentity, file, ...opts} = overrides;
+    return new SQLiteChangeLogComparator(
+      lc,
+      shard,
+      file ?? changeLogFileName(logFile.path),
+      logIdentity ?? identity,
+      pg ?? storer,
+      {
+        comparePercent: 100,
+        retentionMs: RETENTION_MS,
+        // Make the log exactly one retention period old.
+        now: () => seededAtMs + RETENTION_MS,
+        setTimeoutFn: vi.fn() as unknown as typeof setTimeout,
+        yieldFn: () => Promise.resolve(),
+        ...opts,
+      },
+    );
+  }
+
+  /** Returns the production reader with optional overrides. */
+  function pgReader(
+    overrides: Partial<PGChangeLogRangeReader> = {},
+  ): PGChangeLogRangeReader {
+    return {
+      getCatchupBounds: () => storer.getCatchupBounds(),
+      listCommitWatermarks: (after, through, limit) =>
+        storer.listCommitWatermarks(after, through, limit),
+      readCatchupRange: (after, through, batchRows) =>
+        storer.readCatchupRange(after, through, batchRows),
+      ...overrides,
+    };
+  }
+
+  /** Opens the SQLite log for direct fault injection. */
+  function withSQLiteLog<T>(fn: (db: Database) => T): T {
+    const db = new Database(lc, changeLogFileName(logFile.path));
+    try {
+      return fn(db);
+    } finally {
+      db.close();
+    }
+  }
+
+  function cdc(table: string) {
+    return sql(`${cdcSchema(shard)}.${table}`);
+  }
+
+  /** Reads diverged watermarks from production error logs. */
+  function divergedWatermarks(since = 0): string[] {
+    return logSink.messages
+      .slice(since)
+      .filter(([level, , parts]) => level === 'error' && parts.length === 2)
+      .flatMap(([, , parts]) => {
+        const detail = (
+          parts[1] as {
+            sqliteChangeLogCompare?: {watermark: string} | undefined;
+          }
+        ).sqliteChangeLogCompare;
+        return detail === undefined ? [] : [detail.watermark];
+      });
+  }
+
+  async function mutatePGChange(
+    watermark: string,
+    pos: number,
+    mutate: (change: Record<string, unknown>) => void,
+  ) {
+    const [{change}] = await sql<{change: string}[]>`
+      SELECT change::text FROM ${cdc('changeLog')}
+       WHERE watermark = ${watermark} AND pos = ${pos}`;
+    const parsed = JSON.parse(change) as Record<string, unknown>;
+    mutate(parsed);
+    const mutated = JSON.stringify(parsed);
+    await sql`
+      UPDATE ${cdc('changeLog')} SET change = ${mutated}::json
+       WHERE watermark = ${watermark} AND pos = ${pos}`;
+  }
+
+  function deleteFromSQLiteLog(where: string) {
+    withSQLiteLog(db =>
+      db
+        .prepare(
+          /*sql*/ `DELETE FROM "${CHANGE_LOG_STREAM_TABLE}" WHERE ${where}`,
+        )
+        .run(),
+    );
+  }
+
+  /** Inserts rows that do not belong to a committed transaction. */
+  function insertSQLiteRows(watermark: string) {
+    withSQLiteLog(db => {
+      const insert = db.prepare(/*sql*/ `
+          INSERT INTO "${CHANGE_LOG_STREAM_TABLE}"
+            ("watermark", "pos", "tag", "estimatedBytes", "change",
+             "precommit", "writeTimeMs")
+          VALUES (?, ?, ?, ?, ?, NULL, NULL)`);
+      for (const [pos, tag, change] of [
+        [0, 'begin', '{"tag":"begin"}'],
+        [1, 'insert', '{"tag":"insert"}'],
+      ] as const) {
+        insert.run(
+          watermark,
+          pos,
+          tag,
+          estimateChangeLogStreamRowBytes(watermark, tag, change),
+          change,
+        );
+      }
+    });
+  }
+
+  function insertPGRows(watermark: string) {
+    return sql`
+      INSERT INTO ${cdc('changeLog')} ("watermark", "pos", "change", "precommit")
+      VALUES (${watermark}, 0, '{"tag":"begin"}'::json, NULL),
+             (${watermark}, 1, '{"tag":"insert"}'::json, NULL)`;
+  }
+
+  // Use a literal backslash-u sequence. An escaped NUL makes Postgres catchup fail.
+  test('equivalent catchup output matches, across message families and batches', async () => {
+    await feedBoth(
+      tx(
+        '03',
+        messages.insert('foo', {
+          id: 'nul-\\u0000-esc',
+          big: 9007199254740993n,
+          float: 1.5,
+          text: 'quotes " backslash \\ newline \n emoji 🙂 control ',
+          nil: null,
+          bool: true,
+        }),
+      ),
+      tx(
+        '04',
+        messages.insert('foo', {id: 'b', v: 1}),
+        messages.update('foo', {id: 'b', v: 2}),
+        messages.update('foo', {id: 'b2', v: 3}, {id: 'b'}),
+        messages.delete('foo', {id: 'b2'}),
+        messages.truncate('foo'),
+      ),
+      tx(
+        '05',
+        messages.createTable({
+          schema: 'public',
+          name: 'baz',
+          columns: {id: {pos: 0, dataType: 'varchar'}},
+          primaryKey: ['id'],
+        }),
+      ),
+      tx('06', messages.addColumn('foo', 'extra', {dataType: 'text', pos: 9})),
+      tx('07', messages.dropColumn('foo', 'extra'), messages.dropTable('baz')),
+    );
+    // Use small limits to require multiple batches and cycles.
+    const comparator = newComparator({
+      readBatchRows: 2,
+      maxTransactionsPerCycle: 2,
+    });
+
+    const first = await comparator.compareOnce();
+    expect(first).toMatchObject({
+      kind: 'compared',
+      fromWatermark: '01',
+      throughWatermark: '04',
+      transactions: 2,
+      sampled: 2,
+      matched: 2,
+      mismatched: 0,
+    });
+
+    const second = await comparator.compareOnce();
+    expect(second).toMatchObject({
+      fromWatermark: '04',
+      throughWatermark: '06',
+      matched: 2,
+      mismatched: 0,
+    });
+
+    const third = await comparator.compareOnce();
+    expect(third).toMatchObject({
+      fromWatermark: '06',
+      throughWatermark: '07',
+      matched: 1,
+      mismatched: 0,
+    });
+
+    expect(await comparator.compareOnce()).toEqual({
+      kind: 'skipped',
+      reason: 'nothing-to-compare',
+    });
+    expect(divergedWatermarks()).toEqual([]);
+  });
+
+  describe('divergent catchup output mismatches', () => {
+    const cases: {
+      name: string;
+      corrupt: () => Promise<void> | void;
+      diverged: string[];
+    }[] = [
+      {
+        name: 'a mutated PG payload',
+        corrupt: () =>
+          mutatePGChange('04', 1, change => {
+            (change.new as Record<string, unknown>).v = 999;
+          }),
+        diverged: ['04'],
+      },
+      {
+        name: 'a transaction SQLite does not hold',
+        corrupt: () => deleteFromSQLiteLog(`"watermark" = '04'`),
+        diverged: ['04'],
+      },
+      {
+        name: 'a transaction PG does not hold',
+        corrupt: async () => {
+          await sql`DELETE FROM ${cdc('changeLog')} WHERE watermark = '04'`;
+        },
+        diverged: ['04'],
+      },
+      {
+        name: 'a commit row SQLite lost from an otherwise intact transaction',
+        corrupt: () =>
+          deleteFromSQLiteLog(`"watermark" = '04' AND "precommit" IS NOT NULL`),
+        diverged: ['04'],
+      },
+      {
+        name: 'rows only SQLite serves',
+        corrupt: () => insertSQLiteRows('04z'),
+        diverged: ['05'],
+      },
+      {
+        name: 'rows only PG serves',
+        corrupt: async () => {
+          await insertPGRows('04z');
+        },
+        diverged: ['05'],
+      },
+      {
+        // Equal output matches even when no commit owns these rows.
+        name: 'identical extra rows in both stores',
+        corrupt: async () => {
+          insertSQLiteRows('04z');
+          await insertPGRows('04z');
+        },
+        diverged: [],
+      },
+    ];
+
+    for (const {name, corrupt, diverged} of cases) {
+      test(name, async () => {
+        await feedBoth(
+          tx('03', messages.insert('foo', {id: 'boundary'})),
+          tx('04', messages.insert('foo', {id: 'victim', v: 1})),
+          tx('05', messages.insert('foo', {id: 'witness'})),
+        );
+        await corrupt();
+
+        const result = await newComparator().compareOnce();
+        assert(result.kind === 'compared', 'expected a compared cycle');
+        expect(divergedWatermarks()).toEqual(diverged);
+        expect(result.mismatched).toBe(diverged.length);
+        expect(result.inconclusive).toBe(0);
+      });
+    }
+  });
+
+  test('head lag in either direction is not divergence', async () => {
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'boundary'})),
+      tx('04', messages.insert('foo', {id: 'both'})),
+    );
+    const t5 = tx('05', messages.insert('foo', {id: 'trailing-pg'}));
+    const t6 = tx('06', messages.insert('foo', {id: 'trailing-sqlite'}));
+
+    // SQLite leads, so compare only through the Postgres head.
+    feedSQLiteOnly(t5);
+    const comparator = newComparator();
+    expect(await comparator.compareOnce()).toMatchObject({
+      throughWatermark: '04',
+      transactions: 2,
+      matched: 2,
+      mismatched: 0,
+    });
+
+    // Postgres then leads, so compare only through the SQLite head.
+    await feedPGOnly(t5, t6);
+    expect(await comparator.compareOnce()).toMatchObject({
+      fromWatermark: '04',
+      throughWatermark: '05',
+      matched: 1,
+      mismatched: 0,
+    });
+
+    // SQLite catches up, and the earlier skew matches.
+    feedSQLiteOnly(t6);
+    expect(await comparator.compareOnce()).toMatchObject({
+      fromWatermark: '05',
+      throughWatermark: '06',
+      matched: 1,
+      mismatched: 0,
+    });
+    expect(divergedWatermarks()).toEqual([]);
+  });
+
+  test('a limited cycle compares only the range both enumerations cover', async () => {
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'a'})),
+      tx('04', messages.insert('foo', {id: 'b'})),
+      tx('05', messages.insert('foo', {id: 'c'})),
+      tx('06', messages.insert('foo', {id: 'd'})),
+    );
+    deleteFromSQLiteLog(`"watermark" = '04'`);
+
+    const comparator = newComparator({maxTransactionsPerCycle: 2});
+    // The lower complete enumeration ends at 04, so 05 is not missing.
+    expect(await comparator.compareOnce()).toMatchObject({
+      throughWatermark: '04',
+      transactions: 2,
+      matched: 1,
+      mismatched: 1,
+    });
+    expect(divergedWatermarks()).toEqual(['04']);
+
+    // The next cycle completes the remaining range.
+    const before = logSink.messages.length;
+    expect(await comparator.compareOnce()).toMatchObject({
+      throughWatermark: '06',
+      matched: 2,
+    });
+    // Report 04 again because the log cannot serve that boundary.
+    expect(divergedWatermarks(before)).toEqual(['04']);
+  });
+
+  describe('a race with the pinned bounds is inconclusive', () => {
+    const cases: {
+      name: string;
+      pg: () => PGChangeLogRangeReader;
+      matched: number;
+      inconclusive: number;
+    }[] = [
+      {
+        // Purge Postgres after the cycle reads its initial bounds.
+        name: 'a PG purge',
+        pg: () => {
+          let purged = false;
+          return pgReader({
+            readCatchupRange: (after, through, batchRows) =>
+              (async function* (this: void) {
+                if (!purged) {
+                  purged = true;
+                  await storer.purgeRecordsBefore('05');
+                }
+                yield* storer.readCatchupRange(after, through, batchRows);
+              })(),
+          });
+        },
+        matched: 1, // Transaction 05 survives the purge and matches.
+        inconclusive: 2,
+      },
+      {
+        // Purge SQLite after the cycle enumerates its transactions.
+        name: 'a SQLite purge',
+        pg: () =>
+          pgReader({
+            listCommitWatermarks: async (after, through, limit) => {
+              const list = await storer.listCommitWatermarks(
+                after,
+                through,
+                limit,
+              );
+              deleteFromSQLiteLog(`"watermark" < '05'`);
+              return list;
+            },
+          }),
+        matched: 1,
+        inconclusive: 2,
+      },
+      {
+        // Change the seed after the cycle reads its initial bounds.
+        name: 'a reseed',
+        pg: () =>
+          pgReader({
+            listCommitWatermarks: async (after, through, limit) => {
+              const list = await storer.listCommitWatermarks(
+                after,
+                through,
+                limit,
+              );
+              withSQLiteLog(db => {
+                db.prepare(
+                  /*sql*/ `DELETE FROM "${CHANGE_LOG_STREAM_TABLE}" WHERE "watermark" = '04'`,
+                ).run();
+                db.prepare(/*sql*/ `UPDATE "${CHANGE_LOG_META_TABLE}"
+                      SET "seedWatermark" = '03', "seededAtMs" = "seededAtMs" + 1`).run();
+              });
+              return list;
+            },
+          }),
+        matched: 2,
+        inconclusive: 1,
+      },
+    ];
+
+    for (const {name, pg, matched, inconclusive} of cases) {
+      test(name, async () => {
+        await feedBoth(
+          tx('03', messages.insert('foo', {id: 'boundary'})),
+          tx('04', messages.insert('foo', {id: 'raced'})),
+          tx('05', messages.insert('foo', {id: 'witness'})),
+        );
+
+        const result = await newComparator({pg: pg()}).compareOnce();
+        expect(result).toMatchObject({matched, inconclusive, mismatched: 0});
+        // Bounds races do not report divergence.
+        expect(divergedWatermarks()).toEqual([]);
+      });
+    }
+  });
+
+  test('a file rebuild invalidates a cycle before it opens another reader', async () => {
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'removed-before-rebuild'})),
+      tx('04', messages.insert('foo', {id: 'old-head'})),
+    );
+
+    const boundsPinned = resolver();
+    const continueBounds = resolver();
+    let firstBoundsRead = true;
+    const comparator = newComparator({
+      pg: pgReader({
+        getCatchupBounds: async () => {
+          if (firstBoundsRead) {
+            firstBoundsRead = false;
+            boundsPinned.resolve();
+            await continueBounds.promise;
+          }
+          return storer.getCatchupBounds();
+        },
+      }),
+    });
+    onWriterRebuilt = () => comparator.invalidate();
+
+    const comparing = comparator.compareOnce();
+    await boundsPinned.promise;
+
+    // Rebuild while the comparator waits for Postgres bounds.
+    // The old database handle then points to the removed file.
+    deleteFromSQLiteLog(`"watermark" = '03'`);
+    writer.reconcile({
+      resumeWatermark: '03',
+      cookies: EMPTY_COOKIE_SET,
+    });
+    continueBounds.resolve();
+
+    expect(await comparing).toEqual({
+      kind: 'skipped',
+      reason: 'log-rebuilt',
+    });
+    expect(divergedWatermarks()).toEqual([]);
+  });
+
+  test('a suspect that cannot be reconfirmed is inconclusive, then retried', async () => {
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'boundary'})),
+      tx('04', messages.insert('foo', {id: 'victim'})),
+      tx('05', messages.insert('foo', {id: 'witness'})),
+    );
+    deleteFromSQLiteLog(`"watermark" = '04'`);
+
+    // Fail the bounds recheck once, so the first result is inconclusive.
+    let boundsReads = 0;
+    const comparator = newComparator({
+      pg: pgReader({
+        getCatchupBounds: () => {
+          if (++boundsReads === 2) {
+            throw new Error('injected bounds re-read failure');
+          }
+          return storer.getCatchupBounds();
+        },
+      }),
+    });
+    expect(await comparator.compareOnce()).toMatchObject({
+      matched: 2,
+      mismatched: 0,
+      inconclusive: 1,
+    });
+    expect(divergedWatermarks()).toEqual([]);
+
+    // The next cycle retries and reports the persistent mismatch.
+    expect(await comparator.compareOnce()).toMatchObject({mismatched: 1});
+    expect(divergedWatermarks()).toEqual(['04']);
+  });
+
+  test('a read that cannot complete is a mismatch, not a crash', async () => {
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'boundary'})),
+      tx('04', messages.insert('foo', {id: 'unreadable'})),
+    );
+    const result = await newComparator({
+      pg: pgReader({
+        readCatchupRange: (after, through, batchRows) => {
+          if (through === '04') {
+            throw new Error('injected read failure');
+          }
+          return storer.readCatchupRange(after, through, batchRows);
+        },
+      }),
+    }).compareOnce();
+    expect(result).toMatchObject({matched: 1, mismatched: 1});
+    expect(divergedWatermarks()).toEqual(['04']);
+  });
+
+  test('a retried comparison samples the same transactions', async () => {
+    const txs = Array.from({length: 12}, (_, i) =>
+      tx((i + 3).toString(36).padStart(2, '0'), {
+        ...messages.insert('foo', {id: `row-${i}`}),
+      }),
+    );
+    await feedBoth(...txs);
+
+    const percent = 40;
+    const expected = txs.filter(({watermark}) =>
+      isSampledForCompare(shard, watermark, percent),
+    ).length;
+
+    // Independent comparators select the same sample.
+    const first = await newComparator({comparePercent: percent}).compareOnce();
+    const second = await newComparator({comparePercent: percent}).compareOnce();
+    assert(
+      first.kind === 'compared' && second.kind === 'compared',
+      'expected compared cycles',
+    );
+    expect(first.sampled).toBe(expected);
+    expect(second.sampled).toBe(expected);
+    expect(second.fromWatermark).toBe(first.fromWatermark);
+    expect(second.throughWatermark).toBe(first.throughWatermark);
+    expect(first.matched).toBe(first.sampled);
+    expect(second.matched).toBe(second.sampled);
+  });
+
+  test('caps total catchup rows per source and defers an unfinished transaction', async () => {
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'first'})),
+      tx(
+        '04',
+        messages.insert('foo', {id: 'second-a'}),
+        messages.insert('foo', {id: 'second-b'}),
+      ),
+    );
+    const comparator = newComparator({
+      maxRowsPerSourcePerCycle: 5,
+      readBatchRows: 2,
+    });
+
+    expect(await comparator.compareOnce()).toMatchObject({
+      throughWatermark: '03',
+      transactions: 1,
+      sampled: 2,
+      matched: 1,
+      deferred: 1,
+      oversized: 0,
+      mismatched: 0,
+    });
+
+    // The fresh budget in the next cycle fits the transaction.
+    expect(await comparator.compareOnce()).toMatchObject({
+      fromWatermark: '03',
+      throughWatermark: '04',
+      matched: 1,
+      deferred: 0,
+      mismatched: 0,
+    });
+  });
+
+  test('skips a transaction that exceeds a fresh cycle row budget', async () => {
+    await feedBoth(
+      tx(
+        '03',
+        messages.insert('foo', {id: 'large-a'}),
+        messages.insert('foo', {id: 'large-b'}),
+        messages.insert('foo', {id: 'large-c'}),
+      ),
+      tx('04', messages.insert('foo', {id: 'after-large'})),
+    );
+    const comparator = newComparator({maxRowsPerSourcePerCycle: 4});
+
+    expect(await comparator.compareOnce()).toMatchObject({
+      throughWatermark: '03',
+      sampled: 1,
+      matched: 0,
+      oversized: 1,
+      mismatched: 0,
+    });
+
+    // The cursor advances past the oversized transaction.
+    expect(await comparator.compareOnce()).toMatchObject({
+      fromWatermark: '03',
+      throughWatermark: '04',
+      matched: 1,
+      oversized: 0,
+    });
+  });
+
+  test('caps total catchup bytes per source and defers, then skips, a wide transaction', async () => {
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'narrow'})),
+      // One row wider than a whole cycle budget.
+      tx('04', messages.insert('foo', {id: 'wide', pad: 'x'.repeat(5000)})),
+    );
+    const comparator = newComparator({maxBytesPerSourcePerCycle: 2000});
+
+    // The narrow transaction fits and spends part of the budget. The wide one
+    // cannot fit in what remains, so it waits for a fresh budget.
+    expect(await comparator.compareOnce()).toMatchObject({
+      throughWatermark: '03',
+      transactions: 1,
+      sampled: 2,
+      matched: 1,
+      deferred: 1,
+      oversized: 0,
+      mismatched: 0,
+    });
+
+    // A fresh budget does not fit it either, so it is skipped rather than
+    // retried forever, and the cursor advances past it.
+    expect(await comparator.compareOnce()).toMatchObject({
+      fromWatermark: '03',
+      throughWatermark: '04',
+      sampled: 1,
+      matched: 0,
+      deferred: 0,
+      oversized: 1,
+      mismatched: 0,
+    });
+    // A byte limit is not divergence.
+    expect(divergedWatermarks()).toEqual([]);
+  });
+
+  test('a generous byte budget leaves the row budget binding', async () => {
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'first'})),
+      tx(
+        '04',
+        messages.insert('foo', {id: 'second-a'}),
+        messages.insert('foo', {id: 'second-b'}),
+      ),
+    );
+    // The same expectations as the row-budget test above.
+    const comparator = newComparator({
+      maxRowsPerSourcePerCycle: 5,
+      maxBytesPerSourcePerCycle: 1024 * 1024,
+      readBatchRows: 2,
+    });
+
+    expect(await comparator.compareOnce()).toMatchObject({
+      throughWatermark: '03',
+      matched: 1,
+      deferred: 1,
+      oversized: 0,
+    });
+    expect(await comparator.compareOnce()).toMatchObject({
+      fromWatermark: '03',
+      throughWatermark: '04',
+      matched: 1,
+      deferred: 0,
+      oversized: 0,
+    });
+  });
+
+  test('compares a transaction that exactly fills the cycle row budget', async () => {
+    await feedBoth(tx('03', messages.insert('foo', {id: 'exact'})));
+
+    expect(
+      await newComparator({maxRowsPerSourcePerCycle: 3}).compareOnce(),
+    ).toMatchObject({
+      throughWatermark: '03',
+      matched: 1,
+      deferred: 0,
+      oversized: 0,
+    });
+  });
+
+  test('a divergent cursor boundary does not wedge the comparator', async () => {
+    // Remove the transaction at the common upper bound.
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'boundary'})),
+      tx('04', messages.insert('foo', {id: 'sqlite-lost'})),
+    );
+    feedSQLiteOnly(tx('05', messages.insert('foo', {id: 'log-leads'})));
+    deleteFromSQLiteLog(`"watermark" = '04'`);
+
+    const comparator = newComparator();
+    expect(await comparator.compareOnce()).toMatchObject({
+      throughWatermark: '04',
+      matched: 1,
+      mismatched: 1,
+    });
+    expect(divergedWatermarks()).toEqual(['04']);
+
+    // The next cycle starts at the missing boundary and compares later rows.
+    await feedBoth(tx('06', messages.insert('foo', {id: 'next'})));
+
+    const before = logSink.messages.length;
+    expect(await comparator.compareOnce()).toMatchObject({
+      throughWatermark: '06',
+      matched: 1,
+      mismatched: 2,
+    });
+    expect(divergedWatermarks(before)).toEqual(['04', '05']);
+
+    // The cursor advanced.
+    expect(await comparator.compareOnce()).toEqual({
+      kind: 'skipped',
+      reason: 'nothing-to-compare',
+    });
+  });
+
+  test('a capped cycle schedules its continuation without the poll delay', async () => {
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'a'})),
+      tx('04', messages.insert('foo', {id: 'b'})),
+      tx('05', messages.insert('foo', {id: 'c'})),
+    );
+
+    type Scheduled = {callback: () => void; delayMs: number};
+    const scheduled = new Map<ReturnType<typeof setTimeout>, Scheduled>();
+    let nextTimer = 0;
+    const setTimeoutFn = vi.fn((callback: () => void, delayMs?: number) => {
+      const handle = ++nextTimer as unknown as ReturnType<typeof setTimeout>;
+      scheduled.set(handle, {callback, delayMs: delayMs ?? 0});
+      return handle;
+    }) as unknown as typeof setTimeout;
+    const clearTimeoutFn = vi.fn((handle: ReturnType<typeof setTimeout>) => {
+      scheduled.delete(handle);
+    }) as unknown as typeof clearTimeout;
+    const comparator = newComparator({
+      intervalMs: 30_000,
+      maxTransactionsPerCycle: 2,
+      setTimeoutFn,
+      clearTimeoutFn,
+    });
+
+    expect(Array.from(scheduled.values(), ({delayMs}) => delayMs)).toEqual([
+      30_000,
+    ]);
+    expect(await comparator.compareOnce()).toMatchObject({
+      throughWatermark: '04',
+      transactions: 2,
+    });
+    expect(Array.from(scheduled.values(), ({delayMs}) => delayMs)).toEqual([0]);
+
+    comparator.stop();
+  });
+
+  test('divergence reports carry no payload data', async () => {
+    const sentinel = 'SENSITIVE-PAYLOAD-8675309';
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'boundary'})),
+      tx('04', messages.insert('foo', {id: sentinel, secret: sentinel})),
+    );
+    await mutatePGChange('04', 1, change => {
+      (change.new as Record<string, unknown>).secret = `${sentinel}-mutated`;
+    });
+
+    const before = logSink.messages.length;
+    const result = await newComparator().compareOnce();
+    expect(result).toMatchObject({mismatched: 1});
+
+    // Results and logs contain neither payloads nor digests.
+    expect(JSON.stringify(result)).not.toContain(sentinel);
+    expect(JSON.stringify(logSink.messages.slice(before))).not.toContain(
+      sentinel,
+    );
+    expect(divergedWatermarks(before)).toEqual(['04']);
+  });
+
+  test('declines a cold log, a wrong identity, and an absent file', async () => {
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'boundary'})),
+      tx('04', messages.insert('foo', {id: 'content'})),
+    );
+
+    expect(
+      await newComparator({
+        now: () => seededAtMs + RETENTION_MS - 1,
+      }).compareOnce(),
+    ).toEqual({kind: 'skipped', reason: 'cold-log'});
+
+    expect(
+      await newComparator({
+        logIdentity: {...identity, replicaID: 'someone-else'},
+      }).compareOnce(),
+    ).toEqual({kind: 'skipped', reason: 'ineligible-identity'});
+
+    expect(
+      await newComparator({file: `${logFile.path}-absent`}).compareOnce(),
+    ).toEqual({kind: 'skipped', reason: 'log-unavailable'});
+
+    expect(await newComparator().compareOnce()).toMatchObject({
+      matched: 2,
+      mismatched: 0,
+    });
+  });
+
+  test('a freshly seeded log with no traffic has nothing to compare', async () => {
+    // Synthetic seed transactions are boundaries, not compared output.
+    expect(await newComparator().compareOnce()).toEqual({
+      kind: 'skipped',
+      reason: 'nothing-to-compare',
+    });
+  });
+
+  test('stop() ends the comparator', async () => {
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'boundary'})),
+      tx('04', messages.insert('foo', {id: 'content'})),
+    );
+    const comparator = newComparator();
+    comparator.stop();
+    expect(await comparator.compareOnce()).toEqual({
+      kind: 'skipped',
+      reason: 'stopped',
+    });
+  });
+
+  test('property: every corrupted transaction is reported, every clean one is not', async () => {
+    type CorruptionKind = 'clean' | 'drop-sqlite' | 'drop-pg' | 'mutate-pg';
+
+    const faultScenario = fc.record({
+      txs: fc.array(
+        fc.record({
+          width: fc.integer({min: 0, max: 3}),
+          kind: fc.constantFrom<CorruptionKind>(
+            'clean',
+            'drop-sqlite',
+            'drop-pg',
+            'mutate-pg',
+          ),
+        }),
+        {minLength: 1, maxLength: 5},
+      ),
+    });
+
+    // Each run starts above the watermarks from earlier runs.
+    let nextNum = 1;
+    const wm = (n: number) => `w${String(n).padStart(8, '0')}`;
+
+    await fc.assert(
+      fc.asyncProperty(faultScenario, async ({txs}) => {
+        const base = nextNum;
+        nextNum += (txs.length + 2) * 10;
+
+        const runFile = new DbFile('sqlite-change-log-comparator-fuzz');
+        const runWriter = new SQLiteChangeLogWriter(lc, {
+          replicaFile: runFile.path,
+          identity,
+          now: () => seededAtMs,
+        });
+        try {
+          runWriter.reconcile({
+            resumeWatermark: wm(base),
+            cookies: EMPTY_COOKIE_SET,
+          });
+
+          const specs = txs.map((spec, i) => ({
+            ...spec,
+            watermark: wm(base + (i + 1) * 10),
+          }));
+          // A clean sentinel keeps generated transactions below the common head.
+          const sentinel = wm(base + (txs.length + 1) * 10);
+
+          const feedRun = (t: Tx) => {
+            for (const change of t.changes) {
+              runWriter.write(change, storer.store(t.watermark, change));
+            }
+          };
+          for (const spec of specs) {
+            feedRun(
+              tx(
+                spec.watermark,
+                ...Array.from({length: spec.width}, (_, k) =>
+                  messages.insert('foo', {id: `${spec.watermark}-${k}`}),
+                ),
+              ),
+            );
+          }
+          feedRun(tx(sentinel, messages.insert('foo', {id: sentinel})));
+          await storer.allProcessed();
+
+          const withRunLog = <T>(fn: (db: Database) => T): T => {
+            const db = new Database(lc, changeLogFileName(runFile.path));
+            try {
+              return fn(db);
+            } finally {
+              db.close();
+            }
+          };
+
+          // Apply each fault and record its expected watermark.
+          const expected: string[] = [];
+          let expectedMatched = 1; // The sentinel matches.
+          for (const spec of specs) {
+            switch (spec.kind) {
+              case 'clean':
+                expectedMatched++;
+                break;
+              case 'drop-sqlite':
+                withRunLog(db =>
+                  db
+                    .prepare(
+                      /*sql*/ `DELETE FROM "${CHANGE_LOG_STREAM_TABLE}" WHERE "watermark" = ?`,
+                    )
+                    .run(spec.watermark),
+                );
+                expected.push(spec.watermark);
+                break;
+              case 'drop-pg':
+                await sql`
+                  DELETE FROM ${cdc('changeLog')} WHERE watermark = ${spec.watermark}`;
+                expected.push(spec.watermark);
+                break;
+              case 'mutate-pg':
+                await mutatePGChange(spec.watermark, 0, change => {
+                  change.mutated = true;
+                });
+                expected.push(spec.watermark);
+                break;
+            }
+          }
+
+          const before = logSink.messages.length;
+          const comparator = newComparator({
+            file: changeLogFileName(runFile.path),
+          });
+          let matched = 0;
+          for (let guard = 0; ; guard++) {
+            assert(guard < 8, 'comparator failed to reach quiescence');
+            const result = await comparator.compareOnce();
+            if (result.kind === 'skipped') {
+              expect(result.reason).toBe('nothing-to-compare');
+              break;
+            }
+            matched += result.matched;
+          }
+
+          expect(divergedWatermarks(before).toSorted()).toEqual(
+            expected.toSorted(),
+          );
+          expect(matched).toBe(expectedMatched);
+        } finally {
+          runWriter.close();
+          deleteChangeLogDB(runFile.path);
+          runFile.delete();
+        }
+      }),
+      {numRuns: 10},
+    );
+  });
+});

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.ts
@@ -1,0 +1,799 @@
+import type {LogContext} from '@rocicorp/logger';
+import {Database} from '../../../../zqlite/src/db.ts';
+import {
+  getOrCreateCounter,
+  getOrCreateLatencyHistogram,
+} from '../../observability/metrics.ts';
+import type {ShardID} from '../../types/shards.ts';
+import {
+  CHANGE_LOG_DB_SCHEMA_VERSION,
+  CHANGE_LOG_STREAM_TABLE,
+  readChangeLogMeta,
+  type ChangeLogIdentity,
+  type ChangeLogMeta,
+} from '../replicator/change-log-db.ts';
+import {
+  reconstructWatermarkedChange,
+  type ChangeLogEntry,
+} from './change-log-codec.ts';
+import {
+  digestCatchupRange,
+  isSampledForCompare,
+  type CatchupRangeDigest,
+} from './change-log-compare-digest.ts';
+import type {WatermarkedChange} from './change-streamer.ts';
+import {SQLiteChangeLogReader} from './sqlite-change-log-reader.ts';
+
+/** Interval between comparison cycles. */
+const DEFAULT_COMPARE_INTERVAL_MS = 30_000;
+
+/** Maximum transactions enumerated per cycle. */
+const DEFAULT_MAX_TRANSACTIONS_PER_CYCLE = 256;
+
+/** Maximum catchup rows read from each store per cycle. */
+const DEFAULT_MAX_ROWS_PER_SOURCE_PER_CYCLE = 1000;
+
+/**
+ * Maximum normalized catchup bytes read from each store per cycle.
+ *
+ * Rows bound the per-row overhead. Bytes bound the parse and hash work,
+ * which scales with payload size instead of row count. Normal traffic
+ * reaches the row limit first. Wide payloads reach this one.
+ */
+const DEFAULT_MAX_BYTES_PER_SOURCE_PER_CYCLE = 32 * 1024 * 1024;
+
+/** Rows per SQLite catchup batch. */
+const DEFAULT_READ_BATCH_ROWS = 1000;
+
+/**
+ * Result for one committed transaction.
+ *
+ * `mismatch` covers missing, extra, changed, or reordered rows.
+ * `inconclusive` means that store bounds changed during the comparison.
+ */
+export type CompareOutcome =
+  | 'match'
+  | 'mismatch'
+  | 'inconclusive'
+  | 'deferred'
+  | 'oversized';
+
+export type CompareSkipReason =
+  // The comparator was stopped.
+  | 'stopped'
+  // The writer replaced the file during this cycle.
+  | 'log-rebuilt'
+  // The file is absent, unreadable, or uninitialized.
+  | 'log-unavailable'
+  // The schema version does not match this build.
+  | 'ineligible-schema'
+  // The log belongs to a different replica.
+  | 'ineligible-identity'
+  // The log is younger than the warm-up period.
+  | 'cold-log'
+  // The stores have no complete committed range in common.
+  | 'nothing-to-compare'
+  // The cycle failed. The error was logged and counted.
+  | 'error';
+
+export type CompareCycleResult =
+  | {readonly kind: 'skipped'; readonly reason: CompareSkipReason}
+  | {
+      readonly kind: 'compared';
+      /** Exclusive lower bound of the compared range. */
+      readonly fromWatermark: string;
+      /** Inclusive upper bound handled. The next cycle resumes from here. */
+      readonly throughWatermark: string;
+      /** Committed transactions handled through `throughWatermark`. */
+      readonly transactions: number;
+      /** Transactions with compared catchup output. */
+      readonly sampled: number;
+      readonly matched: number;
+      readonly mismatched: number;
+      /** Suspects rejected because store bounds changed. */
+      readonly inconclusive: number;
+      /** Sampled transactions deferred to a fresh budget. */
+      readonly deferred: number;
+      /** Sampled transactions that exceed a fresh budget. */
+      readonly oversized: number;
+    };
+
+/** Provides the Postgres side of the catchup comparison. */
+export interface PGChangeLogRangeReader {
+  getCatchupBounds(): Promise<{
+    minWatermark: string | null;
+    lastWatermark: string;
+  }>;
+  listCommitWatermarks(
+    afterWatermark: string,
+    throughWatermark: string,
+    limit: number,
+  ): Promise<string[]>;
+  readCatchupRange(
+    afterWatermark: string,
+    throughWatermark: string,
+    batchRows?: number | undefined,
+  ): AsyncIterable<ChangeLogEntry[]>;
+}
+
+export type SQLiteChangeLogCompareOptions = {
+  /** Stable percentage of transactions selected for payload comparison. */
+  readonly comparePercent: number;
+  /** Warm-up time after a seed. The comparator skips a younger log. */
+  readonly retentionMs: number;
+  readonly intervalMs?: number | undefined;
+  readonly maxTransactionsPerCycle?: number | undefined;
+  /** Maximum catchup rows read from each store in one cycle. */
+  readonly maxRowsPerSourcePerCycle?: number | undefined;
+  /** Maximum normalized catchup bytes read from each store in one cycle. */
+  readonly maxBytesPerSourcePerCycle?: number | undefined;
+  readonly readBatchRows?: number | undefined;
+  /** Clock for the warm-up period. Defaults to `Date.now`. */
+  readonly now?: (() => number) | undefined;
+  readonly setTimeoutFn?: typeof setTimeout | undefined;
+  readonly clearTimeoutFn?: typeof clearTimeout | undefined;
+  /** Yields between sampled transactions. Defaults to `setImmediate`. */
+  readonly yieldFn?: (() => Promise<void>) | undefined;
+};
+
+/** Uses separate aggregates so SQLite can use an index for each value. */
+const SQLITE_BOUNDS_SQL = /*sql*/ `
+  SELECT
+    (SELECT min("watermark") FROM "${CHANGE_LOG_STREAM_TABLE}")
+      AS "minWatermark",
+    (SELECT max("watermark") FROM "${CHANGE_LOG_STREAM_TABLE}")
+      AS "headWatermark"
+`;
+
+/** Lists committed transaction watermarks in `(@after, @through]`. */
+const SQLITE_COMMITS_SQL = /*sql*/ `
+  SELECT "watermark" FROM "${CHANGE_LOG_STREAM_TABLE}"
+   WHERE "precommit" IS NOT NULL
+     AND "watermark" > @after
+     AND "watermark" <= @through
+   ORDER BY "watermark"
+   LIMIT @limit
+`;
+
+type SQLiteBounds = {
+  readonly minWatermark: string;
+  readonly headWatermark: string;
+};
+
+type PinnedBounds = {
+  readonly meta: ChangeLogMeta;
+  readonly sqlite: SQLiteBounds;
+  readonly pgMinWatermark: string;
+  readonly pgLastWatermark: string;
+};
+
+type SampledComparison = {
+  readonly outcome: CompareOutcome;
+  readonly sqliteRowsRead: number;
+  readonly pgRowsRead: number;
+  readonly sqliteBytesRead: number;
+  readonly pgBytesRead: number;
+};
+
+/**
+ * Compares SQLite and Postgres catchup output without affecting subscribers.
+ *
+ * Each cycle compares complete ranges through the lower store head.
+ * It checks every transaction for presence and samples payloads.
+ * A bounds change makes the affected result `inconclusive`.
+ * Postgres remains authoritative.
+ */
+export class SQLiteChangeLogComparator {
+  readonly #lc: LogContext;
+  readonly #shard: ShardID;
+  readonly #changeLogFile: string;
+  readonly #identity: ChangeLogIdentity;
+  readonly #pg: PGChangeLogRangeReader;
+  readonly #opts: SQLiteChangeLogCompareOptions;
+  readonly #now: () => number;
+  readonly #setTimeoutFn: typeof setTimeout;
+  readonly #clearTimeoutFn: typeof clearTimeout;
+  readonly #yield: () => Promise<void>;
+
+  readonly #compareResults = getOrCreateCounter(
+    'replica',
+    'sqlite_change_log.compare_result',
+    'Outcomes of the dark comparison between what SQLite catchup serves and ' +
+      'what PG catchup serves, per committed transaction. `inconclusive` ' +
+      'means a purge or reseed moved the pinned bounds mid-comparison.',
+  );
+  readonly #compareCycles = getOrCreateCounter(
+    'replica',
+    'sqlite_change_log.compare_cycles',
+    'SQLite change-log comparison cycles, by result.',
+  );
+  readonly #cycleDuration = getOrCreateLatencyHistogram(
+    'replica',
+    'sqlite_change_log.compare_cycle_duration',
+    'Duration of one SQLite change-log comparison cycle.',
+  );
+
+  /** Last handled commit watermark. A restart derives it from current bounds. */
+  #cursor: string | undefined;
+  #running: Promise<CompareCycleResult> | undefined;
+  #timer: ReturnType<typeof setTimeout> | undefined;
+  #stopped = false;
+  #continueWithoutDelay = false;
+  #fileGeneration = 0;
+
+  constructor(
+    lc: LogContext,
+    shard: ShardID,
+    changeLogFile: string,
+    identity: ChangeLogIdentity,
+    pg: PGChangeLogRangeReader,
+    opts: SQLiteChangeLogCompareOptions,
+  ) {
+    this.#lc = lc.withContext('component', 'sqlite-change-log-compare');
+    this.#shard = shard;
+    this.#changeLogFile = changeLogFile;
+    this.#identity = identity;
+    this.#pg = pg;
+    this.#opts = opts;
+    this.#now = opts.now ?? Date.now;
+    this.#setTimeoutFn = opts.setTimeoutFn ?? setTimeout;
+    this.#clearTimeoutFn = opts.clearTimeoutFn ?? clearTimeout;
+    this.#yield =
+      opts.yieldFn ??
+      (() => new Promise<void>(resolve => setImmediate(resolve)));
+    this.#scheduleNext();
+  }
+
+  /**
+   * Runs one cycle. Concurrent calls share the same promise.
+   * Errors produce `skipped: 'error'`.
+   */
+  compareOnce(): Promise<CompareCycleResult> {
+    if (this.#stopped) {
+      return Promise.resolve({kind: 'skipped', reason: 'stopped'});
+    }
+    if (this.#running === undefined) {
+      this.#running = this.#runCycle()
+        .then(result => {
+          if (this.#continueWithoutDelay) {
+            this.#rescheduleNext(0);
+          }
+          return result;
+        })
+        .finally(() => {
+          this.#running = undefined;
+        });
+    }
+    return this.#running;
+  }
+
+  stop(): void {
+    this.#stopped = true;
+    if (this.#timer !== undefined) {
+      this.#clearTimeoutFn(this.#timer);
+      this.#timer = undefined;
+    }
+  }
+
+  /** Invalidates cycles that can still read a replaced file. */
+  invalidate(): void {
+    this.#fileGeneration++;
+    this.#cursor = undefined;
+    this.#continueWithoutDelay = false;
+  }
+
+  #scheduleNext(
+    delayMs = this.#opts.intervalMs ?? DEFAULT_COMPARE_INTERVAL_MS,
+  ): void {
+    if (this.#stopped || this.#timer !== undefined) {
+      return;
+    }
+    this.#timer = this.#setTimeoutFn(() => {
+      this.#timer = undefined;
+      void this.compareOnce().finally(() => this.#scheduleNext());
+    }, delayMs);
+  }
+
+  #rescheduleNext(delayMs: number): void {
+    if (this.#timer !== undefined) {
+      this.#clearTimeoutFn(this.#timer);
+      this.#timer = undefined;
+    }
+    this.#scheduleNext(delayMs);
+  }
+
+  async #runCycle(): Promise<CompareCycleResult> {
+    const startedAt = performance.now();
+    const fileGeneration = this.#fileGeneration;
+    this.#continueWithoutDelay = false;
+    let db: Database | undefined;
+    let reader: SQLiteChangeLogReader | undefined;
+    try {
+      try {
+        // A readonly handle does not create a missing file.
+        db = new Database(this.#lc, this.#changeLogFile, {readonly: true});
+      } catch {
+        return this.#skipped('log-unavailable');
+      }
+
+      const pinned = await this.#pinBounds(db);
+      if (fileGeneration !== this.#fileGeneration) {
+        return this.#skipped('log-rebuilt');
+      }
+      if (typeof pinned === 'string') {
+        return this.#skipped(pinned);
+      }
+      const {meta} = pinned;
+
+      const from = maxWatermark(
+        this.#cursor ?? meta.seedWatermark,
+        // Exclude the synthetic SQLite seed transaction.
+        // The Postgres seed has no `precommit`, so enumeration also excludes it.
+        meta.seedWatermark,
+        // A store cannot serve the transaction at its minimum watermark.
+        pinned.pgMinWatermark,
+        pinned.sqlite.minWatermark,
+      );
+      const through = minWatermark(
+        pinned.pgLastWatermark,
+        pinned.sqlite.headWatermark,
+      );
+      if (through <= from) {
+        return this.#skipped('nothing-to-compare');
+      }
+
+      let transactions = 0;
+      let sampled = 0;
+      const outcomes: Record<CompareOutcome, number> = {
+        match: 0,
+        mismatch: 0,
+        inconclusive: 0,
+        deferred: 0,
+        oversized: 0,
+      };
+      const record = (watermark: string, outcome: CompareOutcome) => {
+        this.#compareResults.add(1, {outcome});
+        outcomes[outcome]++;
+        if (outcome === 'mismatch') {
+          // Log only the watermark because payloads contain customer data.
+          this.#lc.error?.(
+            'SQLite change-log catchup output diverged from Postgres',
+            {sqliteChangeLogCompare: {watermark}},
+          );
+        }
+      };
+
+      reader = new SQLiteChangeLogReader(this.#lc, this.#changeLogFile);
+      const plan = reader.plan(from);
+      if (plan.kind === 'not-ready') {
+        return this.#skipped('log-unavailable');
+      }
+      if (plan.kind === 'ahead') {
+        return this.#skipped('nothing-to-compare');
+      }
+      if (plan.kind === 'too-old') {
+        // A fixed lower bound makes this result a mismatch.
+        // A changed lower bound makes it inconclusive.
+        const reconfirmed = await this.#reconfirm(db, pinned, from);
+        const outcome =
+          fileGeneration === this.#fileGeneration
+            ? reconfirmed
+            : 'inconclusive';
+        record(from, outcome);
+        if (outcome === 'inconclusive') {
+          // Keep the cursor unchanged because the bounds moved.
+          return this.#compared(from, from, transactions, sampled, outcomes);
+        }
+        // Positional reads can continue after a missing boundary.
+        // Advancing avoids reporting the same boundary in every cycle.
+      }
+
+      const limit = Math.max(
+        1,
+        this.#opts.maxTransactionsPerCycle ??
+          DEFAULT_MAX_TRANSACTIONS_PER_CYCLE,
+      );
+      const union = await this.#enumerateCommits(db, from, through, limit);
+      if (fileGeneration !== this.#fileGeneration) {
+        return this.#skipped('log-rebuilt');
+      }
+      const maxRowsPerSource = Math.max(
+        1,
+        this.#opts.maxRowsPerSourcePerCycle ??
+          DEFAULT_MAX_ROWS_PER_SOURCE_PER_CYCLE,
+      );
+      const maxBytesPerSource = Math.max(
+        1,
+        this.#opts.maxBytesPerSourcePerCycle ??
+          DEFAULT_MAX_BYTES_PER_SOURCE_PER_CYCLE,
+      );
+
+      let sqliteRowsRead = 0;
+      let pgRowsRead = 0;
+      let sqliteBytesRead = 0;
+      let pgBytesRead = 0;
+      let previousBoundary = from;
+      let handledThrough = from;
+      for (const {watermark, inSqlite, inPg} of union) {
+        if (this.#stopped) {
+          break;
+        }
+        let stopAfterTransaction = false;
+        if (!inSqlite || !inPg) {
+          // Check every transaction for presence because this needs no payload read.
+          const outcome = await this.#reconfirm(db, pinned, watermark);
+          record(
+            watermark,
+            fileGeneration === this.#fileGeneration ? outcome : 'inconclusive',
+          );
+        } else if (
+          isSampledForCompare(this.#shard, watermark, this.#opts.comparePercent)
+        ) {
+          const sqliteRowsRemaining = maxRowsPerSource - sqliteRowsRead;
+          const pgRowsRemaining = maxRowsPerSource - pgRowsRead;
+          // A read may pass the byte budget by its last row, so this
+          // compares against zero rather than checking for equality.
+          const sqliteBytesRemaining = maxBytesPerSource - sqliteBytesRead;
+          const pgBytesRemaining = maxBytesPerSource - pgBytesRead;
+          if (
+            sqliteRowsRemaining === 0 ||
+            pgRowsRemaining === 0 ||
+            sqliteBytesRemaining <= 0 ||
+            pgBytesRemaining <= 0
+          ) {
+            record(watermark, 'deferred');
+            break;
+          }
+          sampled++;
+          const comparison = await this.#compareTransaction(
+            db,
+            reader,
+            pinned,
+            previousBoundary,
+            watermark,
+            sqliteRowsRemaining,
+            pgRowsRemaining,
+            sqliteBytesRemaining,
+            pgBytesRemaining,
+            maxRowsPerSource,
+            maxBytesPerSource,
+          );
+          sqliteRowsRead += comparison.sqliteRowsRead;
+          pgRowsRead += comparison.pgRowsRead;
+          sqliteBytesRead += comparison.sqliteBytesRead;
+          pgBytesRead += comparison.pgBytesRead;
+          const outcome =
+            fileGeneration === this.#fileGeneration
+              ? comparison.outcome
+              : 'inconclusive';
+          record(watermark, outcome);
+          if (outcome === 'inconclusive') {
+            break;
+          }
+          if (outcome === 'deferred') {
+            break;
+          }
+          if (outcome === 'oversized') {
+            // Advance past a transaction that cannot fit in a fresh budget.
+            stopAfterTransaction = true;
+          }
+          // Yield between sampled reads so other stream work can continue.
+          await this.#yield();
+        }
+        previousBoundary = watermark;
+        handledThrough = watermark;
+        transactions++;
+        if (stopAfterTransaction) {
+          break;
+        }
+      }
+
+      if (
+        !this.#stopped &&
+        fileGeneration === this.#fileGeneration &&
+        outcomes.inconclusive === 0
+      ) {
+        this.#cursor = handledThrough;
+        this.#continueWithoutDelay = handledThrough < through;
+      }
+      return this.#compared(
+        from,
+        handledThrough,
+        transactions,
+        sampled,
+        outcomes,
+      );
+    } catch (e) {
+      this.#lc.warn?.('error comparing the SQLite change log', e);
+      return this.#skipped('error');
+    } finally {
+      reader?.close();
+      db?.close();
+      this.#cycleDuration.recordMs(performance.now() - startedAt);
+    }
+  }
+
+  /** Checks log eligibility and reads the bounds from both stores. */
+  async #pinBounds(db: Database): Promise<PinnedBounds | CompareSkipReason> {
+    let meta: ChangeLogMeta;
+    try {
+      meta = readChangeLogMeta(db);
+    } catch {
+      // The writer has not initialized the log.
+      return 'log-unavailable';
+    }
+    if (meta.schemaVersion !== CHANGE_LOG_DB_SCHEMA_VERSION) {
+      return 'ineligible-schema';
+    }
+    const {epoch, generation, replicaID} = this.#identity;
+    if (
+      meta.epoch !== epoch ||
+      meta.generation !== generation ||
+      meta.replicaID !== replicaID
+    ) {
+      return 'ineligible-identity';
+    }
+    if (this.#now() - meta.seededAtMs < this.#opts.retentionMs) {
+      return 'cold-log';
+    }
+    const sqlite = this.#readSQLiteBounds(db);
+    if (sqlite === undefined) {
+      return 'log-unavailable';
+    }
+    const {minWatermark, lastWatermark} = await this.#pg.getCatchupBounds();
+    if (minWatermark === null) {
+      // Only a new replica has an empty Postgres change log.
+      return 'nothing-to-compare';
+    }
+    return {
+      meta,
+      sqlite,
+      pgMinWatermark: minWatermark,
+      pgLastWatermark: lastWatermark,
+    };
+  }
+
+  #readSQLiteBounds(db: Database): SQLiteBounds | undefined {
+    const bounds = db
+      .prepare(SQLITE_BOUNDS_SQL)
+      .get<{minWatermark: string | null; headWatermark: string | null}>();
+    return bounds.minWatermark === null || bounds.headWatermark === null
+      ? undefined
+      : {
+          minWatermark: bounds.minWatermark,
+          headWatermark: bounds.headWatermark,
+        };
+  }
+
+  /**
+   * Merges committed transaction watermarks from both stores.
+   * If a list reaches the limit, the result ends at the last complete common range.
+   */
+  async #enumerateCommits(
+    db: Database,
+    from: string,
+    through: string,
+    limit: number,
+  ): Promise<{watermark: string; inSqlite: boolean; inPg: boolean}[]> {
+    let sqlite: string[] = db
+      .prepare(SQLITE_COMMITS_SQL)
+      .all<{watermark: string}>({after: from, through, limit: limit + 1})
+      .map(({watermark}) => watermark);
+    let pg = await this.#pg.listCommitWatermarks(from, through, limit + 1);
+
+    let effectiveThrough = through;
+    if (sqlite.length > limit) {
+      sqlite.length = limit;
+      effectiveThrough = minWatermark(effectiveThrough, sqlite[limit - 1]);
+    }
+    if (pg.length > limit) {
+      pg.length = limit;
+      effectiveThrough = minWatermark(effectiveThrough, pg[limit - 1]);
+    }
+    if (effectiveThrough !== through) {
+      sqlite = sqlite.filter(w => w <= effectiveThrough);
+      pg = pg.filter(w => w <= effectiveThrough);
+    }
+
+    const union: {watermark: string; inSqlite: boolean; inPg: boolean}[] = [];
+    let s = 0;
+    let p = 0;
+    while (s < sqlite.length || p < pg.length) {
+      const sw = s < sqlite.length ? sqlite[s] : undefined;
+      const pw = p < pg.length ? pg[p] : undefined;
+      if (sw !== undefined && (pw === undefined || sw < pw)) {
+        union.push({watermark: sw, inSqlite: true, inPg: false});
+        s++;
+      } else if (pw !== undefined && (sw === undefined || pw < sw)) {
+        union.push({watermark: pw, inSqlite: false, inPg: true});
+        p++;
+      } else if (sw !== undefined) {
+        union.push({watermark: sw, inSqlite: true, inPg: true});
+        s++;
+        p++;
+      }
+    }
+    return union;
+  }
+
+  /**
+   * Compares the output in `(previousBoundary, watermark]`.
+   * Positional reads do not require either store to contain the boundary row.
+   */
+  async #compareTransaction(
+    db: Database,
+    reader: SQLiteChangeLogReader,
+    pinned: PinnedBounds,
+    previousBoundary: string,
+    watermark: string,
+    sqliteMaxRows: number,
+    pgMaxRows: number,
+    sqliteMaxBytes: number,
+    pgMaxBytes: number,
+    maxRowsPerSource: number,
+    maxBytesPerSource: number,
+  ): Promise<SampledComparison> {
+    let sqlite: CatchupRangeDigest;
+    let pg: CatchupRangeDigest;
+    try {
+      const readBatchRows = this.#opts.readBatchRows ?? DEFAULT_READ_BATCH_ROWS;
+      sqlite = await digestCatchupRange(
+        reader.read(
+          previousBoundary,
+          watermark,
+          Math.min(readBatchRows, sqliteMaxRows),
+          undefined,
+          sqliteMaxRows,
+        ),
+        watermark,
+        sqliteMaxRows,
+        sqliteMaxBytes,
+      );
+      pg = await digestCatchupRange(
+        reconstructBatches(
+          this.#pg.readCatchupRange(previousBoundary, watermark, pgMaxRows),
+        ),
+        watermark,
+        pgMaxRows,
+        pgMaxBytes,
+      );
+    } catch (e) {
+      // A failed catchup read makes the transaction suspect.
+      this.#lc.warn?.(
+        `error reading transaction ${watermark} for comparison`,
+        e,
+      );
+      return {
+        outcome: await this.#reconfirm(db, pinned, watermark),
+        sqliteRowsRead: 0,
+        pgRowsRead: 0,
+        sqliteBytesRead: 0,
+        pgBytesRead: 0,
+      };
+    }
+    const read = {
+      sqliteRowsRead: sqlite.rows,
+      pgRowsRead: pg.rows,
+      sqliteBytesRead: sqlite.bytes,
+      pgBytesRead: pg.bytes,
+    };
+    if (sqlite.limitReached || pg.limitReached) {
+      // Skip a transaction that cannot fit in a fresh budget.
+      // Defer one that does not fit only in the remaining budget.
+      // A budget is fresh when neither dimension has been spent.
+      const sqliteFresh =
+        sqliteMaxRows === maxRowsPerSource &&
+        sqliteMaxBytes === maxBytesPerSource;
+      const pgFresh =
+        pgMaxRows === maxRowsPerSource && pgMaxBytes === maxBytesPerSource;
+      const outcome =
+        (sqlite.limitReached && sqliteFresh) || (pg.limitReached && pgFresh)
+          ? 'oversized'
+          : 'deferred';
+      return {outcome, ...read};
+    }
+    if (sqlite.digest === pg.digest) {
+      return {outcome: 'match', ...read};
+    }
+    return {
+      outcome: await this.#reconfirm(db, pinned, watermark),
+      ...read,
+    };
+  }
+
+  /**
+   * Rechecks a suspect result against current store bounds.
+   * A moved bound, changed seed, failed read, or lower head makes the result inconclusive.
+   */
+  async #reconfirm(
+    db: Database,
+    pinned: PinnedBounds,
+    watermark: string,
+  ): Promise<'mismatch' | 'inconclusive'> {
+    try {
+      const meta = readChangeLogMeta(db);
+      if (
+        meta.seedWatermark !== pinned.meta.seedWatermark ||
+        meta.seededAtMs !== pinned.meta.seededAtMs
+      ) {
+        return 'inconclusive';
+      }
+      const sqlite = this.#readSQLiteBounds(db);
+      const {minWatermark, lastWatermark} = await this.#pg.getCatchupBounds();
+      if (sqlite === undefined || minWatermark === null) {
+        return 'inconclusive';
+      }
+      if (
+        (sqlite.minWatermark > pinned.sqlite.minWatermark &&
+          watermark <= sqlite.minWatermark) ||
+        (minWatermark > pinned.pgMinWatermark && watermark <= minWatermark) ||
+        watermark > sqlite.headWatermark ||
+        watermark > lastWatermark
+      ) {
+        return 'inconclusive';
+      }
+      return 'mismatch';
+    } catch {
+      return 'inconclusive';
+    }
+  }
+
+  #skipped(reason: CompareSkipReason): CompareCycleResult {
+    this.#compareCycles.add(1, {result: reason});
+    if (reason === 'error') {
+      // The caller logged the error.
+    } else if (reason !== 'nothing-to-compare') {
+      this.#lc.debug?.(`skipping SQLite change-log comparison: ${reason}`);
+    }
+    return {kind: 'skipped', reason};
+  }
+
+  #compared(
+    fromWatermark: string,
+    throughWatermark: string,
+    transactions: number,
+    sampled: number,
+    outcomes: Record<CompareOutcome, number>,
+  ): CompareCycleResult {
+    this.#compareCycles.add(1, {result: 'compared'});
+    const result = {
+      kind: 'compared',
+      fromWatermark,
+      throughWatermark,
+      transactions,
+      sampled,
+      matched: outcomes.match,
+      mismatched: outcomes.mismatch,
+      inconclusive: outcomes.inconclusive,
+      deferred: outcomes.deferred,
+      oversized: outcomes.oversized,
+    } as const;
+    this.#lc.debug?.('SQLite change-log comparison cycle', {
+      sqliteChangeLogCompare: result,
+    });
+    return result;
+  }
+}
+
+/** Applies the same reconstruction as Postgres catchup. */
+async function* reconstructBatches(
+  batches: AsyncIterable<ChangeLogEntry[]>,
+): AsyncIterable<WatermarkedChange[]> {
+  for await (const batch of batches) {
+    yield batch.map(reconstructWatermarkedChange);
+  }
+}
+
+function minWatermark(a: string, b: string): string {
+  return a < b ? a : b;
+}
+
+function maxWatermark(...watermarks: string[]): string {
+  let max = watermarks[0];
+  for (const w of watermarks) {
+    if (w > max) {
+      max = w;
+    }
+  }
+  return max;
+}

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-read-router.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-read-router.test.ts
@@ -1,0 +1,182 @@
+import {describe, expect, test, vi} from 'vitest';
+import type {ShardID} from '../../types/shards.ts';
+import {
+  isSelectedForSQLiteRead,
+  SQLiteChangeLogReadRouter,
+  type SQLiteChangeLogCoverage,
+} from './sqlite-change-log-read-router.ts';
+
+describe('change-streamer/sqlite-change-log-read-router', () => {
+  const shard: ShardID = {appID: 'router', shardNum: 3};
+  const warm: SQLiteChangeLogCoverage = {
+    seededAtMs: 1_000,
+    seedWatermark: '01',
+    minWatermark: '02',
+    headWatermark: '09',
+  };
+
+  test('selection is stable by shard and task, and zero percent still inspects eligibility', () => {
+    const inspect = vi.fn(() => warm);
+    const zero = new SQLiteChangeLogReadRouter({
+      shard,
+      readPercent: 0,
+      retentionMs: 100,
+      now: () => 2_000,
+      inspect,
+    });
+    expect(zero.consume('task-a')).toMatchObject({
+      source: 'pg',
+      reason: 'percentage',
+      coverage: warm,
+    });
+    expect(inspect).toHaveBeenCalledOnce();
+
+    const selected = Array.from({length: 1_000}, (_, i) => `task-${i}`).find(
+      taskID => isSelectedForSQLiteRead(shard, taskID, 10),
+    );
+    const declined = Array.from({length: 1_000}, (_, i) => `task-${i}`).find(
+      taskID => !isSelectedForSQLiteRead(shard, taskID, 10),
+    );
+    expect(selected).toBeDefined();
+    expect(declined).toBeDefined();
+
+    const canary = new SQLiteChangeLogReadRouter({
+      shard,
+      readPercent: 10,
+      retentionMs: 100,
+      now: () => 2_000,
+      inspect: () => warm,
+    });
+    expect(canary.consume(selected as string).source).toBe('sqlite');
+    expect(canary.consume(selected as string).source).toBe('sqlite');
+    expect(canary.consume(declined as string).source).toBe('pg');
+  });
+
+  test('declines a cold log and reports its covered range', () => {
+    const router = new SQLiteChangeLogReadRouter({
+      shard,
+      readPercent: 100,
+      retentionMs: 1_000,
+      now: () => 1_999,
+      inspect: () => warm,
+    });
+    expect(router.consume('task')).toEqual({
+      source: 'pg',
+      reason: 'cold-log',
+      coverage: warm,
+    });
+  });
+
+  test('a reseed resets warm-up eligibility until retention elapses again', () => {
+    let now = 2_000;
+    let coverage = warm;
+    const router = new SQLiteChangeLogReadRouter({
+      shard,
+      readPercent: 100,
+      retentionMs: 1_000,
+      now: () => now,
+      inspect: () => coverage,
+    });
+    expect(router.consume('task').source).toBe('sqlite');
+
+    coverage = {
+      ...warm,
+      seededAtMs: now,
+      seedWatermark: warm.headWatermark,
+      minWatermark: warm.headWatermark,
+    };
+    expect(router.consume('task')).toEqual({
+      source: 'pg',
+      reason: 'cold-log',
+      coverage,
+    });
+
+    now += 1_000;
+    expect(router.consume('task').source).toBe('sqlite');
+  });
+
+  test('a snapshot pin is consumed once and cannot change source mid-restore', () => {
+    let available = true;
+    const router = new SQLiteChangeLogReadRouter({
+      shard,
+      readPercent: 100,
+      retentionMs: 100,
+      now: () => 2_000,
+      inspect: () => (available ? warm : undefined),
+    });
+
+    expect(router.pin('task')).toMatchObject({source: 'sqlite'});
+    available = false;
+    expect(router.peek('task')).toMatchObject({
+      source: 'sqlite',
+      reason: 'selected',
+      pinned: true,
+    });
+    expect(router.consume('task')).toMatchObject({
+      source: 'sqlite',
+      reason: 'selected',
+      pinned: true,
+    });
+    expect(router.peek('task')).toBeUndefined();
+    expect(router.consume('task')).toEqual({
+      source: 'pg',
+      reason: 'log-unavailable',
+    });
+  });
+
+  test('post-registration failures route retries to PG until a bounded probe succeeds', () => {
+    let now = 2_000;
+    let available = true;
+    const inspect = vi.fn(() => (available ? warm : undefined));
+    const router = new SQLiteChangeLogReadRouter({
+      shard,
+      readPercent: 100,
+      retentionMs: 100,
+      failureCooldownMs: 500,
+      now: () => now,
+      inspect,
+    });
+
+    expect(router.consume('task').source).toBe('sqlite');
+    router.trip();
+    expect(router.consume('task')).toEqual({
+      source: 'pg',
+      reason: 'breaker-open',
+    });
+    expect(inspect).toHaveBeenCalledTimes(1);
+
+    available = false;
+    now += 500;
+    expect(router.consume('task')).toEqual({
+      source: 'pg',
+      reason: 'log-unavailable',
+    });
+    // The failed probe rearms the cooldown.
+    available = true;
+    expect(router.consume('task')).toEqual({
+      source: 'pg',
+      reason: 'breaker-open',
+    });
+
+    now += 500;
+    expect(router.consume('task').source).toBe('sqlite');
+  });
+
+  test('writer failure keeps the breaker open for the process lifetime', () => {
+    let now = 2_000;
+    const router = new SQLiteChangeLogReadRouter({
+      shard,
+      readPercent: 100,
+      retentionMs: 100,
+      failureCooldownMs: 1,
+      now: () => now,
+      inspect: () => warm,
+    });
+    router.trip(true);
+    now += 1_000_000;
+    expect(router.consume('task')).toEqual({
+      source: 'pg',
+      reason: 'breaker-open',
+    });
+  });
+});

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-read-router.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-read-router.ts
@@ -1,0 +1,226 @@
+import type {LogContext} from '@rocicorp/logger';
+import {h32} from '../../../../shared/src/hash.ts';
+import {Database} from '../../../../zqlite/src/db.ts';
+import type {ShardID} from '../../types/shards.ts';
+import {
+  CHANGE_LOG_DB_SCHEMA_VERSION,
+  CHANGE_LOG_STREAM_TABLE,
+  readChangeLogMeta,
+  type ChangeLogIdentity,
+} from '../replicator/change-log-db.ts';
+
+export type ChangeLogReadSource = 'pg' | 'sqlite';
+
+export type SQLiteChangeLogCoverage = {
+  readonly seededAtMs: number;
+  readonly seedWatermark: string;
+  readonly minWatermark: string;
+  readonly headWatermark: string;
+};
+
+export type ChangeLogReadRouteReason =
+  | 'selected'
+  | 'percentage'
+  | 'cold-log'
+  | 'log-unavailable'
+  | 'breaker-open';
+
+export type ChangeLogReadRoute = {
+  readonly source: ChangeLogReadSource;
+  readonly reason: ChangeLogReadRouteReason;
+  readonly pinned?: boolean | undefined;
+  readonly coverage?: SQLiteChangeLogCoverage | undefined;
+};
+
+export type SQLiteChangeLogReadRouterOptions = {
+  readonly shard: ShardID;
+  readonly readPercent: number;
+  readonly retentionMs: number;
+  readonly inspect: () => SQLiteChangeLogCoverage | undefined;
+  readonly failureCooldownMs?: number | undefined;
+  readonly now?: (() => number) | undefined;
+};
+
+const DEFAULT_FAILURE_COOLDOWN_MS = 30_000;
+
+/** Stable canary selection keyed by shard and subscriber task identity. */
+export function isSelectedForSQLiteRead(
+  shard: ShardID,
+  taskID: string,
+  percent: number,
+): boolean {
+  if (percent >= 100) {
+    return true;
+  }
+  if (percent <= 0) {
+    return false;
+  }
+  return h32(`${shard.appID}/${shard.shardNum}:${taskID}`) % 100 < percent;
+}
+
+/**
+ * Selects and pins the catchup source shared by `/snapshot` and `/changes`.
+ *
+ * A post-registration SQLite failure opens a process-local breaker. Requests
+ * use PG during the cooldown; the first request after it expires is the
+ * bounded probe. A successful readiness inspection closes the breaker, while
+ * another unavailable result rearms it. A writer failure opens it permanently
+ * because the writer remains disabled and its file stays absent for the life
+ * of the process.
+ */
+export class SQLiteChangeLogReadRouter {
+  readonly #shard: ShardID;
+  readonly #readPercent: number;
+  readonly #retentionMs: number;
+  readonly #inspect: () => SQLiteChangeLogCoverage | undefined;
+  readonly #failureCooldownMs: number;
+  readonly #now: () => number;
+  readonly #pins = new Map<string, ChangeLogReadRoute>();
+
+  #breakerUntilMs: number | undefined;
+  #permanentlyDisabled = false;
+
+  constructor(opts: SQLiteChangeLogReadRouterOptions) {
+    this.#shard = opts.shard;
+    this.#readPercent = opts.readPercent;
+    this.#retentionMs = opts.retentionMs;
+    this.#inspect = opts.inspect;
+    this.#failureCooldownMs =
+      opts.failureCooldownMs ?? DEFAULT_FAILURE_COOLDOWN_MS;
+    this.#now = opts.now ?? Date.now;
+  }
+
+  /** Chooses and pins a source for a snapshot reservation. */
+  pin(taskID: string): ChangeLogReadRoute {
+    const route = this.#choose(taskID);
+    this.#pins.set(taskID, route);
+    return route;
+  }
+
+  /** Returns the source pinned by an active snapshot reservation. */
+  peek(taskID: string): ChangeLogReadRoute | undefined {
+    const route = this.#pins.get(taskID);
+    return route && this.#asPinned(route);
+  }
+
+  /** Consumes a snapshot pin, or makes the stable choice for a direct retry. */
+  consume(taskID: string): ChangeLogReadRoute {
+    const route = this.#pins.get(taskID);
+    if (route === undefined) {
+      return this.#choose(taskID);
+    }
+    this.#pins.delete(taskID);
+    return this.#asPinned(route);
+  }
+
+  /** Releases a pin whose snapshot reservation ended before subscribing. */
+  release(taskID: string): void {
+    this.#pins.delete(taskID);
+  }
+
+  /** Opens the post-registration failure breaker. */
+  trip(permanent = false): void {
+    if (permanent) {
+      this.#permanentlyDisabled = true;
+      this.#breakerUntilMs = undefined;
+      return;
+    }
+    if (!this.#permanentlyDisabled) {
+      this.#breakerUntilMs = this.#now() + this.#failureCooldownMs;
+    }
+  }
+
+  #choose(taskID: string): ChangeLogReadRoute {
+    const now = this.#now();
+    if (
+      this.#permanentlyDisabled ||
+      (this.#breakerUntilMs !== undefined && now < this.#breakerUntilMs)
+    ) {
+      return {source: 'pg', reason: 'breaker-open'};
+    }
+
+    // Inspect eligibility even at readPercent=0. Slice 11 starts its rollout
+    // at zero specifically so warm/cold/unavailable rates are visible before
+    // any subscriber is routed to SQLite.
+    let coverage: SQLiteChangeLogCoverage | undefined;
+    try {
+      coverage = this.#inspect();
+    } catch {
+      coverage = undefined;
+    }
+    if (coverage === undefined) {
+      // This was a breaker probe rather than ordinary startup unavailability.
+      // Rearm it so a busy retry loop does not turn into an open/read loop.
+      if (this.#breakerUntilMs !== undefined) {
+        this.#breakerUntilMs = now + this.#failureCooldownMs;
+      }
+      return {source: 'pg', reason: 'log-unavailable'};
+    }
+    if (now - coverage.seededAtMs < this.#retentionMs) {
+      return {source: 'pg', reason: 'cold-log', coverage};
+    }
+
+    // A successful probe restores eligibility.
+    this.#breakerUntilMs = undefined;
+    // Keeping the percentage decision after readiness makes zero-percent
+    // rollouts emit eligibility metrics without serving reads.
+    if (!isSelectedForSQLiteRead(this.#shard, taskID, this.#readPercent)) {
+      return {source: 'pg', reason: 'percentage', coverage};
+    }
+    return {source: 'sqlite', reason: 'selected', coverage};
+  }
+
+  #asPinned(route: ChangeLogReadRoute): ChangeLogReadRoute {
+    return {...route, pinned: true};
+  }
+}
+
+/**
+ * Reads the coverage and validates the v2 schema and RMv2 identity in one
+ * short-lived readonly connection. It never creates the log.
+ */
+export function inspectSQLiteChangeLog(
+  lc: LogContext,
+  changeLogFile: string,
+  identity: ChangeLogIdentity,
+): SQLiteChangeLogCoverage | undefined {
+  let db: Database | undefined;
+  try {
+    db = new Database(
+      lc.withContext('component', 'sqlite-change-log-read-router'),
+      changeLogFile,
+      {readonly: true},
+    );
+    const meta = readChangeLogMeta(db);
+    if (
+      meta.schemaVersion !== CHANGE_LOG_DB_SCHEMA_VERSION ||
+      meta.epoch !== identity.epoch ||
+      meta.generation !== identity.generation ||
+      meta.replicaID !== identity.replicaID
+    ) {
+      return undefined;
+    }
+    const bounds = db
+      .prepare(/*sql*/ `
+        SELECT
+          (SELECT min("watermark") FROM "${CHANGE_LOG_STREAM_TABLE}")
+            AS "minWatermark",
+          (SELECT max("watermark") FROM "${CHANGE_LOG_STREAM_TABLE}")
+            AS "headWatermark"
+      `)
+      .get<{minWatermark: string | null; headWatermark: string | null}>();
+    if (bounds.minWatermark === null || bounds.headWatermark === null) {
+      return undefined;
+    }
+    return {
+      seededAtMs: meta.seededAtMs,
+      seedWatermark: meta.seedWatermark,
+      minWatermark: bounds.minWatermark,
+      headWatermark: bounds.headWatermark,
+    };
+  } catch {
+    return undefined;
+  } finally {
+    db?.close();
+  }
+}

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-reader.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-reader.test.ts
@@ -267,6 +267,26 @@ describe('sqlite change log reader', () => {
     await expect(collect(reader, '06', '06', 2)).resolves.toEqual([]);
   });
 
+  test('caps total rows across read batches', async () => {
+    const {db, path} = createChangeLog();
+    using writer = db;
+    const tx04 = appendTransaction(writer, '04', [
+      truncate(),
+      truncate(),
+      truncate(),
+      truncate(),
+      truncate(),
+    ]);
+    using reader = new SQLiteChangeLogReader(lc, path);
+
+    const batches: (readonly WatermarkedChange[])[] = [];
+    for await (const batch of reader.read('02', '04', 2, undefined, 5)) {
+      batches.push(batch);
+    }
+    expect(batches.map(batch => batch.length)).toEqual([2, 2, 1]);
+    expect(flatten(batches)).toEqual(tx04.slice(0, 5));
+  });
+
   test('pins the head while another connection appends and purges', async () => {
     const {db, path} = createChangeLog();
     using writer = db;

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-reader.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-reader.ts
@@ -151,10 +151,15 @@ export class SQLiteChangeLogReader implements Disposable {
     throughWatermark: string,
     batchSize: number,
     signal?: AbortSignal | undefined,
+    maxRows?: number | undefined,
   ): AsyncIterable<readonly WatermarkedChange[]> {
     assert(
       Number.isSafeInteger(batchSize) && batchSize > 0,
       'SQLite change log batch size must be a positive safe integer',
+    );
+    assert(
+      maxRows === undefined || (Number.isSafeInteger(maxRows) && maxRows > 0),
+      'SQLite change log row limit must be a positive safe integer',
     );
     this.#assertOpen();
     const statements = this.#prepare();
@@ -168,14 +173,20 @@ export class SQLiteChangeLogReader implements Disposable {
     // real stream position is far below this sentinel.
     let lastPos = Number.MAX_SAFE_INTEGER;
     let lastTag: string | undefined;
+    let rowsRead = 0;
 
     while (true) {
       this.#throwIfAborted(signal);
+      const remainingRows =
+        maxRows === undefined ? batchSize : maxRows - rowsRead;
+      if (remainingRows === 0) {
+        break;
+      }
       const rows = statements.readBatch.all<ChangeLogRow>(
         lastWatermark,
         lastPos,
         throughWatermark,
-        batchSize,
+        Math.min(batchSize, remainingRows),
       );
       this.#throwIfAborted(signal);
 
@@ -189,6 +200,7 @@ export class SQLiteChangeLogReader implements Disposable {
       lastWatermark = last.watermark;
       lastPos = last.pos;
       lastTag = last.tag;
+      rowsRead += rows.length;
 
       // all() has exhausted the SELECT and closed its implicit read
       // transaction. This yield therefore cannot pin the WAL while subscriber
@@ -201,7 +213,12 @@ export class SQLiteChangeLogReader implements Disposable {
     // `_zero.replicationState`, which is what this assertion used to guard.
     // What remains is a concurrent purge of the head transaction, which the
     // purge policy (never past the latest durable transaction) does not do.
-    if (fromWatermark !== throughWatermark) {
+    if (
+      fromWatermark !== throughWatermark &&
+      (maxRows === undefined ||
+        rowsRead < maxRows ||
+        (lastWatermark === throughWatermark && lastTag === 'commit'))
+    ) {
       assert(
         lastWatermark === throughWatermark && lastTag === 'commit',
         () =>

--- a/packages/zero-cache/src/services/change-streamer/storer.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.ts
@@ -313,6 +313,68 @@ export class Storer implements Service {
     return minWatermark;
   }
 
+  /**
+   * Returns the retained Postgres catchup bounds.
+   * `minWatermark` is the oldest transaction, or `null` for a new replica.
+   * `lastWatermark` is the durable head.
+   */
+  async getCatchupBounds(): Promise<{
+    minWatermark: string | null;
+    lastWatermark: string;
+  }> {
+    const [bounds] = await this.#db<
+      {minWatermark: string | null; lastWatermark: string}[]
+    > /*sql*/ `
+      SELECT
+        (SELECT min(watermark) FROM ${this.#cdc('changeLog')}) as "minWatermark",
+        (SELECT "lastWatermark" FROM ${this.#cdc('replicationState')}) as "lastWatermark"`;
+    return bounds;
+  }
+
+  /**
+   * Lists at most `limit` committed transaction watermarks in
+   * `(afterWatermark, throughWatermark]`, in ascending order.
+   */
+  async listCommitWatermarks(
+    afterWatermark: string,
+    throughWatermark: string,
+    limit: number,
+  ): Promise<string[]> {
+    const rows = await this.#db<{watermark: string}[]> /*sql*/ `
+      SELECT watermark FROM ${this.#cdc('changeLog')}
+       WHERE precommit IS NOT NULL
+         AND watermark > ${afterWatermark}
+         AND watermark <= ${throughWatermark}
+       ORDER BY watermark
+       LIMIT ${limit}`;
+    return rows.map(({watermark}) => watermark);
+  }
+
+  /**
+   * Reads `(afterWatermark, throughWatermark]` in stream order and bounded batches.
+   * This query matches the subscriber catchup query.
+   *
+   * Both queries fail when an escaped NUL reaches `change->'tag'`.
+   * Postgres cannot convert that value to text.
+   */
+  readCatchupRange(
+    afterWatermark: string,
+    throughWatermark: string,
+    batchRows = 2000,
+  ): AsyncIterable<ChangeLogEntry[]> {
+    assert(
+      Number.isSafeInteger(batchRows) && batchRows > 0,
+      'Postgres change log batch size must be a positive safe integer',
+    );
+    return this.#db<ChangeLogEntry[]> /*sql*/ `
+      SELECT watermark, change->'tag' as tag, change::text FROM ${this.#cdc('changeLog')}
+       WHERE watermark > ${afterWatermark}
+         AND watermark <= ${throughWatermark}
+       ORDER BY watermark, pos`.cursor(batchRows) as AsyncIterable<
+      ChangeLogEntry[]
+    >;
+  }
+
   purgeRecordsBefore(watermark: string): Promise<number> {
     return runTx(this.#db, async sql => {
       // This NOWAIT pre-check is an optimization to abort the transaction

--- a/packages/zero-cache/src/services/replicator/sqlite-change-log-metrics.test.ts
+++ b/packages/zero-cache/src/services/replicator/sqlite-change-log-metrics.test.ts
@@ -196,6 +196,7 @@ const INFO: SQLiteChangeLogInfo = {
   schemaVersion: CHANGE_LOG_DB_SCHEMA_VERSION,
   seededAtMs: 1_700_000_000_000,
   seedWatermark: '02',
+  minWatermark: '02',
   headWatermark: '02',
   rows: 2,
   estimatedBytes: 100,

--- a/packages/zero-cache/src/services/replicator/sqlite-change-log-observability.test.ts
+++ b/packages/zero-cache/src/services/replicator/sqlite-change-log-observability.test.ts
@@ -115,6 +115,7 @@ describe('SQLite change-log observability', () => {
       schemaVersion: CHANGE_LOG_DB_SCHEMA_VERSION,
       seededAtMs: ANCHOR.nowMs,
       seedWatermark: '02',
+      minWatermark: '02',
       headWatermark: '02',
       rows: 2,
       estimatedBytes: expect.any(Number),
@@ -137,6 +138,7 @@ describe('SQLite change-log observability', () => {
             schemaVersion: CHANGE_LOG_DB_SCHEMA_VERSION,
             seedWatermark: '02',
             seededAtMs: ANCHOR.nowMs,
+            minWatermark: '02',
             headWatermark: '02',
           },
         },
@@ -156,6 +158,7 @@ describe('SQLite change-log observability', () => {
       schemaVersion: CHANGE_LOG_DB_SCHEMA_VERSION,
       seededAtMs: ANCHOR.nowMs,
       seedWatermark: '02',
+      minWatermark: '02',
       headWatermark: '02',
     });
     const {

--- a/packages/zero-cache/src/services/replicator/sqlite-change-log-observability.ts
+++ b/packages/zero-cache/src/services/replicator/sqlite-change-log-observability.ts
@@ -31,7 +31,6 @@ import {
 } from './change-log-cookies.ts';
 import {
   CHANGE_LOG_STREAM_TABLE,
-  readChangeLogHead,
   readChangeLogMeta,
   type ChangeLogMeta,
   type ReconcileResult,
@@ -99,6 +98,7 @@ export function recordSQLiteChangeLogReconcile(
  * consequence of this log rather than a fact about it.
  */
 export type SQLiteChangeLogStartupInfo = ChangeLogMeta & {
+  readonly minWatermark: string;
   readonly headWatermark: string;
 };
 
@@ -109,8 +109,9 @@ export type SQLiteChangeLogInfo = SQLiteChangeLogStartupInfo & {
 };
 
 /**
- * Reads the meta row and the head. The head is an index-optimized `max()`, so
- * unlike {@link getSQLiteChangeLogInfo} this does not scan the log.
+ * Reads the meta row and covered range. The scalar `min()` and `max()`
+ * subqueries each use the watermark index, so unlike
+ * {@link getSQLiteChangeLogInfo} this does not scan the log.
  *
  * Call this after reconciliation, which is the only point at which the head is
  * known to be the resume watermark.
@@ -119,11 +120,19 @@ export function getSQLiteChangeLogStartupInfo(
   changeLog: Database,
 ): SQLiteChangeLogStartupInfo {
   const meta = readChangeLogMeta(changeLog);
-  const head = readChangeLogHead(changeLog);
-  if (head === null) {
+  const {minWatermark, headWatermark} = changeLog
+    .prepare(/*sql*/ `
+      SELECT
+        (SELECT min("watermark") FROM "${CHANGE_LOG_STREAM_TABLE}")
+          AS "minWatermark",
+        (SELECT max("watermark") FROM "${CHANGE_LOG_STREAM_TABLE}")
+          AS "headWatermark"
+    `)
+    .get<{minWatermark: string | null; headWatermark: string | null}>();
+  if (minWatermark === null || headWatermark === null) {
     throw new Error('the SQLite change log must contain its seed transaction');
   }
-  return {...meta, headWatermark: head};
+  return {...meta, minWatermark, headWatermark};
 }
 
 /**
@@ -166,6 +175,7 @@ export function logSQLiteChangeLogStartup(
       schemaVersion: info.schemaVersion,
       seedWatermark: info.seedWatermark,
       seededAtMs: info.seededAtMs,
+      minWatermark: info.minWatermark,
       headWatermark: info.headWatermark,
     },
   });


### PR DESCRIPTION
Rollback happens by turning down serving percent to 0 or flipping the flag.