### PR TITLE
fix(zero-cache): reject/ignore invalid watermarks from litestream v3

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/litestream3-prometheus-poller.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/litestream3-prometheus-poller.test.ts
@@ -106,6 +106,30 @@ litestream_replica_validation_total{db="/tmp/zbugs-sync-replica.db",name="file",
     await vi.waitFor(() => expect(scheduled).toEqual(['618ocqq8', '618p0bw8']));
   });
 
+  test('ignores an invalid watermark reported by litestream metrics', async () => {
+    const time = Date.UTC(2025, 3, 24);
+    vi.setSystemTime(time);
+
+    // Real-world garbage watermark observed in production: not a valid
+    // lexicographic version, so it must be dropped rather than crash the
+    // poller or get scheduled for publishing.
+    const t1 = (Date.now() / 1000).toPrecision(9);
+    setMetricsResponse('cms7batsx004004l2w8i5gtks', t1);
+
+    await poller.checkVerifyAndPublishWatermarks();
+    await Promise.resolve();
+    expect(scheduled).toEqual([]);
+    expect(consumeError).toBeUndefined();
+
+    // A subsequent, valid watermark is still processed normally.
+    vi.setSystemTime(time + 10_000);
+    const t2 = (Date.now() / 1000).toPrecision(9);
+    setMetricsResponse('618p0bw8', t2);
+
+    await poller.checkVerifyAndPublishWatermarks();
+    await vi.waitFor(() => expect(scheduled).toEqual(['618p0bw8']));
+  });
+
   test('blocks publish when actual backup is older than claimed', async () => {
     const time = Date.UTC(2025, 3, 24);
     vi.setSystemTime(time);

--- a/packages/zero-cache/src/services/change-streamer/litestream3-prometheus-poller.ts
+++ b/packages/zero-cache/src/services/change-streamer/litestream3-prometheus-poller.ts
@@ -4,6 +4,7 @@ import parsePrometheusTextFormat from 'parse-prometheus-text-format';
 import {assert} from '../../../../shared/src/asserts.ts';
 import {must} from '../../../../shared/src/must.ts';
 import {getOrCreateCounter} from '../../observability/metrics.ts';
+import {versionFromLexi} from '../../types/lexi-version.ts';
 import type {Source} from '../../types/streams.ts';
 import {Subscription} from '../../types/subscription.ts';
 import {
@@ -244,9 +245,17 @@ export class Litestream3PrometheusPoller {
           const watermark = metric.labels?.watermark;
           const name = metric.labels?.name;
           const time = new Date(parseFloat(metric.value) * 1000);
-
           if (watermark) {
-            yield {watermark, time, name};
+            try {
+              versionFromLexi(watermark); // Sanity check: Ensure that it is valid.
+              yield {watermark, time, name};
+            } catch (e) {
+              this.#lc.warn?.(
+                `ignoring invalid watermark ${watermark}`,
+                {metric},
+                e,
+              );
+            }
           }
         }
       }


### PR DESCRIPTION
Mitigates a one-off case of an invalid watermark that was temporarily reported from litestream's prometheus metrics, with a valid one following soon after.

The root cause of the invalid watermark is still being investigated, but this PR makes the situation recoverable.