### PR TITLE
fix(zero-cache): prevent pg client corruption/blackholing by isolating connections

### DIFF
--- a/packages/zero-cache/src/config/zero-config.test.ts
+++ b/packages/zero-cache/src/config/zero-config.test.ts
@@ -295,12 +295,6 @@ test('zero-cache --help', () => {
                                                                                    to sync multiple view-syncers without requiring multiple replication slots on                                              
                                                                                    the upstream database. If unspecified, the upstream-db will be used.                                                       
                                                                                                                                                                                                               
-     --change-max-conns number                                                     default: 5                                                                                                                 
-       ZERO_CHANGE_MAX_CONNS env                                                                                                                                                                              
-                                                                                   The maximum number of connections to open to the change database.                                                          
-                                                                                   This is used by the change-streamer for catching up                                                                        
-                                                                                   zero-cache replication subscriptions.                                                                                      
-                                                                                                                                                                                                              
      --replica-file string                                                         default: "zero.db"                                                                                                         
        ZERO_REPLICA_FILE env                                                                                                                                                                                  
                                                                                    File path to the SQLite replica that zero-cache maintains.                                                                 

--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -560,13 +560,14 @@ export const zeroOptions = {
       ],
     },
 
+    /** @deprecated */
     maxConns: {
       type: v.number().default(5),
-      desc: [
-        `The maximum number of connections to open to the change database.`,
-        `This is used by the {bold change-streamer} for catching up`,
-        `{bold zero-cache} replication subscriptions.`,
+      deprecated: [
+        `Connections to the change db are created dynamically for subscriber catchup. Ensure`,
+        `that the database supports sufficient connections for at least 5 + numViewSyncers.`,
       ],
+      hidden: true,
     },
 
     statementTimeoutMs: {

--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -102,12 +102,14 @@ export default async function runWorker(
   );
   initEventSink(lc, config);
 
-  // Kick off DB connection warmup in the background.
+  // Startup-time client used for for change-streamer initialization
+  // and handoff / takeover. Steady-state clients are managed by the
+  // change-streamer (Storer) implementation.
   const changeDB = await connectPgClient(
     lc,
     change.db,
-    'change-streamer',
-    {max: change.maxConns},
+    'change-streamer-init',
+    {max: 5},
     {sendStringAsJson: true},
   );
   void warmupConnections(lc, changeDB, 'change').catch(() => {});

--- a/packages/zero-cache/src/services/change-streamer/change-log-test-utils.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-log-test-utils.ts
@@ -112,7 +112,7 @@ export async function createShardStorer(
     'task-id',
     'change-streamer:12345',
     'ws',
-    db,
+    () => db,
     REPLICA_VERSION,
     () => {},
     () => {},

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
@@ -137,13 +137,27 @@ describe('change-streamer/service', () => {
       opts,
       setTimeoutFn as unknown as typeof setTimeout,
     );
-    streamerDone = streamer.run();
+    await run(streamer);
 
     return async () => {
       await streamer.stop();
       await testDBs.drop(sql);
     };
   });
+
+  async function run(streamer: ChangeStreamerService) {
+    // Clear ownership
+    await sql`UPDATE "zoro_3/cdc"."replicationState" SET owner = NULL;`;
+
+    streamerDone = streamer.run();
+
+    // Await confirmation that the streamer has taken ownership
+    await vi.waitFor(async () => {
+      expect(
+        await sql`SELECT owner FROM "zoro_3/cdc"."replicationState"`,
+      ).toEqual([{owner: 'task-id'}]);
+    });
+  }
 
   function drainToQueue(sub: Source<string>): Queue<Downstream> {
     const queue = new Queue<Downstream>();
@@ -202,7 +216,7 @@ describe('change-streamer/service', () => {
       opts,
       setTimeoutFn as unknown as typeof setTimeout,
     );
-    void backupStreamer.run();
+    await run(backupStreamer);
     return backupStreamer;
   }
 
@@ -327,7 +341,7 @@ describe('change-streamer/service', () => {
       {...opts, sqliteCatchup},
       setTimeoutFn as unknown as typeof setTimeout,
     );
-    streamerDone = streamer.run();
+    await run(streamer);
   }
 
   /**
@@ -412,7 +426,7 @@ describe('change-streamer/service', () => {
       },
       setTimeoutFn as unknown as typeof setTimeout,
     );
-    streamerDone = streamer.run();
+    await run(streamer);
   }
 
   /** The oldest watermark retained in the SQLite change log beside `logFile`. */
@@ -1625,7 +1639,7 @@ describe('change-streamer/service', () => {
       // The real timer, because these tests depend on the reconnect backoff
       // actually firing.
     );
-    streamerDone = streamer.run();
+    await run(streamer);
 
     return {
       first,
@@ -1858,7 +1872,7 @@ describe('change-streamer/service', () => {
       },
       setTimeoutFn as unknown as typeof setTimeout,
     );
-    streamerDone = streamer.run();
+    await run(streamer);
 
     try {
       const liveSub = await streamer.subscribe({
@@ -2236,7 +2250,7 @@ describe('change-streamer/service', () => {
       },
       setTimeoutFn as unknown as typeof setTimeout,
     );
-    streamerDone = streamer.run();
+    await run(streamer);
 
     try {
       const observerSub = await streamer.subscribe({
@@ -3829,7 +3843,7 @@ describe('change-streamer/service', () => {
       true,
       opts,
     );
-    void streamer.run();
+    await run(streamer);
 
     expect(await hasRetried).toBe(true);
   });
@@ -3871,7 +3885,7 @@ describe('change-streamer/service', () => {
       true,
       opts,
     );
-    void streamer.run();
+    await run(streamer);
 
     expect(await requests.dequeue()).toBe(REPLICA_VERSION);
 
@@ -3896,7 +3910,7 @@ describe('change-streamer/service', () => {
       true,
       opts,
     );
-    void streamer.run();
+    await run(streamer);
 
     expect(await requests.dequeue()).toBe('04');
   });
@@ -3935,7 +3949,7 @@ describe('change-streamer/service', () => {
       true,
       opts,
     );
-    void streamer.run();
+    await run(streamer);
 
     // This should succeed once the purge lock is released.
     await sql`SELECT FROM "zoro_3/cdc"."changeLog" FOR UPDATE`;
@@ -3979,7 +3993,7 @@ describe('change-streamer/service', () => {
       true,
       opts,
     );
-    void streamer.run();
+    await run(streamer);
 
     changes.fail(new Error('doh'));
 
@@ -4202,7 +4216,7 @@ describe('change-streamer/service', () => {
       true,
       opts,
     );
-    void streamer.run();
+    await run(streamer);
 
     // Insert unexpected data simulating that the stream and store are not in the expected state.
     await sql`INSERT INTO "zoro_3/cdc"."changeLog" (watermark, pos, change)
@@ -4262,7 +4276,7 @@ describe('change-streamer/service', () => {
       true,
       opts,
     );
-    void streamer.run();
+    await run(streamer);
 
     // Stream down a big (1MB) transaction, which should take time to commit.
     const NEW_WATERMARK = '0g';
@@ -4339,7 +4353,7 @@ describe('change-streamer/service', () => {
       true,
       opts,
     );
-    void streamer.run();
+    await run(streamer);
 
     const sub = await streamer.subscribe({
       protocolVersion: PROTOCOL_VERSION,
@@ -4457,7 +4471,7 @@ describe('change-streamer/service', () => {
     changes.push(['data', messages.insert('foo', {id: 'hello'})]);
 
     // Let the next transaction begin, acquiring the lock.
-    await sleep(10);
+    await sleep(500);
 
     // Verify that the lock is held.
     let result;

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -1,6 +1,8 @@
 import {getDefaultHighWaterMark} from 'node:stream';
 import type {LogContext} from '@rocicorp/logger';
 import {resolver, type Resolver} from '@rocicorp/resolver';
+import {defu} from 'defu';
+import postgres, {type Options, type PostgresType} from 'postgres';
 import {assert, unreachable} from '../../../../shared/src/asserts.ts';
 import {must} from '../../../../shared/src/must.ts';
 import {promiseOrAbort} from '../../../../shared/src/promise-race.ts';
@@ -79,6 +81,7 @@ import {
   SQLiteChangeLogWriter,
   type SQLiteChangeLogWriterOptions,
 } from './sqlite-change-log-writer.ts';
+import type {PostgresDBProvider} from './storer.ts';
 import {
   Storer,
   type PurgeLock,
@@ -209,6 +212,26 @@ export async function initializeStreamer(
     setTimeoutFn,
   );
 
+  // Dynamically creates connection pools that the implementation uses to
+  // isolate concurrent, long-running transactions. This works around a bug in
+  // the postgres.js client where connections get swapped in certain conditions.
+  //
+  // https://github.com/porsager/postgres/issues/1204
+  const changeDBProvider: PostgresDBProvider = (
+    applicationName: string,
+    max: number,
+  ) =>
+    postgres(
+      defu(
+        {max, connection: {['application_name']: applicationName}},
+        // ParsedOptions are technically compatible with Options, but happen
+        // to not be typed that way. The postgres.js author does an equivalent
+        // merge of ParsedOptions and Options here:
+        // https://github.com/porsager/postgres/blob/089214e85c23c90cf142d47fb30bd03f42874984/src/subscribe.js#L13
+        changeDB.options as unknown as Options<Record<string, PostgresType>>,
+      ),
+    ) as PostgresDB;
+
   const {replicaVersion} = subscriptionState;
   return new ChangeStreamerImpl(
     lc,
@@ -216,7 +239,7 @@ export async function initializeStreamer(
     taskID,
     discoveryAddress,
     discoveryProtocol,
-    changeDB,
+    changeDBProvider,
     replicaVersion,
     changeSource,
     replicationStatusPublisher,
@@ -380,7 +403,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
   readonly id: string;
   readonly #lc: LogContext;
   readonly #shard: ShardID;
-  readonly #changeDB: PostgresDB;
+  readonly #changeDBProvider: PostgresDBProvider;
   readonly #replicaVersion: string;
   readonly #source: ChangeSource;
   readonly #storer: Storer;
@@ -482,7 +505,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
     taskID: string,
     discoveryAddress: string,
     discoveryProtocol: string,
-    changeDB: PostgresDB,
+    changeDBProvider: PostgresDBProvider,
     replicaVersion: string,
     source: ChangeSource,
     replicationStatusPublisher: ReplicationStatusPublisher,
@@ -495,7 +518,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
     this.id = `change-streamer`;
     this.#lc = lc.withContext('component', 'change-streamer');
     this.#shard = shard;
-    this.#changeDB = changeDB;
+    this.#changeDBProvider = changeDBProvider;
     this.#replicaVersion = replicaVersion;
     this.#source = source;
     this.#storer = new Storer(
@@ -504,7 +527,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
       taskID,
       discoveryAddress,
       discoveryProtocol,
-      changeDB,
+      changeDBProvider,
       replicaVersion,
       consumed => this.#acker.trackPgChangeLog(consumed[2].watermark),
       err => this.stop(err),
@@ -852,7 +875,10 @@ class ChangeStreamerImpl implements ChangeStreamerService {
 
     switch (tag) {
       case 'reset-required':
-        await markResetRequired(this.#changeDB, this.#shard);
+        await markResetRequired(
+          this.#changeDBProvider('change-streamer-reset', 1),
+          this.#shard,
+        );
         await publishReplicationError(
           this.#lc,
           'Replicating',

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-comparator.pg.test.ts
@@ -13,9 +13,9 @@ import {cdcSchema, type ShardID} from '../../types/shards.ts';
 import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
 import {EMPTY_COOKIE_SET} from '../replicator/change-log-cookies.ts';
 import {
-  changeLogFileName,
   CHANGE_LOG_META_TABLE,
   CHANGE_LOG_STREAM_TABLE,
+  changeLogFileName,
   deleteChangeLogDB,
   estimateChangeLogStreamRowBytes,
   type ChangeLogIdentity,
@@ -80,7 +80,7 @@ describe('change-streamer/sqlite-change-log-comparator', () => {
       'task-id',
       'change.streamer:12345',
       'ws',
-      sql,
+      () => sql,
       REPLICA_VERSION,
       () => {},
       vi.fn(),

--- a/packages/zero-cache/src/services/change-streamer/storer.bench.pg.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.bench.pg.ts
@@ -4,7 +4,7 @@
 import {afterEach, describe, expect} from 'vitest';
 import {createManualBenchmarkRecorder} from '../../../../shared/src/bench.ts';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
-import {type PgTest, test} from '../../test/db.ts';
+import {test, type PgTest} from '../../test/db.ts';
 import {
   BENCHMARK_FIXTURE_TABLE_KEYS,
   benchmarkFixturePayloadMB,
@@ -80,7 +80,7 @@ async function makeStorer(
     'task-id',
     'change-streamer:12345',
     'ws',
-    db,
+    () => db,
     REPLICA_VERSION,
     () => {},
     err => {

--- a/packages/zero-cache/src/services/change-streamer/storer.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.pg.test.ts
@@ -6,8 +6,8 @@ import {BigIntJSON} from '../../../../shared/src/bigint-json.ts';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
 import {Queue} from '../../../../shared/src/queue.ts';
 import {sleep} from '../../../../shared/src/sleep.ts';
-import {test, type PgTest} from '../../test/db.ts';
-import {postgresTypeConfig, type PostgresDB} from '../../types/pg.ts';
+import {getConnectionURI, test, type PgTest} from '../../test/db.ts';
+import {pgClient, postgresTypeConfig, type PostgresDB} from '../../types/pg.ts';
 import type {Subscription} from '../../types/subscription.ts';
 import {
   type ChangeStreamData,
@@ -19,7 +19,12 @@ import {extractChangeSubstring} from './change-log-codec.ts';
 import {type Downstream} from './change-streamer.ts';
 import * as ErrorType from './error-type-enum.ts';
 import {ensureReplicationConfig, setupCDCTables} from './schema/tables.ts';
-import {PurgeLocker, Storer, type TuningOptions} from './storer.ts';
+import {
+  PurgeLocker,
+  Storer,
+  type PostgresDBProvider,
+  type TuningOptions,
+} from './storer.ts';
 import {createSubscriber} from './test-utils.ts';
 
 const opts: TuningOptions = {
@@ -69,6 +74,7 @@ function summarize({
 describe('change-streamer/storer', () => {
   const lc = createSilentLogContext();
   let db: PostgresDB;
+  let dbProvider: PostgresDBProvider;
   let storer: Storer;
   let done: Promise<void>;
   let consumed: Queue<Commit | UpstreamStatusMessage>;
@@ -83,6 +89,14 @@ describe('change-streamer/storer', () => {
     db = await testDBs.create('change_streamer_storer', {
       typeOpts: {sendStringAsJson: true},
     });
+    dbProvider = (applicationName: string, maxConns: number) =>
+      pgClient(
+        lc,
+        getConnectionURI(db),
+        applicationName,
+        {max: maxConns},
+        {sendStringAsJson: true},
+      );
     shard = {appID: APP_ID, shardNum: SHARD_NUM};
     await db.begin(tx => setupCDCTables(lc, tx, shard));
     await ensureReplicationConfig(
@@ -152,7 +166,7 @@ describe('change-streamer/storer', () => {
         'task-id',
         'change-streamer:12345',
         'ws',
-        db,
+        dbProvider,
         REPLICA_VERSION,
         msg => consumed.enqueue(msg),
         err => fatalErrors.enqueue(err),
@@ -225,7 +239,7 @@ describe('change-streamer/storer', () => {
         'task-id',
         'change-streamer:12345',
         'ws',
-        db,
+        dbProvider,
         REPLICA_VERSION,
         msg => consumed.enqueue(msg),
         err => fatalErrors.enqueue(err),
@@ -1680,7 +1694,7 @@ describe('change-streamer/storer', () => {
         'task-id',
         'change-streamer:12345',
         'wss',
-        db,
+        dbProvider,
         REPLICA_VERSION,
         msg => consumed.enqueue(msg),
         err => fatalErrors.enqueue(err),
@@ -1714,7 +1728,7 @@ describe('change-streamer/storer', () => {
         'task-id',
         'change-streamer:12345',
         'ws',
-        db,
+        dbProvider,
         REPLICA_VERSION,
         msg => consumed.enqueue(msg),
         err => fatalErrors.enqueue(err),
@@ -1793,7 +1807,7 @@ describe('change-streamer/storer', () => {
         'task-id',
         'change-streamer:12345',
         'ws',
-        singleConnDb,
+        () => singleConnDb,
         REPLICA_VERSION,
         msg => consumed.enqueue(msg),
         err => fatalErrors.enqueue(err),
@@ -1831,7 +1845,7 @@ describe('change-streamer/storer', () => {
         'task-id',
         'change-streamer:12345',
         'ws',
-        db,
+        dbProvider,
         REPLICA_VERSION,
         msg => consumed.enqueue(msg),
         err => fatalErrors.enqueue(err),
@@ -1913,7 +1927,7 @@ describe('change-streamer/storer', () => {
         'task-id',
         'change-streamer:12345',
         'ws',
-        singleConnDb,
+        () => singleConnDb,
         REPLICA_VERSION,
         msg => consumed.enqueue(msg),
         err => fatalErrors.enqueue(err),

--- a/packages/zero-cache/src/services/change-streamer/storer.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.ts
@@ -13,7 +13,7 @@ import {promiseVoid} from '../../../../shared/src/resolved-promises.ts';
 import * as v from '../../../../shared/src/valita.ts';
 import * as Mode from '../../db/mode-enum.ts';
 import {runTx} from '../../db/run-transaction.ts';
-import {TransactionPool} from '../../db/transaction-pool.ts';
+import {sharedSnapshot, TransactionPool} from '../../db/transaction-pool.ts';
 import {type PostgresDB, type PostgresTransaction} from '../../types/pg.ts';
 import {cdcSchema, type ShardID} from '../../types/shards.ts';
 import {orTimeout} from '../../types/timeout.ts';
@@ -57,6 +57,15 @@ import {
   type TableMetadataRow,
 } from './schema/tables.ts';
 import type {Subscriber} from './subscriber.ts';
+
+/**
+ * Factory for creating dynamic connection pools used by the Storer to
+ * isolate concurrent transactions into separate pg clients.
+ */
+export type PostgresDBProvider = (
+  applicationName: string,
+  maxConns: number,
+) => PostgresDB;
 
 type SubscriberAndMode = {
   subscriber: Subscriber;
@@ -149,7 +158,15 @@ export class Storer implements Service {
   readonly #taskID: string;
   readonly #discoveryAddress: string;
   readonly #discoveryProtocol: string;
+  readonly #makeConnectionPool: PostgresDBProvider;
+
+  // Isolated connection pools for steady-state, potentially concurrent
+  // queries, in order to avoid a postgres.js connection-swapping bug:
+  // https://github.com/porsager/postgres/issues/1204
   readonly #db: PostgresDB;
+  readonly #inserter: PostgresDB;
+  readonly #purger: PostgresDB;
+
   readonly #replicaVersion: string;
   readonly #onCommitted: (c: Commit) => void;
   readonly #onFatal: (err: Error) => void;
@@ -169,7 +186,7 @@ export class Storer implements Service {
     taskID: string,
     discoveryAddress: string,
     discoveryProtocol: string,
-    db: PostgresDB,
+    dbProvider: PostgresDBProvider,
     replicaVersion: string,
     onCommitted: (c: Commit | UpstreamStatusMessage) => void,
     onFatal: (err: Error) => void,
@@ -185,7 +202,10 @@ export class Storer implements Service {
     this.#taskID = taskID;
     this.#discoveryAddress = discoveryAddress;
     this.#discoveryProtocol = discoveryProtocol;
-    this.#db = db;
+    this.#makeConnectionPool = dbProvider;
+    this.#db = dbProvider('change-stream-init', 3);
+    this.#inserter = dbProvider('change-log-inserter', 1);
+    this.#purger = dbProvider('change-log-purger', 1);
     this.#replicaVersion = replicaVersion;
     this.#onCommitted = onCommitted;
     this.#onFatal = onFatal;
@@ -425,7 +445,7 @@ export class Storer implements Service {
   //       an arbitrary amount of time. Luckily, this is a background call and
   //       thus cannot cause the storer loop to hang.
   purgeRecordsBefore(watermark: string): Promise<number> {
-    return runTx(this.#db, async sql => {
+    return runTx(this.#purger, async sql => {
       // This NOWAIT pre-check is an optimization to abort the transaction
       // (and release associated resources) early.
       await sql<{watermark: string}[]>`
@@ -703,7 +723,7 @@ export class Storer implements Service {
             batch: [],
             lastFlush: undefined,
           };
-          tx.pool.run(this.#db);
+          tx.pool.run(this.#inserter);
           // Acquire a lock on the replicationState row to detect and/or prevent
           // a concurrent ownership change.
           void tx.pool.process(tx => {
@@ -810,16 +830,27 @@ export class Storer implements Service {
   }
 
   async #startCatchup(subs: SubscriberAndMode[]) {
-    if (subs.length === 0) {
+    const numCatchups = subs.length;
+    if (numCatchups === 0) {
       return;
     }
 
     const lc = this.#lc.withContext('pool', 'catchup');
-    // TODO: Consider setting initialWorkers to accomodate parallel
-    //       catchups of multiple subscribers. The tricky part is
-    //       staying within the db's max connections.
-    const reader = new TransactionPool(lc, {mode: Mode.READONLY});
-    reader.run(this.#db);
+    const {init, cleanup, snapshotID} = sharedSnapshot();
+    const reader = new TransactionPool(lc, {
+      mode: Mode.READONLY,
+      init,
+      cleanup,
+      initialWorkers: subs.length,
+    });
+
+    // A dynamic connection pool is created for catchup, sized to the number
+    // of subscribers being caught up.
+    const catchupConns = this.#makeConnectionPool(
+      'subscriber-catchup',
+      numCatchups,
+    );
+    reader.run(catchupConns);
 
     let lastWatermark: string | undefined;
     const catchupSnapshotted = this.#progressMonitor.trackTask({
@@ -836,6 +867,10 @@ export class Storer implements Service {
         SELECT "lastWatermark" FROM ${this.#cdc('replicationState')}
       `,
       );
+      lc.info?.(
+        `snapshotted db at ${lastWatermark} (${await snapshotID}) ` +
+          `to catchup ${numCatchups} subscriber(s)`,
+      );
     } catch (e) {
       subs.map(({subscriber}) => subscriber.fail(e));
       throw e;
@@ -845,7 +880,7 @@ export class Storer implements Service {
 
     // Run the actual catchup queries in the background. Errors are handled in
     // #catchup() by disconnecting the associated subscriber.
-    void Promise.all(
+    void Promise.allSettled(
       subs.map(sub =>
         this.#catchup(
           lc.withContext('subscriber', sub.subscriber.id),
@@ -854,7 +889,10 @@ export class Storer implements Service {
           reader,
         ),
       ),
-    ).finally(() => reader.setDone());
+    ).finally(() => {
+      reader.setDone();
+      void catchupConns.end().catch(() => {});
+    });
   }
 
   async #catchup(

--- a/packages/zero-cache/src/services/replicator/schema/backfilling.pg.test.ts
+++ b/packages/zero-cache/src/services/replicator/schema/backfilling.pg.test.ts
@@ -81,7 +81,7 @@ describe('replicator/schema/backfill request parity', () => {
       'task-id',
       'change-streamer:12345',
       'ws',
-      db,
+      () => db,
       REPLICA_VERSION,
       (_: Commit | UpstreamStatusMessage) => {},
       () => {},


### PR DESCRIPTION
Fixes the mysterious hung pg query issue that occasionally causes the change-streamer to stop making progress.

This was originally theorized to be caused by TCP/connection issues (e.g. half-closed connections), but incidences continued to happen even with socket-level watchdog logic that should detect it (https://github.com/rocicorp/mono/pull/6220 and https://github.com/rocicorp/mono/pull/6221).

A recent hang detected by the application-level watchdog (https://github.com/rocicorp/mono/pull/6419) was accompanied by corrupted change-db state that should not have been possible given transactional atomicity semantics. 

Application and db logs identified the cause to be a single pg "backend", in which a partial transaction was in progress, being reused for a _second_ application-level "connection", causing the transaction of the latter to commit its statements along with the partial transaction of the former. 

Specifically, in zero-cache semantics, an in-progress change-log multi-INSERT transaction was hijacked by a purge transaction, resulting in a Frankenstein commit of the purge and the unfinished INSERT.

The postgres driver issue has been filed here: https://github.com/porsager/postgres/issues/1204

The workaround in the zero-cache is to use isolated connection pools (i.e. pg clients) for concurrent storer logic to make it impossible for connections to be swapped between its transactions.

### Related

Dynamic connection pool creation also allows safer catchup of multiple subscribers in parallel (i.e. without exhausting a fixed connection pool), which is included in this change.