### PR TITLE
chore(zql): repro some new take bugs

### DIFF
--- a/packages/zql/src/query/take-union-bound.repro.test.ts
+++ b/packages/zql/src/query/take-union-bound.repro.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Minimal repro for the prod `Bound should be set` crash (take.ts:448),
+ * reached through a UnionFanOut/UnionFanIn -- an OR containing a flipped
+ * EXISTS -- sitting directly beneath a Take.
+ *
+ * Found by sweep in take-union-empty-window.sweep.test.ts. Uses MemorySource:
+ * no SQLite, no NULL start-bound lowering, no PG/Zero schema drift. The
+ * inconsistency is produced entirely inside the IVM graph.
+ */
+import {expect, test} from 'vitest';
+import {testLogConfig} from '../../../otel/src/test-log-config.ts';
+import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
+import {must} from '../../../shared/src/must.ts';
+import type {Row} from '../../../zero-protocol/src/data.ts';
+import {relationships} from '../../../zero-schema/src/builder/relationship-builder.ts';
+import {createSchema} from '../../../zero-schema/src/builder/schema-builder.ts';
+import {
+  number,
+  string,
+  table,
+} from '../../../zero-schema/src/builder/table-builder.ts';
+import {
+  makeSourceChangeAdd,
+  makeSourceChangeEdit,
+  makeSourceChangeRemove,
+} from '../ivm/source.ts';
+import {consume} from '../ivm/stream.ts';
+import {createSource} from '../ivm/test/source-factory.ts';
+import {newQuery} from './query-impl.ts';
+import {QueryDelegateImpl} from './test/query-delegate.ts';
+
+const lc = createSilentLogContext();
+
+const chat = table('chat')
+  .columns({
+    id: string(),
+    lastMessageAt: number().optional(),
+    mode: string(),
+  })
+  .primaryKey('id');
+
+const message = table('message')
+  .columns({id: string(), chatId: string(), body: string()})
+  .primaryKey('id');
+
+const schema = createSchema({
+  tables: [chat, message],
+  relationships: [
+    relationships(chat, ({many}) => ({
+      messages: many({
+        sourceField: ['id'],
+        destField: ['chatId'],
+        destSchema: message,
+      }),
+    })),
+  ],
+});
+
+test('Bound should be set: take over union-fan-in with flipped exists', () => {
+  const chatSchema = schema.tables.chat;
+  const messageSchema = schema.tables.message;
+  const sources = {
+    chat: createSource(
+      lc,
+      testLogConfig,
+      'chat',
+      chatSchema.columns,
+      chatSchema.primaryKey,
+    ),
+    message: createSource(
+      lc,
+      testLogConfig,
+      'message',
+      messageSchema.columns,
+      messageSchema.primaryKey,
+    ),
+  };
+  const chatSource = must(sources.chat);
+  const msgSource = must(sources.message);
+
+  // Two chats, neither matching either OR branch yet.
+  const c1 = {id: 'c1', lastMessageAt: 10, mode: 'b'};
+  let c2: Row = {id: 'c2', lastMessageAt: 20, mode: 'b'};
+  consume(chatSource.push(makeSourceChangeAdd(c1)));
+  consume(chatSource.push(makeSourceChangeAdd(c2)));
+
+  const delegate = new QueryDelegateImpl({sources});
+  const q = newQuery(schema, 'chat')
+    .where(({or, cmp, exists}) =>
+      or(
+        cmp('lastMessageAt', '>', 100),
+        exists('messages', m => m.where('body', '=', 'x'), {flip: true}),
+      ),
+    )
+    .orderBy('lastMessageAt', 'asc')
+    .orderBy('id', 'asc')
+    .limit(1);
+
+  const view = delegate.materialize(q);
+  expect(view.data).toEqual([]); // take window hydrates empty
+
+  const mx1 = {id: 'mx1', chatId: 'c1', body: 'x'};
+  const mx2 = {id: 'mx2', chatId: 'c2', body: 'x'};
+
+  // 1. c1 starts matching via the flipped-exists branch.
+  consume(msgSource.push(makeSourceChangeAdd(mx1)));
+  // 2. c2 also starts matching via the flipped-exists branch.
+  consume(msgSource.push(makeSourceChangeAdd(mx2)));
+  // 3. c2's sort key goes NULL (a chat with no messages yet).
+  //    This is ALREADY a violation: the take's refill fetch through the
+  //    fan-in comes back empty for a row the union still holds. In prod
+  //    this is the crash that gets logged and rethrown.
+  const c2b = {...c2, lastMessageAt: null};
+  expect(() => consume(chatSource.push(makeSourceChangeEdit(c2b, c2)))).toThrow(
+    'Take: newBoundNode must be found during fetch',
+  );
+  c2 = c2b;
+
+  // 4. c1 stops matching the exists branch. This drains the take window
+  //    to size 0, leaving takeState.bound === undefined.
+  consume(msgSource.push(makeSourceChangeRemove(mx1)));
+
+  // 5. c2's sort key is set -- the ordinary "a message arrived" update.
+  //    c2 still matches the exists branch (mx2 is still there), so the
+  //    fan-in emits an EDIT into a Take whose bound is undefined.
+  //    Frame-for-frame the prod stack:
+  //      Take.#pushEditChange <- Take.push <- pushAccumulatedChanges
+  //      <- UnionFanIn.fanOutDonePushing <- UnionFanOut.push
+  const c2c = {...c2, lastMessageAt: 200};
+  expect(() => consume(chatSource.push(makeSourceChangeEdit(c2c, c2)))).toThrow(
+    'Bound should be set',
+  );
+});

--- a/packages/zql/src/query/take-union-empty-window.sweep.test.ts
+++ b/packages/zql/src/query/take-union-empty-window.sweep.test.ts
@@ -1,0 +1,458 @@
+/**
+ * Sweep hunting for `Bound should be set` (take.ts) reachable through a
+ * UnionFanOut/UnionFanIn (an OR containing a flipped EXISTS) sitting directly
+ * beneath a Take -- the pipeline shape in the prod stack trace:
+ *
+ *   source -> UnionFanOut -> [filter branch | flipped-exists branch] ->
+ *   UnionFanIn -> Take
+ *
+ * Modelled on `chat.listRich`: nullable leading sort key (`lastMessageAt`),
+ * secondary `id` sort, a top-level limit, and an OR whose branches mix a plain
+ * predicate with a `whereExists`.
+ */
+import {expect, test} from 'vitest';
+import {testLogConfig} from '../../../otel/src/test-log-config.ts';
+import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
+import {must} from '../../../shared/src/must.ts';
+import type {Row} from '../../../zero-protocol/src/data.ts';
+import {relationships} from '../../../zero-schema/src/builder/relationship-builder.ts';
+import {createSchema} from '../../../zero-schema/src/builder/schema-builder.ts';
+import {
+  number,
+  string,
+  table,
+} from '../../../zero-schema/src/builder/table-builder.ts';
+import {
+  makeSourceChangeAdd,
+  makeSourceChangeEdit,
+  makeSourceChangeRemove,
+} from '../ivm/source.ts';
+import type {Source} from '../ivm/source.ts';
+import {consume} from '../ivm/stream.ts';
+import {createSource} from '../ivm/test/source-factory.ts';
+import {newQuery} from './query-impl.ts';
+import type {Query} from './query.ts';
+import {QueryDelegateImpl} from './test/query-delegate.ts';
+
+const lc = createSilentLogContext();
+
+const chat = table('chat')
+  .columns({
+    id: string(),
+    lastMessageAt: number().optional(),
+    mode: string(),
+  })
+  .primaryKey('id');
+
+const message = table('message')
+  .columns({
+    id: string(),
+    chatId: string(),
+    body: string(),
+  })
+  .primaryKey('id');
+
+const chatRelationships = relationships(chat, ({many}) => ({
+  messages: many({
+    sourceField: ['id'],
+    destField: ['chatId'],
+    destSchema: message,
+  }),
+}));
+
+const schema = createSchema({
+  tables: [chat, message],
+  relationships: [chatRelationships],
+});
+
+const chatSchema = schema.tables.chat;
+const messageSchema = schema.tables.message;
+
+function makeSources() {
+  return {
+    chat: createSource(
+      lc,
+      testLogConfig,
+      'chat',
+      chatSchema.columns,
+      chatSchema.primaryKey,
+    ),
+    message: createSource(
+      lc,
+      testLogConfig,
+      'message',
+      messageSchema.columns,
+      messageSchema.primaryKey,
+    ),
+  } as Record<string, Source>;
+}
+
+// --------------------------------------------------------------------------
+// query shapes
+// --------------------------------------------------------------------------
+
+type Dir = 'asc' | 'desc';
+type Shape = {
+  name: string;
+  build: (limit: number, dir: Dir) => Query<'chat', typeof schema>;
+};
+
+const SHAPES: Shape[] = [
+  {
+    name: 'or(cmp, exists-flip)',
+    build: (limit, dir) =>
+      newQuery(schema, 'chat')
+        .where(({or, cmp, exists}) =>
+          or(
+            cmp('mode', '=', 'a'),
+            exists('messages', q => q.where('body', '=', 'x'), {flip: true}),
+          ),
+        )
+        .orderBy('lastMessageAt', dir)
+        .orderBy('id', dir)
+        .limit(limit),
+  },
+  {
+    name: 'or(exists-flip, exists-flip)',
+    build: (limit, dir) =>
+      newQuery(schema, 'chat')
+        .where(({or, exists}) =>
+          or(
+            exists('messages', q => q.where('body', '=', 'x'), {flip: true}),
+            exists('messages', q => q.where('body', '=', 'y'), {flip: true}),
+          ),
+        )
+        .orderBy('lastMessageAt', dir)
+        .orderBy('id', dir)
+        .limit(limit),
+  },
+  {
+    name: 'and(cmp, or(cmp, exists-flip))',
+    build: (limit, dir) =>
+      newQuery(schema, 'chat')
+        .where(({and, or, cmp, exists}) =>
+          and(
+            cmp('mode', '!=', 'zzz'),
+            or(
+              cmp('mode', '=', 'a'),
+              exists('messages', q => q.where('body', '=', 'x'), {flip: true}),
+            ),
+          ),
+        )
+        .orderBy('lastMessageAt', dir)
+        .orderBy('id', dir)
+        .limit(limit),
+  },
+  {
+    name: 'or(cmp-on-sortkey, exists-flip)',
+    build: (limit, dir) =>
+      newQuery(schema, 'chat')
+        .where(({or, cmp, exists}) =>
+          or(
+            cmp('lastMessageAt', '>', 100),
+            exists('messages', q => q.where('body', '=', 'x'), {flip: true}),
+          ),
+        )
+        .orderBy('lastMessageAt', dir)
+        .orderBy('id', dir)
+        .limit(limit),
+  },
+  {
+    name: 'or(cmp, exists-noflip) [control]',
+    build: (limit, dir) =>
+      newQuery(schema, 'chat')
+        .where(({or, cmp, exists}) =>
+          or(
+            cmp('mode', '=', 'a'),
+            exists('messages', q => q.where('body', '=', 'x'), {flip: false}),
+          ),
+        )
+        .orderBy('lastMessageAt', dir)
+        .orderBy('id', dir)
+        .limit(limit),
+  },
+];
+
+// --------------------------------------------------------------------------
+// data + mutation pool
+// --------------------------------------------------------------------------
+
+type Seed = {name: string; chats: Row[]; messages: Row[]};
+
+const SEEDS: Seed[] = [
+  {name: 'empty', chats: [], messages: []},
+  {
+    name: 'all-null-sortkey, none matching',
+    chats: [
+      {id: 'c1', lastMessageAt: null, mode: 'b'},
+      {id: 'c2', lastMessageAt: null, mode: 'b'},
+    ],
+    messages: [],
+  },
+  {
+    name: 'all-null-sortkey, one matching',
+    chats: [
+      {id: 'c1', lastMessageAt: null, mode: 'a'},
+      {id: 'c2', lastMessageAt: null, mode: 'b'},
+    ],
+    messages: [],
+  },
+  {
+    name: 'mixed-null-sortkey',
+    chats: [
+      {id: 'c1', lastMessageAt: null, mode: 'b'},
+      {id: 'c2', lastMessageAt: 50, mode: 'b'},
+      {id: 'c3', lastMessageAt: 150, mode: 'b'},
+    ],
+    messages: [],
+  },
+  {
+    name: 'mixed, one matching via exists',
+    chats: [
+      {id: 'c1', lastMessageAt: null, mode: 'b'},
+      {id: 'c2', lastMessageAt: 50, mode: 'b'},
+    ],
+    messages: [{id: 'm1', chatId: 'c2', body: 'x'}],
+  },
+  {
+    name: 'non-null sortkey, none matching',
+    chats: [
+      {id: 'c1', lastMessageAt: 10, mode: 'b'},
+      {id: 'c2', lastMessageAt: 20, mode: 'b'},
+    ],
+    messages: [],
+  },
+];
+
+type Op = {name: string; run: (r: Runner) => void};
+
+const OPS: Op[] = [
+  // last_message_at transitions -- the hot path in a chat app
+  {name: 'c1.lma null->200', run: r => r.editChat('c1', {lastMessageAt: 200})},
+  {name: 'c1.lma ->null', run: r => r.editChat('c1', {lastMessageAt: null})},
+  {name: 'c1.lma ->75', run: r => r.editChat('c1', {lastMessageAt: 75})},
+  {name: 'c2.lma ->200', run: r => r.editChat('c2', {lastMessageAt: 200})},
+  {name: 'c2.lma ->null', run: r => r.editChat('c2', {lastMessageAt: null})},
+  // mode transitions -- flip which OR branch matches
+  {name: 'c1.mode ->a', run: r => r.editChat('c1', {mode: 'a'})},
+  {name: 'c1.mode ->b', run: r => r.editChat('c1', {mode: 'b'})},
+  {name: 'c2.mode ->a', run: r => r.editChat('c2', {mode: 'a'})},
+  {name: 'c2.mode ->b', run: r => r.editChat('c2', {mode: 'b'})},
+  // exists-branch transitions
+  {name: '+msg c1 x', run: r => r.addMessage('mx1', 'c1', 'x')},
+  {name: '-msg c1 x', run: r => r.removeMessage('mx1')},
+  {name: '+msg c2 x', run: r => r.addMessage('mx2', 'c2', 'x')},
+  {name: '-msg c2 x', run: r => r.removeMessage('mx2')},
+  {name: 'msg mx1 x->y', run: r => r.editMessage('mx1', {body: 'y'})},
+  // chat add/remove
+  {
+    name: '+chat c9 (null,a)',
+    run: r => r.addChat({id: 'c9', lastMessageAt: null, mode: 'a'}),
+  },
+  {name: '-chat c1', run: r => r.removeChat('c1')},
+  {name: '-chat c2', run: r => r.removeChat('c2')},
+];
+
+class Runner {
+  readonly #sources: Record<string, Source>;
+  readonly #chats = new Map<string, Row>();
+  readonly #messages = new Map<string, Row>();
+
+  constructor(sources: Record<string, Source>) {
+    this.#sources = sources;
+  }
+
+  addChat(row: Row) {
+    if (this.#chats.has(row.id as string)) return;
+    this.#chats.set(row.id as string, row);
+    consume(must(this.#sources.chat).push(makeSourceChangeAdd(row)));
+  }
+  removeChat(id: string) {
+    const row = this.#chats.get(id);
+    if (!row) return;
+    this.#chats.delete(id);
+    consume(must(this.#sources.chat).push(makeSourceChangeRemove(row)));
+  }
+  editChat(id: string, patch: Partial<Row>) {
+    const old = this.#chats.get(id);
+    if (!old) return;
+    const next = {...old, ...patch};
+    if (next.lastMessageAt === old.lastMessageAt && next.mode === old.mode) {
+      return;
+    }
+    this.#chats.set(id, next);
+    consume(must(this.#sources.chat).push(makeSourceChangeEdit(next, old)));
+  }
+  addMessage(id: string, chatId: string, body: string) {
+    if (this.#messages.has(id)) return;
+    const row = {id, chatId, body};
+    this.#messages.set(id, row);
+    consume(must(this.#sources.message).push(makeSourceChangeAdd(row)));
+  }
+  removeMessage(id: string) {
+    const row = this.#messages.get(id);
+    if (!row) return;
+    this.#messages.delete(id);
+    consume(must(this.#sources.message).push(makeSourceChangeRemove(row)));
+  }
+  editMessage(id: string, patch: Partial<Row>) {
+    const old = this.#messages.get(id);
+    if (!old) return;
+    const next = {...old, ...patch};
+    if (next.body === old.body) return;
+    this.#messages.set(id, next);
+    consume(must(this.#sources.message).push(makeSourceChangeEdit(next, old)));
+  }
+}
+
+// --------------------------------------------------------------------------
+// sweep
+// --------------------------------------------------------------------------
+
+type Failure = {
+  shape: string;
+  seed: string;
+  dir: Dir;
+  limit: number;
+  script: string[];
+  error: string;
+  stack?: string | undefined;
+};
+
+const SCRIPT_LEN = Number(process.env.SWEEP_LEN ?? 3);
+
+function pick<T>(all: T[], env: string | undefined): T[] {
+  if (!env) return all;
+  return env.split(',').map(i => all[Number(i)]);
+}
+
+const ACTIVE_OPS = pick(OPS, process.env.SWEEP_OPS);
+const ACTIVE_SHAPES = pick(SHAPES, process.env.SWEEP_SHAPES);
+const ACTIVE_SEEDS = pick(SEEDS, process.env.SWEEP_SEEDS);
+const ACTIVE_DIRS = pick(['desc', 'asc'] as Dir[], process.env.SWEEP_DIRS);
+const ACTIVE_LIMITS = pick([1, 2], process.env.SWEEP_LIMITS);
+const ONLY_LEN = process.env.SWEEP_ONLY_LEN === '1';
+const CONTINUE = process.env.SWEEP_CONTINUE === '1';
+
+function* scripts(len: number): Generator<number[]> {
+  const start = ONLY_LEN ? len : 1;
+  for (let l = start; l <= len; l++) {
+    const cur = new Array(l).fill(0);
+    for (;;) {
+      yield cur.slice();
+      let i = l - 1;
+      for (; i >= 0; i--) {
+        cur[i]++;
+        if (cur[i] < ACTIVE_OPS.length) break;
+        cur[i] = 0;
+      }
+      if (i < 0) break;
+    }
+  }
+}
+
+function runOne(
+  shape: Shape,
+  seed: Seed,
+  dir: Dir,
+  limit: number,
+  script: number[],
+  onFailure?: ((f: Failure) => void) | undefined,
+): Failure | undefined {
+  const sources = makeSources();
+  const runner = new Runner(sources);
+  for (const c of seed.chats) runner.addChat(c);
+  for (const m of seed.messages) {
+    runner.addMessage(m.id as string, m.chatId as string, m.body as string);
+  }
+
+  const delegate = new QueryDelegateImpl({sources});
+  const mk = (e: unknown, upTo: number): Failure => ({
+    shape: shape.name,
+    seed: seed.name,
+    dir,
+    limit,
+    script: script.slice(0, upTo + 1).map(i => ACTIVE_OPS[i].name),
+    error: e instanceof Error ? e.message : String(e),
+    stack: e instanceof Error ? e.stack : undefined,
+  });
+
+  let first: Failure | undefined;
+  try {
+    const view = delegate.materialize(shape.build(limit, dir));
+    for (let n = 0; n < script.length; n++) {
+      try {
+        ACTIVE_OPS[script[n]].run(runner);
+      } catch (e) {
+        const f = mk(e, n);
+        if (!first) first = f;
+        onFailure?.(f);
+        // CONTINUE mode: keep pushing so one inconsistency can compound
+        // into the next, the way a long-lived prod pipeline does.
+        if (!CONTINUE) return first;
+      }
+    }
+    void view.data;
+  } catch (e) {
+    const f = mk(e, script.length - 1);
+    if (!first) first = f;
+    onFailure?.(f);
+  }
+  return first;
+}
+
+// Opt-in: this is a long-running search, not a regression gate.
+// Run with SWEEP=1 (plus the SWEEP_* knobs documented above).
+const maybeTest = process.env.SWEEP === '1' ? test : test.skip;
+
+maybeTest(
+  'sweep: take over union-fan-in, empty window + edit',
+  () => {
+    const failures: Failure[] = [];
+    const byError = new Map<string, Failure>();
+    const byShape = new Map<string, number>();
+    const byErrorShape = new Map<string, number>();
+    let runs = 0;
+
+    for (const shape of ACTIVE_SHAPES) {
+      for (const seed of ACTIVE_SEEDS) {
+        for (const dir of ACTIVE_DIRS) {
+          for (const limit of ACTIVE_LIMITS) {
+            for (const script of scripts(SCRIPT_LEN)) {
+              runs++;
+              const record = (f: Failure) => {
+                failures.push(f);
+                if (!byError.has(f.error)) byError.set(f.error, f);
+                byShape.set(f.shape, (byShape.get(f.shape) ?? 0) + 1);
+                const k = `${f.error} @ ${f.shape}`;
+                byErrorShape.set(k, (byErrorShape.get(k) ?? 0) + 1);
+              };
+              runOne(shape, seed, dir, limit, script, record);
+            }
+          }
+        }
+      }
+    }
+
+    // eslint-disable-next-line no-console
+    console.log(
+      JSON.stringify(
+        {
+          runs,
+          failures: failures.length,
+          byShape: Object.fromEntries(byShape),
+          byErrorShape: Object.fromEntries(byErrorShape),
+          distinctErrors: Array.from(byError, ([msg, f]) => ({
+            error: msg,
+            firstRepro: f,
+          })),
+        },
+        null,
+        2,
+      ),
+    );
+
+    expect(byError.size).toBe(0);
+  },
+  900_000,
+);

--- a/packages/zql/src/query/take-union-oracle.test.ts
+++ b/packages/zql/src/query/take-union-oracle.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Ground-truth check for the take-over-union-fan-in sequence.
+ *
+ * Runs the same 5 mutations as take-union-bound.repro.test.ts and asserts the
+ * view against hand-computed expected contents at every step. Run under both
+ * `zql` (MemorySource) and `zqlite-zql-test` (SQLite TableSource) to see which
+ * source produces the wrong answer.
+ */
+import {expect, test} from 'vitest';
+import {testLogConfig} from '../../../otel/src/test-log-config.ts';
+import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
+import {must} from '../../../shared/src/must.ts';
+import type {Row} from '../../../zero-protocol/src/data.ts';
+import {relationships} from '../../../zero-schema/src/builder/relationship-builder.ts';
+import {createSchema} from '../../../zero-schema/src/builder/schema-builder.ts';
+import {
+  number,
+  string,
+  table,
+} from '../../../zero-schema/src/builder/table-builder.ts';
+import {
+  makeSourceChangeAdd,
+  makeSourceChangeEdit,
+  makeSourceChangeRemove,
+} from '../ivm/source.ts';
+import {consume} from '../ivm/stream.ts';
+import {createSource} from '../ivm/test/source-factory.ts';
+import {newQuery} from './query-impl.ts';
+import {QueryDelegateImpl} from './test/query-delegate.ts';
+
+const lc = createSilentLogContext();
+
+const chat = table('chat')
+  .columns({
+    id: string(),
+    lastMessageAt: number().optional(),
+    mode: string(),
+  })
+  .primaryKey('id');
+
+const message = table('message')
+  .columns({id: string(), chatId: string(), body: string()})
+  .primaryKey('id');
+
+const schema = createSchema({
+  tables: [chat, message],
+  relationships: [
+    relationships(chat, ({many}) => ({
+      messages: many({
+        sourceField: ['id'],
+        destField: ['chatId'],
+        destSchema: message,
+      }),
+    })),
+  ],
+});
+
+test('take over union-fan-in matches ground truth at every step', () => {
+  const chatSchema = schema.tables.chat;
+  const messageSchema = schema.tables.message;
+  const sources = {
+    chat: createSource(
+      lc,
+      testLogConfig,
+      'chat',
+      chatSchema.columns,
+      chatSchema.primaryKey,
+    ),
+    message: createSource(
+      lc,
+      testLogConfig,
+      'message',
+      messageSchema.columns,
+      messageSchema.primaryKey,
+    ),
+  };
+  const chatSource = must(sources.chat);
+  const msgSource = must(sources.message);
+
+  const c1 = {id: 'c1', lastMessageAt: 10, mode: 'b'};
+  let c2: Row = {id: 'c2', lastMessageAt: 20, mode: 'b'};
+  consume(chatSource.push(makeSourceChangeAdd(c1)));
+  consume(chatSource.push(makeSourceChangeAdd(c2)));
+
+  const delegate = new QueryDelegateImpl({sources});
+  const view = delegate.materialize(
+    newQuery(schema, 'chat')
+      .where(({or, cmp, exists}) =>
+        or(
+          cmp('lastMessageAt', '>', 100),
+          exists('messages', m => m.where('body', '=', 'x'), {flip: true}),
+        ),
+      )
+      .orderBy('lastMessageAt', 'asc')
+      .orderBy('id', 'asc')
+      .limit(1),
+  );
+
+  const ids = () => (view.data as {id: string}[]).map(r => r.id);
+  const step = (label: string, fn: () => void, expected: string[]) => {
+    try {
+      fn();
+    } catch (e) {
+      throw new Error(
+        `${label}: threw ${e instanceof Error ? e.message : String(e)}`,
+      );
+    }
+    expect(ids(), label).toEqual(expected);
+  };
+
+  //                                                    matching   window(limit 1, asc)
+  expect(ids(), 'hydrate').toEqual([]); //              none       []
+  const mx1 = {id: 'mx1', chatId: 'c1', body: 'x'};
+  const mx2 = {id: 'mx2', chatId: 'c2', body: 'x'};
+
+  step('1 +mx1', () => consume(msgSource.push(makeSourceChangeAdd(mx1))), [
+    'c1', //                                            c1(10)     [c1]
+  ]);
+  step('2 +mx2', () => consume(msgSource.push(makeSourceChangeAdd(mx2))), [
+    'c1', //                                            c1(10),c2(20) [c1]
+  ]);
+  step(
+    '3 c2.lma->null',
+    () => {
+      const next = {...c2, lastMessageAt: null};
+      consume(chatSource.push(makeSourceChangeEdit(next, c2)));
+      c2 = next;
+    },
+    ['c2'], //                                          c2(null),c1(10) [c2]
+  );
+  step('4 -mx1', () => consume(msgSource.push(makeSourceChangeRemove(mx1))), [
+    'c2', //                                            c2(null)   [c2]
+  ]);
+  step(
+    '5 c2.lma->200',
+    () => {
+      const next = {...c2, lastMessageAt: 200};
+      consume(chatSource.push(makeSourceChangeEdit(next, c2)));
+      c2 = next;
+    },
+    ['c2'], //                                          c2(200)    [c2]
+  );
+});


### PR DESCRIPTION
https://rocicorp.slack.com/archives/C0B2S4EF4BD/p1787068441144619


Notes from Claude (kept here for my own reference):

```
What I reproduced

Bound should be set at take.ts:448, with a frame chain identical to your prod trace:

Take.#pushEditChange ← Take.push ← pushAccumulatedChanges
  ← UnionFanIn.fanOutDonePushing ← UnionFanOut.push

Minimal sequence (take-union-bound.repro.test.ts), on a chats-shaped query — nullable leading sort key, id tiebreak, limit, and an OR containing a flipped whereExists:

1. +msg mx1(c1) — c1 matches via the exists branch
2. +msg mx2(c2) — c2 matches too
3. c2.lastMessageAt → null — already throws Take: newBoundNode must be found during fetch
4. -msg mx1 — drains the window to size 0, bound === undefined
5. c2.lastMessageAt → 200 — the ordinary "message arrived" update → Bound should be set

So Bound should be set is a secondary failure. The primary bug is take's refill fetch through the fan-in returning nothing for a row the union still holds.

Across ~19M runs I found 7 distinct error classes, including view-level corruption (node does not exist, Row has duplicate primary key). Every one required a flipped exists inside an OR — the control shape or(cmp, exists-noflip), which builds no union, gave 0 failures in 626k runs.

But it's the client source, not the server one

I wrote an oracle test asserting the view against hand-computed ground truth at each of the 5 steps:

┌────────────────────┬───────────────────────┐
│       Source       │        Result         │
├────────────────────┼───────────────────────┤
│ MemorySource       │ throws at step 3      │
├────────────────────┼───────────────────────┤
│ zqlite TableSource │ correct at every step │
└────────────────────┴───────────────────────┘

And zqlite sweeps found zero failures: depth-3 full (626k runs, 440s) and depth-4 targeted (487s) — configurations where MemorySource fails readily.

MemorySource is production code — zero-client/src/client/ivm-branch.ts:71. So this is a real, previously-unknown client-side bug in zero-client with the same signature. It is not the view-syncer crash you pasted, which runs on zqlite.

I did not reproduce your server-side crash. My earlier message said the frame chain matching was strong evidence for a shared root cause; the oracle test shows the two sources genuinely diverge here, so that inference was wrong.

What this changes

Two separate bugs now, both worth filing:

1. Client-side (new, reproduced): Take over UnionFanIn corrupts state on MemorySource. Any client running a query with limit + an OR containing whereExists can hit this — chat.listRich qualifies. Worth checking whether your users see client-side query failures too.
2. Server-side (your crash, still open): same assert, different producer. The zqlite path resists this at the depths I swept.

The most useful thing for #2 is still what I asked for last time — applyChatModeWhere and applyChatFilterWhere, and whether last_message_at is nullable. My sweep guesses at the OR shape; the real one would let me aim the zqlite sweep at the actual branch structure instead. One difference I can already name: the test zqlite source builds column specs straight from the schema, so optional is truthful — prod derives them from the replica, which is exactly what #6121 had to repair. That gap is not covered by my harness.

Files

All new, uncommitted, in packages/zql/src/query/:

- take-union-empty-window.sweep.test.ts — gated behind SWEEP=1; knobs SWEEP_LEN/SWEEP_SHAPES/SWEEP_SEEDS/SWEEP_DIRS/SWEEP_LIMITS/SWEEP_CONTINUE. Runs under zql or zqlite-zql-test.
- take-union-bound.repro.test.ts — minimal repro, passes as a characterization test.
- take-union-oracle.test.ts — the ground-truth comparison; fails on zql, passes on zqlite-zql-test. Leave it failing or skip it, your call.

lint, check-types, format clean on zql.

One thing I should flag: packages/zero-cache/src/services/view-syncer/{view-syncer.ts, view-syncer.pg.test.ts, e2e-serving-lag.ts} show as modified (+55/−10). Your tree was clean at session start and I didn't touch them — another session or process wrote them.
```