### PR TITLE
fix(deps): pin typedoc resolution for the replicache-doc build

### DIFF
--- a/packages/zero/package.json
+++ b/packages/zero/package.json
@@ -181,7 +181,6 @@
     "shared": "workspace:*",
     "syncpack": "^14.3.0",
     "typedoc": "^0.28.17",
-    "typedoc-plugin-markdown": "^4.10.0",
     "typescript": "~7.0.2",
     "vite": "^8.0.13",
     "vitest": "^4.1.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,8 @@ overrides:
   undici@<6.24.0: ^6.24.0
   webpackbar: ^7.0.0
 
+packageExtensionsChecksum: sha256-NnOXomnH/6V1n8jvosjxCTq9LA9MLNKPbiSSsqLarLI=
+
 patchedDependencies:
   postgres@3.4.7: 2bd119d361250d5ee010b23af4c98504e9c6861b692d2e2ae23b9a9e5de4dbce
 
@@ -620,7 +622,7 @@ importers:
         version: 3.9.2(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.14))(esbuild@0.27.7)(html-minifier-terser@7.2.0)(postcss@8.5.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       docusaurus-plugin-typedoc:
         specifier: ^1.4.2
-        version: 1.4.2(typedoc-plugin-markdown@4.11.0(typedoc@0.28.19(typescript@6.0.3)))
+        version: 1.4.2(typedoc-plugin-markdown@4.11.0(typedoc@0.28.19(typescript@6.0.3)))(typedoc@0.28.19(typescript@6.0.3))
       replicache:
         specifier: 15.2.1
         version: 15.2.1
@@ -1012,9 +1014,6 @@ importers:
       typedoc:
         specifier: ^0.28.17
         version: 0.28.19(typescript@7.0.2)
-      typedoc-plugin-markdown:
-        specifier: ^4.10.0
-        version: 4.11.0(typedoc@0.28.19(typescript@7.0.2))
       typescript:
         specifier: ~7.0.2
         version: 7.0.2
@@ -7834,6 +7833,7 @@ packages:
   docusaurus-plugin-typedoc@1.4.2:
     resolution: {integrity: sha512-1qerRejLSYxEWdyVPLDMMeKFPLA/37yZAsdwJy9ThHFQR78+v3b5spSbk67VHGLr2mAn4FVHu0aGJ6p7iWotSg==}
     peerDependencies:
+      typedoc: 0.28.x
       typedoc-plugin-markdown: '>=4.8.0'
 
   dom-accessibility-api@0.5.16:
@@ -12398,6 +12398,7 @@ packages:
   typedoc-docusaurus-theme@1.4.2:
     resolution: {integrity: sha512-i9YYDcScLD0WUiX8I+LXHX3ZVvRDlJsmRo9l/uWrFT37cHlMz4Ay0GOnWzHUBnnwAo1uzYOw9RjUXznbWozBEA==}
     peerDependencies:
+      typedoc: 0.28.x
       typedoc-plugin-markdown: '>=4.8.0'
 
   typedoc-plugin-markdown@4.11.0:
@@ -20974,9 +20975,10 @@ snapshots:
 
   docusaurus-plugin-script-tags@2.0.0-beta.6: {}
 
-  docusaurus-plugin-typedoc@1.4.2(typedoc-plugin-markdown@4.11.0(typedoc@0.28.19(typescript@6.0.3))):
+  docusaurus-plugin-typedoc@1.4.2(typedoc-plugin-markdown@4.11.0(typedoc@0.28.19(typescript@6.0.3)))(typedoc@0.28.19(typescript@6.0.3)):
     dependencies:
-      typedoc-docusaurus-theme: 1.4.2(typedoc-plugin-markdown@4.11.0(typedoc@0.28.19(typescript@6.0.3)))
+      typedoc: 0.28.19(typescript@6.0.3)
+      typedoc-docusaurus-theme: 1.4.2(typedoc-plugin-markdown@4.11.0(typedoc@0.28.19(typescript@6.0.3)))(typedoc@0.28.19(typescript@6.0.3))
       typedoc-plugin-markdown: 4.11.0(typedoc@0.28.19(typescript@6.0.3))
 
   dom-accessibility-api@0.5.16: {}
@@ -26530,17 +26532,14 @@ snapshots:
     dependencies:
       is-typedarray: 1.0.0
 
-  typedoc-docusaurus-theme@1.4.2(typedoc-plugin-markdown@4.11.0(typedoc@0.28.19(typescript@6.0.3))):
+  typedoc-docusaurus-theme@1.4.2(typedoc-plugin-markdown@4.11.0(typedoc@0.28.19(typescript@6.0.3)))(typedoc@0.28.19(typescript@6.0.3)):
     dependencies:
+      typedoc: 0.28.19(typescript@6.0.3)
       typedoc-plugin-markdown: 4.11.0(typedoc@0.28.19(typescript@6.0.3))
 
   typedoc-plugin-markdown@4.11.0(typedoc@0.28.19(typescript@6.0.3)):
     dependencies:
       typedoc: 0.28.19(typescript@6.0.3)
-
-  typedoc-plugin-markdown@4.11.0(typedoc@0.28.19(typescript@7.0.2)):
-    dependencies:
-      typedoc: 0.28.19(typescript@7.0.2)
 
   typedoc@0.28.19(typescript@6.0.3):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -28,6 +28,21 @@ minimumReleaseAgeExclude:
   - '@rocicorp/logger@6.1.0'
   - '@rocicorp/zero-virtual@0.6.3'
 
+# docusaurus-plugin-typedoc and typedoc-docusaurus-theme both import typedoc
+# without declaring it, so they can only resolve it through pnpm's hoisted
+# virtual store. There is more than one typedoc peer variant in the graph
+# (replicache-doc is on TypeScript 6, packages/zero is on 7), so which one gets
+# hoisted is arbitrary — and typedoc 0.28 throws on import under TypeScript 7,
+# which is what broke the replicache-doc build on Vercel. Declaring the peer
+# makes pnpm link the importer's own typedoc instead of relying on hoisting.
+packageExtensions:
+  docusaurus-plugin-typedoc:
+    peerDependencies:
+      typedoc: 0.28.x
+  typedoc-docusaurus-theme:
+    peerDependencies:
+      typedoc: 0.28.x
+
 overrides:
   '@hono/node-server@<1.19.13': ^1.19.13
   '@types/node': '^22.10.5'


### PR DESCRIPTION
Fixes the `replicache-docs` Vercel build, which has been failing on `main` since [#6421](https://github.com/rocicorp/mono/pull/6421):

```
TypeError: Cannot read properties of undefined (reading 'PropertyDeclaration')
    at typedoc@0.28.19_typescript@7.0.2/.../converter/comments/discovery.js:9:19
    at async Object.bootstrap (docusaurus-plugin-typedoc/dist/typedoc.cjs:13:21)
```

## Cause

typedoc 0.28 throws on import under TypeScript 7 — which is exactly why `replicache-doc` stays on TypeScript 6. But two packages in the chain import typedoc **without declaring it**:

- `docusaurus-plugin-typedoc` does `await import('typedoc')` in `dist/typedoc.cjs`
- `typedoc-docusaurus-theme` imports it too

With nothing declared, pnpm can only resolve those through the hoisted virtual store (`node_modules/.pnpm/node_modules/typedoc`). Before #6421 there was exactly one typedoc peer variant, so hoisting was unambiguous. Now `packages/zero` is on TypeScript 7 and puts a second variant in the graph, so which one gets hoisted is arbitrary — locally it picked the TypeScript 6 copy, on Vercel the TypeScript 7 one. (Vercel restores a build cache and installs incrementally, which makes it likelier to land on a different pick than a clean local install.)

## Fix

Declare `typedoc` as a peer of both packages via `packageExtensions`. pnpm then links the importer's own typedoc into their `node_modules`, so resolution no longer touches the hoisted store at all.

Also drops `typedoc-plugin-markdown` from `packages/zero`, which never used it — no reference anywhere in the package. It was the only source of a second `typedoc-plugin-markdown` peer variant, and typedoc's own plugin loader (`loadPlugins`) resolves plugin names the same hoist-dependent way, so that was the identical bug one frame deeper.

## Verification

The real test is that the build no longer *depends* on hoisting, so I forced the hostile case: pointed `node_modules/.pnpm/node_modules/typedoc` at the TypeScript 7 variant and ran the docs build.

- Before this change: fails with the error above.
- After this change: `[SUCCESS] Generated static files in "build".`

Also clean on a fresh `pnpm install`: `check-types` 42/42, `lint` 0 errors, `check-format`, `syncpack lint`, and `verify-deps` all pass.

## Follow-up, not fixed here

`packages/zero`'s `docs` / `docs:server` scripts are broken by the TypeScript 7 migration — `await import('typedoc')` from that package throws the same error, since its typedoc peers to TypeScript 7. Making them work again means moving that tooling somewhere pinned to TypeScript 6, which seemed like a separate call from unbreaking the deploy.
