### PR TITLE
chaos test RMv2 change log

### DIFF
--- a/apps/zbugs/.gitignore
+++ b/apps/zbugs/.gitignore
@@ -30,3 +30,7 @@ zero-schema.json
 *.db-shm
 *.db-wal
 *.db-wal2
+
+# rmv2 local soak (scripts/build-litestream.sh, scripts/rmv2-soak.ts)
+.litestream/
+.soak/

--- a/apps/zbugs/docker/docker-compose.minio.yml
+++ b/apps/zbugs/docker/docker-compose.minio.yml
@@ -1,0 +1,51 @@
+# S3-compatible backup target for the RMv2 local soak
+# (scripts/rmv2-soak.ts). Overlays the postgres compose file in this
+# directory, so bring both up under one project:
+#
+#   docker compose -f docker-compose.yml -f docker-compose.minio.yml up -d
+#
+# The bucket is created by a one-shot `mc` container that exits when it is
+# done, which is why it has no healthcheck of its own: the orchestrator waits
+# for it to exit 0.
+services:
+  minio:
+    image: minio/minio:RELEASE.2025-04-22T22-12-26Z
+    command: server /data --address ":9000" --console-address ":9001"
+    restart: unless-stopped
+    ports:
+      - 9000:9000
+      - 9001:9001
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+      # A soak restarts minio (chaos action C9); do not spend startup time
+      # scanning the object store for drives that cannot have changed.
+      MINIO_SCANNER_SPEED: fastest
+    healthcheck:
+      test: ['CMD-SHELL', 'mc ready local || exit 1']
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 5s
+    volumes:
+      - zbugs_minio_data:/data
+
+  minio_init:
+    image: minio/mc:RELEASE.2025-04-16T18-13-26Z
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        set -e
+        mc alias set soak http://minio:9000 minioadmin minioadmin
+        mc mb --ignore-existing soak/zero-replica
+        mc anonymous set none soak/zero-replica
+        echo "bucket soak/zero-replica ready"
+    restart: 'no'
+
+volumes:
+  zbugs_minio_data:
+    driver: local

--- a/apps/zbugs/package.json
+++ b/apps/zbugs/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "check-types": "tsc -p tsconfig.json && tsc -p tsconfig.node.json",
+    "check-types": "tsc -p tsconfig.json && tsc -p tsconfig.node.json && tsc -p tsconfig.scripts.json",
     "check-types:client:watch": "tsc -p tsconfig.json --watch",
     "check-types:server:watch": "tsc -p tsconfig.node.json --watch",
     "db-up": "cd docker && docker compose up",
@@ -14,13 +14,15 @@
     "db-migrate": "drizzle-kit migrate",
     "db-seed": "node scripts/seed.ts",
     "change-log-traffic": "node scripts/change-log-traffic.ts",
+    "build-litestream": "bash scripts/build-litestream.sh",
+    "rmv2-soak": "node scripts/rmv2-soak.ts",
     "generate-templates": "node scripts/generate-templates.ts",
     "generate-synthetic": "NODE_OPTIONS='--max-old-space-size=8192' node scripts/generate-synthetic.ts",
     "db-seed-synthetic": "ZERO_SEED_DATA_DIR=db/seed-data/synthetic node scripts/seed.ts",
     "clean": "cd docker && docker compose down && docker volume rm docker_zbugs_pgdata_sync && docker volume rm docker_zbugs_pgdata_upstream && rm -rf /tmp/zbugs-sync-replica.db*",
     "format": "oxfmt --config ../../.oxfmtrc.json .",
     "check-format": "oxfmt --config ../../.oxfmtrc.json --check .",
-    "lint": "oxlint --quiet --config ../../oxlint.config.ts src/",
+    "lint": "oxlint --quiet --config ../../oxlint.config.ts src/ scripts/",
     "preview": "vite preview",
     "zero": "node --trace-warnings ../../packages/zero-cache/src/server/runner/main.ts",
     "zero-cache-compare": "ZERO_LOG_LEVEL=debug ZERO_CHANGE_STREAMER_SQLITE_CHANGE_LOG_MODE=compare ZERO_CHANGE_STREAMER_SQLITE_CHANGE_LOG_COMPARE_PERCENT=100 ZERO_CHANGE_STREAMER_SQLITE_CHANGE_LOG_RETENTION_MS=60000 node ../../packages/zero-cache/src/server/runner/main.ts",
@@ -79,6 +81,7 @@
     "zod": "^4.1.11"
   },
   "devDependencies": {
+    "@rocicorp/logger": "^6.1.0",
     "@tailwindcss/forms": "^0.5.0",
     "@types/hast": "^3.0.4",
     "@types/js-cookie": "^3.0.6",

--- a/apps/zbugs/scripts/build-litestream.sh
+++ b/apps/zbugs/scripts/build-litestream.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+#
+# Builds the three native binaries the RMv2 local soak needs into
+# apps/zbugs/.litestream/bin (gitignored):
+#
+#   litestream-v3  rocicorp/litestream @ zero@v0.0.10        (packages/zero/Dockerfile)
+#   litestream-v5  rocicorp/litestream @ v0.5.17-zero.1      (packages/zero/Dockerfile)
+#   vfs-query      mono/go, `make build` (cgo, -tags vfs)    (go/Makefile)
+#
+# The v3 binary is needed even though v5 does all of the backing up: the
+# change-streamer's PurgeLocker branch is gated on `litestream.executable` --
+# the v3 path -- so omitting it silently skips the purge lock and diverges
+# from production.
+#
+# Idempotent: each artifact carries a stamp file naming the ref it was built
+# from, and is rebuilt only when the stamp is missing or stale. Pass --force
+# to rebuild regardless.
+set -euo pipefail
+
+LITESTREAM_V3_REF="zero@v0.0.10"
+LITESTREAM_V5_VERSION="0.5.17-zero.1"
+LITESTREAM_REPO="https://github.com/rocicorp/litestream.git"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="$(cd "${APP_DIR}/../.." && pwd)"
+OUT_DIR="${APP_DIR}/.litestream"
+BIN_DIR="${OUT_DIR}/bin"
+SRC_DIR="${OUT_DIR}/src"
+
+FORCE=0
+if [[ "${1:-}" == "--force" ]]; then
+  FORCE=1
+fi
+
+log() { printf '[build-litestream] %s\n' "$*" >&2; }
+
+if ! command -v go >/dev/null 2>&1; then
+  log "go is required but was not found on PATH."
+  log "Install it with:  brew install go"
+  exit 1
+fi
+log "using $(go version)"
+
+if ! command -v git >/dev/null 2>&1; then
+  log "git is required but was not found on PATH."
+  exit 1
+fi
+
+mkdir -p "${BIN_DIR}" "${SRC_DIR}"
+
+# $1 stamp file, $2 expected contents -> 0 when a rebuild is needed
+needs_build() {
+  local stamp="$1" want="$2" bin="$3"
+  if [[ "${FORCE}" == "1" ]]; then return 0; fi
+  if [[ ! -x "${bin}" ]]; then return 0; fi
+  if [[ ! -f "${stamp}" ]]; then return 0; fi
+  [[ "$(cat "${stamp}")" != "${want}" ]]
+}
+
+# $1 ref, $2 checkout dir
+clone_litestream() {
+  local ref="$1" dir="$2"
+  if [[ -d "${dir}/.git" ]]; then
+    log "reusing checkout ${dir}"
+    return
+  fi
+  rm -rf "${dir}"
+  log "cloning ${LITESTREAM_REPO} @ ${ref}"
+  git clone --depth 1 --branch "${ref}" "${LITESTREAM_REPO}" "${dir}"
+}
+
+build_litestream_v3() {
+  local bin="${BIN_DIR}/litestream-v3"
+  local stamp="${BIN_DIR}/litestream-v3.stamp"
+  if ! needs_build "${stamp}" "${LITESTREAM_V3_REF}" "${bin}"; then
+    log "litestream-v3 up to date (${LITESTREAM_V3_REF})"
+    return
+  fi
+  local dir="${SRC_DIR}/litestream-v3"
+  clone_litestream "${LITESTREAM_V3_REF}" "${dir}"
+  log "building litestream-v3"
+  # The Dockerfile pins GOTOOLCHAIN=local so the vendored `toolchain`
+  # directive cannot pull an older stdlib; do the same here. `-extldflags
+  # -static` is deliberately omitted: darwin has no static libSystem, and cgo
+  # stays on because litestream calls mattn/go-sqlite3's file-control API.
+  (
+    cd "${dir}"
+    GOTOOLCHAIN=local CGO_ENABLED=1 go build \
+      -ldflags "-s -w -X 'main.Version=0.3.13+z0.0.10'" \
+      -tags osusergo,netgo,sqlite_omit_load_extension \
+      -o "${bin}" ./cmd/litestream
+  )
+  printf '%s' "${LITESTREAM_V3_REF}" >"${stamp}"
+  log "built ${bin}"
+}
+
+build_litestream_v5() {
+  local bin="${BIN_DIR}/litestream-v5"
+  local stamp="${BIN_DIR}/litestream-v5.stamp"
+  if ! needs_build "${stamp}" "${LITESTREAM_V5_VERSION}" "${bin}"; then
+    log "litestream-v5 up to date (${LITESTREAM_V5_VERSION})"
+    return
+  fi
+  local dir="${SRC_DIR}/litestream-v5"
+  clone_litestream "v${LITESTREAM_V5_VERSION}" "${dir}"
+  log "building litestream-v5"
+  (
+    cd "${dir}"
+    CGO_ENABLED=0 go build \
+      -ldflags "-s -w -X 'main.Version=${LITESTREAM_V5_VERSION}'" \
+      -tags osusergo,netgo,sqlite_omit_load_extension \
+      -o "${bin}" ./cmd/litestream
+  )
+  printf '%s' "${LITESTREAM_V5_VERSION}" >"${stamp}"
+  log "built ${bin}"
+}
+
+build_vfs_query() {
+  local bin="${BIN_DIR}/vfs-query"
+  local stamp="${BIN_DIR}/vfs-query.stamp"
+  # vfs-query is built from the working tree rather than a pinned ref, so the
+  # stamp is the tree's own revision of go/.
+  local want
+  want="$(git -C "${REPO_ROOT}" rev-parse HEAD:go 2>/dev/null || echo unknown)"
+  if ! needs_build "${stamp}" "${want}" "${bin}"; then
+    log "vfs-query up to date (go/ @ ${want})"
+    return
+  fi
+  log "building vfs-query from ${REPO_ROOT}/go"
+  # cgo (mattn/go-sqlite3) -- this must be built with the host toolchain, so
+  # it cannot be lifted out of the Docker build.
+  make -C "${REPO_ROOT}/go" build
+  cp "${REPO_ROOT}/go/dist/vfs-query" "${bin}"
+  printf '%s' "${want}" >"${stamp}"
+  log "built ${bin}"
+}
+
+build_litestream_v3
+build_litestream_v5
+build_vfs_query
+
+log "binaries in ${BIN_DIR}:"
+ls -l "${BIN_DIR}" >&2

--- a/apps/zbugs/scripts/change-log-traffic.ts
+++ b/apps/zbugs/scripts/change-log-traffic.ts
@@ -3,6 +3,8 @@
 import '../../../packages/shared/src/dotenv.ts';
 
 import {performance} from 'node:perf_hooks';
+import {argv} from 'node:process';
+import {fileURLToPath} from 'node:url';
 import {parseArgs} from 'node:util';
 import postgres from 'postgres';
 
@@ -11,13 +13,61 @@ type Fixture = {
   projectID: string;
 };
 
-type StageResult = {
+/**
+ * The per-transaction write shapes.
+ *
+ * `churn` is the original driver: insert, update and delete the same row in
+ * one transaction, which commits three row mutations and leaves nothing
+ * behind. Useful stress, but a *history* that leaves no residue makes the
+ * replica-vs-upstream oracle vacuous -- the end state after a million
+ * transactions is byte-identical to the state before them, so the comparison
+ * would pass with the change log disconnected entirely.
+ *
+ * The other three shapes make the final state a function of the whole
+ * history. A monotonically growing table also keeps the burst phase honest:
+ * the backup grows, so restores in later phases move real bytes.
+ */
+export type TrafficShape = 'insert' | 'update' | 'delete' | 'churn';
+
+/** The residue mix, as a 10-slot wheel indexed by transaction sequence. */
+const RESIDUE_WHEEL: readonly TrafficShape[] = [
+  'insert',
+  'update',
+  'insert',
+  'update',
+  'insert',
+  'update',
+  'insert',
+  'update',
+  'delete',
+  'churn',
+];
+
+const PURE_CHURN_WHEEL: readonly TrafficShape[] = ['churn'];
+
+export type TrafficStage = {
+  /** Transactions per second. Zero means an idle stage: no writes at all. */
+  readonly rate: number;
+  readonly durationSeconds: number;
+  readonly concurrency?: number | undefined;
+  readonly payloadBytes?: number | undefined;
+  /** Defaults to true. False restores the original pure-churn driver. */
+  readonly residue?: boolean | undefined;
+  /** Reported verbatim; the orchestrator uses it to name a soak phase. */
+  readonly label?: string | undefined;
+};
+
+export type StageResult = {
+  label: string | undefined;
   targetTransactionsPerSecond: number;
   durationSeconds: number;
   transactions: number;
   mutations: number;
   elapsedSeconds: number;
   actualTransactionsPerSecond: number;
+  shapes: Record<TrafficShape, number>;
+  /** Rows this run has inserted and kept, after the stage. */
+  residueRows: number;
   latencyMs: {
     p50: number;
     p95: number;
@@ -33,16 +83,23 @@ Usage:
   node scripts/change-log-traffic.ts [options]
 
 Options:
-  --rates <list>               Comma-separated transaction rates. Default: 5,25,100
+  --rates <list>               Comma-separated transaction rates. A rate of 0
+                               is an idle stage. Default: 5,25,100
   --duration-seconds <number>  Duration of each stage. Default: 5
   --repeat <number>            Number of times to run all stages. Default: 1
   --concurrency <number>       Maximum in-flight transactions. Default: 32
   --payload-bytes <number>     Approximate issue description size. Default: 256
+  --no-residue                 Use the original pure-churn shape, which leaves
+                               no rows behind. Off by default: the residue mix
+                               is what makes a replica-vs-upstream comparison
+                               depend on the history.
+  --keep                       Do not delete this run's residue rows on exit.
   --json                       Print results as JSON
   --help                       Show this help
 
-Each transaction inserts, updates, and deletes one issue. It commits three row
-mutations and leaves no traffic rows in the database.
+By default each transaction is one of: insert-and-keep (40%), update a kept
+row (40%), delete a kept row (10%), or the original insert+update+delete churn
+(10%).
 `;
 
 function numberInRange(
@@ -78,123 +135,316 @@ function percentile(sorted: readonly number[], percentage: number): number {
   return sorted[Math.ceil(sorted.length * percentage) - 1];
 }
 
-function sleep(ms: number): Promise<void> {
+export function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-async function driveTransaction(
-  sql: ReturnType<typeof postgres>,
-  fixture: Fixture,
-  runID: string,
-  sequence: number,
-  payloadBytes: number,
-): Promise<void> {
-  const id = `change-log-traffic-${runID}-${sequence}`;
-  const prefix = `${runID}:${sequence}:`;
-  const description =
-    prefix + 'x'.repeat(Math.max(0, payloadBytes - prefix.length));
+export type TrafficDriverOptions = {
+  readonly concurrency?: number | undefined;
+  readonly runID?: string | undefined;
+};
 
-  await sql.begin(async tx => {
-    await tx`
-      INSERT INTO issue
-        (id, title, open, "projectID", "creatorID", description, visibility)
-      VALUES
-        (${id}, ${`Change-log traffic ${sequence}`}, true,
-         ${fixture.projectID}, ${fixture.creatorID}, ${description}, 'public')`;
-    await tx`
-      UPDATE issue
-         SET title = ${`Updated change-log traffic ${sequence}`}, open = false
-       WHERE id = ${id}`;
-    await tx`DELETE FROM issue WHERE id = ${id}`;
-  });
-}
+/**
+ * Stages of PostgreSQL traffic against the zbugs `issue` table.
+ *
+ * Exported so that the soak orchestrator can interleave chaos actions between
+ * (and during) stages in-process; {@link main} is a thin wrapper over the
+ * same driver.
+ */
+export class TrafficDriver {
+  readonly #sql: ReturnType<typeof postgres>;
+  readonly #fixture: Fixture;
+  readonly #runID: string;
+  readonly #defaultConcurrency: number;
+  /** Rows inserted and kept, i.e. the residue update/delete draw from. */
+  readonly #kept: string[] = [];
+  #sequence = 0;
 
-async function runStage(
-  sql: ReturnType<typeof postgres>,
-  fixture: Fixture,
-  runID: string,
-  firstSequence: number,
-  rate: number,
-  durationSeconds: number,
-  concurrency: number,
-  payloadBytes: number,
-): Promise<StageResult> {
-  const transactionCount = Math.max(1, Math.round(rate * durationSeconds));
-  const active = new Set<Promise<void>>();
-  const latencies: number[] = [];
-  const errors: unknown[] = [];
-  const startedAt = performance.now();
-
-  for (let i = 0; i < transactionCount; i++) {
-    const targetStart = startedAt + (i * 1000) / rate;
-    const delay = targetStart - performance.now();
-    if (delay > 0) {
-      await sleep(delay);
-    }
-    while (active.size >= concurrency) {
-      await Promise.race(active);
-    }
-
-    const transactionStartedAt = performance.now();
-    const transaction = driveTransaction(
-      sql,
-      fixture,
-      runID,
-      firstSequence + i,
-      payloadBytes,
-    ).then(
-      () => {
-        latencies.push(performance.now() - transactionStartedAt);
-      },
-      error => {
-        errors.push(error);
-      },
-    );
-    active.add(transaction);
-    void transaction.finally(() => active.delete(transaction));
+  private constructor(
+    sql: ReturnType<typeof postgres>,
+    fixture: Fixture,
+    runID: string,
+    defaultConcurrency: number,
+  ) {
+    this.#sql = sql;
+    this.#fixture = fixture;
+    this.#runID = runID;
+    this.#defaultConcurrency = defaultConcurrency;
   }
 
-  await Promise.all(active);
-  const elapsedSeconds = (performance.now() - startedAt) / 1000;
-  latencies.sort((a, b) => a - b);
-  const completed = latencies.length;
-
-  // A stage that saw any failure aborts the run rather than reporting a
-  // partial result: a rate that could not be sustained makes the latencies
-  // below meaningless.
-  if (errors.length > 0) {
-    const first = errors[0];
-    throw new Error(
-      `${errors.length} transaction(s) failed. First error: ${
-        first instanceof Error ? first.message : String(first)
-      }`,
-    );
+  static async connect(
+    databaseURL: string,
+    opts: TrafficDriverOptions = {},
+  ): Promise<TrafficDriver> {
+    const concurrency = opts.concurrency ?? 32;
+    const sql = postgres(databaseURL, {
+      max: concurrency + 2,
+      connect_timeout: 10,
+      idle_timeout: 5,
+    });
+    try {
+      const [fixture] = await sql<Fixture[]>`
+        SELECT u.id AS "creatorID", p.id AS "projectID"
+          FROM public."user" u
+          CROSS JOIN public.project p
+         ORDER BY u.id, p.id
+         LIMIT 1`;
+      if (!fixture) {
+        throw new Error(
+          'zbugs needs at least one user and project. Run db-seed first.',
+        );
+      }
+      const runID = opts.runID ?? `${Date.now().toString(36)}-${process.pid}`;
+      return new TrafficDriver(sql, fixture, runID, concurrency);
+    } catch (e) {
+      await sql.end();
+      throw e;
+    }
   }
 
-  return {
-    targetTransactionsPerSecond: rate,
-    durationSeconds,
-    transactions: completed,
-    mutations: completed * 3,
-    elapsedSeconds,
-    actualTransactionsPerSecond: completed / elapsedSeconds,
-    latencyMs: {
-      p50: percentile(latencies, 0.5),
-      p95: percentile(latencies, 0.95),
-      p99: percentile(latencies, 0.99),
-      max: latencies.at(-1) ?? 0,
-    },
-  };
+  get runID(): string {
+    return this.#runID;
+  }
+
+  /** Rows this run has inserted and not deleted. */
+  get residueRows(): number {
+    return this.#kept.length;
+  }
+
+  async runStage(stage: TrafficStage): Promise<StageResult> {
+    const {
+      rate,
+      durationSeconds,
+      concurrency = this.#defaultConcurrency,
+      payloadBytes = 256,
+      residue = true,
+      label,
+    } = stage;
+    const shapes: Record<TrafficShape, number> = {
+      insert: 0,
+      update: 0,
+      delete: 0,
+      churn: 0,
+    };
+
+    // An idle stage. `--rates` cannot express this (its floor is 0.1/s), and
+    // idle is what drains the purger to its floor and pauses the vfs poller,
+    // so it is a first-class stage rather than a very low rate.
+    if (rate <= 0) {
+      const startedAt = performance.now();
+      await sleep(durationSeconds * 1000);
+      return {
+        label,
+        targetTransactionsPerSecond: 0,
+        durationSeconds,
+        transactions: 0,
+        mutations: 0,
+        elapsedSeconds: (performance.now() - startedAt) / 1000,
+        actualTransactionsPerSecond: 0,
+        shapes,
+        residueRows: this.#kept.length,
+        latencyMs: {p50: 0, p95: 0, p99: 0, max: 0},
+      };
+    }
+
+    const wheel = residue ? RESIDUE_WHEEL : PURE_CHURN_WHEEL;
+    const transactionCount = Math.max(1, Math.round(rate * durationSeconds));
+    const active = new Set<Promise<void>>();
+    const latencies: number[] = [];
+    const errors: unknown[] = [];
+    let mutations = 0;
+    const startedAt = performance.now();
+
+    for (let i = 0; i < transactionCount; i++) {
+      const targetStart = startedAt + (i * 1000) / rate;
+      const delay = targetStart - performance.now();
+      if (delay > 0) {
+        await sleep(delay);
+      }
+      while (active.size >= concurrency) {
+        await Promise.race(active);
+      }
+
+      const sequence = this.#sequence++;
+      // Reserve the shape and its target row synchronously, before the
+      // transaction is dispatched: `delete` removes its row from the pool
+      // here so that no concurrent transaction can target it too.
+      const work = this.#reserve(wheel[sequence % wheel.length], sequence);
+      shapes[work.shape]++;
+
+      const transactionStartedAt = performance.now();
+      const transaction = this.#drive(work, payloadBytes).then(
+        () => {
+          latencies.push(performance.now() - transactionStartedAt);
+          mutations += work.mutations;
+          if (work.shape === 'insert') {
+            this.#kept.push(work.id);
+          }
+        },
+        error => {
+          errors.push(error);
+          // A failed delete never happened; put the row back so the final
+          // cleanup still accounts for it.
+          if (work.shape === 'delete') {
+            this.#kept.push(work.id);
+          }
+        },
+      );
+      active.add(transaction);
+      void transaction.finally(() => active.delete(transaction));
+    }
+
+    await Promise.all(active);
+    const elapsedSeconds = (performance.now() - startedAt) / 1000;
+    latencies.sort((a, b) => a - b);
+    const completed = latencies.length;
+
+    // A stage that saw any failure aborts the run rather than reporting a
+    // partial result: a rate that could not be sustained makes the latencies
+    // below meaningless.
+    if (errors.length > 0) {
+      const first = errors[0];
+      throw new Error(
+        `${errors.length} transaction(s) failed. First error: ${
+          first instanceof Error ? first.message : String(first)
+        }`,
+      );
+    }
+
+    return {
+      label,
+      targetTransactionsPerSecond: rate,
+      durationSeconds,
+      transactions: completed,
+      mutations,
+      elapsedSeconds,
+      actualTransactionsPerSecond: completed / elapsedSeconds,
+      shapes,
+      residueRows: this.#kept.length,
+      latencyMs: {
+        p50: percentile(latencies, 0.5),
+        p95: percentile(latencies, 0.95),
+        p99: percentile(latencies, 0.99),
+        max: latencies.at(-1) ?? 0,
+      },
+    };
+  }
+
+  /** Deletes every row this run inserted and kept. */
+  async deleteResidue(): Promise<number> {
+    if (this.#kept.length === 0) {
+      return 0;
+    }
+    const ids = this.#kept.splice(0, this.#kept.length);
+    for (let i = 0; i < ids.length; i += 500) {
+      const batch = ids.slice(i, i + 500);
+      await this.#sql`DELETE FROM issue WHERE id IN ${this.#sql(batch)}`;
+    }
+    return ids.length;
+  }
+
+  close(): Promise<void> {
+    return this.#sql.end();
+  }
+
+  #reserve(
+    requested: TrafficShape,
+    sequence: number,
+  ): {shape: TrafficShape; id: string; mutations: number} {
+    let shape = requested;
+    // The pool is empty at the start of a run, and after a delete-heavy
+    // stretch. Insert instead: it is the shape that refills the pool.
+    if ((shape === 'update' || shape === 'delete') && this.#kept.length === 0) {
+      shape = 'insert';
+    }
+    switch (shape) {
+      case 'update': {
+        const id = this.#kept[sequence % this.#kept.length];
+        return {shape, id, mutations: 1};
+      }
+      case 'delete': {
+        const index = sequence % this.#kept.length;
+        const [id] = this.#kept.splice(index, 1);
+        return {shape, id, mutations: 1};
+      }
+      case 'churn':
+        return {shape, id: this.#id(sequence), mutations: 3};
+      case 'insert':
+        return {shape, id: this.#id(sequence), mutations: 1};
+    }
+  }
+
+  #id(sequence: number): string {
+    return `change-log-traffic-${this.#runID}-${sequence}`;
+  }
+
+  #drive(
+    work: {shape: TrafficShape; id: string},
+    payloadBytes: number,
+  ): Promise<unknown> {
+    const sql = this.#sql;
+    const {id, shape} = work;
+    const prefix = `${this.#runID}:${id}:`;
+    const description =
+      prefix + 'x'.repeat(Math.max(0, payloadBytes - prefix.length));
+
+    switch (shape) {
+      case 'insert':
+        return sql.begin(tx => [
+          tx`
+            INSERT INTO issue
+              (id, title, open, "projectID", "creatorID", description, visibility)
+            VALUES
+              (${id}, ${`Change-log traffic ${id}`}, true,
+               ${this.#fixture.projectID}, ${this.#fixture.creatorID},
+               ${description}, 'public')`,
+        ]);
+      case 'update':
+        return sql.begin(tx => [
+          tx`
+            UPDATE issue
+               SET title = ${`Updated ${id} @ ${this.#sequence}`},
+                   description = ${description},
+                   open = NOT open
+             WHERE id = ${id}`,
+        ]);
+      case 'delete':
+        return sql.begin(tx => [tx`DELETE FROM issue WHERE id = ${id}`]);
+      case 'churn':
+        return sql.begin(async tx => {
+          await tx`
+            INSERT INTO issue
+              (id, title, open, "projectID", "creatorID", description, visibility)
+            VALUES
+              (${id}, ${`Change-log traffic ${id}`}, true,
+               ${this.#fixture.projectID}, ${this.#fixture.creatorID},
+               ${description}, 'public')`;
+          await tx`
+            UPDATE issue
+               SET title = ${`Updated change-log traffic ${id}`}, open = false
+             WHERE id = ${id}`;
+          await tx`DELETE FROM issue WHERE id = ${id}`;
+        });
+    }
+  }
 }
 
 function printStage(result: StageResult): void {
-  const {latencyMs} = result;
+  const {latencyMs, shapes} = result;
+  if (result.targetTransactionsPerSecond === 0) {
+    console.log(
+      `quiet  duration=${result.durationSeconds}s  residue=${result.residueRows}`,
+    );
+    return;
+  }
   console.log(
     [
       `target=${result.targetTransactionsPerSecond} tx/s`,
       `completed=${result.transactions}`,
       `mutations=${result.mutations}`,
       `actual=${result.actualTransactionsPerSecond.toFixed(1)} tx/s`,
+      `shapes=i${shapes.insert}/u${shapes.update}/d${shapes.delete}/c${shapes.churn}`,
+      `residue=${result.residueRows}`,
       `p50=${latencyMs.p50.toFixed(1)}ms`,
       `p95=${latencyMs.p95.toFixed(1)}ms`,
       `p99=${latencyMs.p99.toFixed(1)}ms`,
@@ -211,6 +461,8 @@ async function main(): Promise<void> {
       'repeat': {type: 'string', default: '1'},
       'concurrency': {type: 'string', default: '32'},
       'payload-bytes': {type: 'string', default: '256'},
+      'no-residue': {type: 'boolean', default: false},
+      'keep': {type: 'boolean', default: false},
       'json': {type: 'boolean', default: false},
       'help': {type: 'boolean', default: false},
     },
@@ -222,11 +474,14 @@ async function main(): Promise<void> {
     return;
   }
 
-  const rates = values.rates
-    .split(',')
-    .map((value, index) =>
-      numberInRange(`rates[${index}]`, value.trim(), 0.1, 10_000),
-    );
+  const rates = values.rates.split(',').map((value, index) => {
+    const trimmed = value.trim();
+    // 0 is the idle stage; anything else keeps the original 0.1 floor, below
+    // which the inter-transaction sleep stops being meaningful.
+    return trimmed === '0'
+      ? 0
+      : numberInRange(`rates[${index}]`, trimmed, 0.1, 10_000);
+  });
   const durationSeconds = numberInRange(
     'duration-seconds',
     values['duration-seconds'],
@@ -246,56 +501,47 @@ async function main(): Promise<void> {
     throw new Error('ZERO_UPSTREAM_DB is required');
   }
 
-  const sql = postgres(databaseURL, {
-    max: concurrency + 2,
-    connect_timeout: 10,
-    idle_timeout: 5,
-  });
+  const driver = await TrafficDriver.connect(databaseURL, {concurrency});
   try {
-    const [fixture] = await sql<Fixture[]>`
-      SELECT u.id AS "creatorID", p.id AS "projectID"
-        FROM public."user" u
-        CROSS JOIN public.project p
-       ORDER BY u.id, p.id
-       LIMIT 1`;
-    if (!fixture) {
-      throw new Error(
-        'zbugs needs at least one user and project. Run db-seed first.',
-      );
-    }
-
-    const runID = `${Date.now().toString(36)}-${process.pid}`;
     const results: StageResult[] = [];
-    let sequence = 0;
     for (let repetition = 0; repetition < repeat; repetition++) {
       for (const rate of rates) {
-        const result = await runStage(
-          sql,
-          fixture,
-          runID,
-          sequence,
+        const result = await driver.runStage({
           rate,
           durationSeconds,
           concurrency,
           payloadBytes,
-        );
+          residue: !values['no-residue'],
+        });
         results.push(result);
-        sequence += Math.max(1, Math.round(rate * durationSeconds));
         if (!values.json) {
           printStage(result);
         }
       }
     }
 
+    let deleted = 0;
+    if (!values.keep) {
+      deleted = await driver.deleteResidue();
+    }
+
     if (values.json) {
-      console.log(JSON.stringify({runID, results}, null, 2));
+      console.log(
+        JSON.stringify({runID: driver.runID, results, deleted}, null, 2),
+      );
+    } else if (deleted > 0) {
+      console.log(`deleted ${deleted} residue row(s)`);
     }
   } finally {
-    await sql.end();
+    await driver.close();
   }
 }
 
-main().catch(error => {
-  console.error(error instanceof Error ? error.message : error);
-  process.exitCode = 1;
-});
+// Run the CLI only when this file is the entry point, so that importing
+// {@link TrafficDriver} from the soak orchestrator does not start a run.
+if (argv[1] && fileURLToPath(import.meta.url) === argv[1]) {
+  main().catch(error => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  });
+}

--- a/apps/zbugs/scripts/rmv2-soak.ts
+++ b/apps/zbugs/scripts/rmv2-soak.ts
@@ -1,0 +1,644 @@
+/* oxlint-disable no-console */
+
+import '../../../packages/shared/src/dotenv.ts';
+
+import {existsSync, mkdirSync} from 'node:fs';
+import {createServer} from 'node:net';
+import {join} from 'node:path';
+import {argv} from 'node:process';
+import {parseArgs} from 'node:util';
+import {consoleLogSink, LogContext} from '@rocicorp/logger';
+import {pgClient} from '../../../packages/zero-cache/src/types/pg.ts';
+import {TrafficDriver, type StageResult} from './change-log-traffic.ts';
+import {
+  CHAOS_ACTIONS,
+  runChaosAction,
+  type ChaosContext,
+  type ChaosOutcome,
+} from './rmv2-soak/chaos.ts';
+import {SoakCluster} from './rmv2-soak/cluster.ts';
+import {
+  APP_ROOT,
+  BIN_DIR,
+  makeRunDir,
+  vsPort,
+  type SoakConfig,
+} from './rmv2-soak/config.ts';
+import {resetBackup, run, sleep, startInfra} from './rmv2-soak/infra.ts';
+import {SoakLog} from './rmv2-soak/logs.ts';
+import {runOracle, type OracleResult} from './rmv2-soak/oracle.ts';
+import {OtlpMetricsReceiver, type MetricStore} from './rmv2-soak/otlp.ts';
+import {
+  buildReport,
+  summarize,
+  writeReport,
+  type PhaseRecord,
+} from './rmv2-soak/report.ts';
+import {ResourceSampler} from './rmv2-soak/resources.ts';
+import {mixedPhase, workloadPhases} from './rmv2-soak/workload.ts';
+
+/** Slice L10: the rollback drills, which must run after everything else. */
+const ROLLBACK_DRILLS = new Set(['C10', 'C11', 'C12']);
+
+/**
+ * Everything except C9 (a five-minute minio outage) and the rollback drills,
+ * which leave the change log rolled back to `off`. `--chaos all` adds them.
+ */
+const DEFAULT_CHAOS = 'C1,C2,C3,C4,C5,C6,C7,C8,C13';
+
+const USAGE = `
+A local, reproducible end-to-end exercise of the SQLite change log in serve
+mode against a real litestream v5 backup (minio/S3), with real view-syncer
+restores, disconnects and reconnects.
+
+Usage:
+  node scripts/rmv2-soak.ts [options]
+
+Prerequisites:
+  scripts/build-litestream.sh          builds litestream v3/v5 and vfs-query
+  docker                               postgres and minio come up from
+                                       docker/docker-compose{,.minio}.yml
+
+Options:
+  --view-syncers <n>        Number of view-syncers. Default: 3
+  --mode <mode>             off | write | compare | serve. Default: serve
+  --read-percent <n>        Default: 100
+  --cold-read-percent <n>   Default: 100 (zeroes the warm-up wait; the
+                            residual wait is a reseed window, not a restore
+                            window)
+  --compare-percent <n>     Default: 100
+  --retention-ms <n>        Default: 60000. Must be > 0; it is the purger's
+                            retention floor, not a routing knob.
+  --scale <f>               Multiplies every phase duration. Default: 1
+  --chaos <list>            Comma-separated action ids, or "none", or "all".
+                            Default: C1-C8 and C13. "all" adds C9 (a long
+                            minio outage) and the C10-C12 rollback drills,
+                            which run last and leave the log turned off.
+  --baseline                Also run the mode=off A/B control pass first
+  --backup-interval-seconds <n>  litestream monitor-interval. Default: 2
+  --vfs-poll-ms <n>         Default: 1000
+  --startup-delay-ms <n>    change-streamer startup delay. Default: 1000
+  --snapshot-hours <n>      litestream snapshot interval. Default: 4
+  --seed                    Run db-migrate and db-seed first
+  --keep                    Leave processes and directories in place on exit
+  --run-id <id>             Default: a timestamp
+  --help
+`;
+
+function numOpt(name: string, value: string | undefined, dflt: number): number {
+  if (value === undefined) {
+    return dflt;
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`--${name} must be a number`);
+  }
+  return parsed;
+}
+
+function parseConfig(): SoakConfig {
+  const {values} = parseArgs({
+    options: {
+      'view-syncers': {type: 'string'},
+      'mode': {type: 'string'},
+      'read-percent': {type: 'string'},
+      'cold-read-percent': {type: 'string'},
+      'compare-percent': {type: 'string'},
+      'retention-ms': {type: 'string'},
+      'scale': {type: 'string'},
+      'chaos': {type: 'string'},
+      'baseline': {type: 'boolean', default: false},
+      'backup-interval-seconds': {type: 'string'},
+      'vfs-poll-ms': {type: 'string'},
+      'startup-delay-ms': {type: 'string'},
+      'snapshot-hours': {type: 'string'},
+      'seed': {type: 'boolean', default: false},
+      'keep': {type: 'boolean', default: false},
+      'run-id': {type: 'string'},
+      'help': {type: 'boolean', default: false},
+    },
+    strict: true,
+  });
+
+  if (values.help) {
+    console.log(USAGE.trim());
+    process.exit(0);
+  }
+
+  const mode = (values.mode ?? 'serve') as SoakConfig['changeLog']['mode'];
+  if (!['off', 'write', 'compare', 'serve'].includes(mode)) {
+    throw new Error(`--mode must be off | write | compare | serve`);
+  }
+  const readPercent = numOpt(
+    'read-percent',
+    values['read-percent'],
+    mode === 'serve' ? 100 : 0,
+  );
+  const coldReadPercent = numOpt(
+    'cold-read-percent',
+    values['cold-read-percent'],
+    mode === 'serve' ? 100 : 0,
+  );
+  const retentionMs = numOpt('retention-ms', values['retention-ms'], 60_000);
+  if (retentionMs <= 0) {
+    // `sqlite-change-log-purge-scheduler.ts` asserts retentionMs > 0. It is
+    // the purger's retention floor; zeroing it would be a request to purge
+    // everything, not a request to serve early.
+    throw new Error('--retention-ms must be a positive integer');
+  }
+
+  const runID =
+    values['run-id'] ?? new Date().toISOString().replace(/[:.]/g, '-');
+  const root = join(APP_ROOT, '.soak', runID);
+  const {logsDir} = makeRunDir(root);
+
+  const chaosArg = values.chaos ?? DEFAULT_CHAOS;
+  const chaos =
+    chaosArg === 'none'
+      ? []
+      : chaosArg === 'all'
+        ? CHAOS_ACTIONS.map(a => a.id)
+        : chaosArg.split(',').map(s => s.trim().toUpperCase());
+  for (const id of chaos) {
+    if (!CHAOS_ACTIONS.some(a => a.id === id)) {
+      throw new Error(
+        `unknown chaos action ${id}; known: ${CHAOS_ACTIONS.map(a => a.id).join(', ')}`,
+      );
+    }
+  }
+
+  const upstreamDB = process.env.ZERO_UPSTREAM_DB;
+  if (!upstreamDB) {
+    throw new Error('ZERO_UPSTREAM_DB is required (apps/zbugs/.env sets it)');
+  }
+
+  return {
+    runID,
+    root,
+    logsDir,
+    reportPath: join(root, 'report.json'),
+    upstreamDB,
+    viewSyncers: numOpt('view-syncers', values['view-syncers'], 3),
+    rmPort: 4850,
+    vsBasePort: 4860,
+    otlpPort: 4899,
+    backupURL: 's3://zero-replica/zbugs',
+    s3Endpoint: 'http://127.0.0.1:9000',
+    s3Region: 'us-east-1',
+    accessKeyID: 'minioadmin',
+    secretAccessKey: 'minioadmin',
+    changeLog: {
+      mode,
+      readPercent,
+      coldReadPercent,
+      comparePercent: numOpt(
+        'compare-percent',
+        values['compare-percent'],
+        mode === 'off' || mode === 'write' ? 0 : 100,
+      ),
+      retentionMs,
+    },
+    backupIntervalSeconds: numOpt(
+      'backup-interval-seconds',
+      values['backup-interval-seconds'],
+      2,
+    ),
+    vfsPollIntervalMs: numOpt('vfs-poll-ms', values['vfs-poll-ms'], 1000),
+    startupDelayMs: numOpt(
+      'startup-delay-ms',
+      values['startup-delay-ms'],
+      1000,
+    ),
+    snapshotBackupIntervalHours: numOpt(
+      'snapshot-hours',
+      values['snapshot-hours'],
+      4,
+    ),
+    // Debug on the replication-manager is what makes the SQLite route
+    // visible: `serving <id> from SQLite catchup` is a debug line. The
+    // view-syncers stay at info so the burst phase's log volume does not
+    // perturb the timings it is measuring.
+    rmLogLevel: 'debug',
+    vsLogLevel: 'info',
+    chaos,
+    baseline: values.baseline,
+    scale: numOpt('scale', values.scale, 1),
+    seed: values.seed,
+    keep: values.keep,
+    metricExportIntervalMs: 2_000,
+  };
+}
+
+async function runOrThrow(
+  command: string,
+  args: readonly string[],
+): Promise<void> {
+  const {code, stdout, stderr} = await run(command, args, APP_ROOT);
+  if (code !== 0) {
+    throw new Error(
+      `${command} ${args.join(' ')} exited with ${code}\n${stdout}\n${stderr}`,
+    );
+  }
+}
+
+/**
+ * A port still held by a previous run's orphaned worker is the most confusing
+ * way for a soak to fail: the new replication-manager cannot take the
+ * replica's journal-mode lock and dies with `SQLITE_BUSY` several layers down.
+ * Fail up front, by name.
+ */
+async function assertPortsFree(config: SoakConfig): Promise<void> {
+  const ports = [
+    config.rmPort,
+    config.rmPort + 1,
+    config.rmPort + 2,
+    config.otlpPort,
+    ...Array.from({length: config.viewSyncers}, (_, i) => vsPort(config, i)),
+    ...Array.from(
+      {length: config.viewSyncers},
+      (_, i) => vsPort(config, i) + 2,
+    ),
+  ];
+  const busy: number[] = [];
+  for (const port of ports) {
+    const free = await new Promise<boolean>(resolve => {
+      const probe = createServer();
+      probe.once('error', () => resolve(false));
+      probe.listen(port, '127.0.0.1', () => probe.close(() => resolve(true)));
+    });
+    if (!free) {
+      busy.push(port);
+    }
+  }
+  if (busy.length > 0) {
+    throw new Error(
+      `port(s) ${busy.join(', ')} are in use. A previous soak may have left ` +
+        `workers running; check with ` +
+        `\`ps -Ao pid=,command= | grep zero-cache/src/server\``,
+    );
+  }
+}
+
+function assertPrerequisites(): void {
+  const missing = ['litestream-v3', 'litestream-v5', 'vfs-query'].filter(
+    bin => !existsSync(join(BIN_DIR, bin)),
+  );
+  if (missing.length > 0) {
+    throw new Error(
+      `missing ${missing.join(', ')} in ${BIN_DIR}. Run scripts/build-litestream.sh`,
+    );
+  }
+}
+
+type ThroughputSnapshot = {
+  transactions: number;
+  forwardDurationSeconds: number;
+  messageProcessingSeconds: number;
+  logCommitSeconds: number;
+};
+
+function throughput(metrics: MetricStore): ThroughputSnapshot {
+  return {
+    transactions: metrics.total('replication.transactions'),
+    forwardDurationSeconds: metrics.total('transaction_forward_duration'),
+    messageProcessingSeconds: metrics.total(
+      'sqlite_change_log.message_processing_duration',
+    ),
+    logCommitSeconds: metrics.total('sqlite_change_log.log_commit_duration'),
+  };
+}
+
+function throughputDelta(
+  before: ThroughputSnapshot,
+  after: ThroughputSnapshot,
+): ThroughputSnapshot {
+  return {
+    transactions: after.transactions - before.transactions,
+    forwardDurationSeconds:
+      after.forwardDurationSeconds - before.forwardDurationSeconds,
+    messageProcessingSeconds:
+      after.messageProcessingSeconds - before.messageProcessingSeconds,
+    logCommitSeconds: after.logCommitSeconds - before.logCommitSeconds,
+  };
+}
+
+function stageSummary(stages: readonly StageResult[]): Record<string, number> {
+  const transactions = stages.reduce((a, s) => a + s.transactions, 0);
+  const elapsed = stages.reduce((a, s) => a + s.elapsedSeconds, 0);
+  const writing = stages.filter(s => s.targetTransactionsPerSecond > 0);
+  return {
+    transactions,
+    elapsedSeconds: Number(elapsed.toFixed(1)),
+    actualTransactionsPerSecond: Number(
+      (transactions / Math.max(1, elapsed)).toFixed(2),
+    ),
+    p95LatencyMs: Number(
+      (
+        writing.reduce((a, s) => a + s.latencyMs.p95, 0) /
+        Math.max(1, writing.length)
+      ).toFixed(1),
+    ),
+  };
+}
+
+async function main(): Promise<void> {
+  const config = parseConfig();
+  assertPrerequisites();
+  await assertPortsFree(config);
+  const lc = new LogContext('warn', {}, consoleLogSink);
+  const startedMs = Date.now();
+
+  const say = (message: string) =>
+    console.log(
+      `[soak +${((Date.now() - startedMs) / 1000).toFixed(0)}s] ${message}`,
+    );
+
+  say(`run ${config.runID}`);
+  say(`root ${config.root}`);
+
+  const receiver = new OtlpMetricsReceiver();
+  await receiver.listen(config.otlpPort);
+  const metrics = receiver.store;
+
+  say('bringing up postgres and minio');
+  await startInfra(config);
+
+  if (config.seed) {
+    say('running db-migrate');
+    await runOrThrow('pnpm', ['run', 'db-migrate']);
+    say('running db-seed');
+    await runOrThrow('pnpm', ['run', 'db-seed']);
+  }
+
+  const sql = pgClient(lc, config.upstreamDB, 'rmv2-soak', {max: 8});
+  const [fixture] = await sql<{projectID: string; creatorID: string}[]>`
+    SELECT u.id AS "creatorID", p.id AS "projectID"
+      FROM public."user" u CROSS JOIN public.project p
+     ORDER BY u.id, p.id LIMIT 1`;
+  if (!fixture) {
+    throw new Error(
+      'zbugs needs at least one user and project. Re-run with --seed.',
+    );
+  }
+
+  const phases: PhaseRecord[] = [];
+  const oracle: OracleResult[] = [];
+  const chaosOutcomes: ChaosOutcome[] = [];
+  let baseline: Record<string, unknown> | undefined;
+  let quiesceCount = 0;
+
+  const soakLog = new SoakLog();
+  soakLog.onTripwire(t => {
+    if (t.name !== 'error-log') {
+      say(`TRIPWIRE ${t.name} on ${t.node}: ${t.message}`);
+    }
+  });
+
+  let cluster: SoakCluster | undefined;
+  let traffic: TrafficDriver | undefined;
+  let sampler: ResourceSampler | undefined;
+
+  const shutdown = async () => {
+    sampler?.stop();
+    await cluster?.stopAll('SIGTERM').catch(() => undefined);
+    await traffic?.close().catch(() => undefined);
+    await receiver.close().catch(() => undefined);
+  };
+  const onSignal = () => {
+    say('interrupted; shutting down');
+    void shutdown().finally(() => process.exit(130));
+  };
+  process.on('SIGINT', onSignal);
+  process.on('SIGTERM', onSignal);
+
+  try {
+    // Phase 0 (slice L9): the A/B control for failure class 6. Without it a
+    // replication-path regression is indistinguishable from the workload.
+    if (config.baseline) {
+      say('phase 0: baseline with the change log off');
+      await resetBackup(config);
+      const baselineLogsDir = join(config.logsDir, 'baseline');
+      mkdirSync(baselineLogsDir, {recursive: true});
+      const control = new SoakCluster(
+        {
+          ...config,
+          logsDir: baselineLogsDir,
+          changeLog: {
+            mode: 'off',
+            readPercent: 0,
+            coldReadPercent: 0,
+            comparePercent: 0,
+            retentionMs: config.changeLog.retentionMs,
+          },
+        },
+        soakLog,
+      );
+      // Tracked so that an interrupt or a failure during the control pass
+      // still tears the control cluster down.
+      cluster = control;
+      const before = throughput(metrics);
+      await control.startReplicationManager();
+      await control.startViewSyncers();
+      const controlTraffic = await TrafficDriver.connect(config.upstreamDB);
+      const controlStages: StageResult[] = [];
+      for (const phase of workloadPhases(config)) {
+        for (const stage of phase.stages) {
+          controlStages.push(await controlTraffic.runStage(stage));
+        }
+      }
+      await sleep(config.metricExportIntervalMs * 3);
+      const after = throughput(metrics);
+      await controlTraffic.deleteResidue();
+      await controlTraffic.close();
+      await control.stopAll('SIGTERM');
+      baseline = {
+        stages: stageSummary(controlStages),
+        replication: throughputDelta(before, after),
+      };
+      cluster = undefined;
+      say('baseline complete; wiping replicas and the backup for the real run');
+      for (const node of control.nodes) {
+        await node.deleteReplica();
+        await node.deleteChangeLog();
+      }
+      await resetBackup(config);
+    } else {
+      await resetBackup(config);
+    }
+
+    const soakCluster = new SoakCluster(config, soakLog);
+    cluster = soakCluster;
+    const mainBefore = throughput(metrics);
+
+    say(
+      'starting the replication-manager (phase 1: initial sync + first backup)',
+    );
+    await soakCluster.startReplicationManager();
+    say('starting view-syncers (each does its own litestream restore)');
+    await soakCluster.startViewSyncers();
+
+    traffic = await TrafficDriver.connect(config.upstreamDB, {
+      runID: `soak-${config.runID}`,
+    });
+    sampler = new ResourceSampler(
+      config,
+      sql,
+      soakCluster.changeLogFile,
+      soakCluster.nodes.map(n => ({node: n.name, replicaFile: n.replicaFile})),
+    );
+    sampler.start();
+
+    const quiesceAndCompare = async (label: string) => {
+      quiesceCount++;
+      const result = await runOracle(
+        lc,
+        sql,
+        // Not `replicaHandles()`: a node that is deliberately down has no
+        // replica to read, and waiting for it would hang the sentinel.
+        soakCluster.nodes
+          .filter(n => n.running)
+          .map(n => ({node: n.name, replicaFile: n.replicaFile})),
+        fixture,
+        label,
+        `rmv2-soak-quiesce-${config.runID}-${quiesceCount}`,
+      );
+      oracle.push(result);
+      say(
+        `oracle "${label}": ${result.ok ? 'ok' : 'DIVERGED'} ` +
+          `(quiesce ${result.quiesceMs}ms, ${result.verdict})`,
+      );
+      return result;
+    };
+
+    // Phases 2-5, each followed by a quiesce-and-compare. Evaluating at every
+    // quiescent point rather than only at the end is what keeps a later
+    // restore from healing -- and hiding -- a divergence.
+    for (const phase of workloadPhases(config)) {
+      say(`phase ${phase.name}: ${phase.stresses}`);
+      sampler.phase = phase.name;
+      const phaseStartedMs = Date.now();
+      const stages: StageResult[] = [];
+      for (const stage of phase.stages) {
+        stages.push(await traffic.runStage(stage));
+      }
+      phases.push({
+        name: phase.name,
+        startedMs: phaseStartedMs,
+        finishedMs: Date.now(),
+        stages,
+      });
+      await quiesceAndCompare(`after phase ${phase.name}`);
+    }
+
+    // Phase 6: the mixed phase, with the chaos matrix interleaved. Every
+    // action is followed by its own quiesce-and-compare, and no view-syncer
+    // is re-restored between an action and its check.
+    if (config.chaos.length > 0) {
+      say(`phase mixed: chaos ${config.chaos.join(', ')}`);
+      sampler.phase = 'mixed';
+      const mixed = mixedPhase(config);
+      const mixedStartedMs = Date.now();
+      const mixedStages: StageResult[] = [];
+      const ctx: ChaosContext = {
+        config,
+        cluster: soakCluster,
+        log: soakLog,
+        metrics,
+        sql,
+        traffic,
+        sampler,
+        note: say,
+      };
+      // The rollback drills leave the change log in `write` and then `off`,
+      // which is not a state the rest of the run can continue from, so they
+      // always go last regardless of the order they were requested in.
+      const ordered = config.chaos.toSorted(
+        (a, b) =>
+          Number(ROLLBACK_DRILLS.has(a)) - Number(ROLLBACK_DRILLS.has(b)),
+      );
+      for (const id of ordered) {
+        const action = CHAOS_ACTIONS.find(a => a.id === id);
+        if (!action) {
+          continue;
+        }
+        // Give the action a workload to land in, rather than hitting an idle
+        // system: the stages cycle underneath the chaos matrix.
+        const stage = mixed.stages[mixedStages.length % mixed.stages.length];
+        const load = traffic.runStage(stage);
+        const outcome = await runChaosAction(action, ctx);
+        mixedStages.push(await load);
+        chaosOutcomes.push(outcome);
+        for (const finding of outcome.findings) {
+          say(`FINDING ${finding}`);
+        }
+        await quiesceAndCompare(`after ${action.id}`);
+      }
+      phases.push({
+        name: mixed.name,
+        startedMs: mixedStartedMs,
+        finishedMs: Date.now(),
+        stages: mixedStages,
+      });
+    }
+
+    await sleep(config.metricExportIntervalMs * 3);
+    const mainAfter = throughput(metrics);
+    if (baseline) {
+      baseline['soakReplication'] = throughputDelta(mainBefore, mainAfter);
+      baseline['soakStages'] = stageSummary(phases.flatMap(p => p.stages));
+    }
+
+    await sampler.sample();
+    sampler.stop();
+
+    const report = buildReport({
+      config,
+      startedMs,
+      phases,
+      oracle,
+      chaos: chaosOutcomes,
+      log: soakLog,
+      metrics,
+      resources: sampler.samples,
+      baseline,
+    });
+    await writeReport(config.reportPath, report);
+    console.log(summarize(report));
+    say(`report written to ${config.reportPath}`);
+    if (!report.pass) {
+      process.exitCode = 1;
+    }
+  } finally {
+    process.off('SIGINT', onSignal);
+    process.off('SIGTERM', onSignal);
+    sampler?.stop();
+    if (!config.keep) {
+      await traffic?.deleteResidue().catch(() => undefined);
+      // A run interrupted mid-quiesce can leave its sentinel row behind, and
+      // a stray row would show up as a diff in the *next* run.
+      await sql`
+        DELETE FROM issue WHERE id LIKE ${`rmv2-soak-quiesce-${config.runID}-%`}
+      `.catch(() => undefined);
+    }
+    await cluster?.stopAll('SIGTERM').catch(() => undefined);
+    await traffic?.close().catch(() => undefined);
+    await sql.end().catch(() => undefined);
+    await receiver.close().catch(() => undefined);
+    if (!config.keep) {
+      // The replicas and the change log; the logs and the report stay.
+      for (const node of cluster?.nodes ?? []) {
+        await node.deleteReplica().catch(() => undefined);
+        await node.deleteChangeLog().catch(() => undefined);
+      }
+    }
+  }
+}
+
+if (argv[1]?.endsWith('rmv2-soak.ts')) {
+  main().catch(error => {
+    console.error(
+      error instanceof Error ? (error.stack ?? error.message) : error,
+    );
+    process.exitCode = 1;
+  });
+}

--- a/apps/zbugs/scripts/rmv2-soak.ts
+++ b/apps/zbugs/scripts/rmv2-soak.ts
@@ -484,6 +484,7 @@ async function main(): Promise<void> {
       runID: `soak-${config.runID}`,
     });
     sampler = new ResourceSampler(
+      lc,
       config,
       sql,
       soakCluster.changeLogFile,

--- a/apps/zbugs/scripts/rmv2-soak.ts
+++ b/apps/zbugs/scripts/rmv2-soak.ts
@@ -44,7 +44,7 @@ const ROLLBACK_DRILLS = new Set(['C10', 'C11', 'C12']);
  * Everything except C9 (a five-minute minio outage) and the rollback drills,
  * which leave the change log rolled back to `off`. `--chaos all` adds them.
  */
-const DEFAULT_CHAOS = 'C1,C2,C3,C4,C5,C6,C7,C8,C13';
+const DEFAULT_CHAOS = 'C1,C2,C3,C4,C5,C6,C7,C8,C13,C14';
 
 const USAGE = `
 A local, reproducible end-to-end exercise of the SQLite change log in serve
@@ -71,9 +71,9 @@ Options:
                             retention floor, not a routing knob.
   --scale <f>               Multiplies every phase duration. Default: 1
   --chaos <list>            Comma-separated action ids, or "none", or "all".
-                            Default: C1-C8 and C13. "all" adds C9 (a long
-                            minio outage) and the C10-C12 rollback drills,
-                            which run last and leave the log turned off.
+                            Default: C1-C8, C13 and C14. "all" adds C9 (a
+                            long minio outage) and the C10-C12 rollback
+                            drills, which run last and leave the log off.
   --baseline                Also run the mode=off A/B control pass first
   --backup-interval-seconds <n>  litestream monitor-interval. Default: 2
   --vfs-poll-ms <n>         Default: 1000

--- a/apps/zbugs/scripts/rmv2-soak.ts
+++ b/apps/zbugs/scripts/rmv2-soak.ts
@@ -178,6 +178,7 @@ function parseConfig(): SoakConfig {
     logsDir,
     reportPath: join(root, 'report.json'),
     upstreamDB,
+    appID: 'rmv2_soak',
     viewSyncers: numOpt('view-syncers', values['view-syncers'], 3),
     rmPort: 4850,
     vsBasePort: 4860,
@@ -443,7 +444,9 @@ async function main(): Promise<void> {
       const controlStages: StageResult[] = [];
       for (const phase of workloadPhases(config)) {
         for (const stage of phase.stages) {
-          controlStages.push(await controlTraffic.runStage(stage));
+          controlStages.push(
+            await control.guard(controlTraffic.runStage(stage)),
+          );
         }
       }
       await sleep(config.metricExportIntervalMs * 3);
@@ -490,17 +493,19 @@ async function main(): Promise<void> {
 
     const quiesceAndCompare = async (label: string) => {
       quiesceCount++;
-      const result = await runOracle(
-        lc,
-        sql,
-        // Not `replicaHandles()`: a node that is deliberately down has no
-        // replica to read, and waiting for it would hang the sentinel.
-        soakCluster.nodes
-          .filter(n => n.running)
-          .map(n => ({node: n.name, replicaFile: n.replicaFile})),
-        fixture,
-        label,
-        `rmv2-soak-quiesce-${config.runID}-${quiesceCount}`,
+      const result = await soakCluster.guard(
+        runOracle(
+          lc,
+          sql,
+          // Not `replicaHandles()`: a node that is deliberately down has no
+          // replica to read, and waiting for it would hang the sentinel.
+          soakCluster.nodes
+            .filter(n => n.running)
+            .map(n => ({node: n.name, replicaFile: n.replicaFile})),
+          fixture,
+          label,
+          `rmv2-soak-quiesce-${config.runID}-${quiesceCount}`,
+        ),
       );
       oracle.push(result);
       say(
@@ -519,7 +524,7 @@ async function main(): Promise<void> {
       const phaseStartedMs = Date.now();
       const stages: StageResult[] = [];
       for (const stage of phase.stages) {
-        stages.push(await traffic.runStage(stage));
+        stages.push(await soakCluster.guard(traffic.runStage(stage)));
       }
       phases.push({
         name: phase.name,
@@ -564,8 +569,8 @@ async function main(): Promise<void> {
         // Give the action a workload to land in, rather than hitting an idle
         // system: the stages cycle underneath the chaos matrix.
         const stage = mixed.stages[mixedStages.length % mixed.stages.length];
-        const load = traffic.runStage(stage);
-        const outcome = await runChaosAction(action, ctx);
+        const load = soakCluster.guard(traffic.runStage(stage));
+        const outcome = await soakCluster.guard(runChaosAction(action, ctx));
         mixedStages.push(await load);
         chaosOutcomes.push(outcome);
         for (const finding of outcome.findings) {

--- a/apps/zbugs/scripts/rmv2-soak/README.md
+++ b/apps/zbugs/scripts/rmv2-soak/README.md
@@ -108,11 +108,18 @@ quietly routes everything to PG would pass the gate while proving nothing, so
 the report lists each required route with its count or an explicit
 `NOT EXERCISED`.
 
-**Resource bounds (7.7)** sample the change log's local disk, the upstream
-replication slot's retained WAL, each replica's footprint and the backup's
-size, and summarize purge-pass stop reasons. A run that sits chronically at
-`continuation: 'immediate'` / `stopped: 'batch-limit'` is a purger losing to the
-write rate.
+**Resource bounds (7.7)** include these samples:
+
+- The physical disk footprint and the live/free pages of the change log.
+- The upstream replication slots for this soak app.
+- The footprint of each replica.
+- The size of the backup.
+
+The report also summarizes the stop reasons for purge passes. SQLite normally
+reuses freed pages instead of shrinking the physical file. Thus, C9 checks that
+live pages decrease after recovery. C9 does not require file truncation. A run
+fails when the purger repeatedly reports `continuation: 'immediate'` and
+`stopped: 'batch-limit'`.
 
 ## Where the numbers come from
 
@@ -177,7 +184,7 @@ consistently held is the evidence that the check can be tightened.
 | C6  | Delete only the change log, restart, then wipe a view-syncer replica | forced `created` reseed; the 1.4 measurement                     |
 | C7  | SIGSTOP the replication-manager 30s, then SIGCONT                    | disconnect and reconnect, no data gap                            |
 | C8  | SIGKILL the replication-manager mid-burst, restart                   | reconcile by _truncation_, not reseed                            |
-| C9  | Stop minio under sustained writes, then restart it                   | log bytes and slot WAL bounded, and both recover                 |
+| C9  | Stop minio for five minutes under sustained writes, then restart it  | live log pages and app-scoped slot WAL grow, then drain          |
 | C10 | `readPercent` 100 -> 0, restart                                      | every route becomes `pg/percentage`                              |
 | C11 | `serve` -> `compare` -> `write`, restart each time                   | the writer stays, reads stop, comparison stops                   |
 | C12 | `write` -> `off`, restart                                            | does turning it off actually free the disk                       |

--- a/apps/zbugs/scripts/rmv2-soak/README.md
+++ b/apps/zbugs/scripts/rmv2-soak/README.md
@@ -1,0 +1,249 @@
+# RMv2 local soak
+
+A local, reproducible end-to-end exercise of the SQLite change log in `serve`
+mode against a _real_ litestream v5 backup (minio/S3), with real view-syncer
+restores, disconnects and reconnects.
+
+Implements `~/workspace/zero/plans/rmv2-local-soak-plan.md`. Section numbers
+below refer to that plan.
+
+## Why this exists, and what `zero-cache-compare` does not cover
+
+`pnpm run zero-cache-compare` runs a single-node zero-cache in `compare` mode
+with no backup URL. Its backup watermark comes from the `ReplicaPoller`, which
+polls the _local_ replica, so the purge floor is pinned to the replica head and
+the log is drained as fast as it fills. With the floor there, `minWatermark`
+never has to cover anything, so neither the snapshot-reservation path nor the
+demotion path can fire, and no follower ever restores.
+
+This harness replaces that with a real topology:
+
+```
+docker:  postgres:16 (6434, existing)     minio (9000/9001) + mc bucket-init
+         |                                 ^
+         | logical replication             | s3
+         v                                 |
+  replication-manager  ---- litestream v5 backup ----
+  port 4850  (change-streamer :4851, litestream metrics :4852)
+  NUM_SYNC_WORKERS=0
+  SQLITE_CHANGE_LOG_MODE=serve / read 100 / cold 100 / compare 100
+         |  ws://localhost:4851/
+         +--------------+--------------+
+         v              v              v
+      vs-0           vs-1           vs-2      each: own replica dir,
+      :4860          :4870          :4880     own TASK_ID, own restore
+```
+
+Three view-syncers rather than one, so a demotion of one is visibly _not_ a
+demotion of the others and the purge floor has more than one ack to be held by.
+
+## Prerequisites
+
+```bash
+# one-time: go, then the three native binaries into .litestream/bin (gitignored)
+brew install go
+pnpm run build-litestream        # idempotent; --force to rebuild
+```
+
+| Binary          | Source                                   | Why                                                                                                                                              |
+| --------------- | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `litestream-v3` | `rocicorp/litestream` @ `zero@v0.0.10`   | the `PurgeLocker` branch is gated on `litestream.executable` -- the _v3_ path. Omitting it silently skips the purge lock and diverges from prod. |
+| `litestream-v5` | `rocicorp/litestream` @ `v0.5.17-zero.1` | does all of the backing up and restoring                                                                                                         |
+| `vfs-query`     | `mono/go`, `make build`                  | reads the backup watermark back out of S3 through the litestream VFS                                                                             |
+
+Both litestream binaries link `mattn/go-sqlite3` via cgo, so they must be built
+with the host toolchain; they cannot be lifted out of the Docker build.
+
+Docker must be running. The soak brings up postgres and minio itself, from
+`docker/docker-compose.yml` + `docker/docker-compose.minio.yml` as one project.
+
+The zbugs database must be migrated and seeded; pass `--seed` to do it.
+
+## Running
+
+```bash
+cd apps/zbugs
+
+pnpm run rmv2-soak                               # the full run
+pnpm run rmv2-soak -- --scale 0.05 --chaos none  # a two-minute smoke test
+pnpm run rmv2-soak -- --chaos all                # adds C9 and the rollback drills
+pnpm run rmv2-soak -- --baseline                 # adds the phase-0 A/B control
+pnpm run rmv2-soak -- --help
+```
+
+Everything lands in `.soak/<run-id>/`: per-incarnation JSON logs under `logs/`,
+each replica under its node's directory, and `report.json`. The summary is also
+printed. A non-zero exit means the gate failed.
+
+## What it checks
+
+**The correctness gate (7.1)** is the only one that survives the cutover: for
+every replica and every replicated table, at a defined transaction bound,
+
+```
+pi(replica.T)  ==  liteRow(PG.T)     as multisets keyed by a unique key
+```
+
+`liteRow` is the replicator's own PG->SQLite value mapping, so both sides are
+canonicalized identically; `pi` drops `_0_version` and the `_zero.*` schema. The
+bound comes from **quiescence** (7.2): writes stopped, one sentinel transaction
+round-tripped through every replica, and every replica's `stateVersion` equal.
+It runs after every phase _and_ after every chaos action, never only at the end
+-- a final-only comparison is nearly worthless, because a later restore heals a
+divergence.
+
+Two stated blind spots: a bug _inside_ `liteRow` is invisible here, and equality
+at a bound cannot see a transient wrong state that heals.
+
+Comparing the replication-manager's replica as well as each view-syncer's
+bisects for free (7.3): RM clean and followers dirty is the change-log/catchup
+path; both dirty points at the replicator or initial sync.
+
+**Coverage (7.6)** is a positive requirement, not an absence check. A soak that
+quietly routes everything to PG would pass the gate while proving nothing, so
+the report lists each required route with its count or an explicit
+`NOT EXERCISED`.
+
+**Resource bounds (7.7)** sample the change log's local disk, the upstream
+replication slot's retained WAL, each replica's footprint and the backup's
+size, and summarize purge-pass stop reasons. A run that sits chronically at
+`continuation: 'immediate'` / `stopped: 'batch-limit'` is a purger losing to the
+write rate.
+
+## Where the numbers come from
+
+Counters, histograms and gauges come from OpenTelemetry: each task exports
+OTLP/HTTP JSON to an in-process receiver on its own path (`otlp.ts`). That is
+the census of record -- `sqlite_change_log.catchup_routes{source,reason}`,
+purge probe outcomes, compare results, log file bytes, backup lag -- and it
+needs no collector.
+
+The JSON log stream (`logs.ts`) supplies _events with a time_: when the log
+reseeded and why, when a reservation opened and when it was confirmed, which
+task was demoted. `ZERO_LOG_LEVEL=debug` on the replication-manager is what
+makes the SQLite route visible at all (`serving <id> from SQLite catchup` is a
+debug line); the view-syncers stay at `info` so the burst phase's log volume
+does not perturb the timings it is measuring.
+
+## The headline measurement
+
+Section 1.4: **the residual wait is a reseed window, not a restore window.**
+
+The purge floor is capped at the backup watermark, so `log.minWatermark <=
+backupWatermark` holds for any log that held the history (invariant 14), and a
+view-syncer restoring from a backup the replication-manager published is
+covered by construction. Only a log that _just reseeded_ sits above the backup
+watermark. Today that ends in a free demotion to PG; after PG is retired it
+becomes a hold.
+
+So the report separates the two populations:
+
+- `reservationHoldMsC3` -- C3 restores against a live log, and should read ~0.
+- `reseedWindowMsC6C13` -- C6 and C13 restore against a log that just reseeded.
+  This is the number that converts to a view-syncer hold at the cutover.
+
+Every demotion and delayed confirmation is also reported with both
+`minWatermark` and `seedWatermark` against the backup watermark, because
+`#confirmReservations` compares `minWatermark` where `seedWatermark` would be
+exact (section 1.5). A population where `seedWatermark <= backupWatermark`
+consistently held is the evidence that the check can be tightened.
+
+## Chaos matrix
+
+`--chaos` takes ids, `none`, or `all`. The default is C1-C8 and C13.
+
+| #   | Action                                                               | Expected route                                   |
+| --- | -------------------------------------------------------------------- | ------------------------------------------------ |
+| C1  | SIGTERM a view-syncer (graceful drain), restart                      | `sqlite/selected`                                |
+| C2  | SIGQUIT a view-syncer (abrupt), restart                              | `sqlite/selected`                                |
+| C3  | Kill a view-syncer, delete its replica, restart                      | restore, then `sqlite`; **must not demote**      |
+| C4  | Kill mid-burst; a short outage, then one past retention              | `sqlite/selected`, then `pg/watermark-uncovered` |
+| C5  | SIGTERM the replication-manager, restart                             | a valid log resumes from its own head            |
+| C6  | Delete only the change log, restart, then wipe a view-syncer replica | forced `created` reseed; the 1.4 measurement     |
+| C7  | SIGSTOP the replication-manager 30s, then SIGCONT                    | disconnect and reconnect, no data gap            |
+| C8  | SIGKILL the replication-manager mid-burst, restart                   | reconcile by _truncation_, not reseed            |
+| C9  | Stop minio under sustained writes, then restart it                   | log bytes and slot WAL bounded, and both recover |
+| C10 | `readPercent` 100 -> 0, restart                                      | every route becomes `pg/percentage`              |
+| C11 | `serve` -> `compare` -> `write`, restart each time                   | the writer stays, reads stop, comparison stops   |
+| C12 | `write` -> `off`, restart                                            | does turning it off actually free the disk       |
+| C13 | C4 and C6 together                                                   | a follower already behind, meeting a reseed      |
+
+`GRACEFUL_SHUTDOWN = ['SIGTERM','SIGINT']` and `FORCEFUL_SHUTDOWN =
+['SIGQUIT','SIGABRT']` are genuinely different paths in `life-cycle.ts`, which
+is why C1 and C2 are two actions and not the same test twice.
+
+C10-C12 always run last regardless of the order they are requested in: C11 and
+C12 leave the change log rolled back to `write` and then `off`, which is not a
+state the rest of the run can continue from.
+
+## Gotchas worth knowing
+
+**Every zero-cache worker is its own process group.** `childWorker` forks with
+`detached: true` so that SIGINT is not propagated automatically. A signal to the
+dispatcher's process group therefore reaches only the dispatcher, and a
+dispatcher that dies without draining leaves its change-streamer,
+backup-replicator, litestream and vfs-query processes running -- still serving
+view-syncers, and still holding the replica's locks. The next start then fails
+several layers down with `SQLITE_BUSY: journal_mode = delete`. `node.ts` tracks
+the whole process tree while the node is alive and reaps it on stop; the run
+also refuses to start if any of its ports are already held.
+
+**The shared `.env`.** `apps/zbugs/.env` sets
+`ZERO_CHANGE_STREAMER_SQLITE_CHANGE_LOG_MODE='write'`. dotenvx does not override
+a variable that is already set, but it _does_ inject one that is absent, so the
+view-syncer environment says `off` explicitly rather than relying on omission.
+(A view-syncer that inherits a writing mode now warns rather than refusing to
+start, since #6412, but it still runs no log.)
+
+**The backup path is not the configured path.**
+`initializePostgresChangeSource` derives a destination backup URL whose last
+segment is a generation id -- the replica fork/resumption identity -- and logs
+it as `setting up backup to s3://<bucket>/<generation>`. The configured
+`s3://zero-replica/zbugs` path is therefore not a prefix of anything, so the
+harness owns and clears the whole bucket instead.
+
+**`--retention-ms 0` is not a thing.** It is asserted `> 0`; it is the purger's
+retention floor, not a routing knob. The dial that zeroes the warm-up wait is
+`--cold-read-percent 100`, which requires `mode=serve` and a nonzero read
+percentage.
+
+**Litestream config paths.** `litestream.configPath` defaults to a path relative
+to the process's cwd (`./src/services/litestream/...`), which only resolves from
+`packages/zero-cache`. The harness passes absolute paths.
+
+## Known limitations
+
+- `snapshotBackupIntervalHours` defaults to 4, so no snapshot occurs during a
+  soak and restores replay from the initial snapshot plus L0/L1. Snapshot-
+  boundary restores are **not** covered; `--snapshot-hours` can be dialled down
+  for a separate short run.
+- `config-v5.yml` tunes its L1/L2/L3 compaction ladder against a 15s
+  monitor-interval, and `--backup-interval-seconds 2` produces roughly seven
+  times the L0 files. Fine for a short soak; run one pass at 15 s before
+  drawing conclusions about compaction cost.
+- `initFromPgChangeLog` is hardcoded `true`. The most direct answer to "what
+  does the cutover feel like" is a run with it flipped to `false` behind a local
+  patch; the harness is what makes that observable.
+- The oracle is an end-state comparison. It cannot see a transient wrong state
+  that heals -- changes served out of order, or an idempotent duplicate. The
+  dark comparator and `Subscriber` dedup cover those today; post-retirement
+  nothing does, which is a gap to raise rather than one this harness closes.
+
+## Layout
+
+| File                                    | Slice   | Contents                                               |
+| --------------------------------------- | ------- | ------------------------------------------------------ |
+| `../build-litestream.sh`                | L1      | the three native binaries, idempotent                  |
+| `../../docker/docker-compose.minio.yml` | L2      | minio + one-shot bucket init                           |
+| `../change-log-traffic.ts`              | L3      | the stage driver, the quiet phase, and the residue mix |
+| `../rmv2-soak.ts`                       | L4      | the orchestrator                                       |
+| `config.ts`                             | L4      | paths, ports and the environment matrices              |
+| `node.ts`, `cluster.ts`                 | L4      | process lifecycle and topology                         |
+| `infra.ts`                              | L2      | docker compose, minio and the S3 helpers               |
+| `oracle.ts`                             | L5      | quiescence, `liteRow` canonicalization, keyed diffs    |
+| `workload.ts`                           | L3      | the phase shapes                                       |
+| `chaos.ts`                              | L6, L10 | C1-C13                                                 |
+| `logs.ts`                               | L7      | JSON log events and tripwires                          |
+| `otlp.ts`                               | L7, L8  | the OTLP metrics receiver                              |
+| `resources.ts`                          | L8      | disk, slot and purge sampling                          |
+| `report.ts`                             | L7, L8  | the census, the gate and the report                    |

--- a/apps/zbugs/scripts/rmv2-soak/README.md
+++ b/apps/zbugs/scripts/rmv2-soak/README.md
@@ -64,12 +64,16 @@ The zbugs database must be migrated and seeded; pass `--seed` to do it.
 ```bash
 cd apps/zbugs
 
-pnpm run rmv2-soak                               # the full run
-pnpm run rmv2-soak -- --scale 0.05 --chaos none  # a two-minute smoke test
-pnpm run rmv2-soak -- --chaos all                # adds C9 and the rollback drills
-pnpm run rmv2-soak -- --baseline                 # adds the phase-0 A/B control
-pnpm run rmv2-soak -- --help
+node scripts/rmv2-soak.ts                               # the full run
+node scripts/rmv2-soak.ts --scale 0.05 --chaos none     # a two-minute smoke test
+node scripts/rmv2-soak.ts --chaos all                   # adds C9 and the rollback drills
+node scripts/rmv2-soak.ts --baseline                    # adds the phase-0 A/B control
+node scripts/rmv2-soak.ts --help
 ```
+
+Call `scripts/rmv2-soak.ts` directly rather than through `pnpm run rmv2-soak --`.
+pnpm forwards the `--` itself as an argument, and `parseArgs` runs `strict`, so
+the pnpm form dies with `ERR_PARSE_ARGS_UNEXPECTED_POSITIONAL`.
 
 Everything lands in `.soak/<run-id>/`: per-incarnation JSON logs under `logs/`,
 each replica under its node's directory, and `report.json`. The summary is also
@@ -161,23 +165,24 @@ consistently held is the evidence that the check can be tightened.
 
 ## Chaos matrix
 
-`--chaos` takes ids, `none`, or `all`. The default is C1-C8 and C13.
+`--chaos` takes ids, `none`, or `all`. The default is C1-C8, C13 and C14.
 
-| #   | Action                                                               | Expected route                                   |
-| --- | -------------------------------------------------------------------- | ------------------------------------------------ |
-| C1  | SIGTERM a view-syncer (graceful drain), restart                      | `sqlite/selected`                                |
-| C2  | SIGQUIT a view-syncer (abrupt), restart                              | `sqlite/selected`                                |
-| C3  | Kill a view-syncer, delete its replica, restart                      | restore, then `sqlite`; **must not demote**      |
-| C4  | Kill mid-burst; a short outage, then one past retention              | `sqlite/selected`, then `pg/watermark-uncovered` |
-| C5  | SIGTERM the replication-manager, restart                             | a valid log resumes from its own head            |
-| C6  | Delete only the change log, restart, then wipe a view-syncer replica | forced `created` reseed; the 1.4 measurement     |
-| C7  | SIGSTOP the replication-manager 30s, then SIGCONT                    | disconnect and reconnect, no data gap            |
-| C8  | SIGKILL the replication-manager mid-burst, restart                   | reconcile by _truncation_, not reseed            |
-| C9  | Stop minio under sustained writes, then restart it                   | log bytes and slot WAL bounded, and both recover |
-| C10 | `readPercent` 100 -> 0, restart                                      | every route becomes `pg/percentage`              |
-| C11 | `serve` -> `compare` -> `write`, restart each time                   | the writer stays, reads stop, comparison stops   |
-| C12 | `write` -> `off`, restart                                            | does turning it off actually free the disk       |
-| C13 | C4 and C6 together                                                   | a follower already behind, meeting a reseed      |
+| #   | Action                                                               | Expected route                                                   |
+| --- | -------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| C1  | SIGTERM a view-syncer (graceful drain), restart                      | `sqlite/selected`                                                |
+| C2  | SIGQUIT a view-syncer (abrupt), restart                              | `sqlite/selected`                                                |
+| C3  | Kill a view-syncer, delete its replica, restart                      | restore, then `sqlite`; **must not demote**                      |
+| C4  | Kill mid-burst; a short outage, then one past retention              | `sqlite/selected`, then `pg/watermark-uncovered`                 |
+| C5  | SIGTERM the replication-manager, restart                             | a valid log resumes from its own head                            |
+| C6  | Delete only the change log, restart, then wipe a view-syncer replica | forced `created` reseed; the 1.4 measurement                     |
+| C7  | SIGSTOP the replication-manager 30s, then SIGCONT                    | disconnect and reconnect, no data gap                            |
+| C8  | SIGKILL the replication-manager mid-burst, restart                   | reconcile by _truncation_, not reseed                            |
+| C9  | Stop minio under sustained writes, then restart it                   | log bytes and slot WAL bounded, and both recover                 |
+| C10 | `readPercent` 100 -> 0, restart                                      | every route becomes `pg/percentage`                              |
+| C11 | `serve` -> `compare` -> `write`, restart each time                   | the writer stays, reads stop, comparison stops                   |
+| C12 | `write` -> `off`, restart                                            | does turning it off actually free the disk                       |
+| C13 | C4 and C6 together                                                   | a follower already behind, meeting a reseed                      |
+| C14 | Wipe the RM's whole volume (replica, litestream state, change log)   | restore from backup into a fresh generation; no follower demoted |
 
 `GRACEFUL_SHUTDOWN = ['SIGTERM','SIGINT']` and `FORCEFUL_SHUTDOWN =
 ['SIGQUIT','SIGABRT']` are genuinely different paths in `life-cycle.ts`, which

--- a/apps/zbugs/scripts/rmv2-soak/README.md
+++ b/apps/zbugs/scripts/rmv2-soak/README.md
@@ -68,8 +68,13 @@ node scripts/rmv2-soak.ts                               # the full run
 node scripts/rmv2-soak.ts --scale 0.05 --chaos none     # a two-minute smoke test
 node scripts/rmv2-soak.ts --chaos all                   # adds C9 and the rollback drills
 node scripts/rmv2-soak.ts --baseline                    # adds the phase-0 A/B control
+node scripts/rmv2-soak.ts --scale 0.1 --chaos C6 --cold-read-percent 0
 node scripts/rmv2-soak.ts --help
 ```
+
+The C6 control disables cold reads but keeps ordinary SQLite reads at 100%.
+Its positive coverage route changes from `sqlite/selected-cold` to
+`pg/cold-log`.
 
 Call `scripts/rmv2-soak.ts` directly rather than through `pnpm run rmv2-soak --`.
 pnpm forwards the `--` itself as an argument, and `parseArgs` runs `strict`, so
@@ -181,7 +186,7 @@ consistently held is the evidence that the check can be tightened.
 | C3  | Kill a view-syncer, delete its replica, restart                      | restore, then `sqlite`; **must not demote**                      |
 | C4  | Kill mid-burst; a short outage, then one past retention              | `sqlite/selected`; stale long-gap replica discarded and restored |
 | C5  | SIGTERM the replication-manager, restart                             | a valid log resumes from its own head                            |
-| C6  | Delete only the change log, restart, then wipe a view-syncer replica | forced `created` reseed; the 1.4 measurement                     |
+| C6  | Delete only the change log, restart, then wipe a view-syncer replica | `sqlite/selected-cold`, or `pg/cold-log` when cold reads are off |
 | C7  | SIGSTOP the replication-manager 30s, then SIGCONT                    | disconnect and reconnect, no data gap                            |
 | C8  | SIGKILL the replication-manager mid-burst, restart                   | reconcile by _truncation_, not reseed                            |
 | C9  | Stop minio for five minutes under sustained writes, then restart it  | live log pages and app-scoped slot WAL grow, then drain          |

--- a/apps/zbugs/scripts/rmv2-soak/README.md
+++ b/apps/zbugs/scripts/rmv2-soak/README.md
@@ -136,9 +136,9 @@ Section 1.4: **the residual wait is a reseed window, not a restore window.**
 The purge floor is capped at the backup watermark, so `log.minWatermark <=
 backupWatermark` holds for any log that held the history (invariant 14), and a
 view-syncer restoring from a backup the replication-manager published is
-covered by construction. Only a log that _just reseeded_ sits above the backup
-watermark. Today that ends in a free demotion to PG; after PG is retired it
-becomes a hold.
+covered by construction. Only a log that _just reseeded_ can sit above the
+backup watermark. The replication-manager readiness gate absorbs that window:
+it waits for a backup that covers the startup replica before serving followers.
 
 The report gives that window two numbers, because one number would lie:
 
@@ -172,7 +172,7 @@ consistently held is the evidence that the check can be tightened.
 | C1  | SIGTERM a view-syncer (graceful drain), restart                      | `sqlite/selected`                                                |
 | C2  | SIGQUIT a view-syncer (abrupt), restart                              | `sqlite/selected`                                                |
 | C3  | Kill a view-syncer, delete its replica, restart                      | restore, then `sqlite`; **must not demote**                      |
-| C4  | Kill mid-burst; a short outage, then one past retention              | `sqlite/selected`, then `pg/watermark-uncovered`                 |
+| C4  | Kill mid-burst; a short outage, then one past retention              | `sqlite/selected`; stale long-gap replica discarded and restored |
 | C5  | SIGTERM the replication-manager, restart                             | a valid log resumes from its own head                            |
 | C6  | Delete only the change log, restart, then wipe a view-syncer replica | forced `created` reseed; the 1.4 measurement                     |
 | C7  | SIGSTOP the replication-manager 30s, then SIGCONT                    | disconnect and reconnect, no data gap                            |

--- a/apps/zbugs/scripts/rmv2-soak/README.md
+++ b/apps/zbugs/scripts/rmv2-soak/README.md
@@ -211,6 +211,13 @@ view-syncer environment says `off` explicitly rather than relying on omission.
 (A view-syncer that inherits a writing mode now warns rather than refusing to
 start, since #6412, but it still runs no log.)
 
+**The app identity is isolated.** Zero defaults `ZERO_APP_ID` to `zero`, which
+is also what an ordinary local zbugs process uses. Sharing it means sharing the
+CDC ownership row and replication slot: another RM startup can set the soak's
+owner to `NULL` and terminate its change-streamer. The harness explicitly uses
+`rmv2_soak`; its fixed ports already prevent two soak runs from competing with
+each other.
+
 **The backup path is not the configured path.**
 `initializePostgresChangeSource` derives a destination backup URL whose last
 segment is a generation id -- the replica fork/resumption identity -- and logs

--- a/apps/zbugs/scripts/rmv2-soak/README.md
+++ b/apps/zbugs/scripts/rmv2-soak/README.md
@@ -136,11 +136,22 @@ covered by construction. Only a log that _just reseeded_ sits above the backup
 watermark. Today that ends in a free demotion to PG; after PG is retired it
 becomes a hold.
 
-So the report separates the two populations:
+The report gives that window two numbers, because one number would lie:
 
-- `reservationHoldMsC3` -- C3 restores against a live log, and should read ~0.
-- `reseedWindowMsC6C13` -- C6 and C13 restore against a log that just reseeded.
-  This is the number that converts to a view-syncer hold at the cutover.
+- **`reseedToCoveringBackupMs`** -- reseed to the first backup the vfs poller
+  observes at or above the seed point. This is the window itself. Nothing can
+  be served from the log before it, so it is the exposure whether or not a
+  follower happens to be waiting on it. Its floor is one litestream
+  `monitor-interval` plus one vfs poll interval, so it scales with those
+  settings rather than being a fixed cost.
+- **`reservationHoldMs`** -- what a follower actually waited, from
+  `created snasphot reservation` to `reserving change-log entries since`. It is
+  ~0 whenever the follower arrived after the covering backup had landed.
+
+`reseedToConfirmMs` is also recorded, but only for reference: it spans the
+replication-manager's own restart as well, so it overstates the stall by
+seconds. `reservationHoldMsC3` is the control -- C3 restores against a _live_
+log, and reads ~1 ms.
 
 Every demotion and delayed confirmation is also reported with both
 `minWatermark` and `seedWatermark` against the backup watermark, because
@@ -224,6 +235,17 @@ to the process's cwd (`./src/services/litestream/...`), which only resolves from
 - `initFromPgChangeLog` is hardcoded `true`. The most direct answer to "what
   does the cutover feel like" is a run with it flipped to `false` behind a local
   patch; the harness is what makes that observable.
+- **`pg/watermark-uncovered` is not reachable from a restart**, so a run that
+  reports it as `NOT EXERCISED` is describing the system rather than a gap in
+  the harness. `restoreReplica` runs on every view-syncer start and
+  `reserveAndGetSnapshotStatus` hands it the log's `minWatermark` before it
+  subscribes, so a replica below the minimum is discarded and re-restored and
+  the subscriber always reaches `/changes` at or above the minimum -- C4's long
+  gap asserts exactly that conversion (`longGapOutcome`). The route belongs to
+  a follower that survives a _stream_ disconnect long enough for the purge
+  floor to pass its ack. SIGSTOP does not produce one: the change-streamer
+  keeps a frozen subscriber registered (`continuing with N subscriber(s) still
+pending`) and lets it drain on resume.
 - The oracle is an end-state comparison. It cannot see a transient wrong state
   that heals -- changes served out of order, or an idempotent duplicate. The
   dark comparator and `Subscriber` dedup cover those today; post-retirement

--- a/apps/zbugs/scripts/rmv2-soak/chaos.test.ts
+++ b/apps/zbugs/scripts/rmv2-soak/chaos.test.ts
@@ -1,0 +1,47 @@
+import {expect, test} from 'vitest';
+import {c9ResourceFindings} from './chaos.ts';
+
+test('accepts C9 recovery when earlier fat payloads make live pages decrease', () => {
+  expect(
+    c9ResourceFindings({
+      changeLogLiveBytesBefore: 20_406_272,
+      changeLogLiveBytesDuring: 13_434_880,
+      changeLogLiveBytesAfter: 1_486_848,
+      slotRetainedBytesBefore: 1_054_720,
+      slotRetainedBytesDuring: 56_292_600,
+      slotRetainedBytesAfter: 858_072,
+    }),
+  ).toEqual([]);
+});
+
+test('reports C9 live-page and WAL recovery failures', () => {
+  expect(
+    c9ResourceFindings({
+      changeLogLiveBytesBefore: 10,
+      changeLogLiveBytesDuring: 20,
+      changeLogLiveBytesAfter: 20,
+      slotRetainedBytesBefore: 10,
+      slotRetainedBytesDuring: 20,
+      slotRetainedBytesAfter: 20,
+    }),
+  ).toEqual([
+    'C9: live change-log pages did not drain after the backup recovered',
+    'C9: retained WAL did not drain after the backup recovered',
+  ]);
+});
+
+test('reports an unavailable C9 live-page sample and an unpinned slot', () => {
+  expect(
+    c9ResourceFindings({
+      changeLogLiveBytesBefore: -1,
+      changeLogLiveBytesDuring: 20,
+      changeLogLiveBytesAfter: 10,
+      slotRetainedBytesBefore: 20,
+      slotRetainedBytesDuring: 20,
+      slotRetainedBytesAfter: 10,
+    }),
+  ).toEqual([
+    'C9: change-log live-page usage was not measurable',
+    'C9: the minio outage did not grow retained WAL',
+  ]);
+});

--- a/apps/zbugs/scripts/rmv2-soak/chaos.ts
+++ b/apps/zbugs/scripts/rmv2-soak/chaos.ts
@@ -59,6 +59,54 @@ export type MutableOutcome = {
   measurements: Record<string, number | string>;
 };
 
+export type C9ResourceMeasurements = {
+  readonly changeLogLiveBytesBefore: number;
+  readonly changeLogLiveBytesDuring: number;
+  readonly changeLogLiveBytesAfter: number;
+  readonly slotRetainedBytesBefore: number;
+  readonly slotRetainedBytesDuring: number;
+  readonly slotRetainedBytesAfter: number;
+};
+
+/**
+ * C9 starts after the fat-payload phase, so its pre-outage live-page count can
+ * exceed the count during the outage. Recovery only requires the pinned live
+ * pages and retained WAL to drain after MinIO returns.
+ */
+export function c9ResourceFindings({
+  changeLogLiveBytesBefore,
+  changeLogLiveBytesDuring,
+  changeLogLiveBytesAfter,
+  slotRetainedBytesBefore,
+  slotRetainedBytesDuring,
+  slotRetainedBytesAfter,
+}: C9ResourceMeasurements): string[] {
+  const findings: string[] = [];
+  if (
+    [
+      changeLogLiveBytesBefore,
+      changeLogLiveBytesDuring,
+      changeLogLiveBytesAfter,
+    ].some(bytes => bytes < 0)
+  ) {
+    findings.push('C9: change-log live-page usage was not measurable');
+  } else if (changeLogLiveBytesAfter >= changeLogLiveBytesDuring) {
+    findings.push(
+      'C9: live change-log pages did not drain after the backup recovered',
+    );
+  }
+  if (slotRetainedBytesDuring <= slotRetainedBytesBefore) {
+    findings.push('C9: the minio outage did not grow retained WAL');
+  }
+  if (
+    slotRetainedBytesAfter >= slotRetainedBytesDuring &&
+    slotRetainedBytesDuring > 0
+  ) {
+    findings.push('C9: retained WAL did not drain after the backup recovered');
+  }
+  return findings;
+}
+
 const CENSUS_METRIC = 'sqlite_change_log.catchup_routes';
 
 /**
@@ -632,20 +680,16 @@ export const CHAOS_ACTIONS: readonly ChaosAction[] = [
       out.measurements['purgePassesAfterRecovery'] = recoveryPurges.length;
       out.measurements['purgedRowsAfterRecovery'] = purgedRowsAfterRecovery;
 
-      if ([before, during, after].some(s => liveBytes(s) < 0)) {
-        out.findings.push('C9: change-log live-page usage was not measurable');
-      } else {
-        if (liveBytes(during) <= liveBytes(before)) {
-          out.findings.push(
-            'C9: the minio outage did not grow live change-log pages',
-          );
-        }
-        if (liveBytes(after) >= liveBytes(during)) {
-          out.findings.push(
-            'C9: live change-log pages did not drain after the backup recovered',
-          );
-        }
-      }
+      out.findings.push(
+        ...c9ResourceFindings({
+          changeLogLiveBytesBefore: liveBytes(before),
+          changeLogLiveBytesDuring: liveBytes(during),
+          changeLogLiveBytesAfter: liveBytes(after),
+          slotRetainedBytesBefore: slotBytes(before),
+          slotRetainedBytesDuring: slotBytes(during),
+          slotRetainedBytesAfter: slotBytes(after),
+        }),
+      );
       if (backupRecoveries === 0) {
         out.findings.push(
           'C9: no backup watermark was observed after minio recovered',
@@ -654,14 +698,6 @@ export const CHAOS_ACTIONS: readonly ChaosAction[] = [
       if (purgedRowsAfterRecovery === 0) {
         out.findings.push(
           'C9: no change-log rows were purged after minio recovered',
-        );
-      }
-      if (slotBytes(during) <= slotBytes(before)) {
-        out.findings.push('C9: the minio outage did not grow retained WAL');
-      }
-      if (slotBytes(after) >= slotBytes(during) && slotBytes(during) > 0) {
-        out.findings.push(
-          'C9: retained WAL did not drain after the backup recovered',
         );
       }
     },

--- a/apps/zbugs/scripts/rmv2-soak/chaos.ts
+++ b/apps/zbugs/scripts/rmv2-soak/chaos.ts
@@ -459,6 +459,13 @@ export const CHAOS_ACTIONS: readonly ChaosAction[] = [
           e.detail.reason === 'watermark-uncovered',
       );
       out.measurements['longGapWatermarkUncovered'] = uncovered ? 'yes' : 'no';
+      if (uncovered) {
+        out.findings.push(
+          'C4 routed a restarting follower through pg/watermark-uncovered; ' +
+            'the snapshot gate should discard and restore a stale replica ' +
+            'before it subscribes',
+        );
+      }
     },
   },
   {
@@ -490,7 +497,7 @@ export const CHAOS_ACTIONS: readonly ChaosAction[] = [
     title:
       'Stop the RM, delete only the change log, restart, then immediately wipe a view-syncer replica',
     expected:
-      'forced `created` reseed, then a restore held until a backup passes the seed',
+      'forced `created` reseed; RM readiness waits for a covering backup, then the restore uses SQLite',
     async run(ctx, out) {
       const since = Date.now();
       await ctx.cluster.rm.stop('SIGTERM');
@@ -507,10 +514,9 @@ export const CHAOS_ACTIONS: readonly ChaosAction[] = [
           'C6 deleted the change log but no reseed was observed',
         );
       }
-      // The restore that has to be held: the RM reseeded at the replica head
-      // while the newest backup still sits behind it, so the log alone cannot
-      // bridge the gap. Today this ends in a free demotion to PG; after PG is
-      // retired it becomes a wait.
+      // The RM reseeded at the replica head while the newest backup may still
+      // sit behind it. The readiness gate must absorb that window so the
+      // follower is never offered an uncovering backup and demoted to PG.
       const backSince = Date.now();
       await restartViewSyncer(ctx, 2, 'SIGQUIT', out, {deleteReplica: true});
       expectNoDemotions(ctx, backSince, 'C6', out);
@@ -721,7 +727,7 @@ export const CHAOS_ACTIONS: readonly ChaosAction[] = [
     id: 'C13',
     title: 'A view-syncer already behind, meeting a reseed (C4 and C6)',
     expected:
-      'watermark-uncovered -> forced restore -> held until a backup passes the seed',
+      'stale replica discarded -> restore; RM readiness waits for a backup that passes the seed',
     async run(ctx, out) {
       const vs = viewSyncerAt(ctx, 1);
       const load = ctx.traffic.runStage({

--- a/apps/zbugs/scripts/rmv2-soak/chaos.ts
+++ b/apps/zbugs/scripts/rmv2-soak/chaos.ts
@@ -239,21 +239,14 @@ function measureReservationHold(
       confirmed.tsMs - opened.tsMs;
   }
   if (confirmed) {
-    // The section 1.4 headline: log seed -> the first restore the log could
-    // serve. Today the same window ends in a demotion to PG and costs
-    // nothing; post-retirement it converts to a view-syncer hold.
-    //
-    // The reseed is the *latest one at or before* the confirmation, not one
-    // after `sinceMs`: in C6 and C13 the log is reseeded by the
-    // replication-manager restart, which happens before the follower is even
-    // brought back.
-    // Bounded by the action's own window on both sides: a reseed from
-    // *before* this action is not this action's window, and reporting the
-    // run's initial seed here would make every ordinary reconnect look like
-    // it had waited out a reseed.
+    // Reseed -> confirm, for reference only. It is *not* the stall: it also
+    // contains the replication-manager's own restart and however long the
+    // harness took to bring a follower back to the door. The follower-visible
+    // wait is `reservationHoldMs` above; the product-intrinsic window is
+    // `reseedToCoveringBackupMs` (see `measureReseedWindow`).
     const reseed = lastBefore(log, confirmed.tsMs, 'change-log-reseed');
     if (reseed && reseed.tsMs >= out.startedMs) {
-      out.measurements['reseedWindowMs'] = confirmed.tsMs - reseed.tsMs;
+      out.measurements['reseedToConfirmMs'] = confirmed.tsMs - reseed.tsMs;
     }
   }
 }
@@ -266,6 +259,45 @@ function measureReservationHold(
 function viewSyncerAt(ctx: ChaosContext, index: number) {
   const {viewSyncers} = ctx.cluster;
   return viewSyncers[index % viewSyncers.length];
+}
+
+/**
+ * Section 1.4's window, measured without a follower in it: from the reseed to
+ * the first backup the vfs poller observes at or above the seed point.
+ *
+ * That is the interval during which a restoring follower *would* be held,
+ * because until such a backup exists the log cannot cover any backup the
+ * follower could restore from. A follower that arrives after it waits zero,
+ * which is why the reservation hold alone understates the exposure while
+ * reseed-to-confirm overstates it -- the latter is mostly restart latency.
+ *
+ * Its floor is one litestream `monitor-interval` plus one vfs poll interval,
+ * so it scales with those settings rather than being a fixed cost.
+ */
+function measureReseedWindow(log: SoakLog, out: MutableOutcome): void {
+  const reseed = log.events.find(
+    e => e.kind === 'change-log-reseed' && e.tsMs >= out.startedMs,
+  );
+  const seed = reseed?.detail.head;
+  if (!reseed || typeof seed !== 'string') {
+    return;
+  }
+  const covering = log.events.find(
+    e =>
+      e.kind === 'backup-watermark' &&
+      e.tsMs >= reseed.tsMs &&
+      typeof e.detail.watermark === 'string' &&
+      e.detail.watermark >= seed,
+  );
+  out.measurements['reseedSeedWatermark'] = seed;
+  out.measurements['reseedToCoveringBackupMs'] = covering
+    ? covering.tsMs - reseed.tsMs
+    : -1;
+  if (covering) {
+    out.measurements['reseedCoveringBackupWatermark'] = str(
+      covering.detail.watermark,
+    );
+  }
 }
 
 async function restartViewSyncer(
@@ -341,7 +373,7 @@ export const CHAOS_ACTIONS: readonly ChaosAction[] = [
     title:
       'Kill a view-syncer mid-burst, leave it down past a backup interval, restart',
     expected:
-      'sqlite / selected over a long gap, then pg / watermark-uncovered once the gap outruns the log',
+      'sqlite / selected over a short gap; over a long one, the snapshot gate discards the stale replica and restores',
     async run(ctx, out) {
       const burst = ctx.traffic.runStage({
         rate: 250,
@@ -358,23 +390,39 @@ export const CHAOS_ACTIONS: readonly ChaosAction[] = [
       const result = await burst;
       out.measurements['burstTransactions'] = result.transactions;
 
-      // Outage B: comfortably longer than the retention window, so the gap
-      // outruns the log. This is the other half of what the coverage table
-      // attributes to C4 -- `pg / watermark-uncovered` -- and it is not
-      // reachable from an outage the purge floor can still cover. Twice the
-      // retention window rather than one plus slack: the purger removes only
-      // history that is both below the floor *and* older than retentionMs, so
-      // an outage of about one window leaves the follower's watermark on the
-      // retained side of it.
+      // Outage B: comfortably longer than the retention window, so the purge
+      // floor outruns the follower's ack.
+      //
+      // What this asserts is *not* `pg / watermark-uncovered`. A restarting
+      // view-syncer can never take that route, however long the gap:
+      // `restoreReplica` runs on every start and `reserveAndGetSnapshotStatus`
+      // hands it the log's `minWatermark` first, so a replica below the
+      // minimum is discarded and re-restored from the backup and the
+      // subscriber always reaches `/changes` at or above the minimum. The
+      // snapshot gate converts the uncovered case into a restore before the
+      // route exists.
+      //
+      // So the assertion is that conversion: the follower comes back, throws
+      // its stale replica away, and is then served from SQLite.
       const downMs = ctx.config.changeLog.retentionMs * 2 + 15_000;
       const load = ctx.traffic.runStage({
         rate: 25,
-        durationSeconds: Math.ceil(downMs / 1000) + 20,
+        durationSeconds: Math.ceil(downMs / 1000) + 25,
         label: 'C4-long-gap',
       });
       const since = Date.now();
+      const target = viewSyncerAt(ctx, 0);
       await restartViewSyncer(ctx, 0, 'SIGQUIT', out, {downMs});
       await load;
+      const discarded = ctx.log.events.some(
+        e =>
+          e.tsMs >= since &&
+          e.kind === 'replica-discarded' &&
+          e.node === target.name,
+      );
+      out.measurements['longGapOutcome'] = discarded
+        ? 'stale-replica-discarded-and-restored'
+        : 'replica-still-covered';
       const uncovered = ctx.log.events.some(
         e =>
           e.tsMs >= since &&
@@ -689,6 +737,7 @@ export async function runChaosAction(
   ctx.note(`${action.id}: ${action.title}`);
   try {
     await action.run(ctx, out);
+    measureReseedWindow(ctx.log, out);
   } catch (e) {
     out.findings.push(
       `${action.id} threw: ${e instanceof Error ? e.message : String(e)}`,

--- a/apps/zbugs/scripts/rmv2-soak/chaos.ts
+++ b/apps/zbugs/scripts/rmv2-soak/chaos.ts
@@ -6,7 +6,7 @@ import type {SoakConfig} from './config.ts';
 import {backupGenerations, sleep, startMinio, stopMinio} from './infra.ts';
 import type {SoakEvent, SoakLog} from './logs.ts';
 import type {MetricStore} from './otlp.ts';
-import type {ResourceSampler} from './resources.ts';
+import type {ResourceSample, ResourceSampler} from './resources.ts';
 
 /**
  * The chaos matrix of plan section 6.
@@ -581,7 +581,7 @@ export const CHAOS_ACTIONS: readonly ChaosAction[] = [
     title: 'Stop minio under sustained writes, then restart it',
     expected: 'backup watermark freezes, then catches up; both bounded',
     async run(ctx, out) {
-      const downSeconds = Math.max(60, Math.round(120 * ctx.config.scale));
+      const downSeconds = Math.max(60, Math.round(300 * ctx.config.scale));
       const load = ctx.traffic.runStage({
         rate: 25,
         durationSeconds: downSeconds + 60,
@@ -593,6 +593,7 @@ export const CHAOS_ACTIONS: readonly ChaosAction[] = [
       await sleep(downSeconds * 1000);
       const during = await ctx.sampler.sample();
       await startMinio(ctx.config);
+      const recoveredAt = Date.now();
       out.notes.push('restarted minio');
       await load;
       // Let the backup catch up and the acker walk the slot forward.
@@ -600,23 +601,65 @@ export const CHAOS_ACTIONS: readonly ChaosAction[] = [
       const after = await ctx.sampler.sample();
       const slotBytes = (s: typeof before) =>
         (s?.slots ?? []).reduce((acc, slot) => acc + slot.retainedBytes, 0);
+      const liveBytes = (s: ResourceSample | undefined) =>
+        s?.changeLogLiveBytes ?? -1;
       out.measurements['changeLogBytesBefore'] = before?.changeLogBytes ?? -1;
       out.measurements['changeLogBytesDuring'] = during?.changeLogBytes ?? -1;
       out.measurements['changeLogBytesAfter'] = after?.changeLogBytes ?? -1;
+      out.measurements['changeLogLiveBytesBefore'] = liveBytes(before);
+      out.measurements['changeLogLiveBytesDuring'] = liveBytes(during);
+      out.measurements['changeLogLiveBytesAfter'] = liveBytes(after);
+      out.measurements['changeLogFreeBytesAfter'] =
+        after?.changeLogFreeBytes ?? -1;
       out.measurements['slotRetainedBytesBefore'] = slotBytes(before);
       out.measurements['slotRetainedBytesDuring'] = slotBytes(during);
       out.measurements['slotRetainedBytesAfter'] = slotBytes(after);
-      if (
-        after &&
-        during &&
-        after.changeLogBytes > during.changeLogBytes &&
-        during.changeLogBytes > 0
-      ) {
+      const backupRecoveries = ctx.log.events.filter(
+        e => e.tsMs >= recoveredAt && e.kind === 'backup-watermark',
+      ).length;
+      const recoveryPurges = ctx.log.events.filter(
+        e => e.tsMs >= recoveredAt && e.kind === 'purge-pass',
+      );
+      const purgedRowsAfterRecovery = recoveryPurges.reduce(
+        (sum, event) =>
+          sum +
+          (typeof event.detail.deletedRows === 'number'
+            ? event.detail.deletedRows
+            : 0),
+        0,
+      );
+      out.measurements['backupRecoveries'] = backupRecoveries;
+      out.measurements['purgePassesAfterRecovery'] = recoveryPurges.length;
+      out.measurements['purgedRowsAfterRecovery'] = purgedRowsAfterRecovery;
+
+      if ([before, during, after].some(s => liveBytes(s) < 0)) {
+        out.findings.push('C9: change-log live-page usage was not measurable');
+      } else {
+        if (liveBytes(during) <= liveBytes(before)) {
+          out.findings.push(
+            'C9: the minio outage did not grow live change-log pages',
+          );
+        }
+        if (liveBytes(after) >= liveBytes(during)) {
+          out.findings.push(
+            'C9: live change-log pages did not drain after the backup recovered',
+          );
+        }
+      }
+      if (backupRecoveries === 0) {
         out.findings.push(
-          'C9: the change log did not shrink after the backup recovered',
+          'C9: no backup watermark was observed after minio recovered',
         );
       }
-      if (slotBytes(after) > slotBytes(during) && slotBytes(during) > 0) {
+      if (purgedRowsAfterRecovery === 0) {
+        out.findings.push(
+          'C9: no change-log rows were purged after minio recovered',
+        );
+      }
+      if (slotBytes(during) <= slotBytes(before)) {
+        out.findings.push('C9: the minio outage did not grow retained WAL');
+      }
+      if (slotBytes(after) >= slotBytes(during) && slotBytes(during) > 0) {
         out.findings.push(
           'C9: retained WAL did not drain after the backup recovered',
         );

--- a/apps/zbugs/scripts/rmv2-soak/chaos.ts
+++ b/apps/zbugs/scripts/rmv2-soak/chaos.ts
@@ -3,7 +3,7 @@ import type postgres from 'postgres';
 import type {TrafficDriver} from '../change-log-traffic.ts';
 import type {SoakCluster} from './cluster.ts';
 import type {SoakConfig} from './config.ts';
-import {sleep, startMinio, stopMinio} from './infra.ts';
+import {backupGenerations, sleep, startMinio, stopMinio} from './infra.ts';
 import type {SoakEvent, SoakLog} from './logs.ts';
 import type {MetricStore} from './otlp.ts';
 import type {ResourceSampler} from './resources.ts';
@@ -184,6 +184,35 @@ function recordConfirmationEvidence(
   if (relevant.length > 0) {
     out.measurements['confirmationHolds'] = relevant.length;
     out.measurements['confirmationHoldsCoveredBySeedWatermark'] = coveredBySeed;
+  }
+}
+
+/**
+ * Asserts that no follower was demoted to PG in this window.
+ *
+ * A warm restart leaves the local LTX chain in place, so litestream re-uploads
+ * it into the freshly minted generation one file per transaction. While that
+ * runs the backup genuinely trails the replica, and `BackupMonitor` holds
+ * `firstBackupReceived` until a watermark actually covers it. If that gate
+ * regresses to releasing on the first watermark of any value, the RM serves
+ * against a backup that does not cover it and demotes the follower.
+ */
+function expectNoDemotions(
+  ctx: ChaosContext,
+  sinceMs: number,
+  id: string,
+  out: MutableOutcome,
+): void {
+  const demotions = ctx.log.events.filter(
+    e => e.tsMs >= sinceMs && e.kind === 'reservation-demoted',
+  );
+  out.measurements['demotions'] = demotions.length;
+  if (demotions.length > 0) {
+    out.findings.push(
+      `${id} demoted ${demotions.length} follower(s) to PG while the new ` +
+        'backup generation was still backfilling; the initial-backup gate ' +
+        'released before the backup covered the replica',
+    );
   }
 }
 
@@ -482,7 +511,9 @@ export const CHAOS_ACTIONS: readonly ChaosAction[] = [
       // while the newest backup still sits behind it, so the log alone cannot
       // bridge the gap. Today this ends in a free demotion to PG; after PG is
       // retired it becomes a wait.
+      const backSince = Date.now();
       await restartViewSyncer(ctx, 2, 'SIGQUIT', out, {deleteReplica: true});
+      expectNoDemotions(ctx, backSince, 'C6', out);
     },
   },
   {
@@ -717,6 +748,95 @@ export const CHAOS_ACTIONS: readonly ChaosAction[] = [
       await vs.start();
       measureReservationHold(ctx.log, backSince, vs.name, out);
       recordConfirmationEvidence(ctx.log, backSince, out);
+      expectNoDemotions(ctx, backSince, 'C13', out);
+      await load;
+    },
+  },
+  {
+    id: 'C14',
+    title: 'Kill the replication-manager and wipe its whole volume, restart',
+    expected:
+      'restore from the backup into a fresh generation, and no follower demoted while it backfills',
+    async run(ctx, out) {
+      // Every other action leaves the RM's disk intact, so the local LTX chain
+      // is always there to be re-uploaded. This is the other case: the RM comes
+      // back on an empty volume and has to restore from S3, which is what a
+      // node replacement looks like in production.
+      const load = ctx.traffic.runStage({
+        rate: 50,
+        durationSeconds: Math.max(30, Math.round(60 * ctx.config.scale)),
+        label: 'C14-load',
+      });
+      await sleep(2_000);
+
+      const before = await backupGenerations(ctx.config);
+      out.measurements['generationsBefore'] = before.length;
+
+      const since = Date.now();
+      await ctx.cluster.rm.stop('SIGTERM');
+      // A lost volume loses everything beside the replica too. `deleteReplica`
+      // takes the `.replica.db-litestream` directory but not the change log,
+      // which lives at `${replicaFile}-change-log`.
+      await ctx.cluster.rm.deleteReplica();
+      await ctx.cluster.rm.deleteChangeLog();
+      out.notes.push("wiped rm's replica, litestream state and change log");
+
+      await ctx.cluster.startReplicationManager();
+      out.measurements['rmRestartMs'] = Date.now() - since;
+
+      // Did it come back from the backup, or fall all the way back to a fresh
+      // initial sync from Postgres? The difference is minutes of downtime in
+      // production, so it is worth naming rather than inferring from timing.
+      const restore = firstAfter(ctx.log, since, 'restore-started');
+      out.measurements['restoreObserved'] = restore ? 'yes' : 'no';
+      if (!restore) {
+        out.findings.push(
+          'C14 wiped the RM volume but no litestream restore was observed; ' +
+            'the RM likely fell back to a full initial sync from Postgres',
+        );
+      }
+
+      // The change log went with the volume, so this must be a `created`
+      // reseed rather than a resume.
+      const reseed = firstAfter(ctx.log, since, 'change-log-reseed');
+      out.measurements['reseedReason'] = str(
+        reseed?.detail.reason,
+        'none-observed',
+      );
+
+      const after = await backupGenerations(ctx.config);
+      out.measurements['generationsAfter'] = after.length;
+      const minted = after.filter(g => !before.includes(g));
+      out.measurements['generationsMinted'] = minted.length;
+      if (minted.length === 0) {
+        out.findings.push(
+          'C14 expected the restarted RM to mint a new backup generation, ' +
+            'but the bucket gained no new top-level prefix',
+        );
+      }
+
+      // Losing the volume is *cheaper* than keeping it, which is worth
+      // measuring rather than assuming. A warm restart still has the local LTX
+      // chain, so litestream re-uploads it into the new generation one file per
+      // transaction and the backup trails the replica while that runs. A
+      // restored volume has no chain, so litestream starts a fresh one at the
+      // restored state and the new generation is covered almost immediately.
+      // The demotion assertion therefore lives on C6/C13, not here; this one
+      // only records that the cheap path stayed cheap.
+      const backSince = Date.now();
+      await restartViewSyncer(ctx, 0, 'SIGTERM', out);
+      const demotions = ctx.log.events.filter(
+        e => e.tsMs >= backSince && e.kind === 'reservation-demoted',
+      );
+      out.measurements['demotionsAfterVolumeLoss'] = demotions.length;
+      if (demotions.length > 0) {
+        out.findings.push(
+          `C14 demoted ${demotions.length} follower(s) to PG after the RM ` +
+            'restored onto a fresh volume, which should be the cheap path: ' +
+            'a restored replica has no local LTX chain to re-upload, so its ' +
+            'new generation is covered almost immediately',
+        );
+      }
       await load;
     },
   },

--- a/apps/zbugs/scripts/rmv2-soak/chaos.ts
+++ b/apps/zbugs/scripts/rmv2-soak/chaos.ts
@@ -1,0 +1,709 @@
+import {stat} from 'node:fs/promises';
+import type postgres from 'postgres';
+import type {TrafficDriver} from '../change-log-traffic.ts';
+import type {SoakCluster} from './cluster.ts';
+import type {SoakConfig} from './config.ts';
+import {sleep, startMinio, stopMinio} from './infra.ts';
+import type {SoakEvent, SoakLog} from './logs.ts';
+import type {MetricStore} from './otlp.ts';
+import type {ResourceSampler} from './resources.ts';
+
+/**
+ * The chaos matrix of plan section 6.
+ *
+ * `GRACEFUL_SHUTDOWN = ['SIGTERM','SIGINT']` and
+ * `FORCEFUL_SHUTDOWN = ['SIGQUIT','SIGABRT']` are genuinely different paths
+ * in `life-cycle.ts`, which is why C1 and C2 are two actions and not the same
+ * test twice.
+ *
+ * Every action returns what it observed; the orchestrator runs a
+ * quiesce-and-compare after each one (section 7.2), because a final-only
+ * comparison is nearly worthless: a later restore heals a divergence.
+ */
+
+export type ChaosContext = {
+  readonly config: SoakConfig;
+  readonly cluster: SoakCluster;
+  readonly log: SoakLog;
+  readonly metrics: MetricStore;
+  readonly sql: postgres.Sql;
+  readonly traffic: TrafficDriver;
+  readonly sampler: ResourceSampler;
+  readonly note: (message: string) => void;
+};
+
+export type ChaosOutcome = {
+  readonly id: string;
+  readonly title: string;
+  readonly startedMs: number;
+  readonly finishedMs: number;
+  readonly notes: string[];
+  /** Route counter deltas for the action's window, `source/reason` keyed. */
+  readonly census: Readonly<Record<string, number>>;
+  readonly findings: string[];
+  readonly measurements: Readonly<Record<string, number | string>>;
+};
+
+export type ChaosAction = {
+  readonly id: string;
+  readonly title: string;
+  readonly expected: string;
+  readonly run: (ctx: ChaosContext, out: MutableOutcome) => Promise<void>;
+};
+
+export type MutableOutcome = {
+  /** When the action started; the lower bound for its own event window. */
+  startedMs: number;
+  notes: string[];
+  findings: string[];
+  measurements: Record<string, number | string>;
+};
+
+const CENSUS_METRIC = 'sqlite_change_log.catchup_routes';
+
+/**
+ * `SoakEvent.detail` is `Record<string, unknown>` by construction -- it is
+ * whatever the JSON log line carried -- so every read of it goes through
+ * here rather than through `String()`, which would stringify an object as
+ * `[object Object]`.
+ */
+function str(value: unknown, dflt = 'unknown'): string {
+  if (value === undefined || value === null) {
+    return dflt;
+  }
+  switch (typeof value) {
+    case 'string':
+      return value;
+    case 'number':
+    case 'boolean':
+    case 'bigint':
+      return String(value);
+    default:
+      return JSON.stringify(value) ?? dflt;
+  }
+}
+
+async function fileSize(path: string): Promise<number> {
+  try {
+    return (await stat(path)).size;
+  } catch {
+    return 0;
+  }
+}
+
+function census(metrics: MetricStore): Record<string, number> {
+  return metrics.byAttributes(CENSUS_METRIC, 'source', 'reason');
+}
+
+function censusDelta(
+  before: Record<string, number>,
+  after: Record<string, number>,
+): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const key of new Set([...Object.keys(before), ...Object.keys(after)])) {
+    const delta = (after[key] ?? 0) - (before[key] ?? 0);
+    if (delta !== 0) {
+      out[key] = delta;
+    }
+  }
+  return out;
+}
+
+/**
+ * The most recent `seedWatermark` the replication-manager reported before
+ * `beforeMs`, from the startup line or from any coverage payload.
+ *
+ * Plan section 1.5: `#confirmReservations` demotes on
+ * `coverage.minWatermark > backupWatermark`, but `minWatermark` conflates
+ * "history was purged away" with "nothing has been written since the seed".
+ * The exact condition is `seedWatermark <= backupWatermark`, so every
+ * demotion and every delayed confirmation is reported with both, and a
+ * population where the exact condition consistently held is the evidence that
+ * the check can be tightened.
+ */
+function latestSeedWatermark(
+  log: SoakLog,
+  beforeMs: number,
+): string | undefined {
+  let seed: string | undefined;
+  for (const event of log.events) {
+    if (event.tsMs > beforeMs) {
+      break;
+    }
+    if (event.kind === 'change-log-startup') {
+      const value = event.detail.seedWatermark;
+      if (typeof value === 'string') {
+        seed = value;
+      }
+    } else if (event.kind === 'change-log-reseed') {
+      const value = event.detail.head;
+      if (typeof value === 'string') {
+        seed = value;
+      }
+    } else {
+      const coverage = event.detail.coverage as
+        | {seedWatermark?: string}
+        | undefined;
+      if (coverage?.seedWatermark) {
+        seed = coverage.seedWatermark;
+      }
+    }
+  }
+  return seed;
+}
+
+/** Annotates each demotion / delayed confirmation with the section 1.5 test. */
+function recordConfirmationEvidence(
+  log: SoakLog,
+  sinceMs: number,
+  out: MutableOutcome,
+): void {
+  const relevant = log.events.filter(
+    e =>
+      e.tsMs >= sinceMs &&
+      (e.kind === 'reservation-demoted' || e.kind === 'reservation-delayed'),
+  );
+  let coveredBySeed = 0;
+  for (const event of relevant) {
+    const backupWatermark = event.detail.backupWatermark;
+    const seedWatermark = latestSeedWatermark(log, event.tsMs);
+    const exact =
+      typeof backupWatermark === 'string' && seedWatermark !== undefined
+        ? seedWatermark <= backupWatermark
+        : undefined;
+    if (exact) {
+      coveredBySeed++;
+    }
+    out.notes.push(
+      `${event.kind}: minWatermark=${str(event.detail.minWatermark)} ` +
+        `backupWatermark=${str(backupWatermark)} ` +
+        `seedWatermark=${seedWatermark ?? 'unknown'} ` +
+        `seedWatermark<=backupWatermark=${exact ?? 'unknown'}`,
+    );
+  }
+  if (relevant.length > 0) {
+    out.measurements['confirmationHolds'] = relevant.length;
+    out.measurements['confirmationHoldsCoveredBySeedWatermark'] = coveredBySeed;
+  }
+}
+
+function firstAfter(
+  log: SoakLog,
+  sinceMs: number,
+  kind: SoakEvent['kind'],
+  predicate: (e: SoakEvent) => boolean = () => true,
+): SoakEvent | undefined {
+  return log.events.find(
+    e => e.tsMs >= sinceMs && e.kind === kind && predicate(e),
+  );
+}
+
+function lastBefore(
+  log: SoakLog,
+  beforeMs: number,
+  kind: SoakEvent['kind'],
+): SoakEvent | undefined {
+  let found: SoakEvent | undefined;
+  for (const event of log.events) {
+    if (event.tsMs > beforeMs) {
+      break;
+    }
+    if (event.kind === kind) {
+      found = event;
+    }
+  }
+  return found;
+}
+
+/** Reservation open -> confirm, i.e. how long the follower waited to restore. */
+function measureReservationHold(
+  log: SoakLog,
+  sinceMs: number,
+  taskID: string,
+  out: MutableOutcome,
+): void {
+  const opened = firstAfter(
+    log,
+    sinceMs,
+    'reservation-opened',
+    e => e.detail.taskID === taskID,
+  );
+  const confirmed = firstAfter(
+    log,
+    sinceMs,
+    'reservation-confirmed',
+    e => e.detail.taskID === taskID,
+  );
+  if (opened && confirmed) {
+    out.measurements[`reservationHoldMs.${taskID}`] =
+      confirmed.tsMs - opened.tsMs;
+  }
+  if (confirmed) {
+    // The section 1.4 headline: log seed -> the first restore the log could
+    // serve. Today the same window ends in a demotion to PG and costs
+    // nothing; post-retirement it converts to a view-syncer hold.
+    //
+    // The reseed is the *latest one at or before* the confirmation, not one
+    // after `sinceMs`: in C6 and C13 the log is reseeded by the
+    // replication-manager restart, which happens before the follower is even
+    // brought back.
+    // Bounded by the action's own window on both sides: a reseed from
+    // *before* this action is not this action's window, and reporting the
+    // run's initial seed here would make every ordinary reconnect look like
+    // it had waited out a reseed.
+    const reseed = lastBefore(log, confirmed.tsMs, 'change-log-reseed');
+    if (reseed && reseed.tsMs >= out.startedMs) {
+      out.measurements['reseedWindowMs'] = confirmed.tsMs - reseed.tsMs;
+    }
+  }
+}
+
+/**
+ * The matrix names three view-syncers so that a demotion of one is visibly
+ * *not* a demotion of the others, but a smaller cluster is a legitimate way
+ * to run it; the index wraps rather than reaching past the end.
+ */
+function viewSyncerAt(ctx: ChaosContext, index: number) {
+  const {viewSyncers} = ctx.cluster;
+  return viewSyncers[index % viewSyncers.length];
+}
+
+async function restartViewSyncer(
+  ctx: ChaosContext,
+  index: number,
+  signal: NodeJS.Signals,
+  out: MutableOutcome,
+  opts: {deleteReplica?: boolean | undefined; downMs?: number | undefined} = {},
+): Promise<void> {
+  const vs = viewSyncerAt(ctx, index);
+  const since = Date.now();
+  out.notes.push(`${signal} ${vs.name}`);
+  await vs.stop(signal);
+  if (opts.downMs) {
+    out.notes.push(`leaving ${vs.name} down for ${opts.downMs}ms`);
+    await sleep(opts.downMs);
+  }
+  if (opts.deleteReplica) {
+    await vs.deleteReplica();
+    out.notes.push(`deleted ${vs.name}'s replica`);
+  }
+  await vs.start();
+  out.measurements[`restartMs.${vs.name}`] = Date.now() - since;
+  measureReservationHold(ctx.log, since, vs.name, out);
+  recordConfirmationEvidence(ctx.log, since, out);
+}
+
+export const CHAOS_ACTIONS: readonly ChaosAction[] = [
+  {
+    id: 'C1',
+    title: 'SIGTERM a view-syncer (graceful drain), restart, replica intact',
+    expected: 'sqlite / selected',
+    run: (ctx, out) => restartViewSyncer(ctx, 0, 'SIGTERM', out),
+  },
+  {
+    id: 'C2',
+    title: 'SIGQUIT a view-syncer (abrupt), restart, replica intact',
+    expected: 'sqlite / selected',
+    run: (ctx, out) => restartViewSyncer(ctx, 1, 'SIGQUIT', out),
+  },
+  {
+    id: 'C3',
+    title: 'Kill a view-syncer, delete its replica, restart',
+    expected: 'litestream restore, then sqlite -- and no demotion',
+    async run(ctx, out) {
+      const since = Date.now();
+      await restartViewSyncer(ctx, 2, 'SIGQUIT', out, {deleteReplica: true});
+      const restored = firstAfter(ctx.log, since, 'restore-started');
+      out.measurements['restoreObserved'] = restored ? 'yes' : 'no';
+      // Invariant 14: the purge floor is capped at the backup watermark, so a
+      // log that held the history covers any backup a follower can restore
+      // from. A `backup-uncovered` demotion here, with no recent reseed, is a
+      // finding rather than an expected outcome.
+      const target = viewSyncerAt(ctx, 2);
+      const demoted = ctx.log.events.filter(
+        e =>
+          e.tsMs >= since &&
+          e.kind === 'reservation-demoted' &&
+          e.detail.taskID === target.name,
+      );
+      const reseeded = firstAfter(ctx.log, since - 60_000, 'change-log-reseed');
+      if (demoted.length > 0 && !reseeded) {
+        out.findings.push(
+          `C3 demoted ${target.name} to PG without a ` +
+            `recent reseed: invariant 14 (minWatermark <= backupWatermark) ` +
+            `did not hold`,
+        );
+      }
+    },
+  },
+  {
+    id: 'C4',
+    title:
+      'Kill a view-syncer mid-burst, leave it down past a backup interval, restart',
+    expected:
+      'sqlite / selected over a long gap, then pg / watermark-uncovered once the gap outruns the log',
+    async run(ctx, out) {
+      const burst = ctx.traffic.runStage({
+        rate: 250,
+        durationSeconds: 20,
+        label: 'C4-burst',
+      });
+      await sleep(3_000);
+      // Outage A: shorter than the retention window. The purge floor should
+      // have held the history for a disconnected subscriber, so the follower
+      // catches up from SQLite across the gap.
+      await restartViewSyncer(ctx, 0, 'SIGQUIT', out, {
+        downMs: ctx.config.backupIntervalSeconds * 3_000 + 5_000,
+      });
+      const result = await burst;
+      out.measurements['burstTransactions'] = result.transactions;
+
+      // Outage B: comfortably longer than the retention window, so the gap
+      // outruns the log. This is the other half of what the coverage table
+      // attributes to C4 -- `pg / watermark-uncovered` -- and it is not
+      // reachable from an outage the purge floor can still cover. Twice the
+      // retention window rather than one plus slack: the purger removes only
+      // history that is both below the floor *and* older than retentionMs, so
+      // an outage of about one window leaves the follower's watermark on the
+      // retained side of it.
+      const downMs = ctx.config.changeLog.retentionMs * 2 + 15_000;
+      const load = ctx.traffic.runStage({
+        rate: 25,
+        durationSeconds: Math.ceil(downMs / 1000) + 20,
+        label: 'C4-long-gap',
+      });
+      const since = Date.now();
+      await restartViewSyncer(ctx, 0, 'SIGQUIT', out, {downMs});
+      await load;
+      const uncovered = ctx.log.events.some(
+        e =>
+          e.tsMs >= since &&
+          e.kind === 'served-from-pg' &&
+          e.detail.reason === 'watermark-uncovered',
+      );
+      out.measurements['longGapWatermarkUncovered'] = uncovered ? 'yes' : 'no';
+    },
+  },
+  {
+    id: 'C5',
+    title: 'SIGTERM the replication-manager, restart',
+    expected: 'valid log resumes from its own head; view-syncers reconnect',
+    async run(ctx, out) {
+      const since = Date.now();
+      await ctx.cluster.rm.stop('SIGTERM');
+      await ctx.cluster.startReplicationManager();
+      out.measurements['rmRestartMs'] = Date.now() - since;
+      const reconcile = firstAfter(ctx.log, since, 'change-log-reconcile');
+      out.measurements['reconcileAction'] = str(
+        reconcile?.detail.action,
+        'none-observed',
+      );
+      if (reconcile?.detail.action === 'reseeded') {
+        out.findings.push(
+          `C5 reseeded the change log (reason=${str(
+            reconcile.detail.reason,
+          )}); a valid log should have resumed from its own head`,
+        );
+      }
+      recordConfirmationEvidence(ctx.log, since, out);
+    },
+  },
+  {
+    id: 'C6',
+    title:
+      'Stop the RM, delete only the change log, restart, then immediately wipe a view-syncer replica',
+    expected:
+      'forced `created` reseed, then a restore held until a backup passes the seed',
+    async run(ctx, out) {
+      const since = Date.now();
+      await ctx.cluster.rm.stop('SIGTERM');
+      await ctx.cluster.rm.deleteChangeLog();
+      out.notes.push('deleted only replica.db-change-log*');
+      await ctx.cluster.startReplicationManager();
+      const reseed = firstAfter(ctx.log, since, 'change-log-reseed');
+      out.measurements['reseedReason'] = str(
+        reseed?.detail.reason,
+        'none-observed',
+      );
+      if (!reseed) {
+        out.findings.push(
+          'C6 deleted the change log but no reseed was observed',
+        );
+      }
+      // The restore that has to be held: the RM reseeded at the replica head
+      // while the newest backup still sits behind it, so the log alone cannot
+      // bridge the gap. Today this ends in a free demotion to PG; after PG is
+      // retired it becomes a wait.
+      await restartViewSyncer(ctx, 2, 'SIGQUIT', out, {deleteReplica: true});
+    },
+  },
+  {
+    id: 'C7',
+    title: 'SIGSTOP the replication-manager for 30s, then SIGCONT',
+    expected: 'view-syncer disconnect and reconnect, no data gap',
+    async run(ctx, out) {
+      const since = Date.now();
+      ctx.cluster.rm.signal('SIGSTOP');
+      out.notes.push('SIGSTOP rm');
+      await sleep(30_000);
+      ctx.cluster.rm.signal('SIGCONT');
+      out.notes.push('SIGCONT rm');
+      // Give the view-syncers a chance to notice and reconnect.
+      await sleep(15_000);
+      out.measurements['pausedMs'] = Date.now() - since;
+      recordConfirmationEvidence(ctx.log, since, out);
+    },
+  },
+  {
+    id: 'C8',
+    title: 'SIGKILL the replication-manager mid-burst, restart',
+    expected: 'reconcile by truncation, not by reseed',
+    async run(ctx, out) {
+      const burst = ctx.traffic.runStage({
+        rate: 250,
+        durationSeconds: 15,
+        label: 'C8-burst',
+      });
+      await sleep(4_000);
+      const since = Date.now();
+      await ctx.cluster.rm.stop('SIGKILL');
+      out.notes.push('SIGKILL rm mid-burst');
+      // The burst cannot commit while the RM is down, but it writes to PG,
+      // not through the RM, so let it finish.
+      const result = await burst.catch(e => {
+        out.notes.push(`burst reported ${String(e)}`);
+        return undefined;
+      });
+      await ctx.cluster.startReplicationManager();
+      const reconcile = firstAfter(ctx.log, since, 'change-log-reconcile');
+      const action = str(reconcile?.detail.action, 'none-observed');
+      out.measurements['reconcileAction'] = action;
+      out.measurements['burstTransactions'] = result?.transactions ?? -1;
+      if (action === 'reseeded') {
+        // If every hard crash reseeds, section 1.4's window is paid on every
+        // crash rather than only on a schema bump.
+        out.findings.push(
+          `C8: a hard crash reseeded the log (reason=${str(
+            reconcile?.detail.reason,
+          )}) rather than truncating a bounded suffix`,
+        );
+      }
+      recordConfirmationEvidence(ctx.log, since, out);
+    },
+  },
+  {
+    id: 'C9',
+    title: 'Stop minio under sustained writes, then restart it',
+    expected: 'backup watermark freezes, then catches up; both bounded',
+    async run(ctx, out) {
+      const downSeconds = Math.max(60, Math.round(120 * ctx.config.scale));
+      const load = ctx.traffic.runStage({
+        rate: 25,
+        durationSeconds: downSeconds + 60,
+        label: 'C9-sustained',
+      });
+      const before = await ctx.sampler.sample();
+      await stopMinio();
+      out.notes.push(`stopped minio for ${downSeconds}s`);
+      await sleep(downSeconds * 1000);
+      const during = await ctx.sampler.sample();
+      await startMinio(ctx.config);
+      out.notes.push('restarted minio');
+      await load;
+      // Let the backup catch up and the acker walk the slot forward.
+      await sleep(30_000);
+      const after = await ctx.sampler.sample();
+      const slotBytes = (s: typeof before) =>
+        (s?.slots ?? []).reduce((acc, slot) => acc + slot.retainedBytes, 0);
+      out.measurements['changeLogBytesBefore'] = before?.changeLogBytes ?? -1;
+      out.measurements['changeLogBytesDuring'] = during?.changeLogBytes ?? -1;
+      out.measurements['changeLogBytesAfter'] = after?.changeLogBytes ?? -1;
+      out.measurements['slotRetainedBytesBefore'] = slotBytes(before);
+      out.measurements['slotRetainedBytesDuring'] = slotBytes(during);
+      out.measurements['slotRetainedBytesAfter'] = slotBytes(after);
+      if (
+        after &&
+        during &&
+        after.changeLogBytes > during.changeLogBytes &&
+        during.changeLogBytes > 0
+      ) {
+        out.findings.push(
+          'C9: the change log did not shrink after the backup recovered',
+        );
+      }
+      if (slotBytes(after) > slotBytes(during) && slotBytes(during) > 0) {
+        out.findings.push(
+          'C9: retained WAL did not drain after the backup recovered',
+        );
+      }
+    },
+  },
+  {
+    id: 'C10',
+    title: 'Roll the read percentage back from 100 to 0 and restart the RM',
+    expected: 'every route becomes pg / percentage',
+    async run(ctx, out) {
+      const before = census(ctx.metrics);
+      await ctx.cluster.rm.stop('SIGTERM');
+      await ctx.cluster.startReplicationManager({
+        readPercent: 0,
+        coldReadPercent: 0,
+      });
+      // Force every view-syncer to re-register so the new routing is
+      // exercised rather than assumed.
+      for (const vs of ctx.cluster.viewSyncers) {
+        await vs.stop('SIGTERM');
+        await vs.start();
+      }
+      await sleep(ctx.config.metricExportIntervalMs * 3);
+      const delta = censusDelta(before, census(ctx.metrics));
+      out.measurements['routesAfterRollback'] = JSON.stringify(delta);
+      const servedFromSQLite = Object.entries(delta)
+        .filter(([key]) => key.startsWith('sqlite/'))
+        .reduce((acc, [, value]) => acc + value, 0);
+      if (servedFromSQLite > 0) {
+        out.findings.push(
+          `C10: ${servedFromSQLite} catchup(s) still routed to SQLite after ` +
+            `the read percentage was rolled back to 0`,
+        );
+      }
+    },
+  },
+  {
+    id: 'C11',
+    title: 'Walk the mode ladder back: serve -> compare -> write',
+    expected: 'the writer stays, reads stop, then comparison stops',
+    async run(ctx, out) {
+      for (const mode of ['compare', 'write'] as const) {
+        const since = Date.now();
+        await ctx.cluster.rm.stop('SIGTERM');
+        await ctx.cluster.startReplicationManager({
+          mode,
+          readPercent: 0,
+          coldReadPercent: 0,
+          comparePercent: mode === 'compare' ? 100 : 0,
+        });
+        await sleep(ctx.config.metricExportIntervalMs * 3);
+        const startup = firstAfter(ctx.log, since, 'change-log-startup');
+        out.notes.push(
+          `mode=${mode}: change log ${startup ? 'still open' : 'not opened'}`,
+        );
+        out.measurements[`headAfter.${mode}`] = str(
+          startup?.detail.headWatermark,
+        );
+        if (!startup) {
+          out.findings.push(
+            `C11: no change-log startup line after rolling back to ${mode}; ` +
+              `the writer should still be running`,
+          );
+        }
+      }
+    },
+  },
+  {
+    id: 'C12',
+    title: 'Turn the change log off and confirm the file is reclaimed',
+    expected: 'replicatorDeletesStaleChangeLog removes the file',
+    async run(ctx, out) {
+      const before = await fileSize(ctx.cluster.changeLogFile);
+      await ctx.cluster.rm.stop('SIGTERM');
+      await ctx.cluster.startReplicationManager({
+        mode: 'off',
+        readPercent: 0,
+        coldReadPercent: 0,
+        comparePercent: 0,
+      });
+      // The delete happens in a replicator worker at startup. The
+      // replication-manager runs none (NUM_SYNC_WORKERS=0), so the reclaim is
+      // observed on a view-syncer's tree; restart one to make it happen.
+      for (const vs of ctx.cluster.viewSyncers) {
+        await vs.stop('SIGTERM');
+        await vs.start();
+      }
+      const after = await fileSize(ctx.cluster.changeLogFile);
+      out.measurements['changeLogBytesBeforeOff'] = before;
+      out.measurements['changeLogBytesAfterOff'] = after;
+      if (before > 0 && after >= before) {
+        // The reclaim is `deleteStaleChangeLog`, called at the top of a
+        // replicator worker. A replication-manager runs no *syncing*
+        // replicator (`NUM_SYNC_WORKERS=0`), but it does run a
+        // backup-replicator over the same replica path whenever a backup URL
+        // is configured, and that is what normally reclaims the file. Report
+        // the bytes rather than a cause: "does turning it off actually free
+        // the disk" is the class-5 question, and a no here is the answer.
+        out.findings.push(
+          `C12: the change log still holds ${after} bytes (was ${before}) ` +
+            `after the mode was rolled back to off`,
+        );
+      }
+    },
+  },
+  {
+    id: 'C13',
+    title: 'A view-syncer already behind, meeting a reseed (C4 and C6)',
+    expected:
+      'watermark-uncovered -> forced restore -> held until a backup passes the seed',
+    async run(ctx, out) {
+      const vs = viewSyncerAt(ctx, 1);
+      const load = ctx.traffic.runStage({
+        rate: 50,
+        durationSeconds: Math.max(30, Math.round(90 * ctx.config.scale)),
+        label: 'C13-load',
+      });
+      await sleep(2_000);
+      await vs.stop('SIGQUIT');
+      out.notes.push(`${vs.name} down and falling behind`);
+      await sleep(ctx.config.backupIntervalSeconds * 4_000 + 10_000);
+
+      const since = Date.now();
+      await ctx.cluster.rm.stop('SIGTERM');
+      await ctx.cluster.rm.deleteChangeLog();
+      await ctx.cluster.startReplicationManager();
+      const reseed = firstAfter(ctx.log, since, 'change-log-reseed');
+      out.measurements['reseedReason'] = str(
+        reseed?.detail.reason,
+        'none-observed',
+      );
+
+      const backSince = Date.now();
+      await vs.start();
+      measureReservationHold(ctx.log, backSince, vs.name, out);
+      recordConfirmationEvidence(ctx.log, backSince, out);
+      await load;
+    },
+  },
+];
+
+export async function runChaosAction(
+  action: ChaosAction,
+  ctx: ChaosContext,
+): Promise<ChaosOutcome> {
+  const startedMs = Date.now();
+  const before = census(ctx.metrics);
+  const out: MutableOutcome = {
+    startedMs,
+    notes: [],
+    findings: [],
+    measurements: {},
+  };
+  ctx.note(`${action.id}: ${action.title}`);
+  try {
+    await action.run(ctx, out);
+  } catch (e) {
+    out.findings.push(
+      `${action.id} threw: ${e instanceof Error ? e.message : String(e)}`,
+    );
+  }
+  // One export interval so the counters for this window have landed.
+  await sleep(ctx.config.metricExportIntervalMs * 2);
+  return {
+    id: action.id,
+    title: action.title,
+    startedMs,
+    finishedMs: Date.now(),
+    notes: out.notes,
+    census: censusDelta(before, census(ctx.metrics)),
+    findings: out.findings,
+    measurements: out.measurements,
+  };
+}

--- a/apps/zbugs/scripts/rmv2-soak/cluster.test.ts
+++ b/apps/zbugs/scripts/rmv2-soak/cluster.test.ts
@@ -1,0 +1,24 @@
+import {expect, test} from 'vitest';
+import {guardNodeExits} from './cluster.ts';
+
+test('returns the guarded operation result', async () => {
+  const neverExits = new Promise<never>(() => {});
+
+  await expect(
+    guardNodeExits(Promise.resolve('done'), [{unexpectedExit: neverExits}]),
+  ).resolves.toBe('done');
+});
+
+test('fails an in-flight operation when a node exits unexpectedly', async () => {
+  let rejectExit: (reason: Error) => void = () => {};
+  const unexpectedExit = new Promise<never>((_resolve, reject) => {
+    rejectExit = reject;
+  });
+  const guarded = guardNodeExits(new Promise<never>(() => {}), [
+    {unexpectedExit},
+  ]);
+
+  rejectExit(new Error('rm exited unexpectedly (code=14 signal=null)'));
+
+  await expect(guarded).rejects.toThrow('rm exited unexpectedly');
+});

--- a/apps/zbugs/scripts/rmv2-soak/cluster.ts
+++ b/apps/zbugs/scripts/rmv2-soak/cluster.ts
@@ -11,6 +11,13 @@ import type {SoakLog} from './logs.ts';
 import {SoakNode} from './node.ts';
 import type {ReplicaHandle} from './oracle.ts';
 
+export function guardNodeExits<T>(
+  operation: Promise<T>,
+  nodes: readonly Pick<SoakNode, 'unexpectedExit'>[],
+): Promise<T> {
+  return Promise.race([operation, ...nodes.map(node => node.unexpectedExit)]);
+}
+
 /**
  * The topology of plan section 2: one replication-manager with
  * `NUM_SYNC_WORKERS=0`, and N view-syncers, each with its own replica
@@ -71,6 +78,11 @@ export class SoakCluster {
 
   replicaHandles(): ReplicaHandle[] {
     return this.nodes.map(n => ({node: n.name, replicaFile: n.replicaFile}));
+  }
+
+  /** Fails an in-flight harness operation if any node dies unexpectedly. */
+  guard<T>(operation: Promise<T>): Promise<T> {
+    return guardNodeExits(operation, this.nodes);
   }
 
   async startReplicationManager(

--- a/apps/zbugs/scripts/rmv2-soak/cluster.ts
+++ b/apps/zbugs/scripts/rmv2-soak/cluster.ts
@@ -1,0 +1,101 @@
+import {
+  changeLogFile,
+  replicaFile,
+  replicationManagerEnv,
+  taskIDFor,
+  viewSyncerEnv,
+  type ChangeLogSettings,
+  type SoakConfig,
+} from './config.ts';
+import type {SoakLog} from './logs.ts';
+import {SoakNode} from './node.ts';
+import type {ReplicaHandle} from './oracle.ts';
+
+/**
+ * The topology of plan section 2: one replication-manager with
+ * `NUM_SYNC_WORKERS=0`, and N view-syncers, each with its own replica
+ * directory, its own task ID, and its own `litestream restore`.
+ *
+ * Three view-syncers rather than one, because the route census needs
+ * concurrent tasks so that a demotion of one is visibly *not* a demotion of
+ * the others, and so the purge floor has more than one ack to be held by.
+ */
+export class SoakCluster {
+  readonly rm: SoakNode;
+  readonly viewSyncers: readonly SoakNode[];
+  readonly #config: SoakConfig;
+  #rmSettings: Partial<ChangeLogSettings> = {};
+
+  constructor(config: SoakConfig, log: SoakLog) {
+    this.#config = config;
+    const rmName = taskIDFor('rm');
+    this.rm = new SoakNode({
+      name: rmName,
+      env: replicationManagerEnv(config),
+      logsDir: config.logsDir,
+      log,
+      replicaFile: replicaFile(config, rmName),
+    });
+    this.viewSyncers = Array.from({length: config.viewSyncers}, (_, i) => {
+      const name = taskIDFor(i);
+      return new SoakNode({
+        name,
+        env: viewSyncerEnv(config, i),
+        logsDir: config.logsDir,
+        log,
+        replicaFile: replicaFile(config, name),
+      });
+    });
+  }
+
+  get nodes(): SoakNode[] {
+    return [this.rm, ...this.viewSyncers];
+  }
+
+  get changeLogFile(): string {
+    return changeLogFile(this.#config, this.rm.name);
+  }
+
+  /** The change-log settings the replication-manager is currently running. */
+  get rmSettings(): ChangeLogSettings {
+    return {...this.#config.changeLog, ...this.#rmSettings};
+  }
+
+  node(name: string): SoakNode {
+    const node = this.nodes.find(n => n.name === name);
+    if (!node) {
+      throw new Error(`no such node: ${name}`);
+    }
+    return node;
+  }
+
+  replicaHandles(): ReplicaHandle[] {
+    return this.nodes.map(n => ({node: n.name, replicaFile: n.replicaFile}));
+  }
+
+  async startReplicationManager(
+    overrides?: Partial<ChangeLogSettings>,
+  ): Promise<void> {
+    if (overrides) {
+      this.#rmSettings = overrides;
+    }
+    // The change-log mode is a startup option, so both the flip and the
+    // rollback are restarts. Rebuild the environment on every start rather
+    // than caching it.
+    this.rm.env = replicationManagerEnv(this.#config, this.#rmSettings);
+    await this.rm.start();
+  }
+
+  async startViewSyncers(): Promise<void> {
+    // Serially, so that the reservation/restore sequence of each is legible
+    // in the logs and the first one does not race the RM's first backup.
+    for (const vs of this.viewSyncers) {
+      await vs.start();
+    }
+  }
+
+  async stopAll(signal: NodeJS.Signals = 'SIGTERM'): Promise<void> {
+    await Promise.all(this.viewSyncers.map(vs => vs.stop(signal)));
+    await this.rm.stop(signal);
+  }
+}

--- a/apps/zbugs/scripts/rmv2-soak/config.ts
+++ b/apps/zbugs/scripts/rmv2-soak/config.ts
@@ -1,0 +1,231 @@
+import {mkdirSync} from 'node:fs';
+import {join} from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+export const APP_ROOT = fileURLToPath(new URL('../..', import.meta.url));
+export const REPO_ROOT = fileURLToPath(new URL('../../../..', import.meta.url));
+
+export const ZERO_CACHE_MAIN = join(
+  REPO_ROOT,
+  'packages/zero-cache/src/server/runner/main.ts',
+);
+export const LITESTREAM_CONFIG_V3 = join(
+  REPO_ROOT,
+  'packages/zero-cache/src/services/litestream/config.yml',
+);
+export const LITESTREAM_CONFIG_V5 = join(
+  REPO_ROOT,
+  'packages/zero-cache/src/services/litestream/config-v5.yml',
+);
+export const BIN_DIR = join(APP_ROOT, '.litestream/bin');
+export const DOCKER_DIR = join(APP_ROOT, 'docker');
+
+/**
+ * The change-log mode ladder. `serve` is the subject of the soak; the others
+ * are the rollback rungs that chaos actions C10-C12 walk back down.
+ */
+export type ChangeLogMode = 'off' | 'write' | 'compare' | 'serve';
+
+export type ChangeLogSettings = {
+  readonly mode: ChangeLogMode;
+  readonly readPercent: number;
+  readonly coldReadPercent: number;
+  readonly comparePercent: number;
+  readonly retentionMs: number;
+};
+
+export type SoakConfig = {
+  readonly runID: string;
+  readonly root: string;
+  readonly logsDir: string;
+  readonly reportPath: string;
+
+  readonly upstreamDB: string;
+  readonly viewSyncers: number;
+
+  readonly rmPort: number;
+  readonly vsBasePort: number;
+  readonly otlpPort: number;
+
+  readonly backupURL: string;
+  readonly s3Endpoint: string;
+  readonly s3Region: string;
+  readonly accessKeyID: string;
+  readonly secretAccessKey: string;
+
+  readonly changeLog: ChangeLogSettings;
+  readonly backupIntervalSeconds: number;
+  readonly vfsPollIntervalMs: number;
+  readonly startupDelayMs: number;
+  readonly snapshotBackupIntervalHours: number;
+
+  readonly rmLogLevel: 'debug' | 'info';
+  readonly vsLogLevel: 'debug' | 'info';
+
+  /** Chaos actions to run, e.g. ['C1','C3','C6']. */
+  readonly chaos: readonly string[];
+  /** Run the mode=off A/B control pass before the real run (phase 0). */
+  readonly baseline: boolean;
+  /** Scales every phase duration; 0.25 makes a smoke run out of a soak. */
+  readonly scale: number;
+  /** Run `db-migrate` and `db-seed` before the run. */
+  readonly seed: boolean;
+  /** Leave processes, containers and directories in place on exit. */
+  readonly keep: boolean;
+  readonly metricExportIntervalMs: number;
+};
+
+export function taskIDFor(index: number | 'rm'): string {
+  return index === 'rm' ? 'rm' : `vs-${index}`;
+}
+
+export function nodeDir(config: SoakConfig, node: string): string {
+  const dir = join(config.root, node);
+  mkdirSync(dir, {recursive: true});
+  return dir;
+}
+
+export function replicaFile(config: SoakConfig, node: string): string {
+  return join(nodeDir(config, node), 'replica.db');
+}
+
+/** The change log lives beside the replica; see `change-log-db.ts`. */
+export function changeLogFile(config: SoakConfig, node: string): string {
+  return `${replicaFile(config, node)}-change-log`;
+}
+
+export function vsPort(config: SoakConfig, index: number): number {
+  return config.vsBasePort + index * 10;
+}
+
+export function otlpEndpoint(config: SoakConfig, node: string): string {
+  return `http://127.0.0.1:${config.otlpPort}/v1/metrics/${node}`;
+}
+
+function commonEnv(config: SoakConfig, node: string): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    NODE_ENV: 'development',
+    DO_NOT_TRACK: '1',
+    ZERO_ENABLE_TELEMETRY: 'false',
+    ZERO_UPSTREAM_DB: config.upstreamDB,
+    ZERO_CVR_DB: config.upstreamDB,
+    ZERO_CHANGE_DB: config.upstreamDB,
+    ZERO_TASK_ID: node,
+    ZERO_LOG_FORMAT: 'json',
+    ZERO_SHADOW_SYNC_ENABLED: 'false',
+    // Litestream reads these from the child's environment; both the RM (which
+    // backs up) and the view-syncers (which restore) need them.
+    ZERO_LITESTREAM_EXECUTABLE: join(BIN_DIR, 'litestream-v3'),
+    ZERO_LITESTREAM_EXECUTABLE_V5: join(BIN_DIR, 'litestream-v5'),
+    ZERO_LITESTREAM_VFS_QUERY_EXECUTABLE: join(BIN_DIR, 'vfs-query'),
+    // The defaults are relative to the process's cwd
+    // (`./src/services/litestream/...`), which only resolves when zero-cache
+    // runs from packages/zero-cache.
+    ZERO_LITESTREAM_CONFIG_PATH: LITESTREAM_CONFIG_V3,
+    ZERO_LITESTREAM_CONFIG_PATH_V5: LITESTREAM_CONFIG_V5,
+    ZERO_LITESTREAM_RESTORE_USING_V5: 'true',
+    ZERO_LITESTREAM_BACKUP_USING_V5: 'true',
+    ZERO_LITESTREAM_ENDPOINT: config.s3Endpoint,
+    ZERO_LITESTREAM_REGION: config.s3Region,
+    AWS_ACCESS_KEY_ID: config.accessKeyID,
+    AWS_SECRET_ACCESS_KEY: config.secretAccessKey,
+    AWS_REGION: config.s3Region,
+    // OTel metrics are the census and the resource-bound sampler: every
+    // worker in every task exports to the orchestrator's in-process OTLP
+    // receiver on a path that names the task. Logs and traces stay off.
+    OTEL_METRICS_EXPORTER: 'otlp',
+    OTEL_LOGS_EXPORTER: 'none',
+    OTEL_TRACES_EXPORTER: 'none',
+    OTEL_EXPORTER_OTLP_PROTOCOL: 'http/json',
+    OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: otlpEndpoint(config, node),
+    OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE: 'delta',
+    OTEL_METRIC_EXPORT_INTERVAL: String(config.metricExportIntervalMs),
+    OTEL_METRIC_EXPORT_TIMEOUT: String(config.metricExportIntervalMs * 2),
+    OTEL_SERVICE_NAME: `rmv2-soak-${node}`,
+  };
+}
+
+function changeLogEnv(settings: ChangeLogSettings): NodeJS.ProcessEnv {
+  return {
+    ZERO_CHANGE_STREAMER_SQLITE_CHANGE_LOG_MODE: settings.mode,
+    ZERO_CHANGE_STREAMER_SQLITE_CHANGE_LOG_READ_PERCENT: String(
+      settings.readPercent,
+    ),
+    ZERO_CHANGE_STREAMER_SQLITE_CHANGE_LOG_COLD_READ_PERCENT: String(
+      settings.coldReadPercent,
+    ),
+    ZERO_CHANGE_STREAMER_SQLITE_CHANGE_LOG_COMPARE_PERCENT: String(
+      settings.comparePercent,
+    ),
+    ZERO_CHANGE_STREAMER_SQLITE_CHANGE_LOG_RETENTION_MS: String(
+      settings.retentionMs,
+    ),
+  };
+}
+
+export function replicationManagerEnv(
+  config: SoakConfig,
+  overrides: Partial<ChangeLogSettings> = {},
+): NodeJS.ProcessEnv {
+  const node = taskIDFor('rm');
+  return {
+    ...commonEnv(config, node),
+    ZERO_PORT: String(config.rmPort),
+    ZERO_NUM_SYNC_WORKERS: '0',
+    ZERO_REPLICA_FILE: replicaFile(config, node),
+    ZERO_LOG_LEVEL: config.rmLogLevel,
+    ZERO_CHANGE_STREAMER_STARTUP_DELAY_MS: String(config.startupDelayMs),
+    ZERO_LITESTREAM_BACKUP_URL: config.backupURL,
+    ZERO_LITESTREAM_INCREMENTAL_BACKUP_INTERVAL_SECONDS: String(
+      config.backupIntervalSeconds,
+    ),
+    ZERO_LITESTREAM_SNAPSHOT_BACKUP_INTERVAL_HOURS: String(
+      config.snapshotBackupIntervalHours,
+    ),
+    ZERO_LITESTREAM_VFS_POLL_INTERVAL_MS: String(config.vfsPollIntervalMs),
+    ...changeLogEnv({...config.changeLog, ...overrides}),
+  };
+}
+
+export function viewSyncerEnv(
+  config: SoakConfig,
+  index: number,
+): NodeJS.ProcessEnv {
+  const node = taskIDFor(index);
+  return {
+    ...commonEnv(config, node),
+    ZERO_PORT: String(vsPort(config, index)),
+    ZERO_NUM_SYNC_WORKERS: '1',
+    ZERO_REPLICA_FILE: replicaFile(config, node),
+    ZERO_LOG_LEVEL: config.vsLogLevel,
+    ZERO_CHANGE_STREAMER_URI: `ws://127.0.0.1:${config.rmPort + 1}/`,
+    // No ZERO_LITESTREAM_BACKUP_URL: `restoreReplica` takes it from the
+    // replication-manager's snapshot response, and a view-syncer that
+    // declared its own would be inferring backup configuration it does not
+    // own. `undefined` clears whatever the parent process inherited; Node
+    // drops undefined entries when it builds the child's environment.
+    ZERO_LITESTREAM_BACKUP_URL: undefined,
+    // REQUIRED. `apps/zbugs/.env` sets the change-log mode, dotenvx injects
+    // any variable the child does not already have, and a view-syncer that
+    // inherits a writing mode logs a warning and runs no log at all. Say
+    // `off` rather than relying on omission.
+    ...changeLogEnv({
+      mode: 'off',
+      readPercent: 0,
+      coldReadPercent: 0,
+      comparePercent: 0,
+      retentionMs: config.changeLog.retentionMs,
+    }),
+  };
+}
+
+export function makeRunDir(root: string): {
+  root: string;
+  logsDir: string;
+} {
+  mkdirSync(root, {recursive: true});
+  const logsDir = join(root, 'logs');
+  mkdirSync(logsDir, {recursive: true});
+  return {root, logsDir};
+}

--- a/apps/zbugs/scripts/rmv2-soak/config.ts
+++ b/apps/zbugs/scripts/rmv2-soak/config.ts
@@ -41,6 +41,7 @@ export type SoakConfig = {
   readonly reportPath: string;
 
   readonly upstreamDB: string;
+  readonly appID: string;
   readonly viewSyncers: number;
 
   readonly rmPort: number;
@@ -111,6 +112,11 @@ function commonEnv(config: SoakConfig, node: string): NodeJS.ProcessEnv {
     ZERO_UPSTREAM_DB: config.upstreamDB,
     ZERO_CVR_DB: config.upstreamDB,
     ZERO_CHANGE_DB: config.upstreamDB,
+    // Do not share the default `zero` app's CDC ownership row or replication
+    // slot with an ordinary local zbugs process. The fixed ports already make
+    // concurrent soak runs mutually exclusive, so a stable dedicated id is
+    // sufficient and avoids leaking a new slot/schema for every run.
+    ZERO_APP_ID: config.appID,
     ZERO_TASK_ID: node,
     ZERO_LOG_FORMAT: 'json',
     ZERO_SHADOW_SYNC_ENABLED: 'false',

--- a/apps/zbugs/scripts/rmv2-soak/infra.ts
+++ b/apps/zbugs/scripts/rmv2-soak/infra.ts
@@ -1,0 +1,194 @@
+import {spawn} from 'node:child_process';
+import {
+  CreateBucketCommand,
+  DeleteObjectsCommand,
+  ListObjectsV2Command,
+  S3Client,
+} from '@aws-sdk/client-s3';
+import {DOCKER_DIR, type SoakConfig} from './config.ts';
+
+const COMPOSE_FILES = [
+  '-f',
+  'docker-compose.yml',
+  '-f',
+  'docker-compose.minio.yml',
+];
+
+export function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+export function run(
+  command: string,
+  args: readonly string[],
+  cwd: string,
+): Promise<{code: number; stdout: string; stderr: string}> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout?.on('data', c => (stdout += String(c)));
+    child.stderr?.on('data', c => (stderr += String(c)));
+    child.once('error', reject);
+    child.once('exit', code => resolve({code: code ?? -1, stdout, stderr}));
+  });
+}
+
+async function compose(...args: string[]): Promise<string> {
+  const {code, stdout, stderr} = await run(
+    'docker',
+    ['compose', ...COMPOSE_FILES, ...args],
+    DOCKER_DIR,
+  );
+  if (code !== 0) {
+    throw new Error(
+      `docker compose ${args.join(' ')} exited with ${code}\n${stderr}`,
+    );
+  }
+  return stdout;
+}
+
+/** Brings up postgres and minio, and waits for both to answer. */
+export async function startInfra(config: SoakConfig): Promise<void> {
+  await compose('up', '-d', 'postgres_primary', 'minio');
+  await waitForMinio(config, 120_000);
+  // The bucket-init container exits 0 once the bucket is present.
+  await compose('up', '--exit-code-from', 'minio_init', 'minio_init');
+}
+
+export async function stopMinio(): Promise<void> {
+  await compose('stop', 'minio');
+}
+
+export async function startMinio(config: SoakConfig): Promise<void> {
+  await compose('start', 'minio');
+  await waitForMinio(config, 120_000);
+}
+
+export async function waitForMinio(
+  config: SoakConfig,
+  timeoutMs: number,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown;
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(
+        new URL('/minio/health/live', config.s3Endpoint),
+      );
+      if (response.ok) {
+        return;
+      }
+      lastError = new Error(`HTTP ${response.status}`);
+    } catch (e) {
+      lastError = e;
+    }
+    await sleep(500);
+  }
+  throw new Error(`minio did not become healthy: ${String(lastError)}`);
+}
+
+export function s3Client(config: SoakConfig): S3Client {
+  return new S3Client({
+    endpoint: config.s3Endpoint,
+    region: config.s3Region,
+    // minio serves virtual-host style only with DNS wildcards, which a
+    // localhost endpoint has no way to provide.
+    forcePathStyle: true,
+    credentials: {
+      accessKeyId: config.accessKeyID,
+      secretAccessKey: config.secretAccessKey,
+    },
+  });
+}
+
+/**
+ * The bucket the soak's backups live in.
+ *
+ * Only the bucket, deliberately: the replication-manager does not publish to
+ * the configured path. `initializePostgresChangeSource` derives a
+ * *destination* backup URL whose last segment is a generation id -- the
+ * replica fork/resumption identity -- and logs it as `setting up backup to
+ * s3://<bucket>/<generation>`. The configured path is therefore not a prefix
+ * of anything, and the soak owns the whole bucket instead.
+ */
+export function backupBucket(backupURL: string): string {
+  const url = new URL(backupURL);
+  if (url.protocol !== 's3:') {
+    throw new Error(`expected an s3:// backup URL, got ${backupURL}`);
+  }
+  return url.hostname;
+}
+
+/**
+ * Empties the backup bucket so that a run starts from a clean generation. A
+ * leftover backup from a previous run carries a different `replicaVersion`
+ * and would be rejected rather than restored, which shows up as a confusing
+ * initial sync rather than as an error.
+ */
+export async function resetBackup(config: SoakConfig): Promise<number> {
+  const client = s3Client(config);
+  const bucket = backupBucket(config.backupURL);
+  try {
+    await client.send(new CreateBucketCommand({Bucket: bucket}));
+  } catch {
+    // Already exists.
+  }
+  let deleted = 0;
+  let token: string | undefined;
+  do {
+    const page = await client.send(
+      new ListObjectsV2Command({
+        Bucket: bucket,
+        ContinuationToken: token,
+      }),
+    );
+    const keys = (page.Contents ?? [])
+      .map(o => o.Key)
+      .filter((k): k is string => k !== undefined);
+    if (keys.length > 0) {
+      await client.send(
+        new DeleteObjectsCommand({
+          Bucket: bucket,
+          Delete: {Objects: keys.map(Key => ({Key}))},
+        }),
+      );
+      deleted += keys.length;
+    }
+    token = page.IsTruncated ? page.NextContinuationToken : undefined;
+  } while (token);
+  client.destroy();
+  return deleted;
+}
+
+/** Total bytes and object count currently held in the backup bucket. */
+export async function backupSize(
+  config: SoakConfig,
+): Promise<{objects: number; bytes: number}> {
+  const client = s3Client(config);
+  const bucket = backupBucket(config.backupURL);
+  let objects = 0;
+  let bytes = 0;
+  let token: string | undefined;
+  try {
+    do {
+      const page = await client.send(
+        new ListObjectsV2Command({
+          Bucket: bucket,
+          ContinuationToken: token,
+        }),
+      );
+      for (const o of page.Contents ?? []) {
+        objects++;
+        bytes += o.Size ?? 0;
+      }
+      token = page.IsTruncated ? page.NextContinuationToken : undefined;
+    } while (token);
+  } finally {
+    client.destroy();
+  }
+  return {objects, bytes};
+}

--- a/apps/zbugs/scripts/rmv2-soak/infra.ts
+++ b/apps/zbugs/scripts/rmv2-soak/infra.ts
@@ -164,6 +164,45 @@ export async function resetBackup(config: SoakConfig): Promise<number> {
   return deleted;
 }
 
+/** Trailing slash on an S3 common prefix. */
+const TRAILING_SLASH = /\/$/;
+
+/**
+ * The backup generations currently in the bucket, oldest first.
+ *
+ * `initializePostgresChangeSource` mints `String(Date.now())` as the backup
+ * path for every non-initial-sync startup under litestream v5, so each
+ * replication-manager incarnation gets its own top-level prefix here. Counting
+ * them is how a chaos action asserts that a restart forked the backup rather
+ * than resuming it.
+ */
+export async function backupGenerations(config: SoakConfig): Promise<string[]> {
+  const client = s3Client(config);
+  const bucket = backupBucket(config.backupURL);
+  const generations = new Set<string>();
+  let token: string | undefined;
+  try {
+    do {
+      const page = await client.send(
+        new ListObjectsV2Command({
+          Bucket: bucket,
+          Delimiter: '/',
+          ContinuationToken: token,
+        }),
+      );
+      for (const prefix of page.CommonPrefixes ?? []) {
+        if (prefix.Prefix) {
+          generations.add(prefix.Prefix.replace(TRAILING_SLASH, ''));
+        }
+      }
+      token = page.IsTruncated ? page.NextContinuationToken : undefined;
+    } while (token);
+  } finally {
+    client.destroy();
+  }
+  return [...generations].toSorted();
+}
+
 /** Total bytes and object count currently held in the backup bucket. */
 export async function backupSize(
   config: SoakConfig,

--- a/apps/zbugs/scripts/rmv2-soak/logs.ts
+++ b/apps/zbugs/scripts/rmv2-soak/logs.ts
@@ -1,0 +1,425 @@
+/**
+ * The soak's view of a zero-cache JSON log stream.
+ *
+ * `ZERO_LOG_FORMAT=json` writes one object per line: `{level, ...context,
+ * ...lastArgObject, message}`. The structured payloads the change log already
+ * attaches -- `sqliteChangeLogReconcile`, `sqliteChangeLogPurge`,
+ * `sqliteChangeLogCoverage`, `backedUp` -- carry most of what this harness
+ * needs; the rest is matched off the message text.
+ *
+ * Counters and distributions come from OTel (see `otlp.ts`). Logs are for
+ * *events with a time*: when the log reseeded, when a reservation opened and
+ * when it was confirmed, which task was demoted.
+ */
+
+export type LogRecord = {
+  readonly node: string;
+  readonly tsMs: number;
+  readonly level: string;
+  readonly message: string;
+  readonly fields: Readonly<Record<string, unknown>>;
+  readonly raw: string;
+};
+
+export type SoakEventKind =
+  | 'change-log-startup'
+  | 'change-log-reconcile'
+  | 'change-log-reseed'
+  | 'purge-pass'
+  | 'floor-probe-violation'
+  | 'compare-mismatch'
+  | 'reservation-opened'
+  | 'reservation-confirmed'
+  | 'reservation-delayed'
+  | 'reservation-demoted'
+  | 'backup-watermark'
+  | 'served-from-sqlite'
+  | 'served-from-pg'
+  | 'subscriber-rejected'
+  | 'restore-started'
+  | 'restore-finished'
+  | 'barrier-timeout'
+  | 'registration-failed';
+
+export type SoakEvent = {
+  readonly kind: SoakEventKind;
+  readonly node: string;
+  readonly tsMs: number;
+  readonly detail: Readonly<Record<string, unknown>>;
+  readonly record: LogRecord;
+};
+
+export type Tripwire = {
+  readonly name: string;
+  readonly node: string;
+  readonly tsMs: number;
+  readonly message: string;
+  readonly detail: Readonly<Record<string, unknown>>;
+};
+
+type Waiter<T> = {
+  predicate: (value: T) => boolean;
+  resolve: (value: T) => void;
+  timer: NodeJS.Timeout;
+};
+
+const DEMOTION =
+  /^demoting (\S+) to PG catchup: SQLite change-log minimum (\S+) is later than backupWatermark (\S+)/;
+const RESERVATION_OPENED = /^created snasphot reservation for (\S+)$/;
+const RESERVATION_CONFIRMED =
+  /^reserving change-log entries since (\S+) for (\S+)$/;
+const RESERVATION_DELAYED =
+  /^pg change-log minWatermark (\S+) is later than backupWatermark (\S+)/;
+const SERVED_FROM_SQLITE = /^serving (\S+) from SQLite catchup$/;
+const SERVED_FROM_PG = /^serving (\S+) from PG catchup: (.*)$/;
+const SQLITE_ROUTE = /^SQLite route (\S+)/;
+
+/**
+ * The reasons `serving ... from PG catchup` is emitted with, mapped back onto
+ * `ChangeLogReadRouteReason`. The route counter in OTel is the census of
+ * record; this is what gives each one a timestamp and a subscriber.
+ */
+function pgRouteReason(rest: string): string {
+  if (rest.startsWith('SQLite change log is still warming')) {
+    return 'cold-log';
+  }
+  if (rest.includes('is below the SQLite change-log minimum')) {
+    return 'watermark-uncovered';
+  }
+  if (rest.startsWith('SQLite catchup registration failed')) {
+    return 'registration-failed';
+  }
+  const routed = SQLITE_ROUTE.exec(rest);
+  return routed ? routed[1] : 'unknown';
+}
+
+export class SoakLog {
+  readonly events: SoakEvent[] = [];
+  readonly tripwires: Tripwire[] = [];
+  readonly #waiters = new Set<Waiter<SoakEvent>>();
+  readonly #recordWaiters = new Set<Waiter<LogRecord>>();
+  readonly #listeners = new Set<(event: SoakEvent) => void>();
+  #onTripwire: ((t: Tripwire) => void) | undefined;
+
+  onTripwire(handler: (t: Tripwire) => void): void {
+    this.#onTripwire = handler;
+  }
+
+  onEvent(listener: (event: SoakEvent) => void): () => void {
+    this.#listeners.add(listener);
+    return () => this.#listeners.delete(listener);
+  }
+
+  /** Feeds one raw stdout/stderr line from `node` into the stream. */
+  push(node: string, line: string): void {
+    const trimmed = line.trim();
+    if (trimmed.length === 0) {
+      return;
+    }
+    let parsed: Record<string, unknown>;
+    if (trimmed.startsWith('{')) {
+      try {
+        parsed = JSON.parse(trimmed) as Record<string, unknown>;
+      } catch {
+        return;
+      }
+    } else {
+      // litestream's own stdout, node warnings, etc.
+      return;
+    }
+    const {level, message, ...fields} = parsed;
+    const record: LogRecord = {
+      node,
+      tsMs: Date.now(),
+      level: typeof level === 'string' ? level : 'INFO',
+      message: typeof message === 'string' ? message : '',
+      fields,
+      raw: trimmed,
+    };
+    // Iterating the set directly is safe: `resolve` deletes only the waiter
+    // currently being visited, which is well defined for Set iteration.
+    for (const waiter of this.#recordWaiters) {
+      if (waiter.predicate(record)) {
+        waiter.resolve(record);
+      }
+    }
+    this.#classify(record);
+  }
+
+  since(tsMs: number, kind?: SoakEventKind): SoakEvent[] {
+    return this.events.filter(
+      e => e.tsMs >= tsMs && (kind === undefined || e.kind === kind),
+    );
+  }
+
+  /**
+   * Resolves with the first matching event, including events that already
+   * arrived at or after `sinceMs`.
+   */
+  waitFor(
+    description: string,
+    predicate: (event: SoakEvent) => boolean,
+    timeoutMs: number,
+    sinceMs = 0,
+  ): Promise<SoakEvent> {
+    const already = this.events.find(e => e.tsMs >= sinceMs && predicate(e));
+    if (already) {
+      return Promise.resolve(already);
+    }
+    return new Promise<SoakEvent>((resolve, reject) => {
+      const waiter: Waiter<SoakEvent> = {
+        predicate,
+        resolve: event => {
+          clearTimeout(waiter.timer);
+          this.#waiters.delete(waiter);
+          resolve(event);
+        },
+        timer: setTimeout(() => {
+          this.#waiters.delete(waiter);
+          reject(
+            new Error(
+              `timed out after ${timeoutMs}ms waiting for ${description}`,
+            ),
+          );
+        }, timeoutMs),
+      };
+      this.#waiters.add(waiter);
+    });
+  }
+
+  /**
+   * Resolves with the first raw log line matching `predicate`. Readiness and
+   * shutdown are announced in prose rather than in a structured payload, so
+   * they are matched here rather than promoted to {@link SoakEvent}s.
+   */
+  waitForRecord(
+    description: string,
+    predicate: (record: LogRecord) => boolean,
+    timeoutMs: number,
+  ): Promise<LogRecord> {
+    return new Promise<LogRecord>((resolve, reject) => {
+      const waiter: Waiter<LogRecord> = {
+        predicate,
+        resolve: record => {
+          clearTimeout(waiter.timer);
+          this.#recordWaiters.delete(waiter);
+          resolve(record);
+        },
+        timer: setTimeout(() => {
+          this.#recordWaiters.delete(waiter);
+          reject(
+            new Error(
+              `timed out after ${timeoutMs}ms waiting for ${description}`,
+            ),
+          );
+        }, timeoutMs),
+      };
+      this.#recordWaiters.add(waiter);
+    });
+  }
+
+  #emit(
+    kind: SoakEventKind,
+    record: LogRecord,
+    detail: Record<string, unknown>,
+  ): void {
+    const event: SoakEvent = {
+      kind,
+      node: record.node,
+      tsMs: record.tsMs,
+      detail,
+      record,
+    };
+    this.events.push(event);
+    for (const listener of this.#listeners) {
+      listener(event);
+    }
+    // See the note in `push`: each `resolve` deletes only its own waiter.
+    for (const waiter of this.#waiters) {
+      if (waiter.predicate(event)) {
+        waiter.resolve(event);
+      }
+    }
+  }
+
+  #trip(
+    name: string,
+    record: LogRecord,
+    detail: Record<string, unknown> = {},
+  ): void {
+    const tripwire: Tripwire = {
+      name,
+      node: record.node,
+      tsMs: record.tsMs,
+      message: record.message,
+      detail,
+    };
+    this.tripwires.push(tripwire);
+    this.#onTripwire?.(tripwire);
+  }
+
+  #classify(record: LogRecord): void {
+    const {message, fields} = record;
+
+    // Matched on the message, not just the field: `reconcileChangeLog` also
+    // attaches `sqliteChangeLogReconcile` to its "at the resume watermark"
+    // trace, which carries a head but no action.
+    const reconcile =
+      message === 'SQLite change-log reconciliation'
+        ? (fields.sqliteChangeLogReconcile as
+            | {action: string; head: string; reason?: string; rows?: number}
+            | undefined)
+        : undefined;
+    if (reconcile) {
+      this.#emit('change-log-reconcile', record, {...reconcile});
+      if (reconcile.action === 'reseeded') {
+        this.#emit('change-log-reseed', record, {...reconcile});
+      }
+      return;
+    }
+
+    if (message === 'SQLite change-log startup') {
+      this.#emit('change-log-startup', record, {
+        ...(fields.sqliteChangeLog as Record<string, unknown>),
+      });
+      return;
+    }
+
+    const purge = fields.sqliteChangeLogPurge as
+      | Record<string, unknown>
+      | undefined;
+    if (purge) {
+      this.#emit('purge-pass', record, {...purge});
+      return;
+    }
+
+    const floorProbe = fields.sqliteChangeLogFloorProbe as
+      | Record<string, unknown>
+      | undefined;
+    if (floorProbe) {
+      this.#emit('floor-probe-violation', record, {...floorProbe});
+      this.#trip('purge-floor-violation', record, {...floorProbe});
+      return;
+    }
+
+    if (message === 'SQLite change-log catchup output diverged from Postgres') {
+      const detail = (fields.sqliteChangeLogCompare ?? {}) as Record<
+        string,
+        unknown
+      >;
+      this.#emit('compare-mismatch', record, {...detail});
+      this.#trip('compare-mismatch', record, {...detail});
+      return;
+    }
+
+    if (message === 'received backup watermark') {
+      const backedUp = (fields.backedUp ?? {}) as {
+        watermark?: string;
+        writeTimeMs?: number;
+        backupTimeMs?: number;
+      };
+      this.#emit('backup-watermark', record, {
+        ...backedUp,
+        lagMs:
+          backedUp.backupTimeMs !== undefined &&
+          backedUp.writeTimeMs !== undefined
+            ? backedUp.backupTimeMs - backedUp.writeTimeMs
+            : undefined,
+      });
+      return;
+    }
+
+    let m = DEMOTION.exec(message);
+    if (m) {
+      this.#emit('reservation-demoted', record, {
+        taskID: m[1],
+        minWatermark: m[2],
+        backupWatermark: m[3],
+      });
+      return;
+    }
+
+    m = RESERVATION_OPENED.exec(message);
+    if (m) {
+      this.#emit('reservation-opened', record, {taskID: m[1]});
+      return;
+    }
+
+    m = RESERVATION_CONFIRMED.exec(message);
+    if (m) {
+      this.#emit('reservation-confirmed', record, {
+        minWatermark: m[1],
+        taskID: m[2],
+      });
+      return;
+    }
+
+    m = RESERVATION_DELAYED.exec(message);
+    if (m) {
+      this.#emit('reservation-delayed', record, {
+        minWatermark: m[1],
+        backupWatermark: m[2],
+      });
+      return;
+    }
+
+    m = SERVED_FROM_SQLITE.exec(message);
+    if (m) {
+      this.#emit('served-from-sqlite', record, {
+        subscriber: m[1],
+        coverage: fields.sqliteChangeLogCoverage,
+      });
+      return;
+    }
+
+    m = SERVED_FROM_PG.exec(message);
+    if (m) {
+      const reason = pgRouteReason(m[2]);
+      this.#emit('served-from-pg', record, {
+        subscriber: m[1],
+        reason,
+        coverage: fields.sqliteChangeLogCoverage,
+      });
+      if (reason === 'registration-failed') {
+        this.#emit('registration-failed', record, {subscriber: m[1]});
+        this.#trip('sqlite-registration-failed', record, {subscriber: m[1]});
+      }
+      return;
+    }
+
+    if (message.startsWith('rejecting subscriber at replica version')) {
+      this.#emit('subscriber-rejected', record, {});
+      this.#trip('wrong-replica-version', record, {});
+      return;
+    }
+
+    if (message.startsWith('starting litestream restore')) {
+      this.#emit('restore-started', record, {...fields});
+      return;
+    }
+    if (
+      message.startsWith('litestream restore complete') ||
+      message.startsWith('finished litestream restore')
+    ) {
+      this.#emit('restore-finished', record, {...fields});
+      return;
+    }
+
+    if (
+      message.includes('WatermarkTooOld') ||
+      message.includes('WrongReplicaVersion')
+    ) {
+      this.#trip('watermark-too-old', record, {});
+      return;
+    }
+
+    if (record.level === 'ERROR') {
+      // Everything else at ERROR is worth surfacing but is not a named
+      // tripwire; the report lists them separately.
+      this.#trip('error-log', record, {
+        errorMsg: fields.errorMsg,
+        name: fields.name,
+      });
+    }
+  }
+}

--- a/apps/zbugs/scripts/rmv2-soak/logs.ts
+++ b/apps/zbugs/scripts/rmv2-soak/logs.ts
@@ -38,6 +38,9 @@ export type SoakEventKind =
   | 'subscriber-rejected'
   | 'restore-started'
   | 'restore-finished'
+  // A view-syncer discarded its own replica because the snapshot
+  // reservation's `minWatermark` was above it, and restored instead.
+  | 'replica-discarded'
   | 'barrier-timeout'
   | 'registration-failed';
 
@@ -390,6 +393,11 @@ export class SoakLog {
     if (message.startsWith('rejecting subscriber at replica version')) {
       this.#emit('subscriber-rejected', record, {});
       this.#trip('wrong-replica-version', record, {});
+      return;
+    }
+
+    if (message.startsWith('Deleting local replica and retrying restore')) {
+      this.#emit('replica-discarded', record, {});
       return;
     }
 

--- a/apps/zbugs/scripts/rmv2-soak/node.ts
+++ b/apps/zbugs/scripts/rmv2-soak/node.ts
@@ -106,6 +106,7 @@ export class SoakNode {
   #logStream: WriteStream | undefined;
   #exited: Promise<{code: number | null; signal: NodeJS.Signals | null}> =
     Promise.resolve({code: null, signal: null});
+  #unexpectedExit: Promise<never> = new Promise(() => {});
   #startCount = 0;
   #stopping = false;
   /**
@@ -139,6 +140,10 @@ export class SoakNode {
 
   get startCount(): number {
     return this.#startCount;
+  }
+
+  get unexpectedExit(): Promise<never> {
+    return this.#unexpectedExit;
   }
 
   /**
@@ -190,6 +195,18 @@ export class SoakNode {
         resolve({code, signal});
       });
     });
+    this.#unexpectedExit = this.#exited.then(({code, signal}) => {
+      if (!this.#stopping) {
+        throw new Error(
+          `${this.name} exited unexpectedly (code=${code} signal=${signal})`,
+        );
+      }
+      return new Promise<never>(() => {});
+    });
+    // A node can exit between awaited harness operations. Mark the rejection
+    // handled here; `SoakCluster.guard()` still observes the original promise
+    // and fails the operation currently in flight.
+    this.#unexpectedExit.catch(() => undefined);
 
     // Sample the tree while the node is coming up, so that a start which
     // fails partway through still leaves a reapable set behind.
@@ -203,20 +220,8 @@ export class SoakNode {
         record.message.startsWith('all workers ready'),
       readyTimeoutMs,
     );
-    const died = this.#exited.then(({code, signal}) => {
-      if (!this.#stopping) {
-        throw new Error(
-          `${this.name} exited before becoming ready (code=${code} signal=${signal})`,
-        );
-      }
-      return undefined;
-    });
-    // The process usually outlives `start()`, so this rejection has to be
-    // marked handled; attaching the handler does not stop the race below from
-    // seeing it.
-    died.catch(() => undefined);
     try {
-      await Promise.race([ready, died]);
+      await Promise.race([ready, this.#unexpectedExit]);
     } catch (e) {
       // A failed start still leaves workers behind; reap them so the next
       // attempt is not blocked by the replica locks they hold.

--- a/apps/zbugs/scripts/rmv2-soak/node.ts
+++ b/apps/zbugs/scripts/rmv2-soak/node.ts
@@ -1,0 +1,360 @@
+import {execFileSync, spawn, type ChildProcess} from 'node:child_process';
+import {createWriteStream, type WriteStream} from 'node:fs';
+import {rm} from 'node:fs/promises';
+import {basename, dirname, join} from 'node:path';
+import {createInterface} from 'node:readline';
+import {APP_ROOT, ZERO_CACHE_MAIN} from './config.ts';
+import type {SoakLog} from './logs.ts';
+
+/**
+ * Every pid in the process tree rooted at `root`, deepest first.
+ *
+ * A signal to the process group is not enough: `childWorker` forks each
+ * zero-cache worker with `detached: true` (so that SIGINT is not propagated
+ * automatically and graceful shutdown happens as intended), which puts every
+ * worker in its own process group. Signalling the dispatcher's group reaches
+ * only the dispatcher and the runner, and a dispatcher that dies without
+ * draining leaves its change-streamer, backup-replicator, litestream and
+ * vfs-query processes running -- still serving view-syncers, and still
+ * holding the replica's locks, which is what makes the next start fail with
+ * `SQLITE_BUSY: journal_mode = delete`.
+ */
+function processTree(root: number): number[] {
+  let listing: string;
+  try {
+    listing = execFileSync('ps', ['-Ao', 'pid=,ppid='], {
+      encoding: 'utf8',
+    });
+  } catch {
+    return [root];
+  }
+  const childrenOf = new Map<number, number[]>();
+  for (const line of listing.split('\n')) {
+    const match = PS_LINE.exec(line);
+    if (!match) {
+      continue;
+    }
+    const pid = Number(match[1]);
+    const ppid = Number(match[2]);
+    const siblings = childrenOf.get(ppid);
+    if (siblings) {
+      siblings.push(pid);
+    } else {
+      childrenOf.set(ppid, [pid]);
+    }
+  }
+  const order: number[] = [];
+  const visit = (pid: number) => {
+    for (const child of childrenOf.get(pid) ?? []) {
+      visit(child);
+    }
+    order.push(pid);
+  };
+  visit(root);
+  return order;
+}
+
+const PS_LINE = /^\s*(\d+)\s+(\d+)\s*$/;
+
+function alive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function signalAll(pids: readonly number[], signal: NodeJS.Signals): void {
+  for (const pid of pids) {
+    try {
+      process.kill(pid, signal);
+    } catch {
+      // Already gone.
+    }
+  }
+}
+
+export type NodeOptions = {
+  readonly name: string;
+  readonly env: NodeJS.ProcessEnv;
+  readonly logsDir: string;
+  readonly log: SoakLog;
+  readonly replicaFile: string;
+};
+
+/**
+ * One zero-cache process tree: the replication-manager, or one view-syncer.
+ *
+ * Started with cwd = apps/zbugs so that `shared/src/dotenv.ts` finds the same
+ * `.env` the ordinary dev flow uses. Every variable this harness cares about
+ * is set explicitly in {@link NodeOptions.env}, and dotenvx does not override
+ * a variable that is already present -- but it does inject one that is
+ * absent, which is why the view-syncer environment says
+ * `SQLITE_CHANGE_LOG_MODE=off` rather than omitting it.
+ */
+export class SoakNode {
+  readonly name: string;
+  readonly replicaFile: string;
+  /**
+   * Mutable: the change-log mode is a startup option, so the rollback drills
+   * (C10-C12) rewrite it between restarts.
+   */
+  env: NodeJS.ProcessEnv;
+  readonly #opts: NodeOptions;
+  #child: ChildProcess | undefined;
+  #logStream: WriteStream | undefined;
+  #exited: Promise<{code: number | null; signal: NodeJS.Signals | null}> =
+    Promise.resolve({code: null, signal: null});
+  #startCount = 0;
+  #stopping = false;
+  /**
+   * Every pid this incarnation has ever been seen to own.
+   *
+   * Accumulated rather than sampled once, because the tree has to be readable
+   * *while* the node is alive: once the dispatcher dies its workers are
+   * reparented to init and `ps` can no longer relate them back to this node.
+   */
+  readonly #tree = new Set<number>();
+
+  constructor(opts: NodeOptions) {
+    this.#opts = opts;
+    this.name = opts.name;
+    this.replicaFile = opts.replicaFile;
+    this.env = opts.env;
+  }
+
+  get running(): boolean {
+    const child = this.#child;
+    return (
+      child !== undefined &&
+      child.exitCode === null &&
+      child.signalCode === null
+    );
+  }
+
+  get pid(): number | undefined {
+    return this.#child?.pid;
+  }
+
+  get startCount(): number {
+    return this.#startCount;
+  }
+
+  /**
+   * Spawns the process and resolves when the dispatcher reports every worker
+   * ready. Rejects if it exits first.
+   */
+  async start(readyTimeoutMs = 300_000): Promise<void> {
+    if (this.running) {
+      throw new Error(`${this.name} is already running`);
+    }
+    this.#startCount++;
+    const logPath = join(
+      this.#opts.logsDir,
+      `${this.name}.${this.#startCount}.log`,
+    );
+    this.#logStream = createWriteStream(logPath, {flags: 'a'});
+
+    const child = spawn(
+      process.execPath,
+      ['--trace-warnings', ZERO_CACHE_MAIN],
+      {
+        cwd: APP_ROOT,
+        env: this.env,
+        stdio: ['ignore', 'pipe', 'pipe'],
+        // Its own process group, so that SIGSTOP/SIGCONT (C7) and SIGKILL
+        // (C8) reach the workers and not just the dispatcher.
+        detached: true,
+      },
+    );
+    this.#child = child;
+    this.#stopping = false;
+    this.#tree.clear();
+
+    for (const stream of [child.stdout, child.stderr]) {
+      if (!stream) {
+        continue;
+      }
+      const lines = createInterface({input: stream, crlfDelay: Infinity});
+      lines.on('line', line => {
+        this.#logStream?.write(`${line}\n`);
+        this.#opts.log.push(this.name, line);
+      });
+    }
+
+    this.#exited = new Promise(resolve => {
+      child.once('exit', (code, signal) => {
+        this.#logStream?.end();
+        this.#logStream = undefined;
+        resolve({code, signal});
+      });
+    });
+
+    // Sample the tree while the node is coming up, so that a start which
+    // fails partway through still leaves a reapable set behind.
+    const tracker = setInterval(() => this.#trackTree(), 500);
+    this.#trackTree();
+
+    const ready = this.#opts.log.waitForRecord(
+      `${this.name} to report all workers ready`,
+      record =>
+        record.node === this.name &&
+        record.message.startsWith('all workers ready'),
+      readyTimeoutMs,
+    );
+    const died = this.#exited.then(({code, signal}) => {
+      if (!this.#stopping) {
+        throw new Error(
+          `${this.name} exited before becoming ready (code=${code} signal=${signal})`,
+        );
+      }
+      return undefined;
+    });
+    // The process usually outlives `start()`, so this rejection has to be
+    // marked handled; attaching the handler does not stop the race below from
+    // seeing it.
+    died.catch(() => undefined);
+    try {
+      await Promise.race([ready, died]);
+    } catch (e) {
+      // A failed start still leaves workers behind; reap them so the next
+      // attempt is not blocked by the replica locks they hold.
+      await this.#reap();
+      throw e;
+    } finally {
+      clearInterval(tracker);
+      this.#trackTree();
+    }
+  }
+
+  #trackTree(): void {
+    const pid = this.#child?.pid;
+    if (pid === undefined) {
+      return;
+    }
+    for (const child of processTree(pid)) {
+      this.#tree.add(child);
+    }
+  }
+
+  /** Sends `signal` and waits for exit. SIGKILLs after `graceMs`. */
+  async stop(
+    signal: NodeJS.Signals = 'SIGTERM',
+    graceMs = 30_000,
+  ): Promise<void> {
+    const child = this.#child;
+    if (!child || !this.running) {
+      return;
+    }
+    this.#stopping = true;
+    const exited = this.#exited;
+    // Refresh the tree before signalling; afterwards the parents are gone and
+    // `ps` can no longer relate the orphans back to this node.
+    this.#trackTree();
+    const tree = [...this.#tree];
+    if (signal === 'SIGKILL') {
+      // A hard crash takes the workers with it, the way losing the container
+      // does in production.
+      signalAll(tree, 'SIGKILL');
+    } else {
+      child.kill(signal);
+    }
+    let killer: NodeJS.Timeout | undefined;
+    if (signal !== 'SIGKILL') {
+      killer = setTimeout(() => {
+        if (this.running) {
+          signalAll(tree, 'SIGKILL');
+        }
+      }, graceMs);
+    }
+    try {
+      await exited;
+    } finally {
+      clearTimeout(killer);
+    }
+    this.#child = undefined;
+    await this.#reap();
+  }
+
+  /**
+   * Waits briefly for the workers to finish their own shutdown, then kills
+   * whatever is left. The dispatcher's exit does not imply its workers have
+   * exited, and a surviving worker holds the replica against the next start.
+   */
+  async #reap(): Promise<void> {
+    const deadline = Date.now() + 10_000;
+    let survivors = [...this.#tree].filter(alive);
+    while (survivors.length > 0 && Date.now() < deadline) {
+      await new Promise(resolve => setTimeout(resolve, 200));
+      survivors = survivors.filter(alive);
+    }
+    if (survivors.length > 0) {
+      signalAll(survivors, 'SIGKILL');
+    }
+  }
+
+  /**
+   * Sends a signal to the whole process tree without waiting; for
+   * SIGSTOP / SIGCONT (chaos C7), where pausing only the dispatcher would
+   * leave the change-streamer serving and pause nothing that matters.
+   */
+  signal(signal: NodeJS.Signals): void {
+    const pid = this.#child?.pid;
+    if (!this.running || pid === undefined) {
+      throw new Error(`${this.name} is not running`);
+    }
+    this.#trackTree();
+    signalAll(processTree(pid), signal);
+  }
+
+  /**
+   * Deletes the replica, its sidecars and litestream's local state, but not
+   * the change log.
+   *
+   * The litestream directory goes too: in production a view-syncer that loses
+   * its replica comes back on a fresh volume with nothing beside it, so
+   * leaving local backup state behind would be a different scenario from the
+   * one C3 means to run.
+   */
+  async deleteReplica(): Promise<void> {
+    if (this.running) {
+      throw new Error(`refusing to delete ${this.name}'s live replica`);
+    }
+    await rm(
+      join(
+        dirname(this.replicaFile),
+        `.${basename(this.replicaFile)}-litestream`,
+      ),
+      {force: true, recursive: true},
+    );
+    await Promise.all(
+      [
+        this.replicaFile,
+        `${this.replicaFile}-shm`,
+        `${this.replicaFile}-wal`,
+        `${this.replicaFile}-wal2`,
+        `${this.replicaFile}-serving-copy`,
+        `${this.replicaFile}-serving-copy-shm`,
+        `${this.replicaFile}-serving-copy-wal`,
+        `${this.replicaFile}-serving-copy-wal2`,
+      ].map(file => rm(file, {force: true})),
+    );
+  }
+
+  /** Deletes only the change log, leaving the replica and backups valid. */
+  async deleteChangeLog(): Promise<void> {
+    if (this.running) {
+      throw new Error(`refusing to delete ${this.name}'s live change log`);
+    }
+    const changeLog = `${this.replicaFile}-change-log`;
+    await Promise.all(
+      [
+        changeLog,
+        `${changeLog}-shm`,
+        `${changeLog}-wal`,
+        `${changeLog}-wal2`,
+      ].map(file => rm(file, {force: true})),
+    );
+  }
+}

--- a/apps/zbugs/scripts/rmv2-soak/oracle.ts
+++ b/apps/zbugs/scripts/rmv2-soak/oracle.ts
@@ -1,0 +1,539 @@
+import type {LogContext} from '@rocicorp/logger';
+import type postgres from 'postgres';
+import {
+  listIndexes,
+  listTables,
+} from '../../../../packages/zero-cache/src/db/lite-tables.ts';
+import type {LiteTableSpec} from '../../../../packages/zero-cache/src/db/specs.ts';
+import {ZERO_VERSION_COLUMN_NAME} from '../../../../packages/zero-cache/src/services/replicator/schema/constants.ts';
+import {
+  JSON_STRINGIFIED,
+  liteRow,
+} from '../../../../packages/zero-cache/src/types/lite.ts';
+import type {RowValue} from '../../../../packages/zero-cache/src/types/row-key.ts';
+import {Database} from '../../../../packages/zqlite/src/db.ts';
+import {sleep} from './infra.ts';
+
+/**
+ * The correctness gate (plan section 7.1):
+ *
+ *   for every replica R and replicated table T, at a defined transaction
+ *   bound,  pi(R.T) === liteRow(PG.T)  as multisets keyed by primary key
+ *
+ * `liteRow` is the replicator's own PG->SQLite value mapping, so both sides
+ * are canonicalized identically; `pi` drops `_0_version` and the `_zero.*`
+ * schema (`listTables` already excludes the latter).
+ *
+ * This is the only gate that survives the cutover: the dark comparator needs
+ * a PG change log to compare against, and once PG is retired it has nothing
+ * to say. It has two stated blind spots -- a bug *inside* `liteRow` is
+ * invisible to it, and equality at a bound cannot see a transient wrong state
+ * that heals.
+ */
+
+export type RowDiff = {
+  readonly key: string;
+  readonly column?: string | undefined;
+  readonly pg?: string | undefined;
+  readonly replica?: string | undefined;
+};
+
+export type TableDiff = {
+  readonly table: string;
+  /** The columns the multiset is keyed by, or `*` for whole-row keying. */
+  readonly key: string;
+  readonly pgRows: number;
+  readonly replicaRows: number;
+  readonly missingFromReplica: RowDiff[];
+  readonly extraInReplica: RowDiff[];
+  readonly mismatched: RowDiff[];
+};
+
+export type ReplicaComparison = {
+  readonly node: string;
+  readonly stateVersion: string;
+  readonly replicaVersion: string;
+  readonly tables: number;
+  readonly rows: number;
+  readonly diffs: TableDiff[];
+  readonly ok: boolean;
+  readonly error?: string | undefined;
+};
+
+export type OracleResult = {
+  readonly label: string;
+  readonly atMs: number;
+  readonly quiesceMs: number;
+  readonly comparisons: ReplicaComparison[];
+  readonly ok: boolean;
+  /** The section 7.3 bisection verdict. */
+  readonly verdict: string;
+};
+
+const MAX_REPORTED_DIFFS = 10;
+
+export type ReplicaHandle = {
+  readonly node: string;
+  readonly replicaFile: string;
+};
+
+function openReplica(lc: LogContext, file: string): Database {
+  try {
+    return new Database(lc, file, {readonly: true});
+  } catch {
+    // A WAL database can refuse a read-only connection when its `-shm` is
+    // not usable; a read/write connection that never writes is equivalent
+    // for our purposes.
+    return new Database(lc, file);
+  }
+}
+
+/** Canonical string for one column value, from either side. */
+function canon(value: unknown): string {
+  if (value === null || value === undefined) {
+    return 'null';
+  }
+  if (typeof value === 'bigint') {
+    return `i:${value}`;
+  }
+  if (typeof value === 'number') {
+    // A PG `numeric` of 1.0 and a SQLite INTEGER 1 are the same value; the
+    // integral check is what keeps type affinity from reading as divergence.
+    return Number.isInteger(value) ? `i:${BigInt(value)}` : `f:${value}`;
+  }
+  if (typeof value === 'string') {
+    return `s:${value}`;
+  }
+  if (typeof value === 'boolean') {
+    return `i:${value ? 1n : 0n}`;
+  }
+  if (value instanceof Uint8Array) {
+    return `b:${Buffer.from(value).toString('base64')}`;
+  }
+  return `j:${JSON.stringify(value)}`;
+}
+
+/**
+ * The replica has no PRIMARY KEY declarations -- `mapPostgresToLite` drops
+ * them and relies on the UNIQUE indexes, including the one upstream created
+ * for its primary key. So the multiset key is derived from the unique indexes
+ * rather than from `LiteTableSpec.primaryKey`, which is always undefined here.
+ *
+ * Candidates are tried shortest first; one is accepted only if it is
+ * *observably* a key of the replica's rows -- no nulls and no duplicates.
+ * When none is, the whole row becomes the key and the comparison degrades to
+ * a plain multiset with counts, which is still exactly the stated gate, only
+ * with less pointed diagnostics.
+ */
+type KeyedRows = {
+  key: string;
+  columns: readonly string[] | undefined;
+  rows: Map<string, {row: Record<string, string>; count: number}>;
+  total: number;
+};
+
+function keyOf(
+  row: Record<string, string>,
+  keyColumns: readonly string[] | undefined,
+  allColumns: readonly string[],
+): string {
+  return (keyColumns ?? allColumns).map(col => row[col]).join(' ');
+}
+
+function keyRows(
+  rows: readonly Record<string, string>[],
+  columns: readonly string[],
+  candidates: readonly (readonly string[])[],
+): KeyedRows {
+  for (const candidate of candidates) {
+    const map = new Map<string, {row: Record<string, string>; count: number}>();
+    let usable = true;
+    for (const row of rows) {
+      if (candidate.some(col => row[col] === 'null')) {
+        usable = false;
+        break;
+      }
+      const key = keyOf(row, candidate, columns);
+      if (map.has(key)) {
+        usable = false;
+        break;
+      }
+      map.set(key, {row, count: 1});
+    }
+    if (usable) {
+      return {
+        key: candidate.join('+'),
+        columns: candidate,
+        rows: map,
+        total: rows.length,
+      };
+    }
+  }
+  const map = new Map<string, {row: Record<string, string>; count: number}>();
+  for (const row of rows) {
+    const key = keyOf(row, undefined, columns);
+    const existing = map.get(key);
+    if (existing) {
+      existing.count++;
+    } else {
+      map.set(key, {row, count: 1});
+    }
+  }
+  return {key: '*', columns: undefined, rows: map, total: rows.length};
+}
+
+function pgTableName(liteName: string): {schema: string; table: string} {
+  const dot = liteName.indexOf('.');
+  return dot < 0
+    ? {schema: 'public', table: liteName}
+    : {schema: liteName.slice(0, dot), table: liteName.slice(dot + 1)};
+}
+
+function comparableColumns(spec: LiteTableSpec): string[] {
+  return Object.keys(spec.columns).filter(c => c !== ZERO_VERSION_COLUMN_NAME);
+}
+
+function canonRow(
+  row: Record<string, unknown>,
+  columns: readonly string[],
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const column of columns) {
+    out[column] = canon(row[column]);
+  }
+  return out;
+}
+
+/**
+ * Establishes the transaction bound by quiescence: no writes in flight, one
+ * sentinel transaction round-tripped through every replica, and every
+ * replica's `stateVersion` equal.
+ *
+ * PG cannot be read at a historical LSN, so quiescence is what pins both
+ * sides to the same transaction set without any LSN bookkeeping. The sentinel
+ * is inserted and then deleted, so it leaves the database exactly as it found
+ * it -- and its *absence* everywhere proves that every replica consumed a
+ * transaction later than all of the traffic.
+ */
+export async function quiesce(
+  lc: LogContext,
+  sql: postgres.Sql,
+  replicas: readonly ReplicaHandle[],
+  fixture: {projectID: string; creatorID: string},
+  sentinelID: string,
+  timeoutMs = 180_000,
+): Promise<{stateVersion: string; elapsedMs: number}> {
+  const start = Date.now();
+  const deadline = start + timeoutMs;
+
+  await sql`
+    INSERT INTO issue
+      (id, title, open, "projectID", "creatorID", description, visibility)
+    VALUES
+      (${sentinelID}, 'rmv2 soak quiesce sentinel', true,
+       ${fixture.projectID}, ${fixture.creatorID}, 'sentinel', 'public')`;
+  await waitForSentinel(lc, replicas, sentinelID, true, deadline);
+
+  await sql`DELETE FROM issue WHERE id = ${sentinelID}`;
+  await waitForSentinel(lc, replicas, sentinelID, false, deadline);
+
+  // Every replica applied the delete, so they are all at or past its
+  // watermark and nothing further is being written. Converging on one
+  // stateVersion is then a matter of the last in-flight notification.
+  let versions: string[] = [];
+  while (Date.now() < deadline) {
+    versions = replicas.map(r => readStateVersion(lc, r.replicaFile));
+    if (new Set(versions).size === 1) {
+      return {stateVersion: versions[0], elapsedMs: Date.now() - start};
+    }
+    await sleep(200);
+  }
+  throw new Error(
+    `replicas did not converge on a stateVersion: ${replicas
+      .map((r, i) => `${r.node}=${versions[i]}`)
+      .join(', ')}`,
+  );
+}
+
+async function waitForSentinel(
+  lc: LogContext,
+  replicas: readonly ReplicaHandle[],
+  sentinelID: string,
+  present: boolean,
+  deadline: number,
+): Promise<void> {
+  const pending = new Set(replicas.map(r => r.node));
+  while (Date.now() < deadline) {
+    for (const replica of replicas) {
+      if (!pending.has(replica.node)) {
+        continue;
+      }
+      if (sentinelIs(lc, replica.replicaFile, sentinelID, present)) {
+        pending.delete(replica.node);
+      }
+    }
+    if (pending.size === 0) {
+      return;
+    }
+    await sleep(100);
+  }
+  throw new Error(
+    `timed out waiting for the quiesce sentinel to be ${
+      present ? 'present' : 'absent'
+    } on: ${[...pending].join(', ')}`,
+  );
+}
+
+/**
+ * Whether `replicaFile` currently agrees with `want` about the sentinel.
+ *
+ * A replica that cannot be read -- missing, or mid-restore -- has not
+ * observed anything, so it never agrees: reporting "absent" there would end
+ * the wait on a replica that has not caught up at all.
+ */
+function sentinelIs(
+  lc: LogContext,
+  replicaFile: string,
+  sentinelID: string,
+  want: boolean,
+): boolean {
+  let db: Database | undefined;
+  try {
+    db = openReplica(lc, replicaFile);
+    const row = db
+      .prepare(`SELECT 1 AS found FROM "issue" WHERE id = ? LIMIT 1`)
+      .get<{found: number} | undefined>(sentinelID);
+    return (row !== undefined) === want;
+  } catch {
+    return false;
+  } finally {
+    db?.close();
+  }
+}
+
+export function readStateVersion(lc: LogContext, replicaFile: string): string {
+  let db: Database | undefined;
+  try {
+    db = openReplica(lc, replicaFile);
+    const row = db
+      .prepare(`SELECT stateVersion FROM "_zero.replicationState"`)
+      .get<{stateVersion: string} | undefined>();
+    return row?.stateVersion ?? '';
+  } catch {
+    return '';
+  } finally {
+    db?.close();
+  }
+}
+
+export function readReplicaVersion(
+  lc: LogContext,
+  replicaFile: string,
+): string {
+  let db: Database | undefined;
+  try {
+    db = openReplica(lc, replicaFile);
+    const row = db
+      .prepare(`SELECT replicaVersion FROM "_zero.replicationConfig"`)
+      .get<{replicaVersion: string} | undefined>();
+    return row?.replicaVersion ?? '';
+  } catch {
+    return '';
+  } finally {
+    db?.close();
+  }
+}
+
+/** Reads one PG table, canonicalized through `liteRow`. */
+async function readPGTable(
+  sql: postgres.Sql,
+  spec: LiteTableSpec,
+  columns: readonly string[],
+): Promise<Record<string, string>[]> {
+  const {schema, table} = pgTableName(spec.name);
+  const select = columns.map(c => `"${c}"`).join(', ');
+  const rows = await sql.unsafe<RowValue[]>(
+    `SELECT ${select} FROM "${schema}"."${table}"`,
+  );
+  return rows.map(row => {
+    const {row: lite} = liteRow(row, spec, JSON_STRINGIFIED);
+    return canonRow(lite, columns);
+  });
+}
+
+function diffTable(
+  table: string,
+  columns: readonly string[],
+  pg: KeyedRows,
+  replica: KeyedRows,
+): TableDiff {
+  const missingFromReplica: RowDiff[] = [];
+  const extraInReplica: RowDiff[] = [];
+  const mismatched: RowDiff[] = [];
+
+  for (const [key, pgEntry] of pg.rows) {
+    const replicaEntry = replica.rows.get(key);
+    if (!replicaEntry) {
+      if (missingFromReplica.length < MAX_REPORTED_DIFFS) {
+        missingFromReplica.push({key});
+      }
+      continue;
+    }
+    if (replicaEntry.count !== pgEntry.count) {
+      if (mismatched.length < MAX_REPORTED_DIFFS) {
+        mismatched.push({
+          key,
+          column: '<multiplicity>',
+          pg: String(pgEntry.count),
+          replica: String(replicaEntry.count),
+        });
+      }
+      continue;
+    }
+    for (const column of columns) {
+      if (pgEntry.row[column] !== replicaEntry.row[column]) {
+        if (mismatched.length < MAX_REPORTED_DIFFS) {
+          mismatched.push({
+            key,
+            column,
+            pg: pgEntry.row[column],
+            replica: replicaEntry.row[column],
+          });
+        }
+        break;
+      }
+    }
+  }
+  for (const key of replica.rows.keys()) {
+    if (!pg.rows.has(key) && extraInReplica.length < MAX_REPORTED_DIFFS) {
+      extraInReplica.push({key});
+    }
+  }
+
+  return {
+    table,
+    key: pg.key === replica.key ? pg.key : `${replica.key}/${pg.key}`,
+    pgRows: pg.total,
+    replicaRows: replica.total,
+    missingFromReplica,
+    extraInReplica,
+    mismatched,
+  };
+}
+
+async function compareReplica(
+  lc: LogContext,
+  sql: postgres.Sql,
+  replica: ReplicaHandle,
+): Promise<ReplicaComparison> {
+  let db: Database | undefined;
+  let tables = 0;
+  let rows = 0;
+  const diffs: TableDiff[] = [];
+  try {
+    db = openReplica(lc, replica.replicaFile);
+    const specs = listTables(db);
+    const uniqueKeys = new Map<string, string[][]>();
+    for (const index of listIndexes(db)) {
+      if (index.unique) {
+        const keys = uniqueKeys.get(index.tableName) ?? [];
+        keys.push(Object.keys(index.columns));
+        uniqueKeys.set(index.tableName, keys);
+      }
+    }
+    for (const spec of specs) {
+      const columns = comparableColumns(spec);
+      const candidates = (uniqueKeys.get(spec.name) ?? [])
+        .filter(key => key.every(col => columns.includes(col)))
+        .sort(
+          (a, b) => a.length - b.length || a.join().localeCompare(b.join()),
+        );
+      const select = columns.map(c => `"${c}"`).join(', ');
+      const replicaRows = db
+        .prepare(`SELECT ${select} FROM "${spec.name}"`)
+        .all<Record<string, unknown>>()
+        .map(row => canonRow(row, columns));
+      const pgRows = await readPGTable(sql, spec, columns);
+      tables++;
+      rows += replicaRows.length;
+      const keyedReplica = keyRows(replicaRows, columns, candidates);
+      const keyedPG = keyRows(pgRows, columns, candidates);
+      const diff = diffTable(spec.name, columns, keyedPG, keyedReplica);
+      if (
+        diff.missingFromReplica.length > 0 ||
+        diff.extraInReplica.length > 0 ||
+        diff.mismatched.length > 0 ||
+        diff.pgRows !== diff.replicaRows
+      ) {
+        diffs.push(diff);
+      }
+    }
+  } catch (e) {
+    return {
+      node: replica.node,
+      stateVersion: '',
+      replicaVersion: '',
+      tables,
+      rows,
+      diffs,
+      ok: false,
+      error: e instanceof Error ? e.message : String(e),
+    };
+  } finally {
+    db?.close();
+  }
+
+  return {
+    node: replica.node,
+    stateVersion: readStateVersion(lc, replica.replicaFile),
+    replicaVersion: readReplicaVersion(lc, replica.replicaFile),
+    tables,
+    rows,
+    diffs,
+    ok: diffs.length === 0,
+  };
+}
+
+/**
+ * Section 7.3: comparing the replication-manager's replica as well as each
+ * view-syncer's separates two failure families for free.
+ */
+function bisect(comparisons: readonly ReplicaComparison[]): string {
+  const rm = comparisons.find(c => c.node === 'rm');
+  const followers = comparisons.filter(c => c.node !== 'rm');
+  const rmOK = rm?.ok ?? true;
+  const followersOK = followers.every(c => c.ok);
+  if (rmOK && followersOK) {
+    return 'clean';
+  }
+  if (rmOK && !followersOK) {
+    return 'the change-log / catchup path -- this harness is pointed at it';
+  }
+  if (!rmOK && !followersOK) {
+    return 'replicator or initial-sync; the change log is downstream and likely innocent';
+  }
+  return 'contradiction -- suspect the quiescence detection before the code';
+}
+
+export async function runOracle(
+  lc: LogContext,
+  sql: postgres.Sql,
+  replicas: readonly ReplicaHandle[],
+  fixture: {projectID: string; creatorID: string},
+  label: string,
+  sentinelID: string,
+): Promise<OracleResult> {
+  const {elapsedMs} = await quiesce(lc, sql, replicas, fixture, sentinelID);
+  const comparisons: ReplicaComparison[] = [];
+  for (const replica of replicas) {
+    comparisons.push(await compareReplica(lc, sql, replica));
+  }
+  return {
+    label,
+    atMs: Date.now(),
+    quiesceMs: elapsedMs,
+    comparisons,
+    ok: comparisons.every(c => c.ok),
+    verdict: bisect(comparisons),
+  };
+}

--- a/apps/zbugs/scripts/rmv2-soak/otlp.ts
+++ b/apps/zbugs/scripts/rmv2-soak/otlp.ts
@@ -1,0 +1,400 @@
+import {createServer, type Server} from 'node:http';
+import {gunzipSync} from 'node:zlib';
+
+/**
+ * A minimal OTLP/HTTP-JSON metrics receiver.
+ *
+ * zero-cache already exports every counter, histogram and gauge this soak
+ * needs -- the route census (`sqlite_change_log.catchup_routes`), the purge
+ * probe outcomes, compare results, log file bytes, backup lag -- through
+ * OpenTelemetry. Pointing each task at its own path on this server is a far
+ * more faithful source than scraping prose out of log lines, and it needs no
+ * collector: `OTEL_EXPORTER_OTLP_PROTOCOL=http/json` posts plain JSON.
+ *
+ * Both temporalities are handled. Delta points are summed. Cumulative points
+ * are held per series and summed across series at read time, where a series
+ * is (node, metric, attributes, resource, startTimeUnixNano) -- a restarted
+ * process opens a new series rather than appearing to count backwards.
+ */
+
+type AnyValue = {
+  stringValue?: string;
+  boolValue?: boolean;
+  intValue?: string | number;
+  doubleValue?: number;
+};
+
+type KeyValue = {key: string; value?: AnyValue};
+
+type NumberDataPoint = {
+  attributes?: KeyValue[];
+  startTimeUnixNano?: string | number;
+  timeUnixNano?: string | number;
+  asInt?: string | number;
+  asDouble?: number;
+};
+
+type HistogramDataPoint = NumberDataPoint & {
+  count?: string | number;
+  sum?: number;
+  min?: number;
+  max?: number;
+};
+
+type OtlpMetric = {
+  name: string;
+  unit?: string;
+  sum?: {
+    dataPoints?: NumberDataPoint[];
+    aggregationTemporality?: number;
+    isMonotonic?: boolean;
+  };
+  gauge?: {dataPoints?: NumberDataPoint[]};
+  histogram?: {
+    dataPoints?: HistogramDataPoint[];
+    aggregationTemporality?: number;
+  };
+  exponentialHistogram?: {
+    dataPoints?: HistogramDataPoint[];
+    aggregationTemporality?: number;
+  };
+};
+
+type ExportRequest = {
+  resourceMetrics?: {
+    resource?: {attributes?: KeyValue[]};
+    scopeMetrics?: {metrics?: OtlpMetric[]}[];
+  }[];
+};
+
+const AGGREGATION_TEMPORALITY_DELTA = 1;
+
+const METRICS_PATH = /^\/v1\/metrics\/([^/?]+)/;
+
+export type Attributes = Readonly<Record<string, string>>;
+
+/** One (node, metric, attributes) series, aggregated over the run. */
+export type MetricSample = {
+  readonly node: string;
+  readonly name: string;
+  readonly attributes: Attributes;
+  /** Sum of counter increments, or of histogram sums. */
+  sum: number;
+  /** Number of histogram observations; 0 for counters and gauges. */
+  count: number;
+  /** Last observed gauge value. */
+  last: number | undefined;
+  min: number | undefined;
+  max: number | undefined;
+  lastSeenMs: number;
+};
+
+type CumulativeSeries = {
+  key: string;
+  value: number;
+};
+
+function attrValue(value: AnyValue | undefined): string {
+  if (!value) {
+    return '';
+  }
+  if (value.stringValue !== undefined) {
+    return value.stringValue;
+  }
+  if (value.boolValue !== undefined) {
+    return String(value.boolValue);
+  }
+  if (value.intValue !== undefined) {
+    return String(value.intValue);
+  }
+  if (value.doubleValue !== undefined) {
+    return String(value.doubleValue);
+  }
+  return '';
+}
+
+function toAttributes(kvs: KeyValue[] | undefined): Attributes {
+  const out: Record<string, string> = {};
+  for (const kv of kvs ?? []) {
+    out[kv.key] = attrValue(kv.value);
+  }
+  return out;
+}
+
+function attrKey(attrs: Attributes): string {
+  return Object.keys(attrs)
+    .sort()
+    .map(k => `${k}=${attrs[k]}`)
+    .join(',');
+}
+
+function numeric(
+  point: NumberDataPoint | HistogramDataPoint,
+): number | undefined {
+  if (point.asInt !== undefined) {
+    return Number(point.asInt);
+  }
+  if (point.asDouble !== undefined) {
+    return point.asDouble;
+  }
+  if ('sum' in point && point.sum !== undefined) {
+    return point.sum;
+  }
+  return undefined;
+}
+
+export class MetricStore {
+  readonly #samples = new Map<string, MetricSample>();
+  readonly #cumulative = new Map<string, CumulativeSeries>();
+  readonly #listeners = new Set<(sample: MetricSample) => void>();
+
+  onSample(listener: (sample: MetricSample) => void): () => void {
+    this.#listeners.add(listener);
+    return () => this.#listeners.delete(listener);
+  }
+
+  ingest(node: string, body: ExportRequest): void {
+    const now = Date.now();
+    for (const rm of body.resourceMetrics ?? []) {
+      const resourceKey = attrKey(toAttributes(rm.resource?.attributes));
+      for (const sm of rm.scopeMetrics ?? []) {
+        for (const metric of sm.metrics ?? []) {
+          this.#ingestMetric(node, resourceKey, metric, now);
+        }
+      }
+    }
+  }
+
+  #ingestMetric(
+    node: string,
+    resourceKey: string,
+    metric: OtlpMetric,
+    now: number,
+  ): void {
+    const histogram = metric.histogram ?? metric.exponentialHistogram;
+    if (metric.sum) {
+      const delta =
+        metric.sum.aggregationTemporality === AGGREGATION_TEMPORALITY_DELTA;
+      for (const point of metric.sum.dataPoints ?? []) {
+        const value = numeric(point) ?? 0;
+        this.#record(node, resourceKey, metric.name, point, now, sample => {
+          if (delta) {
+            sample.sum += value;
+          } else {
+            sample.sum += this.#cumulativeDelta(
+              node,
+              resourceKey,
+              metric.name,
+              point,
+              value,
+            );
+          }
+        });
+      }
+    }
+    if (metric.gauge) {
+      for (const point of metric.gauge.dataPoints ?? []) {
+        const value = numeric(point);
+        this.#record(node, resourceKey, metric.name, point, now, sample => {
+          if (value === undefined) {
+            return;
+          }
+          sample.last = value;
+          sample.min =
+            sample.min === undefined ? value : Math.min(sample.min, value);
+          sample.max =
+            sample.max === undefined ? value : Math.max(sample.max, value);
+        });
+      }
+    }
+    if (histogram) {
+      const delta =
+        histogram.aggregationTemporality === AGGREGATION_TEMPORALITY_DELTA;
+      for (const point of histogram.dataPoints ?? []) {
+        const count = Number(point.count ?? 0);
+        const sum = point.sum ?? 0;
+        this.#record(node, resourceKey, metric.name, point, now, sample => {
+          if (delta) {
+            sample.sum += sum;
+            sample.count += count;
+          } else {
+            const key = this.#seriesKey(node, resourceKey, metric.name, point);
+            const prev = this.#cumulative.get(`${key}#count`);
+            const prevSum = this.#cumulative.get(`${key}#sum`);
+            sample.count += count - (prev?.value ?? 0);
+            sample.sum += sum - (prevSum?.value ?? 0);
+            this.#cumulative.set(`${key}#count`, {key, value: count});
+            this.#cumulative.set(`${key}#sum`, {key, value: sum});
+          }
+          if (point.min !== undefined) {
+            sample.min =
+              sample.min === undefined
+                ? point.min
+                : Math.min(sample.min, point.min);
+          }
+          if (point.max !== undefined) {
+            sample.max =
+              sample.max === undefined
+                ? point.max
+                : Math.max(sample.max, point.max);
+          }
+        });
+      }
+    }
+  }
+
+  #seriesKey(
+    node: string,
+    resourceKey: string,
+    name: string,
+    point: NumberDataPoint,
+  ): string {
+    return `${node}|${resourceKey}|${name}|${attrKey(
+      toAttributes(point.attributes),
+    )}|${point.startTimeUnixNano ?? ''}`;
+  }
+
+  #cumulativeDelta(
+    node: string,
+    resourceKey: string,
+    name: string,
+    point: NumberDataPoint,
+    value: number,
+  ): number {
+    const key = this.#seriesKey(node, resourceKey, name, point);
+    const prev = this.#cumulative.get(key);
+    this.#cumulative.set(key, {key, value});
+    return value - (prev?.value ?? 0);
+  }
+
+  #record(
+    node: string,
+    _resourceKey: string,
+    name: string,
+    point: NumberDataPoint,
+    now: number,
+    update: (sample: MetricSample) => void,
+  ): void {
+    const attributes = toAttributes(point.attributes);
+    const key = `${node}|${name}|${attrKey(attributes)}`;
+    let sample = this.#samples.get(key);
+    if (!sample) {
+      sample = {
+        node,
+        name,
+        attributes,
+        sum: 0,
+        count: 0,
+        last: undefined,
+        min: undefined,
+        max: undefined,
+        lastSeenMs: now,
+      };
+      this.#samples.set(key, sample);
+    }
+    sample.lastSeenMs = now;
+    update(sample);
+    for (const listener of this.#listeners) {
+      listener(sample);
+    }
+  }
+
+  /** Every series whose metric name ends with `suffix`. */
+  series(suffix: string, node?: string): MetricSample[] {
+    return [...this.#samples.values()].filter(
+      s => s.name.endsWith(suffix) && (node === undefined || s.node === node),
+    );
+  }
+
+  /** The summed value of every series whose metric name ends with `suffix`. */
+  total(suffix: string, node?: string): number {
+    return this.series(suffix, node).reduce((acc, s) => acc + s.sum, 0);
+  }
+
+  /** Counter totals broken out by one attribute. */
+  byAttribute(suffix: string, attribute: string): Record<string, number> {
+    const out: Record<string, number> = {};
+    for (const s of this.series(suffix)) {
+      const key = s.attributes[attribute] ?? '';
+      out[key] = (out[key] ?? 0) + s.sum;
+    }
+    return out;
+  }
+
+  /** Counter totals broken out by two attributes, joined with `/`. */
+  byAttributes(
+    suffix: string,
+    first: string,
+    second: string,
+  ): Record<string, number> {
+    const out: Record<string, number> = {};
+    for (const s of this.series(suffix)) {
+      const key = `${s.attributes[first] ?? ''}/${s.attributes[second] ?? ''}`;
+      out[key] = (out[key] ?? 0) + s.sum;
+    }
+    return out;
+  }
+
+  snapshot(): MetricSample[] {
+    return Array.from(this.#samples.values(), s => ({...s}));
+  }
+}
+
+export class OtlpMetricsReceiver {
+  readonly #server: Server;
+  readonly store = new MetricStore();
+  #errors = 0;
+
+  constructor() {
+    this.#server = createServer((req, res) => {
+      const match = METRICS_PATH.exec(req.url ?? '');
+      if (req.method !== 'POST' || !match) {
+        res.writeHead(404).end();
+        return;
+      }
+      const node = decodeURIComponent(match[1]);
+      const chunks: Buffer[] = [];
+      req.on('data', chunk => chunks.push(chunk as Buffer));
+      req.on('end', () => {
+        try {
+          let raw = Buffer.concat(chunks);
+          if (req.headers['content-encoding'] === 'gzip') {
+            raw = gunzipSync(raw);
+          }
+          if (raw.length > 0) {
+            this.store.ingest(node, JSON.parse(raw.toString('utf8')));
+          }
+          // The OTLP spec wants a (possibly empty) ExportMetricsServiceResponse.
+          res.writeHead(200, {'content-type': 'application/json'}).end('{}');
+        } catch {
+          this.#errors++;
+          res.writeHead(400).end();
+        }
+      });
+      req.on('error', () => {
+        this.#errors++;
+      });
+    });
+  }
+
+  get parseErrors(): number {
+    return this.#errors;
+  }
+
+  listen(port: number): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.#server.once('error', reject);
+      this.#server.listen(port, '127.0.0.1', () => {
+        this.#server.off('error', reject);
+        resolve();
+      });
+    });
+  }
+
+  close(): Promise<void> {
+    return new Promise(resolve => {
+      this.#server.closeAllConnections?.();
+      this.#server.close(() => resolve());
+    });
+  }
+}

--- a/apps/zbugs/scripts/rmv2-soak/report.test.ts
+++ b/apps/zbugs/scripts/rmv2-soak/report.test.ts
@@ -31,3 +31,29 @@ test('does not require demotion routes after the backup coverage fix', () => {
 test('has no required routes when chaos is disabled', () => {
   expect(requiredRouteCoverage({}, [])).toEqual([]);
 });
+
+test('requires the PG cold-log route when cold reads are disabled', () => {
+  expect(requiredRouteCoverage({'pg/cold-log': 3}, ['C6'], 0)).toEqual([
+    {
+      route: 'pg/cold-log',
+      count: 3,
+      triggeredBy: 'C6 or C13 after a reseed with cold reads disabled',
+    },
+  ]);
+});
+
+test('accepts either cold route for a partial rollout', () => {
+  expect(
+    requiredRouteCoverage(
+      {'pg/cold-log': 2, 'sqlite/selected-cold': 1},
+      ['C13'],
+      50,
+    ),
+  ).toEqual([
+    {
+      route: 'sqlite/selected-cold or pg/cold-log',
+      count: 3,
+      triggeredBy: 'C6 or C13 with partial cold-read sampling',
+    },
+  ]);
+});

--- a/apps/zbugs/scripts/rmv2-soak/report.test.ts
+++ b/apps/zbugs/scripts/rmv2-soak/report.test.ts
@@ -1,0 +1,33 @@
+import {expect, test} from 'vitest';
+import {requiredRouteCoverage} from './report.ts';
+
+test('requires only routes exercised by the selected chaos actions', () => {
+  const coverage = requiredRouteCoverage(
+    {'sqlite/selected': 3, 'sqlite/selected-cold': 1},
+    ['C1', 'C6'],
+  );
+
+  expect(coverage).toEqual([
+    {
+      route: 'sqlite/selected',
+      count: 3,
+      triggeredBy: 'C1, C2, or C4',
+    },
+    {
+      route: 'sqlite/selected-cold',
+      count: 1,
+      triggeredBy: 'C6 or C13 after a change-log reseed',
+    },
+  ]);
+});
+
+test('does not require demotion routes after the backup coverage fix', () => {
+  const coverage = requiredRouteCoverage({}, ['C6', 'C13']);
+
+  expect(coverage.map(({route}) => route)).toEqual(['sqlite/selected-cold']);
+  expect(coverage[0]?.count).toBe(0);
+});
+
+test('has no required routes when chaos is disabled', () => {
+  expect(requiredRouteCoverage({}, [])).toEqual([]);
+});

--- a/apps/zbugs/scripts/rmv2-soak/report.ts
+++ b/apps/zbugs/scripts/rmv2-soak/report.ts
@@ -27,12 +27,9 @@ export const REQUIRED_ROUTES: readonly {
     triggeredBy: 'C1, C2, or C4',
     chaos: ['C1', 'C2', 'C4'],
   },
-  {
-    route: 'sqlite/selected-cold',
-    triggeredBy: 'C6 or C13 after a change-log reseed',
-    chaos: ['C6', 'C13'],
-  },
 ];
+
+const COLD_LOG_CHAOS = ['C6', 'C13'];
 
 export type RouteCoverage = {
   readonly route: string;
@@ -43,15 +40,41 @@ export type RouteCoverage = {
 export function requiredRouteCoverage(
   census: Readonly<Record<string, number>>,
   selectedChaos: readonly string[],
+  coldReadPercent = 100,
 ): RouteCoverage[] {
   const selected = new Set(selectedChaos);
-  return REQUIRED_ROUTES.filter(({chaos}) =>
+  const coverage = REQUIRED_ROUTES.filter(({chaos}) =>
     chaos.some(id => selected.has(id)),
   ).map(({route, triggeredBy}) => ({
     route,
     count: census[route] ?? 0,
     triggeredBy,
   }));
+  if (!COLD_LOG_CHAOS.some(id => selected.has(id))) {
+    return coverage;
+  }
+  if (coldReadPercent === 0) {
+    coverage.push({
+      route: 'pg/cold-log',
+      count: census['pg/cold-log'] ?? 0,
+      triggeredBy: 'C6 or C13 after a reseed with cold reads disabled',
+    });
+    return coverage;
+  }
+  if (coldReadPercent === 100) {
+    coverage.push({
+      route: 'sqlite/selected-cold',
+      count: census['sqlite/selected-cold'] ?? 0,
+      triggeredBy: 'C6 or C13 after a change-log reseed',
+    });
+    return coverage;
+  }
+  coverage.push({
+    route: 'sqlite/selected-cold or pg/cold-log',
+    count: (census['sqlite/selected-cold'] ?? 0) + (census['pg/cold-log'] ?? 0),
+    triggeredBy: 'C6 or C13 with partial cold-read sampling',
+  });
+  return coverage;
 }
 
 export type PhaseRecord = {
@@ -148,7 +171,11 @@ export function buildReport(args: {
     'source',
     'reason',
   );
-  const coverage = requiredRouteCoverage(census, config.chaos);
+  const coverage = requiredRouteCoverage(
+    census,
+    config.chaos,
+    config.changeLog.coldReadPercent,
+  );
 
   const backupLags = log.events
     .filter(e => e.kind === 'backup-watermark')

--- a/apps/zbugs/scripts/rmv2-soak/report.ts
+++ b/apps/zbugs/scripts/rmv2-soak/report.ts
@@ -296,6 +296,7 @@ export function buildReport(args: {
     startedMs: args.startedMs,
     finishedMs: Date.now(),
     config: {
+      appID: config.appID,
       viewSyncers: config.viewSyncers,
       changeLog: config.changeLog,
       backupIntervalSeconds: config.backupIntervalSeconds,

--- a/apps/zbugs/scripts/rmv2-soak/report.ts
+++ b/apps/zbugs/scripts/rmv2-soak/report.ts
@@ -1,0 +1,426 @@
+import {writeFile} from 'node:fs/promises';
+import type {StageResult} from '../change-log-traffic.ts';
+import type {ChaosOutcome} from './chaos.ts';
+import type {SoakConfig} from './config.ts';
+import type {SoakLog, Tripwire} from './logs.ts';
+import type {OracleResult} from './oracle.ts';
+import type {MetricStore} from './otlp.ts';
+import {purgeStreaks, type ResourceSample} from './resources.ts';
+
+/**
+ * Plan sections 7.5 (tripwires), 7.6 (coverage) and 8 (measured quantities).
+ *
+ * A soak that quietly routes everything to PG passes the oracle and the
+ * tripwires while proving nothing, so coverage is a *positive* requirement:
+ * at least one of each route, or an explicit "not exercised" row.
+ */
+
+/** Drawn from `ChangeLogReadRouteReason`, the closed set of route reasons. */
+export const REQUIRED_ROUTES: readonly {
+  route: string;
+  triggeredBy: string;
+}[] = [
+  {route: 'sqlite/selected', triggeredBy: 'C1, C2, C4'},
+  {
+    route: 'sqlite/selected-cold',
+    triggeredBy: 'C6, and reconnects within retentionMs of a seed',
+  },
+  {route: 'pg/backup-uncovered', triggeredBy: 'C6 inside the reseed window'},
+  {
+    // C4's second outage aims at this deliberately, but reaching it needs the
+    // purger to have advanced the floor past the absent follower's ack, and
+    // the purger removes only history that is both below the floor and older
+    // than retentionMs. A run where the floor never got that far reports the
+    // route as not exercised rather than pretending otherwise.
+    route: 'pg/watermark-uncovered',
+    triggeredBy: "C4's long-gap outage, when the purger outruns the follower",
+  },
+];
+
+export type PhaseRecord = {
+  readonly name: string;
+  readonly startedMs: number;
+  readonly finishedMs: number;
+  readonly stages: StageResult[];
+};
+
+export type SoakReport = {
+  readonly runID: string;
+  readonly startedMs: number;
+  readonly finishedMs: number;
+  readonly config: Record<string, unknown>;
+  readonly phases: PhaseRecord[];
+  readonly oracle: OracleResult[];
+  readonly chaos: ChaosOutcome[];
+  readonly census: Record<string, number>;
+  readonly coverage: {route: string; count: number; triggeredBy: string}[];
+  readonly tripwires: Tripwire[];
+  readonly measurements: Record<string, unknown>;
+  readonly resources: Record<string, unknown>;
+  readonly baseline?: Record<string, unknown> | undefined;
+  readonly findings: string[];
+  readonly pass: boolean;
+};
+
+function stats(values: readonly number[]): {
+  n: number;
+  min?: number | undefined;
+  p50?: number | undefined;
+  p95?: number | undefined;
+  max?: number | undefined;
+  mean?: number | undefined;
+} {
+  if (values.length === 0) {
+    return {n: 0};
+  }
+  const sorted = values.toSorted((a, b) => a - b);
+  const at = (p: number) =>
+    sorted[Math.min(sorted.length - 1, Math.ceil(sorted.length * p) - 1)];
+  return {
+    n: sorted.length,
+    min: sorted[0],
+    p50: at(0.5),
+    p95: at(0.95),
+    max: sorted.at(-1),
+    mean: sorted.reduce((a, b) => a + b, 0) / sorted.length,
+  };
+}
+
+/**
+ * Every numeric measurement whose key is `key` or starts with `${key}.`
+ * (the per-task form, e.g. `reservationHoldMs.vs-0`), optionally restricted
+ * to a set of chaos action ids.
+ */
+function numbersFromChaos(
+  chaos: readonly ChaosOutcome[],
+  key: string,
+  ids?: readonly string[],
+): number[] {
+  const out: number[] = [];
+  for (const outcome of chaos) {
+    if (ids && !ids.includes(outcome.id)) {
+      continue;
+    }
+    for (const [name, value] of Object.entries(outcome.measurements)) {
+      if (
+        (name === key || name.startsWith(`${key}.`)) &&
+        typeof value === 'number'
+      ) {
+        out.push(value);
+      }
+    }
+  }
+  return out;
+}
+
+export function buildReport(args: {
+  config: SoakConfig;
+  startedMs: number;
+  phases: PhaseRecord[];
+  oracle: OracleResult[];
+  chaos: ChaosOutcome[];
+  log: SoakLog;
+  metrics: MetricStore;
+  resources: readonly ResourceSample[];
+  baseline?: Record<string, unknown> | undefined;
+}): SoakReport {
+  const {config, log, metrics, chaos, oracle, resources} = args;
+
+  const census = metrics.byAttributes(
+    'sqlite_change_log.catchup_routes',
+    'source',
+    'reason',
+  );
+  const coverage = REQUIRED_ROUTES.map(({route, triggeredBy}) => ({
+    route,
+    count: census[route] ?? 0,
+    triggeredBy,
+  }));
+
+  const backupLags = log.events
+    .filter(e => e.kind === 'backup-watermark')
+    .map(e => e.detail.lagMs)
+    .filter((v): v is number => typeof v === 'number');
+
+  const reseedWindows = numbersFromChaos(chaos, 'reseedWindowMs');
+  const holds = numbersFromChaos(chaos, 'reservationHoldMs');
+
+  const measurements: Record<string, unknown> = {
+    // Section 8's headline. C3 -- a restore against a live log -- should
+    // measure ~0; C6 -- a restore against a log that just reseeded -- is the
+    // window that becomes a view-syncer hold once PG is retired.
+    reseedWindowMs: stats(reseedWindows),
+    reservationHoldMs: stats(holds),
+    // C3 restores against a *live* log, which invariant 14 says is covered
+    // by construction; this is the number that should read ~0.
+    reservationHoldMsC3: stats(
+      numbersFromChaos(chaos, 'reservationHoldMs', ['C3']),
+    ),
+    // C6 and C13 restore against a log that just reseeded, which is the
+    // window section 1.4 is about.
+    reseedWindowMsC6C13: stats(
+      numbersFromChaos(chaos, 'reseedWindowMs', ['C6', 'C13']),
+    ),
+    backupLagMs: stats(backupLags),
+    reservationConfirmDelays: metrics.total(
+      'sqlite_change_log.reservation_confirm_delays',
+    ),
+    reservationDemotions: metrics.total(
+      'sqlite_change_log.reservation_demotions',
+    ),
+    barrierTimeouts: metrics.total('sqlite_change_log.barrier_timeouts'),
+    compareResults: metrics.byAttribute(
+      'sqlite_change_log.compare_result',
+      'outcome',
+    ),
+    initCompareResults: metrics.byAttribute(
+      'sqlite_change_log.init_compare_result',
+      'result',
+    ),
+    floorProbes: metrics.byAttribute(
+      'sqlite_change_log.purge_floor_probe',
+      'outcome',
+    ),
+    reconcileWipes: metrics.byAttribute(
+      'sqlite_change_log.reconcile_wipes',
+      'reason',
+    ),
+    purgeDeclines: metrics.byAttribute(
+      'sqlite_change_log.purge_declined',
+      'reason',
+    ),
+    catchupRows: metrics.total('sqlite_change_log.catchup_rows'),
+    catchupBytes: metrics.total('sqlite_change_log.catchup_bytes'),
+    catchupDurationSeconds: metrics.total('sqlite_change_log.catchup_duration'),
+    catchupResults: metrics.byAttributes(
+      'sqlite_change_log.catchup_results',
+      'classification',
+      'log_warm',
+    ),
+    litestreamRestores: metrics.byAttribute(
+      'litestream.restore.runs',
+      'result',
+    ),
+    purgedRows: metrics.total('sqlite_change_log.purged_rows'),
+  };
+
+  const changeLogBytes = resources.map(s => s.changeLogBytes);
+  const slotRetained = resources.map(s =>
+    s.slots.reduce((acc, slot) => acc + slot.retainedBytes, 0),
+  );
+  const resourceReport: Record<string, unknown> = {
+    changeLogBytes: stats(changeLogBytes),
+    changeLogBytesFinal: changeLogBytes.at(-1) ?? 0,
+    slotRetainedBytes: stats(slotRetained),
+    slotRetainedBytesFinal: slotRetained.at(-1) ?? 0,
+    backupBytesFinal: resources.at(-1)?.backupBytes ?? -1,
+    backupObjectsFinal: resources.at(-1)?.backupObjects ?? -1,
+    purge: purgeStreaks(log),
+    samples: resources.length,
+  };
+
+  const findings: string[] = [];
+  for (const outcome of chaos) {
+    findings.push(...outcome.findings);
+  }
+  for (const result of oracle) {
+    if (!result.ok) {
+      findings.push(
+        `oracle "${result.label}" diverged (${result.verdict}): ` +
+          result.comparisons
+            .filter(c => !c.ok)
+            .map(
+              c =>
+                `${c.node}${c.error ? ` error=${c.error}` : ''} ` +
+                c.diffs
+                  .map(
+                    d =>
+                      `${d.table}[pg=${d.pgRows} replica=${d.replicaRows} ` +
+                      `missing=${d.missingFromReplica.length} ` +
+                      `extra=${d.extraInReplica.length} ` +
+                      `mismatched=${d.mismatched.length}]`,
+                  )
+                  .join(' '),
+            )
+            .join('; '),
+      );
+    }
+  }
+  const namedTripwires = log.tripwires.filter(t => t.name !== 'error-log');
+  for (const tripwire of namedTripwires) {
+    findings.push(
+      `tripwire ${tripwire.name} on ${tripwire.node}: ${tripwire.message}`,
+    );
+  }
+  const uncovered = coverage.filter(c => c.count === 0);
+  for (const row of uncovered) {
+    findings.push(
+      `coverage: ${row.route} was not exercised (expected from ${row.triggeredBy})`,
+    );
+  }
+  const purge = purgeStreaks(log);
+  if (purge.longestBatchLimitStreak > 20) {
+    findings.push(
+      `resource bound: the purger hit its batch limit ${purge.longestBatchLimitStreak} ` +
+        `passes in a row, which is a purger losing to the write rate`,
+    );
+  }
+
+  // Coverage gaps are reported but do not fail the run: a smoke-scale run
+  // legitimately skips the chaos actions that produce them. Divergence,
+  // tripwires and chaos findings do.
+  const pass =
+    oracle.every(r => r.ok) &&
+    namedTripwires.length === 0 &&
+    chaos.every(c => c.findings.length === 0);
+
+  return {
+    runID: config.runID,
+    startedMs: args.startedMs,
+    finishedMs: Date.now(),
+    config: {
+      viewSyncers: config.viewSyncers,
+      changeLog: config.changeLog,
+      backupIntervalSeconds: config.backupIntervalSeconds,
+      vfsPollIntervalMs: config.vfsPollIntervalMs,
+      startupDelayMs: config.startupDelayMs,
+      snapshotBackupIntervalHours: config.snapshotBackupIntervalHours,
+      chaos: config.chaos,
+      scale: config.scale,
+      baseline: config.baseline,
+      root: config.root,
+    },
+    phases: args.phases,
+    oracle,
+    chaos,
+    census,
+    coverage,
+    tripwires: log.tripwires,
+    measurements,
+    resources: resourceReport,
+    baseline: args.baseline,
+    findings,
+    pass,
+  };
+}
+
+export async function writeReport(
+  path: string,
+  report: SoakReport,
+): Promise<void> {
+  await writeFile(path, JSON.stringify(report, null, 2), 'utf8');
+}
+
+function fmt(value: unknown): string {
+  if (value === undefined) {
+    return '-';
+  }
+  if (typeof value === 'number') {
+    return Number.isInteger(value) ? String(value) : value.toFixed(1);
+  }
+  return typeof value === 'string' ? value : JSON.stringify(value);
+}
+
+export function summarize(report: SoakReport): string {
+  const lines: string[] = [];
+  const seconds = ((report.finishedMs - report.startedMs) / 1000).toFixed(0);
+  lines.push('');
+  lines.push(
+    `RMv2 local soak ${report.runID} -- ${report.pass ? 'PASS' : 'FAIL'} (${seconds}s)`,
+  );
+  lines.push('');
+
+  lines.push('Phases');
+  for (const phase of report.phases) {
+    const tx = phase.stages.reduce((acc, s) => acc + s.transactions, 0);
+    const mutations = phase.stages.reduce((acc, s) => acc + s.mutations, 0);
+    lines.push(
+      `  ${phase.name.padEnd(12)} ${((phase.finishedMs - phase.startedMs) / 1000).toFixed(0)}s ` +
+        `tx=${tx} mutations=${mutations}`,
+    );
+  }
+
+  lines.push('');
+  lines.push('Route census (source/reason)');
+  const censusKeys = Object.keys(report.census).sort();
+  if (censusKeys.length === 0) {
+    lines.push('  (no catchup routes recorded)');
+  }
+  for (const key of censusKeys) {
+    lines.push(`  ${key.padEnd(32)} ${report.census[key]}`);
+  }
+
+  lines.push('');
+  lines.push('Coverage (section 7.6)');
+  for (const row of report.coverage) {
+    lines.push(
+      `  ${row.route.padEnd(28)} ${
+        row.count > 0 ? String(row.count) : 'NOT EXERCISED'
+      }  (${row.triggeredBy})`,
+    );
+  }
+
+  lines.push('');
+  lines.push('Measured quantities (section 8)');
+  for (const [key, value] of Object.entries(report.measurements)) {
+    lines.push(`  ${key.padEnd(32)} ${fmt(value)}`);
+  }
+
+  lines.push('');
+  lines.push('Resource bounds (section 7.7)');
+  for (const [key, value] of Object.entries(report.resources)) {
+    lines.push(`  ${key.padEnd(32)} ${fmt(value)}`);
+  }
+
+  lines.push('');
+  lines.push('Chaos');
+  for (const outcome of report.chaos) {
+    const census = Object.entries(outcome.census)
+      .map(([k, v]) => `${k}=${v}`)
+      .join(' ');
+    lines.push(
+      `  ${outcome.id} ${outcome.title} (${(
+        (outcome.finishedMs - outcome.startedMs) /
+        1000
+      ).toFixed(0)}s)`,
+    );
+    if (census) {
+      lines.push(`      routes: ${census}`);
+    }
+    for (const [key, value] of Object.entries(outcome.measurements)) {
+      lines.push(`      ${key}=${fmt(value)}`);
+    }
+    for (const note of outcome.notes) {
+      lines.push(`      - ${note}`);
+    }
+  }
+
+  lines.push('');
+  lines.push('Oracle');
+  for (const result of report.oracle) {
+    lines.push(
+      `  ${result.ok ? 'ok  ' : 'FAIL'} ${result.label} ` +
+        `(quiesce ${result.quiesceMs}ms, ${result.verdict})`,
+    );
+  }
+
+  if (report.baseline) {
+    lines.push('');
+    lines.push('Baseline A/B (class 6, section 9 slice L9)');
+    for (const [key, value] of Object.entries(report.baseline)) {
+      lines.push(`  ${key.padEnd(32)} ${fmt(value)}`);
+    }
+  }
+
+  lines.push('');
+  if (report.findings.length === 0) {
+    lines.push('Findings: none');
+  } else {
+    lines.push('Findings');
+    for (const finding of report.findings) {
+      lines.push(`  ! ${finding}`);
+    }
+  }
+  lines.push('');
+  return lines.join('\n');
+}

--- a/apps/zbugs/scripts/rmv2-soak/report.ts
+++ b/apps/zbugs/scripts/rmv2-soak/report.ts
@@ -224,12 +224,22 @@ export function buildReport(args: {
   };
 
   const changeLogBytes = resources.map(s => s.changeLogBytes);
+  const changeLogLiveBytes = resources
+    .map(s => s.changeLogLiveBytes)
+    .filter((v): v is number => v !== undefined);
+  const changeLogFreeBytes = resources
+    .map(s => s.changeLogFreeBytes)
+    .filter((v): v is number => v !== undefined);
   const slotRetained = resources.map(s =>
     s.slots.reduce((acc, slot) => acc + slot.retainedBytes, 0),
   );
   const resourceReport: Record<string, unknown> = {
     changeLogBytes: stats(changeLogBytes),
     changeLogBytesFinal: changeLogBytes.at(-1) ?? 0,
+    changeLogLiveBytes: stats(changeLogLiveBytes),
+    changeLogLiveBytesFinal: changeLogLiveBytes.at(-1) ?? 0,
+    changeLogFreeBytes: stats(changeLogFreeBytes),
+    changeLogFreeBytesFinal: changeLogFreeBytes.at(-1) ?? 0,
     slotRetainedBytes: stats(slotRetained),
     slotRetainedBytesFinal: slotRetained.at(-1) ?? 0,
     backupBytesFinal: resources.at(-1)?.backupBytes ?? -1,

--- a/apps/zbugs/scripts/rmv2-soak/report.ts
+++ b/apps/zbugs/scripts/rmv2-soak/report.ts
@@ -27,13 +27,18 @@ export const REQUIRED_ROUTES: readonly {
   },
   {route: 'pg/backup-uncovered', triggeredBy: 'C6 inside the reseed window'},
   {
-    // C4's second outage aims at this deliberately, but reaching it needs the
-    // purger to have advanced the floor past the absent follower's ack, and
-    // the purger removes only history that is both below the floor and older
-    // than retentionMs. A run where the floor never got that far reports the
-    // route as not exercised rather than pretending otherwise.
+    // Structurally hard to reach, and measured to be so. A *restarting*
+    // follower cannot take it at any gap length: `restoreReplica` runs on
+    // every view-syncer start and the snapshot reservation hands it the log's
+    // `minWatermark`, so a replica below the minimum is discarded and
+    // re-restored before the subscriber reaches `/changes` (C4's long gap
+    // asserts exactly that conversion). It belongs instead to a follower that
+    // survives a *stream* disconnect long enough for the purge floor to pass
+    // its ack -- and SIGSTOP does not produce one, because the change-streamer
+    // keeps a frozen subscriber registered and lets it drain on resume.
     route: 'pg/watermark-uncovered',
-    triggeredBy: "C4's long-gap outage, when the purger outruns the follower",
+    triggeredBy:
+      'a stream disconnect outliving the purge floor; not reachable from a restart',
   },
 ];
 
@@ -142,14 +147,20 @@ export function buildReport(args: {
     .map(e => e.detail.lagMs)
     .filter((v): v is number => typeof v === 'number');
 
-  const reseedWindows = numbersFromChaos(chaos, 'reseedWindowMs');
+  const reseedWindows = numbersFromChaos(chaos, 'reseedToCoveringBackupMs');
   const holds = numbersFromChaos(chaos, 'reservationHoldMs');
 
   const measurements: Record<string, unknown> = {
-    // Section 8's headline. C3 -- a restore against a live log -- should
-    // measure ~0; C6 -- a restore against a log that just reseeded -- is the
-    // window that becomes a view-syncer hold once PG is retired.
-    reseedWindowMs: stats(reseedWindows),
+    // Section 8's headline, in the only two forms that mean anything.
+    //
+    // `reseedToCoveringBackupMs` is the window itself: reseed -> the first
+    // backup observed at or above the seed. Nothing can be served from the
+    // log before it, so it is the exposure, and it holds whether or not a
+    // follower happens to be waiting on it.
+    //
+    // `reservationHoldMs` is what a follower actually waited, which is ~0
+    // whenever it arrived after that backup had already landed.
+    reseedToCoveringBackupMs: stats(reseedWindows),
     reservationHoldMs: stats(holds),
     // C3 restores against a *live* log, which invariant 14 says is covered
     // by construction; this is the number that should read ~0.
@@ -158,8 +169,8 @@ export function buildReport(args: {
     ),
     // C6 and C13 restore against a log that just reseeded, which is the
     // window section 1.4 is about.
-    reseedWindowMsC6C13: stats(
-      numbersFromChaos(chaos, 'reseedWindowMs', ['C6', 'C13']),
+    reseedToCoveringBackupMsC6C13: stats(
+      numbersFromChaos(chaos, 'reseedToCoveringBackupMs', ['C6', 'C13']),
     ),
     backupLagMs: stats(backupLags),
     reservationConfirmDelays: metrics.total(

--- a/apps/zbugs/scripts/rmv2-soak/report.ts
+++ b/apps/zbugs/scripts/rmv2-soak/report.ts
@@ -11,36 +11,48 @@ import {purgeStreaks, type ResourceSample} from './resources.ts';
  * Plan sections 7.5 (tripwires), 7.6 (coverage) and 8 (measured quantities).
  *
  * A soak that quietly routes everything to PG passes the oracle and the
- * tripwires while proving nothing, so coverage is a *positive* requirement:
- * at least one of each route, or an explicit "not exercised" row.
+ * tripwires while proving nothing, so coverage is a *positive* requirement.
+ * Only routes exercised by the selected chaos actions are required; this
+ * keeps smoke runs useful without weakening the full soak's gate.
  */
 
 /** Drawn from `ChangeLogReadRouteReason`, the closed set of route reasons. */
 export const REQUIRED_ROUTES: readonly {
   route: string;
   triggeredBy: string;
+  chaos: readonly string[];
 }[] = [
-  {route: 'sqlite/selected', triggeredBy: 'C1, C2, C4'},
+  {
+    route: 'sqlite/selected',
+    triggeredBy: 'C1, C2, or C4',
+    chaos: ['C1', 'C2', 'C4'],
+  },
   {
     route: 'sqlite/selected-cold',
-    triggeredBy: 'C6, and reconnects within retentionMs of a seed',
-  },
-  {route: 'pg/backup-uncovered', triggeredBy: 'C6 inside the reseed window'},
-  {
-    // Structurally hard to reach, and measured to be so. A *restarting*
-    // follower cannot take it at any gap length: `restoreReplica` runs on
-    // every view-syncer start and the snapshot reservation hands it the log's
-    // `minWatermark`, so a replica below the minimum is discarded and
-    // re-restored before the subscriber reaches `/changes` (C4's long gap
-    // asserts exactly that conversion). It belongs instead to a follower that
-    // survives a *stream* disconnect long enough for the purge floor to pass
-    // its ack -- and SIGSTOP does not produce one, because the change-streamer
-    // keeps a frozen subscriber registered and lets it drain on resume.
-    route: 'pg/watermark-uncovered',
-    triggeredBy:
-      'a stream disconnect outliving the purge floor; not reachable from a restart',
+    triggeredBy: 'C6 or C13 after a change-log reseed',
+    chaos: ['C6', 'C13'],
   },
 ];
+
+export type RouteCoverage = {
+  readonly route: string;
+  readonly count: number;
+  readonly triggeredBy: string;
+};
+
+export function requiredRouteCoverage(
+  census: Readonly<Record<string, number>>,
+  selectedChaos: readonly string[],
+): RouteCoverage[] {
+  const selected = new Set(selectedChaos);
+  return REQUIRED_ROUTES.filter(({chaos}) =>
+    chaos.some(id => selected.has(id)),
+  ).map(({route, triggeredBy}) => ({
+    route,
+    count: census[route] ?? 0,
+    triggeredBy,
+  }));
+}
 
 export type PhaseRecord = {
   readonly name: string;
@@ -58,7 +70,7 @@ export type SoakReport = {
   readonly oracle: OracleResult[];
   readonly chaos: ChaosOutcome[];
   readonly census: Record<string, number>;
-  readonly coverage: {route: string; count: number; triggeredBy: string}[];
+  readonly coverage: RouteCoverage[];
   readonly tripwires: Tripwire[];
   readonly measurements: Record<string, unknown>;
   readonly resources: Record<string, unknown>;
@@ -136,11 +148,7 @@ export function buildReport(args: {
     'source',
     'reason',
   );
-  const coverage = REQUIRED_ROUTES.map(({route, triggeredBy}) => ({
-    route,
-    count: census[route] ?? 0,
-    triggeredBy,
-  }));
+  const coverage = requiredRouteCoverage(census, config.chaos);
 
   const backupLags = log.events
     .filter(e => e.kind === 'backup-watermark')
@@ -277,13 +285,11 @@ export function buildReport(args: {
     );
   }
 
-  // Coverage gaps are reported but do not fail the run: a smoke-scale run
-  // legitimately skips the chaos actions that produce them. Divergence,
-  // tripwires and chaos findings do.
   const pass =
     oracle.every(r => r.ok) &&
     namedTripwires.length === 0 &&
-    chaos.every(c => c.findings.length === 0);
+    chaos.every(c => c.findings.length === 0) &&
+    uncovered.length === 0;
 
   return {
     runID: config.runID,

--- a/apps/zbugs/scripts/rmv2-soak/resources.test.ts
+++ b/apps/zbugs/scripts/rmv2-soak/resources.test.ts
@@ -1,0 +1,40 @@
+import {mkdtempSync, rmSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import {afterAll, expect, test} from 'vitest';
+import {createSilentLogContext} from '../../../../packages/shared/src/logging-test-utils.ts';
+import {Database} from '../../../../packages/zqlite/src/db.ts';
+import {sqliteFootprint, sqlitePageUsage} from './resources.ts';
+
+const dir = mkdtempSync(join(tmpdir(), 'rmv2-soak-resources-'));
+const lc = createSilentLogContext();
+
+afterAll(() => rmSync(dir, {recursive: true, force: true}));
+
+test('distinguishes live pages from the physical SQLite footprint', async () => {
+  const file = join(dir, 'change-log.db');
+  using db = new Database(lc, file);
+  db.exec('CREATE TABLE entries (id INTEGER PRIMARY KEY, value TEXT)');
+  const insert = db.prepare('INSERT INTO entries (value) VALUES (?)');
+  db.exec('BEGIN');
+  for (let i = 0; i < 1_000; i++) {
+    insert.run('x'.repeat(1_000));
+  }
+  db.exec('COMMIT');
+
+  const footprintBefore = await sqliteFootprint(file);
+  const usageBefore = sqlitePageUsage(lc, file);
+  db.exec('DELETE FROM entries');
+  const footprintAfter = await sqliteFootprint(file);
+  const usageAfter = sqlitePageUsage(lc, file);
+
+  expect(usageBefore).toBeDefined();
+  expect(usageAfter).toBeDefined();
+  expect(usageAfter?.liveBytes).toBeLessThan(usageBefore?.liveBytes ?? 0);
+  expect(usageAfter?.freeBytes).toBeGreaterThan(usageBefore?.freeBytes ?? 0);
+  expect(footprintAfter).toBe(footprintBefore);
+});
+
+test('returns undefined when the database does not exist', () => {
+  expect(sqlitePageUsage(lc, join(dir, 'missing.db'))).toBeUndefined();
+});

--- a/apps/zbugs/scripts/rmv2-soak/resources.ts
+++ b/apps/zbugs/scripts/rmv2-soak/resources.ts
@@ -1,0 +1,194 @@
+import {stat} from 'node:fs/promises';
+import type postgres from 'postgres';
+import type {SoakConfig} from './config.ts';
+import {backupSize} from './infra.ts';
+import type {SoakLog} from './logs.ts';
+
+/**
+ * Section 7.7, failure class 4: unbounded resource growth when the purge
+ * floor is pinned.
+ *
+ * The floor is `min(backupWatermark, ...acks, ...reservations)`. Two
+ * independent things accumulate whenever it is pinned, and neither is visible
+ * to the oracle or to the tripwires:
+ *
+ *  - the change log's local disk, which is excluded from the backup; and
+ *  - the upstream replication slot, because with litestream v5 the upstream
+ *    ACK is `min(pgChangeLogWatermark, backupWatermark)` -- a stalled backup
+ *    stops acking upstream and the slot grows without bound. Chaos action C9
+ *    is that test.
+ */
+
+export type SlotSample = {
+  readonly slotName: string;
+  readonly active: boolean;
+  readonly retainedBytes: number;
+  readonly unconfirmedBytes: number;
+};
+
+export type ResourceSample = {
+  readonly atMs: number;
+  readonly phase: string;
+  readonly changeLogBytes: number;
+  readonly replicaBytes: Readonly<Record<string, number>>;
+  readonly slots: readonly SlotSample[];
+  readonly backupObjects: number;
+  readonly backupBytes: number;
+};
+
+/** Main file plus `-wal`/`-wal2`; `-shm` is a shared-memory index, not bytes. */
+export async function sqliteFootprint(file: string): Promise<number> {
+  const sizes = await Promise.all(
+    [file, `${file}-wal`, `${file}-wal2`].map(async path => {
+      try {
+        return (await stat(path)).size;
+      } catch {
+        return 0;
+      }
+    }),
+  );
+  return sizes.reduce((a, b) => a + b, 0);
+}
+
+export async function readSlots(sql: postgres.Sql): Promise<SlotSample[]> {
+  const rows = await sql<
+    {
+      slotName: string;
+      active: boolean;
+      retainedBytes: string | number | null;
+      unconfirmedBytes: string | number | null;
+    }[]
+  >`
+    SELECT slot_name AS "slotName",
+           active,
+           pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn) AS "retainedBytes",
+           pg_wal_lsn_diff(pg_current_wal_lsn(), confirmed_flush_lsn)
+             AS "unconfirmedBytes"
+      FROM pg_replication_slots
+     WHERE slot_type = 'logical'`;
+  return rows.map(r => ({
+    slotName: r.slotName,
+    active: r.active,
+    retainedBytes: Number(r.retainedBytes ?? 0),
+    unconfirmedBytes: Number(r.unconfirmedBytes ?? 0),
+  }));
+}
+
+export type PurgeStreaks = {
+  /** Longest run of consecutive passes that hit the per-pass batch limit. */
+  readonly longestBatchLimitStreak: number;
+  readonly passes: number;
+  readonly batchLimitPasses: number;
+  readonly immediateContinuations: number;
+  readonly byStopReason: Readonly<Record<string, number>>;
+};
+
+/**
+ * A run that sits chronically at `continuation: 'immediate'` /
+ * `stopped: 'batch-limit'` is a purger losing to the write rate, and the log
+ * grows without bound. The streak, not the count, is the signal.
+ */
+export function purgeStreaks(log: SoakLog, sinceMs = 0): PurgeStreaks {
+  let longest = 0;
+  let current = 0;
+  let passes = 0;
+  let batchLimitPasses = 0;
+  let immediate = 0;
+  const byStopReason: Record<string, number> = {};
+  for (const event of log.events) {
+    if (event.kind !== 'purge-pass' || event.tsMs < sinceMs) {
+      continue;
+    }
+    passes++;
+    const stopped = event.detail.stopped;
+    const continuation = event.detail.continuation;
+    if (continuation === 'immediate') {
+      immediate++;
+    }
+    const reason = typeof stopped === 'string' ? stopped : 'none';
+    byStopReason[reason] = (byStopReason[reason] ?? 0) + 1;
+    if (reason === 'batch-limit') {
+      batchLimitPasses++;
+      current++;
+      longest = Math.max(longest, current);
+    } else {
+      current = 0;
+    }
+  }
+  return {
+    longestBatchLimitStreak: longest,
+    passes,
+    batchLimitPasses,
+    immediateContinuations: immediate,
+    byStopReason,
+  };
+}
+
+export class ResourceSampler {
+  readonly samples: ResourceSample[] = [];
+  readonly #config: SoakConfig;
+  readonly #sql: postgres.Sql;
+  readonly #files: ReadonlyArray<{node: string; replicaFile: string}>;
+  readonly #changeLogFile: string;
+  #timer: NodeJS.Timeout | undefined;
+  #phase = 'startup';
+  #sampling = false;
+
+  constructor(
+    config: SoakConfig,
+    sql: postgres.Sql,
+    changeLogFile: string,
+    files: ReadonlyArray<{node: string; replicaFile: string}>,
+  ) {
+    this.#config = config;
+    this.#sql = sql;
+    this.#changeLogFile = changeLogFile;
+    this.#files = files;
+  }
+
+  set phase(phase: string) {
+    this.#phase = phase;
+  }
+
+  start(intervalMs = 5_000): void {
+    this.#timer ??= setInterval(() => void this.sample(), intervalMs);
+  }
+
+  stop(): void {
+    clearInterval(this.#timer);
+    this.#timer = undefined;
+  }
+
+  async sample(): Promise<ResourceSample | undefined> {
+    // S3 listing and a PG round trip can both outrun the interval when minio
+    // is down (C9); skipping is better than queueing.
+    if (this.#sampling) {
+      return undefined;
+    }
+    this.#sampling = true;
+    try {
+      const replicaBytes: Record<string, number> = {};
+      for (const {node, replicaFile} of this.#files) {
+        replicaBytes[node] = await sqliteFootprint(replicaFile);
+      }
+      const [changeLogBytes, slots, backup] = await Promise.all([
+        sqliteFootprint(this.#changeLogFile),
+        readSlots(this.#sql).catch(() => [] as SlotSample[]),
+        backupSize(this.#config).catch(() => ({objects: -1, bytes: -1})),
+      ]);
+      const sample: ResourceSample = {
+        atMs: Date.now(),
+        phase: this.#phase,
+        changeLogBytes,
+        replicaBytes,
+        slots,
+        backupObjects: backup.objects,
+        backupBytes: backup.bytes,
+      };
+      this.samples.push(sample);
+      return sample;
+    } finally {
+      this.#sampling = false;
+    }
+  }
+}

--- a/apps/zbugs/scripts/rmv2-soak/resources.ts
+++ b/apps/zbugs/scripts/rmv2-soak/resources.ts
@@ -1,5 +1,8 @@
+import {existsSync} from 'node:fs';
 import {stat} from 'node:fs/promises';
+import type {LogContext} from '@rocicorp/logger';
 import type postgres from 'postgres';
+import {Database} from '../../../../packages/zqlite/src/db.ts';
 import type {SoakConfig} from './config.ts';
 import {backupSize} from './infra.ts';
 import type {SoakLog} from './logs.ts';
@@ -30,6 +33,10 @@ export type ResourceSample = {
   readonly atMs: number;
   readonly phase: string;
   readonly changeLogBytes: number;
+  /** SQLite pages that hold live data, excluding pages on the freelist. */
+  readonly changeLogLiveBytes: number | undefined;
+  /** Reusable pages retained in the physical SQLite database file. */
+  readonly changeLogFreeBytes: number | undefined;
   readonly replicaBytes: Readonly<Record<string, number>>;
   readonly slots: readonly SlotSample[];
   readonly backupObjects: number;
@@ -50,7 +57,56 @@ export async function sqliteFootprint(file: string): Promise<number> {
   return sizes.reduce((a, b) => a + b, 0);
 }
 
-export async function readSlots(sql: postgres.Sql): Promise<SlotSample[]> {
+export type SQLitePageUsage = {
+  readonly liveBytes: number;
+  readonly freeBytes: number;
+};
+
+/**
+ * Physical SQLite files do not normally shrink after DELETE. Pages move to the
+ * freelist and are reused by later writes, so live pages are the recovery
+ * signal while {@link sqliteFootprint} remains the disk-capacity signal.
+ */
+export function sqlitePageUsage(
+  lc: LogContext,
+  file: string,
+): SQLitePageUsage | undefined {
+  if (!existsSync(file)) {
+    return undefined;
+  }
+  let db: Database | undefined;
+  try {
+    try {
+      db = new Database(lc, file, {readonly: true});
+    } catch {
+      // Match the oracle: a WAL database can reject a read-only connection
+      // when its shared-memory file is not usable. This fallback never writes.
+      db = new Database(lc, file);
+    }
+    const [{page_count: pageCount}] = db.pragma<{page_count: number}>(
+      'page_count',
+    );
+    const [{page_size: pageSize}] = db.pragma<{page_size: number}>('page_size');
+    const [{freelist_count: freePages}] = db.pragma<{
+      freelist_count: number;
+    }>('freelist_count');
+    return {
+      liveBytes: Math.max(0, pageCount - freePages) * pageSize,
+      freeBytes: freePages * pageSize,
+    };
+  } catch {
+    // The change log is deliberately deleted and recreated in C6/C12/C14.
+    // A sample racing one of those operations is unavailable, not fatal.
+    return undefined;
+  } finally {
+    db?.close();
+  }
+}
+
+export async function readSlots(
+  sql: postgres.Sql,
+  slotPrefix: string,
+): Promise<SlotSample[]> {
   const rows = await sql<
     {
       slotName: string;
@@ -65,7 +121,8 @@ export async function readSlots(sql: postgres.Sql): Promise<SlotSample[]> {
            pg_wal_lsn_diff(pg_current_wal_lsn(), confirmed_flush_lsn)
              AS "unconfirmedBytes"
       FROM pg_replication_slots
-     WHERE slot_type = 'logical'`;
+     WHERE slot_type = 'logical'
+       AND starts_with(slot_name, ${slotPrefix})`;
   return rows.map(r => ({
     slotName: r.slotName,
     active: r.active,
@@ -127,6 +184,7 @@ export function purgeStreaks(log: SoakLog, sinceMs = 0): PurgeStreaks {
 export class ResourceSampler {
   readonly samples: ResourceSample[] = [];
   readonly #config: SoakConfig;
+  readonly #lc: LogContext;
   readonly #sql: postgres.Sql;
   readonly #files: ReadonlyArray<{node: string; replicaFile: string}>;
   readonly #changeLogFile: string;
@@ -135,11 +193,13 @@ export class ResourceSampler {
   #sampling = false;
 
   constructor(
+    lc: LogContext,
     config: SoakConfig,
     sql: postgres.Sql,
     changeLogFile: string,
     files: ReadonlyArray<{node: string; replicaFile: string}>,
   ) {
+    this.#lc = lc;
     this.#config = config;
     this.#sql = sql;
     this.#changeLogFile = changeLogFile;
@@ -173,13 +233,18 @@ export class ResourceSampler {
       }
       const [changeLogBytes, slots, backup] = await Promise.all([
         sqliteFootprint(this.#changeLogFile),
-        readSlots(this.#sql).catch(() => [] as SlotSample[]),
+        readSlots(this.#sql, `${this.#config.appID}_0_`).catch(
+          () => [] as SlotSample[],
+        ),
         backupSize(this.#config).catch(() => ({objects: -1, bytes: -1})),
       ]);
+      const pageUsage = sqlitePageUsage(this.#lc, this.#changeLogFile);
       const sample: ResourceSample = {
         atMs: Date.now(),
         phase: this.#phase,
         changeLogBytes,
+        changeLogLiveBytes: pageUsage?.liveBytes,
+        changeLogFreeBytes: pageUsage?.freeBytes,
         replicaBytes,
         slots,
         backupObjects: backup.objects,

--- a/apps/zbugs/scripts/rmv2-soak/results/2026-09-02-c9-corrected-post-fix.json
+++ b/apps/zbugs/scripts/rmv2-soak/results/2026-09-02-c9-corrected-post-fix.json
@@ -1,0 +1,656 @@
+{
+  "runID": "c9-corrected-post-fix-2026-09-02",
+  "startedMs": 1788377668466,
+  "finishedMs": 1788378694943,
+  "config": {
+    "appID": "rmv2_soak",
+    "viewSyncers": 3,
+    "changeLog": {
+      "mode": "serve",
+      "readPercent": 100,
+      "coldReadPercent": 100,
+      "comparePercent": 100,
+      "retentionMs": 60000
+    },
+    "backupIntervalSeconds": 2,
+    "vfsPollIntervalMs": 1000,
+    "startupDelayMs": 1000,
+    "snapshotBackupIntervalHours": 4,
+    "chaos": ["C9"],
+    "scale": 1,
+    "baseline": false,
+    "root": "/Users/mlaw/workspace/zero/mono/apps/zbugs/.soak/c9-corrected-post-fix-2026-09-02"
+  },
+  "phases": [
+    {
+      "name": "sustained",
+      "startedMs": 1788377679817,
+      "finishedMs": 1788377979812,
+      "stages": [
+        {
+          "label": "sustained",
+          "targetTransactionsPerSecond": 25,
+          "durationSeconds": 300,
+          "transactions": 7500,
+          "mutations": 9000,
+          "elapsedSeconds": 299.967197083,
+          "actualTransactionsPerSecond": 25.002733875346955,
+          "shapes": {
+            "insert": 3000,
+            "update": 3000,
+            "delete": 750,
+            "churn": 750
+          },
+          "residueRows": 2250,
+          "latencyMs": {
+            "p50": 4.324082999955863,
+            "p95": 7.001583000004757,
+            "p99": 10.022209000017028,
+            "max": 52.41425000000163
+          }
+        }
+      ]
+    },
+    {
+      "name": "burst",
+      "startedMs": 1788377980488,
+      "finishedMs": 1788378080498,
+      "stages": [
+        {
+          "label": "burst-1",
+          "targetTransactionsPerSecond": 500,
+          "durationSeconds": 20,
+          "transactions": 10000,
+          "mutations": 12000,
+          "elapsedSeconds": 20.000067374999983,
+          "actualTransactionsPerSecond": 499.99831563067465,
+          "shapes": {
+            "insert": 4000,
+            "update": 4000,
+            "delete": 1000,
+            "churn": 1000
+          },
+          "residueRows": 5250,
+          "latencyMs": {
+            "p50": 1.4968750000116415,
+            "p95": 3.0627919999533333,
+            "p99": 5.752166999969631,
+            "max": 14.095499999995809
+          }
+        },
+        {
+          "label": "burst-gap-1",
+          "targetTransactionsPerSecond": 0,
+          "durationSeconds": 20,
+          "transactions": 0,
+          "mutations": 0,
+          "elapsedSeconds": 20.001557542000025,
+          "actualTransactionsPerSecond": 0,
+          "shapes": {
+            "insert": 0,
+            "update": 0,
+            "delete": 0,
+            "churn": 0
+          },
+          "residueRows": 5250,
+          "latencyMs": {
+            "p50": 0,
+            "p95": 0,
+            "p99": 0,
+            "max": 0
+          }
+        },
+        {
+          "label": "burst-2",
+          "targetTransactionsPerSecond": 500,
+          "durationSeconds": 20,
+          "transactions": 10000,
+          "mutations": 12000,
+          "elapsedSeconds": 20.000873334000005,
+          "actualTransactionsPerSecond": 499.9781676033486,
+          "shapes": {
+            "insert": 4000,
+            "update": 4000,
+            "delete": 1000,
+            "churn": 1000
+          },
+          "residueRows": 8250,
+          "latencyMs": {
+            "p50": 1.585625000006985,
+            "p95": 3.4449169999570586,
+            "p99": 6.7827500000130385,
+            "max": 31.68962499999907
+          }
+        },
+        {
+          "label": "burst-gap-2",
+          "targetTransactionsPerSecond": 0,
+          "durationSeconds": 20,
+          "transactions": 0,
+          "mutations": 0,
+          "elapsedSeconds": 20.00110183399997,
+          "actualTransactionsPerSecond": 0,
+          "shapes": {
+            "insert": 0,
+            "update": 0,
+            "delete": 0,
+            "churn": 0
+          },
+          "residueRows": 8250,
+          "latencyMs": {
+            "p50": 0,
+            "p95": 0,
+            "p99": 0,
+            "max": 0
+          }
+        },
+        {
+          "label": "burst-3",
+          "targetTransactionsPerSecond": 500,
+          "durationSeconds": 20,
+          "transactions": 10000,
+          "mutations": 12000,
+          "elapsedSeconds": 19.999027750000007,
+          "actualTransactionsPerSecond": 500.02430743164484,
+          "shapes": {
+            "insert": 4000,
+            "update": 4000,
+            "delete": 1000,
+            "churn": 1000
+          },
+          "residueRows": 11250,
+          "latencyMs": {
+            "p50": 1.6112090000533499,
+            "p95": 3.39570900000399,
+            "p99": 6.430041000014171,
+            "max": 37.08045799995307
+          }
+        }
+      ]
+    },
+    {
+      "name": "quiet",
+      "startedMs": 1788378081325,
+      "finishedMs": 1788378171327,
+      "stages": [
+        {
+          "label": "quiet",
+          "targetTransactionsPerSecond": 0,
+          "durationSeconds": 90,
+          "transactions": 0,
+          "mutations": 0,
+          "elapsedSeconds": 90.00125779200002,
+          "actualTransactionsPerSecond": 0,
+          "shapes": {
+            "insert": 0,
+            "update": 0,
+            "delete": 0,
+            "churn": 0
+          },
+          "residueRows": 11250,
+          "latencyMs": {
+            "p50": 0,
+            "p95": 0,
+            "p99": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "fat",
+      "startedMs": 1788378172272,
+      "finishedMs": 1788378292244,
+      "stages": [
+        {
+          "label": "fat",
+          "targetTransactionsPerSecond": 25,
+          "durationSeconds": 120,
+          "transactions": 3000,
+          "mutations": 3600,
+          "elapsedSeconds": 119.96768516699998,
+          "actualTransactionsPerSecond": 25.006734070294645,
+          "shapes": {
+            "insert": 1200,
+            "update": 1200,
+            "delete": 300,
+            "churn": 300
+          },
+          "residueRows": 12150,
+          "latencyMs": {
+            "p50": 4.719500000006519,
+            "p95": 7.63737500004936,
+            "p99": 11.025332999997772,
+            "max": 30.51100000005681
+          }
+        }
+      ]
+    },
+    {
+      "name": "mixed",
+      "startedMs": 1788378293521,
+      "finishedMs": 1788378688939,
+      "stages": [
+        {
+          "label": "mixed-sustained",
+          "targetTransactionsPerSecond": 25,
+          "durationSeconds": 60,
+          "transactions": 1500,
+          "mutations": 1526,
+          "elapsedSeconds": 59.96444254199997,
+          "actualTransactionsPerSecond": 25.014824392795415,
+          "shapes": {
+            "insert": 1161,
+            "update": 39,
+            "delete": 287,
+            "churn": 13
+          },
+          "residueRows": 13050,
+          "latencyMs": {
+            "p50": 4.2091669999063015,
+            "p95": 6.338667000061832,
+            "p99": 8.848250000039116,
+            "max": 22.598333000089042
+          }
+        }
+      ]
+    }
+  ],
+  "oracle": [
+    {
+      "label": "after phase sustained",
+      "atMs": 1788377980488,
+      "quiesceMs": 230,
+      "comparisons": [
+        {
+          "node": "rm",
+          "stateVersion": "6951frg0",
+          "replicaVersion": "694c4954",
+          "tables": 13,
+          "rows": 16484,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-0",
+          "stateVersion": "6951frg0",
+          "replicaVersion": "694c4954",
+          "tables": 13,
+          "rows": 16484,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-1",
+          "stateVersion": "6951frg0",
+          "replicaVersion": "694c4954",
+          "tables": 13,
+          "rows": 16484,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-2",
+          "stateVersion": "6951frg0",
+          "replicaVersion": "694c4954",
+          "tables": 13,
+          "rows": 16484,
+          "diffs": [],
+          "ok": true
+        }
+      ],
+      "ok": true,
+      "verdict": "clean"
+    },
+    {
+      "label": "after phase burst",
+      "atMs": 1788378081325,
+      "quiesceMs": 106,
+      "comparisons": [
+        {
+          "node": "rm",
+          "stateVersion": "697nmxs0",
+          "replicaVersion": "694c4954",
+          "tables": 13,
+          "rows": 25484,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-0",
+          "stateVersion": "697nmxs0",
+          "replicaVersion": "694c4954",
+          "tables": 13,
+          "rows": 25484,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-1",
+          "stateVersion": "697nmxs0",
+          "replicaVersion": "694c4954",
+          "tables": 13,
+          "rows": 25484,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-2",
+          "stateVersion": "697nmxs0",
+          "replicaVersion": "694c4954",
+          "tables": 13,
+          "rows": 25484,
+          "diffs": [],
+          "ok": true
+        }
+      ],
+      "ok": true,
+      "verdict": "clean"
+    },
+    {
+      "label": "after phase quiet",
+      "atMs": 1788378172272,
+      "quiesceMs": 244,
+      "comparisons": [
+        {
+          "node": "rm",
+          "stateVersion": "697y1cyg",
+          "replicaVersion": "694c4954",
+          "tables": 13,
+          "rows": 25484,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-0",
+          "stateVersion": "697y1cyg",
+          "replicaVersion": "694c4954",
+          "tables": 13,
+          "rows": 25484,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-1",
+          "stateVersion": "697y1cyg",
+          "replicaVersion": "694c4954",
+          "tables": 13,
+          "rows": 25484,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-2",
+          "stateVersion": "697y1cyg",
+          "replicaVersion": "694c4954",
+          "tables": 13,
+          "rows": 25484,
+          "diffs": [],
+          "ok": true
+        }
+      ],
+      "ok": true,
+      "verdict": "clean"
+    },
+    {
+      "label": "after phase fat",
+      "atMs": 1788378293521,
+      "quiesceMs": 226,
+      "comparisons": [
+        {
+          "node": "rm",
+          "stateVersion": "6989l63k",
+          "replicaVersion": "694c4954",
+          "tables": 13,
+          "rows": 26384,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-0",
+          "stateVersion": "6989l63k",
+          "replicaVersion": "694c4954",
+          "tables": 13,
+          "rows": 26384,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-1",
+          "stateVersion": "6989l63k",
+          "replicaVersion": "694c4954",
+          "tables": 13,
+          "rows": 26384,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-2",
+          "stateVersion": "6989l63k",
+          "replicaVersion": "694c4954",
+          "tables": 13,
+          "rows": 26384,
+          "diffs": [],
+          "ok": true
+        }
+      ],
+      "ok": true,
+      "verdict": "clean"
+    },
+    {
+      "label": "after C9",
+      "atMs": 1788378688939,
+      "quiesceMs": 243,
+      "comparisons": [
+        {
+          "node": "rm",
+          "stateVersion": "699fphco",
+          "replicaVersion": "694c4954",
+          "tables": 13,
+          "rows": 29534,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-0",
+          "stateVersion": "699fphco",
+          "replicaVersion": "694c4954",
+          "tables": 13,
+          "rows": 29534,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-1",
+          "stateVersion": "699fphco",
+          "replicaVersion": "694c4954",
+          "tables": 13,
+          "rows": 29534,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-2",
+          "stateVersion": "699fphco",
+          "replicaVersion": "694c4954",
+          "tables": 13,
+          "rows": 29534,
+          "diffs": [],
+          "ok": true
+        }
+      ],
+      "ok": true,
+      "verdict": "clean"
+    }
+  ],
+  "chaos": [
+    {
+      "id": "C9",
+      "title": "Stop minio under sustained writes, then restart it",
+      "startedMs": 1788378293521,
+      "finishedMs": 1788378687552,
+      "notes": ["stopped minio for 300s", "restarted minio"],
+      "census": {},
+      "findings": ["C9: the minio outage did not grow live change-log pages"],
+      "measurements": {
+        "changeLogBytesBefore": 42334672,
+        "changeLogBytesDuring": 42334672,
+        "changeLogBytesAfter": 42334672,
+        "changeLogLiveBytesBefore": 20406272,
+        "changeLogLiveBytesDuring": 13434880,
+        "changeLogLiveBytesAfter": 1486848,
+        "changeLogFreeBytesAfter": 31989760,
+        "slotRetainedBytesBefore": 1054720,
+        "slotRetainedBytesDuring": 56292600,
+        "slotRetainedBytesAfter": 858072,
+        "backupRecoveries": 21,
+        "purgePassesAfterRecovery": 2,
+        "purgedRowsAfterRecovery": 30604
+      }
+    }
+  ],
+  "census": {
+    "pg/not-ready": 1,
+    "pg/log-unavailable": 1,
+    "sqlite/selected-cold": 2
+  },
+  "coverage": [],
+  "tripwires": [
+    {
+      "name": "error-log",
+      "node": "rm",
+      "tsMs": 1788378297512,
+      "message": "vfs-query exited with error",
+      "detail": {}
+    },
+    {
+      "name": "error-log",
+      "node": "rm",
+      "tsMs": 1788378404766,
+      "message": "",
+      "detail": {}
+    },
+    {
+      "name": "error-log",
+      "node": "rm",
+      "tsMs": 1788378406040,
+      "message": "vfs-query exited with error",
+      "detail": {}
+    },
+    {
+      "name": "error-log",
+      "node": "rm",
+      "tsMs": 1788378526591,
+      "message": "",
+      "detail": {}
+    },
+    {
+      "name": "error-log",
+      "node": "rm",
+      "tsMs": 1788378528816,
+      "message": "vfs-query exited with error",
+      "detail": {}
+    }
+  ],
+  "measurements": {
+    "reseedToCoveringBackupMs": {
+      "n": 0
+    },
+    "reservationHoldMs": {
+      "n": 0
+    },
+    "reservationHoldMsC3": {
+      "n": 0
+    },
+    "reseedToCoveringBackupMsC6C13": {
+      "n": 0
+    },
+    "backupLagMs": {
+      "n": 291,
+      "min": 13,
+      "p50": 226,
+      "p95": 1053,
+      "max": 2624,
+      "mean": 539.6323024054983
+    },
+    "reservationConfirmDelays": 0,
+    "reservationDemotions": 0,
+    "barrierTimeouts": 0,
+    "compareResults": {
+      "match": 40567
+    },
+    "initCompareResults": {
+      "equal": 1
+    },
+    "floorProbes": {
+      "retained": 24
+    },
+    "reconcileWipes": {
+      "created": 1
+    },
+    "purgeDeclines": {},
+    "catchupRows": 0,
+    "catchupBytes": 0,
+    "catchupDurationSeconds": 0,
+    "catchupResults": {
+      "range/false": 2
+    },
+    "litestreamRestores": {
+      "no_backup": 1,
+      "success": 3
+    },
+    "purgedRows": 160169
+  },
+  "resources": {
+    "changeLogBytes": {
+      "n": 205,
+      "min": 2274248,
+      "p50": 42334672,
+      "p95": 42334672,
+      "max": 42334672,
+      "mean": 32087123.2
+    },
+    "changeLogBytesFinal": 42334672,
+    "changeLogLiveBytes": {
+      "n": 205,
+      "min": 77824,
+      "p50": 8536064,
+      "p95": 26480640,
+      "max": 32718848,
+      "mean": 9374065.63902439
+    },
+    "changeLogLiveBytesFinal": 1486848,
+    "changeLogFreeBytes": {
+      "n": 205,
+      "min": 0,
+      "p50": 18362368,
+      "p95": 30887936,
+      "max": 33398784,
+      "mean": 14123407.609756097
+    },
+    "changeLogFreeBytesFinal": 31989760,
+    "slotRetainedBytes": {
+      "n": 205,
+      "min": 56,
+      "p50": 2824488,
+      "p95": 53883560,
+      "max": 59051648,
+      "mean": 13028350.43902439
+    },
+    "slotRetainedBytesFinal": 936184,
+    "backupBytesFinal": 75785048,
+    "backupObjectsFinal": 813,
+    "purge": {
+      "longestBatchLimitStreak": 0,
+      "passes": 24,
+      "batchLimitPasses": 0,
+      "immediateContinuations": 0,
+      "byStopReason": {
+        "none": 24
+      }
+    },
+    "samples": 205
+  },
+  "findings": ["C9: the minio outage did not grow live change-log pages"],
+  "pass": false
+}

--- a/apps/zbugs/scripts/rmv2-soak/results/2026-09-02-c9-final-post-fix.json
+++ b/apps/zbugs/scripts/rmv2-soak/results/2026-09-02-c9-final-post-fix.json
@@ -1,0 +1,658 @@
+{
+  "runID": "c9-final-post-fix-2026-09-02",
+  "startedMs": 1788378840880,
+  "finishedMs": 1788379866552,
+  "config": {
+    "appID": "rmv2_soak",
+    "viewSyncers": 3,
+    "changeLog": {
+      "mode": "serve",
+      "readPercent": 100,
+      "coldReadPercent": 100,
+      "comparePercent": 100,
+      "retentionMs": 60000
+    },
+    "backupIntervalSeconds": 2,
+    "vfsPollIntervalMs": 1000,
+    "startupDelayMs": 1000,
+    "snapshotBackupIntervalHours": 4,
+    "chaos": ["C9"],
+    "scale": 1,
+    "baseline": false,
+    "root": "/Users/mlaw/workspace/zero/mono/apps/zbugs/.soak/c9-final-post-fix-2026-09-02"
+  },
+  "phases": [
+    {
+      "name": "sustained",
+      "startedMs": 1788378851628,
+      "finishedMs": 1788379151603,
+      "stages": [
+        {
+          "label": "sustained",
+          "targetTransactionsPerSecond": 25,
+          "durationSeconds": 300,
+          "transactions": 7500,
+          "mutations": 9000,
+          "elapsedSeconds": 299.9666975,
+          "actualTransactionsPerSecond": 25.002775516438785,
+          "shapes": {
+            "insert": 3000,
+            "update": 3000,
+            "delete": 750,
+            "churn": 750
+          },
+          "residueRows": 2250,
+          "latencyMs": {
+            "p50": 3.9139169999980368,
+            "p95": 6.244708000012906,
+            "p99": 9.164624999997613,
+            "max": 26.966709000000264
+          }
+        }
+      ]
+    },
+    {
+      "name": "burst",
+      "startedMs": 1788379152205,
+      "finishedMs": 1788379252210,
+      "stages": [
+        {
+          "label": "burst-1",
+          "targetTransactionsPerSecond": 500,
+          "durationSeconds": 20,
+          "transactions": 10000,
+          "mutations": 12000,
+          "elapsedSeconds": 19.998769542000023,
+          "actualTransactionsPerSecond": 500.0307633426495,
+          "shapes": {
+            "insert": 4000,
+            "update": 4000,
+            "delete": 1000,
+            "churn": 1000
+          },
+          "residueRows": 5250,
+          "latencyMs": {
+            "p50": 1.5053749999497086,
+            "p95": 3.1939580000471324,
+            "p99": 6.404041000001598,
+            "max": 24.815332999976818
+          }
+        },
+        {
+          "label": "burst-gap-1",
+          "targetTransactionsPerSecond": 0,
+          "durationSeconds": 20,
+          "transactions": 0,
+          "mutations": 0,
+          "elapsedSeconds": 19.999868166,
+          "actualTransactionsPerSecond": 0,
+          "shapes": {
+            "insert": 0,
+            "update": 0,
+            "delete": 0,
+            "churn": 0
+          },
+          "residueRows": 5250,
+          "latencyMs": {
+            "p50": 0,
+            "p95": 0,
+            "p99": 0,
+            "max": 0
+          }
+        },
+        {
+          "label": "burst-2",
+          "targetTransactionsPerSecond": 500,
+          "durationSeconds": 20,
+          "transactions": 10000,
+          "mutations": 12000,
+          "elapsedSeconds": 20.001147999999986,
+          "actualTransactionsPerSecond": 499.97130164728577,
+          "shapes": {
+            "insert": 4000,
+            "update": 4000,
+            "delete": 1000,
+            "churn": 1000
+          },
+          "residueRows": 8250,
+          "latencyMs": {
+            "p50": 1.530834000033792,
+            "p95": 3.328166000021156,
+            "p99": 6.6739159999997355,
+            "max": 33.229874999960884
+          }
+        },
+        {
+          "label": "burst-gap-2",
+          "targetTransactionsPerSecond": 0,
+          "durationSeconds": 20,
+          "transactions": 0,
+          "mutations": 0,
+          "elapsedSeconds": 20.000620542000046,
+          "actualTransactionsPerSecond": 0,
+          "shapes": {
+            "insert": 0,
+            "update": 0,
+            "delete": 0,
+            "churn": 0
+          },
+          "residueRows": 8250,
+          "latencyMs": {
+            "p50": 0,
+            "p95": 0,
+            "p99": 0,
+            "max": 0
+          }
+        },
+        {
+          "label": "burst-3",
+          "targetTransactionsPerSecond": 500,
+          "durationSeconds": 20,
+          "transactions": 10000,
+          "mutations": 12000,
+          "elapsedSeconds": 19.998570625000053,
+          "actualTransactionsPerSecond": 500.03573692907236,
+          "shapes": {
+            "insert": 4000,
+            "update": 4000,
+            "delete": 1000,
+            "churn": 1000
+          },
+          "residueRows": 11250,
+          "latencyMs": {
+            "p50": 1.5710420000250451,
+            "p95": 3.166875000053551,
+            "p99": 6.0131669999682344,
+            "max": 34.567250000021886
+          }
+        }
+      ]
+    },
+    {
+      "name": "quiet",
+      "startedMs": 1788379252995,
+      "finishedMs": 1788379342998,
+      "stages": [
+        {
+          "label": "quiet",
+          "targetTransactionsPerSecond": 0,
+          "durationSeconds": 90,
+          "transactions": 0,
+          "mutations": 0,
+          "elapsedSeconds": 90.00145237500006,
+          "actualTransactionsPerSecond": 0,
+          "shapes": {
+            "insert": 0,
+            "update": 0,
+            "delete": 0,
+            "churn": 0
+          },
+          "residueRows": 11250,
+          "latencyMs": {
+            "p50": 0,
+            "p95": 0,
+            "p99": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "fat",
+      "startedMs": 1788379343898,
+      "finishedMs": 1788379463866,
+      "stages": [
+        {
+          "label": "fat",
+          "targetTransactionsPerSecond": 25,
+          "durationSeconds": 120,
+          "transactions": 3000,
+          "mutations": 3600,
+          "elapsedSeconds": 119.96451670799998,
+          "actualTransactionsPerSecond": 25.007394539021565,
+          "shapes": {
+            "insert": 1200,
+            "update": 1200,
+            "delete": 300,
+            "churn": 300
+          },
+          "residueRows": 12150,
+          "latencyMs": {
+            "p50": 4.6077920000534505,
+            "p95": 6.999540999997407,
+            "p99": 10.143750000046566,
+            "max": 25.246500000008382
+          }
+        }
+      ]
+    },
+    {
+      "name": "mixed",
+      "startedMs": 1788379465141,
+      "finishedMs": 1788379860491,
+      "stages": [
+        {
+          "label": "mixed-sustained",
+          "targetTransactionsPerSecond": 25,
+          "durationSeconds": 60,
+          "transactions": 1500,
+          "mutations": 1510,
+          "elapsedSeconds": 59.96493650000007,
+          "actualTransactionsPerSecond": 25.0146183344995,
+          "shapes": {
+            "insert": 1181,
+            "update": 19,
+            "delete": 295,
+            "churn": 5
+          },
+          "residueRows": 13050,
+          "latencyMs": {
+            "p50": 4.420250000082888,
+            "p95": 6.206624999991618,
+            "p99": 8.769417000003159,
+            "max": 24.9617080000462
+          }
+        }
+      ]
+    }
+  ],
+  "oracle": [
+    {
+      "label": "after phase sustained",
+      "atMs": 1788379152204,
+      "quiesceMs": 127,
+      "comparisons": [
+        {
+          "node": "rm",
+          "stateVersion": "69atv2so",
+          "replicaVersion": "69a4czsg",
+          "tables": 13,
+          "rows": 16484,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-0",
+          "stateVersion": "69atv2so",
+          "replicaVersion": "69a4czsg",
+          "tables": 13,
+          "rows": 16484,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-1",
+          "stateVersion": "69atv2so",
+          "replicaVersion": "69a4czsg",
+          "tables": 13,
+          "rows": 16484,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-2",
+          "stateVersion": "69atv2so",
+          "replicaVersion": "69a4czsg",
+          "tables": 13,
+          "rows": 16484,
+          "diffs": [],
+          "ok": true
+        }
+      ],
+      "ok": true,
+      "verdict": "clean"
+    },
+    {
+      "label": "after phase burst",
+      "atMs": 1788379252995,
+      "quiesceMs": 106,
+      "comparisons": [
+        {
+          "node": "rm",
+          "stateVersion": "69dd30mo",
+          "replicaVersion": "69a4czsg",
+          "tables": 13,
+          "rows": 25484,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-0",
+          "stateVersion": "69dd30mo",
+          "replicaVersion": "69a4czsg",
+          "tables": 13,
+          "rows": 25484,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-1",
+          "stateVersion": "69dd30mo",
+          "replicaVersion": "69a4czsg",
+          "tables": 13,
+          "rows": 25484,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-2",
+          "stateVersion": "69dd30mo",
+          "replicaVersion": "69a4czsg",
+          "tables": 13,
+          "rows": 25484,
+          "diffs": [],
+          "ok": true
+        }
+      ],
+      "ok": true,
+      "verdict": "clean"
+    },
+    {
+      "label": "after phase quiet",
+      "atMs": 1788379343898,
+      "quiesceMs": 228,
+      "comparisons": [
+        {
+          "node": "rm",
+          "stateVersion": "69dg2o0g",
+          "replicaVersion": "69a4czsg",
+          "tables": 13,
+          "rows": 25484,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-0",
+          "stateVersion": "69dg2o0g",
+          "replicaVersion": "69a4czsg",
+          "tables": 13,
+          "rows": 25484,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-1",
+          "stateVersion": "69dg2o0g",
+          "replicaVersion": "69a4czsg",
+          "tables": 13,
+          "rows": 25484,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-2",
+          "stateVersion": "69dg2o0g",
+          "replicaVersion": "69a4czsg",
+          "tables": 13,
+          "rows": 25484,
+          "diffs": [],
+          "ok": true
+        }
+      ],
+      "ok": true,
+      "verdict": "clean"
+    },
+    {
+      "label": "after phase fat",
+      "atMs": 1788379465141,
+      "quiesceMs": 132,
+      "comparisons": [
+        {
+          "node": "rm",
+          "stateVersion": "69drghbs",
+          "replicaVersion": "69a4czsg",
+          "tables": 13,
+          "rows": 26384,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-0",
+          "stateVersion": "69drghbs",
+          "replicaVersion": "69a4czsg",
+          "tables": 13,
+          "rows": 26384,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-1",
+          "stateVersion": "69drghbs",
+          "replicaVersion": "69a4czsg",
+          "tables": 13,
+          "rows": 26384,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-2",
+          "stateVersion": "69drghbs",
+          "replicaVersion": "69a4czsg",
+          "tables": 13,
+          "rows": 26384,
+          "diffs": [],
+          "ok": true
+        }
+      ],
+      "ok": true,
+      "verdict": "clean"
+    },
+    {
+      "label": "after C9",
+      "atMs": 1788379860491,
+      "quiesceMs": 245,
+      "comparisons": [
+        {
+          "node": "rm",
+          "stateVersion": "69f0a5fk",
+          "replicaVersion": "69a4czsg",
+          "tables": 13,
+          "rows": 29534,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-0",
+          "stateVersion": "69f0a5fk",
+          "replicaVersion": "69a4czsg",
+          "tables": 13,
+          "rows": 29534,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-1",
+          "stateVersion": "69f0a5fk",
+          "replicaVersion": "69a4czsg",
+          "tables": 13,
+          "rows": 29534,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-2",
+          "stateVersion": "69f0a5fk",
+          "replicaVersion": "69a4czsg",
+          "tables": 13,
+          "rows": 29534,
+          "diffs": [],
+          "ok": true
+        }
+      ],
+      "ok": true,
+      "verdict": "clean"
+    }
+  ],
+  "chaos": [
+    {
+      "id": "C9",
+      "title": "Stop minio under sustained writes, then restart it",
+      "startedMs": 1788379465141,
+      "finishedMs": 1788379859140,
+      "notes": ["stopped minio for 300s", "restarted minio"],
+      "census": {},
+      "findings": [],
+      "measurements": {
+        "changeLogBytesBefore": 42371632,
+        "changeLogBytesDuring": 42371632,
+        "changeLogBytesAfter": 42371632,
+        "changeLogLiveBytesBefore": 20357120,
+        "changeLogLiveBytesDuring": 13860864,
+        "changeLogLiveBytesAfter": 1875968,
+        "changeLogFreeBytesAfter": 31621120,
+        "slotRetainedBytesBefore": 5314688,
+        "slotRetainedBytesDuring": 65997768,
+        "slotRetainedBytesAfter": 176,
+        "backupRecoveries": 26,
+        "purgePassesAfterRecovery": 2,
+        "purgedRowsAfterRecovery": 29897
+      }
+    }
+  ],
+  "census": {
+    "pg/not-ready": 1,
+    "pg/log-unavailable": 1,
+    "sqlite/selected-cold": 2
+  },
+  "coverage": [],
+  "tripwires": [
+    {
+      "name": "error-log",
+      "node": "rm",
+      "tsMs": 1788379575141,
+      "message": "cannot fetch page",
+      "detail": {
+        "name": "zero-backup.db"
+      }
+    },
+    {
+      "name": "error-log",
+      "node": "rm",
+      "tsMs": 1788379575142,
+      "message": "vfs-query exited with error",
+      "detail": {}
+    },
+    {
+      "name": "error-log",
+      "node": "rm",
+      "tsMs": 1788379581301,
+      "message": "",
+      "detail": {}
+    },
+    {
+      "name": "error-log",
+      "node": "rm",
+      "tsMs": 1788379692137,
+      "message": "vfs-query exited with error",
+      "detail": {}
+    },
+    {
+      "name": "error-log",
+      "node": "rm",
+      "tsMs": 1788379704181,
+      "message": "",
+      "detail": {}
+    }
+  ],
+  "measurements": {
+    "reseedToCoveringBackupMs": {
+      "n": 0
+    },
+    "reservationHoldMs": {
+      "n": 0
+    },
+    "reservationHoldMsC3": {
+      "n": 0
+    },
+    "reseedToCoveringBackupMsC6C13": {
+      "n": 0
+    },
+    "backupLagMs": {
+      "n": 294,
+      "min": 12,
+      "p50": 895,
+      "p95": 1042,
+      "max": 2570,
+      "mean": 567.8299319727892
+    },
+    "reservationConfirmDelays": 0,
+    "reservationDemotions": 0,
+    "barrierTimeouts": 0,
+    "compareResults": {
+      "match": 40558
+    },
+    "initCompareResults": {
+      "equal": 1
+    },
+    "floorProbes": {
+      "retained": 24
+    },
+    "reconcileWipes": {
+      "created": 1
+    },
+    "purgeDeclines": {},
+    "catchupRows": 0,
+    "catchupBytes": 0,
+    "catchupDurationSeconds": 0.001,
+    "catchupResults": {
+      "range/false": 2
+    },
+    "litestreamRestores": {
+      "no_backup": 1,
+      "success": 3
+    },
+    "purgedRows": 159314
+  },
+  "resources": {
+    "changeLogBytes": {
+      "n": 206,
+      "min": 2249528,
+      "p50": 42371632,
+      "p95": 42371632,
+      "max": 42371632,
+      "mean": 32116694.446601942
+    },
+    "changeLogBytesFinal": 42371632,
+    "changeLogLiveBytes": {
+      "n": 206,
+      "min": 77824,
+      "p50": 8228864,
+      "p95": 26521600,
+      "max": 32751616,
+      "mean": 9270798.912621358
+    },
+    "changeLogLiveBytesFinal": 778240,
+    "changeLogFreeBytes": {
+      "n": 206,
+      "min": 0,
+      "p50": 18460672,
+      "p95": 31621120,
+      "max": 33419264,
+      "mean": 14288677.281553399
+    },
+    "changeLogFreeBytesFinal": 32718848,
+    "slotRetainedBytes": {
+      "n": 206,
+      "min": 56,
+      "p50": 3748216,
+      "p95": 62359776,
+      "max": 66792608,
+      "mean": 16487895.18446602
+    },
+    "slotRetainedBytesFinal": 24096,
+    "backupBytesFinal": 85150714,
+    "backupObjectsFinal": 876,
+    "purge": {
+      "longestBatchLimitStreak": 0,
+      "passes": 25,
+      "batchLimitPasses": 0,
+      "immediateContinuations": 0,
+      "byStopReason": {
+        "none": 25
+      }
+    },
+    "samples": 206
+  },
+  "findings": [],
+  "pass": true
+}

--- a/apps/zbugs/scripts/rmv2-soak/results/2026-09-02-cold-read-control-post-fix.json
+++ b/apps/zbugs/scripts/rmv2-soak/results/2026-09-02-cold-read-control-post-fix.json
@@ -1,0 +1,639 @@
+{
+  "runID": "cold-read-control-post-fix-2026-09-02",
+  "startedMs": 1788380378657,
+  "finishedMs": 1788380537315,
+  "config": {
+    "appID": "rmv2_soak",
+    "viewSyncers": 3,
+    "changeLog": {
+      "mode": "serve",
+      "readPercent": 100,
+      "coldReadPercent": 0,
+      "comparePercent": 100,
+      "retentionMs": 60000
+    },
+    "backupIntervalSeconds": 2,
+    "vfsPollIntervalMs": 1000,
+    "startupDelayMs": 1000,
+    "snapshotBackupIntervalHours": 4,
+    "chaos": ["C6"],
+    "scale": 0.1,
+    "baseline": false,
+    "root": "/Users/mlaw/workspace/zero/mono/apps/zbugs/.soak/cold-read-control-post-fix-2026-09-02"
+  },
+  "phases": [
+    {
+      "name": "sustained",
+      "startedMs": 1788380390446,
+      "finishedMs": 1788380420413,
+      "stages": [
+        {
+          "label": "sustained",
+          "targetTransactionsPerSecond": 25,
+          "durationSeconds": 30,
+          "transactions": 750,
+          "mutations": 900,
+          "elapsedSeconds": 29.965306540999997,
+          "actualTransactionsPerSecond": 25.028944688879232,
+          "shapes": {
+            "insert": 300,
+            "update": 300,
+            "delete": 75,
+            "churn": 75
+          },
+          "residueRows": 225,
+          "latencyMs": {
+            "p50": 4.262624999999389,
+            "p95": 6.900999999998021,
+            "p99": 12.39916699999958,
+            "max": 23.08245900000111
+          }
+        }
+      ]
+    },
+    {
+      "name": "burst",
+      "startedMs": 1788380420955,
+      "finishedMs": 1788380430957,
+      "stages": [
+        {
+          "label": "burst-1",
+          "targetTransactionsPerSecond": 500,
+          "durationSeconds": 2,
+          "transactions": 1000,
+          "mutations": 1200,
+          "elapsedSeconds": 2.0003761659999943,
+          "actualTransactionsPerSecond": 499.90597618428274,
+          "shapes": {
+            "insert": 400,
+            "update": 400,
+            "delete": 100,
+            "churn": 100
+          },
+          "residueRows": 525,
+          "latencyMs": {
+            "p50": 1.6126670000012382,
+            "p95": 3.9229170000035083,
+            "p99": 13.4209170000031,
+            "max": 23.141749999995227
+          }
+        },
+        {
+          "label": "burst-gap-1",
+          "targetTransactionsPerSecond": 0,
+          "durationSeconds": 2,
+          "transactions": 0,
+          "mutations": 0,
+          "elapsedSeconds": 2.0006885830000027,
+          "actualTransactionsPerSecond": 0,
+          "shapes": {
+            "insert": 0,
+            "update": 0,
+            "delete": 0,
+            "churn": 0
+          },
+          "residueRows": 525,
+          "latencyMs": {
+            "p50": 0,
+            "p95": 0,
+            "p99": 0,
+            "max": 0
+          }
+        },
+        {
+          "label": "burst-2",
+          "targetTransactionsPerSecond": 500,
+          "durationSeconds": 2,
+          "transactions": 1000,
+          "mutations": 1200,
+          "elapsedSeconds": 1.9999947909999973,
+          "actualTransactionsPerSecond": 500.0013022533924,
+          "shapes": {
+            "insert": 400,
+            "update": 400,
+            "delete": 100,
+            "churn": 100
+          },
+          "residueRows": 825,
+          "latencyMs": {
+            "p50": 1.5197079999998095,
+            "p95": 3.3882919999959995,
+            "p99": 5.386833000004117,
+            "max": 7.4487909999952535
+          }
+        },
+        {
+          "label": "burst-gap-2",
+          "targetTransactionsPerSecond": 0,
+          "durationSeconds": 2,
+          "transactions": 0,
+          "mutations": 0,
+          "elapsedSeconds": 1.9998939159999936,
+          "actualTransactionsPerSecond": 0,
+          "shapes": {
+            "insert": 0,
+            "update": 0,
+            "delete": 0,
+            "churn": 0
+          },
+          "residueRows": 825,
+          "latencyMs": {
+            "p50": 0,
+            "p95": 0,
+            "p99": 0,
+            "max": 0
+          }
+        },
+        {
+          "label": "burst-3",
+          "targetTransactionsPerSecond": 500,
+          "durationSeconds": 2,
+          "transactions": 1000,
+          "mutations": 1200,
+          "elapsedSeconds": 2.000735166999999,
+          "actualTransactionsPerSecond": 499.81627578399065,
+          "shapes": {
+            "insert": 400,
+            "update": 400,
+            "delete": 100,
+            "churn": 100
+          },
+          "residueRows": 1125,
+          "latencyMs": {
+            "p50": 1.563125000000582,
+            "p95": 3.3439590000052704,
+            "p99": 5.824583000001439,
+            "max": 11.139917000000423
+          }
+        }
+      ]
+    },
+    {
+      "name": "quiet",
+      "startedMs": 1788380431431,
+      "finishedMs": 1788380506432,
+      "stages": [
+        {
+          "label": "quiet",
+          "targetTransactionsPerSecond": 0,
+          "durationSeconds": 75,
+          "transactions": 0,
+          "mutations": 0,
+          "elapsedSeconds": 75.00039091699999,
+          "actualTransactionsPerSecond": 0,
+          "shapes": {
+            "insert": 0,
+            "update": 0,
+            "delete": 0,
+            "churn": 0
+          },
+          "residueRows": 1125,
+          "latencyMs": {
+            "p50": 0,
+            "p95": 0,
+            "p99": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "fat",
+      "startedMs": 1788380507068,
+      "finishedMs": 1788380519039,
+      "stages": [
+        {
+          "label": "fat",
+          "targetTransactionsPerSecond": 25,
+          "durationSeconds": 12,
+          "transactions": 300,
+          "mutations": 360,
+          "elapsedSeconds": 11.970676250000004,
+          "actualTransactionsPerSecond": 25.061240796650893,
+          "shapes": {
+            "insert": 120,
+            "update": 120,
+            "delete": 30,
+            "churn": 30
+          },
+          "residueRows": 1215,
+          "latencyMs": {
+            "p50": 5.034875000012107,
+            "p95": 8.172665999998571,
+            "p99": 12.558332999993581,
+            "max": 20.340666000003694
+          }
+        }
+      ]
+    },
+    {
+      "name": "mixed",
+      "startedMs": 1788380519688,
+      "finishedMs": 1788380531294,
+      "stages": [
+        {
+          "label": "mixed-sustained",
+          "targetTransactionsPerSecond": 25,
+          "durationSeconds": 6,
+          "transactions": 150,
+          "mutations": 180,
+          "elapsedSeconds": 5.964619959000003,
+          "actualTransactionsPerSecond": 25.14829126265879,
+          "shapes": {
+            "insert": 60,
+            "update": 60,
+            "delete": 15,
+            "churn": 15
+          },
+          "residueRows": 1260,
+          "latencyMs": {
+            "p50": 3.6127080000005662,
+            "p95": 8.507666999998037,
+            "p99": 38.72399999998743,
+            "max": 42.02708299999358
+          }
+        }
+      ]
+    }
+  ],
+  "oracle": [
+    {
+      "label": "after phase sustained",
+      "atMs": 1788380420955,
+      "quiesceMs": 127,
+      "comparisons": [
+        {
+          "node": "rm",
+          "stateVersion": "69fljjm8",
+          "replicaVersion": "69fj4we8",
+          "tables": 13,
+          "rows": 14459,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-0",
+          "stateVersion": "69fljjm8",
+          "replicaVersion": "69fj4we8",
+          "tables": 13,
+          "rows": 14459,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-1",
+          "stateVersion": "69fljjm8",
+          "replicaVersion": "69fj4we8",
+          "tables": 13,
+          "rows": 14459,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-2",
+          "stateVersion": "69fljjm8",
+          "replicaVersion": "69fj4we8",
+          "tables": 13,
+          "rows": 14459,
+          "diffs": [],
+          "ok": true
+        }
+      ],
+      "ok": true,
+      "verdict": "clean"
+    },
+    {
+      "label": "after phase burst",
+      "atMs": 1788380431431,
+      "quiesceMs": 108,
+      "comparisons": [
+        {
+          "node": "rm",
+          "stateVersion": "69fuj4yo",
+          "replicaVersion": "69fj4we8",
+          "tables": 13,
+          "rows": 15359,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-0",
+          "stateVersion": "69fuj4yo",
+          "replicaVersion": "69fj4we8",
+          "tables": 13,
+          "rows": 15359,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-1",
+          "stateVersion": "69fuj4yo",
+          "replicaVersion": "69fj4we8",
+          "tables": 13,
+          "rows": 15359,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-2",
+          "stateVersion": "69fuj4yo",
+          "replicaVersion": "69fj4we8",
+          "tables": 13,
+          "rows": 15359,
+          "diffs": [],
+          "ok": true
+        }
+      ],
+      "ok": true,
+      "verdict": "clean"
+    },
+    {
+      "label": "after phase quiet",
+      "atMs": 1788380507068,
+      "quiesceMs": 233,
+      "comparisons": [
+        {
+          "node": "rm",
+          "stateVersion": "69fvbx6w",
+          "replicaVersion": "69fj4we8",
+          "tables": 13,
+          "rows": 15359,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-0",
+          "stateVersion": "69fvbx6w",
+          "replicaVersion": "69fj4we8",
+          "tables": 13,
+          "rows": 15359,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-1",
+          "stateVersion": "69fvbx6w",
+          "replicaVersion": "69fj4we8",
+          "tables": 13,
+          "rows": 15359,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-2",
+          "stateVersion": "69fvbx6w",
+          "replicaVersion": "69fj4we8",
+          "tables": 13,
+          "rows": 15359,
+          "diffs": [],
+          "ok": true
+        }
+      ],
+      "ok": true,
+      "verdict": "clean"
+    },
+    {
+      "label": "after phase fat",
+      "atMs": 1788380519688,
+      "quiesceMs": 226,
+      "comparisons": [
+        {
+          "node": "rm",
+          "stateVersion": "69fwxbko",
+          "replicaVersion": "69fj4we8",
+          "tables": 13,
+          "rows": 15449,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-0",
+          "stateVersion": "69fwxbko",
+          "replicaVersion": "69fj4we8",
+          "tables": 13,
+          "rows": 15449,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-1",
+          "stateVersion": "69fwxbko",
+          "replicaVersion": "69fj4we8",
+          "tables": 13,
+          "rows": 15449,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-2",
+          "stateVersion": "69fwxbko",
+          "replicaVersion": "69fj4we8",
+          "tables": 13,
+          "rows": 15449,
+          "diffs": [],
+          "ok": true
+        }
+      ],
+      "ok": true,
+      "verdict": "clean"
+    },
+    {
+      "label": "after C6",
+      "atMs": 1788380531294,
+      "quiesceMs": 232,
+      "comparisons": [
+        {
+          "node": "rm",
+          "stateVersion": "69fxmukg",
+          "replicaVersion": "69fj4we8",
+          "tables": 13,
+          "rows": 15494,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-0",
+          "stateVersion": "69fxmukg",
+          "replicaVersion": "69fj4we8",
+          "tables": 13,
+          "rows": 15494,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-1",
+          "stateVersion": "69fxmukg",
+          "replicaVersion": "69fj4we8",
+          "tables": 13,
+          "rows": 15494,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-2",
+          "stateVersion": "69fxmukg",
+          "replicaVersion": "69fj4we8",
+          "tables": 13,
+          "rows": 15494,
+          "diffs": [],
+          "ok": true
+        }
+      ],
+      "ok": true,
+      "verdict": "clean"
+    }
+  ],
+  "chaos": [
+    {
+      "id": "C6",
+      "title": "Stop the RM, delete only the change log, restart, then immediately wipe a view-syncer replica",
+      "startedMs": 1788380519688,
+      "finishedMs": 1788380530650,
+      "notes": [
+        "deleted only replica.db-change-log*",
+        "SIGQUIT vs-2",
+        "deleted vs-2's replica"
+      ],
+      "census": {
+        "pg/not-ready": 4,
+        "pg/cold-log": 1
+      },
+      "findings": [],
+      "measurements": {
+        "reseedReason": "created",
+        "restartMs.vs-2": 1597,
+        "reservationHoldMs.vs-2": 3,
+        "reseedToConfirmMs": 4782,
+        "demotions": 0,
+        "reseedSeedWatermark": "69fwxbko",
+        "reseedToCoveringBackupMs": 3697,
+        "reseedCoveringBackupWatermark": "69fxdw34"
+      }
+    }
+  ],
+  "census": {
+    "pg/not-ready": 5,
+    "pg/log-unavailable": 1,
+    "pg/cold-log": 3
+  },
+  "coverage": [
+    {
+      "route": "pg/cold-log",
+      "count": 3,
+      "triggeredBy": "C6 or C13 after a reseed with cold reads disabled"
+    }
+  ],
+  "tripwires": [],
+  "measurements": {
+    "reseedToCoveringBackupMs": {
+      "n": 1,
+      "min": 3697,
+      "p50": 3697,
+      "p95": 3697,
+      "max": 3697,
+      "mean": 3697
+    },
+    "reservationHoldMs": {
+      "n": 1,
+      "min": 3,
+      "p50": 3,
+      "p95": 3,
+      "max": 3,
+      "mean": 3
+    },
+    "reservationHoldMsC3": {
+      "n": 0
+    },
+    "reseedToCoveringBackupMsC6C13": {
+      "n": 1,
+      "min": 3697,
+      "p50": 3697,
+      "p95": 3697,
+      "max": 3697,
+      "mean": 3697
+    },
+    "backupLagMs": {
+      "n": 33,
+      "min": 20,
+      "p50": 1008,
+      "p95": 2623,
+      "max": 111766,
+      "mean": 4047.939393939394
+    },
+    "reservationConfirmDelays": 0,
+    "reservationDemotions": 0,
+    "barrierTimeouts": 0,
+    "compareResults": {},
+    "initCompareResults": {
+      "equal": 2
+    },
+    "floorProbes": {
+      "retained": 4
+    },
+    "reconcileWipes": {
+      "created": 2
+    },
+    "purgeDeclines": {},
+    "catchupRows": 0,
+    "catchupBytes": 0,
+    "catchupDurationSeconds": 0,
+    "catchupResults": {},
+    "litestreamRestores": {
+      "no_backup": 1,
+      "success": 5
+    },
+    "purgedRows": 12008
+  },
+  "resources": {
+    "changeLogBytes": {
+      "n": 30,
+      "min": 0,
+      "p50": 13536504,
+      "p95": 14115816,
+      "max": 14115816,
+      "mean": 10399174.133333333
+    },
+    "changeLogBytesFinal": 2809848,
+    "changeLogLiveBytes": {
+      "n": 29,
+      "min": 221184,
+      "p50": 4583424,
+      "p95": 5517312,
+      "max": 5517312,
+      "mean": 3214653.793103448
+    },
+    "changeLogLiveBytesFinal": 262144,
+    "changeLogFreeBytes": {
+      "n": 29,
+      "min": 0,
+      "p50": 0,
+      "p95": 3526656,
+      "max": 4677632,
+      "mean": 476124.6896551724
+    },
+    "changeLogFreeBytesFinal": 0,
+    "slotRetainedBytes": {
+      "n": 30,
+      "min": 56,
+      "p50": 908336,
+      "p95": 7502328,
+      "max": 7602776,
+      "mean": 1925095.7333333334
+    },
+    "slotRetainedBytesFinal": 3211592,
+    "backupBytesFinal": 33780719,
+    "backupObjectsFinal": 130,
+    "purge": {
+      "longestBatchLimitStreak": 0,
+      "passes": 4,
+      "batchLimitPasses": 0,
+      "immediateContinuations": 0,
+      "byStopReason": {
+        "none": 4
+      }
+    },
+    "samples": 30
+  },
+  "findings": [],
+  "pass": true
+}

--- a/apps/zbugs/scripts/rmv2-soak/results/2026-09-02-post-fix-full-isolated.json
+++ b/apps/zbugs/scripts/rmv2-soak/results/2026-09-02-post-fix-full-isolated.json
@@ -1,0 +1,1798 @@
+{
+  "runID": "post-fix-full-isolated-2026-09-02",
+  "startedMs": 1788374694872,
+  "finishedMs": 1788376875107,
+  "config": {
+    "appID": "rmv2_soak",
+    "viewSyncers": 3,
+    "changeLog": {
+      "mode": "serve",
+      "readPercent": 100,
+      "coldReadPercent": 100,
+      "comparePercent": 100,
+      "retentionMs": 60000
+    },
+    "backupIntervalSeconds": 2,
+    "vfsPollIntervalMs": 1000,
+    "startupDelayMs": 1000,
+    "snapshotBackupIntervalHours": 4,
+    "chaos": [
+      "C1",
+      "C2",
+      "C3",
+      "C4",
+      "C5",
+      "C6",
+      "C7",
+      "C8",
+      "C9",
+      "C10",
+      "C11",
+      "C12",
+      "C13",
+      "C14"
+    ],
+    "scale": 1,
+    "baseline": true,
+    "root": "/Users/mlaw/workspace/zero/mono/apps/zbugs/.soak/post-fix-full-isolated-2026-09-02"
+  },
+  "phases": [
+    {
+      "name": "sustained",
+      "startedMs": 1788375332730,
+      "finishedMs": 1788375632702,
+      "stages": [
+        {
+          "label": "sustained",
+          "targetTransactionsPerSecond": 25,
+          "durationSeconds": 300,
+          "transactions": 7500,
+          "mutations": 9000,
+          "elapsedSeconds": 299.9661684999999,
+          "actualTransactionsPerSecond": 25.002819609638752,
+          "shapes": {
+            "insert": 3000,
+            "update": 3000,
+            "delete": 750,
+            "churn": 750
+          },
+          "residueRows": 2250,
+          "latencyMs": {
+            "p50": 4.044750000000931,
+            "p95": 6.255500000086613,
+            "p99": 9.887833000044338,
+            "max": 306.6561249999795
+          }
+        }
+      ]
+    },
+    {
+      "name": "burst",
+      "startedMs": 1788375633285,
+      "finishedMs": 1788375733295,
+      "stages": [
+        {
+          "label": "burst-1",
+          "targetTransactionsPerSecond": 500,
+          "durationSeconds": 20,
+          "transactions": 10000,
+          "mutations": 12000,
+          "elapsedSeconds": 20.00073454199999,
+          "actualTransactionsPerSecond": 499.98163712441544,
+          "shapes": {
+            "insert": 4000,
+            "update": 4000,
+            "delete": 1000,
+            "churn": 1000
+          },
+          "residueRows": 5250,
+          "latencyMs": {
+            "p50": 1.5144169999985024,
+            "p95": 3.3079170000273734,
+            "p99": 6.105166999972425,
+            "max": 26.42966600006912
+          }
+        },
+        {
+          "label": "burst-gap-1",
+          "targetTransactionsPerSecond": 0,
+          "durationSeconds": 20,
+          "transactions": 0,
+          "mutations": 0,
+          "elapsedSeconds": 20.00162837499997,
+          "actualTransactionsPerSecond": 0,
+          "shapes": {
+            "insert": 0,
+            "update": 0,
+            "delete": 0,
+            "churn": 0
+          },
+          "residueRows": 5250,
+          "latencyMs": {
+            "p50": 0,
+            "p95": 0,
+            "p99": 0,
+            "max": 0
+          }
+        },
+        {
+          "label": "burst-2",
+          "targetTransactionsPerSecond": 500,
+          "durationSeconds": 20,
+          "transactions": 10000,
+          "mutations": 12000,
+          "elapsedSeconds": 20.000167333999997,
+          "actualTransactionsPerSecond": 499.99581668500065,
+          "shapes": {
+            "insert": 4000,
+            "update": 4000,
+            "delete": 1000,
+            "churn": 1000
+          },
+          "residueRows": 8250,
+          "latencyMs": {
+            "p50": 1.653792000026442,
+            "p95": 3.6815829999977723,
+            "p99": 7.645625000004657,
+            "max": 35.21262499992736
+          }
+        },
+        {
+          "label": "burst-gap-2",
+          "targetTransactionsPerSecond": 0,
+          "durationSeconds": 20,
+          "transactions": 0,
+          "mutations": 0,
+          "elapsedSeconds": 20.00115275000001,
+          "actualTransactionsPerSecond": 0,
+          "shapes": {
+            "insert": 0,
+            "update": 0,
+            "delete": 0,
+            "churn": 0
+          },
+          "residueRows": 8250,
+          "latencyMs": {
+            "p50": 0,
+            "p95": 0,
+            "p99": 0,
+            "max": 0
+          }
+        },
+        {
+          "label": "burst-3",
+          "targetTransactionsPerSecond": 500,
+          "durationSeconds": 20,
+          "transactions": 10000,
+          "mutations": 12000,
+          "elapsedSeconds": 20.00014945799997,
+          "actualTransactionsPerSecond": 499.99626357792266,
+          "shapes": {
+            "insert": 4000,
+            "update": 4000,
+            "delete": 1000,
+            "churn": 1000
+          },
+          "residueRows": 11250,
+          "latencyMs": {
+            "p50": 1.6202499999199063,
+            "p95": 3.5356250000186265,
+            "p99": 6.633042000001296,
+            "max": 34.28604100004304
+          }
+        }
+      ]
+    },
+    {
+      "name": "quiet",
+      "startedMs": 1788375734417,
+      "finishedMs": 1788375824420,
+      "stages": [
+        {
+          "label": "quiet",
+          "targetTransactionsPerSecond": 0,
+          "durationSeconds": 90,
+          "transactions": 0,
+          "mutations": 0,
+          "elapsedSeconds": 90.00142179200007,
+          "actualTransactionsPerSecond": 0,
+          "shapes": {
+            "insert": 0,
+            "update": 0,
+            "delete": 0,
+            "churn": 0
+          },
+          "residueRows": 11250,
+          "latencyMs": {
+            "p50": 0,
+            "p95": 0,
+            "p99": 0,
+            "max": 0
+          }
+        }
+      ]
+    },
+    {
+      "name": "fat",
+      "startedMs": 1788375825510,
+      "finishedMs": 1788375945479,
+      "stages": [
+        {
+          "label": "fat",
+          "targetTransactionsPerSecond": 25,
+          "durationSeconds": 120,
+          "transactions": 3000,
+          "mutations": 3600,
+          "elapsedSeconds": 119.96663404199994,
+          "actualTransactionsPerSecond": 25.00695317457777,
+          "shapes": {
+            "insert": 1200,
+            "update": 1200,
+            "delete": 300,
+            "churn": 300
+          },
+          "residueRows": 12150,
+          "latencyMs": {
+            "p50": 3.86850000009872,
+            "p95": 6.641791000030935,
+            "p99": 9.689499999862164,
+            "max": 27.4753750001546
+          }
+        }
+      ]
+    },
+    {
+      "name": "mixed",
+      "startedMs": 1788375946977,
+      "finishedMs": 1788376868909,
+      "stages": [
+        {
+          "label": "mixed-sustained",
+          "targetTransactionsPerSecond": 25,
+          "durationSeconds": 60,
+          "transactions": 1500,
+          "mutations": 1800,
+          "elapsedSeconds": 59.96625691600004,
+          "actualTransactionsPerSecond": 25.014067529697254,
+          "shapes": {
+            "insert": 600,
+            "update": 600,
+            "delete": 150,
+            "churn": 150
+          },
+          "residueRows": 12600,
+          "latencyMs": {
+            "p50": 3.203250000020489,
+            "p95": 5.180625000037253,
+            "p99": 7.633499999996275,
+            "max": 24.816916999872774
+          }
+        },
+        {
+          "label": "mixed-burst",
+          "targetTransactionsPerSecond": 300,
+          "durationSeconds": 15,
+          "transactions": 4500,
+          "mutations": 5400,
+          "elapsedSeconds": 14.998635916,
+          "actualTransactionsPerSecond": 300.02728416119254,
+          "shapes": {
+            "insert": 1800,
+            "update": 1800,
+            "delete": 450,
+            "churn": 450
+          },
+          "residueRows": 13950,
+          "latencyMs": {
+            "p50": 1.1675410000607371,
+            "p95": 2.891708000097424,
+            "p99": 6.730125000001863,
+            "max": 18.063166999956593
+          }
+        },
+        {
+          "label": "mixed-quiet",
+          "targetTransactionsPerSecond": 0,
+          "durationSeconds": 30,
+          "transactions": 0,
+          "mutations": 0,
+          "elapsedSeconds": 30.000967665999895,
+          "actualTransactionsPerSecond": 0,
+          "shapes": {
+            "insert": 0,
+            "update": 0,
+            "delete": 0,
+            "churn": 0
+          },
+          "residueRows": 13950,
+          "latencyMs": {
+            "p50": 0,
+            "p95": 0,
+            "p99": 0,
+            "max": 0
+          }
+        },
+        {
+          "label": "mixed-sustained",
+          "targetTransactionsPerSecond": 25,
+          "durationSeconds": 60,
+          "transactions": 1500,
+          "mutations": 1998,
+          "elapsedSeconds": 59.963488999999825,
+          "actualTransactionsPerSecond": 25.01522217961674,
+          "shapes": {
+            "insert": 198,
+            "update": 1002,
+            "delete": 51,
+            "churn": 249
+          },
+          "residueRows": 16200,
+          "latencyMs": {
+            "p50": 2.580165999941528,
+            "p95": 6.209375000093132,
+            "p99": 9.357250000117347,
+            "max": 22.50845899991691
+          }
+        },
+        {
+          "label": "mixed-burst",
+          "targetTransactionsPerSecond": 300,
+          "durationSeconds": 15,
+          "transactions": 4500,
+          "mutations": 5400,
+          "elapsedSeconds": 14.998242584000108,
+          "actualTransactionsPerSecond": 300.035152438495,
+          "shapes": {
+            "insert": 1800,
+            "update": 1800,
+            "delete": 450,
+            "churn": 450
+          },
+          "residueRows": 18450,
+          "latencyMs": {
+            "p50": 1.484209000132978,
+            "p95": 3.6352500000502914,
+            "p99": 7.027291000122204,
+            "max": 26.877208000048995
+          }
+        },
+        {
+          "label": "mixed-quiet",
+          "targetTransactionsPerSecond": 0,
+          "durationSeconds": 30,
+          "transactions": 0,
+          "mutations": 0,
+          "elapsedSeconds": 30.001339875000063,
+          "actualTransactionsPerSecond": 0,
+          "shapes": {
+            "insert": 0,
+            "update": 0,
+            "delete": 0,
+            "churn": 0
+          },
+          "residueRows": 18450,
+          "latencyMs": {
+            "p50": 0,
+            "p95": 0,
+            "p99": 0,
+            "max": 0
+          }
+        },
+        {
+          "label": "mixed-sustained",
+          "targetTransactionsPerSecond": 25,
+          "durationSeconds": 60,
+          "transactions": 1500,
+          "mutations": 1800,
+          "elapsedSeconds": 59.967126750000055,
+          "actualTransactionsPerSecond": 25.01370469613168,
+          "shapes": {
+            "insert": 600,
+            "update": 600,
+            "delete": 150,
+            "churn": 150
+          },
+          "residueRows": 18900,
+          "latencyMs": {
+            "p50": 3.853332999860868,
+            "p95": 6.027999999932945,
+            "p99": 10.035667000105605,
+            "max": 33.31391700007953
+          }
+        },
+        {
+          "label": "mixed-burst",
+          "targetTransactionsPerSecond": 300,
+          "durationSeconds": 15,
+          "transactions": 4500,
+          "mutations": 5388,
+          "elapsedSeconds": 15.013954333000118,
+          "actualTransactionsPerSecond": 299.7211727299027,
+          "shapes": {
+            "insert": 1809,
+            "update": 1791,
+            "delete": 456,
+            "churn": 444
+          },
+          "residueRows": 21375,
+          "latencyMs": {
+            "p50": 1.4924170000012964,
+            "p95": 3.137334000086412,
+            "p99": 6.76687499997206,
+            "max": 45.6019999999553
+          }
+        },
+        {
+          "label": "mixed-quiet",
+          "targetTransactionsPerSecond": 0,
+          "durationSeconds": 30,
+          "transactions": 0,
+          "mutations": 0,
+          "elapsedSeconds": 30.000911667000036,
+          "actualTransactionsPerSecond": 0,
+          "shapes": {
+            "insert": 0,
+            "update": 0,
+            "delete": 0,
+            "churn": 0
+          },
+          "residueRows": 21600,
+          "latencyMs": {
+            "p50": 0,
+            "p95": 0,
+            "p99": 0,
+            "max": 0
+          }
+        },
+        {
+          "label": "mixed-sustained",
+          "targetTransactionsPerSecond": 25,
+          "durationSeconds": 60,
+          "transactions": 1500,
+          "mutations": 1814,
+          "elapsedSeconds": 59.9623732090001,
+          "actualTransactionsPerSecond": 25.015687667526414,
+          "shapes": {
+            "insert": 600,
+            "update": 603,
+            "delete": 140,
+            "churn": 157
+          },
+          "residueRows": 24075,
+          "latencyMs": {
+            "p50": 2.5726670001167804,
+            "p95": 4.879582999972627,
+            "p99": 9.060625000158325,
+            "max": 27.61962500005029
+          }
+        },
+        {
+          "label": "mixed-burst",
+          "targetTransactionsPerSecond": 300,
+          "durationSeconds": 15,
+          "transactions": 4500,
+          "mutations": 5398,
+          "elapsedSeconds": 15.00054224999994,
+          "actualTransactionsPerSecond": 299.98915539203375,
+          "shapes": {
+            "insert": 1797,
+            "update": 1804,
+            "delete": 450,
+            "churn": 449
+          },
+          "residueRows": 26101,
+          "latencyMs": {
+            "p50": 1.537167000118643,
+            "p95": 3.479500000132248,
+            "p99": 7.592874999856576,
+            "max": 28.69799999985844
+          }
+        },
+        {
+          "label": "mixed-quiet",
+          "targetTransactionsPerSecond": 0,
+          "durationSeconds": 30,
+          "transactions": 0,
+          "mutations": 0,
+          "elapsedSeconds": 30.001356499999993,
+          "actualTransactionsPerSecond": 0,
+          "shapes": {
+            "insert": 0,
+            "update": 0,
+            "delete": 0,
+            "churn": 0
+          },
+          "residueRows": 26775,
+          "latencyMs": {
+            "p50": 0,
+            "p95": 0,
+            "p99": 0,
+            "max": 0
+          }
+        },
+        {
+          "label": "mixed-sustained",
+          "targetTransactionsPerSecond": 25,
+          "durationSeconds": 60,
+          "transactions": 1500,
+          "mutations": 1800,
+          "elapsedSeconds": 59.96494274999993,
+          "actualTransactionsPerSecond": 25.014615727286788,
+          "shapes": {
+            "insert": 600,
+            "update": 600,
+            "delete": 150,
+            "churn": 150
+          },
+          "residueRows": 27225,
+          "latencyMs": {
+            "p50": 3.297583000268787,
+            "p95": 5.551500000059605,
+            "p99": 12.187125000171363,
+            "max": 30.01974999997765
+          }
+        },
+        {
+          "label": "mixed-burst",
+          "targetTransactionsPerSecond": 300,
+          "durationSeconds": 15,
+          "transactions": 4500,
+          "mutations": 5400,
+          "elapsedSeconds": 14.998416791999713,
+          "actualTransactionsPerSecond": 300.03166750242195,
+          "shapes": {
+            "insert": 1800,
+            "update": 1800,
+            "delete": 450,
+            "churn": 450
+          },
+          "residueRows": 28575,
+          "latencyMs": {
+            "p50": 1.3834170000627637,
+            "p95": 3.397708000149578,
+            "p99": 11.428542000241578,
+            "max": 58.29241700004786
+          }
+        }
+      ]
+    }
+  ],
+  "oracle": [
+    {
+      "label": "after phase sustained",
+      "atMs": 1788375633285,
+      "quiesceMs": 133,
+      "comparisons": [
+        {
+          "node": "rm",
+          "stateVersion": "68ukkbuo",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 16484,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-0",
+          "stateVersion": "68ukkbuo",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 16484,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-1",
+          "stateVersion": "68ukkbuo",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 16484,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-2",
+          "stateVersion": "68ukkbuo",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 16484,
+          "diffs": [],
+          "ok": true
+        }
+      ],
+      "ok": true,
+      "verdict": "clean"
+    },
+    {
+      "label": "after phase burst",
+      "atMs": 1788375734417,
+      "quiesceMs": 213,
+      "comparisons": [
+        {
+          "node": "rm",
+          "stateVersion": "68xb5orc",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 25484,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-0",
+          "stateVersion": "68xb5orc",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 25484,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-1",
+          "stateVersion": "68xb5orc",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 25484,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-2",
+          "stateVersion": "68xb5orc",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 25484,
+          "diffs": [],
+          "ok": true
+        }
+      ],
+      "ok": true,
+      "verdict": "clean"
+    },
+    {
+      "label": "after phase quiet",
+      "atMs": 1788375825510,
+      "quiesceMs": 232,
+      "comparisons": [
+        {
+          "node": "rm",
+          "stateVersion": "68xdyeds",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 25484,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-0",
+          "stateVersion": "68xdyeds",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 25484,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-1",
+          "stateVersion": "68xdyeds",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 25484,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-2",
+          "stateVersion": "68xdyeds",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 25484,
+          "diffs": [],
+          "ok": true
+        }
+      ],
+      "ok": true,
+      "verdict": "clean"
+    },
+    {
+      "label": "after phase fat",
+      "atMs": 1788375946977,
+      "quiesceMs": 232,
+      "comparisons": [
+        {
+          "node": "rm",
+          "stateVersion": "68xml2uw",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 26384,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-0",
+          "stateVersion": "68xml2uw",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 26384,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-1",
+          "stateVersion": "68xml2uw",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 26384,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-2",
+          "stateVersion": "68xml2uw",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 26384,
+          "diffs": [],
+          "ok": true
+        }
+      ],
+      "ok": true,
+      "verdict": "clean"
+    },
+    {
+      "label": "after C1",
+      "atMs": 1788376008264,
+      "quiesceMs": 224,
+      "comparisons": [
+        {
+          "node": "rm",
+          "stateVersion": "68xsr7q8",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 26834,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-0",
+          "stateVersion": "68xsr7q8",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 26834,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-1",
+          "stateVersion": "68xsr7q8",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 26834,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-2",
+          "stateVersion": "68xsr7q8",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 26834,
+          "diffs": [],
+          "ok": true
+        }
+      ],
+      "ok": true,
+      "verdict": "clean"
+    },
+    {
+      "label": "after C2",
+      "atMs": 1788376025340,
+      "quiesceMs": 216,
+      "comparisons": [
+        {
+          "node": "rm",
+          "stateVersion": "68y8unmo",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 28184,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-0",
+          "stateVersion": "68y8unmo",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 28184,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-1",
+          "stateVersion": "68y8unmo",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 28184,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-2",
+          "stateVersion": "68y8unmo",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 28184,
+          "diffs": [],
+          "ok": true
+        }
+      ],
+      "ok": true,
+      "verdict": "clean"
+    },
+    {
+      "label": "after C3",
+      "atMs": 1788376057263,
+      "quiesceMs": 220,
+      "comparisons": [
+        {
+          "node": "rm",
+          "stateVersion": "68ydsbqw",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 28184,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-0",
+          "stateVersion": "68ydsbqw",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 28184,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-1",
+          "stateVersion": "68ydsbqw",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 28184,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-2",
+          "stateVersion": "68ydsbqw",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 28184,
+          "diffs": [],
+          "ok": true
+        }
+      ],
+      "ok": true,
+      "verdict": "clean"
+    },
+    {
+      "label": "after C4",
+      "atMs": 1788376243181,
+      "quiesceMs": 219,
+      "comparisons": [
+        {
+          "node": "rm",
+          "stateVersion": "68zbmlfk",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 31334,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-0",
+          "stateVersion": "68zbmlfk",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 31334,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-1",
+          "stateVersion": "68zbmlfk",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 31334,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-2",
+          "stateVersion": "68zbmlfk",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 31334,
+          "diffs": [],
+          "ok": true
+        }
+      ],
+      "ok": true,
+      "verdict": "clean"
+    },
+    {
+      "label": "after C5",
+      "atMs": 1788376260059,
+      "quiesceMs": 114,
+      "comparisons": [
+        {
+          "node": "rm",
+          "stateVersion": "68zp0t6g",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 32684,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-0",
+          "stateVersion": "68zp0t6g",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 32684,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-1",
+          "stateVersion": "68zp0t6g",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 32684,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-2",
+          "stateVersion": "68zp0t6g",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 32684,
+          "diffs": [],
+          "ok": true
+        }
+      ],
+      "ok": true,
+      "verdict": "clean"
+    },
+    {
+      "label": "after C6",
+      "atMs": 1788376292077,
+      "quiesceMs": 225,
+      "comparisons": [
+        {
+          "node": "rm",
+          "stateVersion": "68zp5900",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 32684,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-0",
+          "stateVersion": "68zp5900",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 32684,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-1",
+          "stateVersion": "68zp5900",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 32684,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-2",
+          "stateVersion": "68zp5900",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 32684,
+          "diffs": [],
+          "ok": true
+        }
+      ],
+      "ok": true,
+      "verdict": "clean"
+    },
+    {
+      "label": "after C7",
+      "atMs": 1788376353855,
+      "quiesceMs": 223,
+      "comparisons": [
+        {
+          "node": "rm",
+          "stateVersion": "68zyzkf4",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 33134,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-0",
+          "stateVersion": "68zyzkf4",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 33134,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-1",
+          "stateVersion": "68zyzkf4",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 33134,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-2",
+          "stateVersion": "68zyzkf4",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 33134,
+          "diffs": [],
+          "ok": true
+        }
+      ],
+      "ok": true,
+      "verdict": "clean"
+    },
+    {
+      "label": "after C8",
+      "atMs": 1788376382941,
+      "quiesceMs": 208,
+      "comparisons": [
+        {
+          "node": "rm",
+          "stateVersion": "690nmrbk",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 35609,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-0",
+          "stateVersion": "690nmrbk",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 35609,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-1",
+          "stateVersion": "690nmrbk",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 35609,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-2",
+          "stateVersion": "690nmrbk",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 35609,
+          "diffs": [],
+          "ok": true
+        }
+      ],
+      "ok": true,
+      "verdict": "clean"
+    },
+    {
+      "label": "after C9",
+      "atMs": 1788376599140,
+      "quiesceMs": 234,
+      "comparisons": [
+        {
+          "node": "rm",
+          "stateVersion": "691cn7d4",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 36959,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-0",
+          "stateVersion": "691cn7d4",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 36959,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-1",
+          "stateVersion": "691cn7d4",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 36959,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-2",
+          "stateVersion": "691cn7d4",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 36959,
+          "diffs": [],
+          "ok": true
+        }
+      ],
+      "ok": true,
+      "verdict": "clean"
+    },
+    {
+      "label": "after C13",
+      "atMs": 1788376694233,
+      "quiesceMs": 132,
+      "comparisons": [
+        {
+          "node": "rm",
+          "stateVersion": "6920hqo8",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 38759,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-0",
+          "stateVersion": "6920hqo8",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 38759,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-1",
+          "stateVersion": "6920hqo8",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 38759,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-2",
+          "stateVersion": "6920hqo8",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 38759,
+          "diffs": [],
+          "ok": true
+        }
+      ],
+      "ok": true,
+      "verdict": "clean"
+    },
+    {
+      "label": "after C14",
+      "atMs": 1788376759727,
+      "quiesceMs": 217,
+      "comparisons": [
+        {
+          "node": "rm",
+          "stateVersion": "692sgl1s",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 41009,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-0",
+          "stateVersion": "692sgl1s",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 41009,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-1",
+          "stateVersion": "692sgl1s",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 41009,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-2",
+          "stateVersion": "692sgl1s",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 41009,
+          "diffs": [],
+          "ok": true
+        }
+      ],
+      "ok": true,
+      "verdict": "clean"
+    },
+    {
+      "label": "after C10",
+      "atMs": 1788376790997,
+      "quiesceMs": 223,
+      "comparisons": [
+        {
+          "node": "rm",
+          "stateVersion": "692sgrh4",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 41009,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-0",
+          "stateVersion": "692sgrh4",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 41009,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-1",
+          "stateVersion": "692sgrh4",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 41009,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-2",
+          "stateVersion": "692sgrh4",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 41009,
+          "diffs": [],
+          "ok": true
+        }
+      ],
+      "ok": true,
+      "verdict": "clean"
+    },
+    {
+      "label": "after C11",
+      "atMs": 1788376852460,
+      "quiesceMs": 225,
+      "comparisons": [
+        {
+          "node": "rm",
+          "stateVersion": "692xg9yw",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 41459,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-0",
+          "stateVersion": "692xg9yw",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 41459,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-1",
+          "stateVersion": "692xg9yw",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 41459,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-2",
+          "stateVersion": "692xg9yw",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 41459,
+          "diffs": [],
+          "ok": true
+        }
+      ],
+      "ok": true,
+      "verdict": "clean"
+    },
+    {
+      "label": "after C12",
+      "atMs": 1788376868909,
+      "quiesceMs": 107,
+      "comparisons": [
+        {
+          "node": "rm",
+          "stateVersion": "693bk2jc",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 42809,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-0",
+          "stateVersion": "693bk2jc",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 42809,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-1",
+          "stateVersion": "693bk2jc",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 42809,
+          "diffs": [],
+          "ok": true
+        },
+        {
+          "node": "vs-2",
+          "stateVersion": "693bk2jc",
+          "replicaVersion": "68tr5rnk",
+          "tables": 13,
+          "rows": 42809,
+          "diffs": [],
+          "ok": true
+        }
+      ],
+      "ok": true,
+      "verdict": "clean"
+    }
+  ],
+  "chaos": [
+    {
+      "id": "C1",
+      "title": "SIGTERM a view-syncer (graceful drain), restart, replica intact",
+      "startedMs": 1788375946977,
+      "finishedMs": 1788375952539,
+      "notes": ["SIGTERM vs-0"],
+      "census": {
+        "sqlite/selected": 1
+      },
+      "findings": [],
+      "measurements": {
+        "restartMs.vs-0": 1560,
+        "reservationHoldMs.vs-0": 2
+      }
+    },
+    {
+      "id": "C2",
+      "title": "SIGQUIT a view-syncer (abrupt), restart, replica intact",
+      "startedMs": 1788376008264,
+      "finishedMs": 1788376014257,
+      "notes": ["SIGQUIT vs-1"],
+      "census": {
+        "sqlite/selected": 1
+      },
+      "findings": [],
+      "measurements": {
+        "restartMs.vs-1": 1992,
+        "reservationHoldMs.vs-1": 1
+      }
+    },
+    {
+      "id": "C3",
+      "title": "Kill a view-syncer, delete its replica, restart",
+      "startedMs": 1788376025340,
+      "finishedMs": 1788376031459,
+      "notes": ["SIGQUIT vs-2", "deleted vs-2's replica"],
+      "census": {
+        "sqlite/selected": 1
+      },
+      "findings": [],
+      "measurements": {
+        "restartMs.vs-2": 2117,
+        "reservationHoldMs.vs-2": 11,
+        "restoreObserved": "yes"
+      }
+    },
+    {
+      "id": "C4",
+      "title": "Kill a view-syncer mid-burst, leave it down past a backup interval, restart",
+      "startedMs": 1788376057264,
+      "finishedMs": 1788376241235,
+      "notes": [
+        "SIGQUIT vs-0",
+        "leaving vs-0 down for 11000ms",
+        "SIGQUIT vs-0",
+        "leaving vs-0 down for 135000ms"
+      ],
+      "census": {
+        "sqlite/selected": 2
+      },
+      "findings": [],
+      "measurements": {
+        "restartMs.vs-0": 140236,
+        "reservationHoldMs.vs-0": 4,
+        "burstTransactions": 5000,
+        "longGapOutcome": "stale-replica-discarded-and-restored",
+        "longGapWatermarkUncovered": "no"
+      }
+    },
+    {
+      "id": "C5",
+      "title": "SIGTERM the replication-manager, restart",
+      "startedMs": 1788376243181,
+      "finishedMs": 1788376254624,
+      "notes": [],
+      "census": {
+        "pg/not-ready": 4
+      },
+      "findings": [],
+      "measurements": {
+        "rmRestartMs": 7441,
+        "reconcileAction": "none"
+      }
+    },
+    {
+      "id": "C6",
+      "title": "Stop the RM, delete only the change log, restart, then immediately wipe a view-syncer replica",
+      "startedMs": 1788376260059,
+      "finishedMs": 1788376273670,
+      "notes": [
+        "deleted only replica.db-change-log*",
+        "SIGQUIT vs-2",
+        "deleted vs-2's replica"
+      ],
+      "census": {
+        "pg/not-ready": 4,
+        "sqlite/selected-cold": 1
+      },
+      "findings": [],
+      "measurements": {
+        "reseedReason": "created",
+        "restartMs.vs-2": 2139,
+        "reservationHoldMs.vs-2": 5,
+        "reseedToConfirmMs": 7150,
+        "demotions": 0,
+        "reseedSeedWatermark": "68zp0t6g",
+        "reseedToCoveringBackupMs": 5824,
+        "reseedCoveringBackupWatermark": "68zp0t6g"
+      }
+    },
+    {
+      "id": "C7",
+      "title": "SIGSTOP the replication-manager for 30s, then SIGCONT",
+      "startedMs": 1788376292077,
+      "finishedMs": 1788376341143,
+      "notes": ["SIGSTOP rm", "SIGCONT rm"],
+      "census": {},
+      "findings": [],
+      "measurements": {
+        "pausedMs": 45065
+      }
+    },
+    {
+      "id": "C8",
+      "title": "SIGKILL the replication-manager mid-burst, restart",
+      "startedMs": 1788376353855,
+      "finishedMs": 1788376381264,
+      "notes": ["SIGKILL rm mid-burst"],
+      "census": {
+        "pg/not-ready": 4
+      },
+      "findings": [],
+      "measurements": {
+        "reconcileAction": "truncated",
+        "burstTransactions": 3750
+      }
+    },
+    {
+      "id": "C9",
+      "title": "Stop minio under sustained writes, then restart it",
+      "startedMs": 1788376382941,
+      "finishedMs": 1788376597026,
+      "notes": ["stopped minio for 120s", "restarted minio"],
+      "census": {},
+      "findings": [
+        "C9: the change log did not shrink after the backup recovered"
+      ],
+      "measurements": {
+        "changeLogBytesBefore": 22514936,
+        "changeLogBytesDuring": 23293248,
+        "changeLogBytesAfter": 23544568,
+        "slotRetainedBytesBefore": 661269720,
+        "slotRetainedBytesDuring": 722234264,
+        "slotRetainedBytesAfter": 699295848
+      }
+    },
+    {
+      "id": "C13",
+      "title": "A view-syncer already behind, meeting a reseed (C4 and C6)",
+      "startedMs": 1788376599140,
+      "finishedMs": 1788376693129,
+      "notes": ["vs-1 down and falling behind"],
+      "census": {
+        "pg/not-ready": 3,
+        "sqlite/selected-cold": 1
+      },
+      "findings": [],
+      "measurements": {
+        "reseedReason": "created",
+        "reservationHoldMs.vs-1": 2,
+        "reseedToConfirmMs": 6574,
+        "demotions": 0,
+        "reseedSeedWatermark": "691l5n60",
+        "reseedToCoveringBackupMs": 5743,
+        "reseedCoveringBackupWatermark": "691mesgw"
+      }
+    },
+    {
+      "id": "C14",
+      "title": "Kill the replication-manager and wipe its whole volume, restart",
+      "startedMs": 1788376694233,
+      "finishedMs": 1788376758232,
+      "notes": [
+        "wiped rm's replica, litestream state and change log",
+        "SIGTERM vs-0"
+      ],
+      "census": {
+        "pg/not-ready": 4,
+        "sqlite/selected-cold": 1
+      },
+      "findings": [],
+      "measurements": {
+        "generationsBefore": 5,
+        "rmRestartMs": 4916,
+        "restoreObserved": "yes",
+        "reseedReason": "created",
+        "generationsAfter": 6,
+        "generationsMinted": 1,
+        "restartMs.vs-0": 1713,
+        "reservationHoldMs.vs-0": 1,
+        "reseedToConfirmMs": 2823,
+        "demotionsAfterVolumeLoss": 0,
+        "reseedSeedWatermark": "6922ors0",
+        "reseedToCoveringBackupMs": 1669,
+        "reseedCoveringBackupWatermark": "69260m5k"
+      }
+    },
+    {
+      "id": "C10",
+      "title": "Roll the read percentage back from 100 to 0 and restart the RM",
+      "startedMs": 1788376759727,
+      "finishedMs": 1788376777875,
+      "notes": [],
+      "census": {
+        "pg/not-ready": 4,
+        "pg/percentage": 3
+      },
+      "findings": [],
+      "measurements": {
+        "routesAfterRollback": "{\"pg/not-ready\":4,\"pg/percentage\":3}"
+      }
+    },
+    {
+      "id": "C11",
+      "title": "Walk the mode ladder back: serve -> compare -> write",
+      "startedMs": 1788376790997,
+      "finishedMs": 1788376816262,
+      "notes": [
+        "mode=compare: change log still open",
+        "mode=write: change log still open"
+      ],
+      "census": {
+        "pg/not-ready": 8
+      },
+      "findings": [],
+      "measurements": {
+        "headAfter.compare": "692sgrh4",
+        "headAfter.write": "692tbj48"
+      }
+    },
+    {
+      "id": "C12",
+      "title": "Turn the change log off and confirm the file is reclaimed",
+      "startedMs": 1788376852460,
+      "finishedMs": 1788376865200,
+      "notes": [],
+      "census": {
+        "pg/not-ready": 4,
+        "pg/selector": 3
+      },
+      "findings": [],
+      "measurements": {
+        "changeLogBytesBeforeOff": 11624448,
+        "changeLogBytesAfterOff": 0
+      }
+    }
+  ],
+  "census": {
+    "pg/not-ready": 37,
+    "pg/selector": 6,
+    "pg/log-unavailable": 1,
+    "sqlite/selected-cold": 5,
+    "sqlite/selected": 5,
+    "pg/percentage": 3
+  },
+  "coverage": [
+    {
+      "route": "sqlite/selected",
+      "count": 5,
+      "triggeredBy": "C1, C2, or C4"
+    },
+    {
+      "route": "sqlite/selected-cold",
+      "count": 5,
+      "triggeredBy": "C6 or C13 after a change-log reseed"
+    }
+  ],
+  "tripwires": [
+    {
+      "name": "error-log",
+      "node": "rm",
+      "tsMs": 1788376322144,
+      "message": "vfs-query exited with error",
+      "detail": {}
+    },
+    {
+      "name": "error-log",
+      "node": "rm",
+      "tsMs": 1788376499280,
+      "message": "",
+      "detail": {}
+    }
+  ],
+  "measurements": {
+    "reseedToCoveringBackupMs": {
+      "n": 3,
+      "min": 1669,
+      "p50": 5743,
+      "p95": 5824,
+      "max": 5824,
+      "mean": 4412
+    },
+    "reservationHoldMs": {
+      "n": 7,
+      "min": 1,
+      "p50": 2,
+      "p95": 11,
+      "max": 11,
+      "mean": 3.7142857142857144
+    },
+    "reservationHoldMsC3": {
+      "n": 1,
+      "min": 11,
+      "p50": 11,
+      "p95": 11,
+      "max": 11,
+      "mean": 11
+    },
+    "reseedToCoveringBackupMsC6C13": {
+      "n": 2,
+      "min": 5743,
+      "p50": 5743,
+      "p95": 5824,
+      "max": 5824,
+      "mean": 5783.5
+    },
+    "backupLagMs": {
+      "n": 835,
+      "min": 13,
+      "p50": 906,
+      "p95": 1044,
+      "max": 1274980,
+      "mean": 10160.615568862275
+    },
+    "reservationConfirmDelays": 0,
+    "reservationDemotions": 0,
+    "barrierTimeouts": 0,
+    "compareResults": {
+      "match": 53233,
+      "inconclusive": 1
+    },
+    "initCompareResults": {
+      "equal": 5,
+      "inconclusive": 3
+    },
+    "floorProbes": {
+      "retained": 41
+    },
+    "reconcileWipes": {
+      "created": 4
+    },
+    "purgeDeclines": {},
+    "catchupRows": 5885,
+    "catchupBytes": 2286319,
+    "catchupDurationSeconds": 0.8620000000000001,
+    "catchupResults": {
+      "range/false": 5,
+      "range/true": 5
+    },
+    "litestreamRestores": {
+      "success": 29,
+      "no_backup": 1
+    },
+    "purgedRows": 243010
+  },
+  "resources": {
+    "changeLogBytes": {
+      "n": 312,
+      "min": 0,
+      "p50": 23293248,
+      "p95": 42452856,
+      "max": 42452856,
+      "mean": 24785908.051282052
+    },
+    "changeLogBytesFinal": 0,
+    "slotRetainedBytes": {
+      "n": 312,
+      "min": 241366624,
+      "p50": 563560864,
+      "p95": 792223336,
+      "max": 829739880,
+      "mean": 541942766.7435898
+    },
+    "slotRetainedBytesFinal": 822128352,
+    "backupBytesFinal": 887992744,
+    "backupObjectsFinal": 5587,
+    "purge": {
+      "longestBatchLimitStreak": 0,
+      "passes": 41,
+      "batchLimitPasses": 0,
+      "immediateContinuations": 0,
+      "byStopReason": {
+        "none": 41
+      }
+    },
+    "samples": 312
+  },
+  "baseline": {
+    "stages": {
+      "transactions": 40500,
+      "elapsedSeconds": 609.9,
+      "actualTransactionsPerSecond": 66.4,
+      "p95LatencyMs": 4.5
+    },
+    "replication": {
+      "transactions": 40501,
+      "forwardDurationSeconds": 9.79837914399345,
+      "messageProcessingSeconds": 0,
+      "logCommitSeconds": 0
+    },
+    "soakReplication": {
+      "transactions": 93769,
+      "forwardDurationSeconds": 34.876711003998096,
+      "messageProcessingSeconds": 13.906618634983953,
+      "logCommitSeconds": 9.07315826600958
+    },
+    "soakStages": {
+      "transactions": 70500,
+      "elapsedSeconds": 1104.8,
+      "actualTransactionsPerSecond": 63.81,
+      "p95LatencyMs": 4.5
+    }
+  },
+  "findings": ["C9: the change log did not shrink after the backup recovered"],
+  "pass": false
+}

--- a/apps/zbugs/scripts/rmv2-soak/results/README.md
+++ b/apps/zbugs/scripts/rmv2-soak/results/README.md
@@ -39,3 +39,19 @@ live-page usage was 20.41 MB. Thus, the outage sample was smaller even though
 MinIO pinned the purge floor. The app-slot growth proves that the outage pinned
 the upstream acknowledgment. C9 must check the post-recovery decrease, not the
 change from the pre-outage sample.
+
+## `2026-09-02-c9-final-post-fix.json`
+
+- Integration branch: `mlaw/soak-post-fix-run` at `716690ffc`.
+- Backup fix: `425ced06a`.
+- Command: `node scripts/rmv2-soak.ts --chaos C9 --seed --run-id c9-final-post-fix-2026-09-02`.
+- Duration: 1,026 seconds.
+- Result: `PASS` with no findings.
+- Correctness: all five oracle checks passed.
+- Purge: 29,897 rows were removed after MinIO recovered.
+- WAL: the app slot grew from 5.31 MB to 66.00 MB, then decreased to 176 bytes.
+- Live pages: usage decreased from 13.86 MB to 1.88 MB after recovery.
+- Purge bounds: no pass reached the batch limit or requested an immediate continuation.
+
+This run confirms C9 recovery after the planned five-minute MinIO outage. The
+physical SQLite file stayed at 42.37 MB and reused 31.62 MB of free pages.

--- a/apps/zbugs/scripts/rmv2-soak/results/README.md
+++ b/apps/zbugs/scripts/rmv2-soak/results/README.md
@@ -55,3 +55,21 @@ change from the pre-outage sample.
 
 This run confirms C9 recovery after the planned five-minute MinIO outage. The
 physical SQLite file stayed at 42.37 MB and reused 31.62 MB of free pages.
+
+## `2026-09-02-cold-read-control-post-fix.json`
+
+- Integration branch: `mlaw/soak-post-fix-run` at `560f313ee`.
+- Backup fix: `425ced06a`.
+- Command: `node scripts/rmv2-soak.ts --scale 0.1 --chaos C6 --read-percent 100 --cold-read-percent 0 --seed --run-id cold-read-control-post-fix-2026-09-02`.
+- Duration: 159 seconds.
+- Result: `PASS` with no findings.
+- Coverage: three requests used `pg/cold-log`.
+- Correctness: all five oracle checks passed.
+- Reseed window: 3,697 ms.
+- Reservation hold: 3 ms.
+- Safety: no reservation demotions, barrier timeouts, or purge-floor violations occurred.
+
+The full run with `coldReadPercent=100` routed C6 through
+`sqlite/selected-cold`. This control routed the same cold C6 path through
+`pg/cold-log`. Thus, the cold-read setting is the only route-selection
+difference between these run shapes.

--- a/apps/zbugs/scripts/rmv2-soak/results/README.md
+++ b/apps/zbugs/scripts/rmv2-soak/results/README.md
@@ -21,3 +21,21 @@ correctly.
 
 The next harness change measures live and free SQLite pages. It also limits the
 WAL measurement to replication slots that start with `rmv2_soak_0_`.
+
+## `2026-09-02-c9-corrected-post-fix.json`
+
+- Integration branch: `mlaw/soak-post-fix-run` at `879016fb6`.
+- Backup fix: `425ced06a`.
+- Command: `node scripts/rmv2-soak.ts --chaos C9 --seed --run-id c9-corrected-post-fix-2026-09-02`.
+- Duration: 1,026 seconds.
+- Result: `FAIL` because C9 reported one harness finding.
+- Correctness: all five oracle checks passed.
+- Purge: 30,604 rows were removed after MinIO recovered.
+- WAL: the app slot grew from 1.05 MB to 56.29 MB, then decreased to 0.86 MB.
+- Live pages: usage decreased from 13.43 MB to 1.49 MB after recovery.
+
+The pre-outage sample still contained data from the 8 KB payload phase. Its
+live-page usage was 20.41 MB. Thus, the outage sample was smaller even though
+MinIO pinned the purge floor. The app-slot growth proves that the outage pinned
+the upstream acknowledgment. C9 must check the post-recovery decrease, not the
+change from the pre-outage sample.

--- a/apps/zbugs/scripts/rmv2-soak/results/README.md
+++ b/apps/zbugs/scripts/rmv2-soak/results/README.md
@@ -1,0 +1,23 @@
+# Recorded soak results
+
+This directory preserves reports from important soak runs. The files in
+`.soak/` are ignored and are not a permanent record.
+
+## `2026-09-02-post-fix-full-isolated.json`
+
+- Integration branch: `mlaw/soak-post-fix-run` at `f3afadbc4`.
+- Backup fix: `425ced06a`.
+- Command: `node scripts/rmv2-soak.ts --chaos all --baseline --seed --run-id post-fix-full-isolated-2026-09-02`.
+- Duration: 2,180 seconds.
+- Result: `FAIL` because C9 reported one harness finding.
+- Correctness: all 18 oracle checks passed.
+- Coverage: all required SQLite routes ran.
+- Safety: no reservation demotions, barrier timeouts, or purge-floor violations occurred.
+
+C9 stopped MinIO for 120 seconds in this run. The soak then reported that the
+physical SQLite file did not shrink. SQLite reused the freed pages instead of
+truncating the file. The C9 assertion therefore did not measure purge recovery
+correctly.
+
+The next harness change measures live and free SQLite pages. It also limits the
+WAL measurement to replication slots that start with `rmv2_soak_0_`.

--- a/apps/zbugs/scripts/rmv2-soak/workload.ts
+++ b/apps/zbugs/scripts/rmv2-soak/workload.ts
@@ -1,0 +1,86 @@
+import type {TrafficStage} from '../change-log-traffic.ts';
+import type {SoakConfig} from './config.ts';
+
+/**
+ * The workload phases of plan section 5.
+ *
+ * A flat rate does not stress purge scheduling, the barrier, or the vfs
+ * poller's pause/resume; sustained rate, bursts and idle gaps do. Every
+ * duration is multiplied by `config.scale`, so the same shape runs as a
+ * two-minute smoke test or as a thirty-minute soak.
+ */
+
+export type PhaseSpec = {
+  readonly name: string;
+  readonly stresses: string;
+  readonly stages: readonly TrafficStage[];
+};
+
+function scaled(config: SoakConfig, seconds: number): number {
+  return Math.max(2, Math.round(seconds * config.scale));
+}
+
+export function workloadPhases(config: SoakConfig): PhaseSpec[] {
+  return [
+    {
+      name: 'sustained',
+      stresses: 'steady append and purge cadence',
+      stages: [
+        {rate: 25, durationSeconds: scaled(config, 300), label: 'sustained'},
+      ],
+    },
+    {
+      name: 'burst',
+      stresses: 'the barrier under backlog pressure; batch limits',
+      stages: [
+        {rate: 500, durationSeconds: scaled(config, 20), label: 'burst-1'},
+        {rate: 0, durationSeconds: scaled(config, 20), label: 'burst-gap-1'},
+        {rate: 500, durationSeconds: scaled(config, 20), label: 'burst-2'},
+        {rate: 0, durationSeconds: scaled(config, 20), label: 'burst-gap-2'},
+        {rate: 500, durationSeconds: scaled(config, 20), label: 'burst-3'},
+      ],
+    },
+    {
+      name: 'quiet',
+      stresses:
+        'the purger draining to its floor, and the vfs poller pausing when local == remote',
+      stages: [
+        {
+          // Longer than retentionMs, so the log ages out of its warm-up
+          // window and the purger has something to do.
+          rate: 0,
+          durationSeconds: Math.max(
+            scaled(config, 90),
+            Math.ceil(config.changeLog.retentionMs / 1000) + 15,
+          ),
+          label: 'quiet',
+        },
+      ],
+    },
+    {
+      name: 'fat',
+      stresses: 'the `oversized` compare outcome and multipart backup',
+      stages: [
+        {
+          rate: 25,
+          durationSeconds: scaled(config, 120),
+          payloadBytes: 8000,
+          label: 'fat',
+        },
+      ],
+    },
+  ];
+}
+
+/** Phase 6: phases 2-4 again, with chaos interleaved by the orchestrator. */
+export function mixedPhase(config: SoakConfig): PhaseSpec {
+  return {
+    name: 'mixed',
+    stresses: 'everything at once',
+    stages: [
+      {rate: 25, durationSeconds: scaled(config, 60), label: 'mixed-sustained'},
+      {rate: 300, durationSeconds: scaled(config, 15), label: 'mixed-burst'},
+      {rate: 0, durationSeconds: scaled(config, 30), label: 'mixed-quiet'},
+    ],
+  };
+}

--- a/apps/zbugs/tsconfig.scripts.json
+++ b/apps/zbugs/tsconfig.scripts.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["node"]
+  },
+  "include": [
+    "scripts/change-log-traffic.ts",
+    "scripts/rmv2-soak.ts",
+    "scripts/rmv2-soak/**/*.ts"
+  ]
+}

--- a/apps/zbugs/vitest.config.ts
+++ b/apps/zbugs/vitest.config.ts
@@ -55,6 +55,7 @@ export function configForNoPg(url: string) {
         'src/**/*.test.?(c|m)[jt]s?(x)',
         'server/**/*.test.?(c|m)[jt]s?(x)',
         'shared/**/*.test.?(c|m)[jt]s?(x)',
+        'scripts/**/*.test.?(c|m)[jt]s?(x)',
       ],
       exclude: [
         'src/**/*.pg.test.?(c|m)[jt]s?(x)',
@@ -64,7 +65,7 @@ export function configForNoPg(url: string) {
       coverage: {
         enabled: !ci,
         reporter: [['html'], ['clover', {file: 'coverage.xml'}]],
-        include: ['src/**', 'server/**'],
+        include: ['src/**', 'server/**', 'scripts/**'],
       },
     },
   });

--- a/packages/zero-cache/src/config/normalize.test.ts
+++ b/packages/zero-cache/src/config/normalize.test.ts
@@ -10,6 +10,7 @@ function configWith(litestream: Partial<ZeroConfig['litestream']>): ZeroConfig {
     changeStreamer: {
       port: 4849,
       address: 'localhost',
+      pgChangeLogEnabled: true,
       sqliteChangeLogMode: 'off',
       sqliteChangeLogReadPercent: 0,
       sqliteChangeLogColdReadPercent: 0,
@@ -128,6 +129,46 @@ describe('config/normalize litestream v5 gating', () => {
 });
 
 describe('config/normalize SQLite change log', () => {
+  test('PG change log is enabled by default configuration', () => {
+    const config = configWith({});
+
+    expect(config.changeStreamer.pgChangeLogEnabled).toBe(true);
+    expect(() => assertNormalized(config)).not.toThrow();
+  });
+
+  test('disabling the PG change log requires authoritative SQLite and v5 backup settings', () => {
+    const config = configWith({});
+    config.changeStreamer.pgChangeLogEnabled = false;
+
+    expect(() => assertNormalized(config)).toThrow(
+      'requires --change-streamer-sqlite-change-log-mode=serve',
+    );
+
+    config.changeStreamer.sqliteChangeLogMode = 'serve';
+    expect(() => assertNormalized(config)).toThrow(
+      'requires --change-streamer-sqlite-change-log-read-percent=100',
+    );
+
+    config.changeStreamer.sqliteChangeLogReadPercent = 100;
+    expect(() => assertNormalized(config)).toThrow(
+      'requires --change-streamer-sqlite-change-log-cold-read-percent=100',
+    );
+
+    config.changeStreamer.sqliteChangeLogColdReadPercent = 100;
+    expect(() => assertNormalized(config)).toThrow(
+      'requires a litestream v5 backup',
+    );
+
+    Object.assign(config.litestream, {
+      backupURL: 's3://bucket/replica',
+      backupUsingV5: true,
+      restoreUsingV5: true,
+      executableV5: '/bin/litestream-v5',
+      vfsQueryExecutable: '/bin/vfs-query',
+    });
+    expect(() => assertNormalized(config)).not.toThrow();
+  });
+
   test('read percentage is only allowed in serve mode', () => {
     const config = configWith({});
     config.changeStreamer.sqliteChangeLogMode = 'compare';

--- a/packages/zero-cache/src/config/normalize.ts
+++ b/packages/zero-cache/src/config/normalize.ts
@@ -53,6 +53,7 @@ export function assertNormalized(
   assert(config.changeStreamer.port, 'missing --change-streamer-port');
   assert(config.changeStreamer.address, 'missing --change-streamer-address');
   const {
+    pgChangeLogEnabled,
     sqliteChangeLogMode,
     sqliteChangeLogReadPercent,
     sqliteChangeLogColdReadPercent,
@@ -97,6 +98,24 @@ export function assertNormalized(
     sqliteChangeLogReadPercent > 0 || sqliteChangeLogColdReadPercent === 0,
     '--change-streamer-sqlite-change-log-cold-read-percent must be 0 when --change-streamer-sqlite-change-log-read-percent is 0',
   );
+  if (!pgChangeLogEnabled) {
+    assert(
+      sqliteChangeLogMode === 'serve',
+      '--change-streamer-pg-change-log-enabled=false requires --change-streamer-sqlite-change-log-mode=serve',
+    );
+    assert(
+      sqliteChangeLogReadPercent === 100,
+      '--change-streamer-pg-change-log-enabled=false requires --change-streamer-sqlite-change-log-read-percent=100',
+    );
+    assert(
+      sqliteChangeLogColdReadPercent === 100,
+      '--change-streamer-pg-change-log-enabled=false requires --change-streamer-sqlite-change-log-cold-read-percent=100',
+    );
+    assert(
+      config.litestream.backupURL && config.litestream.backupUsingV5,
+      '--change-streamer-pg-change-log-enabled=false requires a litestream v5 backup',
+    );
+  }
   for (const [flag, value] of [
     ['retention-ms', sqliteChangeLogRetentionMs],
     ['read-batch-rows', sqliteChangeLogReadBatchRows],

--- a/packages/zero-cache/src/config/zero-config.test.ts
+++ b/packages/zero-cache/src/config/zero-config.test.ts
@@ -891,6 +891,24 @@ test('--enable-query-covering can be disabled', () => {
   expect(config.enableQueryCovering).toBe(false);
 });
 
+test('PG change log is enabled by default and can be disabled by env', () => {
+  const defaults = parseOptionsAdvanced(zeroOptions, {
+    envNamePrefix: 'ZERO_',
+    allowUnknown: false,
+    allowPartial: true,
+    env: {},
+  }).config;
+  const disabled = parseOptionsAdvanced(zeroOptions, {
+    envNamePrefix: 'ZERO_',
+    allowUnknown: false,
+    allowPartial: true,
+    env: {ZERO_CHANGE_STREAMER_PG_CHANGE_LOG_ENABLED: 'false'},
+  }).config;
+
+  expect(defaults.changeStreamer.pgChangeLogEnabled).toBe(true);
+  expect(disabled.changeStreamer.pgChangeLogEnabled).toBe(false);
+});
+
 test('legacy queries are disabled by default', () => {
   const {config} = parseOptionsAdvanced(zeroOptions, {
     envNamePrefix: 'ZERO_',

--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -734,6 +734,16 @@ export const zeroOptions = {
       hidden: true,
     },
 
+    pgChangeLogEnabled: {
+      type: v.boolean().default(true),
+      desc: [
+        `Whether the legacy Postgres change log remains authoritative for`,
+        `stream initialization, persistence, catchup, and upstream ACKs.`,
+        `Disabling it requires SQLite serve mode at 100 percent and a v5 backup.`,
+      ],
+      hidden: true,
+    },
+
     sqliteChangeLogReadPercent: {
       type: v.number().default(0),
       desc: [

--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -67,6 +67,7 @@ export default async function runWorker(
       backPressureLimitHeapProportion,
       flowControlConsensusTimeoutProportion,
       flowControlSlowSubscriberGracePeriodSeconds,
+      pgChangeLogEnabled,
       sqliteChangeLogMode,
       sqliteChangeLogReadPercent,
       sqliteChangeLogColdReadPercent,
@@ -123,7 +124,7 @@ export default async function runWorker(
   // purges. This ensures that (this) change-streamer will be able to resume
   // from the backup.
   let purgeLock =
-    litestream.backupURL && litestream.executable
+    pgChangeLogEnabled && litestream.backupURL && litestream.executable
       ? await new PurgeLocker(lc, shard, changeDB).acquire()
       : null;
   const restoreOptions = {litestream, constraints: purgeLock ?? undefined};
@@ -220,6 +221,7 @@ export default async function runWorker(
         purgeLock,
         autoReset ?? false,
         {
+          pgChangeLogEnabled,
           backPressureLimitHeapProportion,
           flowControlConsensusTimeoutProportion,
           flowControlSlowSubscriberGracePeriodMs:
@@ -258,14 +260,15 @@ export default async function runWorker(
               }
             : undefined,
           // Compare mode runs both advisory checks. Postgres remains authoritative.
-          sqliteChangeLogCompare: sqliteChangeLogComparing
-            ? {
-                replicaFile: replica.file,
-                comparePercent: sqliteChangeLogComparePercent,
-                retentionMs: sqliteChangeLogRetentionMs,
-                readBatchRows: sqliteChangeLogReadBatchRows,
-              }
-            : undefined,
+          sqliteChangeLogCompare:
+            pgChangeLogEnabled && sqliteChangeLogComparing
+              ? {
+                  replicaFile: replica.file,
+                  comparePercent: sqliteChangeLogComparePercent,
+                  retentionMs: sqliteChangeLogRetentionMs,
+                  readBatchRows: sqliteChangeLogReadBatchRows,
+                }
+              : undefined,
           // Slice 11 lands dark by default: serve mode constructs the stable
           // router, while readPercent=0 keeps every catchup on PG and emits
           // eligibility metrics before any canary traffic is enabled.

--- a/packages/zero-cache/src/services/change-streamer/change-log-codec.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-log-codec.test.ts
@@ -4,6 +4,7 @@ import {
   extractChangeSubstring,
   reconstructWatermarkedChange,
   serializeChangeStreamData,
+  serializeChangeStreamDataWithChange,
   type ChangeLogEntry,
 } from './change-log-codec.ts';
 import type {ChangeTag, WatermarkedChange} from './change-streamer.ts';
@@ -146,8 +147,10 @@ describe('change log codec', () => {
       const {watermark, data, json, change} = fixture;
       const tag = data[1].tag;
       const serialized = serializeChangeStreamData(data);
+      const parts = serializeChangeStreamDataWithChange(data);
 
       expect(serialized).toBe(json);
+      expect(parts).toEqual({json, change});
       expect(extractChangeSubstring(serialized, tag)).toBe(change);
 
       const entry = {watermark, tag, change};

--- a/packages/zero-cache/src/services/change-streamer/change-log-codec.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-log-codec.ts
@@ -8,16 +8,49 @@ export type ChangeLogEntry = {
   change: string;
 };
 
+export type SerializedChangeStreamData = {
+  /** The canonical downstream representation forwarded to subscribers. */
+  readonly json: string;
+  /** The already-serialized change tuple element stored in change logs. */
+  readonly change: string;
+};
+
+/**
+ * Serializes a data-plane message and its stored change payload in one pass.
+ *
+ * Change logs retain only the second tuple element for backwards
+ * compatibility. Serializing that element first avoids stringifying the full
+ * message and then copying the payload back out of the resulting string on the
+ * replication hot path.
+ */
+export function serializeChangeStreamDataWithChange(
+  data: ChangeStreamData,
+): SerializedChangeStreamData {
+  const change = BigIntJSON.stringify(data[1]);
+  const type = data[0];
+  switch (type) {
+    case 'begin':
+    case 'commit':
+      return {
+        json: `[${JSON.stringify(type)},${change},${BigIntJSON.stringify(data[2])}]`,
+        change,
+      };
+    case 'data':
+    case 'rollback':
+      return {json: `[${JSON.stringify(type)},${change}]`, change};
+  }
+}
+
 /** Serializes a data-plane message to the canonical downstream JSON form. */
 export function serializeChangeStreamData(data: ChangeStreamData): string {
-  return BigIntJSON.stringify(data);
+  return serializeChangeStreamDataWithChange(data).json;
 }
 
 /**
- * Extracts the stringified change message from the stringified stream message
- * (the second tuple element). This allows the stream message to be stringified
- * once while storing only the change message in the change log for backwards
- * compatibility.
+ * Extracts the second tuple element for callers that only have the canonical
+ * downstream JSON. The live write path uses
+ * {@link serializeChangeStreamDataWithChange} and does not scan or copy the
+ * completed message.
  */
 export function extractChangeSubstring(
   streamMessageJSON: string,

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-http.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-http.pg.test.ts
@@ -305,11 +305,11 @@ describe('change-streamer/http', () => {
       expect(await drain(2, sub)).toEqual([
         {
           data: ['begin', {tag: 'begin'}, {commitWatermark: '456'}],
-          json: begin,
+          size: `{"id":1,"msg":${begin}}`.length,
         },
         {
           data: ['commit', {tag: 'commit'}, {watermark: '456'}],
-          json: commit,
+          size: `{"id":2,"msg":${commit}}`.length,
         },
       ]);
 
@@ -349,6 +349,8 @@ describe('change-streamer/http', () => {
 
     const json = BigIntJSON.stringify(['data', insert]);
     downstream.push(json);
-    expect(await drain(1, sub)).toEqual([{data: ['data', insert], json}]);
+    expect(await drain(1, sub)).toEqual([
+      {data: ['data', insert], size: `{"id":1,"msg":${json}}`.length},
+    ]);
   });
 });

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-http.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-http.ts
@@ -10,7 +10,7 @@ import {type Worker} from '../../types/processes.ts';
 import {type ShardID} from '../../types/shards.ts';
 import {
   streamIn,
-  streamInStringified,
+  streamInWithSize,
   streamOut,
   streamOutStringified,
   type Source,
@@ -24,7 +24,7 @@ import {
   PROTOCOL_VERSION,
   type ChangeStreamer,
   type ChangeStreamerService,
-  type SerializedDownstream,
+  type SizedDownstream,
   type SubscriberContext,
 } from './change-streamer.ts';
 import {discoverChangeStreamerAddress} from './schema/tables.ts';
@@ -234,15 +234,13 @@ export class ChangeStreamerHttpClient implements ChangeStreamer {
     return streamIn(this.#lc, ws, snapshotMessageSchema);
   }
 
-  async subscribe(
-    ctx: SubscriberContext,
-  ): Promise<Source<SerializedDownstream>> {
+  async subscribe(ctx: SubscriberContext): Promise<Source<SizedDownstream>> {
     const uri = await this.#resolveChangeStreamer(CHANGES_PATH);
 
     const params = getParams(ctx);
     const ws = new WebSocket(uri + `?${params.toString()}`);
 
-    return streamInStringified(this.#lc, ws, downstreamSchema);
+    return streamInWithSize(this.#lc, ws, downstreamSchema);
   }
 }
 

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
@@ -71,6 +71,7 @@ import {SQLiteChangeLogWriter} from './sqlite-change-log-writer.ts';
 import {PurgeLocker, Storer} from './storer.ts';
 
 const opts: TuningOptions = {
+  pgChangeLogEnabled: true,
   backPressureLimitHeapProportion: 0.04,
   flowControlConsensusTimeoutProportion: 2,
   statementTimeoutMs: 20_000,
@@ -350,9 +351,11 @@ describe('change-streamer/service', () => {
    * and can serve catchup from what it wrote.
    */
   type InlineChangeLogWriterOptions = {
+    pgChangeLogEnabled?: boolean | undefined;
     sqliteCatchup?: Partial<SQLiteCatchupOptions> | undefined;
     sqliteChangeLogPurge?: TuningOptions['sqliteChangeLogPurge'] | undefined;
     backupURL?: string | undefined;
+    backupVersion?: LitestreamVersion | undefined;
     sqliteChangeLogCompare?:
       | TuningOptions['sqliteChangeLogCompare']
       | undefined;
@@ -362,18 +365,27 @@ describe('change-streamer/service', () => {
   async function restartWithInlineChangeLogWriter(
     logFile: DbFile,
     {
+      pgChangeLogEnabled = true,
       sqliteCatchup,
       sqliteChangeLogPurge,
       backupURL,
+      backupVersion = 'legacy',
       sqliteChangeLogCompare,
       sqliteChangeLogServe,
     }: InlineChangeLogWriterOptions = {},
-  ): Promise<void> {
+  ): Promise<Mock<ChangeSource['startStream']>> {
     await streamer.stop();
     await streamerDone;
 
     changes = Subscription.create();
     acks = new Queue();
+    const startStream = vi.fn(() =>
+      Promise.resolve({
+        initialWatermark: REPLICA_VERSION,
+        changes,
+        acks: {push: (status: UpstreamStatusMessage) => acks.enqueue(status)},
+      }),
+    );
     streamer = await initializeStreamer(
       lc,
       shard,
@@ -382,22 +394,20 @@ describe('change-streamer/service', () => {
       'ws',
       sql,
       {
-        startStream: () =>
-          Promise.resolve({
-            initialWatermark: REPLICA_VERSION,
-            changes,
-            acks: {push: status => acks.enqueue(status)},
-          }),
+        startStream,
         startLagReporter: () => null,
         stop: () => Promise.resolve(),
       },
       ReplicationStatusPublisher.forTesting(),
       replicaConfig,
-      backupURL === undefined ? null : {backupURL, litestreamVersion: 'legacy'},
+      backupURL === undefined
+        ? null
+        : {backupURL, litestreamVersion: backupVersion},
       null,
       true,
       {
         ...opts,
+        pgChangeLogEnabled,
         // No replica beside it: the writer's anchor is the watermark its stream
         // connection resumes from, which is Postgres's `lastWatermark`.
         sqliteChangeLogWriter: {
@@ -427,6 +437,7 @@ describe('change-streamer/service', () => {
       setTimeoutFn as unknown as typeof setTimeout,
     );
     await run(streamer);
+    return startStream;
   }
 
   /** The oldest watermark retained in the SQLite change log beside `logFile`. */
@@ -1186,6 +1197,138 @@ describe('change-streamer/service', () => {
       await streamerDone;
       deleteChangeLogDB(logFile.path);
       logFile.delete();
+    }
+  });
+
+  test('PG change-log flag makes SQLite authoritative and leaves PG frozen', async () => {
+    const readerRead = vi.spyOn(SQLiteChangeLogReader.prototype, 'read');
+    const replicaFile = new DbFile('sqlite-change-log-authoritative');
+    const replica = replicaFile.connect(lc);
+    replica.pragma('journal_mode = wal');
+    initReplicationState(replica, ['zero_data'], REPLICA_VERSION);
+
+    await sql`
+      INSERT INTO "zoro_3/cdc"."changeLog" (watermark, pos, change)
+        VALUES
+          ('04', 0, '{"tag":"begin"}'::json),
+          ('04', 1, '{"tag":"commit"}'::json)`;
+    await sql`
+      UPDATE "zoro_3/cdc"."replicationState" SET "lastWatermark" = '04'`;
+    const pgRowsBefore = await sql`
+      SELECT watermark, pos FROM "zoro_3/cdc"."changeLog"
+        ORDER BY watermark, pos`;
+
+    try {
+      const startStream = await restartWithInlineChangeLogWriter(replicaFile, {
+        pgChangeLogEnabled: false,
+        backupURL: 's3://foo/bar',
+        backupVersion: 'v5',
+        sqliteCatchup: {barrierPollIntervalMs: 10},
+        sqliteChangeLogPurge: {
+          retentionMs: 60_000,
+          batchRows: 100,
+        },
+        sqliteChangeLogServe: {
+          readPercent: 100,
+          coldReadPercent: 100,
+          retentionMs: 60_000,
+        },
+      });
+
+      // The replica, not the stale PG log, supplies the stream resume point.
+      expect(startStream).toHaveBeenCalledWith(REPLICA_VERSION, []);
+
+      changes.push(['begin', messages.begin(), {commitWatermark: '06'}]);
+      changes.push(['data', messages.insert('foo', {id: 'sqlite-only'})]);
+      changes.push(['commit', messages.commit(), {watermark: '06'}]);
+
+      await vi.waitFor(() => {
+        using log = openChangeLogDB(lc, replicaFile.path, {readonly: true});
+        expect(readChangeLogHead(log)).toBe('06');
+      });
+      expect(acks.size()).toBe(0);
+
+      const sub = await subscribeServing('sqlite-only');
+      const output = drainToQueue(sub);
+      expect(await nextChange(output)).toMatchObject({tag: 'status'});
+      expect(await nextChange(output)).toMatchObject({tag: 'begin'});
+      expect(await nextChange(output)).toMatchObject({
+        tag: 'insert',
+        new: {id: 'sqlite-only'},
+      });
+      expect(await nextChange(output)).toMatchObject({tag: 'commit'});
+      expect(readerRead).toHaveBeenCalled();
+      sub.cancel();
+
+      // Once SQLite has discarded the requested history, there is no stale
+      // PG fallback: the subscriber receives the terminal signal that causes
+      // its view-syncer to restore a fresh replica.
+      using changeLog = openChangeLogDB(lc, replicaFile.path, {
+        readonly: false,
+      });
+      changeLog
+        .prepare(`DELETE FROM "_zero.changeLogStream" WHERE watermark < '06'`)
+        .run();
+
+      // A backup below the SQLite seed cannot be demoted to PG. Its snapshot
+      // reservation stays pending until a later backup reaches the log.
+      const reservation =
+        await streamer.startSnapshotReservation('sqlite-restore');
+      const snapshots = drainSnapshotMessages(reservation);
+      streamer.trackBackupWatermark('04');
+      await expectAcks('04');
+      const timedOut: SnapshotMessage = [
+        'status',
+        {
+          tag: 'status',
+          backupURL: 'timed-out',
+          replicaVersion: 'timed-out',
+          minWatermark: 'timed-out',
+        },
+      ];
+      expect(await snapshots.dequeue(timedOut, 50)).toBe(timedOut);
+
+      // With PG persistence out of the ACK set, the verified v5 backup owns
+      // source ACK progress and releases the held reservation.
+      streamer.trackBackupWatermark('06');
+      await expectAcks('06');
+      expect(await snapshots.dequeue()).toEqual([
+        'status',
+        {
+          tag: 'status',
+          backupURL: 's3://foo/bar',
+          replicaVersion: REPLICA_VERSION,
+          minWatermark: '06',
+        },
+      ]);
+      reservation.cancel();
+
+      const tooOld = await subscribeServing('sqlite-too-old');
+      const tooOldOutput = drainToQueue(tooOld);
+      expect(await tooOldOutput.dequeue()).toEqual([
+        'error',
+        {
+          type: ErrorType.WatermarkTooOld,
+          message: 'earliest supported watermark is 06 (requested 01)',
+        },
+      ]);
+
+      expect(
+        await sql`
+          SELECT watermark, pos FROM "zoro_3/cdc"."changeLog"
+            ORDER BY watermark, pos`,
+      ).toEqual(pgRowsBefore);
+      expect(
+        await sql`
+          SELECT "lastWatermark" FROM "zoro_3/cdc"."replicationState"`,
+      ).toEqual([{lastWatermark: '04'}]);
+    } finally {
+      readerRead.mockRestore();
+      await streamer.stop();
+      await streamerDone;
+      replica.close();
+      deleteChangeLogDB(replicaFile.path);
+      replicaFile.delete();
     }
   });
 

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -38,6 +38,7 @@ import {
   RunningState,
   UnrecoverableError,
 } from '../running-state.ts';
+import {serializeChangeStreamData} from './change-log-codec.ts';
 import {
   ChangeLogInitializer,
   replicaInitializationSource,
@@ -147,6 +148,12 @@ export type SQLiteChangeLogServeOptions = {
 };
 
 export type TuningOptions = StorerOptions & {
+  /**
+   * Keeps the legacy Postgres change log on the initialization, persistence,
+   * catchup, purge, and ACK paths. Disable only after SQLite and the replica
+   * backup are authoritative for all of those responsibilities.
+   */
+  pgChangeLogEnabled: boolean;
   flowControlConsensusTimeoutProportion: number;
   flowControlSlowSubscriberGracePeriodMs?: number | undefined;
   sqliteCatchup?: SQLiteCatchupOptions | undefined;
@@ -210,6 +217,7 @@ export async function initializeStreamer(
     autoReset,
     purgeLock ?? undefined,
     setTimeoutFn,
+    opts.pgChangeLogEnabled,
   );
 
   // Dynamically creates connection pools that the implementation uses to
@@ -407,6 +415,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
   readonly #replicaVersion: string;
   readonly #source: ChangeSource;
   readonly #storer: Storer;
+  readonly #pgChangeLogEnabled: boolean;
   readonly #forwarder: Forwarder;
   readonly #reservations: SnapshotReservations | undefined;
   readonly #replicationStatusPublisher: ReplicationStatusPublisher;
@@ -521,6 +530,22 @@ class ChangeStreamerImpl implements ChangeStreamerService {
     this.#changeDBProvider = changeDBProvider;
     this.#replicaVersion = replicaVersion;
     this.#source = source;
+    this.#pgChangeLogEnabled = opts.pgChangeLogEnabled;
+    if (!this.#pgChangeLogEnabled) {
+      assert(
+        opts.sqliteChangeLogWriter &&
+          opts.sqliteChangeLogPurge &&
+          opts.sqliteCatchup &&
+          opts.sqliteChangeLogServe?.readPercent === 100 &&
+          opts.sqliteChangeLogServe.coldReadPercent === 100 &&
+          backupConfig?.litestreamVersion === 'v5',
+        'disabling the PG change log requires SQLite serving at 100 percent and a v5 backup',
+      );
+      assert(
+        opts.sqliteChangeLogCompare === undefined,
+        'SQLite change-log comparison requires the PG change log',
+      );
+    }
     this.#storer = new Storer(
       lc,
       shard,
@@ -610,16 +635,21 @@ class ChangeStreamerImpl implements ChangeStreamerService {
           )
         : undefined;
     this.#acker = new UpstreamAcker({
-      trackPgChangeLog: true, // TODO: set false when retiring PG
+      trackPgChangeLog: this.#pgChangeLogEnabled,
       trackBackup: backupConfig?.litestreamVersion === 'v5',
     });
-    const replicaSource = opts.sqliteChangeLogCompare
-      ? replicaInitializationSource(lc, opts.sqliteChangeLogCompare.replicaFile)
+    const replicaFile =
+      opts.sqliteChangeLogCompare?.replicaFile ??
+      (!this.#pgChangeLogEnabled
+        ? opts.sqliteChangeLogWriter?.replicaFile
+        : undefined);
+    const replicaSource = replicaFile
+      ? replicaInitializationSource(lc, replicaFile)
       : undefined;
     this.#initializer = new ChangeLogInitializer(
       lc,
       {
-        initFromPgChangeLog: true, // TODO: set false when retiring PG
+        initFromPgChangeLog: this.#pgChangeLogEnabled,
         initFromReplica: replicaSource !== undefined,
       },
       {
@@ -649,6 +679,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
       : undefined;
     // Compare mode requires the writer and catchup configuration.
     this.#comparator =
+      this.#pgChangeLogEnabled &&
       opts.sqliteChangeLogCompare &&
       opts.sqliteChangeLogWriter &&
       opts.sqliteCatchup
@@ -704,14 +735,16 @@ class ChangeStreamerImpl implements ChangeStreamerService {
         const {lastWatermark, backfillRequests} =
           await this.#initializer.initialize();
         // SQLite catchup must not be eligible until this has been initialized
-        // from the durable PG head. Commits observed only since process startup
-        // are insufficient after a change-streamer restart.
+        // from the selected durable head. Commits observed only since process
+        // startup are insufficient after a change-streamer restart.
         this.#lastForwardedCommitWatermark = lastWatermark;
         const stream = await this.#source.startStream(
           lastWatermark,
           backfillRequests,
         );
-        this.#storer.run().catch(e => stream.changes.cancel(e));
+        if (this.#pgChangeLogEnabled) {
+          this.#storer.run().catch(e => stream.changes.cancel(e));
+        }
 
         this.#stream = stream;
         if (
@@ -776,16 +809,17 @@ class ChangeStreamerImpl implements ChangeStreamerService {
               break;
           }
 
-          const json = this.#storer.store(watermark, change);
+          const json = this.#pgChangeLogEnabled
+            ? this.#storer.store(watermark, change)
+            : serializeChangeStreamData(change);
           // The SQLite change log commits at transaction boundaries, and its
           // commit for this transaction lands here -- before the forward of the
           // `commit` message, and before #recordForwardedTransactionBoundary
           // advances what #captureRequiredHead reads. No `await` separates it
-          // from #storer.store() above, which is the assertable form of
-          // invariant 1: the storer only enqueues, and its Postgres commit
-          // cannot complete without yielding, so a synchronous SQLite commit in
-          // the same loop iteration always precedes anything that can advance
-          // the watermark this stream would resume from. Never throws; a write
+          // from serialization or the optional PG enqueue above. This is the
+          // assertable form of invariant 1: a synchronous SQLite commit in the
+          // same loop iteration always precedes anything that can advance the
+          // watermark this stream would resume from. Never throws; a write
           // failure disables the writer rather than stopping replication.
           this.#changeLogWriter?.write(change, json);
           const entry: WatermarkedChange = [watermark, change[1].tag, json];
@@ -820,8 +854,10 @@ class ChangeStreamerImpl implements ChangeStreamerService {
             watermark = null;
           }
 
-          // Allow the storer to exert back pressure.
-          const readyForMore = this.#storer.readyForMore();
+          // Allow the PG storer to exert back pressure when it is enabled.
+          const readyForMore = this.#pgChangeLogEnabled
+            ? this.#storer.readyForMore()
+            : undefined;
           if (readyForMore) {
             await promiseOrAbort(
               readyForMore,
@@ -840,7 +876,9 @@ class ChangeStreamerImpl implements ChangeStreamerService {
       // When the change stream is interrupted, abort any pending transaction.
       if (watermark) {
         this.#lc.warn?.(`aborting interrupted transaction ${watermark}`);
-        this.#storer.abort();
+        if (this.#pgChangeLogEnabled) {
+          this.#storer.abort();
+        }
         // Rolling back the log leaves no rows for the interrupted transaction,
         // so the next connection's reconciliation sees a head at or below its
         // resume watermark rather than a partial transaction.
@@ -934,17 +972,32 @@ class ChangeStreamerImpl implements ChangeStreamerService {
       lc.info?.(`adding subscriber ${subscriber.id}`);
 
       const catchupFromPG = () => {
+        assert(
+          this.#pgChangeLogEnabled,
+          'cannot catch up from a disabled PG change log',
+        );
         // Keep the existing PG registration/catchup lockstep unchanged when
         // SQLite was not selected before Forwarder.add().
         cleanupSubscriber = removeFromForwarder;
         this.#forwarder.add(subscriber);
         this.#storer.catchup(subscriber, mode);
       };
-      const sqliteSelection = this.#selectSQLiteCatchup(lc, ctx);
-      if (!sqliteSelection) {
+      const sqliteDecision = this.#selectSQLiteCatchup(lc, ctx);
+      if (!sqliteDecision) {
         catchupFromPG();
+      } else if (sqliteDecision.kind === 'rejected') {
+        lc.warn?.(
+          `${
+            sqliteDecision.terminal ? 'rejecting' : 'ending'
+          } subscription for ${ctx.id}: ${sqliteDecision.message}`,
+        );
+        if (sqliteDecision.terminal) {
+          subscriber.close(ErrorType.WatermarkTooOld, sqliteDecision.message);
+        } else {
+          subscriber.close();
+        }
       } else {
-        const {catchup, reason, coverage, logWarm} = sqliteSelection;
+        const {catchup, reason, coverage, logWarm} = sqliteDecision;
         cleanupSubscriber = () => catchup.remove(subscriber);
         const registration = await catchup.catchup(
           subscriber,
@@ -960,28 +1013,51 @@ class ChangeStreamerImpl implements ChangeStreamerService {
             this.#recordCatchupRoute('sqlite', reason);
             break;
           case 'uncovered':
-            lc.info?.(
-              `serving ${ctx.id} from PG catchup: subscriber watermark ` +
-                `${ctx.watermark} is below the SQLite change-log minimum ` +
-                registration.minWatermark,
-            );
-            this.#recordCatchupRoute('pg', 'watermark-uncovered');
-            catchupFromPG();
+            if (this.#pgChangeLogEnabled) {
+              lc.info?.(
+                `serving ${ctx.id} from PG catchup: subscriber watermark ` +
+                  `${ctx.watermark} is below the SQLite change-log minimum ` +
+                  registration.minWatermark,
+              );
+              this.#recordCatchupRoute('pg', 'watermark-uncovered');
+              catchupFromPG();
+            } else {
+              const message =
+                `earliest supported watermark is ` +
+                `${registration.minWatermark} (requested ${ctx.watermark})`;
+              lc.warn?.(
+                `rejecting subscriber at watermark ${ctx.watermark}: ` +
+                  `the SQLite change log starts at ` +
+                  `${registration.minWatermark} and the PG change log is disabled`,
+              );
+              this.#recordCatchupRoute('none', 'watermark-uncovered');
+              subscriber.close(ErrorType.WatermarkTooOld, message);
+            }
             break;
           case 'declined':
             // Registration failed before the subscriber was committed to
-            // SQLite, so PG is still available. The coordinator has already
-            // tripped the breaker, which keeps the retry off SQLite for the
-            // cooldown; it is deliberately not closed here, since closing it
-            // would abort the catchups of every other subscriber it is
-            // serving.
-            lc.error?.(
-              `serving ${ctx.id} from PG catchup: SQLite catchup ` +
-                `registration failed`,
-              registration.error,
-            );
-            this.#recordCatchupRoute('pg', 'registration-failed');
-            catchupFromPG();
+            // SQLite. Use PG when enabled; otherwise end this subscription so
+            // it retries. The coordinator has already tripped the breaker,
+            // which keeps the retry off SQLite for the cooldown; it is
+            // deliberately not closed here, since closing it would abort the
+            // catchups of every other subscriber it is serving.
+            if (this.#pgChangeLogEnabled) {
+              lc.error?.(
+                `serving ${ctx.id} from PG catchup: SQLite catchup ` +
+                  `registration failed`,
+                registration.error,
+              );
+              this.#recordCatchupRoute('pg', 'registration-failed');
+              catchupFromPG();
+            } else {
+              lc.error?.(
+                `ending subscription for ${ctx.id} to retry SQLite catchup: ` +
+                  `registration failed and the PG change log is disabled`,
+                registration.error,
+              );
+              this.#recordCatchupRoute('none', 'registration-failed');
+              subscriber.fail(registration.error);
+            }
             break;
           case 'handled':
             // The coordinator closed or failed the subscriber itself, so
@@ -1065,14 +1141,15 @@ class ChangeStreamerImpl implements ChangeStreamerService {
       return;
     }
 
-    // Resolve PG bounds before touching any pin. Everything below runs to
-    // completion without awaiting, which is what keeps a reservation's
+    // Resolve PG bounds, when enabled, before touching any pin. Everything
+    // below runs to completion without awaiting, which keeps a reservation's
     // advertised bounds and its pin in agreement: a concurrent /snapshot
     // retry for the same task replaces the reservation and re-pins it, and
     // confirming that replacement with the previous pin's bounds is exactly
-    // the mismatch pinning exists to prevent. The cost is one PG round trip
-    // per call even when every reservation is pinned to SQLite.
-    const pgState = await this.#getChangeLogState();
+    // the mismatch pinning exists to prevent.
+    const pgState = this.#pgChangeLogEnabled
+      ? await this.#getChangeLogState()
+      : undefined;
     for (const taskID of reservations.unconfirmedTaskIDs()) {
       let route = this.#readRouter?.peek(taskID);
       // startSnapshotReservation pins only after an in-flight purge has
@@ -1081,12 +1158,34 @@ class ChangeStreamerImpl implements ChangeStreamerService {
         continue;
       }
 
+      // A transiently unavailable or broken SQLite log normally pins the
+      // reservation to PG. With PG disabled, re-evaluate that choice on each
+      // backup notification and keep the reservation pending until SQLite can
+      // supply bounds.
+      if (!this.#pgChangeLogEnabled && route?.source === 'pg') {
+        this.#readRouter?.release(taskID);
+        route = this.#readRouter?.pin(taskID);
+        if (route?.source === 'pg') {
+          if (reservations.noteConfirmationDelayed(taskID)) {
+            this.#reservationConfirmDelays.add(1);
+          }
+          this.#lc.warn?.(
+            `delaying snapshot reservation for ${taskID}: SQLite change log ` +
+              `is unavailable and the PG change log is disabled`,
+          );
+          continue;
+        }
+      }
+
       if (route?.source === 'sqlite') {
         const coverage = must(
           route.coverage,
           'a pinned SQLite route must carry its covered range',
         );
-        if (coverage.minWatermark > backupWatermark) {
+        if (
+          this.#pgChangeLogEnabled &&
+          coverage.minWatermark > backupWatermark
+        ) {
           // A log seeded after this backup, most often. Holding the
           // reservation until a backup reaches the log's minimum would stall
           // a follower that PG can serve now, so move it -- pin included.
@@ -1110,13 +1209,16 @@ class ChangeStreamerImpl implements ChangeStreamerService {
           'a pinned SQLite route must carry its covered range',
         ).minWatermark;
       } else {
-        ({minWatermark} = pgState);
+        minWatermark = must(
+          pgState,
+          'a PG reservation route requires the PG change log',
+        ).minWatermark;
       }
 
       if (minWatermark <= backupWatermark) {
         reservations.confirmFor(
           taskID,
-          pgState.replicaVersion,
+          this.#replicaVersion,
           backupWatermark,
           source,
         );
@@ -1128,7 +1230,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
           this.#reservationConfirmDelays.add(1);
         }
         this.#lc.error?.(
-          `pg change-log minWatermark ${minWatermark} is later than ` +
+          `${source} change-log minWatermark ${minWatermark} is later than ` +
             `backupWatermark ${backupWatermark}. Delaying confirmation of ` +
             `snapshot reservation until next backup.`,
         );
@@ -1139,6 +1241,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
   #maybeSchedulePGPurge(): void {
     const backupWatermark = this.#backupWatermark;
     if (
+      !this.#pgChangeLogEnabled ||
       this.#pgPurgeScheduled ||
       this.#pgPurgeRunning ||
       backupWatermark === undefined ||
@@ -1369,11 +1472,13 @@ class ChangeStreamerImpl implements ChangeStreamerService {
   #selectSQLiteCatchup(
     lc: LogContext,
     ctx: SubscriberContext,
-  ): SQLiteCatchupSelection | undefined {
+  ): SQLiteCatchupDecision | undefined {
     const opts = this.#sqliteCatchupOptions;
     if (this.#lastForwardedCommitWatermark === undefined || !opts) {
-      this.#recordCatchupRoute('pg', 'not-ready');
-      return undefined;
+      return this.#fallbackOrReject(
+        'not-ready',
+        'SQLite catchup is not ready and the PG change log is disabled',
+      );
     }
     // SQLite catchup is only for disposable serving replicas. Backup
     // subscribers retain the existing PG recovery policy until RMv2 can
@@ -1381,8 +1486,11 @@ class ChangeStreamerImpl implements ChangeStreamerService {
     // Enforce this before the selector so no canary policy can override it.
     if (ctx.mode !== 'serving') {
       lc.info?.(`not serving backup subscriber ${ctx.id} from SQLite catchup`);
-      this.#recordCatchupRoute('pg', 'ineligible-mode');
-      return undefined;
+      return this.#fallbackOrReject(
+        'ineligible-mode',
+        `SQLite catchup does not support ${ctx.mode} subscribers and the PG ` +
+          `change log is disabled`,
+      );
     }
 
     let route: ChangeLogReadRoute | undefined;
@@ -1409,8 +1517,11 @@ class ChangeStreamerImpl implements ChangeStreamerService {
               : []),
           );
         }
-        this.#recordCatchupRoute('pg', route.reason);
-        return undefined;
+        return this.#fallbackOrReject(
+          route.reason,
+          `SQLite catchup route ${route.reason} is unavailable and the PG ` +
+            `change log is disabled`,
+        );
       }
       const coverage = route.coverage;
       assert(coverage, 'a SQLite route must carry its covered range');
@@ -1421,26 +1532,35 @@ class ChangeStreamerImpl implements ChangeStreamerService {
             coverage.minWatermark,
           {sqliteChangeLogCoverage: coverage},
         );
-        this.#recordCatchupRoute('pg', 'watermark-uncovered');
-        return undefined;
+        return this.#fallbackOrReject(
+          'watermark-uncovered',
+          `earliest supported watermark is ${coverage.minWatermark} ` +
+            `(requested ${ctx.watermark})`,
+          true,
+        );
       }
     }
 
     // `shouldUse` remains as a test hook and an optional extra policy gate.
     // Production selection comes from #readRouter.
     if (!this.#readRouter && !opts.shouldUse?.(ctx)) {
-      this.#recordCatchupRoute('pg', 'selector');
-      return undefined;
+      return this.#fallbackOrReject(
+        'selector',
+        'SQLite catchup was not selected and the PG change log is disabled',
+      );
     }
     if (this.#readRouter && opts.shouldUse && !opts.shouldUse(ctx)) {
-      this.#recordCatchupRoute('pg', 'selector');
-      return undefined;
+      return this.#fallbackOrReject(
+        'selector',
+        'SQLite catchup was not selected and the PG change log is disabled',
+      );
     }
 
     const catchup =
       this.#sqliteCatchup ?? this.#openSQLiteCatchup(lc, opts, ctx);
     if (catchup) {
       return {
+        kind: 'selected',
         catchup,
         reason: route?.reason ?? 'selector',
         coverage: route?.coverage,
@@ -1449,12 +1569,25 @@ class ChangeStreamerImpl implements ChangeStreamerService {
           route === undefined ? undefined : route.reason !== 'selected-cold',
       };
     } else {
-      this.#recordCatchupRoute('pg', 'log-unavailable');
+      return this.#fallbackOrReject(
+        'log-unavailable',
+        'SQLite change log is unavailable and the PG change log is disabled',
+      );
     }
-    return undefined;
   }
 
-  #recordCatchupRoute(source: 'pg' | 'sqlite', reason: string): void {
+  #fallbackOrReject(
+    reason: string,
+    message: string,
+    terminal = false,
+  ): SQLiteCatchupRejection | undefined {
+    this.#recordCatchupRoute(this.#pgChangeLogEnabled ? 'pg' : 'none', reason);
+    return this.#pgChangeLogEnabled
+      ? undefined
+      : {kind: 'rejected', message, terminal};
+  }
+
+  #recordCatchupRoute(source: 'pg' | 'sqlite' | 'none', reason: string): void {
     this.#catchupRoutes.add(1, {source, reason});
   }
 
@@ -1466,10 +1599,11 @@ class ChangeStreamerImpl implements ChangeStreamerService {
    * first reconcile, and deletes it when it fails soft -- or may exist without
    * content, or may be unreadable. None of those can be allowed to fail a
    * subscription:
-   * this is the last point at which PG catchup is still available -- past
-   * `Forwarder.add()` the subscriber is committed to SQLite -- so each declines
-   * here instead. Neither the failure nor the reader is retained, so a later
-   * subscription retries from scratch.
+   * this is the last point at which PG catchup can be selected when it is
+   * enabled -- past `Forwarder.add()` the subscriber is committed to SQLite --
+   * so each declines here instead. With PG disabled, the caller ends the
+   * subscription so that it retries. Neither the failure nor the reader is
+   * retained, so a later subscription retries from scratch.
    */
   #openSQLiteCatchup(
     lc: LogContext,
@@ -1551,7 +1685,10 @@ class ChangeStreamerImpl implements ChangeStreamerService {
       opts.notReadyWarnThresholdMs ??
       DEFAULT_CHANGE_LOG_UNAVAILABLE_WARN_THRESHOLD_MS;
     lc[unavailableMs >= threshold ? 'warn' : 'debug']?.(
-      `serving ${ctx.id} from PG catchup: ${reason} ` +
+      (this.#pgChangeLogEnabled
+        ? `serving ${ctx.id} from PG catchup: `
+        : `cannot serve ${ctx.id} from SQLite catchup: `) +
+        `${reason} ` +
         `(unavailable for ${unavailableMs} ms)`,
       ...(error === undefined ? [] : [error]),
     );
@@ -1563,6 +1700,7 @@ type ForwardedTransactionCompletion =
   | {kind: 'rolled-back'; watermark: string};
 
 type SQLiteCatchupSelection = {
+  readonly kind: 'selected';
   readonly catchup: SQLiteChangeLogCatchup;
   readonly reason: string;
   readonly coverage: SQLiteChangeLogCoverage | undefined;
@@ -1572,6 +1710,15 @@ type SQLiteCatchupSelection = {
    */
   readonly logWarm: boolean | undefined;
 };
+
+type SQLiteCatchupRejection = {
+  readonly kind: 'rejected';
+  readonly message: string;
+  /** A terminal rejection forces the view-syncer to restore a fresh replica. */
+  readonly terminal: boolean;
+};
+
+type SQLiteCatchupDecision = SQLiteCatchupSelection | SQLiteCatchupRejection;
 
 // The delay between receiving an initial, backup-based watermark
 // and performing a check of whether to purge records before it.

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -38,7 +38,7 @@ import {
   RunningState,
   UnrecoverableError,
 } from '../running-state.ts';
-import {serializeChangeStreamData} from './change-log-codec.ts';
+import {serializeChangeStreamDataWithChange} from './change-log-codec.ts';
 import {
   ChangeLogInitializer,
   replicaInitializationSource,
@@ -809,9 +809,11 @@ class ChangeStreamerImpl implements ChangeStreamerService {
               break;
           }
 
-          const json = this.#pgChangeLogEnabled
-            ? this.#storer.store(watermark, change)
-            : serializeChangeStreamData(change);
+          const serialized = serializeChangeStreamDataWithChange(change);
+          const {json} = serialized;
+          if (this.#pgChangeLogEnabled) {
+            this.#storer.store(watermark, change, serialized);
+          }
           // The SQLite change log commits at transaction boundaries, and its
           // commit for this transaction lands here -- before the forward of the
           // `commit` message, and before #recordForwardedTransactionBoundary
@@ -821,7 +823,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
           // same loop iteration always precedes anything that can advance the
           // watermark this stream would resume from. Never throws; a write
           // failure disables the writer rather than stopping replication.
-          this.#changeLogWriter?.write(change, json);
+          this.#changeLogWriter?.write(change, json, serialized.change);
           const entry: WatermarkedChange = [watermark, change[1].tag, json];
           unflushedBytes += json.length;
           if (unflushedBytes < flushBytesThreshold) {

--- a/packages/zero-cache/src/services/change-streamer/change-streamer.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer.ts
@@ -1,6 +1,6 @@
 import type {Enum} from '../../../../shared/src/enum.ts';
 import * as v from '../../../../shared/src/valita.ts';
-import type {ParsedJSON, Source} from '../../types/streams.ts';
+import type {Sized, Source} from '../../types/streams.ts';
 import {
   changeStreamDataSchema,
   type ChangeStreamData,
@@ -67,10 +67,10 @@ export interface ChangeStreamer {
   /**
    * Subscribes to changes based on the supplied subscriber `ctx`,
    * which indicates the watermark at which the subscriber is up to
-   * date. Each result contains both parsed, validated data and the exact JSON
-   * payload sent by the ChangeStreamerService.
+   * date. Each result contains parsed, validated data and its approximate
+   * serialized transport size.
    */
-  subscribe(ctx: SubscriberContext): Promise<Source<SerializedDownstream>>;
+  subscribe(ctx: SubscriberContext): Promise<Source<SizedDownstream>>;
 }
 
 // v1: v0.18
@@ -228,8 +228,8 @@ export function errorTypeToReadableName(val: ErrorType) {
  */
 export type Downstream = v.Infer<typeof downstreamSchema>;
 
-/** A downstream message and its canonical ChangeStreamer JSON. */
-export type SerializedDownstream = ParsedJSON<Downstream>;
+/** A downstream message and its approximate serialized transport size. */
+export type SizedDownstream = Sized<Downstream>;
 
 export interface ChangeStreamerService
   extends Omit<ChangeStreamer, 'subscribe'>, Service {

--- a/packages/zero-cache/src/services/change-streamer/schema/tables.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/schema/tables.pg.test.ts
@@ -268,6 +268,53 @@ describe('change-streamer/schema/tables', () => {
     expect(purgeLock.release).not.toHaveBeenCalled();
   });
 
+  test('disabled PG change log is neither initialized nor reset', async () => {
+    await ensureReplicationConfig(
+      lc,
+      sql,
+      {
+        replicaVersion: '183',
+        publications: ['zero_data'],
+        watermark: '183',
+      },
+      shard,
+      true,
+      undefined,
+      undefined,
+      false,
+    );
+    expect(
+      await sql`SELECT watermark, pos FROM "rezo_8/cdc"."changeLog"`,
+    ).toEqual([]);
+
+    await sql`
+      INSERT INTO "rezo_8/cdc"."changeLog" (watermark, pos, change)
+        VALUES ('stale', 0, '{"tag":"begin"}'::json)`;
+
+    await ensureReplicationConfig(
+      lc,
+      sql,
+      {
+        replicaVersion: '1g8',
+        publications: ['zero_data'],
+        watermark: '1g8',
+      },
+      shard,
+      true,
+      undefined,
+      undefined,
+      false,
+    );
+
+    expect(
+      await sql`SELECT watermark, pos FROM "rezo_8/cdc"."changeLog"`,
+    ).toEqual([{watermark: 'stale', pos: 0n}]);
+    expect(
+      await sql`
+        SELECT "lastWatermark" FROM "rezo_8/cdc"."replicationState"`,
+    ).toEqual([{lastWatermark: '1g8'}]);
+  });
+
   test('no deadlocks when table is reset', async () => {
     // Set up initial replication config.
     await ensureReplicationConfig(

--- a/packages/zero-cache/src/services/change-streamer/schema/tables.ts
+++ b/packages/zero-cache/src/services/change-streamer/schema/tables.ts
@@ -174,6 +174,7 @@ export async function ensureReplicationConfig(
   autoReset: boolean,
   purgeLock?: PurgeLock,
   setTimeoutFn: typeof setTimeout = setTimeout,
+  pgChangeLogEnabled = true,
 ) {
   const {publications, replicaVersion, watermark} = subscriptionState;
   const replicaConfig = {publications, replicaVersion};
@@ -230,7 +231,9 @@ export async function ensureReplicationConfig(
         needsTruncate = true;
         stmts.push(
           sql`TRUNCATE TABLE ${sql(schema)}."replicationState"`,
-          sql`TRUNCATE TABLE ${sql(schema)}."changeLog"`,
+          ...(pgChangeLogEnabled
+            ? [sql`TRUNCATE TABLE ${sql(schema)}."changeLog"`]
+            : []),
           sql`TRUNCATE TABLE ${sql(schema)}."replicationConfig"`,
           sql`TRUNCATE TABLE ${sql(schema)}."tableMetadata"`,
           sql`TRUNCATE TABLE ${sql(schema)}."backfilling"`,
@@ -239,18 +242,20 @@ export async function ensureReplicationConfig(
     }
     // Initialize (or re-initialize TRUNCATED) tables
     if (results.length === 0 || needsTruncate) {
-      // The storer uses the earliest changeLog entry as the safe watermark
-      // from which subscribers can be resumed. These initial entries ensure
-      // that subscribers can start from a freshly synced replica, even if
-      // new changes have been replicated and not purged from the changeLog.
+      // When enabled, the PG storer uses the earliest changeLog entry as the
+      // safe watermark from which subscribers can be resumed. These initial
+      // entries ensure that subscribers can start from a freshly synced
+      // replica, even if new changes have been replicated and not purged.
       //
       // TODO: Replace this with an explicit `firstWatermark` column in the
       //       change db.
       const watermark = replicaConfig.replicaVersion;
-      const initialTx: FullChangeLogEntry[] = [
-        {watermark, pos: 0, change: {tag: 'begin'}},
-        {watermark, pos: 1, change: {tag: 'commit'}},
-      ];
+      const initialTx: FullChangeLogEntry[] = pgChangeLogEnabled
+        ? [
+            {watermark, pos: 0, change: {tag: 'begin'}},
+            {watermark, pos: 1, change: {tag: 'commit'}},
+          ]
+        : [];
 
       stmts.push(
         sql`INSERT INTO ${sql(schema)}."replicationConfig" ${sql(replicaConfig)}`,

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-writer.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-writer.test.ts
@@ -53,7 +53,11 @@ function resumeAt(
   return {resumeWatermark, cookies};
 }
 
-function setup(name: string, resumeWatermark = '02') {
+function setup(
+  name: string,
+  resumeWatermark = '02',
+  shadowValidationPercent = 100,
+) {
   const sink = new TestLogSink();
   const lc = new LogContext('debug', undefined, sink);
   const file = new DbFile(name);
@@ -68,6 +72,7 @@ function setup(name: string, resumeWatermark = '02') {
     onDisabled: () => disabled++,
     onRebuilt: () => rebuilt++,
     now: () => 1_700_000_000_000,
+    shadowValidationPercent,
   });
   writer.reconcile(resumeAt(resumeWatermark));
   return {
@@ -131,6 +136,24 @@ describe('change-streamer/sqlite-change-log-writer', () => {
       headLag: 0,
       invariantFailures: 0,
       hashMatches: 2,
+      hashMismatches: 0,
+      hashUnpaired: 0,
+    });
+  });
+
+  test('can skip rollout-only shadow validation', () => {
+    using fixture = setup('change-log-writer-no-shadow-validation', '02', 0);
+
+    transaction(fixture.writer, '04', [
+      'data',
+      messages.insert('foo', {id: 'one'}),
+    ]);
+
+    expect(fixture.head()).toBe('04');
+    expect(fixture.writer.state()).toMatchObject({
+      sqliteHead: '04',
+      receivedHead: '04',
+      hashMatches: 0,
       hashMismatches: 0,
       hashUnpaired: 0,
     });

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-writer.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-writer.ts
@@ -1,5 +1,7 @@
 import type {LogContext} from '@rocicorp/logger';
 import {SqliteError} from '@rocicorp/zero-sqlite3';
+import {assert} from '../../../../shared/src/asserts.ts';
+import {h32} from '../../../../shared/src/hash.ts';
 import {must} from '../../../../shared/src/must.ts';
 import type {Database} from '../../../../zqlite/src/db.ts';
 import {
@@ -35,6 +37,7 @@ import {
   type ChangeLogCommit,
   type SQLiteChangeLogObservabilityState,
 } from '../replicator/sqlite-change-log-observability.ts';
+import {extractChangeSubstring} from './change-log-codec.ts';
 
 export type SQLiteChangeLogWriterOptions = {
   /** The replica file the log is named after, i.e. `${replicaFile}-change-log`. */
@@ -58,7 +61,14 @@ export type SQLiteChangeLogWriterOptions = {
   onRebuilt?: (() => void) | undefined;
   /** Overridable for tests. */
   now?: (() => number) | undefined;
+  /**
+   * Percentage of transactions that retain the rollout-only per-message
+   * timing and source-vs-stored hash validation. Defaults to 1.
+   */
+  shadowValidationPercent?: number | undefined;
 };
+
+const DEFAULT_SHADOW_VALIDATION_PERCENT = 1;
 
 /**
  * Appends the canonical change stream to the SQLite change log, from the
@@ -94,16 +104,26 @@ export class SQLiteChangeLogWriter {
   readonly #lc: LogContext;
   readonly #opts: SQLiteChangeLogWriterOptions;
   readonly #now: () => number;
+  readonly #shadowValidationPercent: number;
 
   #db: Database | undefined;
   #writer: ChangeLogStreamWriter | undefined;
   #observer: SQLiteChangeLogObserver | undefined;
   #disabled = false;
+  #validateTransaction = false;
 
   constructor(lc: LogContext, opts: SQLiteChangeLogWriterOptions) {
     this.#lc = lc.withContext('component', 'sqlite-change-log-writer');
     this.#opts = opts;
     this.#now = opts.now ?? Date.now;
+    this.#shadowValidationPercent =
+      opts.shadowValidationPercent ?? DEFAULT_SHADOW_VALIDATION_PERCENT;
+    assert(
+      Number.isInteger(this.#shadowValidationPercent) &&
+        this.#shadowValidationPercent >= 0 &&
+        this.#shadowValidationPercent <= 100,
+      'SQLite change-log shadow validation percentage must be an integer between 0 and 100',
+    );
   }
 
   /** False once the writer has failed soft, or after {@link close}. */
@@ -269,26 +289,46 @@ export class SQLiteChangeLogWriter {
    * Writes one stream message, committing at transaction boundaries. Never
    * throws: a write failure disables the writer instead of failing the stream.
    */
-  write(change: ChangeStreamData, json: string): void {
+  write(
+    change: ChangeStreamData,
+    json: string,
+    storedChange = extractChangeSubstring(json, change[1].tag),
+  ): void {
     const writer = this.#writer;
     const db = this.#db;
     if (this.#disabled || writer === undefined || db === undefined) {
       return;
     }
-    const observer = this.#observer;
-    observer?.messageReceived(change, json);
     const [type, msg] = change;
-    const startedAt = performance.now();
+    if (type === 'begin') {
+      this.#validateTransaction = this.#isSelectedForShadowValidation(
+        change[2].commitWatermark,
+      );
+    }
+    const validateTransaction = this.#validateTransaction;
+    const observer = this.#observer;
+    observer?.messageReceived(change, json, validateTransaction, storedChange);
+    const startedAt = validateTransaction ? performance.now() : undefined;
     try {
       let commit: ChangeLogCommit | null = null;
       switch (type) {
         case 'begin':
-          writer.begin(change[2].commitWatermark, json);
+          writer.begin(
+            change[2].commitWatermark,
+            json,
+            storedChange,
+            validateTransaction,
+          );
           break;
         case 'commit': {
           const {watermark} = change[2];
           const commitStart = performance.now();
-          const stats = writer.commit(watermark, json, this.#now());
+          const stats = writer.commit(
+            watermark,
+            json,
+            this.#now(),
+            storedChange,
+          );
           commit = {
             watermark,
             stats,
@@ -300,10 +340,14 @@ export class SQLiteChangeLogWriter {
           writer.rollback();
           break;
         default:
-          writer.append(json, msg);
+          writer.append(json, msg, storedChange);
           break;
       }
-      observer?.messageProcessed(change, commit, performance.now() - startedAt);
+      observer?.messageProcessed(
+        change,
+        commit,
+        startedAt === undefined ? undefined : performance.now() - startedAt,
+      );
       if (commit !== null && commit.stats.cookieMutations.length > 0) {
         // Only re-counted when a schema change actually moved the cookie jar,
         // which keeps the count off the forward path of every other
@@ -319,8 +363,16 @@ export class SQLiteChangeLogWriter {
         // what makes its poll interval a backstop rather than the mechanism.
         this.#opts.onCommit?.(commit.watermark);
       }
+      if (type === 'commit' || type === 'rollback') {
+        this.#validateTransaction = false;
+      }
     } catch (e) {
-      observer?.messageFailed(change, e, performance.now() - startedAt);
+      observer?.messageFailed(
+        change,
+        e,
+        startedAt === undefined ? undefined : performance.now() - startedAt,
+      );
+      this.#validateTransaction = false;
       if (isConstraintViolation(e)) {
         // Reconciliation should have truncated whatever this collided with.
         // Report it as an invariant failure before failing soft, so that a
@@ -335,12 +387,26 @@ export class SQLiteChangeLogWriter {
     }
   }
 
+  #isSelectedForShadowValidation(watermark: string): boolean {
+    const percent = this.#shadowValidationPercent;
+    return (
+      percent >= 100 ||
+      (percent > 0 &&
+        h32(
+          `${this.#opts.identity.generation}/${this.#opts.identity.replicaID ?? ''}:${watermark}`,
+        ) %
+          100 <
+          percent)
+    );
+  }
+
   /**
    * Discards the open transaction, if any. Called when the change stream is
    * interrupted mid-transaction.
    */
   abort(): void {
     const writer = this.#writer;
+    this.#validateTransaction = false;
     if (this.#disabled || writer === undefined) {
       return;
     }
@@ -354,6 +420,7 @@ export class SQLiteChangeLogWriter {
 
   close(): void {
     this.#disabled = true;
+    this.#validateTransaction = false;
     this.#writer = undefined;
     this.#observer = undefined;
     const db = this.#db;

--- a/packages/zero-cache/src/services/change-streamer/storer.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.ts
@@ -44,10 +44,10 @@ import {
 import type {ReplicatorMode} from '../replicator/replicator.ts';
 import type {Service} from '../service.ts';
 import {
-  extractChangeSubstring,
   reconstructWatermarkedChange,
-  serializeChangeStreamData,
+  serializeChangeStreamDataWithChange,
   type ChangeLogEntry,
+  type SerializedChangeStreamData,
 } from './change-log-codec.ts';
 import * as ErrorType from './error-type-enum.ts';
 import {
@@ -77,6 +77,7 @@ type QueueEntry =
       'change',
       watermark: string,
       json: string,
+      storedChange: string,
       orig: Exclude<Change, DataChange> | null, // null for DataChanges
     ]
   | ['ready', callback: () => void]
@@ -488,11 +489,17 @@ export class Storer implements Service {
   /**
    * @returns The JSON stringified stream message to be sent downstream.
    */
-  store(watermark: string, data: ChangeStreamData) {
+  store(
+    watermark: string,
+    data: ChangeStreamData,
+    serialized: SerializedChangeStreamData = serializeChangeStreamDataWithChange(
+      data,
+    ),
+  ) {
     // Eagerly stringify the JSON payload to:
     // - avoid redundant stringification when fanning out to subscribers
     // - efficiently estimate the amount of memory the payload consumes
-    const json = serializeChangeStreamData(data);
+    const {json, change: storedChange} = serialized;
     this.#approximateQueuedBytes += json.length;
 
     const change = data[1];
@@ -500,6 +507,7 @@ export class Storer implements Service {
       'change',
       watermark,
       json,
+      storedChange,
       isDataChange(change) ? null : change, // drop DataChanges to save memory
     ]);
 
@@ -703,7 +711,7 @@ export class Storer implements Service {
           }
         }
         // msgType === 'change'
-        const [_, watermark, json, change] = msg;
+        const [_, watermark, json, storedChange, change] = msg;
         const tag = change?.tag;
         this.#approximateQueuedBytes -= json.length;
 
@@ -744,8 +752,9 @@ export class Storer implements Service {
           precommit: tag === 'commit' ? tx.preCommitWatermark : null,
           pos: tx.pos,
           // For backwards compatibility, only the change message is stored
-          // in the cdc changeLog.
-          change: extractChangeSubstring(json, tag),
+          // in the cdc changeLog. It was serialized separately with the
+          // downstream envelope, so no full-message scan is needed here.
+          change: storedChange,
         };
 
         if (change !== null && isSchemaChange(change)) {

--- a/packages/zero-cache/src/services/replicator/change-log-stream-writer.ts
+++ b/packages/zero-cache/src/services/replicator/change-log-stream-writer.ts
@@ -15,7 +15,8 @@ import {
 export type ChangeLogStreamTransactionStats = {
   readonly rows: number;
   readonly estimatedBytes: number;
-  readonly hash: string;
+  /** Present only for transactions selected for shadow-write validation. */
+  readonly hash?: string | undefined;
   /**
    * The cookie mutations this transaction's schema changes folded in, in stream
    * order. Empty for the overwhelming majority of transactions.
@@ -79,7 +80,12 @@ export class ChangeLogStreamWriter {
     this.#cookies = new ChangeLogCookieWriter(db.db);
   }
 
-  begin(watermark: string, json: string): void {
+  begin(
+    watermark: string,
+    json: string,
+    storedChange = extractChangeSubstring(json, 'begin'),
+    hash = true,
+  ): void {
     assertInvariant(
       this.#watermark === undefined,
       `change-log stream transaction already open at ${this.#watermark}`,
@@ -90,7 +96,7 @@ export class ChangeLogStreamWriter {
     this.#db.beginImmediate();
     this.#watermark = watermark;
     this.#pos = 0;
-    const change = extractChangeSubstring(json, 'begin');
+    const change = storedChange;
     const estimatedBytes = estimateChangeLogStreamRowBytes(
       watermark,
       'begin',
@@ -103,14 +109,16 @@ export class ChangeLogStreamWriter {
       estimatedBytes,
       change,
     );
-    this.#hasher = new ChangeLogTransactionHasher();
-    this.#hasher.add({
-      watermark,
-      pos: this.#pos,
-      tag: 'begin',
-      change,
-      precommit: null,
-    });
+    if (hash) {
+      this.#hasher = new ChangeLogTransactionHasher();
+      this.#hasher.add({
+        watermark,
+        pos: this.#pos,
+        tag: 'begin',
+        change,
+        precommit: null,
+      });
+    }
     this.#estimatedBytes = estimatedBytes;
   }
 
@@ -124,17 +132,21 @@ export class ChangeLogStreamWriter {
    * has to flush its buffered batch to get the same ordering
    * (`Storer.#processQueue()`); SQLite gets it from statement order.
    */
-  append(json: string, change: DataOrSchemaChange): void {
+  append(
+    json: string,
+    change: DataOrSchemaChange,
+    storedChange = extractChangeSubstring(json, change.tag),
+  ): void {
     const watermark = this.#requireWatermark();
     const {tag} = change;
-    const stored = extractChangeSubstring(json, tag);
+    const stored = storedChange;
     const estimatedBytes = estimateChangeLogStreamRowBytes(
       watermark,
       tag,
       stored,
     );
     this.#insertChange.run(watermark, ++this.#pos, tag, estimatedBytes, stored);
-    this.#requireHasher().add({
+    this.#hasher?.add({
       watermark,
       pos: this.#pos,
       tag,
@@ -154,13 +166,14 @@ export class ChangeLogStreamWriter {
     watermark: string,
     json: string,
     writeTimeMs: number,
+    storedChange = extractChangeSubstring(json, 'commit'),
   ): ChangeLogStreamTransactionStats {
     const precommit = this.#requireWatermark();
     assertInvariant(
       watermark === precommit,
       `change-log stream commit ${watermark} does not match begin ${precommit}`,
     );
-    const change = extractChangeSubstring(json, 'commit');
+    const change = storedChange;
     const estimatedBytes = estimateChangeLogStreamRowBytes(
       watermark,
       'commit',
@@ -176,8 +189,8 @@ export class ChangeLogStreamWriter {
       precommit,
       writeTimeMs,
     );
-    const hasher = this.#requireHasher();
-    hasher.add({
+    const hasher = this.#hasher;
+    hasher?.add({
       watermark,
       pos: this.#pos,
       tag: 'commit',
@@ -187,7 +200,7 @@ export class ChangeLogStreamWriter {
     const stats = {
       rows: this.#pos + 1,
       estimatedBytes: this.#estimatedBytes + estimatedBytes,
-      hash: hasher.digest(),
+      hash: hasher?.digest(),
       cookieMutations: this.#cookieMutations,
     };
     // The log is durable at `watermark` from here on, and nothing that can
@@ -228,13 +241,5 @@ export class ChangeLogStreamWriter {
       'change-log stream message received outside of a transaction',
     );
     return this.#watermark;
-  }
-
-  #requireHasher(): ChangeLogTransactionHasher {
-    assertInvariant(
-      this.#hasher !== undefined,
-      'change-log stream hash received outside of a transaction',
-    );
-    return this.#hasher;
   }
 }

--- a/packages/zero-cache/src/services/replicator/incremental-sync.test.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.test.ts
@@ -9,10 +9,7 @@ import {
   vi,
   type MockedFunction,
 } from 'vitest';
-import {
-  BigIntJSON,
-  type JSONObject,
-} from '../../../../shared/src/bigint-json.ts';
+import type {JSONObject} from '../../../../shared/src/bigint-json.ts';
 import type {Enum} from '../../../../shared/src/enum.ts';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
 import type {ZeroEvent} from '../../../../zero-events/src/index.ts';
@@ -26,7 +23,7 @@ import {orTimeoutWith} from '../../types/timeout.ts';
 import {
   PROTOCOL_VERSION,
   type Downstream,
-  type SerializedDownstream,
+  type SizedDownstream,
   type SubscriberContext,
 } from '../change-streamer/change-streamer.ts';
 import * as ErrorType from '../change-streamer/error-type-enum.ts';
@@ -54,10 +51,10 @@ describe('replicator/incremental-sync', () => {
   let worker: ThreadWriteWorkerClient;
   let syncer: IncrementalSyncer;
   let syncing: Promise<void> | undefined;
-  let downstream: Subscription<SerializedDownstream, Downstream>;
+  let downstream: Subscription<SizedDownstream, Downstream>;
   let eventSink: ZeroEvent[];
   let subscribeFn: MockedFunction<
-    (ctx: SubscriberContext) => Promise<Source<SerializedDownstream>>
+    (ctx: SubscriberContext) => Promise<Source<SizedDownstream>>
   >;
 
   beforeEach(async () => {
@@ -67,10 +64,7 @@ describe('replicator/incremental-sync', () => {
     mainDb.pragma('journal_mode = wal');
     createReplicationStateTables(mainDb);
 
-    downstream = new Subscription({}, data => ({
-      data,
-      json: BigIntJSON.stringify(data),
-    }));
+    downstream = new Subscription({}, data => ({data, size: 1}));
     eventSink = [];
     initEventSinkForTesting(
       eventSink,
@@ -132,7 +126,7 @@ describe('replicator/incremental-sync', () => {
     // making the write async would break both callers here.
     const replica = new StatementRunner(mainDb);
     const acked: {watermark: string; stateVersion: string}[] = [];
-    downstream = new Subscription<SerializedDownstream, Downstream>(
+    downstream = new Subscription<SizedDownstream, Downstream>(
       {
         consumed: message => {
           if (message[0] === 'commit') {
@@ -143,7 +137,7 @@ describe('replicator/incremental-sync', () => {
           }
         },
       },
-      data => ({data, json: BigIntJSON.stringify(data)}),
+      data => ({data, size: 1}),
     );
     subscribeFn.mockResolvedValue(downstream);
 
@@ -179,7 +173,7 @@ describe('replicator/incremental-sync', () => {
 
   test('replicates transactions', async () => {
     const issues = new ReplicationMessages({issues: ['issueID', 'bool']});
-    const processMessage = vi.spyOn(worker, 'processMessage');
+    const processMessages = vi.spyOn(worker, 'processMessages');
 
     initReplicationState(mainDb, ['zero_data'], '02', {}, false);
 
@@ -471,10 +465,14 @@ describe('replicator/incremental-sync', () => {
         },
       ]
     `);
-    expect(processMessage).toHaveBeenCalledTimes(11);
-    // The parsed change, and nothing else: the canonical JSON went to the write
-    // worker only for the change log, which the change-streamer now writes.
-    expect(processMessage).toHaveBeenNthCalledWith(1, firstBegin);
+    expect(processMessages).toHaveBeenCalledTimes(3);
+    expect(processMessages.mock.calls.flatMap(([batch]) => batch)).toHaveLength(
+      11,
+    );
+    expect(processMessages).toHaveBeenNthCalledWith(
+      1,
+      expect.arrayContaining([firstBegin]),
+    );
   });
 
   test('replicates schema changes', async () => {
@@ -904,7 +902,7 @@ describe('replicator/incremental-sync', () => {
 
   test('shut down on change-streamer error message', async () => {
     initReplicationState(mainDb, ['zero_data'], '02', {}, false);
-    const processMessage = vi.spyOn(worker, 'processMessage');
+    const processMessages = vi.spyOn(worker, 'processMessages');
 
     const syncing = syncer.run();
 
@@ -915,6 +913,6 @@ describe('replicator/incremental-sync', () => {
 
     // Should stop / resolve
     await syncing;
-    expect(processMessage).not.toHaveBeenCalled();
+    expect(processMessages).not.toHaveBeenCalled();
   });
 });

--- a/packages/zero-cache/src/services/replicator/incremental-sync.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.ts
@@ -9,7 +9,7 @@ import {
   errorTypeToReadableName,
   PROTOCOL_VERSION,
   type ChangeStreamer,
-  type SerializedDownstream,
+  type SizedDownstream,
 } from '../change-streamer/change-streamer.ts';
 import type * as ErrorType from '../change-streamer/error-type-enum.ts';
 import {RunningState} from '../running-state.ts';
@@ -22,6 +22,9 @@ import type {ReplicationReport} from './reporter/report-schema.ts';
 import type {WriteWorkerClient} from './write-worker-client.ts';
 
 type ErrorType = Enum<typeof ErrorType>;
+
+const MAX_WORKER_BATCH_MESSAGES = 256;
+const MAX_WORKER_BATCH_SIZE = 1024 * 1024;
 
 /**
  * The {@link IncrementalSyncer} manages a logical replication stream from upstream,
@@ -92,7 +95,7 @@ export class IncrementalSyncer {
       const {replicaVersion, watermark} =
         await this.#worker.getSubscriptionState();
 
-      let downstream: Source<SerializedDownstream> | undefined;
+      let downstream: Source<SizedDownstream> | undefined;
       let unregister = () => {};
       let err: unknown | undefined;
 
@@ -120,8 +123,26 @@ export class IncrementalSyncer {
         );
 
         let backfillStatus: DownloadStatus | undefined;
+        let writeBatch: ChangeStreamData[] = [];
+        let writeBatchSize = 0;
+        let inTransaction = false;
 
-        for await (const {data: message} of downstream) {
+        const flushWrites = async () => {
+          if (writeBatch.length === 0) {
+            return;
+          }
+          const batch = writeBatch;
+          writeBatch = [];
+          writeBatchSize = 0;
+
+          const result = await this.#worker.processMessages(batch);
+          this.#handleResult(lc, result);
+          if (result?.completedBackfill) {
+            backfillStatus = undefined;
+          }
+        };
+
+        for await (const {data: message, size} of downstream) {
           this.#replicationEvents.add(1);
           switch (message[0]) {
             case 'status': {
@@ -185,12 +206,29 @@ export class IncrementalSyncer {
                 backfillStatus = status; // Update the current status
               }
 
-              const data = message as ChangeStreamData;
-              const result = await this.#worker.processMessage(data);
+              const type = message[0];
+              const invalidTransactionSequence =
+                type === 'begin' ? inTransaction : !inTransaction;
+              if (type === 'begin') {
+                inTransaction = true;
+              } else if (type === 'commit' || type === 'rollback') {
+                inTransaction = false;
+              }
 
-              this.#handleResult(lc, result);
-              if (result?.completedBackfill) {
-                backfillStatus = undefined;
+              writeBatch.push(message as ChangeStreamData);
+              writeBatchSize += size;
+              if (
+                // Waiting here ensures that consuming the commit, which ACKs
+                // it upstream, only happens after the SQLite commit finishes.
+                type === 'commit' ||
+                type === 'rollback' ||
+                // Promptly surface malformed transaction sequences instead
+                // of leaving a partial batch waiting for another message.
+                invalidTransactionSequence ||
+                writeBatch.length >= MAX_WORKER_BATCH_MESSAGES ||
+                writeBatchSize >= MAX_WORKER_BATCH_SIZE
+              ) {
+                await flushWrites();
               }
               break;
             }

--- a/packages/zero-cache/src/services/replicator/replication-resumption-child.ts
+++ b/packages/zero-cache/src/services/replicator/replication-resumption-child.ts
@@ -9,7 +9,7 @@ import {getPragmaConfig, setupReplica} from '../../workers/replicator.ts';
 import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
 import type {
   ChangeStreamer,
-  SerializedDownstream,
+  SizedDownstream,
   SubscriberContext,
 } from '../change-streamer/change-streamer.ts';
 import {exitAfter, runUntilKilled} from '../life-cycle.ts';
@@ -24,10 +24,7 @@ import {
 type ChildFailpoint = 'none' | 'after-sqlite-commit-before-ack';
 
 type ParentMessage =
-  | [
-      'replication-resumption:downstream',
-      {seq: number; msg: SerializedDownstream},
-    ]
+  | ['replication-resumption:downstream', {seq: number; msg: SizedDownstream}]
   | ['replication-resumption:source-error', {message: string}]
   | ['replication-resumption:source-end', Record<string, never>];
 
@@ -67,17 +64,17 @@ class IPCChangeStreamer implements ChangeStreamer {
     this.#parent = parent;
   }
 
-  subscribe(ctx: SubscriberContext): Promise<Source<SerializedDownstream>> {
+  subscribe(ctx: SubscriberContext): Promise<Source<SizedDownstream>> {
     send(this.#parent, ['replication-resumption:subscribe', ctx]);
     return Promise.resolve(new IPCDownstreamSource(this.#parent));
   }
 }
 
 type QueueEntry =
-  | {type: 'message'; seq: number; msg: SerializedDownstream}
+  | {type: 'message'; seq: number; msg: SizedDownstream}
   | {type: 'end'};
 
-export class IPCDownstreamSource implements Source<SerializedDownstream> {
+export class IPCDownstreamSource implements Source<SizedDownstream> {
   readonly #parent: Worker;
   readonly #queue = new Queue<QueueEntry>();
   readonly #abortController = new AbortController();
@@ -127,7 +124,7 @@ export class IPCDownstreamSource implements Source<SerializedDownstream> {
     return this.#abortController.signal;
   }
 
-  [Symbol.asyncIterator](): AsyncIterator<SerializedDownstream> {
+  [Symbol.asyncIterator](): AsyncIterator<SizedDownstream> {
     let previousSeq: number | undefined;
     return {
       next: async () => {
@@ -190,10 +187,10 @@ class FailpointWriteWorkerClient implements WriteWorkerClient {
     return this.#inner.getSubscriptionState();
   }
 
-  async processMessage(
-    downstream: ChangeStreamData,
+  async processMessages(
+    downstream: readonly ChangeStreamData[],
   ): Promise<CommitResult | null> {
-    const result = await this.#inner.processMessage(downstream);
+    const result = await this.#inner.processMessages(downstream);
     if (
       result?.watermark &&
       this.#failpoint === 'after-sqlite-commit-before-ack' &&

--- a/packages/zero-cache/src/services/replicator/replication-resumption.pg.test.ts
+++ b/packages/zero-cache/src/services/replicator/replication-resumption.pg.test.ts
@@ -51,6 +51,7 @@ const shard = {
 };
 
 const streamerOptions: TuningOptions = {
+  pgChangeLogEnabled: true,
   backPressureLimitHeapProportion: 0.04,
   flowControlConsensusTimeoutProportion: 2,
   statementTimeoutMs: 20_000,

--- a/packages/zero-cache/src/services/replicator/replication-resumption.pg.test.ts
+++ b/packages/zero-cache/src/services/replicator/replication-resumption.pg.test.ts
@@ -29,7 +29,7 @@ import {
   type ChangeStreamer,
   type ChangeStreamerService,
   type Downstream,
-  type SerializedDownstream,
+  type SizedDownstream,
 } from '../change-streamer/change-streamer.ts';
 import {initChangeStreamerSchema} from '../change-streamer/schema/init.ts';
 import {ReplicationStatusPublisher} from './replication-status.ts';
@@ -144,10 +144,7 @@ type ParentMessage =
     ];
 
 type ChildMessage =
-  | [
-      'replication-resumption:downstream',
-      {seq: number; msg: SerializedDownstream},
-    ]
+  | ['replication-resumption:downstream', {seq: number; msg: SizedDownstream}]
   | ['replication-resumption:source-error', {message: string}]
   | ['replication-resumption:source-end', Record<string, never>];
 
@@ -284,7 +281,10 @@ class ForkedReplicator {
           'replication-resumption:downstream',
           {
             seq,
-            msg: {data: BigIntJSON.parse(value) as Downstream, json: value},
+            msg: {
+              data: BigIntJSON.parse(value) as Downstream,
+              size: value.length,
+            },
           },
         ]);
         await this.#waitForConsumed(bridge, seq);

--- a/packages/zero-cache/src/services/replicator/replication-throughput.bench.pg.ts
+++ b/packages/zero-cache/src/services/replicator/replication-throughput.bench.pg.ts
@@ -59,6 +59,7 @@ const shard = {
 };
 const benchmarkRecorder = createManualBenchmarkRecorder();
 const streamerOptions = {
+  pgChangeLogEnabled: true,
   backPressureLimitHeapProportion: 0.04,
   flowControlConsensusTimeoutProportion: 2,
   statementTimeoutMs: 60_000,

--- a/packages/zero-cache/src/services/replicator/replication-throughput.bench.pg.ts
+++ b/packages/zero-cache/src/services/replicator/replication-throughput.bench.pg.ts
@@ -1,9 +1,10 @@
 // Benchmarks end-to-end logical replication throughput from upstream Postgres
 // writes through the change-streamer and into the SQLite replica.
 //
-// The change log is written by the change-streamer rather than by this write
-// path, so there is no writer axis here any more: this measures the replicator's
-// baseline, which is what slice 7I returned it to.
+// The change log is written by the change-streamer rather than by the
+// replicator. The three modes below measure the complete PG-to-RM path with the
+// legacy PG log, both logs, and only the SQLite log. No view-syncer subscribes,
+// so its backpressure cannot hide the change-streamer's throughput ceiling.
 //
 //   pnpm --filter zero-cache run bench:pg replication-throughput
 
@@ -12,6 +13,7 @@ import {createManualBenchmarkRecorder} from '../../../../shared/src/bench.ts';
 import {BigIntJSON} from '../../../../shared/src/bigint-json.ts';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
 import {sleep} from '../../../../shared/src/sleep.ts';
+import {Database} from '../../../../zqlite/src/db.ts';
 import {getConnectionURI, type PgTest, test} from '../../test/db.ts';
 import {DbFile} from '../../test/lite.ts';
 import {
@@ -27,7 +29,10 @@ import type {PostgresDB} from '../../types/pg.ts';
 import type {Source} from '../../types/streams.ts';
 import {getPragmaConfig, setupReplica} from '../../workers/replicator.ts';
 import {initializePostgresChangeSource} from '../change-source/pg/change-source.ts';
-import {initializeStreamer} from '../change-streamer/change-streamer-service.ts';
+import {
+  initializeStreamer,
+  type TuningOptions,
+} from '../change-streamer/change-streamer-service.ts';
 import {
   type ChangeStreamer,
   type ChangeStreamerService,
@@ -35,13 +40,11 @@ import {
   type SerializedDownstream,
 } from '../change-streamer/change-streamer.ts';
 import {initChangeStreamerSchema} from '../change-streamer/schema/init.ts';
+import {changeLogFileName, deleteChangeLogDB} from './change-log-db.ts';
 import {ReplicationStatusPublisher} from './replication-status.ts';
 import {ReplicatorService} from './replicator.ts';
 import {ThreadWriteWorkerClient} from './write-worker-client.ts';
 
-const WARMUP_ROWS = 25_000;
-const MEASURED_ROWS = 100_000;
-const ROWS_PER_TRANSACTION = 500;
 const CHANGE_LOG_BATCH_SIZE = 2000;
 const MEASURED_WARMUP_REPS = 1;
 const REPS = 10;
@@ -58,13 +61,41 @@ const shard = {
   publications: [BENCHMARK_FIXTURE_PUBLICATION],
 };
 const benchmarkRecorder = createManualBenchmarkRecorder();
-const streamerOptions = {
-  pgChangeLogEnabled: true,
+const baseStreamerOptions = {
   backPressureLimitHeapProportion: 0.04,
   flowControlConsensusTimeoutProportion: 2,
   statementTimeoutMs: 60_000,
   changeLogBatchSize: CHANGE_LOG_BATCH_SIZE,
-};
+} satisfies Omit<TuningOptions, 'pgChangeLogEnabled'>;
+
+const changeLogModes = [
+  {name: 'pg-only', pgChangeLogEnabled: true, sqliteChangeLogEnabled: false},
+  {name: 'dual', pgChangeLogEnabled: true, sqliteChangeLogEnabled: true},
+  {
+    name: 'sqlite-only',
+    pgChangeLogEnabled: false,
+    sqliteChangeLogEnabled: true,
+  },
+] as const;
+
+type ChangeLogMode = (typeof changeLogModes)[number];
+
+const workloads = [
+  {
+    name: 'single-row-transactions',
+    warmupRows: 2_500,
+    measuredRows: 5_000,
+    rowsPerTransaction: 1,
+  },
+  {
+    name: '500-row-transactions',
+    warmupRows: 25_000,
+    measuredRows: 100_000,
+    rowsPerTransaction: 500,
+  },
+] as const;
+
+type Workload = (typeof workloads)[number];
 
 let cleanup: (() => Promise<void>)[] = [];
 
@@ -122,15 +153,63 @@ async function waitForReplicaRows(replicaPath: string, expected: number) {
   );
 }
 
-async function startReplicationPipeline(testDBs: PgTest['testDBs']) {
-  const upstream = await testDBs.create('logical_replication_bench_upstream');
-  const changeDB = await testDBs.create('logical_replication_bench_change', {
-    typeOpts: {sendStringAsJson: true},
-  });
-  const replicaDbFile = new DbFile('logical-replication-throughput-bench');
+async function waitForPGChangeLog(
+  changeDB: PostgresDB,
+  targetWatermark: string,
+): Promise<void> {
+  const deadline = performance.now() + TEST_TIMEOUT_MS;
+  let lastWatermark = '';
+  while (performance.now() < deadline) {
+    [{lastWatermark}] = await changeDB<{lastWatermark: string}[]> /*sql*/ `
+      SELECT "lastWatermark"
+        FROM ${changeDB(`${shard.appID}_${shard.shardNum}/cdc`)}."replicationState"`;
+    if (lastWatermark >= targetWatermark) {
+      return;
+    }
+    await sleep(50);
+  }
+  throw new Error(
+    `timed out waiting for PG change log: expected ${targetWatermark}, got ${lastWatermark}`,
+  );
+}
+
+async function waitForReplication(
+  replicaPath: string,
+  expectedRows: number,
+  changeDB: PostgresDB,
+  mode: ChangeLogMode,
+): Promise<number> {
+  const actualRows = await waitForReplicaRows(replicaPath, expectedRows);
+  if (mode.pgChangeLogEnabled) {
+    using replica = new Database(lc, replicaPath, {readonly: true});
+    const {stateVersion} = replica
+      .prepare(`SELECT "stateVersion" FROM "_zero.replicationState"`)
+      .get<{stateVersion: string}>();
+    await waitForPGChangeLog(changeDB, stateVersion);
+  }
+  return actualRows;
+}
+
+async function startReplicationPipeline(
+  testDBs: PgTest['testDBs'],
+  mode: ChangeLogMode,
+) {
+  const upstream = await testDBs.create(
+    `logical_replication_bench_upstream_${mode.name}`,
+  );
+  const changeDB = await testDBs.create(
+    `logical_replication_bench_change_${mode.name}`,
+    {typeOpts: {sendStringAsJson: true}},
+  );
+  const replicaDbFile = new DbFile(
+    `logical-replication-throughput-bench-${mode.name}`,
+  );
 
   // oxlint-disable require-await
-  cleanup.push(async () => replicaDbFile.delete());
+  cleanup.push(async () => {
+    deleteChangeLogDB(replicaDbFile.path);
+    replicaDbFile.delete();
+  });
   cleanup.push(async () => {
     await testDBs.drop(upstream, changeDB);
   });
@@ -139,7 +218,7 @@ async function startReplicationPipeline(testDBs: PgTest['testDBs']) {
     publication: BENCHMARK_FIXTURE_PUBLICATION,
   });
   const upstreamURI = getConnectionURI(upstream);
-  const {subscriptionState, changeSource} =
+  const {subscriptionState, changeSource, replicaID} =
     await initializePostgresChangeSource(
       lc,
       upstreamURI,
@@ -151,6 +230,29 @@ async function startReplicationPipeline(testDBs: PgTest['testDBs']) {
 
   await setupReplica(lc, 'serving', {file: replicaDbFile.path});
   await initChangeStreamerSchema(lc, changeDB, shard);
+  const sqliteOptions = mode.sqliteChangeLogEnabled
+    ? {
+        sqliteChangeLogWriter: {
+          replicaFile: replicaDbFile.path,
+          identity: {
+            epoch: null,
+            generation: subscriptionState.replicaVersion,
+            replicaID,
+          },
+        },
+        sqliteChangeLogPurge: {retentionMs: 60_000, batchRows: 1_000},
+        sqliteCatchup: {
+          changeLogFile: changeLogFileName(replicaDbFile.path),
+          readBatchRows: 1_000,
+          barrierTimeoutMs: 300_000,
+        },
+        sqliteChangeLogServe: {
+          readPercent: 100,
+          coldReadPercent: 100,
+          retentionMs: 60_000,
+        },
+      }
+    : {};
   const changeStreamer = await initializeStreamer(
     lc,
     shard,
@@ -163,10 +265,17 @@ async function startReplicationPipeline(testDBs: PgTest['testDBs']) {
       Promise.resolve(),
     ),
     subscriptionState,
-    null,
+    // This satisfies the SQLite-only production guard and gives every mode
+    // the same ACK policy. The benchmark deliberately does not report backup
+    // watermarks: it isolates PG-to-RM replication from Litestream and purge.
+    {backupURL: 's3://logical-replication-bench', litestreamVersion: 'v5'},
     null,
     true,
-    streamerOptions,
+    {
+      ...baseStreamerOptions,
+      pgChangeLogEnabled: mode.pgChangeLogEnabled,
+      ...sqliteOptions,
+    },
   );
   const streamerDone = changeStreamer.run();
   cleanup.push(async () => {
@@ -195,79 +304,122 @@ async function startReplicationPipeline(testDBs: PgTest['testDBs']) {
     await replicatorDone;
   });
 
-  return {upstream, replicaPath: replicaDbFile.path};
+  return {upstream, changeDB, replicaPath: replicaDbFile.path};
 }
 
-describe('replicator/logical replication throughput', () => {
-  test(
-    'end-to-end payload MB/sec',
-    {timeout: TEST_TIMEOUT_MS},
-    async ({testDBs}: PgTest) => {
-      const {upstream, replicaPath} = await startReplicationPipeline(testDBs);
-      const samples: {elapsedMs: number; operations: number}[] = [];
+describe.each(changeLogModes)(
+  'replicator/logical replication throughput ($name)',
+  mode => {
+    describe.each(workloads)('$name', workload => {
+      test(
+        'end-to-end throughput',
+        {timeout: TEST_TIMEOUT_MS},
+        async ({testDBs}: PgTest) => {
+          const {upstream, changeDB, replicaPath} =
+            await startReplicationPipeline(testDBs, mode);
+          const samples: {elapsedMs: number; operations: number}[] = [];
 
-      expect(replicaRowCount(replicaPath)).toBe(0);
+          expect(replicaRowCount(replicaPath)).toBe(0);
 
-      await insertBenchmarkFixtureRows(
-        upstream,
-        1,
-        WARMUP_ROWS,
-        ROWS_PER_TRANSACTION,
+          await insertBenchmarkFixtureRows(
+            upstream,
+            1,
+            workload.warmupRows,
+            workload.rowsPerTransaction,
+          );
+          expect(
+            await waitForReplication(
+              replicaPath,
+              workload.warmupRows,
+              changeDB,
+              mode,
+            ),
+          ).toBe(workload.warmupRows);
+
+          for (
+            let warmupRep = 0;
+            warmupRep < MEASURED_WARMUP_REPS;
+            warmupRep++
+          ) {
+            const startID =
+              workload.warmupRows + warmupRep * workload.measuredRows + 1;
+            const expectedRows =
+              workload.warmupRows + (warmupRep + 1) * workload.measuredRows;
+            await insertPrecomputedFixtureRows(upstream, startID, workload);
+            expect(
+              await waitForReplication(
+                replicaPath,
+                expectedRows,
+                changeDB,
+                mode,
+              ),
+            ).toBe(expectedRows);
+          }
+
+          for (let rep = 0; rep < REPS; rep++) {
+            const startID =
+              workload.warmupRows +
+              (MEASURED_WARMUP_REPS + rep) * workload.measuredRows +
+              1;
+            const expectedRows =
+              workload.warmupRows +
+              (MEASURED_WARMUP_REPS + rep + 1) * workload.measuredRows;
+
+            const batches = makeBenchmarkFixtureRowBatches(
+              startID,
+              workload.measuredRows,
+              workload.rowsPerTransaction,
+            );
+            const start = performance.now();
+            await insertBenchmarkFixtureRowBatches(upstream, batches);
+            expect(
+              await waitForReplication(
+                replicaPath,
+                expectedRows,
+                changeDB,
+                mode,
+              ),
+            ).toBe(expectedRows);
+            samples.push({
+              elapsedMs: performance.now() - start,
+              operations: benchmarkFixturePayloadMB(
+                startID,
+                workload.measuredRows,
+              ),
+            });
+          }
+
+          const dimensions =
+            `changeLog=${mode.name} ` +
+            `rowsPerTransaction=${workload.rowsPerTransaction}`;
+          benchmarkRecorder.recordThroughputSamples(
+            `replicator/logical replication end-to-end payload MB ` +
+              dimensions,
+            samples,
+          );
+          benchmarkRecorder.recordThroughputSamples(
+            `replicator/logical replication end-to-end transactions ` +
+              dimensions,
+            samples.map(({elapsedMs}) => ({
+              elapsedMs,
+              operations: workload.measuredRows / workload.rowsPerTransaction,
+            })),
+          );
+        },
       );
-      expect(await waitForReplicaRows(replicaPath, WARMUP_ROWS)).toBe(
-        WARMUP_ROWS,
-      );
-
-      for (let warmupRep = 0; warmupRep < MEASURED_WARMUP_REPS; warmupRep++) {
-        const startID = WARMUP_ROWS + warmupRep * MEASURED_ROWS + 1;
-        const expectedRows = WARMUP_ROWS + (warmupRep + 1) * MEASURED_ROWS;
-        await insertPrecomputedFixtureRows(upstream, startID, MEASURED_ROWS);
-        expect(await waitForReplicaRows(replicaPath, expectedRows)).toBe(
-          expectedRows,
-        );
-      }
-
-      for (let rep = 0; rep < REPS; rep++) {
-        const startID =
-          WARMUP_ROWS + (MEASURED_WARMUP_REPS + rep) * MEASURED_ROWS + 1;
-        const expectedRows =
-          WARMUP_ROWS + (MEASURED_WARMUP_REPS + rep + 1) * MEASURED_ROWS;
-
-        const batches = makeBenchmarkFixtureRowBatches(
-          startID,
-          MEASURED_ROWS,
-          ROWS_PER_TRANSACTION,
-        );
-        const start = performance.now();
-        await insertBenchmarkFixtureRowBatches(upstream, batches);
-        expect(await waitForReplicaRows(replicaPath, expectedRows)).toBe(
-          expectedRows,
-        );
-        samples.push({
-          elapsedMs: performance.now() - start,
-          operations: benchmarkFixturePayloadMB(startID, MEASURED_ROWS),
-        });
-      }
-
-      // The change-log writer is no longer on this path: it lives in the
-      // change-streamer, so this is the write path's baseline again.
-      benchmarkRecorder.recordThroughputSamples(
-        'replicator/logical replication end-to-end payload MB',
-        samples,
-      );
-    },
-  );
-});
+    });
+  },
+);
 
 async function insertPrecomputedFixtureRows(
   upstream: PostgresDB,
   startID: number,
-  count: number,
+  workload: Workload,
 ) {
   const batches = makeBenchmarkFixtureRowBatches(
     startID,
-    count,
-    ROWS_PER_TRANSACTION,
+    workload.measuredRows,
+    workload.rowsPerTransaction,
   );
   await insertBenchmarkFixtureRowBatches(upstream, batches);
 }

--- a/packages/zero-cache/src/services/replicator/replication-throughput.bench.pg.ts
+++ b/packages/zero-cache/src/services/replicator/replication-throughput.bench.pg.ts
@@ -37,7 +37,7 @@ import {
   type ChangeStreamer,
   type ChangeStreamerService,
   type Downstream,
-  type SerializedDownstream,
+  type SizedDownstream,
 } from '../change-streamer/change-streamer.ts';
 import {initChangeStreamerSchema} from '../change-streamer/schema/init.ts';
 import {changeLogFileName, deleteChangeLogDB} from './change-log-db.ts';
@@ -112,13 +112,13 @@ afterEach(async () => {
 
 function parseStringifiedSource(
   source: Source<string>,
-): Source<SerializedDownstream> {
+): Source<SizedDownstream> {
   return {
     cancel: err => source.cancel(err),
     signal: source.signal,
     async *[Symbol.asyncIterator]() {
       for await (const json of source) {
-        yield {data: BigIntJSON.parse(json) as Downstream, json};
+        yield {data: BigIntJSON.parse(json) as Downstream, size: json.length};
       }
     },
   };

--- a/packages/zero-cache/src/services/replicator/replicator.ts
+++ b/packages/zero-cache/src/services/replicator/replicator.ts
@@ -141,7 +141,7 @@ export class ReplicatorService implements Replicator, Service {
   async stop() {
     this.#incrementalSyncer.stop(this.#lc);
     // Wait for the syncer's run loop to finish so that any in-flight
-    // worker.processMessage() call completes and clears #pending
+    // worker.processMessages() call completes and clears #pending
     // before we send the 'stop' message to the worker.
     await this.#runPromise;
     await this.#worker.stop();

--- a/packages/zero-cache/src/services/replicator/sqlite-change-log-observability.ts
+++ b/packages/zero-cache/src/services/replicator/sqlite-change-log-observability.ts
@@ -240,12 +240,12 @@ export class SQLiteChangeLogObserver {
   readonly #messageProcessing = getOrCreateLatencyHistogram(
     'replica',
     'sqlite_change_log.message_processing_duration',
-    'Time to write a replication message to the SQLite change log.',
+    'Sampled time to write a replication message to the SQLite change log.',
   );
   // The commit that sits on the forward path. There is no second commit to
   // order against any more: the replica's belongs to a subscriber downstream of
   // this loop, so `sqlite_change_log.replica_commit_duration` and the phantom
-  // window it measured are gone. A failed commit is still timed, by
+  // window it measured are gone. Sampled failed commits are still timed by
   // `message_processing_duration` keyed `tag="commit"`.
   readonly #logCommitDuration = getOrCreateLatencyHistogram(
     'replica',
@@ -276,7 +276,7 @@ export class SQLiteChangeLogObserver {
   readonly #hashComparisonCounter = getOrCreateCounter(
     'replica',
     'sqlite_change_log.hash_comparisons',
-    'Ephemeral transaction hash comparisons between the received change stream and SQLite change-log writes.',
+    'Sampled ephemeral transaction hash comparisons between the received change stream and SQLite change-log writes.',
   );
   readonly #hashUnpairedCounter = getOrCreateCounter(
     'replica',
@@ -361,11 +361,16 @@ export class SQLiteChangeLogObserver {
   }
 
   /**
-   * Called as each message arrives, before it is written. Hashes the *received*
-   * stream, which is compared against the hash the writer computes over what it
-   * *stored*.
+   * Called as each message arrives, before it is written. For a sampled
+   * transaction, hashes the *received* stream and compares it with the hash the
+   * writer computes over what it *stored*.
    */
-  messageReceived(data: ChangeStreamData, json: string): void {
+  messageReceived(
+    data: ChangeStreamData,
+    json: string,
+    validateHash = true,
+    storedChange = extractChangeSubstring(json, data[1].tag),
+  ): void {
     const tag = data[1].tag;
     if (data[0] === 'begin') {
       if (this.#sourceHasher !== undefined) {
@@ -375,14 +380,16 @@ export class SQLiteChangeLogObserver {
         );
       }
       const watermark = data[2].commitWatermark;
-      this.#sourceHasher = new ChangeLogTransactionHasher();
+      this.#sourceHasher = validateHash
+        ? new ChangeLogTransactionHasher()
+        : undefined;
       this.#sourcePos = 0;
       this.#sourceCommitHash = undefined;
-      this.#sourceHasher.add({
+      this.#sourceHasher?.add({
         watermark,
         pos: this.#sourcePos,
         tag,
-        change: extractChangeSubstring(json, tag),
+        change: storedChange,
         precommit: null,
       });
       return;
@@ -395,6 +402,10 @@ export class SQLiteChangeLogObserver {
 
     if (data[0] === 'commit') {
       this.#receivedHead = data[2].watermark;
+    }
+
+    if (!validateHash) {
+      return;
     }
 
     const watermark = this.#transactionWatermark;
@@ -412,7 +423,7 @@ export class SQLiteChangeLogObserver {
       watermark: commitWatermark,
       pos: ++this.#sourcePos,
       tag,
-      change: extractChangeSubstring(json, tag),
+      change: storedChange,
       precommit: data[0] === 'commit' ? watermark : null,
     });
     if (data[0] === 'commit') {
@@ -425,10 +436,12 @@ export class SQLiteChangeLogObserver {
   messageProcessed(
     data: ChangeStreamData,
     commit: ChangeLogCommit | null,
-    durationMs: number,
+    durationMs: number | undefined,
   ): void {
     const tag = data[1].tag;
-    this.#messageProcessing.recordMs(durationMs, {tag, outcome: 'success'});
+    if (durationMs !== undefined) {
+      this.#messageProcessing.recordMs(durationMs, {tag, outcome: 'success'});
+    }
 
     if (data[0] === 'begin') {
       if (this.#transactionWatermark !== undefined) {
@@ -478,7 +491,16 @@ export class SQLiteChangeLogObserver {
       this.#rows += commit.stats.rows;
       this.#estimatedBytes += commit.stats.estimatedBytes;
       this.#transactionRows.record(commit.stats.rows);
-      this.#compareHashes(watermark, this.#sourceCommitHash, commit.stats.hash);
+      if (
+        this.#sourceCommitHash !== undefined ||
+        commit.stats.hash !== undefined
+      ) {
+        this.#compareHashes(
+          watermark,
+          this.#sourceCommitHash,
+          commit.stats.hash,
+        );
+      }
     }
     if (watermark < this.#sqliteHead) {
       this.#invariantFailure('SQLite change-log head regressed', {
@@ -494,11 +516,13 @@ export class SQLiteChangeLogObserver {
   messageFailed(
     data: ChangeStreamData,
     error: unknown,
-    durationMs: number,
+    durationMs: number | undefined,
   ): void {
     const tag = data[1].tag;
-    this.#messageProcessing.recordMs(durationMs, {tag, outcome: 'error'});
-    if (data[0] === 'commit') {
+    if (durationMs !== undefined) {
+      this.#messageProcessing.recordMs(durationMs, {tag, outcome: 'error'});
+    }
+    if (data[0] === 'commit' && this.#sourceCommitHash !== undefined) {
       // No commit duration here: a failed commit produces no statistics, so
       // there is nothing to attribute. The attempt is timed by
       // `message_processing_duration{tag="commit",outcome="error"}` above.
@@ -593,10 +617,14 @@ export class SQLiteChangeLogObserver {
   #compareHashes(
     watermark: string,
     sourceHash: string | undefined,
-    sqliteHash: string,
+    sqliteHash: string | undefined,
   ): void {
     if (sourceHash === undefined) {
       this.#recordUnpaired(watermark, 'missing-source-hash');
+      return;
+    }
+    if (sqliteHash === undefined) {
+      this.#recordUnpaired(watermark, 'missing-sqlite-hash');
       return;
     }
     if (sourceHash === sqliteHash) {

--- a/packages/zero-cache/src/services/replicator/write-worker-client.ts
+++ b/packages/zero-cache/src/services/replicator/write-worker-client.ts
@@ -21,7 +21,9 @@ type ErrorHandler = (err: Error) => void;
  */
 export interface WriteWorkerClient {
   getSubscriptionState(): Promise<SubscriptionState>;
-  processMessage(downstream: ChangeStreamData): Promise<CommitResult | null>;
+  processMessages(
+    downstream: readonly ChangeStreamData[],
+  ): Promise<CommitResult | null>;
   abort(): void;
   stop(): Promise<void>;
   onError(handler: ErrorHandler): void;
@@ -89,7 +91,7 @@ export function deserializeError(serialized: SerializedError): Error {
 export type ArgsMap = {
   init: [string, ChangeProcessorMode, PragmaConfig, LogConfig];
   getSubscriptionState: [];
-  processMessage: [ChangeStreamData];
+  processMessages: [readonly ChangeStreamData[]];
   abort: [];
   stop: [];
 };
@@ -101,7 +103,7 @@ export type Request<M extends Method = Method> = {method: M; args: ArgsMap[M]};
 export type ResultMap = {
   init: void;
   getSubscriptionState: SubscriptionState;
-  processMessage: CommitResult | null;
+  processMessages: CommitResult | null;
   abort: void;
   stop: void;
 };
@@ -194,8 +196,10 @@ export class ThreadWriteWorkerClient implements WriteWorkerClient {
     return this.#call('getSubscriptionState', []);
   }
 
-  processMessage(downstream: ChangeStreamData): Promise<CommitResult | null> {
-    return this.#call('processMessage', [downstream]);
+  processMessages(
+    downstream: readonly ChangeStreamData[],
+  ): Promise<CommitResult | null> {
+    return this.#call('processMessages', [downstream]);
   }
 
   abort(): void {

--- a/packages/zero-cache/src/services/replicator/write-worker.test.ts
+++ b/packages/zero-cache/src/services/replicator/write-worker.test.ts
@@ -72,13 +72,7 @@ describe('write-worker', () => {
       ['commit', issues.commit(), {watermark: '06'}],
     ];
 
-    let commitResult = null;
-    for (let i = 0; i < messages.length; i++) {
-      const result = await worker.processMessage(messages[i]);
-      if (result) {
-        commitResult = result;
-      }
-    }
+    const commitResult = await worker.processMessages(messages);
 
     expect(commitResult).toEqual({
       watermark: '06',
@@ -107,13 +101,11 @@ describe('write-worker', () => {
   // to their own inode.
   test('the write worker never creates a change log', async () => {
     const issues = new ReplicationMessages({issues: ['issueID', 'bool']});
-    for (const message of [
+    await worker.processMessages([
       ['begin', issues.begin(), {commitWatermark: '06'}],
       ['data', issues.insert('issues', {issueID: 1, bool: true})],
       ['commit', issues.commit(), {watermark: '06'}],
-    ] satisfies ChangeStreamData[]) {
-      await worker.processMessage(message);
-    }
+    ] satisfies ChangeStreamData[]);
 
     expect(existsSync(changeLogFileName(dbFile.path))).toBe(false);
   });
@@ -122,14 +114,9 @@ describe('write-worker', () => {
     const issues = new ReplicationMessages({issues: ['issueID', 'bool']});
 
     // Start a transaction but don't commit
-    await worker.processMessage([
-      'begin',
-      issues.begin(),
-      {commitWatermark: '06'},
-    ]);
-    await worker.processMessage([
-      'data',
-      issues.insert('issues', {issueID: 123, bool: true}),
+    await worker.processMessages([
+      ['begin', issues.begin(), {commitWatermark: '06'}],
+      ['data', issues.insert('issues', {issueID: 123, bool: true})],
     ]);
 
     // Abort should roll back
@@ -146,9 +133,7 @@ describe('write-worker', () => {
       ['commit', issues.commit(), {watermark: '07'}],
     ];
 
-    for (let i = 0; i < messages.length; i++) {
-      await worker.processMessage(messages[i]);
-    }
+    await worker.processMessages(messages);
 
     const rowsAfter = mainDb.prepare('SELECT issueID FROM issues').all();
     expect(rowsAfter).toEqual([{issueID: 789}]);
@@ -171,19 +156,21 @@ describe('write-worker', () => {
       errorReceived = err;
     });
 
-    // Send a processMessage without a begin - should cause a failure
+    // Send a processMessages without a begin - should cause a failure
     await expect(
-      worker.processMessage([
-        'data',
-        {
-          tag: 'insert',
-          relation: {
-            schema: 'public',
-            name: 'nonexistent',
-            rowKey: {columns: ['id'], type: 'default'},
+      worker.processMessages([
+        [
+          'data',
+          {
+            tag: 'insert',
+            relation: {
+              schema: 'public',
+              name: 'nonexistent',
+              rowKey: {columns: ['id'], type: 'default'},
+            },
+            new: {id: [1, 'int4']},
           },
-          new: {id: [1, 'int4']},
-        },
+        ],
       ]),
     ).rejects.toThrow();
 
@@ -207,9 +194,9 @@ describe('write-worker', () => {
       },
     ];
     const request = {
-      method: 'processMessage',
-      args: [data],
-    } satisfies Request<'processMessage'>;
+      method: 'processMessages',
+      args: [[data]],
+    } satisfies Request<'processMessages'>;
     const echoWorker = new Worker(
       /*js*/ `
         const {parentPort} = require('node:worker_threads');
@@ -224,7 +211,7 @@ describe('write-worker', () => {
       const [roundTripped] = (await response) as [typeof request];
 
       expect(roundTripped).toEqual(request);
-      expect(roundTripped.args[0][1]).toMatchObject({
+      expect(roundTripped.args[0][0][1]).toMatchObject({
         new: {issueID: 9007199254740993n, text: 'before\0after'},
       });
     } finally {

--- a/packages/zero-cache/src/services/replicator/write-worker.ts
+++ b/packages/zero-cache/src/services/replicator/write-worker.ts
@@ -107,9 +107,14 @@ function createAPI(): API {
       }
     },
 
-    processMessage(downstream: ChangeStreamData) {
+    processMessages(downstream: readonly ChangeStreamData[]) {
       try {
-        return must(processor).processMessage(must(lc), downstream);
+        let commitResult = null;
+        for (const message of downstream) {
+          commitResult =
+            must(processor).processMessage(must(lc), message) ?? commitResult;
+        }
+        return commitResult;
       } catch (e) {
         handleCorruptedDb(e);
         throw e;

--- a/packages/zero-cache/src/types/streams.test.ts
+++ b/packages/zero-cache/src/types/streams.test.ts
@@ -17,7 +17,7 @@ import * as v from '../../../shared/src/valita.ts';
 import {
   stream,
   streamIn,
-  streamInStringified,
+  streamInWithSize,
   streamOut,
   streamOutStringified,
   type Sink,
@@ -269,11 +269,11 @@ describe('streams with internal acks', () => {
     };
   }
 
-  async function startStringifiedReceiver() {
+  async function startSizedReceiver() {
     ws = new WebSocket(`http://localhost:${port}/`);
     return {
       ws,
-      consumer: await streamInStringified(lc, ws, messageSchema),
+      consumer: await streamInWithSize(lc, ws, messageSchema),
     };
   }
 
@@ -477,12 +477,12 @@ describe('streams with internal acks', () => {
     ]);
   });
 
-  test('stringified source', async () => {
+  test('sized source', async () => {
     const json =
       '{"from":1,"to":2,"str":"before\\u0000after","big":9007199254740993}';
     stringifiedProducer.push(json);
 
-    const {consumer} = await startStringifiedReceiver();
+    const {consumer} = await startSizedReceiver();
     expect(await drain(1, consumer)).toEqual([
       {
         data: {
@@ -491,7 +491,7 @@ describe('streams with internal acks', () => {
           str: 'before\0after',
           big: 9007199254740993n,
         },
-        json,
+        size: `{"id":1,"msg":${json}}`.length,
       },
     ]);
   });

--- a/packages/zero-cache/src/types/streams.ts
+++ b/packages/zero-cache/src/types/streams.ts
@@ -223,10 +223,10 @@ const ackSchema = v.object({ack: v.number()});
 
 type Ack = v.Infer<typeof ackSchema>;
 
-/** A parsed JSON value paired with the exact source text it was parsed from. */
-export type ParsedJSON<T> = {
+/** A parsed value paired with its approximate serialized transport size. */
+export type Sized<T> = {
   data: T;
-  json: string;
+  size: number;
 };
 
 export function streamOut<T extends JSONValue>(
@@ -322,17 +322,17 @@ export function streamIn<T extends JSONValue>(
 }
 
 /**
- * Streams in messages sent by {@link streamOutStringified}, preserving the
- * exact application-level JSON alongside its parsed and validated value.
+ * Streams in parsed messages while retaining only the transport-frame size.
+ * The size bounds downstream batching without keeping or copying the JSON.
  */
-export function streamInStringified<T extends JSONValue>(
+export function streamInWithSize<T extends JSONValue>(
   lc: LogContext,
   source: WebSocket,
   schema: v.Type<T>,
-): Promise<Source<ParsedJSON<T>>> {
-  return streamInInternal(lc, source, schema, (data, frame, id) => ({
+): Promise<Source<Sized<T>>> {
+  return streamInInternal(lc, source, schema, (data, frame) => ({
     data,
-    json: extractStringifiedMessage(frame, id),
+    size: frame.length,
   }));
 }
 
@@ -381,15 +381,6 @@ async function streamInInternal<T extends JSONValue, Out>(
 
   await closer.connected;
   return sink;
-}
-
-function extractStringifiedMessage(frame: string, id: number): string {
-  const prefix = `{"id":${id},"msg":`;
-  assert(
-    frame.startsWith(prefix) && frame.endsWith('}'),
-    `invalid streamed message frame`,
-  );
-  return frame.slice(prefix.length, -1);
 }
 
 class WebSocketCloser {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -217,6 +217,9 @@ importers:
         specifier: ^4.1.11
         version: 4.4.3
     devDependencies:
+      '@rocicorp/logger':
+        specifier: ^6.1.0
+        version: 6.1.0
       '@tailwindcss/forms':
         specifier: ^0.5.0
         version: 0.5.11(tailwindcss@3.4.19(tsx@4.22.0)(yaml@2.9.0))
@@ -19450,9 +19453,9 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0))
+      vitest: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0))
     optionalDependencies:
-      '@vitest/browser': 4.1.6(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0))(vitest@4.1.6)
+      '@vitest/browser': 4.1.6(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0))(vitest@4.1.6)
 
   '@vitest/expect@4.1.6':
     dependencies:


### PR DESCRIPTION
Putting this up more as a record / artifact I can find later rather than something to merge.

- starts / stops / restarts ViewSyncer
- does same for Replication Managers
- Simulates S3 via Minio
- Runs Litestream 5
- Times catchup
- Compares PG change log to SQLite change log at transaction bounds

findings: https://claude.ai/code/artifact/ae2e3424-7bad-444b-8592-2df5e307d190?via=auto_preview