### PR TITLE
fix(release): use immutable skopeo image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -318,7 +318,7 @@ jobs:
           path: dist/docker
 
       - name: Push GHCR Docker image
-        uses: docker://quay.io/containers/skopeo:v1.22.2@sha256:e268031b80e65ba25dd2020383232587daf0ae670727b5ccdbe7a0008e9216bc
+        uses: docker://quay.io/containers/skopeo:v1.22.2-immutable@sha256:ca4fd94dba8cab15cf79c4c156bfc26d28e2265411294e9bba87756942e739ad
         with:
           args: >-
             copy --all
@@ -330,7 +330,7 @@ jobs:
         # Moving tag tracking the newest head release. The cosign signature
         # below covers it because signatures attach to the digest.
         if: needs.plan.outputs.mode == 'head'
-        uses: docker://quay.io/containers/skopeo:v1.22.2@sha256:e268031b80e65ba25dd2020383232587daf0ae670727b5ccdbe7a0008e9216bc
+        uses: docker://quay.io/containers/skopeo:v1.22.2-immutable@sha256:ca4fd94dba8cab15cf79c4c156bfc26d28e2265411294e9bba87756942e739ad
         with:
           args: >-
             copy --all
@@ -340,7 +340,7 @@ jobs:
 
       - name: Push Docker Hub image
         if: needs.plan.outputs.mode != 'head'
-        uses: docker://quay.io/containers/skopeo:v1.22.2@sha256:e268031b80e65ba25dd2020383232587daf0ae670727b5ccdbe7a0008e9216bc
+        uses: docker://quay.io/containers/skopeo:v1.22.2-immutable@sha256:ca4fd94dba8cab15cf79c4c156bfc26d28e2265411294e9bba87756942e739ad
         with:
           args: >-
             copy --all


### PR DESCRIPTION
### What

Make Zero release Docker publishing use upstream’s immutable Skopeo image rather than its daily-rebuilt version tag.

### Why

Quay moved the mutable `v1.22.2` tag and garbage-collected the workflow’s pinned manifest, causing the Release Zero Docker publish job to fail with `manifest unknown`. These move because they rebuild every day on a mutable base for OS security patches. Because the workflow already pins a digest, the daily image rebuilds were not providing automatic updates.

### Changes

- Switch all three Skopeo action references to `v1.22.2-immutable`.
- Pin the verified immutable multi-architecture manifest digest.