### PR TITLE
fix(supabase): fix classification of schema changes with COMMENT ON PUBLICATION

### DIFF
--- a/packages/zero-cache/src/services/change-source/pg/change-source.backfill.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.backfill.pg.test.ts
@@ -1,4 +1,5 @@
 import type {LogContext} from '@rocicorp/logger';
+import {literal} from 'pg-format';
 import {beforeEach, describe, expect, test} from 'vitest';
 import {
   BigIntJSON,
@@ -23,8 +24,32 @@ import type {
   ChangeStreamMessage,
 } from '../protocol/current/downstream.ts';
 import {initializePostgresChangeSource} from './change-source.ts';
+import {TAGS} from './schema/ddl.ts';
 
 const APP_ID = 'bf';
+
+// Simulates the Supabase environment, which does not fire event triggers for
+// `ALTER PUBLICATION` commands (https://github.com/supabase/supautils/issues/123),
+// by recreating the shard's event triggers with `ALTER PUBLICATION` removed
+// from the tag list. All other tags (CREATE TABLE, COMMENT, etc.) still fire.
+function removeAlterPublication(tags: readonly string[]) {
+  return tags.filter(tag => tag !== 'ALTER PUBLICATION');
+}
+
+const DISABLE_ALTER_PUBLICATION_TRIGGER = /*sql*/ `
+  DROP EVENT TRIGGER ${APP_ID}_ddl_start_0;
+  DROP EVENT TRIGGER ${APP_ID}_ddl_end_0;
+
+  CREATE EVENT TRIGGER ${APP_ID}_ddl_start_0
+    ON ddl_command_start
+    WHEN TAG IN (${literal(removeAlterPublication(TAGS))})
+    EXECUTE PROCEDURE ${APP_ID}_0.emit_ddl_start();
+
+  CREATE EVENT TRIGGER ${APP_ID}_ddl_end_0
+    ON ddl_command_end
+    WHEN TAG IN (${literal(removeAlterPublication([...TAGS, 'COMMENT']))})
+    EXECUTE PROCEDURE ${APP_ID}_0.emit_ddl_end();
+`;
 const PG_15_UP = 150000;
 const PG_18_UP = 180000;
 
@@ -786,6 +811,96 @@ describe.each([
           name: 'published.late_pk',
           columns: {
             id: {dataType: 'text|NOT_NULL', pos: 1},
+          },
+        },
+      ],
+    ],
+    [
+      // Repro for a Supabase bug: because Supabase does not fire event
+      // triggers for `ALTER PUBLICATION`, the schema change is detected via
+      // the `COMMENT ON PUBLICATION` hook (emitted as a `schemaSnapshot`
+      // event). If a `CREATE TABLE` immediately precedes the publish (in a
+      // *separate* transaction), the stale `CREATE TABLE` ddlStart event must
+      // not be misattributed as the command tag for the schemaSnapshot --
+      // otherwise the newly published table is treated as a freshly `CREATE`d
+      // table and (incorrectly) skips backfill of its pre-existing rows.
+      'supabase: CREATE TABLE, then ALTER PUBLICATION + COMMENT hook',
+      PG_15_UP,
+      // First transaction: create and seed the table. The CREATE TABLE fires
+      // a `CREATE TABLE` ddlStart event which lingers as the last-seen event.
+      // (The table is not yet published, so the seeded rows are "pre-existing"
+      // and must be backfilled once the table is added to the publication.)
+      /*sql*/ `
+      ${DISABLE_ALTER_PUBLICATION_TRIGGER}
+
+      CREATE TABLE drill (
+        id INT PRIMARY KEY,
+        num INT
+      );
+
+      INSERT INTO drill (id, num) SELECT g, g FROM generate_series(1, 3) g;
+      `,
+      // Second (separate) transaction: the publish. The ALTER PUBLICATION
+      // fires no event trigger (Supabase); the trailing COMMENT ON PUBLICATION
+      // is the hook that emits the schemaSnapshot. The stale CREATE TABLE
+      // ddlStart from the previous transaction must not be misattributed here.
+      /*sql*/ `
+      ALTER PUBLICATION published_tables ADD TABLE drill (id, num);
+      COMMENT ON PUBLICATION published_tables IS 'drill fingerprint test';
+      `,
+      {
+        ['drill']: [
+          {id: 1n, num: 1n},
+          {id: 2n, num: 2n},
+          {id: 3n, num: 3n},
+        ],
+      },
+      [
+        {
+          name: 'drill',
+          columns: {
+            id: {dataType: 'int4|NOT_NULL', pos: 1},
+            num: {dataType: 'int4', pos: 2},
+          },
+        },
+      ],
+    ],
+    [
+      // Same as above, but with the CREATE TABLE, the seeding, and the
+      // publish (ALTER PUBLICATION + COMMENT hook) all in a *single*
+      // transaction. Here there is no commit boundary between the stale
+      // CREATE TABLE ddlStart and the schemaSnapshot, so a `schemaSnapshot`
+      // must never adopt a preceding ddlStart's command tag -- it is a
+      // standalone hook that must always backfill newly published tables.
+      'supabase: CREATE TABLE + ALTER PUBLICATION + COMMENT in one txn',
+      PG_15_UP,
+      /*sql*/ `
+      ${DISABLE_ALTER_PUBLICATION_TRIGGER}
+
+      CREATE TABLE drill2 (
+        id INT PRIMARY KEY,
+        num INT
+      );
+
+      INSERT INTO drill2 (id, num) SELECT g, g FROM generate_series(1, 3) g;
+
+      ALTER PUBLICATION published_tables ADD TABLE drill2 (id, num);
+      COMMENT ON PUBLICATION published_tables IS 'drill2 fingerprint test';
+      `,
+      null,
+      {
+        ['drill2']: [
+          {id: 1n, num: 1n},
+          {id: 2n, num: 2n},
+          {id: 3n, num: 3n},
+        ],
+      },
+      [
+        {
+          name: 'drill2',
+          columns: {
+            id: {dataType: 'int4|NOT_NULL', pos: 1},
+            num: {dataType: 'int4', pos: 2},
           },
         },
       ],

--- a/packages/zero-cache/src/services/change-source/pg/change-source.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.ts
@@ -1205,6 +1205,18 @@ class ChangeMaker {
         }
 
       case 'commit':
+        // The DDL event that provides command-tag context for a subsequent
+        // event (see #handleDdlMessage) is only meaningful within a single
+        // (upstream) transaction, since related ddl events (e.g. the nested
+        // start->start->end->end sequence) are always emitted together. Clear
+        // it at the transaction boundary so that a lingering event (e.g. a
+        // `CREATE TABLE` ddlStart) is not misattributed as the context for an
+        // unrelated event in a later transaction. Note that this is safe for
+        // the one type of DDL event that spans multiple transactions,
+        // `CREATE INDEX CONCURRENTLY`, because that change is self declaring
+        // in the `ddlUpdate` and does not depend on the value of the preceding
+        // event.
+        this.#lastReplicationEvent = undefined;
         return [
           [
             'commit',
@@ -1302,12 +1314,24 @@ class ChangeMaker {
     // ddl_start (e.g. cases 1, 2, and 4), and from the current event
     // if it is a ddl_end (case 5), and 'UNKNOWN' otherwise (case 3 and
     // 'schemaSnapshot' workarounds).
+    //
+    // A 'schemaSnapshot' is special: it is a standalone hook (emitted by the
+    // COMMENT ON PUBLICATION workaround, or a MANUAL update_schemas() call)
+    // that substitutes for a missing ALTER PUBLICATION event on databases
+    // (e.g. supabase) that do not fire event triggers for it. It must never
+    // adopt the command tag of a preceding ddlStart (e.g. a `CREATE TABLE`
+    // in the same transaction), as that would cause a newly *published*
+    // table to be misclassified as a freshly *created* one and skip the
+    // backfill of its pre-existing rows. It therefore always falls back to
+    // 'UNKNOWN', which conservatively initiates a backfill.
     const effectiveTag =
-      prevEvent?.type === 'ddlStart'
-        ? prevEvent.event.tag
-        : event.type === 'ddlUpdate'
-          ? event.event.tag
-          : 'UNKNOWN';
+      event.type === 'schemaSnapshot'
+        ? 'UNKNOWN'
+        : prevEvent?.type === 'ddlStart'
+          ? prevEvent.event.tag
+          : event.type === 'ddlUpdate'
+            ? event.event.tag
+            : 'UNKNOWN';
     lc.info?.(`processing ${effectiveTag} command from ${msg.prefix}/${type}`, {
       event: summarizeReplicationEventForLog(event),
     });


### PR DESCRIPTION
Fix the classification of schema change type when processing a `COMMENT ON PUBLICATION` tag. Examining the previous schema change is incorrect as in Supabase the `ALTER PUBLICATION` will be missing. So always consider a schema change detected by `COMMENT ON PUBLICATION` as "unknown" which will correctly initiate a backfill for new tables/columns.

Context:
* https://rocicorp.slack.com/archives/C0B3A4P3W56/p1787956562056209