### PR TITLE
fix(zql): forward 'yield' sentinels when UnionFanIn probes sibling branches

### DIFF
--- a/packages/zql/src/ivm/stream.test.ts
+++ b/packages/zql/src/ivm/stream.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, test} from 'vitest';
-import {first, type Stream, take} from './stream.ts';
+import {type Stream, take} from './stream.ts';
 
 describe('take', () => {
   test('take the first n elements from the stream', () => {
@@ -18,19 +18,5 @@ describe('take', () => {
     const stream: Stream<number> = [1, 2, 3];
     const result = [...take(stream, 5)];
     expect(result).toEqual([1, 2, 3]);
-  });
-});
-
-describe('first', () => {
-  test('return the first element of the stream', () => {
-    const stream: Stream<number> = [1, 2, 3, 4, 5];
-    const result = first(stream);
-    expect(result).toBe(1);
-  });
-
-  test('return undefined if the stream is empty', () => {
-    const stream: Stream<number> = [];
-    const result = first(stream);
-    expect(result).toBeUndefined();
   });
 });

--- a/packages/zql/src/ivm/stream.ts
+++ b/packages/zql/src/ivm/stream.ts
@@ -20,13 +20,6 @@ export function* take<T>(stream: Stream<T>, limit: number): Stream<T> {
   }
 }
 
-export function first<T>(stream: Stream<T>): T | undefined {
-  const it = stream[Symbol.iterator]();
-  const {value} = it.next();
-  it.return?.();
-  return value;
-}
-
 export function consume<T>(stream: Stream<T>): void {
   // Required to prevent some minifiers (e.g. Terser) from removing this empty loop
   for (const _ of stream);

--- a/packages/zql/src/ivm/union-fan-in.ts
+++ b/packages/zql/src/ivm/union-fan-in.ts
@@ -19,7 +19,7 @@ import {
   pushAccumulatedChanges,
 } from './push-accumulated.ts';
 import type {SourceSchema} from './schema.ts';
-import {first, type Stream} from './stream.ts';
+import type {Stream} from './stream.ts';
 import type {UnionFanOut} from './union-fan-out.ts';
 
 export class UnionFanIn implements Operator {
@@ -170,7 +170,24 @@ export class UnionFanIn implements Operator {
         constraint,
       });
 
-      if (first(fetchResult) !== undefined) {
+      // `fetch` interleaves 'yield' sentinels for cooperative multitasking.
+      // They must be forwarded, not just skipped: this probe runs inside a
+      // push, and the sentinel is the source offering the scheduler a breath.
+      // They must also not be mistaken for rows -- reading one as a row is
+      // what broke this before, since an empty branch that happened to yield
+      // looked like a branch holding the row, silently dropping the
+      // add/remove and desyncing a downstream `Take`'s push and fetch paths.
+      let otherBranchHasRow = false;
+      for (const node of fetchResult) {
+        if (node === 'yield') {
+          yield node;
+          continue;
+        }
+        otherBranchHasRow = true;
+        break;
+      }
+
+      if (otherBranchHasRow) {
         // Another branch has the row, so the add/remove is not needed.
         return;
       }

--- a/packages/zql/src/query/take-union-bound.repro.test.ts
+++ b/packages/zql/src/query/take-union-bound.repro.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Regression test for the prod `Bound should be set` crash (take.ts:448).
+ *
+ *   source -> UnionFanOut -> [filter | flipped-exists] -> UnionFanIn -> Take
+ *
+ * Root cause: `UnionFanIn.#pushInternalChange` probed each sibling branch with
+ * `first(input.fetch(...))` to decide whether another branch already held the
+ * row. `fetch` interleaves 'yield' sentinels for cooperative multitasking, so
+ * an empty branch that happened to yield was misread as a branch holding the
+ * row, and the add was silently dropped. `Take` then never saw the row its own
+ * fetch could see, leaving `bound` unset for the following edit. Fixed by
+ * `first(skipYields(...))` in union-fan-in.ts.
+ *
+ * Only reproduced when cooperative multitasking is in play: prod's view-syncer
+ * constructs TableSource with a `shouldYield` callback
+ * (pipeline-driver.ts:1095), so sentinels thread through every fetch and push
+ * stream. Without yields, 3M+ zqlite runs found nothing; with them, a
+ * 2-operation script was enough.
+ *
+ * Run under `zql` (MemorySource) and `zqlite-zql-test` (SQLite TableSource).
+ */
+import {expect, test} from 'vitest';
+import {testLogConfig} from '../../../otel/src/test-log-config.ts';
+import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
+import {must} from '../../../shared/src/must.ts';
+import type {Row} from '../../../zero-protocol/src/data.ts';
+import {relationships} from '../../../zero-schema/src/builder/relationship-builder.ts';
+import {createSchema} from '../../../zero-schema/src/builder/schema-builder.ts';
+import {
+  number,
+  string,
+  table,
+} from '../../../zero-schema/src/builder/table-builder.ts';
+import {makeSourceChangeAdd, makeSourceChangeEdit} from '../ivm/source.ts';
+import type {Source} from '../ivm/source.ts';
+import {consume} from '../ivm/stream.ts';
+import {wrapSourcesWithRandomYield} from '../ivm/test/random-yield-source.ts';
+import {createSource} from '../ivm/test/source-factory.ts';
+import {newQuery} from './query-impl.ts';
+import {QueryDelegateImpl} from './test/query-delegate.ts';
+
+const lc = createSilentLogContext();
+
+const chat = table('chat')
+  .columns({
+    id: string(),
+    lastMessageAt: number().optional(),
+    mode: string(),
+  })
+  .primaryKey('id');
+
+const message = table('message')
+  .columns({id: string(), chatId: string(), body: string()})
+  .primaryKey('id');
+
+const schema = createSchema({
+  tables: [chat, message],
+  relationships: [
+    relationships(chat, ({many}) => ({
+      messages: many({
+        sourceField: ['id'],
+        destField: ['chatId'],
+        destSchema: message,
+      }),
+    })),
+  ],
+});
+
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/**
+ * The yield schedule decides where sentinels land, so scan seeds rather than
+ * pinning one: before the fix the MemorySource and SQLite sources broke on
+ * different schedules, each within the first seed tried.
+ */
+function findFailingSeed(): {seed: number; error: string} | undefined {
+  for (let i = 0; i < 400; i++) {
+    const seed = 31685999679057 + i * 2654435761;
+    let sources: Record<string, Source> = {
+      chat: createSource(
+        lc,
+        testLogConfig,
+        'chat',
+        schema.tables.chat.columns,
+        schema.tables.chat.primaryKey,
+      ),
+      message: createSource(
+        lc,
+        testLogConfig,
+        'message',
+        schema.tables.message.columns,
+        schema.tables.message.primaryKey,
+      ),
+    };
+    sources = wrapSourcesWithRandomYield(sources, mulberry32(seed), 0.3);
+    const chatSource = must(sources.chat);
+    const msgSource = must(sources.message);
+
+    const c1: Row = {id: 'c1', lastMessageAt: null, mode: 'b'};
+    const c2: Row = {id: 'c2', lastMessageAt: null, mode: 'b'};
+    consume(chatSource.push(makeSourceChangeAdd(c1)));
+    consume(chatSource.push(makeSourceChangeAdd(c2)));
+
+    const delegate = new QueryDelegateImpl({sources});
+    try {
+      const view = delegate.materialize(
+        newQuery(schema, 'chat')
+          .where(({or, cmp, exists}) =>
+            or(
+              cmp('mode', '=', 'a'),
+              exists('messages', m => m.where('body', '=', 'x'), {flip: true}),
+            ),
+          )
+          .orderBy('lastMessageAt', 'desc')
+          .orderBy('id', 'desc')
+          .limit(1),
+      );
+      // 1. c1 starts matching via the flipped-exists branch.
+      consume(
+        msgSource.push(
+          makeSourceChangeAdd({id: 'mx1', chatId: 'c1', body: 'x'}),
+        ),
+      );
+      // 2. The ordinary "a message arrived" update on the sort key.
+      consume(
+        chatSource.push(makeSourceChangeEdit({...c1, lastMessageAt: 75}, c1)),
+      );
+      void view.data;
+    } catch (e) {
+      return {seed, error: e instanceof Error ? e.message : String(e)};
+    }
+  }
+  return undefined;
+}
+
+test('take over union-fan-in survives cooperative yields', () => {
+  // Before the fix this returned on the first seed tried, on both source
+  // implementations, with 'Bound should be set' -- the exact assert from the
+  // prod view-syncer crash (take.ts:448).
+  expect(findFailingSeed()).toBeUndefined();
+});


### PR DESCRIPTION
https://rocicorp.slack.com/archives/C0B2S4EF4BD/p1787068441144619

## The bug

`UnionFanIn.#pushInternalChange` decides whether to forward an add/remove by asking each sibling branch whether it already holds the row:

```ts
if (first(input.fetch({constraint})) !== undefined) return;
```

`fetch` streams are `Stream<Node | 'yield'>` — they interleave `'yield'` sentinels for cooperative multitasking. So `first()` answers *"was the stream non-empty?"*, not *"did it produce a row"*. The call is type-correct and semantically wrong: **an empty branch that happens to emit a sentinel is misread as a branch that holds the row**, and the add/remove is silently dropped.

A dropped `add` leaves a downstream `Take` with an empty window while its own fetch still reports the row. The next edit trips `assert(takeState.bound, 'Bound should be set')` — in the view-syncer that rethrows and disconnects every client on the group, re-arming on rehydrate. A dropped `remove` is quieter: the take keeps a row that no longer matches.

Needs an `OR` containing a flipped `whereExists` plus a `limit`, so it only appears once the planner's cost model chooses to flip. Present on `main` and in 1.9.0.

## The fix

The probe now iterates explicitly, **forwarding** each sentinel and treating only a real node as a match.
