### PR TITLE
test(zql): add the opt-in yield-interleave sweep harness

### DIFF
--- a/packages/zql/src/ivm/test/mode-yield-source.ts
+++ b/packages/zql/src/ivm/test/mode-yield-source.ts
@@ -1,0 +1,122 @@
+/**
+ * A source wrapper like `RandomYieldSource`, but able to inject 'yield'
+ * sentinels into ONLY the fetch stream, ONLY the push streams, or both.
+ *
+ * Splitting the two isolates where the take-over-union-fan-in corruption comes
+ * from: an interrupted Take maintenance fetch (which reads through UnionFanIn
+ * into every OR branch) versus an interrupted push through UnionFanOut ->
+ * branches -> UnionFanIn's accumulate/collapse.
+ */
+import type {Condition, Ordering} from '../../../../zero-protocol/src/ast.ts';
+import type {DebugDelegate} from '../../builder/debug-delegate.ts';
+import type {Node} from '../data.ts';
+import type {FetchRequest} from '../operator.ts';
+import type {Source, SourceChange, SourceInput} from '../source.ts';
+import type {Stream} from '../stream.ts';
+
+export type YieldMode = 'fetch' | 'push' | 'both';
+
+export class ModeYieldSource implements Source {
+  readonly #source: Source;
+  readonly #rng: () => number;
+  readonly #p: number;
+  readonly #mode: YieldMode;
+
+  constructor(
+    source: Source,
+    rng: () => number,
+    mode: YieldMode,
+    yieldProbability = 0.3,
+  ) {
+    this.#source = source;
+    this.#rng = rng;
+    this.#mode = mode;
+    this.#p = yieldProbability;
+  }
+
+  get tableSchema() {
+    return this.#source.tableSchema;
+  }
+
+  get #yieldsInFetch() {
+    return this.#mode === 'fetch' || this.#mode === 'both';
+  }
+
+  get #yieldsInPush() {
+    return this.#mode === 'push' || this.#mode === 'both';
+  }
+
+  connect(
+    sort: Ordering | undefined,
+    filters?: Condition,
+    splitEditKeys?: Set<string>,
+    debug?: DebugDelegate,
+  ): SourceInput {
+    const sourceInput = this.#source.connect(
+      sort,
+      filters,
+      splitEditKeys,
+      debug,
+    );
+    if (!this.#yieldsInFetch) {
+      return sourceInput;
+    }
+    const rng = this.#rng;
+    const p = this.#p;
+    const originalFetch = sourceInput.fetch.bind(sourceInput);
+    return {
+      ...sourceInput,
+      *fetch(req: FetchRequest): Stream<Node | 'yield'> {
+        for (const item of originalFetch(req)) {
+          if (rng() < p) {
+            yield 'yield';
+          }
+          yield item;
+        }
+        if (rng() < p) {
+          yield 'yield';
+        }
+      },
+    };
+  }
+
+  *push(change: SourceChange): Stream<'yield'> {
+    for (const item of this.#source.push(change)) {
+      if (this.#yieldsInPush && this.#rng() < this.#p) {
+        yield 'yield';
+      }
+      if (item === 'yield') {
+        yield item;
+      }
+    }
+    if (this.#yieldsInPush && this.#rng() < this.#p) {
+      yield 'yield';
+    }
+  }
+
+  *genPush(change: SourceChange): Stream<'yield' | undefined> {
+    for (const item of this.#source.genPush(change)) {
+      if (this.#yieldsInPush && this.#rng() < this.#p) {
+        yield 'yield';
+      }
+      yield item;
+    }
+    if (this.#yieldsInPush && this.#rng() < this.#p) {
+      yield 'yield';
+    }
+  }
+}
+
+export function wrapSourcesWithModeYield(
+  sources: Record<string, Source>,
+  rng: () => number,
+  mode: YieldMode,
+  yieldProbability = 0.3,
+): Record<string, Source> {
+  return Object.fromEntries(
+    Object.entries(sources).map(([k, s]) => [
+      k,
+      new ModeYieldSource(s, rng, mode, yieldProbability),
+    ]),
+  );
+}

--- a/packages/zql/src/query/take-union-empty-window.sweep.test.ts
+++ b/packages/zql/src/query/take-union-empty-window.sweep.test.ts
@@ -1,0 +1,524 @@
+/**
+ * Sweep hunting for Take invariant violations -- `Bound should be set`
+ * (take.ts:448) and its siblings -- reachable through a
+ * UnionFanOut/UnionFanIn (an OR containing a flipped EXISTS) sitting directly
+ * beneath a Take. That is the pipeline shape in the prod stack trace:
+ *
+ *   source -> [Skip] -> UnionFanOut -> [filter | flipped-exists branches] ->
+ *   UnionFanIn -> Take
+ *
+ * Modelled on `chat.listRich`: nullable leading sort key (`lastMessageAt`),
+ * secondary `id` sort, a top-level limit, an OR mixing a plain predicate with
+ * a `whereExists`, and optionally a `.start()` cursor (which is what puts the
+ * Skip below the fan-out -- see builder.ts:324).
+ *
+ * Opt in with SWEEP=1. Knobs:
+ *   SWEEP_LEN, SWEEP_ONLY_LEN, SWEEP_CONTINUE,
+ *   SWEEP_SHAPES, SWEEP_SEEDS, SWEEP_DIRS, SWEEP_LIMITS, SWEEP_OPS
+ * Run under `zql` (MemorySource) or `zqlite-zql-test` (SQLite TableSource).
+ */
+import {expect, test} from 'vitest';
+import {testLogConfig} from '../../../otel/src/test-log-config.ts';
+import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
+import {must} from '../../../shared/src/must.ts';
+import type {Row} from '../../../zero-protocol/src/data.ts';
+import {relationships} from '../../../zero-schema/src/builder/relationship-builder.ts';
+import {createSchema} from '../../../zero-schema/src/builder/schema-builder.ts';
+import {
+  number,
+  string,
+  table,
+} from '../../../zero-schema/src/builder/table-builder.ts';
+import {
+  makeSourceChangeAdd,
+  makeSourceChangeEdit,
+  makeSourceChangeRemove,
+} from '../ivm/source.ts';
+import type {Source} from '../ivm/source.ts';
+import {consume} from '../ivm/stream.ts';
+import {
+  wrapSourcesWithModeYield,
+  type YieldMode,
+} from '../ivm/test/mode-yield-source.ts';
+import {createSource} from '../ivm/test/source-factory.ts';
+import {newQuery} from './query-impl.ts';
+import type {Query} from './query.ts';
+import {QueryDelegateImpl} from './test/query-delegate.ts';
+
+const lc = createSilentLogContext();
+
+const chat = table('chat')
+  .columns({
+    id: string(),
+    lastMessageAt: number().optional(),
+    mode: string(),
+  })
+  .primaryKey('id');
+
+const message = table('message')
+  .columns({id: string(), chatId: string(), body: string()})
+  .primaryKey('id');
+
+const schema = createSchema({
+  tables: [chat, message],
+  relationships: [
+    relationships(chat, ({many}) => ({
+      messages: many({
+        sourceField: ['id'],
+        destField: ['chatId'],
+        destSchema: message,
+      }),
+    })),
+  ],
+});
+
+const chatSchema = schema.tables.chat;
+const messageSchema = schema.tables.message;
+
+function makeSources(): Record<string, Source> {
+  return {
+    chat: createSource(
+      lc,
+      testLogConfig,
+      'chat',
+      chatSchema.columns,
+      chatSchema.primaryKey,
+    ),
+    message: createSource(
+      lc,
+      testLogConfig,
+      'message',
+      messageSchema.columns,
+      messageSchema.primaryKey,
+    ),
+  };
+}
+
+type Dir = 'asc' | 'desc';
+type Shape = {
+  name: string;
+  build: (limit: number, dir: Dir) => Query<'chat', typeof schema>;
+};
+
+const base = (dir: Dir, limit: number) =>
+  newQuery(schema, 'chat')
+    .orderBy('lastMessageAt', dir)
+    .orderBy('id', dir)
+    .limit(limit);
+
+const SHAPES: Shape[] = [
+  {
+    name: 'or(cmp, exists-flip)',
+    build: (limit, dir) =>
+      base(dir, limit).where(({or, cmp, exists}) =>
+        or(
+          cmp('mode', '=', 'a'),
+          exists('messages', q => q.where('body', '=', 'x'), {flip: true}),
+        ),
+      ),
+  },
+  {
+    name: 'or(exists-flip, exists-flip)',
+    build: (limit, dir) =>
+      base(dir, limit).where(({or, exists}) =>
+        or(
+          exists('messages', q => q.where('body', '=', 'x'), {flip: true}),
+          exists('messages', q => q.where('body', '=', 'y'), {flip: true}),
+        ),
+      ),
+  },
+  {
+    name: 'and(cmp, or(cmp, exists-flip))',
+    build: (limit, dir) =>
+      base(dir, limit).where(({and, or, cmp, exists}) =>
+        and(
+          cmp('mode', '!=', 'zzz'),
+          or(
+            cmp('mode', '=', 'a'),
+            exists('messages', q => q.where('body', '=', 'x'), {flip: true}),
+          ),
+        ),
+      ),
+  },
+  {
+    name: 'or(cmp-on-sortkey, exists-flip)',
+    build: (limit, dir) =>
+      base(dir, limit).where(({or, cmp, exists}) =>
+        or(
+          cmp('lastMessageAt', '>', 100),
+          exists('messages', q => q.where('body', '=', 'x'), {flip: true}),
+        ),
+      ),
+  },
+  {
+    name: 'or(cmp, exists-noflip) [control]',
+    build: (limit, dir) =>
+      base(dir, limit).where(({or, cmp, exists}) =>
+        or(
+          cmp('mode', '=', 'a'),
+          exists('messages', q => q.where('body', '=', 'x'), {flip: false}),
+        ),
+      ),
+  },
+  // ---- .start() cursor variants: these put a Skip BELOW the fan-out
+  // (builder.ts:324), the shape #6122 described.
+  {
+    name: 'start(null-cursor) + or(cmp, exists-flip)',
+    build: (limit, dir) =>
+      base(dir, limit)
+        .start({id: 'c0', lastMessageAt: null})
+        .where(({or, cmp, exists}) =>
+          or(
+            cmp('mode', '=', 'a'),
+            exists('messages', q => q.where('body', '=', 'x'), {flip: true}),
+          ),
+        ),
+  },
+  {
+    name: 'start(value-cursor) + or(cmp, exists-flip)',
+    build: (limit, dir) =>
+      base(dir, limit)
+        .start({id: 'c1', lastMessageAt: 15})
+        .where(({or, cmp, exists}) =>
+          or(
+            cmp('mode', '=', 'a'),
+            exists('messages', q => q.where('body', '=', 'x'), {flip: true}),
+          ),
+        ),
+  },
+  {
+    name: 'start(null-cursor) + or(cmp-on-sortkey, exists-flip)',
+    build: (limit, dir) =>
+      base(dir, limit)
+        .start({id: 'c0', lastMessageAt: null})
+        .where(({or, cmp, exists}) =>
+          or(
+            cmp('lastMessageAt', '>', 100),
+            exists('messages', q => q.where('body', '=', 'x'), {flip: true}),
+          ),
+        ),
+  },
+];
+
+type Seed = {name: string; chats: Row[]; messages: Row[]};
+
+const SEEDS: Seed[] = [
+  {name: 'empty', chats: [], messages: []},
+  {
+    name: 'all-null-sortkey, none matching',
+    chats: [
+      {id: 'c1', lastMessageAt: null, mode: 'b'},
+      {id: 'c2', lastMessageAt: null, mode: 'b'},
+    ],
+    messages: [],
+  },
+  {
+    name: 'all-null-sortkey, one matching',
+    chats: [
+      {id: 'c1', lastMessageAt: null, mode: 'a'},
+      {id: 'c2', lastMessageAt: null, mode: 'b'},
+    ],
+    messages: [],
+  },
+  {
+    name: 'mixed-null-sortkey',
+    chats: [
+      {id: 'c1', lastMessageAt: null, mode: 'b'},
+      {id: 'c2', lastMessageAt: 50, mode: 'b'},
+      {id: 'c3', lastMessageAt: 150, mode: 'b'},
+    ],
+    messages: [],
+  },
+  {
+    name: 'mixed, one matching via exists',
+    chats: [
+      {id: 'c1', lastMessageAt: null, mode: 'b'},
+      {id: 'c2', lastMessageAt: 50, mode: 'b'},
+    ],
+    messages: [{id: 'm1', chatId: 'c2', body: 'x'}],
+  },
+  {
+    name: 'non-null sortkey, none matching',
+    chats: [
+      {id: 'c1', lastMessageAt: 10, mode: 'b'},
+      {id: 'c2', lastMessageAt: 20, mode: 'b'},
+    ],
+    messages: [],
+  },
+  {
+    name: 'null-run then values (cursor lands in NULL group)',
+    chats: [
+      {id: 'c1', lastMessageAt: null, mode: 'b'},
+      {id: 'c2', lastMessageAt: null, mode: 'b'},
+      {id: 'c3', lastMessageAt: null, mode: 'b'},
+      {id: 'c4', lastMessageAt: 120, mode: 'b'},
+    ],
+    messages: [],
+  },
+];
+
+type Op = {name: string; run: (r: Runner) => void};
+
+const OPS: Op[] = [
+  {name: 'c1.lma null->200', run: r => r.editChat('c1', {lastMessageAt: 200})},
+  {name: 'c1.lma ->null', run: r => r.editChat('c1', {lastMessageAt: null})},
+  {name: 'c1.lma ->75', run: r => r.editChat('c1', {lastMessageAt: 75})},
+  {name: 'c2.lma ->200', run: r => r.editChat('c2', {lastMessageAt: 200})},
+  {name: 'c2.lma ->null', run: r => r.editChat('c2', {lastMessageAt: null})},
+  {name: 'c1.mode ->a', run: r => r.editChat('c1', {mode: 'a'})},
+  {name: 'c1.mode ->b', run: r => r.editChat('c1', {mode: 'b'})},
+  {name: 'c2.mode ->a', run: r => r.editChat('c2', {mode: 'a'})},
+  {name: 'c2.mode ->b', run: r => r.editChat('c2', {mode: 'b'})},
+  {name: '+msg c1 x', run: r => r.addMessage('mx1', 'c1', 'x')},
+  {name: '-msg c1 x', run: r => r.removeMessage('mx1')},
+  {name: '+msg c2 x', run: r => r.addMessage('mx2', 'c2', 'x')},
+  {name: '-msg c2 x', run: r => r.removeMessage('mx2')},
+  {name: 'msg mx1 x->y', run: r => r.editMessage('mx1', {body: 'y'})},
+  {
+    name: '+chat c9 (null,a)',
+    run: r => r.addChat({id: 'c9', lastMessageAt: null, mode: 'a'}),
+  },
+  {name: '-chat c1', run: r => r.removeChat('c1')},
+  {name: '-chat c2', run: r => r.removeChat('c2')},
+  {name: 'c3.lma ->null', run: r => r.editChat('c3', {lastMessageAt: null})},
+  {name: 'c3.lma ->90', run: r => r.editChat('c3', {lastMessageAt: 90})},
+  {name: '+msg c3 x', run: r => r.addMessage('mx3', 'c3', 'x')},
+  {name: '-msg c3 x', run: r => r.removeMessage('mx3')},
+];
+
+class Runner {
+  readonly #sources: Record<string, Source>;
+  readonly #chats = new Map<string, Row>();
+  readonly #messages = new Map<string, Row>();
+
+  constructor(sources: Record<string, Source>) {
+    this.#sources = sources;
+  }
+
+  addChat(row: Row) {
+    if (this.#chats.has(row.id as string)) return;
+    this.#chats.set(row.id as string, row);
+    consume(must(this.#sources.chat).push(makeSourceChangeAdd(row)));
+  }
+  removeChat(id: string) {
+    const row = this.#chats.get(id);
+    if (!row) return;
+    this.#chats.delete(id);
+    consume(must(this.#sources.chat).push(makeSourceChangeRemove(row)));
+  }
+  editChat(id: string, patch: Partial<Row>) {
+    const old = this.#chats.get(id);
+    if (!old) return;
+    const next = {...old, ...patch};
+    if (next.lastMessageAt === old.lastMessageAt && next.mode === old.mode) {
+      return;
+    }
+    this.#chats.set(id, next);
+    consume(must(this.#sources.chat).push(makeSourceChangeEdit(next, old)));
+  }
+  addMessage(id: string, chatId: string, body: string) {
+    if (this.#messages.has(id)) return;
+    const row = {id, chatId, body};
+    this.#messages.set(id, row);
+    consume(must(this.#sources.message).push(makeSourceChangeAdd(row)));
+  }
+  removeMessage(id: string) {
+    const row = this.#messages.get(id);
+    if (!row) return;
+    this.#messages.delete(id);
+    consume(must(this.#sources.message).push(makeSourceChangeRemove(row)));
+  }
+  editMessage(id: string, patch: Partial<Row>) {
+    const old = this.#messages.get(id);
+    if (!old) return;
+    const next = {...old, ...patch};
+    if (next.body === old.body) return;
+    this.#messages.set(id, next);
+    consume(must(this.#sources.message).push(makeSourceChangeEdit(next, old)));
+  }
+}
+
+type Failure = {
+  shape: string;
+  seed: string;
+  dir: Dir;
+  limit: number;
+  script: string[];
+  error: string;
+  yieldSeed?: number | undefined;
+  stack?: string | undefined;
+};
+
+/** Deterministic RNG so any yield-mode failure is replayable from its seed. */
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const SCRIPT_LEN = Number(process.env.SWEEP_LEN ?? 3);
+
+function pick<T>(all: T[], env: string | undefined): T[] {
+  if (!env) return all;
+  return env.split(',').map(i => all[Number(i)]);
+}
+
+const ACTIVE_OPS = pick(OPS, process.env.SWEEP_OPS);
+const ACTIVE_SHAPES = pick(SHAPES, process.env.SWEEP_SHAPES);
+const ACTIVE_SEEDS = pick(SEEDS, process.env.SWEEP_SEEDS);
+const ACTIVE_DIRS = pick(['desc', 'asc'] as Dir[], process.env.SWEEP_DIRS);
+const ACTIVE_LIMITS = pick([1, 2, 3], process.env.SWEEP_LIMITS);
+const ONLY_LEN = process.env.SWEEP_ONLY_LEN === '1';
+const CONTINUE = process.env.SWEEP_CONTINUE === '1';
+// Cooperative-multitasking dimension: prod's view-syncer builds TableSource
+// with a shouldYield callback, so 'yield' sentinels thread through every
+// fetch/push stream. Nothing in a plain harness ever yields.
+const YIELD_SEEDS = Number(process.env.SWEEP_YIELD ?? 0);
+// 'fetch' | 'push' | 'both' -- isolates which stream the corruption needs.
+const YIELD_MODE = (process.env.SWEEP_YIELD_MODE ?? 'both') as YieldMode;
+
+function* scripts(len: number): Generator<number[]> {
+  const start = ONLY_LEN ? len : 1;
+  for (let l = start; l <= len; l++) {
+    const cur = new Array(l).fill(0);
+    for (;;) {
+      yield cur.slice();
+      let i = l - 1;
+      for (; i >= 0; i--) {
+        cur[i]++;
+        if (cur[i] < ACTIVE_OPS.length) break;
+        cur[i] = 0;
+      }
+      if (i < 0) break;
+    }
+  }
+}
+
+function runOne(
+  shape: Shape,
+  seed: Seed,
+  dir: Dir,
+  limit: number,
+  script: number[],
+  onFailure?: ((f: Failure) => void) | undefined,
+  yieldSeed?: number | undefined,
+): void {
+  let sources = makeSources();
+  if (yieldSeed !== undefined) {
+    sources = wrapSourcesWithModeYield(
+      sources,
+      mulberry32(yieldSeed),
+      YIELD_MODE,
+      0.3,
+    );
+  }
+  const runner = new Runner(sources);
+  for (const c of seed.chats) runner.addChat(c);
+  for (const m of seed.messages) {
+    runner.addMessage(m.id as string, m.chatId as string, m.body as string);
+  }
+
+  const delegate = new QueryDelegateImpl({sources});
+  const mk = (e: unknown, upTo: number): Failure => ({
+    shape: shape.name,
+    seed: seed.name,
+    dir,
+    limit,
+    script: script.slice(0, upTo + 1).map(i => ACTIVE_OPS[i].name),
+    error: e instanceof Error ? e.message : String(e),
+    yieldSeed,
+    stack: e instanceof Error ? e.stack : undefined,
+  });
+
+  try {
+    const view = delegate.materialize(shape.build(limit, dir));
+    for (let n = 0; n < script.length; n++) {
+      try {
+        ACTIVE_OPS[script[n]].run(runner);
+      } catch (e) {
+        onFailure?.(mk(e, n));
+        // CONTINUE mode keeps pushing so one inconsistency can compound into
+        // the next, the way a long-lived prod pipeline does.
+        if (!CONTINUE) return;
+      }
+    }
+    void view.data;
+  } catch (e) {
+    onFailure?.(mk(e, script.length - 1));
+  }
+}
+
+// Opt-in: this is a long-running search, not a regression gate.
+const maybeTest = process.env.SWEEP === '1' ? test : test.skip;
+
+maybeTest(
+  'sweep: take over union-fan-in',
+  () => {
+    const byError = new Map<string, Failure>();
+    const byShape = new Map<string, number>();
+    const byErrorShape = new Map<string, number>();
+    let runs = 0;
+    let failures = 0;
+
+    for (const shape of ACTIVE_SHAPES) {
+      for (const seed of ACTIVE_SEEDS) {
+        for (const dir of ACTIVE_DIRS) {
+          for (const limit of ACTIVE_LIMITS) {
+            for (const script of scripts(SCRIPT_LEN)) {
+              const record = (f: Failure) => {
+                failures++;
+                if (!byError.has(f.error)) byError.set(f.error, f);
+                byShape.set(f.shape, (byShape.get(f.shape) ?? 0) + 1);
+                const k = `${f.error} @ ${f.shape}`;
+                byErrorShape.set(k, (byErrorShape.get(k) ?? 0) + 1);
+              };
+              if (YIELD_SEEDS === 0) {
+                runs++;
+                runOne(shape, seed, dir, limit, script, record);
+              } else {
+                for (let s = 0; s < YIELD_SEEDS; s++) {
+                  runs++;
+                  runOne(
+                    shape,
+                    seed,
+                    dir,
+                    limit,
+                    script,
+                    record,
+                    runs * 2654435761 + s,
+                  );
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    // oxlint-disable-next-line no-console -- the sweep result IS the output
+    console.log(
+      JSON.stringify(
+        {
+          runs,
+          failures,
+          byShape: Object.fromEntries(byShape),
+          byErrorShape: Object.fromEntries(byErrorShape),
+          distinctErrors: Array.from(byError, ([msg, f]) => ({
+            error: msg,
+            firstRepro: f,
+          })),
+        },
+        null,
+        2,
+      ),
+    );
+
+    expect(byError.size).toBe(0);
+  },
+  1_800_000,
+);

--- a/packages/zql/src/query/take-union-yield-mode.diag.test.ts
+++ b/packages/zql/src/query/take-union-yield-mode.diag.test.ts
@@ -1,0 +1,174 @@
+/** Which yield stream does the 2-op repro need: fetch, push, or both? */
+import {expect, test} from 'vitest';
+import {testLogConfig} from '../../../otel/src/test-log-config.ts';
+import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
+import {must} from '../../../shared/src/must.ts';
+import type {Row} from '../../../zero-protocol/src/data.ts';
+import {relationships} from '../../../zero-schema/src/builder/relationship-builder.ts';
+import {createSchema} from '../../../zero-schema/src/builder/schema-builder.ts';
+import {
+  number,
+  string,
+  table,
+} from '../../../zero-schema/src/builder/table-builder.ts';
+import {makeSourceChangeAdd, makeSourceChangeEdit} from '../ivm/source.ts';
+import type {Source} from '../ivm/source.ts';
+import {consume} from '../ivm/stream.ts';
+import {
+  wrapSourcesWithModeYield,
+  type YieldMode,
+} from '../ivm/test/mode-yield-source.ts';
+import {createSource} from '../ivm/test/source-factory.ts';
+import {newQuery} from './query-impl.ts';
+import {QueryDelegateImpl} from './test/query-delegate.ts';
+
+const lc = createSilentLogContext();
+
+const chat = table('chat')
+  .columns({id: string(), lastMessageAt: number().optional(), mode: string()})
+  .primaryKey('id');
+const message = table('message')
+  .columns({id: string(), chatId: string(), body: string()})
+  .primaryKey('id');
+const schema = createSchema({
+  tables: [chat, message],
+  relationships: [
+    relationships(chat, ({many}) => ({
+      messages: many({
+        sourceField: ['id'],
+        destField: ['chatId'],
+        destSchema: message,
+      }),
+    })),
+  ],
+});
+
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+type Window = 'always' | 'hydration' | 'post';
+
+function attempt(
+  mode: YieldMode,
+  seed: number,
+  tables: 'all' | 'chat' | 'message' = 'all',
+  window: Window = 'always',
+  shape: 'flip' | 'noflip' | 'nosubquery' = 'flip',
+): string | undefined {
+  let sources: Record<string, Source> = {
+    chat: createSource(
+      lc,
+      testLogConfig,
+      'chat',
+      schema.tables.chat.columns,
+      schema.tables.chat.primaryKey,
+    ),
+    message: createSource(
+      lc,
+      testLogConfig,
+      'message',
+      schema.tables.message.columns,
+      schema.tables.message.primaryKey,
+    ),
+  };
+  const base = mulberry32(seed);
+  // Returning 1 disables yielding (the wrapper tests `rng() < p`).
+  let live = window !== 'post';
+  const rng = () => (live ? base() : 1);
+  const wrapped = wrapSourcesWithModeYield(sources, rng, mode, 0.3);
+  sources =
+    tables === 'all' ? wrapped : {...sources, [tables]: must(wrapped[tables])};
+  const chatSource = must(sources.chat);
+  const msgSource = must(sources.message);
+  const c1: Row = {id: 'c1', lastMessageAt: null, mode: 'b'};
+  const c2: Row = {id: 'c2', lastMessageAt: null, mode: 'b'};
+  consume(chatSource.push(makeSourceChangeAdd(c1)));
+  consume(chatSource.push(makeSourceChangeAdd(c2)));
+  const delegate = new QueryDelegateImpl({sources});
+  try {
+    const q = newQuery(schema, 'chat')
+      .orderBy('lastMessageAt', 'desc')
+      .orderBy('id', 'desc')
+      .limit(1);
+    const view = delegate.materialize(
+      shape === 'nosubquery'
+        ? q.where(({cmp}) => cmp('mode', '!=', 'zzz'))
+        : q.where(({or, cmp, exists}) =>
+            or(
+              cmp('mode', '=', 'a'),
+              exists('messages', m => m.where('body', '=', 'x'), {
+                flip: shape === 'flip',
+              }),
+            ),
+          ),
+    );
+    if (window === 'hydration') live = false;
+    if (window === 'post') live = true;
+    consume(
+      msgSource.push(makeSourceChangeAdd({id: 'mx1', chatId: 'c1', body: 'x'})),
+    );
+    consume(
+      chatSource.push(makeSourceChangeEdit({...c1, lastMessageAt: 75}, c1)),
+    );
+    void view.data;
+  } catch (e) {
+    return e instanceof Error ? e.message : String(e);
+  }
+  return undefined;
+}
+
+// Opt-in diagnostic (14k pipeline runs), not a regression gate: run with
+// SWEEP=1 under `zql` and/or `zqlite-zql-test`.
+const maybeTest = process.env.SWEEP === '1' ? test : test.skip;
+
+maybeTest(
+  'yield-mode breakdown for the 2-op repro',
+  () => {
+    const report: Record<string, Record<string, number>> = {};
+    const cases: [
+      YieldMode,
+      'all' | 'chat' | 'message',
+      Window,
+      ('flip' | 'noflip' | 'nosubquery')?,
+    ][] = [
+      ['both', 'all', 'always'],
+      ['fetch', 'all', 'always'],
+      ['push', 'all', 'always'],
+      ['fetch', 'chat', 'always'],
+      ['fetch', 'message', 'always'],
+      ['fetch', 'chat', 'hydration'],
+      ['fetch', 'chat', 'post'],
+      // Controls: same script + same yield window, but no UnionFanOut/FanIn.
+      ['fetch', 'chat', 'post', 'noflip'],
+      ['fetch', 'chat', 'post', 'nosubquery'],
+      ['fetch', 'all', 'always', 'noflip'],
+    ];
+    for (const [mode, tables, window, shape = 'flip'] of cases) {
+      const counts: Record<string, number> = {};
+      for (let i = 0; i < 2000; i++) {
+        const err = attempt(
+          mode,
+          31685999679057 + i * 2654435761,
+          tables,
+          window,
+          shape,
+        );
+        const k = err ?? '(no error)';
+        counts[k] = (counts[k] ?? 0) + 1;
+      }
+      report[`${shape}: ${mode}/${tables}/${window}`] = counts;
+    }
+    // oxlint-disable-next-line no-console -- the breakdown IS the output
+    console.log(JSON.stringify(report, null, 2));
+    expect(Object.keys(report).length).toBeGreaterThan(0);
+  },
+  600_000,
+);


### PR DESCRIPTION
> Stacked on #6380, #6381, #6382. Needs the two fixes — the sweep asserts zero errors, so it is red without them. **Entirely gated behind `SWEEP=1`, so CI skips it and it costs nothing until someone opts in.**

The harness that isolated the two `Take` defects in this stack. Opening it separately so reviewers can take or leave it independently of the fixes.

## What's here

**`mode-yield-source.ts`** — a source wrapper that injects `'yield'` sentinels into ONLY the fetch stream, ONLY the push streams, or both. Splitting the two is what separates an interrupted maintenance fetch from an interrupted push. Reusable for any future cooperative-multitasking bug; the existing `RandomYieldSource` can't make that distinction.

**`take-union-yield-mode.diag.test.ts`** — 2,000 yield schedules per cell across `{fetch, push, both} × {parent, child, all} × {hydration, post-hydration}`, plus no-flip and no-subquery controls, printing the isolation table. This is what reduced "a yield somewhere breaks `Take`" to four necessary conditions:

| Yield injected into | Failures / 2000 |
| --- | --- |
| fetch + push, both tables | 985 |
| **fetch only**, both tables | **1083** |
| **push only**, both tables | **0** |
| fetch, **parent source only** | 991 |
| fetch, **child source only** | **0** |
| fetch/parent, **hydration only** | **0** |
| fetch/parent, **post-hydration** | 1000 |
| *control:* no flip → no union | **0** |
| *control:* no subquery | **0** |

Those five zeros are what pointed at `#pushInternalChange` rather than `mergeFetches`. Every cell reads 0 after #6380.

**`take-union-empty-window.sweep.test.ts`** — the broad script sweep, knobs `SWEEP_LEN` / `SWEEP_YIELD` / `SWEEP_YIELD_MODE` / `SWEEP_SHAPES` / `SWEEP_SEEDS` / `SWEEP_DIRS` / `SWEEP_LIMITS` / `SWEEP_OPS` / `SWEEP_CONTINUE`. At depth 2 with 4 yield schedules that is 620,928 runs over the sqlite source: **1,888 failures before the fixes, 0 after**. It asserts zero errors, so it is a real gate for anyone who runs it. (For scale: without yields, 3M+ zqlite runs at depth 3–4 found nothing.)

## Running it

```bash
cd packages/zql && SWEEP=1 npx vitest run take-union-yield-mode.diag --disable-console-intercept

SWEEP=1 SWEEP_LEN=2 SWEEP_YIELD=4 pnpm --filter zqlite-zql-test run test take-union-empty-window
```

Both run under `zql` (MemorySource) and `zqlite-zql-test` (TableSource). Default `pnpm test` shows them as skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)