### PR TITLE
fix(zero-cache): clean up Litestream restore temp files

### DIFF
--- a/packages/zero-cache/src/db/delete-lite-db.ts
+++ b/packages/zero-cache/src/db/delete-lite-db.ts
@@ -1,7 +1,7 @@
 import {rmSync} from 'node:fs';
 
 export function deleteLiteDB(dbFile: string) {
-  for (const suffix of ['', '-wal', '-wal2', '-shm']) {
+  for (const suffix of ['', '-wal', '-wal2', '-shm', '-journal']) {
     rmSync(`${dbFile}${suffix}`, {force: true});
   }
 }

--- a/packages/zero-cache/src/services/litestream/commands.test.ts
+++ b/packages/zero-cache/src/services/litestream/commands.test.ts
@@ -347,13 +347,16 @@ describe('litestream/commands restoreReplica', () => {
     const source = join(dir, 'source.db');
     const replica = join(dir, 'replica.db');
     const temporaryReplica = `${replica}.tmp`;
+    const stagedWAL = `${temporaryReplica}-deadbeef-wal`;
     createRestorableReplica(source, '01');
     writeSQLiteFamily(temporaryReplica);
+    writeFileSync(stagedWAL, 'stale WAL data');
     const {litestream} = configWithFakeLitestream(
       `if [ "$1" = "restore" ]; then\n` +
         `  for suffix in "" "-wal" "-wal2" "-shm" "-journal"; do\n` +
         `    if [ -e "$6.tmp$suffix" ]; then exit 9; fi\n` +
         `  done\n` +
+        `  if [ -e "$6.tmp-deadbeef-wal" ]; then exit 9; fi\n` +
         `  cp "${source}" "$6"\n` +
         `  exit 0\n` +
         `fi\n` +
@@ -372,17 +375,20 @@ describe('litestream/commands restoreReplica', () => {
     ).resolves.toMatchObject({restored: true, result: 'success'});
 
     expect(sqliteFamilyFiles(temporaryReplica).some(existsSync)).toBe(false);
+    expect(existsSync(stagedWAL)).toBe(false);
   });
 
   test('deletes a temporary SQLite family left by a failed restore', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'litestream-restore-test-'));
     const replica = join(dir, 'replica.db');
     const temporaryReplica = `${replica}.tmp`;
+    const stagedWAL = `${temporaryReplica}-deadbeef-wal`;
     const {litestream} = configWithFakeLitestream(
       `if [ "$1" = "restore" ]; then\n` +
         `  for suffix in "" "-wal" "-wal2" "-shm" "-journal"; do\n` +
         `    printf "temporary" > "$6.tmp$suffix"\n` +
         `  done\n` +
+        `  printf "temporary WAL" > "${stagedWAL}"\n` +
         `  exit 1\n` +
         `fi\n` +
         `exit 1`,
@@ -400,6 +406,7 @@ describe('litestream/commands restoreReplica', () => {
     ).rejects.toThrow('litestream exited with code 1');
 
     expect(sqliteFamilyFiles(temporaryReplica).some(existsSync)).toBe(false);
+    expect(existsSync(stagedWAL)).toBe(false);
   });
 
   test('temporary restore cleanup preserves the real replica family', async () => {
@@ -500,6 +507,7 @@ describe('litestream/commands restoreReplica', () => {
   test('includes captured output when restore fails', async () => {
     const {litestream, replica} = configWithFakeLitestream(
       `if [ "$1" = "restore" ]; then\n` +
+        `  mkdir "$6.tmp"\n` +
         `  echo "restore stdout"\n` +
         `  echo "restore stderr" >&2\n` +
         `  exit 1\n` +

--- a/packages/zero-cache/src/services/litestream/commands.test.ts
+++ b/packages/zero-cache/src/services/litestream/commands.test.ts
@@ -74,6 +74,18 @@ function createRestorableReplica(file: string, watermark: string) {
   }
 }
 
+const SQLITE_FAMILY_SUFFIXES = ['', '-wal', '-wal2', '-shm', '-journal'];
+
+function sqliteFamilyFiles(file: string) {
+  return SQLITE_FAMILY_SUFFIXES.map(suffix => `${file}${suffix}`);
+}
+
+function writeSQLiteFamily(file: string, contents = 'test data') {
+  for (const familyFile of sqliteFamilyFiles(file)) {
+    writeFileSync(familyFile, contents);
+  }
+}
+
 describe('litestream/commands parseBackupCreatedTimes', () => {
   const lc = createSilentLogContext();
 
@@ -328,6 +340,161 @@ describe('litestream/commands restoreReplica', () => {
     );
 
     expect(restoredDbBytesAdd).not.toHaveBeenCalled();
+  });
+
+  test('deletes a stale temporary SQLite family before restore', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'litestream-restore-test-'));
+    const source = join(dir, 'source.db');
+    const replica = join(dir, 'replica.db');
+    const temporaryReplica = `${replica}.tmp`;
+    createRestorableReplica(source, '01');
+    writeSQLiteFamily(temporaryReplica);
+    const {litestream} = configWithFakeLitestream(
+      `if [ "$1" = "restore" ]; then\n` +
+        `  for suffix in "" "-wal" "-wal2" "-shm" "-journal"; do\n` +
+        `    if [ -e "$6.tmp$suffix" ]; then exit 9; fi\n` +
+        `  done\n` +
+        `  cp "${source}" "$6"\n` +
+        `  exit 0\n` +
+        `fi\n` +
+        `exit 1`,
+      replica,
+    );
+
+    await expect(
+      tryRestore(
+        lc,
+        litestream,
+        replica,
+        {replicaVersion: '01', minWatermark: '01'},
+        'replication_manager',
+      ),
+    ).resolves.toMatchObject({restored: true, result: 'success'});
+
+    expect(sqliteFamilyFiles(temporaryReplica).some(existsSync)).toBe(false);
+  });
+
+  test('deletes a temporary SQLite family left by a failed restore', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'litestream-restore-test-'));
+    const replica = join(dir, 'replica.db');
+    const temporaryReplica = `${replica}.tmp`;
+    const {litestream} = configWithFakeLitestream(
+      `if [ "$1" = "restore" ]; then\n` +
+        `  for suffix in "" "-wal" "-wal2" "-shm" "-journal"; do\n` +
+        `    printf "temporary" > "$6.tmp$suffix"\n` +
+        `  done\n` +
+        `  exit 1\n` +
+        `fi\n` +
+        `exit 1`,
+      replica,
+    );
+
+    await expect(
+      tryRestore(
+        lc,
+        litestream,
+        replica,
+        {replicaVersion: '01', minWatermark: '01'},
+        'replication_manager',
+      ),
+    ).rejects.toThrow('litestream exited with code 1');
+
+    expect(sqliteFamilyFiles(temporaryReplica).some(existsSync)).toBe(false);
+  });
+
+  test('temporary restore cleanup preserves the real replica family', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'litestream-restore-test-'));
+    const replica = join(dir, 'replica.db');
+    const temporaryReplica = `${replica}.tmp`;
+    writeSQLiteFamily(replica, 'real replica');
+    const {litestream} = configWithFakeLitestream(
+      `if [ "$1" = "restore" ]; then\n` +
+        `  printf "temporary" > "$6.tmp"\n` +
+        `  printf "temporary journal" > "$6.tmp-journal"\n` +
+        `  exit 1\n` +
+        `fi\n` +
+        `exit 1`,
+      replica,
+    );
+
+    await expect(
+      tryRestore(
+        lc,
+        litestream,
+        replica,
+        {replicaVersion: '01', minWatermark: '01'},
+        'replication_manager',
+      ),
+    ).rejects.toThrow('litestream exited with code 1');
+
+    for (const familyFile of sqliteFamilyFiles(replica)) {
+      expect(readFileSync(familyFile, 'utf8')).toBe('real replica');
+    }
+    expect(sqliteFamilyFiles(temporaryReplica).some(existsSync)).toBe(false);
+  });
+
+  test('logs restore directory contents before and after temporary cleanup', async () => {
+    const sink = new TestLogSink();
+    const loggingLC = new LogContext('debug', undefined, sink);
+    const dir = mkdtempSync(join(tmpdir(), 'litestream-restore-test-'));
+    const source = join(dir, 'source.db');
+    const replica = join(dir, 'replica.db');
+    const temporaryReplica = `${replica}.tmp`;
+    const unexpectedFile = join(dir, 'unexpected-restore-file');
+    createRestorableReplica(source, '01');
+    writeFileSync(temporaryReplica, 'stale temporary data');
+    writeFileSync(unexpectedFile, 'unexpected data');
+    const {litestream} = configWithFakeLitestream(
+      `if [ "$1" = "restore" ]; then\n` +
+        `  cp "${source}" "$6"\n` +
+        `  exit 0\n` +
+        `fi\n` +
+        `exit 1`,
+      replica,
+    );
+
+    await tryRestore(
+      loggingLC,
+      litestream,
+      replica,
+      {replicaVersion: '01', minWatermark: '01'},
+      'replication_manager',
+    );
+
+    const snapshots = sink.messages
+      .filter(
+        ([, , args]) => args[0] === 'Litestream restore directory contents',
+      )
+      .map(
+        ([, , args]) =>
+          args[1] as {
+            phase: string;
+            entryCount: number;
+            entries: {name: string; sizeBytes: number}[];
+          },
+      );
+    expect(snapshots.map(snapshot => snapshot.phase)).toEqual([
+      'before-temp-cleanup',
+      'after-temp-cleanup',
+    ]);
+    expect(snapshots[0]?.entries).toContainEqual(
+      expect.objectContaining({
+        name: 'replica.db.tmp',
+        sizeBytes: 20,
+      }),
+    );
+    expect(snapshots[1]?.entries.map(entry => entry.name)).not.toContain(
+      'replica.db.tmp',
+    );
+    for (const snapshot of snapshots) {
+      expect(snapshot.entryCount).toBeGreaterThan(0);
+      expect(snapshot.entries).toContainEqual(
+        expect.objectContaining({
+          name: 'unexpected-restore-file',
+          sizeBytes: 15,
+        }),
+      );
+    }
   });
 
   test('includes captured output when restore fails', async () => {

--- a/packages/zero-cache/src/services/litestream/commands.ts
+++ b/packages/zero-cache/src/services/litestream/commands.ts
@@ -1,6 +1,7 @@
 import type {ChildProcess} from 'node:child_process';
 import {spawn} from 'node:child_process';
-import {existsSync, statSync} from 'node:fs';
+import {existsSync, readdirSync, statSync} from 'node:fs';
+import {dirname, join} from 'node:path';
 import type {LogContext, LogLevel} from '@rocicorp/logger';
 import {resolver} from '@rocicorp/resolver';
 import {must} from '../../../../shared/src/must.ts';
@@ -44,6 +45,8 @@ type RestoreAttempt = {
   backupURL: string | undefined;
   result: RestoreResult;
 };
+
+const MAX_LOGGED_RESTORE_DIRECTORY_ENTRIES = 100;
 
 export class BackupNotFoundException extends Error {
   static readonly name = 'BackupNotFoundException';
@@ -129,8 +132,11 @@ export async function tryRestore(
 ): Promise<RestoreAttempt> {
   const {backupURL} = config;
   const attrs = litestreamRestoreMetricAttrs(config, role, backupURL);
+  const temporaryReplicaFile = `${replicaFile}.tmp`;
   let result: RestoreResult = 'error';
   try {
+    logRestoreDirectoryContents(lc, replicaFile, 'before-temp-cleanup');
+    deleteLiteDB(temporaryReplicaFile);
     const replicaExistedBeforeRestore = existsSync(replicaFile);
     const {litestream, env} = getLitestream(
       'restore',
@@ -250,7 +256,44 @@ export async function tryRestore(
     }
     return {restored: true, backupURL, result};
   } finally {
-    litestreamRestoreAttempts().add(1, {...attrs, result});
+    try {
+      deleteLiteDB(temporaryReplicaFile);
+    } finally {
+      logRestoreDirectoryContents(lc, replicaFile, 'after-temp-cleanup');
+      litestreamRestoreAttempts().add(1, {...attrs, result});
+    }
+  }
+}
+
+function logRestoreDirectoryContents(
+  lc: LogContext,
+  replicaFile: string,
+  phase: 'before-temp-cleanup' | 'after-temp-cleanup',
+) {
+  const directory = dirname(replicaFile);
+  try {
+    const names = readdirSync(directory).sort();
+    const entries = names
+      .slice(0, MAX_LOGGED_RESTORE_DIRECTORY_ENTRIES)
+      .map(name => ({name, sizeBytes: statSync(join(directory, name)).size}));
+    lc.info?.('Litestream restore directory contents', {
+      phase,
+      directory,
+      replicaFile,
+      entryCount: names.length,
+      omittedEntryCount: Math.max(
+        0,
+        names.length - MAX_LOGGED_RESTORE_DIRECTORY_ENTRIES,
+      ),
+      entries,
+    });
+  } catch (e) {
+    lc.warn?.('Unable to inspect Litestream restore directory', {
+      phase,
+      directory,
+      replicaFile,
+      error: String(e),
+    });
   }
 }
 

--- a/packages/zero-cache/src/services/litestream/commands.ts
+++ b/packages/zero-cache/src/services/litestream/commands.ts
@@ -1,7 +1,7 @@
 import type {ChildProcess} from 'node:child_process';
 import {spawn} from 'node:child_process';
-import {existsSync, readdirSync, statSync} from 'node:fs';
-import {dirname, join} from 'node:path';
+import {existsSync, readdirSync, rmSync, statSync} from 'node:fs';
+import {basename, dirname, join} from 'node:path';
 import type {LogContext, LogLevel} from '@rocicorp/logger';
 import {resolver} from '@rocicorp/resolver';
 import {must} from '../../../../shared/src/must.ts';
@@ -47,6 +47,7 @@ type RestoreAttempt = {
 };
 
 const MAX_LOGGED_RESTORE_DIRECTORY_ENTRIES = 100;
+const LEGACY_RESTORE_WAL_INDEX = /^[0-9a-f]{8}$/;
 
 export class BackupNotFoundException extends Error {
   static readonly name = 'BackupNotFoundException';
@@ -132,11 +133,10 @@ export async function tryRestore(
 ): Promise<RestoreAttempt> {
   const {backupURL} = config;
   const attrs = litestreamRestoreMetricAttrs(config, role, backupURL);
-  const temporaryReplicaFile = `${replicaFile}.tmp`;
   let result: RestoreResult = 'error';
   try {
     logRestoreDirectoryContents(lc, replicaFile, 'before-temp-cleanup');
-    deleteLiteDB(temporaryReplicaFile);
+    deleteRestoreTempFiles(replicaFile);
     const replicaExistedBeforeRestore = existsSync(replicaFile);
     const {litestream, env} = getLitestream(
       'restore',
@@ -257,10 +257,36 @@ export async function tryRestore(
     return {restored: true, backupURL, result};
   } finally {
     try {
-      deleteLiteDB(temporaryReplicaFile);
-    } finally {
-      logRestoreDirectoryContents(lc, replicaFile, 'after-temp-cleanup');
-      litestreamRestoreAttempts().add(1, {...attrs, result});
+      deleteRestoreTempFiles(replicaFile);
+    } catch (e) {
+      lc.warn?.('Unable to clean up Litestream restore temporary files', {
+        replicaFile,
+        error: String(e),
+      });
+    }
+    logRestoreDirectoryContents(lc, replicaFile, 'after-temp-cleanup');
+    litestreamRestoreAttempts().add(1, {...attrs, result});
+  }
+}
+
+function deleteRestoreTempFiles(replicaFile: string) {
+  const temporaryReplicaFile = `${replicaFile}.tmp`;
+  deleteLiteDB(temporaryReplicaFile);
+
+  // rocicorp/litestream zero@v0.0.9 downloads WAL indexes in parallel to
+  // `<output>.tmp-<8 lowercase hex digits>-wal` before applying them.
+  const directory = dirname(temporaryReplicaFile);
+  if (!existsSync(directory)) {
+    return;
+  }
+  const prefix = `${basename(temporaryReplicaFile)}-`;
+  for (const name of readdirSync(directory)) {
+    if (!name.startsWith(prefix) || !name.endsWith('-wal')) {
+      continue;
+    }
+    const index = name.slice(prefix.length, -'-wal'.length);
+    if (LEGACY_RESTORE_WAL_INDEX.test(index)) {
+      rmSync(join(directory, name), {force: true});
     }
   }
 }

--- a/packages/zero-cache/src/services/replicator/change-log-db.test.ts
+++ b/packages/zero-cache/src/services/replicator/change-log-db.test.ts
@@ -52,7 +52,7 @@ const ANCHOR: ChangeLogAnchor = {
 };
 
 /** The main file and the sidecars `deleteLiteDB` removes. */
-const SIDECARS = ['', '-wal', '-wal2', '-shm'];
+const SIDECARS = ['', '-wal', '-wal2', '-shm', '-journal'];
 
 const dbFiles: DbFile[] = [];
 


### PR DESCRIPTION
### What

Prevent failed or interrupted Litestream restores from leaving temporary databases and staged WAL files that consume the replica volume. The restore path also records bounded directory snapshots around cleanup to expose any other files accumulating beside the replica.

### Why

The bundled Litestream implementations use several temporary file shapes during restore:

- `rocicorp/litestream` `zero@v0.0.9` restores into `${replicaFile}.tmp` and stages parallel WAL downloads as `${replicaFile}.tmp-<8-hex-index>-wal`.
- Litestream `v0.5.16` restores into `${replicaFile}.tmp`; its v0.3 compatibility path may also create normal SQLite sidecars such as `-wal` and `-shm`.

Our fork does not clean all of these files after a failed restore. Repeated attempts can therefore amplify disk usage while logical replica DB/WAL metrics remain comparatively small.

### Changes

- Delete the temporary SQLite family before every restore and again after the attempt.
- Remove the exact indexed-WAL staging pattern emitted by `rocicorp/litestream` `zero@v0.0.9`.
- Extend `deleteLiteDB` to remove rollback-journal (`-journal`) files.
- Preserve the original restore result if final cleanup fails, while logging a warning.
- Log up to 100 directory entries and sizes before and after cleanup for additional disk-usage diagnostics.
- Add regression coverage for stale files, failed restores, indexed WAL staging, rollback journals, cleanup-error precedence, directory diagnostics, and preservation of the real replica family.