### PR TITLE
fix(zero): stream Litestream WAL segments sequentially

### DIFF
--- a/packages/zero/Dockerfile
+++ b/packages/zero/Dockerfile
@@ -1,10 +1,10 @@
 FROM golang:1.25.10@sha256:cd05a378aaf011e8056745363e5c40f4f2bef0fa4d9bf19b9c38316079c332ff AS litestream
 
 WORKDIR /src/
-RUN git clone --depth 1 --branch zero@v0.0.11 https://github.com/rocicorp/litestream.git
+RUN git clone --depth 1 --branch zero@v0.0.12-canary.0 https://github.com/rocicorp/litestream.git
 WORKDIR /src/litestream/
 
-ARG LITESTREAM_VERSION=0.3.13+z0.0.11  # upstream version + zero version
+ARG LITESTREAM_VERSION=0.3.13+z0.0.12-canary.0  # upstream version + zero version
 
 # Force use of the toolchain bundled in the builder image so the resulting
 # binary is compiled with Go 1.25.10 stdlib (fixes CVE-2025-68121 and a


### PR DESCRIPTION
### What

Update the Zero 1.9 maintenance image to embed rocicorp/litestream `zero@v0.0.12-canary.0` for the next production restore canary.

The Litestream prerelease retains the wide-offset parser from `zero@v0.0.11` and changes WAL restoration to open, stream, and close each segment before requesting the next segment in the same WAL index.

### Why

`1.9.1-canary.0` made the previously skipped wide-offset segments visible, but its restores repeatedly failed while downloading WAL index `000012c3` with `connection reset by peer`.

That index contains a 2.05 GB compressed segment followed by three wide-offset segments. Litestream opened every S3 response body up front, leaving the later response bodies idle while the 2.05 GB segment was consumed. The production replication-manager failed all three restore attempts at that index, and the canary view-syncer repeatedly exited in the same phase.

The sequential-reader change is merged in rocicorp/litestream#19 and published as `zero@v0.0.12-canary.0`. This image will be published as Zero `1.9.1-canary.1` and tested against the same affected backup generation.

### Changes

- Build legacy Litestream from `zero@v0.0.12-canary.0`.
- Report its embedded version as `0.3.13+z0.0.12-canary.0`.
- Keep the Zero package base version at `1.9.1` so the release workflow advances to `1.9.1-canary.1`.