### PR TITLE
chore(rmv2): add the SQLite change-log comparator service

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.pg.test.ts
@@ -1,0 +1,1168 @@
+import {LogContext} from '@rocicorp/logger';
+import {resolver} from '@rocicorp/resolver';
+import fc from 'fast-check';
+import {beforeEach, describe, expect, vi} from 'vitest';
+import {assert} from '../../../../shared/src/asserts.ts';
+import {TestLogSink} from '../../../../shared/src/logging-test-utils.ts';
+import {Database} from '../../../../zqlite/src/db.ts';
+import {StatementRunner} from '../../db/statements.ts';
+import {test, type PgTest} from '../../test/db.ts';
+import {DbFile} from '../../test/lite.ts';
+import type {PostgresDB} from '../../types/pg.ts';
+import {cdcSchema, type ShardID} from '../../types/shards.ts';
+import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
+import {EMPTY_COOKIE_SET} from '../replicator/change-log-cookies.ts';
+import {
+  changeLogFileName,
+  CHANGE_LOG_META_TABLE,
+  CHANGE_LOG_STREAM_TABLE,
+  deleteChangeLogDB,
+  estimateChangeLogStreamRowBytes,
+  type ChangeLogIdentity,
+} from '../replicator/change-log-db.ts';
+import {
+  getSubscriptionState,
+  initReplicationState,
+} from '../replicator/schema/replication-state.ts';
+import {ReplicationMessages} from '../replicator/test-utils.ts';
+import {serializeChangeStreamData} from './change-log-codec.ts';
+import {isSampledForCompare} from './change-log-compare-digest.ts';
+import {initChangeStreamerSchema} from './schema/init.ts';
+import {ensureReplicationConfig} from './schema/tables.ts';
+import {
+  SQLiteChangeLogComparator,
+  type PGChangeLogRangeReader,
+  type SQLiteChangeLogCompareOptions,
+} from './sqlite-change-log-comparator.ts';
+import {SQLiteChangeLogWriter} from './sqlite-change-log-writer.ts';
+import {Storer} from './storer.ts';
+
+describe('change-streamer/sqlite-change-log-comparator', () => {
+  const REPLICA_VERSION = '01';
+  const RETENTION_MS = 60_000;
+  const shard: ShardID = {appID: 'cmp', shardNum: 7};
+  const identity: ChangeLogIdentity = {
+    epoch: null,
+    generation: REPLICA_VERSION,
+    replicaID: 'replica-id',
+  };
+
+  let lc: LogContext;
+  let logSink: TestLogSink;
+  let sql: PostgresDB;
+  let storer: Storer;
+  let storerDone: Promise<void>;
+  let writer: SQLiteChangeLogWriter;
+  let logFile: DbFile;
+  let seededAtMs: number;
+  let onWriterRebuilt: () => void;
+
+  beforeEach<PgTest>(async ({testDBs}) => {
+    logSink = new TestLogSink();
+    lc = new LogContext('debug', {}, logSink);
+
+    sql = await testDBs.create('sqlite_change_log_comparator_test', {
+      typeOpts: {sendStringAsJson: true},
+    });
+
+    const replica = new Database(lc, ':memory:');
+    initReplicationState(replica, ['zero_data'], REPLICA_VERSION);
+    const subscriptionState = getSubscriptionState(
+      new StatementRunner(replica),
+    );
+
+    await initChangeStreamerSchema(lc, sql, shard);
+    await ensureReplicationConfig(lc, sql, subscriptionState, shard, true);
+
+    storer = new Storer(
+      lc,
+      shard,
+      'task-id',
+      'change.streamer:12345',
+      'ws',
+      sql,
+      REPLICA_VERSION,
+      () => {},
+      vi.fn(),
+      {
+        backPressureLimitHeapProportion: 0.04,
+        statementTimeoutMs: 20_000,
+        changeLogBatchSize: 2000,
+      },
+    );
+    await storer.assumeOwnership();
+    storerDone = storer.run();
+
+    seededAtMs = 1_000_000;
+    onWriterRebuilt = () => {};
+    logFile = new DbFile('sqlite-change-log-comparator');
+    writer = new SQLiteChangeLogWriter(lc, {
+      replicaFile: logFile.path,
+      identity,
+      now: () => seededAtMs,
+      onRebuilt: () => onWriterRebuilt(),
+    });
+    // Resume from the Postgres watermark at the replica version.
+    writer.reconcile({
+      resumeWatermark: REPLICA_VERSION,
+      cookies: EMPTY_COOKIE_SET,
+    });
+
+    return async () => {
+      await storer.stop();
+      await storerDone;
+      writer.close();
+      logFile.delete();
+      await testDBs.drop(sql);
+    };
+  });
+
+  const messages = new ReplicationMessages({foo: 'id'});
+
+  type Tx = {watermark: string; changes: ChangeStreamData[]};
+
+  function tx(watermark: string, ...data: object[]): Tx {
+    return {
+      watermark,
+      changes: [
+        [
+          'begin',
+          messages.begin(),
+          {commitWatermark: watermark},
+        ] as unknown as ChangeStreamData,
+        ...data.map(d => ['data', d] as unknown as ChangeStreamData),
+        [
+          'commit',
+          messages.commit(),
+          {watermark},
+        ] as unknown as ChangeStreamData,
+      ],
+    };
+  }
+
+  function feedTx(t: Tx, target: {pg: boolean; sqlite: boolean}) {
+    for (const change of t.changes) {
+      const json = target.pg
+        ? storer.store(t.watermark, change)
+        : serializeChangeStreamData(change);
+      if (target.sqlite) {
+        writer.write(change, json);
+      }
+    }
+  }
+
+  async function feedBoth(...txs: Tx[]) {
+    txs.forEach(t => feedTx(t, {pg: true, sqlite: true}));
+    await storer.allProcessed();
+  }
+
+  async function feedPGOnly(...txs: Tx[]) {
+    txs.forEach(t => feedTx(t, {pg: true, sqlite: false}));
+    await storer.allProcessed();
+  }
+
+  function feedSQLiteOnly(...txs: Tx[]) {
+    txs.forEach(t => feedTx(t, {pg: false, sqlite: true}));
+  }
+
+  function newComparator(
+    overrides: Partial<SQLiteChangeLogCompareOptions> & {
+      pg?: PGChangeLogRangeReader;
+      logIdentity?: ChangeLogIdentity;
+      file?: string;
+    } = {},
+  ): SQLiteChangeLogComparator {
+    const {pg, logIdentity, file, ...opts} = overrides;
+    return new SQLiteChangeLogComparator(
+      lc,
+      shard,
+      file ?? changeLogFileName(logFile.path),
+      logIdentity ?? identity,
+      pg ?? storer,
+      {
+        comparePercent: 100,
+        retentionMs: RETENTION_MS,
+        // Make the log exactly one retention period old.
+        now: () => seededAtMs + RETENTION_MS,
+        setTimeoutFn: vi.fn() as unknown as typeof setTimeout,
+        yieldFn: () => Promise.resolve(),
+        ...opts,
+      },
+    );
+  }
+
+  /** Returns the production reader with optional overrides. */
+  function pgReader(
+    overrides: Partial<PGChangeLogRangeReader> = {},
+  ): PGChangeLogRangeReader {
+    return {
+      getCatchupBounds: () => storer.getCatchupBounds(),
+      listCommitWatermarks: (after, through, limit) =>
+        storer.listCommitWatermarks(after, through, limit),
+      readCatchupRange: (after, through, batchRows) =>
+        storer.readCatchupRange(after, through, batchRows),
+      ...overrides,
+    };
+  }
+
+  /** Opens the SQLite log for direct fault injection. */
+  function withSQLiteLog<T>(fn: (db: Database) => T): T {
+    const db = new Database(lc, changeLogFileName(logFile.path));
+    try {
+      return fn(db);
+    } finally {
+      db.close();
+    }
+  }
+
+  function cdc(table: string) {
+    return sql(`${cdcSchema(shard)}.${table}`);
+  }
+
+  /** Reads diverged watermarks from production error logs. */
+  function divergedWatermarks(since = 0): string[] {
+    return logSink.messages
+      .slice(since)
+      .filter(([level, , parts]) => level === 'error' && parts.length === 2)
+      .flatMap(([, , parts]) => {
+        const detail = (
+          parts[1] as {
+            sqliteChangeLogCompare?: {watermark: string} | undefined;
+          }
+        ).sqliteChangeLogCompare;
+        return detail === undefined ? [] : [detail.watermark];
+      });
+  }
+
+  async function mutatePGChange(
+    watermark: string,
+    pos: number,
+    mutate: (change: Record<string, unknown>) => void,
+  ) {
+    const [{change}] = await sql<{change: string}[]>`
+      SELECT change::text FROM ${cdc('changeLog')}
+       WHERE watermark = ${watermark} AND pos = ${pos}`;
+    const parsed = JSON.parse(change) as Record<string, unknown>;
+    mutate(parsed);
+    const mutated = JSON.stringify(parsed);
+    await sql`
+      UPDATE ${cdc('changeLog')} SET change = ${mutated}::json
+       WHERE watermark = ${watermark} AND pos = ${pos}`;
+  }
+
+  function deleteFromSQLiteLog(where: string) {
+    withSQLiteLog(db =>
+      db
+        .prepare(
+          /*sql*/ `DELETE FROM "${CHANGE_LOG_STREAM_TABLE}" WHERE ${where}`,
+        )
+        .run(),
+    );
+  }
+
+  /** Inserts rows that do not belong to a committed transaction. */
+  function insertSQLiteRows(watermark: string) {
+    withSQLiteLog(db => {
+      const insert = db.prepare(/*sql*/ `
+          INSERT INTO "${CHANGE_LOG_STREAM_TABLE}"
+            ("watermark", "pos", "tag", "estimatedBytes", "change",
+             "precommit", "writeTimeMs")
+          VALUES (?, ?, ?, ?, ?, NULL, NULL)`);
+      for (const [pos, tag, change] of [
+        [0, 'begin', '{"tag":"begin"}'],
+        [1, 'insert', '{"tag":"insert"}'],
+      ] as const) {
+        insert.run(
+          watermark,
+          pos,
+          tag,
+          estimateChangeLogStreamRowBytes(watermark, tag, change),
+          change,
+        );
+      }
+    });
+  }
+
+  function insertPGRows(watermark: string) {
+    return sql`
+      INSERT INTO ${cdc('changeLog')} ("watermark", "pos", "change", "precommit")
+      VALUES (${watermark}, 0, '{"tag":"begin"}'::json, NULL),
+             (${watermark}, 1, '{"tag":"insert"}'::json, NULL)`;
+  }
+
+  // Use a literal backslash-u sequence. An escaped NUL makes Postgres catchup fail.
+  test('equivalent catchup output matches, across message families and batches', async () => {
+    await feedBoth(
+      tx(
+        '03',
+        messages.insert('foo', {
+          id: 'nul-\\u0000-esc',
+          big: 9007199254740993n,
+          float: 1.5,
+          text: 'quotes " backslash \\ newline \n emoji 🙂 control ',
+          nil: null,
+          bool: true,
+        }),
+      ),
+      tx(
+        '04',
+        messages.insert('foo', {id: 'b', v: 1}),
+        messages.update('foo', {id: 'b', v: 2}),
+        messages.update('foo', {id: 'b2', v: 3}, {id: 'b'}),
+        messages.delete('foo', {id: 'b2'}),
+        messages.truncate('foo'),
+      ),
+      tx(
+        '05',
+        messages.createTable({
+          schema: 'public',
+          name: 'baz',
+          columns: {id: {pos: 0, dataType: 'varchar'}},
+          primaryKey: ['id'],
+        }),
+      ),
+      tx('06', messages.addColumn('foo', 'extra', {dataType: 'text', pos: 9})),
+      tx('07', messages.dropColumn('foo', 'extra'), messages.dropTable('baz')),
+    );
+    // Use small limits to require multiple batches and cycles.
+    const comparator = newComparator({
+      readBatchRows: 2,
+      maxTransactionsPerCycle: 2,
+    });
+
+    const first = await comparator.compareOnce();
+    expect(first).toMatchObject({
+      kind: 'compared',
+      fromWatermark: '01',
+      throughWatermark: '04',
+      transactions: 2,
+      sampled: 2,
+      matched: 2,
+      mismatched: 0,
+    });
+
+    const second = await comparator.compareOnce();
+    expect(second).toMatchObject({
+      fromWatermark: '04',
+      throughWatermark: '06',
+      matched: 2,
+      mismatched: 0,
+    });
+
+    const third = await comparator.compareOnce();
+    expect(third).toMatchObject({
+      fromWatermark: '06',
+      throughWatermark: '07',
+      matched: 1,
+      mismatched: 0,
+    });
+
+    expect(await comparator.compareOnce()).toEqual({
+      kind: 'skipped',
+      reason: 'nothing-to-compare',
+    });
+    expect(divergedWatermarks()).toEqual([]);
+  });
+
+  describe('divergent catchup output mismatches', () => {
+    const cases: {
+      name: string;
+      corrupt: () => Promise<void> | void;
+      diverged: string[];
+    }[] = [
+      {
+        name: 'a mutated PG payload',
+        corrupt: () =>
+          mutatePGChange('04', 1, change => {
+            (change.new as Record<string, unknown>).v = 999;
+          }),
+        diverged: ['04'],
+      },
+      {
+        name: 'a transaction SQLite does not hold',
+        corrupt: () => deleteFromSQLiteLog(`"watermark" = '04'`),
+        diverged: ['04'],
+      },
+      {
+        name: 'a transaction PG does not hold',
+        corrupt: async () => {
+          await sql`DELETE FROM ${cdc('changeLog')} WHERE watermark = '04'`;
+        },
+        diverged: ['04'],
+      },
+      {
+        name: 'a commit row SQLite lost from an otherwise intact transaction',
+        corrupt: () =>
+          deleteFromSQLiteLog(`"watermark" = '04' AND "precommit" IS NOT NULL`),
+        diverged: ['04'],
+      },
+      {
+        name: 'rows only SQLite serves',
+        corrupt: () => insertSQLiteRows('04z'),
+        diverged: ['05'],
+      },
+      {
+        name: 'rows only PG serves',
+        corrupt: async () => {
+          await insertPGRows('04z');
+        },
+        diverged: ['05'],
+      },
+      {
+        // Equal output matches even when no commit owns these rows.
+        name: 'identical extra rows in both stores',
+        corrupt: async () => {
+          insertSQLiteRows('04z');
+          await insertPGRows('04z');
+        },
+        diverged: [],
+      },
+    ];
+
+    for (const {name, corrupt, diverged} of cases) {
+      test(name, async () => {
+        await feedBoth(
+          tx('03', messages.insert('foo', {id: 'boundary'})),
+          tx('04', messages.insert('foo', {id: 'victim', v: 1})),
+          tx('05', messages.insert('foo', {id: 'witness'})),
+        );
+        await corrupt();
+
+        const result = await newComparator().compareOnce();
+        assert(result.kind === 'compared', 'expected a compared cycle');
+        expect(divergedWatermarks()).toEqual(diverged);
+        expect(result.mismatched).toBe(diverged.length);
+        expect(result.inconclusive).toBe(0);
+      });
+    }
+  });
+
+  test('head lag in either direction is not divergence', async () => {
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'boundary'})),
+      tx('04', messages.insert('foo', {id: 'both'})),
+    );
+    const t5 = tx('05', messages.insert('foo', {id: 'trailing-pg'}));
+    const t6 = tx('06', messages.insert('foo', {id: 'trailing-sqlite'}));
+
+    // SQLite leads, so compare only through the Postgres head.
+    feedSQLiteOnly(t5);
+    const comparator = newComparator();
+    expect(await comparator.compareOnce()).toMatchObject({
+      throughWatermark: '04',
+      transactions: 2,
+      matched: 2,
+      mismatched: 0,
+    });
+
+    // Postgres then leads, so compare only through the SQLite head.
+    await feedPGOnly(t5, t6);
+    expect(await comparator.compareOnce()).toMatchObject({
+      fromWatermark: '04',
+      throughWatermark: '05',
+      matched: 1,
+      mismatched: 0,
+    });
+
+    // SQLite catches up, and the earlier skew matches.
+    feedSQLiteOnly(t6);
+    expect(await comparator.compareOnce()).toMatchObject({
+      fromWatermark: '05',
+      throughWatermark: '06',
+      matched: 1,
+      mismatched: 0,
+    });
+    expect(divergedWatermarks()).toEqual([]);
+  });
+
+  test('a limited cycle compares only the range both enumerations cover', async () => {
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'a'})),
+      tx('04', messages.insert('foo', {id: 'b'})),
+      tx('05', messages.insert('foo', {id: 'c'})),
+      tx('06', messages.insert('foo', {id: 'd'})),
+    );
+    deleteFromSQLiteLog(`"watermark" = '04'`);
+
+    const comparator = newComparator({maxTransactionsPerCycle: 2});
+    // The lower complete enumeration ends at 04, so 05 is not missing.
+    expect(await comparator.compareOnce()).toMatchObject({
+      throughWatermark: '04',
+      transactions: 2,
+      matched: 1,
+      mismatched: 1,
+    });
+    expect(divergedWatermarks()).toEqual(['04']);
+
+    // The next cycle completes the remaining range.
+    const before = logSink.messages.length;
+    expect(await comparator.compareOnce()).toMatchObject({
+      throughWatermark: '06',
+      matched: 2,
+    });
+    // Report 04 again because the log cannot serve that boundary.
+    expect(divergedWatermarks(before)).toEqual(['04']);
+  });
+
+  describe('a race with the pinned bounds is inconclusive', () => {
+    const cases: {
+      name: string;
+      pg: () => PGChangeLogRangeReader;
+      transactions: number;
+      matched: number;
+      inconclusive: number;
+    }[] = [
+      {
+        // Purge Postgres after the cycle reads its initial bounds, so the
+        // enumeration already sees the smaller Postgres range.
+        name: 'a PG purge before the enumeration',
+        pg: () => {
+          let purged = false;
+          return pgReader({
+            getCatchupBounds: async () => {
+              const bounds = await storer.getCatchupBounds();
+              if (!purged) {
+                purged = true;
+                await storer.purgeRecordsBefore('05');
+              }
+              return bounds;
+            },
+          });
+        },
+        // A presence check needs no payload read, so the cycle continues
+        // past the purged transactions and still compares 05.
+        transactions: 3,
+        matched: 1,
+        inconclusive: 2,
+      },
+      {
+        // Purge Postgres once the cycle starts reading payloads, so the
+        // enumeration still lists the transactions that the purge removes.
+        name: 'a PG purge during a payload read',
+        pg: () => {
+          let purged = false;
+          return pgReader({
+            readCatchupRange: (after, through, batchRows) =>
+              (async function* (this: void) {
+                if (!purged) {
+                  purged = true;
+                  await storer.purgeRecordsBefore('05');
+                }
+                yield* storer.readCatchupRange(after, through, batchRows);
+              })(),
+          });
+        },
+        // A sampled read that cannot be reconfirmed ends the cycle, so the
+        // first purged transaction is the only result.
+        transactions: 0,
+        matched: 0,
+        inconclusive: 1,
+      },
+      {
+        // Purge SQLite after the cycle enumerates its transactions.
+        name: 'a SQLite purge during the enumeration',
+        pg: () =>
+          pgReader({
+            listCommitWatermarks: async (after, through, limit) => {
+              const list = await storer.listCommitWatermarks(
+                after,
+                through,
+                limit,
+              );
+              deleteFromSQLiteLog(`"watermark" < '05'`);
+              return list;
+            },
+          }),
+        transactions: 0,
+        matched: 0,
+        inconclusive: 1,
+      },
+      {
+        // Change the seed after the cycle enumerates its transactions.
+        name: 'a reseed during the enumeration',
+        pg: () =>
+          pgReader({
+            listCommitWatermarks: async (after, through, limit) => {
+              const list = await storer.listCommitWatermarks(
+                after,
+                through,
+                limit,
+              );
+              withSQLiteLog(db => {
+                db.prepare(
+                  /*sql*/ `DELETE FROM "${CHANGE_LOG_STREAM_TABLE}" WHERE "watermark" = '04'`,
+                ).run();
+                db.prepare(/*sql*/ `UPDATE "${CHANGE_LOG_META_TABLE}"
+                      SET "seedWatermark" = '03', "seededAtMs" = "seededAtMs" + 1`).run();
+              });
+              return list;
+            },
+          }),
+        // 03 still matches because the reseed only removes 04.
+        transactions: 1,
+        matched: 1,
+        inconclusive: 1,
+      },
+    ];
+
+    for (const {name, pg, transactions, matched, inconclusive} of cases) {
+      test(name, async () => {
+        await feedBoth(
+          tx('03', messages.insert('foo', {id: 'boundary'})),
+          tx('04', messages.insert('foo', {id: 'raced'})),
+          tx('05', messages.insert('foo', {id: 'witness'})),
+        );
+
+        const result = await newComparator({pg: pg()}).compareOnce();
+        expect(result).toMatchObject({
+          transactions,
+          matched,
+          inconclusive,
+          mismatched: 0,
+        });
+        // Bounds races do not report divergence.
+        expect(divergedWatermarks()).toEqual([]);
+      });
+    }
+  });
+
+  test('a file rebuild invalidates a cycle before it opens another reader', async () => {
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'removed-before-rebuild'})),
+      tx('04', messages.insert('foo', {id: 'old-head'})),
+    );
+
+    const boundsPinned = resolver();
+    const continueBounds = resolver();
+    let firstBoundsRead = true;
+    const comparator = newComparator({
+      pg: pgReader({
+        getCatchupBounds: async () => {
+          if (firstBoundsRead) {
+            firstBoundsRead = false;
+            boundsPinned.resolve();
+            await continueBounds.promise;
+          }
+          return storer.getCatchupBounds();
+        },
+      }),
+    });
+    onWriterRebuilt = () => comparator.invalidate();
+
+    const comparing = comparator.compareOnce();
+    await boundsPinned.promise;
+
+    // Rebuild while the comparator waits for Postgres bounds.
+    // The old database handle then points to the removed file.
+    deleteFromSQLiteLog(`"watermark" = '03'`);
+    writer.reconcile({
+      resumeWatermark: '03',
+      cookies: EMPTY_COOKIE_SET,
+    });
+    continueBounds.resolve();
+
+    expect(await comparing).toEqual({
+      kind: 'skipped',
+      reason: 'log-rebuilt',
+    });
+    expect(divergedWatermarks()).toEqual([]);
+  });
+
+  test('a suspect that cannot be reconfirmed is inconclusive, then retried', async () => {
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'boundary'})),
+      tx('04', messages.insert('foo', {id: 'victim'})),
+      tx('05', messages.insert('foo', {id: 'witness'})),
+    );
+    deleteFromSQLiteLog(`"watermark" = '04'`);
+
+    // Fail the bounds recheck once, so the first result is inconclusive.
+    let boundsReads = 0;
+    const comparator = newComparator({
+      pg: pgReader({
+        getCatchupBounds: () => {
+          if (++boundsReads === 2) {
+            throw new Error('injected bounds re-read failure');
+          }
+          return storer.getCatchupBounds();
+        },
+      }),
+    });
+    expect(await comparator.compareOnce()).toMatchObject({
+      matched: 2,
+      mismatched: 0,
+      inconclusive: 1,
+    });
+    expect(divergedWatermarks()).toEqual([]);
+
+    // The next cycle retries and reports the persistent mismatch.
+    expect(await comparator.compareOnce()).toMatchObject({mismatched: 1});
+    expect(divergedWatermarks()).toEqual(['04']);
+  });
+
+  test('a read that cannot complete is a mismatch, not a crash', async () => {
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'boundary'})),
+      tx('04', messages.insert('foo', {id: 'unreadable'})),
+    );
+    const result = await newComparator({
+      pg: pgReader({
+        readCatchupRange: (after, through, batchRows) => {
+          if (through === '04') {
+            throw new Error('injected read failure');
+          }
+          return storer.readCatchupRange(after, through, batchRows);
+        },
+      }),
+    }).compareOnce();
+    expect(result).toMatchObject({matched: 1, mismatched: 1});
+    expect(divergedWatermarks()).toEqual(['04']);
+  });
+
+  test('a retried comparison samples the same transactions', async () => {
+    const txs = Array.from({length: 12}, (_, i) =>
+      tx((i + 3).toString(36).padStart(2, '0'), {
+        ...messages.insert('foo', {id: `row-${i}`}),
+      }),
+    );
+    await feedBoth(...txs);
+
+    const percent = 40;
+    const expected = txs.filter(({watermark}) =>
+      isSampledForCompare(shard, watermark, percent),
+    ).length;
+
+    // Independent comparators select the same sample.
+    const first = await newComparator({comparePercent: percent}).compareOnce();
+    const second = await newComparator({comparePercent: percent}).compareOnce();
+    assert(
+      first.kind === 'compared' && second.kind === 'compared',
+      'expected compared cycles',
+    );
+    expect(first.sampled).toBe(expected);
+    expect(second.sampled).toBe(expected);
+    expect(second.fromWatermark).toBe(first.fromWatermark);
+    expect(second.throughWatermark).toBe(first.throughWatermark);
+    expect(first.matched).toBe(first.sampled);
+    expect(second.matched).toBe(second.sampled);
+  });
+
+  test('caps total catchup rows per source and defers an unfinished transaction', async () => {
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'first'})),
+      tx(
+        '04',
+        messages.insert('foo', {id: 'second-a'}),
+        messages.insert('foo', {id: 'second-b'}),
+      ),
+    );
+    const comparator = newComparator({
+      maxRowsPerSourcePerCycle: 5,
+      readBatchRows: 2,
+    });
+
+    expect(await comparator.compareOnce()).toMatchObject({
+      throughWatermark: '03',
+      transactions: 1,
+      sampled: 2,
+      matched: 1,
+      deferred: 1,
+      oversized: 0,
+      mismatched: 0,
+    });
+
+    // The fresh budget in the next cycle fits the transaction.
+    expect(await comparator.compareOnce()).toMatchObject({
+      fromWatermark: '03',
+      throughWatermark: '04',
+      matched: 1,
+      deferred: 0,
+      mismatched: 0,
+    });
+  });
+
+  test('skips a transaction that exceeds a fresh cycle row budget', async () => {
+    await feedBoth(
+      tx(
+        '03',
+        messages.insert('foo', {id: 'large-a'}),
+        messages.insert('foo', {id: 'large-b'}),
+        messages.insert('foo', {id: 'large-c'}),
+      ),
+      tx('04', messages.insert('foo', {id: 'after-large'})),
+    );
+    const comparator = newComparator({maxRowsPerSourcePerCycle: 4});
+
+    expect(await comparator.compareOnce()).toMatchObject({
+      throughWatermark: '03',
+      sampled: 1,
+      matched: 0,
+      oversized: 1,
+      mismatched: 0,
+    });
+
+    // The cursor advances past the oversized transaction.
+    expect(await comparator.compareOnce()).toMatchObject({
+      fromWatermark: '03',
+      throughWatermark: '04',
+      matched: 1,
+      oversized: 0,
+    });
+  });
+
+  test('caps total catchup bytes per source and defers, then skips, a wide transaction', async () => {
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'narrow'})),
+      // One row wider than a whole cycle budget.
+      tx('04', messages.insert('foo', {id: 'wide', pad: 'x'.repeat(5000)})),
+    );
+    const comparator = newComparator({maxBytesPerSourcePerCycle: 2000});
+
+    // The narrow transaction fits and spends part of the budget. The wide one
+    // cannot fit in what remains, so it waits for a fresh budget.
+    expect(await comparator.compareOnce()).toMatchObject({
+      throughWatermark: '03',
+      transactions: 1,
+      sampled: 2,
+      matched: 1,
+      deferred: 1,
+      oversized: 0,
+      mismatched: 0,
+    });
+
+    // A fresh budget does not fit it either, so it is skipped rather than
+    // retried forever, and the cursor advances past it.
+    expect(await comparator.compareOnce()).toMatchObject({
+      fromWatermark: '03',
+      throughWatermark: '04',
+      sampled: 1,
+      matched: 0,
+      deferred: 0,
+      oversized: 1,
+      mismatched: 0,
+    });
+    // A byte limit is not divergence.
+    expect(divergedWatermarks()).toEqual([]);
+  });
+
+  test('a generous byte budget leaves the row budget binding', async () => {
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'first'})),
+      tx(
+        '04',
+        messages.insert('foo', {id: 'second-a'}),
+        messages.insert('foo', {id: 'second-b'}),
+      ),
+    );
+    // The same expectations as the row-budget test above.
+    const comparator = newComparator({
+      maxRowsPerSourcePerCycle: 5,
+      maxBytesPerSourcePerCycle: 1024 * 1024,
+      readBatchRows: 2,
+    });
+
+    expect(await comparator.compareOnce()).toMatchObject({
+      throughWatermark: '03',
+      matched: 1,
+      deferred: 1,
+      oversized: 0,
+    });
+    expect(await comparator.compareOnce()).toMatchObject({
+      fromWatermark: '03',
+      throughWatermark: '04',
+      matched: 1,
+      deferred: 0,
+      oversized: 0,
+    });
+  });
+
+  test('compares a transaction that exactly fills the cycle row budget', async () => {
+    await feedBoth(tx('03', messages.insert('foo', {id: 'exact'})));
+
+    expect(
+      await newComparator({maxRowsPerSourcePerCycle: 3}).compareOnce(),
+    ).toMatchObject({
+      throughWatermark: '03',
+      matched: 1,
+      deferred: 0,
+      oversized: 0,
+    });
+  });
+
+  test('a divergent cursor boundary does not wedge the comparator', async () => {
+    // Remove the transaction at the common upper bound.
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'boundary'})),
+      tx('04', messages.insert('foo', {id: 'sqlite-lost'})),
+    );
+    feedSQLiteOnly(tx('05', messages.insert('foo', {id: 'log-leads'})));
+    deleteFromSQLiteLog(`"watermark" = '04'`);
+
+    const comparator = newComparator();
+    expect(await comparator.compareOnce()).toMatchObject({
+      throughWatermark: '04',
+      matched: 1,
+      mismatched: 1,
+    });
+    expect(divergedWatermarks()).toEqual(['04']);
+
+    // The next cycle starts at the missing boundary and compares later rows.
+    await feedBoth(tx('06', messages.insert('foo', {id: 'next'})));
+
+    const before = logSink.messages.length;
+    expect(await comparator.compareOnce()).toMatchObject({
+      throughWatermark: '06',
+      matched: 1,
+      mismatched: 2,
+    });
+    expect(divergedWatermarks(before)).toEqual(['04', '05']);
+
+    // The cursor advanced.
+    expect(await comparator.compareOnce()).toEqual({
+      kind: 'skipped',
+      reason: 'nothing-to-compare',
+    });
+  });
+
+  test('a capped cycle schedules its continuation without the poll delay', async () => {
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'a'})),
+      tx('04', messages.insert('foo', {id: 'b'})),
+      tx('05', messages.insert('foo', {id: 'c'})),
+    );
+
+    type Scheduled = {callback: () => void; delayMs: number};
+    const scheduled = new Map<ReturnType<typeof setTimeout>, Scheduled>();
+    let nextTimer = 0;
+    const setTimeoutFn = vi.fn((callback: () => void, delayMs?: number) => {
+      const handle = ++nextTimer as unknown as ReturnType<typeof setTimeout>;
+      scheduled.set(handle, {callback, delayMs: delayMs ?? 0});
+      return handle;
+    }) as unknown as typeof setTimeout;
+    const clearTimeoutFn = vi.fn((handle: ReturnType<typeof setTimeout>) => {
+      scheduled.delete(handle);
+    }) as unknown as typeof clearTimeout;
+    const comparator = newComparator({
+      intervalMs: 30_000,
+      maxTransactionsPerCycle: 2,
+      setTimeoutFn,
+      clearTimeoutFn,
+    });
+
+    expect(Array.from(scheduled.values(), ({delayMs}) => delayMs)).toEqual([
+      30_000,
+    ]);
+    expect(await comparator.compareOnce()).toMatchObject({
+      throughWatermark: '04',
+      transactions: 2,
+    });
+    expect(Array.from(scheduled.values(), ({delayMs}) => delayMs)).toEqual([0]);
+
+    comparator.stop();
+  });
+
+  test('divergence reports carry no payload data', async () => {
+    const sentinel = 'SENSITIVE-PAYLOAD-8675309';
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'boundary'})),
+      tx('04', messages.insert('foo', {id: sentinel, secret: sentinel})),
+    );
+    await mutatePGChange('04', 1, change => {
+      (change.new as Record<string, unknown>).secret = `${sentinel}-mutated`;
+    });
+
+    const before = logSink.messages.length;
+    const result = await newComparator().compareOnce();
+    expect(result).toMatchObject({mismatched: 1});
+
+    // Results and logs contain neither payloads nor digests.
+    expect(JSON.stringify(result)).not.toContain(sentinel);
+    expect(JSON.stringify(logSink.messages.slice(before))).not.toContain(
+      sentinel,
+    );
+    expect(divergedWatermarks(before)).toEqual(['04']);
+  });
+
+  test('declines a cold log, a wrong identity, and an absent file', async () => {
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'boundary'})),
+      tx('04', messages.insert('foo', {id: 'content'})),
+    );
+
+    expect(
+      await newComparator({
+        now: () => seededAtMs + RETENTION_MS - 1,
+      }).compareOnce(),
+    ).toEqual({kind: 'skipped', reason: 'cold-log'});
+
+    expect(
+      await newComparator({
+        logIdentity: {...identity, replicaID: 'someone-else'},
+      }).compareOnce(),
+    ).toEqual({kind: 'skipped', reason: 'ineligible-identity'});
+
+    expect(
+      await newComparator({file: `${logFile.path}-absent`}).compareOnce(),
+    ).toEqual({kind: 'skipped', reason: 'log-unavailable'});
+
+    expect(await newComparator().compareOnce()).toMatchObject({
+      matched: 2,
+      mismatched: 0,
+    });
+  });
+
+  test('a freshly seeded log with no traffic has nothing to compare', async () => {
+    // Synthetic seed transactions are boundaries, not compared output.
+    expect(await newComparator().compareOnce()).toEqual({
+      kind: 'skipped',
+      reason: 'nothing-to-compare',
+    });
+  });
+
+  test('stop() ends the comparator', async () => {
+    await feedBoth(
+      tx('03', messages.insert('foo', {id: 'boundary'})),
+      tx('04', messages.insert('foo', {id: 'content'})),
+    );
+    const comparator = newComparator();
+    comparator.stop();
+    expect(await comparator.compareOnce()).toEqual({
+      kind: 'skipped',
+      reason: 'stopped',
+    });
+  });
+
+  test('property: every corrupted transaction is reported, every clean one is not', async () => {
+    type CorruptionKind = 'clean' | 'drop-sqlite' | 'drop-pg' | 'mutate-pg';
+
+    const faultScenario = fc.record({
+      txs: fc.array(
+        fc.record({
+          width: fc.integer({min: 0, max: 3}),
+          kind: fc.constantFrom<CorruptionKind>(
+            'clean',
+            'drop-sqlite',
+            'drop-pg',
+            'mutate-pg',
+          ),
+        }),
+        {minLength: 1, maxLength: 5},
+      ),
+    });
+
+    // Each run starts above the watermarks from earlier runs.
+    let nextNum = 1;
+    const wm = (n: number) => `w${String(n).padStart(8, '0')}`;
+
+    await fc.assert(
+      fc.asyncProperty(faultScenario, async ({txs}) => {
+        const base = nextNum;
+        nextNum += (txs.length + 2) * 10;
+
+        const runFile = new DbFile('sqlite-change-log-comparator-fuzz');
+        const runWriter = new SQLiteChangeLogWriter(lc, {
+          replicaFile: runFile.path,
+          identity,
+          now: () => seededAtMs,
+        });
+        try {
+          runWriter.reconcile({
+            resumeWatermark: wm(base),
+            cookies: EMPTY_COOKIE_SET,
+          });
+
+          const specs = txs.map((spec, i) => ({
+            ...spec,
+            watermark: wm(base + (i + 1) * 10),
+          }));
+          // A clean sentinel keeps generated transactions below the common head.
+          const sentinel = wm(base + (txs.length + 1) * 10);
+
+          const feedRun = (t: Tx) => {
+            for (const change of t.changes) {
+              runWriter.write(change, storer.store(t.watermark, change));
+            }
+          };
+          for (const spec of specs) {
+            feedRun(
+              tx(
+                spec.watermark,
+                ...Array.from({length: spec.width}, (_, k) =>
+                  messages.insert('foo', {id: `${spec.watermark}-${k}`}),
+                ),
+              ),
+            );
+          }
+          feedRun(tx(sentinel, messages.insert('foo', {id: sentinel})));
+          await storer.allProcessed();
+
+          const withRunLog = <T>(fn: (db: Database) => T): T => {
+            const db = new Database(lc, changeLogFileName(runFile.path));
+            try {
+              return fn(db);
+            } finally {
+              db.close();
+            }
+          };
+
+          // Apply each fault and record its expected watermark.
+          const expected: string[] = [];
+          let expectedMatched = 1; // The sentinel matches.
+          for (const spec of specs) {
+            switch (spec.kind) {
+              case 'clean':
+                expectedMatched++;
+                break;
+              case 'drop-sqlite':
+                withRunLog(db =>
+                  db
+                    .prepare(
+                      /*sql*/ `DELETE FROM "${CHANGE_LOG_STREAM_TABLE}" WHERE "watermark" = ?`,
+                    )
+                    .run(spec.watermark),
+                );
+                expected.push(spec.watermark);
+                break;
+              case 'drop-pg':
+                await sql`
+                  DELETE FROM ${cdc('changeLog')} WHERE watermark = ${spec.watermark}`;
+                expected.push(spec.watermark);
+                break;
+              case 'mutate-pg':
+                await mutatePGChange(spec.watermark, 0, change => {
+                  change.mutated = true;
+                });
+                expected.push(spec.watermark);
+                break;
+            }
+          }
+
+          const before = logSink.messages.length;
+          const comparator = newComparator({
+            file: changeLogFileName(runFile.path),
+          });
+          let matched = 0;
+          for (let guard = 0; ; guard++) {
+            assert(guard < 8, 'comparator failed to reach quiescence');
+            const result = await comparator.compareOnce();
+            if (result.kind === 'skipped') {
+              expect(result.reason).toBe('nothing-to-compare');
+              break;
+            }
+            matched += result.matched;
+          }
+
+          expect(divergedWatermarks(before).toSorted()).toEqual(
+            expected.toSorted(),
+          );
+          expect(matched).toBe(expectedMatched);
+        } finally {
+          runWriter.close();
+          deleteChangeLogDB(runFile.path);
+          runFile.delete();
+        }
+      }),
+      {numRuns: 10},
+    );
+  });
+});

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.ts
@@ -1,0 +1,799 @@
+import type {LogContext} from '@rocicorp/logger';
+import {Database} from '../../../../zqlite/src/db.ts';
+import {
+  getOrCreateCounter,
+  getOrCreateLatencyHistogram,
+} from '../../observability/metrics.ts';
+import type {ShardID} from '../../types/shards.ts';
+import {
+  CHANGE_LOG_DB_SCHEMA_VERSION,
+  CHANGE_LOG_STREAM_TABLE,
+  readChangeLogMeta,
+  type ChangeLogIdentity,
+  type ChangeLogMeta,
+} from '../replicator/change-log-db.ts';
+import {
+  reconstructWatermarkedChange,
+  type ChangeLogEntry,
+} from './change-log-codec.ts';
+import {
+  digestCatchupRange,
+  isSampledForCompare,
+  type CatchupRangeDigest,
+} from './change-log-compare-digest.ts';
+import type {WatermarkedChange} from './change-streamer.ts';
+import {SQLiteChangeLogReader} from './sqlite-change-log-reader.ts';
+
+/** Interval between comparison cycles. */
+const DEFAULT_COMPARE_INTERVAL_MS = 30_000;
+
+/** Maximum transactions enumerated per cycle. */
+const DEFAULT_MAX_TRANSACTIONS_PER_CYCLE = 256;
+
+/** Maximum catchup rows read from each store per cycle. */
+const DEFAULT_MAX_ROWS_PER_SOURCE_PER_CYCLE = 1000;
+
+/**
+ * Maximum catchup bytes read from each store per cycle.
+ *
+ * Rows bound the per-row overhead. Bytes bound the read and hash work,
+ * which scales with payload size instead of row count. Normal traffic
+ * reaches the row limit first. Wide payloads reach this one.
+ */
+const DEFAULT_MAX_BYTES_PER_SOURCE_PER_CYCLE = 32 * 1024 * 1024;
+
+/** Rows per SQLite catchup batch. */
+const DEFAULT_READ_BATCH_ROWS = 1000;
+
+/**
+ * Result for one committed transaction.
+ *
+ * `mismatch` covers missing, extra, changed, or reordered rows.
+ * `inconclusive` means that store bounds changed during the comparison.
+ */
+export type CompareOutcome =
+  | 'match'
+  | 'mismatch'
+  | 'inconclusive'
+  | 'deferred'
+  | 'oversized';
+
+export type CompareSkipReason =
+  // The comparator was stopped.
+  | 'stopped'
+  // The writer replaced the file during this cycle.
+  | 'log-rebuilt'
+  // The file is absent, unreadable, or uninitialized.
+  | 'log-unavailable'
+  // The schema version does not match this build.
+  | 'ineligible-schema'
+  // The log belongs to a different replica.
+  | 'ineligible-identity'
+  // The log is younger than the warm-up period.
+  | 'cold-log'
+  // The stores have no complete committed range in common.
+  | 'nothing-to-compare'
+  // The cycle failed. The error was logged and counted.
+  | 'error';
+
+export type CompareCycleResult =
+  | {readonly kind: 'skipped'; readonly reason: CompareSkipReason}
+  | {
+      readonly kind: 'compared';
+      /** Exclusive lower bound of the compared range. */
+      readonly fromWatermark: string;
+      /** Inclusive upper bound handled. The next cycle resumes from here. */
+      readonly throughWatermark: string;
+      /** Committed transactions handled through `throughWatermark`. */
+      readonly transactions: number;
+      /** Transactions with compared catchup output. */
+      readonly sampled: number;
+      readonly matched: number;
+      readonly mismatched: number;
+      /** Suspects rejected because store bounds changed. */
+      readonly inconclusive: number;
+      /** Sampled transactions deferred to a fresh budget. */
+      readonly deferred: number;
+      /** Sampled transactions that exceed a fresh budget. */
+      readonly oversized: number;
+    };
+
+/** Provides the Postgres side of the catchup comparison. */
+export interface PGChangeLogRangeReader {
+  getCatchupBounds(): Promise<{
+    minWatermark: string | null;
+    lastWatermark: string;
+  }>;
+  listCommitWatermarks(
+    afterWatermark: string,
+    throughWatermark: string,
+    limit: number,
+  ): Promise<string[]>;
+  readCatchupRange(
+    afterWatermark: string,
+    throughWatermark: string,
+    batchRows?: number | undefined,
+  ): AsyncIterable<ChangeLogEntry[]>;
+}
+
+export type SQLiteChangeLogCompareOptions = {
+  /** Stable percentage of transactions selected for payload comparison. */
+  readonly comparePercent: number;
+  /** Warm-up time after a seed. The comparator skips a younger log. */
+  readonly retentionMs: number;
+  readonly intervalMs?: number | undefined;
+  readonly maxTransactionsPerCycle?: number | undefined;
+  /** Maximum catchup rows read from each store in one cycle. */
+  readonly maxRowsPerSourcePerCycle?: number | undefined;
+  /** Maximum catchup bytes read from each store in one cycle. */
+  readonly maxBytesPerSourcePerCycle?: number | undefined;
+  readonly readBatchRows?: number | undefined;
+  /** Clock for the warm-up period. Defaults to `Date.now`. */
+  readonly now?: (() => number) | undefined;
+  readonly setTimeoutFn?: typeof setTimeout | undefined;
+  readonly clearTimeoutFn?: typeof clearTimeout | undefined;
+  /** Yields between sampled transactions. Defaults to `setImmediate`. */
+  readonly yieldFn?: (() => Promise<void>) | undefined;
+};
+
+/** Uses separate aggregates so SQLite can use an index for each value. */
+const SQLITE_BOUNDS_SQL = /*sql*/ `
+  SELECT
+    (SELECT min("watermark") FROM "${CHANGE_LOG_STREAM_TABLE}")
+      AS "minWatermark",
+    (SELECT max("watermark") FROM "${CHANGE_LOG_STREAM_TABLE}")
+      AS "headWatermark"
+`;
+
+/** Lists committed transaction watermarks in `(@after, @through]`. */
+const SQLITE_COMMITS_SQL = /*sql*/ `
+  SELECT "watermark" FROM "${CHANGE_LOG_STREAM_TABLE}"
+   WHERE "precommit" IS NOT NULL
+     AND "watermark" > @after
+     AND "watermark" <= @through
+   ORDER BY "watermark"
+   LIMIT @limit
+`;
+
+type SQLiteBounds = {
+  readonly minWatermark: string;
+  readonly headWatermark: string;
+};
+
+type PinnedBounds = {
+  readonly meta: ChangeLogMeta;
+  readonly sqlite: SQLiteBounds;
+  readonly pgMinWatermark: string;
+  readonly pgLastWatermark: string;
+};
+
+type SampledComparison = {
+  readonly outcome: CompareOutcome;
+  readonly sqliteRowsRead: number;
+  readonly pgRowsRead: number;
+  readonly sqliteBytesRead: number;
+  readonly pgBytesRead: number;
+};
+
+/**
+ * Compares SQLite and Postgres catchup output without affecting subscribers.
+ *
+ * Each cycle compares complete ranges through the lower store head.
+ * It checks every transaction for presence and samples payloads.
+ * A bounds change makes the affected result `inconclusive`.
+ * Postgres remains authoritative.
+ */
+export class SQLiteChangeLogComparator {
+  readonly #lc: LogContext;
+  readonly #shard: ShardID;
+  readonly #changeLogFile: string;
+  readonly #identity: ChangeLogIdentity;
+  readonly #pg: PGChangeLogRangeReader;
+  readonly #opts: SQLiteChangeLogCompareOptions;
+  readonly #now: () => number;
+  readonly #setTimeoutFn: typeof setTimeout;
+  readonly #clearTimeoutFn: typeof clearTimeout;
+  readonly #yield: () => Promise<void>;
+
+  readonly #compareResults = getOrCreateCounter(
+    'replica',
+    'sqlite_change_log.compare_result',
+    'Outcomes of the dark comparison between what SQLite catchup serves and ' +
+      'what PG catchup serves, per committed transaction. `inconclusive` ' +
+      'means a purge or reseed moved the pinned bounds mid-comparison.',
+  );
+  readonly #compareCycles = getOrCreateCounter(
+    'replica',
+    'sqlite_change_log.compare_cycles',
+    'SQLite change-log comparison cycles, by result.',
+  );
+  readonly #cycleDuration = getOrCreateLatencyHistogram(
+    'replica',
+    'sqlite_change_log.compare_cycle_duration',
+    'Duration of one SQLite change-log comparison cycle.',
+  );
+
+  /** Last handled commit watermark. A restart derives it from current bounds. */
+  #cursor: string | undefined;
+  #running: Promise<CompareCycleResult> | undefined;
+  #timer: ReturnType<typeof setTimeout> | undefined;
+  #stopped = false;
+  #continueWithoutDelay = false;
+  #fileGeneration = 0;
+
+  constructor(
+    lc: LogContext,
+    shard: ShardID,
+    changeLogFile: string,
+    identity: ChangeLogIdentity,
+    pg: PGChangeLogRangeReader,
+    opts: SQLiteChangeLogCompareOptions,
+  ) {
+    this.#lc = lc.withContext('component', 'sqlite-change-log-compare');
+    this.#shard = shard;
+    this.#changeLogFile = changeLogFile;
+    this.#identity = identity;
+    this.#pg = pg;
+    this.#opts = opts;
+    this.#now = opts.now ?? Date.now;
+    this.#setTimeoutFn = opts.setTimeoutFn ?? setTimeout;
+    this.#clearTimeoutFn = opts.clearTimeoutFn ?? clearTimeout;
+    this.#yield =
+      opts.yieldFn ??
+      (() => new Promise<void>(resolve => setImmediate(resolve)));
+    this.#scheduleNext();
+  }
+
+  /**
+   * Runs one cycle. Concurrent calls share the same promise.
+   * Errors produce `skipped: 'error'`.
+   */
+  compareOnce(): Promise<CompareCycleResult> {
+    if (this.#stopped) {
+      return Promise.resolve({kind: 'skipped', reason: 'stopped'});
+    }
+    if (this.#running === undefined) {
+      this.#running = this.#runCycle()
+        .then(result => {
+          if (this.#continueWithoutDelay) {
+            this.#rescheduleNext(0);
+          }
+          return result;
+        })
+        .finally(() => {
+          this.#running = undefined;
+        });
+    }
+    return this.#running;
+  }
+
+  stop(): void {
+    this.#stopped = true;
+    if (this.#timer !== undefined) {
+      this.#clearTimeoutFn(this.#timer);
+      this.#timer = undefined;
+    }
+  }
+
+  /** Invalidates cycles that can still read a replaced file. */
+  invalidate(): void {
+    this.#fileGeneration++;
+    this.#cursor = undefined;
+    this.#continueWithoutDelay = false;
+  }
+
+  #scheduleNext(
+    delayMs = this.#opts.intervalMs ?? DEFAULT_COMPARE_INTERVAL_MS,
+  ): void {
+    if (this.#stopped || this.#timer !== undefined) {
+      return;
+    }
+    this.#timer = this.#setTimeoutFn(() => {
+      this.#timer = undefined;
+      void this.compareOnce().finally(() => this.#scheduleNext());
+    }, delayMs);
+  }
+
+  #rescheduleNext(delayMs: number): void {
+    if (this.#timer !== undefined) {
+      this.#clearTimeoutFn(this.#timer);
+      this.#timer = undefined;
+    }
+    this.#scheduleNext(delayMs);
+  }
+
+  async #runCycle(): Promise<CompareCycleResult> {
+    const startedAt = performance.now();
+    const fileGeneration = this.#fileGeneration;
+    this.#continueWithoutDelay = false;
+    let db: Database | undefined;
+    let reader: SQLiteChangeLogReader | undefined;
+    try {
+      try {
+        // A readonly handle does not create a missing file.
+        db = new Database(this.#lc, this.#changeLogFile, {readonly: true});
+      } catch {
+        return this.#skipped('log-unavailable');
+      }
+
+      const pinned = await this.#pinBounds(db);
+      if (fileGeneration !== this.#fileGeneration) {
+        return this.#skipped('log-rebuilt');
+      }
+      if (typeof pinned === 'string') {
+        return this.#skipped(pinned);
+      }
+      const {meta} = pinned;
+
+      const from = maxWatermark(
+        this.#cursor ?? meta.seedWatermark,
+        // Exclude the synthetic SQLite seed transaction.
+        // The Postgres seed has no `precommit`, so enumeration also excludes it.
+        meta.seedWatermark,
+        // A store cannot serve the transaction at its minimum watermark.
+        pinned.pgMinWatermark,
+        pinned.sqlite.minWatermark,
+      );
+      const through = minWatermark(
+        pinned.pgLastWatermark,
+        pinned.sqlite.headWatermark,
+      );
+      if (through <= from) {
+        return this.#skipped('nothing-to-compare');
+      }
+
+      let transactions = 0;
+      let sampled = 0;
+      const outcomes: Record<CompareOutcome, number> = {
+        match: 0,
+        mismatch: 0,
+        inconclusive: 0,
+        deferred: 0,
+        oversized: 0,
+      };
+      const record = (watermark: string, outcome: CompareOutcome) => {
+        this.#compareResults.add(1, {outcome});
+        outcomes[outcome]++;
+        if (outcome === 'mismatch') {
+          // Log only the watermark because payloads contain customer data.
+          this.#lc.error?.(
+            'SQLite change-log catchup output diverged from Postgres',
+            {sqliteChangeLogCompare: {watermark}},
+          );
+        }
+      };
+
+      reader = new SQLiteChangeLogReader(this.#lc, this.#changeLogFile);
+      const plan = reader.plan(from);
+      if (plan.kind === 'not-ready') {
+        return this.#skipped('log-unavailable');
+      }
+      if (plan.kind === 'ahead') {
+        return this.#skipped('nothing-to-compare');
+      }
+      if (plan.kind === 'too-old') {
+        // A fixed lower bound makes this result a mismatch.
+        // A changed lower bound makes it inconclusive.
+        const reconfirmed = await this.#reconfirm(db, pinned, from);
+        const outcome =
+          fileGeneration === this.#fileGeneration
+            ? reconfirmed
+            : 'inconclusive';
+        record(from, outcome);
+        if (outcome === 'inconclusive') {
+          // Keep the cursor unchanged because the bounds moved.
+          return this.#compared(from, from, transactions, sampled, outcomes);
+        }
+        // Positional reads can continue after a missing boundary.
+        // Advancing avoids reporting the same boundary in every cycle.
+      }
+
+      const limit = Math.max(
+        1,
+        this.#opts.maxTransactionsPerCycle ??
+          DEFAULT_MAX_TRANSACTIONS_PER_CYCLE,
+      );
+      const union = await this.#enumerateCommits(db, from, through, limit);
+      if (fileGeneration !== this.#fileGeneration) {
+        return this.#skipped('log-rebuilt');
+      }
+      const maxRowsPerSource = Math.max(
+        1,
+        this.#opts.maxRowsPerSourcePerCycle ??
+          DEFAULT_MAX_ROWS_PER_SOURCE_PER_CYCLE,
+      );
+      const maxBytesPerSource = Math.max(
+        1,
+        this.#opts.maxBytesPerSourcePerCycle ??
+          DEFAULT_MAX_BYTES_PER_SOURCE_PER_CYCLE,
+      );
+
+      let sqliteRowsRead = 0;
+      let pgRowsRead = 0;
+      let sqliteBytesRead = 0;
+      let pgBytesRead = 0;
+      let previousBoundary = from;
+      let handledThrough = from;
+      for (const {watermark, inSqlite, inPg} of union) {
+        if (this.#stopped) {
+          break;
+        }
+        let stopAfterTransaction = false;
+        if (!inSqlite || !inPg) {
+          // Check every transaction for presence because this needs no payload read.
+          const outcome = await this.#reconfirm(db, pinned, watermark);
+          record(
+            watermark,
+            fileGeneration === this.#fileGeneration ? outcome : 'inconclusive',
+          );
+        } else if (
+          isSampledForCompare(this.#shard, watermark, this.#opts.comparePercent)
+        ) {
+          const sqliteRowsRemaining = maxRowsPerSource - sqliteRowsRead;
+          const pgRowsRemaining = maxRowsPerSource - pgRowsRead;
+          // A read may pass the byte budget by its last row, so this
+          // compares against zero rather than checking for equality.
+          const sqliteBytesRemaining = maxBytesPerSource - sqliteBytesRead;
+          const pgBytesRemaining = maxBytesPerSource - pgBytesRead;
+          if (
+            sqliteRowsRemaining === 0 ||
+            pgRowsRemaining === 0 ||
+            sqliteBytesRemaining <= 0 ||
+            pgBytesRemaining <= 0
+          ) {
+            record(watermark, 'deferred');
+            break;
+          }
+          sampled++;
+          const comparison = await this.#compareTransaction(
+            db,
+            reader,
+            pinned,
+            previousBoundary,
+            watermark,
+            sqliteRowsRemaining,
+            pgRowsRemaining,
+            sqliteBytesRemaining,
+            pgBytesRemaining,
+            maxRowsPerSource,
+            maxBytesPerSource,
+          );
+          sqliteRowsRead += comparison.sqliteRowsRead;
+          pgRowsRead += comparison.pgRowsRead;
+          sqliteBytesRead += comparison.sqliteBytesRead;
+          pgBytesRead += comparison.pgBytesRead;
+          const outcome =
+            fileGeneration === this.#fileGeneration
+              ? comparison.outcome
+              : 'inconclusive';
+          record(watermark, outcome);
+          if (outcome === 'inconclusive') {
+            break;
+          }
+          if (outcome === 'deferred') {
+            break;
+          }
+          if (outcome === 'oversized') {
+            // Advance past a transaction that cannot fit in a fresh budget.
+            stopAfterTransaction = true;
+          }
+          // Yield between sampled reads so other stream work can continue.
+          await this.#yield();
+        }
+        previousBoundary = watermark;
+        handledThrough = watermark;
+        transactions++;
+        if (stopAfterTransaction) {
+          break;
+        }
+      }
+
+      if (
+        !this.#stopped &&
+        fileGeneration === this.#fileGeneration &&
+        outcomes.inconclusive === 0
+      ) {
+        this.#cursor = handledThrough;
+        this.#continueWithoutDelay = handledThrough < through;
+      }
+      return this.#compared(
+        from,
+        handledThrough,
+        transactions,
+        sampled,
+        outcomes,
+      );
+    } catch (e) {
+      this.#lc.warn?.('error comparing the SQLite change log', e);
+      return this.#skipped('error');
+    } finally {
+      reader?.close();
+      db?.close();
+      this.#cycleDuration.recordMs(performance.now() - startedAt);
+    }
+  }
+
+  /** Checks log eligibility and reads the bounds from both stores. */
+  async #pinBounds(db: Database): Promise<PinnedBounds | CompareSkipReason> {
+    let meta: ChangeLogMeta;
+    try {
+      meta = readChangeLogMeta(db);
+    } catch {
+      // The writer has not initialized the log.
+      return 'log-unavailable';
+    }
+    if (meta.schemaVersion !== CHANGE_LOG_DB_SCHEMA_VERSION) {
+      return 'ineligible-schema';
+    }
+    const {epoch, generation, replicaID} = this.#identity;
+    if (
+      meta.epoch !== epoch ||
+      meta.generation !== generation ||
+      meta.replicaID !== replicaID
+    ) {
+      return 'ineligible-identity';
+    }
+    if (this.#now() - meta.seededAtMs < this.#opts.retentionMs) {
+      return 'cold-log';
+    }
+    const sqlite = this.#readSQLiteBounds(db);
+    if (sqlite === undefined) {
+      return 'log-unavailable';
+    }
+    const {minWatermark, lastWatermark} = await this.#pg.getCatchupBounds();
+    if (minWatermark === null) {
+      // Only a new replica has an empty Postgres change log.
+      return 'nothing-to-compare';
+    }
+    return {
+      meta,
+      sqlite,
+      pgMinWatermark: minWatermark,
+      pgLastWatermark: lastWatermark,
+    };
+  }
+
+  #readSQLiteBounds(db: Database): SQLiteBounds | undefined {
+    const bounds = db
+      .prepare(SQLITE_BOUNDS_SQL)
+      .get<{minWatermark: string | null; headWatermark: string | null}>();
+    return bounds.minWatermark === null || bounds.headWatermark === null
+      ? undefined
+      : {
+          minWatermark: bounds.minWatermark,
+          headWatermark: bounds.headWatermark,
+        };
+  }
+
+  /**
+   * Merges committed transaction watermarks from both stores.
+   * If a list reaches the limit, the result ends at the last complete common range.
+   */
+  async #enumerateCommits(
+    db: Database,
+    from: string,
+    through: string,
+    limit: number,
+  ): Promise<{watermark: string; inSqlite: boolean; inPg: boolean}[]> {
+    let sqlite: string[] = db
+      .prepare(SQLITE_COMMITS_SQL)
+      .all<{watermark: string}>({after: from, through, limit: limit + 1})
+      .map(({watermark}) => watermark);
+    let pg = await this.#pg.listCommitWatermarks(from, through, limit + 1);
+
+    let effectiveThrough = through;
+    if (sqlite.length > limit) {
+      sqlite.length = limit;
+      effectiveThrough = minWatermark(effectiveThrough, sqlite[limit - 1]);
+    }
+    if (pg.length > limit) {
+      pg.length = limit;
+      effectiveThrough = minWatermark(effectiveThrough, pg[limit - 1]);
+    }
+    if (effectiveThrough !== through) {
+      sqlite = sqlite.filter(w => w <= effectiveThrough);
+      pg = pg.filter(w => w <= effectiveThrough);
+    }
+
+    const union: {watermark: string; inSqlite: boolean; inPg: boolean}[] = [];
+    let s = 0;
+    let p = 0;
+    while (s < sqlite.length || p < pg.length) {
+      const sw = s < sqlite.length ? sqlite[s] : undefined;
+      const pw = p < pg.length ? pg[p] : undefined;
+      if (sw !== undefined && (pw === undefined || sw < pw)) {
+        union.push({watermark: sw, inSqlite: true, inPg: false});
+        s++;
+      } else if (pw !== undefined && (sw === undefined || pw < sw)) {
+        union.push({watermark: pw, inSqlite: false, inPg: true});
+        p++;
+      } else if (sw !== undefined) {
+        union.push({watermark: sw, inSqlite: true, inPg: true});
+        s++;
+        p++;
+      }
+    }
+    return union;
+  }
+
+  /**
+   * Compares the output in `(previousBoundary, watermark]`.
+   * Positional reads do not require either store to contain the boundary row.
+   */
+  async #compareTransaction(
+    db: Database,
+    reader: SQLiteChangeLogReader,
+    pinned: PinnedBounds,
+    previousBoundary: string,
+    watermark: string,
+    sqliteMaxRows: number,
+    pgMaxRows: number,
+    sqliteMaxBytes: number,
+    pgMaxBytes: number,
+    maxRowsPerSource: number,
+    maxBytesPerSource: number,
+  ): Promise<SampledComparison> {
+    let sqlite: CatchupRangeDigest;
+    let pg: CatchupRangeDigest;
+    try {
+      const readBatchRows = this.#opts.readBatchRows ?? DEFAULT_READ_BATCH_ROWS;
+      sqlite = await digestCatchupRange(
+        reader.read(
+          previousBoundary,
+          watermark,
+          Math.min(readBatchRows, sqliteMaxRows),
+          undefined,
+          sqliteMaxRows,
+        ),
+        watermark,
+        sqliteMaxRows,
+        sqliteMaxBytes,
+      );
+      pg = await digestCatchupRange(
+        reconstructBatches(
+          this.#pg.readCatchupRange(previousBoundary, watermark, pgMaxRows),
+        ),
+        watermark,
+        pgMaxRows,
+        pgMaxBytes,
+      );
+    } catch (e) {
+      // A failed catchup read makes the transaction suspect.
+      this.#lc.warn?.(
+        `error reading transaction ${watermark} for comparison`,
+        e,
+      );
+      return {
+        outcome: await this.#reconfirm(db, pinned, watermark),
+        sqliteRowsRead: 0,
+        pgRowsRead: 0,
+        sqliteBytesRead: 0,
+        pgBytesRead: 0,
+      };
+    }
+    const read = {
+      sqliteRowsRead: sqlite.rows,
+      pgRowsRead: pg.rows,
+      sqliteBytesRead: sqlite.bytes,
+      pgBytesRead: pg.bytes,
+    };
+    if (sqlite.limitReached || pg.limitReached) {
+      // Skip a transaction that cannot fit in a fresh budget.
+      // Defer one that does not fit only in the remaining budget.
+      // A budget is fresh when neither dimension has been spent.
+      const sqliteFresh =
+        sqliteMaxRows === maxRowsPerSource &&
+        sqliteMaxBytes === maxBytesPerSource;
+      const pgFresh =
+        pgMaxRows === maxRowsPerSource && pgMaxBytes === maxBytesPerSource;
+      const outcome =
+        (sqlite.limitReached && sqliteFresh) || (pg.limitReached && pgFresh)
+          ? 'oversized'
+          : 'deferred';
+      return {outcome, ...read};
+    }
+    if (sqlite.digest === pg.digest) {
+      return {outcome: 'match', ...read};
+    }
+    return {
+      outcome: await this.#reconfirm(db, pinned, watermark),
+      ...read,
+    };
+  }
+
+  /**
+   * Rechecks a suspect result against current store bounds.
+   * A moved bound, changed seed, failed read, or lower head makes the result inconclusive.
+   */
+  async #reconfirm(
+    db: Database,
+    pinned: PinnedBounds,
+    watermark: string,
+  ): Promise<'mismatch' | 'inconclusive'> {
+    try {
+      const meta = readChangeLogMeta(db);
+      if (
+        meta.seedWatermark !== pinned.meta.seedWatermark ||
+        meta.seededAtMs !== pinned.meta.seededAtMs
+      ) {
+        return 'inconclusive';
+      }
+      const sqlite = this.#readSQLiteBounds(db);
+      const {minWatermark, lastWatermark} = await this.#pg.getCatchupBounds();
+      if (sqlite === undefined || minWatermark === null) {
+        return 'inconclusive';
+      }
+      if (
+        (sqlite.minWatermark > pinned.sqlite.minWatermark &&
+          watermark <= sqlite.minWatermark) ||
+        (minWatermark > pinned.pgMinWatermark && watermark <= minWatermark) ||
+        watermark > sqlite.headWatermark ||
+        watermark > lastWatermark
+      ) {
+        return 'inconclusive';
+      }
+      return 'mismatch';
+    } catch {
+      return 'inconclusive';
+    }
+  }
+
+  #skipped(reason: CompareSkipReason): CompareCycleResult {
+    this.#compareCycles.add(1, {result: reason});
+    if (reason === 'error') {
+      // The caller logged the error.
+    } else if (reason !== 'nothing-to-compare') {
+      this.#lc.debug?.(`skipping SQLite change-log comparison: ${reason}`);
+    }
+    return {kind: 'skipped', reason};
+  }
+
+  #compared(
+    fromWatermark: string,
+    throughWatermark: string,
+    transactions: number,
+    sampled: number,
+    outcomes: Record<CompareOutcome, number>,
+  ): CompareCycleResult {
+    this.#compareCycles.add(1, {result: 'compared'});
+    const result = {
+      kind: 'compared',
+      fromWatermark,
+      throughWatermark,
+      transactions,
+      sampled,
+      matched: outcomes.match,
+      mismatched: outcomes.mismatch,
+      inconclusive: outcomes.inconclusive,
+      deferred: outcomes.deferred,
+      oversized: outcomes.oversized,
+    } as const;
+    this.#lc.debug?.('SQLite change-log comparison cycle', {
+      sqliteChangeLogCompare: result,
+    });
+    return result;
+  }
+}
+
+/** Applies the same reconstruction as Postgres catchup. */
+async function* reconstructBatches(
+  batches: AsyncIterable<ChangeLogEntry[]>,
+): AsyncIterable<WatermarkedChange[]> {
+  for await (const batch of batches) {
+    yield batch.map(reconstructWatermarkedChange);
+  }
+}
+
+function minWatermark(a: string, b: string): string {
+  return a < b ? a : b;
+}
+
+function maxWatermark(...watermarks: string[]): string {
+  let max = watermarks[0];
+  for (const w of watermarks) {
+    if (w > max) {
+      max = w;
+    }
+  }
+  return max;
+}


### PR DESCRIPTION
Adds the background service that compares catchup output between the Postgres and SQLite change logs. Not yet constructed by anything.
