### PR TITLE
Make transient errors retryable

### DIFF
--- a/packages/zero-cache/src/custom/fetch.test.ts
+++ b/packages/zero-cache/src/custom/fetch.test.ts
@@ -131,6 +131,7 @@ describe('fetchFromAPIServer', () => {
     metricsOptions: Parameters<typeof fetchFromAPIServer>[6],
     options: FetchContextOptions = {},
     requestBody: typeof body = body,
+    requestTimeoutMs?: number,
   ) {
     return fetchFromAPIServer(
       validator,
@@ -140,6 +141,7 @@ describe('fetchFromAPIServer', () => {
       shard,
       requestBody,
       metricsOptions,
+      requestTimeoutMs,
     );
   }
 
@@ -289,10 +291,17 @@ describe('fetchFromAPIServer', () => {
 
     const promise = fetchWithContext(validator, 'push', {operation: 'mutate'});
 
-    await Promise.all([
-      expect(promise).rejects.toThrow(/non-OK status 502/),
-      vi.advanceTimersByTimeAsync(5000),
-    ]);
+    const caughtPromise = promise.catch(error => error);
+    await vi.advanceTimersByTimeAsync(5000);
+    const caught: unknown = await caughtPromise;
+
+    assert(isProtocolError(caught), 'Expected protocol error');
+    expect(caught.errorBody).toMatchObject({
+      kind: ErrorKind.PushFailed,
+      reason: ErrorReason.HTTP,
+      status: 502,
+      retryable: true,
+    });
 
     expect(metrics.attemptsAdd).toHaveBeenCalledTimes(4);
     expect(metrics.attemptsAdd).toHaveBeenLastCalledWith(
@@ -795,6 +804,7 @@ describe('fetchFromAPIServer', () => {
     expect(caught.errorBody.status).toBe(400);
     expect(caught.errorBody.bodyPreview).toBe('failure-body');
     expect(caught.errorBody.message).toMatch(/non-OK status 400/);
+    expect(caught.errorBody.retryable).toBe(false);
   });
 
   test('wraps JSON parse failures in ProtocolError with parse type', async () => {
@@ -821,6 +831,7 @@ describe('fetchFromAPIServer', () => {
     );
     expect(caught.errorBody.reason).toBe(ErrorReason.Parse);
     expect(caught.errorBody.message).toMatch(/Failed to parse response/);
+    expect(caught.errorBody.retryable).toBe(false);
   });
 
   test('wraps JSON parse failures for transform in ProtocolError with parse type', async () => {
@@ -975,7 +986,7 @@ describe('fetchFromAPIServer', () => {
       vi.useFakeTimers();
     });
 
-    test.each([500, 502, 503, 504, 599])(
+    test.each([408, 425, 429, 500, 502, 503, 504, 599])(
       'retries on %i and succeeds',
       async status => {
         mockFetch
@@ -1014,6 +1025,90 @@ describe('fetchFromAPIServer', () => {
       expect(mockFetch).toHaveBeenCalledTimes(2);
     });
 
+    test('times out, retries, and marks exhaustion retryable', async () => {
+      mockFetch.mockImplementation(
+        (_input, init) =>
+          new Promise((_resolve, reject) => {
+            init?.signal?.addEventListener(
+              'abort',
+              () => reject(init.signal?.reason),
+              {once: true},
+            );
+          }),
+      );
+
+      const promise = fetchWithContext(
+        validator,
+        'push',
+        {operation: 'mutate'},
+        {},
+        body,
+        10,
+      );
+      const caughtPromise = promise.catch(error => error);
+
+      await vi.advanceTimersByTimeAsync(5000);
+      const caught: unknown = await caughtPromise;
+
+      assert(isProtocolError(caught), 'Expected protocol error');
+      expect(caught.errorBody).toMatchObject({
+        kind: ErrorKind.PushFailed,
+        reason: ErrorReason.Timeout,
+        retryable: true,
+      });
+      expect(mockFetch).toHaveBeenCalledTimes(4);
+      expect(metrics.attemptsAdd).toHaveBeenLastCalledWith(
+        1,
+        expect.objectContaining({
+          attempt: 4,
+          result: 'timeout',
+          will_retry: false,
+        }),
+      );
+      expect(metrics.requestsAdd).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({
+          result: 'timeout',
+          attempt_count: 4,
+          error_reason: ErrorReason.Timeout,
+        }),
+      );
+    });
+
+    test('the timeout also bounds reading the response body', async () => {
+      const stalledResponse = new Response('', {status: 200});
+      Object.defineProperty(stalledResponse, 'json', {
+        value: vi.fn().mockReturnValue(new Promise(() => {})),
+      });
+      mockFetch
+        .mockResolvedValueOnce(stalledResponse)
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({success: true}), {status: 200}),
+        );
+
+      const promise = fetchWithContext(
+        validator,
+        'push',
+        {operation: 'mutate'},
+        {},
+        body,
+        10,
+      );
+
+      await vi.advanceTimersByTimeAsync(1200);
+
+      await expect(promise).resolves.toEqual({success: true});
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(metrics.attemptsAdd).toHaveBeenNthCalledWith(
+        1,
+        1,
+        expect.objectContaining({
+          result: 'timeout',
+          will_retry: true,
+        }),
+      );
+    });
+
     test('fails after max retries (status code)', async () => {
       mockFetch.mockResolvedValue(new Response('bad gateway', {status: 502}));
 
@@ -1039,10 +1134,16 @@ describe('fetchFromAPIServer', () => {
       });
 
       // Exhaust all retries
-      await Promise.all([
-        expect(promise).rejects.toThrow(/threw error: fetch failed/),
-        vi.advanceTimersByTimeAsync(5000),
-      ]);
+      const caughtPromise = promise.catch(error => error);
+      await vi.advanceTimersByTimeAsync(5000);
+      const caught: unknown = await caughtPromise;
+
+      assert(isProtocolError(caught), 'Expected protocol error');
+      expect(caught.errorBody).toMatchObject({
+        kind: ErrorKind.PushFailed,
+        reason: ErrorReason.Internal,
+        retryable: true,
+      });
 
       // Initial + 3 retries = 4 calls
       expect(mockFetch).toHaveBeenCalledTimes(4);

--- a/packages/zero-cache/src/custom/fetch.ts
+++ b/packages/zero-cache/src/custom/fetch.ts
@@ -13,6 +13,7 @@ import {ErrorOrigin} from '../../../zero-protocol/src/error-origin.ts';
 import {ErrorReason} from '../../../zero-protocol/src/error-reason.ts';
 import {
   errorBodySchema,
+  isRetryableHTTPStatus,
   isProtocolError,
   type ErrorBody,
 } from '../../../zero-protocol/src/error.ts';
@@ -83,11 +84,52 @@ export const getBodyPreview = async (
 };
 
 const MAX_ATTEMPTS = 4;
+export const API_REQUEST_TIMEOUT_MS = 10_000;
 
 type ApiFailedReason =
   | typeof ErrorReason.HTTP
   | typeof ErrorReason.Parse
-  | typeof ErrorReason.Internal;
+  | typeof ErrorReason.Internal
+  | typeof ErrorReason.Timeout;
+
+class APIRequestTimeoutError extends Error {
+  constructor(timeoutMs: number) {
+    super(`Fetch from API server timed out after ${timeoutMs} ms`);
+    this.name = 'APIRequestTimeoutError';
+  }
+}
+
+class APIRequestTimeout {
+  readonly #controller = new AbortController();
+  readonly #timeout: Promise<never>;
+  readonly #timeoutID: ReturnType<typeof setTimeout>;
+
+  constructor(timeoutMs: number) {
+    const timeoutError = new APIRequestTimeoutError(timeoutMs);
+    let rejectTimeout: (reason: APIRequestTimeoutError) => void;
+    this.#timeout = new Promise<never>((_resolve, reject) => {
+      rejectTimeout = reject;
+    });
+    this.#timeoutID = setTimeout(() => {
+      // Reject pending races before aborting so callers consistently receive
+      // the timeout error even when fetch rejects synchronously on abort.
+      rejectTimeout(timeoutError);
+      this.#controller.abort(timeoutError);
+    }, timeoutMs);
+  }
+
+  get signal(): AbortSignal {
+    return this.#controller.signal;
+  }
+
+  race<T>(promise: Promise<T>): Promise<T> {
+    return Promise.race([promise, this.#timeout]);
+  }
+
+  clear(): void {
+    clearTimeout(this.#timeoutID);
+  }
+}
 
 export type FetchMetricsOptions = {
   operation: ApiOperation;
@@ -102,6 +144,7 @@ export async function fetchFromAPIServer<TValidator extends Type>(
   shard: ShardID,
   body: ReadonlyJSONValue,
   metricsOpts: FetchMetricsOptions,
+  requestTimeoutMs = API_REQUEST_TIMEOUT_MS,
 ) {
   const metricAttrs: ApiMetricBaseAttrs =
     metricsOpts.operation === 'cleanup' && metricsOpts.cleanupType !== undefined
@@ -142,6 +185,7 @@ export async function fetchFromAPIServer<TValidator extends Type>(
         source === 'push'
           ? `URL "${url}" is not allowed by the ZERO_MUTATE_URL configuration`
           : `URL "${url}" is not allowed by the ZERO_QUERY_URL configuration`,
+        false,
       );
       requestMetricAttrs = apiRequestMetricAttrs(metricAttrs, {
         result: 'url_not_allowed',
@@ -210,25 +254,28 @@ export async function fetchFromAPIServer<TValidator extends Type>(
         return false;
       };
       const attemptStart = performance.now();
+      const requestTimeout = new APIRequestTimeout(requestTimeoutMs);
       try {
-        const response = await fetch(finalUrl, {
-          method: 'POST',
-          headers,
-          body: JSON.stringify(body),
-        });
+        const response = await requestTimeout.race(
+          fetch(finalUrl, {
+            method: 'POST',
+            headers,
+            body: JSON.stringify(body),
+            signal: requestTimeout.signal,
+          }),
+        );
 
         if (!response.ok) {
-          const bodyPreview = await getBodyPreview(response, lc);
+          const bodyPreview = await requestTimeout.race(
+            getBodyPreview(response, lc),
+          );
           lc.warn?.('fetch from API server returned non-OK status', {
             url: finalUrl,
             status: response.status,
             bodyPreview,
           });
-          // Server errors can be transient, so retry if attempts remain.
-          const willRetry =
-            response.status >= 500 &&
-            response.status < 600 &&
-            attempt < MAX_ATTEMPTS;
+          const retryable = isRetryableHTTPStatus(response.status);
+          const willRetry = retryable && attempt < MAX_ATTEMPTS;
           recordApiAttempt(performance.now() - attemptStart, metricAttrs, {
             attempt,
             result: 'http_error',
@@ -243,6 +290,7 @@ export async function fetchFromAPIServer<TValidator extends Type>(
             source,
             ErrorReason.HTTP,
             `Fetch from API server returned non-OK status ${response.status}`,
+            retryable,
             response,
             bodyPreview,
           );
@@ -255,8 +303,10 @@ export async function fetchFromAPIServer<TValidator extends Type>(
           throw new ProtocolErrorWithLevel(errorBody, 'warn');
         }
 
+        let readingBody = true;
         try {
-          const json = await response.json();
+          const json = await requestTimeout.race(response.json());
+          readingBody = false;
           const result = validator.parse(json, {
             mode: 'passthrough',
           });
@@ -291,6 +341,12 @@ export async function fetchFromAPIServer<TValidator extends Type>(
           lc.debug?.('fetch from API server succeeded');
           return result;
         } catch (error) {
+          if (
+            error instanceof APIRequestTimeoutError ||
+            (readingBody && error instanceof TypeError)
+          ) {
+            throw error;
+          }
           lc.warn?.(
             'failed to parse response',
             {
@@ -303,6 +359,7 @@ export async function fetchFromAPIServer<TValidator extends Type>(
             source,
             ErrorReason.Parse,
             `Failed to parse response from API server: ${getErrorMessage(error)}`,
+            false,
           );
           recordApiAttempt(performance.now() - attemptStart, metricAttrs, {
             attempt,
@@ -324,21 +381,25 @@ export async function fetchFromAPIServer<TValidator extends Type>(
           throw error;
         }
 
-        const isFetchFailed =
-          error instanceof TypeError && error.message === 'fetch failed';
+        const isTimeout = error instanceof APIRequestTimeoutError;
+        // A TypeError thrown by fetch represents a network-layer failure in
+        // Node (DNS, connection reset, TLS, etc.). The request URL and init are
+        // constructed above, so it is safe to retry this class of failure.
+        const isFetchFailed = error instanceof TypeError;
+        const retryable = isTimeout || isFetchFailed;
         // unexpected/unknown errors should be logged at 'error' level so they
         // are investigated
-        let logLevel: LogLevel = isFetchFailed ? 'warn' : 'error';
+        const logLevel: LogLevel = retryable ? 'warn' : 'error';
         lc[logLevel]?.(
           'fetch from API server threw error',
           {url: finalUrl},
           error,
         );
 
-        const willRetry = isFetchFailed && attempt < MAX_ATTEMPTS;
+        const willRetry = retryable && attempt < MAX_ATTEMPTS;
         recordApiAttempt(performance.now() - attemptStart, metricAttrs, {
           attempt,
-          result: 'fetch_error',
+          result: isTimeout ? 'timeout' : 'fetch_error',
           willRetry,
         });
 
@@ -348,15 +409,20 @@ export async function fetchFromAPIServer<TValidator extends Type>(
 
         const errorBody = apiFailedBody(
           source,
-          ErrorReason.Internal,
-          `Fetch from API server threw error: ${getErrorMessage(error)}`,
+          isTimeout ? ErrorReason.Timeout : ErrorReason.Internal,
+          isTimeout
+            ? getErrorMessage(error)
+            : `Fetch from API server threw error: ${getErrorMessage(error)}`,
+          retryable,
         );
         requestMetricAttrs = apiRequestMetricAttrs(metricAttrs, {
-          result: 'fetch_error',
+          result: isTimeout ? 'timeout' : 'fetch_error',
           attemptCount,
           errorBody,
         });
         throw new ProtocolErrorWithLevel(errorBody, logLevel, {cause: error});
+      } finally {
+        requestTimeout.clear();
       }
     }
     unreachable();
@@ -412,6 +478,7 @@ function apiFailedBody(
   source: 'push' | 'transform',
   reason: ApiFailedReason,
   message: string,
+  retryable: boolean,
   response?: Response | undefined,
   bodyPreview?: string | undefined,
 ): ErrorBody {
@@ -421,6 +488,7 @@ function apiFailedBody(
           kind: ErrorKind.PushFailed,
           origin: ErrorOrigin.ZeroCache,
           reason,
+          retryable,
           status: response?.status ?? 0,
           ...(bodyPreview !== undefined ? {bodyPreview} : {}),
           message,
@@ -430,6 +498,7 @@ function apiFailedBody(
           kind: ErrorKind.PushFailed,
           origin: ErrorOrigin.ZeroCache,
           reason,
+          retryable,
           message,
           mutationIDs: [],
         };
@@ -440,6 +509,7 @@ function apiFailedBody(
         kind: ErrorKind.TransformFailed,
         origin: ErrorOrigin.ZeroCache,
         reason,
+        retryable,
         status: response?.status ?? 0,
         ...(bodyPreview !== undefined ? {bodyPreview} : {}),
         message,
@@ -449,6 +519,7 @@ function apiFailedBody(
         kind: ErrorKind.TransformFailed,
         origin: ErrorOrigin.ZeroCache,
         reason,
+        retryable,
         message,
         queryIDs: [],
       };

--- a/packages/zero-cache/src/custom/metrics.ts
+++ b/packages/zero-cache/src/custom/metrics.ts
@@ -18,6 +18,7 @@ export type ApiRequestResult =
   | 'http_error'
   | 'parse_error'
   | 'fetch_error'
+  | 'timeout'
   | 'url_not_allowed'
   | 'config_error';
 
@@ -26,7 +27,8 @@ export type ApiAttemptResult =
   | 'api_error'
   | 'http_error'
   | 'parse_error'
-  | 'fetch_error';
+  | 'fetch_error'
+  | 'timeout';
 
 export type ApiRequestMetricAttrs = ApiMetricBaseAttrs & {
   result: ApiRequestResult;

--- a/packages/zero-client/src/client/error.test.ts
+++ b/packages/zero-client/src/client/error.test.ts
@@ -18,6 +18,7 @@ import {
   isOfflineError,
   isServerError,
   isZeroError,
+  MAX_AMBIGUOUS_ERROR_RETRIES,
   NO_STATUS_TRANSITION,
 } from './error.ts';
 
@@ -313,6 +314,8 @@ describe('getErrorConnectionTransition', () => {
     ClientErrorKind.CleanClose,
     ClientErrorKind.ConnectTimeout,
     ClientErrorKind.PingTimeout,
+    ClientErrorKind.PullTimeout,
+    ClientErrorKind.UnexpectedBaseCookie,
   ] as const)(
     'returns no status transition for retryable client error %s',
     kind => {
@@ -328,9 +331,27 @@ describe('getErrorConnectionTransition', () => {
     },
   );
 
-  test('returns error status for fatal client errors', () => {
+  test('bounds retries for an internal client error', () => {
     const error = new ClientError({
       kind: ClientErrorKind.Internal,
+      message: 'internal',
+    });
+
+    expect(getErrorConnectionTransition(error)).toEqual({
+      status: NO_STATUS_TRANSITION,
+      reason: error,
+      maxRetries: MAX_AMBIGUOUS_ERROR_RETRIES,
+    });
+  });
+
+  test.each([
+    // The client sent a message the server refused (e.g. an oversized
+    // mutation). Reconnecting replays it, so this must not retry.
+    ClientErrorKind.InvalidMessage,
+    ClientErrorKind.UserDisconnect,
+  ] as const)('returns error status for fatal client error %s', kind => {
+    const error = new ClientError({
+      kind,
       message: 'fatal',
     });
 
@@ -423,6 +444,37 @@ describe('getErrorConnectionTransition', () => {
     },
   );
 
+  test('bounds retries for an unmarked server internal error', () => {
+    const error = new ProtocolError({
+      kind: ErrorKind.Internal,
+      message: 'internal',
+      origin: ErrorOrigin.Server,
+    });
+
+    expect(getErrorConnectionTransition(error)).toEqual({
+      status: NO_STATUS_TRANSITION,
+      reason: error,
+      maxRetries: MAX_AMBIGUOUS_ERROR_RETRIES,
+    });
+  });
+
+  test.each([true, false] as const)(
+    'honors retryable=%s on a server internal error',
+    retryable => {
+      const error = new ProtocolError({
+        kind: ErrorKind.Internal,
+        message: 'internal',
+        origin: ErrorOrigin.Server,
+        retryable,
+      });
+
+      expect(getErrorConnectionTransition(error)).toEqual({
+        status: retryable ? NO_STATUS_TRANSITION : ConnectionStatus.Error,
+        reason: error,
+      });
+    },
+  );
+
   test.each([ErrorKind.AuthInvalidated, ErrorKind.Unauthorized] as const)(
     'returns needs auth status for auth error %s',
     kind => {
@@ -442,24 +494,147 @@ describe('getErrorConnectionTransition', () => {
   test('wraps unknown errors as internal client error', () => {
     const result = getErrorConnectionTransition(new Error('boom'));
 
-    expect(result.status).toBe(ConnectionStatus.Error);
+    expect(result.status).toBe(NO_STATUS_TRANSITION);
     expect(result.reason).toBeInstanceOf(ClientError);
     expect(result.reason?.kind).toBe(ClientErrorKind.Internal);
     expect(result.reason?.message).toBe('Unexpected internal error: boom');
     expect(result.reason?.errorBody.message).toBe(
       'Unexpected internal error: boom',
     );
+    expect(result).toHaveProperty('maxRetries', MAX_AMBIGUOUS_ERROR_RETRIES);
   });
 
   test('wraps string errors as internal client error', () => {
     const result = getErrorConnectionTransition('string error');
 
-    expect(result.status).toBe(ConnectionStatus.Error);
+    expect(result.status).toBe(NO_STATUS_TRANSITION);
     expect(result.reason).toBeInstanceOf(ClientError);
     expect(result.reason?.kind).toBe(ClientErrorKind.Internal);
     expect(result.reason?.message).toBe(
       'Unexpected internal error: string error',
     );
+    expect(result).toHaveProperty('maxRetries', MAX_AMBIGUOUS_ERROR_RETRIES);
+  });
+
+  test.each([
+    {reason: ErrorReason.HTTP, status: 500},
+    {reason: ErrorReason.HTTP, status: 408},
+    {reason: ErrorReason.HTTP, status: 425},
+    {reason: ErrorReason.HTTP, status: 429},
+    {reason: ErrorReason.Timeout},
+  ] as const)('PushFailed with %o keeps retrying', body => {
+    const error = new ProtocolError({
+      kind: ErrorKind.PushFailed,
+      origin: ErrorOrigin.ZeroCache,
+      message: 'push failed',
+      mutationIDs: [],
+      ...body,
+    } as ErrorBody);
+
+    expect(getErrorConnectionTransition(error)).toEqual({
+      status: NO_STATUS_TRANSITION,
+      reason: error,
+    });
+  });
+
+  test.each([
+    {reason: ErrorReason.HTTP, status: 500},
+    {reason: ErrorReason.Timeout},
+  ] as const)('TransformFailed with %o keeps retrying', body => {
+    const error = new ProtocolError({
+      kind: ErrorKind.TransformFailed,
+      origin: ErrorOrigin.ZeroCache,
+      message: 'transform failed',
+      queryIDs: [],
+      ...body,
+    } as ErrorBody);
+
+    expect(getErrorConnectionTransition(error)).toEqual({
+      status: NO_STATUS_TRANSITION,
+      reason: error,
+    });
+  });
+
+  test.each([
+    {reason: ErrorReason.HTTP, status: 400},
+    {reason: ErrorReason.Parse},
+  ] as const)('PushFailed with %o is fatal', body => {
+    const error = new ProtocolError({
+      kind: ErrorKind.PushFailed,
+      origin: ErrorOrigin.ZeroCache,
+      message: 'push failed',
+      mutationIDs: [],
+      ...body,
+    } as ErrorBody);
+
+    expect(getErrorConnectionTransition(error)).toEqual({
+      status: ConnectionStatus.Error,
+      reason: error,
+    });
+  });
+
+  test.each([ErrorKind.PushFailed, ErrorKind.TransformFailed] as const)(
+    'bounds retries for an unmarked %s internal error',
+    kind => {
+      const error = new ProtocolError({
+        kind,
+        origin: ErrorOrigin.ZeroCache,
+        reason: ErrorReason.Internal,
+        message: 'internal',
+        ...(kind === ErrorKind.PushFailed ? {mutationIDs: []} : {queryIDs: []}),
+      } as ErrorBody);
+
+      expect(getErrorConnectionTransition(error)).toEqual({
+        status: NO_STATUS_TRANSITION,
+        reason: error,
+        maxRetries: MAX_AMBIGUOUS_ERROR_RETRIES,
+      });
+    },
+  );
+
+  test('honors an explicit retryable marker over inferred classification', () => {
+    const retryableParse = new ProtocolError({
+      kind: ErrorKind.TransformFailed,
+      origin: ErrorOrigin.ZeroCache,
+      reason: ErrorReason.Parse,
+      retryable: true,
+      message: 'temporary parse failure',
+      queryIDs: [],
+    });
+    const nonRetryable500 = new ProtocolError({
+      kind: ErrorKind.PushFailed,
+      origin: ErrorOrigin.ZeroCache,
+      reason: ErrorReason.HTTP,
+      retryable: false,
+      status: 500,
+      message: 'do not retry',
+      mutationIDs: [],
+    });
+
+    expect(getErrorConnectionTransition(retryableParse)).toEqual({
+      status: NO_STATUS_TRANSITION,
+      reason: retryableParse,
+    });
+    expect(getErrorConnectionTransition(nonRetryable500)).toEqual({
+      status: ConnectionStatus.Error,
+      reason: nonRetryable500,
+    });
+  });
+
+  // Retrying would replay the same unsupported push forever.
+  test('PushFailed with an unsupported push version is fatal', () => {
+    const error = new ProtocolError({
+      kind: ErrorKind.PushFailed,
+      origin: ErrorOrigin.Server,
+      reason: ErrorReason.UnsupportedPushVersion,
+      message: 'unsupported push version',
+      mutationIDs: [],
+    });
+
+    expect(getErrorConnectionTransition(error)).toEqual({
+      status: ConnectionStatus.Error,
+      reason: error,
+    });
   });
 
   test('returns needs auth status for auth errors via HTTP status codes', () => {

--- a/packages/zero-client/src/client/error.ts
+++ b/packages/zero-client/src/client/error.ts
@@ -4,11 +4,12 @@ import type {Expand} from '../../../shared/src/expand.ts';
 import {ErrorKind} from '../../../zero-protocol/src/error-kind.ts';
 import {ErrorOrigin} from '../../../zero-protocol/src/error-origin.ts';
 import {ErrorReason} from '../../../zero-protocol/src/error-reason.ts';
-import type {ProtocolError} from '../../../zero-protocol/src/error.ts';
 import {
   type BackoffBody,
   type ErrorBody,
+  isRetryableHTTPStatus,
   isProtocolError,
+  type ProtocolError,
   type PushFailedBody,
   type TransformFailedBody,
 } from '../../../zero-protocol/src/error.ts';
@@ -134,9 +135,20 @@ export function getBackoffParams(error: ZeroError): BackoffBody | undefined {
 }
 
 export const NO_STATUS_TRANSITION = 'NO_STATUS_TRANSITION';
+export const MAX_AMBIGUOUS_ERROR_RETRIES = 3;
+
+type RetryTransition = {
+  status: typeof NO_STATUS_TRANSITION;
+  reason: ZeroError;
+  /**
+   * Stop retrying after this many reconnects. Omitted for errors known to be
+   * transient.
+   */
+  maxRetries?: number | undefined;
+};
 
 export type ErrorConnectionTransition =
-  | {status: typeof NO_STATUS_TRANSITION; reason: ZeroError}
+  | RetryTransition
   | {status: ConnectionStatus.NeedsAuth; reason: AuthError}
   | {status: ConnectionStatus.Error; reason: ZeroError}
   | {status: ConnectionStatus.Disconnected; reason: DisconnectedReason}
@@ -168,8 +180,22 @@ export function getErrorConnectionTransition(
       case ClientErrorKind.UnexpectedBaseCookie:
         return {status: NO_STATUS_TRANSITION, reason: ex} as const;
 
-      // Fatal errors that should transition to error state
+      // Internal is the catch-all for unexpected exceptions (poke processing,
+      // socket event handlers). Reconnecting starts a fresh snapshot, which
+      // clears many of them. Bound the retries because a deterministic client
+      // bug can otherwise reconnect forever.
       case ClientErrorKind.Internal:
+        return {
+          status: NO_STATUS_TRANSITION,
+          reason: ex,
+          maxRetries: MAX_AMBIGUOUS_ERROR_RETRIES,
+        } as const;
+
+      // Fatal errors that should transition to error state.
+      // InvalidMessage means we sent a message the server refused (e.g. a
+      // mutation over the size limit). Reconnecting re-sends it from IndexedDB,
+      // so retrying here would loop forever; the caller pairs this with
+      // disableClientGroup() + onClientStateNotFound.
       case ClientErrorKind.InvalidMessage:
       case ClientErrorKind.UserDisconnect:
         return {status: ConnectionStatus.Error, reason: ex} as const;
@@ -193,7 +219,10 @@ export function getErrorConnectionTransition(
   }
 
   if (isServerError(ex)) {
-    switch (ex.kind) {
+    // Switch on the body rather than the `kind` getter so that TypeScript
+    // narrows the body's per-kind fields (e.g. `reason`).
+    const body = ex.errorBody;
+    switch (body.kind) {
       // Errors that should transition to error state
       case ErrorKind.ClientNotFound:
       case ErrorKind.InvalidConnectionRequest:
@@ -204,18 +233,34 @@ export function getErrorConnectionTransition(
       case ErrorKind.InvalidPush:
       case ErrorKind.VersionNotSupported:
       case ErrorKind.SchemaVersionNotSupported:
-      case ErrorKind.Internal:
-      // PushFailed and TransformFailed can be auth errors (401/403)
-      // or other errors - handle non-auth cases here
+        return {status: ConnectionStatus.Error, reason: ex} as const;
+
       case ErrorKind.PushFailed:
       case ErrorKind.TransformFailed:
-        return {status: ConnectionStatus.Error, reason: ex} as const;
+        return pushOrTransformFailedTransition(ex, body);
 
       // Errors that should continue with backoff/retry
       case ErrorKind.Rebalance:
       case ErrorKind.Rehome:
       case ErrorKind.ServerOverloaded:
         return {status: NO_STATUS_TRANSITION, reason: ex} as const;
+
+      case ErrorKind.Internal: {
+        if (body.retryable === false) {
+          return {status: ConnectionStatus.Error, reason: ex} as const;
+        }
+        if (body.retryable === true) {
+          return {status: NO_STATUS_TRANSITION, reason: ex} as const;
+        }
+        // The next connection may land on a healthy task, but an unmarked
+        // Internal can also be a deterministic bug. Give it a bounded chance
+        // to recover.
+        return {
+          status: NO_STATUS_TRANSITION,
+          reason: ex,
+          maxRetries: MAX_AMBIGUOUS_ERROR_RETRIES,
+        } as const;
+      }
 
       // Auth errors are handled above by isAuthError check
       case ErrorKind.AuthInvalidated:
@@ -231,14 +276,14 @@ export function getErrorConnectionTransition(
         return {status: NO_STATUS_TRANSITION, reason: ex} as const;
 
       default:
-        unreachable(ex.kind);
+        unreachable(body);
     }
   }
 
-  // we default to error state if we don't know what to do
-  // this is a catch-all for unexpected errors
+  // Catch-all for unexpected errors. Give the connection a bounded chance to
+  // recover without allowing an unknown deterministic error to loop forever.
   return {
-    status: ConnectionStatus.Error,
+    status: NO_STATUS_TRANSITION,
     reason: new ClientError(
       {
         kind: ClientErrorKind.Internal,
@@ -246,5 +291,45 @@ export function getErrorConnectionTransition(
       },
       {cause: ex},
     ),
+    maxRetries: MAX_AMBIGUOUS_ERROR_RETRIES,
   } as const;
+}
+
+function pushOrTransformFailedTransition(
+  error: ServerError,
+  body: PushFailedBody | TransformFailedBody,
+): Extract<
+  ErrorConnectionTransition,
+  {status: typeof NO_STATUS_TRANSITION | ConnectionStatus.Error}
+> {
+  // Newer servers make the decision explicit. Fall back to fields understood
+  // by older servers when the marker is absent.
+  if (body.retryable === true) {
+    return {status: NO_STATUS_TRANSITION, reason: error};
+  }
+  if (body.retryable === false) {
+    return {status: ConnectionStatus.Error, reason: error};
+  }
+
+  switch (body.reason) {
+    case ErrorReason.HTTP:
+      return isRetryableHTTPStatus(body.status)
+        ? {status: NO_STATUS_TRANSITION, reason: error}
+        : {status: ConnectionStatus.Error, reason: error};
+    case ErrorReason.Timeout:
+      return {status: NO_STATUS_TRANSITION, reason: error};
+    case ErrorReason.Database:
+    case ErrorReason.Internal:
+      return {
+        status: NO_STATUS_TRANSITION,
+        reason: error,
+        maxRetries: MAX_AMBIGUOUS_ERROR_RETRIES,
+      };
+    case ErrorReason.Parse:
+    case ErrorReason.OutOfOrderMutation:
+    case ErrorReason.UnsupportedPushVersion:
+      return {status: ConnectionStatus.Error, reason: error};
+    default:
+      unreachable(body);
+  }
 }

--- a/packages/zero-client/src/client/zero.connection.test.ts
+++ b/packages/zero-client/src/client/zero.connection.test.ts
@@ -22,10 +22,11 @@ test('run-loop error->connect race', async () => {
   await z.triggerConnected();
   await z.waitForConnectionStatus(ConnectionStatus.Connected);
 
-  // Trigger a non-auth error
+  // Trigger a non-auth error that is fatal (a zero-cache Internal error is
+  // retried, so it would not park the connection in the error state).
   await z.triggerError({
-    kind: ErrorKind.Internal,
-    message: 'internal error',
+    kind: ErrorKind.InvalidPush,
+    message: 'invalid push',
     origin: ErrorOrigin.ZeroCache,
   });
   await z.waitForConnectionStatus(ConnectionStatus.Error);
@@ -53,10 +54,11 @@ test('run-loop error->connect race using state.subscribe', async () => {
     }
   });
 
-  // Trigger a non-auth error
+  // Trigger a non-auth error that is fatal (a zero-cache Internal error is
+  // retried, so it would not park the connection in the error state).
   await z.triggerError({
-    kind: ErrorKind.Internal,
-    message: 'internal error',
+    kind: ErrorKind.InvalidPush,
+    message: 'invalid push',
     origin: ErrorOrigin.ZeroCache,
   });
   await z.waitForConnectionStatus(ConnectionStatus.Error);

--- a/packages/zero-client/src/client/zero.test.ts
+++ b/packages/zero-client/src/client/zero.test.ts
@@ -34,6 +34,7 @@ import {
   overrideBrowserGlobal,
 } from '../../../shared/src/browser-env.ts';
 import {TestLogSink} from '../../../shared/src/logging-test-utils.ts';
+import {must} from '../../../shared/src/must.ts';
 import * as valita from '../../../shared/src/valita.ts';
 import {changeDesiredQueriesMessageSchema} from '../../../zero-protocol/src/change-desired-queries.ts';
 import type {ClientSchema} from '../../../zero-protocol/src/client-schema.ts';
@@ -79,7 +80,11 @@ import {ConnectionStatus} from './connection-status.ts';
 import type {ConnectionState} from './connection.ts';
 import type {CustomMutatorDefs} from './custom.ts';
 import {DeleteClientsManager} from './delete-clients-manager.ts';
-import {ClientError, isServerError} from './error.ts';
+import {
+  ClientError,
+  isServerError,
+  MAX_AMBIGUOUS_ERROR_RETRIES,
+} from './error.ts';
 import type {WSString} from './http-string.ts';
 import type {UpdateNeededReason, ZeroOptions} from './options.ts';
 import type {QueryManager} from './query-manager.ts';
@@ -100,12 +105,35 @@ import {
   DEFAULT_DISCONNECT_HIDDEN_DELAY_MS,
   DEFAULT_PING_TIMEOUT_MS,
   getInternalReplicacheImplForTesting,
+  MAX_RUN_LOOP_INTERVAL_MS,
   PULL_TIMEOUT_MS,
   RUN_LOOP_INTERVAL_MS,
+  RUN_LOOP_JITTER_FRACTION,
+  STABLE_CONNECTION_MS,
   type Zero,
 } from './zero.ts';
 
 const startTime = 1678829450000;
+
+/**
+ * The base backoff the run loop uses after `consecutiveFailures` failed
+ * attempts, before jitter. Jitter is additive, so the actual sleep lands in
+ * `[minBackoffMs(n), maxBackoffMs(n)]`.
+ */
+function minBackoffMs(consecutiveFailures: number): number {
+  return Math.min(
+    RUN_LOOP_INTERVAL_MS * 2 ** (consecutiveFailures - 1),
+    MAX_RUN_LOOP_INTERVAL_MS,
+  );
+}
+
+/**
+ * Advancing fake timers by this much guarantees the run loop's backoff for
+ * `consecutiveFailures` has elapsed, whatever the jitter.
+ */
+function maxBackoffMs(consecutiveFailures: number): number {
+  return minBackoffMs(consecutiveFailures) * (1 + RUN_LOOP_JITTER_FRACTION);
+}
 
 let rejectionHandler: (event: PromiseRejectionEvent) => void;
 beforeEach(() => {
@@ -411,7 +439,7 @@ describe('onOnlineChange callback', () => {
     // and we got an offline callback on timeout
     expect(getOfflineCount()).toBe(1);
     // and back online
-    await vi.advanceTimersByTimeAsync(RUN_LOOP_INTERVAL_MS);
+    await vi.advanceTimersByTimeAsync(maxBackoffMs(1));
     await z.triggerConnected();
     expect(z.online).toBe(true);
     expect(getOnlineCount()).toBe(2);
@@ -432,7 +460,8 @@ describe('connect error metrics', () => {
         message: 'boom',
         origin: ErrorOrigin.ZeroCache,
       });
-      await z.waitForConnectionStatus(ConnectionStatus.Error);
+      // A zero-cache Internal error is retried, so we land back in connecting.
+      await z.waitForConnectionStatus(ConnectionStatus.Connecting);
 
       const newLogs = z.testLogSink.messages.slice(initialLogCount);
       const disconnectLog = newLogs.find(
@@ -2482,10 +2511,11 @@ test('connect() without opts preserves existing auth', async () => {
   await z.triggerConnected();
   await z.waitForConnectionStatus(ConnectionStatus.Connected);
 
-  // Trigger a non-auth error
+  // Trigger a non-auth error that is fatal (a zero-cache Internal error is
+  // retried, so it would not park the connection here).
   await z.triggerError({
-    kind: ErrorKind.Internal,
-    message: 'internal error',
+    kind: ErrorKind.InvalidPush,
+    message: 'invalid push',
     origin: ErrorOrigin.ZeroCache,
   });
   await z.waitForConnectionStatus(ConnectionStatus.Error);
@@ -2592,6 +2622,75 @@ test('Disconnect on error', async () => {
     origin: ErrorOrigin.ZeroCache,
   });
   expect(z.connectionStatus).toBe(ConnectionStatus.Error);
+});
+
+test('ambiguous internal errors have a bounded retry budget', async () => {
+  const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0);
+  const z = zeroForTest({logLevel: 'debug'});
+  await z.triggerConnected();
+
+  const triggerInternal = () =>
+    z.triggerError({
+      kind: ErrorKind.Internal,
+      message: 'ambiguous internal failure',
+      origin: ErrorOrigin.ZeroCache,
+    });
+
+  for (let attempt = 1; attempt <= MAX_AMBIGUOUS_ERROR_RETRIES; attempt++) {
+    await triggerInternal();
+    await z.waitForConnectionStatus(ConnectionStatus.Connecting);
+    await vi.advanceTimersByTimeAsync(minBackoffMs(attempt));
+    await z.triggerConnected();
+    await z.waitForConnectionStatus(ConnectionStatus.Connected);
+  }
+
+  await triggerInternal();
+  await z.waitForConnectionStatus(ConnectionStatus.Error);
+  expect(z.connectionState).toMatchObject({
+    name: ConnectionStatus.Error,
+    reason: {
+      errorBody: {
+        kind: ErrorKind.Internal,
+        message: 'ambiguous internal failure',
+      },
+    },
+  });
+
+  // Explicit developer intervention starts a fresh bounded retry budget.
+  await z.connection.connect();
+  await z.triggerConnected();
+  await triggerInternal();
+  await z.waitForConnectionStatus(ConnectionStatus.Connecting);
+
+  randomSpy.mockRestore();
+  await z.close();
+});
+
+test('a stable connection resets the ambiguous error retry budget', async () => {
+  const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0);
+  const z = zeroForTest();
+  await z.triggerConnected();
+
+  const triggerInternal = () =>
+    z.triggerError({
+      kind: ErrorKind.Internal,
+      message: 'ambiguous internal failure',
+      origin: ErrorOrigin.ZeroCache,
+    });
+
+  for (let attempt = 1; attempt <= MAX_AMBIGUOUS_ERROR_RETRIES; attempt++) {
+    await triggerInternal();
+    await vi.advanceTimersByTimeAsync(minBackoffMs(attempt));
+    await z.triggerConnected();
+  }
+
+  await vi.advanceTimersByTimeAsync(STABLE_CONNECTION_MS);
+  await triggerInternal();
+  await z.waitForConnectionStatus(ConnectionStatus.Connecting);
+  expect(z.connectionStatus).toBe(ConnectionStatus.Connecting);
+
+  randomSpy.mockRestore();
+  await z.close();
 });
 
 test('No backoff on errors', async () => {
@@ -2756,6 +2855,9 @@ function connectEvents(
 }
 
 test('Connect timeout', async () => {
+  // Pin the backoff jitter to zero so the retry schedule below is exact.
+  // Math.random is only used by the run loop's backoff in this package.
+  const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0);
   const z = zeroForTest({logLevel: 'debug'});
 
   const connectionStates: ConnectionState[] = [];
@@ -2772,18 +2874,33 @@ test('Connect timeout', async () => {
     },
   ]);
 
-  const step = async (sleepMS: number) => {
+  const connectAttempts = () =>
+    z.testLogSink.messages.filter(
+      ([level, _context, messages]) =>
+        level === 'info' && messages.includes('Connecting...'),
+    ).length;
+
+  // Once the disconnect timeout elapses the run loop keeps retrying but the
+  // reported status stays `disconnected`, so accept either here.
+  const expectNotConnected = () => {
+    expect([
+      ConnectionStatus.Connecting,
+      ConnectionStatus.Disconnected,
+    ]).toContain(z.connectionStatus);
+  };
+
+  const step = async (attempt: number) => {
     // Need to drain the microtask queue without changing the clock because we are
     // using the time below to check when the connect times out.
     for (let i = 0; i < 10; i++) {
       await vi.advanceTimersByTimeAsync(0);
     }
 
-    expect(z.connectionStatus).toBe(ConnectionStatus.Connecting);
+    expectNotConnected();
     await vi.advanceTimersByTimeAsync(CONNECT_TIMEOUT_MS - 1);
     expect(z.connectionStatus).not.toBe(ConnectionStatus.Connected);
     await vi.advanceTimersByTimeAsync(1);
-    expect(z.connectionStatus).toBe(ConnectionStatus.Connecting);
+    expectNotConnected();
     expectLogMessages(z).contain(connectTimeoutMessage);
     const events = connectEvents(connectTimeoutErrors(z).at(-1));
     expect(events.map(([_date, event]) => event)).toEqual([
@@ -2801,15 +2918,17 @@ test('Connect timeout', async () => {
       true,
     );
     const nextSocketPromise = z.socket;
+    const attemptsBeforeSleep = connectAttempts();
 
-    // We stay in connecting state and sleep for RUN_LOOP_INTERVAL_MS before trying again
-
-    await vi.advanceTimersByTimeAsync(sleepMS - 1);
-    expect(z.connectionStatus).toBe(ConnectionStatus.Connecting);
+    // The run loop backs off exponentially before trying again, so each
+    // successive attempt waits twice as long as the last.
+    await vi.advanceTimersByTimeAsync(minBackoffMs(attempt) - 1);
+    expect(connectAttempts()).toBe(attemptsBeforeSleep);
     await vi.advanceTimersByTimeAsync(1);
     for (let i = 0; i < 10; i++) {
       await vi.advanceTimersByTimeAsync(0);
     }
+    expect(connectAttempts()).toBe(attemptsBeforeSleep + 1);
     const nextSocket = await nextSocketPromise;
     // After the timeout the state can remain Disconnected; confirming a new socket ensures
     // the reconnect attempt is happening even without a visible status change.
@@ -2817,14 +2936,20 @@ test('Connect timeout', async () => {
     currentSocket = nextSocket;
   };
 
-  await step(RUN_LOOP_INTERVAL_MS);
+  await step(1);
 
-  // Try again to connect
-  await step(RUN_LOOP_INTERVAL_MS);
-  await step(RUN_LOOP_INTERVAL_MS);
-  await step(RUN_LOOP_INTERVAL_MS);
+  // Try again to connect, each time after a longer backoff.
+  await step(2);
+  await step(3);
+  await step(4);
 
-  expect(connectionStates.length).toEqual(1 + 4 * 2);
+  // Each retry publishes a fresh `connecting` state. Once the disconnect
+  // window elapses the client reports `disconnected` while the run loop keeps
+  // retrying underneath, so don't pin the exact count to the backoff schedule.
+  expect(
+    connectionStates.filter(s => s.name === 'connecting').length,
+  ).toBeGreaterThanOrEqual(4);
+  expect(connectionStates.at(-1)?.name).toBe('disconnected');
   expect([...new Set(connectionStates.map(s => s.name))]).toEqual([
     'connecting',
     'disconnected',
@@ -2841,6 +2966,7 @@ test('Connect timeout', async () => {
   ]);
 
   connectionStatusCleanup();
+  randomSpy.mockRestore();
 });
 
 test('connect timeout during setup retries without an unhandled rejection', async () => {
@@ -2888,7 +3014,7 @@ test('connect timeout during setup retries without an unhandled rejection', asyn
       'initializing active clients',
     ]);
 
-    await tickAFewTimes(vi, RUN_LOOP_INTERVAL_MS);
+    await tickAFewTimes(vi, maxBackoffMs(1));
     expect(connectAttempts()).toBe(2);
   } finally {
     window.removeEventListener('unhandledrejection', onUnhandled);
@@ -3647,7 +3773,7 @@ describe('Downstream message with unknown fields', () => {
 });
 
 describe('Downstream handler errors', () => {
-  test('disconnects with internal error when handler throws', async () => {
+  test('disconnects and retries when handler throws', async () => {
     const spy = vi
       .spyOn(DeleteClientsManager.prototype, 'clientsDeletedOnServer')
       .mockImplementation(() => {
@@ -3666,13 +3792,21 @@ describe('Downstream handler errors', () => {
     ] as unknown as Downstream);
 
     expect(spy).toHaveBeenCalledTimes(1);
-    expect(z.connectionStatus).toBe(ConnectionStatus.Error);
 
+    // The handler bug drops the connection, but the client keeps retrying --
+    // reconnecting starts a fresh snapshot, which clears most such failures.
+    await vi.waitFor(() => {
+      assert(
+        z.connectionState.name === ConnectionStatus.Connecting,
+        'Expected connection state to be Connecting',
+      );
+      expect(z.connectionState.reason).toBeDefined();
+    });
     assert(
-      z.connectionState.name === ConnectionStatus.Error,
-      'Expected connection state to be Error',
+      z.connectionState.name === ConnectionStatus.Connecting,
+      'Expected connection state to be Connecting',
     );
-    const {reason} = z.connectionState;
+    const reason = must(z.connectionState.reason);
     expect(reason).toBeInstanceOf(ClientError);
     expect(reason.kind).toBe(ClientErrorKind.Internal);
     expect(reason.message).toBe('handler boom');
@@ -3841,7 +3975,7 @@ test('Close during connect should sleep', async () => {
   );
   expect(hasSleeping).toBe(true);
 
-  await vi.advanceTimersByTimeAsync(RUN_LOOP_INTERVAL_MS);
+  await vi.advanceTimersByTimeAsync(maxBackoffMs(1));
 
   const reconnectAfterSleep = z.socket;
   await reconnectAfterSleep;
@@ -4592,7 +4726,7 @@ test('calling mutate on the non batch version should throw inside a batch', asyn
 });
 
 describe('WebSocket event error handling', () => {
-  test('onOpen catches unexpected errors and transitions to error state', async () => {
+  test('onOpen catches unexpected errors and keeps retrying', async () => {
     const z = zeroForTest({logLevel: 'debug'});
     await z.waitForConnectionStatus(ConnectionStatus.Connecting);
     const socket = (await z.socket) as unknown as MockSocket;
@@ -4600,13 +4734,20 @@ describe('WebSocket event error handling', () => {
     (socket as {url: string}).url = 'not a valid url';
     socket.dispatchEvent(new Event('open'));
 
-    await z.waitForConnectionStatus(ConnectionStatus.Error);
-    expect(z.connectionStatus).toBe(ConnectionStatus.Error);
+    // An unexpected exception is transient as far as the client can tell, so it
+    // stays in connecting and retries rather than parking in a terminal state.
+    await vi.waitFor(() => {
+      assert(
+        z.connectionState.name === ConnectionStatus.Connecting,
+        'Expected connection state to be Connecting after onOpen failure',
+      );
+      expect(z.connectionState.reason).toBeDefined();
+    });
     assert(
-      z.connectionState.name === ConnectionStatus.Error,
-      'Expected connection state to be Error after onOpen failure',
+      z.connectionState.name === ConnectionStatus.Connecting,
+      'Expected connection state to be Connecting after onOpen failure',
     );
-    const {reason} = z.connectionState;
+    const reason = must(z.connectionState.reason);
     expect(reason).toBeInstanceOf(ClientError);
     expect(reason.kind).toBe(ClientErrorKind.Internal);
     expect(reason.message).toContain('URL');
@@ -4620,7 +4761,7 @@ describe('WebSocket event error handling', () => {
     await z.close().catch(() => {});
   });
 
-  test('onClose catches unexpected errors and transitions to error state', async () => {
+  test('onClose catches unexpected errors and keeps retrying', async () => {
     const z = zeroForTest({logLevel: 'debug'});
     await z.waitForConnectionStatus(ConnectionStatus.Connecting);
     const socket = (await z.socket) as unknown as MockSocket;
@@ -4630,13 +4771,18 @@ describe('WebSocket event error handling', () => {
       new CloseEvent('close', {code: 1006, reason: 'test', wasClean: false}),
     );
 
-    await z.waitForConnectionStatus(ConnectionStatus.Error);
-    expect(z.connectionStatus).toBe(ConnectionStatus.Error);
+    await vi.waitFor(() => {
+      assert(
+        z.connectionState.name === ConnectionStatus.Connecting,
+        'Expected connection state to be Connecting after onClose failure',
+      );
+      expect(z.connectionState.reason).toBeDefined();
+    });
     assert(
-      z.connectionState.name === ConnectionStatus.Error,
-      'Expected connection state to be Error after onClose failure',
+      z.connectionState.name === ConnectionStatus.Connecting,
+      'Expected connection state to be Connecting after onClose failure',
     );
-    const {reason} = z.connectionState;
+    const reason = must(z.connectionState.reason);
     expect(reason).toBeInstanceOf(ClientError);
     expect(reason.kind).toBe(ClientErrorKind.Internal);
     expect(reason.message).toContain('URL');
@@ -4805,7 +4951,7 @@ describe('Zero replicache refresh integration', () => {
 
       // Trigger error to transition to Error state
       await z.triggerError({
-        kind: ErrorKind.Internal,
+        kind: ErrorKind.InvalidPush,
         message: 'test error',
         origin: ErrorOrigin.ZeroCache,
       });
@@ -4896,7 +5042,7 @@ describe('Zero replicache refresh integration', () => {
 
       // Trigger disconnect via error
       await z.triggerError({
-        kind: ErrorKind.Internal,
+        kind: ErrorKind.InvalidPush,
         message: 'test error',
         origin: ErrorOrigin.ZeroCache,
       });

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -268,6 +268,41 @@ export const DEFAULT_DISCONNECT_TIMEOUT_MS = 60 * 1_000;
  */
 export const CONNECT_TIMEOUT_MS = 10_000;
 
+/**
+ * The upper bound on the exponential backoff between reconnect attempts,
+ * before jitter is added.
+ */
+export const MAX_RUN_LOOP_INTERVAL_MS = 60_000;
+
+/**
+ * Jitter added to each backoff, as a fraction of the backoff itself. Jitter is
+ * always additive, so the delay lands in
+ * `[backoff, backoff * (1 + RUN_LOOP_JITTER_FRACTION)]`. This spreads
+ * reconnects across a fleet of clients so a recovering server (or a recovering
+ * API server behind zero-cache) is not hit by every client at once.
+ */
+export const RUN_LOOP_JITTER_FRACTION = 0.5;
+
+/**
+ * How long a connection must stay up before we consider it healthy and reset
+ * the backoff. Without this, an error that arrives immediately after every
+ * successful connect (e.g. a pending mutation whose push keeps failing) would
+ * reset the backoff on each attempt and never actually back off.
+ */
+export const STABLE_CONNECTION_MS = 5_000;
+
+/**
+ * Returns how long to wait before the next reconnect attempt, given the number
+ * of consecutive failures since the last healthy connection.
+ */
+export function runLoopBackoffMs(consecutiveFailures: number): number {
+  const backoff = Math.min(
+    RUN_LOOP_INTERVAL_MS * 2 ** Math.max(0, consecutiveFailures - 1),
+    MAX_RUN_LOOP_INTERVAL_MS,
+  );
+  return backoff + Math.random() * backoff * RUN_LOOP_JITTER_FRACTION;
+}
+
 const CHECK_CONNECTIVITY_ON_ERROR_FREQUENCY = 6;
 
 const DEFAULT_QUERY_CHANGE_THROTTLE_MS = 10;
@@ -2107,13 +2142,18 @@ export class Zero<
     const {auth} = this.#options;
     this.#setAuth(auth);
 
-    let backoffMs: number | undefined;
     let additionalConnectParams: Record<string, string> | undefined;
+    // Consecutive failures since the last connection that stayed up for at
+    // least STABLE_CONNECTION_MS. Drives the exponential backoff below.
+    let consecutiveFailures = 0;
+    // Unexpected internal failures can be transient, but can also be a
+    // deterministic client or server bug. Limit retries until the connection
+    // is proven healthy or the application explicitly asks to reconnect.
+    let ambiguousErrorFailures = 0;
 
     while (this.#connectionManager.shouldContinueRunLoop()) {
       runLoopCounter++;
       let lc = getLogContext();
-      backoffMs = RUN_LOOP_INTERVAL_MS;
 
       try {
         const currentState = this.#connectionManager.state;
@@ -2224,7 +2264,21 @@ export class Zero<
           }
 
           case ConnectionStatus.Connected: {
+            // The connection has been up long enough to call it healthy, so
+            // start the next backoff from scratch.
+            if (
+              this.#connectedAt !== 0 &&
+              Date.now() - this.#connectedAt >= STABLE_CONNECTION_MS
+            ) {
+              consecutiveFailures = 0;
+              ambiguousErrorFailures = 0;
+            }
+
             const ready = this.#connectionReadyResolver;
+            // Capture this before waiting because #disconnect clears the
+            // instance field. If the connection survives the stability
+            // window and then fails, that failure starts a fresh retry budget.
+            const connectedAt = this.#connectedAt;
             // When connected we wait for whatever happens first out of:
             // - After pingTimeoutMs we send a ping
             // - We get a message
@@ -2245,6 +2299,14 @@ export class Zero<
                 tabHidden: this.#visibilityWatcher.waitForHidden(),
                 stateChange: this.#connectionManager.waitForStateChange(),
               });
+
+              if (
+                connectedAt !== 0 &&
+                Date.now() - connectedAt >= STABLE_CONNECTION_MS
+              ) {
+                consecutiveFailures = 0;
+                ambiguousErrorFailures = 0;
+              }
 
               switch (raceResult.key) {
                 case 'waitForPing': {
@@ -2295,6 +2357,8 @@ export class Zero<
               stateChange: this.#connectionManager.waitForStateChange(),
             });
             if (resumeResult.key === 'connectRequest') {
+              consecutiveFailures = 0;
+              ambiguousErrorFailures = 0;
               this.#connectionManager.resumeFromConnectRequest();
             }
             break;
@@ -2311,6 +2375,8 @@ export class Zero<
               stateChange: this.#connectionManager.waitForStateChange(),
             });
             if (resumeResult.key === 'connectRequest') {
+              consecutiveFailures = 0;
+              ambiguousErrorFailures = 0;
               this.#connectionManager.resumeFromConnectRequest();
             }
             break;
@@ -2354,6 +2420,26 @@ export class Zero<
             // We continue the loop because the error does not indicate
             // a need to transition to a new state and we should continue retrying
 
+            if (transition.maxRetries !== undefined) {
+              ambiguousErrorFailures++;
+              if (ambiguousErrorFailures > transition.maxRetries) {
+                lc.error?.(
+                  'Retry budget exhausted for ambiguous error; transitioning to error state',
+                  {
+                    attempts: ambiguousErrorFailures,
+                    maxRetries: transition.maxRetries,
+                    error: transition.reason.errorBody,
+                  },
+                );
+                this.#connectionManager.error(transition.reason);
+                break;
+              }
+            }
+
+            consecutiveFailures++;
+            let backoffMs = runLoopBackoffMs(consecutiveFailures);
+
+            // A server-directed backoff always wins over ours.
             const backoffParams = getBackoffParams(transition.reason);
             if (backoffParams) {
               if (backoffParams.minBackoffMs !== undefined) {
@@ -2368,7 +2454,7 @@ export class Zero<
             lc.debug?.(
               'Sleeping',
               backoffMs,
-              'ms before reconnecting due to error, state:',
+              `ms before reconnecting due to error (consecutive failures: ${consecutiveFailures}), state:`,
               this.#connectionManager.state,
             );
             sleepMs = backoffMs;

--- a/packages/zero-protocol/src/error.test.ts
+++ b/packages/zero-protocol/src/error.test.ts
@@ -2,7 +2,14 @@ import {describe, expect, test} from 'vitest';
 
 import {ErrorKind} from './error-kind.ts';
 import {ErrorOrigin} from './error-origin.ts';
-import {ProtocolError, isProtocolError, type ErrorBody} from './error.ts';
+import {ErrorReason} from './error-reason.ts';
+import {
+  errorBodySchema,
+  isRetryableHTTPStatus,
+  ProtocolError,
+  isProtocolError,
+  type ErrorBody,
+} from './error.ts';
 
 describe('ProtocolError', () => {
   test('exposes error body and metadata', () => {
@@ -47,4 +54,38 @@ describe('ProtocolError', () => {
     // while WebKit often only includes callsite URLs and line numbers.
     expect(error.stack).toMatch(/ProtocolError|error\.test\.ts:\d+:\d+/);
   });
+});
+
+describe('retryable errors', () => {
+  test('parses retryable markers on internal and operation errors', () => {
+    expect(
+      errorBodySchema.parse({
+        kind: ErrorKind.Internal,
+        origin: ErrorOrigin.ZeroCache,
+        message: 'temporary failure',
+        retryable: true,
+      }),
+    ).toMatchObject({retryable: true});
+
+    expect(
+      errorBodySchema.parse({
+        kind: ErrorKind.PushFailed,
+        origin: ErrorOrigin.ZeroCache,
+        reason: ErrorReason.Timeout,
+        message: 'timed out',
+        mutationIDs: [],
+        retryable: true,
+      }),
+    ).toMatchObject({retryable: true});
+  });
+
+  test.each([408, 425, 429, 500, 503, 599])(
+    'classifies HTTP %i as retryable',
+    status => expect(isRetryableHTTPStatus(status)).toBe(true),
+  );
+
+  test.each([0, 200, 400, 401, 403, 404, 600])(
+    'classifies HTTP %i as non-retryable',
+    status => expect(isRetryableHTTPStatus(status)).toBe(false),
+  );
 });

--- a/packages/zero-protocol/src/error.ts
+++ b/packages/zero-protocol/src/error.ts
@@ -25,6 +25,11 @@ const basicErrorKindSchema = v.literalUnion(
 const basicErrorBodySchema = v.object({
   kind: basicErrorKindSchema,
   message: v.string(),
+  /**
+   * Whether retrying the failed operation can succeed without changing the
+   * request. Optional for compatibility with older senders.
+   */
+  retryable: v.boolean().optional(),
   // this is optional for backwards compatibility
   origin: v.literalUnion(ErrorOrigin.Server, ErrorOrigin.ZeroCache).optional(),
 });
@@ -65,6 +70,11 @@ const pushFailedBaseSchema = v.object({
   kind: pushFailedErrorKindSchema,
   details: jsonSchema.optional(),
   /**
+   * Whether retrying the push can succeed without changing the request.
+   * Optional for compatibility with older senders.
+   */
+  retryable: v.boolean().optional(),
+  /**
    * The mutationIDs of the mutations that failed to process.
    * This can be a subset of the mutationIDs in the request.
    */
@@ -102,6 +112,11 @@ export const pushFailedBodySchema = v.union(
 const transformFailedBaseSchema = v.object({
   kind: transformFailedErrorKindSchema,
   details: jsonSchema.optional(),
+  /**
+   * Whether retrying the transform can succeed without changing the request.
+   * Optional for compatibility with older senders.
+   */
+  retryable: v.boolean().optional(),
   /**
    * The queryIDs of the queries that failed to transform.
    */
@@ -152,6 +167,19 @@ export const errorMessageSchema: v.Type<ErrorMessage> = v.tuple([
 ]);
 
 export type ErrorMessage = ['error', ErrorBody];
+
+/**
+ * HTTP responses that are expected to succeed when retried without changing
+ * the request.
+ */
+export function isRetryableHTTPStatus(status: number): boolean {
+  return (
+    status === 408 ||
+    status === 425 ||
+    status === 429 ||
+    (status >= 500 && status <= 599)
+  );
+}
 
 /**
  * Represents an error used across zero-client, zero-cache, and zero-server.


### PR DESCRIPTION
Codex authored. Currently reviewing.

---

 - Client retries HTTP 408/425/429/5xx and timeout errors. HTTP 4xx, parse/configuration
    errors, and explicit retryable: false remain terminal. packages/zero-client/src/client/
    error.ts:138

  - Ambiguous client/server Internal and database errors get three reconnects before entering
    error. A stable connection or explicit connection.connect() resets the budget. packages/
    zero-client/src/client/zero.ts:2152

  - Added an optional wire-level retryable marker. Older 1.8 clients safely ignore it; they
    require an upgrade to gain the new client behavior. packages/zero-protocol/src/
    error.ts:25

  - zero-cache API calls now have a 10-second timeout per attempt, covering headers and
    response-body reads. Timeouts, network failures, and retryable HTTP statuses receive four
    backend attempts. Exhaustion is reported with retryable: true. packages/zero-cache/src/
    custom/fetch.ts:87