### PR TITLE
feat(zero-cache): add /profz and /profrmz on-demand multi-process CPU profiling endpoints

### DIFF
--- a/apps/zero-throughput/src/config.ts
+++ b/apps/zero-throughput/src/config.ts
@@ -46,6 +46,8 @@ const options = {
   numSyncWorkers: v.number().optional(),
   profileRM: v.boolean().default(false),
   profileVS: v.boolean().default(false),
+  profileDurationSec: v.number().default(5),
+  adminPassword: v.string().optional(),
 
   pg: {
     url: v.string().optional(),
@@ -96,6 +98,8 @@ export type BenchmarkConfig = {
   readonly profileDir: string;
   readonly profileRM: boolean;
   readonly profileVS: boolean;
+  readonly profileDurationSec: number;
+  readonly adminPassword?: string | undefined;
   readonly processLogMode: 'file' | 'inherit' | 'ignore';
   readonly reset: boolean;
   readonly appServerPort: number;
@@ -196,6 +200,11 @@ export function loadConfig(): BenchmarkConfig {
     profileDir: parsed.profileDir,
     profileRM: parsed.profileRM,
     profileVS: parsed.profileVS,
+    profileDurationSec: parsed.profileDurationSec,
+    adminPassword:
+      parsed.adminPassword ??
+      process.env.ZERO_ADMIN_PASSWORD ??
+      process.env.ADMIN_PASSWORD,
     processLogMode: parsed.processLogMode,
     reset: parsed.reset,
     appServerPort: parsed.appServerPort,

--- a/apps/zero-throughput/src/main.ts
+++ b/apps/zero-throughput/src/main.ts
@@ -1,6 +1,9 @@
+import {mkdirSync} from 'node:fs';
+import {writeFile} from 'node:fs/promises';
+import {join} from 'node:path';
 import {inspect} from 'node:util';
 import {startSyntheticClients, type SyntheticClient} from './client.ts';
-import {loadConfig} from './config.ts';
+import {appPath, loadConfig, type BenchmarkConfig} from './config.ts';
 import {
   connectBenchmarkDB,
   resetBenchmarkDatabase,
@@ -148,6 +151,8 @@ async function main(): Promise<void> {
     };
     const sampler = setInterval(recordSample, config.sampleIntervalMs);
 
+    const profiling = startSteadyStateProfiling(config);
+
     let writerStats: WriterStats;
     try {
       writerStats = await writer.run(config.durationMs);
@@ -155,6 +160,8 @@ async function main(): Promise<void> {
     } finally {
       clearInterval(sampler);
     }
+
+    await profiling;
 
     if (config.settleMs > 0) {
       log(
@@ -287,6 +294,88 @@ function formatError(error: unknown): string {
     return error;
   }
   return inspect(error);
+}
+
+async function startSteadyStateProfiling(
+  config: BenchmarkConfig,
+): Promise<void> {
+  if (!config.profileVS && !config.profileRM) {
+    return;
+  }
+
+  const profileDir = appPath(config.profileDir);
+  mkdirSync(profileDir, {recursive: true});
+
+  const warmupDelay = Math.min(
+    2000,
+    Math.max(500, Math.floor(config.durationMs / 4)),
+  );
+  await sleep(warmupDelay);
+
+  const durationSec = Math.min(
+    config.profileDurationSec,
+    Math.max(1, Math.floor((config.durationMs - warmupDelay) / 1000)),
+  );
+
+  const targets = [
+    ...(config.profileVS
+      ? [{endpoint: 'profz', label: 'View-Syncer', prefix: 'vs'}]
+      : []),
+    ...(config.profileRM
+      ? [{endpoint: 'profrmz', label: 'RM', prefix: 'rm'}]
+      : []),
+  ];
+
+  const headers: Record<string, string> = {};
+  if (config.adminPassword) {
+    headers.authorization = `Basic ${Buffer.from(`admin:${config.adminPassword}`).toString('base64')}`;
+  }
+
+  await Promise.all(
+    targets.map(async ({endpoint, label, prefix}) => {
+      const url = `${config.cacheURL}/${endpoint}?duration=${durationSec}`;
+      try {
+        log(`Triggering ${label} CPU profile (${durationSec}s) via ${url}...`);
+        const res = await fetch(url, {headers});
+        if (!res.ok) {
+          warn(`Failed to fetch ${label} profile: HTTP ${res.status}`);
+          return;
+        }
+        const data = await res.json();
+        await unpackProfiles(data, `${config.runID}-${prefix}`, profileDir);
+      } catch (err) {
+        warn(`Error capturing ${label} profile: ${String(err)}`);
+      }
+    }),
+  );
+}
+
+async function unpackProfiles(
+  data: unknown,
+  prefix: string,
+  outDir: string,
+): Promise<void> {
+  if (typeof data !== 'object' || data === null) {
+    return;
+  }
+
+  const record = data as Record<string, unknown>;
+  // Single profile with nodes array
+  if ('nodes' in record && Array.isArray(record.nodes)) {
+    const filename = `${prefix}.cpuprofile`;
+    const outPath = join(outDir, filename);
+    await writeFile(outPath, JSON.stringify(data, null, 2));
+    log(`Saved CPU profile to ${outPath}`);
+    return;
+  }
+
+  // Multi-process bundle: { [processName]: CpuProfile }
+  for (const [name, prof] of Object.entries(record)) {
+    const filename = `${prefix}-${name}.cpuprofile`;
+    const outPath = join(outDir, filename);
+    await writeFile(outPath, JSON.stringify(prof, null, 2));
+    log(`Saved ${name} CPU profile to ${outPath}`);
+  }
 }
 
 await main();

--- a/apps/zero-throughput/src/processes.ts
+++ b/apps/zero-throughput/src/processes.ts
@@ -244,7 +244,6 @@ export async function startZeroTopology(
       numSyncWorkers: config.zero.numSyncWorkers,
       replicaFile: config.zero.replicaFile,
       metricsEndpoint,
-      profile: config.profileVS,
     });
     return {
       processes: [singleProc],
@@ -269,7 +268,6 @@ export async function startZeroTopology(
     numSyncWorkers: 0,
     replicaFile: `${config.zero.replicaFile}-rm`,
     metricsEndpoint,
-    profile: config.profileRM,
   });
   processes.push(rmProcess);
 
@@ -300,7 +298,6 @@ export async function startZeroTopology(
       numSyncWorkers: config.zero.numSyncWorkers,
       replicaFile: `${config.zero.replicaFile}-vs${i}`,
       metricsEndpoint,
-      profile: config.profileVS && i === 0,
     });
     processes.push(vs);
   }
@@ -334,7 +331,6 @@ function spawnZeroProcess(args: {
   readonly changeStreamerPort?: number | undefined;
   readonly changeStreamerMode?: string | undefined;
   readonly metricsEndpoint?: string | undefined;
-  readonly profile?: boolean | undefined;
 }): ManagedProcess {
   const {config, name, port, numSyncWorkers, replicaFile} = args;
   const zeroCacheMain = fileURLToPath(
@@ -366,6 +362,10 @@ function spawnZeroProcess(args: {
     ZERO_MUTATE_URL: `http://127.0.0.1:${config.appServerPort}/api/mutate`,
   };
 
+  if (config.adminPassword) {
+    env.ZERO_ADMIN_PASSWORD = config.adminPassword;
+  }
+
   if (args.changeStreamerURI) {
     env.ZERO_CHANGE_STREAMER_URI = args.changeStreamerURI;
   }
@@ -384,12 +384,6 @@ function spawnZeroProcess(args: {
     env.OTEL_EXPORTER_OTLP_PROTOCOL = 'http/json';
     env.OTEL_METRIC_EXPORT_INTERVAL = '500';
     env.OTEL_METRIC_EXPORT_TIMEOUT = '500';
-  }
-
-  if (args.profile) {
-    const profDir = appPath(config.profileDir);
-    mkdirSync(profDir, {recursive: true});
-    env.NODE_OPTIONS = `--cpu-prof --cpu-prof-dir="${profDir}" ${process.env.NODE_OPTIONS ?? ''}`;
   }
 
   const logPath =

--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -37,11 +37,14 @@ import {
 import {sqliteFileBytes} from '../services/replicator/sqlite-change-log-observability.ts';
 import {connectPgClient} from '../types/pg.ts';
 import {
+  broadcastWorker,
   childWorker,
   parentWorker,
   singleProcessMode,
+  type ProfileResponseMessage,
   type Worker,
 } from '../types/processes.ts';
+import {installProfileHandler} from '../types/profiler.ts';
 import {getShardConfig} from '../types/shards.ts';
 import type {ReplicaFileMode} from '../workers/replicator.ts';
 import {createLogContext} from './logging.ts';
@@ -56,6 +59,7 @@ export default async function runWorker(
   env: NodeJS.ProcessEnv,
   ...argv: string[]
 ): Promise<void> {
+  installProfileHandler(parent, 'change-streamer');
   const config = getNormalizedZeroConfig({env, argv});
   const {
     taskID,
@@ -323,13 +327,14 @@ export default async function runWorker(
   assert(changeStreamer, `resetting replica did not advance replicaVersion`);
 
   const processes = new ProcessManager(lc, parent);
+  const profileSubWorkers: Worker[] = [];
   if (backupURL) {
     lc.info?.('setting up backup to', backupURL);
     litestream.backupURL = backupURL;
     const {promise: backupStarted, resolve} = resolver();
 
     // Start a backup replicator and corresponding litestream backup process.
-    processes
+    const backupReplicator = processes
       .addWorker(
         childWorker(REPLICATOR_URL, env, 'backup' satisfies ReplicaFileMode),
         'supporting',
@@ -346,6 +351,12 @@ export default async function runWorker(
         );
         resolve();
       });
+    profileSubWorkers.push(backupReplicator);
+    // Relay profileResponse messages from backup-replicator up to parent
+    backupReplicator.onMessageType<ProfileResponseMessage>(
+      'profileResponse',
+      res => parent.send(['profileResponse', res]),
+    );
     await backupStarted;
   }
 
@@ -367,9 +378,21 @@ export default async function runWorker(
     });
   }
 
+  const getProfileWorker =
+    profileSubWorkers.length > 0
+      ? () => Promise.resolve(broadcastWorker(profileSubWorkers))
+      : undefined;
+
   const changeStreamerWebServer = new ChangeStreamerHttpServer(
     lc,
-    {port, keepaliveTimeoutMs, startupDelayMs, readinessGate},
+    {
+      port,
+      keepaliveTimeoutMs,
+      startupDelayMs,
+      readinessGate,
+      config,
+      getProfileWorker,
+    },
     parent,
     changeStreamer,
   );

--- a/packages/zero-cache/src/server/main.ts
+++ b/packages/zero-cache/src/server/main.ts
@@ -17,6 +17,8 @@ import {
   childWorker,
   parentWorker,
   singleProcessMode,
+  type ProfileMessage,
+  type ProfileResponseMessage,
   type Worker,
 } from '../types/processes.ts';
 import {
@@ -90,6 +92,7 @@ export default async function runWorker(
           String(Math.floor(config.cvr.maxConns / numSyncers)),
         ];
 
+  const allSubWorkers: Worker[] = [];
   function loadWorker(
     moduleUrl: URL,
     type: WorkerType,
@@ -98,7 +101,12 @@ export default async function runWorker(
   ): Worker {
     const worker = childWorker(moduleUrl, env, ...args, ...internalFlags);
     const name = path.basename(moduleUrl.pathname) + (id ? ` (${id})` : '');
-    return processes.addWorker(worker, type, name);
+    const w = processes.addWorker(worker, type, name);
+    allSubWorkers.push(w);
+    w.onMessageType<ProfileResponseMessage>('profileResponse', res =>
+      parent.send(['profileResponse', res]),
+    );
+    return w;
   }
 
   const {taskID, litestream} = config;
@@ -190,6 +198,11 @@ export default async function runWorker(
   recordStartupDurationMs(startupDurationMs);
 
   parent.send(['ready', {ready: true}]);
+  parent.onMessageType<ProfileMessage>('profile', req => {
+    for (const w of allSubWorkers) {
+      w.send(['profile', req]);
+    }
+  });
 
   try {
     await runUntilKilled(

--- a/packages/zero-cache/src/server/mutator.ts
+++ b/packages/zero-cache/src/server/mutator.ts
@@ -8,6 +8,7 @@ import {
   singleProcessMode,
   type Worker,
 } from '../types/processes.ts';
+import {installProfileHandler} from '../types/profiler.ts';
 import {Mutator} from '../workers/mutator.ts';
 import {createLogContext} from './logging.ts';
 import {startOtelAuto} from './otel-start.ts';
@@ -20,6 +21,7 @@ function runWorker(
   env: NodeJS.ProcessEnv,
   ...args: string[]
 ): Promise<void> {
+  installProfileHandler(parent, 'mutator');
   const config = getNormalizedZeroConfig({env, argv: args.slice(1)});
   startOtelAuto(createLogContext(config, 'mutator', 0, false), 'mutator', 0);
   lc = createLogContext(config, 'mutator');

--- a/packages/zero-cache/src/server/reaper.ts
+++ b/packages/zero-cache/src/server/reaper.ts
@@ -12,6 +12,7 @@ import {
   singleProcessMode,
   type Worker,
 } from '../types/processes.ts';
+import {installProfileHandler} from '../types/profiler.ts';
 import {getShardID} from '../types/shards.ts';
 import {startAnonymousTelemetry} from './anonymous-otel-start.ts';
 import {createLogContext} from './logging.ts';
@@ -27,6 +28,7 @@ export default async function runWorker(
   env: NodeJS.ProcessEnv,
   ...argv: string[]
 ): Promise<void> {
+  installProfileHandler(parent, 'reaper');
   const config = getNormalizedZeroConfig({env, argv});
 
   startOtelAuto(createLogContext(config, 'reaper', 0, false), 'reaper', 0);

--- a/packages/zero-cache/src/server/replicator.ts
+++ b/packages/zero-cache/src/server/replicator.ts
@@ -41,6 +41,7 @@ import {
   singleProcessMode,
   type Worker,
 } from '../types/processes.ts';
+import {installProfileHandler} from '../types/profiler.ts';
 import {getShardConfig} from '../types/shards.ts';
 import {
   deleteStaleChangeLog,
@@ -69,6 +70,7 @@ export default async function runWorker(
   const runningLocalChangeStreamer =
     config.changeStreamer.mode === 'dedicated' && !config.changeStreamer.uri;
   const workerName = `${mode}-replicator`;
+  installProfileHandler(parent, workerName);
   startOtelAuto(createLogContext(config, workerName, 0, false), workerName, 0);
   lc = createLogContext(config, workerName);
   const unregisterInitialCorruptionDiagnosticTarget =

--- a/packages/zero-cache/src/server/runner/zero-dispatcher.ts
+++ b/packages/zero-cache/src/server/runner/zero-dispatcher.ts
@@ -2,6 +2,10 @@ import type {LogContext} from '@rocicorp/logger';
 import type {NormalizedZeroConfig} from '../../config/normalize.ts';
 import {handleHeapzRequest} from '../../services/heapz.ts';
 import {HttpService, type Options} from '../../services/http-service.ts';
+import {
+  handleProfrmzRequest,
+  handleProfzRequest,
+} from '../../services/profz.ts';
 import {handleStatzRequest} from '../../services/statz.ts';
 import type {IncomingMessageSubset} from '../../types/http.ts';
 import type {Worker} from '../../types/processes.ts';
@@ -28,6 +32,12 @@ export class ZeroDispatcher extends HttpService {
       );
       fastify.get('/heapz', (req, res) =>
         handleHeapzRequest(lc, config, req, res),
+      );
+      fastify.get('/profz', (req, res) =>
+        handleProfzRequest(lc, config, req, res, this.#getWorker),
+      );
+      fastify.get('/profrmz', (req, res) =>
+        handleProfrmzRequest(lc, config, req, res, this.#getWorker),
       );
       installWebSocketHandoff(lc, this.#handoff, fastify.server);
     });

--- a/packages/zero-cache/src/server/syncer.ts
+++ b/packages/zero-cache/src/server/syncer.ts
@@ -36,6 +36,7 @@ import {
   singleProcessMode,
   type Worker,
 } from '../types/processes.ts';
+import {installProfileHandler} from '../types/profiler.ts';
 import {getShardID} from '../types/shards.ts';
 import type {Subscription} from '../types/subscription.ts';
 import {replicaFileModeSchema, replicaFileName} from '../workers/replicator.ts';
@@ -79,6 +80,7 @@ export default async function runWorker(
   assert(args.length >= 2, `expected [fileMode, workerIndex, ...flags]`);
   const fileMode = v.parse(args[0], replicaFileModeSchema);
   const workerIndex = Number(args[1]);
+  installProfileHandler(parent, `syncer-${workerIndex}`, workerIndex);
   const config = getNormalizedZeroConfig({env, argv: args.slice(2)});
 
   startOtelAuto(

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-http.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-http.ts
@@ -4,6 +4,7 @@ import type {LogContext} from '@rocicorp/logger';
 import WebSocket from 'ws';
 import {assert} from '../../../../shared/src/asserts.ts';
 import {promiseVoid} from '../../../../shared/src/resolved-promises.ts';
+import type {NormalizedZeroConfig} from '../../config/normalize.ts';
 import type {IncomingMessageSubset} from '../../types/http.ts';
 import {pgClient, type PostgresDB} from '../../types/pg.ts';
 import {type Worker} from '../../types/processes.ts';
@@ -19,6 +20,7 @@ import {URLParams} from '../../types/url-params.ts';
 import {installWebSocketReceiver} from '../../types/websocket-handoff.ts';
 import {closeWithError, PROTOCOL_ERROR} from '../../types/ws.ts';
 import {HttpService, type Options as HttpOptions} from '../http-service.ts';
+import {handleProfzRequest} from '../profz.ts';
 import {
   downstreamSchema,
   PROTOCOL_VERSION,
@@ -41,6 +43,8 @@ const CHANGES_PATH = `/replication/v${PROTOCOL_VERSION}/changes`;
 
 type Options = HttpOptions & {
   startupDelayMs: number;
+  config?: Pick<NormalizedZeroConfig, 'adminPassword'> | undefined;
+  getProfileWorker?: (() => Promise<Worker>) | undefined;
 };
 
 export class ChangeStreamerHttpServer extends HttpService {
@@ -63,6 +67,18 @@ export class ChangeStreamerHttpServer extends HttpService {
         SNAPSHOT_PATH_PATTERN,
         {websocket: true},
         this.#reserveSnapshot,
+      );
+
+      fastify.get('/profz', (req, res) =>
+        handleProfzRequest(
+          lc,
+          opts.config ?? {adminPassword: undefined},
+          req,
+          res,
+          opts.getProfileWorker,
+          undefined,
+          'change-streamer',
+        ),
       );
 
       installWebSocketReceiver<'snapshot' | 'changes'>(

--- a/packages/zero-cache/src/services/profz.test.ts
+++ b/packages/zero-cache/src/services/profz.test.ts
@@ -1,0 +1,165 @@
+import fastify, {type FastifyInstance} from 'fastify';
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
+import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
+import type {NormalizedZeroConfig} from '../config/normalize.ts';
+import {CpuProfiler} from '../types/profiler.ts';
+import {handleProfrmzRequest, handleProfzRequest} from './profz.ts';
+
+describe('profz', () => {
+  const lc = createSilentLogContext();
+  const config = {
+    adminPassword: 'secret',
+    changeStreamer: {},
+  } as unknown as NormalizedZeroConfig;
+
+  const authHeader = {
+    authorization: `Basic ${Buffer.from('user:secret').toString('base64')}`,
+  };
+
+  let app: FastifyInstance;
+  let profileSpy: ReturnType<typeof vi.spyOn>;
+
+  const mockProfile = {
+    nodes: [{id: 1, callFrame: {functionName: 'root'}}],
+    samples: [1],
+    timeDeltas: [1000],
+    startTime: 0,
+    endTime: 1000,
+  };
+
+  beforeEach(async () => {
+    profileSpy = vi
+      .spyOn(CpuProfiler, 'profile')
+      .mockResolvedValue(mockProfile);
+
+    app = fastify();
+    app.get('/profz', (req, res) => handleProfzRequest(lc, config, req, res));
+    app.get('/profrmz', (req, res) =>
+      handleProfrmzRequest(lc, config, req, res),
+    );
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    profileSpy.mockRestore();
+    await app.close();
+  });
+
+  test('requires auth when adminPassword is set', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/profz',
+    });
+
+    expect(res.statusCode).toBe(401);
+  });
+
+  test('returns multi-process profile bundle by default', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/profz?duration=1',
+      headers: authHeader,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-type']).toContain('application/json');
+    expect(res.headers['content-disposition']).toContain('zero-profile-bundle');
+
+    const body = JSON.parse(res.body) as Record<string, typeof mockProfile>;
+    expect(body).toHaveProperty('dispatcher');
+    expect(body.dispatcher).toEqual(mockProfile);
+    expect(profileSpy).toHaveBeenCalledWith(1000);
+  });
+
+  test('returns single profile when specific worker is requested', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/profz?duration=2&worker=dispatcher',
+      headers: authHeader,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-type']).toContain('application/json');
+    expect(res.headers['content-disposition']).toContain(
+      'dispatcher.cpuprofile',
+    );
+
+    const body = JSON.parse(res.body) as typeof mockProfile;
+    expect(body).toEqual(mockProfile);
+    expect(profileSpy).toHaveBeenCalledWith(2000);
+  });
+
+  test('clamps duration between 1 and 60 seconds', async () => {
+    await app.inject({
+      method: 'GET',
+      url: '/profz?duration=100',
+      headers: authHeader,
+    });
+    expect(profileSpy).toHaveBeenLastCalledWith(60_000);
+
+    await app.inject({
+      method: 'GET',
+      url: '/profz?duration=0',
+      headers: authHeader,
+    });
+    expect(profileSpy).toHaveBeenLastCalledWith(1_000);
+  });
+
+  test('profrmz in single-node mode profiles change-streamer', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/profrmz?duration=1',
+      headers: authHeader,
+    });
+
+    // In local mode without changeStreamer.uri, it profiles change-streamer directly
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body) as typeof mockProfile;
+    expect(body).toEqual(mockProfile);
+  });
+
+  test('profrmz in distributed mode proxies to changeStreamer.uri', async () => {
+    const distributedConfig = {
+      adminPassword: 'secret',
+      changeStreamer: {
+        uri: 'http://127.0.0.1:4849',
+      },
+    } as unknown as NormalizedZeroConfig;
+
+    const distApp = fastify();
+    distApp.get('/profrmz', (req, res) =>
+      handleProfrmzRequest(lc, distributedConfig, req, res),
+    );
+    await distApp.ready();
+
+    // Mock global fetch
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({'change-streamer': mockProfile}), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+          'content-disposition': 'attachment; filename="rm-bundle.json"',
+        },
+      }),
+    );
+
+    const res = await distApp.inject({
+      method: 'GET',
+      url: '/profrmz?duration=5',
+      headers: authHeader,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'http://127.0.0.1:4849/profz?duration=5',
+      expect.objectContaining({
+        method: 'GET',
+      }),
+    );
+    const body = JSON.parse(res.body) as Record<string, typeof mockProfile>;
+    expect(body).toHaveProperty('change-streamer');
+
+    fetchSpy.mockRestore();
+    await distApp.close();
+  });
+});

--- a/packages/zero-cache/src/services/profz.ts
+++ b/packages/zero-cache/src/services/profz.ts
@@ -1,0 +1,203 @@
+import {randomUUID} from 'node:crypto';
+import type {LogContext} from '@rocicorp/logger';
+import auth from 'basic-auth';
+import type {FastifyReply, FastifyRequest} from 'fastify';
+import {sleep} from '../../../shared/src/sleep.ts';
+import type {NormalizedZeroConfig} from '../config/normalize.ts';
+import {isAdminPasswordValid} from '../config/zero-config.ts';
+import {
+  singleProcessMode,
+  type ProfileResponse,
+  type ProfileResponseMessage,
+  type Worker,
+} from '../types/processes.ts';
+import {CpuProfiler} from '../types/profiler.ts';
+import {URLParams} from '../types/url-params.ts';
+
+export async function handleProfzRequest(
+  lc: LogContext,
+  config: Pick<NormalizedZeroConfig, 'adminPassword'>,
+  req: FastifyRequest,
+  res: FastifyReply,
+  getWorker?: (() => Promise<Worker>) | undefined,
+  forcedWorker?: string | undefined,
+  localProcessName: string = 'dispatcher',
+): Promise<void> {
+  const credentials = auth(req);
+  if (!isAdminPasswordValid(lc, config, credentials?.pass)) {
+    void res
+      .code(401)
+      .header('WWW-Authenticate', 'Basic realm="Profz Protected Area"')
+      .send('Unauthorized');
+    return;
+  }
+
+  const params = new URLParams(new URL(req.url, 'http://localhost'));
+  const rawDuration =
+    params.getInteger('duration', false) ??
+    params.getInteger('seconds', false) ??
+    5;
+  const durationSec = Math.max(1, Math.min(60, rawDuration));
+  const durationMs = durationSec * 1000;
+  const targetWorker = forcedWorker ?? params.get('worker', false) ?? undefined;
+  const targetWorkerIndex = params.getInteger('index', false) ?? undefined;
+  const id = randomUUID();
+
+  const responses = new Map<string, unknown>();
+
+  // Profile dispatcher / local process if requested, when profiling all processes,
+  // or when no worker dispatcher is available (single process / standalone mode)
+  const shouldProfileLocal =
+    singleProcessMode() ||
+    getWorker === undefined ||
+    targetWorker === undefined ||
+    targetWorker === localProcessName;
+
+  const localProfilePromise = shouldProfileLocal
+    ? CpuProfiler.profile(durationMs).catch(err => {
+        lc.warn?.('Failed to capture local CPU profile:', err);
+        return null;
+      })
+    : Promise.resolve(null);
+
+  if (!singleProcessMode() && getWorker !== undefined) {
+    try {
+      const worker = await getWorker();
+      const onMessage = (msg: ProfileResponse) => {
+        if (msg.id === id && msg.profile) {
+          responses.set(msg.name, msg.profile);
+        } else if (msg.id === id && msg.error) {
+          lc.warn?.(`Worker ${msg.name} profile error: ${msg.error}`);
+        }
+      };
+
+      worker.onMessageType<ProfileResponseMessage>(
+        'profileResponse',
+        onMessage,
+      );
+      worker.send([
+        'profile',
+        {
+          id,
+          durationMs,
+          worker: targetWorker === localProcessName ? '__none__' : targetWorker,
+          workerIndex: targetWorkerIndex,
+        },
+      ]);
+
+      // Wait for duration plus grace period for IPC transfer
+      await sleep(durationMs + 500);
+    } catch (err) {
+      lc.warn?.('Failed to dispatch profile request to child workers:', err);
+    }
+  }
+
+  const localProfile = await localProfilePromise;
+  if (localProfile) {
+    const localName =
+      targetWorker ?? (singleProcessMode() ? 'zero-cache' : localProcessName);
+    responses.set(localName, localProfile);
+  }
+
+  // If a single specific worker was requested, return that profile directly
+  if (targetWorker !== undefined && targetWorker !== 'all') {
+    let matchedProfile = responses.get(targetWorker);
+    if (!matchedProfile) {
+      // Try matching by prefix or substring (e.g. 'syncer' matches 'syncer-0')
+      for (const [name, prof] of responses.entries()) {
+        if (name === targetWorker || name.startsWith(`${targetWorker}-`)) {
+          matchedProfile = prof;
+          break;
+        }
+      }
+    }
+
+    if (matchedProfile) {
+      void res
+        .header('Content-Type', 'application/json')
+        .header(
+          'Content-Disposition',
+          `attachment; filename="${targetWorker}.cpuprofile"`,
+        )
+        .send(matchedProfile);
+      return;
+    }
+
+    void res.code(404).send({
+      error: `No profile captured for worker "${targetWorker}". Available: ${[...responses.keys()].join(', ')}`,
+    });
+    return;
+  }
+
+  // Default (Option A): Return multi-process profile bundle as a JSON map
+  const bundle: Record<string, unknown> = {};
+  for (const [name, prof] of responses.entries()) {
+    bundle[name] = prof;
+  }
+
+  void res
+    .header('Content-Type', 'application/json')
+    .header(
+      'Content-Disposition',
+      `attachment; filename="zero-profile-bundle-${Date.now()}.json"`,
+    )
+    .send(bundle);
+}
+
+export async function handleProfrmzRequest(
+  lc: LogContext,
+  config: NormalizedZeroConfig,
+  req: FastifyRequest,
+  res: FastifyReply,
+  getWorker?: (() => Promise<Worker>) | undefined,
+): Promise<void> {
+  const credentials = auth(req);
+  if (!isAdminPasswordValid(lc, config, credentials?.pass)) {
+    void res
+      .code(401)
+      .header('WWW-Authenticate', 'Basic realm="Profrmz Protected Area"')
+      .send('Unauthorized');
+    return;
+  }
+
+  // In distributed mode, proxy to the upstream Replication Manager
+  if (config.changeStreamer.uri) {
+    const upstreamURL = new URL('/profz', config.changeStreamer.uri);
+    const incomingURL = new URL(req.url, 'http://localhost');
+    for (const [key, value] of incomingURL.searchParams.entries()) {
+      upstreamURL.searchParams.set(key, value);
+    }
+
+    try {
+      const headers: Record<string, string> = {};
+      if (req.headers.authorization) {
+        headers.authorization = req.headers.authorization;
+      }
+      const response = await fetch(upstreamURL.toString(), {
+        method: 'GET',
+        headers,
+      });
+
+      res.code(response.status);
+      const contentType = response.headers.get('content-type');
+      if (contentType) {
+        res.header('content-type', contentType);
+      }
+      const contentDisposition = response.headers.get('content-disposition');
+      if (contentDisposition) {
+        res.header('content-disposition', contentDisposition);
+      }
+
+      const body = await response.text();
+      return res.send(body);
+    } catch (err) {
+      lc.error?.(`Failed to proxy /profrmz to RM at ${upstreamURL}:`, err);
+      return res.code(502).send({
+        error: `Failed to proxy profiling request to RM at ${upstreamURL}: ${String(err)}`,
+      });
+    }
+  }
+
+  // In single-node mode, profile local change-streamer / RM process
+  return handleProfzRequest(lc, config, req, res, getWorker, 'change-streamer');
+}

--- a/packages/zero-cache/src/types/processes.ts
+++ b/packages/zero-cache/src/types/processes.ts
@@ -24,7 +24,26 @@ export const MESSAGE_TYPES = {
   notify: 'notify',
   ready: 'ready',
   backupWatermarkUpdate: 'backupWatermakUpdate',
+  profile: 'profile',
+  profileResponse: 'profileResponse',
 } as const;
+
+export type ProfileRequest = {
+  readonly id: string;
+  readonly durationMs: number;
+  readonly worker?: string | undefined;
+  readonly workerIndex?: number | undefined;
+};
+
+export type ProfileResponse = {
+  readonly id: string;
+  readonly name: string;
+  readonly profile?: unknown | undefined;
+  readonly error?: string | undefined;
+};
+
+export type ProfileMessage = ['profile', ProfileRequest];
+export type ProfileResponseMessage = ['profileResponse', ProfileResponse];
 
 export type Message<Payload> = [keyof typeof MESSAGE_TYPES, Payload];
 
@@ -281,4 +300,43 @@ export function inProcChannel(): [Worker, Worker] {
       Object.assign(worker2, {send: sendTo(worker1), kill: kill(worker1), pid}),
     ),
   ];
+}
+
+/**
+ * Creates a {@link Worker} facade that broadcasts `send()` to all provided
+ * workers and aggregates their `'message'` events into one stream.
+ *
+ * This is useful for code that expects a single Worker for IPC (e.g.
+ * `handleProfzRequest`) but needs to reach multiple child workers.
+ */
+export function broadcastWorker(workers: Worker[]): Worker {
+  const emitter = new EventEmitter();
+
+  for (const w of workers) {
+    w.on('message', (message: Serializable, sendHandle?: SendHandle) =>
+      emitter.emit('message', message, sendHandle),
+    );
+  }
+
+  const send = <M extends Message<unknown>>(
+    message: M,
+    sendHandle?: SendHandle,
+    callback?: (error: Error | null) => void,
+  ) => {
+    for (const w of workers) {
+      w.send(message, sendHandle);
+    }
+    if (callback) {
+      callback(null);
+    }
+    return true;
+  };
+
+  const kill = (signal: NodeJS.Signals = 'SIGTERM') => {
+    for (const w of workers) {
+      w.kill(signal);
+    }
+  };
+
+  return wrap(Object.assign(emitter, {send, kill, pid}));
 }

--- a/packages/zero-cache/src/types/profiler.ts
+++ b/packages/zero-cache/src/types/profiler.ts
@@ -3,6 +3,7 @@ import {Session} from 'node:inspector/promises';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import type {LogContext} from '@rocicorp/logger';
+import type {ProfileMessage, Worker} from './processes.ts';
 
 /**
  * Convenience wrapper around a `node:inspector` {@link Session} for
@@ -26,6 +27,24 @@ export class CpuProfiler {
     await this.#session.post('Profiler.start');
   }
 
+  /**
+   * Captures a CPU profile for the specified duration (in milliseconds)
+   * and returns the V8 profile object.
+   */
+  static async profile(durationMs: number): Promise<unknown> {
+    const profiler = await CpuProfiler.connect();
+    await profiler.start();
+    await new Promise(resolve => setTimeout(resolve, durationMs));
+    return await profiler.stop();
+  }
+
+  async stop(): Promise<unknown> {
+    const {profile} = await this.#session.post('Profiler.stop');
+    await this.#session.post('Profiler.disable');
+    this.#session.disconnect();
+    return profile;
+  }
+
   async stopAndDispose(lc: LogContext, filename: string) {
     const {profile} = await this.#session.post('Profiler.stop');
     const path = join(tmpdir(), `${filename}.cpuprofile`);
@@ -33,4 +52,45 @@ export class CpuProfiler {
     lc.info?.(`wrote cpu profile to ${path}`);
     this.#session.disconnect();
   }
+}
+
+const WORKER_INDEX_SUFFIX = /-\d+$/;
+
+/**
+ * Registers an IPC handler on `parent` to capture a CPU profile when
+ * requested, sending back the resulting V8 profile.
+ */
+export function installProfileHandler(
+  parent: Worker | null,
+  workerName: string,
+  workerIndex?: number | undefined,
+): void {
+  if (!parent) {
+    return;
+  }
+  parent.onMessageType<ProfileMessage>('profile', async req => {
+    if (req.worker !== undefined) {
+      const baseName = workerName.replace(WORKER_INDEX_SUFFIX, '');
+      const matchesName = req.worker === workerName || req.worker === baseName;
+      if (!matchesName) {
+        return;
+      }
+      if (
+        req.workerIndex !== undefined &&
+        workerIndex !== undefined &&
+        req.workerIndex !== workerIndex
+      ) {
+        return;
+      }
+    }
+    try {
+      const profile = await CpuProfiler.profile(req.durationMs);
+      parent.send(['profileResponse', {id: req.id, name: workerName, profile}]);
+    } catch (err) {
+      parent.send([
+        'profileResponse',
+        {id: req.id, name: workerName, error: String(err)},
+      ]);
+    }
+  });
 }


### PR DESCRIPTION
Adds two new HTTP endpoints to zero-cache for on-demand V8 CPU profiling:

- GET /profz: Profiles all active processes in the pod concurrently (dispatcher, syncers, replicator, etc.) and returns a JSON bundle mapping process names to their V8 .cpuprofile. Supports ?worker=X to target a single worker and return a raw .cpuprofile directly.

- GET /profrmz: On View-Syncers in distributed mode, proxies the profiling request to the upstream Replication Manager via ZERO_CHANGE_STREAMER_URI. In single-node mode, profiles the local change-streamer process.

Both endpoints use isAdminPasswordValid for auth (unauthenticated in dev mode). Duration is configurable via ?duration=N (1-60 seconds, default 5).

Implementation:
- CpuProfiler gains a static profile(durationMs) method
- installProfileHandler() wires IPC on each worker entrypoint (syncer, change-streamer, replicator, reaper, mutator)
- main.ts relays profile/profileResponse messages between parent and all sub-workers
- ChangeStreamerHttpServer registers /profz directly (since it runs in the change-streamer process on the RM)
- ProfileRequest/ProfileResponse/ProfileMessage types added to MESSAGE_TYPES

Also updates apps/zero-throughput:
- Replaces --cpu-prof NODE_OPTIONS flags with HTTP-based profile collection via /profz and /profrmz during steady-state writes
- Unpacks multi-process bundles into individual .cpuprofile files
- Adds --profile-duration-sec config option