### PR TITLE
fix(zero-cache): improve detection of orphaned change-db connections

### DIFF
--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -570,7 +570,7 @@ export const zeroOptions = {
     },
 
     statementTimeoutMs: {
-      type: v.number().default(20_000),
+      type: v.number().default(30_000),
       desc: [
         `Fail change-log transactions if a statement response from postgres is not received within`,
         `the specified timeout. This differs from a postgres {bold statement_timeout} in that`,

--- a/packages/zero-cache/src/services/change-streamer/forwarder.ts
+++ b/packages/zero-cache/src/services/change-streamer/forwarder.ts
@@ -48,7 +48,7 @@ export class Forwarder {
       flowControlConsensusTimeoutProportion: 2.0,
     },
   ) {
-    this.#lc = lc.withContext('component', 'progress-monitor');
+    this.#lc = lc.withContext('component', 'subscriber-progress-monitor');
     this.#setTimeout = opts.setTimeoutFn ?? setTimeout;
     this.#clearTimeout = opts.clearTimeoutFn ?? clearTimeout;
 

--- a/packages/zero-cache/src/services/change-streamer/storer.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.pg.test.ts
@@ -1,4 +1,5 @@
 import {PG_LOCK_NOT_AVAILABLE} from '@drdgvhbh/postgres-error-codes';
+import {resolver} from '@rocicorp/resolver';
 import postgres from 'postgres';
 import {afterEach, beforeEach, describe, expect} from 'vitest';
 import {BigIntJSON} from '../../../../shared/src/bigint-json.ts';
@@ -1801,6 +1802,229 @@ describe('change-streamer/storer', () => {
       // A stale, already-rejected resolver must not be reused: with nothing
       // queued, back pressure should no longer be in effect.
       expect(storer.readyForMore()).toBeUndefined();
+    });
+  });
+
+  // The ProgressMonitor is the storer's watchdog for a db operation that hangs
+  // without ever returning (e.g. a half-open connection). These tests exercise
+  // real #processQueue / catchup code paths and assert that a hang surfaces as
+  // a *fatal* error (via onFatal), which is what the ProgressMonitor -- and
+  // *only* the ProgressMonitor -- produces.
+  //
+  // Both wedges are deliberately chosen to be invisible to the write pool's
+  // statementResponseTimeout, so the fatal error is unambiguously the
+  // ProgressMonitor's doing even while that (soon-to-be-removed) watchdog is
+  // still wired up:
+  //  * The write-path test wedges *before any statement is dispatched* (the
+  //    sole connection is reserved), so the pool's #pending set is empty and
+  //    statementResponseTimeout has nothing to time out.
+  //  * The catchup reader pool is constructed without a statementResponseTimeout
+  //    at all, so a hung catchup read can only be caught by the ProgressMonitor.
+  describe('ProgressMonitor hang detection', () => {
+    const TIMEOUT_MS = 100;
+
+    function newRawConnection() {
+      const {host, port, database, user: username, pass} = db.options;
+      return postgres({
+        host: host[0],
+        port: port[0],
+        username,
+        password: pass ?? undefined,
+        database,
+        ...postgresTypeConfig({sendStringAsJson: true}),
+      });
+    }
+
+    test('a hung write transaction (begin/commit) triggers a fatal error', async () => {
+      // Single-connection pool: reserving its one connection means the storer's
+      // write TransactionPool can never even open its `BEGIN`, so the commit's
+      // `await tx.startingReplicationState` (the begin-time SELECT ... FOR
+      // UPDATE) never resolves -- a hang *before* any statement reaches PG.
+      const {host, port, database, user: username, pass} = db.options;
+      const singleConnDb = postgres({
+        host: host[0],
+        port: port[0],
+        username,
+        password: pass ?? undefined,
+        database,
+        max: 1,
+        ...postgresTypeConfig({sendStringAsJson: true}),
+      });
+
+      storer = new Storer(
+        lc,
+        shard,
+        'task-id',
+        'change-streamer:12345',
+        'ws',
+        singleConnDb,
+        REPLICA_VERSION,
+        msg => consumed.enqueue(msg),
+        err => fatalErrors.enqueue(err),
+        {...opts, statementTimeoutMs: TIMEOUT_MS, drainTimeoutMs: 5_000},
+      );
+      await storer.assumeOwnership();
+      done = storer.run();
+
+      const reserved = await singleConnDb.reserve();
+      try {
+        storer.store('08', [
+          'begin',
+          messages.begin(),
+          {commitWatermark: '08'},
+        ]);
+        storer.store('08', ['data', messages.insert('issues', {id: 'a'})]);
+        storer.store('08', ['commit', messages.commit(), {watermark: '08'}]);
+
+        const err = await fatalErrors.dequeue();
+        // The commit's queue-entry task is the one that fails to progress.
+        expect(err.message).toContain('failed to progress');
+        expect(err.message).toContain('queue-entry');
+      } finally {
+        // Release so #processQueue unwedges and stop() can drain in afterEach.
+        reserved.release();
+        await storer.stop().catch(() => {});
+        await singleConnDb.end();
+      }
+    });
+
+    test('a hung catchup read triggers a fatal error', async () => {
+      storer = new Storer(
+        lc,
+        shard,
+        'task-id',
+        'change-streamer:12345',
+        'ws',
+        db,
+        REPLICA_VERSION,
+        msg => consumed.enqueue(msg),
+        err => fatalErrors.enqueue(err),
+        {...opts, statementTimeoutMs: TIMEOUT_MS, drainTimeoutMs: 5_000},
+      );
+      await storer.assumeOwnership();
+      done = storer.run();
+
+      // Hold an ACCESS EXCLUSIVE lock on the changeLog so the catchup cursor
+      // read blocks indefinitely. (The lastWatermark read in #startCatchup is
+      // against replicationState, so it still completes; the hang is in the
+      // background #catchup cursor.) The lock is held until `release` resolves,
+      // so cleanup can let the transaction commit and end the connection
+      // cleanly rather than tearing down an in-flight query.
+      const lockConn = newRawConnection();
+      const acquired = resolver<void>();
+      const release = resolver<void>();
+      void lockConn
+        .begin(async tx => {
+          await tx`LOCK TABLE "xero_5/cdc"."changeLog" IN ACCESS EXCLUSIVE MODE`;
+          acquired.resolve();
+          await release.promise;
+        })
+        .catch(() => {});
+      await acquired.promise;
+
+      // A subscriber behind the durable watermark forces a catchup read.
+      // Consume its stream in the background so that, once the lock is
+      // released during cleanup, the catchup can send its buffered entries,
+      // complete, and close its reader connection (otherwise the orphaned
+      // reader keeps the worker alive after the test).
+      const [sub, , subStream] = createSubscriber('03');
+      const draining = drain(subStream, '06');
+
+      try {
+        storer.catchup(sub, 'serving');
+
+        const err = await fatalErrors.dequeue();
+        expect(err.message).toContain('failed to progress');
+        expect(err.message).toContain('catchup');
+      } finally {
+        release.resolve(); // let the held tx commit, releasing the lock
+        await draining; // catchup drains to the subscriber and completes
+        await lockConn.end();
+        await storer.stop().catch(() => {});
+      }
+    });
+  });
+
+  // assumeOwnership(), getStartStreamInitializationParameters(),
+  // getMinWatermarkForCatchup(), and getCatchupBounds() are one-off db calls,
+  // not part of the main storer loop or the background catchup read, so they
+  // are bounded by a plain #withTimeout() race instead of the ProgressMonitor.
+  // This matters concretely for assumeOwnership() and
+  // getStartStreamInitializationParameters(): both are called by
+  // ChangeStreamerImpl.run() *before* Storer.run() (see
+  // change-streamer-service.ts), i.e. before the ProgressMonitor's polling
+  // has started -- so a hang in either must be caught without relying on it.
+  // These tests call the methods directly, without ever calling
+  // `storer.run()`, to prove that.
+  describe('one-off db call timeout', () => {
+    const TIMEOUT_MS = 100;
+    let singleConnDb: PostgresDB;
+
+    beforeEach(() => {
+      const {host, port, database, user: username, pass} = db.options;
+      singleConnDb = postgres({
+        host: host[0],
+        port: port[0],
+        username,
+        password: pass ?? undefined,
+        database,
+        max: 1,
+        ...postgresTypeConfig({sendStringAsJson: true}),
+      });
+      storer = new Storer(
+        lc,
+        shard,
+        'task-id',
+        'change-streamer:12345',
+        'ws',
+        singleConnDb,
+        REPLICA_VERSION,
+        msg => consumed.enqueue(msg),
+        err => fatalErrors.enqueue(err),
+        {...opts, statementTimeoutMs: TIMEOUT_MS},
+      );
+    });
+
+    afterEach(async () => {
+      await singleConnDb.end();
+    });
+
+    // Reserving the sole connection means the call can never even dispatch
+    // its statement, so its own #withTimeout is the only thing that can
+    // possibly reject it (there is no in-flight statement for anything else
+    // to time out).
+    async function withReservedConnection(fn: () => Promise<unknown>) {
+      const reserved = await singleConnDb.reserve();
+      try {
+        const start = Date.now();
+        await expect(fn()).rejects.toThrow(
+          `did not complete within ${TIMEOUT_MS}ms`,
+        );
+        expect(Date.now() - start).toBeLessThan(TIMEOUT_MS * 5);
+        // Not the ProgressMonitor's doing: run() (and thus its polling) was
+        // never called.
+        expect(fatalErrors.size()).toBe(0);
+      } finally {
+        reserved.release();
+      }
+    }
+
+    test('assumeOwnership rejects on a hang, without run() ever having started the ProgressMonitor', async () => {
+      await withReservedConnection(() => storer.assumeOwnership());
+    });
+
+    test('getStartStreamInitializationParameters rejects on a hang', async () => {
+      await withReservedConnection(() =>
+        storer.getStartStreamInitializationParameters(),
+      );
+    });
+
+    test('getMinWatermarkForCatchup rejects on a hang', async () => {
+      await withReservedConnection(() => storer.getMinWatermarkForCatchup());
+    });
+
+    test('getCatchupBounds rejects on a hang', async () => {
+      await withReservedConnection(() => storer.getCatchupBounds());
     });
   });
 

--- a/packages/zero-cache/src/services/change-streamer/storer.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.test.ts
@@ -1,0 +1,348 @@
+import {LogContext} from '@rocicorp/logger';
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
+import {
+  createSilentLogContext,
+  TestLogSink,
+} from '../../../../shared/src/logging-test-utils.ts';
+import {ProgressMonitor} from './storer.ts';
+
+describe('storer/ProgressMonitor', () => {
+  function captureFailures() {
+    const errors: Error[] = [];
+    return {errors, onFailure: (err: Error) => void errors.push(err)};
+  }
+
+  // Most of these drive checkTaskProgress() with explicit Date objects
+  // (rather than start()'s real setInterval), so they're deterministic and
+  // don't depend on wall-clock timing. start()/stop() wiring is covered
+  // separately below with fake timers.
+
+  test('a task refreshed within the threshold never fires', () => {
+    const {errors, onFailure} = captureFailures();
+    const monitor = new ProgressMonitor(
+      createSilentLogContext(),
+      100,
+      onFailure,
+    );
+    const t0 = new Date('2026-01-01T00:00:00.000Z');
+
+    // Mirrors real usage: call the previous done-fn, then track anew.
+    let done = monitor.trackTask({task: 'db-write'}, t0);
+    for (let i = 1; i <= 10; i++) {
+      const now = new Date(t0.getTime() + i * 50);
+      done();
+      done = monitor.trackTask({task: 'db-write'}, now);
+      monitor.checkTaskProgress(new Date(now.getTime() + 50));
+    }
+
+    expect(errors).toHaveLength(0);
+  });
+
+  test('re-tracking the same object refreshes its timestamp in place', () => {
+    const {errors, onFailure} = captureFailures();
+    const monitor = new ProgressMonitor(
+      createSilentLogContext(),
+      100,
+      onFailure,
+    );
+    const t0 = new Date('2026-01-01T00:00:00.000Z');
+    const task = {task: 'queue-entry', type: 'change'};
+
+    monitor.trackTask(task, t0);
+    monitor.trackTask(task, new Date(t0.getTime() + 90));
+
+    // 100ms after the *second* track, still under threshold from it.
+    monitor.checkTaskProgress(new Date(t0.getTime() + 189));
+    expect(errors).toHaveLength(0);
+
+    monitor.checkTaskProgress(new Date(t0.getTime() + 190));
+    expect(errors).toHaveLength(1);
+  });
+
+  test('fires once a task goes stale for at least the failure threshold', () => {
+    const {errors, onFailure} = captureFailures();
+    const monitor = new ProgressMonitor(
+      createSilentLogContext(),
+      100,
+      onFailure,
+    );
+    const t0 = new Date('2026-01-01T00:00:00.000Z');
+
+    monitor.trackTask({task: 'catchup', subscriber: 'sub1'}, t0);
+
+    // Just under the threshold: no failure yet.
+    monitor.checkTaskProgress(new Date(t0.getTime() + 99));
+    expect(errors).toHaveLength(0);
+
+    // At (>=) the threshold: fires.
+    monitor.checkTaskProgress(new Date(t0.getTime() + 100));
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toBeInstanceOf(Error);
+    expect(errors[0].message).toContain('catchup');
+    expect(errors[0].message).toContain('sub1');
+    expect(errors[0].message).toContain('100ms');
+  });
+
+  test('logs the stale task and last-update time at error level', () => {
+    const logSink = new TestLogSink();
+    const lc = new LogContext('error', undefined, logSink);
+    const {onFailure} = captureFailures();
+    const monitor = new ProgressMonitor(lc, 50, onFailure);
+    const t0 = new Date('2026-01-01T00:00:00.000Z');
+    const task = {task: 'queue-entry', type: 'commit'};
+
+    monitor.trackTask(task, t0);
+    monitor.checkTaskProgress(new Date(t0.getTime() + 50));
+
+    expect(logSink.messages).toHaveLength(1);
+    const [level, , args] = logSink.messages[0];
+    expect(level).toBe('error');
+    expect(args[0]).toContain('more than 50ms ago');
+    expect(args[1]).toMatchObject({task, lastUpdate: t0});
+  });
+
+  test('the done callback removes the task so it never fires', () => {
+    const {errors, onFailure} = captureFailures();
+    const monitor = new ProgressMonitor(
+      createSilentLogContext(),
+      50,
+      onFailure,
+    );
+    const t0 = new Date('2026-01-01T00:00:00.000Z');
+
+    const done = monitor.trackTask(
+      {task: 'start-catchup', subscribers: ['sub1', 'sub2']},
+      t0,
+    );
+    done();
+
+    monitor.checkTaskProgress(new Date(t0.getTime() + 1000));
+
+    expect(errors).toHaveLength(0);
+  });
+
+  test('calling the done callback twice is a harmless no-op', () => {
+    const {errors, onFailure} = captureFailures();
+    const monitor = new ProgressMonitor(
+      createSilentLogContext(),
+      50,
+      onFailure,
+    );
+    const t0 = new Date('2026-01-01T00:00:00.000Z');
+
+    const done = monitor.trackTask({task: 'db-write'}, t0);
+    done();
+    expect(() => done()).not.toThrow();
+
+    monitor.checkTaskProgress(new Date(t0.getTime() + 1000));
+    expect(errors).toHaveLength(0);
+  });
+
+  test('tracks concurrent tasks independently', () => {
+    const {errors, onFailure} = captureFailures();
+    const monitor = new ProgressMonitor(
+      createSilentLogContext(),
+      100,
+      onFailure,
+    );
+    const t0 = new Date('2026-01-01T00:00:00.000Z');
+
+    monitor.trackTask({task: 'catchup', subscriber: 'sub1'}, t0);
+    let healthyDone = monitor.trackTask(
+      {task: 'queue-entry', type: 'change'},
+      t0,
+    );
+
+    // Keep refreshing only the healthy task, well past when `stuck` goes stale.
+    for (let i = 1; i <= 5; i++) {
+      const now = new Date(t0.getTime() + i * 40);
+      healthyDone();
+      healthyDone = monitor.trackTask(
+        {task: 'queue-entry', type: 'change'},
+        now,
+      );
+    }
+
+    monitor.checkTaskProgress(new Date(t0.getTime() + 5 * 40));
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain('catchup');
+    expect(errors[0].message).not.toContain('"type":"change"');
+  });
+
+  test('reports only the first stale task found and stops tracking the rest', () => {
+    // Current design: one failure is enough to tear the process down, so
+    // checkTaskProgress() reports the first stale task (in insertion order)
+    // and then stops the monitor (clearing the interval and the map) rather
+    // than reporting every stale task.
+    const {errors, onFailure} = captureFailures();
+    const monitor = new ProgressMonitor(
+      createSilentLogContext(),
+      50,
+      onFailure,
+    );
+    const t0 = new Date('2026-01-01T00:00:00.000Z');
+
+    monitor.trackTask({task: 'catchup', subscriber: 'a'}, t0);
+    monitor.trackTask({task: 'catchup', subscriber: 'b'}, t0);
+
+    monitor.checkTaskProgress(new Date(t0.getTime() + 60));
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain('"subscriber":"a"');
+  });
+
+  test('does not fire again on a later check after reporting once', () => {
+    const {errors, onFailure} = captureFailures();
+    const monitor = new ProgressMonitor(
+      createSilentLogContext(),
+      50,
+      onFailure,
+    );
+    const t0 = new Date('2026-01-01T00:00:00.000Z');
+
+    monitor.trackTask({task: 'db-write'}, t0);
+
+    monitor.checkTaskProgress(new Date(t0.getTime() + 60));
+    expect(errors).toHaveLength(1);
+
+    // The map was cleared by the self-stop, so a later check is a no-op even
+    // though nothing was ever explicitly marked done.
+    monitor.checkTaskProgress(new Date(t0.getTime() + 10_000));
+    expect(errors).toHaveLength(1);
+  });
+
+  test('stop() clears tracked tasks so a stale one is dropped', () => {
+    const {errors, onFailure} = captureFailures();
+    const monitor = new ProgressMonitor(
+      createSilentLogContext(),
+      50,
+      onFailure,
+    );
+    const t0 = new Date('2026-01-01T00:00:00.000Z');
+
+    monitor.trackTask({task: 'db-write'}, t0);
+    monitor.stop();
+
+    monitor.checkTaskProgress(new Date(t0.getTime() + 1000));
+
+    expect(errors).toHaveLength(0);
+  });
+
+  test('stop() is idempotent', () => {
+    const monitor = new ProgressMonitor(createSilentLogContext(), 50, () => {});
+    monitor.start();
+    expect(() => {
+      monitor.stop();
+      monitor.stop();
+    }).not.toThrow();
+  });
+
+  describe('start() / stop() wiring', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    test('start() polls on the failure-threshold interval and fires onFailure', async () => {
+      const {errors, onFailure} = captureFailures();
+      const monitor = new ProgressMonitor(
+        createSilentLogContext(),
+        100,
+        onFailure,
+      );
+      monitor.start();
+
+      monitor.trackTask({task: 'db-write'});
+
+      await vi.advanceTimersByTimeAsync(99);
+      expect(errors).toHaveLength(0);
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(errors).toHaveLength(1);
+    });
+
+    test('a failure self-stops the interval so it does not fire again', async () => {
+      const {errors, onFailure} = captureFailures();
+      const monitor = new ProgressMonitor(
+        createSilentLogContext(),
+        100,
+        onFailure,
+      );
+      monitor.start();
+      monitor.trackTask({task: 'db-write'});
+
+      await vi.advanceTimersByTimeAsync(100);
+      expect(errors).toHaveLength(1);
+
+      // If the interval weren't cleared on self-stop, it would keep firing
+      // (there's nothing left in the map, but this also proves no timer
+      // is still scheduled to run at all).
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(errors).toHaveLength(1);
+    });
+
+    test('stop() halts the interval so no further checks run', async () => {
+      const {errors, onFailure} = captureFailures();
+      const monitor = new ProgressMonitor(
+        createSilentLogContext(),
+        100,
+        onFailure,
+      );
+      monitor.start();
+      monitor.trackTask({task: 'db-write'});
+
+      monitor.stop();
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      expect(errors).toHaveLength(0);
+    });
+
+    test('calling start() again resets the interval without duplicating it', async () => {
+      const {errors, onFailure} = captureFailures();
+      const monitor = new ProgressMonitor(
+        createSilentLogContext(),
+        100,
+        onFailure,
+      );
+      monitor.start();
+      monitor.start(); // simulate a restart; must clear the first interval
+
+      monitor.trackTask({task: 'db-write'});
+      await vi.advanceTimersByTimeAsync(100);
+
+      // Exactly one failure, not two (which a leaked first interval running
+      // alongside the second would produce).
+      expect(errors).toHaveLength(1);
+    });
+
+    test('a task tracked after start() does not fire until it too goes stale', async () => {
+      // Note: checkTaskProgress() polls on a fixed cadence set by start()
+      // (t=100, 200, 300, ...), not one re-synced to when a task is
+      // tracked. A task tracked at t=80 is first checked at t=100 (only
+      // 20ms old: not stale) and isn't caught as stale until the t=200
+      // check (120ms old by then) -- so detection latency for a
+      // newly-tracked task can be nearly 2x the threshold in the worst case.
+      const {errors, onFailure} = captureFailures();
+      const monitor = new ProgressMonitor(
+        createSilentLogContext(),
+        100,
+        onFailure,
+      );
+      monitor.start();
+
+      await vi.advanceTimersByTimeAsync(80);
+      monitor.trackTask({task: 'catchup', subscriber: 'sub1'});
+
+      await vi.advanceTimersByTimeAsync(20); // t=100 check: 20ms old
+      expect(errors).toHaveLength(0);
+
+      await vi.advanceTimersByTimeAsync(100); // t=200 check: 120ms old
+      expect(errors).toHaveLength(1);
+    });
+  });
+});

--- a/packages/zero-cache/src/services/change-streamer/storer.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.ts
@@ -4,6 +4,10 @@ import {resolver, type Resolver} from '@rocicorp/resolver';
 import {type PendingQuery, type Row} from 'postgres';
 import {AbortError} from '../../../../shared/src/abort-error.ts';
 import {assert, unreachable} from '../../../../shared/src/asserts.ts';
+import {
+  BigIntJSON,
+  type JSONObject,
+} from '../../../../shared/src/bigint-json.ts';
 import {Queue} from '../../../../shared/src/queue.ts';
 import {promiseVoid} from '../../../../shared/src/resolved-promises.ts';
 import * as v from '../../../../shared/src/valita.ts';
@@ -154,6 +158,7 @@ export class Storer implements Service {
   readonly #statementTimeoutMs: number;
   readonly #changeLogBatchSize: number;
   readonly #drainTimeoutMs: number;
+  readonly #progressMonitor: ProgressMonitor;
 
   #approximateQueuedBytes = 0;
   #running = false;
@@ -187,6 +192,11 @@ export class Storer implements Service {
     this.#statementTimeoutMs = statementTimeoutMs;
     this.#changeLogBatchSize = Math.max(1, changeLogBatchSize);
     this.#drainTimeoutMs = drainTimeoutMs;
+    this.#progressMonitor = new ProgressMonitor(
+      lc,
+      statementTimeoutMs,
+      onFatal,
+    );
 
     const heapStats = getHeapStatistics();
     this.#backPressureThresholdBytes =
@@ -206,6 +216,31 @@ export class Storer implements Service {
     return this.#db(`${cdcSchema(this.#shard)}.${table}`);
   }
 
+  /**
+   * Bounds a one-off db call (i.e. not part of the main storer loop or the
+   * background catchup read, which are tracked by the ProgressMonitor
+   * instead) with a plain timeout. This covers calls like
+   * {@link assumeOwnership} and {@link getStartStreamInitializationParameters}
+   * that are made by the caller *before* {@link run()} -- and thus before the
+   * ProgressMonitor's polling starts -- as well as ones made well after,
+   * where a continuously-polling watchdog would be overkill for a single
+   * bounded db round trip.
+   *
+   * Does not cancel `promise` on timeout (there is no cancellation mechanism
+   * for a postgres.js query); it just stops waiting for it, and swallows a
+   * later rejection so it doesn't surface as an unhandled rejection.
+   */
+  async #withTimeout<T>(name: string, promise: Promise<T>): Promise<T> {
+    const result = await orTimeout(promise, this.#statementTimeoutMs);
+    if (result === 'timed-out') {
+      void promise.catch(() => {});
+      throw new AbortError(
+        `${name} did not complete within ${this.#statementTimeoutMs}ms`,
+      );
+    }
+    return result;
+  }
+
   async assumeOwnership(purgeLock?: PurgeLock | null) {
     const db = this.#db;
     const owner = this.#taskID;
@@ -218,7 +253,10 @@ export class Storer implements Service {
         : `${ownerProtocol}://${ownerAddress}`;
     this.#lc.info?.(`assuming ownership at ${addressWithProtocol}`);
     const start = performance.now();
-    await db`UPDATE ${this.#cdc('replicationState')} SET ${db({owner, ownerAddress: addressWithProtocol})}`;
+    await this.#withTimeout(
+      'assume-ownership',
+      db`UPDATE ${this.#cdc('replicationState')} SET ${db({owner, ownerAddress: addressWithProtocol})}`,
+    );
     const elapsed = (performance.now() - start).toFixed(2);
     this.#lc.info?.(
       `assumed ownership at ${addressWithProtocol} (${elapsed} ms)`,
@@ -255,16 +293,19 @@ export class Storer implements Service {
     backfillRequests: BackfillRequest[];
     cookies: CookieSet;
   }> {
-    const [[{lastWatermark}], result, tableMetadata, backfilling] = await runTx(
-      this.#db,
-      sql => [
-        sql<{lastWatermark: string}[]>`
+    const [[{lastWatermark}], result, tableMetadata, backfilling] =
+      await this.#withTimeout(
+        'get-stream-params',
+        runTx(
+          this.#db,
+          sql => [
+            sql<{lastWatermark: string}[]>`
         SELECT "lastWatermark" FROM ${this.#cdc('replicationState')}`,
 
-        // Formats a BackfillRequest using json_object_agg() to construct the
-        // `columns` object. It is LEFT JOIN'ed with the `tableMetadata` table
-        // to make it optional and possibly `null`.
-        sql`
+            // Formats a BackfillRequest using json_object_agg() to construct the
+            // `columns` object. It is LEFT JOIN'ed with the `tableMetadata` table
+            // to make it optional and possibly `null`.
+            sql`
         SELECT
             json_build_object(
               'schema', b."schema",
@@ -279,22 +320,23 @@ export class Storer implements Service {
           GROUP BY b."schema", b."table", t."metadata"
         `,
 
-        // Ordered by primary key, so that this set and the SQLite change log's
-        // can be compared row for row. `COLLATE "C"` because that comparison is
-        // against a store whose TEXT columns sort by byte: a linguistic
-        // collation orders `foo-bar` and `foobar` differently than SQLite's
-        // BINARY does, which would read as a divergence rather than as the
-        // identical set it is.
-        sql<TableMetadataCookie[]>`
+            // Ordered by primary key, so that this set and the SQLite change log's
+            // can be compared row for row. `COLLATE "C"` because that comparison is
+            // against a store whose TEXT columns sort by byte: a linguistic
+            // collation orders `foo-bar` and `foobar` differently than SQLite's
+            // BINARY does, which would read as a divergence rather than as the
+            // identical set it is.
+            sql<TableMetadataCookie[]>`
         SELECT "schema", "table", "metadata" FROM ${this.#cdc('tableMetadata')}
           ORDER BY "schema" COLLATE "C", "table" COLLATE "C"`,
 
-        sql<BackfillCookie[]>`
+            sql<BackfillCookie[]>`
         SELECT "schema", "table", "column", "backfill" FROM ${this.#cdc('backfilling')}
           ORDER BY "schema" COLLATE "C", "table" COLLATE "C", "column" COLLATE "C"`,
-      ],
-      {mode: Mode.READONLY},
-    );
+          ],
+          {mode: Mode.READONLY},
+        ),
+      );
 
     return {
       lastWatermark,
@@ -307,9 +349,11 @@ export class Storer implements Service {
   }
 
   async getMinWatermarkForCatchup(): Promise<string | null> {
-    const [{minWatermark}] = await this.#db<{minWatermark: string | null}[]>
-    /*sql*/ `
-      SELECT min(watermark) as "minWatermark" FROM ${this.#cdc('changeLog')}`;
+    const [{minWatermark}] = await this.#withTimeout(
+      'get-min-watermark',
+      this.#db<{minWatermark: string | null}[]> /*sql*/ `
+      SELECT min(watermark) as "minWatermark" FROM ${this.#cdc('changeLog')}`,
+    );
     return minWatermark;
   }
 
@@ -322,12 +366,13 @@ export class Storer implements Service {
     minWatermark: string | null;
     lastWatermark: string;
   }> {
-    const [bounds] = await this.#db<
-      {minWatermark: string | null; lastWatermark: string}[]
-    > /*sql*/ `
+    const [bounds] = await this.#withTimeout(
+      'get-catchup-bounds',
+      this.#db<{minWatermark: string | null; lastWatermark: string}[]> /*sql*/ `
       SELECT
         (SELECT min(watermark) FROM ${this.#cdc('changeLog')}) as "minWatermark",
-        (SELECT "lastWatermark" FROM ${this.#cdc('replicationState')}) as "lastWatermark"`;
+        (SELECT "lastWatermark" FROM ${this.#cdc('replicationState')}) as "lastWatermark"`,
+    );
     return bounds;
   }
 
@@ -375,6 +420,10 @@ export class Storer implements Service {
     >;
   }
 
+  // Note: These are the only db `await`s that are not tracked by the
+  //       ProgressMonitor, as the delete can legitimately block and/or take
+  //       an arbitrary amount of time. Luckily, this is a background call and
+  //       thus cannot cause the storer loop to hang.
   purgeRecordsBefore(watermark: string): Promise<number> {
     return runTx(this.#db, async sql => {
       // This NOWAIT pre-check is an optimization to abort the transaction
@@ -553,6 +602,7 @@ export class Storer implements Service {
     this.#stopped = stopped;
 
     this.#lc.info?.('starting storer');
+    this.#progressMonitor.start(); // Note: This is stopped in stop()
     let err: unknown;
     try {
       await this.#processQueue();
@@ -606,9 +656,27 @@ export class Storer implements Service {
     let tx: PendingTransaction | null = null;
     let msg: QueueEntry | false;
 
+    // Track the progress of each (previous and next) queue entry before it is
+    // processed in the loop.
+    let lastTaskDone: TaskDoneFn | undefined;
+    const nextMessage = async () => {
+      lastTaskDone?.();
+      lastTaskDone = undefined;
+      const entry = await this.#queue.dequeue();
+      if (entry !== 'stop') {
+        lastTaskDone = this.#progressMonitor.trackTask({
+          task: 'queue-entry',
+          // Note: TaskKeys are logged, so only include entry[0] (the type) to
+          // avoid logging application data.
+          type: entry[0],
+        });
+      }
+      return entry;
+    };
+
     const catchupQueue: SubscriberAndMode[] = [];
     try {
-      while ((msg = await this.#queue.dequeue()) !== 'stop') {
+      while ((msg = await nextMessage()) !== 'stop') {
         const [msgType] = msg;
         switch (msgType) {
           case 'ready': {
@@ -777,6 +845,10 @@ export class Storer implements Service {
     reader.run(this.#db);
 
     let lastWatermark: string | undefined;
+    const catchupSnapshotted = this.#progressMonitor.trackTask({
+      task: 'capture-catchup-snapshot',
+      subscribers: subs.map(({subscriber: s}) => s.id),
+    });
     try {
       // Ensure that the transaction has started (and is thus holding a snapshot
       // of the database) before continuing on to commit more changes. This is
@@ -790,6 +862,8 @@ export class Storer implements Service {
     } catch (e) {
       subs.map(({subscriber}) => subscriber.fail(e));
       throw e;
+    } finally {
+      catchupSnapshotted();
     }
 
     // Run the actual catchup queries in the background. Errors are handled in
@@ -812,6 +886,12 @@ export class Storer implements Service {
     lastWatermark: string,
     reader: TransactionPool,
   ) {
+    let entriesReceived = 0;
+    let catchupProgressed = this.#progressMonitor.trackTask({
+      task: 'catchup',
+      subscriber: sub.id,
+      entriesReceived,
+    });
     try {
       lc.info?.(`starting catchup`);
       await reader.processReadTask(async tx => {
@@ -829,47 +909,61 @@ export class Storer implements Service {
            WHERE watermark >= ${sub.watermark}
              AND watermark <= ${lastWatermark}
            ORDER BY watermark, pos`.cursor(2000)) {
-          // Wait for the last batch of entries to be consumed by the
-          // subscriber before sending down the current batch. This pipelining
-          // allows one batch of changes to be received from the change-db
-          // while the previous batch of changes are sent to the subscriber,
-          // resulting in flow control that caps the number of changes
-          // referenced in memory to 2 * batch-size.
-          const start = performance.now();
-          await lastBatchConsumed;
-          const elapsed = performance.now() - start;
-          if (lastBatchConsumed) {
-            lc[elapsed > 100 ? 'info' : 'debug']?.(
-              `waited ${elapsed.toFixed(3)} ms for ${sub.id} to consume last batch of catchup entries`,
-            );
-          }
+          catchupProgressed();
+          entriesReceived += entries.length;
 
-          for (const entry of entries) {
-            if (entry.watermark === sub.watermark) {
-              // This should be the first entry.
-              // Catchup starts from *after* the watermark.
-              watermarkFound = true;
-            } else if (watermarkFound) {
-              lastBatchConsumed = sub.catchup(
-                reconstructWatermarkedChange(entry),
+          try {
+            // Wait for the last batch of entries to be consumed by the
+            // subscriber before sending down the current batch. This pipelining
+            // allows one batch of changes to be received from the change-db
+            // while the previous batch of changes are sent to the subscriber,
+            // resulting in flow control that caps the number of changes
+            // referenced in memory to 2 * batch-size.
+            const start = performance.now();
+            await lastBatchConsumed;
+            const elapsed = performance.now() - start;
+            if (lastBatchConsumed) {
+              lc[elapsed > 100 ? 'info' : 'debug']?.(
+                `waited ${elapsed.toFixed(3)} ms for ${sub.id} to consume last batch of catchup entries`,
               );
-              count++;
-            } else if (mode === 'backup') {
-              throw new AutoResetSignal(
-                `backup replica at watermark ${sub.watermark} is behind change db: ${entry.watermark})`,
-              );
-            } else {
-              lc.warn?.(
-                `rejecting subscriber at watermark ${sub.watermark} (earliest watermark: ${entry.watermark})`,
-              );
-              sub.close(
-                ErrorType.WatermarkTooOld,
-                `earliest supported watermark is ${entry.watermark} (requested ${sub.watermark})`,
-              );
-              return;
             }
+
+            for (const entry of entries) {
+              if (entry.watermark === sub.watermark) {
+                // This should be the first entry.
+                // Catchup starts from *after* the watermark.
+                watermarkFound = true;
+              } else if (watermarkFound) {
+                lastBatchConsumed = sub.catchup(
+                  reconstructWatermarkedChange(entry),
+                );
+                count++;
+              } else if (mode === 'backup') {
+                throw new AutoResetSignal(
+                  `backup replica at watermark ${sub.watermark} is behind change db: ${entry.watermark})`,
+                );
+              } else {
+                lc.warn?.(
+                  `rejecting subscriber at watermark ${sub.watermark} (earliest watermark: ${entry.watermark})`,
+                );
+                sub.close(
+                  ErrorType.WatermarkTooOld,
+                  `earliest supported watermark is ${entry.watermark} (requested ${sub.watermark})`,
+                );
+                return;
+              }
+            }
+          } finally {
+            // Track the db's read of the next chunk of changes.
+            catchupProgressed = this.#progressMonitor.trackTask({
+              task: 'catchup',
+              subscriber: sub.id,
+              entriesReceived,
+            });
           }
         }
+        catchupProgressed();
+
         if (watermarkFound) {
           await lastBatchConsumed;
           lc.info?.(
@@ -907,6 +1001,8 @@ export class Storer implements Service {
         this.#onFatal(err);
       }
       sub.fail(err);
+    } finally {
+      catchupProgressed();
     }
   }
 
@@ -1031,6 +1127,7 @@ export class Storer implements Service {
    */
   async stop() {
     if (this.#running) {
+      this.#progressMonitor.stop();
       this.#lc.info?.(`draining ${this.#queue.size()} changeLog entries`);
       this.abort(); // for cleanliness, abort any open transactions
       this.#queue.enqueue('stop');
@@ -1121,5 +1218,92 @@ export class PurgeLocker {
       `locked watermark ${watermark} from being purged from replica@${replicaVersion}`,
     );
     return new PurgeLock(this.#lc, tx, replicaVersion, watermark);
+  }
+}
+
+// A TaskKey, keyed by identity, representing an db task monitored by the
+// ProgressMonitor. The contents are stringified in error messages if the
+// task fails to make progress for more than a failure threshold interval.
+type TaskKey = JSONObject;
+
+type TaskDoneFn = () => void;
+
+/**
+ * Periodic monitor for detecting the pathological condition in which a db
+ * query hangs forever because of a connection problem, such as a half-closed
+ * socket.
+ *
+ * Use this for db calls that recur or accumulate progress within a single
+ * logical operation on the main storer loop (e.g. the queue-processing loop,
+ * or a multi-batch catchup read), where "no progress for N ms" is the
+ * meaningful signal. For a one-off db call -- including ones made before
+ * {@link Storer.run} starts this monitor's polling -- use a plain timeout
+ * (see `Storer.#withTimeout`) instead.
+ *
+ * The failure handler should stop the server. The ProgressMonitor will
+ * assume this and stop itself after calling it.
+ *
+ * Internal to the Storer, but exported for testing.
+ */
+export class ProgressMonitor {
+  readonly #lc: LogContext;
+  readonly #failureThresholdMs;
+  readonly #onFailure: (err: Error) => void;
+  readonly #taskUpdates = new Map<TaskKey, Date>();
+
+  #timer: NodeJS.Timeout | undefined;
+
+  constructor(
+    lc: LogContext,
+    failureThresholdMs: number,
+    onFailure: (err: Error) => void,
+  ) {
+    this.#lc = lc.withContext('component', 'storer-progress-monitor');
+    this.#failureThresholdMs = failureThresholdMs;
+    this.#onFailure = onFailure;
+  }
+
+  start() {
+    clearInterval(this.#timer);
+    this.#timer = setInterval(
+      () => this.checkTaskProgress(new Date()),
+      this.#failureThresholdMs,
+    ).unref();
+  }
+
+  // Called by an internal periodic timer, but exported for testing.
+  checkTaskProgress(now: Date) {
+    for (const [task, lastUpdate] of this.#taskUpdates.entries()) {
+      if (now.getTime() - lastUpdate.getTime() >= this.#failureThresholdMs) {
+        this.#lc.error?.(
+          `Last task update was more than ${this.#failureThresholdMs}ms ago`,
+          {task, lastUpdate},
+        );
+        this.#onFailure(
+          new Error(
+            `Task failed to progress for over ${this.#failureThresholdMs}ms: ${BigIntJSON.stringify(task)}`,
+          ),
+        );
+        this.stop();
+        return;
+      }
+    }
+  }
+
+  /**
+   * Starts a task to be tracked.
+   *
+   * @return a callback to invoke when the task is done.
+   */
+  trackTask(task: TaskKey, now = new Date()): TaskDoneFn {
+    this.#taskUpdates.set(task, now);
+    return () => {
+      this.#taskUpdates.delete(task);
+    };
+  }
+
+  stop() {
+    clearInterval(this.#timer);
+    this.#taskUpdates.clear();
   }
 }


### PR DESCRIPTION
Improves detection of half-closed pg connections which manifest as queries never completing, often resulting in the change-db's `Storer` loop hanging the server indefinitely.

This PR subsumes previous attempts to do this at different levels:
* https://github.com/rocicorp/mono/pull/5819
* https://github.com/rocicorp/mono/pull/6348

While those two mechanisms are fine in an of themselves, this new ProgressMonitor covers both cases as well as other cases that were previously not covered in the Storer:
* Hanging when failing to get a connection
* Hanging on `BEGIN` and `COMMIT` of the TransactionPool, before any back-pressure kicks in
* Hanging on catchup requests

The ProgressMonitor covers all cases in the main change-streamer and storer loops. 

Context:
* https://rocicorp.slack.com/archives/C0ATEPDS694/p1787617588732219?thread_ts=1787546057.483619&cid=C0ATEPDS694

Miscellaneous:
* To conservatively avoid false positives, increase the statement response timeout from 20s to 30s since it now technically cover BEGINs and COMMITs in addition to INSERTs. Also, INSERTs have become slightly heavier with batching optimizations.

TODO:
* Remove the statement response timeout and backpressure timeout logic to simplify the code. This will be done separately to make this PR easier to cherry-pick.
