### PR TITLE
chore(zero-cache): exempt the backup-replicator from laggard detection

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/broadcast.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/broadcast.test.ts
@@ -305,4 +305,209 @@ describe('change-streamer/broadcast', () => {
     expect(sub2.getStats().missedLastTimeout).toBe(false);
     expect(sub3.getStats().missedLastTimeout).toBe(false);
   });
+
+  describe('backup-replicator is a required consensus member', () => {
+    // Helper: a serving-mode subscriber (the default) and a backup-mode one.
+    const serving = () => createSubscriber('00', true);
+    const backup = () => createSubscriber('00', true, {}, 'backup');
+
+    test('a majority of serving replicas does NOT early-release while the backup is still pending', async () => {
+      const [s1] = serving();
+      const [s2] = serving();
+      const [s3] = serving();
+      const [b] = backup();
+      const {scheduled, setTimeoutFn, clearTimeoutFn} = captureTimers();
+
+      // 4 subscribers => majority of 3.
+      const broadcast = new Broadcast(lc, [s1, s2, s3, b], begin, {
+        consensusTimeoutProportion: 2,
+        setTimeoutFn,
+        clearTimeoutFn,
+      });
+
+      // All 3 serving replicas ack: the majority is met, but the backup has
+      // not responded, so no early-release timer is armed.
+      s1.close();
+      s2.close();
+      s3.close();
+      await sleep(1);
+      expect(scheduled).toHaveLength(0);
+      expect(broadcast.isDone).toBe(false);
+
+      // The backup acking completes the set and releases via all-subscribers.
+      b.close();
+      await broadcast.done;
+      expect(broadcast.releaseMode).toBe('all-subscribers');
+      // The backup is never marked as a laggard.
+      expect(b.getStats().missedLastTimeout).toBe(false);
+    });
+
+    test('the backup acking AFTER the majority arms the timer and drops the remaining laggard', async () => {
+      const [s1] = serving();
+      const [s2] = serving();
+      const [s3] = serving();
+      const [s4] = serving();
+      const [b] = backup();
+      const {scheduled, setTimeoutFn, clearTimeoutFn} = captureTimers();
+
+      // 5 subscribers => majority of 3.
+      const broadcast = new Broadcast(lc, [s1, s2, s3, s4, b], begin, {
+        consensusTimeoutProportion: 2,
+        setTimeoutFn,
+        clearTimeoutFn,
+      });
+
+      // 3 serving acks reach the majority, but the backup is still pending, so
+      // no timer is armed (regression guard: `>=` vs `===` on the majority).
+      s1.close();
+      s2.close();
+      s3.close();
+      await sleep(1);
+      expect(scheduled).toHaveLength(0);
+      expect(broadcast.isDone).toBe(false);
+
+      // The backup acks last. Even though `completed` (4) is now past the
+      // majority (3), the timer must still arm so the remaining laggard (s4)
+      // does not stall the pipeline.
+      b.close();
+      await sleep(1);
+      expect(scheduled).toHaveLength(1);
+      expect(broadcast.isDone).toBe(false);
+
+      // Firing the timer drops s4 as a laggard; the backup stays on-time.
+      scheduled[0].cb();
+      await broadcast.done;
+      expect(broadcast.releaseMode).toBe('consensus-timeout');
+      expect(s4.getStats().missedLastTimeout).toBe(true);
+      expect(b.getStats().missedLastTimeout).toBe(false);
+    });
+
+    test('a backup that acks WITHIN the majority arms the timer at the majority', async () => {
+      const [b] = backup();
+      const [s1] = serving();
+      const [s2] = serving();
+      const [s3] = serving();
+      const {scheduled, setTimeoutFn, clearTimeoutFn} = captureTimers();
+
+      // 4 subscribers => majority of 3.
+      const broadcast = new Broadcast(lc, [b, s1, s2, s3], begin, {
+        consensusTimeoutProportion: 2,
+        setTimeoutFn,
+        clearTimeoutFn,
+      });
+
+      // Backup acks early, then two serving replicas reach the majority: the
+      // timer arms at the majority since the backup has already responded.
+      b.close();
+      s1.close();
+      s2.close();
+      await sleep(1);
+      expect(scheduled).toHaveLength(1);
+      expect(broadcast.isDone).toBe(false);
+
+      // The remaining serving replica is dropped; the backup is never a laggard.
+      scheduled[0].cb();
+      await broadcast.done;
+      expect(broadcast.releaseMode).toBe('consensus-timeout');
+      expect(s3.getStats().missedLastTimeout).toBe(true);
+      expect(b.getStats().missedLastTimeout).toBe(false);
+    });
+
+    test('a consensus-timeout with a still-pending backup never marks the backup timed-out', async () => {
+      // Guards the core guarantee directly: even if the timer somehow fires
+      // while the backup is pending, the backup must not be flagged as a
+      // laggard. With the fix the timer cannot arm until the backup responds,
+      // so this asserts the backup is on-time after a normal release.
+      const [s1] = serving();
+      const [s2] = serving();
+      const [s3] = serving();
+      const [b] = backup();
+      const {scheduled, setTimeoutFn, clearTimeoutFn} = captureTimers();
+
+      const broadcast = new Broadcast(lc, [s1, s2, s3, b], begin, {
+        consensusTimeoutProportion: 2,
+        setTimeoutFn,
+        clearTimeoutFn,
+      });
+
+      s1.close();
+      s2.close();
+      s3.close();
+      await sleep(1);
+      // No timer while the backup is pending.
+      expect(scheduled).toHaveLength(0);
+
+      b.close();
+      await broadcast.done;
+      expect(b.getStats().missedLastTimeout).toBe(false);
+    });
+
+    test('a catching-up (backlogged) backup does NOT gate consensus', async () => {
+      const [s1] = serving();
+      const [s2] = serving();
+      const [s3] = serving();
+      // A backup that is still in its initial catchup: not caught up, and with a
+      // tiny backlog high-water so its live send blocks (stays pending) instead
+      // of resolving. isBacklogged() is true, so it must not be required for
+      // consensus.
+      const [b] = createSubscriber(
+        '00',
+        false,
+        {backlogHighWaterBytes: 1},
+        'backup',
+      );
+      const {scheduled, setTimeoutFn, clearTimeoutFn} = captureTimers();
+
+      // 4 subscribers => majority of 3.
+      const broadcast = new Broadcast(lc, [s1, s2, s3, b], begin, {
+        consensusTimeoutProportion: 2,
+        setTimeoutFn,
+        clearTimeoutFn,
+      });
+
+      // The 3 serving replicas reaching the majority arms the timer immediately,
+      // even though the backup (still catching up) has not responded.
+      s1.close();
+      s2.close();
+      s3.close();
+      await sleep(1);
+      expect(scheduled).toHaveLength(1);
+      expect(broadcast.isDone).toBe(false);
+
+      // Firing the timer releases via consensus-timeout. The catching-up backup
+      // is left pending and recorded timed-out (the forwarder fail-safe, not the
+      // Broadcast, is what keeps it from being disconnected).
+      scheduled[0].cb();
+      await broadcast.done;
+      expect(broadcast.releaseMode).toBe('consensus-timeout');
+      expect(b.getStats().missedLastTimeout).toBe(true);
+    });
+
+    test('no backup present: a majority alone early-releases (unchanged behavior)', async () => {
+      const [s1] = serving();
+      const [s2] = serving();
+      const [s3] = serving();
+      const [s4] = serving();
+      const {scheduled, setTimeoutFn, clearTimeoutFn} = captureTimers();
+
+      // 4 serving subscribers, no backup => majority of 3 releases on its own.
+      const broadcast = new Broadcast(lc, [s1, s2, s3, s4], begin, {
+        consensusTimeoutProportion: 2,
+        setTimeoutFn,
+        clearTimeoutFn,
+      });
+
+      s1.close();
+      s2.close();
+      s3.close();
+      await sleep(1);
+      expect(scheduled).toHaveLength(1);
+      expect(broadcast.isDone).toBe(false);
+
+      scheduled[0].cb();
+      await broadcast.done;
+      expect(broadcast.releaseMode).toBe('consensus-timeout');
+      expect(s4.getStats().missedLastTimeout).toBe(true);
+    });
+  });
 });

--- a/packages/zero-cache/src/services/change-streamer/broadcast.ts
+++ b/packages/zero-cache/src/services/change-streamer/broadcast.ts
@@ -109,6 +109,11 @@ export class Broadcast {
   readonly #clearTimeout: typeof clearTimeout;
   #earlyReleaseTimer: ReturnType<typeof setTimeout> | undefined;
 
+  // Tracks whether the backup-replicator responded. It is a required member
+  // of the consensus timeout since it cannot be dropped as a laggard (since
+  // that would shutdown the replication-manager itself).
+  #needsBackupResponse = false;
+
   /**
    * Broadcasts the `change` to the `subscribers` and tracks their
    * completion.
@@ -131,6 +136,11 @@ export class Broadcast {
 
     for (const sub of this.#pending) {
       const changes = sub.numPending + 1; // add one for this `change`
+      if (sub.mode === 'backup') {
+        // Only gate consensus on the backup-replicator after it has finished
+        // its initial catchup.
+        this.#needsBackupResponse ||= !sub.isBacklogged();
+      }
       void sub
         .send(change)
         .catch(() => {})
@@ -149,20 +159,24 @@ export class Broadcast {
     }
     const elapsed = performance.now() - this.#start;
     sub.trackResponseResult('on-time');
-
+    if (sub.mode === 'backup') {
+      this.#needsBackupResponse = false;
+    }
     this.#completed.push({sub, changes, elapsed});
     this.#pending.delete(sub);
     if (this.#pending.size === 0) {
       this.#setDone('all-subscribers');
       return;
     }
-    // Event-driven consensus-timeout: the moment a majority acks, arm a single
-    // release timer proportional to how long the majority took to ack. The
-    // broadcast resolves when it fires, unless all subscribers ack first.
+    // Event-driven consensus-timeout: the moment a majority acks, and it
+    // includes the backup-replicator, arm a single release timer
+    // proportional to how long the majority took to ack. The broadcast
+    // resolves when it fires, unless all subscribers ack first.
     if (
       this.#earlyReleaseTimeoutProportion !== undefined &&
       this.#earlyReleaseTimer === undefined &&
-      this.#completed.length === this.#majority
+      this.#completed.length >= this.#majority &&
+      !this.#needsBackupResponse
     ) {
       const timeoutMs = Math.ceil(
         elapsed * this.#earlyReleaseTimeoutProportion,

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -910,6 +910,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
     const subscriber = new Subscriber(
       protocolVersion,
       id,
+      mode,
       watermark,
       downstream,
       () => this.#latestStatus,

--- a/packages/zero-cache/src/services/change-streamer/forwarder.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/forwarder.test.ts
@@ -1,6 +1,11 @@
+import {LogContext} from '@rocicorp/logger';
 import {describe, expect, test, vi} from 'vitest';
 import {BigIntJSON} from '../../../../shared/src/bigint-json.ts';
-import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
+import {
+  createSilentLogContext,
+  TestLogSink,
+} from '../../../../shared/src/logging-test-utils.ts';
+import type {ReplicatorMode} from '../replicator/replicator.ts';
 import {ReplicationMessages} from '../replicator/test-utils.ts';
 import {StreamTooFarBehind} from './error-type-enum.ts';
 import {Forwarder} from './forwarder.ts';
@@ -355,8 +360,9 @@ describe('change-streamer/forwarder', () => {
     function addSubscriber(
       forwarder: Forwarder,
       stats: {processRate: number; missedLastTimeout: boolean},
+      mode: ReplicatorMode = 'serving',
     ) {
-      const [sub] = createSubscriber('00', true);
+      const [sub] = createSubscriber('00', true, {}, mode);
       vi.spyOn(sub, 'getStats').mockReturnValue({
         processRate: stats.processRate,
         pending: 0,
@@ -420,6 +426,100 @@ describe('change-streamer/forwarder', () => {
       forwarder.checkSubscriberProgress(5000);
       forwarder.checkSubscriberProgress(60_000);
       expect(catchingUp.close).not.toHaveBeenCalled();
+    });
+
+    test('a lagging backup subscriber is never disconnected (fail-safe)', () => {
+      const forwarder = new Forwarder(createSilentLogContext(), {
+        flowControlConsensusTimeoutProportion: 2,
+        flowControlSlowSubscriberGracePeriodMs: 1000,
+      });
+      addSubscriber(forwarder, {processRate: 10, missedLastTimeout: false});
+      // A backup-replicator that is genuinely lagging (slower than the healthy
+      // baseline, timing out). Disconnecting it would shut down the whole
+      // replication-manager, so the forwarder must never close it even long
+      // after the grace period has elapsed.
+      const backup = addSubscriber(
+        forwarder,
+        {processRate: 1, missedLastTimeout: true},
+        'backup',
+      );
+
+      forwarder.checkSubscriberProgress(1000);
+      forwarder.checkSubscriberProgress(2000);
+      forwarder.checkSubscriberProgress(60_000);
+      expect(backup.close).not.toHaveBeenCalled();
+    });
+
+    test('a lagging backup does not shield a lagging serving replica', () => {
+      const forwarder = new Forwarder(createSilentLogContext(), {
+        flowControlConsensusTimeoutProportion: 2,
+        flowControlSlowSubscriberGracePeriodMs: 1000,
+      });
+      addSubscriber(forwarder, {processRate: 10, missedLastTimeout: false});
+      const backup = addSubscriber(
+        forwarder,
+        {processRate: 1, missedLastTimeout: true},
+        'backup',
+      );
+      const serving = addSubscriber(forwarder, {
+        processRate: 1,
+        missedLastTimeout: true,
+      });
+
+      forwarder.checkSubscriberProgress(1000);
+      forwarder.checkSubscriberProgress(1500);
+      forwarder.checkSubscriberProgress(2000);
+
+      // The serving replica is still disconnected on its own merits; only the
+      // backup is exempt.
+      expect(serving.close).toHaveBeenCalledWith(
+        StreamTooFarBehind,
+        expect.stringContaining('lagging'),
+      );
+      expect(backup.close).not.toHaveBeenCalled();
+    });
+
+    test('backup lag warnings are throttled to once per grace period and report a running total', () => {
+      const logSink = new TestLogSink();
+      const forwarder = new Forwarder(
+        new LogContext('warn', undefined, logSink),
+        {
+          flowControlConsensusTimeoutProportion: 2,
+          flowControlSlowSubscriberGracePeriodMs: 1000,
+        },
+      );
+      addSubscriber(forwarder, {processRate: 10, missedLastTimeout: false});
+      addSubscriber(
+        forwarder,
+        {processRate: 1, missedLastTimeout: true},
+        'backup',
+      );
+
+      const backupWarnings = () =>
+        logSink.messages
+          .map(([, , args]) => String(args[0]))
+          .filter(msg => msg.startsWith('backup subscriber'));
+
+      // t=1000 seeds the lagging clock (laggingDuration 0, below the grace
+      // period), so no event yet.
+      forwarder.checkSubscriberProgress(1000);
+      expect(backupWarnings()).toHaveLength(0);
+
+      // t=2000 crosses the grace period: the first event is warned immediately.
+      forwarder.checkSubscriberProgress(2000);
+      // t=2400/2800 are within a grace period of the last warning: counted but
+      // suppressed.
+      forwarder.checkSubscriberProgress(2400);
+      forwarder.checkSubscriberProgress(2800);
+      expect(backupWarnings()).toHaveLength(1);
+      expect(backupWarnings()[0]).toContain('1 lag events so far');
+
+      // t=3000 is a full grace period after the first warning: warned again,
+      // now reporting the accumulated total.
+      forwarder.checkSubscriberProgress(3000);
+      const warnings = backupWarnings();
+      expect(warnings).toHaveLength(2);
+      expect(warnings[1]).toContain('4 lag events so far');
     });
 
     test('recovering before the grace period elapses avoids disconnection', () => {

--- a/packages/zero-cache/src/services/change-streamer/forwarder.ts
+++ b/packages/zero-cache/src/services/change-streamer/forwarder.ts
@@ -42,6 +42,13 @@ export class Forwarder {
   #currentBroadcast: Broadcast | undefined;
   #progressMonitor: NodeJS.Timeout | undefined;
 
+  // The backup-replicator is never disconnected as a laggard, so its lag
+  // detections are logged (rather than acted upon). Track the running total and
+  // throttle the warning to at most once per grace period to avoid spamming the
+  // log for the duration of a slow catchup.
+  #backupLagEventCount = 0;
+  #lastBackupLagWarnMs: number | undefined;
+
   constructor(
     lc: LogContext,
     opts: ProgressMonitorOptions = {
@@ -153,14 +160,36 @@ export class Forwarder {
             : 'catching-up';
         const laggingDuration = sub.reportChangeRate(now, rate);
         if (laggingDuration >= this.#flowControlSlowSubscriberGracePeriodMs) {
-          this.#lc.warn?.(
-            `subscriber ${sub.id} has lagged for ${laggingDuration}ms. disconnecting`,
-            {stats},
-          );
-          sub.close(
-            StreamTooFarBehind,
-            `lagging for over ${this.#flowControlSlowSubscriberGracePeriodMs}ms (${laggingDuration}ms)`,
-          );
+          if (sub.mode === 'backup') {
+            // The backup-replicator can only be detected as a laggard during
+            // initial catchup; after that it is required for consensus. If it
+            // triggers laggard detection in the former case, just log and
+            // continue; as disconnecting it would otherwise kill the
+            // change-streamer task altogether.
+            this.#backupLagEventCount++;
+            const grace = this.#flowControlSlowSubscriberGracePeriodMs;
+            if (
+              this.#lastBackupLagWarnMs === undefined ||
+              now - this.#lastBackupLagWarnMs >= grace
+            ) {
+              this.#lastBackupLagWarnMs = now;
+              this.#lc.warn?.(
+                `backup subscriber ${sub.id} has lagged for ${laggingDuration}ms ` +
+                  `(${this.#backupLagEventCount} lag events so far). ` +
+                  `this is only expected during initial catchup`,
+                {stats},
+              );
+            }
+          } else {
+            this.#lc.warn?.(
+              `serving subscriber ${sub.id} has lagged for ${laggingDuration}ms. disconnecting`,
+              {stats},
+            );
+            sub.close(
+              StreamTooFarBehind,
+              `lagging for over ${this.#flowControlSlowSubscriberGracePeriodMs}ms (${laggingDuration}ms)`,
+            );
+          }
         }
       }
     }

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.metrics.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.metrics.test.ts
@@ -96,9 +96,16 @@ test('log_warm is recorded per catchup, not per coordinator', async () => {
       ['cold-subscriber', false],
     ] as const) {
       const downstream = Subscription.create<string>();
-      const subscriber = new Subscriber(5, id, '01', downstream, () => ({
-        tag: 'status',
-      }));
+      const subscriber = new Subscriber(
+        5,
+        id,
+        'serving',
+        '01',
+        downstream,
+        () => ({
+          tag: 'status',
+        }),
+      );
       expect(
         await coordinator.catchup(subscriber, () => '06', {logWarm}),
       ).toEqual({kind: 'registered'});

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-catchup.test.ts
@@ -13,9 +13,9 @@ import type {Downstream, WatermarkedChange} from './change-streamer.ts';
 import * as ErrorType from './error-type-enum.ts';
 import {Forwarder} from './forwarder.ts';
 import {
-  SQLiteChangeLogCatchup,
   SQLiteChangeLogBarrierBacklogError,
   SQLiteChangeLogBarrierTimeoutError,
+  SQLiteChangeLogCatchup,
   type SQLiteChangeLogCatchupOptions,
   type SQLiteChangeLogCatchupReader,
   type SQLiteChangeLogCleanupGuard,
@@ -685,6 +685,7 @@ function createSubscriber(watermark: string, options: SubscriberOptions = {}) {
   const subscriber = new Subscriber(
     5,
     `subscriber-${watermark}`,
+    'serving',
     watermark,
     downstream,
     () => ({tag: 'status'}),

--- a/packages/zero-cache/src/services/change-streamer/subscriber.ts
+++ b/packages/zero-cache/src/services/change-streamer/subscriber.ts
@@ -7,6 +7,7 @@ import {promiseVoid} from '../../../../shared/src/resolved-promises.ts';
 import {RingBuffer} from '../../../../shared/src/ring-buffer.ts';
 import {max} from '../../types/lexi-version.ts';
 import type {Subscription} from '../../types/subscription.ts';
+import type {ReplicatorMode} from '../replicator/replicator.ts';
 import type {
   ChangeTag,
   Downstream,
@@ -56,6 +57,7 @@ export type SubscriberStats = {
 export class Subscriber {
   readonly #protocolVersion: number;
   readonly id: string;
+  readonly mode: ReplicatorMode;
   readonly #downstream: Subscription<string>;
   readonly #latestStatus: () => Status;
   #watermark: string;
@@ -74,6 +76,7 @@ export class Subscriber {
   constructor(
     protocolVersion: number,
     id: string,
+    mode: ReplicatorMode,
     watermark: string,
     downstream: Subscription<string>,
     latestStatus: () => Status,
@@ -81,6 +84,7 @@ export class Subscriber {
   ) {
     this.#protocolVersion = protocolVersion;
     this.id = id;
+    this.mode = mode;
     this.#downstream = downstream;
     this.#latestStatus = latestStatus;
     this.#watermark = watermark;
@@ -111,6 +115,14 @@ export class Subscriber {
     return (
       this.#bufferedBacklogBytes >= this.#backlogBackpressure.highWaterBytes
     );
+  }
+
+  /**
+   * @returns whether the subscriber is currently sending backlogged messages,
+   *          vs caught up and sending the "head" of the replication stream.
+   */
+  isBacklogged() {
+    return this.#backlog !== null || this.#bufferedBacklogBytes > 0;
   }
 
   /**

--- a/packages/zero-cache/src/services/change-streamer/test-utils.ts
+++ b/packages/zero-cache/src/services/change-streamer/test-utils.ts
@@ -1,4 +1,5 @@
 import {Subscription} from '../../types/subscription.ts';
+import type {ReplicatorMode} from '../replicator/replicator.ts';
 import {PROTOCOL_VERSION, type Downstream} from './change-streamer.ts';
 import {Subscriber, type SubscriberOptions} from './subscriber.ts';
 
@@ -8,6 +9,7 @@ export function createSubscriber(
   watermark = '00',
   caughtUp = false,
   options: SubscriberOptions = {},
+  mode: ReplicatorMode = 'serving',
 ): [Subscriber, Downstream[], Subscription<string>] {
   const id = '' + nextID++;
   const received: Downstream[] = [];
@@ -17,6 +19,7 @@ export function createSubscriber(
   const subscriber = new Subscriber(
     PROTOCOL_VERSION,
     id,
+    mode,
     watermark,
     sub,
     () => ({tag: 'status'}),


### PR DESCRIPTION
Avoid classifying the `backup-replicator` as a laggard, as disconnecting it kills the replication-manager and is contrary to the goal.

In the steady state, the backup-replicator is required before triggering the consensus timeout. This ensures that even if the backup-replicator is chronically behind (e.g. under-provisioned: https://rocicorp.slack.com/archives/C0ADJ6A02D7/p1788207169632789?thread_ts=1788197984.300939&cid=C0ADJ6A02D7), the replication stream will flow control behind it and not result in a buildup of websocket messages.

Initial catchup is exempted from this consensus requirement, thereby preventing a catching up backup-replicator from slowing down serving-replicators that already caught up. In this case, a lagging backup-replicator is throttle-logged at warning but not disconnected.