### PR TITLE
fix(zero): surface inspector errors and analyze NOT EXISTS

### DIFF
--- a/packages/zero-cache/src/services/analyze.test.ts
+++ b/packages/zero-cache/src/services/analyze.test.ts
@@ -136,6 +136,7 @@ describe('analyzeQuery', () => {
         tableSpecs: expect.any(Map),
         host: expect.objectContaining({
           debug: expect.any(Object),
+          enableNotExists: true,
           getSource: expect.any(Function),
           createStorage: expect.any(Function),
           decorateSourceInput: expect.any(Function),

--- a/packages/zero-cache/src/services/analyze.ts
+++ b/packages/zero-cache/src/services/analyze.ts
@@ -73,6 +73,7 @@ export async function analyzeQuery(
       planDebugger,
       host: {
         debug: new Debug(),
+        enableNotExists: true,
         getSource(tableName: string) {
           let source = tables.get(tableName);
           if (source) {

--- a/packages/zero-cache/src/services/view-syncer/view-syncer-inspect.pg.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer-inspect.pg.test.ts
@@ -27,6 +27,7 @@ import type {ConnectionValidation} from './connection-context-manager.ts';
 import {
   expectNoPokes,
   ISSUES_QUERY,
+  ISSUES_QUERY_WITH_NOT_EXISTS_AND_RELATED,
   messages,
   nextPoke,
   permissions,
@@ -357,6 +358,39 @@ describe('view-syncer/service', () => {
         warnings: expect.any(Array),
       }),
     });
+  });
+
+  test('analyze-query with not exists', async () => {
+    const {queue: client} = connectWithQueueAndSource(SYNC_CONTEXT, []);
+
+    await nextPoke(client);
+    stateChanges.push({state: 'version-ready'});
+    await nextPoke(client);
+    await expectNoPokes(client);
+
+    const inspectId = 'test-analyze-query-not-exists';
+
+    await vs.inspect(SYNC_CONTEXT, [
+      'inspect',
+      {
+        op: 'analyze-query',
+        id: inspectId,
+        ast: ISSUES_QUERY_WITH_NOT_EXISTS_AND_RELATED,
+        options: {},
+      },
+    ]);
+
+    const msg = (await client.dequeue()) as InspectDownMessage;
+    expect(msg).toMatchObject([
+      'inspect',
+      {
+        id: inspectId,
+        op: 'analyze-query',
+        value: {
+          syncedRowCount: expect.any(Number),
+        },
+      },
+    ]);
   });
 
   test('analyze-query with options', async () => {

--- a/packages/zero-client/src/client/inspector/inspector.test.ts
+++ b/packages/zero-client/src/client/inspector/inspector.test.ts
@@ -2006,7 +2006,7 @@ describe('authenticate', () => {
   });
 
   describe('RPC error handling', () => {
-    test('handles validation error for wrong op in response', async () => {
+    test('handles error response', async () => {
       const z = zeroForTest({schema});
       await z.triggerConnected();
       await Promise.resolve();
@@ -2015,8 +2015,6 @@ describe('authenticate', () => {
       const p = z.inspector.serverVersion();
       const id = await idPromise;
 
-      // Simulate error response - this will fail schema validation
-      // because inspectVersionDownSchema expects op: 'version', not op: 'error'
       await z.triggerMessage([
         'inspect',
         {
@@ -2026,9 +2024,7 @@ describe('authenticate', () => {
         },
       ] satisfies InspectDownMessage);
 
-      // The RPC will reject with a validation error since the response
-      // doesn't match the expected schema
-      await expect(p).rejects.toThrow('Expected literal value "version"');
+      await expect(p).rejects.toThrow('Server encountered an internal error');
 
       await z.close();
     });

--- a/packages/zero-client/src/client/inspector/lazy-inspector.ts
+++ b/packages/zero-client/src/client/inspector/lazy-inspector.ts
@@ -20,6 +20,7 @@ import type {Row} from '../../../../zero-protocol/src/data.ts';
 import {
   inspectAnalyzeQueryDownSchema,
   inspectAuthenticatedDownSchema,
+  inspectErrorDownSchema,
   inspectMetricsDownSchema,
   inspectQueriesDownSchema,
   inspectVersionDownSchema,
@@ -109,25 +110,26 @@ function rpcNoAuthTry<T extends InspectDownBody>(
       if (body.id !== id) {
         return;
       }
-      const res = valita.test(body, downSchema);
-      if (res.ok) {
-        if (res.value.op === 'error') {
-          reject(new Error(res.value.value));
-        } else {
-          resolve(res.value.value);
-        }
+      const errorRes = valita.test(body, inspectErrorDownSchema);
+      if (errorRes.ok) {
+        reject(new Error(errorRes.value.value));
       } else {
-        // Check if we got un authenticated/false response
-        const authRes = valita.test(body, inspectAuthenticatedDownSchema);
-        if (authRes.ok) {
-          // Handle authenticated response
-          assert(
-            authRes.value.value === false,
-            'Expected unauthenticated response',
-          );
-          reject(new UnauthenticatedError());
+        const res = valita.test(body, downSchema);
+        if (res.ok) {
+          resolve(res.value.value);
         } else {
-          reject(res.error);
+          // Check if we got un authenticated/false response
+          const authRes = valita.test(body, inspectAuthenticatedDownSchema);
+          if (authRes.ok) {
+            // Handle authenticated response
+            assert(
+              authRes.value.value === false,
+              'Expected unauthenticated response',
+            );
+            reject(new UnauthenticatedError());
+          } else {
+            reject(res.error);
+          }
         }
       }
       socket.removeEventListener('message', f);


### PR DESCRIPTION
## Original bug report

[Slack thread](https://rocicorp.slack.com/archives/C0B3A4P3W56/p1788123657889809?thread_ts=1788108778.772109&cid=C0B3A4P3W56)

A user tried to analyze a query containing `not(exists(...))`. Instead of seeing a useful result or error, the CLI printed:

```text
Expected literal value "analyze-query" at op Got "error"
```

There were two separate problems.

## What this fixes

First, inspector RPCs can return either the requested response or an error response. The client only checked the requested response schema, so it replaced the real server error with a schema-validation error. The client now recognizes the error response and shows its message.

Second, after exposing the real message, the server said that `not(exists())` was unsupported on the client. But query analysis runs on the server, where `NOT EXISTS` is supported. The analyzer was accidentally using the client restriction. It now enables `NOT EXISTS`, just like the normal server query path does.

This does not enable `NOT EXISTS` in queries executed by clients. It only allows the server-side analyzer to analyze them.

## Manual testing

We reproduced the original failure with the real zbugs analyze-query CLI. After applying the inspector fix, we ran the same command again and confirmed that the CLI showed the server error instead of the misleading schema-validation error.

## Automated tests

- Inspector RPC test verifies that server error messages reach the caller.
- Analyzer unit test verifies that server-side `NOT EXISTS` support is enabled.
- PostgreSQL inspector test analyzes a real `NOT EXISTS` query end to end.
- zero-client and zero-cache formatting, lint, and type checks pass.