### PR TITLE
fix(zql): use the connection comparator for the overlay's startAt pruning

### DIFF
--- a/packages/zql/src/ivm/memory-source.test.ts
+++ b/packages/zql/src/ivm/memory-source.test.ts
@@ -971,6 +971,7 @@ describe('multiConstraints overlay handling — both helpers', () => {
             overlay,
             1,
             compare,
+            compare,
             undefined,
             multiConstraints,
           ),

--- a/packages/zql/src/ivm/memory-source.ts
+++ b/packages/zql/src/ivm/memory-source.ts
@@ -383,6 +383,15 @@ export class MemorySource implements Source {
       // not yet yielded add overlay will be yielded when the first row
       // not matching the constraint is reached.
       indexComparator,
+      // `startAt` is `req.start.row`, a bound in the connection's sort order,
+      // so it must be compared in that order -- not `indexComparator`, which
+      // with a constraint leads with the constraint keys. The two agree only
+      // when the overlay row and `startAt` share those key values; they do not
+      // for `#fetchMulti`'s per-value sub-fetches, which pin one primary key
+      // while still carrying the caller's connection-sort `start`. Comparing
+      // there by the constraint key dropped the in-flight overlay and served
+      // pre-push data. Same distinction #4926 drew for `generateWithStart`.
+      connectionComparator,
       conn.filters?.predicate,
     );
 
@@ -715,7 +724,15 @@ export function* generateWithStart(
  * @param constraint - constraint that was applied to the rowIterator and should
  * also be applied to the overlay.
  * @param overlay - the overlay values to splice in
- * @param compare - the comparator to use to find the position for the overlay
+ * @param compare - the comparator to use to find the position for the overlay.
+ * Must order rows the same way `rows` is ordered. For `MemorySource` that is
+ * *index* order, which leads with the constraint keys.
+ * @param startAtCompare - the comparator for `startAt`, which is a bound in the
+ * *connection's* sort order. Only the same as `compare` when the stream's order
+ * happens to be the connection's -- true for `TableSource` (SQL does the
+ * ordering) but not for a constrained `MemorySource` fetch. Conflating the two
+ * is what #4926 fixed for `generateWithStart`; this parameter is the same
+ * distinction for the overlay's own `startAt` pruning.
  */
 export function* generateWithOverlay(
   startAt: Row | undefined,
@@ -724,6 +741,7 @@ export function* generateWithOverlay(
   overlay: Overlay | undefined,
   lastPushedEpoch: number,
   compare: Comparator,
+  startAtCompare: Comparator,
   filterPredicate?: (row: Row) => boolean | undefined,
   multiConstraints?: readonly MultiConstraint[] | undefined,
 ) {
@@ -735,7 +753,7 @@ export function* generateWithOverlay(
     startAt,
     constraint,
     overlayToApply,
-    compare,
+    startAtCompare,
     filterPredicate,
     multiConstraints,
   );
@@ -746,7 +764,9 @@ function computeOverlays(
   startAt: Row | undefined,
   constraint: Constraint | undefined,
   overlay: Overlay | undefined,
-  compare: Comparator,
+  // Only ever used for `overlaysForStartAt`, so this is the *connection*-order
+  // comparator, not the one used to splice the overlay into the row stream.
+  startAtCompare: Comparator,
   filterPredicate?: (row: Row) => boolean | undefined,
   multiConstraints?: readonly MultiConstraint[] | undefined,
 ): Overlays {
@@ -776,7 +796,7 @@ function computeOverlays(
   }
 
   if (startAt) {
-    overlays = overlaysForStartAt(overlays, startAt, compare);
+    overlays = overlaysForStartAt(overlays, startAt, startAtCompare);
   }
 
   if (constraint) {

--- a/packages/zql/src/query/flip-take-overlay-start.test.ts
+++ b/packages/zql/src/query/flip-take-overlay-start.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Regression tests for the push-overlay / `start` interaction in `MemorySource`.
+ *
+ * `MemorySource.#fetch` passed `req.start.row` to `generateWithOverlay` as the
+ * stream's lower bound, and `overlaysForStartAt` pruned the in-flight push
+ * overlay with the **index** comparator. That is only sound when the index sort
+ * *is* the connection sort — i.e. when there is no constraint, so `scanStart`
+ * really is `req.start.row`. With a constraint the index leads with the
+ * constraint keys, so the comparison measured the wrong thing and dropped a
+ * valid overlay, and the fetch returned pre-push data.
+ *
+ * A flipped EXISTS is what puts the two together: `FlippedJoin.#fetchBatched`
+ * fetches its parent with `multiConstraints` (which `#fetchMulti` splits into
+ * per-value sub-fetches, each carrying a primary-key `constraint`) while
+ * forwarding the `start` that `Take` uses for its maintenance fetches. `Take`
+ * then reads a stale stream mid-push and either asserts or silently drops rows.
+ *
+ * Both cases below were found by the chinook backbone fuzzer
+ * (`checkYieldPush`), but neither needs the `'yield'` machinery — they are
+ * plain push-maintenance bugs. `TableSource` (SQLite) was never affected;
+ * these run under both source implementations to pin that they agree.
+ */
+import {expect, test} from 'vitest';
+import {testLogConfig} from '../../../otel/src/test-log-config.ts';
+import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
+import {must} from '../../../shared/src/must.ts';
+import type {Row} from '../../../zero-protocol/src/data.ts';
+import {relationships} from '../../../zero-schema/src/builder/relationship-builder.ts';
+import {createSchema} from '../../../zero-schema/src/builder/schema-builder.ts';
+import {
+  number,
+  string,
+  table,
+} from '../../../zero-schema/src/builder/table-builder.ts';
+import {makeSourceChangeAdd, makeSourceChangeEdit} from '../ivm/source.ts';
+import type {Source} from '../ivm/source.ts';
+import {consume} from '../ivm/stream.ts';
+import {createSource} from '../ivm/test/source-factory.ts';
+import {newQuery} from './query-impl.ts';
+import {QueryDelegateImpl} from './test/query-delegate.ts';
+
+const lc = createSilentLogContext();
+
+// ── Case A: the overlay is invisible, so Take cannot find the row after its bound ──
+
+const genre = table('genre')
+  .columns({id: number(), name: string()})
+  .primaryKey('id');
+const track = table('track')
+  .columns({id: number(), genreId: number()})
+  .primaryKey('id');
+
+const genreSchema = createSchema({
+  tables: [genre, track],
+  relationships: [
+    relationships(genre, ({many}) => ({
+      tracks: many({
+        sourceField: ['id'],
+        destField: ['genreId'],
+        destSchema: track,
+      }),
+    })),
+  ],
+});
+
+test('flipped exists + take: editing a row past the bound keeps the window correct', () => {
+  const sources: Record<string, Source> = {
+    genre: createSource(
+      lc,
+      testLogConfig,
+      'genre',
+      genreSchema.tables.genre.columns,
+      genreSchema.tables.genre.primaryKey,
+    ),
+    track: createSource(
+      lc,
+      testLogConfig,
+      'track',
+      genreSchema.tables.track.columns,
+      genreSchema.tables.track.primaryKey,
+    ),
+  };
+  const g = must(sources.genre);
+  const t = must(sources.track);
+  for (const row of [
+    {id: 1, name: 'Rock'},
+    {id: 2, name: 'Jazz'},
+    {id: 3, name: 'Metal'},
+    {id: 4, name: 'Empty'}, // no tracks -- filtered out by the gate
+  ] as Row[]) {
+    consume(g.push(makeSourceChangeAdd(row)));
+  }
+  for (const row of [
+    {id: 100, genreId: 1},
+    {id: 102, genreId: 2},
+    {id: 103, genreId: 3},
+  ] as Row[]) {
+    consume(t.push(makeSourceChangeAdd(row)));
+  }
+  const delegate = new QueryDelegateImpl({sources});
+
+  // `limit` >= the number of matching rows, so the take window is never full
+  // and its bound is the largest row. That is what drives the edit below into
+  // Take's "old inside, new past the bound" arm, whose maintenance fetch
+  // carries a `start`.
+  const view = delegate.materialize(
+    newQuery(genreSchema, 'genre')
+      .where(({exists}) => exists('tracks', undefined, {flip: true}))
+      .orderBy('name', 'asc')
+      .orderBy('id', 'desc')
+      .limit(10),
+  );
+  expect(view.data.map(r => r.name)).toEqual(['Jazz', 'Metal', 'Rock']);
+
+  // Rock(1) is the bound. Move it to the front; Metal(3) becomes the bound.
+  consume(
+    g.push(makeSourceChangeEdit({id: 1, name: 'AAA'}, {id: 1, name: 'Rock'})),
+  );
+  expect(view.data.map(r => r.name)).toEqual(['AAA', 'Jazz', 'Metal']);
+
+  // Move it back past the bound. Take fetches for the row after Metal(3); that
+  // row is the edit itself, visible only through the push overlay. Before the
+  // fix the overlay was pruned and this threw
+  // `Take: afterBoundNode must be found during fetch`.
+  consume(
+    g.push(makeSourceChangeEdit({id: 1, name: 'Rock'}, {id: 1, name: 'AAA'})),
+  );
+  expect(view.data.map(r => r.name)).toEqual(['Jazz', 'Metal', 'Rock']);
+});
+
+// ── Case B: same defect, silent -- a row that should enter the window does not ──
+
+const employee = table('employee')
+  .columns({id: number(), name: string(), reportsTo: number().optional()})
+  .primaryKey('id');
+
+const employeeSchema = createSchema({
+  tables: [employee],
+  relationships: [
+    relationships(employee, ({one}) => ({
+      manager: one({
+        sourceField: ['reportsTo'],
+        destField: ['id'],
+        destSchema: employee,
+      }),
+    })),
+  ],
+});
+
+test('flipped self-join exists in an OR, with start + limit: an edit adds the row', () => {
+  const sources: Record<string, Source> = {
+    employee: createSource(
+      lc,
+      testLogConfig,
+      'employee',
+      employeeSchema.tables.employee.columns,
+      employeeSchema.tables.employee.primaryKey,
+    ),
+  };
+  const e = must(sources.employee);
+  for (const row of [
+    {id: 1, name: 'Adams', reportsTo: null},
+    {id: 2, name: 'Mills', reportsTo: 1},
+    {id: 3, name: 'Park', reportsTo: 2},
+  ] as Row[]) {
+    consume(e.push(makeSourceChangeAdd(row)));
+  }
+  const delegate = new QueryDelegateImpl({sources});
+
+  const view = delegate.materialize(
+    newQuery(employeeSchema, 'employee')
+      .where(({or, cmp, exists}) =>
+        or(exists('manager', undefined, {flip: true}), cmp('id', '=', 2)),
+      )
+      .orderBy('reportsTo', 'desc')
+      .start({id: 3, reportsTo: 2}, {inclusive: false})
+      .limit(2),
+  );
+  expect(view.data.map(r => r.id)).toEqual([2]);
+
+  // Adams starts reporting to itself, so it now passes the flipped gate and
+  // sorts into the window. Before the fix the push overlay was invisible to the
+  // constrained maintenance fetch and Adams was silently never added.
+  consume(
+    e.push(
+      makeSourceChangeEdit(
+        {id: 1, name: 'Adams', reportsTo: 1},
+        {id: 1, name: 'Adams', reportsTo: null},
+      ),
+    ),
+  );
+  expect(view.data.map(r => r.id)).toEqual([1, 2]);
+});

--- a/packages/zqlite/src/table-source.ts
+++ b/packages/zqlite/src/table-source.ts
@@ -310,6 +310,10 @@ export class TableSource implements Source {
               this.#overlay,
               connection.lastPushedEpoch,
               comparator,
+              // SQL does the ordering and constraining, so the row stream is
+              // already in the connection's sort order: the splice comparator
+              // and the `startAt` comparator coincide here.
+              comparator,
               connection.filters?.predicate,
               req.multiConstraints,
             ),


### PR DESCRIPTION
> Stacked on #6380 for a clean diff, but **independent of it** — different file, different root cause, different test. Can be rebased onto `main` and merged in either order.

Follow-up to #4926, which fixed exactly this confusion one call away.

## The bug

#4926 found that `generateWithStart` was being passed `indexComparator` when `req.start.row` is a bound in the **connection's** sort order, and introduced `connectionComparator` for it. It deliberately left `generateWithOverlay` on `indexComparator`, with a comment explaining that `generateWithOverlayInner` depends on index order to flush a not-yet-yielded add overlay.

That reasoning is correct — but it is about the **splice**. The same `compare` argument is also handed to `computeOverlays`, whose *only* use of it is `overlaysForStartAt`:

```ts
const undefinedIfBeforeStartAt = (row: Row | undefined) =>
  row === undefined || compare(row, startAt) < 0 ? undefined : row;
```

…and that compares against `startAt` — the very connection-sort bound #4926 was about. So the two orders get conflated again, one call deeper.

They coincide only when the overlay row and `startAt` agree on the constraint keys. An ordinary partitioned fetch agrees. `#fetchMulti`'s per-value sub-fetches do not.

## The fix

Give `generateWithOverlay` a separate `startAtCompare` parameter. `compare` keeps ordering the splice (index order, per #4926); `startAtCompare` orders `startAt`.

- `MemorySource` passes `connectionComparator`.
- `TableSource` passes its single comparator twice, since SQL already returns rows in connection order — **which is why `TableSource` never had this bug.**
