### PR TITLE
fix(zero-cache): reset litestream state with replica

### DIFF
--- a/packages/zero-cache/src/server/change-streamer.pg.test.ts
+++ b/packages/zero-cache/src/server/change-streamer.pg.test.ts
@@ -1,4 +1,5 @@
-import {existsSync, writeFileSync} from 'node:fs';
+import {existsSync, mkdirSync, rmSync, writeFileSync} from 'node:fs';
+import {basename, dirname, join} from 'node:path';
 import {gunzipSync} from 'node:zlib';
 import {getLocal, type Mockttp} from 'mockttp';
 import {expect, vi} from 'vitest';
@@ -177,6 +178,10 @@ test('change-streamer startup does not deadlock on autoreset retry when change a
   );
   const upstreamURI = getConnectionURI(upstream);
   const replicaFile = new DbFile('change-streamer-worker-autoreset-deadlock');
+  const litestreamState = join(
+    dirname(replicaFile.path),
+    `.${basename(replicaFile.path)}-litestream`,
+  );
 
   let initialSource:
     | Awaited<ReturnType<typeof initializePostgresChangeSource>>['changeSource']
@@ -226,6 +231,12 @@ test('change-streamer startup does not deadlock on autoreset retry when change a
     const changeLog = changeLogFileName(replicaFile.path);
     writeFileSync(changeLog, '');
     writeFileSync(`${changeLog}-wal2`, '');
+    const ltxDirectory = join(litestreamState, 'ltx', '0');
+    mkdirSync(ltxDirectory, {recursive: true});
+    writeFileSync(
+      join(ltxDirectory, '0000000000000001-0000000000000001.ltx'),
+      '',
+    );
 
     const [worker, parent] = inProcChannel();
     const ready = new Promise<void>(resolve => {
@@ -286,8 +297,10 @@ test('change-streamer startup does not deadlock on autoreset retry when change a
 
     expect(existsSync(changeLog)).toBe(false);
     expect(existsSync(`${changeLog}-wal2`)).toBe(false);
+    expect(existsSync(litestreamState)).toBe(false);
   } finally {
     await initialSource?.stop().catch(() => {});
+    rmSync(litestreamState, {recursive: true, force: true});
     deleteChangeLogDB(replicaFile.path);
     replicaFile.delete();
     await testDBs.drop(upstream);

--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -6,7 +6,6 @@ import {promiseVoid} from '../../../shared/src/resolved-promises.ts';
 import {DatabaseInitError} from '../../../zqlite/src/db.ts';
 import {getServerContext} from '../config/server-context.ts';
 import {getNormalizedZeroConfig} from '../config/zero-config.ts';
-import {deleteLiteDB} from '../db/delete-lite-db.ts';
 import {registerSQLiteCorruptionDiagnosticTarget} from '../db/sqlite-corruption.ts';
 import {warmupConnections} from '../db/warmup.ts';
 import {initEventSink, publishCriticalEvent} from '../observability/events.ts';
@@ -25,7 +24,10 @@ import {
   ProcessManager,
   runUntilKilled,
 } from '../services/life-cycle.ts';
-import {startReplicaBackupProcess} from '../services/litestream/commands.ts';
+import {
+  deleteReplicaAndLitestreamState,
+  startReplicaBackupProcess,
+} from '../services/litestream/commands.ts';
 import {
   changeLogFileName,
   deleteChangeLogDB,
@@ -283,9 +285,7 @@ export default async function runWorker(
     } catch (e) {
       if (first && e instanceof AutoResetSignal) {
         lc.warn?.(`resetting replica ${replica.file}`, e);
-        // TODO: Make deleteLiteDB work with litestream. It will probably have to be
-        //       a semantic wipe instead of a file delete.
-        deleteLiteDB(replica.file);
+        deleteReplicaAndLitestreamState(replica.file);
         // The change log carries the identity of the replica it was written
         // beside, and the retry performs a fresh initial sync with a new
         // replicaVersion. Reconciliation would catch that on its own (as

--- a/packages/zero-cache/src/services/litestream/commands.ts
+++ b/packages/zero-cache/src/services/litestream/commands.ts
@@ -57,6 +57,14 @@ export class BackupNotFoundException extends Error {
   }
 }
 
+export function deleteReplicaAndLitestreamState(replicaFile: string) {
+  rmSync(join(dirname(replicaFile), `.${basename(replicaFile)}-litestream`), {
+    recursive: true,
+    force: true,
+  });
+  deleteLiteDB(replicaFile);
+}
+
 function getLitestream(
   mode: 'restore' | 'replicate',
   config: LitestreamConfig,


### PR DESCRIPTION
### What

Keep local Litestream metadata aligned with the SQLite replica lifecycle during zero-cache auto-resets. When upstream state can no longer service a restored replica, auto-reset now removes Litestream sidecar state before starting a fresh initial sync.

### Why

Auto-reset previously deleted replica.db and its standard SQLite sidecars but left `.replica.db-litestream` behind. Litestream could then start against a new replica using LTX state from the deleted replica and report a missing LTX file before auto-recovering.

### Changes

- Remove the replica-specific Litestream state directory before deleting the SQLite replica.
- Use the coordinated cleanup in the AutoResetSignal retry path.
- Extend the existing PostgreSQL auto-reset regression test to verify nested LTX state is removed.