### PR TITLE
chore(release): fix the release.yml action to have the --build-context

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,6 +206,7 @@ jobs:
           cp "$TARBALL_PATH" "source/packages/zero/pkgs/$TARBALL"
           docker buildx build \
             --platform linux/amd64,linux/arm64 \
+            --build-context monogo=source/go \
             --build-arg ZERO_VERSION="$VERSION" \
             --build-arg ZERO_PACKAGE="$TARBALL" \
             --label org.opencontainers.image.revision="$SOURCE_SHA" \


### PR DESCRIPTION
https://github.com/rocicorp/mono/pull/6394 updated the `docker buildx` command in `js.yml` but it missed the command in `release.yml`.