### PR TITLE
fix(zero-cache): chunk backfills into small commits to avoid monopolizing the replica

### DIFF
--- a/packages/zero-cache/src/services/change-source/common/backfill-manager.test.ts
+++ b/packages/zero-cache/src/services/change-source/common/backfill-manager.test.ts
@@ -15,19 +15,20 @@ import type {
   ChangeStreamMessage,
   MessageBackfill,
 } from '../protocol/current.ts';
-import {BackfillManager} from './backfill-manager.ts';
+import {BackfillManager, type BackfillMessage} from './backfill-manager.ts';
 import {ChangeStreamMultiplexer} from './change-stream-multiplexer.ts';
+
+type TestStreamItem = MessageBackfill | BackfillCompleted | BackfillMessage;
 
 describe('backfill-manager', () => {
   let backfillManager: BackfillManager;
   let changeStream: ChangeStreamMultiplexer;
   let backfillRequests: BackfillRequest[];
-  let testStreams: ((MessageBackfill | BackfillCompleted)[] | Error)[];
+  let testStreams: (TestStreamItem[] | Error)[];
   let changes: Queue<ChangeStreamMessage>;
   let lc: LogContext;
 
-  beforeEach(() => {
-    lc = createSilentLogContext();
+  function initBackfillManager(commitThresholdBytes?: number) {
     changeStream = new ChangeStreamMultiplexer(lc, '123');
     backfillManager = new BackfillManager(
       lc,
@@ -36,10 +37,9 @@ describe('backfill-manager', () => {
       JSON_PARSED,
       10,
       50,
+      commitThresholdBytes,
     );
     changeStream.addProducers(backfillManager).addListeners(backfillManager);
-    backfillRequests = [];
-    testStreams = [];
     changes = new Queue<ChangeStreamMessage>();
 
     // Drain ChangeStreamMessages to the changes queue.
@@ -48,11 +48,18 @@ describe('backfill-manager', () => {
         changes.enqueue(msg);
       }
     })();
+  }
+
+  beforeEach(() => {
+    lc = createSilentLogContext();
+    backfillRequests = [];
+    testStreams = [];
+    initBackfillManager();
   });
 
   async function* backfillStreamer(
     req: BackfillRequest,
-  ): AsyncGenerator<MessageBackfill | BackfillCompleted> {
+  ): AsyncGenerator<BackfillMessage> {
     lc.debug?.(`starting test backfill stream for`, req);
     backfillRequests.push(req);
     const stream = must(
@@ -64,8 +71,8 @@ describe('backfill-manager', () => {
       throw stream; // For testing backfill errors
     }
 
-    for (const msg of stream) {
-      yield msg;
+    for (const item of stream) {
+      yield 'message' in item ? item : {message: item, byteSize: 0};
     }
   }
 
@@ -184,6 +191,110 @@ describe('backfill-manager', () => {
         },
       },
     ]);
+  });
+
+  test('commits a transaction when the byte threshold is reached', async () => {
+    // Small threshold so that two 60-byte messages (120 bytes) cross it, but a
+    // single one (60 bytes) does not.
+    initBackfillManager(100);
+
+    const relation = {schema: 'foo', name: 'bar', rowKey: {columns: ['a']}};
+    testStreams.push([
+      {
+        message: {
+          tag: 'backfill',
+          relation,
+          watermark: '130',
+          columns: ['b'],
+          rowValues: [[1, 2]],
+        },
+        byteSize: 60,
+      },
+      {
+        message: {
+          tag: 'backfill',
+          relation,
+          watermark: '130',
+          columns: ['b'],
+          rowValues: [[3, 4]],
+        },
+        byteSize: 60,
+      },
+      {
+        message: {
+          tag: 'backfill',
+          relation,
+          watermark: '130',
+          columns: ['b'],
+          rowValues: [[5, 6]],
+        },
+        byteSize: 60,
+      },
+      {
+        tag: 'backfill-completed',
+        relation,
+        columns: ['b'],
+        watermark: '130',
+      },
+    ]);
+
+    backfillManager.run('123', [
+      {
+        columns: {a: {id: '123'}, b: {id: '234'}},
+        table: {metadata: {rowKey: {a: 123}}, name: 'bar', schema: 'foo'},
+      },
+    ]);
+
+    changeStream.pushStatus(['status', {ack: false}, {watermark: '130'}]);
+
+    const data = (rowValues: number[][]) =>
+      [
+        'data',
+        {
+          tag: 'backfill',
+          columns: ['b'],
+          relation: {name: 'bar', rowKey: {columns: ['a']}, schema: 'foo'},
+          watermark: '130',
+          rowValues,
+        },
+      ] satisfies ChangeStreamMessage;
+
+    await expectChanges([
+      // First transaction: accumulates two messages (120 bytes >= 100)...
+      [
+        'begin',
+        {tag: 'begin', json: 'p', skipAck: true},
+        {commitWatermark: '123.01'},
+      ],
+      data([[1, 2]]),
+      data([[3, 4]]),
+      // ...then the threshold forces a commit before the third message.
+      ['commit', {tag: 'commit'}, {watermark: '123.01'}],
+      // Second transaction: the third message opens a fresh transaction.
+      [
+        'begin',
+        {tag: 'begin', json: 'p', skipAck: true},
+        {commitWatermark: '123.02'},
+      ],
+      data([[5, 6]]),
+      // Committed to reach the backfill watermark before completing.
+      ['commit', {tag: 'commit'}, {watermark: '123.02'}],
+      [
+        'begin',
+        {tag: 'begin', json: 'p', skipAck: true},
+        {commitWatermark: '130'},
+      ],
+      [
+        'data',
+        {
+          tag: 'backfill-completed',
+          columns: ['b'],
+          relation: {name: 'bar', rowKey: {columns: ['a']}, schema: 'foo'},
+          watermark: '130',
+        },
+      ],
+      ['commit', {tag: 'commit'}, {watermark: '130'}],
+    ] satisfies ChangeStreamMessage[]);
   });
 
   test('table backfill initiated by create-table', async () => {

--- a/packages/zero-cache/src/services/change-source/common/backfill-manager.ts
+++ b/packages/zero-cache/src/services/change-source/common/backfill-manager.ts
@@ -27,9 +27,27 @@ function tableKey({schema, name}: Identifier) {
   return `${schema}.${name}`;
 }
 
+/**
+ * A {@link MessageBackfill} or {@link BackfillCompleted} paired with the
+ * approximate number of upstream bytes it represents. The BackfillManager uses
+ * `byteSize` to bound the size of each replica transaction, committing and
+ * reopening once {@link COMMIT_THRESHOLD_BYTES} is reached.
+ */
+export type BackfillMessage = {
+  message: MessageBackfill | BackfillCompleted;
+  byteSize: number;
+};
+
 type BackfillStreamer = (
   req: BackfillRequest,
-) => AsyncGenerator<MessageBackfill | BackfillCompleted>;
+) => AsyncGenerator<BackfillMessage>;
+
+/**
+ * Commit (and reopen) the current backfill transaction once this many bytes of
+ * backfill data have accumulated in it. Bounds the size of a single replica
+ * COMMIT/checkpoint so it can't monopolize the replica.
+ */
+const COMMIT_THRESHOLD_BYTES = 8 * 1024 * 1024;
 
 type RunningBackfillState = {
   request: BackfillRequest;
@@ -91,6 +109,8 @@ export class BackfillManager implements Cancelable, Listener {
   /** The watermark of the current transaction in the change stream. */
   #currentTxWatermark: string | null = null;
 
+  readonly #commitThresholdBytes: number;
+
   constructor(
     lc: LogContext,
     changeStreamer: ChangeStreamMultiplexer,
@@ -98,6 +118,7 @@ export class BackfillManager implements Cancelable, Listener {
     jsonFormat: JSONFormat = JSON_STRINGIFIED,
     minBackoffMs = MIN_BACKOFF_INTERVAL_MS,
     maxBackoffMs = MAX_BACKOFF_INTERVAL_MS,
+    commitThresholdBytes = COMMIT_THRESHOLD_BYTES,
   ) {
     this.#lc = lc.withContext('component', 'backfill-manager');
     this.#changeStreamer = changeStreamer;
@@ -106,6 +127,7 @@ export class BackfillManager implements Cancelable, Listener {
     this.#minBackoffMs = minBackoffMs;
     this.#maxBackoffMs = maxBackoffMs;
     this.#retryDelayMs = minBackoffMs;
+    this.#commitThresholdBytes = commitThresholdBytes;
   }
 
   run(lastWatermark: string, initialRequests: BackfillRequest[]) {
@@ -206,6 +228,7 @@ export class BackfillManager implements Cancelable, Listener {
     // backfillTx is set if and only if a changeStreamer reservation has been
     // acquired and the backfill stream is inside a transaction.
     let backfillTx: string | null = null;
+    let uncommittedBytes = 0;
 
     /**
      * @returns the new tx watermark, or null if backfill was cancelled
@@ -267,9 +290,12 @@ export class BackfillManager implements Cancelable, Listener {
         changeStream.release(backfillTx);
       }
       backfillTx = null;
+      uncommittedBytes = 0;
     };
 
-    for await (const msg of this.#backfillStreamer(state.request)) {
+    for await (const {message: msg, byteSize} of this.#backfillStreamer(
+      state.request,
+    )) {
       // Before sending `backfill-completed`, the main replication stream
       // may need to catch up, and/or the current transaction may need to be
       // committed to open a new transaction that's up to backfill watermark.
@@ -278,10 +304,14 @@ export class BackfillManager implements Cancelable, Listener {
         (this.#changeStreamReached(lc, msg.watermark) ||
           (backfillTx !== null && backfillTx < msg.watermark));
 
-      // If necessary, yield the reservation to the main stream.
+      // Commit (and later reopen) the transaction if the main stream is
+      // waiting on the reservation, if we must catch up before completing, or
+      // if the size of current transaction has reached the commit threshold.
       if (
         backfillTx &&
-        (changeStream.waiterDelay() > 0 || mustWaitBeforeFlush)
+        (changeStream.waiterDelay() > 0 ||
+          mustWaitBeforeFlush ||
+          uncommittedBytes >= this.#commitThresholdBytes)
       ) {
         commitTx();
       }
@@ -309,6 +339,7 @@ export class BackfillManager implements Cancelable, Listener {
       // `await` to allow the change streamer to exert back pressure
       // on backfills.
       await changeStream.push(['data', msg]);
+      uncommittedBytes += byteSize;
     }
 
     // Flush any final tx and release the stream.

--- a/packages/zero-cache/src/services/change-source/pg/backfill-stream.bench.pg.ts
+++ b/packages/zero-cache/src/services/change-source/pg/backfill-stream.bench.pg.ts
@@ -264,7 +264,7 @@ describe('zero-cache/backfill throughput', () => {
         for (const request of requests) {
           let sample: BackfillSample | undefined;
           const start = performance.now();
-          for await (const message of streamBackfill(
+          for await (const {message} of streamBackfill(
             lc,
             getConnectionURI(upstream),
             {

--- a/packages/zero-cache/src/services/change-source/pg/backfill-stream.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/backfill-stream.pg.test.ts
@@ -109,9 +109,9 @@ describe('backfill-stream', () => {
   });
 
   test.each([
-    {mode: 'binary', textCopy: false},
-    {mode: 'text', textCopy: true},
-  ])(`column backfill ($mode)`, async ({textCopy}) => {
+    {mode: 'binary', textCopy: false, dataBytes: 922},
+    {mode: 'text', textCopy: true, dataBytes: 474},
+  ])(`column backfill ($mode)`, async ({textCopy, dataBytes}) => {
     const stream = streamBackfill(
       lc,
       upstreamURI,
@@ -130,45 +130,51 @@ describe('backfill-stream', () => {
 
     expect(results).toMatchObject([
       {
-        tag: 'backfill',
-        watermark: expect.any(String),
-        relation: {
-          schema: 'public',
-          name: 'foo',
-          rowKey: {columns: ['id1', 'id2']},
+        byteSize: dataBytes,
+        message: {
+          tag: 'backfill',
+          watermark: expect.any(String),
+          relation: {
+            schema: 'public',
+            name: 'foo',
+            rowKey: {columns: ['id1', 'id2']},
+          },
+          columns: ['c', 'b'],
+          rowValues: [
+            [1n, 2, arr([1, 2, '3', {e: 4}]), '{"d" : 1}'],
+            [2n, 3, arr([2, 3, '4', {e: 5}]), '{"d" : 2}'],
+            [3n, 4, arr([3, 4, '5', {e: 6}]), '{"d" : 3}'],
+            [4n, 5, arr([4, 5, '6', {e: 7}]), '{"d" : 4}'],
+            [5n, 6, arr([5, 6, '7', {e: 8}]), '{"d" : 5}'],
+            [6n, 7, arr([6, 7, '8', {e: 9}]), '{"d" : 6}'],
+            [7n, 8, arr([7, 8, '9', {e: 10}]), '{"d" : 7}'],
+            [8n, 9, arr([8, 9, '10', {e: 11}]), '{"d" : 8}'],
+            [9n, 10, arr([9, 10, '11', {e: 12}]), '{"d" : 9}'],
+            [10n, 11, arr([10, 11, '12', {e: 13}]), '{"d" : 10}'],
+          ],
+          status: {rows: 10, totalRows: 10, totalBytes: expect.any(Number)},
         },
-        columns: ['c', 'b'],
-        rowValues: [
-          [1n, 2, arr([1, 2, '3', {e: 4}]), '{"d" : 1}'],
-          [2n, 3, arr([2, 3, '4', {e: 5}]), '{"d" : 2}'],
-          [3n, 4, arr([3, 4, '5', {e: 6}]), '{"d" : 3}'],
-          [4n, 5, arr([4, 5, '6', {e: 7}]), '{"d" : 4}'],
-          [5n, 6, arr([5, 6, '7', {e: 8}]), '{"d" : 5}'],
-          [6n, 7, arr([6, 7, '8', {e: 9}]), '{"d" : 6}'],
-          [7n, 8, arr([7, 8, '9', {e: 10}]), '{"d" : 7}'],
-          [8n, 9, arr([8, 9, '10', {e: 11}]), '{"d" : 8}'],
-          [9n, 10, arr([9, 10, '11', {e: 12}]), '{"d" : 9}'],
-          [10n, 11, arr([10, 11, '12', {e: 13}]), '{"d" : 10}'],
-        ],
-        status: {rows: 10, totalRows: 10, totalBytes: expect.any(Number)},
       },
       {
-        tag: 'backfill-completed',
-        relation: {
-          schema: 'public',
-          name: 'foo',
-          rowKey: {columns: ['id1', 'id2']},
+        byteSize: 0,
+        message: {
+          tag: 'backfill-completed',
+          relation: {
+            schema: 'public',
+            name: 'foo',
+            rowKey: {columns: ['id1', 'id2']},
+          },
+          columns: ['c', 'b'],
+          status: {rows: 10, totalRows: 10, totalBytes: expect.any(Number)},
         },
-        columns: ['c', 'b'],
-        status: {rows: 10, totalRows: 10, totalBytes: expect.any(Number)},
       },
     ]);
   });
 
   test.each([
-    {mode: 'binary', textCopy: false},
-    {mode: 'text', textCopy: true},
-  ])(`table backfill ($mode)`, async ({textCopy}) => {
+    {mode: 'binary', textCopy: false, dataBytes: 1072},
+    {mode: 'text', textCopy: true, dataBytes: 594},
+  ])(`table backfill ($mode)`, async ({textCopy, dataBytes}) => {
     const stream = streamBackfill(
       lc,
       upstreamURI,
@@ -186,43 +192,49 @@ describe('backfill-stream', () => {
     // Columns should deduped and ordered: [id2, id1, a, c, b]
     expect(results).toMatchObject([
       {
-        tag: 'backfill',
-        watermark: expect.any(String),
-        relation: {
-          schema: 'public',
-          name: 'foo',
-          rowKey: {columns: ['id2', 'id1']},
-        },
-        columns: ['a', 'c', 'b'],
-        rowValues: [
-          [2, 1n, '1111111111', arr([1, 2, '3', {e: 4}]), '{"d" : 1}'],
-          [3, 2n, '2222222222', arr([2, 3, '4', {e: 5}]), '{"d" : 2}'],
-          [4, 3n, '3333333333', arr([3, 4, '5', {e: 6}]), '{"d" : 3}'],
-          [5, 4n, '4444444444', arr([4, 5, '6', {e: 7}]), '{"d" : 4}'],
-          [6, 5n, '5555555555', arr([5, 6, '7', {e: 8}]), '{"d" : 5}'],
-          [7, 6n, '6666666666', arr([6, 7, '8', {e: 9}]), '{"d" : 6}'],
-          [8, 7n, '7777777777', arr([7, 8, '9', {e: 10}]), '{"d" : 7}'],
-          [9, 8n, '8888888888', arr([8, 9, '10', {e: 11}]), '{"d" : 8}'],
-          [10, 9n, '9999999999', arr([9, 10, '11', {e: 12}]), '{"d" : 9}'],
-          [
-            11,
-            10n,
-            '10101010101010101010',
-            arr([10, 11, '12', {e: 13}]),
-            '{"d" : 10}',
+        byteSize: dataBytes,
+        message: {
+          tag: 'backfill',
+          watermark: expect.any(String),
+          relation: {
+            schema: 'public',
+            name: 'foo',
+            rowKey: {columns: ['id2', 'id1']},
+          },
+          columns: ['a', 'c', 'b'],
+          rowValues: [
+            [2, 1n, '1111111111', arr([1, 2, '3', {e: 4}]), '{"d" : 1}'],
+            [3, 2n, '2222222222', arr([2, 3, '4', {e: 5}]), '{"d" : 2}'],
+            [4, 3n, '3333333333', arr([3, 4, '5', {e: 6}]), '{"d" : 3}'],
+            [5, 4n, '4444444444', arr([4, 5, '6', {e: 7}]), '{"d" : 4}'],
+            [6, 5n, '5555555555', arr([5, 6, '7', {e: 8}]), '{"d" : 5}'],
+            [7, 6n, '6666666666', arr([6, 7, '8', {e: 9}]), '{"d" : 6}'],
+            [8, 7n, '7777777777', arr([7, 8, '9', {e: 10}]), '{"d" : 7}'],
+            [9, 8n, '8888888888', arr([8, 9, '10', {e: 11}]), '{"d" : 8}'],
+            [10, 9n, '9999999999', arr([9, 10, '11', {e: 12}]), '{"d" : 9}'],
+            [
+              11,
+              10n,
+              '10101010101010101010',
+              arr([10, 11, '12', {e: 13}]),
+              '{"d" : 10}',
+            ],
           ],
-        ],
-        status: {rows: 10, totalRows: 10, totalBytes: expect.any(Number)},
+          status: {rows: 10, totalRows: 10, totalBytes: expect.any(Number)},
+        },
       },
       {
-        tag: 'backfill-completed',
-        relation: {
-          schema: 'public',
-          name: 'foo',
-          rowKey: {columns: ['id2', 'id1']},
+        byteSize: 0,
+        message: {
+          tag: 'backfill-completed',
+          relation: {
+            schema: 'public',
+            name: 'foo',
+            rowKey: {columns: ['id2', 'id1']},
+          },
+          columns: ['a', 'c', 'b'],
+          status: {rows: 10, totalRows: 10, totalBytes: expect.any(Number)},
         },
-        columns: ['a', 'c', 'b'],
-        status: {rows: 10, totalRows: 10, totalBytes: expect.any(Number)},
       },
     ]);
   });

--- a/packages/zero-cache/src/services/change-source/pg/backfill-stream.ts
+++ b/packages/zero-cache/src/services/change-source/pg/backfill-stream.ts
@@ -20,13 +20,15 @@ import {getTypeParsers} from '../../../db/pg-type-parser.ts';
 import type {PublishedTableSpec} from '../../../db/specs.ts';
 import {importSnapshot, TransactionPool} from '../../../db/transaction-pool.ts';
 import {connectPgClient, pgClient, type PostgresDB} from '../../../types/pg.ts';
-import {SchemaIncompatibilityError} from '../common/backfill-manager.ts';
+import {
+  SchemaIncompatibilityError,
+  type BackfillMessage,
+} from '../common/backfill-manager.ts';
 import type {
   BackfillCompleted,
   BackfillRequest,
   DownloadStatus,
   JSONValue,
-  MessageBackfill,
 } from '../protocol/current.ts';
 import {
   columnMetadataSchema,
@@ -82,7 +84,7 @@ export async function* streamBackfill(
   {slot, publications}: Pick<Replica, 'slot' | 'publications'>,
   bf: BackfillRequest,
   opts: StreamOptions = {},
-): AsyncGenerator<MessageBackfill | BackfillCompleted> {
+): AsyncGenerator<BackfillMessage> {
   lc = lc
     .withContext('component', 'backfill')
     .withContext('table', bf.table.name);
@@ -90,7 +92,15 @@ export async function* streamBackfill(
   const {flushThresholdBytes = POSTGRES_COPY_CHUNK_SIZE, textCopy = false} =
     opts;
   const db = await connectPgClient(lc, upstreamURI, 'backfill-stream', {
-    ['max_lifetime']: 120 * 60, // set a long (2h) limit for COPY streaming
+    // The COPY is a single stream that must outlive the entire table download,
+    // so allow a very long (24h) connection lifetime.
+    ['max_lifetime']: 24 * 60 * 60,
+    // A backfill COPY is a background process that can be preempted by
+    // upstream replication changes, potentially requiring it to sit idle for
+    // long stretches. Use TCP keepalive to detect dead connections instead
+    // of the inactivity watchdog, which could kill connnections that are
+    // taking a back seat for upstream replication changes.
+    liveness: 'keepalive',
   });
   let tx: TransactionPool | undefined;
   let watermark: string;
@@ -190,7 +200,7 @@ async function* stream<T>(
   parser: {parse(chunk: Buffer): Iterable<T | null>},
   decoders: ((field: T) => JSONValue)[],
   flushThresholdBytes: number,
-): AsyncGenerator<MessageBackfill | BackfillCompleted> {
+): AsyncGenerator<BackfillMessage> {
   // Backfill must read every row: TABLESAMPLE / LIMIT are reserved for shadow
   // sync and must never appear in a backfill COPY.
   assert(
@@ -274,7 +284,10 @@ async function* stream<T>(
     totalBytes += chunk.byteLength;
 
     if (bufferedBytes >= flushThresholdBytes) {
-      yield {tag: 'backfill', ...backfill, rowValues, status};
+      yield {
+        message: {tag: 'backfill', ...backfill, rowValues, status},
+        byteSize: bufferedBytes,
+      };
       totalMsgs++;
       logFlushed();
       rowValues = [];
@@ -290,12 +303,18 @@ async function* stream<T>(
 
   // Flush the last batch of rows.
   if (rowValues.length > 0) {
-    yield {tag: 'backfill', ...backfill, rowValues, status};
+    yield {
+      message: {tag: 'backfill', ...backfill, rowValues, status},
+      byteSize: bufferedBytes,
+    };
     totalMsgs++;
     logFlushed();
   }
 
-  yield {tag: 'backfill-completed', ...backfill, status};
+  yield {
+    message: {tag: 'backfill-completed', ...backfill, status},
+    byteSize: 0,
+  };
   elapsed = (performance.now() - start).toFixed(3);
   lc.info?.(
     `Finished streaming ${status.rows} rows, ${totalMsgs} msgs, ${totalBytes} bytes ` +

--- a/packages/zero-cache/src/types/pg.ts
+++ b/packages/zero-cache/src/types/pg.ts
@@ -366,9 +366,23 @@ type SocketFactoryOptions = {
 export function inactivityTimeoutSocket(
   lc: LogContext,
   timeoutMs = SOCKET_INACTIVITY_TIMEOUT_MS,
+  // When > 0, enables OS-level TCP keepalive probes with this initial delay.
+  // Unlike the inactivity watchdog, keepalive distinguishes an idle-but-alive
+  // connection from a dead one (the OS tears down the socket only when probes
+  // go unanswered), so it does not false-positive on connections that are
+  // legitimately idle for long stretches -- e.g. a backfill COPY stream that
+  // this process deliberately back-pressures. It does NOT catch a proxy that
+  // ACKs keepalives after its backend is gone (the case the watchdog guards);
+  // callers that disable the watchdog (timeoutMs = 0) in favor of keepalive
+  // accept that residual risk. Keepalive is a socket option, not a listener,
+  // so it survives postgres.js's removeAllListeners() on TLS upgrade.
+  keepAliveMs = 0,
 ) {
   return (options: SocketFactoryOptions): Socket => {
     const socket = new Socket();
+    if (keepAliveMs > 0) {
+      socket.setKeepAlive(true, keepAliveMs);
+    }
     const target = options.path
       ? options.path
       : `${options.host[0]}:${options.port[0]}`;
@@ -428,7 +442,20 @@ export function pgClient(
   options?: postgres.Options<{
     bigint: PostgresType<bigint>;
     json: PostgresType<JSONValue>;
-  }>,
+  }> & {
+    /**
+     * How to detect a dead ("half-open") connection:
+     *  - `'inactivity-timeout'` (default): reset the socket after
+     *    {@link SOCKET_INACTIVITY_TIMEOUT_MS} of no read/write activity. Catches
+     *    proxy-level half-opens, but false-positives on connections that are
+     *    legitimately idle for long stretches.
+     *  - `'keepalive'`: disable the inactivity watchdog and rely on OS TCP
+     *    keepalive probes instead. Use for connections that are expected to sit
+     *    idle under back-pressure (e.g. the backfill COPY stream), where the
+     *    watchdog would reset a perfectly healthy connection.
+     */
+    liveness?: 'inactivity-timeout' | 'keepalive';
+  },
   opts?: TypeOptions,
 ): PostgresDB {
   applicationName = `zero-${applicationName}`;
@@ -483,12 +510,18 @@ export function pgClient(
 
   // Set connections to expire between 5 and 10 minutes to free up state on PG.
   const maxLifetimeSeconds = randInt(5 * 60, 10 * 60);
-  const providedConnection = options?.connection ?? {};
+  const {liveness = 'inactivity-timeout', ...pgOptions} = options ?? {};
+  const providedConnection = pgOptions.connection ?? {};
 
   // postgres.js supports a custom socket factory via the `socket` option,
   // but it is missing from its type declarations, hence the untyped spread.
+  const socketLc = lc.withContext('appName', applicationName);
   const socketFactory = {
-    socket: inactivityTimeoutSocket(lc.withContext('appName', applicationName)),
+    socket:
+      liveness === 'keepalive'
+        ? // Disable the inactivity watchdog and use TCP keepalive instead.
+          inactivityTimeoutSocket(socketLc, 0, 60_000)
+        : inactivityTimeoutSocket(socketLc),
   };
 
   return postgres(connectionURI, {
@@ -501,7 +534,7 @@ export function pgClient(
     ['idle_timeout']: 60,
     ssl,
     ...socketFactory,
-    ...options,
+    ...pgOptions,
     connection: {
       ...providedConnection,
       ['application_name']: applicationName,


### PR DESCRIPTION
Bound the size of each backfill transaction (in terms of row data size) so that data is regularly committed to the SQLite replica in manageable (8MB) chunks. This avoids (1) monopolizing the replica and (2) stalling flow control, which can otherwise trip our socket watch dog.

In parallel, disable the socket watchdog for backfill connections, as it is processed in low-priority, and consumption of the COPY stream can technically yield for an arbitrary amount of time while changes arrive in the replication stream. (In practice, backfill messages get read as soon as there is a break in the replication stream).

Context:
* https://rocicorp.slack.com/archives/C0B3A4P3W56/p1788205150425019?thread_ts=1787956562.056209&cid=C0B3A4P3W56