### PR TITLE
fix(backfill): reset pipelines when backfills begin

### DIFF
--- a/packages/zero-cache/src/services/replicator/change-processor.test.ts
+++ b/packages/zero-cache/src/services/replicator/change-processor.test.ts
@@ -2830,6 +2830,14 @@ describe('replicator/change-processor', () => {
         ],
         ['_zero.changeLog2']: [
           {
+            backfillingColumnVersions: '{}',
+            op: 'r',
+            pos: -1n,
+            rowKey: '0e',
+            stateVersion: '0e',
+            table: 'bff',
+          },
+          {
             backfillingColumnVersions:
               '{"a":"101","b":"101","c":"101","d":"101","e":"101"}',
             op: 's',
@@ -3244,6 +3252,14 @@ describe('replicator/change-processor', () => {
         ],
         ['_zero.changeLog2']: [
           {
+            backfillingColumnVersions: '{}',
+            op: 'r',
+            pos: -1n,
+            rowKey: '0e',
+            stateVersion: '0e',
+            table: 'bff',
+          },
+          {
             backfillingColumnVersions:
               '{"a":"101","b":"101","c":"101","d":"101","e":"101"}',
             op: 's',
@@ -3593,6 +3609,14 @@ describe('replicator/change-processor', () => {
           {id: 83n, _0_version: '115'},
         ],
         ['_zero.changeLog2']: [
+          {
+            backfillingColumnVersions: '{}',
+            op: 'r',
+            pos: -1n,
+            rowKey: '0e',
+            stateVersion: '0e',
+            table: 'bff',
+          },
           {
             backfillingColumnVersions: '{}',
             op: 'r',

--- a/packages/zero-cache/src/services/replicator/change-processor.ts
+++ b/packages/zero-cache/src/services/replicator/change-processor.ts
@@ -625,17 +625,7 @@ class TransactionProcessor {
       );
     }
 
-    if (
-      Object.keys(create.backfill ?? {}).length ===
-      Object.keys(create.spec.columns).length
-    ) {
-      this.#reloadTableSpecs();
-    } else {
-      // Make the table visible immediately unless all of the columns are
-      // being backfilled. In the backfill case, the version bump will happen
-      // with the backfill is complete.
-      this.#logResetOp(table.name);
-    }
+    this.#logResetOp(table.name);
     this.#lc.info?.(create.tag, table.name);
   }
 
@@ -829,17 +819,7 @@ class TransactionProcessor {
 
     // indexes affect tables visibility (e.g. sync-ability is gated on
     // having a unique index), so reset pipelines to refresh table schemas.
-    // However, the reset is not necessary if the index is for a table
-    // that is not yet visible due to backfilling.
-    const tableSpec = must(this.#tableSpecs.get(index.tableName));
-    if (
-      (tableSpec.backfilling ?? []).length ===
-      Object.entries(tableSpec.columns).length - 1 // don't count _0_version
-    ) {
-      this.#reloadTableSpecs();
-    } else {
-      this.#logResetOp(index.tableName);
-    }
+    this.#logResetOp(index.tableName);
     this.#lc.info?.(create.tag, index.name);
   }
 


### PR DESCRIPTION
Remove an incorrect optimization in the original backfill implementation (https://github.com/rocicorp/mono/pull/5518) where pipeline resets were skipped when backfilling tables are created.

Pipelines should still be reset to refresh the schema; otherwise, subsequent DML statements for the newly created (but backfilling) tables will be unrecognized by the pipeline and throw an error.

Context:
* https://rocicorp.slack.com/archives/C0BU1HX8ELA/p1788236811691309