### PR TITLE
perf(zero-client): batch btree scan child node reads

### DIFF
--- a/packages/replicache/src/btree/node.test.ts
+++ b/packages/replicache/src/btree/node.test.ts
@@ -315,7 +315,7 @@ describe('btree node', () => {
         const r = new BTreeRead(dagRead, formatVersion);
         expect(await r.get('a')).toBeUndefined();
         expect(await r.has('b')).toBe(false);
-        expect(await asyncIterToArray(r.scan(''))).toEqual([]);
+        expect(await asyncIterToArray(r.scan('', false))).toEqual([]);
       });
     });
 
@@ -337,7 +337,7 @@ describe('btree node', () => {
         );
         expect(await w.get('a')).toBeUndefined();
         expect(await w.has('b')).toBe(false);
-        expect(await asyncIterToArray(w.scan(''))).toEqual([]);
+        expect(await asyncIterToArray(w.scan('', false))).toEqual([]);
 
         const h = await w.flush();
         expect(h).toBe(fakeHash('1'));
@@ -1271,7 +1271,7 @@ describe('btree node', () => {
 
         await doRead(rootHash, dagStore, formatVersion, async r => {
           const res: Entry<FrozenJSONValue>[] = [];
-          const scanResult = r.scan(fromKey);
+          const scanResult = r.scan(fromKey, false);
           for await (const e of scanResult) {
             res.push(e);
           }

--- a/packages/replicache/src/btree/read.test.ts
+++ b/packages/replicache/src/btree/read.test.ts
@@ -1,9 +1,15 @@
-import {expect, test} from 'vitest';
+import {LogContext} from '@rocicorp/logger';
+import {expect, test, vi} from 'vitest';
+import {getSizeOfValue} from '../../../shared/src/size-of-value.ts';
+import type {Chunk} from '../dag/chunk.ts';
 import {TestStore} from '../dag/test-store.ts';
+import {Read as DBRead} from '../db/read.ts';
 import * as FormatVersion from '../format-version-enum.ts';
 import type {Hash} from '../hash.ts';
-import {withWrite} from '../with-transactions.ts';
+import {ReadTransactionImpl} from '../transactions.ts';
+import {withRead, withWrite} from '../with-transactions.ts';
 import type {DataNodeImpl, Entry, InternalNodeImpl} from './node.ts';
+import {BTreeRead} from './read.ts';
 import {BTreeWrite} from './write.ts';
 
 const formatVersion = FormatVersion.Latest;
@@ -181,5 +187,54 @@ test('prefetch is opt-in', async () => {
     expect((await prefetchScan.next()).done).toBe(false);
     expect(map.poisonReads).toBeGreaterThan(0);
     await prefetchScan.return?.();
+  });
+});
+
+test('limit 1 scan reads only the root-to-leaf path', async () => {
+  const dagStore = new TestStore();
+  const value = 'x'.repeat(256);
+  const entries = Array.from({length: 20_000}, (_, i) => [
+    String(i).padStart(8, '0'),
+    value,
+  ]) as [string, string][];
+
+  const rootHash = await withWrite(dagStore, async dagWrite => {
+    const map = new BTreeWrite(dagWrite, formatVersion);
+    await map.putMany(entries);
+    const hash = await map.flush();
+    await dagWrite.setHead('scan-test', hash);
+    return hash;
+  });
+
+  const rootLevel = await withRead(dagStore, async dagRead => {
+    const map = new BTreeRead(dagRead, formatVersion, rootHash);
+    return (await map.getNode(rootHash)).level;
+  });
+  expect(rootLevel).toBeGreaterThan(1);
+
+  await withRead(dagStore, async dagRead => {
+    const chunksRead: Chunk[] = [];
+    const mustGetChunk = dagRead.mustGetChunk.bind(dagRead);
+    vi.spyOn(dagRead, 'mustGetChunk').mockImplementation(async hash => {
+      const chunk = await mustGetChunk(hash);
+      chunksRead.push(chunk);
+      return chunk;
+    });
+
+    const map = new BTreeRead(dagRead, formatVersion, rootHash);
+    const dbRead = new DBRead(dagRead, map, new Map());
+    const tx = new ReadTransactionImpl('client-id', dbRead, new LogContext());
+
+    expect(await tx.scan({limit: 1}).entries().toArray()).toEqual([entries[0]]);
+
+    // A cold scan needs one chunk for each level, including the root and leaf.
+    // Reading more means the B-tree eagerly loaded siblings that the limit
+    // prevented the public scan from visiting.
+    const bytesRead = chunksRead.reduce(
+      (sum, chunk) => sum + getSizeOfValue(chunk.data),
+      0,
+    );
+    expect(bytesRead).toBeLessThanOrEqual((rootLevel + 1) * 16 * 1024);
+    expect(chunksRead).toHaveLength(rootLevel + 1);
   });
 });

--- a/packages/replicache/src/btree/read.test.ts
+++ b/packages/replicache/src/btree/read.test.ts
@@ -63,57 +63,6 @@ test('scan over a multi-level btree yields all entries in order', async () => {
   });
 });
 
-test('prefetch preserves scan output across many tree shapes and fromKeys', async () => {
-  // Deterministic MINSTD PRNG so the shapes are reproducible (no Date/random).
-  let seed = 1;
-  const rand = () => {
-    seed = (seed * 48271) % 0x7fffffff;
-    return seed / 0x7fffffff;
-  };
-
-  const shapes = [
-    {count: 1, min: 2, max: 3},
-    {count: 7, min: 2, max: 3},
-    {count: 64, min: 2, max: 4},
-    {count: 200, min: 2, max: 3},
-    {count: 500, min: 3, max: 6},
-  ];
-
-  for (const {count, min, max} of shapes) {
-    const keySet = new Set<string>();
-    while (keySet.size < count) {
-      keySet.add(String(Math.floor(rand() * count * 10)).padStart(6, '0'));
-    }
-    const keys = [...keySet];
-    const sorted = keys.toSorted();
-
-    const dagStore = new TestStore();
-    await withWrite(dagStore, async dagWrite => {
-      const map = makeTree(dagWrite, min, max);
-      for (const k of keys) {
-        await map.put(k, k);
-      }
-      await map.flush();
-
-      // '' + before-first + after-last + every key + a key wedged between
-      // each key and its successor. Covers the binarySearch index boundaries
-      // that decide slice(i) in the prefetch.
-      const fromKeys = [
-        '',
-        '000000',
-        '999999',
-        ...sorted,
-        ...sorted.map(k => `${k}5`),
-      ];
-      for (const fromKey of fromKeys) {
-        expect(await drainKeys(map.scan(fromKey))).toEqual(
-          sorted.filter(k => k >= fromKey),
-        );
-      }
-    });
-  }
-});
-
 // Overrides getNode so a single chunk read can be made to fail, letting us
 // probe the boundaries of the prefetch added to scanForHash.
 class PoisonBTree extends BTreeWrite {

--- a/packages/replicache/src/btree/read.test.ts
+++ b/packages/replicache/src/btree/read.test.ts
@@ -52,14 +52,14 @@ test('scan over a multi-level btree yields all entries in order', async () => {
 
     const sorted = keys.toSorted();
 
-    expect(await drainKeys(map.scan(''))).toEqual(sorted);
-    expect(await drainKeys(map.scan('0100'))).toEqual(
+    expect(await drainKeys(map.scan('', {prefetch: true}))).toEqual(sorted);
+    expect(await drainKeys(map.scan('0100', {prefetch: true}))).toEqual(
       sorted.filter(k => k >= '0100'),
     );
-    expect(await drainKeys(map.scan('01005'))).toEqual(
+    expect(await drainKeys(map.scan('01005', {prefetch: true}))).toEqual(
       sorted.filter(k => k >= '01005'),
     );
-    expect(await drainKeys(map.scan('9999'))).toEqual([]);
+    expect(await drainKeys(map.scan('9999', {prefetch: true}))).toEqual([]);
   });
 });
 
@@ -67,9 +67,11 @@ test('scan over a multi-level btree yields all entries in order', async () => {
 // probe the boundaries of the prefetch added to scanForHash.
 class PoisonBTree extends BTreeWrite {
   poisonHash: Hash | undefined = undefined;
+  poisonReads = 0;
 
   override getNode(hash: Hash): Promise<DataNodeImpl | InternalNodeImpl> {
     if (this.poisonHash !== undefined && hash === this.poisonHash) {
+      this.poisonReads++;
       return Promise.reject(new Error('poisoned chunk'));
     }
     return super.getNode(hash);
@@ -101,7 +103,9 @@ test('prefetch error on a node the scan reaches is not masked by the catch', asy
     // Child 0 is reached first when scanning from the start. The prefetch
     // swallows its own read error, but the serial recursion must still throw.
     map.poisonHash = (root.entries[0] as Entry<Hash>)[1];
-    await expect(drainKeys(map.scan(''))).rejects.toThrow('poisoned chunk');
+    await expect(drainKeys(map.scan('', {prefetch: true}))).rejects.toThrow(
+      'poisoned chunk',
+    );
   });
 });
 
@@ -137,8 +141,45 @@ test('prefetch respects fromKey and does not read children before the search ind
     expect(fromKey > firstChildMaxKey).toBe(true);
 
     const sorted = keys.toSorted();
-    expect(await drainKeys(map.scan(fromKey))).toEqual(
+    expect(await drainKeys(map.scan(fromKey, {prefetch: true}))).toEqual(
       sorted.filter(k => k >= fromKey),
     );
+  });
+});
+
+test('prefetch is opt-in', async () => {
+  const dagStore = new TestStore();
+  const keys = Array.from({length: 200}, (_, i) => String(i).padStart(4, '0'));
+
+  await withWrite(dagStore, async dagWrite => {
+    const map = new PoisonBTree(
+      dagWrite,
+      formatVersion,
+      undefined,
+      2,
+      3,
+      () => 1,
+      0,
+    );
+    for (const k of keys) {
+      await map.put(k, k);
+    }
+    await map.flush();
+
+    const root = await map.getNode(map.rootHash);
+    expect(root.level).toBeGreaterThan(0);
+    expect(root.entries.length).toBeGreaterThan(1);
+
+    map.poisonHash = (root.entries.at(-1) as Entry<Hash>)[1];
+
+    const lazyScan = map.scan('');
+    expect((await lazyScan.next()).done).toBe(false);
+    expect(map.poisonReads).toBe(0);
+    await lazyScan.return?.();
+
+    const prefetchScan = map.scan('', {prefetch: true});
+    expect((await prefetchScan.next()).done).toBe(false);
+    expect(map.poisonReads).toBeGreaterThan(0);
+    await prefetchScan.return?.();
   });
 });

--- a/packages/replicache/src/btree/read.test.ts
+++ b/packages/replicache/src/btree/read.test.ts
@@ -1,0 +1,195 @@
+import {expect, test} from 'vitest';
+import {TestStore} from '../dag/test-store.ts';
+import * as FormatVersion from '../format-version-enum.ts';
+import type {Hash} from '../hash.ts';
+import {withWrite} from '../with-transactions.ts';
+import type {DataNodeImpl, Entry, InternalNodeImpl} from './node.ts';
+import {BTreeWrite} from './write.ts';
+
+const formatVersion = FormatVersion.Latest;
+
+// Small min/max sizes force a deep, multi-level tree so the internal-node
+// branch of scanForHash (the one that prefetches children) is exercised.
+function makeTree(
+  dagWrite: ConstructorParameters<typeof BTreeWrite>[0],
+  min = 2,
+  max = 3,
+) {
+  return new BTreeWrite(
+    dagWrite,
+    formatVersion,
+    undefined,
+    min,
+    max,
+    () => 1,
+    0,
+  );
+}
+
+async function drainKeys(
+  iter: AsyncIterable<Entry<unknown>>,
+): Promise<string[]> {
+  const out: string[] = [];
+  for await (const entry of iter) {
+    out.push(entry[0]);
+  }
+  return out;
+}
+
+test('scan over a multi-level btree yields all entries in order', async () => {
+  const dagStore = new TestStore();
+  const keys = Array.from({length: 200}, (_, i) => String(i).padStart(4, '0'));
+
+  await withWrite(dagStore, async dagWrite => {
+    const map = makeTree(dagWrite);
+    for (const k of keys) {
+      await map.put(k, k);
+    }
+    await map.flush();
+
+    const rootNode = await map.getNode(map.rootHash);
+    expect(rootNode.level).toBeGreaterThan(0);
+
+    const sorted = keys.toSorted();
+
+    expect(await drainKeys(map.scan(''))).toEqual(sorted);
+    expect(await drainKeys(map.scan('0100'))).toEqual(
+      sorted.filter(k => k >= '0100'),
+    );
+    expect(await drainKeys(map.scan('01005'))).toEqual(
+      sorted.filter(k => k >= '01005'),
+    );
+    expect(await drainKeys(map.scan('9999'))).toEqual([]);
+  });
+});
+
+test('prefetch preserves scan output across many tree shapes and fromKeys', async () => {
+  // Deterministic MINSTD PRNG so the shapes are reproducible (no Date/random).
+  let seed = 1;
+  const rand = () => {
+    seed = (seed * 48271) % 0x7fffffff;
+    return seed / 0x7fffffff;
+  };
+
+  const shapes = [
+    {count: 1, min: 2, max: 3},
+    {count: 7, min: 2, max: 3},
+    {count: 64, min: 2, max: 4},
+    {count: 200, min: 2, max: 3},
+    {count: 500, min: 3, max: 6},
+  ];
+
+  for (const {count, min, max} of shapes) {
+    const keySet = new Set<string>();
+    while (keySet.size < count) {
+      keySet.add(String(Math.floor(rand() * count * 10)).padStart(6, '0'));
+    }
+    const keys = [...keySet];
+    const sorted = keys.toSorted();
+
+    const dagStore = new TestStore();
+    await withWrite(dagStore, async dagWrite => {
+      const map = makeTree(dagWrite, min, max);
+      for (const k of keys) {
+        await map.put(k, k);
+      }
+      await map.flush();
+
+      // '' + before-first + after-last + every key + a key wedged between
+      // each key and its successor. Covers the binarySearch index boundaries
+      // that decide slice(i) in the prefetch.
+      const fromKeys = [
+        '',
+        '000000',
+        '999999',
+        ...sorted,
+        ...sorted.map(k => `${k}5`),
+      ];
+      for (const fromKey of fromKeys) {
+        expect(await drainKeys(map.scan(fromKey))).toEqual(
+          sorted.filter(k => k >= fromKey),
+        );
+      }
+    });
+  }
+});
+
+// Overrides getNode so a single chunk read can be made to fail, letting us
+// probe the boundaries of the prefetch added to scanForHash.
+class PoisonBTree extends BTreeWrite {
+  poisonHash: Hash | undefined = undefined;
+
+  override getNode(hash: Hash): Promise<DataNodeImpl | InternalNodeImpl> {
+    if (this.poisonHash !== undefined && hash === this.poisonHash) {
+      return Promise.reject(new Error('poisoned chunk'));
+    }
+    return super.getNode(hash);
+  }
+}
+
+test('prefetch error on a node the scan reaches is not masked by the catch', async () => {
+  const dagStore = new TestStore();
+  const keys = Array.from({length: 200}, (_, i) => String(i).padStart(4, '0'));
+
+  await withWrite(dagStore, async dagWrite => {
+    const map = new PoisonBTree(
+      dagWrite,
+      formatVersion,
+      undefined,
+      2,
+      3,
+      () => 1,
+      0,
+    );
+    for (const k of keys) {
+      await map.put(k, k);
+    }
+    await map.flush();
+
+    const root = await map.getNode(map.rootHash);
+    expect(root.level).toBeGreaterThan(0);
+
+    // Child 0 is reached first when scanning from the start. The prefetch
+    // swallows its own read error, but the serial recursion must still throw.
+    map.poisonHash = (root.entries[0] as Entry<Hash>)[1];
+    await expect(drainKeys(map.scan(''))).rejects.toThrow('poisoned chunk');
+  });
+});
+
+test('prefetch respects fromKey and does not read children before the search index', async () => {
+  const dagStore = new TestStore();
+  const keys = Array.from({length: 200}, (_, i) => String(i).padStart(4, '0'));
+
+  await withWrite(dagStore, async dagWrite => {
+    const map = new PoisonBTree(
+      dagWrite,
+      formatVersion,
+      undefined,
+      2,
+      3,
+      () => 1,
+      0,
+    );
+    for (const k of keys) {
+      await map.put(k, k);
+    }
+    await map.flush();
+
+    const root = await map.getNode(map.rootHash);
+    expect(root.level).toBeGreaterThan(0);
+
+    // Poison child 0 and scan starting past child 0's max key. slice(i) must
+    // exclude it, so neither the prefetch nor the serial walk may read it.
+    const firstChild = root.entries[0] as Entry<Hash>;
+    const firstChildMaxKey = firstChild[0];
+    map.poisonHash = firstChild[1];
+
+    const fromKey = keys.at(-1) ?? '';
+    expect(fromKey > firstChildMaxKey).toBe(true);
+
+    const sorted = keys.toSorted();
+    expect(await drainKeys(map.scan(fromKey))).toEqual(
+      sorted.filter(k => k >= fromKey),
+    );
+  });
+});

--- a/packages/replicache/src/btree/read.test.ts
+++ b/packages/replicache/src/btree/read.test.ts
@@ -58,14 +58,14 @@ test('scan over a multi-level btree yields all entries in order', async () => {
 
     const sorted = keys.toSorted();
 
-    expect(await drainKeys(map.scan('', {prefetch: true}))).toEqual(sorted);
-    expect(await drainKeys(map.scan('0100', {prefetch: true}))).toEqual(
+    expect(await drainKeys(map.scan('', true))).toEqual(sorted);
+    expect(await drainKeys(map.scan('0100', true))).toEqual(
       sorted.filter(k => k >= '0100'),
     );
-    expect(await drainKeys(map.scan('01005', {prefetch: true}))).toEqual(
+    expect(await drainKeys(map.scan('01005', true))).toEqual(
       sorted.filter(k => k >= '01005'),
     );
-    expect(await drainKeys(map.scan('9999', {prefetch: true}))).toEqual([]);
+    expect(await drainKeys(map.scan('9999', true))).toEqual([]);
   });
 });
 
@@ -109,7 +109,7 @@ test('prefetch error on a node the scan reaches is not masked by the catch', asy
     // Child 0 is reached first when scanning from the start. The prefetch
     // swallows its own read error, but the serial recursion must still throw.
     map.poisonHash = (root.entries[0] as Entry<Hash>)[1];
-    await expect(drainKeys(map.scan('', {prefetch: true}))).rejects.toThrow(
+    await expect(drainKeys(map.scan('', true))).rejects.toThrow(
       'poisoned chunk',
     );
   });
@@ -147,7 +147,7 @@ test('prefetch respects fromKey and does not read children before the search ind
     expect(fromKey > firstChildMaxKey).toBe(true);
 
     const sorted = keys.toSorted();
-    expect(await drainKeys(map.scan(fromKey, {prefetch: true}))).toEqual(
+    expect(await drainKeys(map.scan(fromKey, true))).toEqual(
       sorted.filter(k => k >= fromKey),
     );
   });
@@ -178,12 +178,12 @@ test('prefetch is opt-in', async () => {
 
     map.poisonHash = (root.entries.at(-1) as Entry<Hash>)[1];
 
-    const lazyScan = map.scan('');
+    const lazyScan = map.scan('', false);
     expect((await lazyScan.next()).done).toBe(false);
     expect(map.poisonReads).toBe(0);
     await lazyScan.return?.();
 
-    const prefetchScan = map.scan('', {prefetch: true});
+    const prefetchScan = map.scan('', true);
     expect((await prefetchScan.next()).done).toBe(false);
     expect(map.poisonReads).toBeGreaterThan(0);
     await prefetchScan.return?.();

--- a/packages/replicache/src/btree/read.ts
+++ b/packages/replicache/src/btree/read.ts
@@ -30,6 +30,16 @@ import {
 
 type FormatVersion = Enum<typeof FormatVersion>;
 
+export type BTreeScanOptions = {
+  /**
+   * Read sibling nodes in parallel before traversing them so stores can batch
+   * the reads. This can read nodes that the caller never visits. Enable it
+   * only when the caller expects to consume most of the scan or explicitly
+   * accepts that extra work.
+   */
+  prefetch?: boolean | undefined;
+};
+
 /**
  * The size of the header of a node. (If we had compile time
  * constants we would have used that).
@@ -117,7 +127,10 @@ export class BTreeRead implements AsyncIterable<Entry<FrozenJSONValue>> {
   // determining from an entry.key alone whether it is a regular key or an
   // encoded IndexKey in an index map. Without encoding regular map keys the
   // caller has to deal with encoding and decoding the keys for the index map.
-  scan(fromKey: string): AsyncIterableIterator<Entry<FrozenJSONValue>> {
+  scan(
+    fromKey: string,
+    {prefetch = false}: BTreeScanOptions = {},
+  ): AsyncIterableIterator<Entry<FrozenJSONValue>> {
     return scanForHash(
       this.rootHash,
       () => this.rootHash,
@@ -138,6 +151,7 @@ export class BTreeRead implements AsyncIterable<Entry<FrozenJSONValue>> {
           this.getEntrySize,
         );
       },
+      prefetch,
     );
   }
 
@@ -295,6 +309,7 @@ async function* scanForHash(
   hash: Hash,
   fromKey: string,
   readNode: ReadNode,
+  prefetch: boolean,
 ): AsyncIterableIterator<Entry<FrozenJSONValue>> {
   if (hash === emptyHash) {
     return;
@@ -307,26 +322,30 @@ async function* scanForHash(
     i = binarySearch(fromKey, entries);
   }
   if (data[NODE_LEVEL] > 0) {
-    // Preload children in parallel so the backing store can coalesce their
-    // reads. This can waste work when a caller stops before visiting every
-    // child. Zero currently accepts that tradeoff: startup scans the entire
-    // cached entity range into IVM memory before becoming ready (see
-    // `ZeroRep.init` in packages/zero-client/src/client/zero-rep.ts), and client
-    // views are intended to remain small. If views commonly outgrow the 100 MB
-    // `LAZY_STORE_SOURCE_CHUNK_CACHE_SIZE_LIMIT`, reconsider the preload
-    // window, although batching may still be a useful general optimization.
-    // Longer term, the Replicache/IVM boundary should also be revisited because
-    // materializing entities into `MemorySource` duplicates B-tree storage.
-    //
-    // The serial scan below preserves traversal order and remains the
-    // authoritative read, so speculative failures are ignored here.
-    await Promise.all(
-      entries
-        .slice(i)
-        .map(entry =>
-          readNode((entry as Entry<Hash>)[1]).catch(() => undefined),
-        ),
-    );
+    if (prefetch) {
+      // Preload children in parallel so the backing store can coalesce their
+      // reads. This can waste work when a caller stops before visiting every
+      // child, so callers must explicitly opt in when they expect to consume
+      // the full scan. Zero currently accepts that tradeoff: startup scans the
+      // entire cached entity range into IVM memory before becoming ready (see
+      // `ZeroRep.init` in packages/zero-client/src/client/zero-rep.ts), and
+      // client views are intended to remain small. If views commonly outgrow
+      // the 100 MB `LAZY_STORE_SOURCE_CHUNK_CACHE_SIZE_LIMIT`, reconsider the
+      // preload window, although batching may still be a useful general
+      // optimization. Longer term, the Replicache/IVM boundary should also be
+      // revisited because materializing entities into `MemorySource`
+      // duplicates B-tree storage.
+      //
+      // The serial scan below preserves traversal order and remains the
+      // authoritative read, so speculative failures are ignored here.
+      await Promise.all(
+        entries
+          .slice(i)
+          .map(entry =>
+            readNode((entry as Entry<Hash>)[1]).catch(() => undefined),
+          ),
+      );
+    }
     for (; i < entries.length; i++) {
       yield* scanForHash(
         expectedRootHash,
@@ -334,6 +353,7 @@ async function* scanForHash(
         (entries[i] as Entry<Hash>)[1],
         fromKey,
         readNode,
+        prefetch,
       );
       fromKey = '';
     }
@@ -348,6 +368,7 @@ async function* scanForHash(
           rootHash,
           entries[i][0],
           readNode,
+          prefetch,
         );
         return;
       }

--- a/packages/replicache/src/btree/read.ts
+++ b/packages/replicache/src/btree/read.ts
@@ -134,19 +134,8 @@ export class BTreeRead implements AsyncIterable<Entry<FrozenJSONValue>> {
       this.rootHash,
       fromKey,
       async hash => {
-        const cached = await this.getNode(hash);
-        if (cached) {
-          return [
-            cached.level,
-            cached.isMutable ? cached.entries.slice() : cached.entries,
-          ];
-        }
-        const chunk = await this._dagRead.mustGetChunk(hash);
-        return parseBTreeNode(
-          chunk.data,
-          this._formatVersion,
-          this.getEntrySize,
-        );
+        const {level, isMutable, entries} = await this.getNode(hash);
+        return [level, isMutable ? entries.slice() : entries];
       },
       prefetch,
     );

--- a/packages/replicache/src/btree/read.ts
+++ b/packages/replicache/src/btree/read.ts
@@ -30,16 +30,6 @@ import {
 
 type FormatVersion = Enum<typeof FormatVersion>;
 
-export type BTreeScanOptions = {
-  /**
-   * Read sibling nodes in parallel before traversing them so stores can batch
-   * the reads. This can read nodes that the caller never visits. Enable it
-   * only when the caller expects to consume most of the scan or explicitly
-   * accepts that extra work.
-   */
-  prefetch?: boolean | undefined;
-};
-
 /**
  * The size of the header of a node. (If we had compile time
  * constants we would have used that).
@@ -123,13 +113,20 @@ export class BTreeRead implements AsyncIterable<Entry<FrozenJSONValue>> {
     return node.entries.length === 0;
   }
 
-  // We don't do any encoding of the key in the map, so we have no way of
-  // determining from an entry.key alone whether it is a regular key or an
-  // encoded IndexKey in an index map. Without encoding regular map keys the
-  // caller has to deal with encoding and decoding the keys for the index map.
+  /**
+   * We don't do any encoding of the key in the map, so we have no way of
+   * determining from an entry.key alone whether it is a regular key or an
+   * encoded IndexKey in an index map. Without encoding regular map keys the
+   * caller has to deal with encoding and decoding the keys for the index map.
+   *
+   * @param prefetch Read sibling nodes in parallel before traversing them so
+   * stores can batch the reads. This can read nodes that the caller never
+   * visits. Enable it only when the caller expects to consume most of the scan
+   * or explicitly accepts that extra work.
+   */
   scan(
     fromKey: string,
-    {prefetch = false}: BTreeScanOptions = {},
+    prefetch: boolean,
   ): AsyncIterableIterator<Entry<FrozenJSONValue>> {
     return scanForHash(
       this.rootHash,

--- a/packages/replicache/src/btree/read.ts
+++ b/packages/replicache/src/btree/read.ts
@@ -307,6 +307,13 @@ async function* scanForHash(
     i = binarySearch(fromKey, entries);
   }
   if (data[NODE_LEVEL] > 0) {
+    await Promise.all(
+      entries
+        .slice(i)
+        .map(entry =>
+          readNode((entry as Entry<Hash>)[1]).catch(() => undefined),
+        ),
+    );
     for (; i < entries.length; i++) {
       yield* scanForHash(
         expectedRootHash,

--- a/packages/replicache/src/btree/read.ts
+++ b/packages/replicache/src/btree/read.ts
@@ -307,6 +307,19 @@ async function* scanForHash(
     i = binarySearch(fromKey, entries);
   }
   if (data[NODE_LEVEL] > 0) {
+    // Preload children in parallel so the backing store can coalesce their
+    // reads. This can waste work when a caller stops before visiting every
+    // child. Zero currently accepts that tradeoff: startup scans the entire
+    // cached entity range into IVM memory before becoming ready (see
+    // `ZeroRep.init` in packages/zero-client/src/client/zero-rep.ts), and client
+    // views are intended to remain small. If views commonly outgrow the 100 MB
+    // `LAZY_STORE_SOURCE_CHUNK_CACHE_SIZE_LIMIT`, reconsider the preload
+    // window, although batching may still be a useful general optimization.
+    // Longer term, the Replicache/IVM boundary should also be revisited because
+    // materializing entities into `MemorySource` duplicates B-tree storage.
+    //
+    // The serial scan below preserves traversal order and remains the
+    // authoritative read, so speculative failures are ignored here.
     await Promise.all(
       entries
         .slice(i)

--- a/packages/replicache/src/db/scan.test.ts
+++ b/packages/replicache/src/db/scan.test.ts
@@ -24,7 +24,7 @@ test('scan', async () => {
       await map.flush();
 
       const actual = [];
-      for await (const entry of map.scan(fromKey)) {
+      for await (const entry of map.scan(fromKey, false)) {
         actual.push(entry[0]);
       }
       const expected2 = expected;
@@ -77,7 +77,7 @@ test('scan index startKey', async () => {
         indexName: 'dummy',
       });
       const actual = [];
-      for await (const entry of map.scan(fromKey)) {
+      for await (const entry of map.scan(fromKey, false)) {
         const [secondaryKey, primaryKey] = decodeIndexKey(entry[0]);
         actual.push({primaryKey, secondaryKey, val: entry[1]});
       }

--- a/packages/replicache/src/db/write.ts
+++ b/packages/replicache/src/db/write.ts
@@ -424,7 +424,7 @@ export async function createIndexBTree(
   formatVersion: FormatVersion,
 ): Promise<BTreeWrite> {
   const indexMap = new BTreeWrite(dagWrite, formatVersion);
-  for await (const entry of valueMap.scan(prefix)) {
+  for await (const entry of valueMap.scan(prefix, false)) {
     const key = entry[0];
     if (!key.startsWith(prefix)) {
       break;

--- a/packages/replicache/src/sync/pull.test.ts
+++ b/packages/replicache/src/sync/pull.test.ts
@@ -469,7 +469,7 @@ test('begin try pull DD31', async () => {
         let got = false;
 
         const indexMap = read.getMapForIndex('2');
-        for await (const _ of indexMap.scan('')) {
+        for await (const _ of indexMap.scan('', false)) {
           got = true;
           break;
         }
@@ -559,7 +559,7 @@ test('begin try pull DD31', async () => {
               formatVersion,
             );
             const indexMap = read.getMapForIndex('2');
-            for await (const _ of indexMap.scan('')) {
+            for await (const _ of indexMap.scan('', false)) {
               expect(false).toBe(true);
             }
           });

--- a/packages/replicache/src/sync/push.test.ts
+++ b/packages/replicache/src/sync/push.test.ts
@@ -248,7 +248,7 @@ test.for(cases)('try push [DD31] $name', async c => {
 
       const indexMap = read.getMapForIndex('2');
 
-      for await (const _ of indexMap.scan('')) {
+      for await (const _ of indexMap.scan('', false)) {
         got = true;
         break;
       }

--- a/packages/replicache/src/transactions.ts
+++ b/packages/replicache/src/transactions.ts
@@ -368,9 +368,10 @@ function getScanIterator<Options extends ScanOptions, V>(
     >;
   }
 
-  return dbRead.map.scan(fromKeyForNonIndexScan(options)) as AsyncIterable<
-    EntryForOptions<Options, V>
-  >;
+  return dbRead.map.scan(
+    fromKeyForNonIndexScan(options),
+    false,
+  ) as AsyncIterable<EntryForOptions<Options, V>>;
 }
 
 export function fromKeyForNonIndexScan(
@@ -410,7 +411,10 @@ async function* getScanIteratorForIndexMap(
     throw new Error(`Unknown index name: ${options.indexName}`);
   }
   const map = dbRead.getMapForIndex(options.indexName);
-  for await (const entry of map.scan(fromKeyForIndexScanInternal(options))) {
+  for await (const entry of map.scan(
+    fromKeyForIndexScanInternal(options),
+    false,
+  )) {
     yield [decodeIndexKey(entry[0]), entry[1]];
   }
 }

--- a/packages/zero-client/src/client/inspector/lazy-inspector.ts
+++ b/packages/zero-client/src/client/inspector/lazy-inspector.ts
@@ -321,7 +321,7 @@ export function clientMap(
   return withDagRead(delegate, async dagRead => {
     const tree = await getBTree(dagRead, clientID);
     const map = new Map<string, ReadonlyJSONValue>();
-    for await (const [key, value] of tree.scan('')) {
+    for await (const [key, value] of tree.scan('', true)) {
       map.set(key, value);
     }
     return map;
@@ -337,7 +337,7 @@ export function clientRows(
     const prefix = ENTITIES_KEY_PREFIX + tableName + '/';
     const tree = await getBTree(dagRead, clientID);
     const rows: Row[] = [];
-    for await (const [key, value] of tree.scan(prefix)) {
+    for await (const [key, value] of tree.scan(prefix, true)) {
       if (!key.startsWith(prefix)) {
         break;
       }

--- a/packages/zero-client/src/client/inspector/lazy-inspector.ts
+++ b/packages/zero-client/src/client/inspector/lazy-inspector.ts
@@ -337,7 +337,7 @@ export function clientRows(
     const prefix = ENTITIES_KEY_PREFIX + tableName + '/';
     const tree = await getBTree(dagRead, clientID);
     const rows: Row[] = [];
-    for await (const [key, value] of tree.scan(prefix, true)) {
+    for await (const [key, value] of tree.scan(prefix, false)) {
       if (!key.startsWith(prefix)) {
         break;
       }

--- a/packages/zero-client/src/client/ivm-branch.ts
+++ b/packages/zero-client/src/client/ivm-branch.ts
@@ -160,9 +160,7 @@ export async function initFromStore(
   const diffs: InternalDiffOperation[] = [];
   await withRead(store, async dagRead => {
     const read = await readFromHash(hash, dagRead, FormatVersion.Latest);
-    for await (const entry of read.map.scan(ENTITIES_KEY_PREFIX, {
-      prefetch: true,
-    })) {
+    for await (const entry of read.map.scan(ENTITIES_KEY_PREFIX, true)) {
       if (!entry[0].startsWith(ENTITIES_KEY_PREFIX)) {
         break;
       }

--- a/packages/zero-client/src/client/ivm-branch.ts
+++ b/packages/zero-client/src/client/ivm-branch.ts
@@ -160,7 +160,9 @@ export async function initFromStore(
   const diffs: InternalDiffOperation[] = [];
   await withRead(store, async dagRead => {
     const read = await readFromHash(hash, dagRead, FormatVersion.Latest);
-    for await (const entry of read.map.scan(ENTITIES_KEY_PREFIX)) {
+    for await (const entry of read.map.scan(ENTITIES_KEY_PREFIX, {
+      prefetch: true,
+    })) {
       if (!entry[0].startsWith(ENTITIES_KEY_PREFIX)) {
         break;
       }

--- a/packages/zero-client/src/client/zero-rep.ts
+++ b/packages/zero-client/src/client/zero-rep.ts
@@ -64,9 +64,7 @@ export class ZeroRep implements ZeroOption {
     const diffs: InternalDiffOperation[] = [];
     await withRead(store, async dagRead => {
       const read = await readFromHash(hash, dagRead, FormatVersion.Latest);
-      for await (const entry of read.map.scan(ENTITIES_KEY_PREFIX, {
-        prefetch: true,
-      })) {
+      for await (const entry of read.map.scan(ENTITIES_KEY_PREFIX, true)) {
         if (!entry[0].startsWith(ENTITIES_KEY_PREFIX)) {
           break;
         }

--- a/packages/zero-client/src/client/zero-rep.ts
+++ b/packages/zero-client/src/client/zero-rep.ts
@@ -64,7 +64,9 @@ export class ZeroRep implements ZeroOption {
     const diffs: InternalDiffOperation[] = [];
     await withRead(store, async dagRead => {
       const read = await readFromHash(hash, dagRead, FormatVersion.Latest);
-      for await (const entry of read.map.scan(ENTITIES_KEY_PREFIX)) {
+      for await (const entry of read.map.scan(ENTITIES_KEY_PREFIX, {
+        prefetch: true,
+      })) {
         if (!entry[0].startsWith(ENTITIES_KEY_PREFIX)) {
           break;
         }


### PR DESCRIPTION
Based on #6291 by @santhoshJus

For Replicache's BTree scan we can prefetch the whole tree under some cirumstances. This is generally not a good idea but the way that Zero uses scan it is fine because we end up keeping the whole tree in memory anyway.

scanForHash descends an internal node's children serially, awaiting each child before reading the next. Since the kv store coalesces concurrent gets into a single batched read (e.g. one SQL statement), the serial awaits defeat that batching and issue one store read per child.

Prefetch the children about to be visited in parallel before the serial DFS, so their reads coalesce. Traversal order and results are unchanged (the recursion below reads from the now-warm node cache). Prefetch errors are swallowed so a speculative read can't throw for — or ahead of — a node the serial DFS hasn't reached. The serial recursion stays the authoritative reader and still throws, at the same point in the traversal, for any node the scan actually visits.

On a React Native op-sqlite client this cut cold-connect DAG hydration from 558 store reads to 18 (avg batch 2.0 -> 61) and native SQL time from ~4,500ms to ~1,200ms. The win is store-dependent: large on stores where each get is a discrete round-trip, ~neutral where concurrent gets already share a transaction (e.g. IDBStore).