### PR TITLE
fix(backfill): prevent non-shard lag reports from interrupting backfills

### DIFF
--- a/packages/zero-cache/src/services/change-source/pg/change-source.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.test.ts
@@ -1,7 +1,197 @@
 import {expect, test, vi} from 'vitest';
 import {createSilentLogContext} from '../../../../../shared/src/logging-test-utils.ts';
 import type {PostgresDB} from '../../../types/pg.ts';
-import {Acker, LagReporter} from './change-source.ts';
+import type {Sink} from '../../../types/streams.ts';
+import {Subscription} from '../../../types/subscription.ts';
+import type {BackfillMessage} from '../common/backfill-manager.ts';
+import type {
+  BackfillRequest,
+  ChangeStreamMessage,
+  MessageBackfill,
+} from '../protocol/current.ts';
+import {Acker, LagReporter, PostgresChangeSource} from './change-source.ts';
+import type {ServerContext} from './initial-sync.ts';
+import type {StreamMessage} from './logical-replication/stream.ts';
+import type {
+  BackupOptions,
+  InternalShardConfig,
+  Replica,
+} from './schema/shard.ts';
+
+/**
+ * Regression test for the backfill-starvation priority inversion (a ~30 minute
+ * idle gap observed in the canary logs), driving the real
+ * {@link PostgresChangeSource} replication + backfill multiplexing loop (with
+ * the upstream `subscribe()` and `streamBackfill()` dependencies mocked).
+ *
+ * Root cause: a *different* shard's lag report arrives as a standalone,
+ * non-transactional logical `message`. It was misclassified as transactional,
+ * so the main replication producer reserved the change-stream for it even
+ * though it produces no changes. The backfill would commit/release to hand over
+ * the reservation, and the main producer would then sit on the (empty)
+ * reservation — starving the backfill until the next real upstream transaction.
+ *
+ * The fix classifies a non-transactional foreign-shard `message` as
+ * non-transactional, so the main producer never reserves for it. This test
+ * asserts that such a message does not interrupt a running backfill at all: the
+ * backfill streams straight through it in a single, uninterrupted transaction
+ * (no commit boundary, no handover). Reverting the fix — reserving for the
+ * foreign message — starves the backfill and this test fails (batch 2 never
+ * arrives).
+ */
+test('a non-transactional foreign-shard message does not interrupt a running backfill', async () => {
+  const lc = createSilentLogContext();
+
+  // A backfill message batch tagged with distinct rowValues so we can spot it
+  // in the downstream change stream.
+  const backfillMessage = (id: number): BackfillMessage => ({
+    message: {
+      tag: 'backfill',
+      relation: {schema: 'public', name: 'foo', rowKey: {columns: ['id']}},
+      columns: [],
+      watermark: '00',
+      rowValues: [[id]],
+    } satisfies MessageBackfill,
+    byteSize: 10,
+  });
+
+  // The mocked upstream logical replication stream. We push StreamMessages into
+  // it to drive the main producer.
+  const messages = Subscription.create<StreamMessage>();
+  const acks: Sink<bigint> = {
+    push: () => ({result: Promise.resolve('consumed')}),
+  };
+
+  // The mocked backfill stream. We push BackfillMessages into it to drive the
+  // BackfillManager, one row batch at a time.
+  const backfillStream = new Channel<BackfillMessage>();
+
+  const source = new PostgresChangeSource(
+    lc,
+    'postgres://upstream/unused', // never connected (subscribe is mocked)
+    {appID: 'zero', shardNum: 0},
+    {
+      slot: 'test_slot',
+      publications: ['zero_pub'],
+      initialSchema: {},
+    } as unknown as Replica,
+    {backupPath: null, backupV5: false} as unknown as BackupOptions,
+    {} as ServerContext,
+    0, // lagReportIntervalMs: no LagReporter
+    false,
+    undefined,
+    {
+      subscribe: () => Promise.resolve({messages, acks}),
+      streamBackfill: () => backfillStream[Symbol.asyncIterator](),
+    },
+  );
+
+  const backfillRequest: BackfillRequest = {
+    table: {schema: 'public', name: 'foo', metadata: null},
+    columns: {id: {}},
+  };
+
+  const shardConfig = {
+    publications: ['zero_pub'],
+  } as unknown as InternalShardConfig;
+
+  const stream = await source.startStreamInternal(
+    'test_slot',
+    '00',
+    shardConfig,
+    [backfillRequest],
+  );
+
+  // Consume the downstream change stream in the background, recording every
+  // message so we can observe backfill progress.
+  const output: ChangeStreamMessage[] = [];
+  void (async () => {
+    for await (const change of stream.changes) {
+      output.push(change);
+    }
+  })();
+
+  // Flushes the microtask queue. The reserve/release/push machinery is entirely
+  // promise-based (no timers or IO in this test), so draining microtasks
+  // deterministically settles each step.
+  const settle = async () => {
+    for (let i = 0; i < 50; i++) {
+      await Promise.resolve();
+    }
+  };
+
+  const dataRows = () =>
+    output
+      .filter(c => c[0] === 'data' && c[1].tag === 'backfill')
+      .flatMap(c => (c[1] as MessageBackfill).rowValues);
+
+  // 1. Backfill streams its first batch, opening a transaction and holding the
+  //    change-stream reservation.
+  backfillStream.push(backfillMessage(1));
+  await settle();
+  expect(dataRows()).toEqual([[1]]);
+
+  // 2. A different shard's lag report arrives on the main stream as a
+  //    standalone, non-transactional logical message. The main producer must
+  //    classify it as non-transactional and NOT reserve the stream.
+  const foreignLagReport: StreamMessage = [
+    1n,
+    {
+      tag: 'message',
+      flags: 0,
+      transactional: false,
+      messageLsn: null,
+      prefix: 'zero/1/lag-report/v1', // a different shard (zero/1)
+      content: new Uint8Array(),
+    },
+  ];
+  messages.push(foreignLagReport);
+  await settle();
+
+  // 3. The backfill streams its second batch. Because the foreign message never
+  //    reserved the stream, the backfill was never preempted: both batches are
+  //    in the same transaction.
+  backfillStream.push(backfillMessage(2));
+  await settle();
+
+  // The backfill streamed straight through the foreign message, uninterrupted:
+  // both batches delivered, within a single transaction (one begin, no commit
+  // boundary / handover in between).
+  expect(dataRows()).toEqual([[1], [2]]);
+  expect(output.filter(c => c[0] === 'begin')).toHaveLength(1);
+  expect(output.some(c => c[0] === 'commit')).toBe(false);
+
+  messages.cancel();
+  await source.stop();
+});
+
+/**
+ * A minimal push-driven async iterable, standing in for the `streamBackfill()`
+ * AsyncGenerator. `push()` enqueues a value; the consumer's `for await`
+ * receives values as they arrive and otherwise waits.
+ */
+class Channel<T> {
+  readonly #buffer: T[] = [];
+  #wake: (() => void) | null = null;
+
+  push(value: T): void {
+    this.#buffer.push(value);
+    const wake = this.#wake;
+    this.#wake = null;
+    wake?.();
+  }
+
+  async *[Symbol.asyncIterator](): AsyncGenerator<T> {
+    for (;;) {
+      while (this.#buffer.length) {
+        yield this.#buffer.shift() as T;
+      }
+      await new Promise<void>(resolve => {
+        this.#wake = resolve;
+      });
+    }
+  }
+}
 
 test('acker', () => {
   const sink = {push: vi.fn()};

--- a/packages/zero-cache/src/services/change-source/pg/change-source.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.ts
@@ -367,7 +367,7 @@ type ReservationState = {
  * Postgres implementation of a {@link ChangeSource} backed by a logical
  * replication stream.
  */
-class PostgresChangeSource implements ChangeSource {
+export class PostgresChangeSource implements ChangeSource {
   readonly #lc: LogContext;
   readonly #db: PostgresDB;
   readonly #upstreamUri: string;
@@ -378,6 +378,8 @@ class PostgresChangeSource implements ChangeSource {
   readonly #lagReporter: LagReporter | null;
   readonly #textCopy: boolean;
   readonly #streamInboundTimeoutMs: number | undefined;
+  readonly #subscribe: typeof subscribe;
+  readonly #streamBackfill: typeof streamBackfill;
   #stopped = false;
 
   constructor(
@@ -390,8 +392,16 @@ class PostgresChangeSource implements ChangeSource {
     lagReportIntervalMs: number,
     textCopy?: boolean | undefined,
     streamInboundTimeoutMs?: number | undefined,
+    // Injectable dependencies, overridable in tests. Default to the production
+    // implementations.
+    deps: {
+      subscribe?: typeof subscribe;
+      streamBackfill?: typeof streamBackfill;
+    } = {},
   ) {
     this.#lc = lc.withContext('component', 'change-source');
+    this.#subscribe = deps.subscribe ?? subscribe;
+    this.#streamBackfill = deps.streamBackfill ?? streamBackfill;
     this.#db = pgClient(lc, upstreamUri, 'replication-monitor', {
       max: 1,
       // used occasionally for schema changes, periodically for lag reporting
@@ -463,17 +473,23 @@ class PostgresChangeSource implements ChangeSource {
     const config = await getInternalShardConfig(this.#db, this.#shard);
     const {slot} = this.#replica;
     this.#lc.info?.(`starting replication stream@${slot}`);
-    return this.#startStream(slot, clientWatermark, config, backfillRequests);
+    return this.startStreamInternal(
+      slot,
+      clientWatermark,
+      config,
+      backfillRequests,
+    );
   }
 
-  async #startStream(
+  // Exported for testing.
+  async startStreamInternal(
     slot: string,
     clientWatermark: string,
     shardConfig: InternalShardConfig,
     backfillRequests: BackfillRequest[],
   ): Promise<ChangeStream> {
     const clientStart = majorVersionFromString(clientWatermark) + 1n;
-    const {messages, acks} = await subscribe(
+    const {messages, acks} = await this.#subscribe(
       this.#lc,
       this.#db,
       slot,
@@ -490,7 +506,7 @@ class PostgresChangeSource implements ChangeSource {
     // BackfillManager.
     const changes = new ChangeStreamMultiplexer(this.#lc, clientWatermark);
     const backfillManager = new BackfillManager(this.#lc, changes, req =>
-      streamBackfill(this.#lc, this.#upstreamUri, this.#replica, req, {
+      this.#streamBackfill(this.#lc, this.#upstreamUri, this.#replica, req, {
         textCopy: this.#textCopy,
       }),
     );
@@ -536,6 +552,20 @@ class PostgresChangeSource implements ChangeSource {
         ]);
         return false;
       }
+
+      // The only non-transaction "message" we process is our own lagReporter's
+      // message (handled above). Non-transactional messages from other shards
+      // (e.g. lag reports), should be ignored but properly classified as
+      // non-transactional, so as not to incorrectly request a stream
+      // reservation.
+      if (msg.tag === 'message' && !msg.transactional) {
+        this.#lc.debug?.(
+          'ignoring non-transactional message for different shard',
+          msg.prefix,
+        );
+        return false;
+      }
+
       return true;
     };
 
@@ -558,8 +588,8 @@ class PostgresChangeSource implements ChangeSource {
 
           if (!reservation) {
             const res = changes.reserve('replication');
-            typeof res === 'string' || (await res); // awaits should be uncommon
-            reservation = {};
+            const lastWatermark = typeof res === 'string' ? res : await res;
+            reservation = {lastWatermark};
           }
 
           let lastChange: ChangeStreamMessage | undefined;


### PR DESCRIPTION
Fix a situation in which a backfill gets unnecessarily interrupted by a lag report from a different shard (e.g. `ZERO_APP_ID`), causing it to idle until a new transaction arrives.

The error stemmed from the fact that the non-shard lag report, although ignored, was improperly classified as a "transactional" message, thereby initiating a change-stream reservation unnecessarily. With no other changes in the stream, that reservation was held until new change messages came in.

With the fix, the non-shard lag reports are properly recognized as non-transactional, avoiding the spurious and problematic change-stream reservation.

Context:
* https://rocicorp.slack.com/archives/C0B3A4P3W56/p1788294436747829?thread_ts=1788279391.627549&cid=C0B3A4P3W56