### PR TITLE
feat(rmv2): let a share of cold logs serve, behind coldReadPercent

### DIFF
--- a/packages/zero-cache/src/config/normalize.test.ts
+++ b/packages/zero-cache/src/config/normalize.test.ts
@@ -12,6 +12,7 @@ function configWith(litestream: Partial<ZeroConfig['litestream']>): ZeroConfig {
       address: 'localhost',
       sqliteChangeLogMode: 'off',
       sqliteChangeLogReadPercent: 0,
+      sqliteChangeLogColdReadPercent: 0,
       sqliteChangeLogComparePercent: 1,
       sqliteChangeLogRetentionMs: 60_000,
       sqliteChangeLogReadBatchRows: 1000,
@@ -146,10 +147,47 @@ describe('config/normalize SQLite change log', () => {
     expect(() => assertNormalized(config)).not.toThrow();
   });
 
+  test('cold read percentage is only allowed in serve mode', () => {
+    const config = configWith({});
+    config.changeStreamer.sqliteChangeLogMode = 'compare';
+    config.changeStreamer.sqliteChangeLogColdReadPercent = 1;
+
+    expect(() => assertNormalized(config)).toThrow(
+      '--change-streamer-sqlite-change-log-cold-read-percent must be 0 unless ' +
+        '--change-streamer-sqlite-change-log-mode=serve',
+    );
+  });
+
+  test('cold read percentage must be an integer from 0 through 100', () => {
+    for (const percent of [-1, 1.5, 101]) {
+      const config = configWith({});
+      config.changeStreamer.sqliteChangeLogMode = 'serve';
+      config.changeStreamer.sqliteChangeLogColdReadPercent = percent;
+
+      expect(() => assertNormalized(config)).toThrow(
+        '--change-streamer-sqlite-change-log-cold-read-percent must be an ' +
+          'integer between 0 and 100',
+      );
+    }
+  });
+
+  test('cold read percentage must be 0 when the read percentage is 0', () => {
+    const config = configWith({});
+    config.changeStreamer.sqliteChangeLogMode = 'serve';
+    config.changeStreamer.sqliteChangeLogReadPercent = 0;
+    config.changeStreamer.sqliteChangeLogColdReadPercent = 25;
+
+    expect(() => assertNormalized(config)).toThrow(
+      '--change-streamer-sqlite-change-log-cold-read-percent must be 0 when ' +
+        '--change-streamer-sqlite-change-log-read-percent is 0',
+    );
+  });
+
   test('accepts positive integer tuning values', () => {
     const config = configWith({});
     config.changeStreamer.sqliteChangeLogMode = 'serve';
     config.changeStreamer.sqliteChangeLogReadPercent = 100;
+    config.changeStreamer.sqliteChangeLogColdReadPercent = 5;
 
     expect(() => assertNormalized(config)).not.toThrow();
   });

--- a/packages/zero-cache/src/config/normalize.ts
+++ b/packages/zero-cache/src/config/normalize.ts
@@ -46,6 +46,7 @@ export function assertNormalized(
   const {
     sqliteChangeLogMode,
     sqliteChangeLogReadPercent,
+    sqliteChangeLogColdReadPercent,
     sqliteChangeLogComparePercent,
     sqliteChangeLogRetentionMs,
     sqliteChangeLogReadBatchRows,
@@ -58,6 +59,12 @@ export function assertNormalized(
       sqliteChangeLogReadPercent <= 100,
     '--change-streamer-sqlite-change-log-read-percent must be an integer between 0 and 100',
   );
+  assert(
+    Number.isSafeInteger(sqliteChangeLogColdReadPercent) &&
+      sqliteChangeLogColdReadPercent >= 0 &&
+      sqliteChangeLogColdReadPercent <= 100,
+    '--change-streamer-sqlite-change-log-cold-read-percent must be an integer between 0 and 100',
+  );
   // This setting has no mode restriction. Comparison starts in `compare` mode.
   assert(
     Number.isSafeInteger(sqliteChangeLogComparePercent) &&
@@ -68,6 +75,18 @@ export function assertNormalized(
   assert(
     sqliteChangeLogMode === 'serve' || sqliteChangeLogReadPercent === 0,
     '--change-streamer-sqlite-change-log-read-percent must be 0 unless --change-streamer-sqlite-change-log-mode=serve',
+  );
+  assert(
+    sqliteChangeLogMode === 'serve' || sqliteChangeLogColdReadPercent === 0,
+    '--change-streamer-sqlite-change-log-cold-read-percent must be 0 unless --change-streamer-sqlite-change-log-mode=serve',
+  );
+  // The cold gate only admits a task to the read gate; it never serves one on
+  // its own. A nonzero cold percentage with a zero read percentage is a
+  // silent no-op, which is the shape of a rollout that looks enabled and
+  // serves nothing.
+  assert(
+    sqliteChangeLogReadPercent > 0 || sqliteChangeLogColdReadPercent === 0,
+    '--change-streamer-sqlite-change-log-cold-read-percent must be 0 when --change-streamer-sqlite-change-log-read-percent is 0',
   );
   for (const [flag, value] of [
     ['retention-ms', sqliteChangeLogRetentionMs],

--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -724,6 +724,19 @@ export const zeroOptions = {
       hidden: true,
     },
 
+    sqliteChangeLogColdReadPercent: {
+      type: v.number().default(0),
+      desc: [
+        `The stable percentage of eligible catchup subscriptions served from a`,
+        `SQLite change log that is younger than its retention window, i.e. one`,
+        `seeded less than {bold --change-streamer-sqlite-change-log-retention-ms}`,
+        `ago. Selection uses the same hash as`,
+        `{bold --change-streamer-sqlite-change-log-read-percent}, so a task that`,
+        `serves cold is always one that would serve warm.`,
+      ],
+      hidden: true,
+    },
+
     sqliteChangeLogComparePercent: {
       type: v.number().default(1),
       desc: [

--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -68,6 +68,7 @@ export default async function runWorker(
       flowControlSlowSubscriberGracePeriodSeconds,
       sqliteChangeLogMode,
       sqliteChangeLogReadPercent,
+      sqliteChangeLogColdReadPercent,
       sqliteChangeLogComparePercent,
       sqliteChangeLogRetentionMs,
       sqliteChangeLogReadBatchRows,
@@ -268,6 +269,7 @@ export default async function runWorker(
             sqliteChangeLogMode === 'serve'
               ? {
                   readPercent: sqliteChangeLogReadPercent,
+                  coldReadPercent: sqliteChangeLogColdReadPercent,
                   retentionMs: sqliteChangeLogRetentionMs,
                 }
               : undefined,

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
@@ -674,6 +674,52 @@ describe('change-streamer/service', () => {
     }
   });
 
+  test('cold reads serve a freshly seeded log from its seed anchor', async () => {
+    const readerRead = vi.spyOn(SQLiteChangeLogReader.prototype, 'read');
+    const logFile = new DbFile('sqlite-change-log-cold-serve');
+    const retentionMs = 60_000;
+    // Never advanced: the log stays inside its warm-up window throughout.
+    const now = Date.now();
+    await restartWithInlineChangeLogWriter(logFile, {
+      sqliteCatchup: {barrierPollIntervalMs: 10},
+      sqliteChangeLogServe: {
+        readPercent: 100,
+        coldReadPercent: 100,
+        retentionMs,
+        now: () => now,
+      },
+    });
+
+    try {
+      changes.push(['begin', messages.begin(), {commitWatermark: '06'}]);
+      changes.push(['data', messages.insert('foo', {id: 'bootstrap'})]);
+      changes.push(['commit', messages.commit(), {watermark: '06'}]);
+      await expectAcks('06');
+
+      // The subscriber is exactly at the watermark the log was seeded at,
+      // which is what `seedChangeLogStream`'s synthetic transaction exists to
+      // make serviceable. The warm-up gate is the reason that had never run
+      // outside a reader unit test.
+      const sub = await subscribeServing('cold-serve');
+      const output = drainToQueue(sub);
+      expect(await nextChange(output)).toMatchObject({tag: 'status'});
+      expect(await nextChange(output)).toMatchObject({tag: 'begin'});
+      expect(await nextChange(output)).toMatchObject({
+        tag: 'insert',
+        new: {id: 'bootstrap'},
+      });
+      expect(await nextChange(output)).toMatchObject({tag: 'commit'});
+      expect(readerRead).toHaveBeenCalled();
+      sub.cancel();
+    } finally {
+      readerRead.mockRestore();
+      await streamer.stop();
+      await streamerDone;
+      deleteChangeLogDB(logFile.path);
+      logFile.delete();
+    }
+  });
+
   test('serve mode sends a subscriber below the SQLite floor to PG', async () => {
     const readerRead = vi.spyOn(SQLiteChangeLogReader.prototype, 'read');
     const pgCatchup = vi.spyOn(Storer.prototype, 'catchup');

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
@@ -789,6 +789,98 @@ describe('change-streamer/service', () => {
     }
   });
 
+  test('a reservation the log cannot cover is demoted to PG, pin included', async () => {
+    const readerRead = vi.spyOn(SQLiteChangeLogReader.prototype, 'read');
+    const pgCatchup = vi.spyOn(Storer.prototype, 'catchup');
+    const logFile = new DbFile('sqlite-change-log-reservation-demotion');
+    await restartWithInlineChangeLogWriter(logFile, {
+      sqliteCatchup: {barrierPollIntervalMs: 10},
+      backupURL: 's3://foo/bar',
+      sqliteChangeLogServe: {
+        readPercent: 100,
+        retentionMs: 0,
+        // A log seeded after the backup this follower restores from. Its
+        // minimum is later than the durable watermark, so it cannot catch
+        // that replica up no matter how long the reservation waits.
+        inspect: () => ({
+          seededAtMs: 0,
+          seedWatermark: '08',
+          minWatermark: '08',
+          headWatermark: '08',
+        }),
+      },
+    });
+
+    try {
+      changes.push(['begin', messages.begin(), {commitWatermark: '06'}]);
+      changes.push(['data', messages.insert('foo', {id: 'from-pg'})]);
+      changes.push(['commit', messages.commit(), {watermark: '06'}]);
+      await expectAcks('06');
+
+      streamer.trackBackupWatermark('06');
+      const reservation = await streamer.startSnapshotReservation('follower');
+      const [, status] = await drainSnapshotMessages(reservation).dequeue();
+
+      // Confirmed at all: without the demotion the log's '08' minimum fails
+      // the coverage check against backup '06', and the reservation stays
+      // pending with no status pushed. The advertised bound is the backup
+      // watermark, reached via PG's range rather than the log's.
+      expect(status).toMatchObject({
+        minWatermark: '06',
+        replicaVersion: REPLICA_VERSION,
+      });
+      expect(logSink.messages).toContainEqual([
+        'info',
+        expect.anything(),
+        [
+          expect.stringContaining(
+            'demoting follower to PG catchup: SQLite change-log minimum 08 ' +
+              'is later than backupWatermark 06',
+          ),
+        ],
+      ]);
+
+      // The pin moved with the bounds: the /changes request that follows the
+      // reservation resolves to PG for the same reason.
+      const sub = await streamer.subscribe({
+        protocolVersion: PROTOCOL_VERSION,
+        taskID: 'follower',
+        id: 'follower',
+        mode: 'serving',
+        watermark: REPLICA_VERSION,
+        replicaVersion: REPLICA_VERSION,
+        initial: true,
+        logsChangeStream: false,
+      });
+      const output = drainToQueue(sub);
+      expect(await nextChange(output)).toMatchObject({tag: 'status'});
+      expect(await nextChange(output)).toMatchObject({tag: 'begin'});
+      expect(await nextChange(output)).toMatchObject({
+        tag: 'insert',
+        new: {id: 'from-pg'},
+      });
+      expect(logSink.messages).toContainEqual([
+        'debug',
+        expect.anything(),
+        [
+          expect.stringContaining(
+            'serving follower from PG catchup: SQLite route backup-uncovered',
+          ),
+        ],
+      ]);
+      expect(pgCatchup).toHaveBeenCalled();
+      expect(readerRead).not.toHaveBeenCalled();
+      sub.cancel();
+    } finally {
+      readerRead.mockRestore();
+      pgCatchup.mockRestore();
+      await streamer.stop();
+      await streamerDone;
+      deleteChangeLogDB(logFile.path);
+      logFile.delete();
+    }
+  });
+
   /**
    * §6.6's rollback drill. At readPercent=100, with a subscriber served from
    * SQLite and a snapshot reservation confirmed while SQLite was the pinned

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -423,6 +423,14 @@ class ChangeStreamerImpl implements ChangeStreamerService {
     'sqlite_change_log.catchup_routes',
     'Catchup subscriptions by selected source and low-cardinality reason.',
   );
+  readonly #reservationDemotions = getOrCreateCounter(
+    'replication',
+    'sqlite_change_log.reservation_demotions',
+    'Snapshot reservations demoted from SQLite to PG because the change ' +
+      'log could not cover the backup being restored. With PG retired ' +
+      'these followers have no fallback, so this is the rate at which one ' +
+      'would instead have to wait for a later backup.',
+  );
   readonly #reservationConfirmDelays = getOrCreateCounter(
     'replication',
     'sqlite_change_log.reservation_confirm_delays',
@@ -1021,18 +1029,41 @@ class ChangeStreamerImpl implements ChangeStreamerService {
     // per call even when every reservation is pinned to SQLite.
     const pgState = await this.#getChangeLogState();
     for (const taskID of reservations.unconfirmedTaskIDs()) {
-      const route = this.#readRouter?.peek(taskID);
+      let route = this.#readRouter?.peek(taskID);
       // startSnapshotReservation pins only after an in-flight purge has
       // completed. A task with no pin yet is confirmed by that path instead.
       if (this.#readRouter && route === undefined) {
         continue;
       }
 
+      if (route?.source === 'sqlite') {
+        const coverage = must(
+          route.coverage,
+          'a pinned SQLite route must carry its covered range',
+        );
+        if (coverage.minWatermark > backupWatermark) {
+          // A log seeded after this backup, most often. Holding the
+          // reservation until a backup reaches the log's minimum would stall
+          // a follower that PG can serve now, so move it -- pin included.
+          this.#lc.info?.(
+            `demoting ${taskID} to PG catchup: SQLite change-log minimum ` +
+              `${coverage.minWatermark} is later than backupWatermark ` +
+              backupWatermark,
+          );
+          this.#reservationDemotions.add(1);
+          route = must(this.#readRouter).demote(taskID);
+        }
+      }
+
+      const source = route?.source ?? 'pg';
       let minWatermark: string;
       if (route?.source === 'sqlite') {
-        const coverage = route.coverage;
-        assert(coverage, 'a pinned SQLite route must carry its covered range');
-        minWatermark = coverage.minWatermark;
+        // Demotion above already moved every SQLite route the backup is
+        // outside of, so this one covers it and confirms below.
+        minWatermark = must(
+          route.coverage,
+          'a pinned SQLite route must carry its covered range',
+        ).minWatermark;
       } else {
         ({minWatermark} = pgState);
       }
@@ -1042,21 +1073,19 @@ class ChangeStreamerImpl implements ChangeStreamerService {
           taskID,
           pgState.replicaVersion,
           backupWatermark,
-          route?.source ?? 'pg',
+          source,
         );
       } else {
-        // The selected source cannot catch a restored replica up from this
-        // backup yet. Keep the reservation pending until a later backup moves
-        // the durable watermark into its covered range.
+        // PG cannot catch a restored replica up from this backup yet. Keep
+        // the reservation pending until a later backup moves the durable
+        // watermark into its covered range.
         if (reservations.noteConfirmationDelayed(taskID)) {
-          this.#reservationConfirmDelays.add(1, {
-            source: route?.source ?? 'pg',
-          });
+          this.#reservationConfirmDelays.add(1);
         }
         this.#lc.error?.(
-          `${route?.source ?? 'pg'} change-log minWatermark ${minWatermark} ` +
-            `is later than backupWatermark ${backupWatermark}. Delaying ` +
-            `confirmation of snapshot reservation until next backup.`,
+          `pg change-log minWatermark ${minWatermark} is later than ` +
+            `backupWatermark ${backupWatermark}. Delaying confirmation of ` +
+            `snapshot reservation until next backup.`,
         );
       }
     }

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -124,7 +124,15 @@ export type SQLiteCatchupOptions = {
 export type SQLiteChangeLogServeOptions = {
   /** Stable percentage of eligible serving tasks routed to SQLite. */
   readPercent: number;
-  /** A reseeded log must age through this whole window before it can serve. */
+  /**
+   * Stable percentage of eligible serving tasks routed to a log that has not
+   * yet aged through {@link retentionMs}. Zero keeps a reseeded log on PG for
+   * that whole window; above zero it serves that share of tasks, and a
+   * reservation it cannot cover is demoted rather than held pending.
+   * Defaults to zero.
+   */
+  coldReadPercent?: number | undefined;
+  /** The warm-up window a reseeded log ages through. */
   retentionMs: number;
   /** Injectable for deterministic breaker tests. */
   failureCooldownMs?: number | undefined;
@@ -515,6 +523,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
         ? new SQLiteChangeLogReadRouter({
             shard,
             readPercent: serveOptions.readPercent,
+            coldReadPercent: serveOptions.coldReadPercent,
             retentionMs: serveOptions.retentionMs,
             failureCooldownMs: serveOptions.failureCooldownMs,
             now: serveOptions.now,
@@ -1399,9 +1408,9 @@ class ChangeStreamerImpl implements ChangeStreamerService {
         catchup,
         reason: route?.reason ?? 'selector',
         coverage: route?.coverage,
-        // Every route the router selects has passed the warm-up gate.
         // Legacy focused-test selection has no warm classification.
-        logWarm: route === undefined ? undefined : true,
+        logWarm:
+          route === undefined ? undefined : route.reason !== 'selected-cold',
       };
     } else {
       this.#recordCatchupRoute('pg', 'log-unavailable');

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -423,6 +423,13 @@ class ChangeStreamerImpl implements ChangeStreamerService {
     'sqlite_change_log.catchup_routes',
     'Catchup subscriptions by selected source and low-cardinality reason.',
   );
+  readonly #reservationConfirmDelays = getOrCreateCounter(
+    'replication',
+    'sqlite_change_log.reservation_confirm_delays',
+    'Snapshot reservations whose confirmation was deferred because the ' +
+      "selected source's change-log minimum was later than the backup " +
+      'watermark. Counted once per reservation, by that source.',
+  );
 
   #latestStatus: Status;
   #latestLagReportCommitTimeMs = 0;
@@ -1035,11 +1042,17 @@ class ChangeStreamerImpl implements ChangeStreamerService {
           taskID,
           pgState.replicaVersion,
           backupWatermark,
+          route?.source ?? 'pg',
         );
       } else {
         // The selected source cannot catch a restored replica up from this
         // backup yet. Keep the reservation pending until a later backup moves
         // the durable watermark into its covered range.
+        if (reservations.noteConfirmationDelayed(taskID)) {
+          this.#reservationConfirmDelays.add(1, {
+            source: route?.source ?? 'pg',
+          });
+        }
         this.#lc.error?.(
           `${route?.source ?? 'pg'} change-log minWatermark ${minWatermark} ` +
             `is later than backupWatermark ${backupWatermark}. Delaying ` +

--- a/packages/zero-cache/src/services/change-streamer/snapshot-reservations.metrics.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/snapshot-reservations.metrics.test.ts
@@ -1,0 +1,139 @@
+/**
+ * `observability/metrics.ts` caches every instrument in module scope, so an
+ * instrument created against a previous test's meter provider would be
+ * handed back to the next one. Each test therefore resets modules and
+ * imports through a fresh provider, matching `backup-monitor.metrics.test.ts`.
+ */
+
+import {metrics, type Attributes} from '@opentelemetry/api';
+import {
+  AggregationTemporality,
+  InMemoryMetricExporter,
+  MeterProvider,
+  PeriodicExportingMetricReader,
+} from '@opentelemetry/sdk-metrics';
+import {afterEach, expect, test, vi} from 'vitest';
+import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
+import type {BackupConfig} from './change-streamer-service.ts';
+
+afterEach(() => {
+  metrics.disable();
+  vi.resetModules();
+});
+
+const CONFIRM_DURATION =
+  'zero.replica.litestream.snapshot.reservation_confirm_duration';
+const RESERVATION_DURATION =
+  'zero.replica.litestream.snapshot.reservation_duration';
+
+const BACKUP_CONFIG: BackupConfig = {
+  backupURL: 's3://foo/bar',
+  litestreamVersion: 'v5',
+};
+
+function withProvider() {
+  const exporter = new InMemoryMetricExporter(
+    AggregationTemporality.CUMULATIVE,
+  );
+  const provider = new MeterProvider({
+    readers: [
+      new PeriodicExportingMetricReader({
+        exporter,
+        exportIntervalMillis: 60_000,
+      }),
+    ],
+  });
+  expect(metrics.setGlobalMeterProvider(provider)).toBe(true);
+  return {exporter, provider};
+}
+
+/** The most recent export's points for one instrument, with their attributes. */
+function pointsFor(
+  exporter: InMemoryMetricExporter,
+  name: string,
+): {attributes: Attributes; count: number}[] {
+  return (
+    exporter
+      .getMetrics()
+      .at(-1)
+      ?.scopeMetrics.flatMap(scope => scope.metrics)
+      .find(metric => metric.descriptor.name === name)
+      ?.dataPoints.map(point => ({
+        attributes: point.attributes,
+        count: (point.value as {count: number}).count,
+      })) ?? []
+  );
+}
+
+test('confirmFor() records the wait by the source the bounds came from', async () => {
+  const {exporter, provider} = withProvider();
+  try {
+    const {SnapshotReservations} = await import('./snapshot-reservations.ts');
+    const reservations = new SnapshotReservations(
+      createSilentLogContext(),
+      BACKUP_CONFIG,
+    );
+    reservations.open('task-1');
+    reservations.open('task-2');
+    reservations.confirmFor('task-1', 'replica-v1', 'sqlite-min', 'sqlite');
+    reservations.confirmFor('task-2', 'replica-v1', 'pg-min', 'pg');
+    // Already confirmed: not a second wait.
+    reservations.confirmFor('task-1', 'replica-v1', 'sqlite-min', 'sqlite');
+
+    await provider.forceFlush();
+    const points = pointsFor(exporter, CONFIRM_DURATION);
+    expect(
+      points.map(({attributes, count}) => [attributes.source, count]).sort(),
+    ).toEqual([
+      ['pg', 1],
+      ['sqlite', 1],
+    ]);
+    expect(points[0].attributes).toMatchObject({
+      role: 'view_syncer',
+      backup_scheme: 's3',
+      litestream: 'v5',
+    });
+  } finally {
+    await provider.shutdown();
+  }
+});
+
+test('a reservation that never confirmed is distinguishable at close', async () => {
+  const {exporter, provider} = withProvider();
+  try {
+    const {SnapshotReservations} = await import('./snapshot-reservations.ts');
+    const reservations = new SnapshotReservations(
+      createSilentLogContext(),
+      BACKUP_CONFIG,
+    );
+
+    // Confirmed, then closed by the service once the follower subscribed.
+    reservations.open('confirmed-task');
+    reservations.confirmFor(
+      'confirmed-task',
+      'replica-v1',
+      'sqlite-min',
+      'sqlite',
+    );
+    reservations.close('confirmed-task');
+
+    // Gave up while still waiting for its bounds.
+    const pending = reservations.open('waiting-task');
+    pending.cancel();
+
+    await provider.forceFlush();
+    expect(
+      pointsFor(exporter, RESERVATION_DURATION).map(({attributes}) => [
+        attributes.result,
+        attributes.confirmed,
+      ]),
+    ).toEqual([
+      ['closed', true],
+      ['cancelled', false],
+    ]);
+    // No confirmation was recorded for the reservation that never got one.
+    expect(pointsFor(exporter, CONFIRM_DURATION)).toHaveLength(1);
+  } finally {
+    await provider.shutdown();
+  }
+});

--- a/packages/zero-cache/src/services/change-streamer/snapshot-reservations.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/snapshot-reservations.test.ts
@@ -54,7 +54,7 @@ describe('change-streamer/snapshot-reservations', () => {
     const sub = reservations.open('task-1');
     const message = getFirstMessage(sub);
 
-    reservations.confirmFor('task-1', 'replica-v1', 'watermark-1');
+    reservations.confirmFor('task-1', 'replica-v1', 'watermark-1', 'pg');
 
     expect(await message).toEqual([
       'status',
@@ -73,8 +73,8 @@ describe('change-streamer/snapshot-reservations', () => {
     const reservations = newReservations();
     reservations.open('task-1');
 
-    reservations.confirmFor('task-1', 'replica-v1', 'watermark-1');
-    reservations.confirmFor('task-1', 'replica-v1', 'watermark-2');
+    reservations.confirmFor('task-1', 'replica-v1', 'watermark-1', 'pg');
+    reservations.confirmFor('task-1', 'replica-v1', 'watermark-2', 'pg');
 
     // The reservation stays pinned to the watermark from its first
     // confirmation; the second confirmFor() call is a no-op for it.
@@ -87,10 +87,10 @@ describe('change-streamer/snapshot-reservations', () => {
     reservations.open('task-2');
     expect(reservations.confirmationsRequired()).toBe(true);
 
-    reservations.confirmFor('task-1', 'replica-v1', 'watermark-1');
+    reservations.confirmFor('task-1', 'replica-v1', 'watermark-1', 'pg');
     expect(reservations.confirmationsRequired()).toBe(true);
 
-    reservations.confirmFor('task-2', 'replica-v1', 'watermark-1');
+    reservations.confirmFor('task-2', 'replica-v1', 'watermark-1', 'sqlite');
     expect(reservations.confirmationsRequired()).toBe(false);
     expect(reservations.getReservedWatermarks().sort()).toEqual([
       'watermark-1',
@@ -107,7 +107,7 @@ describe('change-streamer/snapshot-reservations', () => {
       'task-1',
       'task-2',
     ]);
-    reservations.confirmFor('task-1', 'replica-v1', 'sqlite-min');
+    reservations.confirmFor('task-1', 'replica-v1', 'sqlite-min', 'sqlite');
 
     expect(await first).toMatchObject([
       'status',
@@ -120,13 +120,13 @@ describe('change-streamer/snapshot-reservations', () => {
   test('a reservation opened after a confirmation is still unconfirmed', () => {
     const reservations = newReservations();
     reservations.open('task-1');
-    reservations.confirmFor('task-1', 'replica-v1', 'watermark-1');
+    reservations.confirmFor('task-1', 'replica-v1', 'watermark-1', 'pg');
 
     reservations.open('task-2');
     expect(reservations.confirmationsRequired()).toBe(true);
     expect(reservations.getReservedWatermarks()).toEqual(['watermark-1']);
 
-    reservations.confirmFor('task-2', 'replica-v1', 'watermark-2');
+    reservations.confirmFor('task-2', 'replica-v1', 'watermark-2', 'pg');
     expect(reservations.confirmationsRequired()).toBe(false);
     expect(reservations.getReservedWatermarks().sort()).toEqual([
       'watermark-1',
@@ -146,7 +146,7 @@ describe('change-streamer/snapshot-reservations', () => {
     // Only one reservation is tracked for the taskID, and it's the new one:
     // it still receives the confirmation push.
     const message = getFirstMessage(sub2);
-    reservations.confirmFor('task-1', 'replica-v1', 'watermark-1');
+    reservations.confirmFor('task-1', 'replica-v1', 'watermark-1', 'pg');
     await message;
     expect(reservations.getReservedWatermarks()).toEqual(['watermark-1']);
   });
@@ -173,7 +173,7 @@ describe('change-streamer/snapshot-reservations', () => {
     expect(reservations.confirmationsRequired()).toBe(true);
 
     const message = getFirstMessage(sub2);
-    reservations.confirmFor('task-1', 'replica-v1', 'watermark-1');
+    reservations.confirmFor('task-1', 'replica-v1', 'watermark-1', 'pg');
     await message;
     expect(reservations.getReservedWatermarks()).toEqual(['watermark-1']);
 
@@ -212,7 +212,27 @@ describe('change-streamer/snapshot-reservations', () => {
   test('confirmFor() an unknown taskID is a no-op', () => {
     const reservations = newReservations();
     expect(() =>
-      reservations.confirmFor('task-1', 'replica-v1', 'watermark-1'),
+      reservations.confirmFor('task-1', 'replica-v1', 'watermark-1', 'pg'),
     ).not.toThrow();
+  });
+
+  test('noteConfirmationDelayed() reports once per reservation', () => {
+    const reservations = newReservations();
+    reservations.open('task-1');
+
+    // Confirmation is retried on every backup. Only the first deferral for a
+    // reservation counts, so the metric measures followers, not backups.
+    expect(reservations.noteConfirmationDelayed('task-1')).toBe(true);
+    expect(reservations.noteConfirmationDelayed('task-1')).toBe(false);
+    expect(reservations.noteConfirmationDelayed('task-1')).toBe(false);
+
+    // A replacement reservation for the same task is a new follower.
+    reservations.open('task-1');
+    expect(reservations.noteConfirmationDelayed('task-1')).toBe(true);
+  });
+
+  test('noteConfirmationDelayed() is false for an unknown taskID', () => {
+    const reservations = newReservations();
+    expect(reservations.noteConfirmationDelayed('unknown-task')).toBe(false);
   });
 });

--- a/packages/zero-cache/src/services/change-streamer/snapshot-reservations.ts
+++ b/packages/zero-cache/src/services/change-streamer/snapshot-reservations.ts
@@ -3,10 +3,12 @@ import type {Source} from '../../types/streams.ts';
 import {Subscription} from '../../types/subscription.ts';
 import {
   litestreamMonitorMetricAttrs,
+  litestreamSnapshotReservationConfirmDuration,
   litestreamSnapshotReservationDuration,
 } from '../litestream/metrics.ts';
 import type {BackupConfig} from './change-streamer-service.ts';
 import type {SnapshotMessage} from './snapshot.ts';
+import type {ChangeLogReadSource} from './sqlite-change-log-read-router.ts';
 
 export class SnapshotReservations {
   readonly #lc: LogContext;
@@ -44,6 +46,14 @@ export class SnapshotReservations {
     return this.#reservations.get(taskID)?.owns(source) ?? false;
   }
 
+  #metricAttrs() {
+    return litestreamMonitorMetricAttrs(
+      this.#backupConfig.backupURL,
+      this.#backupConfig.litestreamVersion,
+      'view_syncer',
+    );
+  }
+
   #close(taskID: string, cancelledInstanceID: InstanceID | undefined) {
     const res = this.#reservations.get(taskID);
     if (
@@ -59,14 +69,15 @@ export class SnapshotReservations {
       this.#lc.info?.(
         `ended snapshot reservation for ${taskID} (${duration} ms)`,
       );
+      // `result` reports how the reservation ended and `confirmed` whether it
+      // ever received its bounds. They are separate dimensions: a follower
+      // that gives up while waiting for a confirmation is
+      // `result=cancelled, confirmed=false`, which a single collapsed
+      // attribute cannot distinguish from a client that simply went away.
       litestreamSnapshotReservationDuration().recordMs(duration, {
-        ...litestreamMonitorMetricAttrs(
-          this.#backupConfig.backupURL,
-          this.#backupConfig.litestreamVersion,
-          'view_syncer',
-        ),
-        result:
-          cancelledInstanceID || !res.confirmed() ? 'cancelled' : 'closed',
+        ...this.#metricAttrs(),
+        result: cancelledInstanceID ? 'cancelled' : 'closed',
+        confirmed: res.confirmed(),
       });
     }
   }
@@ -91,6 +102,7 @@ export class SnapshotReservations {
     taskID: string,
     replicaVersion: string,
     minWatermark: string,
+    source: ChangeLogReadSource,
   ): void {
     const res = this.#reservations.get(taskID);
     if (res && !res.confirmed()) {
@@ -98,7 +110,22 @@ export class SnapshotReservations {
         `reserving change-log entries since ${minWatermark} for ${taskID}`,
       );
       res.confirm(this.#backupConfig.backupURL, replicaVersion, minWatermark);
+      // Measured from `open()`, not from the first confirmation attempt: what
+      // matters is how long the follower waited before it could restore.
+      litestreamSnapshotReservationConfirmDuration().recordMs(
+        Date.now() - res.startTime.getTime(),
+        {...this.#metricAttrs(), source},
+      );
     }
+  }
+
+  /**
+   * Notes that a confirmation was deferred, returning true only the first time
+   * for this reservation. Confirmation is retried on every backup, so an
+   * undeduplicated count would measure backups rather than delayed followers.
+   */
+  noteConfirmationDelayed(taskID: string): boolean {
+    return this.#reservations.get(taskID)?.noteDelayed() ?? false;
   }
 
   getReservedWatermarks() {
@@ -116,6 +143,7 @@ class Reservation {
   readonly startTime: Date = new Date();
   readonly #downstream: Subscription<SnapshotMessage>;
   #watermark: string | null = null;
+  #delayNoted = false;
 
   constructor(
     instanceID: InstanceID,
@@ -135,6 +163,14 @@ class Reservation {
 
   owns(source: Source<SnapshotMessage>): boolean {
     return this.#downstream === source;
+  }
+
+  noteDelayed(): boolean {
+    if (this.#delayNoted) {
+      return false;
+    }
+    this.#delayNoted = true;
+    return true;
   }
 
   confirm(backupURL: string, replicaVersion: string, minWatermark: string) {

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-read-router.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-read-router.test.ts
@@ -95,6 +95,74 @@ describe('change-streamer/sqlite-change-log-read-router', () => {
     expect(router.consume('task').source).toBe('sqlite');
   });
 
+  test('coldReadPercent serves a share of cold logs, marked as such', () => {
+    const cold: SQLiteChangeLogCoverage = {...warm, seededAtMs: 1_500};
+    const router = new SQLiteChangeLogReadRouter({
+      shard,
+      readPercent: 100,
+      coldReadPercent: 100,
+      retentionMs: 1_000,
+      now: () => 1_999,
+      inspect: () => cold,
+    });
+    // Distinct from 'selected' so bootstrap serving is separable from
+    // steady-state serving in the route metrics.
+    expect(router.consume('task')).toEqual({
+      source: 'sqlite',
+      reason: 'selected-cold',
+      coverage: cold,
+    });
+  });
+
+  test('cold selection is a subset of warm selection', () => {
+    const cold: SQLiteChangeLogCoverage = {...warm, seededAtMs: 1_500};
+    // Selected at 100% but not at 10%: eligible warm, ineligible cold.
+    const warmOnly = Array.from({length: 1_000}, (_, i) => `task-${i}`).find(
+      taskID => !isSampledForShard(shard, taskID, 10),
+    );
+    expect(warmOnly).toBeDefined();
+
+    const router = new SQLiteChangeLogReadRouter({
+      shard,
+      readPercent: 100,
+      coldReadPercent: 10,
+      retentionMs: 1_000,
+      now: () => 1_999,
+      inspect: () => cold,
+    });
+    expect(router.consume(warmOnly as string)).toMatchObject({
+      source: 'pg',
+      reason: 'cold-log',
+    });
+
+    const selected = Array.from({length: 1_000}, (_, i) => `task-${i}`).find(
+      taskID => isSampledForShard(shard, taskID, 10),
+    );
+    expect(selected).toBeDefined();
+    expect(router.consume(selected as string)).toMatchObject({
+      source: 'sqlite',
+      reason: 'selected-cold',
+    });
+  });
+
+  test('the read percentage still applies to an eligible cold log', () => {
+    const cold: SQLiteChangeLogCoverage = {...warm, seededAtMs: 1_500};
+    const router = new SQLiteChangeLogReadRouter({
+      shard,
+      readPercent: 0,
+      coldReadPercent: 100,
+      retentionMs: 1_000,
+      now: () => 1_999,
+      inspect: () => cold,
+    });
+    // Cold eligibility opens the warm-up gate; it does not bypass the
+    // rollout dial behind it.
+    expect(router.consume('task')).toMatchObject({
+      source: 'pg',
+      reason: 'percentage',
+    });
+  });
+
   test('a snapshot pin is consumed once and cannot change source mid-restore', () => {
     let available = true;
     const router = new SQLiteChangeLogReadRouter({

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-read-router.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-read-router.test.ts
@@ -124,6 +124,58 @@ describe('change-streamer/sqlite-change-log-read-router', () => {
     });
   });
 
+  test('demote() moves the pin, not just the reservation bounds', () => {
+    const router = new SQLiteChangeLogReadRouter({
+      shard,
+      readPercent: 100,
+      retentionMs: 100,
+      now: () => 2_000,
+      inspect: () => warm,
+    });
+
+    expect(router.pin('task')).toMatchObject({source: 'sqlite'});
+    expect(router.demote('task')).toEqual({
+      source: 'pg',
+      reason: 'backup-uncovered',
+    });
+    // The /changes request that follows the reservation must agree with the
+    // bounds it was confirmed with.
+    expect(router.peek('task')).toMatchObject({
+      source: 'pg',
+      reason: 'backup-uncovered',
+      pinned: true,
+    });
+    expect(router.consume('task')).toMatchObject({
+      source: 'pg',
+      reason: 'backup-uncovered',
+      pinned: true,
+    });
+  });
+
+  test('demote() does not resurrect a released pin', () => {
+    const router = new SQLiteChangeLogReadRouter({
+      shard,
+      readPercent: 100,
+      retentionMs: 100,
+      now: () => 2_000,
+      inspect: () => warm,
+    });
+
+    router.pin('task');
+    router.release('task');
+    expect(router.demote('task')).toEqual({
+      source: 'pg',
+      reason: 'backup-uncovered',
+    });
+    // Unpinned: the next request makes a fresh choice rather than inheriting
+    // a demotion that belonged to a reservation that is already gone.
+    expect(router.peek('task')).toBeUndefined();
+    expect(router.consume('task')).toMatchObject({
+      source: 'sqlite',
+      reason: 'selected',
+    });
+  });
+
   test('post-registration failures route retries to PG until a bounded probe succeeds', () => {
     let now = 2_000;
     let available = true;

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-read-router.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-read-router.ts
@@ -23,7 +23,11 @@ export type ChangeLogReadRouteReason =
   | 'percentage'
   | 'cold-log'
   | 'log-unavailable'
-  | 'breaker-open';
+  | 'breaker-open'
+  // Pinned to SQLite, then demoted because the log could not cover the
+  // backup the reservation is restoring from. See {@link
+  // SQLiteChangeLogReadRouter.demote}.
+  | 'backup-uncovered';
 
 export type ChangeLogReadRoute = {
   readonly source: ChangeLogReadSource;
@@ -101,6 +105,28 @@ export class SQLiteChangeLogReadRouter {
   /** Releases a pin whose snapshot reservation ended before subscribing. */
   release(taskID: string): void {
     this.#pins.delete(taskID);
+  }
+
+  /**
+   * Replaces a pinned SQLite route with PG, for a reservation whose backup
+   * the log cannot cover -- most often a log seeded after that backup.
+   *
+   * The pin moves, not just the reservation's advertised bounds. Confirming
+   * with PG bounds while the task's `/changes` request still resolves to
+   * SQLite is exactly the mismatch the reservation path exists to prevent,
+   * so the two have to change together.
+   *
+   * A task with no pin is left alone: `consume` makes it a fresh choice.
+   */
+  demote(taskID: string): ChangeLogReadRoute {
+    const route: ChangeLogReadRoute = {
+      source: 'pg',
+      reason: 'backup-uncovered',
+    };
+    if (this.#pins.has(taskID)) {
+      this.#pins.set(taskID, route);
+    }
+    return route;
   }
 
   /** Opens the post-registration failure breaker. */

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-read-router.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-read-router.ts
@@ -20,6 +20,10 @@ export type SQLiteChangeLogCoverage = {
 
 export type ChangeLogReadRouteReason =
   | 'selected'
+  // Selected while the log was still inside its warm-up window. Kept
+  // distinct from 'selected' so bootstrap serving is separable in metrics
+  // from steady-state serving.
+  | 'selected-cold'
   | 'percentage'
   | 'cold-log'
   | 'log-unavailable'
@@ -39,6 +43,12 @@ export type ChangeLogReadRoute = {
 export type SQLiteChangeLogReadRouterOptions = {
   readonly shard: ShardID;
   readonly readPercent: number;
+  /**
+   * Percentage of eligible tasks served from a log that has not yet aged
+   * through {@link retentionMs}. Defaults to zero, which keeps every such
+   * task on PG.
+   */
+  readonly coldReadPercent?: number | undefined;
   readonly retentionMs: number;
   readonly inspect: () => SQLiteChangeLogCoverage | undefined;
   readonly failureCooldownMs?: number | undefined;
@@ -60,6 +70,7 @@ const DEFAULT_FAILURE_COOLDOWN_MS = 30_000;
 export class SQLiteChangeLogReadRouter {
   readonly #shard: ShardID;
   readonly #readPercent: number;
+  readonly #coldReadPercent: number;
   readonly #retentionMs: number;
   readonly #inspect: () => SQLiteChangeLogCoverage | undefined;
   readonly #failureCooldownMs: number;
@@ -72,6 +83,7 @@ export class SQLiteChangeLogReadRouter {
   constructor(opts: SQLiteChangeLogReadRouterOptions) {
     this.#shard = opts.shard;
     this.#readPercent = opts.readPercent;
+    this.#coldReadPercent = opts.coldReadPercent ?? 0;
     this.#retentionMs = opts.retentionMs;
     this.#inspect = opts.inspect;
     this.#failureCooldownMs =
@@ -172,7 +184,16 @@ export class SQLiteChangeLogReadRouter {
     // -- does not leave the cooldown armed against the next ordinary
     // unavailability.
     this.#breakerUntilMs = undefined;
-    if (now - coverage.seededAtMs < this.#retentionMs) {
+    // A log seeded less than a retention window ago holds less history than
+    // the purger promises to keep, so it is the case that most often cannot
+    // cover a follower. It is also the only path that has no PG to fall back
+    // to once PG is retired, which is the argument for exercising it now
+    // rather than meeting it at the cutover: `coldReadPercent` is that dial.
+    const cold = now - coverage.seededAtMs < this.#retentionMs;
+    if (
+      cold &&
+      !isSampledForShard(this.#shard, taskID, this.#coldReadPercent)
+    ) {
       return {source: 'pg', reason: 'cold-log', coverage};
     }
 
@@ -181,7 +202,11 @@ export class SQLiteChangeLogReadRouter {
     if (!isSampledForShard(this.#shard, taskID, this.#readPercent)) {
       return {source: 'pg', reason: 'percentage', coverage};
     }
-    return {source: 'sqlite', reason: 'selected', coverage};
+    return {
+      source: 'sqlite',
+      reason: cold ? 'selected-cold' : 'selected',
+      coverage,
+    };
   }
 
   #asPinned(route: ChangeLogReadRoute): ChangeLogReadRoute {

--- a/packages/zero-cache/src/services/litestream/metrics.ts
+++ b/packages/zero-cache/src/services/litestream/metrics.ts
@@ -182,6 +182,14 @@ export function litestreamSnapshotReservationDuration() {
   );
 }
 
+export function litestreamSnapshotReservationConfirmDuration() {
+  return litestreamDurationHistogram(
+    'litestream.snapshot.reservation_confirm_duration',
+    'Time from opening a snapshot reservation to confirming its change-log ' +
+      'bounds, by the source those bounds came from.',
+  );
+}
+
 function litestreamDurationHistogram(name: string, description: string) {
   return getOrCreateHistogram('replica', name, {
     description,


### PR DESCRIPTION
Models a world where pg is retired and measures how often we fail to find a valid floor to the catchup log.