### PR TITLE
chore(zero-cache): avoid deleting the replica on change-streamer error

### DIFF
--- a/packages/zero-cache/src/server/replicator.ts
+++ b/packages/zero-cache/src/server/replicator.ts
@@ -138,7 +138,6 @@ export default async function runWorker(
     taskID,
     `${workerName}-${pid}`,
     mode,
-    dbPath,
     changeStreamer,
     workerClient,
     runningLocalChangeStreamer

--- a/packages/zero-cache/src/services/replicator/incremental-sync.test.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.test.ts
@@ -1,4 +1,3 @@
-import {existsSync} from 'node:fs';
 import type {LogContext} from '@rocicorp/logger';
 import {resolver} from '@rocicorp/resolver';
 import {
@@ -95,7 +94,6 @@ describe('replicator/incremental-sync', () => {
       {subscribe: subscribeFn.mockResolvedValue(downstream)},
       worker,
       'serving',
-      dbFile.path,
       ReplicationStatusPublisher.forReplicaFile(dbFile.path),
     );
   });
@@ -656,7 +654,6 @@ describe('replicator/incremental-sync', () => {
       TASK_ID,
       REPLICA_ID,
       'backup',
-      dbFile.path,
       {subscribe: subscribeFn.mockResolvedValue(downstream)},
       worker,
       ReplicationStatusPublisher.forReplicaFile(dbFile.path),
@@ -862,7 +859,6 @@ describe('replicator/incremental-sync', () => {
       },
       worker,
       'serving',
-      dbFile.path,
       ReplicationStatusPublisher.forReplicaFile(dbFile.path),
     );
 
@@ -893,7 +889,6 @@ describe('replicator/incremental-sync', () => {
       },
       worker,
       'serving',
-      dbFile.path,
       ReplicationStatusPublisher.forReplicaFile(dbFile.path),
     );
 
@@ -921,7 +916,5 @@ describe('replicator/incremental-sync', () => {
     // Should stop / resolve
     await syncing;
     expect(processMessage).not.toHaveBeenCalled();
-
-    expect(existsSync(dbFile.path)).toBe(false);
   });
 });

--- a/packages/zero-cache/src/services/replicator/incremental-sync.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.ts
@@ -1,7 +1,6 @@
 import type {LogContext} from '@rocicorp/logger';
 import {AbortError} from '../../../../shared/src/abort-error.ts';
 import type {Enum} from '../../../../shared/src/enum.ts';
-import {deleteLiteDB} from '../../db/delete-lite-db.ts';
 import {getOrCreateCounter} from '../../observability/metrics.ts';
 import type {Source} from '../../types/streams.ts';
 import type {DownloadStatus} from '../change-source/protocol/current.ts';
@@ -38,7 +37,6 @@ export class IncrementalSyncer {
   readonly #changeStreamer: ChangeStreamer;
   readonly #worker: WriteWorkerClient;
   readonly #mode: ReplicatorMode;
-  readonly #replicaDbPath: string;
   readonly #statusPublisher: ReplicationStatusPublisher | null;
   readonly #notifier: Notifier;
   readonly #reporter: ReplicationReportRecorder;
@@ -58,7 +56,6 @@ export class IncrementalSyncer {
     changeStreamer: ChangeStreamer,
     worker: WriteWorkerClient,
     mode: ReplicatorMode,
-    replicaDbPath: string,
     statusPublisher: ReplicationStatusPublisher | null,
   ) {
     this.#lc = lc;
@@ -67,7 +64,6 @@ export class IncrementalSyncer {
     this.#changeStreamer = changeStreamer;
     this.#worker = worker;
     this.#mode = mode;
-    this.#replicaDbPath = replicaDbPath;
     this.#statusPublisher = statusPublisher;
     this.#notifier = new Notifier();
     this.#reporter = new ReplicationReportRecorder(lc);
@@ -148,16 +144,6 @@ export class IncrementalSyncer {
               // Signal from the replication-manager that the view-syncer must
               // shut down and restore a new backup from litestream.
               const {type, message: msg} = message[1];
-              // Explicit errors from the change-streamer (e.g. watermark too
-              // old) often indicate a problem with the replica. As a
-              // conservative measure, delete the replica before shutting down
-              // so that the process restarts from scratch even if reusing the
-              // same volume.
-              lc.warn?.(
-                `received error from change-streamer. deleting replica file`,
-                {error: message[1]},
-              );
-              deleteLiteDB(this.#replicaDbPath);
               this.stop(
                 lc,
                 // Note: The AbortError indicates a clean / intentional shutdown.

--- a/packages/zero-cache/src/services/replicator/replication-resumption-child.ts
+++ b/packages/zero-cache/src/services/replicator/replication-resumption-child.ts
@@ -257,7 +257,6 @@ export default async function runWorker(
     'replication-resumption-test',
     `replication-resumption-child-${pid}`,
     'serving',
-    dbPath,
     new IPCChangeStreamer(parent),
     worker,
     null,

--- a/packages/zero-cache/src/services/replicator/replication-throughput.bench.pg.ts
+++ b/packages/zero-cache/src/services/replicator/replication-throughput.bench.pg.ts
@@ -184,7 +184,6 @@ async function startReplicationPipeline(testDBs: PgTest['testDBs']) {
     TASK_ID,
     'logical-replication-throughput-replicator',
     'serving',
-    replicaDbFile.path,
     parseStringifiedChangeStreamer(changeStreamer),
     worker,
     null,

--- a/packages/zero-cache/src/services/replicator/replicator.ts
+++ b/packages/zero-cache/src/services/replicator/replicator.ts
@@ -94,7 +94,6 @@ export class ReplicatorService implements Replicator, Service {
     taskID: string,
     id: string,
     mode: ReplicatorMode,
-    replicaDbPath: string,
     changeStreamer: ChangeStreamer,
     worker: WriteWorkerClient,
     statusPublisher: ReplicationStatusPublisher | null,
@@ -113,7 +112,6 @@ export class ReplicatorService implements Replicator, Service {
       changeStreamer,
       worker,
       mode,
-      replicaDbPath,
       statusPublisher,
     );
   }

--- a/packages/zql-integration-tests/src/chinook/chinook-zero-cache-fuzzer.pg.test.ts
+++ b/packages/zql-integration-tests/src/chinook/chinook-zero-cache-fuzzer.pg.test.ts
@@ -375,7 +375,6 @@ async function startZeroCacheReplica(testDBs: PgTest['testDBs']) {
       TASK_ID,
       'chinook-zero-cache-fuzzer-replicator',
       'serving',
-      replicaDbFile.path,
       parseStringifiedChangeStreamer(changeStreamer),
       worker,
       null,


### PR DESCRIPTION
Partial revert of https://github.com/rocicorp/mono/pull/6358; avoid deleting the replica file when the change-streamer sends a shutdown signal. 

Server startup already checks the validity of the replica (and re-restores if invalid), so deleting on shutdown is unnecessary. It can also lead to unexpected behavior when run on the replication-manager (e.g. 0-byte replica files) when the litestream process also holds a handle to the file.