### PR TITLE
chore(rmv2): warn on CL config set where it cannot be ued

### DIFF
--- a/packages/zero-cache/src/config/normalize.test.ts
+++ b/packages/zero-cache/src/config/normalize.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, test} from 'vitest';
-import {assertNormalized} from './normalize.ts';
+import {assertNormalized, runsChangeStreamer} from './normalize.ts';
 import type {ZeroConfig} from './zero-config.ts';
 
 function configWith(litestream: Partial<ZeroConfig['litestream']>): ZeroConfig {
@@ -209,4 +209,48 @@ describe('config/normalize SQLite change log', () => {
 
     expect(() => assertNormalized(config)).not.toThrow();
   });
+});
+
+describe('config/normalize change-streamer role', () => {
+  function configFor(
+    changeStreamer: Partial<ZeroConfig['changeStreamer']>,
+  ): ZeroConfig {
+    const config = configWith({});
+    Object.assign(config.changeStreamer, {mode: 'dedicated'}, changeStreamer);
+    return config;
+  }
+
+  test('a task that runs its own change-streamer', () => {
+    expect(runsChangeStreamer(configFor({}))).toBe(true);
+  });
+
+  test('a task pointed at another change-streamer does not run one', () => {
+    expect(
+      runsChangeStreamer(configFor({uri: 'ws://replication-manager:4849/'})),
+    ).toBe(false);
+    expect(runsChangeStreamer(configFor({mode: 'discover'}))).toBe(false);
+  });
+
+  // A multi-node deployment configures every task from one environment, so the
+  // change log's options reach the view-syncers too. They are unread there,
+  // and the change-log invariant in `main.ts` warns rather than refusing to
+  // start, so nothing here may reject the configuration either.
+  test.each(['write', 'compare', 'serve'] as const)(
+    'a fleet-wide mode=%s is accepted by both roles',
+    mode => {
+      for (const uri of [undefined, 'ws://replication-manager:4849/']) {
+        const serving = mode === 'serve';
+        expect(() =>
+          assertNormalized(
+            configFor({
+              uri,
+              sqliteChangeLogMode: mode,
+              sqliteChangeLogReadPercent: serving ? 100 : 0,
+              sqliteChangeLogColdReadPercent: serving ? 25 : 0,
+            }),
+          ),
+        ).not.toThrow();
+      }
+    },
+  );
 });

--- a/packages/zero-cache/src/config/normalize.ts
+++ b/packages/zero-cache/src/config/normalize.ts
@@ -37,6 +37,15 @@ function isRunningInECS(): boolean {
 
 const DEFAULT_ECS_KEEPALIVE_TIMEOUT_MS = 20_000;
 
+/**
+ * Whether this process tree runs the change-streamer, as opposed to connecting
+ * to one that another task runs.
+ */
+export function runsChangeStreamer(config: ZeroConfig): boolean {
+  const {mode, uri} = config.changeStreamer;
+  return mode === 'dedicated' && uri === undefined;
+}
+
 export function assertNormalized(
   config: ZeroConfig,
 ): asserts config is NormalizedZeroConfig {

--- a/packages/zero-cache/src/server/main.ts
+++ b/packages/zero-cache/src/server/main.ts
@@ -1,8 +1,8 @@
 import path from 'node:path';
 import {consoleLogSink, LogContext} from '@rocicorp/logger';
 import {resolver} from '@rocicorp/resolver';
-import {assert} from '../../../shared/src/asserts.ts';
 import {must} from '../../../shared/src/must.ts';
+import {runsChangeStreamer} from '../config/normalize.ts';
 import {getNormalizedZeroConfig} from '../config/zero-config.ts';
 import {registerSQLiteCorruptionDiagnosticTarget} from '../db/sqlite-corruption.ts';
 import {initEventSink} from '../observability/events.ts';
@@ -101,19 +101,24 @@ export default async function runWorker(
     return processes.addWorker(worker, type, name);
   }
 
-  const {
-    taskID,
-    changeStreamer: {mode: changeStreamerMode, uri: changeStreamerURI},
-    litestream,
-  } = config;
-  const runChangeStreamer =
-    changeStreamerMode === 'dedicated' && changeStreamerURI === undefined;
+  const {taskID, litestream} = config;
+  const runChangeStreamer = runsChangeStreamer(config);
   const sqliteChangeLogEnabled =
     config.changeStreamer.sqliteChangeLogMode !== 'off';
-  assert(
-    !sqliteChangeLogEnabled || runChangeStreamer,
-    'SQLite change-log writing requires this process tree to run the change-streamer, which is where the writer lives',
-  );
+  if (sqliteChangeLogEnabled && !runChangeStreamer) {
+    // A multi-node deployment configures every task from one environment, so
+    // the change log's options reach the view-syncers too. The log lives in
+    // the change-streamer, and a task that connects to one simply never writes
+    // a log. Warning rather than refusing to start is what makes the
+    // fleet-wide environment -- often the only knob an operator has -- able to
+    // express the rollout at all.
+    lc.warn?.(
+      `ignoring --change-streamer-sqlite-change-log-mode=` +
+        `${config.changeStreamer.sqliteChangeLogMode}: this task connects to ` +
+        `a change-streamer rather than running one, and the SQLite change log ` +
+        `lives in the change-streamer`,
+    );
+  }
 
   let changeStreamer: Worker | undefined;
 


### PR DESCRIPTION
We would fatal if the SQLite Change Log config was provided to a process that could not use it. This means we couldn't flip this on in prod because we apply the same env to all processes. ViewSyncers would not start 🫠