### PR TITLE
test(zql-integration-tests): close the flip × push × yield cell in the fuzzer

### DIFF
--- a/packages/zql-integration-tests/src/chinook/chinook-fuzz-backbone.pg.test.ts
+++ b/packages/zql-integration-tests/src/chinook/chinook-fuzz-backbone.pg.test.ts
@@ -32,6 +32,9 @@ import {
   checkL1,
   checkPushWalk,
   checkYield,
+  checkYieldPush,
+  fanInTakeCases,
+  l1QueryCases,
   panicIfFailed,
 } from './fuzz/driver.ts';
 import {Data} from './fuzz/literals.ts';
@@ -67,7 +70,7 @@ test(
 );
 
 test(
-  'L1 — pairwise covering array: 100% coverage + hydrate-equal over mini',
+  'L1 — 3-way covering array: 100% coverage + hydrate-equal over mini',
   async () => {
     const {report, coverage} = await checkL1(harness.delegates, data);
     console.log(
@@ -75,7 +78,7 @@ test(
     );
     expect(
       coverage.fraction(),
-      `pairwise coverage incomplete (${coverage.summary()}); missed: ${JSON.stringify(
+      `t-wise coverage incomplete (${coverage.summary()}); missed: ${JSON.stringify(
         coverage.missed(),
       )}`,
     ).toBe(1);
@@ -156,6 +159,35 @@ test(
     );
     console.log(
       `Random-yield backbone (D≤1): ${report.total} cases, ${report.failures.length} failures`,
+    );
+    panicIfFailed(report, 12);
+  },
+  TIMEOUT_MS,
+);
+
+test(
+  'Random-yield push — Take over UnionFanIn survives interleaved maintenance fetches',
+  async () => {
+    // The cell no other lane reaches. `checkYield` runs decoration-free skeletons, so it
+    // never carries a `limit` (hence never a `Take`); `checkFlipInvariance` enumerates
+    // flips but only hydrates. A `Take` sitting above a `UnionFanIn` while a `'yield'`
+    // interrupts a maintenance fetch mid-push is a 3-way axis interaction
+    // (`flip` x `exists_*_or` x `limit`) that only exists in the corpus at t >= 3.
+    const {cases} = l1QueryCases(data);
+    const selected = fanInTakeCases(cases);
+    expect(
+      selected.length,
+      'no L1 case builds a Take over a UnionFanIn — the flip axis or t=3 regressed',
+    ).toBeGreaterThan(0);
+    const report = await checkYieldPush(
+      harness.transact,
+      data,
+      cases,
+      1,
+      YIELD_SEED,
+    );
+    console.log(
+      `Random-yield push (fan-in+take): ${report.total}/${selected.length} selected, ${report.failures.length} failures`,
     );
     panicIfFailed(report, 12);
   },

--- a/packages/zql-integration-tests/src/chinook/fuzz/axes.ts
+++ b/packages/zql-integration-tests/src/chinook/fuzz/axes.ts
@@ -319,6 +319,18 @@ export const START_VALS = [
 ] as const;
 export type StartVal = (typeof START_VALS)[number];
 
+/**
+ * How an EXISTS gate is **planned**: `none` leaves the builder's default lowering (a
+ * semi-join), `flip` forces a `FlippedJoin`. `flip` is a plan choice the oracle ignores,
+ * so it must never change the answer — but it changes the *operator graph*: an OR
+ * containing a flipped gate is the only thing that makes `builder.ts` construct a
+ * `UnionFanOut`/`UnionFanIn` pair. Without this axis, no fan-in ever appears in a
+ * covering-array query, and every interaction with `limit` (`Take` over `UnionFanIn`),
+ * `start`, or `order` is invisible to t-wise coverage.
+ */
+export const FLIP_VALS = ['none', 'flip'] as const;
+export type FlipVal = (typeof FLIP_VALS)[number];
+
 /** One formal axis: a name + its ordered value-token domain. */
 export type AxisSpec = {
   readonly name: string;
@@ -336,6 +348,7 @@ export const AXES: readonly AxisSpec[] = [
   {name: 'order', values: ORDER_VALS},
   {name: 'limit', values: LIMIT_VALS},
   {name: 'start', values: START_VALS},
+  {name: 'flip', values: FLIP_VALS},
 ];
 
 export const N_AXES = AXES.length;
@@ -347,4 +360,60 @@ export function axisIndex(name: string): number {
     throw new Error(`unknown axis ${name}`);
   }
   return i;
+}
+
+// ── the one inter-axis constraint (exists x flip) ─────────────────────────────────────
+
+/**
+ * `flip` is only meaningful on a **positive** EXISTS gate: with no gate there is nothing
+ * to flip, and a flipped NOT EXISTS (anti-join) is not a supported plan — the same
+ * restriction `flip.ts` applies to flip-invariance.
+ *
+ * This is the **only** inter-axis constraint in the space. The covering-array builder and
+ * the coverage report both consult it, so unrealizable cells are never generated and never
+ * counted in the denominator — otherwise the "100% pairwise" gate could never be met.
+ */
+export function flipRealizable(ev: ExistsVal, fv: FlipVal): boolean {
+  return fv === 'none' || ev.startsWith('exists');
+}
+
+/**
+ * Whether a t-tuple (a list of `[axisIndex, valueIndex]`) is structurally realizable.
+ * Only constrained when the tuple pins **both** `exists` and `flip`; a tuple that pins
+ * just one of them is realizable, since the other axis is free to take a compatible
+ * value in some row.
+ */
+export function tupleRealizable(
+  tuple: ReadonlyArray<readonly [number, number]>,
+): boolean {
+  const ei = axisIndex('exists');
+  const fi = axisIndex('flip');
+  let e: number | undefined;
+  let f: number | undefined;
+  for (const [a, v] of tuple) {
+    if (a === ei) {
+      e = v;
+    } else if (a === fi) {
+      f = v;
+    }
+  }
+  if (e === undefined || f === undefined) {
+    return true;
+  }
+  return flipRealizable(EXISTS_VALS[e], FLIP_VALS[f]);
+}
+
+/**
+ * Whether a partial assignment (`null` = not yet chosen) violates the constraint. Used by
+ * the greedy fill so it never commits to an unrealizable pair.
+ */
+export function assignmentRealizable(
+  row: ReadonlyArray<number | null>,
+): boolean {
+  const e = row[axisIndex('exists')];
+  const f = row[axisIndex('flip')];
+  if (e === null || e === undefined || f === null || f === undefined) {
+    return true;
+  }
+  return flipRealizable(EXISTS_VALS[e], FLIP_VALS[f]);
 }

--- a/packages/zql-integration-tests/src/chinook/fuzz/cover.ts
+++ b/packages/zql-integration-tests/src/chinook/fuzz/cover.ts
@@ -20,6 +20,7 @@ import type {AnyQuery} from '../../../../zql/src/query/query.ts';
 import {newStaticQuery} from '../../../../zql/src/query/static-query.ts';
 import {schema} from '../schema.ts';
 import {
+  assignmentRealizable,
   AXES,
   axisIndex,
   EXISTS_VALS,
@@ -35,8 +36,11 @@ import {
   type Rel,
   relsOf,
   rolesOf,
+  FLIP_VALS,
+  type FlipVal,
   START_VALS,
   type StartVal,
+  tupleRealizable,
 } from './axes.ts';
 import {axisCombinations} from './coverage.ts';
 import {type Data, filterCondition, simple} from './literals.ts';
@@ -56,6 +60,9 @@ function allTuples(domains: readonly number[], t: number): Map<string, Tuple> {
     const sizes = combo.map(a => domains[a]);
     for (const values of cartesianLocal(sizes)) {
       const tuple = combo.map((a, i) => [a, values[i]] as const);
+      if (!tupleRealizable(tuple)) {
+        continue; // structurally impossible (exists x flip) — never a coverage goal
+      }
       out.set(tupleKey(tuple), tuple);
     }
   }
@@ -122,13 +129,28 @@ export function greedyCover(t: number): number[][] {
       let bestGain = -1;
       for (let v = 0; v < domains[axis]; v++) {
         row[axis] = v;
+        if (!assignmentRealizable(row)) {
+          continue; // would pin an impossible exists x flip pair
+        }
         const gain = coveredNow(row, uncovered);
         if (gain > bestGain) {
           bestGain = gain;
           bestV = v;
         }
       }
-      row[axis] = bestV; // value 0 (a "none") is always a valid fallback
+      if (bestGain < 0) {
+        // No value gained a tuple: fall back to the first *realizable* one. Value 0 is
+        // "none" on every axis, but "none" on `exists` is itself unrealizable when the
+        // seed already pinned flip=flip, so the constraint still has to be consulted.
+        for (let v = 0; v < domains[axis]; v++) {
+          row[axis] = v;
+          if (assignmentRealizable(row)) {
+            bestV = v;
+            break;
+          }
+        }
+      }
+      row[axis] = bestV;
     }
     const full = row.map(x => x as number);
     for (const tuple of rowTuples(full, t)) {
@@ -247,12 +269,17 @@ export function existsCondition(
   table: string,
   rel: Rel,
   ev: ExistsVal,
+  /**
+   * Force a positive gate to lower as a `FlippedJoin` rather than a semi-join. Only a
+   * positive gate is flippable (see `flipRealizable`); a `not_exists_*` value ignores it.
+   */
+  flip = false,
 ): Condition {
   const r = rolesOf(table);
   const notExists = ev.startsWith('not_exists');
   const gate: Condition = notExists
     ? eb.not(eb.exists(rel.name))
-    : eb.exists(rel.name);
+    : eb.exists(rel.name, undefined, flip ? {flip: true} : undefined);
   switch (ev) {
     case 'exists_top':
     case 'not_exists_top':
@@ -275,6 +302,7 @@ function applyWhere(
   filterCond: Condition | null,
   gateRel: Rel | undefined,
   ev: ExistsVal,
+  flip: boolean,
 ): AnyQuery {
   if (!filterCond && !gateRel) {
     return q;
@@ -286,7 +314,7 @@ function applyWhere(
       parts.push(filterCond);
     }
     if (gateRel) {
-      parts.push(existsCondition(eb, table, gateRel, ev));
+      parts.push(existsCondition(eb, table, gateRel, ev, flip));
     }
     return parts.length === 1 ? parts[0] : eb.and(...parts);
   });
@@ -309,6 +337,7 @@ function applyDecorations(
   const ov = ORDER_VALS[a[axisIndex('order')]] as OrderVal;
   const lv = LIMIT_VALS[a[axisIndex('limit')]] as LimitVal;
   const sv = START_VALS[a[axisIndex('start')]] as StartVal;
+  const flv = FLIP_VALS[a[axisIndex('flip')]] as FlipVal;
 
   if (!filterRealizable(table, fv)) {
     return null;
@@ -325,7 +354,7 @@ function applyDecorations(
     }
   }
 
-  let out = applyWhere(q, table, filterCond, gateRel, ev);
+  let out = applyWhere(q, table, filterCond, gateRel, ev, flv === 'flip');
   out = applyOrder(out, table, ov);
   const started = applyStart(out, table, sv, data);
   if (!started) {

--- a/packages/zql-integration-tests/src/chinook/fuzz/coverage.ts
+++ b/packages/zql-integration-tests/src/chinook/fuzz/coverage.ts
@@ -19,7 +19,7 @@ import type {
   Condition,
   CorrelatedSubquery,
 } from '../../../../zero-protocol/src/ast.ts';
-import {AXES, columnsOf, hasColumn, N_AXES} from './axes.ts';
+import {AXES, columnsOf, hasColumn, N_AXES, tupleRealizable} from './axes.ts';
 
 // ── combinatorics (shared with the covering-array builder) ────────────────────────────
 
@@ -109,11 +109,21 @@ export class Coverage {
     }
   }
 
-  /** Total coverable t-tuples (Σ over t-axis subsets of value combinations). */
+  /**
+   * Total coverable t-tuples (Σ over t-axis subsets of value combinations), **excluding
+   * structurally unrealizable ones** — see `tupleRealizable`. A tuple that can never be
+   * built is not a coverage goal, so it must not sit in the denominator or the "100%
+   * pairwise" gate could never be met.
+   */
   total(): number {
     let n = 0;
     for (const combo of axisCombinations(N_AXES, this.#t)) {
-      n += combo.reduce((acc, a) => acc * this.#domains[a], 1);
+      const sizes = combo.map(a => this.#domains[a]);
+      for (const values of cartesian(sizes)) {
+        if (tupleRealizable(combo.map((a, i) => [a, values[i]] as const))) {
+          n += 1;
+        }
+      }
     }
     return n;
   }
@@ -136,6 +146,9 @@ export class Coverage {
       const sizes = combo.map(a => this.#domains[a]);
       for (const values of cartesian(sizes)) {
         const tuple = combo.map((a, i) => [a, values[i]] as const);
+        if (!tupleRealizable(tuple)) {
+          continue;
+        }
         if (!this.#hit.has(tupleKey(tuple))) {
           out.push(
             tuple.map(

--- a/packages/zql-integration-tests/src/chinook/fuzz/driver.ts
+++ b/packages/zql-integration-tests/src/chinook/fuzz/driver.ts
@@ -18,7 +18,7 @@ import {expect} from 'vitest';
 import {astToZQL} from '../../../../ast-to-zql/src/ast-to-zql.ts';
 import {formatOutput} from '../../../../ast-to-zql/src/format.ts';
 import {must} from '../../../../shared/src/must.ts';
-import type {AST} from '../../../../zero-protocol/src/ast.ts';
+import type {AST, Condition} from '../../../../zero-protocol/src/ast.ts';
 import type {Row} from '../../../../zero-protocol/src/data.ts';
 import type {NameMapper} from '../../../../zero-schema/src/name-mapper.ts';
 import {makeServerTransaction} from '../../../../zero-server/src/custom.ts';
@@ -50,7 +50,7 @@ import {Coverage} from './coverage.ts';
 import {flipAssignments, flippableExistsCount, setFlips} from './flip.ts';
 import type {Data} from './literals.ts';
 import {mutate} from './mutate.ts';
-import {type Mutation, pushForSkeleton} from './push.ts';
+import {fourPhase, type Mutation, pushForSkeleton} from './push.ts';
 import type {Regression} from './regressions.ts';
 import {rng} from './rng.ts';
 import {scalarizableExistsCount, setScalars} from './scalar.ts';
@@ -143,13 +143,24 @@ export function skeletonQueryCases(
   return skels.map(s => ({label: label(s), query: lower(s)}));
 }
 
-/** The L1 pairwise-decoration corpus as target-independent query cases. */
-export function l1QueryCases(data: Data): {
+/**
+ * The L1 decoration corpus as target-independent query cases.
+ *
+ * Strength defaults to **3**. Pairwise is not enough once `flip` is an axis: the shapes
+ * that matter are 3-way — a flipped gate must sit *inside an OR* (that is what makes
+ * `builder.ts` construct the `UnionFanOut`/`UnionFanIn` pair) *and* carry a `limit` (to
+ * put a `Take` above the fan-in). At `t=2` the greedy cover realizes
+ * `flip x exists_or x limit` in zero rows; at `t=3`, in 17.
+ */
+export function l1QueryCases(
+  data: Data,
+  t = 3,
+): {
   readonly cases: readonly QueryCase[];
   readonly coverage: Coverage;
 } {
-  const rows = greedyCover(2);
-  const coverage = new Coverage(2);
+  const rows = greedyCover(t);
+  const coverage = new Coverage(t);
   const cases: QueryCase[] = [];
 
   for (const row of rows) {
@@ -681,29 +692,150 @@ export async function checkYield(
   skels: readonly Skeleton[],
   n: number,
   seed: number,
+  maxFlips = 2,
 ): Promise<Report> {
   const failures: Array<[string, string]> = [];
   let total = 0;
   let idx = 0;
   for (const s of skels) {
-    const i = idx++;
-    // Per-skeleton deterministic yield stream so a failure replays from (seed, index).
-    const r = rng((seed ^ Math.imul(i + 1, 0x9e3779b9)) >>> 0);
-    const wrap = createRandomYieldWrapper(() => r.float(), YIELD_P);
-    const query = lower(s);
     const mutations = pushForSkeleton(data, s, n);
+    for (const [suffix, query] of yieldPlanVariants(s, maxFlips)) {
+      const i = idx++;
+      // Per-variant deterministic yield stream so a failure replays from (seed, index).
+      const r = rng((seed ^ Math.imul(i + 1, 0x9e3779b9)) >>> 0);
+      const wrap = createRandomYieldWrapper(() => r.float(), YIELD_P);
+      total += 1;
+      const msg = await capture(() =>
+        transact(
+          d =>
+            mutations.length > 0
+              ? pushWalk(d, query, mutations)
+              : runAndCompare(schema, d, query, undefined),
+          wrap,
+        ),
+      );
+      if (msg) {
+        failures.push([`yield|${label(s)}${suffix}`, msg]);
+      }
+    }
+  }
+  return {total, failures};
+}
+
+/**
+ * The plan variants a skeleton contributes to the yield lane: the builder's default
+ * lowering, plus **every** flip assignment of its positive EXISTS gates.
+ *
+ * Flips are not cosmetic here. A flipped gate is the only thing that makes `builder.ts`
+ * construct a `UnionFanOut`/`UnionFanIn` pair, so without them the yield lane never
+ * interleaves a fetch or push through a fan-in at all — the operator whose maintenance
+ * fetch is the one that has to survive a `'yield'`. The flip-invariance lane enumerates
+ * the same assignments but only *hydrates* them; this is where they meet pushes.
+ */
+function yieldPlanVariants(
+  s: Skeleton,
+  maxFlips: number,
+): Array<[string, AnyQuery]> {
+  const base = lower(s);
+  const out: Array<[string, AnyQuery]> = [['', base]];
+  const ast = asQueryInternals(base).ast;
+  const k = flippableExistsCount(ast);
+  if (k === 0 || k > maxFlips) {
+    return out;
+  }
+  for (const bits of flipAssignments(k)) {
+    if (!bits.some(b => b)) {
+      continue; // all-false is the default lowering, already in `out`
+    }
+    out.push([
+      `|flip${bits.map(b => (b ? 1 : 0)).join('')}`,
+      wrapAst(setFlips(ast, bits)),
+    ]);
+  }
+  return out;
+}
+
+/**
+ * The tables an AST touches (root + every correlated subquery / related child), so a
+ * decorated case can be given mutations on both sides of a gate.
+ */
+function astTables(ast: AST, out: Set<string> = new Set()): Set<string> {
+  out.add(ast.table);
+  for (const r of ast.related ?? []) {
+    astTables(r.subquery, out);
+  }
+  const walk = (c: Condition | undefined): void => {
+    if (!c) {
+      return;
+    }
+    if (c.type === 'and' || c.type === 'or') {
+      c.conditions.forEach(walk);
+    } else if (c.type === 'correlatedSubquery') {
+      astTables(c.related.subquery, out);
+    }
+  };
+  walk(ast.where);
+  return out;
+}
+
+/**
+ * The L1 cases that build a **`Take` above a `UnionFanIn`**: a flipped EXISTS gate (the
+ * only thing that makes `builder.ts` construct a `UnionFanOut`/`UnionFanIn` pair) sitting
+ * under a `limit`. This is a 3-way axis interaction (`flip` x `exists_*_or` x `limit`), so
+ * it exists in the corpus only at `t >= 3`.
+ */
+export function fanInTakeCases(
+  cases: readonly QueryCase[],
+): readonly QueryCase[] {
+  return cases.filter(c => {
+    const ast = asQueryInternals(c.query).ast;
+    return (
+      ast.limit !== undefined &&
+      JSON.stringify(ast.where ?? null).includes('"flip":true')
+    );
+  });
+}
+
+/**
+ * **Random-yield push sweep over decorated L1 cases.**
+ *
+ * {@link checkYield} runs *skeletons* — structure only, no decorations — so it never has a
+ * `limit`, hence never a `Take`. {@link checkFlipInvariance} enumerates flips but only
+ * hydrates. Neither lane can reach a `Take` sitting above a `UnionFanIn` while a `'yield'`
+ * interrupts a maintenance fetch mid-push, which is exactly where that pair breaks.
+ *
+ * This lane closes that cell: decorated cases (so `limit` is real), filtered to the ones
+ * that actually build the fan-in, driven through the four-phase push walk with both IVM
+ * sources yield-wrapped. `max` caps the fan-out so it stays a per-PR cost.
+ */
+export async function checkYieldPush(
+  transact: Transact,
+  data: Data,
+  cases: readonly QueryCase[],
+  n: number,
+  seed: number,
+  max = 48,
+): Promise<Report> {
+  const selected = fanInTakeCases(cases).slice(0, max);
+  const failures: Array<[string, string]> = [];
+  let total = 0;
+  for (let i = 0; i < selected.length; i++) {
+    const c = selected[i];
+    const r = rng((seed ^ Math.imul(i + 1, 0x27d4eb2f)) >>> 0);
+    const wrap = createRandomYieldWrapper(() => r.float(), YIELD_P);
+    const ast = asQueryInternals(c.query).ast;
+    // Mutate both sides of the gate: parent pushes drive the fan-out, child pushes drive
+    // the flipped join's own push path into the fan-in.
+    const mutations = [...astTables(ast)].flatMap(t => fourPhase(data, t, n));
+    if (mutations.length === 0) {
+      continue;
+    }
     total += 1;
     const msg = await capture(() =>
-      transact(
-        d =>
-          mutations.length > 0
-            ? pushWalk(d, query, mutations)
-            : runAndCompare(schema, d, query, undefined),
-        wrap,
-      ),
+      transact(d => pushWalk(d, c.query, mutations), wrap),
     );
     if (msg) {
-      failures.push([`yield|${label(s)}`, msg]);
+      failures.push([`yieldPush|${c.label}`, msg]);
     }
   }
   return {total, failures};

--- a/packages/zql-integration-tests/src/chinook/fuzz/fuzz.test.ts
+++ b/packages/zql-integration-tests/src/chinook/fuzz/fuzz.test.ts
@@ -19,7 +19,17 @@ import type {AnyQuery} from '../../../../zql/src/query/query.ts';
 import {newStaticQuery} from '../../../../zql/src/query/static-query.ts';
 import {QueryDelegateImpl as TestMemoryQueryDelegate} from '../../../../zql/src/query/test/query-delegate.ts';
 import {schema} from '../schema.ts';
-import {AXES, hasText, pkOf, relsOf, tables} from './axes.ts';
+import {
+  AXES,
+  axisIndex,
+  EXISTS_VALS,
+  FLIP_VALS,
+  hasText,
+  LIMIT_VALS,
+  pkOf,
+  relsOf,
+  tables,
+} from './axes.ts';
 import {CostModel} from './cost.ts';
 import {
   decorate,
@@ -97,29 +107,71 @@ describe('coverage', () => {
     }
     expect(cov.fraction()).toBe(1);
     expect(cov.missed()).toEqual([]);
-    // Far smaller than the full cross-product (16·7·4·3·4 = 5376) …
+    // Far smaller than the full cross-product (16·7·4·3·4·2 = 10752) …
     expect(rows.length).toBeLessThan(200);
     // … but at least the largest single-pair domain product (filter·exists = 16·7).
     expect(rows.length).toBeGreaterThanOrEqual(16 * 7);
   });
 
-  test('observe marks every t-subset; total is the pairwise tuple count', () => {
+  test('observe marks every t-subset; total is the realizable pairwise tuple count', () => {
     const cov = new Coverage(2);
     expect(cov.hitCount()).toBe(0);
-    // Pairwise total is Σ over axis-pairs of dom_i·dom_j.
+    // Pairwise total is Σ over axis-pairs of dom_i·dom_j …
     const domains = AXES.map(a => a.values.length);
-    const expected = domains.flatMap((d, i) =>
-      domains.slice(i + 1).map(e => d * e),
-    );
+    const gross = domains
+      .flatMap((d, i) => domains.slice(i + 1).map(e => d * e))
+      .reduce((acc, n) => acc + n, 0);
+    // … minus the structurally unrealizable exists×flip cells: `flip=flip` is only
+    // meaningful on a positive gate, so it pairs with none of the 4 non-positive
+    // `exists` values (`none` + the three `not_exists_*`).
+    const unrealizable = EXISTS_VALS.filter(
+      e => !e.startsWith('exists'),
+    ).length;
+    expect(unrealizable).toBe(4);
+    expect(cov.total()).toBe(gross - unrealizable);
+
     const pairCount = (AXES.length * (AXES.length - 1)) / 2;
-    const total = cov.total();
-    expect(total).toBe(expected.reduce((acc, n) => acc + n, 0));
-    cov.observe([0, 0, 0, 0, 0]); // one assignment hits C(N_AXES,2) tuples
+    const zeros = new Array(AXES.length).fill(0);
+    const ones = new Array(AXES.length).fill(1);
+    cov.observe(zeros); // one assignment hits C(N_AXES,2) tuples
     expect(cov.hitCount()).toBe(pairCount);
-    cov.observe([1, 1, 1, 1, 1]); // a fully-different assignment adds fresh tuples
+    cov.observe(ones); // a fully-different assignment adds fresh tuples
     expect(cov.hitCount()).toBe(pairCount * 2);
-    cov.observe([0, 0, 0, 0, 0]); // re-observing is idempotent
+    cov.observe(zeros); // re-observing is idempotent
     expect(cov.hitCount()).toBe(pairCount * 2);
+  });
+
+  test('the flip axis is covered and never pairs with a non-positive gate', () => {
+    const rows = greedyCover(2);
+    const ei = axisIndex('exists');
+    const fi = axisIndex('flip');
+    const flipped = rows.filter(r => FLIP_VALS[r[fi]] === 'flip');
+    expect(flipped.length).toBeGreaterThan(0);
+    for (const r of flipped) {
+      expect(
+        EXISTS_VALS[r[ei]].startsWith('exists'),
+        `flip=flip paired with exists=${EXISTS_VALS[r[ei]]}`,
+      ).toBe(true);
+    }
+  });
+
+  test('strength 3 is what reaches the flip×or×limit shape', () => {
+    // A flipped gate only builds a UnionFanOut/FanIn when it sits inside an OR, and a
+    // Take only sits above that fan-in when the query is limited. That is a 3-way
+    // interaction, so pairwise does not guarantee it — this pins why `l1QueryCases`
+    // defaults to t=3.
+    const ei = axisIndex('exists');
+    const fi = axisIndex('flip');
+    const li = axisIndex('limit');
+    const hits = (t: number) =>
+      greedyCover(t).filter(
+        r =>
+          FLIP_VALS[r[fi]] === 'flip' &&
+          EXISTS_VALS[r[ei]] === 'exists_or' &&
+          LIMIT_VALS[r[li]] !== 'none',
+      ).length;
+    expect(hits(2)).toBe(0);
+    expect(hits(3)).toBeGreaterThan(0);
   });
 });
 

--- a/packages/zql/src/query/take-union-shape.test.ts
+++ b/packages/zql/src/query/take-union-shape.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Proves the take-over-union-fan-in pipeline is actually built, and built the
+ * same way, for both MemorySource (zql) and the SQLite TableSource
+ * (zqlite-zql-test). If the union were absent under one source, a sweep that
+ * finds nothing there would prove nothing.
+ */
+import {expect, test} from 'vitest';
+import {testLogConfig} from '../../../otel/src/test-log-config.ts';
+import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
+import {relationships} from '../../../zero-schema/src/builder/relationship-builder.ts';
+import {createSchema} from '../../../zero-schema/src/builder/schema-builder.ts';
+import {
+  number,
+  string,
+  table,
+} from '../../../zero-schema/src/builder/table-builder.ts';
+import type {Input} from '../ivm/operator.ts';
+import {createSource} from '../ivm/test/source-factory.ts';
+import {newQuery} from './query-impl.ts';
+import {QueryDelegateImpl} from './test/query-delegate.ts';
+
+const lc = createSilentLogContext();
+
+const chat = table('chat')
+  .columns({
+    id: string(),
+    lastMessageAt: number().optional(),
+    mode: string(),
+  })
+  .primaryKey('id');
+
+const message = table('message')
+  .columns({id: string(), chatId: string(), body: string()})
+  .primaryKey('id');
+
+const schema = createSchema({
+  tables: [chat, message],
+  relationships: [
+    relationships(chat, ({many}) => ({
+      messages: many({
+        sourceField: ['id'],
+        destField: ['chatId'],
+        destSchema: message,
+      }),
+    })),
+  ],
+});
+
+class ShapeRecordingDelegate extends QueryDelegateImpl {
+  readonly names: string[] = [];
+  override decorateInput(input: Input, name: string): Input {
+    this.names.push(name);
+    return super.decorateInput(input, name);
+  }
+}
+
+function shapeFor(flip: boolean | undefined): string[] {
+  const chatSchema = schema.tables.chat;
+  const messageSchema = schema.tables.message;
+  const delegate = new ShapeRecordingDelegate({
+    sources: {
+      chat: createSource(
+        lc,
+        testLogConfig,
+        'chat',
+        chatSchema.columns,
+        chatSchema.primaryKey,
+      ),
+      message: createSource(
+        lc,
+        testLogConfig,
+        'message',
+        messageSchema.columns,
+        messageSchema.primaryKey,
+      ),
+    },
+  });
+  delegate.materialize(
+    newQuery(schema, 'chat')
+      .where(({or, cmp, exists}) =>
+        or(
+          cmp('lastMessageAt', '>', 100),
+          exists(
+            'messages',
+            m => m.where('body', '=', 'x'),
+            flip === undefined ? undefined : {flip},
+          ),
+        ),
+      )
+      .orderBy('lastMessageAt', 'asc')
+      .orderBy('id', 'asc')
+      .limit(1),
+  );
+  return delegate.names.map(n => n.slice(n.lastIndexOf(':') + 1));
+}
+
+test('an EXISTS lowered without an explicit flip builds no union', () => {
+  // The fuzzer's `lower()` calls `.whereExists(rel, sub)` with no flip option and
+  // its driver never runs the planner, so every fuzzed EXISTS takes this path.
+  expect(shapeFor(undefined)).not.toContain('ufo');
+  expect(shapeFor(undefined)).not.toContain('ufi');
+  expect(shapeFor(false)).not.toContain('ufi');
+  // Only an explicit flip builds the fan-out/fan-in pair.
+  expect(shapeFor(true)).toContain('ufi');
+});
+
+test('take sits above a union fan-in for both source implementations', () => {
+  const chatSchema = schema.tables.chat;
+  const messageSchema = schema.tables.message;
+  const delegate = new ShapeRecordingDelegate({
+    sources: {
+      chat: createSource(
+        lc,
+        testLogConfig,
+        'chat',
+        chatSchema.columns,
+        chatSchema.primaryKey,
+      ),
+      message: createSource(
+        lc,
+        testLogConfig,
+        'message',
+        messageSchema.columns,
+        messageSchema.primaryKey,
+      ),
+    },
+  });
+
+  delegate.materialize(
+    newQuery(schema, 'chat')
+      .where(({or, cmp, exists}) =>
+        or(
+          cmp('lastMessageAt', '>', 100),
+          exists('messages', m => m.where('body', '=', 'x'), {flip: true}),
+        ),
+      )
+      .orderBy('lastMessageAt', 'asc')
+      .orderBy('id', 'asc')
+      .limit(1),
+  );
+
+  const suffixes = delegate.names.map(n => n.slice(n.lastIndexOf(':') + 1));
+  // The union fan-out/fan-in pair and the take must all be present, and the
+  // take must be built after (i.e. above) the fan-in.
+  expect(suffixes).toContain('ufo');
+  expect(suffixes).toContain('ufi');
+  expect(delegate.names.some(n => n.endsWith(':take'))).toBe(true);
+  expect(suffixes.indexOf('ufi')).toBeLessThan(
+    suffixes.findIndex(n => n === 'take'),
+  );
+});


### PR DESCRIPTION
> Stacked on #6380 and #6381. **Must land after both** — on `main` alone this lane reports 4 failures in 48 selected cases, which are exactly the two defects those PRs fix.

## Why the fuzzer missed two real bugs

The chinook fuzzer had a flip lane and a yield lane, and they never intersected. Both defects lived in the uncovered cell.

- **The yield lane never built a union.** `checkYield` lowers with `lower(s)`, which calls `.whereExists(rel, sub)` with no flip option, and the fuzz driver never runs the planner. So `flip` stayed undefined, every EXISTS lowered as a semi-join, and no `UnionFanOut`/`UnionFanIn` was ever constructed in a yield-lane pipeline.
- **The flip lane never pushed and never yielded.** `checkFlipInvariance` enumerates all `2^k` flip assignments but routes them to `checkHydrateCases` — hydrate only. Both bugs need a post-hydration maintenance fetch during a push.
- **The scale yield lane is hydrate-only too**, per `checkYieldTail`'s own doc.

Contributing: `flip` was not one of the covering-array axes at all, so it was never part of t-wise coverage — a bolt-on lane rather than part of the space.

Worth noting the oracle never had to catch a silent divergence here: one bug **throws**. The fuzzer simply never built the pipeline.

## What changed

Three changes, because closing the cell needed all three.

1. **`flip` is now a real axis** (`FLIP_VALS = ['none', 'flip']`). It carries the space's only inter-axis constraint — flip is meaningful only on a *positive* gate — so `flipRealizable` / `tupleRealizable` / `assignmentRealizable` teach both the covering-array builder and the coverage report about it. Unrealizable cells are never generated and never counted in the denominator, so the 100% gate stays meetable.

2. **L1 runs at strength 3** (`l1QueryCases(data, t = 3)`). Pairwise is not enough: a flipped gate only builds a fan-in when it sits *inside an OR*, and a `Take` only sits above that fan-in when the query is *limited*. That is a 3-way interaction. Measured: at `t=2` the greedy cover realizes `flip × exists_or × limit` in **0** rows; at `t=3`, in **17**. Cost: 112 → 494 rows, 4,640 L1 cases (~35s on the backbone), still 100% t-wise.

3. **A new push lane** (`checkYieldPush` + `fanInTakeCases`). Coverage alone was not enough: the covering array only fed *hydrate* lanes, while `checkYield` ran decoration-free skeletons (no `limit`, hence no `Take`). The new lane takes the decorated L1 cases that actually build a `Take` over a `UnionFanIn` and drives them through the four-phase push walk with both IVM sources yield-wrapped. `checkYield` itself now also runs every flip assignment, not just the builder default.

`take-union-shape.test.ts` pins the two structural claims this rests on: an EXISTS lowered without an explicit flip builds no union, and a `Take` sits above the `UnionFanIn` when it does.

## Result

The lane found both defects in this stack:

| State | Failures / 48 selected |
| --- | --- |
| `main` | 4 |
| + #6380 | 2 |
| + #6381 | **0** — all 7 backbone tests pass |

Neither defect actually needed the `'yield'` machinery — re-running with yields forced off reproduces both — but this is the lane that built the pipeline shape that exposes them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)