### PR TITLE
perf(shared): hash once per string in h64/h128, not once per word

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -32,7 +32,6 @@
     "command-line-args": "^6.0.1",
     "command-line-usage": "^7.0.3",
     "defu": "^6.1.4",
-    "js-xxhash": "^4.0.0",
     "json-custom-numbers": "^3.1.1",
     "kasi": "^1.1.0",
     "semver": "^7.5.4"
@@ -48,6 +47,7 @@
     "@vitest/runner": "^4.1.6",
     "compare-utf8": "^0.2.0",
     "fast-check": "^3.18.0",
+    "js-xxhash": "^4.0.0",
     "mitata": "^1.0.34",
     "oxfmt": "^0.65.0",
     "package-up": "^5.0.0",

--- a/packages/shared/src/hash.bench.ts
+++ b/packages/shared/src/hash.bench.ts
@@ -1,0 +1,60 @@
+import {xxHash32} from 'js-xxhash';
+import {bench, describe, use} from './bench.ts';
+import {h128, h32, h64} from './hash.ts';
+
+/**
+ * The implementation `hash.ts` replaced: one `xxHash32` pass per word, each
+ * pass UTF-8 encoding the string again.
+ */
+function multiPass(str: string, words: number): bigint {
+  let hash = 0n;
+  for (let i = 0; i < words; i++) {
+    hash = (hash << 32n) + BigInt(xxHash32(str, i));
+  }
+  return hash;
+}
+
+// Sizes chosen around what the callers hash: a row key, a normalized query AST,
+// a view-syncer row-set signature.
+const SIZES = [64, 256, 1024, 8192];
+
+function makeInput(len: number): string {
+  let s = '';
+  for (let i = 0; s.length < len; i++) {
+    s += `{"table":"issue${i}","column":"created${i}","value":${i}},`;
+  }
+  return s.slice(0, len);
+}
+
+describe('h64', () => {
+  for (const size of SIZES) {
+    const s = makeInput(size);
+    bench(`${size} chars | multi-pass (before)`, () => {
+      use(multiPass(s, 2));
+    });
+    bench(`${size} chars | single-pass (after)`, () => {
+      use(h64(s));
+    });
+  }
+});
+
+describe('h128', () => {
+  for (const size of SIZES) {
+    const s = makeInput(size);
+    bench(`${size} chars | multi-pass (before)`, () => {
+      use(multiPass(s, 4));
+    });
+    bench(`${size} chars | single-pass (after)`, () => {
+      use(h128(s));
+    });
+  }
+});
+
+describe('h32', () => {
+  for (const size of SIZES) {
+    const s = makeInput(size);
+    bench(`${size} chars`, () => {
+      use(h32(s));
+    });
+  }
+});

--- a/packages/shared/src/hash.bench.ts
+++ b/packages/shared/src/hash.bench.ts
@@ -53,7 +53,10 @@ describe('h128', () => {
 describe('h32', () => {
   for (const size of SIZES) {
     const s = makeInput(size);
-    bench(`${size} chars`, () => {
+    bench(`${size} chars | js-xxhash (before)`, () => {
+      use(xxHash32(s, 0));
+    });
+    bench(`${size} chars | single-pass (after)`, () => {
       use(h32(s));
     });
   }

--- a/packages/shared/src/hash.test.ts
+++ b/packages/shared/src/hash.test.ts
@@ -1,0 +1,73 @@
+import fc from 'fast-check';
+import {xxHash32} from 'js-xxhash';
+import {expect, test} from 'vitest';
+import {h128, h32, h64} from './hash.ts';
+
+/**
+ * The original implementation: fold `words` independent `xxHash32` passes over
+ * the string. `hash.ts` now does this in a single pass over a single UTF-8
+ * encoding; these tests pin the output to the original.
+ */
+function referenceHash(str: string, words: number): bigint {
+  let hash = 0n;
+  for (let i = 0; i < words; i++) {
+    hash = (hash << 32n) + BigInt(xxHash32(str, i));
+  }
+  return hash;
+}
+
+const INTERESTING = [
+  '',
+  'a',
+  'abc',
+  '0123456789abcde', // 15 bytes: no stripe
+  '0123456789abcdef', // 16 bytes: exactly one stripe
+  '0123456789abcdefg', // stripe + tail
+  '0123456789abcdefghijklmnopqrstu', // stripe + 4-byte lanes + tail
+  'ä'.repeat(17), // 2-byte UTF-8
+  '€'.repeat(11), // 3-byte UTF-8
+  '😀'.repeat(7), // surrogate pairs
+  'a\0b', // embedded NUL
+  JSON.stringify({table: 'issue', where: null, limit: 100}),
+  'x'.repeat(1000),
+];
+
+test('h32 is xxHash32 with seed 0', () => {
+  for (const s of INTERESTING) {
+    expect(h32(s)).toBe(xxHash32(s, 0));
+  }
+});
+
+test('h64 and h128 match the multi-pass reference', () => {
+  for (const s of INTERESTING) {
+    expect(h64(s)).toBe(referenceHash(s, 2));
+    expect(h128(s)).toBe(referenceHash(s, 4));
+  }
+});
+
+test('h64 and h128 match the reference for arbitrary strings', () => {
+  fc.assert(
+    fc.property(fc.string({maxLength: 300}), s => {
+      expect(h64(s)).toBe(referenceHash(s, 2));
+      expect(h128(s)).toBe(referenceHash(s, 4));
+    }),
+    {numRuns: 500},
+  );
+});
+
+test('h64 and h128 match the reference for arbitrary unicode', () => {
+  fc.assert(
+    fc.property(fc.fullUnicodeString({maxLength: 300}), s => {
+      expect(h64(s)).toBe(referenceHash(s, 2));
+      expect(h128(s)).toBe(referenceHash(s, 4));
+    }),
+    {numRuns: 500},
+  );
+});
+
+test('successive calls do not share state', () => {
+  const a = h128('some string');
+  h64('a different string');
+  h128('yet another');
+  expect(h128('some string')).toBe(a);
+});

--- a/packages/shared/src/hash.test.ts
+++ b/packages/shared/src/hash.test.ts
@@ -45,9 +45,10 @@ test('h64 and h128 match the multi-pass reference', () => {
   }
 });
 
-test('h64 and h128 match the reference for arbitrary strings', () => {
+test('all three match the reference for arbitrary strings', () => {
   fc.assert(
     fc.property(fc.string({maxLength: 300}), s => {
+      expect(h32(s)).toBe(xxHash32(s, 0));
       expect(h64(s)).toBe(referenceHash(s, 2));
       expect(h128(s)).toBe(referenceHash(s, 4));
     }),
@@ -55,9 +56,10 @@ test('h64 and h128 match the reference for arbitrary strings', () => {
   );
 });
 
-test('h64 and h128 match the reference for arbitrary unicode', () => {
+test('all three match the reference for arbitrary unicode', () => {
   fc.assert(
     fc.property(fc.fullUnicodeString({maxLength: 300}), s => {
+      expect(h32(s)).toBe(xxHash32(s, 0));
       expect(h64(s)).toBe(referenceHash(s, 2));
       expect(h128(s)).toBe(referenceHash(s, 4));
     }),
@@ -68,6 +70,7 @@ test('h64 and h128 match the reference for arbitrary unicode', () => {
 test('successive calls do not share state', () => {
   const a = h128('some string');
   h64('a different string');
+  h32('a third string');
   h128('yet another');
   expect(h128('some string')).toBe(a);
 });

--- a/packages/shared/src/hash.ts
+++ b/packages/shared/src/hash.ts
@@ -4,14 +4,166 @@ export const h32 = (s: string) => xxHash32(s, 0);
 export const h64 = (s: string) => hash(s, 2);
 export const h128 = (s: string) => hash(s, 4);
 
+const PRIME32_1 = 2654435761;
+const PRIME32_2 = 2246822519;
+const PRIME32_3 = 3266489917;
+const PRIME32_4 = 668265263;
+const PRIME32_5 = 374761393;
+
+const MAX_WORDS = 4;
+
+// `hash` is synchronous and does not recurse, so these can be reused across
+// calls instead of allocated per call.
+const accs = new Int32Array(MAX_WORDS);
+const stripes = new Int32Array(MAX_WORDS * 4);
+let encoder: TextEncoder | undefined;
+
+function round(acc: number, lane: number): number {
+  const laneN0 = lane & 0xffff;
+  const laneN1 = lane >>> 16;
+  acc =
+    (acc + (laneN0 * PRIME32_2 + ((laneN1 * PRIME32_2) << 16))) & 0xffffffff;
+  acc = (acc << 13) | (acc >>> 19);
+  return (
+    ((acc & 0xffff) * PRIME32_1 + (((acc >>> 16) * PRIME32_1) << 16)) &
+    0xffffffff
+  );
+}
+
 /**
  * xxHash32 only computes 32-bit values. Run it n times with different seeds to
  * get a larger hash with better collision resistance.
+ *
+ * A seed only changes the initial accumulator values, so every word digests the
+ * same input lanes. This walks the bytes once, advancing all `words` sets of
+ * accumulators per lane, and UTF-8 encodes the string once. The result is
+ * identical to folding `words` separate `xxHash32(str, i)` calls, which is what
+ * this used to do — and what `hash.test.ts` checks it still matches.
  */
 function hash(str: string, words: number): bigint {
-  let hash = 0n;
-  for (let i = 0; i < words; i++) {
-    hash = (hash << 32n) + BigInt(xxHash32(str, i));
+  const b = (encoder ??= new TextEncoder()).encode(str);
+  const len = b.length;
+
+  for (let w = 0; w < words; w++) {
+    accs[w] = (w + PRIME32_5) & 0xffffffff;
   }
-  return hash;
+
+  let offset = 0;
+
+  /*
+      Step 2. Process stripes
+      A stripe is a contiguous segment of 16 bytes, evenly divided into 4 lanes
+      of 4 bytes each, each lane updating its own accumulator. Inputs shorter
+      than a stripe skip straight to step 4 with a single accumulator.
+  */
+  if (len >= 16) {
+    for (let w = 0; w < words; w++) {
+      const base = w << 2;
+      stripes[base] = (w + PRIME32_1 + PRIME32_2) & 0xffffffff;
+      stripes[base + 1] = (w + PRIME32_2) & 0xffffffff;
+      stripes[base + 2] = w;
+      stripes[base + 3] = (w - PRIME32_1) & 0xffffffff;
+    }
+
+    const limit = len - 16;
+    for (; offset <= limit; offset += 16) {
+      const l0 =
+        b[offset] |
+        (b[offset + 1] << 8) |
+        (b[offset + 2] << 16) |
+        (b[offset + 3] << 24);
+      const l1 =
+        b[offset + 4] |
+        (b[offset + 5] << 8) |
+        (b[offset + 6] << 16) |
+        (b[offset + 7] << 24);
+      const l2 =
+        b[offset + 8] |
+        (b[offset + 9] << 8) |
+        (b[offset + 10] << 16) |
+        (b[offset + 11] << 24);
+      const l3 =
+        b[offset + 12] |
+        (b[offset + 13] << 8) |
+        (b[offset + 14] << 16) |
+        (b[offset + 15] << 24);
+      for (let w = 0; w < words; w++) {
+        const base = w << 2;
+        stripes[base] = round(stripes[base], l0);
+        stripes[base + 1] = round(stripes[base + 1], l1);
+        stripes[base + 2] = round(stripes[base + 2], l2);
+        stripes[base + 3] = round(stripes[base + 3], l3);
+      }
+    }
+
+    /*
+        Step 3. Accumulator convergence
+        acc = (acc1 <<< 1) + (acc2 <<< 7) + (acc3 <<< 12) + (acc4 <<< 18);
+    */
+    for (let w = 0; w < words; w++) {
+      const base = w << 2;
+      const s0 = stripes[base];
+      const s1 = stripes[base + 1];
+      const s2 = stripes[base + 2];
+      const s3 = stripes[base + 3];
+      accs[w] =
+        (((s0 << 1) | (s0 >>> 31)) +
+          ((s1 << 7) | (s1 >>> 25)) +
+          ((s2 << 12) | (s2 >>> 20)) +
+          ((s3 << 18) | (s3 >>> 14))) &
+        0xffffffff;
+    }
+  }
+
+  // Step 4. Add input length.
+  for (let w = 0; w < words; w++) {
+    accs[w] = (accs[w] + len) & 0xffffffff;
+  }
+
+  // Step 5. Consume the remaining input, 4 bytes at a time and then 1 at a time.
+  const limit4 = len - 4;
+  for (; offset <= limit4; offset += 4) {
+    const laneN0 = b[offset] + (b[offset + 1] << 8);
+    const laneN1 = b[offset + 2] + (b[offset + 3] << 8);
+    const laneP = laneN0 * PRIME32_3 + ((laneN1 * PRIME32_3) << 16);
+    for (let w = 0; w < words; w++) {
+      let acc = (accs[w] + laneP) & 0xffffffff;
+      acc = (acc << 17) | (acc >>> 15);
+      accs[w] =
+        ((acc & 0xffff) * PRIME32_4 + (((acc >>> 16) * PRIME32_4) << 16)) &
+        0xffffffff;
+    }
+  }
+
+  for (; offset < len; ++offset) {
+    const lane = b[offset];
+    for (let w = 0; w < words; w++) {
+      let acc = accs[w] + lane * PRIME32_5;
+      acc = (acc << 11) | (acc >>> 21);
+      accs[w] =
+        ((acc & 0xffff) * PRIME32_1 + (((acc >>> 16) * PRIME32_1) << 16)) &
+        0xffffffff;
+    }
+  }
+
+  /*
+      Step 6. Final mix (avalanche), then fold the words into one big int,
+      highest seed first.
+  */
+  let result = 0n;
+  for (let w = 0; w < words; w++) {
+    let acc = accs[w];
+    acc = acc ^ (acc >>> 15);
+    acc =
+      (((acc & 0xffff) * PRIME32_2) & 0xffffffff) +
+      (((acc >>> 16) * PRIME32_2) << 16);
+    acc = acc ^ (acc >>> 13);
+    acc =
+      (((acc & 0xffff) * PRIME32_3) & 0xffffffff) +
+      (((acc >>> 16) * PRIME32_3) << 16);
+    acc = acc ^ (acc >>> 16);
+    // Turn any negatives back into a positive number.
+    result = (result << 32n) + BigInt(acc < 0 ? acc + 4294967296 : acc);
+  }
+  return result;
 }

--- a/packages/shared/src/hash.ts
+++ b/packages/shared/src/hash.ts
@@ -1,8 +1,9 @@
-import {xxHash32} from 'js-xxhash';
-
-export const h32 = (s: string) => xxHash32(s, 0);
-export const h64 = (s: string) => hash(s, 2);
-export const h128 = (s: string) => hash(s, 4);
+export const h32 = (s: string) => {
+  digest(s, 1);
+  return digests[0];
+};
+export const h64 = (s: string) => wide(s, 2);
+export const h128 = (s: string) => wide(s, 4);
 
 const PRIME32_1 = 2654435761;
 const PRIME32_2 = 2246822519;
@@ -12,10 +13,11 @@ const PRIME32_5 = 374761393;
 
 const MAX_WORDS = 4;
 
-// `hash` is synchronous and does not recurse, so these can be reused across
+// `digest` is synchronous and does not recurse, so these can be reused across
 // calls instead of allocated per call.
 const accs = new Int32Array(MAX_WORDS);
 const stripes = new Int32Array(MAX_WORDS * 4);
+const digests = new Uint32Array(MAX_WORDS);
 let encoder: TextEncoder | undefined;
 
 function round(acc: number, lane: number): number {
@@ -31,16 +33,16 @@ function round(acc: number, lane: number): number {
 }
 
 /**
- * xxHash32 only computes 32-bit values. Run it n times with different seeds to
- * get a larger hash with better collision resistance.
+ * xxHash32 over the UTF-8 bytes of `str` under seeds `0..words-1`, leaving the
+ * digests in `digests[0..words)`.
  *
  * A seed only changes the initial accumulator values, so every word digests the
  * same input lanes. This walks the bytes once, advancing all `words` sets of
  * accumulators per lane, and UTF-8 encodes the string once. The result is
- * identical to folding `words` separate `xxHash32(str, i)` calls, which is what
- * this used to do — and what `hash.test.ts` checks it still matches.
+ * identical to `words` separate `xxHash32(str, i)` calls — which is what this
+ * used to delegate to, and what `hash.test.ts` checks it still matches.
  */
-function hash(str: string, words: number): bigint {
+function digest(str: string, words: number): void {
   const b = (encoder ??= new TextEncoder()).encode(str);
   const len = b.length;
 
@@ -146,11 +148,8 @@ function hash(str: string, words: number): bigint {
     }
   }
 
-  /*
-      Step 6. Final mix (avalanche), then fold the words into one big int,
-      highest seed first.
-  */
-  let result = 0n;
+  // Step 6. Final mix (avalanche). The Uint32Array store turns any negatives
+  // back into a positive number.
   for (let w = 0; w < words; w++) {
     let acc = accs[w];
     acc = acc ^ (acc >>> 15);
@@ -161,9 +160,19 @@ function hash(str: string, words: number): bigint {
     acc =
       (((acc & 0xffff) * PRIME32_3) & 0xffffffff) +
       (((acc >>> 16) * PRIME32_3) << 16);
-    acc = acc ^ (acc >>> 16);
-    // Turn any negatives back into a positive number.
-    result = (result << 32n) + BigInt(acc < 0 ? acc + 4294967296 : acc);
+    digests[w] = acc ^ (acc >>> 16);
+  }
+}
+
+/**
+ * A hash wider than 32 bits, folding `words` digests together highest seed
+ * first.
+ */
+function wide(str: string, words: number): bigint {
+  digest(str, words);
+  let result = 0n;
+  for (let w = 0; w < words; w++) {
+    result = (result << 32n) + BigInt(digests[w]);
   }
   return result;
 }

--- a/packages/zero/package.json
+++ b/packages/zero/package.json
@@ -157,7 +157,6 @@
     "fastify": "^5.0.0",
     "is-in-subnet": "^4.0.1",
     "jose": "^5.9.3",
-    "js-xxhash": "^4.0.0",
     "json-custom-numbers": "^3.1.1",
     "kasi": "^1.1.0",
     "nanoid": "^5.1.2",

--- a/packages/zql-benchmarks/package.json
+++ b/packages/zql-benchmarks/package.json
@@ -25,6 +25,7 @@
   },
   "devDependencies": {
     "@types/tmp": "^0.2.6",
+    "js-xxhash": "^4.0.0",
     "mitata": "^1.0.34",
     "otel": "workspace:*",
     "oxfmt": "^0.65.0",

--- a/packages/zql-benchmarks/src/query-hash.bench.ts
+++ b/packages/zql-benchmarks/src/query-hash.bench.ts
@@ -1,0 +1,150 @@
+/**
+ * Benchmarks for `hashOfAST` (`packages/zero-protocol/src/query-hash.ts`).
+ *
+ * `hashOfAST(ast)` is `h64(JSON.stringify(normalizeAST(ast))).toString(36)`.
+ * `h64` used to run `xxHash32` twice over the string, and `xxHash32` UTF-8
+ * encodes its string argument on every call, so one hash allocated a JSON
+ * string plus two identical byte arrays and walked the bytes twice. `h64` now
+ * encodes once and derives both words in one pass; `multiPassH64` below is the
+ * old behaviour, kept as the "before" baseline.
+ *
+ * Both `normalizeAST` and `hashOfAST` memoize on object identity, so the
+ * pipeline only runs for an AST the process has not seen before. That is the
+ * common case in a client: a component that rebuilds its query on render
+ * produces a fresh AST object each time. These benchmarks therefore measure the
+ * uncached pipeline, feeding it an already-normalized AST so the numbers are
+ * about hashing and not about `normalizeAST`.
+ *
+ * The `parts` suite breaks the pipeline down; the `pipeline` suite compares the
+ * whole thing before and after.
+ */
+import {xxHash32} from 'js-xxhash';
+import {bench, describe, use} from '../../shared/src/bench.ts';
+import {h64} from '../../shared/src/hash.ts';
+import {normalizeAST, type AST} from '../../zero-protocol/src/ast.ts';
+import {hashOfAST} from '../../zero-protocol/src/query-hash.ts';
+import {asQueryInternals} from '../../zql/src/query/query-internals.ts';
+import type {AnyQuery} from '../../zql/src/query/query.ts';
+import {builder} from './schema.ts';
+
+function astOf(q: AnyQuery): AST {
+  return asQueryInternals(q).ast;
+}
+
+// `SELECT * FROM user WHERE id = ? LIMIT 1`
+const tiny = astOf(builder.user.where('id', 'user-1').one() as AnyQuery);
+
+// Roughly the zbugs issue list.
+const medium = astOf(
+  builder.issue
+    .where('open', true)
+    .where('visibility', 'public')
+    .related('labels')
+    .related('creator')
+    .orderBy('modified', 'desc')
+    .orderBy('id', 'desc')
+    .limit(100) as AnyQuery,
+);
+
+// Roughly the zbugs `issuePreloadV2` query: relationships several levels deep.
+const large = astOf(
+  builder.issue
+    .whereExists('project', q => q.where('id', 'project-zero'), {
+      scalar: true,
+    })
+    .related('labels')
+    .related('viewState', q => q.where('userID', 'user-1'))
+    .related('creator')
+    .related('assignee')
+    .related('emoji', emoji => emoji.related('creator'))
+    .related('comments', comments =>
+      comments
+        .related('creator')
+        .related('emoji', emoji => emoji.related('creator'))
+        .limit(10)
+        .orderBy('created', 'desc'),
+    )
+    .where('visibility', 'public')
+    .orderBy('modified', 'desc')
+    .orderBy('id', 'desc')
+    .limit(1000) as AnyQuery,
+);
+
+const CASES = [
+  ['tiny', tiny],
+  ['medium', medium],
+  ['large', large],
+] as const;
+
+let encoder: TextEncoder | undefined;
+
+/** What `h64` did before: one encode and one pass per 32-bit word. */
+function multiPassH64(str: string): bigint {
+  let hash = 0n;
+  for (let i = 0; i < 2; i++) {
+    hash = (hash << 32n) + BigInt(xxHash32(str, i));
+  }
+  return hash;
+}
+
+describe('hashOfAST parts', () => {
+  for (const [name, ast] of CASES) {
+    const normalized = normalizeAST(ast);
+    const json = JSON.stringify(normalized);
+    const bytes = new TextEncoder().encode(json);
+    const big = h64(json);
+    const label = `${name} (${json.length} chars)`;
+
+    bench(`${label} | cache hit`, () => {
+      use(hashOfAST(ast));
+    });
+
+    bench(`${label} | whole pipeline`, () => {
+      use(h64(JSON.stringify(normalized)).toString(36));
+    });
+
+    bench(`${label} | whole pipeline, old h64`, () => {
+      use(multiPassH64(JSON.stringify(normalized)).toString(36));
+    });
+
+    bench(`${label} | JSON.stringify`, () => {
+      use(JSON.stringify(normalized));
+    });
+
+    bench(`${label} | TextEncoder.encode`, () => {
+      use((encoder ??= new TextEncoder()).encode(json));
+    });
+
+    bench(`${label} | xxHash32(string)`, () => {
+      use(xxHash32(json, 0));
+    });
+
+    bench(`${label} | xxHash32(bytes)`, () => {
+      use(xxHash32(bytes, 0));
+    });
+
+    bench(`${label} | h64(string)`, () => {
+      use(h64(json));
+    });
+
+    bench(`${label} | bigint.toString(36)`, () => {
+      use(big.toString(36));
+    });
+  }
+});
+
+describe('hashOfAST pipeline', () => {
+  for (const [name, ast] of CASES) {
+    const normalized = normalizeAST(ast);
+    const json = JSON.stringify(normalized);
+    const label = `${name} (${json.length} chars)`;
+
+    bench(`${label} | before: h64 encoded and walked twice`, () => {
+      use(multiPassH64(JSON.stringify(normalized)).toString(36));
+    });
+
+    bench(`${label} | after: h64 encodes once, one pass`, () => {
+      use(h64(JSON.stringify(normalized)).toString(36));
+    });
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1626,6 +1626,9 @@ importers:
       '@types/tmp':
         specifier: ^0.2.6
         version: 0.2.6
+      js-xxhash:
+        specifier: ^4.0.0
+        version: 4.0.0
       mitata:
         specifier: ^1.0.34
         version: 1.0.34

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -720,9 +720,6 @@ importers:
       defu:
         specifier: ^6.1.4
         version: 6.1.7
-      js-xxhash:
-        specifier: ^4.0.0
-        version: 4.0.0
       json-custom-numbers:
         specifier: ^3.1.1
         version: 3.1.1
@@ -763,6 +760,9 @@ importers:
       fast-check:
         specifier: ^3.18.0
         version: 3.23.2
+      js-xxhash:
+        specifier: ^4.0.0
+        version: 4.0.0
       mitata:
         specifier: ^1.0.34
         version: 1.0.34
@@ -947,9 +947,6 @@ importers:
       jose:
         specifier: ^5.9.3
         version: 5.10.0
-      js-xxhash:
-        specifier: ^4.0.0
-        version: 4.0.0
       json-custom-numbers:
         specifier: ^3.1.1
         version: 3.1.1


### PR DESCRIPTION
`h64` and `h128` build a wider digest by running `xxHash32` under several seeds. `js-xxhash` UTF-8 encodes its string argument on *every* call, so `h64` encoded the same string twice and walked the bytes twice, and `h128` did both four times.

A seed only changes the initial accumulator values — every word digests the same input lanes. So encode once and advance all the words' accumulators in a single pass over the bytes.

## Output is unchanged

This is a pure speedup, not a new hash. `hash.test.ts` pins all three functions against the old implementation, including `fast-check` property tests over arbitrary unicode, so digests already persisted in CVRs and IndexedDB stay valid and no protocol version moves.

## Numbers

`packages/shared/src/hash.bench.ts`, before vs. after:

| input | `h64` | `h128` | `h32` |
| --- | --- | --- | --- |
| 64 chars | 361 → 181 ns (2.0x) | 729 → 232 ns (3.1x) | 156 → 161 ns |
| 256 chars | 666 → 365 ns (1.8x) | 1.37 µs → 459 ns (3.0x) | 315 → 315 ns |
| 1024 chars | 1.90 → 1.07 µs (1.8x) | 3.87 → 1.33 µs (2.9x) | 933 → 924 ns |
| 8192 chars | 13.48 → 7.77 µs (1.7x) | 27.01 → 9.72 µs (2.8x) | 6.75 → 6.58 µs |

`h128` gains most and is the one in `zero-cache`'s `row-key.ts`. `h64` is used by `row-set-signature.ts` and by `hashOfAST`. `h32` is a wash — see the third commit.

## Commits

**1. `perf(shared)`** — the single-pass change itself, plus `hash.test.ts` and `hash.bench.ts`.

**2. `chore(zql-benchmarks)`** — `query-hash.bench.ts` benchmarks `hashOfAST`, which is what sent me here. It breaks the pipeline into its parts over tiny/medium/large zbugs-shaped ASTs. End to end that query hash goes from 9.06 → 6.77 µs on the large AST (1.34x).

**3. `refactor(shared)`** — commit 1 left two copies of xxHash32 in the file: `h32` still delegated to `js-xxhash` while the multi-seed path reimplemented the algorithm. Now there is one implementation. `digest(str, words)` fills a `digests` array; `h32` reads word 0, `h64`/`h128` fold 2 and 4 words into a bigint. `h32`'s output is unchanged and the property tests now cover it too.

That leaves `js-xxhash` with no runtime importer — only `hash.test.ts` (as the reference oracle) and the benchmarks — so it moves to `devDependencies` in `shared` and drops out of `packages/zero`'s `dependencies`. Verified rather than assumed: the built `zero` bundle contains no reference to it, and that build validates every bare import in its output is declared, so it would fail if anything still needed it.

⚠️ That last part changes the published package's dependency list. It's correct, but if you'd rather keep this PR narrow I can split it out or drop it.

## What this does *not* do

`JSON.stringify` is now the dominant term in `hashOfAST`, ~65% of what remains. Serializing the AST straight into a byte buffer instead (prototyped, not included here) got the large AST to ~4.1 µs. But it changes the hash string, and `hashOfNameAndArgs` is computed on both the client and the server, so it needs a protocol version bump. Left for a separate discussion, along with streaming the hash through a tree visitor and folding it incrementally as the query is built.

Also worth recording: both `normalizeAST` and `hashOfAST` memoize on object identity, so a cache hit is ~20 ns. None of this matters unless fresh ASTs are being built — which a component that rebuilds its query on render does every time.

## Test plan

- `pnpm --filter shared test` — 762 pass, including the new `hash.test.ts`
- `pnpm --filter zero-protocol test` — 52 pass
- `pnpm --filter zero-client test` — 650 pass
- `pnpm --filter @rocicorp/zero build` — clean
- `pnpm exec syncpack lint` and `pnpm run verify-deps` — clean
- `lint`, `format` and `check-types` clean on both touched packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)
