### PR TITLE
chore(zero-cache): remove obsolete query watchdog logic

### DIFF
--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -572,10 +572,10 @@ export const zeroOptions = {
     statementTimeoutMs: {
       type: v.number().default(30_000),
       desc: [
-        `Fail change-log transactions if a statement response from postgres is not received within`,
-        `the specified timeout. This differs from a postgres {bold statement_timeout} in that`,
-        `it is implemented to handle a pathological case in which Postgres does not return a`,
-        `response but otherwise believes the transaction to be idle.`,
+        `Fail change-log db operations that make no progress within the specified timeout. This`,
+        `differs from a postgres {bold statement_timeout} in that it is implemented to handle a`,
+        `pathological case in which Postgres does not return a response but otherwise believes the`,
+        `connection to be idle (e.g. a half-open connection).`,
       ],
       hidden: true, // make visible if proven to be effective/necessary
     },

--- a/packages/zero-cache/src/db/transaction-pool.pg.test.ts
+++ b/packages/zero-cache/src/db/transaction-pool.pg.test.ts
@@ -11,7 +11,6 @@ import type {PostgresDB} from '../types/pg.ts';
 import * as Mode from './mode-enum.ts';
 import {
   importSnapshot,
-  ResponseTimeoutError,
   sharedSnapshot,
   synchronizedSnapshots,
   TIMEOUT_TASKS,
@@ -111,40 +110,6 @@ describe('db/transaction-pool', () => {
       ],
       ['public.workers']: [{id: 1}],
       ['public.cleaned']: [{id: 1}],
-    });
-  });
-
-  test('response timeout', async () => {
-    await db`INSERT INTO foo (id) VALUES (1)`;
-
-    // To induce a response timeout, we hold a lock in one tx and wait
-    // for another tx to timeout.
-    const lockHolder = newTransactionPool(Mode.READ_COMMITTED).run(db);
-    void lockHolder.process(task(`SELECT * FROM foo FOR UPDATE`));
-
-    const lockWaiter = newTransactionPoolWithOpts({
-      mode: Mode.READ_COMMITTED,
-      statementResponseTimeout: 50,
-    }).run(db);
-
-    const promise = lockWaiter.process(task(`DELETE FROM foo`));
-    lockWaiter.setDone();
-
-    // Note: The promise returned by process never throws, but it should
-    //       resolve once the response timeout aborts the transaction.
-    await promise;
-
-    // Release the lock to allow the transaction to proceed.
-    lockHolder.setDone();
-
-    // The final transaction should abort with the ResponseTimeoutError.
-    await expect(lockWaiter.done()).rejects.toThrow(ResponseTimeoutError);
-
-    await lockHolder.done();
-
-    // The delete should not have succeeded.
-    await expectTables(db, {
-      ['public.foo']: [{id: 1, val: null}],
     });
   });
 

--- a/packages/zero-cache/src/db/transaction-pool.ts
+++ b/packages/zero-cache/src/db/transaction-pool.ts
@@ -70,16 +70,6 @@ export type Options = {
    * workers will be shut down after an idle timeout of 5 seconds.
    */
   maxWorkers?: number;
-
-  /**
-   * Aborts the transaction if the response for a statement is not received
-   * within the specified timeout. Note that this is different from a Postgres
-   * `statement_timeout` or `lock_timeout` in that it is specifically intended
-   * to detect situations in which Postgres either never received the
-   * statement, or the application never got the response for the executed
-   * statement.
-   */
-  statementResponseTimeout?: number;
 };
 
 /**
@@ -99,7 +89,6 @@ export class TransactionPool {
   readonly #workers: Promise<unknown>[] = [];
   readonly #initialWorkers: number;
   readonly #maxWorkers: number;
-  readonly #responseTimeout: number | undefined;
   readonly #timeoutTask: TimeoutTasks;
   #numWorkers: number;
   #numWorking = 0;
@@ -107,7 +96,6 @@ export class TransactionPool {
 
   #done = false;
   #failure: Error | undefined;
-  #orphanedQueryCheckInterval: NodeJS.Timeout;
 
   constructor(
     lc: LogContext,
@@ -120,7 +108,6 @@ export class TransactionPool {
       cleanup,
       initialWorkers = 1,
       maxWorkers = initialWorkers,
-      statementResponseTimeout,
     } = opts;
     assert(initialWorkers > 0, 'initialWorkers must be positive');
     assert(
@@ -136,12 +123,6 @@ export class TransactionPool {
     this.#numWorkers = initialWorkers;
     this.#maxWorkers = maxWorkers;
     this.#timeoutTask = timeoutTasks;
-    this.#responseTimeout = statementResponseTimeout;
-
-    this.#orphanedQueryCheckInterval = setInterval(
-      this.#checkForOrphanedQueries,
-      Math.min(5_000, statementResponseTimeout ?? 5_000),
-    );
   }
 
   /**
@@ -332,13 +313,6 @@ export class TransactionPool {
 
   readonly #start = performance.now();
   #stmts = 0;
-  #latestDoneIndex = 0;
-  #latestDoneTime = 0;
-
-  readonly #pending = new Map<
-    Query,
-    {index: number; time: number; abort: (e: ResponseTimeoutError) => void}
-  >();
 
   /**
    * Implements the semantics specified in {@link process()}.
@@ -371,15 +345,10 @@ export class TransactionPool {
         // Execute the statements (i.e. send to the db) immediately.
         // The last result is returned for the worker to await before
         // closing the transaction.
-        const time = Date.now();
         const last = stmts.reduce((_, stmt) => {
           const query = stmt as unknown as Query;
           const index = ++this.#stmts;
-          const {promise: aborted, reject: abort} = resolver();
-          aborted.catch(() => {}); // always consider it "handled"
-
-          this.#pending.set(query, {index, time, abort});
-          const responded = stmt
+          return stmt
             .execute()
             .then(() => {
               if (index % 1000 === 0) {
@@ -390,70 +359,13 @@ export class TransactionPool {
                 );
               }
             })
-            .catch(e => this.fail(e))
-            .finally(() => {
-              this.#pending.delete(query);
-              if (index > this.#latestDoneIndex) {
-                this.#latestDoneIndex = index;
-                this.#latestDoneTime = Date.now();
-              }
-            });
-
-          const done = Promise.race([responded, aborted]);
-          done.catch(() => {});
-
-          return done;
+            .catch(e => this.fail(e));
         }, promiseVoid);
         return {pending: last.finally(r.resolve)};
       },
       rejected: r.resolve,
     };
   }
-
-  /**
-   * Periodically checks the map of `#pending` queries for which Promises
-   * have yet to be resolved. Checks for pathological scenarios that have
-   * been observed:
-   *
-   * * A promise does not resolve, even though the transaction is otherwise
-   *   healthy with keepalives being sent.
-   * * A transaction never "finishes" at the postgres.js level after the
-   *   worker exits, implying that postgres.js is awaiting the `last` promise
-   *   returned. In this case Postgres disconnected the application with an
-   *   idle-in-transaction timeout, suggesting that all statements did in
-   *   fact complete.
-   */
-  readonly #checkForOrphanedQueries = () => {
-    if (this.#pending.size === 0) {
-      return;
-    }
-    const now = Date.now();
-    for (const [query, {index, time, abort}] of this.#pending.entries()) {
-      const statement = query.string;
-      const abortWith = (msg: string) => {
-        this.#lc.warn?.(msg, {statement});
-        const err = new ResponseTimeoutError(msg);
-        abort(err);
-        this.fail(err);
-        this.#pending.delete(query);
-      };
-
-      if (index < this.#latestDoneIndex) {
-        const elapsed = now - this.#latestDoneTime;
-        if (this.#responseTimeout && elapsed > this.#responseTimeout) {
-          abortWith(
-            `statement ${this.#latestDoneIndex} completed ${elapsed} ms ago, but statement ${index} has not.`,
-          );
-        }
-      } else {
-        // Nothing out of order, but checking for a response timeout.
-        const elapsed = now - time;
-        if (this.#responseTimeout && elapsed > this.#responseTimeout) {
-          abortWith(`response for statement timed out after ${elapsed} ms`);
-        }
-      }
-    }
-  };
 
   /**
    * Processes and returns the result of executing the {@link ReadTask} from
@@ -534,9 +446,6 @@ export class TransactionPool {
     for (let i = 0; i < this.#numWorkers; i++) {
       this.#tasks.enqueue('done');
     }
-    void Promise.allSettled(this.#workers).then(() =>
-      clearInterval(this.#orphanedQueryCheckInterval),
-    );
   }
 
   isRunning(): boolean {
@@ -559,9 +468,6 @@ export class TransactionPool {
         // Enqueue the Error to terminate any workers waiting for tasks.
         this.#tasks.enqueue(this.#failure);
       }
-      void Promise.allSettled(this.#workers).then(() =>
-        clearInterval(this.#orphanedQueryCheckInterval),
-      );
     }
   }
 }
@@ -858,11 +764,3 @@ export const TIMEOUT_TASKS: TimeoutTasks = {
 // The slice of information from the Query object in Postgres.js that gets logged for debugging.
 // https://github.com/porsager/postgres/blob/f58cd4f3affd3e8ce8f53e42799672d86cd2c70b/src/connection.js#L219
 type Query = {string: string; parameters: object[]};
-
-export class ResponseTimeoutError extends Error {
-  static readonly name = 'ResponseTimeoutError';
-
-  constructor(msg: string) {
-    super(msg);
-  }
-}

--- a/packages/zero-cache/src/services/change-streamer/storer.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.pg.test.ts
@@ -1697,110 +1697,53 @@ describe('change-streamer/storer', () => {
     });
   });
 
-  describe('back pressure timeout', () => {
+  // Back pressure is a memory-protection mechanism, not a hang watchdog: a
+  // wedged connection (e.g. one that can never even open its `BEGIN`) is
+  // instead caught by the ProgressMonitor (see 'ProgressMonitor hang
+  // detection' below), which is what actually recovers the process in that
+  // case. These tests exercise only the apply/release threshold logic.
+  describe('back pressure', () => {
     // Small enough that any nonzero backlog counts as "applying back
     // pressure", and short enough to keep the test fast.
     const TINY_BACKPRESSURE_PROPORTION = 1e-9;
-    const TIMEOUT_MS = 100;
-
-    let singleConnDb: PostgresDB;
 
     beforeEach(async () => {
-      const {host, port, database, user: username, pass} = db.options;
-      // A dedicated, single-connection pool to the same test database, so
-      // that reserving its one connection deterministically blocks the
-      // storer from ever acquiring a connection for its next transaction --
-      // simulating a wedge that happens *before* any statement is sent to
-      // PG. This is the gap that TransactionPool's own
-      // statementResponseTimeout cannot see, since it only tracks
-      // statements that have already been dispatched.
-      singleConnDb = postgres({
-        host: host[0],
-        port: port[0],
-        username,
-        password: pass ?? undefined,
-        database,
-        max: 1,
-        ...postgresTypeConfig({sendStringAsJson: true}),
-      });
-
       storer = new Storer(
         lc,
         shard,
         'task-id',
         'change-streamer:12345',
         'ws',
-        singleConnDb,
+        db,
         REPLICA_VERSION,
         msg => consumed.enqueue(msg),
         err => fatalErrors.enqueue(err),
         {
           ...opts,
-          statementTimeoutMs: TIMEOUT_MS,
           backPressureLimitHeapProportion: TINY_BACKPRESSURE_PROPORTION,
-          // Flush every change immediately, so that the *second* flush of
-          // the backlog blocks awaiting the still-pending first flush (which
-          // itself can never complete: the sole connection is reserved, so
-          // TransactionPool can't even start its `BEGIN`). This is what
-          // stalls #processQueue's loop mid-message, before it reaches the
-          // per-message #maybeReleaseBackPressure() call for that message,
-          // leaving the still-unprocessed backlog behind it counted against
-          // approximateQueuedBytes -- which is what keeps back pressure
-          // (and the watchdog timer) engaged instead of self-releasing.
-          changeLogBatchSize: 1,
         },
       );
       await storer.assumeOwnership();
       done = storer.run();
     });
 
-    afterEach(async () => {
-      await storer.stop();
-      await singleConnDb.end();
-    });
-
-    // Queues a 'begin' plus enough data changes that #processQueue gets
-    // stuck (per the note above) with some of the backlog still undrained,
-    // and returns the resulting readyForMore() promise.
-    function storeUntilWedged() {
+    test('readyForMore() applies pressure once queued, and releases once the backlog drains', async () => {
       storer.store('20', ['begin', messages.begin(), {commitWatermark: '20'}]);
-      for (let i = 0; i < 4; i++) {
-        storer.store('20', ['data', messages.insert('issues', {id: `${i}`})]);
-      }
+      storer.store('20', ['data', messages.insert('issues', {id: '0'})]);
       // Called synchronously with the store()s above (no intervening
-      // `await`) so that the async queue-processing loop has not yet had a
+      // `await`), so the async queue-processing loop has not yet had a
       // chance to run and decrement approximateQueuedBytes.
-      return storer.readyForMore();
-    }
+      const readyForMore = storer.readyForMore();
+      expect(readyForMore).toBeDefined();
 
-    test('rejects with AbortError when the connection cannot be acquired within the timeout', async () => {
-      const reserved = await singleConnDb.reserve();
-      try {
-        const readyForMore = storeUntilWedged();
-        expect(readyForMore).toBeDefined();
-
-        const start = Date.now();
-        await expect(readyForMore).rejects.toThrow(
-          /Considering the change-log to be wedged/,
-        );
-        expect(Date.now() - start).toBeLessThan(TIMEOUT_MS * 5);
-      } finally {
-        reserved.release();
-      }
-    });
-
-    test('recovers after a timeout once the backlog can drain again', async () => {
-      const reserved = await singleConnDb.reserve();
-      const firstReadyForMore = storeUntilWedged();
-      await expect(firstReadyForMore).rejects.toThrow(/wedged/);
-
-      // Release the connection so the storer can make progress again.
-      reserved.release();
       storer.store('20', ['commit', messages.commit(), {watermark: '20'}]);
       await expectConsumed('20');
 
-      // A stale, already-rejected resolver must not be reused: with nothing
-      // queued, back pressure should no longer be in effect.
+      // The backlog drains once the transaction is processed (a real,
+      // unwedged connection), resolving readyForMore().
+      await readyForMore;
+
+      // With nothing queued, back pressure is no longer in effect.
       expect(storer.readyForMore()).toBeUndefined();
     });
   });
@@ -1809,17 +1752,10 @@ describe('change-streamer/storer', () => {
   // without ever returning (e.g. a half-open connection). These tests exercise
   // real #processQueue / catchup code paths and assert that a hang surfaces as
   // a *fatal* error (via onFatal), which is what the ProgressMonitor -- and
-  // *only* the ProgressMonitor -- produces.
-  //
-  // Both wedges are deliberately chosen to be invisible to the write pool's
-  // statementResponseTimeout, so the fatal error is unambiguously the
-  // ProgressMonitor's doing even while that (soon-to-be-removed) watchdog is
-  // still wired up:
-  //  * The write-path test wedges *before any statement is dispatched* (the
-  //    sole connection is reserved), so the pool's #pending set is empty and
-  //    statementResponseTimeout has nothing to time out.
-  //  * The catchup reader pool is constructed without a statementResponseTimeout
-  //    at all, so a hung catchup read can only be caught by the ProgressMonitor.
+  // *only* the ProgressMonitor -- produces (the write pool has no per-statement
+  // response timeout of its own, and the write-path test wedges *before any
+  // statement is dispatched* -- the sole connection is reserved -- so there
+  // is nothing else that could possibly time it out).
   describe('ProgressMonitor hang detection', () => {
     const TIMEOUT_MS = 100;
 

--- a/packages/zero-cache/src/services/change-streamer/storer.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.ts
@@ -495,7 +495,6 @@ export class Storer implements Service {
   }
 
   #readyForMore: Resolver<void> | null = null;
-  #backpressureTimeout: NodeJS.Timeout | undefined;
 
   readyForMore(): Promise<void> | undefined {
     if (!this.#running) {
@@ -519,23 +518,8 @@ export class Storer implements Service {
           `  LIMIT 20;`,
       );
       this.#readyForMore = resolver();
-      this.#resetBackpressureTimeout(true);
     }
     return this.#readyForMore?.promise;
-  }
-
-  #resetBackpressureTimeout(reschedule: boolean) {
-    clearTimeout(this.#backpressureTimeout);
-    this.#backpressureTimeout = reschedule
-      ? setTimeout(() => {
-          this.#readyForMore?.reject(
-            new AbortError(
-              `No statement processed within the last ${this.#statementTimeoutMs}ms. Considering the change-log to be wedged.`,
-            ),
-          );
-          this.#readyForMore = null;
-        }, this.#statementTimeoutMs)
-      : undefined;
   }
 
   #maybeReleaseBackPressure() {
@@ -550,9 +534,6 @@ export class Storer implements Service {
         );
         this.#readyForMore.resolve();
         this.#readyForMore = null;
-        this.#resetBackpressureTimeout(false);
-      } else {
-        this.#resetBackpressureTimeout(true);
       }
     }
   }
@@ -615,7 +596,6 @@ export class Storer implements Service {
         this.#readyForMore.resolve();
         this.#readyForMore = null;
       }
-      this.#resetBackpressureTimeout(false);
       this.#cancelQueueEntries(
         this.#queue.drain().filter(entry => entry !== undefined),
         err,
@@ -714,10 +694,7 @@ export class Storer implements Service {
           tx = {
             pool: new TransactionPool(
               this.#lc.withContext('watermark', watermark),
-              {
-                mode: Mode.READ_COMMITTED,
-                statementResponseTimeout: this.#statementTimeoutMs,
-              },
+              {mode: Mode.READ_COMMITTED},
             ),
             preCommitWatermark: watermark,
             pos: 0,

--- a/packages/zero-cache/src/types/pg.ts
+++ b/packages/zero-cache/src/types/pg.ts
@@ -333,8 +333,7 @@ export type PostgresTransaction = postgres.TransactionSql<{
 // Guards against half-open TCP connections, which otherwise hang the pool
 // indefinitely: a proxy can keep the client-facing socket alive (ACKing TCP
 // keepalives) after its backend is gone, so no 'close' or 'error' event ever
-// fires and statements like BEGIN / COMMIT — which are not covered by the
-// TransactionPool's statementResponseTimeout — await forever.
+// fires and statements like BEGIN / COMMIT await forever.
 // See https://github.com/porsager/postgres/issues/1089.
 //
 // If no bytes are read or written for this long, the socket is reset, which


### PR DESCRIPTION
Remove obsolete query watchdog logic for handing half-closed connections:
* https://github.com/rocicorp/mono/pull/5819
* https://github.com/rocicorp/mono/pull/6348

which have both been subsumed by the higher-level ProgressMonitor introduced in: https://github.com/rocicorp/mono/pull/6419