### PR TITLE
fix(shared): deepEqual should treat undefined values as non-existent

### DIFF
--- a/packages/shared/src/json.test.ts
+++ b/packages/shared/src/json.test.ts
@@ -124,3 +124,22 @@ test('isJSONValue', () => {
   t([undefined], [0]);
   t({x: [undefined]}, ['x', 0]);
 });
+
+test('xxx', () => {
+  const t = (
+    a: JSONValue | undefined,
+    b: JSONValue | undefined,
+    expected: boolean,
+  ) => {
+    expect(deepEqual(a, b)).toBe(expected);
+    expect(deepEqual(b, a)).toBe(expected);
+  };
+
+  t({a: 1}, {a: 1, b: 'x'}, false);
+  t({a: 1}, {a: 1, b: undefined}, true);
+  t({}, {a: undefined}, true);
+  t({a: undefined}, {b: undefined}, true);
+  t({a: undefined}, {b: 1}, false);
+  t({a: undefined, b: 1}, {b: 1}, true);
+  t({b: 1}, {a: undefined, b: 1}, true);
+});

--- a/packages/shared/src/json.test.ts
+++ b/packages/shared/src/json.test.ts
@@ -125,7 +125,7 @@ test('isJSONValue', () => {
   t({x: [undefined]}, ['x', 0]);
 });
 
-test('xxx', () => {
+test('undefined property values', () => {
   const t = (
     a: JSONValue | undefined,
     b: JSONValue | undefined,

--- a/packages/shared/src/json.ts
+++ b/packages/shared/src/json.ts
@@ -107,9 +107,16 @@ export function deepEqual(
   // We use for-in loops instead of for of Object.keys() to make sure deepEquals
   // does not allocate any objects.
 
+  // The behavior we want is that property values that are undefined are treated
+  // as if they do not exist. For example, the following two values are
+  // considered equal:
+  // ```
+  // deepEqual({a: undefined}, {})
+  // ```
+
   let aSize = 0;
   for (const key in a) {
-    if (hasOwn(a, key)) {
+    if (hasOwn(a, key) && a[key] !== undefined) {
       if (!deepEqual(a[key], b[key])) {
         return false;
       }
@@ -119,7 +126,7 @@ export function deepEqual(
 
   let bSize = 0;
   for (const key in b) {
-    if (hasOwn(b, key)) {
+    if (hasOwn(b, key) && b[key] !== undefined) {
       bSize++;
     }
   }


### PR DESCRIPTION
Our deepEqual function was treating undefined values as existing properties, which caused some unexpected behavior. For example, deepEqual({a: undefined}, {}) would return false, even though we want it to return true.