### PR TITLE
feat(zql): warn when a manual {flip: true} is costlier than the semi-join

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
@@ -696,6 +696,7 @@ export class PipelineDriver {
         },
         queryID,
         costModel,
+        this.#lc.withContext('queryID', queryID),
       );
       const schema = input.getSchema();
       input.setOutput({

--- a/packages/zql/src/planner/planner-graph.ts
+++ b/packages/zql/src/planner/planner-graph.ts
@@ -379,6 +379,60 @@ export class PlannerGraph {
         'no plan was found but flippable joins did exist!',
       );
     }
+
+    if (lc) {
+      this.#warnCostlyManualFlips(fofiCache, lc, planDebugger);
+    }
+  }
+
+  /**
+   * Costs the chosen plan against the same plan with each `{flip: true}` join
+   * undone. A manual flip is pinned, so the enumeration above never tests the
+   * alternative; a flip whose subquery isn't selective drives a full scan on
+   * every hydration and nothing else will report it.
+   */
+  #warnCostlyManualFlips(
+    fofiCache: Map<PlannerFanOut, FOFIInfo>,
+    lc: LogContext,
+    planDebugger?: PlanDebugger,
+  ): void {
+    const manual = this.joins.filter(j => j.isManuallyFlipped());
+    if (manual.length === 0) {
+      return;
+    }
+
+    const chosen = this.capturePlanningSnapshot();
+    const chosenFlips = this.joins.filter(
+      j => j.isFlippable() && j.type === 'flipped',
+    );
+    const evaluate = (asSemi?: PlannerJoin): number => {
+      this.resetPlanningState();
+      for (const j of chosenFlips) j.flip();
+      asSemi?.evaluateAsSemi();
+      checkAndConvertFOFI(fofiCache);
+      propagateUnlimitForFlippedJoins(this);
+      this.propagateConstraints(planDebugger);
+      return this.getTotalCost(planDebugger);
+    };
+
+    const chosenCost = evaluate();
+    for (const join of manual) {
+      const semiCost = evaluate(join);
+      if (semiCost < chosenCost) {
+        lc.warn?.(
+          `{flip: true} on ${join.getName()} costs ~${Math.round(chosenCost)} ` +
+            `but ~${Math.round(semiCost)} without it. The flip makes the ` +
+            `subquery the driving side and pins the join out of planning, so ` +
+            `the planner cannot correct it: it will scan the subquery on ` +
+            `every hydration. Drop the flip to let the planner decide.`,
+        );
+      }
+    }
+
+    // restorePlanningSnapshot converts FO->UFO but not back; reset first.
+    this.resetPlanningState();
+    this.restorePlanningSnapshot(chosen);
+    this.propagateConstraints(planDebugger);
   }
 }
 

--- a/packages/zql/src/planner/planner-join.ts
+++ b/packages/zql/src/planner/planner-join.ts
@@ -168,6 +168,24 @@ export class PlannerJoin {
     return this.#flippable;
   }
 
+  /** True for a `{flip: true}` join: pinned flipped, excluded from planning. */
+  isManuallyFlipped(): boolean {
+    return !this.#flippable && this.#initialType === 'flipped';
+  }
+
+  /**
+   * Costs a manually flipped join as a semi-join. Only valid between a
+   * resetPlanningState() and the next reset; never capture a snapshot while
+   * this is in effect.
+   */
+  evaluateAsSemi(): void {
+    assert(
+      this.isManuallyFlipped(),
+      'Only manual flips can be evaluated as semi',
+    );
+    this.#type = 'semi';
+  }
+
   /**
    * Propagate unlimiting when this join is flipped.
    * When a join is flipped:

--- a/packages/zql/src/planner/planner-manual-flip.test.ts
+++ b/packages/zql/src/planner/planner-manual-flip.test.ts
@@ -1,0 +1,113 @@
+import {LogContext} from '@rocicorp/logger';
+import {expect, suite, test} from 'vitest';
+import {TestLogSink} from '../../../shared/src/logging-test-utils.ts';
+import type {AST} from '../../../zero-protocol/src/ast.ts';
+import {asQueryInternals} from '../query/query-internals.ts';
+import type {AnyQuery} from '../query/query.ts';
+import {buildPlanGraph} from './planner-builder.ts';
+import type {ConnectionCostModel} from './planner-connection.ts';
+import {builder} from './test/test-schema.ts';
+
+function getAST(q: AnyQuery): AST {
+  return asQueryInternals(q).ast;
+}
+
+const fanout = () => ({fanout: 1, confidence: 'none'}) as const;
+
+// A constraint is an index seek (1 row); an unconstrained scan returns the
+// whole table.
+function sized(sizes: Record<string, number>): ConnectionCostModel {
+  return (table, _sort, _filters, constraint) => ({
+    startupCost: 0,
+    rows:
+      constraint && Object.keys(constraint).length > 0
+        ? 1
+        : (sizes[table] ?? 100),
+    fanout,
+  });
+}
+
+function planAndCollectWarnings(ast: AST, model: ConnectionCostModel) {
+  const sink = new TestLogSink();
+  const lc = new LogContext('warn', undefined, sink);
+  const plans = buildPlanGraph(ast, model, true);
+  plans.plan.plan(undefined, lc);
+  const warnings = sink.messages
+    .filter(([level]) => level === 'warn')
+    .map(([, , args]) => String(args[0]));
+  return {plans, warnings};
+}
+
+suite('manual flip cost warning', () => {
+  test('warns when {flip: true} drives from the larger side', () => {
+    const ast = getAST(builder.users.whereExists('posts', {flip: true}));
+    const {warnings} = planAndCollectWarnings(
+      ast,
+      sized({users: 10, posts: 1_000_000}),
+    );
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('{flip: true} on users ⋈ posts');
+  });
+
+  test('is quiet when {flip: true} drives from the smaller side', () => {
+    const ast = getAST(builder.users.whereExists('posts', {flip: true}));
+    const {warnings} = planAndCollectWarnings(
+      ast,
+      sized({users: 1_000_000, posts: 10}),
+    );
+    expect(warnings).toHaveLength(0);
+  });
+
+  test('is quiet when there is no manual flip', () => {
+    const ast = getAST(builder.users.whereExists('posts'));
+    const {warnings} = planAndCollectWarnings(
+      ast,
+      sized({users: 10, posts: 1_000_000}),
+    );
+    expect(warnings).toHaveLength(0);
+  });
+
+  test('is quiet without a LogContext', () => {
+    const ast = getAST(builder.users.whereExists('posts', {flip: true}));
+    const plans = buildPlanGraph(
+      ast,
+      sized({users: 10, posts: 1_000_000}),
+      true,
+    );
+    expect(() => plans.plan.plan()).not.toThrow();
+  });
+
+  test('warns per manual flip and leaves the chosen plan intact', () => {
+    // The incident shape: two manual flips inside an OR (branches do not
+    // constrain each other), plus one join left to the planner. Only the bad
+    // flip should warn, and no join type should change.
+    const ast = getAST(
+      builder.users
+        .where(({or, exists}) =>
+          or(
+            exists('posts', q => q, {flip: true}),
+            exists('comments', q => q, {flip: true}),
+          ),
+        )
+        .whereExists('likes'),
+    );
+    // likes is large so the planner keeps it semi; a flipped likes would push
+    // its constraint into the OR branches and make the posts flip cheap.
+    const model = sized({
+      users: 100,
+      posts: 1_000_000,
+      comments: 1,
+      likes: 1_000_000,
+    });
+
+    const silent = buildPlanGraph(ast, model, true);
+    silent.plan.plan();
+    const expectedTypes = silent.plan.joins.map(j => j.type);
+    expect(expectedTypes).toEqual(['flipped', 'flipped', 'semi']);
+
+    const {plans, warnings} = planAndCollectWarnings(ast, model);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('FO ⋈ posts');
+    expect(plans.plan.joins.map(j => j.type)).toEqual(expectedTypes);
+  });
+});


### PR DESCRIPTION
## Problem

`{flip: true}` does two things: it makes the subquery the driving side of the join, and it sets `flippable = false`, which removes the join from the planner's search. When the flipped subquery has no selective filter, this drives a full scan of that table on every hydration pass, holds the read snapshot open for the duration, and blocks WAL checkpointing on the replica for as long as it runs — and nothing reports it. The alternative is never costed, so the planner cannot correct it.

## Change

After `PlannerGraph.plan()` selects the best plan, re-cost it with each manual flip undone, using the same reset → flip → FOFI → unlimit → propagate → cost sequence the search uses. If the semi-join is cheaper, `lc.warn` with both estimates. Manual flips are still honored; this only surfaces the planner's opinion.

Also passes `lc` through `buildPipeline` at hydration in `pipeline-driver.ts`. Without it, `planQuery` gets `lc = undefined` in production, so neither this warning nor the existing `MAX_FLIPPABLE_JOINS` warning can fire.

Going through the planner rather than a row-count heuristic matters: when a sibling join is flipped, its constraint propagates into the OR branches and can make a "bad-looking" flip genuinely cheap — the check correctly stays quiet in that case (covered by a test).

## Testing

- `pnpm run check-types` clean in `zql` and `zero-cache`
- `zql`: 1318/1318 tests; `pipeline-driver`: 45/45
- New `planner-manual-flip.test.ts` (5 tests): two manual flips inside `or(...)` warns for the costly one only; quiet for a good flip / no flip / no `lc`; chosen plan left intact.
