### PR TITLE
chore(zero-cache): support replica backup with litestream v5

### DIFF
--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -178,6 +178,7 @@ export default async function runWorker(
               context,
               replicationLag.reportIntervalMs,
               restoreOptions,
+              {backupV5: litestream.backupUsingV5},
               purgeLock,
               upstream.pgStreamInboundTimeoutMs,
             )
@@ -204,7 +205,10 @@ export default async function runWorker(
         replicationStatusPublisher,
         subscriptionState,
         destinationBackupURL
-          ? {backupURL: destinationBackupURL, litestreamVersion: 'legacy'}
+          ? {
+              backupURL: destinationBackupURL,
+              litestreamVersion: litestream.backupUsingV5 ? 'v5' : 'legacy',
+            }
           : null,
         purgeLock,
         autoReset ?? false,
@@ -341,10 +345,14 @@ export default async function runWorker(
   );
 
   if (waitForFirstBackupBeforeServing) {
+    const start = performance.now();
     lc.info?.(`awaiting initial backup ...`);
-    void backupMonitor
-      .firstBackupReceived()
-      .then(() => parent.send(['ready', {ready: true}]));
+
+    void backupMonitor.firstBackupReceived().then(() => {
+      const elapsed = performance.now() - start;
+      lc.info?.(`initial backup confirmed after ${elapsed.toFixed(2)}ms`);
+      parent.send(['ready', {ready: true}]);
+    });
   } else {
     parent.send(['ready', {ready: true}]);
   }

--- a/packages/zero-cache/src/services/change-source/pg/change-source.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.pg.test.ts
@@ -147,7 +147,13 @@ describe('change-source/pg', {timeout: 30000, retry: 3}, () => {
     return toBigInt(lsn);
   }
 
-  async function startReplication(lagReportIntervalMs?: number) {
+  async function startReplication({
+    lagReportIntervalMs,
+    backupV5 = true,
+  }: {
+    lagReportIntervalMs?: number;
+    backupV5?: boolean;
+  } = {}) {
     ({changeSource: source} = await initializePostgresChangeSource(
       lc,
       upstreamURI,
@@ -160,6 +166,8 @@ describe('change-source/pg', {timeout: 30000, retry: 3}, () => {
       {tableCopyWorkers: 5},
       {test: 'context'},
       lagReportIntervalMs,
+      {},
+      {backupV5},
     ));
 
     const [{slot, initialSyncContext, subscriberContext}] = await upstream`
@@ -891,7 +899,7 @@ describe('change-source/pg', {timeout: 30000, retry: 3}, () => {
     ['received', false],
     ['resumed if skipped', true],
   ])('replication lag reports: %s', async (_name, startStreamAfterReport) => {
-    await startReplication(10);
+    await startReplication({lagReportIntervalMs: 10});
 
     const initialSend = await source?.startLagReporter();
     expect(initialSend).toMatchObject({
@@ -995,6 +1003,62 @@ describe('change-source/pg', {timeout: 30000, retry: 3}, () => {
       err = e;
     }
     expect(err).toBeInstanceOf(AbortError);
+  });
+
+  async function backupOptions() {
+    return (
+      await upstream /*sql*/ `
+        SELECT "backupPath", "backupV5" FROM ${upstream(`${APP_ID}_${SHARD_NUM}.replicas`)}`
+    )[0];
+  }
+
+  test('v5 backup options recordes', async () => {
+    await startReplication({backupV5: true});
+
+    const originalBackupOptions = await backupOptions();
+    expect(originalBackupOptions).toMatchObject({
+      backupPath: /\d{10,}/,
+      backupV5: true,
+    });
+
+    // Now simulate the state after a different replication-manager was backing
+    // up with this slot.
+    await upstream /*sql*/ `
+      UPDATE ${upstream(`${APP_ID}_${SHARD_NUM}.replicas`)}
+        SET "backupPath" = NULL,
+            "backupV5" = false
+    `;
+
+    // Starting the stream should update the replicas table with the
+    // stream's configured backup options.
+    const {changes} = await startStream('00');
+    expect(await backupOptions()).toEqual(originalBackupOptions);
+
+    changes.cancel();
+  });
+
+  test('v3 backup options recorded', async () => {
+    await startReplication({backupV5: false});
+    const originalBackupOptions = await backupOptions();
+    expect(originalBackupOptions).toEqual({
+      backupPath: null,
+      backupV5: false,
+    });
+
+    // Now simulate the state after a different replication-manager was backing
+    // up with this slot.
+    await upstream /*sql*/ `
+      UPDATE ${upstream(`${APP_ID}_${SHARD_NUM}.replicas`)}
+        SET "backupPath" = 'foo-bar-baz',
+            "backupV5" = true
+    `;
+
+    // Starting the stream should update the replicas table with the
+    // stream's configured backup options.
+    const {changes} = await startStream('00');
+    expect(await backupOptions()).toEqual(originalBackupOptions);
+
+    changes.cancel();
   });
 
   test('handoff', {retry: 3}, async () => {

--- a/packages/zero-cache/src/services/change-source/pg/change-source.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.pg.test.ts
@@ -1012,7 +1012,7 @@ describe('change-source/pg', {timeout: 30000, retry: 3}, () => {
     )[0];
   }
 
-  test('v5 backup options recordes', async () => {
+  test('v5 backup options recorded', async () => {
     await startReplication({backupV5: true});
 
     const originalBackupOptions = await backupOptions();

--- a/packages/zero-cache/src/services/change-source/pg/change-source.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.ts
@@ -86,6 +86,7 @@ import {streamBackfill} from './backfill-stream.ts';
 import {
   initialSync,
   type InitialSyncOptions,
+  type ReplicaOptions,
   type ServerContext,
 } from './initial-sync.ts';
 import type {
@@ -112,6 +113,7 @@ import {
   internalPublicationPrefix,
   replicaIdentitiesForTablesWithoutPrimaryKeys,
   replicationSlotPrefix,
+  type BackupOptions,
   type InternalShardConfig,
   type Replica,
   type ReplicaState,
@@ -138,6 +140,7 @@ export async function initializePostgresChangeSource(
   context: ServerContext,
   lagReportIntervalMs = 0,
   restoreOptions: RestoreOptions = {},
+  {backupV5}: ReplicaOptions = {backupV5: true},
   purgeLock?: PurgeLock | null,
   streamInboundTimeoutMs?: number | undefined,
 ): Promise<InitializeResult> {
@@ -171,6 +174,7 @@ export async function initializePostgresChangeSource(
           upstreamURI,
           syncOptions,
           context,
+          {backupV5},
         );
       },
     );
@@ -188,20 +192,30 @@ export async function initializePostgresChangeSource(
       db,
       shard,
       subscriptionState,
+      (initialSyncedReplica ?? restoredReplica)?.id,
     );
+
+    const backupPath = initialSyncedReplica
+      ? // If initial sync was performed, use that initial backupPath.
+        initialSyncedReplica.backupPath
+      : // Otherwise, use a new, unique path when backing up with litestream v5. This will be
+        // recorded in the replicas table by the PostgresChangeSource.
+        backupV5
+        ? String(Date.now())
+        : (restoredReplica?.backupPath ?? null);
 
     const changeSource = new PostgresChangeSource(
       lc,
       upstreamURI,
       shard,
       upstreamReplica,
+      {backupPath, backupV5},
       context,
       lagReportIntervalMs,
       syncOptions.textCopy,
       streamInboundTimeoutMs,
     );
 
-    const backupPath = must(initialSyncedReplica ?? restoredReplica).backupPath;
     const destinationBackupURL =
       backupPath && restoreOptions.litestream?.backupURL
         ? new URL(backupPath, restoreOptions.litestream.backupURL).toString()
@@ -217,11 +231,12 @@ export async function initializePostgresChangeSource(
       // `replicaVersion`) is shared by every sibling of a forked replica and so
       // cannot distinguish two siblings' logs.
       replicaID: upstreamReplica.id,
-      // For RMv1, wait for the backup if an initial-sync was performed. When
-      // replica-specific backups are enabled (e.g. for > RMv1), the condition
-      // can be generalized to:
-      //   restoredReplica?.backupPath !== initializedReplica?.backupPath,
-      waitForBackupBeforeServing: initialSyncedReplica !== undefined,
+      waitForBackupBeforeServing:
+        // Wait for the first backup if there was an initial sync,
+        initialSyncedReplica !== undefined ||
+        // or if the destination differs from where it was restored
+        // (i.e. backupV5).
+        backupPath !== (restoredReplica?.backupPath ?? null),
     };
   } finally {
     await db.end();
@@ -235,19 +250,19 @@ async function selectAndRestoreReplica(
   replicaFile: string,
   {litestream, constraints}: RestoreOptions,
 ): Promise<ReplicaState | undefined> {
+  const replicas = (await getActiveReplicas(lc, sql, shard)).filter(
+    // filter to the generation specified by the constraints, if present
+    ({generation}) =>
+      generation === (constraints?.replicaVersion ?? generation),
+  );
+  if (replicas.length === 0) {
+    lc.info?.(`no suitable replicas to restore from`, {replicas});
+    return undefined;
+  }
+  const [replica] = replicas;
+
   if (litestream?.backupURL) {
     const {backupURL: backupBaseURL} = litestream;
-    const replicas = (await getActiveReplicas(lc, sql, shard)).filter(
-      // filter to the generation specified by the constraints, if present
-      ({generation}) =>
-        generation === (constraints?.replicaVersion ?? generation),
-    );
-    if (replicas.length === 0) {
-      lc.info?.(`no suitable replicas to restore from`, {replicas});
-      return undefined;
-    }
-
-    const [replica] = replicas;
     const {slot, backupPath, confirmedFlushLsn} = replica;
     const backupURL = new URL(backupPath ?? '', backupBaseURL).toString();
     lc.info?.(
@@ -260,9 +275,8 @@ async function selectAndRestoreReplica(
       replicaFile,
       constraints,
     );
-    return replica;
   }
-  return undefined;
+  return replica;
 }
 
 async function checkAndUpdateUpstream(
@@ -274,17 +288,19 @@ async function checkAndUpdateUpstream(
     publications: subscribed,
     initialSyncContext,
   }: SubscriptionStateAndContext,
+  replicaID: string | undefined,
 ) {
   const upstreamReplica = await getReplicaAtVersion(
     lc,
     sql,
     shard,
     replicaVersion,
+    replicaID,
     initialSyncContext,
   );
   if (!upstreamReplica) {
     throw new AutoResetSignal(
-      `No replication slot for replica at version ${replicaVersion}`,
+      `No replication slot for replica at version ${replicaVersion} and id ${replicaID}}`,
     );
   }
 
@@ -357,6 +373,7 @@ class PostgresChangeSource implements ChangeSource {
   readonly #upstreamUri: string;
   readonly #shard: ShardID;
   readonly #replica: Replica;
+  readonly #backupOptions: BackupOptions;
   readonly #context: ServerContext;
   readonly #lagReporter: LagReporter | null;
   readonly #textCopy: boolean;
@@ -368,6 +385,7 @@ class PostgresChangeSource implements ChangeSource {
     upstreamUri: string,
     shard: ShardID,
     replica: Replica,
+    backupOptions: BackupOptions,
     context: ServerContext,
     lagReportIntervalMs: number,
     textCopy?: boolean | undefined,
@@ -382,6 +400,7 @@ class PostgresChangeSource implements ChangeSource {
     this.#upstreamUri = upstreamUri;
     this.#shard = shard;
     this.#replica = replica;
+    this.#backupOptions = backupOptions;
     this.#context = context;
     this.#textCopy = textCopy ?? false;
     this.#streamInboundTimeoutMs = streamInboundTimeoutMs;
@@ -440,7 +459,7 @@ class PostgresChangeSource implements ChangeSource {
     clientWatermark: string,
     backfillRequests: BackfillRequest[] = [],
   ): Promise<ChangeStream> {
-    await this.#stopExistingReplicationSlotSubscriber();
+    await this.#takeoverReplicationSlot();
     const config = await getInternalShardConfig(this.#db, this.#shard);
     const {slot} = this.#replica;
     this.#lc.info?.(`starting replication stream@${slot}`);
@@ -607,6 +626,7 @@ class PostgresChangeSource implements ChangeSource {
         this.#db,
         this.#shard,
         this.#replica.generation,
+        this.#replica.id,
       );
       if (replica) {
         this.#lc.info?.(
@@ -619,10 +639,22 @@ class PostgresChangeSource implements ChangeSource {
   }
 
   /**
-   * Stops replication slots associated with this shard, and asynchronously
-   * runs a cleanup task that drops older replicas and slots.
+   * In RMv1, a single replication slot is taken over by the next
+   * replication-manager, signaling the old one to shut down.
+   *
+   * With litestream v5, the two replication-managers must replicate to unique
+   * backupPaths, as is required by the LTX backup schema.
+   *
+   * Thus, in addition to taking over the replication slot, the
+   * replication-manager also updates the `replicas` table with its
+   * `backupPath` so that future RM's restore from that path instead
+   * of the vestigial path of the previous replication-manager.
+   *
+   * In RMv2, each replication-manager will have its own slot and
+   * row in the `replicas` table, so this "takeover" will be unnecessary
+   * (but a harmless no-op).
    */
-  async #stopExistingReplicationSlotSubscriber() {
+  async #takeoverReplicationSlot() {
     const sql = this.#db;
     const {id: replicaID, slot} = this.#replica;
     const replicasTable = `${upstreamSchema(this.#shard)}.replicas`;
@@ -655,7 +687,9 @@ class PostgresChangeSource implements ChangeSource {
     this.#lc.info?.(`terminated replication slots: ${JSON.stringify(result)}`);
     await sql`
       UPDATE ${sql(replicasTable)} 
-        SET "subscriberContext" = ${this.#context}
+        SET "subscriberContext" = ${this.#context},
+            "backupPath" = ${this.#backupOptions.backupPath},
+            "backupV5" = ${this.#backupOptions.backupV5}
         WHERE id = ${replicaID}`;
     void this.#cleanUpOlderReplicasAndSlots();
   }

--- a/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
@@ -95,6 +95,10 @@ export type InitialSyncOptions = {
     | undefined;
 };
 
+export type ReplicaOptions = {
+  backupV5: boolean;
+};
+
 /** Server context to store with the initial sync metadata for debugging. */
 export type ServerContext = JSONObject;
 
@@ -109,6 +113,7 @@ export async function initialSync(
   upstreamURI: string,
   syncOptions: InitialSyncOptions,
   context: ServerContext,
+  {backupV5}: ReplicaOptions = {backupV5: true},
 ): Promise<ReplicaState | undefined> {
   if (!ALLOWED_APP_ID_CHARACTERS.test(shard.appID)) {
     throw new Error(
@@ -184,6 +189,13 @@ export async function initialSync(
         shard,
         replicaID,
         replicationSlotFailover && pgVersion >= PG_17,
+        {
+          // When backing up with litestream v5, a unique backup path is
+          // required since the LTX format does not tolerate multiple writers
+          // (and there are no v3 "generations" to workaround it).
+          backupPath: backupV5 ? replicaID : null,
+          backupV5,
+        },
       );
       snapshot = slot.snapshot_name;
       lsn = slot.consistent_point;

--- a/packages/zero-cache/src/services/change-source/pg/replication-slots.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/replication-slots.pg.test.ts
@@ -172,7 +172,10 @@ describe('createReplicationSlot', () => {
     ).toEqual([['zero_18_a'], ['zero_18_d']]);
 
     const create = (id: string) =>
-      createReplicaAndSlot(lc, upstream, session, shard, id, false);
+      createReplicaAndSlot(lc, upstream, session, shard, id, false, {
+        backupPath: id,
+        backupV5: true,
+      });
 
     let {slot_name: name} = await create('rep_1');
     expect(name).toBe('zero_18_a');
@@ -241,7 +244,10 @@ describe('createReplicationSlot', () => {
 
     const results = await Promise.all(
       sessions.map((session, i) =>
-        createReplicaAndSlot(lc, upstream, session, shard, `rep_${i}`, false),
+        createReplicaAndSlot(lc, upstream, session, shard, `rep_${i}`, false, {
+          backupPath: `rep_${i}`,
+          backupV5: true,
+        }),
       ),
     );
     const expectedSlots = new Set(['zero_18_a', 'zero_18_b', 'zero_18_c']);
@@ -271,7 +277,10 @@ describe('createReplicationSlot', () => {
     await upstream`CREATE PUBLICATION foo_pub FOR ALL TABLES`;
 
     const create = (id: string) =>
-      createReplicaAndSlot(lc, upstream, session, shard, id, false);
+      createReplicaAndSlot(lc, upstream, session, shard, id, false, {
+        backupPath: id,
+        backupV5: true,
+      });
 
     await create('rep_1');
     await create('rep_2');

--- a/packages/zero-cache/src/services/change-source/pg/replication-slots.ts
+++ b/packages/zero-cache/src/services/change-source/pg/replication-slots.ts
@@ -13,6 +13,7 @@ import {
   createReplica,
   replicationSlotExpression,
   replicationSlotPrefix,
+  type BackupOptions,
 } from './schema/shard.ts';
 
 // Record returned by `CREATE_REPLICATION_SLOT`
@@ -136,6 +137,7 @@ export async function createReplicaAndSlot(
   shard: ShardID,
   replicaID: string,
   failover: boolean,
+  backupOptions: BackupOptions,
 ): Promise<ReplicationSlot> {
   const lockName = replicationSlotManagementLock(shard);
   const slotPoolPrefix = replicationSlotPrefix(shard);
@@ -171,6 +173,7 @@ export async function createReplicaAndSlot(
           replicaID,
           slot.slot_name,
           toStateVersionString(slot.consistent_point),
+          backupOptions,
         );
 
         return slot;

--- a/packages/zero-cache/src/services/change-source/pg/schema/init.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/init.pg.test.ts
@@ -67,7 +67,8 @@ describe('change-streamer/pg/schema/init', () => {
             slot: `${APP_ID}_${SHARD_NUM}_1234`,
             version: '2dhf29ef',
             generation: '2dhf29ef',
-            backupPath: null,
+            backupPath: '12345',
+            backupV5: true,
             initialSchema: {tables: [], indexes: []},
             initialSyncContext: {foo: 'bar'},
             subscriberContext: null,
@@ -100,7 +101,8 @@ describe('change-streamer/pg/schema/init', () => {
             slot: `${APP_ID}_${SHARD_NUM}_5678`,
             version: 's8dfh2d',
             generation: 's8dfh2d',
-            backupPath: null,
+            backupPath: '12345',
+            backupV5: true,
             initialSchema: {tables: [], indexes: []},
           },
         ],
@@ -186,6 +188,7 @@ describe('change-streamer/pg/schema/init', () => {
             version: '123',
             generation: '123',
             backupPath: null,
+            backupV5: false,
             initialSchema: {tables: [], indexes: []},
           },
         ],
@@ -215,6 +218,10 @@ describe('change-streamer/pg/schema/init', () => {
           '12345',
           c.newReplica[0],
           c.newReplica[1],
+          {
+            backupPath: '12345',
+            backupV5: true,
+          },
         );
         await initReplica(
           upstream,

--- a/packages/zero-cache/src/services/change-source/pg/schema/init.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/init.ts
@@ -232,7 +232,7 @@ function getIncrementalMigrations(shard: ShardConfig): IncrementalMigrationMap {
 
     // v25 (1.10.0):
     // - adds the "backupV5" column to signal the current semantics
-    //   of the replication slot's confirmed_lsn with respect to what
+    //   of the replication slot's confirmed_flush_lsn with respect to what
     //   has been backed up.
     25: {
       migrateSchema: async (_, sql) => {

--- a/packages/zero-cache/src/services/change-source/pg/schema/init.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/init.ts
@@ -229,6 +229,19 @@ function getIncrementalMigrations(shard: ShardConfig): IncrementalMigrationMap {
         `;
       },
     },
+
+    // v25 (1.10.0):
+    // - adds the "backupV5" column to signal the current semantics
+    //   of the replication slot's confirmed_lsn with respect to what
+    //   has been backed up.
+    25: {
+      migrateSchema: async (_, sql) => {
+        await sql`
+          ALTER TABLE ${sql(upstreamSchema(shard))}.replicas 
+            ADD COLUMN "backupV5" BOOL DEFAULT false;
+        `;
+      },
+    },
   };
 }
 

--- a/packages/zero-cache/src/services/change-source/pg/schema/shard.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/shard.pg.test.ts
@@ -58,6 +58,7 @@ describe('change-source/pg', () => {
         '12345',
         'zro_0_1234',
         '0wdfj02',
+        {backupPath: '12345', backupV5: true},
       );
       await initReplica(
         tx,
@@ -90,7 +91,8 @@ describe('change-source/pg', () => {
           slot: 'zro_0_1234',
           version: '0wdfj02',
           generation: '0wdfj02',
-          backupPath: null,
+          backupPath: '12345',
+          backupV5: true,
           initialSchema: {tables: [], indexes: []},
           initialSyncContext: {foo: 'bar'},
           subscriberContext: null,

--- a/packages/zero-cache/src/services/change-source/pg/schema/shard.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/shard.ts
@@ -203,6 +203,7 @@ export function shardSetup(
     "version"            TEXT NOT NULL,
     "generation"         TEXT,  -- to replace version, NULL-able in the interim
     "backupPath"         TEXT,  -- subpath within the litestream backup URL
+    "backupV5"           BOOL DEFAULT false,
     "initialSchema"      JSON,  -- set after initial sync
     "initialSyncContext" JSON,
     "subscriberContext"  JSON
@@ -238,6 +239,7 @@ const replicaInfoSchema = v.object({
   version: v.string(),
   generation: v.string().nullable(),
   backupPath: v.string().nullable(),
+  backupV5: v.boolean(),
 });
 
 const fullReplicaRowSchema = replicaInfoSchema.extend({
@@ -280,6 +282,11 @@ function triggerSetup(shard: ShardConfig): string {
   );
 }
 
+export type BackupOptions = {
+  backupPath: string | null;
+  backupV5: boolean;
+};
+
 /**
  * Creates a new replica to mark it as the owner of a specified `slot`.
  * This should be done with an advisory lock for replica/slot management
@@ -295,6 +302,7 @@ export async function createReplica(
   id: string,
   slot: string,
   replicaVersion: string,
+  {backupPath, backupV5}: BackupOptions,
 ) {
   const schema = upstreamSchema(shard);
   const values: Partial<v.Infer<typeof fullReplicaRowSchema>> = {
@@ -302,9 +310,8 @@ export async function createReplica(
     slot,
     version: replicaVersion,
     generation: replicaVersion,
-    // TODO: Start setting replica-specific backupPaths after the code that
-    //       supports reading from them has been in one release.
-    // backupPath: id,
+    backupPath,
+    backupV5,
   };
   await sql`INSERT INTO ${sql(schema)}.replicas ${sql(values)}`;
 }
@@ -324,13 +331,15 @@ export async function initReplica(
 }
 
 /**
- * Gets the latest (by rank) initialized replica at the specified version.
+ * Gets at the given version and optional ID. If no ID is specified, gets
+ * the latest (i.e. highest rank) replica with that version.
  */
 export async function getReplicaAtVersion(
   lc: LogContext,
   sql: PostgresDB,
   shard: ShardID,
   replicaVersion: string,
+  id: string | null = null,
   context?: JSONObject,
 ): Promise<Replica | null> {
   const schema = sql(upstreamSchema(shard));
@@ -342,6 +351,7 @@ export async function getReplicaAtVersion(
       replicas."version",
       replicas."generation",
       replicas."backupPath",
+      replicas."backupV5",
       replicas."initialSchema",
       replicas."initialSyncContext",
       replicas."subscriberContext",
@@ -349,6 +359,7 @@ export async function getReplicaAtVersion(
       "shardConfig"."ddlDetection"
     FROM ${schema}.replicas JOIN ${schema}."shardConfig" ON true
       WHERE version = ${replicaVersion} AND "initialSyncContext" IS NOT NULL
+      AND id = COALESCE(${id}, id)
       ORDER BY rank DESC LIMIT 1;
   `;
   if (result.length === 0) {
@@ -357,7 +368,7 @@ export async function getReplicaAtVersion(
       SELECT id, slot, version, "initialSyncContext", "subscriberContext" 
         FROM ${schema}.replicas`;
     lc.info?.(
-      `Replica ${replicaVersion} ` +
+      `Replica ${id} ` +
         (context ? `(context: ${stringify(context)}) ` : '') +
         `not found in: ${stringify(allReplicas)}`,
     );
@@ -380,6 +391,7 @@ export async function getActiveReplicas(
       replicas."version",
       replicas."generation",
       replicas."backupPath",
+      replicas."backupV5",
       slots."active",
       slots."confirmed_flush_lsn" as "confirmedFlushLsn"
     FROM ${schema}.replicas JOIN pg_replication_slots slots ON slot = slot_name
@@ -387,7 +399,7 @@ export async function getActiveReplicas(
       ORDER BY generation DESC, confirmed_flush_lsn DESC;
   `;
   const replicas = v.parse(results, v.array(replicaStateSchema), 'passthrough');
-  lc.info?.(`current replicas`, {replicas});
+  lc.info?.(`current replicas in ${shard.appID}_${shard.shardNum}`, {replicas});
   return replicas;
 }
 
@@ -405,6 +417,7 @@ export async function getReplicaState(
       replicas."version",
       replicas."generation",
       replicas."backupPath",
+      replicas."backupV5",
       slots."active",
       slots."confirmed_flush_lsn" as "confirmedFlushLsn"
     FROM ${schema}.replicas JOIN pg_replication_slots slots ON slot = slot_name

--- a/packages/zero-cache/src/services/change-source/pg/schema/shard.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/shard.ts
@@ -368,7 +368,7 @@ export async function getReplicaAtVersion(
       SELECT id, slot, version, "initialSyncContext", "subscriberContext" 
         FROM ${schema}.replicas`;
     lc.info?.(
-      `Replica ${id} ` +
+      `Replica ${id}@${replicaVersion}` +
         (context ? `(context: ${stringify(context)}) ` : '') +
         `not found in: ${stringify(allReplicas)}`,
     );
@@ -399,7 +399,7 @@ export async function getActiveReplicas(
       ORDER BY generation DESC, confirmed_flush_lsn DESC;
   `;
   const replicas = v.parse(results, v.array(replicaStateSchema), 'passthrough');
-  lc.info?.(`current replicas in ${shard.appID}_${shard.shardNum}`, {replicas});
+  lc.info?.(`current replicas`, {replicas});
   return replicas;
 }
 


### PR DESCRIPTION
Adds support for backing up the replica using litestream v5, using the `ZERO_LITESTREAM_BACKUP_USING_V5` option.

With this option:
* litestream v5 is used to back up the replica, at a shorter interval (defaulting to every 15 seconds)
* litestream vfs is used to poll the backup to confirm the latest backed up watermark
* postgres replication stream acknowledgements (i.e. determining the `confirmed_flush_lsn` value) are gated by confirmation of the corresponding change being backed up by litestream.
  * while the PG change-log is still active, acknowledgement is also gated on committing the change to the change-log.
* each replication-manager backs up to a (new) unique subpath under the backup folder. This is required by LTX.

Note that the zero-cache does _not_ clean up old backup files; the operator must handle backup expiration separately, with the recommendation being configuring a 1+ day lifecycle expiration on the object store (e.g. s3).