### PR TITLE
fix(litestream-v3): correctly read watermarks from  pages late in the db file

### DIFF
--- a/packages/zero/Dockerfile
+++ b/packages/zero/Dockerfile
@@ -1,10 +1,10 @@
 FROM golang:1.25.10@sha256:cd05a378aaf011e8056745363e5c40f4f2bef0fa4d9bf19b9c38316079c332ff AS litestream
 
-WORKDIR /src/
-RUN git clone --depth 1 --branch zero@v0.0.10 https://github.com/rocicorp/litestream.git
-WORKDIR /src/litestream/
+ARG LITESTREAM_V3_VERSION=0.3.13-zero.11
 
-ARG LITESTREAM_VERSION=0.3.13+z0.0.10  # upstream version + zero version
+WORKDIR /src/
+RUN git clone --depth 1 --branch v${LITESTREAM_V3_VERSION}  https://github.com/rocicorp/litestream.git
+WORKDIR /src/litestream/
 
 # Force use of the toolchain bundled in the builder image so the resulting
 # binary is compiled with Go 1.25.10 stdlib (fixes CVE-2025-68121 and a
@@ -14,7 +14,7 @@ ENV GOTOOLCHAIN=local
 
 RUN --mount=type=cache,target=/root/.cache/go-build \
 	--mount=type=cache,target=/go/pkg \
-	go build -ldflags "-s -w -X 'main.Version=${LITESTREAM_VERSION}' -extldflags '-static'" -tags osusergo,netgo,sqlite_omit_load_extension -o /usr/local/bin/litestream ./cmd/litestream
+	go build -ldflags "-s -w -X 'main.Version=${LITESTREAM_V3_VERSION}' -extldflags '-static'" -tags osusergo,netgo,sqlite_omit_load_extension -o /usr/local/bin/litestream ./cmd/litestream
 
 FROM golang:1.25.10@sha256:cd05a378aaf011e8056745363e5c40f4f2bef0fa4d9bf19b9c38316079c332ff AS litestream-v5
 


### PR DESCRIPTION
Includes https://github.com/rocicorp/litestream/pull/25

Context:
* https://rocicorp.slack.com/archives/C0BTAS932TE/p1787869243301499