### PR TITLE
feat(zql): implement NOT EXISTS (anti-join) planning and costing

### DIFF
--- a/packages/zql-integration-tests/src/chinook/planner-not-exists.pg.test.ts
+++ b/packages/zql-integration-tests/src/chinook/planner-not-exists.pg.test.ts
@@ -1,0 +1,249 @@
+import {beforeAll, describe, expect, test} from 'vitest';
+import {must} from '../../../shared/src/must.ts';
+import {
+  createPlannerInfrastructure,
+  type PlanAttemptResult,
+} from '../helpers/planner-exec.ts';
+import {runAndCompare} from '../helpers/runner.ts';
+import {getChinook} from './get-deps.ts';
+import {schema} from './schema.ts';
+
+/**
+ * End-to-end validation of NOT EXISTS (anti-join) planning against the real
+ * Chinook dataset, measured in actual rows scanned during hydration.
+ *
+ * NOT EXISTS joins can never be flipped, so the planner's job for a query
+ * containing one is to:
+ * 1. plan it at all (a NOT EXISTS-only query has exactly one plan, which
+ *    still needs constraints propagated and a cost estimate), and
+ * 2. estimate its cost/selectivity well enough that flip decisions for
+ *    sibling EXISTS joins are correct.
+ *
+ * "Unplanned" baselines are produced by pinning the sibling EXISTS with
+ * `{flip: false}` (the query exactly as written) and the alternative with
+ * `{flip: true}`, then comparing the planner's pick against both.
+ *
+ * Useful Chinook facts (fixed dataset, so these are stable):
+ * - 3503 tracks; 1519 of them appear in no invoiceLine ("unsold").
+ * - Exactly one album titled 'Frank' (id 322). Its tracks are at the very
+ *   END of the track table (ids 3467+) and exactly 5 of them are unsold.
+ * - Exactly one album titled 'Big Ones'. Its tracks are near the START of
+ *   the track table.
+ * - 71 of 275 artists have no albums; 4 of 18 playlists have no tracks.
+ */
+
+const pgContent = await getChinook();
+
+const infra = await createPlannerInfrastructure({
+  suiteName: 'chinook_planner_not_exists',
+  pgContent,
+  schema,
+  // The "indexed" database mimics a production deployment: filter columns
+  // and FKs used by these queries are indexed.
+  indices: [
+    'CREATE INDEX IF NOT EXISTS idx_album_title ON album(title)',
+    'CREATE INDEX IF NOT EXISTS idx_track_album_id ON track(album_id)',
+    'CREATE INDEX IF NOT EXISTS idx_invoice_line_track_id ON invoice_line(track_id)',
+  ],
+});
+
+const {queries, delegates, executeAllPlanAttempts} = infra;
+
+function picked(results: PlanAttemptResult[]): PlanAttemptResult {
+  return results.reduce((best, r) =>
+    r.estimatedCost < best.estimatedCost ? r : best,
+  );
+}
+
+function baseline(results: PlanAttemptResult[]): PlanAttemptResult {
+  return must(
+    results.find(r => r.attemptNumber === 0),
+    'baseline (attempt 0) missing',
+  );
+}
+
+function optimal(results: PlanAttemptResult[]): PlanAttemptResult {
+  return results.reduce((best, r) =>
+    r.actualRowsScanned < best.actualRowsScanned ? r : best,
+  );
+}
+
+// Query under test: "the first 5 unsold tracks on the album 'Frank'".
+// The 5 matching tracks are the last rows of the track table, so the
+// as-written plan scans essentially the whole table.
+function unsoldFrankTracks(flip?: boolean) {
+  return queries.track
+    .where(({not, exists}) => not(exists('invoiceLines')))
+    .whereExists(
+      'album',
+      a => a.where('title', 'Frank'),
+      flip === undefined ? undefined : {flip},
+    )
+    .orderBy('id', 'asc')
+    .limit(5);
+}
+
+describe('Chinook NOT EXISTS planning', {timeout: 60_000}, () => {
+  beforeAll(() => {
+    infra.initializePlannerInfrastructure();
+    infra.initializeIndexedDatabase();
+  });
+
+  test('a NOT EXISTS-only query is planned (exactly one attempt)', () => {
+    // No join in this query is flippable, but the planner must still
+    // evaluate the single all-semi plan so the query gets constraint
+    // propagation and cost estimates (e.g. for analyze-query output).
+    const query = queries.artist.where(({not, exists}) =>
+      not(exists('albums')),
+    );
+
+    const results = executeAllPlanAttempts(query);
+    expect(results).toHaveLength(1);
+    expect(results[0].flipPattern).toBe(0);
+    expect(results[0].actualRowsScanned).toBeGreaterThan(0);
+  });
+
+  test('pinning flip on the sibling EXISTS yields exactly the forced plan', () => {
+    // `{flip: false}` / `{flip: true}` remove the planner's choice; each
+    // pinned query has exactly one plan, and those plans match the two
+    // attempts the planner enumerates for the unpinned query.
+    const free = executeAllPlanAttempts(unsoldFrankTracks(), true);
+    const forcedSemi = executeAllPlanAttempts(unsoldFrankTracks(false), true);
+    const forcedFlipped = executeAllPlanAttempts(unsoldFrankTracks(true), true);
+
+    expect(free).toHaveLength(2);
+    expect(forcedSemi).toHaveLength(1);
+    expect(forcedFlipped).toHaveLength(1);
+
+    const semiAttempt = must(free.find(r => r.flipPattern === 0));
+    const flippedAttempt = must(free.find(r => r.flipPattern === 1));
+    expect(forcedSemi[0].actualRowsScanned).toBe(semiAttempt.actualRowsScanned);
+    expect(forcedFlipped[0].actualRowsScanned).toBe(
+      flippedAttempt.actualRowsScanned,
+    );
+  });
+
+  test('planner beats the forced-unplanned baseline ~200x (indexed db)', () => {
+    // As written (flip: false), hydration scans every track (~3503 of them,
+    // ~6000 rows vended in total across sources) probing invoiceLines and
+    // album for each, because the 5 matching tracks are at the end of the
+    // table. The planner instead flips the album join: 1 album -> its 11
+    // tracks -> 11 existence probes (~28 rows total).
+    const results = executeAllPlanAttempts(unsoldFrankTracks(), true);
+    const pick = picked(results);
+    const base = baseline(results);
+
+    // The planner chose the flipped plan, and it is the optimal attempt.
+    expect(pick.flipPattern).toBe(1);
+    expect(pick.actualRowsScanned).toBe(optimal(results).actualRowsScanned);
+
+    // The as-written plan really is a near-full scan...
+    expect(base.actualRowsScanned).toBeGreaterThan(3000);
+    // ...and the picked plan does a small fraction of its work.
+    // (Measured: 28 vs 5988 rows = 0.005; threshold leaves 10x headroom.)
+    expect(pick.actualRowsScanned).toBeLessThan(0.05 * base.actualRowsScanned);
+  });
+
+  test('without a title index, value-position skew is invisible (documented limitation)', () => {
+    // On the base db (no index on album.title) the flipped plan is costed
+    // as a full album scan, so the planner keeps the as-written semi plan.
+    // The semi plan happens to scan ~6000 rows because the matching tracks
+    // are last - but no statistics can see WHERE in the table matches live,
+    // so this is the best call available. (The indexed-db test above shows
+    // the planner exploiting the index the moment it exists.)
+    const results = executeAllPlanAttempts(unsoldFrankTracks());
+    expect(picked(results).flipPattern).toBe(0);
+  });
+
+  test('planner flips only when flipping actually wins (Big Ones)', () => {
+    // Same query shape, but album 'Big Ones' has its tracks near the START
+    // of the track table, so the semi plan terminates early and is genuinely
+    // cheap. The planner should keep it on the base db and flip on the
+    // indexed db - and in both cases its pick must be the optimal attempt.
+    const query = queries.track
+      .where(({not, exists}) => not(exists('invoiceLines')))
+      .whereExists('album', a => a.where('title', 'Big Ones'))
+      .limit(5);
+
+    const base = executeAllPlanAttempts(query);
+    expect(picked(base).flipPattern).toBe(0);
+    expect(picked(base).actualRowsScanned).toBe(
+      optimal(base).actualRowsScanned,
+    );
+
+    const indexed = executeAllPlanAttempts(query, true);
+    expect(picked(indexed).flipPattern).toBe(1);
+    expect(picked(indexed).actualRowsScanned).toBe(
+      optimal(indexed).actualRowsScanned,
+    );
+    // Measured: 40 vs 71 rows. Modest here, but it is the cheaper plan.
+    expect(picked(indexed).actualRowsScanned).toBeLessThan(
+      baseline(indexed).actualRowsScanned,
+    );
+  });
+
+  test('planner avoids a catastrophic flip inside a junction NOT EXISTS', () => {
+    // not(exists('tracks')) on playlist goes through the playlistTrack
+    // junction: the outer NOT EXISTS cannot flip, but the inner
+    // playlistTrack->track EXISTS can. Flipping it drives the query from
+    // the track table and scans ~670x more rows (measured: 63168 vs 94).
+    // The planner must keep the semi plan.
+    const query = queries.playlist.where(({not, exists}) =>
+      not(exists('tracks')),
+    );
+
+    for (const useIndexedDb of [false, true]) {
+      const results = executeAllPlanAttempts(query, useIndexedDb);
+      const pick = picked(results);
+      expect(pick.flipPattern).toBe(0);
+      expect(pick.actualRowsScanned).toBe(optimal(results).actualRowsScanned);
+
+      const flipped = results.find(r => r.flipPattern === 1);
+      expect(
+        must(flipped).actualRowsScanned / pick.actualRowsScanned,
+      ).toBeGreaterThan(100);
+
+      // The semi plan's estimate must be in the right ballpark. NOT EXISTS
+      // executes as a capped existence probe, and the estimate should
+      // reflect that (measured: est 36 vs 94 rows actually scanned). Before
+      // anti-join costing, each probe was costed as an unlimited scan of
+      // the junction table, inflating the estimate ~220x (est 20736).
+      expect(pick.estimatedCost).toBeLessThan(10 * pick.actualRowsScanned);
+    }
+  });
+
+  // All plan variants must produce identical results - flipping a sibling
+  // EXISTS is an execution strategy, never a semantics change. Each variant
+  // is checked against Postgres (which ignores flip flags entirely).
+  test.each([
+    {
+      name: 'artists with no albums',
+      query: () =>
+        queries.artist.where(({not, exists}) => not(exists('albums'))),
+    },
+    {
+      name: 'playlists with no tracks',
+      query: () =>
+        queries.playlist.where(({not, exists}) => not(exists('tracks'))),
+    },
+    {
+      name: 'unsold Frank tracks - as written',
+      query: () => unsoldFrankTracks(false),
+    },
+    {
+      name: 'unsold Frank tracks - sibling EXISTS flipped',
+      query: () => unsoldFrankTracks(true),
+    },
+    {
+      name: 'unsold Big Ones tracks - sibling EXISTS flipped',
+      query: () =>
+        queries.track
+          .where(({not, exists}) => not(exists('invoiceLines')))
+          .whereExists('album', a => a.where('title', 'Big Ones'), {flip: true})
+          .orderBy('id', 'asc')
+          .limit(5),
+    },
+  ])('results match Postgres: $name', async ({query}) => {
+    await runAndCompare(schema, delegates, query(), undefined);
+  });
+});

--- a/packages/zql-integration-tests/src/helpers/planner-exec.ts
+++ b/packages/zql-integration-tests/src/helpers/planner-exec.ts
@@ -515,6 +515,13 @@ export async function createPlannerInfrastructure(config: {
     const selectedCostModel = useIndexedDb ? indexedCostModel : costModel;
     const selectedDelegate = useIndexedDb ? indexedDelegate : delegates.sqlite;
 
+    // The loop below overrides delegate state (debug tracking, and mapAst is
+    // cleared because the AST is pre-mapped to server names here). The
+    // delegate is shared with other helpers (e.g. runAndCompare), so restore
+    // its original state when done.
+    const originalDebug = selectedDelegate.debug;
+    const originalMapAst = selectedDelegate.mapAst;
+
     // Plan with debugger to collect all attempts
     const planDebugger = new AccumulatorDebugger();
     planQuery(ast, selectedCostModel, planDebugger);
@@ -592,6 +599,10 @@ export async function createPlannerInfrastructure(config: {
         runtimeDebugFlags.trackRowCountsVended = false;
       }
     }
+
+    // Restore the delegate for other users (see note above).
+    selectedDelegate.debug = originalDebug;
+    selectedDelegate.mapAst = originalMapAst;
 
     return results;
   }

--- a/packages/zql/src/planner/README.md
+++ b/packages/zql/src/planner/README.md
@@ -75,8 +75,33 @@ A join can execute in two directions:
 
 **Key constraints:**
 
-- `NOT EXISTS` joins cannot be flipped (marked `flippable: false`)
+- `NOT EXISTS` joins cannot be flipped (marked `flippable: false`): a flipped
+  join discovers parent rows by scanning children, but `NOT EXISTS` returns
+  exactly the parents with no child rows to scan. They are still cost-estimated
+  as anti-joins (see below) so that plans containing them — and flip decisions
+  for sibling joins — use realistic estimates.
 - Flipping a join makes both parent and child unlimited (removes LIMIT propagation)
+
+### 2a. NOT EXISTS (Anti-Join) Costing
+
+`NOT EXISTS` executes as the same existence probe as `EXISTS`: fetch child rows
+matching the parent's correlation and check whether any exist (the runtime caps
+both with `EXISTS_LIMIT`). So its child connection is modeled with `limit: 1`,
+just like `EXISTS`.
+
+Its selectivity is inverted, however. Where `EXISTS` passes a parent row with
+probability `1 - (1 - childSelectivity)^fanout` (the chance at least one child
+matches), `NOT EXISTS` passes with the complement:
+
+```
+antiSelectivity = max((1 - childSelectivity)^fanout, MIN_ANTI_JOIN_SELECTIVITY)
+```
+
+The floor exists because fanout statistics only see parents that have children
+— the childless parents `NOT EXISTS` returns are invisible to the child index.
+An unfiltered `NOT EXISTS` subquery has `childSelectivity = 1.0`, so the raw
+complement would be 0 (no parents survive), zeroing out scan estimates and
+making all candidate plans look equally free.
 
 ### 3. Constraint Propagation
 

--- a/packages/zql/src/planner/SELECTIVITY_PLAN.md
+++ b/packages/zql/src/planner/SELECTIVITY_PLAN.md
@@ -251,11 +251,16 @@ This should be fixed in the same PR.
 
 ### 6. NOT EXISTS
 
-For `NOT EXISTS`, we don't short-circuit on first match:
+`NOT EXISTS` is costed as an anti-join:
 
-- Must scan ALL children to verify none match
-- Don't apply limit or use semi-join selectivity
-- Current code correctly doesn't set limit for NOT EXISTS
+- The child is still an existence probe (the runtime applies `EXISTS_LIMIT`
+  to both `EXISTS` and `NOT EXISTS` subqueries), so the child connection is
+  modeled with `limit: 1` just like `EXISTS`
+- The pass rate is the complement of the semi-join selectivity:
+  `(1 - filterSelectivity)^fanOut`, clamped to a floor
+  (`MIN_ANTI_JOIN_SELECTIVITY`) because fan-out statistics cannot see
+  childless parents — exactly the rows `NOT EXISTS` returns — and an
+  unfiltered subquery would otherwise estimate a pass rate of 0
 
 ## Future Enhancements
 

--- a/packages/zql/src/planner/planner-builder.test.ts
+++ b/packages/zql/src/planner/planner-builder.test.ts
@@ -53,6 +53,7 @@ suite('buildPlanGraph', () => {
       expect(plans.plan.joins).toHaveLength(1);
       const join = plans.plan.joins[0];
       expect(join.kind).toBe('join');
+      expect(join.op).toBe('EXISTS');
 
       // Test that it can be flipped (doesn't throw)
       expect(() => join.flip()).not.toThrow();
@@ -82,6 +83,7 @@ suite('buildPlanGraph', () => {
 
       expect(plans.plan.joins).toHaveLength(1);
       const join = plans.plan.joins[0];
+      expect(join.op).toBe('NOT EXISTS');
 
       // Test that it cannot be flipped (throws UnflippableJoinError)
       expect(() => join.flip()).toThrow('Cannot flip a non-flippable join');
@@ -314,7 +316,7 @@ suite('buildPlanGraph', () => {
       expect(postsConnection?.limit).toBe(1);
     });
 
-    test('NOT EXISTS child connection has no limit', () => {
+    test('NOT EXISTS child connection has limit=1 (existence probe)', () => {
       const ast = {
         table: 'users',
         where: {
@@ -340,8 +342,9 @@ suite('buildPlanGraph', () => {
       );
 
       expect(postsConnection).toBeDefined();
-      // NOT EXISTS child should have no limit
-      expect(postsConnection?.limit).toBeUndefined();
+      // NOT EXISTS is an existence probe just like EXISTS (the runtime caps
+      // both with EXISTS_LIMIT), so the child is costed as a limit-1 fetch.
+      expect(postsConnection?.limit).toBe(1);
     });
 
     test('AND with multiple EXISTS - each child has limit=1', () => {

--- a/packages/zql/src/planner/planner-builder.ts
+++ b/packages/zql/src/planner/planner-builder.ts
@@ -209,7 +209,12 @@ function processCorrelatedSubquery(
     related.subquery.where,
     false,
     undefined, // no base constraints for EXISTS/NOT EXISTS
-    condition.op === 'EXISTS' ? 1 : undefined,
+    // Both EXISTS and NOT EXISTS execute as an existence probe against the
+    // child: fetch rows matching the parent's correlation and check whether
+    // any exist. The runtime caps both with EXISTS_LIMIT (see
+    // builder.ts), so model the probe as fetching a single row rather than
+    // scanning the whole child table per parent row.
+    1,
   );
   graph.connections.push(childConnection);
 
@@ -245,7 +250,11 @@ function processCorrelatedSubquery(
   let initialType: 'semi' | 'flipped';
 
   if (isNotExists) {
-    // NOT EXISTS joins can never be flipped
+    // NOT EXISTS joins can never be flipped: a flipped join discovers parent
+    // rows by scanning children, but NOT EXISTS returns exactly the parents
+    // that have no child rows to scan. The join is still cost-estimated as
+    // an anti-join (inverted selectivity) so that plans containing it — and
+    // flip decisions for sibling joins — are based on realistic estimates.
     flippable = false;
     initialType = 'semi';
   } else if (manualFlip === true) {
@@ -270,6 +279,7 @@ function processCorrelatedSubquery(
     flippable,
     planId,
     initialType,
+    condition.op,
   );
   graph.joins.push(join);
 

--- a/packages/zql/src/planner/planner-connection.ts
+++ b/packages/zql/src/planner/planner-connection.ts
@@ -121,8 +121,8 @@ export class PlannerConnection {
     this.#constraints = new Map();
     this.#isRoot = isRoot;
 
-    // Compute selectivity for EXISTS child connections (baseLimit === 1)
-    // Selectivity = fraction of rows that pass filters
+    // Compute selectivity for EXISTS/NOT EXISTS child connections
+    // (baseLimit === 1). Selectivity = fraction of rows that pass filters
     if (limit !== undefined && filters) {
       const costWithFilters = model(table, sort, filters, undefined);
       const costWithoutFilters = model(table, sort, undefined, undefined);

--- a/packages/zql/src/planner/planner-graph.ts
+++ b/packages/zql/src/planner/planner-graph.ts
@@ -269,8 +269,17 @@ export class PlannerGraph {
     // Build FO→FI cache once to avoid redundant BFS traversals in each iteration
     const fofiCache = buildFOFICache(this);
 
+    // With no flippable joins there is only one possible plan, but if the
+    // graph has joins at all (e.g. only NOT EXISTS, or only manually pinned
+    // flips) we still evaluate that single plan so constraints propagate and
+    // cost estimates / debug events are produced for it. A join-free graph
+    // has nothing to plan.
     const numPatterns =
-      flippableJoins.length === 0 ? 0 : 2 ** flippableJoins.length;
+      flippableJoins.length === 0
+        ? this.joins.length === 0
+          ? 0
+          : 1
+        : 2 ** flippableJoins.length;
     let bestCost = Infinity;
     let bestPlan: PlanState | undefined = undefined;
     let bestAttemptNumber = -1;
@@ -374,10 +383,7 @@ export class PlannerGraph {
         });
       }
     } else {
-      assert(
-        numPatterns === 0,
-        'no plan was found but flippable joins did exist!',
-      );
+      assert(numPatterns === 0, 'no plan was found but joins did exist!');
     }
   }
 }

--- a/packages/zql/src/planner/planner-join.test.ts
+++ b/packages/zql/src/planner/planner-join.test.ts
@@ -1,4 +1,5 @@
 import {expect, suite, test} from 'vitest';
+import type {Condition} from '../../../zero-protocol/src/ast.ts';
 import {
   getMultiConstraintChunkSize,
   setMultiConstraintChunkSizeForTest,
@@ -224,6 +225,158 @@ suite('PlannerJoin', () => {
       }
       // After restore, cost returns to the default chunking.
       expect(flippedCost(256)).toBe(defaultCost);
+    });
+  });
+
+  suite('anti-join (NOT EXISTS) costing', () => {
+    // Child filter passing 20% of rows (200 of 1000).
+    const CHILD_FILTER: Condition = {
+      type: 'simple',
+      op: '=',
+      left: {type: 'column', name: 'deleted'},
+      right: {type: 'literal', value: false},
+    };
+
+    // parent: 1000 rows. child: 1000 rows unfiltered, 200 filtered
+    // (filter selectivity 0.2).
+    function makeJoin(opts: {
+      op: 'EXISTS' | 'NOT EXISTS';
+      childFilters?: Condition | undefined;
+      fanout?: number;
+      parentLimit?: number | undefined;
+    }) {
+      const {op, childFilters, fanout = 1, parentLimit} = opts;
+      const model: ConnectionCostModel = (table, _sort, filters) => ({
+        startupCost: 0,
+        rows: table === 'child' ? (filters ? 200 : 1000) : 1000,
+        fanout: () => ({fanout, confidence: 'high'}) as const,
+      });
+      const parent = new PlannerSource('parent', model).connect(
+        DEFAULT_SORT,
+        undefined,
+        true,
+        undefined,
+        parentLimit,
+      );
+      const child = new PlannerSource('child', model).connect(
+        DEFAULT_SORT,
+        childFilters,
+        false,
+        undefined,
+        1, // existence probe, same as EXISTS
+      );
+      const join = new PlannerJoin(
+        parent,
+        child,
+        CONSTRAINTS.userId,
+        CONSTRAINTS.id,
+        op === 'EXISTS',
+        0,
+        'semi',
+        op,
+      );
+      return {parent, child, join};
+    }
+
+    test('NOT EXISTS pass rate is the complement of the EXISTS match rate', () => {
+      // filter selectivity 0.2, fanout 2:
+      // match rate = 1 - (1 - 0.2)^2 = 0.36 → anti pass rate = 0.64
+      const {join} = makeJoin({
+        op: 'NOT EXISTS',
+        childFilters: CHILD_FILTER,
+        fanout: 2,
+      });
+      const cost = join.estimateCost(1, []);
+      expect(cost.selectivity).toBeCloseTo(0.64);
+      expect(cost.returnedRows).toBeCloseTo(640);
+    });
+
+    test('EXISTS costing is unchanged by the op parameter', () => {
+      const {join} = makeJoin({
+        op: 'EXISTS',
+        childFilters: CHILD_FILTER,
+        fanout: 2,
+      });
+      const cost = join.estimateCost(1, []);
+      // EXISTS keeps the historical unscaled child filter selectivity for
+      // row estimates.
+      expect(cost.selectivity).toBeCloseTo(0.2);
+      expect(cost.returnedRows).toBeCloseTo(200);
+    });
+
+    test('unfiltered NOT EXISTS clamps to a selectivity floor instead of 0', () => {
+      // Unfiltered child selectivity is 1.0 so the raw complement is 0,
+      // which would estimate that no parent rows survive and zero out all
+      // plan costs. The clamp keeps estimates finite and comparable.
+      const {join} = makeJoin({op: 'NOT EXISTS'});
+      const cost = join.estimateCost(1, []);
+      expect(cost.selectivity).toBeCloseTo(0.1);
+      expect(cost.returnedRows).toBeCloseTo(100);
+    });
+
+    test('anti-join pass rate scales how many parent rows must be scanned', () => {
+      // Pass rate 0.64 with limit 10 → scan ~10/0.64 ≈ 15.6 parents, each
+      // paying one limit-1 child probe.
+      const {join} = makeJoin({
+        op: 'NOT EXISTS',
+        childFilters: CHILD_FILTER,
+        fanout: 2,
+        parentLimit: 10,
+      });
+      const cost = join.estimateCost(1, []);
+      expect(cost.cost).toBeCloseTo(10 / 0.64);
+    });
+
+    test('NOT EXISTS child probe is costed as a limit-1 fetch per parent row', () => {
+      // 1000 parents each pay a probe of scanEst 1 → cost 1000, not a full
+      // 1000-row child scan per parent (10^6).
+      const {join} = makeJoin({op: 'NOT EXISTS'});
+      const cost = join.estimateCost(1, []);
+      expect(cost.cost).toBe(1000);
+    });
+
+    test('NOT EXISTS joins must be constructed non-flippable and semi', () => {
+      const model: ConnectionCostModel = () => ({
+        startupCost: 0,
+        rows: 100,
+        fanout: () => ({fanout: 1, confidence: 'none'}) as const,
+      });
+      const parent = new PlannerSource('parent', model).connect(
+        DEFAULT_SORT,
+        undefined,
+        false,
+      );
+      const child = new PlannerSource('child', model).connect(
+        DEFAULT_SORT,
+        undefined,
+        false,
+      );
+      expect(
+        () =>
+          new PlannerJoin(
+            parent,
+            child,
+            CONSTRAINTS.userId,
+            CONSTRAINTS.id,
+            true, // flippable NOT EXISTS is invalid
+            0,
+            'semi',
+            'NOT EXISTS',
+          ),
+      ).toThrow('NOT EXISTS joins must be non-flippable semi-joins');
+      expect(
+        () =>
+          new PlannerJoin(
+            parent,
+            child,
+            CONSTRAINTS.userId,
+            CONSTRAINTS.id,
+            false,
+            0,
+            'flipped', // flipped NOT EXISTS is invalid
+            'NOT EXISTS',
+          ),
+      ).toThrow('NOT EXISTS joins must be non-flippable semi-joins');
     });
   });
 });

--- a/packages/zql/src/planner/planner-join.ts
+++ b/packages/zql/src/planner/planner-join.ts
@@ -66,11 +66,31 @@ function translateConstraintsForFlippedJoin(
 // const SEMI_JOIN_OVERHEAD_MULTIPLIER = 1.5;
 
 /**
+ * Minimum fraction of parent rows assumed to survive a NOT EXISTS
+ * (anti-join) filter.
+ *
+ * The anti-join pass rate is estimated as the complement of the EXISTS match
+ * rate: `(1 - childSelectivity)^fanout`. That formula systematically
+ * overestimates matching because the fanout statistics only see parents that
+ * actually have children — parents with zero children are invisible to the
+ * child index, yet they are exactly the rows NOT EXISTS returns. In the most
+ * common case (an unfiltered NOT EXISTS subquery) child selectivity is 1.0,
+ * so the raw complement collapses to 0: the planner would estimate that no
+ * parent rows survive, zeroing out scan estimates and making every candidate
+ * plan look free (and therefore indistinguishable).
+ *
+ * Clamping to a floor keeps estimates finite and plans comparable while
+ * still letting a NOT EXISTS with selective child filters report a high pass
+ * rate (e.g. few children match → most parents pass).
+ */
+const MIN_ANTI_JOIN_SELECTIVITY = 0.1;
+
+/**
  * Represents a join between two data streams (parent and child).
  *
  * # Dual-State Pattern
  * Like all planner nodes, PlannerJoin separates:
- * 1. IMMUTABLE STRUCTURE: Parent/child nodes, constraints, flippability
+ * 1. IMMUTABLE STRUCTURE: Parent/child nodes, constraints, flippability, operator
  * 2. MUTABLE STATE: Join type (semi/flipped), pinned status
  *
  * # Join Flipping
@@ -79,7 +99,17 @@ function translateConstraintsForFlippedJoin(
  * - 'flipped': Child is outer loop, parent is inner
  *
  * Flipping is the key optimization: choosing which table scans first.
- * NOT EXISTS joins cannot be flipped (#flippable = false).
+ * NOT EXISTS joins cannot be flipped (#flippable = false): a flipped join
+ * discovers parent rows by scanning children, but the parents NOT EXISTS
+ * returns are precisely those with no child rows to scan.
+ *
+ * # NOT EXISTS (anti-join) costing
+ * NOT EXISTS executes as the same existence probe as EXISTS (fetch child
+ * rows for the parent's correlation, check whether any exist), so its cost
+ * structure matches a semi-join. Its selectivity is inverted, however: a
+ * parent row passes when NO child matches, so the pass rate is the
+ * complement of the EXISTS match rate (clamped — see
+ * MIN_ANTI_JOIN_SELECTIVITY).
  *
  * # Constraint Propagation
  * - Semi-join: Sends childConstraint to child, forwards received constraints to parent
@@ -101,6 +131,7 @@ export class PlannerJoin {
   readonly #parentConstraint: PlannerConstraint;
   readonly #childConstraint: PlannerConstraint;
   readonly #flippable: boolean;
+  readonly #op: 'EXISTS' | 'NOT EXISTS';
   readonly planId: number;
   #output?: PlannerNode | undefined; // Set once during graph construction
 
@@ -116,7 +147,12 @@ export class PlannerJoin {
     flippable: boolean,
     planId: number,
     initialType: 'semi' | 'flipped' = 'semi',
+    op: 'EXISTS' | 'NOT EXISTS' = 'EXISTS',
   ) {
+    assert(
+      op === 'EXISTS' || (!flippable && initialType === 'semi'),
+      'NOT EXISTS joins must be non-flippable semi-joins',
+    );
     this.#type = initialType;
     this.#initialType = initialType;
     this.#parent = parent;
@@ -124,6 +160,7 @@ export class PlannerJoin {
     this.#childConstraint = childConstraint;
     this.#parentConstraint = parentConstraint;
     this.#flippable = flippable;
+    this.#op = op;
     this.planId = planId;
   }
 
@@ -163,6 +200,9 @@ export class PlannerJoin {
 
   get type(): 'semi' | 'flipped' {
     return this.#type;
+  }
+  get op(): 'EXISTS' | 'NOT EXISTS' {
+    return this.#op;
   }
   isFlippable(): boolean {
     return this.#flippable;
@@ -320,6 +360,16 @@ export class PlannerJoin {
     const scaledChildSelectivity =
       1 - Math.pow(1 - child.selectivity, fanoutFactor.fanout);
 
+    // Fraction of parent rows that pass this join's filter.
+    // EXISTS passes a parent row when a child matches; NOT EXISTS
+    // (anti-join) passes when NO child matches, so its pass rate is the
+    // complement of the match rate, clamped to a floor (see
+    // MIN_ANTI_JOIN_SELECTIVITY for why the raw complement is unusable).
+    const passSelectivity =
+      this.#op === 'NOT EXISTS'
+        ? Math.max(1 - scaledChildSelectivity, MIN_ANTI_JOIN_SELECTIVITY)
+        : scaledChildSelectivity;
+
     // Why do we not need fanout in the other direction?
     // E.g., for an `inventory -> film` flipped-join, if each film has 100 inventories (100 copies)
     // then we're more likely to hit an inventory row compared to if each film has 1 inventory.
@@ -345,7 +395,7 @@ export class PlannerJoin {
       // so we can determine the total selectivity of all ANDed exists checks.
       this.#type === 'flipped'
         ? 1 * downstreamChildSelectivity
-        : scaledChildSelectivity * downstreamChildSelectivity,
+        : passSelectivity * downstreamChildSelectivity,
       branchPattern,
       planDebugger,
     );
@@ -353,6 +403,12 @@ export class PlannerJoin {
     let costEstimate: CostEstimate;
 
     if (this.type === 'semi') {
+      // EXISTS keeps the historical (unscaled) child filter selectivity for
+      // the row estimate. NOT EXISTS must use the anti-join pass rate: the
+      // raw complement (1 - child.selectivity) is 0 for any unfiltered
+      // subquery, which would estimate that no parent rows survive.
+      const rowSelectivity =
+        this.#op === 'NOT EXISTS' ? passSelectivity : child.selectivity;
       costEstimate = {
         startupCost: parent.startupCost,
         scanEst:
@@ -367,8 +423,8 @@ export class PlannerJoin {
         cost:
           parent.cost +
           parent.scanEst * (child.startupCost + child.cost + child.scanEst),
-        returnedRows: parent.returnedRows * child.selectivity,
-        selectivity: child.selectivity * parent.selectivity,
+        returnedRows: parent.returnedRows * rowSelectivity,
+        selectivity: rowSelectivity * parent.selectivity,
         limit: parent.limit,
         fanout: parent.fanout,
       };
@@ -436,11 +492,13 @@ export class PlannerJoin {
   getDebugInfo(): {
     name: string;
     type: 'semi' | 'flipped';
+    op: 'EXISTS' | 'NOT EXISTS';
     planId: number;
   } {
     return {
       name: this.getName(),
       type: this.#type,
+      op: this.#op,
       planId: this.planId,
     };
   }

--- a/packages/zql/src/planner/planner-not-exists.test.ts
+++ b/packages/zql/src/planner/planner-not-exists.test.ts
@@ -1,0 +1,174 @@
+import {expect, suite, test} from 'vitest';
+import type {AST, Condition} from '../../../zero-protocol/src/ast.ts';
+import {applyPlansToAST, buildPlanGraph} from './planner-builder.ts';
+import type {ConnectionCostModel} from './planner-connection.ts';
+import {AccumulatorDebugger} from './planner-debug.ts';
+
+/**
+ * Plan-level tests for NOT EXISTS (anti-join) optimization.
+ *
+ * NOT EXISTS joins cannot be flipped, but the planner still needs to:
+ * 1. Evaluate and cost plans for queries whose only joins are NOT EXISTS
+ *    (constraint propagation, cost estimates, debug/analyze events).
+ * 2. Use realistic anti-join selectivity so flip decisions for sibling
+ *    EXISTS joins are based on how many parent rows actually survive the
+ *    NOT EXISTS filter.
+ */
+suite('planning NOT EXISTS', () => {
+  function notExists(
+    childTable: string,
+    parentField = 'id',
+    childField = 'userId',
+  ): Condition {
+    return {
+      type: 'correlatedSubquery',
+      op: 'NOT EXISTS',
+      related: {
+        correlation: {
+          parentField: [parentField],
+          childField: [childField],
+        },
+        subquery: {
+          table: childTable,
+          alias: childTable,
+        },
+      },
+    };
+  }
+
+  function exists(
+    childTable: string,
+    parentField = 'id',
+    childField = 'userId',
+  ): Condition {
+    return {
+      type: 'correlatedSubquery',
+      op: 'EXISTS',
+      related: {
+        correlation: {
+          parentField: [parentField],
+          childField: [childField],
+        },
+        subquery: {
+          table: childTable,
+          alias: childTable,
+        },
+      },
+    };
+  }
+
+  test('a NOT EXISTS-only query still gets a planning pass', () => {
+    // No joins are flippable, so there is only one possible plan — but the
+    // planner must still evaluate it so constraints propagate and cost
+    // estimates / analyze output exist for the query.
+    const ast: AST = {
+      table: 'users',
+      where: notExists('bans'),
+    };
+
+    const model: ConnectionCostModel = (
+      table,
+      _sort,
+      _filters,
+      constraint,
+    ) => ({
+      startupCost: 0,
+      rows: constraint ? 2 : table === 'users' ? 1000 : 5000,
+      fanout: () => ({fanout: 1, confidence: 'high'}) as const,
+    });
+
+    const plans = buildPlanGraph(ast, model, true);
+    const dbg = new AccumulatorDebugger();
+    plans.plan.plan(dbg);
+
+    // Exactly one plan (all-semi) was evaluated and selected.
+    expect(dbg.getEvents('plan-complete')).toHaveLength(1);
+    expect(dbg.getEvents('best-plan-selected')).toHaveLength(1);
+
+    // The correlation constraint was propagated to the NOT EXISTS child, so
+    // its probe is costed as a constrained (indexed) lookup.
+    const bansConnection = plans.plan.connections.find(c => c.table === 'bans');
+    expect(bansConnection?.getConstraintsForDebug()).toEqual({
+      '': {userId: undefined},
+    });
+
+    // The plan has a finite, non-zero cost: the anti-join selectivity floor
+    // prevents the "no rows survive" estimate that would zero everything out.
+    const totalCost = plans.plan.getTotalCost();
+    expect(Number.isFinite(totalCost)).toBe(true);
+    expect(totalCost).toBeGreaterThan(0);
+
+    // NOT EXISTS stays a semi (anti) join.
+    expect(plans.plan.joins).toHaveLength(1);
+    expect(plans.plan.joins[0].type).toBe('semi');
+    expect(plans.plan.joins[0].op).toBe('NOT EXISTS');
+  });
+
+  test('anti-join selectivity informs flip decisions for sibling EXISTS joins', () => {
+    // users(1000 rows, limit 10) filtered by NOT EXISTS bans AND EXISTS posts.
+    //
+    // The unfiltered NOT EXISTS estimates that only a small fraction of users
+    // survive (the anti-join selectivity floor), so the semi plan must scan
+    // many users — each paying a bans probe — to fill the limit. Scanning the
+    // small posts table (20 rows) and fetching users per post is cheaper, so
+    // the planner should flip the EXISTS join.
+    //
+    // (Before anti-join costing, NOT EXISTS was estimated with EXISTS
+    // semantics: ~every user survives, making the semi plan look ~5x cheaper
+    // than it is and keeping the EXISTS join unflipped.)
+    const ast: AST = {
+      table: 'users',
+      limit: 10,
+      where: {
+        type: 'and',
+        conditions: [notExists('bans'), exists('posts')],
+      },
+    };
+
+    const model: ConnectionCostModel = (table, _sort, _filters, constraint) => {
+      const constrained =
+        constraint !== undefined && Object.keys(constraint).length > 0;
+      const rows =
+        table === 'users'
+          ? constrained
+            ? 1
+            : 1000
+          : table === 'posts'
+            ? constrained
+              ? 1
+              : 20
+            : constrained // bans
+              ? 1
+              : 100_000;
+      return {
+        startupCost: 0,
+        rows,
+        fanout: () => ({fanout: 1, confidence: 'high'}) as const,
+      };
+    };
+
+    const plans = buildPlanGraph(ast, model, true);
+    plans.plan.plan();
+
+    expect(plans.plan.joins).toHaveLength(2);
+    const [bansJoin, postsJoin] = plans.plan.joins;
+
+    // The NOT EXISTS join can never flip.
+    expect(bansJoin.op).toBe('NOT EXISTS');
+    expect(bansJoin.type).toBe('semi');
+
+    // The EXISTS join is flipped: driving from the small posts table beats
+    // scanning ~limit/antiSelectivity users.
+    expect(postsJoin.op).toBe('EXISTS');
+    expect(postsJoin.type).toBe('flipped');
+
+    // The decision lands in the AST: EXISTS gets flip: true, NOT EXISTS
+    // stays unflipped.
+    const planned = applyPlansToAST(ast, plans);
+    const where = planned.where;
+    expect(where?.type).toBe('and');
+    const conditions = (where as Extract<Condition, {type: 'and'}>).conditions;
+    expect(conditions[0]).toMatchObject({op: 'NOT EXISTS', flip: false});
+    expect(conditions[1]).toMatchObject({op: 'EXISTS', flip: true});
+  });
+});


### PR DESCRIPTION
tldr: while `not exists` cannot be flipped, we can model its estimated cost better so we know how to change the components of _the surrounding query_ for a better plan.

As an example:

```ts
track.whereExists('album', a => a.whereNotExists('artist'))
```

While we cannot flip the `whereNotExists` piece we can flip the `whereExists`. Knowing that albums always have artists, this can be a reasonable choice since `whereExists` will return no rows due to the `whereNotExists` filter it contains.


## Key Changes

- **Anti-join costing model**: Implemented realistic selectivity estimation for `NOT EXISTS` by computing the complement of the `EXISTS` match rate, clamped to a floor (`MIN_ANTI_JOIN_SELECTIVITY = 0.1`) to prevent zero-cost estimates when child selectivity is 1.0. This ensures plans containing `NOT EXISTS` are comparable and flip decisions for sibling joins are based on accurate row survival estimates.

- **Single-plan evaluation for non-flippable queries**: Modified `PlannerGraph.plan()` to evaluate exactly one plan when all joins are non-flippable (e.g., `NOT EXISTS`-only queries), enabling constraint propagation and debug events even when no flip decisions are needed.

- **Operator tracking in joins**: Added `op: 'EXISTS' | 'NOT EXISTS'` parameter to `PlannerJoin` with validation that `NOT EXISTS` joins must be non-flippable semi-joins. Both operators now model the child as an existence probe (`limit: 1`) since the runtime caps both with `EXISTS_LIMIT`.

- **Comprehensive test coverage**:
  - Unit tests in `planner-not-exists.test.ts` validating single-plan evaluation, constraint propagation, and anti-join selectivity informing flip decisions
  - Unit tests in `planner-join.test.ts` covering anti-join pass rate calculation, selectivity floor behavior, and parent row scan scaling with limits
  - End-to-end integration tests in `chinook/planner-not-exists.pg.test.ts` measuring actual rows scanned against the Chinook dataset, demonstrating the planner beats forced baselines by ~200x on indexed databases and correctly avoids catastrophic flips in junction `NOT EXISTS` queries

- **Documentation updates**: Clarified in `README.md` and `SELECTIVITY_PLAN.md` that `NOT EXISTS` executes as an existence probe with inverted selectivity semantics, and explained the selectivity floor rationale.

## Implementation Details

- The anti-join pass rate formula: `max((1 - childSelectivity)^fanout, MIN_ANTI_JOIN_SELECTIVITY)` inverts the `EXISTS` match rate while clamping to prevent zero estimates
- Child connections for both `EXISTS` and `NOT EXISTS` use `limit: 1` to model existence probes, matching runtime behavior
- `NOT EXISTS` joins are constructed with `flippable: false` and `type: 'semi'`, enforced by assertion in the constructor
- When no flippable joins exist but non-flippable joins are present, the planner evaluates the single all-semi plan (flipPattern 0) to produce cost estimates and debug events

https://claude.ai/code/session_01CQmQXG6Wq5fKP7wh7BdMCo


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CVKH5t16hH3rahToTB9n4D
