### PR TITLE
fix(zero-cache): stage initial sync replicas before publishing

### DIFF
--- a/packages/zero-cache/src/services/change-source/common/replica-schema.test.ts
+++ b/packages/zero-cache/src/services/change-source/common/replica-schema.test.ts
@@ -1,6 +1,8 @@
+import {existsSync, statSync} from 'node:fs';
 import {beforeEach, describe, expect, test} from 'vitest';
 import {createSilentLogContext} from '../../../../../shared/src/logging-test-utils.ts';
 import {promiseVoid} from '../../../../../shared/src/resolved-promises.ts';
+import {deleteLiteDB} from '../../../db/delete-lite-db.ts';
 import {runSchemaMigrations} from '../../../db/migration-lite.ts';
 import {
   DbFile,
@@ -667,10 +669,33 @@ describe('replica-schema-migrations', () => {
 
   beforeEach(() => {
     replicaFile = new DbFile('replica_schema_test');
-    return () => replicaFile.delete();
+    return () => {
+      replicaFile.delete();
+      deleteLiteDB(`${replicaFile.path}.tmp`);
+    };
   });
 
   const lc = createSilentLogContext();
+
+  test('publishes a new replica only after initial sync succeeds', async () => {
+    const temporaryReplica = `${replicaFile.path}.tmp`;
+    await expect(
+      initReplica(lc, 'test', replicaFile.path, () => {
+        throw new Error('initial sync failed');
+      }),
+    ).rejects.toThrow('initial sync failed');
+
+    expect(existsSync(replicaFile.path)).toBe(false);
+    expect(statSync(temporaryReplica).size).toBe(8192);
+
+    await initReplica(lc, 'test', replicaFile.path, (_, db) => {
+      initReplicationState(db, ['foo_publication'], '123');
+      return promiseVoid;
+    });
+
+    expect(existsSync(replicaFile.path)).toBe(true);
+    expect(existsSync(temporaryReplica)).toBe(false);
+  });
 
   for (const c of cases) {
     test(`from v${c.fromSchemaVersion}: ${c.desc}`, async () => {

--- a/packages/zero-cache/src/services/change-source/common/replica-schema.ts
+++ b/packages/zero-cache/src/services/change-source/common/replica-schema.ts
@@ -1,6 +1,8 @@
+import {existsSync, renameSync} from 'node:fs';
 import type {LogContext} from '@rocicorp/logger';
 import {assert} from '../../../../../shared/src/asserts.ts';
 import type {Database} from '../../../../../zqlite/src/db.ts';
+import {deleteLiteDB} from '../../../db/delete-lite-db.ts';
 import {listTables} from '../../../db/lite-tables.ts';
 import {
   runSchemaMigrations,
@@ -28,6 +30,12 @@ export async function initReplica(
   dbPath: string,
   initialSync: (lc: LogContext, tx: Database) => Promise<void>,
 ): Promise<void> {
+  const isInitialSync = !existsSync(dbPath);
+  const migrationPath = isInitialSync ? `${dbPath}.tmp` : dbPath;
+  if (isInitialSync) {
+    deleteLiteDB(migrationPath);
+  }
+
   const setupMigration: Migration = {
     migrateSchema: (log, tx) => initialSync(log, tx),
     minSafeVersion: 1,
@@ -37,12 +45,15 @@ export async function initReplica(
     await runSchemaMigrations(
       log,
       debugName,
-      dbPath,
+      migrationPath,
       setupMigration,
       schemaVersionMigrationMap,
     );
+    if (isInitialSync) {
+      renameSync(migrationPath, dbPath);
+    }
   } catch (e) {
-    throwAutoResetForCorruption(log, debugName, dbPath, e);
+    throwAutoResetForCorruption(log, debugName, migrationPath, e);
   }
 }
 


### PR DESCRIPTION
### What

Stage fresh Zero replica init in a temporary SQLite database and atomically publish it to the canonical replica path only after initial sync and schema setup complete.

Existing replicas continue to run schema migrations in place. The change only affects initialization when the canonical replica does not yet exist.

### Why

During production recovery, an initial sync failed while setting up its PostgreSQL replication slot. Before the initial-sync transaction began, the SQLite migration framework had committed the `_zero.versionHistory` bootstrap table. The failed transaction rolled back the remaining replica schema, but left a valid 8192-byte, two-page SQLite database at the canonical `replica.db` path.

A container restart preserved that file. Litestream correctly uses a temporary file for restores, but its `-if-db-not-exists` guard saw the canonical file and skipped downloading the available backup. The local replica then failed validation because it had no `_zero.replicationConfig` or replication state.

The canonical replica path should therefore mean that initial sync completed, not merely that SQLite bootstrap started.

### Changes

- Run fresh replica initialization against `replica.db.tmp` when no canonical replica exists.
- Remove any stale temporary SQLite family before starting another initial sync.
- Atomically rename the temporary database to `replica.db` only after initialization and migrations succeed.
- Leave the canonical path absent when initial sync fails, allowing Litestream startup cleanup and backup restore to proceed normally.
- Add a regression test reproducing the 8192-byte bootstrap artifact and verifying that a later successful attempt replaces it and publishes the completed replica.