### PR TITLE
fix(zero-cache): ignore pushes for closed connections

### DIFF
--- a/packages/zero-cache/src/services/mutagen/pusher.test.ts
+++ b/packages/zero-cache/src/services/mutagen/pusher.test.ts
@@ -1585,6 +1585,23 @@ describe('pusher streaming', () => {
     vi.resetAllMocks();
   });
 
+  test('ignores a push after its websocket connection closes', () => {
+    const pusher = newPusherService({
+      url: ['http://example.com'],
+      apiKey: 'api-key',
+      forwardCookies: false,
+    });
+
+    const {selector} = openConnection(pusher, {
+      clientID,
+      wsID,
+      auth: 'jwt',
+    });
+    getContextManager(pusher).closeConnection(selector);
+
+    expect(pusher.enqueuePush(selector, makePush(1))).toEqual({type: 'ok'});
+  });
+
   test('returns ok for subsequent pushes from same client', () => {
     const pusher = newPusherService({
       url: ['http://example.com'],

--- a/packages/zero-cache/src/services/mutagen/pusher.ts
+++ b/packages/zero-cache/src/services/mutagen/pusher.ts
@@ -103,10 +103,10 @@ export class PusherService implements Service, Pusher {
     selector: ConnectionSelector,
     push: PushBody,
   ): Exclude<HandlerResult, StreamResult> {
-    this.#pusher.enqueuePush(
-      this.#connContextManager.mustGetConnectionContext(selector),
-      push,
-    );
+    const connCtx = this.#connContextManager.getConnectionContext(selector);
+    if (connCtx) {
+      this.#pusher.enqueuePush(connCtx, push);
+    }
 
     return {
       type: 'ok',


### PR DESCRIPTION
when Zero encounters a connection error (e.g. outdated client schema) it invalidates the WebSocket's authentication context and begins closing the connection. during this time, if a custom mutation is pushed, it will call `mustGetConnectionContext()` and since the shutdown removed the context, Zero will throw the following error:

```
Connection auth state was not available for this websocket.
```

this PR fixes this by checking whether the connection context exists before pushing the mutation. if the context exists, we proceed with the push. if it does not exist, that means the connection is closing, so we drop the invocation and leave it to be retried by the client upon reconnecting.