### PR TITLE
chore(rmv2): turns on change log comparison when compare mode is enabled

### DIFF
--- a/packages/zero-cache/src/config/normalize.test.ts
+++ b/packages/zero-cache/src/config/normalize.test.ts
@@ -12,6 +12,7 @@ function configWith(litestream: Partial<ZeroConfig['litestream']>): ZeroConfig {
       address: 'localhost',
       sqliteChangeLogMode: 'off',
       sqliteChangeLogReadPercent: 0,
+      sqliteChangeLogComparePercent: 1,
       sqliteChangeLogRetentionMs: 60_000,
       sqliteChangeLogReadBatchRows: 1000,
       sqliteChangeLogPurgeBatchRows: 1000,
@@ -128,6 +129,21 @@ describe('config/normalize SQLite change log', () => {
         'must be an integer between 0 and 100',
       );
     }
+  });
+
+  test('compare percentage must be an integer from 0 through 100, in any mode', () => {
+    for (const percent of [-1, 1.5, 101]) {
+      const config = configWith({});
+      config.changeStreamer.sqliteChangeLogComparePercent = percent;
+
+      expect(() => assertNormalized(config)).toThrow(
+        '--change-streamer-sqlite-change-log-compare-percent must be an integer between 0 and 100',
+      );
+    }
+    // A nonzero value is valid in every mode. Sampling starts in `compare` mode.
+    const config = configWith({});
+    config.changeStreamer.sqliteChangeLogComparePercent = 100;
+    expect(() => assertNormalized(config)).not.toThrow();
   });
 
   test('accepts positive integer tuning values', () => {

--- a/packages/zero-cache/src/config/normalize.ts
+++ b/packages/zero-cache/src/config/normalize.ts
@@ -46,6 +46,7 @@ export function assertNormalized(
   const {
     sqliteChangeLogMode,
     sqliteChangeLogReadPercent,
+    sqliteChangeLogComparePercent,
     sqliteChangeLogRetentionMs,
     sqliteChangeLogReadBatchRows,
     sqliteChangeLogPurgeBatchRows,
@@ -56,6 +57,13 @@ export function assertNormalized(
       sqliteChangeLogReadPercent >= 0 &&
       sqliteChangeLogReadPercent <= 100,
     '--change-streamer-sqlite-change-log-read-percent must be an integer between 0 and 100',
+  );
+  // This setting has no mode restriction. Comparison starts in `compare` mode.
+  assert(
+    Number.isSafeInteger(sqliteChangeLogComparePercent) &&
+      sqliteChangeLogComparePercent >= 0 &&
+      sqliteChangeLogComparePercent <= 100,
+    '--change-streamer-sqlite-change-log-compare-percent must be an integer between 0 and 100',
   );
   assert(
     sqliteChangeLogMode === 'serve' || sqliteChangeLogReadPercent === 0,

--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -724,6 +724,15 @@ export const zeroOptions = {
       hidden: true,
     },
 
+    sqliteChangeLogComparePercent: {
+      type: v.number().default(1),
+      desc: [
+        `The stable percentage of committed transactions whose catchup output is`,
+        `compared between the Postgres and SQLite change logs in {bold compare} mode.`,
+      ],
+      hidden: true,
+    },
+
     sqliteChangeLogRetentionMs: {
       type: v.number().default(60_000),
       desc: [`The minimum time window retained in the SQLite change log.`],

--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -67,6 +67,7 @@ export default async function runWorker(
       flowControlConsensusTimeoutProportion,
       flowControlSlowSubscriberGracePeriodSeconds,
       sqliteChangeLogMode,
+      sqliteChangeLogComparePercent,
       sqliteChangeLogRetentionMs,
       sqliteChangeLogReadBatchRows,
       sqliteChangeLogPurgeBatchRows,
@@ -250,11 +251,14 @@ export default async function runWorker(
                 batchRows: sqliteChangeLogPurgeBatchRows,
               }
             : undefined,
-          // `compare` and above. The replica-derived initialization path runs
-          // at full rate and is checked against Postgres, which stays
-          // authoritative. Flipping authority to the replica comes later.
+          // Compare mode runs both advisory checks. Postgres remains authoritative.
           sqliteChangeLogCompare: sqliteChangeLogComparing
-            ? {replicaFile: replica.file}
+            ? {
+                replicaFile: replica.file,
+                comparePercent: sqliteChangeLogComparePercent,
+                retentionMs: sqliteChangeLogRetentionMs,
+                readBatchRows: sqliteChangeLogReadBatchRows,
+              }
             : undefined,
         },
         setTimeout,

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
@@ -340,6 +340,7 @@ describe('change-streamer/service', () => {
     sqliteCatchup?: Partial<SQLiteCatchupOptions>,
     sqliteChangeLogPurge?: TuningOptions['sqliteChangeLogPurge'],
     backupURL?: string,
+    sqliteChangeLogCompare?: TuningOptions['sqliteChangeLogCompare'],
   ): Promise<void> {
     await streamer.stop();
     await streamerDone;
@@ -381,6 +382,9 @@ describe('change-streamer/service', () => {
           },
         },
         ...(sqliteChangeLogPurge === undefined ? {} : {sqliteChangeLogPurge}),
+        ...(sqliteChangeLogCompare === undefined
+          ? {}
+          : {sqliteChangeLogCompare}),
         ...(sqliteCatchup === undefined
           ? {}
           : {
@@ -870,6 +874,125 @@ describe('change-streamer/service', () => {
       storeSpy.mockRestore();
       writeSpy.mockRestore();
       forwardSpy.mockRestore();
+      await streamer.stop();
+      await streamerDone;
+      deleteChangeLogDB(logFile.path);
+      logFile.delete();
+    }
+  });
+
+  /**
+   * Compare mode runs initialization and catchup checks independently.
+   * Failures do not stop replication.
+   * A warm log reports injected Postgres divergence.
+   */
+  test('compare mode: both checks run and fail independently', async () => {
+    const COLD_INTERVAL_MS = 777_001;
+    const WARM_INTERVAL_MS = 777_002;
+    const logFile = new DbFile('sqlite-change-log-compare-coexist');
+    const noSuchReplica = `${logFile.path}-no-such-replica`;
+
+    const fireCompareCycle = (intervalMs: number, fromIndex: number) => {
+      const call = setTimeoutFn.mock.calls
+        .slice(fromIndex)
+        .find(([, delay]) => delay === intervalMs);
+      assert(call, `no comparison cycle scheduled at ${intervalMs}ms`);
+      (call[0] as () => void)();
+    };
+    const logged = (level: string, message: string) =>
+      logSink.messages.some(
+        ([lvl, , parts]) => lvl === level && parts[0] === message,
+      );
+    // Read diverged watermarks from production error logs.
+    const divergedWatermarks = () =>
+      logSink.messages
+        .filter(([level, , parts]) => level === 'error' && parts.length === 2)
+        .flatMap(([, , parts]) => {
+          const detail = (
+            parts[1] as {
+              sqliteChangeLogCompare?: {watermark: string} | undefined;
+            }
+          ).sqliteChangeLogCompare;
+          return detail === undefined ? [] : [detail.watermark];
+        });
+
+    try {
+      // Start with a new log and a missing replica file.
+      await restartWithInlineChangeLogWriter(
+        logFile,
+        {},
+        undefined,
+        undefined,
+        {
+          replicaFile: noSuchReplica,
+          comparePercent: 100,
+          retentionMs: 60_000,
+          intervalMs: COLD_INTERVAL_MS,
+        },
+      );
+
+      // Both advisory checks leave replication active.
+      changes.push(['begin', messages.begin(), {commitWatermark: '06'}]);
+      changes.push(['data', messages.insert('foo', {id: 'compared'})]);
+      changes.push(['commit', messages.commit(), {watermark: '06'}]);
+      await expectAcks('06');
+
+      // The missing replica causes a warning, but startup continues.
+      await vi.waitFor(() =>
+        expect(
+          logged(
+            'warn',
+            'failed to derive change-log initialization from the replica',
+          ),
+        ).toBe(true),
+      );
+
+      // The comparator skips the new log without reporting divergence.
+      fireCompareCycle(COLD_INTERVAL_MS, 0);
+      await vi.waitFor(() =>
+        expect(
+          logged('debug', 'skipping SQLite change-log comparison: cold-log'),
+        ).toBe(true),
+      );
+      expect(divergedWatermarks()).toEqual([]);
+
+      // Restart with a clock that makes the log warm.
+      const warmStart = setTimeoutFn.mock.calls.length;
+      await restartWithInlineChangeLogWriter(
+        logFile,
+        {},
+        undefined,
+        undefined,
+        {
+          replicaFile: noSuchReplica,
+          comparePercent: 100,
+          retentionMs: 60_000,
+          intervalMs: WARM_INTERVAL_MS,
+          now: () => Date.now() + 3_600_000,
+        },
+      );
+
+      changes.push(['begin', messages.begin(), {commitWatermark: '08'}]);
+      changes.push(['data', messages.insert('foo', {id: 'diverged'})]);
+      changes.push(['commit', messages.commit(), {watermark: '08'}]);
+      await expectAcks('08');
+
+      // Change the stored Postgres row after commit.
+      const [{change}] = await sql<{change: string}[]>`
+        SELECT change::text FROM "zoro_3/cdc"."changeLog"
+         WHERE watermark = '08' AND pos = 1`;
+      const mutated = JSON.stringify({
+        ...(JSON.parse(change) as Record<string, unknown>),
+        divergence: true,
+      });
+      await sql`
+        UPDATE "zoro_3/cdc"."changeLog" SET change = ${mutated}::json
+         WHERE watermark = '08' AND pos = 1`;
+
+      // Transaction 06 matches. Transaction 08 diverges.
+      fireCompareCycle(WARM_INTERVAL_MS, warmStart);
+      await vi.waitFor(() => expect(divergedWatermarks()).toEqual(['08']));
+    } finally {
       await streamer.stop();
       await streamerDone;
       deleteChangeLogDB(logFile.path);

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -59,6 +59,10 @@ import {
   type SQLiteChangeLogCleanupGuard,
 } from './sqlite-change-log-catchup.ts';
 import {
+  SQLiteChangeLogComparator,
+  type SQLiteChangeLogCompareOptions,
+} from './sqlite-change-log-comparator.ts';
+import {
   SQLiteChangeLogPurgeScheduler,
   type PurgeContinuation,
   type SQLiteChangeLogPurgeSchedulerOptions,
@@ -137,14 +141,15 @@ export type TuningOptions = StorerOptions & {
    */
   sqliteChangeLogPurge?: SQLiteChangeLogPurgeSchedulerOptions | undefined;
   /**
-   * Supplied at `sqliteChangeLogMode >= compare`, and the gate on deriving the
-   * stream's initialization parameters from the replica as well as from
-   * Postgres. Postgres stays authoritative; the two are compared and the
-   * result is reported. Not a new configuration option -- the mode ladder
-   * carries it, because a state in which the log's buffer and its cookies were
-   * at different rollout stages is what invariant 15 exists to forbid.
+   * Supplied in `compare` mode and later modes.
+   * `replicaFile` enables the initialization comparison.
+   * The other fields configure sampled catchup comparisons.
+   * Both checks are advisory, and Postgres remains authoritative.
+   * The comparator also requires the writer and catchup options.
    */
-  sqliteChangeLogCompare?: {replicaFile: string} | undefined;
+  sqliteChangeLogCompare?:
+    | (SQLiteChangeLogCompareOptions & {replicaFile: string})
+    | undefined;
 };
 
 /**
@@ -357,6 +362,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
   readonly #sqliteCatchupOptions: SQLiteCatchupOptions | undefined;
   readonly #changeLogWriter: SQLiteChangeLogWriter | undefined;
   readonly #purgeScheduler: SQLiteChangeLogPurgeScheduler | undefined;
+  readonly #comparator: SQLiteChangeLogComparator | undefined;
   readonly #acker: UpstreamAcker;
   readonly #initializer: ChangeLogInitializer;
 
@@ -479,8 +485,15 @@ class ChangeStreamerImpl implements ChangeStreamerService {
           // Fail-soft deletes the file, and the reader is cached here, so it
           // has to go with it: otherwise it serves an unlinked inode while
           // every new open sees nothing.
-          onDisabled: () => this.#closeSQLiteCatchup(),
-          onRebuilt: () => this.#closeSQLiteCatchup(),
+          onDisabled: () => {
+            this.#closeSQLiteCatchup();
+            this.#comparator?.stop();
+          },
+          onRebuilt: () => {
+            this.#closeSQLiteCatchup();
+            // Invalidate cycles that can still read the replaced file.
+            this.#comparator?.invalidate();
+          },
         })
       : undefined;
     // The purge scheduler runs on the writer's own connection, which is also
@@ -535,6 +548,20 @@ class ChangeStreamerImpl implements ChangeStreamerService {
             this.#purgeScheduler?.cleanupGuard,
         }
       : undefined;
+    // Compare mode requires the writer and catchup configuration.
+    this.#comparator =
+      opts.sqliteChangeLogCompare &&
+      opts.sqliteChangeLogWriter &&
+      opts.sqliteCatchup
+        ? new SQLiteChangeLogComparator(
+            lc,
+            shard,
+            opts.sqliteCatchup.changeLogFile,
+            opts.sqliteChangeLogWriter.identity,
+            this.#storer,
+            {setTimeoutFn, ...opts.sqliteChangeLogCompare},
+          )
+        : undefined;
     this.#purgeLock = initialPurgeLock;
     this.#autoReset = autoReset;
     this.#state = new RunningState(this.id, undefined, setTimeoutFn);
@@ -1034,6 +1061,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
     this.#state.stop(this.#lc, err);
     this.#stream?.changes.cancel();
     this.#purgeScheduler?.stop();
+    this.#comparator?.stop();
     this.#sqliteCatchup?.close();
     this.#changeLogWriter?.close();
     await Promise.allSettled([this.#storer.stop(), this.#source.stop()]);


### PR DESCRIPTION
Wires the comparator into compare mode and adds the option that controls its sampling rate.

`--change-streamer-sqlite-change-log-compare-percent` sets the stable percentage of committed transactions whose catchup output is compared.