### PR TITLE
chore(litestream): bump litestream fork version to include SQLite with wal-reset fix

### DIFF
--- a/packages/zero/Dockerfile
+++ b/packages/zero/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.25.10@sha256:cd05a378aaf011e8056745363e5c40f4f2bef0fa4d9bf19b9c38316079c332ff AS litestream
 
 WORKDIR /src/
-RUN git clone --depth 1 --branch zero@v0.0.9 https://github.com/rocicorp/litestream.git
+RUN git clone --depth 1 --branch zero@v0.0.10 https://github.com/rocicorp/litestream.git
 WORKDIR /src/litestream/
 
 ARG LITESTREAM_VERSION=0.3.13+z0.0.9  # upstream version + zero version

--- a/packages/zero/Dockerfile
+++ b/packages/zero/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /src/
 RUN git clone --depth 1 --branch zero@v0.0.10 https://github.com/rocicorp/litestream.git
 WORKDIR /src/litestream/
 
-ARG LITESTREAM_VERSION=0.3.13+z0.0.9  # upstream version + zero version
+ARG LITESTREAM_VERSION=0.3.13+z0.0.10  # upstream version + zero version
 
 # Force use of the toolchain bundled in the builder image so the resulting
 # binary is compiled with Go 1.25.10 stdlib (fixes CVE-2025-68121 and a


### PR DESCRIPTION
Bumps our litestream v3 fork to a version that includes the SQLite wal-reset fix (https://github.com/rocicorp/litestream/pull/17). 