### PR TITLE
fix(zero): restore WAL segments with wide offsets

### DIFF
--- a/packages/zero/Dockerfile
+++ b/packages/zero/Dockerfile
@@ -1,10 +1,10 @@
 FROM golang:1.25.10@sha256:cd05a378aaf011e8056745363e5c40f4f2bef0fa4d9bf19b9c38316079c332ff AS litestream
 
 WORKDIR /src/
-RUN git clone --depth 1 --branch zero@v0.0.9 https://github.com/rocicorp/litestream.git
+RUN git clone --depth 1 --branch zero@v0.0.11 https://github.com/rocicorp/litestream.git
 WORKDIR /src/litestream/
 
-ARG LITESTREAM_VERSION=0.3.13+z0.0.9  # upstream version + zero version
+ARG LITESTREAM_VERSION=0.3.13+z0.0.11  # upstream version + zero version
 
 # Force use of the toolchain bundled in the builder image so the resulting
 # binary is compiled with Go 1.25.10 stdlib (fixes CVE-2025-68121 and a

--- a/packages/zero/package.json
+++ b/packages/zero/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocicorp/zero",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Zero is a web framework for serverless web development.",
   "homepage": "https://zero.rocicorp.dev",
   "bugs": {


### PR DESCRIPTION
### What

Update the Zero 1.9 maintenance release to embed rocicorp/litestream `zero@v0.0.11`, which restores legacy v0.3 WAL segments whose offsets grow beyond eight hexadecimal digits.

The package base version becomes `1.9.1` so the canary release workflow publishes this change as `1.9.1-canary.0`.

### Why

A production view-syncer repeatedly restored a roughly 189 GB backup, passed Zero metadata validation, became ready, and then failed its first incremental transaction with `SQLITE_CORRUPT: database disk image is malformed`. Existing replicas remained healthy, isolating the failure to fresh restores.

The backup contains valid WAL segment names such as `000012c3_11a6bfa58.wal.lz4`. Litestream formats offsets with `%08x`, which emits more than eight digits above 4 GiB, but its reader previously accepted exactly eight digits. Replica iterators silently skipped those wider names, allowing restore to omit the tail of one WAL index and continue with later indexes.

The reader fix is merged in rocicorp/litestream#18 and published as `zero@v0.0.11`. Existing S3 objects remain available, so embedding the corrected reader should recover the affected backup without a full resync. The writer format is intentionally unchanged for compatibility with deployed readers.

### Changes

- Build the legacy Litestream executable from `zero@v0.0.11`.
- Report its embedded version as `0.3.13+z0.0.11`.
- Set the Zero package base version to `1.9.1` for canary publication.