### PR TITLE
fix(zero-cache): stop logging app data

### DIFF
--- a/packages/zero-cache/src/auth/write-authorizer.ts
+++ b/packages/zero-cache/src/auth/write-authorizer.ts
@@ -455,8 +455,9 @@ export class WriteAuthorizerImpl implements WriteAuthorizer {
         rowQuery,
       ))
     ) {
-      // Never log `op` or `authData`: `op.value` is the row the client is
-      // writing and `authData` is the decoded JWT payload.
+      // `op.value` is the row being written and `authData` is the decoded
+      // JWT payload, so neither can go into the log. Column names and policy
+      // counts are enough to debug a failed permission check.
       this.#lc.warn?.('Permission check failed', {
         action,
         phase,

--- a/packages/zero-cache/src/auth/write-authorizer.ts
+++ b/packages/zero-cache/src/auth/write-authorizer.ts
@@ -455,15 +455,16 @@ export class WriteAuthorizerImpl implements WriteAuthorizer {
         rowQuery,
       ))
     ) {
-      this.#lc.warn?.(
-        `Permission check failed for ${JSON.stringify(
-          op,
-        )}, action ${action}, phase ${phase}, authData: ${JSON.stringify(
-          authData,
-        )}, rowPolicies: ${JSON.stringify(
-          applicableRowPolicy,
-        )}, cellPolicies: ${JSON.stringify(applicableCellPolicies)}`,
-      );
+      // Never log `op` or `authData`: `op.value` is the row the client is
+      // writing and `authData` is the decoded JWT payload.
+      this.#lc.warn?.('Permission check failed', {
+        action,
+        phase,
+        tableName: op.tableName,
+        columns: Object.keys(op.value),
+        rowPolicy: applicableRowPolicy !== undefined,
+        cellPolicyCount: applicableCellPolicies.length,
+      });
       return false;
     }
 

--- a/packages/zero-cache/src/services/mutagen/mutagen.ts
+++ b/packages/zero-cache/src/services/mutagen/mutagen.ts
@@ -329,7 +329,9 @@ export async function processMutationWithTx(
       return await stmt.execute();
     } finally {
       const q = stmt as unknown as Query;
-      lc.debug?.(`${q.string}: ${JSON.stringify(q.parameters)}`);
+      // `q.parameters` are the bound row values -- log the parameterized
+      // statement and the parameter count, never the values themselves.
+      lc.debug?.(`${q.string} (${q.parameters.length} params)`);
     }
   }
 

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -1802,8 +1802,16 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
 
     for (const q of transformedCustomQueries) {
       if ('error' in q) {
-        const errorMessage = `Error transforming custom query ${q.name}: ${q.error}${q.details ? ` ${JSON.stringify(q.details)}` : ''}`;
-        lc.warn?.(errorMessage, q);
+        // `q.details` and app-supplied `q.message` come from the customer's
+        // own query handler and can carry arbitrary data. Log the query
+        // identity and the error kind only.
+        lc.warn?.('Error transforming custom query', {
+          id: q.id,
+          name: q.name,
+          error: q.error,
+          message: q.error === 'parse' ? q.message : undefined,
+          hasDetails: q.details !== undefined,
+        });
         appQueryErrors.push(q);
         continue;
       }

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -1802,14 +1802,14 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
 
     for (const q of transformedCustomQueries) {
       if ('error' in q) {
-        // `q.details` and app-supplied `q.message` come from the customer's
-        // own query handler and can carry arbitrary data. Log the query
-        // identity and the error kind only.
+        // `q.message` and `q.details` are app-supplied and can carry
+        // arbitrary data, so they stay out of the log. The client still
+        // receives the whole error, including both, via
+        // `#sendQueryTransformErrorToClients` below.
         lc.warn?.('Error transforming custom query', {
           id: q.id,
           name: q.name,
           error: q.error,
-          message: q.error === 'parse' ? q.message : undefined,
           hasDetails: q.details !== undefined,
         });
         appQueryErrors.push(q);

--- a/packages/zero-cache/src/types/pg.ts
+++ b/packages/zero-cache/src/types/pg.ts
@@ -434,24 +434,39 @@ export function pgClient(
 ): PostgresDB {
   applicationName = `zero-${applicationName}`;
 
+  // Postgres carries row values in the `detail`, `hint`, `where` and
+  // `internal_query` fields -- e.g. a unique violation reports
+  // `Key (email)=(someone@example.com) already exists` in `detail`. Forward
+  // only the severity, SQLSTATE and schema location; never the Notice itself.
+  const safeNotice = (n: Notice) => ({
+    severity: n.severity,
+    code: n.code,
+    message: n.message,
+    schema: n.schema_name,
+    table: n.table_name,
+    column: n.column_name,
+    constraint: n.constraint_name,
+    routine: n.routine,
+  });
+
   const onnotice = (n: Notice) => {
     // https://www.postgresql.org/docs/current/plpgsql-errors-and-messages.html#PLPGSQL-STATEMENTS-RAISE
     switch (n.severity) {
       case 'NOTICE':
         return; // silenced
       case 'DEBUG':
-        lc.debug?.(n);
+        lc.debug?.('pg notice', safeNotice(n));
         return;
       case 'WARNING':
-        lc.warn?.(n);
+        lc.warn?.('pg notice', safeNotice(n));
         return;
       case 'EXCEPTION':
-        lc.error?.(n);
+        lc.error?.('pg notice', safeNotice(n));
         return;
       case 'LOG':
       case 'INFO':
       default:
-        lc.info?.(n);
+        lc.info?.('pg notice', safeNotice(n));
     }
   };
   const url = new URL(connectionURI);


### PR DESCRIPTION
Removes row values, JWT payloads, bound SQL parameters and app-supplied error details from four log sites, three of which run at the default `info` level. Each site now logs column names, counts or error kinds instead, and postgres notices are reduced to severity, SQLSTATE and schema location.