### PR TITLE
chore(zero-cache): fix the initial takeover delay to account for backup

### DIFF
--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -2,6 +2,7 @@ import {consoleLogSink, LogContext} from '@rocicorp/logger';
 import {resolver} from '@rocicorp/resolver';
 import {assert} from '../../../shared/src/asserts.ts';
 import {must} from '../../../shared/src/must.ts';
+import {promiseVoid} from '../../../shared/src/resolved-promises.ts';
 import {DatabaseInitError} from '../../../zqlite/src/db.ts';
 import {getServerContext} from '../config/server-context.ts';
 import {getNormalizedZeroConfig} from '../config/zero-config.ts';
@@ -352,25 +353,25 @@ export default async function runWorker(
     changeStreamer,
   });
 
-  const changeStreamerWebServer = new ChangeStreamerHttpServer(
-    lc,
-    {port, keepaliveTimeoutMs, startupDelayMs},
-    parent,
-    changeStreamer,
-  );
-
+  let readinessGate = promiseVoid;
   if (waitForFirstBackupBeforeServing) {
     const start = performance.now();
     lc.info?.(`awaiting initial backup ...`);
 
-    void backupMonitor.firstBackupReceived().then(() => {
+    readinessGate = backupMonitor.firstBackupReceived().then(() => {
       const elapsed = performance.now() - start;
       lc.info?.(`initial backup confirmed after ${elapsed.toFixed(2)}ms`);
-      parent.send(['ready', {ready: true}]);
     });
-  } else {
-    parent.send(['ready', {ready: true}]);
   }
+
+  const changeStreamerWebServer = new ChangeStreamerHttpServer(
+    lc,
+    {port, keepaliveTimeoutMs, startupDelayMs, readinessGate},
+    parent,
+    changeStreamer,
+  );
+
+  void readinessGate.then(() => parent.send(['ready', {ready: true}]));
 
   // Note: The changeStreamer itself is not started here; it is started by the
   //       changeStreamerWebServer after a delay to ensure that routing

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-http.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-http.ts
@@ -3,6 +3,7 @@ import websocket from '@fastify/websocket';
 import type {LogContext} from '@rocicorp/logger';
 import WebSocket from 'ws';
 import {assert} from '../../../../shared/src/asserts.ts';
+import {promiseVoid} from '../../../../shared/src/resolved-promises.ts';
 import type {IncomingMessageSubset} from '../../types/http.ts';
 import {pgClient, type PostgresDB} from '../../types/pg.ts';
 import {type Worker} from '../../types/processes.ts';
@@ -17,7 +18,7 @@ import {
 import {URLParams} from '../../types/url-params.ts';
 import {installWebSocketReceiver} from '../../types/websocket-handoff.ts';
 import {closeWithError, PROTOCOL_ERROR} from '../../types/ws.ts';
-import {HttpService} from '../http-service.ts';
+import {HttpService, type Options as HttpOptions} from '../http-service.ts';
 import {
   downstreamSchema,
   PROTOCOL_VERSION,
@@ -38,9 +39,7 @@ const PATH_REGEX = /\/replication\/v(?<version>\d+)\/(changes|snapshot)$/;
 const SNAPSHOT_PATH = `/replication/v${PROTOCOL_VERSION}/snapshot`;
 const CHANGES_PATH = `/replication/v${PROTOCOL_VERSION}/changes`;
 
-type Options = {
-  port: number;
-  keepaliveTimeoutMs: number | undefined;
+type Options = HttpOptions & {
   startupDelayMs: number;
 };
 
@@ -151,14 +150,32 @@ export class ChangeStreamerHttpServer extends HttpService {
   }
 
   protected override _onStart(): void {
-    const {startupDelayMs} = this.#opts;
-    this._state.setTimeout(
-      () =>
-        this.#ensureChangeStreamerStarted(
-          `startup delay elapsed (${startupDelayMs} ms)`,
-        ),
-      startupDelayMs,
-    );
+    const {startupDelayMs, readinessGate = promiseVoid} = this.#opts;
+    void readinessGate.then(() => {
+      if (startupDelayMs > 0) {
+        // In RMv1, starting the change-streamer forcibly shuts down the
+        // previous change-streamer, causing view-syncers to reconnect.
+        // If this replication-manager has just started, the routing layer may
+        // not have registered it with DNS, as that only happens after it
+        // confirms health checks. To minimize downtime, the takeover is
+        // delayed for the configured startupDelayMs _after_ beginning to
+        // advertise readiness.
+        this.#lc.info?.(
+          `waiting ${startupDelayMs}ms before taking over the change log`,
+        );
+        this._state.setTimeout(
+          () =>
+            this.#ensureChangeStreamerStarted(
+              `startup delay elapsed (${startupDelayMs} ms)`,
+            ),
+          startupDelayMs,
+        );
+      } else {
+        // In RMv2, this is not necessary because a new RM does not kill the
+        // old one; it is started as soon as possible.
+        this.#ensureChangeStreamerStarted('no startup delay configured');
+      }
+    });
   }
 
   protected override async _onStop(): Promise<void> {

--- a/packages/zero-cache/src/services/http-service.test.ts
+++ b/packages/zero-cache/src/services/http-service.test.ts
@@ -1,0 +1,62 @@
+import {resolver} from '@rocicorp/resolver';
+import type {FastifyInstance} from 'fastify';
+import {afterEach, describe, expect, test} from 'vitest';
+import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
+import {HttpService} from './http-service.ts';
+
+const lc = createSilentLogContext();
+
+let service: HttpService | undefined;
+
+afterEach(async () => {
+  await service?.stop();
+  service = undefined;
+});
+
+function startService(readinessGate?: Promise<void>) {
+  service = new HttpService(
+    'test-service',
+    lc,
+    {port: 0, keepaliveTimeoutMs: undefined, readinessGate},
+    (_fastify: FastifyInstance) => {},
+  );
+  return service.start();
+}
+
+describe.each(['/', '/keepalive'])('%s', path => {
+  test('responds OK once ready by default', async () => {
+    const address = await startService();
+
+    const res = await fetch(address + path);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('OK');
+  });
+
+  test('never responds to a request made before the readiness gate resolves', async () => {
+    const {promise: readinessGate, resolve} = resolver<void>();
+    const address = await startService(readinessGate);
+
+    // The handler sends no response at all while not ready, so a request
+    // in flight before readiness hangs forever, even after the gate later
+    // resolves (the handler already ran and won't be invoked again).
+    const controller = new AbortController();
+    const pending = fetch(address + path, {signal: controller.signal});
+    let settled = false;
+    void pending.then(
+      () => (settled = true),
+      () => (settled = true),
+    );
+
+    await new Promise(r => setTimeout(r, 50));
+    expect(settled).toBe(false);
+
+    resolve();
+    await new Promise(r => setTimeout(r, 50));
+    expect(settled).toBe(false);
+    controller.abort();
+
+    // A new request made after the gate resolves succeeds normally.
+    const res = await fetch(address + path);
+    expect(await res.text()).toBe('OK');
+  });
+});

--- a/packages/zero-cache/src/services/http-service.ts
+++ b/packages/zero-cache/src/services/http-service.ts
@@ -8,6 +8,9 @@ import type {Service} from './service.ts';
 export type Options = {
   port: number;
   keepaliveTimeoutMs: number | undefined;
+
+  // Wait for the readinessGate to resolve before responding to health checks.
+  readinessGate?: Promise<void> | undefined;
 };
 
 /**
@@ -24,13 +27,15 @@ export class HttpService implements Service {
   readonly #heartbeatMonitor: HeartbeatMonitor | undefined;
   readonly #init: (fastify: FastifyInstance) => void | Promise<void>;
 
+  #ready = false;
+
   constructor(
     id: string,
     lc: LogContext,
     opts: Options,
     init: (fastify: FastifyInstance) => void | Promise<void>,
   ) {
-    const {port, keepaliveTimeoutMs} = opts;
+    const {port, keepaliveTimeoutMs, readinessGate = promiseVoid} = opts;
     this.id = id;
     this._lc = lc.withContext('component', this.id);
     this.#fastify = Fastify();
@@ -40,6 +45,8 @@ export class HttpService implements Service {
     this.#heartbeatMonitor = keepaliveTimeoutMs
       ? new HeartbeatMonitor(this._lc, keepaliveTimeoutMs)
       : undefined;
+
+    void readinessGate.then(() => (this.#ready = true));
   }
 
   // Life-cycle hooks for subclass implementations
@@ -50,10 +57,16 @@ export class HttpService implements Service {
   // start() is used in unit tests.
   // run() is the lifecycle method called by the ServiceRunner.
   async start(): Promise<string> {
-    this.#fastify.get('/', (_req, res) => res.send('OK'));
+    this.#fastify.get('/', (_req, res) => {
+      if (this.#ready) {
+        res.send('OK');
+      }
+    });
     this.#fastify.get('/keepalive', ({headers}, res) => {
       this.#heartbeatMonitor?.onHeartbeat(headers);
-      return res.send('OK');
+      if (this.#ready) {
+        res.send('OK');
+      }
     });
     await this.#init(this.#fastify);
     const address = await this.#fastify.listen({


### PR DESCRIPTION
Fix the RMv1 takeover delay (which allows routing layer to register health of the new RM before the old RM is killed) to take into account the backup delay introduced for initial sync and litestream v5 backups.

The startup sequence (for RMv1) is now:
* wait for first backup (so that new subscribers can restore)
* start responding to health checks
* wait for startup delay (to allow routing layer to register healthiness)
* takeover the slot + change-log

(For RMv2, the latter two steps will be eliminated)