### PR TITLE
chore(zero-cache): allow --executable and --executableV5 to differ

### DIFF
--- a/packages/zero-cache/src/config/normalize.test.ts
+++ b/packages/zero-cache/src/config/normalize.test.ts
@@ -50,6 +50,7 @@ describe('config/normalize litestream v5 gating', () => {
     expect(() =>
       assertNormalized(
         configWith({
+          backupURL: 's3://foo/bar',
           backupUsingV5: true,
           restoreUsingV5: true,
           executableV5: undefined,
@@ -66,6 +67,7 @@ describe('config/normalize litestream v5 gating', () => {
     expect(() =>
       assertNormalized(
         configWith({
+          backupURL: 's3://foo/bar',
           restoreUsingV5: true,
           executableV5: undefined,
         }),

--- a/packages/zero-cache/src/config/normalize.test.ts
+++ b/packages/zero-cache/src/config/normalize.test.ts
@@ -46,44 +46,42 @@ describe('config/normalize litestream v5 gating', () => {
     );
   });
 
-  test('backupUsingV5 requires the executable flipped to the v5 binary', () => {
+  test('restoreUsingV5 requires executableV5 to actually be configured', () => {
+    expect(() =>
+      assertNormalized(
+        configWith({
+          backupUsingV5: true,
+          restoreUsingV5: true,
+          executableV5: undefined,
+        }),
+      ),
+    ).toThrow(
+      '--litestream-restore-using-v5 and --litestream-backup-using-v5 require --litestream-executable to be specified',
+    );
+  });
+
+  test('restoreUsingV5 requires executableV5 to actually be configured', () => {
+    // Guards against `undefined === undefined` slipping past the equality check
+    // when neither executable is set.
+    expect(() =>
+      assertNormalized(
+        configWith({
+          restoreUsingV5: true,
+          executableV5: undefined,
+        }),
+      ),
+    ).toThrow(
+      '--litestream-restore-using-v5 and --litestream-backup-using-v5 require --litestream-executable to be specified',
+    );
+  });
+
+  test('allows backupUsingV5 when executable !== executableV5', () => {
     expect(() =>
       assertNormalized(
         configWith({
           backupUsingV5: true,
           restoreUsingV5: true,
           executable: '/bin/litestream-v3',
-          executableV5: '/bin/litestream-v5',
-        }),
-      ),
-    ).toThrow(
-      '--litestream-backup-using-v5 requires --litestream-executable to be ' +
-        'flipped to the v5 binary',
-    );
-  });
-
-  test('backupUsingV5 requires executableV5 to actually be configured', () => {
-    // Guards against `undefined === undefined` slipping past the equality check
-    // when neither executable is set.
-    expect(() =>
-      assertNormalized(
-        configWith({
-          backupUsingV5: true,
-          restoreUsingV5: true,
-          executable: undefined,
-          executableV5: undefined,
-        }),
-      ),
-    ).toThrow('--litestream-executable must equal');
-  });
-
-  test('allows backupUsingV5 when executable === executableV5', () => {
-    expect(() =>
-      assertNormalized(
-        configWith({
-          backupUsingV5: true,
-          restoreUsingV5: true,
-          executable: '/bin/litestream-v5',
           executableV5: '/bin/litestream-v5',
         }),
       ),

--- a/packages/zero-cache/src/config/normalize.ts
+++ b/packages/zero-cache/src/config/normalize.ts
@@ -78,7 +78,8 @@ export function assertNormalized(
     '--litestream-backup-using-v5 requires --litestream-restore-using-v5',
   );
   assert(
-    config.litestream.executableV5 ||
+    !config.litestream.backupURL ||
+      config.litestream.executableV5 ||
       !(config.litestream.restoreUsingV5 || config.litestream.backupUsingV5),
     '--litestream-restore-using-v5 and --litestream-backup-using-v5 ' +
       'require --litestream-executable to be specified',

--- a/packages/zero-cache/src/config/normalize.ts
+++ b/packages/zero-cache/src/config/normalize.ts
@@ -77,19 +77,11 @@ export function assertNormalized(
     !config.litestream.backupUsingV5 || config.litestream.restoreUsingV5,
     '--litestream-backup-using-v5 requires --litestream-restore-using-v5',
   );
-  // The `litestream replicate` process always runs --litestream-executable, so
-  // enabling v5 backups (which write the LTX format read by the VFS monitor)
-  // requires --litestream-executable itself to have been flipped to the v5
-  // binary. Restoring is verified separately via --litestream-restore-using-v5,
-  // which is the prerequisite step that must roll out *before* the executable
-  // is flipped (so every replica can restore both WAL and LTX formats).
   assert(
-    !config.litestream.backupUsingV5 ||
-      (config.litestream.executableV5 !== undefined &&
-        config.litestream.executable === config.litestream.executableV5),
-    '--litestream-backup-using-v5 requires --litestream-executable to be ' +
-      'flipped to the v5 binary (--litestream-executable must equal ' +
-      '--litestream-executable-v5)',
+    config.litestream.executableV5 ||
+      !(config.litestream.restoreUsingV5 || config.litestream.backupUsingV5),
+    '--litestream-restore-using-v5 and --litestream-backup-using-v5 ' +
+      'require --litestream-executable to be specified',
   );
   assert(config.change.db, 'missing --change-db');
   assert(config.cvr.db, 'missing --cvr-db');


### PR DESCRIPTION
Removes the policy that the (litestream) `--executable` must equal `--executableV5` when `--backupUsingV5` is on.

This is no longer relevant/necessary now that the `--executableV5` is actually used when `--backupUsingV5` is enabled (https://github.com/rocicorp/mono/pull/6364).