### PR TITLE
chore(rmv2): add `serve` mode for serving from sqlite change log

### DIFF
--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -67,6 +67,7 @@ export default async function runWorker(
       flowControlConsensusTimeoutProportion,
       flowControlSlowSubscriberGracePeriodSeconds,
       sqliteChangeLogMode,
+      sqliteChangeLogReadPercent,
       sqliteChangeLogComparePercent,
       sqliteChangeLogRetentionMs,
       sqliteChangeLogReadBatchRows,
@@ -260,6 +261,16 @@ export default async function runWorker(
                 readBatchRows: sqliteChangeLogReadBatchRows,
               }
             : undefined,
+          // Slice 11 lands dark by default: serve mode constructs the stable
+          // router, while readPercent=0 keeps every catchup on PG and emits
+          // eligibility metrics before any canary traffic is enabled.
+          sqliteChangeLogServe:
+            sqliteChangeLogMode === 'serve'
+              ? {
+                  readPercent: sqliteChangeLogReadPercent,
+                  retentionMs: sqliteChangeLogRetentionMs,
+                }
+              : undefined,
         },
         setTimeout,
       );

--- a/packages/zero-cache/src/services/change-streamer/change-log-compare-digest.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-log-compare-digest.test.ts
@@ -2,11 +2,7 @@
 
 import fc from 'fast-check';
 import {describe, expect, test} from 'vitest';
-import type {ShardID} from '../../types/shards.ts';
-import {
-  digestCatchupRange,
-  isSampledForCompare,
-} from './change-log-compare-digest.ts';
+import {digestCatchupRange} from './change-log-compare-digest.ts';
 import type {ChangeTag, WatermarkedChange} from './change-streamer.ts';
 
 describe('change-streamer/change-log-compare-digest', () => {
@@ -259,35 +255,6 @@ describe('change-streamer/change-log-compare-digest', () => {
     // encoding costs more of it.
     expect(b.rows).toBe(a.rows);
     expect(b.bytes).toBeGreaterThan(a.bytes);
-  });
-
-  test('sampling is stable, bounded, and monotone in the percentage', () => {
-    fc.assert(
-      fc.property(
-        fc.record({
-          appID: fc.string({minLength: 1, maxLength: 8}),
-          shardNum: fc.nat({max: 1000}),
-          watermark: fc.hexaString({minLength: 2, maxLength: 10}),
-          p1: fc.integer({min: 0, max: 100}),
-          p2: fc.integer({min: 0, max: 100}),
-        }),
-        ({appID, shardNum, watermark, p1, p2}) => {
-          const shard: ShardID = {appID, shardNum};
-          const lo = Math.min(p1, p2);
-          const hi = Math.max(p1, p2);
-          // A retry selects the same transactions.
-          expect(isSampledForCompare(shard, watermark, hi)).toBe(
-            isSampledForCompare(shard, watermark, hi),
-          );
-          // A larger percentage keeps the transactions in a smaller sample.
-          if (isSampledForCompare(shard, watermark, lo)) {
-            expect(isSampledForCompare(shard, watermark, hi)).toBe(true);
-          }
-          expect(isSampledForCompare(shard, watermark, 0)).toBe(false);
-          expect(isSampledForCompare(shard, watermark, 100)).toBe(true);
-        },
-      ),
-    );
   });
 
   test('a change is hashed exactly as stored, including large integers', async () => {

--- a/packages/zero-cache/src/services/change-streamer/change-log-compare-digest.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-log-compare-digest.ts
@@ -1,35 +1,16 @@
 /**
  * Pure building blocks for comparing catchup output between the Postgres and
- * SQLite change logs: which transactions to sample, and how to reduce a
- * catchup range to a single comparable digest.
+ * SQLite change logs: how to reduce a catchup range to a single comparable
+ * digest. Which transactions to sample is `isSampledForShard`, in
+ * `shard-sampling.ts`.
  *
  * Nothing here touches either store. The comparator service supplies the
  * batches.
  */
 
-import {createHash} from 'node:crypto';
-import type {ShardID} from '../../types/shards.ts';
 import {extractChangeSubstring} from './change-log-codec.ts';
 import {ChangeLogTransactionHasher} from './change-log-transaction-hash.ts';
 import type {WatermarkedChange} from './change-streamer.ts';
-
-/** Selects a stable sample by shard and watermark. */
-export function isSampledForCompare(
-  shard: ShardID,
-  watermark: string,
-  percent: number,
-): boolean {
-  if (percent >= 100) {
-    return true;
-  }
-  if (percent <= 0) {
-    return false;
-  }
-  const digest = createHash('sha256')
-    .update(`${shard.appID}/${shard.shardNum}:${watermark}`)
-    .digest();
-  return digest.readUInt32BE(0) % 100 < percent;
-}
 
 export type CatchupRangeDigest = {
   readonly digest: string;

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
@@ -335,12 +335,25 @@ describe('change-streamer/service', () => {
    * production topology: this process writes the log from its own stream loop,
    * and can serve catchup from what it wrote.
    */
+  type InlineChangeLogWriterOptions = {
+    sqliteCatchup?: Partial<SQLiteCatchupOptions> | undefined;
+    sqliteChangeLogPurge?: TuningOptions['sqliteChangeLogPurge'] | undefined;
+    backupURL?: string | undefined;
+    sqliteChangeLogCompare?:
+      | TuningOptions['sqliteChangeLogCompare']
+      | undefined;
+    sqliteChangeLogServe?: TuningOptions['sqliteChangeLogServe'] | undefined;
+  };
+
   async function restartWithInlineChangeLogWriter(
     logFile: DbFile,
-    sqliteCatchup?: Partial<SQLiteCatchupOptions>,
-    sqliteChangeLogPurge?: TuningOptions['sqliteChangeLogPurge'],
-    backupURL?: string,
-    sqliteChangeLogCompare?: TuningOptions['sqliteChangeLogCompare'],
+    {
+      sqliteCatchup,
+      sqliteChangeLogPurge,
+      backupURL,
+      sqliteChangeLogCompare,
+      sqliteChangeLogServe,
+    }: InlineChangeLogWriterOptions = {},
   ): Promise<void> {
     await streamer.stop();
     await streamerDone;
@@ -385,6 +398,7 @@ describe('change-streamer/service', () => {
         ...(sqliteChangeLogCompare === undefined
           ? {}
           : {sqliteChangeLogCompare}),
+        ...(sqliteChangeLogServe === undefined ? {} : {sqliteChangeLogServe}),
         ...(sqliteCatchup === undefined
           ? {}
           : {
@@ -472,8 +486,10 @@ describe('change-streamer/service', () => {
   test('the change-streamer writes the log inline and serves catchup from it', async () => {
     const logFile = new DbFile('sqlite-change-log-inline-writer');
     await restartWithInlineChangeLogWriter(logFile, {
-      barrierPollIntervalMs: 10,
-      shouldUse: ctx => ctx.id === 'from-sqlite',
+      sqliteCatchup: {
+        barrierPollIntervalMs: 10,
+        shouldUse: ctx => ctx.id === 'from-sqlite',
+      },
     });
 
     const liveSub = await subscribeServing('live-observer');
@@ -564,14 +580,225 @@ describe('change-streamer/service', () => {
     }
   });
 
+  test('serve mode at zero percent measures eligibility but keeps catchup on PG', async () => {
+    const readerRead = vi.spyOn(SQLiteChangeLogReader.prototype, 'read');
+    const logFile = new DbFile('sqlite-change-log-zero-percent');
+    await restartWithInlineChangeLogWriter(logFile, {
+      sqliteCatchup: {barrierPollIntervalMs: 10},
+      sqliteChangeLogServe: {readPercent: 0, retentionMs: 0},
+    });
+
+    try {
+      changes.push(['begin', messages.begin(), {commitWatermark: '06'}]);
+      changes.push(['data', messages.insert('foo', {id: 'from-pg'})]);
+      changes.push(['commit', messages.commit(), {watermark: '06'}]);
+      await expectAcks('06');
+
+      const sub = await subscribeServing('zero-percent');
+      const output = drainToQueue(sub);
+      expect(await nextChange(output)).toMatchObject({tag: 'status'});
+      expect(await nextChange(output)).toMatchObject({tag: 'begin'});
+      expect(await nextChange(output)).toMatchObject({
+        tag: 'insert',
+        new: {id: 'from-pg'},
+      });
+      expect(await nextChange(output)).toMatchObject({tag: 'commit'});
+      expect(readerRead).not.toHaveBeenCalled();
+
+      // The route log carries the covered range even though the percentage
+      // gate kept this eligible subscriber on PG.
+      expect(logSink.messages).toContainEqual([
+        'debug',
+        expect.anything(),
+        [
+          expect.stringContaining('SQLite route percentage'),
+          expect.objectContaining({
+            sqliteChangeLogCoverage: expect.objectContaining({
+              minWatermark: REPLICA_VERSION,
+              headWatermark: '06',
+            }),
+          }),
+        ],
+      ]);
+      sub.cancel();
+    } finally {
+      readerRead.mockRestore();
+      await streamer.stop();
+      await streamerDone;
+      deleteChangeLogDB(logFile.path);
+      logFile.delete();
+    }
+  });
+
+  test('serve mode declines a freshly seeded log until its retention window elapses', async () => {
+    const readerRead = vi.spyOn(SQLiteChangeLogReader.prototype, 'read');
+    const logFile = new DbFile('sqlite-change-log-warmup');
+    const retentionMs = 60_000;
+    let now = Date.now();
+    await restartWithInlineChangeLogWriter(logFile, {
+      sqliteCatchup: {barrierPollIntervalMs: 10},
+      sqliteChangeLogServe: {readPercent: 100, retentionMs, now: () => now},
+    });
+
+    try {
+      changes.push(['begin', messages.begin(), {commitWatermark: '06'}]);
+      changes.push(['data', messages.insert('foo', {id: 'warmup'})]);
+      changes.push(['commit', messages.commit(), {watermark: '06'}]);
+      await expectAcks('06');
+
+      const coldSub = await subscribeServing('cold-log');
+      const cold = drainToQueue(coldSub);
+      expect(await nextChange(cold)).toMatchObject({tag: 'status'});
+      expect(await nextChange(cold)).toMatchObject({tag: 'begin'});
+      expect(await nextChange(cold)).toMatchObject({tag: 'insert'});
+      expect(await nextChange(cold)).toMatchObject({tag: 'commit'});
+      expect(readerRead).not.toHaveBeenCalled();
+
+      now += retentionMs + 10_000;
+      const warmSub = await subscribeServing('warm-log');
+      const warm = drainToQueue(warmSub);
+      expect(await nextChange(warm)).toMatchObject({tag: 'status'});
+      expect(await nextChange(warm)).toMatchObject({tag: 'begin'});
+      expect(await nextChange(warm)).toMatchObject({tag: 'insert'});
+      expect(await nextChange(warm)).toMatchObject({tag: 'commit'});
+      expect(readerRead).toHaveBeenCalled();
+
+      coldSub.cancel();
+      warmSub.cancel();
+    } finally {
+      readerRead.mockRestore();
+      await streamer.stop();
+      await streamerDone;
+      deleteChangeLogDB(logFile.path);
+      logFile.delete();
+    }
+  });
+
+  test('serve mode sends a subscriber below the SQLite floor to PG', async () => {
+    const readerRead = vi.spyOn(SQLiteChangeLogReader.prototype, 'read');
+    const pgCatchup = vi.spyOn(Storer.prototype, 'catchup');
+    const logFile = new DbFile('sqlite-change-log-uncovered-watermark');
+    await restartWithInlineChangeLogWriter(logFile, {
+      sqliteCatchup: {barrierPollIntervalMs: 10},
+      sqliteChangeLogServe: {
+        readPercent: 100,
+        retentionMs: 0,
+        // The route inspection raced the purge and still saw the old floor.
+        inspect: () => ({
+          seededAtMs: 0,
+          seedWatermark: REPLICA_VERSION,
+          minWatermark: REPLICA_VERSION,
+          headWatermark: '06',
+        }),
+      },
+    });
+
+    try {
+      changes.push(['begin', messages.begin(), {commitWatermark: '06'}]);
+      changes.push(['data', messages.insert('foo', {id: 'from-pg'})]);
+      changes.push(['commit', messages.commit(), {watermark: '06'}]);
+      await expectAcks('06');
+
+      // Model a SQLite purge that has moved past a still-retained PG boundary.
+      using changeLog = openChangeLogDB(lc, logFile.path, {readonly: false});
+      changeLog
+        .prepare(/*sql*/ `DELETE FROM "_zero.changeLogStream"
+                            WHERE "watermark" < '06'`)
+        .run();
+      expect(sqliteMinWatermark(logFile)).toBe('06');
+
+      const sub = await subscribeServing('below-sqlite-floor');
+      const output = drainToQueue(sub);
+      expect(await nextChange(output)).toMatchObject({tag: 'status'});
+      expect(await nextChange(output)).toMatchObject({tag: 'begin'});
+      expect(await nextChange(output)).toMatchObject({
+        tag: 'insert',
+        new: {id: 'from-pg'},
+      });
+      expect(await nextChange(output)).toMatchObject({tag: 'commit'});
+      expect(pgCatchup).toHaveBeenCalled();
+      expect(readerRead).not.toHaveBeenCalled();
+      expect(logSink.messages).toContainEqual([
+        'info',
+        expect.anything(),
+        [
+          expect.stringContaining(
+            'subscriber watermark 01 is below the SQLite change-log minimum 06',
+          ),
+        ],
+      ]);
+      sub.cancel();
+    } finally {
+      readerRead.mockRestore();
+      pgCatchup.mockRestore();
+      await streamer.stop();
+      await streamerDone;
+      deleteChangeLogDB(logFile.path);
+      logFile.delete();
+    }
+  });
+
+  test('a post-registration SQLite read failure sends the retry to PG', async () => {
+    const readerRead = vi
+      .spyOn(SQLiteChangeLogReader.prototype, 'read')
+      .mockImplementationOnce(async function* () {
+        throw new Error('injected SQLite read failure');
+      });
+    const logFile = new DbFile('sqlite-change-log-read-breaker');
+    await restartWithInlineChangeLogWriter(logFile, {
+      sqliteCatchup: {barrierPollIntervalMs: 10},
+      sqliteChangeLogServe: {readPercent: 100, retentionMs: 0},
+    });
+
+    try {
+      changes.push(['begin', messages.begin(), {commitWatermark: '06'}]);
+      changes.push(['data', messages.insert('foo', {id: 'from-pg-retry'})]);
+      changes.push(['commit', messages.commit(), {watermark: '06'}]);
+      await expectAcks('06');
+
+      const failed = await subscribeServing('breaker-retry');
+      for await (const _ of failed) {
+        // The injected reader failure happens before SQLite emits catchup.
+      }
+      expect(readerRead).toHaveBeenCalledOnce();
+      expect(logSink.messages).toContainEqual([
+        'warn',
+        expect.anything(),
+        [expect.stringContaining('temporarily disabling SQLite catchup')],
+      ]);
+
+      // The same stable task would ordinarily select SQLite again. The open
+      // breaker sends this immediate reconnect through the complete PG path.
+      const retrySub = await subscribeServing('breaker-retry');
+      const retry = drainToQueue(retrySub);
+      expect(await nextChange(retry)).toMatchObject({tag: 'status'});
+      expect(await nextChange(retry)).toMatchObject({tag: 'begin'});
+      expect(await nextChange(retry)).toMatchObject({
+        tag: 'insert',
+        new: {id: 'from-pg-retry'},
+      });
+      expect(await nextChange(retry)).toMatchObject({tag: 'commit'});
+      expect(readerRead).toHaveBeenCalledOnce();
+      retrySub.cancel();
+    } finally {
+      readerRead.mockRestore();
+      await streamer.stop();
+      await streamerDone;
+      deleteChangeLogDB(logFile.path);
+      logFile.delete();
+    }
+  });
+
   test('SQLite cleanup continues independently after PG reaches the floor', async () => {
     const logFile = new DbFile('sqlite-change-log-independent-purge');
-    await restartWithInlineChangeLogWriter(logFile, undefined, {
-      retentionMs: 1,
-      batchRows: 2,
-      maxBatchesPerPass: 1,
-      now: () => Date.now() + 60_000,
-      yieldFn: () => Promise.resolve(),
+    await restartWithInlineChangeLogWriter(logFile, {
+      sqliteChangeLogPurge: {
+        retentionMs: 1,
+        batchRows: 2,
+        maxBatchesPerPass: 1,
+        now: () => Date.now() + 60_000,
+        yieldFn: () => Promise.resolve(),
+      },
     });
 
     const watermarks = ['03', '04', '05', '06', '07', '08', '09'];
@@ -634,11 +861,13 @@ describe('change-streamer/service', () => {
    */
   test('a laggard ACK holds the SQLite floor until its subscriber catches up', async () => {
     const logFile = new DbFile('sqlite-change-log-laggard-purge');
-    await restartWithInlineChangeLogWriter(logFile, undefined, {
-      retentionMs: 1,
-      batchRows: 100,
-      now: () => Date.now() + 60_000,
-      yieldFn: () => Promise.resolve(),
+    await restartWithInlineChangeLogWriter(logFile, {
+      sqliteChangeLogPurge: {
+        retentionMs: 1,
+        batchRows: 100,
+        now: () => Date.now() + 60_000,
+        yieldFn: () => Promise.resolve(),
+      },
     });
 
     const watermarks = ['03', '04', '05', '06', '07', '08'];
@@ -726,18 +955,19 @@ describe('change-streamer/service', () => {
    * pinned once the restore is over.
    */
   test('a snapshot reservation pauses the SQLite purge until it closes', async () => {
+    const readerRead = vi.spyOn(SQLiteChangeLogReader.prototype, 'read');
     const logFile = new DbFile('sqlite-change-log-reservation-pause');
-    await restartWithInlineChangeLogWriter(
-      logFile,
-      undefined,
-      {
+    await restartWithInlineChangeLogWriter(logFile, {
+      sqliteCatchup: {barrierPollIntervalMs: 10},
+      sqliteChangeLogPurge: {
         retentionMs: 1,
         batchRows: 100,
         now: () => Date.now() + 60_000,
         yieldFn: () => Promise.resolve(),
       },
-      's3://foo/bar',
-    );
+      backupURL: 's3://foo/bar',
+      sqliteChangeLogServe: {readPercent: 100, retentionMs: 0},
+    });
 
     const watermarks = ['03', '04', '05', '06', '07', '08'];
     try {
@@ -787,14 +1017,32 @@ describe('change-streamer/service', () => {
       await fireNextTimer();
       expect(sqliteMinWatermark(logFile)).toBe(REPLICA_VERSION);
 
+      // The matching /changes request consumes the source pinned by
+      // /snapshot. Its ACK keeps protecting the same SQLite range while
+      // subscribe() closes the reservation and resumes purging.
+      const sub = await streamer.subscribe({
+        protocolVersion: PROTOCOL_VERSION,
+        taskID: 'view-syncer-1',
+        id: 'view-syncer-1',
+        mode: 'serving',
+        watermark: '08',
+        replicaVersion: REPLICA_VERSION,
+        initial: true,
+        logsChangeStream: false,
+      });
+      const output = drainToQueue(sub);
+      expect(await nextChange(output)).toMatchObject({tag: 'status'});
+      expect(readerRead).toHaveBeenCalled();
+
       // Closing the reservation resumes purging: the next armed pass drains
-      // the SQLite log to the floor.
-      reservation.cancel();
+      // the SQLite log to the floor protected by the subscriber ACK.
       await fireNextTimer();
       expect(sqliteMinWatermark(logFile)).toBe('08');
       // Cleanup reached the backup watermark: nothing further is armed.
       expect(setTimeoutFn).toHaveBeenCalledTimes(fired);
+      sub.cancel();
     } finally {
+      readerRead.mockRestore();
       await streamer.stop();
       await streamerDone;
       deleteChangeLogDB(logFile.path);
@@ -918,18 +1166,15 @@ describe('change-streamer/service', () => {
 
     try {
       // Start with a new log and a missing replica file.
-      await restartWithInlineChangeLogWriter(
-        logFile,
-        {},
-        undefined,
-        undefined,
-        {
+      await restartWithInlineChangeLogWriter(logFile, {
+        sqliteCatchup: {},
+        sqliteChangeLogCompare: {
           replicaFile: noSuchReplica,
           comparePercent: 100,
           retentionMs: 60_000,
           intervalMs: COLD_INTERVAL_MS,
         },
-      );
+      });
 
       // Both advisory checks leave replication active.
       changes.push(['begin', messages.begin(), {commitWatermark: '06'}]);
@@ -958,19 +1203,16 @@ describe('change-streamer/service', () => {
 
       // Restart with a clock that makes the log warm.
       const warmStart = setTimeoutFn.mock.calls.length;
-      await restartWithInlineChangeLogWriter(
-        logFile,
-        {},
-        undefined,
-        undefined,
-        {
+      await restartWithInlineChangeLogWriter(logFile, {
+        sqliteCatchup: {},
+        sqliteChangeLogCompare: {
           replicaFile: noSuchReplica,
           comparePercent: 100,
           retentionMs: 60_000,
           intervalMs: WARM_INTERVAL_MS,
           now: () => Date.now() + 3_600_000,
         },
-      );
+      });
 
       changes.push(['begin', messages.begin(), {commitWatermark: '08'}]);
       changes.push(['data', messages.insert('foo', {id: 'diverged'})]);
@@ -1457,9 +1699,11 @@ describe('change-streamer/service', () => {
 
     const logFile = new DbFile('sqlite-change-log-barrier');
     await restartWithInlineChangeLogWriter(logFile, {
-      barrierTimeoutMs: 60_000,
-      barrierPollIntervalMs: 60_000,
-      shouldUse: ctx => ctx.id === 'from-sqlite',
+      sqliteCatchup: {
+        barrierTimeoutMs: 60_000,
+        barrierPollIntervalMs: 60_000,
+        shouldUse: ctx => ctx.id === 'from-sqlite',
+      },
     });
 
     const liveSub = await subscribeServing('live-observer');
@@ -1520,8 +1764,14 @@ describe('change-streamer/service', () => {
     const readerClose = vi.spyOn(SQLiteChangeLogReader.prototype, 'close');
     const logFile = new DbFile('sqlite-change-log-fail-soft');
     await restartWithInlineChangeLogWriter(logFile, {
-      barrierPollIntervalMs: 10,
-      shouldUse: ctx => ctx.id.startsWith('from-sqlite'),
+      sqliteCatchup: {
+        barrierPollIntervalMs: 10,
+        shouldUse: ctx => ctx.id.startsWith('from-sqlite'),
+      },
+      sqliteChangeLogServe: {
+        readPercent: 100,
+        retentionMs: 0,
+      },
     });
 
     const liveSub = await subscribeServing('live-observer');
@@ -1611,10 +1861,7 @@ describe('change-streamer/service', () => {
     }
   });
 
-  // The exclusion outlives its original reason -- the writer is no longer a
-  // subscriber, so nothing can wait on its own ACK -- because a replicator that
-  // predates the writer's move still sets the parameter. Slice 11 lifts it.
-  test('backup subscribers and legacy change-log writers cannot select SQLite catchup', async () => {
+  test('backup subscribers stay on PG while the legacy writer hint can select SQLite', async () => {
     await streamer.stop();
     await streamerDone;
 
@@ -1713,39 +1960,34 @@ describe('change-streamer/service', () => {
       });
       expect(await nextChange(backed)).toMatchObject({tag: 'commit'});
 
+      appendSQLiteTransaction(catchupReplica, catchupChangeLog, '04', [
+        ['data', messages.insert('foo', {id: 'from-sqlite'})],
+      ]);
+
       shouldUse.mockClear();
       const writerSub = await streamer.subscribe({
         protocolVersion: PROTOCOL_VERSION,
         taskID: 'task-id',
         id: 'change-log-writer',
-        // A single-node canonical writer has serving mode, so the independent
-        // logsChangeStream guard remains necessary.
+        // Slice 11 deliberately ignores this legacy hint: the writer now lives
+        // in the change-streamer, and no subscriber ACK advances the log.
         mode: 'serving',
         watermark: REPLICA_VERSION,
         replicaVersion: REPLICA_VERSION,
         initial: true,
         logsChangeStream: true,
       });
-      expect(shouldUse).not.toHaveBeenCalled();
+      expect(shouldUse).toHaveBeenCalledOnce();
       const written = drainToQueue(writerSub);
 
-      // Served from PG instead of waiting on itself.
+      // Served from SQLite; the payload differs from PG only to pin routing.
       expect(await nextChange(written)).toMatchObject({tag: 'status'});
       expect(await nextChange(written)).toMatchObject({tag: 'begin'});
       expect(await nextChange(written)).toMatchObject({
         tag: 'insert',
-        new: {id: 'forwarded'},
+        new: {id: 'from-sqlite'},
       });
       expect(await nextChange(written)).toMatchObject({tag: 'commit'});
-      expect(logSink.messages).toContainEqual([
-        'warn',
-        expect.anything(),
-        [
-          expect.stringContaining(
-            'not serving legacy change-log writer change-log-writer',
-          ),
-        ],
-      ]);
 
       observerSub.cancel();
       backupSub.cancel();

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
@@ -789,6 +789,190 @@ describe('change-streamer/service', () => {
     }
   });
 
+  /**
+   * §6.6's rollback drill. At readPercent=100, with a subscriber served from
+   * SQLite and a snapshot reservation confirmed while SQLite was the pinned
+   * source, a restart back to un-flipped routing keeps every promise on PG:
+   * everything SQLite can promise, PG can serve.
+   */
+  test('rollback drill: a restart out of serve mode keeps every subscriber on PG range', async () => {
+    const readerRead = vi.spyOn(SQLiteChangeLogReader.prototype, 'read');
+    const logFile = new DbFile('sqlite-change-log-rollback-drill');
+    await restartWithInlineChangeLogWriter(logFile, {
+      sqliteCatchup: {barrierPollIntervalMs: 10},
+      backupURL: 's3://foo/bar',
+      sqliteChangeLogServe: {readPercent: 100, retentionMs: 0},
+    });
+
+    try {
+      changes.push(['begin', messages.begin(), {commitWatermark: '06'}]);
+      changes.push(['data', messages.insert('foo', {id: 'pre-rollback'})]);
+      changes.push(['commit', messages.commit(), {watermark: '06'}]);
+      await expectAcks('06');
+
+      // Flipped: a serving subscriber reads from SQLite.
+      const flipped = await subscribeServing('flipped');
+      const flippedOut = drainToQueue(flipped);
+      expect(await nextChange(flippedOut)).toMatchObject({tag: 'status'});
+      expect(await nextChange(flippedOut)).toMatchObject({tag: 'begin'});
+      expect(await nextChange(flippedOut)).toMatchObject({
+        tag: 'insert',
+        new: {id: 'pre-rollback'},
+      });
+      expect(await nextChange(flippedOut)).toMatchObject({tag: 'commit'});
+      expect(readerRead).toHaveBeenCalled();
+      flipped.cancel();
+
+      // A follower's reservation, confirmed while SQLite is the pinned
+      // source. The advertised bounds are the promise the rollback must keep.
+      streamer.trackBackupWatermark('06');
+      const reservation = await streamer.startSnapshotReservation('follower');
+      const [, status] = await drainSnapshotMessages(reservation).dequeue();
+      const promisedMin = (status as {minWatermark: string}).minWatermark;
+      expect(promisedMin).toBe('06');
+
+      // The rollback deploy: same log and stores, no serve option, so no
+      // router is constructed and routing reverts to PG.
+      readerRead.mockClear();
+      await restartWithInlineChangeLogWriter(logFile, {
+        sqliteCatchup: {barrierPollIntervalMs: 10},
+        backupURL: 's3://foo/bar',
+      });
+
+      changes.push(['begin', messages.begin(), {commitWatermark: '08'}]);
+      changes.push(['data', messages.insert('foo', {id: 'post-rollback'})]);
+      changes.push(['commit', messages.commit(), {watermark: '08'}]);
+      await expectAcks('08');
+
+      // The pre-rollback subscriber reconnects where it left off and gets
+      // range from PG -- not too-old, not a reset.
+      const reconnected = await streamer.subscribe({
+        protocolVersion: PROTOCOL_VERSION,
+        taskID: 'flipped-task',
+        id: 'flipped',
+        mode: 'serving',
+        watermark: '06',
+        replicaVersion: REPLICA_VERSION,
+        initial: true,
+        logsChangeStream: false,
+      });
+      const reconnectedOut = drainToQueue(reconnected);
+      expect(await nextChange(reconnectedOut)).toMatchObject({tag: 'status'});
+      expect(await nextChange(reconnectedOut)).toMatchObject({tag: 'begin'});
+      expect(await nextChange(reconnectedOut)).toMatchObject({
+        tag: 'insert',
+        new: {id: 'post-rollback'},
+      });
+      expect(await nextChange(reconnectedOut)).toMatchObject({tag: 'commit'});
+      reconnected.cancel();
+
+      // The follower restores at the bounds advertised under SQLite pinning
+      // and catches up from PG.
+      const follower = await streamer.subscribe({
+        protocolVersion: PROTOCOL_VERSION,
+        taskID: 'follower',
+        id: 'follower',
+        mode: 'serving',
+        watermark: promisedMin,
+        replicaVersion: REPLICA_VERSION,
+        initial: true,
+        logsChangeStream: false,
+      });
+      const followerOut = drainToQueue(follower);
+      expect(await nextChange(followerOut)).toMatchObject({tag: 'status'});
+      expect(await nextChange(followerOut)).toMatchObject({tag: 'begin'});
+      expect(await nextChange(followerOut)).toMatchObject({
+        tag: 'insert',
+        new: {id: 'post-rollback'},
+      });
+      expect(readerRead).not.toHaveBeenCalled();
+      follower.cancel();
+    } finally {
+      readerRead.mockRestore();
+      await streamer.stop();
+      await streamerDone;
+      deleteChangeLogDB(logFile.path);
+      logFile.delete();
+    }
+  });
+
+  /**
+   * §6.6's flip-forward drill. A restart from un-flipped routing into serve
+   * mode at 100 percent, against a log that survived the restart, moves
+   * catchup to SQLite with no reset and the same committed sequence.
+   */
+  test('flip-forward drill: a restart into serve mode moves catchup to SQLite', async () => {
+    const readerRead = vi.spyOn(SQLiteChangeLogReader.prototype, 'read');
+    const logFile = new DbFile('sqlite-change-log-flip-drill');
+    // Un-flipped: the writer runs, catchup is served from PG.
+    await restartWithInlineChangeLogWriter(logFile, {
+      sqliteCatchup: {
+        barrierPollIntervalMs: 10,
+      },
+    });
+
+    try {
+      changes.push(['begin', messages.begin(), {commitWatermark: '06'}]);
+      changes.push(['data', messages.insert('foo', {id: 'pre-flip'})]);
+      changes.push(['commit', messages.commit(), {watermark: '06'}]);
+      await expectAcks('06');
+
+      const before = await subscribeServing('pre-flip');
+      const beforeOut = drainToQueue(before);
+      expect(await nextChange(beforeOut)).toMatchObject({tag: 'status'});
+      expect(await nextChange(beforeOut)).toMatchObject({tag: 'begin'});
+      expect(await nextChange(beforeOut)).toMatchObject({
+        tag: 'insert',
+        new: {id: 'pre-flip'},
+      });
+      expect(await nextChange(beforeOut)).toMatchObject({tag: 'commit'});
+      expect(readerRead).not.toHaveBeenCalled();
+      before.cancel();
+
+      // The flip deploy. The log's head equals the resume watermark, so
+      // reconciliation keeps it -- the flip serves from the same log the
+      // un-flipped process wrote, with no reseed and no warm-up hole.
+      await restartWithInlineChangeLogWriter(logFile, {
+        sqliteCatchup: {barrierPollIntervalMs: 10},
+        sqliteChangeLogServe: {readPercent: 100, retentionMs: 0},
+      });
+
+      changes.push(['begin', messages.begin(), {commitWatermark: '08'}]);
+      changes.push(['data', messages.insert('foo', {id: 'post-flip'})]);
+      changes.push(['commit', messages.commit(), {watermark: '08'}]);
+      await expectAcks('08');
+
+      // A subscriber reconnecting across the flip is served the same
+      // committed sequence, now from SQLite.
+      const after = await streamer.subscribe({
+        protocolVersion: PROTOCOL_VERSION,
+        taskID: 'pre-flip-task',
+        id: 'pre-flip',
+        mode: 'serving',
+        watermark: '06',
+        replicaVersion: REPLICA_VERSION,
+        initial: true,
+        logsChangeStream: false,
+      });
+      const afterOut = drainToQueue(after);
+      expect(await nextChange(afterOut)).toMatchObject({tag: 'status'});
+      expect(await nextChange(afterOut)).toMatchObject({tag: 'begin'});
+      expect(await nextChange(afterOut)).toMatchObject({
+        tag: 'insert',
+        new: {id: 'post-flip'},
+      });
+      expect(await nextChange(afterOut)).toMatchObject({tag: 'commit'});
+      expect(readerRead).toHaveBeenCalled();
+      after.cancel();
+    } finally {
+      readerRead.mockRestore();
+      await streamer.stop();
+      await streamerDone;
+      deleteChangeLogDB(logFile.path);
+      logFile.delete();
+    }
+  });
+
   test('SQLite cleanup continues independently after PG reaches the floor', async () => {
     const logFile = new DbFile('sqlite-change-log-independent-purge');
     await restartWithInlineChangeLogWriter(logFile, {

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -67,6 +67,12 @@ import {
   type PurgeContinuation,
   type SQLiteChangeLogPurgeSchedulerOptions,
 } from './sqlite-change-log-purge-scheduler.ts';
+import {
+  inspectSQLiteChangeLog,
+  SQLiteChangeLogReadRouter,
+  type ChangeLogReadRoute,
+  type SQLiteChangeLogCoverage,
+} from './sqlite-change-log-read-router.ts';
 import {SQLiteChangeLogReader} from './sqlite-change-log-reader.ts';
 import {
   SQLiteChangeLogWriter,
@@ -96,11 +102,9 @@ export type SQLiteCatchupOptions = {
    */
   barrierPollIntervalMs?: number | undefined;
   /**
-   * Slice 11 supplies the production canary selector.
-   *
-   * It does not need to exclude backup subscribers or the change-log writer:
-   * eligibility checks reject both before invoking this selector. Serving a
-   * writer from SQLite would make it wait on its own ACK.
+   * Optional policy hook used by focused tests. Production canary selection is
+   * supplied by `sqliteChangeLogServe` and is stable by shard plus task ID.
+   * Backup subscribers are rejected before either selector is invoked.
    */
   shouldUse?: ((ctx: SubscriberContext) => boolean) | undefined;
   /**
@@ -115,6 +119,19 @@ export type SQLiteCatchupOptions = {
    * {@link DEFAULT_CHANGE_LOG_UNAVAILABLE_WARN_THRESHOLD_MS}.
    */
   notReadyWarnThresholdMs?: number | undefined;
+};
+
+export type SQLiteChangeLogServeOptions = {
+  /** Stable percentage of eligible serving tasks routed to SQLite. */
+  readPercent: number;
+  /** A reseeded log must age through this whole window before it can serve. */
+  retentionMs: number;
+  /** Injectable for deterministic breaker tests. */
+  failureCooldownMs?: number | undefined;
+  /** Injectable for deterministic warm-up and breaker tests. */
+  now?: (() => number) | undefined;
+  /** Injectable readiness inspection for service-level tests. */
+  inspect?: (() => SQLiteChangeLogCoverage | undefined) | undefined;
 };
 
 export type TuningOptions = StorerOptions & {
@@ -150,6 +167,8 @@ export type TuningOptions = StorerOptions & {
   sqliteChangeLogCompare?:
     | (SQLiteChangeLogCompareOptions & {replicaFile: string})
     | undefined;
+  /** Supplied only in `serve` mode. A zero percentage keeps every read on PG. */
+  sqliteChangeLogServe?: SQLiteChangeLogServeOptions | undefined;
 };
 
 /**
@@ -365,6 +384,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
   readonly #comparator: SQLiteChangeLogComparator | undefined;
   readonly #acker: UpstreamAcker;
   readonly #initializer: ChangeLogInitializer;
+  readonly #readRouter: SQLiteChangeLogReadRouter | undefined;
 
   readonly #autoReset: boolean;
   readonly #state: RunningState;
@@ -397,6 +417,11 @@ class ChangeStreamerImpl implements ChangeStreamerService {
     'transaction_forward_duration',
     "Time from receiving a transaction's `begin` to forwarding its `commit`, " +
       'i.e. the change-streamer half of forward-to-subscriber latency.',
+  );
+  readonly #catchupRoutes = getOrCreateCounter(
+    'replication',
+    'sqlite_change_log.catchup_routes',
+    'Catchup subscriptions by selected source and low-cardinality reason.',
   );
 
   #latestStatus: Status;
@@ -467,10 +492,32 @@ class ChangeStreamerImpl implements ChangeStreamerService {
       flowControlSlowSubscriberGracePeriodMs:
         opts.flowControlSlowSubscriberGracePeriodMs,
     });
+    const serveOptions = opts.sqliteChangeLogServe;
+    const writerOptions = opts.sqliteChangeLogWriter;
+    const catchupOptions = opts.sqliteCatchup;
+    this.#readRouter =
+      serveOptions && writerOptions && catchupOptions
+        ? new SQLiteChangeLogReadRouter({
+            shard,
+            readPercent: serveOptions.readPercent,
+            retentionMs: serveOptions.retentionMs,
+            failureCooldownMs: serveOptions.failureCooldownMs,
+            now: serveOptions.now,
+            inspect:
+              serveOptions.inspect ??
+              (() =>
+                inspectSQLiteChangeLog(
+                  lc,
+                  catchupOptions.changeLogFile,
+                  writerOptions.identity,
+                )),
+          })
+        : undefined;
     this.#reservations = backupConfig
-      ? new SnapshotReservations(lc, backupConfig, taskID =>
-          this.#purgeScheduler?.resume(taskID),
-        )
+      ? new SnapshotReservations(lc, backupConfig, taskID => {
+          this.#readRouter?.release(taskID);
+          this.#purgeScheduler?.resume(taskID);
+        })
       : undefined;
     this.#replicationStatusPublisher = replicationStatusPublisher;
     this.#changeLogWriter = opts.sqliteChangeLogWriter
@@ -486,6 +533,10 @@ class ChangeStreamerImpl implements ChangeStreamerService {
           // has to go with it: otherwise it serves an unlinked inode while
           // every new open sees nothing.
           onDisabled: () => {
+            // The writer stays disabled and the file stays absent for the life
+            // of this process, so unlike a transient read/barrier failure this
+            // breaker never expires.
+            this.#readRouter?.trip(true);
             this.#closeSQLiteCatchup();
             this.#comparator?.stop();
           },
@@ -806,10 +857,11 @@ class ChangeStreamerImpl implements ChangeStreamerService {
       {},
     );
     const lc = this.#lc.withContext('subscriber', subscriber.id);
-    cleanupSubscriber = () => {
+    const removeFromForwarder = () => {
       lc.info?.(`removing subscriber ${subscriber.id}`);
       this.#forwarder.remove(subscriber);
     };
+    cleanupSubscriber = removeFromForwarder;
     if (replicaVersion !== this.#replicaVersion) {
       lc.warn?.(`rejecting subscriber at replica version ${replicaVersion}`);
       subscriber.close(
@@ -821,17 +873,65 @@ class ChangeStreamerImpl implements ChangeStreamerService {
     } else {
       lc.info?.(`adding subscriber ${subscriber.id}`);
 
-      const sqliteCatchup = this.#selectSQLiteCatchup(ctx);
-      if (sqliteCatchup) {
-        cleanupSubscriber = () => sqliteCatchup.remove(subscriber);
-        await sqliteCatchup.catchup(subscriber, () =>
-          this.#captureRequiredHead(),
-        );
-      } else {
+      const catchupFromPG = () => {
         // Keep the existing PG registration/catchup lockstep unchanged when
         // SQLite was not selected before Forwarder.add().
+        cleanupSubscriber = removeFromForwarder;
         this.#forwarder.add(subscriber);
         this.#storer.catchup(subscriber, mode);
+      };
+      const sqliteSelection = this.#selectSQLiteCatchup(lc, ctx);
+      if (!sqliteSelection) {
+        catchupFromPG();
+      } else {
+        const {catchup, reason, coverage, logWarm} = sqliteSelection;
+        cleanupSubscriber = () => catchup.remove(subscriber);
+        const registration = await catchup.catchup(
+          subscriber,
+          () => this.#captureRequiredHead(),
+          {logWarm},
+        );
+        switch (registration.kind) {
+          case 'registered':
+            lc.debug?.(
+              `serving ${ctx.id} from SQLite catchup`,
+              ...(coverage ? [{sqliteChangeLogCoverage: coverage}] : []),
+            );
+            this.#recordCatchupRoute('sqlite', reason);
+            break;
+          case 'uncovered':
+            lc.info?.(
+              `serving ${ctx.id} from PG catchup: subscriber watermark ` +
+                `${ctx.watermark} is below the SQLite change-log minimum ` +
+                registration.minWatermark,
+            );
+            this.#recordCatchupRoute('pg', 'watermark-uncovered');
+            catchupFromPG();
+            break;
+          case 'declined':
+            // Registration failed before the subscriber was committed to
+            // SQLite, so PG is still available. The coordinator has already
+            // tripped the breaker, which keeps the retry off SQLite for the
+            // cooldown; it is deliberately not closed here, since closing it
+            // would abort the catchups of every other subscriber it is
+            // serving.
+            lc.error?.(
+              `serving ${ctx.id} from PG catchup: SQLite catchup ` +
+                `registration failed`,
+              registration.error,
+            );
+            this.#recordCatchupRoute('pg', 'registration-failed');
+            catchupFromPG();
+            break;
+          case 'handled':
+            // The coordinator closed or failed the subscriber itself, so
+            // there is nothing left to route. Still counted, so that the
+            // route counter sums to the number of subscriptions.
+            this.#recordCatchupRoute('sqlite', 'registration-handled');
+            break;
+          default:
+            unreachable(registration);
+        }
       }
     }
     // Any snapshot reservation held by this task can be closed now that
@@ -852,6 +952,16 @@ class ChangeStreamerImpl implements ChangeStreamerService {
       // Wait for an in-flight SQLite purge batch before reading and
       // advertising the reservation's bounds.
       await (this.#purgeScheduler?.pause(taskID) ?? promiseVoid);
+      // A concurrent retry for this task may have superseded and cancelled
+      // this reservation while its purge pause was settling. Only the current
+      // owner may replace the task's source pin.
+      if (!this.#reservations.isCurrent(taskID, downstream)) {
+        return downstream;
+      }
+      // Pin after the purge pause has settled, so the SQLite minimum captured
+      // by the router cannot move before it is advertised. #confirmReservations
+      // skips an unpinned task while this await is in flight.
+      this.#readRouter?.pin(taskID);
       // If a backup has been confirmed, immediately confirm the reservation.
       await this.#confirmReservations();
       return downstream;
@@ -886,18 +996,54 @@ class ChangeStreamerImpl implements ChangeStreamerService {
   }
 
   async #confirmReservations() {
-    if (this.#backupWatermark && this.#reservations?.confirmationsRequired()) {
-      const {replicaVersion, minWatermark} = await this.#getChangeLogState();
-      if (minWatermark <= this.#backupWatermark) {
-        this.#reservations?.confirm(replicaVersion, this.#backupWatermark);
+    const backupWatermark = this.#backupWatermark;
+    const reservations = this.#reservations;
+    if (
+      backupWatermark === undefined ||
+      !reservations?.confirmationsRequired()
+    ) {
+      return;
+    }
+
+    // Resolve PG bounds before touching any pin. Everything below runs to
+    // completion without awaiting, which is what keeps a reservation's
+    // advertised bounds and its pin in agreement: a concurrent /snapshot
+    // retry for the same task replaces the reservation and re-pins it, and
+    // confirming that replacement with the previous pin's bounds is exactly
+    // the mismatch pinning exists to prevent. The cost is one PG round trip
+    // per call even when every reservation is pinned to SQLite.
+    const pgState = await this.#getChangeLogState();
+    for (const taskID of reservations.unconfirmedTaskIDs()) {
+      const route = this.#readRouter?.peek(taskID);
+      // startSnapshotReservation pins only after an in-flight purge has
+      // completed. A task with no pin yet is confirmed by that path instead.
+      if (this.#readRouter && route === undefined) {
+        continue;
+      }
+
+      let minWatermark: string;
+      if (route?.source === 'sqlite') {
+        const coverage = route.coverage;
+        assert(coverage, 'a pinned SQLite route must carry its covered range');
+        minWatermark = coverage.minWatermark;
       } else {
-        // Something is wrong here ... the change-log should not have been
-        // purged past the backup watermark. If we confirm the reservation,
-        // we may not be able to catch up from the backup that the requester
-        // restores.
+        ({minWatermark} = pgState);
+      }
+
+      if (minWatermark <= backupWatermark) {
+        reservations.confirmFor(
+          taskID,
+          pgState.replicaVersion,
+          backupWatermark,
+        );
+      } else {
+        // The selected source cannot catch a restored replica up from this
+        // backup yet. Keep the reservation pending until a later backup moves
+        // the durable watermark into its covered range.
         this.#lc.error?.(
-          `change-log minWatermark ${minWatermark} is later than backupWatermark ${this.#backupWatermark}. ` +
-            `Delaying confirmation of snapshot reservation until next backup.`,
+          `${route?.source ?? 'pg'} change-log minWatermark ${minWatermark} ` +
+            `is later than backupWatermark ${backupWatermark}. Delaying ` +
+            `confirmation of snapshot reservation until next backup.`,
         );
       }
     }
@@ -1134,13 +1280,12 @@ class ChangeStreamerImpl implements ChangeStreamerService {
   }
 
   #selectSQLiteCatchup(
+    lc: LogContext,
     ctx: SubscriberContext,
-  ): SQLiteChangeLogCatchup | undefined {
+  ): SQLiteCatchupSelection | undefined {
     const opts = this.#sqliteCatchupOptions;
-    // Slice 11 supplies a non-default selector. Until then, this keeps all
-    // production subscriptions on PG even though the complete SQLite handoff
-    // path is wired and testable.
     if (this.#lastForwardedCommitWatermark === undefined || !opts) {
+      this.#recordCatchupRoute('pg', 'not-ready');
       return undefined;
     }
     // SQLite catchup is only for disposable serving replicas. Backup
@@ -1148,27 +1293,82 @@ class ChangeStreamerImpl implements ChangeStreamerService {
     // resume the canonical replica directly from replica/backup/slot state.
     // Enforce this before the selector so no canary policy can override it.
     if (ctx.mode !== 'serving') {
-      this.#lc.info?.(
-        `not serving backup subscriber ${ctx.id} from SQLite catchup`,
-      );
+      lc.info?.(`not serving backup subscriber ${ctx.id} from SQLite catchup`);
+      this.#recordCatchupRoute('pg', 'ineligible-mode');
       return undefined;
     }
-    if (ctx.logsChangeStream) {
-      // The reason for this exclusion is gone: the writer is no longer a
-      // subscriber, so nothing can wait on its own ACK, and no replicator this
-      // version ships sets the parameter. It stays until slice 11 lifts it
-      // deliberately, because a subscriber that predates the writer's move does
-      // set it, and serving one from SQLite is a change in behavior rather than
-      // a cleanup.
-      this.#lc.warn?.(
-        `not serving legacy change-log writer ${ctx.id} from SQLite catchup`,
-      );
+
+    let route: ChangeLogReadRoute | undefined;
+    if (this.#readRouter) {
+      route = this.#readRouter.consume(ctx.taskID);
+      if (route.source === 'pg') {
+        if (route.reason === 'cold-log') {
+          lc.info?.(
+            `serving ${ctx.id} from PG catchup: SQLite change log is still warming`,
+            {sqliteChangeLogCoverage: route.coverage},
+          );
+        } else if (route.reason === 'log-unavailable') {
+          this.#declineSQLiteCatchup(
+            lc,
+            ctx,
+            opts,
+            `${opts.changeLogFile} is unavailable or incompatible`,
+          );
+        } else {
+          lc.debug?.(
+            `serving ${ctx.id} from PG catchup: SQLite route ${route.reason}`,
+            ...(route.coverage
+              ? [{sqliteChangeLogCoverage: route.coverage}]
+              : []),
+          );
+        }
+        this.#recordCatchupRoute('pg', route.reason);
+        return undefined;
+      }
+      const coverage = route.coverage;
+      assert(coverage, 'a SQLite route must carry its covered range');
+      if (ctx.watermark < coverage.minWatermark) {
+        lc.info?.(
+          `serving ${ctx.id} from PG catchup: subscriber watermark ` +
+            `${ctx.watermark} is below the SQLite change-log minimum ` +
+            coverage.minWatermark,
+          {sqliteChangeLogCoverage: coverage},
+        );
+        this.#recordCatchupRoute('pg', 'watermark-uncovered');
+        return undefined;
+      }
+    }
+
+    // `shouldUse` remains as a test hook and an optional extra policy gate.
+    // Production selection comes from #readRouter.
+    if (!this.#readRouter && !opts.shouldUse?.(ctx)) {
+      this.#recordCatchupRoute('pg', 'selector');
       return undefined;
     }
-    if (!opts.shouldUse?.(ctx)) {
+    if (this.#readRouter && opts.shouldUse && !opts.shouldUse(ctx)) {
+      this.#recordCatchupRoute('pg', 'selector');
       return undefined;
     }
-    return this.#sqliteCatchup ?? this.#openSQLiteCatchup(opts, ctx);
+
+    const catchup =
+      this.#sqliteCatchup ?? this.#openSQLiteCatchup(lc, opts, ctx);
+    if (catchup) {
+      return {
+        catchup,
+        reason: route?.reason ?? 'selector',
+        coverage: route?.coverage,
+        // Every route the router selects has passed the warm-up gate.
+        // Legacy focused-test selection has no warm classification.
+        logWarm: route === undefined ? undefined : true,
+      };
+    } else {
+      this.#recordCatchupRoute('pg', 'log-unavailable');
+    }
+    return undefined;
+  }
+
+  #recordCatchupRoute(source: 'pg' | 'sqlite', reason: string): void {
+    this.#catchupRoutes.add(1, {source, reason});
   }
 
   /**
@@ -1185,6 +1385,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
    * subscription retries from scratch.
    */
   #openSQLiteCatchup(
+    lc: LogContext,
     opts: SQLiteCatchupOptions,
     ctx: SubscriberContext,
   ): SQLiteChangeLogCatchup | undefined {
@@ -1198,6 +1399,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
       if (reader.plan(ctx.watermark).kind === 'not-ready') {
         reader.close();
         this.#declineSQLiteCatchup(
+          lc,
           ctx,
           opts,
           `${opts.changeLogFile} has no changes to serve yet`,
@@ -1210,6 +1412,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
       // not a reason to fail the subscription.
       reader?.close();
       this.#declineSQLiteCatchup(
+        lc,
         ctx,
         opts,
         `cannot read ${opts.changeLogFile}`,
@@ -1231,6 +1434,12 @@ class ChangeStreamerImpl implements ChangeStreamerService {
         barrierTimeoutMs: opts.barrierTimeoutMs,
         barrierPollIntervalMs: opts.barrierPollIntervalMs,
         cleanupGuard: opts.cleanupGuard,
+        onFailure: failure => {
+          this.#lc.warn?.(
+            `temporarily disabling SQLite catchup after ${failure}`,
+          );
+          this.#readRouter?.trip();
+        },
       },
     );
     return this.#sqliteCatchup;
@@ -1242,6 +1451,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
    * first reconcile does not look like an incident.
    */
   #declineSQLiteCatchup(
+    lc: LogContext,
     ctx: SubscriberContext,
     opts: SQLiteCatchupOptions,
     reason: string,
@@ -1253,7 +1463,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
     const threshold =
       opts.notReadyWarnThresholdMs ??
       DEFAULT_CHANGE_LOG_UNAVAILABLE_WARN_THRESHOLD_MS;
-    this.#lc[unavailableMs >= threshold ? 'warn' : 'debug']?.(
+    lc[unavailableMs >= threshold ? 'warn' : 'debug']?.(
       `serving ${ctx.id} from PG catchup: ${reason} ` +
         `(unavailable for ${unavailableMs} ms)`,
       ...(error === undefined ? [] : [error]),
@@ -1264,6 +1474,17 @@ class ChangeStreamerImpl implements ChangeStreamerService {
 type ForwardedTransactionCompletion =
   | {kind: 'committed'; watermark: string}
   | {kind: 'rolled-back'; watermark: string};
+
+type SQLiteCatchupSelection = {
+  readonly catchup: SQLiteChangeLogCatchup;
+  readonly reason: string;
+  readonly coverage: SQLiteChangeLogCoverage | undefined;
+  /**
+   * Whether the router classified the log as warm for this subscriber, or
+   * undefined when selection did not run through the router (focused tests).
+   */
+  readonly logWarm: boolean | undefined;
+};
 
 // The delay between receiving an initial, backup-based watermark
 // and performing a check of whether to purge records before it.

--- a/packages/zero-cache/src/services/change-streamer/change-streamer.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer.ts
@@ -151,15 +151,9 @@ export type SubscriberContext = {
   initial: boolean;
 
   /**
-   * Whether the subscriber's replica writes the SQLite change log that the
-   * `change-streamer` reads for catchup.
-   *
-   * Always `false` from this version on: the change-streamer writes that log
-   * itself, from the stream loop, so no subscriber advances it and no
-   * subscriber's ACK releases the catchup barrier. The parameter stays on the
-   * wire because a subscriber that predates the writer's move still sets it,
-   * and such a subscriber is excluded from SQLite catchup until slice 11 lifts
-   * the exclusion deliberately.
+   * Legacy topology hint retained on the wire. It no longer affects local
+   * routing: the change-streamer writes the SQLite log itself, so no
+   * subscriber's ACK advances its head or releases its catchup barrier.
    */
   logsChangeStream: boolean;
 };

--- a/packages/zero-cache/src/services/change-streamer/shard-sampling.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/shard-sampling.test.ts
@@ -1,0 +1,46 @@
+import fc from 'fast-check';
+import {describe, expect, test} from 'vitest';
+import type {ShardID} from '../../types/shards.ts';
+import {isSampledForShard} from './shard-sampling.ts';
+
+describe('change-streamer/shard-sampling', () => {
+  test('sampling is stable, bounded, and monotone in the percentage', () => {
+    fc.assert(
+      fc.property(
+        fc.record({
+          appID: fc.string({minLength: 1, maxLength: 8}),
+          shardNum: fc.nat({max: 1000}),
+          key: fc.hexaString({minLength: 2, maxLength: 10}),
+          p1: fc.integer({min: 0, max: 100}),
+          p2: fc.integer({min: 0, max: 100}),
+        }),
+        ({appID, shardNum, key, p1, p2}) => {
+          const shard: ShardID = {appID, shardNum};
+          const lo = Math.min(p1, p2);
+          const hi = Math.max(p1, p2);
+          // A retry selects the same keys.
+          expect(isSampledForShard(shard, key, hi)).toBe(
+            isSampledForShard(shard, key, hi),
+          );
+          // A larger percentage keeps the keys in a smaller sample.
+          if (isSampledForShard(shard, key, lo)) {
+            expect(isSampledForShard(shard, key, hi)).toBe(true);
+          }
+          expect(isSampledForShard(shard, key, 0)).toBe(false);
+          expect(isSampledForShard(shard, key, 100)).toBe(true);
+        },
+      ),
+    );
+  });
+
+  test('the shard is part of the key, so shards sample independently', () => {
+    const keys = Array.from({length: 200}, (_, i) => `task-${i}`);
+    const a = keys.filter(key =>
+      isSampledForShard({appID: 'zero', shardNum: 0}, key, 25),
+    );
+    const b = keys.filter(key =>
+      isSampledForShard({appID: 'zero', shardNum: 1}, key, 25),
+    );
+    expect(a).not.toEqual(b);
+  });
+});

--- a/packages/zero-cache/src/services/change-streamer/shard-sampling.ts
+++ b/packages/zero-cache/src/services/change-streamer/shard-sampling.ts
@@ -1,0 +1,24 @@
+import {h32} from '../../../../shared/src/hash.ts';
+import type {ShardID} from '../../types/shards.ts';
+
+/**
+ * Stable percentage sampling keyed by shard and an arbitrary identity: a
+ * subscriber's task for read routing, a watermark for catchup comparison.
+ *
+ * The same key always lands in the same bucket, so raising `percent` only ever
+ * adds to the sampled set, and every process in a shard agrees on the set
+ * without coordinating.
+ */
+export function isSampledForShard(
+  shard: ShardID,
+  key: string,
+  percent: number,
+): boolean {
+  if (percent >= 100) {
+    return true;
+  }
+  if (percent <= 0) {
+    return false;
+  }
+  return h32(`${shard.appID}/${shard.shardNum}:${key}`) % 100 < percent;
+}

--- a/packages/zero-cache/src/services/change-streamer/snapshot-reservations.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/snapshot-reservations.test.ts
@@ -49,12 +49,12 @@ describe('change-streamer/snapshot-reservations', () => {
     expect(reservations.getReservedWatermarks()).toEqual([]);
   });
 
-  test('confirm() pushes a status message and confirms the reservation', async () => {
+  test('confirmFor() pushes a status message and confirms the reservation', async () => {
     const reservations = newReservations();
     const sub = reservations.open('task-1');
     const message = getFirstMessage(sub);
 
-    reservations.confirm('replica-v1', 'watermark-1');
+    reservations.confirmFor('task-1', 'replica-v1', 'watermark-1');
 
     expect(await message).toEqual([
       'status',
@@ -69,26 +69,28 @@ describe('change-streamer/snapshot-reservations', () => {
     expect(reservations.getReservedWatermarks()).toEqual(['watermark-1']);
   });
 
-  test('confirm() is a no-op for an already-confirmed reservation', () => {
+  test('confirmFor() is a no-op for an already-confirmed reservation', () => {
     const reservations = newReservations();
     reservations.open('task-1');
 
-    reservations.confirm('replica-v1', 'watermark-1');
-    reservations.confirm('replica-v1', 'watermark-2');
+    reservations.confirmFor('task-1', 'replica-v1', 'watermark-1');
+    reservations.confirmFor('task-1', 'replica-v1', 'watermark-2');
 
     // The reservation stays pinned to the watermark from its first
-    // confirmation; the second confirm() call is a no-op for it.
+    // confirmation; the second confirmFor() call is a no-op for it.
     expect(reservations.getReservedWatermarks()).toEqual(['watermark-1']);
   });
 
-  test('a single confirm() call resolves all pending reservations at once', () => {
+  test('the confirmation requirement clears once every task is confirmed', () => {
     const reservations = newReservations();
     reservations.open('task-1');
     reservations.open('task-2');
     expect(reservations.confirmationsRequired()).toBe(true);
 
-    reservations.confirm('replica-v1', 'watermark-1');
+    reservations.confirmFor('task-1', 'replica-v1', 'watermark-1');
+    expect(reservations.confirmationsRequired()).toBe(true);
 
+    reservations.confirmFor('task-2', 'replica-v1', 'watermark-1');
     expect(reservations.confirmationsRequired()).toBe(false);
     expect(reservations.getReservedWatermarks().sort()).toEqual([
       'watermark-1',
@@ -96,17 +98,35 @@ describe('change-streamer/snapshot-reservations', () => {
     ]);
   });
 
-  test('confirm() only resolves reservations opened before it was called', () => {
+  test('confirmFor() applies the pinned source bounds to one task only', async () => {
+    const reservations = newReservations();
+    const first = getFirstMessage(reservations.open('task-1'));
+    reservations.open('task-2');
+
+    expect(reservations.unconfirmedTaskIDs().sort()).toEqual([
+      'task-1',
+      'task-2',
+    ]);
+    reservations.confirmFor('task-1', 'replica-v1', 'sqlite-min');
+
+    expect(await first).toMatchObject([
+      'status',
+      {replicaVersion: 'replica-v1', minWatermark: 'sqlite-min'},
+    ]);
+    expect(reservations.unconfirmedTaskIDs()).toEqual(['task-2']);
+    expect(reservations.getReservedWatermarks()).toEqual(['sqlite-min']);
+  });
+
+  test('a reservation opened after a confirmation is still unconfirmed', () => {
     const reservations = newReservations();
     reservations.open('task-1');
-    reservations.confirm('replica-v1', 'watermark-1');
+    reservations.confirmFor('task-1', 'replica-v1', 'watermark-1');
 
-    // Opened after the first confirm(); still unconfirmed.
     reservations.open('task-2');
     expect(reservations.confirmationsRequired()).toBe(true);
     expect(reservations.getReservedWatermarks()).toEqual(['watermark-1']);
 
-    reservations.confirm('replica-v1', 'watermark-2');
+    reservations.confirmFor('task-2', 'replica-v1', 'watermark-2');
     expect(reservations.confirmationsRequired()).toBe(false);
     expect(reservations.getReservedWatermarks().sort()).toEqual([
       'watermark-1',
@@ -120,11 +140,13 @@ describe('change-streamer/snapshot-reservations', () => {
     const sub2 = reservations.open('task-1');
 
     expect(await isCancelled(sub1)).toBe(true);
+    expect(reservations.isCurrent('task-1', sub1)).toBe(false);
+    expect(reservations.isCurrent('task-1', sub2)).toBe(true);
 
     // Only one reservation is tracked for the taskID, and it's the new one:
-    // it still receives the confirm() push.
+    // it still receives the confirmation push.
     const message = getFirstMessage(sub2);
-    reservations.confirm('replica-v1', 'watermark-1');
+    reservations.confirmFor('task-1', 'replica-v1', 'watermark-1');
     await message;
     expect(reservations.getReservedWatermarks()).toEqual(['watermark-1']);
   });
@@ -151,7 +173,7 @@ describe('change-streamer/snapshot-reservations', () => {
     expect(reservations.confirmationsRequired()).toBe(true);
 
     const message = getFirstMessage(sub2);
-    reservations.confirm('replica-v1', 'watermark-1');
+    reservations.confirmFor('task-1', 'replica-v1', 'watermark-1');
     await message;
     expect(reservations.getReservedWatermarks()).toEqual(['watermark-1']);
 
@@ -187,10 +209,10 @@ describe('change-streamer/snapshot-reservations', () => {
     expect(reservations.getReservedWatermarks()).toEqual([]);
   });
 
-  test('confirm() with no reservations is a no-op', () => {
+  test('confirmFor() an unknown taskID is a no-op', () => {
     const reservations = newReservations();
     expect(() =>
-      reservations.confirm('replica-v1', 'watermark-1'),
+      reservations.confirmFor('task-1', 'replica-v1', 'watermark-1'),
     ).not.toThrow();
   });
 });

--- a/packages/zero-cache/src/services/change-streamer/snapshot-reservations.ts
+++ b/packages/zero-cache/src/services/change-streamer/snapshot-reservations.ts
@@ -40,6 +40,10 @@ export class SnapshotReservations {
     this.#close(taskID, undefined);
   }
 
+  isCurrent(taskID: string, source: Source<SnapshotMessage>): boolean {
+    return this.#reservations.get(taskID)?.owns(source) ?? false;
+  }
+
   #close(taskID: string, cancelledInstanceID: InstanceID | undefined) {
     const res = this.#reservations.get(taskID);
     if (
@@ -76,14 +80,24 @@ export class SnapshotReservations {
     return false;
   }
 
-  confirm(replicaVersion: string, minWatermark: string) {
-    for (const [taskID, res] of this.#reservations.entries()) {
-      if (!res.confirmed()) {
-        this.#lc.info?.(
-          `reserving change-log entries since ${minWatermark} for ${taskID}`,
-        );
-        res.confirm(this.#backupConfig.backupURL, replicaVersion, minWatermark);
-      }
+  unconfirmedTaskIDs(): string[] {
+    return [...this.#reservations.entries()]
+      .filter(([, reservation]) => !reservation.confirmed())
+      .map(([taskID]) => taskID);
+  }
+
+  /** Confirms one reservation with the bounds of its pinned read source. */
+  confirmFor(
+    taskID: string,
+    replicaVersion: string,
+    minWatermark: string,
+  ): void {
+    const res = this.#reservations.get(taskID);
+    if (res && !res.confirmed()) {
+      this.#lc.info?.(
+        `reserving change-log entries since ${minWatermark} for ${taskID}`,
+      );
+      res.confirm(this.#backupConfig.backupURL, replicaVersion, minWatermark);
     }
   }
 
@@ -117,6 +131,10 @@ class Reservation {
 
   confirmed() {
     return this.#watermark !== null;
+  }
+
+  owns(source: Source<SnapshotMessage>): boolean {
+    return this.#downstream === source;
   }
 
   confirm(backupURL: string, replicaVersion: string, minWatermark: string) {

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.metrics.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.metrics.test.ts
@@ -1,0 +1,122 @@
+/**
+ * `observability/metrics.ts` caches every instrument in module scope, so an
+ * instrument created against a previous test's meter provider would be handed
+ * back to the next one. Each test therefore resets modules and imports through
+ * a fresh provider, matching `snapshot-reservations.metrics.test.ts`.
+ */
+
+import {metrics, type Attributes} from '@opentelemetry/api';
+import {
+  AggregationTemporality,
+  InMemoryMetricExporter,
+  MeterProvider,
+  PeriodicExportingMetricReader,
+} from '@opentelemetry/sdk-metrics';
+import {LogContext} from '@rocicorp/logger';
+import {afterEach, expect, test, vi} from 'vitest';
+import {TestLogSink} from '../../../../shared/src/logging-test-utils.ts';
+import {Subscription} from '../../types/subscription.ts';
+import type {WatermarkedChange} from './change-streamer.ts';
+import {Forwarder} from './forwarder.ts';
+import type {SQLiteChangeLogCatchupReader} from './sqlite-change-log-catchup.ts';
+import type {CatchupPlan} from './sqlite-change-log-reader.ts';
+import {Subscriber} from './subscriber.ts';
+
+afterEach(() => {
+  metrics.disable();
+  vi.resetModules();
+});
+
+const CATCHUP_RESULTS = 'zero.replication.sqlite_change_log.catchup_results';
+
+function withProvider() {
+  const exporter = new InMemoryMetricExporter(
+    AggregationTemporality.CUMULATIVE,
+  );
+  const provider = new MeterProvider({
+    readers: [
+      new PeriodicExportingMetricReader({
+        exporter,
+        exportIntervalMillis: 60_000,
+      }),
+    ],
+  });
+  expect(metrics.setGlobalMeterProvider(provider)).toBe(true);
+  return {exporter, provider};
+}
+
+function pointsFor(
+  exporter: InMemoryMetricExporter,
+  name: string,
+): {attributes: Attributes; value: number}[] {
+  return (
+    exporter
+      .getMetrics()
+      .at(-1)
+      ?.scopeMetrics.flatMap(scope => scope.metrics)
+      .find(metric => metric.descriptor.name === name)
+      ?.dataPoints.map(point => ({
+        attributes: point.attributes,
+        value: point.value as number,
+      })) ?? []
+  );
+}
+
+/** A log that is always ready and never has anything to hand back. */
+class EmptyReader implements SQLiteChangeLogCatchupReader {
+  plan(): CatchupPlan {
+    return {kind: 'range', minWatermark: '01', headWatermark: '06'};
+  }
+
+  read(): AsyncIterable<readonly WatermarkedChange[]> {
+    return (async function* () {})();
+  }
+
+  close(): void {}
+}
+
+test('log_warm is recorded per catchup, not per coordinator', async () => {
+  const {exporter, provider} = withProvider();
+  try {
+    const {SQLiteChangeLogCatchup} =
+      await import('./sqlite-change-log-catchup.ts');
+    const lc = new LogContext('error', undefined, new TestLogSink());
+    using coordinator = new SQLiteChangeLogCatchup(
+      lc,
+      new Forwarder(lc),
+      new EmptyReader(),
+      {batchSize: 2, barrierTimeoutMs: 1_000},
+    );
+
+    // One coordinator serves both: `coldReadPercent` routes some subscribers
+    // to a log that is still inside its warm-up window, so the classification
+    // cannot be a property of the coordinator they share.
+    for (const [id, logWarm] of [
+      ['warm-subscriber', true],
+      ['cold-subscriber', false],
+    ] as const) {
+      const downstream = Subscription.create<string>();
+      const subscriber = new Subscriber(5, id, '01', downstream, () => ({
+        tag: 'status',
+      }));
+      expect(
+        await coordinator.catchup(subscriber, () => '06', {logWarm}),
+      ).toEqual({kind: 'registered'});
+      await subscriber.setCaughtUp();
+    }
+
+    await provider.forceFlush();
+    const classifications = pointsFor(exporter, CATCHUP_RESULTS).map(
+      ({attributes}) => [attributes.classification, attributes.log_warm],
+    );
+    expect(classifications).toHaveLength(2);
+    expect(classifications).toEqual(
+      expect.arrayContaining([
+        ['range', true],
+        ['range', false],
+      ]),
+    );
+  } finally {
+    await provider.shutdown();
+  }
+});

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.test.ts
@@ -255,7 +255,7 @@ describe('SQLiteChangeLogCatchup', () => {
     const plan = vi.spyOn(fixture.reader, 'plan');
     const {subscriber, output} = createSubscriber('01');
     await fixture.coordinator.catchup(subscriber, () => '06');
-    await vi.waitFor(() => expect(plan).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(plan).toHaveBeenCalledTimes(2));
 
     fixture.reader.entries.push(...transaction('06'));
     fixture.reader.boundaries.add('06');
@@ -279,13 +279,13 @@ describe('SQLiteChangeLogCatchup', () => {
     const plan = vi.spyOn(fixture.reader, 'plan');
     const {subscriber, output} = createSubscriber('01');
     await fixture.coordinator.catchup(subscriber, () => '06');
-    await vi.waitFor(() => expect(plan).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(plan).toHaveBeenCalledTimes(2));
 
     // The writer is still behind the required head. Waking on every commit
     // would re-read the log at the writer's commit rate for no reason.
     fixture.coordinator.onChangeLogCommit('04');
     await sleep(20);
-    expect(plan).toHaveBeenCalledOnce();
+    expect(plan).toHaveBeenCalledTimes(2);
     expect(output.size()).toBe(0);
 
     fixture.reader.entries.push(...transaction('06'));
@@ -313,12 +313,12 @@ describe('SQLiteChangeLogCatchup', () => {
     const cancelBacklogWait = vi.spyOn(backlogFull, 'cancel');
     vi.spyOn(subscriber, 'whenBacklogFull').mockReturnValue(backlogFull);
     await fixture.coordinator.catchup(subscriber, () => '06');
-    await vi.waitFor(() => expect(plan).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(plan).toHaveBeenCalledTimes(2));
 
     // An ACK that the reader cannot yet corroborate wakes the barrier but does
     // not release it: plan() decides what is readable.
     fixture.coordinator.onChangeLogCommit('06');
-    await vi.waitFor(() => expect(plan).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() => expect(plan).toHaveBeenCalledTimes(3));
     expect(output.size()).toBe(0);
 
     fixture.reader.entries.push(...transaction('06'));
@@ -340,6 +340,17 @@ describe('SQLiteChangeLogCatchup', () => {
     fixture.reader.head = '06';
     fixture.reader.boundaries.add('04');
     const {output, subscriber} = createSubscriber('01');
+    vi.spyOn(fixture.reader, 'plan')
+      .mockReturnValueOnce({
+        kind: 'range',
+        minWatermark: '01',
+        headWatermark: '06',
+      })
+      .mockReturnValueOnce({
+        kind: 'too-old',
+        minWatermark: '04',
+        headWatermark: '06',
+      });
     await fixture.coordinator.catchup(subscriber, () => '06');
     expect(await output.dequeue()).toEqual([
       'error',
@@ -350,12 +361,29 @@ describe('SQLiteChangeLogCatchup', () => {
     ]);
   });
 
+  test('declines an uncovered watermark before registering', async () => {
+    const fixture = createFixture();
+    fixture.reader.min = '04';
+    fixture.reader.head = '06';
+    fixture.reader.boundaries.add('04');
+    const {output, subscriber} = createSubscriber('01');
+
+    expect(await fixture.coordinator.catchup(subscriber, () => '06')).toEqual({
+      kind: 'uncovered',
+      minWatermark: '04',
+    });
+    expect(fixture.forwarder.getAcks()).toEqual(new Set());
+    expect(output.size()).toBe(0);
+  });
+
   test('gives up the barrier once the subscriber backlog fills', async () => {
+    const onFailure = vi.fn();
     // Long enough that only the backlog can end this wait. Bytes, not time,
     // are the real bound; the deadline is only a backstop for an idle shard.
     const fixture = createFixture({
       barrierTimeoutMs: 60_000,
       barrierPollIntervalMs: 60_000,
+      onFailure,
     });
     fixture.reader.head = '01';
 
@@ -374,6 +402,10 @@ describe('SQLiteChangeLogCatchup', () => {
     // holding replication while the backlog grows.
     expect(fail).not.toHaveBeenCalled();
     expect(output.size()).toBe(0);
+    // The breaker stays closed: a backlog high water mark is a property of
+    // this one subscriber's consumption, not of the log, and tripping it
+    // would take every task in the shard off SQLite.
+    expect(onFailure).not.toHaveBeenCalled();
     expect(fixture.logSink.messages).toContainEqual([
       'warn',
       expect.anything(),
@@ -387,7 +419,8 @@ describe('SQLiteChangeLogCatchup', () => {
   });
 
   test('ends only the selected subscription, cleanly, on barrier timeout', async () => {
-    const fixture = createFixture({barrierTimeoutMs: 5});
+    const onFailure = vi.fn();
+    const fixture = createFixture({barrierTimeoutMs: 5, onFailure});
     fixture.reader.head = '01';
     const {subscriber, done, output} = createSubscriber('01');
     const fail = vi.spyOn(subscriber, 'fail');
@@ -400,6 +433,7 @@ describe('SQLiteChangeLogCatchup', () => {
     // caught up yet" warrants.
     expect(fail).not.toHaveBeenCalled();
     expect(output.size()).toBe(0);
+    expect(onFailure).toHaveBeenCalledExactlyOnceWith('barrier-timeout');
     expect(fixture.logSink.messages).toContainEqual([
       'warn',
       expect.anything(),
@@ -461,7 +495,8 @@ describe('SQLiteChangeLogCatchup', () => {
   });
 
   test('fails closed on reader errors after registration', async () => {
-    const fixture = createFixture();
+    const onFailure = vi.fn();
+    const fixture = createFixture({onFailure});
     fixture.reader.head = '06';
     fixture.reader.boundaries.add('01');
     fixture.reader.readError = new Error('broken SQLite read');
@@ -473,6 +508,7 @@ describe('SQLiteChangeLogCatchup', () => {
     // operators through the log below, not through the subscriber.
     await done;
     expect(output.size()).toBe(0);
+    expect(onFailure).toHaveBeenCalledExactlyOnceWith('reader-error');
     expect(fixture.logSink.messages).toContainEqual([
       'error',
       expect.anything(),
@@ -481,6 +517,36 @@ describe('SQLiteChangeLogCatchup', () => {
         expect.objectContaining({message: 'broken SQLite read'}),
       ],
     ]);
+  });
+
+  test('declines to PG when registration fails before the Forwarder add', async () => {
+    const onFailure = vi.fn();
+    const fixture = createFixture({onFailure});
+    fixture.reader.head = '06';
+    fixture.reader.boundaries.add('01');
+    // A corrupt or truncated log: plan() is the first thing registration
+    // reads, and it throws before anything is committed to SQLite.
+    fixture.reader.planError = new Error('SQLITE_CORRUPT');
+    const {subscriber, output} = createSubscriber('01');
+    const fail = vi.spyOn(subscriber, 'fail');
+
+    const registration = await fixture.coordinator.catchup(
+      subscriber,
+      () => '06',
+    );
+
+    // Declined, not failed: the subscriber never reached the Forwarder, so PG
+    // catchup is still available and the caller falls back to it. Failing it
+    // would send a terminal ['error', ...] and cost a full replica restore.
+    expect(registration).toEqual({
+      kind: 'declined',
+      error: fixture.reader.planError,
+    });
+    expect(fail).not.toHaveBeenCalled();
+    expect(fixture.forwarder.getAcks()).toEqual(new Set());
+    expect(output.size()).toBe(0);
+    // The breaker opens, so the retry does not pick SQLite again.
+    expect(onFailure).toHaveBeenCalledExactlyOnceWith('reader-error');
   });
 
   test('cancellation and shutdown release catchup resources', async () => {
@@ -526,6 +592,7 @@ function createFixture(
     barrierPollIntervalMs?: number | undefined;
     cleanupGuard?: SQLiteChangeLogCleanupGuard | undefined;
     now?: SQLiteChangeLogCatchupOptions['now'];
+    onFailure?: SQLiteChangeLogCatchupOptions['onFailure'];
     sleep?: SQLiteChangeLogCatchupOptions['sleep'];
   } = {},
 ) {
@@ -539,6 +606,7 @@ function createFixture(
     barrierPollIntervalMs: opts.barrierPollIntervalMs ?? 1,
     cleanupGuard: opts.cleanupGuard,
     now: opts.now,
+    onFailure: opts.onFailure,
     sleep: opts.sleep,
   });
   coordinators.push(coordinator);
@@ -552,10 +620,14 @@ class TestReader implements SQLiteChangeLogCatchupReader {
   min = '01';
   head = '01';
   beforeRead: Promise<void> | undefined;
+  planError: Error | undefined;
   readError: Error | undefined;
   closed = false;
 
   plan(fromWatermark: string): CatchupPlan {
+    if (this.planError) {
+      throw this.planError;
+    }
     if (fromWatermark > this.head) {
       return {kind: 'ahead', headWatermark: this.head};
     }

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.ts
@@ -2,7 +2,11 @@ import type {LogContext} from '@rocicorp/logger';
 import {resolver} from '@rocicorp/resolver';
 import {AbortError} from '../../../../shared/src/abort-error.ts';
 import {sleep} from '../../../../shared/src/sleep.ts';
-import {getOrCreateCounter} from '../../observability/metrics.ts';
+import {
+  getOrCreateCounter,
+  getOrCreateLatencyHistogram,
+  getOrCreateValueHistogram,
+} from '../../observability/metrics.ts';
 import type {WatermarkedChange} from './change-streamer.ts';
 import * as ErrorType from './error-type-enum.ts';
 import type {Forwarder} from './forwarder.ts';
@@ -42,7 +46,31 @@ export type SQLiteChangeLogCatchupOptions = {
   cleanupGuard?: SQLiteChangeLogCleanupGuard | undefined;
   sleep?: typeof sleep | undefined;
   now?: (() => number) | undefined;
+  /** Opens slice 11's process-local breaker after registration has committed. */
+  onFailure?: ((failure: SQLiteChangeLogCatchupFailure) => void) | undefined;
 };
+
+export type SQLiteChangeLogCatchupRequest = {
+  /**
+   * Whether the routing warm-up gate classified the log as warm *for this
+   * subscriber*. The coordinator is opened once and reused, so this cannot be
+   * a property of it: `coldReadPercent` serves some subscribers from a log
+   * that is still inside its warm-up window, and the catchup metrics have to
+   * separate those from steady-state serving.
+   */
+  readonly logWarm?: boolean | undefined;
+};
+
+export type SQLiteChangeLogCatchupFailure = 'barrier-timeout' | 'reader-error';
+
+export type SQLiteChangeLogCatchupRegistration =
+  | {readonly kind: 'registered'}
+  | {readonly kind: 'uncovered'; readonly minWatermark: string}
+  // Registration failed before the subscriber was committed to SQLite, so PG
+  // catchup is still available and the caller falls back to it.
+  | {readonly kind: 'declined'; readonly error: unknown}
+  // The coordinator closed or failed the subscriber itself.
+  | {readonly kind: 'handled'};
 
 const NOOP_CLEANUP_GUARD: SQLiteChangeLogCleanupGuard = {
   runWhilePurgeBlocked: register => Promise.resolve(register()),
@@ -67,6 +95,9 @@ export class SQLiteChangeLogCatchup implements Disposable {
   readonly #cleanupGuard: SQLiteChangeLogCleanupGuard;
   readonly #sleep: typeof sleep;
   readonly #now: () => number;
+  readonly #onFailure:
+    | ((failure: SQLiteChangeLogCatchupFailure) => void)
+    | undefined;
   readonly #barrierTimeouts = getOrCreateCounter(
     'replication',
     'sqlite_change_log.barrier_timeouts',
@@ -84,6 +115,46 @@ export class SQLiteChangeLogCatchup implements Disposable {
     'SQLite catchup barrier waits, labeled by what ended the wait. A ' +
       'population dominated by "poll" means the change-log writer\'s commit ' +
       'notification is not reaching the barrier.',
+  );
+  readonly #catchupResults = getOrCreateCounter(
+    'replication',
+    'sqlite_change_log.catchup_results',
+    'SQLite catchup subscriptions by outcome.',
+  );
+  readonly #catchupRows = getOrCreateCounter(
+    'replication',
+    'sqlite_change_log.catchup_rows',
+    'Rows served from the SQLite change log during catchup.',
+  );
+  readonly #catchupBytes = getOrCreateCounter(
+    'replication',
+    'sqlite_change_log.catchup_bytes',
+    {
+      description: 'Bytes served from the SQLite change log during catchup.',
+      unit: 'By',
+    },
+  );
+  readonly #catchupDuration = getOrCreateLatencyHistogram(
+    'replication',
+    'sqlite_change_log.catchup_duration',
+    'Duration of a SQLite change-log catchup.',
+  );
+  readonly #barrierWaitDuration = getOrCreateLatencyHistogram(
+    'replication',
+    'sqlite_change_log.barrier_wait_duration',
+    'Time SQLite catchup waits for its pinned required head.',
+  );
+  readonly #catchupBacklogPeak = getOrCreateValueHistogram(
+    'replication',
+    'sqlite_change_log.catchup_backlog_peak_bytes',
+    {
+      description:
+        'Peak live backlog bytes buffered while a subscriber catches up from SQLite.',
+      unit: 'By',
+      bucketBoundaries: [
+        0, 1024, 16_384, 65_536, 262_144, 1_048_576, 4_194_304, 16_777_216,
+      ],
+    },
   );
   readonly #catchups = new Map<Subscriber, AbortController>();
   readonly #commitWaiters = new Set<CommitWaiter>();
@@ -105,6 +176,7 @@ export class SQLiteChangeLogCatchup implements Disposable {
     this.#cleanupGuard = opts.cleanupGuard ?? NOOP_CLEANUP_GUARD;
     this.#sleep = opts.sleep ?? sleep;
     this.#now = opts.now ?? Date.now;
+    this.#onFailure = opts.onFailure;
   }
 
   /**
@@ -115,34 +187,70 @@ export class SQLiteChangeLogCatchup implements Disposable {
   async catchup(
     subscriber: Subscriber,
     captureRequiredHead: () => string | Promise<string>,
-  ): Promise<void> {
+    request: SQLiteChangeLogCatchupRequest = {},
+  ): Promise<SQLiteChangeLogCatchupRegistration> {
     if (this.#closed) {
       subscriber.fail(new AbortError('SQLite change-log catchup is closed'));
-      return;
+      return {kind: 'handled'};
     }
 
     const abort = new AbortController();
     this.#catchups.set(subscriber, abort);
     let requiredHead: string | Promise<string> | undefined;
+    let uncoveredMinWatermark: string | undefined;
+    let committed = false;
     try {
       await this.#cleanupGuard.runWhilePurgeBlocked(() => {
         this.#throwIfAborted(abort.signal);
+        // The router's eligibility inspection happens before this async guard
+        // is acquired. Recheck the exact boundary here: an in-flight purge can
+        // have advanced the minimum while registration waited. Once added to
+        // the Forwarder, the subscriber's ACK prevents any later purge from
+        // crossing this boundary.
+        const plan = this.#reader.plan(subscriber.watermark);
+        if (plan.kind === 'too-old') {
+          uncoveredMinWatermark = plan.minWatermark;
+          return;
+        }
         requiredHead = captureRequiredHead();
         this.#forwarder.add(subscriber);
+        committed = true;
       });
     } catch (error) {
       this.#catchups.delete(subscriber);
-      if (!abort.signal.aborted) {
-        this.#lc.error?.(
-          `error while registering SQLite catchup subscriber ${subscriber.id}`,
-          error,
-        );
-        subscriber.fail(error);
+      if (abort.signal.aborted) {
+        return {kind: 'handled'};
       }
-      return;
+      if (!committed) {
+        // Nothing was committed to SQLite -- the subscriber never reached
+        // Forwarder.add() -- so PG catchup is still available. Failing here
+        // would send the client a terminal ['error', ...], which
+        // IncrementalSyncer answers with a full litestream replica restore,
+        // for a fallback that was still open. Trip the breaker as well: this
+        // is a reader failure like any other, and without it the retry picks
+        // SQLite again and the reset repeats.
+        this.#onFailure?.('reader-error');
+        return {kind: 'declined', error};
+      }
+      this.#lc.error?.(
+        `error while registering SQLite catchup subscriber ${subscriber.id}`,
+        error,
+      );
+      subscriber.fail(error);
+      return {kind: 'handled'};
+    }
+    if (uncoveredMinWatermark !== undefined) {
+      this.#catchups.delete(subscriber);
+      return {kind: 'uncovered', minWatermark: uncoveredMinWatermark};
     }
 
-    void this.#run(subscriber, requiredHead as string | Promise<string>, abort);
+    void this.#run(
+      subscriber,
+      requiredHead as string | Promise<string>,
+      abort,
+      request.logWarm,
+    );
+    return {kind: 'registered'};
   }
 
   /**
@@ -190,8 +298,12 @@ export class SQLiteChangeLogCatchup implements Disposable {
     subscriber: Subscriber,
     requiredHead: string | Promise<string>,
     abort: AbortController,
+    logWarm: boolean | undefined,
   ): Promise<void> {
     const {signal} = abort;
+    const catchupStart = this.#now();
+    let outcome = 'aborted';
+    let backlogPeakBytes = 0;
     try {
       const requiredHeadStart = this.#now();
       const required = await this.#awaitRequiredHead(requiredHead, signal);
@@ -208,15 +320,19 @@ export class SQLiteChangeLogCatchup implements Disposable {
       // during a transaction longer than barrierTimeoutMs, however current
       // the replica is.
       const deadline = this.#now() + this.#barrierTimeoutMs;
-      const plan = await this.#waitForPlan(
-        subscriber,
-        required,
-        deadline,
-        signal,
-      );
+      const barrierStart = this.#now();
+      let plan: CatchupPlan;
+      try {
+        plan = await this.#waitForPlan(subscriber, required, deadline, signal);
+      } finally {
+        // Record failed and aborted barriers too; their wait distribution is
+        // at least as operationally important as the successful path.
+        this.#barrierWaitDuration.recordMs(this.#now() - barrierStart);
+      }
       this.#throwIfAborted(signal);
 
       if (plan.kind === 'too-old') {
+        outcome = 'too-old';
         const message =
           `earliest supported watermark is ${plan.minWatermark} ` +
           `(requested ${subscriber.watermark})`;
@@ -229,6 +345,7 @@ export class SQLiteChangeLogCatchup implements Disposable {
       }
 
       let count = 0;
+      let bytes = 0;
       const start = this.#now();
       if (plan.kind === 'range') {
         let lastBatchConsumed: Promise<unknown> | undefined;
@@ -251,10 +368,17 @@ export class SQLiteChangeLogCatchup implements Disposable {
           for (const change of changes) {
             lastBatchConsumed = subscriber.catchup(change);
             count++;
+            bytes += Buffer.byteLength(change[2]);
           }
+          backlogPeakBytes = Math.max(
+            backlogPeakBytes,
+            subscriber.getStats().backlogBytes,
+          );
         }
         await lastBatchConsumed;
+        outcome = 'range';
       } else {
+        outcome = 'ahead';
         this.#lc.warn?.(
           `subscriber ${subscriber.id} at watermark ${subscriber.watermark} ` +
             `is ahead of the SQLite change-log head ${plan.headWatermark}; ` +
@@ -267,6 +391,12 @@ export class SQLiteChangeLogCatchup implements Disposable {
         `caught up ${subscriber.id} from SQLite with ${count} changes ` +
           `(${this.#now() - start} ms)`,
       );
+      const attributes = {
+        classification: outcome,
+        log_warm: logWarm ?? 'unknown',
+      };
+      this.#catchupRows.add(count, attributes);
+      this.#catchupBytes.add(bytes, attributes);
       // Keep buffering live sends until the asynchronous backlog drain has
       // established its ordering boundary.
       void subscriber.setCaughtUp();
@@ -277,6 +407,15 @@ export class SQLiteChangeLogCatchup implements Disposable {
       if (error instanceof SQLiteChangeLogBarrierError) {
         if (error instanceof SQLiteChangeLogBarrierTimeoutError) {
           this.#barrierTimeouts.add(1);
+          outcome = 'barrier-timeout';
+          this.#onFailure?.('barrier-timeout');
+        } else {
+          // No #onFailure: a backlog high water mark is a property of this
+          // one subscriber's consumption, not of the log. Tripping the
+          // process-wide breaker for it would take every task in the shard
+          // off SQLite, which a client that reconnects and stalls again
+          // could hold open indefinitely.
+          outcome = 'barrier-backlog';
         }
         // Giving up on the barrier means the replica has not caught up *yet*,
         // not that it cannot serve this subscriber. End the subscription
@@ -293,12 +432,25 @@ export class SQLiteChangeLogCatchup implements Disposable {
         subscriber.close();
         return;
       }
+      outcome = 'reader-error';
+      this.#onFailure?.('reader-error');
       this.#lc.error?.(
         `error while catching up subscriber ${subscriber.id} from SQLite`,
         error,
       );
       subscriber.fail(error);
     } finally {
+      backlogPeakBytes = Math.max(
+        backlogPeakBytes,
+        subscriber.getStats().backlogBytes,
+      );
+      const attributes = {
+        classification: outcome,
+        log_warm: logWarm ?? 'unknown',
+      };
+      this.#catchupResults.add(1, attributes);
+      this.#catchupDuration.recordMs(this.#now() - catchupStart, attributes);
+      this.#catchupBacklogPeak.record(backlogPeakBytes, attributes);
       if (this.#catchups.get(subscriber) === abort) {
         this.#catchups.delete(subscriber);
       }

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.pg.test.ts
@@ -26,9 +26,9 @@ import {
 } from '../replicator/schema/replication-state.ts';
 import {ReplicationMessages} from '../replicator/test-utils.ts';
 import {serializeChangeStreamData} from './change-log-codec.ts';
-import {isSampledForCompare} from './change-log-compare-digest.ts';
 import {initChangeStreamerSchema} from './schema/init.ts';
 import {ensureReplicationConfig} from './schema/tables.ts';
+import {isSampledForShard} from './shard-sampling.ts';
 import {
   SQLiteChangeLogComparator,
   type PGChangeLogRangeReader,
@@ -729,7 +729,7 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
 
     const percent = 40;
     const expected = txs.filter(({watermark}) =>
-      isSampledForCompare(shard, watermark, percent),
+      isSampledForShard(shard, watermark, percent),
     ).length;
 
     // Independent comparators select the same sample.

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.ts
@@ -18,10 +18,10 @@ import {
 } from './change-log-codec.ts';
 import {
   digestCatchupRange,
-  isSampledForCompare,
   type CatchupRangeDigest,
 } from './change-log-compare-digest.ts';
 import type {WatermarkedChange} from './change-streamer.ts';
+import {isSampledForShard} from './shard-sampling.ts';
 import {SQLiteChangeLogReader} from './sqlite-change-log-reader.ts';
 
 /** Interval between comparison cycles. */
@@ -427,7 +427,7 @@ export class SQLiteChangeLogComparator {
             fileGeneration === this.#fileGeneration ? outcome : 'inconclusive',
           );
         } else if (
-          isSampledForCompare(this.#shard, watermark, this.#opts.comparePercent)
+          isSampledForShard(this.#shard, watermark, this.#opts.comparePercent)
         ) {
           const sqliteRowsRemaining = maxRowsPerSource - sqliteRowsRead;
           const pgRowsRemaining = maxRowsPerSource - pgRowsRead;

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-read-router.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-read-router.test.ts
@@ -1,0 +1,221 @@
+import {describe, expect, test, vi} from 'vitest';
+import type {ShardID} from '../../types/shards.ts';
+import {isSampledForShard} from './shard-sampling.ts';
+import {
+  SQLiteChangeLogReadRouter,
+  type SQLiteChangeLogCoverage,
+} from './sqlite-change-log-read-router.ts';
+
+describe('change-streamer/sqlite-change-log-read-router', () => {
+  const shard: ShardID = {appID: 'router', shardNum: 3};
+  const warm: SQLiteChangeLogCoverage = {
+    seededAtMs: 1_000,
+    seedWatermark: '01',
+    minWatermark: '02',
+    headWatermark: '09',
+  };
+
+  test('selection is stable by shard and task, and zero percent still inspects eligibility', () => {
+    const inspect = vi.fn(() => warm);
+    const zero = new SQLiteChangeLogReadRouter({
+      shard,
+      readPercent: 0,
+      retentionMs: 100,
+      now: () => 2_000,
+      inspect,
+    });
+    expect(zero.consume('task-a')).toMatchObject({
+      source: 'pg',
+      reason: 'percentage',
+      coverage: warm,
+    });
+    expect(inspect).toHaveBeenCalledOnce();
+
+    const selected = Array.from({length: 1_000}, (_, i) => `task-${i}`).find(
+      taskID => isSampledForShard(shard, taskID, 10),
+    );
+    const declined = Array.from({length: 1_000}, (_, i) => `task-${i}`).find(
+      taskID => !isSampledForShard(shard, taskID, 10),
+    );
+    expect(selected).toBeDefined();
+    expect(declined).toBeDefined();
+
+    const canary = new SQLiteChangeLogReadRouter({
+      shard,
+      readPercent: 10,
+      retentionMs: 100,
+      now: () => 2_000,
+      inspect: () => warm,
+    });
+    expect(canary.consume(selected as string).source).toBe('sqlite');
+    expect(canary.consume(selected as string).source).toBe('sqlite');
+    expect(canary.consume(declined as string).source).toBe('pg');
+  });
+
+  test('declines a cold log and reports its covered range', () => {
+    const router = new SQLiteChangeLogReadRouter({
+      shard,
+      readPercent: 100,
+      retentionMs: 1_000,
+      now: () => 1_999,
+      inspect: () => warm,
+    });
+    expect(router.consume('task')).toEqual({
+      source: 'pg',
+      reason: 'cold-log',
+      coverage: warm,
+    });
+  });
+
+  test('a reseed resets warm-up eligibility until retention elapses again', () => {
+    let now = 2_000;
+    let coverage = warm;
+    const router = new SQLiteChangeLogReadRouter({
+      shard,
+      readPercent: 100,
+      retentionMs: 1_000,
+      now: () => now,
+      inspect: () => coverage,
+    });
+    expect(router.consume('task').source).toBe('sqlite');
+
+    coverage = {
+      ...warm,
+      seededAtMs: now,
+      seedWatermark: warm.headWatermark,
+      minWatermark: warm.headWatermark,
+    };
+    expect(router.consume('task')).toEqual({
+      source: 'pg',
+      reason: 'cold-log',
+      coverage,
+    });
+
+    now += 1_000;
+    expect(router.consume('task').source).toBe('sqlite');
+  });
+
+  test('a snapshot pin is consumed once and cannot change source mid-restore', () => {
+    let available = true;
+    const router = new SQLiteChangeLogReadRouter({
+      shard,
+      readPercent: 100,
+      retentionMs: 100,
+      now: () => 2_000,
+      inspect: () => (available ? warm : undefined),
+    });
+
+    expect(router.pin('task')).toMatchObject({source: 'sqlite'});
+    available = false;
+    expect(router.peek('task')).toMatchObject({
+      source: 'sqlite',
+      reason: 'selected',
+      pinned: true,
+    });
+    expect(router.consume('task')).toMatchObject({
+      source: 'sqlite',
+      reason: 'selected',
+      pinned: true,
+    });
+    expect(router.peek('task')).toBeUndefined();
+    expect(router.consume('task')).toEqual({
+      source: 'pg',
+      reason: 'log-unavailable',
+    });
+  });
+
+  test('post-registration failures route retries to PG until a bounded probe succeeds', () => {
+    let now = 2_000;
+    let available = true;
+    const inspect = vi.fn(() => (available ? warm : undefined));
+    const router = new SQLiteChangeLogReadRouter({
+      shard,
+      readPercent: 100,
+      retentionMs: 100,
+      failureCooldownMs: 500,
+      now: () => now,
+      inspect,
+    });
+
+    expect(router.consume('task').source).toBe('sqlite');
+    router.trip();
+    expect(router.consume('task')).toEqual({
+      source: 'pg',
+      reason: 'breaker-open',
+    });
+    expect(inspect).toHaveBeenCalledTimes(1);
+
+    available = false;
+    now += 500;
+    expect(router.consume('task')).toEqual({
+      source: 'pg',
+      reason: 'log-unavailable',
+    });
+    // The failed probe rearms the cooldown.
+    available = true;
+    expect(router.consume('task')).toEqual({
+      source: 'pg',
+      reason: 'breaker-open',
+    });
+
+    now += 500;
+    expect(router.consume('task').source).toBe('sqlite');
+  });
+
+  test('a probe that lands on a cold log still closes the breaker', () => {
+    let now = 2_000;
+    // Seeded 500 ms before the probe against a 1s retention window: eligible,
+    // but still inside its warm-up window, so it stays on PG.
+    const coverage: SQLiteChangeLogCoverage = {...warm, seededAtMs: 2_000};
+    let available = true;
+    const router = new SQLiteChangeLogReadRouter({
+      shard,
+      readPercent: 100,
+      retentionMs: 1_000,
+      failureCooldownMs: 500,
+      now: () => now,
+      inspect: () => (available ? coverage : undefined),
+    });
+
+    router.trip();
+    now += 500;
+    // The probe reads the log successfully; the warm-up gate, not the
+    // breaker, is what keeps this task on PG.
+    expect(router.consume('task')).toMatchObject({
+      source: 'pg',
+      reason: 'cold-log',
+    });
+
+    // A later ordinary unavailability is startup, not a failed probe, so it
+    // must not rearm a full cooldown against an eligibility inspection that
+    // already succeeded.
+    available = false;
+    expect(router.consume('task')).toEqual({
+      source: 'pg',
+      reason: 'log-unavailable',
+    });
+    available = true;
+    expect(router.consume('task')).toMatchObject({
+      source: 'pg',
+      reason: 'cold-log',
+    });
+  });
+
+  test('writer failure keeps the breaker open for the process lifetime', () => {
+    let now = 2_000;
+    const router = new SQLiteChangeLogReadRouter({
+      shard,
+      readPercent: 100,
+      retentionMs: 100,
+      failureCooldownMs: 1,
+      now: () => now,
+      inspect: () => warm,
+    });
+    router.trip(true);
+    now += 1_000_000;
+    expect(router.consume('task')).toEqual({
+      source: 'pg',
+      reason: 'breaker-open',
+    });
+  });
+});

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-read-router.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-read-router.ts
@@ -1,0 +1,206 @@
+import type {LogContext} from '@rocicorp/logger';
+import {Database} from '../../../../zqlite/src/db.ts';
+import type {ShardID} from '../../types/shards.ts';
+import {
+  CHANGE_LOG_DB_SCHEMA_VERSION,
+  readChangeLogBounds,
+  readChangeLogMeta,
+  type ChangeLogIdentity,
+} from '../replicator/change-log-db.ts';
+import {isSampledForShard} from './shard-sampling.ts';
+
+export type ChangeLogReadSource = 'pg' | 'sqlite';
+
+export type SQLiteChangeLogCoverage = {
+  readonly seededAtMs: number;
+  readonly seedWatermark: string;
+  readonly minWatermark: string;
+  readonly headWatermark: string;
+};
+
+export type ChangeLogReadRouteReason =
+  | 'selected'
+  | 'percentage'
+  | 'cold-log'
+  | 'log-unavailable'
+  | 'breaker-open';
+
+export type ChangeLogReadRoute = {
+  readonly source: ChangeLogReadSource;
+  readonly reason: ChangeLogReadRouteReason;
+  readonly pinned?: boolean | undefined;
+  readonly coverage?: SQLiteChangeLogCoverage | undefined;
+};
+
+export type SQLiteChangeLogReadRouterOptions = {
+  readonly shard: ShardID;
+  readonly readPercent: number;
+  readonly retentionMs: number;
+  readonly inspect: () => SQLiteChangeLogCoverage | undefined;
+  readonly failureCooldownMs?: number | undefined;
+  readonly now?: (() => number) | undefined;
+};
+
+const DEFAULT_FAILURE_COOLDOWN_MS = 30_000;
+
+/**
+ * Selects and pins the catchup source shared by `/snapshot` and `/changes`.
+ *
+ * A post-registration SQLite failure opens a process-local breaker. Requests
+ * use PG during the cooldown; the first request after it expires is the
+ * bounded probe. A successful readiness inspection closes the breaker, while
+ * another unavailable result rearms it. A writer failure opens it permanently
+ * because the writer remains disabled and its file stays absent for the life
+ * of the process.
+ */
+export class SQLiteChangeLogReadRouter {
+  readonly #shard: ShardID;
+  readonly #readPercent: number;
+  readonly #retentionMs: number;
+  readonly #inspect: () => SQLiteChangeLogCoverage | undefined;
+  readonly #failureCooldownMs: number;
+  readonly #now: () => number;
+  readonly #pins = new Map<string, ChangeLogReadRoute>();
+
+  #breakerUntilMs: number | undefined;
+  #permanentlyDisabled = false;
+
+  constructor(opts: SQLiteChangeLogReadRouterOptions) {
+    this.#shard = opts.shard;
+    this.#readPercent = opts.readPercent;
+    this.#retentionMs = opts.retentionMs;
+    this.#inspect = opts.inspect;
+    this.#failureCooldownMs =
+      opts.failureCooldownMs ?? DEFAULT_FAILURE_COOLDOWN_MS;
+    this.#now = opts.now ?? Date.now;
+  }
+
+  /** Chooses and pins a source for a snapshot reservation. */
+  pin(taskID: string): ChangeLogReadRoute {
+    const route = this.#choose(taskID);
+    this.#pins.set(taskID, route);
+    return route;
+  }
+
+  /** Returns the source pinned by an active snapshot reservation. */
+  peek(taskID: string): ChangeLogReadRoute | undefined {
+    const route = this.#pins.get(taskID);
+    return route && this.#asPinned(route);
+  }
+
+  /** Consumes a snapshot pin, or makes the stable choice for a direct retry. */
+  consume(taskID: string): ChangeLogReadRoute {
+    const route = this.#pins.get(taskID);
+    if (route === undefined) {
+      return this.#choose(taskID);
+    }
+    this.#pins.delete(taskID);
+    return this.#asPinned(route);
+  }
+
+  /** Releases a pin whose snapshot reservation ended before subscribing. */
+  release(taskID: string): void {
+    this.#pins.delete(taskID);
+  }
+
+  /** Opens the post-registration failure breaker. */
+  trip(permanent = false): void {
+    if (permanent) {
+      this.#permanentlyDisabled = true;
+      this.#breakerUntilMs = undefined;
+      return;
+    }
+    if (!this.#permanentlyDisabled) {
+      this.#breakerUntilMs = this.#now() + this.#failureCooldownMs;
+    }
+  }
+
+  #choose(taskID: string): ChangeLogReadRoute {
+    const now = this.#now();
+    if (
+      this.#permanentlyDisabled ||
+      (this.#breakerUntilMs !== undefined && now < this.#breakerUntilMs)
+    ) {
+      return {source: 'pg', reason: 'breaker-open'};
+    }
+
+    // Inspect eligibility even at readPercent=0. Slice 11 starts its rollout
+    // at zero specifically so warm/cold/unavailable rates are visible before
+    // any subscriber is routed to SQLite.
+    let coverage: SQLiteChangeLogCoverage | undefined;
+    try {
+      coverage = this.#inspect();
+    } catch {
+      coverage = undefined;
+    }
+    if (coverage === undefined) {
+      // This was a breaker probe rather than ordinary startup unavailability.
+      // Rearm it so a busy retry loop does not turn into an open/read loop.
+      if (this.#breakerUntilMs !== undefined) {
+        this.#breakerUntilMs = now + this.#failureCooldownMs;
+      }
+      return {source: 'pg', reason: 'log-unavailable'};
+    }
+    // A successful probe restores eligibility. This happens before the gates
+    // below so that declining a task -- for a cold log or for the percentage
+    // -- does not leave the cooldown armed against the next ordinary
+    // unavailability.
+    this.#breakerUntilMs = undefined;
+    if (now - coverage.seededAtMs < this.#retentionMs) {
+      return {source: 'pg', reason: 'cold-log', coverage};
+    }
+
+    // Keeping the percentage decision after readiness makes zero-percent
+    // rollouts emit eligibility metrics without serving reads.
+    if (!isSampledForShard(this.#shard, taskID, this.#readPercent)) {
+      return {source: 'pg', reason: 'percentage', coverage};
+    }
+    return {source: 'sqlite', reason: 'selected', coverage};
+  }
+
+  #asPinned(route: ChangeLogReadRoute): ChangeLogReadRoute {
+    return {...route, pinned: true};
+  }
+}
+
+/**
+ * Reads the coverage and validates the v2 schema and RMv2 identity in one
+ * short-lived readonly connection. It never creates the log.
+ */
+export function inspectSQLiteChangeLog(
+  lc: LogContext,
+  changeLogFile: string,
+  identity: ChangeLogIdentity,
+): SQLiteChangeLogCoverage | undefined {
+  let db: Database | undefined;
+  try {
+    db = new Database(
+      lc.withContext('component', 'sqlite-change-log-read-router'),
+      changeLogFile,
+      {readonly: true},
+    );
+    const meta = readChangeLogMeta(db);
+    if (
+      meta.schemaVersion !== CHANGE_LOG_DB_SCHEMA_VERSION ||
+      meta.epoch !== identity.epoch ||
+      meta.generation !== identity.generation ||
+      meta.replicaID !== identity.replicaID
+    ) {
+      return undefined;
+    }
+    const bounds = readChangeLogBounds(db);
+    if (bounds.minWatermark === null || bounds.headWatermark === null) {
+      return undefined;
+    }
+    return {
+      seededAtMs: meta.seededAtMs,
+      seedWatermark: meta.seedWatermark,
+      minWatermark: bounds.minWatermark,
+      headWatermark: bounds.headWatermark,
+    };
+  } catch {
+    return undefined;
+  } finally {
+    db?.close();
+  }
+}

--- a/packages/zero-cache/src/services/replicator/change-log-db.ts
+++ b/packages/zero-cache/src/services/replicator/change-log-db.ts
@@ -932,6 +932,28 @@ export function readChangeLogHead(db: Database): string | null {
 }
 
 /**
+ * The covered watermark range. Both scalar subqueries seek the watermark
+ * index, so unlike a `count()` this does not scan the log. Both bounds are
+ * null when it is empty.
+ */
+export function readChangeLogBounds(db: Database): ChangeLogBounds {
+  return db
+    .prepare(/*sql*/ `
+      SELECT
+        (SELECT min("watermark") FROM "${CHANGE_LOG_STREAM_TABLE}")
+          AS "minWatermark",
+        (SELECT max("watermark") FROM "${CHANGE_LOG_STREAM_TABLE}")
+          AS "headWatermark"
+    `)
+    .get<ChangeLogBounds>();
+}
+
+export type ChangeLogBounds = {
+  readonly minWatermark: string | null;
+  readonly headWatermark: string | null;
+};
+
+/**
  * What was installed, for the reconcile log line. Normally `{0, 0}`: a nonzero
  * `backfilling` means the resumed stream is being handed backfills to re-request.
  */

--- a/packages/zero-cache/src/services/replicator/sqlite-change-log-metrics.test.ts
+++ b/packages/zero-cache/src/services/replicator/sqlite-change-log-metrics.test.ts
@@ -196,6 +196,7 @@ const INFO: SQLiteChangeLogInfo = {
   schemaVersion: CHANGE_LOG_DB_SCHEMA_VERSION,
   seededAtMs: 1_700_000_000_000,
   seedWatermark: '02',
+  minWatermark: '02',
   headWatermark: '02',
   rows: 2,
   estimatedBytes: 100,

--- a/packages/zero-cache/src/services/replicator/sqlite-change-log-observability.test.ts
+++ b/packages/zero-cache/src/services/replicator/sqlite-change-log-observability.test.ts
@@ -115,6 +115,7 @@ describe('SQLite change-log observability', () => {
       schemaVersion: CHANGE_LOG_DB_SCHEMA_VERSION,
       seededAtMs: ANCHOR.nowMs,
       seedWatermark: '02',
+      minWatermark: '02',
       headWatermark: '02',
       rows: 2,
       estimatedBytes: expect.any(Number),
@@ -137,6 +138,7 @@ describe('SQLite change-log observability', () => {
             schemaVersion: CHANGE_LOG_DB_SCHEMA_VERSION,
             seedWatermark: '02',
             seededAtMs: ANCHOR.nowMs,
+            minWatermark: '02',
             headWatermark: '02',
           },
         },
@@ -156,6 +158,7 @@ describe('SQLite change-log observability', () => {
       schemaVersion: CHANGE_LOG_DB_SCHEMA_VERSION,
       seededAtMs: ANCHOR.nowMs,
       seedWatermark: '02',
+      minWatermark: '02',
       headWatermark: '02',
     });
     const {

--- a/packages/zero-cache/src/services/replicator/sqlite-change-log-observability.ts
+++ b/packages/zero-cache/src/services/replicator/sqlite-change-log-observability.ts
@@ -31,7 +31,7 @@ import {
 } from './change-log-cookies.ts';
 import {
   CHANGE_LOG_STREAM_TABLE,
-  readChangeLogHead,
+  readChangeLogBounds,
   readChangeLogMeta,
   type ChangeLogMeta,
   type ReconcileResult,
@@ -99,6 +99,7 @@ export function recordSQLiteChangeLogReconcile(
  * consequence of this log rather than a fact about it.
  */
 export type SQLiteChangeLogStartupInfo = ChangeLogMeta & {
+  readonly minWatermark: string;
   readonly headWatermark: string;
 };
 
@@ -109,8 +110,8 @@ export type SQLiteChangeLogInfo = SQLiteChangeLogStartupInfo & {
 };
 
 /**
- * Reads the meta row and the head. The head is an index-optimized `max()`, so
- * unlike {@link getSQLiteChangeLogInfo} this does not scan the log.
+ * Reads the meta row and covered range. Unlike {@link getSQLiteChangeLogInfo}
+ * this does not scan the log; see {@link readChangeLogBounds}.
  *
  * Call this after reconciliation, which is the only point at which the head is
  * known to be the resume watermark.
@@ -119,11 +120,11 @@ export function getSQLiteChangeLogStartupInfo(
   changeLog: Database,
 ): SQLiteChangeLogStartupInfo {
   const meta = readChangeLogMeta(changeLog);
-  const head = readChangeLogHead(changeLog);
-  if (head === null) {
+  const {minWatermark, headWatermark} = readChangeLogBounds(changeLog);
+  if (minWatermark === null || headWatermark === null) {
     throw new Error('the SQLite change log must contain its seed transaction');
   }
-  return {...meta, headWatermark: head};
+  return {...meta, minWatermark, headWatermark};
 }
 
 /**
@@ -166,6 +167,7 @@ export function logSQLiteChangeLogStartup(
       schemaVersion: info.schemaVersion,
       seedWatermark: info.seedWatermark,
       seededAtMs: info.seededAtMs,
+      minWatermark: info.minWatermark,
       headWatermark: info.headWatermark,
     },
   });


### PR DESCRIPTION
also adds tests to test rollback