### PR TITLE
chore(rmv2): add range reads to both change logs

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-reader.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-reader.test.ts
@@ -267,6 +267,26 @@ describe('sqlite change log reader', () => {
     await expect(collect(reader, '06', '06', 2)).resolves.toEqual([]);
   });
 
+  test('caps total rows across read batches', async () => {
+    const {db, path} = createChangeLog();
+    using writer = db;
+    const tx04 = appendTransaction(writer, '04', [
+      truncate(),
+      truncate(),
+      truncate(),
+      truncate(),
+      truncate(),
+    ]);
+    using reader = new SQLiteChangeLogReader(lc, path);
+
+    const batches: (readonly WatermarkedChange[])[] = [];
+    for await (const batch of reader.read('02', '04', 2, undefined, 5)) {
+      batches.push(batch);
+    }
+    expect(batches.map(batch => batch.length)).toEqual([2, 2, 1]);
+    expect(flatten(batches)).toEqual(tx04.slice(0, 5));
+  });
+
   test('pins the head while another connection appends and purges', async () => {
     const {db, path} = createChangeLog();
     using writer = db;

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-reader.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-reader.ts
@@ -151,10 +151,15 @@ export class SQLiteChangeLogReader implements Disposable {
     throughWatermark: string,
     batchSize: number,
     signal?: AbortSignal | undefined,
+    maxRows?: number | undefined,
   ): AsyncIterable<readonly WatermarkedChange[]> {
     assert(
       Number.isSafeInteger(batchSize) && batchSize > 0,
       'SQLite change log batch size must be a positive safe integer',
+    );
+    assert(
+      maxRows === undefined || (Number.isSafeInteger(maxRows) && maxRows > 0),
+      'SQLite change log row limit must be a positive safe integer',
     );
     this.#assertOpen();
     const statements = this.#prepare();
@@ -168,14 +173,20 @@ export class SQLiteChangeLogReader implements Disposable {
     // real stream position is far below this sentinel.
     let lastPos = Number.MAX_SAFE_INTEGER;
     let lastTag: string | undefined;
+    let rowsRead = 0;
 
     while (true) {
       this.#throwIfAborted(signal);
+      const remainingRows =
+        maxRows === undefined ? batchSize : maxRows - rowsRead;
+      if (remainingRows === 0) {
+        break;
+      }
       const rows = statements.readBatch.all<ChangeLogRow>(
         lastWatermark,
         lastPos,
         throughWatermark,
-        batchSize,
+        Math.min(batchSize, remainingRows),
       );
       this.#throwIfAborted(signal);
 
@@ -189,6 +200,7 @@ export class SQLiteChangeLogReader implements Disposable {
       lastWatermark = last.watermark;
       lastPos = last.pos;
       lastTag = last.tag;
+      rowsRead += rows.length;
 
       // all() has exhausted the SELECT and closed its implicit read
       // transaction. This yield therefore cannot pin the WAL while subscriber
@@ -201,7 +213,14 @@ export class SQLiteChangeLogReader implements Disposable {
     // `_zero.replicationState`, which is what this assertion used to guard.
     // What remains is a concurrent purge of the head transaction, which the
     // purge policy (never past the latest durable transaction) does not do.
-    if (fromWatermark !== throughWatermark) {
+    // A read that stopped at `maxRows` cannot know whether more rows follow,
+    // so completeness is only asserted for a read that ran out on its own.
+    // Detecting a short bounded read is left to the caller, which set the
+    // limit and is the only side that knows what a full range should hold.
+    if (
+      fromWatermark !== throughWatermark &&
+      (maxRows === undefined || rowsRead < maxRows)
+    ) {
       assert(
         lastWatermark === throughWatermark && lastTag === 'commit',
         () =>

--- a/packages/zero-cache/src/services/change-streamer/storer.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.ts
@@ -313,6 +313,68 @@ export class Storer implements Service {
     return minWatermark;
   }
 
+  /**
+   * Returns the retained Postgres catchup bounds.
+   * `minWatermark` is the oldest transaction, or `null` for a new replica.
+   * `lastWatermark` is the durable head.
+   */
+  async getCatchupBounds(): Promise<{
+    minWatermark: string | null;
+    lastWatermark: string;
+  }> {
+    const [bounds] = await this.#db<
+      {minWatermark: string | null; lastWatermark: string}[]
+    > /*sql*/ `
+      SELECT
+        (SELECT min(watermark) FROM ${this.#cdc('changeLog')}) as "minWatermark",
+        (SELECT "lastWatermark" FROM ${this.#cdc('replicationState')}) as "lastWatermark"`;
+    return bounds;
+  }
+
+  /**
+   * Lists at most `limit` committed transaction watermarks in
+   * `(afterWatermark, throughWatermark]`, in ascending order.
+   */
+  async listCommitWatermarks(
+    afterWatermark: string,
+    throughWatermark: string,
+    limit: number,
+  ): Promise<string[]> {
+    const rows = await this.#db<{watermark: string}[]> /*sql*/ `
+      SELECT watermark FROM ${this.#cdc('changeLog')}
+       WHERE precommit IS NOT NULL
+         AND watermark > ${afterWatermark}
+         AND watermark <= ${throughWatermark}
+       ORDER BY watermark
+       LIMIT ${limit}`;
+    return rows.map(({watermark}) => watermark);
+  }
+
+  /**
+   * Reads `(afterWatermark, throughWatermark]` in stream order and bounded batches.
+   * This query matches the subscriber catchup query.
+   *
+   * Both queries fail when an escaped NUL reaches `change->'tag'`.
+   * Postgres cannot convert that value to text.
+   */
+  readCatchupRange(
+    afterWatermark: string,
+    throughWatermark: string,
+    batchRows = 2000,
+  ): AsyncIterable<ChangeLogEntry[]> {
+    assert(
+      Number.isSafeInteger(batchRows) && batchRows > 0,
+      'Postgres change log batch size must be a positive safe integer',
+    );
+    return this.#db<ChangeLogEntry[]> /*sql*/ `
+      SELECT watermark, change->'tag' as tag, change::text FROM ${this.#cdc('changeLog')}
+       WHERE watermark > ${afterWatermark}
+         AND watermark <= ${throughWatermark}
+       ORDER BY watermark, pos`.cursor(batchRows) as AsyncIterable<
+      ChangeLogEntry[]
+    >;
+  }
+
   purgeRecordsBefore(watermark: string): Promise<number> {
     return runTx(this.#db, async sql => {
       // This NOWAIT pre-check is an optimization to abort the transaction


### PR DESCRIPTION
Add functions to read portions of the change log (from PG and SQLite). This will be used by our "comparator" to compare SQLite and PG changes logs while we're in a dark launch