### PR TITLE
chore(zero-cache): ignore duplicate or early backup watermarks

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/backup-monitor.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/backup-monitor.test.ts
@@ -49,16 +49,19 @@ describe('change-streamer/backup-monitor', () => {
     await run;
   });
 
-  test('forwards every watermark to the changeStreamer, in order', async () => {
+  test('forwards watermarks to the changeStreamer, in order, skipping redundant watermarks', async () => {
     const run = monitor.run();
 
-    watermarks.push(backedUp('01'));
+    watermarks.push(backedUp('01', 1000));
+    watermarks.push(backedUp('01', 1234)); // duplicate suppressed
     await vi.waitFor(() =>
       expect(trackBackupWatermark).toHaveBeenCalledTimes(1),
     );
 
     watermarks.push(backedUp('02'));
     watermarks.push(backedUp('03'));
+    watermarks.push(backedUp('03', 2345)); // duplicate suppressed
+    watermarks.push(backedUp('02')); // ignored earlier watermarks
     await vi.waitFor(() =>
       expect(trackBackupWatermark).toHaveBeenCalledTimes(3),
     );

--- a/packages/zero-cache/src/services/change-streamer/backup-monitor.ts
+++ b/packages/zero-cache/src/services/change-streamer/backup-monitor.ts
@@ -45,9 +45,15 @@ export class BackupMonitor implements SingletonService {
 
     for await (const backedUp of this.#watermarks) {
       if (!this.#latestBackup) {
-        this.#lc.info?.(`received first backup up watermark`, {backedUp});
         this.#firstBackupReceived.resolve();
+      } else if (backedUp.watermark < this.#latestBackup.watermark) {
+        this.#lc.warn?.(`ignoring earlier backup watermark`, {backedUp});
+        continue;
+      } else if (backedUp.watermark === this.#latestBackup.watermark) {
+        this.#lc.debug?.(`ignoring redundant backup watermark`, {backedUp});
+        continue;
       }
+      this.#lc.info?.(`received backup watermark`, {backedUp});
       this.#latestBackup = backedUp;
       this.#changeStreamer.trackBackupWatermark(backedUp.watermark);
     }


### PR DESCRIPTION
Ignore redundant (or backwards) watermarks received from backup watermark pollers. This reduces the assumptions of polling implementations and allows them to be simpler / keep less state. 