### PR TITLE
chore(zero-cache): improve coverage of terminating flow control waits

### DIFF
--- a/packages/shared/src/promise-race.test.ts
+++ b/packages/shared/src/promise-race.test.ts
@@ -1,9 +1,43 @@
-import {getEventListeners} from 'node:events';
 import {resolver} from '@rocicorp/resolver';
 import {describe, expect, expectTypeOf, test} from 'vitest';
 import {assert} from './asserts.ts';
 import {promiseOrAbort, promiseRace} from './promise-race.ts';
 import {sleep} from './sleep.ts';
+
+/**
+ * Wraps `signal`'s addEventListener/removeEventListener to track the number
+ * of 'abort' listeners currently registered, without relying on Node's
+ * `node:events.getEventListeners` (which isn't available in browser tests).
+ */
+function trackAbortListenerCount(signal: AbortSignal): () => number {
+  let count = 0;
+  const nativeAdd = signal.addEventListener.bind(signal);
+  const nativeRemove = signal.removeEventListener.bind(signal);
+
+  signal.addEventListener = ((
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    options?: boolean | AddEventListenerOptions,
+  ) => {
+    if (type === 'abort') {
+      count++;
+    }
+    nativeAdd(type, listener, options);
+  }) as AbortSignal['addEventListener'];
+
+  signal.removeEventListener = ((
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    options?: boolean | EventListenerOptions,
+  ) => {
+    if (type === 'abort') {
+      count--;
+    }
+    nativeRemove(type, listener, options);
+  }) as AbortSignal['removeEventListener'];
+
+  return () => count;
+}
 
 describe('promiseRace with record', () => {
   test('returns key of first settled promise', async () => {
@@ -189,32 +223,37 @@ describe('promiseOrAbort', () => {
 
   test('removes the abort listener once the short-lived promise wins', async () => {
     const controller = new AbortController();
+    const abortListenerCount = trackAbortListenerCount(controller.signal);
     const {promise, resolve} = resolver<string>();
 
     const raced = promiseOrAbort(promise, controller.signal);
     resolve('value');
     await raced;
 
-    expect(getEventListeners(controller.signal, 'abort')).toHaveLength(0);
+    expect(abortListenerCount()).toBe(0);
   });
 
   test('removes abort listeners on all signals once one wins', async () => {
     const a = new AbortController();
     const b = new AbortController();
     const c = new AbortController();
+    const aCount = trackAbortListenerCount(a.signal);
+    const bCount = trackAbortListenerCount(b.signal);
+    const cCount = trackAbortListenerCount(c.signal);
     const never = new Promise<string>(() => {});
 
     const raced = promiseOrAbort(never, a.signal, b.signal, c.signal);
     b.abort(new Error('boom'));
     await raced.catch(() => {});
 
-    expect(getEventListeners(a.signal, 'abort')).toHaveLength(0);
-    expect(getEventListeners(b.signal, 'abort')).toHaveLength(0);
-    expect(getEventListeners(c.signal, 'abort')).toHaveLength(0);
+    expect(aCount()).toBe(0);
+    expect(bCount()).toBe(0);
+    expect(cCount()).toBe(0);
   });
 
   test('repeated races do not accumulate abort listeners on the shared signal', async () => {
     const controller = new AbortController();
+    const abortListenerCount = trackAbortListenerCount(controller.signal);
 
     // Each race resolves via the short-lived promise; the abort listener
     // must be removed in the `finally` so listeners don't accumulate on
@@ -228,7 +267,7 @@ describe('promiseOrAbort', () => {
       expect(await raced).toBe(i);
     }
 
-    expect(getEventListeners(controller.signal, 'abort')).toHaveLength(0);
+    expect(abortListenerCount()).toBe(0);
 
     // The signal still terminates the race cleanly afterwards.
     const never = new Promise<number>(() => {});

--- a/packages/shared/src/promise-race.test.ts
+++ b/packages/shared/src/promise-race.test.ts
@@ -1,6 +1,8 @@
+import {getEventListeners} from 'node:events';
+import {resolver} from '@rocicorp/resolver';
 import {describe, expect, expectTypeOf, test} from 'vitest';
 import {assert} from './asserts.ts';
-import {promiseRace} from './promise-race.ts';
+import {promiseOrAbort, promiseRace} from './promise-race.ts';
 import {sleep} from './sleep.ts';
 
 describe('promiseRace with record', () => {
@@ -116,5 +118,123 @@ describe('promiseRace with record', () => {
 
     expect(['first', 'second']).toContain(result.key);
     expect(['value1', 'value2']).toContain(result.result);
+  });
+});
+
+describe('promiseOrAbort', () => {
+  test('short-lived promise resolves first', async () => {
+    const controller = new AbortController();
+
+    const result = await promiseOrAbort(
+      Promise.resolve('value'),
+      controller.signal,
+    );
+
+    expect(result).toBe('value');
+  });
+
+  test('short-lived promise rejects first', async () => {
+    const error = new Error('boom');
+    const controller = new AbortController();
+
+    const raced = promiseOrAbort(Promise.reject(error), controller.signal);
+
+    await expect(raced).rejects.toBe(error);
+  });
+
+  test('abort wins over a never-settling short-lived promise', async () => {
+    const controller = new AbortController();
+    const never = new Promise<string>(() => {});
+    const reason = new Error('aborted');
+
+    const raced = promiseOrAbort(never, controller.signal);
+    controller.abort(reason);
+
+    await expect(raced).rejects.toBe(reason);
+  });
+
+  test('already-aborted signal rejects immediately', async () => {
+    const controller = new AbortController();
+    const reason = new Error('already aborted');
+    controller.abort(reason);
+
+    const never = new Promise<string>(() => {});
+    await expect(promiseOrAbort(never, controller.signal)).rejects.toBe(reason);
+  });
+
+  test('any of several long-lived signals can win the race', async () => {
+    const a = new AbortController();
+    const b = new AbortController();
+    const c = new AbortController();
+    const reason = new Error('b aborted');
+    const never = new Promise<string>(() => {});
+
+    const raced = promiseOrAbort(never, a.signal, b.signal, c.signal);
+    b.abort(reason);
+
+    await expect(raced).rejects.toBe(reason);
+  });
+
+  test('an already-aborted signal among several rejects immediately', async () => {
+    const a = new AbortController();
+    const b = new AbortController();
+    const reason = new Error('a already aborted');
+    a.abort(reason);
+    const never = new Promise<string>(() => {});
+
+    await expect(promiseOrAbort(never, a.signal, b.signal)).rejects.toBe(
+      reason,
+    );
+  });
+
+  test('removes the abort listener once the short-lived promise wins', async () => {
+    const controller = new AbortController();
+    const {promise, resolve} = resolver<string>();
+
+    const raced = promiseOrAbort(promise, controller.signal);
+    resolve('value');
+    await raced;
+
+    expect(getEventListeners(controller.signal, 'abort')).toHaveLength(0);
+  });
+
+  test('removes abort listeners on all signals once one wins', async () => {
+    const a = new AbortController();
+    const b = new AbortController();
+    const c = new AbortController();
+    const never = new Promise<string>(() => {});
+
+    const raced = promiseOrAbort(never, a.signal, b.signal, c.signal);
+    b.abort(new Error('boom'));
+    await raced.catch(() => {});
+
+    expect(getEventListeners(a.signal, 'abort')).toHaveLength(0);
+    expect(getEventListeners(b.signal, 'abort')).toHaveLength(0);
+    expect(getEventListeners(c.signal, 'abort')).toHaveLength(0);
+  });
+
+  test('repeated races do not accumulate abort listeners on the shared signal', async () => {
+    const controller = new AbortController();
+
+    // Each race resolves via the short-lived promise; the abort listener
+    // must be removed in the `finally` so listeners don't accumulate on
+    // the long-lived signal (the whole point of promiseOrAbort over
+    // Promise.race with a long-lived AbortSignal promise, see
+    // https://github.com/nodejs/node/issues/17469).
+    for (let i = 0; i < 100; i++) {
+      const {promise, resolve} = resolver<number>();
+      const raced = promiseOrAbort(promise, controller.signal);
+      resolve(i);
+      expect(await raced).toBe(i);
+    }
+
+    expect(getEventListeners(controller.signal, 'abort')).toHaveLength(0);
+
+    // The signal still terminates the race cleanly afterwards.
+    const never = new Promise<number>(() => {});
+    const raced = promiseOrAbort(never, controller.signal);
+    const reason = new Error('final abort');
+    controller.abort(reason);
+    await expect(raced).rejects.toBe(reason);
   });
 });

--- a/packages/shared/src/promise-race.ts
+++ b/packages/shared/src/promise-race.ts
@@ -1,3 +1,5 @@
+import {resolver} from '@rocicorp/resolver';
+
 type PromiseRaceResult<T extends Record<string, PromiseLike<unknown>>> = {
   [K in Extract<keyof T, string>]: {
     key: K;
@@ -39,4 +41,42 @@ export async function promiseRace<
   );
 
   return await Promise.race(wrapped);
+}
+
+/**
+ * A memory-safe way to race a short lived `Promise` with one or more
+ * long-leved `AbortSignal`s. This works around the deceptively unsafe practice
+ * of racing a short-lived promise (e.g. in a loop) with a long-lived one,
+ * which results in accumulating memory via `then` callbacks on the latter:
+ *
+ * https://github.com/nodejs/node/issues/17469
+ *
+ * The safe way to race a short-lived, expected-to-complete Promise against a
+ * long-lived termination signal is to control the latter via an
+ * {@link AbortController} and race the former against the signals of the
+ * latter.
+ */
+export async function promiseOrAbort<T>(
+  shortLived: Promise<T>,
+  ...longLived: AbortSignal[]
+): Promise<T> {
+  const promises: Promise<T>[] = [];
+  const cleanup: (() => void)[] = [];
+  for (const signal of longLived) {
+    if (signal.aborted) {
+      promises.push(Promise.reject(signal.reason));
+    } else {
+      const {promise, reject} = resolver<T>();
+      const handler = () => reject(signal.reason);
+      signal.addEventListener('abort', handler);
+      cleanup.push(() => signal.removeEventListener('abort', handler));
+      promises.push(promise);
+    }
+  }
+
+  try {
+    return await Promise.race([shortLived, ...promises]);
+  } finally {
+    cleanup.forEach(fn => fn());
+  }
 }

--- a/packages/shared/src/promise-race.ts
+++ b/packages/shared/src/promise-race.ts
@@ -44,8 +44,8 @@ export async function promiseRace<
 }
 
 /**
- * A memory-safe way to race a short lived `Promise` with one or more
- * long-leved `AbortSignal`s. This works around the deceptively unsafe practice
+ * A memory-safe way to race a short-lived `Promise` with one or more
+ * long-leved `AbortSignal`s. This works around the unsafe practice
  * of racing a short-lived promise (e.g. in a loop) with a long-lived one,
  * which results in accumulating memory via `then` callbacks on the latter:
  *
@@ -53,7 +53,7 @@ export async function promiseRace<
  *
  * The safe way to race a short-lived, expected-to-complete Promise against a
  * long-lived termination signal is to control the latter via an
- * {@link AbortController} and race the former against the signals of the
+ * {@link AbortController} and race the former against the signal of the
  * latter.
  */
 export async function promiseOrAbort<T>(

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -3,6 +3,7 @@ import type {LogContext} from '@rocicorp/logger';
 import {resolver, type Resolver} from '@rocicorp/resolver';
 import {assert, unreachable} from '../../../../shared/src/asserts.ts';
 import {must} from '../../../../shared/src/must.ts';
+import {promiseOrAbort} from '../../../../shared/src/promise-race.ts';
 import {promiseVoid} from '../../../../shared/src/resolved-promises.ts';
 import {publishCriticalEvent} from '../../observability/events.ts';
 import {
@@ -784,7 +785,11 @@ class ChangeStreamerImpl implements ChangeStreamerService {
             // control promise. Record the boundary before awaiting that promise
             // so registrations during the wait observe the forwarded state.
             this.#recordForwardedTransactionBoundary(type, entry[0]);
-            await stream.changes.doneOr(forwarded);
+            await promiseOrAbort(
+              forwarded,
+              stream.changes.signal,
+              this.#state.signal,
+            );
             unflushedBytes = 0;
           }
 
@@ -795,7 +800,11 @@ class ChangeStreamerImpl implements ChangeStreamerService {
           // Allow the storer to exert back pressure.
           const readyForMore = this.#storer.readyForMore();
           if (readyForMore) {
-            await stream.changes.doneOr(readyForMore);
+            await promiseOrAbort(
+              readyForMore,
+              stream.changes.signal,
+              this.#state.signal,
+            );
           }
         }
       } catch (e) {

--- a/packages/zero-cache/src/services/replicator/replication-resumption-child.test.ts
+++ b/packages/zero-cache/src/services/replicator/replication-resumption-child.test.ts
@@ -1,5 +1,6 @@
 import {EventEmitter} from 'node:events';
 import {describe, expect, test, vi} from 'vitest';
+import {promiseOrAbort} from '../../../../shared/src/promise-race.ts';
 import type * as processes from '../../types/processes.ts';
 import type {Worker} from '../../types/processes.ts';
 
@@ -27,33 +28,39 @@ function fakeWorker(): Worker & {sent: unknown[]} {
   return ee as unknown as Worker & {sent: unknown[]};
 }
 
-describe('replication-resumption-child/doneOr', () => {
+describe('replication-resumption-child/signal', () => {
   const never = () => new Promise<string>(() => {});
 
   test('other resolves first', async () => {
     const source = new IPCDownstreamSource(fakeWorker());
-    expect(await source.doneOr(Promise.resolve('foo'))).toBe('foo');
+    expect(await promiseOrAbort(Promise.resolve('foo'), source.signal)).toBe(
+      'foo',
+    );
   });
 
-  test('local cancel() resolves doneOr', async () => {
+  test('local cancel() resolves signal', async () => {
     const source = new IPCDownstreamSource(fakeWorker());
-    const raced = source.doneOr(never());
+    const raced = promiseOrAbort(never(), source.signal);
     source.cancel();
-    expect(await raced).toBeUndefined();
+    await expect(raced).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[AbortError: This operation was aborted]`,
+    );
   });
 
-  test('producer source-end resolves doneOr', async () => {
+  test('producer source-end resolves signal', async () => {
     const worker = fakeWorker();
     const source = new IPCDownstreamSource(worker);
-    const raced = source.doneOr(never());
+    const raced = promiseOrAbort(never(), source.signal);
     worker.emit('message', ['replication-resumption:source-end', {}]);
-    expect(await raced).toBeUndefined();
+    await expect(raced).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[AbortError: This operation was aborted]`,
+    );
   });
 
-  test('producer source-error rejects doneOr with the error', async () => {
+  test('producer source-error rejects sigal with the error', async () => {
     const worker = fakeWorker();
     const source = new IPCDownstreamSource(worker);
-    const raced = source.doneOr(never());
+    const raced = promiseOrAbort(never(), source.signal);
     worker.emit('message', [
       'replication-resumption:source-error',
       {message: 'upstream-boom'},
@@ -61,33 +68,26 @@ describe('replication-resumption-child/doneOr', () => {
     await expect(raced).rejects.toThrow('upstream-boom');
   });
 
-  test('doneOr after source-error rejects immediately', async () => {
+  test('signal after source-error rejects immediately', async () => {
     const worker = fakeWorker();
     const source = new IPCDownstreamSource(worker);
     worker.emit('message', [
       'replication-resumption:source-error',
       {message: 'upstream-boom'},
     ]);
-    await expect(source.doneOr(never())).rejects.toThrow('upstream-boom');
+    await expect(promiseOrAbort(never(), source.signal)).rejects.toThrow(
+      'upstream-boom',
+    );
   });
 
-  test('doneOr after source-end resolves immediately', async () => {
+  test('signal after source-end resolves immediately', async () => {
     const worker = fakeWorker();
     const source = new IPCDownstreamSource(worker);
     worker.emit('message', ['replication-resumption:source-end', {}]);
-    expect(await source.doneOr(never())).toBeUndefined();
-  });
-
-  test('unrecognized messages do not terminate doneOr', async () => {
-    const worker = fakeWorker();
-    const source = new IPCDownstreamSource(worker);
-    const resolveWith = vi.fn();
-    const raced = source.doneOr(never()).then(resolveWith);
-    worker.emit('message', ['some-other-message', {}]);
-    worker.emit('message', 'not-even-an-array');
-    await Promise.resolve();
-    expect(resolveWith).not.toHaveBeenCalled();
-    source.cancel(); // settle the outstanding race so the test ends cleanly.
-    await raced;
+    await expect(
+      promiseOrAbort(never(), source.signal),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[AbortError: This operation was aborted]`,
+    );
   });
 });

--- a/packages/zero-cache/src/services/replicator/replication-resumption-child.ts
+++ b/packages/zero-cache/src/services/replicator/replication-resumption-child.ts
@@ -103,7 +103,7 @@ export class IPCDownstreamSource implements Source<SerializedDownstream> {
       case 'replication-resumption:source-error':
         this.#error = new Error(msg[1].message);
         this.#queue.enqueueRejection(this.#error);
-        this.#abortController.abort();
+        this.#abortController.abort(this.#error);
         break;
       case 'replication-resumption:source-end':
         this.#queue.enqueue({type: 'end'});
@@ -123,22 +123,8 @@ export class IPCDownstreamSource implements Source<SerializedDownstream> {
     this.#abortController.abort();
   }
 
-  async doneOr<R>(other: Promise<R>) {
-    const result = resolver();
-    const {signal} = this.#abortController;
-    const handler = () =>
-      this.#error ? result.reject(this.#error) : result.resolve();
-    if (signal.aborted) {
-      handler();
-    } else {
-      signal.addEventListener('abort', handler);
-    }
-
-    try {
-      return await Promise.race([other, result.promise]);
-    } finally {
-      signal.removeEventListener('abort', handler);
-    }
+  get signal() {
+    return this.#abortController.signal;
   }
 
   [Symbol.asyncIterator](): AsyncIterator<SerializedDownstream> {

--- a/packages/zero-cache/src/services/replicator/replication-throughput.bench.pg.ts
+++ b/packages/zero-cache/src/services/replicator/replication-throughput.bench.pg.ts
@@ -83,7 +83,7 @@ function parseStringifiedSource(
 ): Source<SerializedDownstream> {
   return {
     cancel: err => source.cancel(err),
-    doneOr: other => source.doneOr(other),
+    signal: source.signal,
     async *[Symbol.asyncIterator]() {
       for await (const json of source) {
         yield {data: BigIntJSON.parse(json) as Downstream, json};

--- a/packages/zero-cache/src/types/streams.ts
+++ b/packages/zero-cache/src/types/streams.ts
@@ -40,16 +40,11 @@ export type Source<T> = AsyncIterable<T> & {
   cancel: (err?: Error) => void;
 
   /**
-   * Resolves the result of the specified `other` Promise, or a
-   * resolved/rejected Promise when the Source is terminated or
-   * rejects.
-   *
-   * This is similar to using `Promise.race([other, sourceDone])`, but
-   * in a memory safe way, as repeatedly calling `Promise.race([ ... ])` with
-   * a long-lived Promise results in leaking memory via a growing list of
-   * `then()` callbacks (https://github.com/nodejs/node/issues/17469).
+   * An AbortSignal that can be used to listen for termination or
+   * race a short-lived promise against the termination of the iterable
+   * (via `promiseOrAbort()`)
    */
-  doneOr<R>(other: Promise<R>): Promise<void | R>;
+  readonly signal: AbortSignal;
 
   /**
    * The presence of a `pipeline` iterable allows the usual "consumed-on-iterate" semantics

--- a/packages/zero-cache/src/types/subscription.test.ts
+++ b/packages/zero-cache/src/types/subscription.test.ts
@@ -1,6 +1,7 @@
 import {resolver} from '@rocicorp/resolver';
 import {describe, expect, test, vi} from 'vitest';
 import {assert} from '../../../shared/src/asserts.ts';
+import {promiseOrAbort} from '../../../shared/src/promise-race.ts';
 import {sleep} from '../../../shared/src/sleep.ts';
 import {type Result, Subscription} from './subscription.ts';
 
@@ -630,12 +631,12 @@ describe('types/subscription', () => {
     expect(subWithCoalesceAndPipeline.pipeline).not.toBeUndefined();
   });
 
-  describe('doneOr', () => {
+  describe('signal', () => {
     test('other resolves first, subscription remains active', async () => {
       const sub = Subscription.create<number>();
       const other = resolver<string>();
 
-      const raced = sub.doneOr(other.promise);
+      const raced = promiseOrAbort(other.promise, sub.signal);
       other.resolve('foo');
 
       expect(await raced).toBe('foo');
@@ -646,7 +647,7 @@ describe('types/subscription', () => {
       const sub = Subscription.create<number>();
       const other = resolver<string>();
 
-      const raced = sub.doneOr(other.promise);
+      const raced = promiseOrAbort(other.promise, sub.signal);
       other.reject(new Error('other-boom'));
 
       await expect(raced).rejects.toThrow('other-boom');
@@ -657,17 +658,17 @@ describe('types/subscription', () => {
       const sub = Subscription.create<number>();
       const never = new Promise<string>(() => {});
 
-      const raced = sub.doneOr(never);
+      const raced = promiseOrAbort(never, sub.signal);
       sub.cancel();
 
-      expect(await raced).toBeUndefined();
+      await expect(raced).rejects.toThrow('canceled');
     });
 
     test('fail wins over a never-settling other, rejecting with the error', async () => {
       const sub = Subscription.create<number>();
       const never = new Promise<string>(() => {});
 
-      const raced = sub.doneOr(never);
+      const raced = promiseOrAbort(never, sub.signal);
       sub.fail(new Error('sub-boom'));
 
       await expect(raced).rejects.toThrow('sub-boom');
@@ -677,10 +678,10 @@ describe('types/subscription', () => {
       const sub = Subscription.create<number>();
       const never = new Promise<string>(() => {});
 
-      const raced = sub.doneOr(never);
+      const raced = promiseOrAbort(never, sub.signal);
       sub.end(); // no queued messages => immediate cancel
 
-      expect(await raced).toBeUndefined();
+      await expect(raced).rejects.toThrow('canceled');
     });
 
     test('already-canceled subscription resolves immediately', async () => {
@@ -688,7 +689,9 @@ describe('types/subscription', () => {
       sub.cancel();
 
       const never = new Promise<string>(() => {});
-      expect(await sub.doneOr(never)).toBeUndefined();
+      await expect(promiseOrAbort(never, sub.signal)).rejects.toThrow(
+        'canceled',
+      );
     });
 
     test('already-failed subscription rejects immediately', async () => {
@@ -696,7 +699,9 @@ describe('types/subscription', () => {
       sub.fail(new Error('already-boom'));
 
       const never = new Promise<string>(() => {});
-      await expect(sub.doneOr(never)).rejects.toThrow('already-boom');
+      await expect(promiseOrAbort(never, sub.signal)).rejects.toThrow(
+        'already-boom',
+      );
     });
 
     test('repeated races do not accumulate abort listeners', async () => {
@@ -708,15 +713,15 @@ describe('types/subscription', () => {
       // promise, see https://github.com/nodejs/node/issues/17469).
       for (let i = 0; i < 100; i++) {
         const other = resolver<number>();
-        const raced = sub.doneOr(other.promise);
+        const raced = promiseOrAbort(other.promise, sub.signal);
         other.resolve(i);
         expect(await raced).toBe(i);
       }
 
       // The subscription still terminates cleanly afterwards.
-      const raced = sub.doneOr(new Promise<number>(() => {}));
+      const raced = promiseOrAbort(new Promise<number>(() => {}), sub.signal);
       sub.cancel();
-      expect(await raced).toBeUndefined();
+      await expect(raced).rejects.toThrow('canceled');
     });
   });
 });

--- a/packages/zero-cache/src/types/subscription.ts
+++ b/packages/zero-cache/src/types/subscription.ts
@@ -188,6 +188,11 @@ export class Subscription<T, M = T> implements Source<T>, Sink<M> {
     return this.#consuming.size;
   }
 
+  /** Satisfies the Source interface. */
+  get signal() {
+    return this.#abortController.signal;
+  }
+
   /**
    * Cancels the subscription after any queued messages are consumed. This is
    * meant for the producer-side code.
@@ -226,41 +231,6 @@ export class Subscription<T, M = T> implements Source<T>, Sink<M> {
   /** Fails the subscription, cleans up, and throws from any iteration. */
   fail(err: Error) {
     this.#terminate(err);
-  }
-
-  /**
-   * Resolves the result of the specified `other` Promise, or a
-   * resolved/rejected Promise when the Subscription {@link end}s,
-   * is {@link cancel}ed, or {@link fail}s.
-   *
-   * This is similar to using `Promise.race([other, subscriptionDone])`, but
-   * in a memory safe way, as repeatedly calling `Promise.race([ ... ])` with
-   * a long-lived Promise results in leaking memory via a growing list of
-   * `then()` callbacks (https://github.com/nodejs/node/issues/17469).
-   */
-  async doneOr<R>(other: Promise<R>): Promise<void | R> {
-    const result = resolver();
-    const handler = () => {
-      if (this.#sentinel instanceof Error) {
-        result.reject(this.#sentinel);
-      } else {
-        result.resolve();
-      }
-    };
-    const {signal} = this.#abortController;
-    if (signal.aborted) {
-      // The subscription is already terminated. `addEventListener('abort')`
-      // would never fire on an already-aborted signal, so settle eagerly.
-      handler();
-    } else {
-      signal.addEventListener('abort', handler);
-    }
-
-    try {
-      return await Promise.race([other, result.promise]);
-    } finally {
-      signal.removeEventListener('abort', handler);
-    }
   }
 
   #terminate(sentinel: 'canceled' | Error) {

--- a/packages/zql-integration-tests/src/chinook/chinook-zero-cache-fuzzer.pg.test.ts
+++ b/packages/zql-integration-tests/src/chinook/chinook-zero-cache-fuzzer.pg.test.ts
@@ -253,7 +253,7 @@ function parseStringifiedSource(
 ): Source<SerializedDownstream> {
   return {
     cancel: err => source.cancel(err),
-    doneOr: other => source.doneOr(other),
+    signal: source.signal,
     async *[Symbol.asyncIterator]() {
       for await (const json of source) {
         yield {data: BigIntJSON.parse(json) as Downstream, json};


### PR DESCRIPTION
Generalizes the logic for racing a short-lived, in-loop promise against a longer lived termination signal (previous `Source.doneOr()`) to the `promiseOrAbort()` utility function that can accept any number of termination signals.

Adjust the change-streamer's in-loop flow control signals to detect termination signals from both the upstream Changes source, as well as the change-streamer's internal RunningState.

Context:
* https://rocicorp.slack.com/archives/C0ATEPDS694/p1787617588732219?thread_ts=1787546057.483619&cid=C0ATEPDS694