### PR TITLE
chore(zero-cache): allow awaiting all importSnapshot's in a tx pool

### DIFF
--- a/packages/zero-cache/src/db/transaction-pool.pg.test.ts
+++ b/packages/zero-cache/src/db/transaction-pool.pg.test.ts
@@ -991,11 +991,19 @@ describe('db/transaction-pool', () => {
     // Run the pool.
     pool.run(db);
 
-    // Run the readers.
+    // Run 2 readers.
+    const numReadWorkers = 2;
     const {init: importInit, imported} = importSnapshot(await snapshotID);
-    const readers = newTransactionPool(Mode.READONLY, importInit);
+    const readers = newTransactionPool(
+      Mode.READONLY,
+      importInit,
+      undefined,
+      numReadWorkers,
+    );
     readers.run(db);
-    await imported;
+    for (let i = 0; i < numReadWorkers; i++) {
+      await imported.dequeue();
+    }
 
     const processed: Promise<number[]>[] = [];
 

--- a/packages/zero-cache/src/db/transaction-pool.ts
+++ b/packages/zero-cache/src/db/transaction-pool.ts
@@ -718,18 +718,23 @@ export function sharedSnapshot(): {
 }
 
 /**
- * @returns An `init` Task for importing a snapshot from another transaction.
+ * @returns An `init` Task for importing a snapshot from another transaction,
+ *          as well as an `imported` Queue which resolves or rejects when each
+ *          worker is initialized.
  */
 export function importSnapshot(snapshotID: string): {
   init: Task;
-  imported: Promise<void>;
+  imported: Queue<void>;
 } {
-  const {promise: imported, resolve, reject} = resolver<void>();
+  const imported = new Queue<void>();
 
   return {
     init: tx => {
       const stmt = tx.unsafe(`SET TRANSACTION SNAPSHOT '${snapshotID}'`);
-      stmt.then(() => resolve(), reject);
+      stmt.then(
+        () => imported.enqueue(),
+        err => imported.enqueueRejection(err),
+      );
       return [stmt];
     },
 

--- a/packages/zero-cache/src/services/change-source/pg/backfill-stream.ts
+++ b/packages/zero-cache/src/services/change-source/pg/backfill-stream.ts
@@ -309,7 +309,7 @@ async function createSnapshotTransaction(
 
     const {init, imported} = importSnapshot(snapshot);
     const tx = new TransactionPool(lc, {mode: READONLY, init}).run(db);
-    await imported;
+    await imported.dequeue();
 
     const watermark = toStateVersionString(lsn);
     lc.info?.(`Opened snapshot transaction at LSN ${lsn} (${watermark})`);


### PR DESCRIPTION
In an upcoming change we will need to wait for all workers in a TransactionPool to be initialized (rather than just the first).

Update the `importSnapshot()` method to return a Queue instead of a single resolver Promise to facilitate this.