### PR TITLE
fix(zero-cache): validate litestream vfs executable

### DIFF
--- a/packages/zero-cache/src/config/normalize.test.ts
+++ b/packages/zero-cache/src/config/normalize.test.ts
@@ -27,6 +27,7 @@ function configWith(litestream: Partial<ZeroConfig['litestream']>): ZeroConfig {
       restoreUsingV5: false,
       executable: undefined,
       executableV5: undefined,
+      vfsPollIntervalMs: 15_000,
       ...litestream,
     },
   } as unknown as ZeroConfig;

--- a/packages/zero-cache/src/config/normalize.ts
+++ b/packages/zero-cache/src/config/normalize.ts
@@ -114,7 +114,7 @@ export function assertNormalized(
   assert(
     !config.litestream.backupURL ||
       !config.litestream.backupUsingV5 ||
-      config.litestream.vfsPollIntervalMs,
+      config.litestream.vfsQueryExecutable,
     '--litestream-backup-using-v5 requires --litestream-vfs-query-executable to be specified',
   );
   assert(config.change.db, 'missing --change-db');


### PR DESCRIPTION
### What

Validate that Litestream V5 backups have the VFS query executable required by the backup cleanup monitor.

### Why

The startup assertion checked the polling interval instead of the executable. Because the polling interval defaults to 15 seconds, configurations enabling V5 backups without ZERO_LITESTREAM_VFS_QUERY_EXECUTABLE passed normalization and failed later during monitor construction.

### Changes

- Check vfsQueryExecutable when V5 backups are enabled.
- Include the default VFS poll interval in the normalization test fixture so the regression test exercises the intended field.