### PR TITLE
fix(zero-cache): skip restore in single-node mode

### DIFF
--- a/packages/zero-cache/src/integration/integration.pg.test.ts
+++ b/packages/zero-cache/src/integration/integration.pg.test.ts
@@ -778,6 +778,18 @@ describe('integration', {timeout: 30000}, () => {
 
   test.for([
     ['single-node', 'pg', () => [env], undefined],
+    [
+      'single-node with bundled Litestream executables and no backup',
+      'pg',
+      () => [
+        {
+          ...env,
+          ['ZERO_LITESTREAM_EXECUTABLE']: '/not-used/litestream',
+          ['ZERO_LITESTREAM_EXECUTABLE_V5']: '/not-used/litestream-v5',
+        },
+      ],
+      undefined,
+    ],
     ['replica identity full', 'pg', () => [env], 'FULL'],
     [
       'lazy single-node standalone',

--- a/packages/zero-cache/src/server/replicator.ts
+++ b/packages/zero-cache/src/server/replicator.ts
@@ -78,8 +78,12 @@ export default async function runWorker(
     );
   initEventSink(lc, config);
 
+  // Remote view-syncers restore from the replication-manager, which supplies
+  // the backup URL. A local change-streamer owns the canonical replica and
+  // must not infer backup configuration from bundled executable paths.
   if (
     fileMode === 'serving' &&
+    !runningLocalChangeStreamer &&
     (config.litestream.executable || config.litestream.executableV5)
   ) {
     await restoreReplica(lc, config);


### PR DESCRIPTION
### What

Prevent single-node `zero-cache` deployments from entering the multi-node view-syncer backup restore path merely because the Docker image bundles Litestream executables.

Remote view-syncers continue to restore through replication-manager snapshots.

### Why

Zero 1.9 made the restore decision in the dispatcher. It restored only when the process [was not running its own change-streamer](https://github.com/rocicorp/mono/blob/7fb31b033738535c31d83ef476e57771b792474c/packages/zero-cache/src/server/main.ts#L112-L123), which excluded single-node deployments.

[#6268](https://github.com/rocicorp/mono/pull/6268) moved view-syncer restore logic into the replicator worker and initially gated it on `ZERO_LITESTREAM_BACKUP_URL`. That broke multi-node view-syncers because they intentionally learn the backup URL from the replication-manager instead of receiving it in their local configuration.

[#6274](https://github.com/rocicorp/mono/pull/6274) corrected that by using Litestream executable presence as the restore signal, but the refactor did not preserve the old “not running a local change-streamer” condition.

This became a regression in the official Docker image because it [sets both Litestream executable paths](https://github.com/rocicorp/mono/blob/dbc9dbeeb77145ca1c21f3b36d677021ac7cb646/packages/zero/Dockerfile#L127-L128), even when `ZERO_LITESTREAM_BACKUP_URL` is unset. A single-node serving replicator therefore attempted to reserve a backup snapshot from its local change-streamer, which had no backup configured, and failed with [`backups are not configured`](https://github.com/rocicorp/mono/blob/dbc9dbeeb77145ca1c21f3b36d677021ac7cb646/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts#L967-L972).

### Changes

- Require the serving replicator to use a remote or discovered change-streamer before entering backup restore flow, restoring the topology distinction that shipped in Zero 1.9.
- Preserve executable-based restore detection for multi-node view-syncers, including Litestream v5.
- Add a PostgreSQL integration scenario that mirrors the Docker image environment and verifies single-node startup and replication with both executables present but no backup URL.
