### PR TITLE
fix(zero-protocol): normalize condition nodes into a canonical field order

### DIFF
--- a/packages/zero-cache/src/auth/read-authorizer.test.ts
+++ b/packages/zero-cache/src/auth/read-authorizer.test.ts
@@ -623,6 +623,7 @@ describe('unreadable tables', () => {
           "where": {
             "conditions": [
               {
+                "flip": undefined,
                 "op": "EXISTS",
                 "related": {
                   "correlation": {
@@ -633,6 +634,7 @@ describe('unreadable tables', () => {
                       "unreadableId",
                     ],
                   },
+                  "hidden": undefined,
                   "subquery": {
                     "alias": "zsubq_unreadable",
                     "limit": undefined,
@@ -648,6 +650,7 @@ describe('unreadable tables', () => {
                   },
                   "system": "permissions",
                 },
+                "scalar": undefined,
                 "type": "correlatedSubquery",
               },
             ],
@@ -668,6 +671,7 @@ describe('unreadable tables', () => {
           "where": {
             "conditions": [
               {
+                "flip": undefined,
                 "op": "EXISTS",
                 "related": {
                   "correlation": {
@@ -678,6 +682,7 @@ describe('unreadable tables', () => {
                       "unreadableId",
                     ],
                   },
+                  "hidden": undefined,
                   "subquery": {
                     "alias": "zsubq_unreadable",
                     "limit": undefined,
@@ -693,6 +698,7 @@ describe('unreadable tables', () => {
                   },
                   "system": "permissions",
                 },
+                "scalar": undefined,
                 "type": "correlatedSubquery",
               },
             ],
@@ -725,6 +731,7 @@ describe('unreadable tables', () => {
         "where": {
           "conditions": [
             {
+              "flip": undefined,
               "op": "NOT EXISTS",
               "related": {
                 "correlation": {
@@ -735,6 +742,7 @@ describe('unreadable tables', () => {
                     "unreadableId",
                   ],
                 },
+                "hidden": undefined,
                 "subquery": {
                   "alias": "zsubq_unreadable",
                   "limit": undefined,
@@ -750,6 +758,7 @@ describe('unreadable tables', () => {
                 },
                 "system": "permissions",
               },
+              "scalar": undefined,
               "type": "correlatedSubquery",
             },
           ],
@@ -780,6 +789,7 @@ describe('unreadable tables', () => {
         "where": {
           "conditions": [
             {
+              "flip": undefined,
               "op": "NOT EXISTS",
               "related": {
                 "correlation": {
@@ -790,6 +800,7 @@ describe('unreadable tables', () => {
                     "unreadableId",
                   ],
                 },
+                "hidden": undefined,
                 "subquery": {
                   "alias": "zsubq_unreadable",
                   "limit": undefined,
@@ -805,6 +816,7 @@ describe('unreadable tables', () => {
                 },
                 "system": "permissions",
               },
+              "scalar": undefined,
               "type": "correlatedSubquery",
             },
           ],
@@ -837,6 +849,7 @@ describe('unreadable tables', () => {
         "where": {
           "conditions": [
             {
+              "flip": undefined,
               "op": "EXISTS",
               "related": {
                 "correlation": {
@@ -847,6 +860,7 @@ describe('unreadable tables', () => {
                     "readableId",
                   ],
                 },
+                "hidden": undefined,
                 "subquery": {
                   "alias": "zsubq_readable",
                   "limit": undefined,
@@ -858,6 +872,7 @@ describe('unreadable tables', () => {
                   "where": {
                     "conditions": [
                       {
+                        "flip": undefined,
                         "op": "EXISTS",
                         "related": {
                           "correlation": {
@@ -868,6 +883,7 @@ describe('unreadable tables', () => {
                               "unreadableId",
                             ],
                           },
+                          "hidden": undefined,
                           "subquery": {
                             "alias": "zsubq_unreadable",
                             "limit": undefined,
@@ -883,6 +899,7 @@ describe('unreadable tables', () => {
                           },
                           "system": "permissions",
                         },
+                        "scalar": undefined,
                         "type": "correlatedSubquery",
                       },
                     ],
@@ -891,6 +908,7 @@ describe('unreadable tables', () => {
                 },
                 "system": "permissions",
               },
+              "scalar": undefined,
               "type": "correlatedSubquery",
             },
           ],
@@ -922,6 +940,7 @@ describe('unreadable tables', () => {
         "where": {
           "conditions": [
             {
+              "flip": undefined,
               "op": "EXISTS",
               "related": {
                 "correlation": {
@@ -932,6 +951,7 @@ describe('unreadable tables', () => {
                     "readableId",
                   ],
                 },
+                "hidden": undefined,
                 "subquery": {
                   "alias": "zsubq_readable",
                   "limit": undefined,
@@ -943,6 +963,7 @@ describe('unreadable tables', () => {
                   "where": {
                     "conditions": [
                       {
+                        "flip": undefined,
                         "op": "EXISTS",
                         "related": {
                           "correlation": {
@@ -953,6 +974,7 @@ describe('unreadable tables', () => {
                               "unreadableId",
                             ],
                           },
+                          "hidden": undefined,
                           "subquery": {
                             "alias": "zsubq_unreadable",
                             "limit": undefined,
@@ -968,6 +990,7 @@ describe('unreadable tables', () => {
                           },
                           "system": "permissions",
                         },
+                        "scalar": undefined,
                         "type": "correlatedSubquery",
                       },
                     ],
@@ -976,6 +999,7 @@ describe('unreadable tables', () => {
                 },
                 "system": "permissions",
               },
+              "scalar": undefined,
               "type": "correlatedSubquery",
             },
           ],
@@ -1008,6 +1032,7 @@ describe('unreadable tables', () => {
         "where": {
           "conditions": [
             {
+              "flip": undefined,
               "op": "EXISTS",
               "related": {
                 "correlation": {
@@ -1018,6 +1043,7 @@ describe('unreadable tables', () => {
                     "readableId",
                   ],
                 },
+                "hidden": undefined,
                 "subquery": {
                   "alias": "zsubq_readable",
                   "limit": undefined,
@@ -1033,9 +1059,11 @@ describe('unreadable tables', () => {
                 },
                 "system": "permissions",
               },
+              "scalar": undefined,
               "type": "correlatedSubquery",
             },
             {
+              "flip": undefined,
               "op": "NOT EXISTS",
               "related": {
                 "correlation": {
@@ -1046,6 +1074,7 @@ describe('unreadable tables', () => {
                     "unreadableId",
                   ],
                 },
+                "hidden": undefined,
                 "subquery": {
                   "alias": "zsubq_unreadable",
                   "limit": undefined,
@@ -1061,6 +1090,7 @@ describe('unreadable tables', () => {
                 },
                 "system": "permissions",
               },
+              "scalar": undefined,
               "type": "correlatedSubquery",
             },
           ],
@@ -1092,6 +1122,7 @@ describe('unreadable tables', () => {
         "where": {
           "conditions": [
             {
+              "flip": undefined,
               "op": "EXISTS",
               "related": {
                 "correlation": {
@@ -1102,6 +1133,7 @@ describe('unreadable tables', () => {
                     "readableId",
                   ],
                 },
+                "hidden": undefined,
                 "subquery": {
                   "alias": "zsubq_readable",
                   "limit": undefined,
@@ -1117,9 +1149,11 @@ describe('unreadable tables', () => {
                 },
                 "system": "permissions",
               },
+              "scalar": undefined,
               "type": "correlatedSubquery",
             },
             {
+              "flip": undefined,
               "op": "NOT EXISTS",
               "related": {
                 "correlation": {
@@ -1130,6 +1164,7 @@ describe('unreadable tables', () => {
                     "unreadableId",
                   ],
                 },
+                "hidden": undefined,
                 "subquery": {
                   "alias": "zsubq_unreadable",
                   "limit": undefined,
@@ -1145,6 +1180,7 @@ describe('unreadable tables', () => {
                 },
                 "system": "permissions",
               },
+              "scalar": undefined,
               "type": "correlatedSubquery",
             },
           ],
@@ -1605,6 +1641,7 @@ describe('admin readable', () => {
         "where": {
           "conditions": [
             {
+              "flip": undefined,
               "op": "EXISTS",
               "related": {
                 "correlation": {
@@ -1615,6 +1652,7 @@ describe('admin readable', () => {
                     "id",
                   ],
                 },
+                "hidden": undefined,
                 "subquery": {
                   "alias": "zsubq_self1",
                   "limit": undefined,
@@ -1638,6 +1676,7 @@ describe('admin readable', () => {
                 },
                 "system": "permissions",
               },
+              "scalar": undefined,
               "type": "correlatedSubquery",
             },
             {
@@ -1681,6 +1720,7 @@ describe('admin readable', () => {
         "where": {
           "conditions": [
             {
+              "flip": undefined,
               "op": "EXISTS",
               "related": {
                 "correlation": {
@@ -1691,6 +1731,7 @@ describe('admin readable', () => {
                     "id",
                   ],
                 },
+                "hidden": undefined,
                 "subquery": {
                   "alias": "zsubq_self1",
                   "limit": undefined,
@@ -1731,6 +1772,7 @@ describe('admin readable', () => {
                 },
                 "system": "permissions",
               },
+              "scalar": undefined,
               "type": "correlatedSubquery",
             },
             {
@@ -1774,6 +1816,7 @@ describe('admin readable', () => {
         "where": {
           "conditions": [
             {
+              "flip": undefined,
               "op": "EXISTS",
               "related": {
                 "correlation": {
@@ -1784,6 +1827,7 @@ describe('admin readable', () => {
                     "id",
                   ],
                 },
+                "hidden": undefined,
                 "subquery": {
                   "alias": "zsubq_self1",
                   "limit": undefined,
@@ -1795,6 +1839,7 @@ describe('admin readable', () => {
                   "where": {
                     "conditions": [
                       {
+                        "flip": undefined,
                         "op": "EXISTS",
                         "related": {
                           "correlation": {
@@ -1805,6 +1850,7 @@ describe('admin readable', () => {
                               "id",
                             ],
                           },
+                          "hidden": undefined,
                           "subquery": {
                             "alias": "zsubq_self2",
                             "limit": undefined,
@@ -1828,6 +1874,7 @@ describe('admin readable', () => {
                           },
                           "system": "permissions",
                         },
+                        "scalar": undefined,
                         "type": "correlatedSubquery",
                       },
                       {
@@ -1848,6 +1895,7 @@ describe('admin readable', () => {
                 },
                 "system": "permissions",
               },
+              "scalar": undefined,
               "type": "correlatedSubquery",
             },
             {

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg.test.ts
@@ -5085,14 +5085,19 @@ describe('view-syncer/service', () => {
       // deployment would see a spurious re-send of every row.
       expect(await drainUntilRowsPatchOrQuiet(queue)).toBeUndefined();
 
-      // The sig *does* get initialized on this cycle — but through
-      // CVRQueryDrivenUpdater.flush's opportunistic pass over all queries
-      // (triggered by the normal add of internal queries on restart), not
-      // through drift re-execution. That's the intended "sigs get initialized
-      // whenever they next re-execute via the normal path" behavior.
-      expect(await loadStoredSig('query-hash1')).toEqual(
-        expectedIssuesSig(issueRowID('2'), issueRowID('6')),
-      );
+      // The sig stays uninitialized. Nothing re-executes on this restart:
+      // every query re-hashes to its stored transformationHash and is hydrated
+      // as unchanged, which does not go through CVRQueryDrivenUpdater and its
+      // opportunistic sig pass. It gets initialized whenever the query next
+      // re-executes for a real reason (transformation hash change, etc.).
+      //
+      // This assertion used to expect the sig to be written here — but only
+      // because normalization passed condition objects through with whatever
+      // key order they arrived with, and Postgres jsonb reorders keys, so the
+      // internal queries spuriously hash-mismatched on every restart and
+      // dragged hydration through the updater path. Now that normalization is
+      // canonical, the spurious re-execution (and this side effect) is gone.
+      expect(await loadStoredSig('query-hash1')).toBeNull();
     } finally {
       await cleanup();
     }

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.yield-during-hydrate.pg.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.yield-during-hydrate.pg.test.ts
@@ -230,9 +230,9 @@ describe('view-syncer/yield-during-hydrate', () => {
     updater.trackQueries(
       lc,
       [
-        {id: 'query-hash1', transformationHash: 'gojujxnrngdx'},
-        {id: 'lmids', transformationHash: '2jf1ycuha0k5e'},
-        {id: 'mutationResults', transformationHash: 'lcbd7o1qvz9g'},
+        {id: 'query-hash1', transformationHash: '3mzgp92sfsypq'},
+        {id: 'lmids', transformationHash: '1sjov59xnpa6'},
+        {id: 'mutationResults', transformationHash: '289re8rdeh88f'},
       ],
       [],
     );

--- a/packages/zero-client/src/client/query-manager.test.ts
+++ b/packages/zero-client/src/client/query-manager.test.ts
@@ -334,6 +334,7 @@ test('add renamed fields', () => {
                     "type": "simple",
                   },
                   {
+                    "flip": undefined,
                     "op": "EXISTS",
                     "related": {
                       "correlation": {
@@ -344,6 +345,7 @@ test('add renamed fields', () => {
                           "id",
                         ],
                       },
+                      "hidden": undefined,
                       "subquery": {
                         "alias": undefined,
                         "limit": undefined,
@@ -354,14 +356,16 @@ test('add renamed fields', () => {
                         "table": "comments",
                         "where": undefined,
                       },
+                      "system": undefined,
                     },
+                    "scalar": undefined,
                     "type": "correlatedSubquery",
                   },
                 ],
                 "type": "and",
               },
             },
-            "hash": "2courpv3kf7et",
+            "hash": "30cxf0i8cbdop",
             "name": undefined,
             "op": "put",
             "ttl": 600000,

--- a/packages/zero-protocol/src/ast.test.ts
+++ b/packages/zero-protocol/src/ast.test.ts
@@ -1,4 +1,4 @@
-import {expect, test} from 'vitest';
+import {describe, expect, test} from 'vitest';
 import {h64} from '../../shared/src/hash.ts';
 import {
   number,
@@ -867,5 +867,131 @@ test('values of different types are ordered', () => {
   ).toEqual({
     type: 'and',
     conditions: values.map(cond),
+  });
+});
+
+describe('normalization is canonical across key reordering', () => {
+  // Postgres jsonb reorders object keys (by length, then bytewise), so an AST
+  // stored in the CVR comes back with different key order than it was written
+  // with. Normalization must erase that difference: hashOfAST is
+  // h64(JSON.stringify(normalizeAST(ast))), and JSON.stringify is
+  // key-order-sensitive, so any node normalization passes through unchanged
+  // makes a reloaded query record hash differently than it did when stored.
+  // Every such record then looks changed and re-executes on every view-syncer
+  // restart.
+  function reordered<T>(v: T): T {
+    if (Array.isArray(v)) {
+      return v.map(reordered) as T;
+    }
+    if (v !== null && typeof v === 'object') {
+      const out: Record<string, unknown> = {};
+      for (const k of Object.keys(v).reverse()) {
+        out[k] = reordered((v as Record<string, unknown>)[k]);
+      }
+      return out as T;
+    }
+    return v;
+  }
+
+  const CASES: [name: string, ast: AST][] = [
+    ['bare table', {table: 'issue'}],
+    [
+      'simple condition',
+      {
+        table: 'issue',
+        where: {
+          type: 'simple',
+          op: '=',
+          left: {type: 'column', name: 'id'},
+          right: {type: 'literal', value: 'a'},
+        },
+      },
+    ],
+    [
+      'parameter reference',
+      {
+        table: 'issue',
+        where: {
+          type: 'simple',
+          op: '=',
+          left: {type: 'column', name: 'creatorID'},
+          right: {type: 'static', anchor: 'authData', field: 'sub'},
+        },
+      },
+    ],
+    [
+      'conjunction',
+      {
+        table: 'issue',
+        where: {
+          type: 'and',
+          conditions: [
+            {
+              type: 'simple',
+              op: '=',
+              left: {type: 'column', name: 'a'},
+              right: {type: 'literal', value: 1},
+            },
+            {
+              type: 'simple',
+              op: '<',
+              left: {type: 'column', name: 'b'},
+              right: {type: 'literal', value: 2},
+            },
+          ],
+        },
+      },
+    ],
+    [
+      'correlated subquery condition',
+      {
+        table: 'issue',
+        where: {
+          type: 'correlatedSubquery',
+          op: 'EXISTS',
+          flip: true,
+          related: {
+            correlation: {parentField: ['creatorID'], childField: ['id']},
+            subquery: {
+              table: 'user',
+              alias: 'creator',
+              where: {
+                type: 'simple',
+                op: '=',
+                left: {type: 'column', name: 'role'},
+                right: {type: 'literal', value: 'crew'},
+              },
+            },
+            system: 'client',
+          },
+        },
+      },
+    ],
+    [
+      'related',
+      {
+        table: 'issue',
+        related: [
+          {
+            correlation: {parentField: ['id'], childField: ['issueID']},
+            subquery: {table: 'comment', alias: 'comments', limit: 10},
+            hidden: true,
+            system: 'client',
+          },
+        ],
+        orderBy: [['id', 'asc']],
+        limit: 100,
+      },
+    ],
+  ];
+
+  test.each(CASES)('%s', (_name, ast) => {
+    const shuffled = reordered(ast);
+    // Key order is the only thing that differs going in...
+    expect(shuffled).toEqual(ast);
+    // ...and nothing may differ coming out.
+    expect(JSON.stringify(normalizeAST(shuffled))).toBe(
+      JSON.stringify(normalizeAST(ast)),
+    );
   });
 });

--- a/packages/zero-protocol/src/ast.ts
+++ b/packages/zero-protocol/src/ast.ts
@@ -589,16 +589,53 @@ export function normalizedRelated(
   };
 }
 
+function normalizeValuePosition<T extends ValuePosition>(v: T): T {
+  switch (v.type) {
+    case 'literal':
+      return {type: 'literal', value: v.value} as T;
+    case 'column':
+      return {type: 'column', name: v.name} as T;
+    default:
+      return {type: 'static', anchor: v.anchor, field: v.field} as T;
+  }
+}
+
 /**
  * Normalizes a condition, assuming that the ASTs of any correlated subqueries
  * it contains are already normalized.
+ *
+ * Like {@link normalizedAST}, this rebuilds every node with its fields in a
+ * fixed order, so that structurally equal conditions have the same JSON
+ * encoding (and thus the same hash) no matter how they were put together.
+ * That includes a round trip through Postgres, whose jsonb type reorders
+ * object keys: without the rebuild, every query record reloaded from the CVR
+ * re-hashed to a different transformationHash than was stored, making it look
+ * changed and re-execute on every view-syncer restart.
  */
 export function normalizeCondition(cond: Condition): Condition {
-  if (cond.type === 'simple' || cond.type === 'correlatedSubquery') {
-    return cond;
-  }
   if (normalizedConditions.has(cond)) {
     return cond;
+  }
+  if (cond.type === 'simple') {
+    const normalized: Condition = {
+      type: 'simple',
+      op: cond.op,
+      left: normalizeValuePosition(cond.left),
+      right: normalizeValuePosition(cond.right),
+    };
+    normalizedConditions.add(normalized);
+    return normalized;
+  }
+  if (cond.type === 'correlatedSubquery') {
+    const normalized: Condition = {
+      type: 'correlatedSubquery',
+      related: normalizedRelated(cond.related),
+      op: cond.op,
+      flip: cond.flip,
+      scalar: cond.scalar,
+    };
+    normalizedConditions.add(normalized);
+    return normalized;
   }
 
   // Flatten the conditions of nested conjunctions of the same type and sort

--- a/packages/zql/src/query/complete-ordering.test.ts
+++ b/packages/zql/src/query/complete-ordering.test.ts
@@ -326,6 +326,7 @@ describe('completeOrdering', () => {
         "start": undefined,
         "table": "issue",
         "where": {
+          "flip": undefined,
           "op": "EXISTS",
           "related": {
             "correlation": {
@@ -336,6 +337,7 @@ describe('completeOrdering', () => {
                 "id",
               ],
             },
+            "hidden": undefined,
             "subquery": {
               "alias": "zsubq_labels",
               "limit": undefined,
@@ -345,6 +347,7 @@ describe('completeOrdering', () => {
               "start": undefined,
               "table": "issueLabel",
               "where": {
+                "flip": undefined,
                 "op": "EXISTS",
                 "related": {
                   "correlation": {
@@ -355,6 +358,7 @@ describe('completeOrdering', () => {
                       "labelId",
                     ],
                   },
+                  "hidden": undefined,
                   "subquery": {
                     "alias": "zsubq_zhidden_labels",
                     "limit": undefined,
@@ -367,11 +371,13 @@ describe('completeOrdering', () => {
                   },
                   "system": "client",
                 },
+                "scalar": undefined,
                 "type": "correlatedSubquery",
               },
             },
             "system": "client",
           },
+          "scalar": undefined,
           "type": "correlatedSubquery",
         },
       }
@@ -392,6 +398,7 @@ describe('completeOrdering', () => {
           "start": undefined,
           "table": "issue",
           "where": {
+            "flip": undefined,
             "op": "EXISTS",
             "related": {
               "correlation": {
@@ -402,6 +409,7 @@ describe('completeOrdering', () => {
                   "id",
                 ],
               },
+              "hidden": undefined,
               "subquery": {
                 "alias": "zsubq_labels",
                 "limit": undefined,
@@ -420,6 +428,7 @@ describe('completeOrdering', () => {
                 "start": undefined,
                 "table": "issueLabel",
                 "where": {
+                  "flip": undefined,
                   "op": "EXISTS",
                   "related": {
                     "correlation": {
@@ -430,6 +439,7 @@ describe('completeOrdering', () => {
                         "labelId",
                       ],
                     },
+                    "hidden": undefined,
                     "subquery": {
                       "alias": "zsubq_zhidden_labels",
                       "limit": undefined,
@@ -447,11 +457,13 @@ describe('completeOrdering', () => {
                     },
                     "system": "client",
                   },
+                  "scalar": undefined,
                   "type": "correlatedSubquery",
                 },
               },
               "system": "client",
             },
+            "scalar": undefined,
             "type": "correlatedSubquery",
           },
         }
@@ -506,6 +518,7 @@ describe('completeOrdering', () => {
                   "type": "simple",
                 },
                 {
+                  "flip": undefined,
                   "op": "EXISTS",
                   "related": {
                     "correlation": {
@@ -516,6 +529,7 @@ describe('completeOrdering', () => {
                         "id",
                       ],
                     },
+                    "hidden": undefined,
                     "subquery": {
                       "alias": "zsubq_comments",
                       "limit": undefined,
@@ -528,12 +542,14 @@ describe('completeOrdering', () => {
                     },
                     "system": "client",
                   },
+                  "scalar": undefined,
                   "type": "correlatedSubquery",
                 },
               ],
               "type": "or",
             },
             {
+              "flip": undefined,
               "op": "EXISTS",
               "related": {
                 "correlation": {
@@ -544,6 +560,7 @@ describe('completeOrdering', () => {
                     "ownerId",
                   ],
                 },
+                "hidden": undefined,
                 "subquery": {
                   "alias": "zsubq_owner",
                   "limit": undefined,
@@ -556,6 +573,7 @@ describe('completeOrdering', () => {
                 },
                 "system": "client",
               },
+              "scalar": undefined,
               "type": "correlatedSubquery",
             },
           ],
@@ -607,6 +625,7 @@ describe('completeOrdering', () => {
                     "type": "simple",
                   },
                   {
+                    "flip": undefined,
                     "op": "EXISTS",
                     "related": {
                       "correlation": {
@@ -617,6 +636,7 @@ describe('completeOrdering', () => {
                           "id",
                         ],
                       },
+                      "hidden": undefined,
                       "subquery": {
                         "alias": "zsubq_comments",
                         "limit": undefined,
@@ -634,12 +654,14 @@ describe('completeOrdering', () => {
                       },
                       "system": "client",
                     },
+                    "scalar": undefined,
                     "type": "correlatedSubquery",
                   },
                 ],
                 "type": "or",
               },
               {
+                "flip": undefined,
                 "op": "EXISTS",
                 "related": {
                   "correlation": {
@@ -650,6 +672,7 @@ describe('completeOrdering', () => {
                       "ownerId",
                     ],
                   },
+                  "hidden": undefined,
                   "subquery": {
                     "alias": "zsubq_owner",
                     "limit": undefined,
@@ -667,6 +690,7 @@ describe('completeOrdering', () => {
                   },
                   "system": "client",
                 },
+                "scalar": undefined,
                 "type": "correlatedSubquery",
               },
             ],

--- a/packages/zql/src/query/query-impl.ast.test.ts
+++ b/packages/zql/src/query/query-impl.ast.test.ts
@@ -41,6 +41,7 @@ describe('building the AST', () => {
         "start": undefined,
         "table": "issue",
         "where": {
+          "flip": undefined,
           "op": "EXISTS",
           "related": {
             "correlation": {
@@ -51,6 +52,7 @@ describe('building the AST', () => {
                 "id",
               ],
             },
+            "hidden": undefined,
             "subquery": {
               "alias": "zsubq_labels",
               "limit": undefined,
@@ -60,6 +62,7 @@ describe('building the AST', () => {
               "start": undefined,
               "table": "issueLabel",
               "where": {
+                "flip": undefined,
                 "op": "EXISTS",
                 "related": {
                   "correlation": {
@@ -70,6 +73,7 @@ describe('building the AST', () => {
                       "labelId",
                     ],
                   },
+                  "hidden": undefined,
                   "subquery": {
                     "alias": "zsubq_zhidden_labels",
                     "limit": undefined,
@@ -110,11 +114,13 @@ describe('building the AST', () => {
                   },
                   "system": "client",
                 },
+                "scalar": undefined,
                 "type": "correlatedSubquery",
               },
             },
             "system": "client",
           },
+          "scalar": undefined,
           "type": "correlatedSubquery",
         },
       }
@@ -1627,6 +1633,7 @@ describe('exists', () => {
           "start": undefined,
           "table": "issue",
           "where": {
+            "flip": undefined,
             "op": "EXISTS",
             "related": {
               "correlation": {
@@ -1637,6 +1644,7 @@ describe('exists', () => {
                   "ownerId",
                 ],
               },
+              "hidden": undefined,
               "subquery": {
                 "alias": "zsubq_owner",
                 "limit": undefined,
@@ -1649,6 +1657,7 @@ describe('exists', () => {
               },
               "system": "client",
             },
+            "scalar": undefined,
             "type": "correlatedSubquery",
           },
         }
@@ -1665,6 +1674,7 @@ describe('exists', () => {
         "start": undefined,
         "table": "issue",
         "where": {
+          "flip": undefined,
           "op": "EXISTS",
           "related": {
             "correlation": {
@@ -1675,6 +1685,7 @@ describe('exists', () => {
                 "ownerId",
               ],
             },
+            "hidden": undefined,
             "subquery": {
               "alias": "zsubq_owner",
               "limit": undefined,
@@ -1687,6 +1698,7 @@ describe('exists', () => {
             },
             "system": "client",
           },
+          "scalar": undefined,
           "type": "correlatedSubquery",
         },
       }
@@ -1707,6 +1719,7 @@ describe('exists', () => {
           "start": undefined,
           "table": "issue",
           "where": {
+            "flip": undefined,
             "op": "EXISTS",
             "related": {
               "correlation": {
@@ -1717,6 +1730,7 @@ describe('exists', () => {
                   "ownerId",
                 ],
               },
+              "hidden": undefined,
               "subquery": {
                 "alias": "zsubq_owner",
                 "limit": undefined,
@@ -1740,6 +1754,7 @@ describe('exists', () => {
               },
               "system": "client",
             },
+            "scalar": undefined,
             "type": "correlatedSubquery",
           },
         }
@@ -1761,6 +1776,7 @@ describe('exists', () => {
         "start": undefined,
         "table": "issue",
         "where": {
+          "flip": undefined,
           "op": "EXISTS",
           "related": {
             "correlation": {
@@ -1771,6 +1787,7 @@ describe('exists', () => {
                 "ownerId",
               ],
             },
+            "hidden": undefined,
             "subquery": {
               "alias": "zsubq_owner",
               "limit": undefined,
@@ -1811,6 +1828,7 @@ describe('exists', () => {
             },
             "system": "client",
           },
+          "scalar": undefined,
           "type": "correlatedSubquery",
         },
       }
@@ -1830,6 +1848,7 @@ describe('exists', () => {
         "start": undefined,
         "table": "issue",
         "where": {
+          "flip": undefined,
           "op": "EXISTS",
           "related": {
             "correlation": {
@@ -1840,6 +1859,7 @@ describe('exists', () => {
                 "id",
               ],
             },
+            "hidden": undefined,
             "subquery": {
               "alias": "zsubq_labels",
               "limit": undefined,
@@ -1849,6 +1869,7 @@ describe('exists', () => {
               "start": undefined,
               "table": "issueLabel",
               "where": {
+                "flip": undefined,
                 "op": "EXISTS",
                 "related": {
                   "correlation": {
@@ -1859,6 +1880,7 @@ describe('exists', () => {
                       "labelId",
                     ],
                   },
+                  "hidden": undefined,
                   "subquery": {
                     "alias": "zsubq_zhidden_labels",
                     "limit": undefined,
@@ -1871,11 +1893,13 @@ describe('exists', () => {
                   },
                   "system": "client",
                 },
+                "scalar": undefined,
                 "type": "correlatedSubquery",
               },
             },
             "system": "client",
           },
+          "scalar": undefined,
           "type": "correlatedSubquery",
         },
       }
@@ -1903,6 +1927,7 @@ describe('exists', () => {
         "where": {
           "conditions": [
             {
+              "flip": undefined,
               "op": "EXISTS",
               "related": {
                 "correlation": {
@@ -1913,6 +1938,7 @@ describe('exists', () => {
                     "id",
                   ],
                 },
+                "hidden": undefined,
                 "subquery": {
                   "alias": "zsubq_comments",
                   "limit": undefined,
@@ -1925,9 +1951,11 @@ describe('exists', () => {
                 },
                 "system": "client",
               },
+              "scalar": undefined,
               "type": "correlatedSubquery",
             },
             {
+              "flip": undefined,
               "op": "EXISTS",
               "related": {
                 "correlation": {
@@ -1938,6 +1966,7 @@ describe('exists', () => {
                     "ownerId",
                   ],
                 },
+                "hidden": undefined,
                 "subquery": {
                   "alias": "zsubq_owner",
                   "limit": undefined,
@@ -1950,6 +1979,7 @@ describe('exists', () => {
                 },
                 "system": "client",
               },
+              "scalar": undefined,
               "type": "correlatedSubquery",
             },
           ],
@@ -1973,6 +2003,7 @@ describe('exists', () => {
           "start": undefined,
           "table": "issue",
           "where": {
+            "flip": undefined,
             "op": "NOT EXISTS",
             "related": {
               "correlation": {
@@ -1983,6 +2014,7 @@ describe('exists', () => {
                   "id",
                 ],
               },
+              "hidden": undefined,
               "subquery": {
                 "alias": "zsubq_comments",
                 "limit": undefined,
@@ -1995,6 +2027,7 @@ describe('exists', () => {
               },
               "system": "permissions",
             },
+            "scalar": undefined,
             "type": "correlatedSubquery",
           },
         }
@@ -2017,6 +2050,7 @@ describe('exists', () => {
         "start": undefined,
         "table": "issue",
         "where": {
+          "flip": undefined,
           "op": "NOT EXISTS",
           "related": {
             "correlation": {
@@ -2027,6 +2061,7 @@ describe('exists', () => {
                 "id",
               ],
             },
+            "hidden": undefined,
             "subquery": {
               "alias": "zsubq_labels",
               "limit": undefined,
@@ -2036,6 +2071,7 @@ describe('exists', () => {
               "start": undefined,
               "table": "issueLabel",
               "where": {
+                "flip": undefined,
                 "op": "EXISTS",
                 "related": {
                   "correlation": {
@@ -2046,6 +2082,7 @@ describe('exists', () => {
                       "labelId",
                     ],
                   },
+                  "hidden": undefined,
                   "subquery": {
                     "alias": "zsubq_zhidden_labels",
                     "limit": undefined,
@@ -2058,11 +2095,13 @@ describe('exists', () => {
                   },
                   "system": "permissions",
                 },
+                "scalar": undefined,
                 "type": "correlatedSubquery",
               },
             },
             "system": "permissions",
           },
+          "scalar": undefined,
           "type": "correlatedSubquery",
         },
       }
@@ -2091,6 +2130,7 @@ describe('exists', () => {
         "where": {
           "conditions": [
             {
+              "flip": undefined,
               "op": "EXISTS",
               "related": {
                 "correlation": {
@@ -2101,6 +2141,7 @@ describe('exists', () => {
                     "id",
                   ],
                 },
+                "hidden": undefined,
                 "subquery": {
                   "alias": "zsubq_comments",
                   "limit": undefined,
@@ -2113,9 +2154,11 @@ describe('exists', () => {
                 },
                 "system": "client",
               },
+              "scalar": undefined,
               "type": "correlatedSubquery",
             },
             {
+              "flip": undefined,
               "op": "EXISTS",
               "related": {
                 "correlation": {
@@ -2126,6 +2169,7 @@ describe('exists', () => {
                     "id",
                   ],
                 },
+                "hidden": undefined,
                 "subquery": {
                   "alias": "zsubq_labels",
                   "limit": undefined,
@@ -2135,6 +2179,7 @@ describe('exists', () => {
                   "start": undefined,
                   "table": "issueLabel",
                   "where": {
+                    "flip": undefined,
                     "op": "EXISTS",
                     "related": {
                       "correlation": {
@@ -2145,6 +2190,7 @@ describe('exists', () => {
                           "labelId",
                         ],
                       },
+                      "hidden": undefined,
                       "subquery": {
                         "alias": "zsubq_zhidden_labels",
                         "limit": undefined,
@@ -2157,14 +2203,17 @@ describe('exists', () => {
                       },
                       "system": "client",
                     },
+                    "scalar": undefined,
                     "type": "correlatedSubquery",
                   },
                 },
                 "system": "client",
               },
+              "scalar": undefined,
               "type": "correlatedSubquery",
             },
             {
+              "flip": undefined,
               "op": "EXISTS",
               "related": {
                 "correlation": {
@@ -2175,6 +2224,7 @@ describe('exists', () => {
                     "ownerId",
                   ],
                 },
+                "hidden": undefined,
                 "subquery": {
                   "alias": "zsubq_owner",
                   "limit": undefined,
@@ -2187,6 +2237,7 @@ describe('exists', () => {
                 },
                 "system": "client",
               },
+              "scalar": undefined,
               "type": "correlatedSubquery",
             },
           ],
@@ -2222,6 +2273,7 @@ describe('exists', () => {
                   "ownerId",
                 ],
               },
+              "hidden": undefined,
               "subquery": {
                 "alias": "zsubq_owner",
                 "limit": undefined,
@@ -2234,6 +2286,7 @@ describe('exists', () => {
               },
               "system": "client",
             },
+            "scalar": undefined,
             "type": "correlatedSubquery",
           },
         }
@@ -2267,6 +2320,7 @@ describe('exists', () => {
                 "ownerId",
               ],
             },
+            "hidden": undefined,
             "subquery": {
               "alias": "zsubq_owner",
               "limit": undefined,
@@ -2279,6 +2333,7 @@ describe('exists', () => {
             },
             "system": "client",
           },
+          "scalar": undefined,
           "type": "correlatedSubquery",
         },
       }
@@ -2310,6 +2365,7 @@ describe('exists', () => {
                   "id",
                 ],
               },
+              "hidden": undefined,
               "subquery": {
                 "alias": "zsubq_labels",
                 "limit": undefined,
@@ -2330,6 +2386,7 @@ describe('exists', () => {
                         "labelId",
                       ],
                     },
+                    "hidden": undefined,
                     "subquery": {
                       "alias": "zsubq_zhidden_labels",
                       "limit": undefined,
@@ -2342,11 +2399,13 @@ describe('exists', () => {
                     },
                     "system": "client",
                   },
+                  "scalar": undefined,
                   "type": "correlatedSubquery",
                 },
               },
               "system": "client",
             },
+            "scalar": undefined,
             "type": "correlatedSubquery",
           },
         }
@@ -2381,6 +2440,7 @@ describe('exists', () => {
                 "ownerId",
               ],
             },
+            "hidden": undefined,
             "subquery": {
               "alias": "zsubq_owner",
               "limit": undefined,
@@ -2404,6 +2464,7 @@ describe('exists', () => {
             },
             "system": "client",
           },
+          "scalar": undefined,
           "type": "correlatedSubquery",
         },
       }
@@ -2433,6 +2494,7 @@ describe('exists', () => {
         "where": {
           "conditions": [
             {
+              "flip": undefined,
               "op": "EXISTS",
               "related": {
                 "correlation": {
@@ -2443,6 +2505,7 @@ describe('exists', () => {
                     "ownerId",
                   ],
                 },
+                "hidden": undefined,
                 "subquery": {
                   "alias": "zsubq_owner",
                   "limit": undefined,
@@ -2466,9 +2529,11 @@ describe('exists', () => {
                 },
                 "system": "client",
               },
+              "scalar": undefined,
               "type": "correlatedSubquery",
             },
             {
+              "flip": undefined,
               "op": "EXISTS",
               "related": {
                 "correlation": {
@@ -2479,6 +2544,7 @@ describe('exists', () => {
                     "ownerId",
                   ],
                 },
+                "hidden": undefined,
                 "subquery": {
                   "alias": "zsubq_owner",
                   "limit": undefined,
@@ -2502,6 +2568,7 @@ describe('exists', () => {
                 },
                 "system": "client",
               },
+              "scalar": undefined,
               "type": "correlatedSubquery",
             },
           ],
@@ -2566,6 +2633,7 @@ test('scalar option on two-hop relationship applies to inner condition', () => {
               "id",
             ],
           },
+          "hidden": undefined,
           "subquery": {
             "alias": "zsubq_labels",
             "limit": undefined,
@@ -2586,6 +2654,7 @@ test('scalar option on two-hop relationship applies to inner condition', () => {
                     "labelId",
                   ],
                 },
+                "hidden": undefined,
                 "subquery": {
                   "alias": "zsubq_zhidden_labels",
                   "limit": undefined,
@@ -2615,6 +2684,7 @@ test('scalar option on two-hop relationship applies to inner condition', () => {
           },
           "system": "client",
         },
+        "scalar": undefined,
         "type": "correlatedSubquery",
       },
     }
@@ -2641,6 +2711,7 @@ describe('whereExists with scalar option', () => {
         "start": undefined,
         "table": "issue",
         "where": {
+          "flip": undefined,
           "op": "EXISTS",
           "related": {
             "correlation": {
@@ -2651,6 +2722,7 @@ describe('whereExists with scalar option', () => {
                 "ownerId",
               ],
             },
+            "hidden": undefined,
             "subquery": {
               "alias": "zsubq_owner",
               "limit": undefined,
@@ -2700,6 +2772,7 @@ describe('whereExists with scalar option', () => {
         "start": undefined,
         "table": "issue",
         "where": {
+          "flip": undefined,
           "op": "EXISTS",
           "related": {
             "correlation": {
@@ -2710,6 +2783,7 @@ describe('whereExists with scalar option', () => {
                 "ownerId",
               ],
             },
+            "hidden": undefined,
             "subquery": {
               "alias": "zsubq_owner",
               "limit": undefined,
@@ -2785,6 +2859,7 @@ describe('whereExists with scalar option', () => {
         "start": undefined,
         "table": "issue",
         "where": {
+          "flip": undefined,
           "op": "NOT EXISTS",
           "related": {
             "correlation": {
@@ -2795,6 +2870,7 @@ describe('whereExists with scalar option', () => {
                 "ownerId",
               ],
             },
+            "hidden": undefined,
             "subquery": {
               "alias": "zsubq_owner",
               "limit": undefined,

--- a/packages/zql/src/query/query-impl.ts
+++ b/packages/zql/src/query/query-impl.ts
@@ -552,8 +552,9 @@ export class QueryImpl<
           },
           subquery: {
             ...tableAST(junctionSchema, `${SUBQ_PREFIX}${relationship}`),
-            // A single condition is flattened and sorted.
-            where: {
+            // A single condition needs no flattening or sorting, but the node
+            // itself still has to be rebuilt into the canonical field order.
+            where: normalizeCondition({
               type: 'correlatedSubquery',
               related: {
                 system: this.#system,
@@ -566,7 +567,7 @@ export class QueryImpl<
               op: 'EXISTS',
               ...(flip !== undefined ? {flip} : {}),
               ...(scalar !== undefined ? {scalar} : {}),
-            },
+            }),
           },
         },
         op: 'EXISTS',

--- a/packages/zql/src/query/test/query-gen.test.ts
+++ b/packages/zql/src/query/test/query-gen.test.ts
@@ -156,6 +156,7 @@ test('stable generation', () => {
             "type": "simple",
           },
           {
+            "flip": undefined,
             "op": "NOT EXISTS",
             "related": {
               "correlation": {
@@ -166,6 +167,7 @@ test('stable generation', () => {
                   "councilman",
                 ],
               },
+              "hidden": undefined,
               "subquery": {
                 "alias": "zsubq_cleaner",
                 "limit": undefined,
@@ -189,6 +191,7 @@ test('stable generation', () => {
                       "type": "simple",
                     },
                     {
+                      "flip": undefined,
                       "op": "EXISTS",
                       "related": {
                         "correlation": {
@@ -199,6 +202,7 @@ test('stable generation', () => {
                             "amendment",
                           ],
                         },
+                        "hidden": undefined,
                         "subquery": {
                           "alias": "zsubq_cleaner",
                           "limit": undefined,
@@ -263,6 +267,7 @@ test('stable generation', () => {
                         },
                         "system": "permissions",
                       },
+                      "scalar": undefined,
                       "type": "correlatedSubquery",
                     },
                   ],
@@ -271,6 +276,7 @@ test('stable generation', () => {
               },
               "system": "permissions",
             },
+            "scalar": undefined,
             "type": "correlatedSubquery",
           },
         ],


### PR DESCRIPTION
Isolated from the AST-visitor work (#6450), where the investigation of a failing test turned this up. This is the underlying bug on `main`, fixed on `main`'s own terms — no hash algorithm change.

## The bug

Postgres `jsonb` reorders object keys (by length, then bytewise), so an AST reloaded from the CVR comes back with different key order than it was stored with. `normalizedAST` rebuilds the top level in a fixed order — its comment even promises the same JSON encoding "no matter how they were put together" — but `normalizeCondition` passed `simple` and `correlatedSubquery` conditions through **as-is**, so their arrival key order survived normalization. And `hashOfAST` is `h64(JSON.stringify(normalizeAST(ast)))`, which is key-order-sensitive.

**Consequence: every query record with a `where` clause re-hashes to a different `transformationHash` on reload than was stored.** The view-syncer treats its internal queries (`lmids`, `mutationResults`) — and any reloaded legacy client query — as *changed* on every restart, re-transforming and re-executing them each time. Observed directly while tracing: `lmids` stored `3poeb854iefq8`, recomputed `2jf1ycuha0k5e` from the same logical AST after one DB round trip.

(It's not new with #6449 — the pre-#6449 `transformWhere` spread conditions, which also preserves key order. It's just newly *visible* because the tracing happened to run through here.)

## The fix

`normalizeCondition` now rebuilds `simple` and `correlatedSubquery` nodes (and their value positions) with fields in a fixed order — the same treatment `normalizedAST` and `normalizedRelated` already give their levels. Rebuilt nodes go into the existing `normalizedConditions` WeakSet so repeated normalization during query building doesn't re-allocate.

One builder path inlined a condition literal without normalizing it: the junction `whereExists` subquery, whose comment "a single condition is flattened and sorted" relied on the old pass-through. It routes through `normalizeCondition` now — the "normalized by construction" test caught it, which was satisfying to watch.

## Tests

- New: a corpus of ASTs is deep-key-reversed and normalization must erase the difference (`JSON.stringify` equal). **Fails 4 of 6 cases without the fix**; the two passing ones are the levels that already rebuilt.
- `view-syncer.pg.test.ts` "rowSetSignature absent (legacy)" expected a nulled legacy sig to be re-initialized on restart. That only ever happened because the spurious hash mismatch dragged hydration through `CVRQueryDrivenUpdater`, whose flush opportunistically writes sigs — the test was green *because of* the bug. It now asserts the sig stays null until the query re-executes for a real reason, which is what the code's own comment documents.
- Hard-coded digests updated where key order changed (the builder emits more than one order today — `expression.ts` alone has `{type,left,right,op}` and `{type,op,left,right}` — so some churn was unavoidable no matter which canonical order won; I used the type-declaration order).
- Snapshot updates are the rebuilt nodes carrying explicit `flip: undefined` etc., the same style #6449 established (`JSON.stringify` drops them).

## Deploy note

Digests of conditions built in a non-canonical key order change once: client query IDs re-register via `getQueriesPatch` (self-healing) and transformations re-run once. In exchange, restarts stop re-executing every reloaded query. A residual stays open: `start` bounds' row objects (which can hold JSON-column values) are data, not structure, and remain order-sensitive here; #6450's visitor closes that by hashing object values with sorted keys.

## Test plan

- `zero-protocol` 63, `zql` 1323, `zero-client` 650, `zero-cache` no-pg 1983 + pg-16 **724 (full suite, 0 failed)**, `zero-react` 74, `zero-solid` 59, `shared` 762
- `zql-integration-tests` 1140 (two suite-level container flakes under full parallel load; both files pass in isolation)
- lint, format, check-types clean on every touched package
