### PR TITLE
chore(zero-cache): activate the replication slot during initial-sync

### DIFF
--- a/packages/zero-cache/src/server/change-streamer.pg.test.ts
+++ b/packages/zero-cache/src/server/change-streamer.pg.test.ts
@@ -212,7 +212,12 @@ test('change-streamer startup does not deadlock on autoreset retry when change a
     await ensureReplicationConfig(lc, upstream, subscriptionState, shard, true);
 
     await initialSource.stop();
-    await upstream`SELECT pg_drop_replication_slot(${oldSlot})`;
+    await upstream`
+      SELECT pg_terminate_backend(active_pid) FROM pg_replication_slots
+        WHERE slot_name = ${oldSlot}`;
+    await vi.waitFor(
+      () => upstream`SELECT pg_drop_replication_slot(${oldSlot})`,
+    );
 
     // The auto-reset resyncs the replica at a new replicaVersion, so the
     // change log written beside the old one must not survive it. Asserted here

--- a/packages/zero-cache/src/services/change-source/pg/decommission.ts
+++ b/packages/zero-cache/src/services/change-source/pg/decommission.ts
@@ -1,7 +1,10 @@
 import type {LogContext} from '@rocicorp/logger';
+import {sleep} from '../../../../../shared/src/sleep.ts';
 import {runTx} from '../../../db/run-transaction.ts';
 import type {PostgresDB} from '../../../types/pg.ts';
 import {dropShard} from './schema/shard.ts';
+
+const MAX_ATTEMPTS = 3;
 
 export async function decommissionShard(
   lc: LogContext,
@@ -12,32 +15,48 @@ export async function decommissionShard(
   const shard = `${appID}_${shardID}`;
 
   lc.info?.(`Decommissioning zero shard ${shard}`);
-  await runTx(db, async sql => {
-    // Kill the active_pid's on existing slots before altering publications,
-    // as deleting a publication associated with an existing subscriber causes
-    // weirdness; the active_pid becomes null and thus unable to be terminated.
-    const slots = await sql<{pid: string | null}[]>`
+  for (let i = 1; ; i++) {
+    try {
+      await runTx(db, async sql => {
+        // Kill the active_pid's on existing slots before altering publications,
+        // as deleting a publication associated with an existing subscriber causes
+        // weirdness; the active_pid becomes null and thus unable to be terminated.
+        const slots = await sql<{pid: string | null}[]>`
     SELECT pg_terminate_backend(active_pid), active_pid as pid
       FROM pg_replication_slots 
       WHERE slot_name = ${shard} 
          OR slot_name LIKE ${shard + '_%'}`;
-    if (slots.length > 0) {
-      if (slots[0].pid !== null) {
-        lc.info?.(`signaled subscriber ${slots[0].pid} to shut down`);
-      }
-      // Escape underscores for the LIKE expression.
-      const slotExpression = `${appID}_${shardID}_%`.replaceAll('_', '\\_');
-      const dropped = await sql<{slotName: string}[]>`
+        if (slots.length > 0) {
+          if (slots[0].pid !== null) {
+            lc.info?.(`signaled subscriber ${slots[0].pid} to shut down`);
+          }
+          // Escape underscores for the LIKE expression.
+          const slotExpression = `${appID}_${shardID}_%`.replaceAll('_', '\\_');
+          const dropped = await sql<{slotName: string}[]>`
         SELECT pg_drop_replication_slot(slot_name), slot_name as "slotName"
           FROM pg_replication_slots 
           WHERE slot_name = ${shard} 
              OR slot_name LIKE ${slotExpression}`;
-      lc.debug?.(
-        `Dropped replication slot(s) ${dropped.map(({slotName}) => slotName)}`,
-      );
-      await sql.unsafe(dropShard(appID, shardID));
-      lc.debug?.(`Dropped upstream shard schema ${shard} and event triggers`);
+          lc.debug?.(
+            `Dropped replication slot(s) ${dropped.map(({slotName}) => slotName)}`,
+          );
+          await sql.unsafe(dropShard(appID, shardID));
+          lc.debug?.(
+            `Dropped upstream shard schema ${shard} and event triggers`,
+          );
+        }
+      });
+      lc.info?.(`Finished decommissioning zero shard ${shard}`);
+      return;
+    } catch (e) {
+      lc.warn?.(`error decommissioning shard`, e);
+      if (i === MAX_ATTEMPTS) {
+        throw e;
+      } else {
+        // pg_terminate_backend is not transactional, which results in the
+        // slot to sometimes fail to be dropped. Wait and retry.
+        await sleep(3000);
+      }
     }
-  });
-  lc.info?.(`Finished decommissioning zero shard ${shard}`);
+  }
 }

--- a/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
@@ -1,10 +1,9 @@
 import {mkdtemp, rm} from 'node:fs/promises';
 import {platform, tmpdir} from 'node:os';
 import {join} from 'node:path';
-import {Writable} from 'node:stream';
+import {Writable, type Readable} from 'node:stream';
 import {pipeline} from 'node:stream/promises';
 import type {LogContext} from '@rocicorp/logger';
-import {resolver} from '@rocicorp/resolver';
 import {assert} from '../../../../../shared/src/asserts.ts';
 import type {JSONObject} from '../../../../../shared/src/bigint-json.ts';
 import {must} from '../../../../../shared/src/must.ts';
@@ -45,7 +44,6 @@ import {liteTableName} from '../../../types/names.ts';
 import {PG_15, PG_17} from '../../../types/pg-versions.ts';
 import {
   connectPgClient,
-  pgClient,
   type PostgresDB,
   type PostgresTransaction,
   type PostgresValueType,
@@ -131,27 +129,16 @@ export async function initialSync(
   const copyFormat: CopyFormat = textCopy ? 'text' : 'binary';
   const start = performance.now();
   let sql: PostgresDB | undefined;
-  let replicationSession: PostgresDB | undefined;
   const replicaID = Date.now().toString();
   let slotName: string | undefined; // undefined === shadow
+  let slotSession: Readable | undefined; // undefined === shadow
   const statusPublisher = ReplicationStatusPublisher.forRunningTransaction(
     tx,
     shadow ? async () => {} : undefined,
   ).publish(lc, 'Initializing');
-  let releaseShadowSnapshot: (() => Promise<void>) | undefined;
   try {
     const copyProfiler = profileCopy ? await CpuProfiler.connect() : null;
     sql = await connectPgClient(lc, upstreamURI, 'initial-sync');
-    // Replication session is only needed to create a replication slot in the
-    // real path. In shadow mode we export a snapshot on a normal connection
-    // instead, so no replication session is opened.
-    replicationSession = shadow
-      ? undefined
-      : pgClient(lc, upstreamURI, 'initial-sync-replication-session', {
-          ['fetch_types']: false, // Necessary for the streaming protocol
-          connection: {replication: 'database'}, // https://www.postgresql.org/docs/current/protocol-replication.html
-        });
-
     const pgVersion = await checkUpstreamConfig(sql);
 
     // In shadow mode we assume the shard is already initialized and just
@@ -170,22 +157,79 @@ export async function initialSync(
         : `opening replication session to ${database}@${host}`,
     );
 
-    let snapshot: string;
-    let lsn: string;
+    // Captures the necessary information from the consistent snapshot
+    // created for the new replication slot (or a suitable equivalent
+    // for shadow sync).
+    async function captureSnapshot(snapshot: string) {
+      // Run up to MAX_WORKERS to copy of tables at the replication slot's snapshot.
+      // Retrieve the published schema at the consistent_point.
+      const published = await runTx(
+        must(sql),
+        async tx => {
+          await tx.unsafe(/* sql*/ `SET TRANSACTION SNAPSHOT '${snapshot}'`);
+          return getPublicationInfo(tx, publications);
+        },
+        {mode: Mode.READONLY},
+      );
+      // Note: If this throws, initial-sync is aborted.
+      validatePublications(lc, published);
 
-    if (shadow) {
-      const acquired = await acquireExportedSnapshotForShadowSync(
+      // Now that tables have been validated, kick off the copiers.
+      const {tables, indexes} = published;
+      const numTables = tables.length;
+      if (platform() === 'win32' && tableCopyWorkers < numTables) {
+        lc.warn?.(
+          `Increasing the number of copy workers from ${tableCopyWorkers} to ` +
+            `${numTables} to work around a Node/Postgres connection bug`,
+        );
+      }
+      const numWorkers =
+        platform() === 'win32'
+          ? numTables
+          : Math.min(tableCopyWorkers, numTables);
+
+      const copyPool = await connectPgClient(
         lc,
         upstreamURI,
+        'initial-sync-copy-worker',
+        {
+          max: numWorkers,
+          ['max_lifetime']: 120 * 60, // set a long (2h) limit for COPY streaming
+        },
       );
-      snapshot = acquired.snapshot;
-      lsn = acquired.lsn;
-      releaseShadowSnapshot = acquired.release;
+      const copiers = await startTableCopyWorkers(
+        lc,
+        copyPool,
+        snapshot,
+        numWorkers,
+        numTables,
+      );
+      return {
+        published,
+        tables,
+        indexes,
+        numTables,
+        copyPool,
+        copiers,
+      };
+    }
+
+    let lsn: string;
+    let snapshotResult: Awaited<ReturnType<typeof captureSnapshot>>;
+
+    if (shadow) {
+      const exported = await acquireExportedSnapshotForShadowSync(
+        lc,
+        upstreamURI,
+        captureSnapshot,
+      );
+      lsn = exported.lsn;
+      snapshotResult = exported.result;
     } else {
-      const slot = await createReplicaAndSlot(
+      const replication = await createReplicaAndSlot(
         lc,
         sql,
-        must(replicationSession),
+        'initial-sync-replication-session',
         shard,
         replicaID,
         replicationSlotFailover && pgVersion >= PG_17,
@@ -196,59 +240,19 @@ export async function initialSync(
           backupPath: backupV5 ? replicaID : null,
           backupV5,
         },
+        captureSnapshot,
       );
-      snapshot = slot.snapshot_name;
-      lsn = slot.consistent_point;
-      slotName = slot.slot_name;
+      lsn = replication.slot.consistent_point;
+      slotName = replication.slot.slot_name;
+      snapshotResult = replication.capturedSnapshot;
+      slotSession = replication.initialSession;
     }
+
+    const {published, tables, indexes, numTables, copyPool, copiers} =
+      snapshotResult;
 
     const initialVersion = toStateVersionString(lsn);
-
     initReplicationState(tx, publications, initialVersion, context);
-
-    // Run up to MAX_WORKERS to copy of tables at the replication slot's snapshot.
-    // Retrieve the published schema at the consistent_point.
-    const published = await runTx(
-      sql,
-      async tx => {
-        await tx.unsafe(/* sql*/ `SET TRANSACTION SNAPSHOT '${snapshot}'`);
-        return getPublicationInfo(tx, publications);
-      },
-      {mode: Mode.READONLY},
-    );
-    // Note: If this throws, initial-sync is aborted.
-    validatePublications(lc, published);
-
-    // Now that tables have been validated, kick off the copiers.
-    const {tables, indexes} = published;
-    const numTables = tables.length;
-    if (platform() === 'win32' && tableCopyWorkers < numTables) {
-      lc.warn?.(
-        `Increasing the number of copy workers from ${tableCopyWorkers} to ` +
-          `${numTables} to work around a Node/Postgres connection bug`,
-      );
-    }
-    const numWorkers =
-      platform() === 'win32'
-        ? numTables
-        : Math.min(tableCopyWorkers, numTables);
-
-    const copyPool = await connectPgClient(
-      lc,
-      upstreamURI,
-      'initial-sync-copy-worker',
-      {
-        max: numWorkers,
-        ['max_lifetime']: 120 * 60, // set a long (2h) limit for COPY streaming
-      },
-    );
-    const copiers = startTableCopyWorkers(
-      lc,
-      copyPool,
-      snapshot,
-      numWorkers,
-      numTables,
-    );
     try {
       createLiteTables(tx, tables, initialVersion);
       const sampleRate = shadow?.sampleRate;
@@ -373,6 +377,8 @@ export async function initialSync(
       // orphaned replication slot to avoid running out of slots in
       // pathological cases that result in repeated failures.
       lc.warn?.(`dropping replication slot ${slotName}`, e);
+      // release any initial replication session so the slot can be dropped
+      slotSession?.destroy();
       await sql`
         SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots
           WHERE slot_name = ${slotName};
@@ -381,14 +387,6 @@ export async function initialSync(
     throw await statusPublisher.publishAndThrowError(lc, 'Initializing', e);
   } finally {
     statusPublisher.stop();
-    if (releaseShadowSnapshot) {
-      await releaseShadowSnapshot().catch(e =>
-        lc.warn?.(`Error releasing shadow snapshot`, e),
-      );
-    }
-    if (replicationSession) {
-      await replicationSession.end();
-    }
     if (sql) {
       await sql.end();
     }
@@ -524,20 +522,26 @@ async function ensurePublishedTables(
   return {publications};
 }
 
-function startTableCopyWorkers(
+async function startTableCopyWorkers(
   lc: LogContext,
   db: PostgresDB,
   snapshot: string,
   numWorkers: number,
   numTables: number,
-): TransactionPool {
-  const {init} = importSnapshot(snapshot);
+): Promise<TransactionPool> {
+  const {init, imported} = importSnapshot(snapshot);
   const tableCopiers = new TransactionPool(lc, {
     mode: Mode.READONLY,
     init,
     initialWorkers: numWorkers,
   });
   tableCopiers.run(db);
+
+  // Wait for all workers to run the importSnapshot() init task before
+  // proceeding (to allow the snapshot to be released).
+  for (let i = 0; i < numWorkers; i++) {
+    await imported.dequeue();
+  }
 
   lc.info?.(`Started ${numWorkers} workers to copy ${numTables} tables`);
 
@@ -557,70 +561,31 @@ function startTableCopyWorkers(
 /**
  * Shadow-mode alternative to `createReplicationSlot`: opens a dedicated
  * READ ONLY REPEATABLE READ transaction on a normal connection, exports the
- * snapshot and captures the current WAL LSN, then holds the transaction
- * open until `release()` is called. The held transaction keeps the snapshot
- * importable by the table-copy workers for the duration of the COPY phase.
- *
- * Idle-in-transaction timeout is disabled locally so the exporter doesn't
- * get killed while workers are still importing.
+ * snapshot and captures the current WAL LSN. Note that the LSN and snapshot
+ * are not guaranteed to be consistent but it this is fine for shadow sync
+ * where the LSN is not actually relied on for anything.
  */
-async function acquireExportedSnapshotForShadowSync(
+async function acquireExportedSnapshotForShadowSync<T>(
   lc: LogContext,
   upstreamURI: string,
+  captureSnapshot: (snapshot: string) => Promise<T>,
 ): Promise<{
-  snapshot: string;
   lsn: string;
-  release: () => Promise<void>;
+  result: T;
 }> {
   const holder = await connectPgClient(
     lc,
     upstreamURI,
     'shadow-initial-sync-snapshot',
-    {
-      max: 1,
-    },
+    {max: 1},
   );
-  const ready = resolver<{snapshot: string; lsn: string}>();
-  const release = resolver<void>();
-  const held = holder
-    .begin(Mode.READONLY, async tx => {
-      await tx`SET LOCAL idle_in_transaction_session_timeout = 0`.execute();
-      const [row] = await tx<{snapshot: string; lsn: string}[]>`
+  return holder.begin(Mode.READONLY, async tx => {
+    const [{lsn, snapshot}] = await tx<{snapshot: string; lsn: string}[]>`
         SELECT pg_export_snapshot() AS snapshot,
                pg_current_wal_lsn()::text AS lsn`;
-      ready.resolve(row);
-      await release.promise;
-    })
-    .catch(e => ready.reject(e));
-
-  let snapshot: string;
-  let lsn: string;
-  try {
-    ({snapshot, lsn} = await ready.promise);
-  } catch (e) {
-    await holder
-      .end()
-      .catch(err =>
-        lc.warn?.(`Error ending shadow snapshot holder after failure`, err),
-      );
-    throw e;
-  }
-  lc.info?.(
-    `Exported snapshot ${snapshot} at LSN ${lsn} (shadow initial sync)`,
-  );
-  return {
-    snapshot,
-    lsn,
-    release: async () => {
-      release.resolve();
-      try {
-        await held;
-      } catch (e) {
-        lc.warn?.(`snapshot holder transaction ended with error`, e);
-      }
-      await holder.end();
-    },
-  };
+    const result = await captureSnapshot(snapshot);
+    return {lsn, result};
+  });
 }
 
 function createLiteTables(

--- a/packages/zero-cache/src/services/change-source/pg/logical-replication/stream.ts
+++ b/packages/zero-cache/src/services/change-source/pg/logical-replication/stream.ts
@@ -31,20 +31,11 @@ type SourceWithPendingQueue<T> = Source<T> & {
   queued: number;
 };
 
-export async function subscribe(
-  lc: LogContext,
+export function createReplicationSessionFor(
   db: PostgresDB,
-  slot: string,
-  publications: string[],
-  lsn: bigint,
-  retriesIfReplicationSlotActive = DEFAULT_RETRIES_IF_REPLICATION_SLOT_ACTIVE,
-  applicationName = 'zero-replicator',
-  inboundTimeoutOverrideMs?: number | undefined,
-): Promise<{
-  messages: SourceWithPendingQueue<StreamMessage>;
-  acks: Sink<bigint>;
-}> {
-  const session = postgres(
+  applicationName: string,
+) {
+  return postgres(
     defu(
       {
         max: 1,
@@ -63,6 +54,22 @@ export async function subscribe(
       db.options as unknown as Options<Record<string, PostgresType>>,
     ),
   );
+}
+
+export async function subscribe(
+  lc: LogContext,
+  db: PostgresDB,
+  slot: string,
+  publications: string[],
+  lsn: bigint,
+  retriesIfReplicationSlotActive = DEFAULT_RETRIES_IF_REPLICATION_SLOT_ACTIVE,
+  applicationName = 'zero-replicator',
+  inboundTimeoutOverrideMs?: number | undefined,
+): Promise<{
+  messages: SourceWithPendingQueue<StreamMessage>;
+  acks: Sink<bigint>;
+}> {
+  const session = createReplicationSessionFor(db, applicationName);
 
   // Postgres will send keepalives before timing out a wal_sender. It is possible that
   // these keepalives are not received if there is back-pressure in the replication
@@ -360,6 +367,60 @@ async function startReplicationStream(
   throw new Error(
     `exceeded max attempts (${maxAttempts}) to start the Postgres stream`,
   );
+}
+
+/**
+ * Starts a "dummy" replication session for the specified `slot` which:
+ * * does not consume any records
+ * * keeps the session alive by sending status messages at the starting LSN
+ *
+ * This essentially reserves the replication slot for this process by marking
+ * it as "active" in pg_replication_slots, allowing replication slot cleanup
+ * logic to distinguish a new-but-initializing replication slot from one that
+ * has been abandoned / orphaned.
+ *
+ * When initialization (e.g. initial-sync) has finished, the server should take
+ * over the replication slot using pg_terminate_backend, which will close the
+ * session.
+ *
+ * Note that caller should not close the supplied `session`, as that will
+ * also terminate the dummy replication session.
+ */
+export async function keepSlotActiveUntilTakenOver(
+  lc: LogContext,
+  session: postgres.Sql,
+  slot: string,
+  dummyPublication: string,
+  lsn: bigint,
+) {
+  const [readable, writeable] = await startReplicationStream(
+    lc,
+    session,
+    slot,
+    [dummyPublication],
+    lsn,
+    1,
+  );
+  lc.info?.(`keeping ${slot} active until taken over ...`);
+  // Send periodic status messages upstream to indicate that the session is
+  // alive, but keep the confirmed_flush_lsn at the initial lsn.
+  const keepalive = setInterval(() => writeable.write(makeAck(lsn)), 10_000);
+
+  readable.on('close', async () => {
+    lc.info?.(`released initial reservation of ${slot}`);
+    clearInterval(keepalive);
+    try {
+      await session.end();
+      lc.info?.(`ended session`);
+    } catch (e) {
+      lc.warn?.(`error ending session`, e);
+    }
+  });
+  readable.once('error', e => {
+    lc.info?.(`closing replication session to ${session.options.host}`, e);
+    readable.destroy();
+  });
+  return readable;
 }
 
 function parseStreamMessage(

--- a/packages/zero-cache/src/services/change-source/pg/replication-slots.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/replication-slots.pg.test.ts
@@ -2,7 +2,7 @@ import {PG_LOCK_NOT_AVAILABLE} from '@drdgvhbh/postgres-error-codes';
 import postgres from 'postgres';
 import {beforeEach, describe, expect, vi} from 'vitest';
 import {createSilentLogContext} from '../../../../../shared/src/logging-test-utils.ts';
-import {getConnectionURI, type PgTest, test} from '../../../test/db.ts';
+import {getConnectionURI, test, type PgTest} from '../../../test/db.ts';
 import {PG_17} from '../../../types/pg-versions.ts';
 import {pgClient, type PostgresDB} from '../../../types/pg.ts';
 import type {ShardID} from '../../../types/shards.ts';
@@ -11,8 +11,13 @@ import {
   createReplicationSlot,
   dropOldReplicasAndSlots,
   slotPoolSuffix,
+  type ReplicationSlotResult,
 } from './replication-slots.ts';
-import {ensureGlobalTables, shardSetup} from './schema/shard.ts';
+import {
+  ensureGlobalTables,
+  metadataPublicationName,
+  shardSetup,
+} from './schema/shard.ts';
 
 test.each([
   [0, 'a'],
@@ -41,8 +46,12 @@ describe('createReplicationSlot', () => {
     [{pgVersion}] =
       await upstream`SELECT current_setting('server_version_num')::int as "pgVersion"`;
     await ensureGlobalTables(upstream, shard);
+    const metadataPub = metadataPublicationName(APP_ID, SHARD_NUM);
     await upstream.unsafe(
-      shardSetup({...shard, publications: ['foo_pub', 'meta_pub']}, 'meta_pub'),
+      shardSetup(
+        {...shard, publications: ['foo_pub', metadataPub]},
+        metadataPublicationName(APP_ID, SHARD_NUM),
+      ),
     );
     return () => testDBs.drop(upstream);
   });
@@ -171,25 +180,47 @@ describe('createReplicationSlot', () => {
         ORDER BY slot_name`.values(),
     ).toEqual([['zero_18_a'], ['zero_18_d']]);
 
-    const create = (id: string) =>
-      createReplicaAndSlot(lc, upstream, session, shard, id, false, {
-        backupPath: id,
-        backupV5: true,
-      });
+    const results: ReplicationSlotResult<string>[] = [];
+    const create = async (id: string) => {
+      const result = await createReplicaAndSlot(
+        lc,
+        upstream,
+        'initial-sync',
+        shard,
+        id,
+        false,
+        {
+          backupPath: id,
+          backupV5: true,
+        },
+        snapshot => Promise.resolve(`captured(${snapshot})`),
+      );
+      expect(result.capturedSnapshot).toBe(
+        `captured(${result.slot.snapshot_name})`,
+      );
+      const [status] = await upstream<{active: boolean}[]>`
+        SELECT active FROM pg_replication_slots
+          WHERE slot_name = ${result.slot.slot_name};
+      `;
+      expect(status.active).toBe(true);
+      results.push(result);
+    };
 
-    let {slot_name: name} = await create('rep_1');
-    expect(name).toBe('zero_18_a');
+    await create('rep_1');
+    expect(results.at(-1)?.slot.slot_name).toBe('zero_18_a');
 
-    ({slot_name: name} = await create('rep_2'));
-    expect(name).toBe('zero_18_b');
+    await create('rep_2');
+    expect(results.at(-1)?.slot.slot_name).toBe('zero_18_b');
+    // Close the replication session so that it can be dropped.
+    results.at(-1)?.initialSession.destroy();
 
-    ({slot_name: name} = await create('rep_3'));
-    expect(name).toBe('zero_18_c');
+    await create('rep_3');
+    expect(results.at(-1)?.slot.slot_name).toBe('zero_18_c');
 
     await session`DROP_REPLICATION_SLOT zero_18_b`.simple();
 
-    ({slot_name: name} = await create('rep_4'));
-    expect(name).toBe('zero_18_b');
+    await create('rep_4');
+    expect(results.at(-1)?.slot.slot_name).toBe('zero_18_b');
 
     expect(
       await upstream`
@@ -225,33 +256,33 @@ describe('createReplicationSlot', () => {
 
     // Cleanup
     expect(await dropOldReplicasAndSlots(lc, upstream, shard, 100n)).toEqual({
-      dropped: 3,
+      dropped: 0,
       active: 0,
-      draining: 0,
+      draining: 3,
     });
   });
 
   test('concurrent replica creation uses different slot names', async () => {
     const lc = createSilentLogContext();
-    const upstreamURI = getConnectionURI(upstream);
-    const sessions = Array.from({length: 3}, () =>
-      pgClient(lc, upstreamURI, 'slot-pool', {
-        max: 1,
-        ['fetch_types']: false,
-        connection: {replication: 'database'},
-      }),
-    );
-
     const results = await Promise.all(
-      sessions.map((session, i) =>
-        createReplicaAndSlot(lc, upstream, session, shard, `rep_${i}`, false, {
-          backupPath: `rep_${i}`,
-          backupV5: true,
-        }),
+      Array.from({length: 3}, (_, i) =>
+        createReplicaAndSlot(
+          lc,
+          upstream,
+          'initial-sync',
+          shard,
+          `rep_${i}`,
+          false,
+          {
+            backupPath: `rep_${i}`,
+            backupV5: true,
+          },
+          snapshot => Promise.resolve(`captured(${snapshot})`),
+        ),
       ),
     );
     const expectedSlots = new Set(['zero_18_a', 'zero_18_b', 'zero_18_c']);
-    const names = new Set(results.map(({slot_name}) => slot_name));
+    const names = new Set(results.map(({slot: {slot_name}}) => slot_name));
     expect(names).toEqual(expectedSlots);
 
     const replicaSlots = await upstream<{slot: string}[]> /*sql*/ `
@@ -260,60 +291,83 @@ describe('createReplicationSlot', () => {
 
     // Cleanup
     expect(await dropOldReplicasAndSlots(lc, upstream, shard, 100n)).toEqual({
-      dropped: 3,
+      dropped: 0,
       active: 0,
-      draining: 0,
+      draining: 3,
     });
+  });
+
+  test('failure from captureSnapshot cleans up slot', async () => {
+    const lc = createSilentLogContext();
+    const failure = new Error('oh nose');
+    await expect(
+      createReplicaAndSlot(
+        lc,
+        upstream,
+        'initial-sync',
+        shard,
+        `foo`,
+        false,
+        {
+          backupPath: `foo`,
+          backupV5: true,
+        },
+        () => Promise.reject(failure),
+      ),
+    ).rejects.toThrow(failure);
+
+    const replicaSlots = await upstream<{slot: string}[]> /*sql*/ `
+      SELECT slot FROM zero_18.replicas`.values();
+    expect(replicaSlots).toEqual([]);
   });
 
   test('dropReplicaAndSlots', async () => {
     const lc = createSilentLogContext();
-    const upstreamURI = getConnectionURI(upstream);
-    const session = pgClient(lc, upstreamURI, 'slot-pool', {
-      max: 1,
-      ['fetch_types']: false,
-      connection: {replication: 'database'},
-    });
-    await upstream`CREATE PUBLICATION foo_pub FOR ALL TABLES`;
-
-    const create = (id: string) =>
-      createReplicaAndSlot(lc, upstream, session, shard, id, false, {
-        backupPath: id,
-        backupV5: true,
-      });
+    const results: ReplicationSlotResult<string>[] = [];
+    const create = async (id: string) => {
+      const result = await createReplicaAndSlot(
+        lc,
+        upstream,
+        'initial-sync',
+        shard,
+        id,
+        false,
+        {
+          backupPath: id,
+          backupV5: true,
+        },
+        snapshot => Promise.resolve(`captured(${snapshot})`),
+      );
+      results.push(result);
+    };
 
     await create('rep_1');
     await create('rep_2');
     await create('rep_3');
 
-    // Subscribe to the second replication slot to prevent it from
-    // being dropped.
-    const stream = await session
-      .unsafe(`
-      START_REPLICATION SLOT zero_18_b LOGICAL 0/0 
-        (proto_version '1', publication_names 'foo_pub');`)
-      .readable();
+    // Close end the first replication slot but leave the second
+    // one active.
+    results[0].initialSession.destroy();
 
-    expect(await dropOldReplicasAndSlots(lc, upstream, shard, 3n)).toEqual({
-      active: 1,
-      draining: 1,
-      dropped: 1,
+    await vi.waitFor(async () => {
+      expect(await dropOldReplicasAndSlots(lc, upstream, shard, 3n)).toEqual({
+        active: 1,
+        draining: 1,
+        dropped: 1,
+      });
     });
 
-    stream.destroy();
+    // Now close the rest.
+    results[1].initialSession.destroy();
+    results[2].initialSession.destroy();
+
     await vi.waitFor(async () => {
       expect(
-        await upstream<{active: boolean}[]> /*sql*/ `
-          SELECT active FROM pg_replication_slots
-            WHERE slot_name = 'zero_18_b'
-        `,
-      ).toEqual([{active: false}]);
-    });
-
-    expect(await dropOldReplicasAndSlots(lc, upstream, shard, 4n)).toEqual({
-      active: 0,
-      draining: 0,
-      dropped: 2,
+        await dropOldReplicasAndSlots(lc, upstream, shard, 4n),
+      ).toMatchObject({
+        active: 0,
+        draining: 0,
+      });
     });
   });
 });

--- a/packages/zero-cache/src/services/change-source/pg/replication-slots.ts
+++ b/packages/zero-cache/src/services/change-source/pg/replication-slots.ts
@@ -1,3 +1,4 @@
+import type {Readable} from 'node:stream';
 import {
   PG_CONFIGURATION_LIMIT_EXCEEDED,
   PG_INSUFFICIENT_PRIVILEGE,
@@ -8,9 +9,14 @@ import {runTx} from '../../../db/run-transaction.ts';
 import {isPostgresError, type PostgresDB} from '../../../types/pg.ts';
 import {upstreamSchema, type ShardID} from '../../../types/shards.ts';
 import {orTimeout} from '../../../types/timeout.ts';
-import {toStateVersionString} from './lsn.ts';
+import {
+  createReplicationSessionFor,
+  keepSlotActiveUntilTakenOver,
+} from './logical-replication/stream.ts';
+import {toBigInt, toStateVersionString} from './lsn.ts';
 import {
   createReplica,
+  metadataPublicationName,
   replicationSlotExpression,
   replicationSlotPrefix,
   type BackupOptions,
@@ -22,6 +28,12 @@ export type ReplicationSlot = {
   consistent_point: string;
   snapshot_name: string;
   output_plugin: string;
+};
+
+export type ReplicationSlotResult<T> = {
+  slot: ReplicationSlot;
+  capturedSnapshot: T;
+  initialSession: Readable;
 };
 
 export type CreateSlotSpec = {
@@ -129,26 +141,49 @@ export async function createReplicationSlot(
  * 2. Running replication managers (which use an earlier replica of a lower
  *    rank) will not delete the new slot during their cleanup logic, since
  *    the slot will belong to a replica of a higher rank.
+ *
+ * When the replication slot is created, `captureSnapshot` callback is first
+ * run while the snapshot at the consistent point is available. The callback
+ * must capture the snapshot in postgres (e.g. `SET TRANSACTION SNAPSHOT`)
+ * in order to use it. Once the callback completes, a placeholder replication
+ * session (i.e. that does not consume any messages) is started, in order to
+ * reserve the slot by mark it "active", effectively distinguishing the
+ * initializing session from a failed or abandoned session.
+ *
+ * Note that starting the replication session releases the initial snapshot,
+ * which is why the callback must capture it synchronously, before the
+ * replication session is started.
+ *
+ * The placeholder replication session is closed when the
+ * PostgresChangeSource takes over the slot to process the stream in earnest.
+ * It is also returned for cleanup in the case of failures (and for control
+ * in unit tests).
  */
-export async function createReplicaAndSlot(
+export async function createReplicaAndSlot<T>(
   lc: LogContext,
   sql: PostgresDB,
-  replicationSession: postgres.Sql,
+  sessionName: string,
   shard: ShardID,
   replicaID: string,
   failover: boolean,
   backupOptions: BackupOptions,
-): Promise<ReplicationSlot> {
+  captureSnapshot: (snapshot: string) => Promise<T>,
+): Promise<ReplicationSlotResult<T>> {
+  // Note: The replicationSession is closed by keepSlotActiveUntilTakenOver,
+  // and only closed in this function if an error occurrs.
+  const replicationSession = createReplicationSessionFor(sql, sessionName);
   const lockName = replicationSlotManagementLock(shard);
   const slotPoolPrefix = replicationSlotPrefix(shard);
+
   for (let first = true; ; first = false) {
     await dropUnclaimedSlots(lc, sql, shard);
+
+    let slotName: string | undefined;
     try {
       return await runTx(sql, async tx => {
         await tx`SELECT pg_advisory_xact_lock(hashtext(${lockName}))`;
 
         // Pick an available slotName from the slotPoolPrefix pool.
-        let slotName: string;
         const names = await tx<{name: string}[]> /*sql*/ `
           SELECT slot_name as name FROM pg_replication_slots
             WHERE slot_name LIKE ${slotPoolPrefix + '%'};
@@ -166,6 +201,14 @@ export async function createReplicaAndSlot(
           slotName,
           failover,
         });
+        const capturedSnapshot = await captureSnapshot(slot.snapshot_name);
+        const initialSession = await keepSlotActiveUntilTakenOver(
+          lc,
+          replicationSession,
+          slot.slot_name,
+          metadataPublicationName(shard.appID, shard.shardNum),
+          toBigInt(slot.consistent_point),
+        );
 
         await createReplica(
           tx,
@@ -176,7 +219,7 @@ export async function createReplicaAndSlot(
           backupOptions,
         );
 
-        return slot;
+        return {slot, capturedSnapshot, initialSession};
       });
     } catch (e) {
       if (first && isPostgresError(e, PG_INSUFFICIENT_PRIVILEGE)) {
@@ -202,6 +245,12 @@ export async function createReplicaAndSlot(
           DELETE FROM ${sql(replicasTable)} USING pg_replication_slots slots
             WHERE replicas.slot = slots.slot_name AND NOT slots.active`;
         continue; // then let dropUnclaimedSlots() perform its cleanup
+      }
+      // Otherwise, clean up any created slot if something went wrong.
+      if (slotName) {
+        lc.warn?.(`deleting slot ${slotName} due to error`, e);
+        await replicationSession.end();
+        await sql`SELECT pg_drop_replication_slot(${slotName})`;
       }
       throw e;
     }


### PR DESCRIPTION
Eagerly start a replication session on the slot created for initial-sync (thereby marking it as "active" in `pg_replication_slots`). The initial session does not consume any records or change the slot LSN, as its sole purpose is to prevent replication slot cleanup logic in other processes (e.g. other replication-managers) from considering the slot abandoned and cleaning it up.

This will be used for RMv2 when replication-slots are created more frequently and have a higher chance of being orphaned, but it is also relevant to RMv1 for cleaning up abandoned slots (e.g. if initial-sync fails).

The cleanup logic is forthcoming; this change only includes the activation/reservation of the new replication slot.

### Implementation Note

The initial snapshot created by the replication slot for initial-sync is only importable _before_ the first replication session is started, so the snapshotting logic is moved into a callback that is executed when the replication slot is created.