### PR TITLE
fix(zero-protocol): fold a query's name, args and system into its hash

### DIFF
--- a/packages/zero-protocol/src/query-hash-visitor.test.ts
+++ b/packages/zero-protocol/src/query-hash-visitor.test.ts
@@ -1,6 +1,11 @@
 import {expect, test} from 'vitest';
+import type {Format} from '../../zero-types/src/format.ts';
 import {normalizeAST, type AST, type Condition} from './ast.ts';
-import {hashAST, hashNameAndArgs} from './query-hash-visitor.ts';
+import {
+  hashAST,
+  hashNameAndArgs,
+  hashOfQueryInternals,
+} from './query-hash-visitor.ts';
 
 const base: AST = {table: 'issue'};
 
@@ -522,4 +527,60 @@ test('a hash taken from inside another walk does not corrupt it', () => {
   };
   expect(hashNameAndArgs('q', [sneaky])).toBe(plain);
   expect(inner).toBe(innerExpected);
+});
+
+const fmt: Format = {singular: false, relationships: {}};
+
+test('hashOfQueryInternals separates queries that differ only by name or args', () => {
+  const a = CORPUS[0];
+  // `nameAndArgs` reuses the AST it is given, so the name and args are the only
+  // thing telling these apart -- the AST and the format are identical.
+  const seen = new Map<string, string>();
+  const cases: [string | undefined, readonly unknown[] | undefined][] = [
+    [undefined, undefined],
+    ['foo', []],
+    ['foo', [1]],
+    ['foo', [2]],
+    ['foo', [1, 2]],
+    ['bar', [1]],
+    ['bar', []],
+  ];
+  for (const [name, args] of cases) {
+    const key = `${name} ${JSON.stringify(args)}`;
+    const h = hashOfQueryInternals(a, fmt, name, args);
+    const existing = seen.get(h);
+    expect(
+      existing,
+      `collision between\n  ${existing}\n  ${key}`,
+    ).toBeUndefined();
+    seen.set(h, key);
+  }
+});
+
+test('hashOfQueryInternals still separates every AST in the corpus', () => {
+  const byHash = new Map<string, number>();
+  CORPUS.forEach((a, i) => {
+    const h = hashOfQueryInternals(a, fmt, 'q', [1]);
+    expect(byHash.get(h), `collision at corpus ${i}`).toBeUndefined();
+    byHash.set(h, i);
+  });
+});
+
+test('hashOfQueryInternals depends only on the values, not call order', () => {
+  const a = CORPUS[0];
+  const h = hashOfQueryInternals(a, fmt, 'foo', [1, {b: 2}]);
+  hashAST(CORPUS[1]);
+  hashNameAndArgs('other', [9]);
+  expect(hashOfQueryInternals(a, fmt, 'foo', [1, {b: 2}])).toBe(h);
+  // Structurally equal but distinct args hash the same.
+  expect(hashOfQueryInternals(a, fmt, 'foo', [1, {b: 2}])).toBe(h);
+});
+
+test('an absent custom query is not confusable with a named one', () => {
+  const a = CORPUS[0];
+  // The absent case mixes its own tag rather than nothing at all, so a query
+  // with no name cannot fold like some query that has one.
+  expect(hashOfQueryInternals(a, fmt, undefined, undefined)).not.toBe(
+    hashOfQueryInternals(a, fmt, '', []),
+  );
 });

--- a/packages/zero-protocol/src/query-hash-visitor.test.ts
+++ b/packages/zero-protocol/src/query-hash-visitor.test.ts
@@ -547,7 +547,7 @@ test('hashOfQueryInternals separates queries that differ only by name or args', 
   ];
   for (const [name, args] of cases) {
     const key = `${name} ${JSON.stringify(args)}`;
-    const h = hashOfQueryInternals(a, fmt, name, args);
+    const h = hashOfQueryInternals(a, fmt, 'client', name, args);
     const existing = seen.get(h);
     expect(
       existing,
@@ -560,7 +560,7 @@ test('hashOfQueryInternals separates queries that differ only by name or args', 
 test('hashOfQueryInternals still separates every AST in the corpus', () => {
   const byHash = new Map<string, number>();
   CORPUS.forEach((a, i) => {
-    const h = hashOfQueryInternals(a, fmt, 'q', [1]);
+    const h = hashOfQueryInternals(a, fmt, 'client', 'q', [1]);
     expect(byHash.get(h), `collision at corpus ${i}`).toBeUndefined();
     byHash.set(h, i);
   });
@@ -568,19 +568,36 @@ test('hashOfQueryInternals still separates every AST in the corpus', () => {
 
 test('hashOfQueryInternals depends only on the values, not call order', () => {
   const a = CORPUS[0];
-  const h = hashOfQueryInternals(a, fmt, 'foo', [1, {b: 2}]);
+  const h = hashOfQueryInternals(a, fmt, 'client', 'foo', [1, {b: 2}]);
   hashAST(CORPUS[1]);
   hashNameAndArgs('other', [9]);
-  expect(hashOfQueryInternals(a, fmt, 'foo', [1, {b: 2}])).toBe(h);
+  expect(hashOfQueryInternals(a, fmt, 'client', 'foo', [1, {b: 2}])).toBe(h);
   // Structurally equal but distinct args hash the same.
-  expect(hashOfQueryInternals(a, fmt, 'foo', [1, {b: 2}])).toBe(h);
+  expect(hashOfQueryInternals(a, fmt, 'client', 'foo', [1, {b: 2}])).toBe(h);
 });
 
 test('an absent custom query is not confusable with a named one', () => {
   const a = CORPUS[0];
   // The absent case mixes its own tag rather than nothing at all, so a query
   // with no name cannot fold like some query that has one.
-  expect(hashOfQueryInternals(a, fmt, undefined, undefined)).not.toBe(
-    hashOfQueryInternals(a, fmt, '', []),
+  expect(hashOfQueryInternals(a, fmt, 'client', undefined, undefined)).not.toBe(
+    hashOfQueryInternals(a, fmt, 'client', '', []),
   );
+});
+
+test('hashOfQueryInternals separates queries that differ only by system', () => {
+  // A query with no relationship and no `exists` has nowhere to stamp its
+  // system, so the AST is identical whether it was built for the client or for
+  // permissions. This is the only place system is not already covered.
+  const a = CORPUS[0];
+  const client = hashOfQueryInternals(a, fmt, 'client', undefined, undefined);
+  const perms = hashOfQueryInternals(
+    a,
+    fmt,
+    'permissions',
+    undefined,
+    undefined,
+  );
+  const test_ = hashOfQueryInternals(a, fmt, 'test', undefined, undefined);
+  expect(new Set([client, perms, test_]).size).toBe(3);
 });

--- a/packages/zero-protocol/src/query-hash-visitor.ts
+++ b/packages/zero-protocol/src/query-hash-visitor.ts
@@ -407,7 +407,25 @@ export function hashNameAndArgs(
   }
 }
 
-export function hashOfQueryInternals(ast: AST, format: Format): string {
+/**
+ * The identity of a query as the client sees it: its AST, the shape it returns,
+ * and -- for a custom query -- the name and arguments it was declared with.
+ *
+ * The name and args have to be in here because they are the one part of a
+ * query's identity that leaves no trace in its AST: `nameAndArgs` reuses the
+ * AST it is given and only attaches a `CustomQueryID`, so without this two
+ * different named queries over the same table would be indistinguishable.
+ *
+ * They are taken apart rather than as a `CustomQueryID` because that type lives
+ * in `zql`, which is above this package; `hashNameAndArgs` splits them the same
+ * way.
+ */
+export function hashOfQueryInternals(
+  ast: AST,
+  format: Format,
+  customQueryName: string | undefined,
+  customQueryArgs: readonly unknown[] | undefined,
+): string {
   const s1 = h1;
   const s2 = h2;
   try {
@@ -415,6 +433,13 @@ export function hashOfQueryInternals(ast: AST, format: Format): string {
     visitAST(ast);
     mix(TAG_FORMAT);
     visitValue(format);
+    if (customQueryName === undefined) {
+      mix(TAG_UNDEF);
+    } else {
+      mix(TAG_NAME_ARGS);
+      mixString(customQueryName);
+      visitValue(customQueryArgs);
+    }
     return finalize();
   } finally {
     h1 = s1;

--- a/packages/zero-protocol/src/query-hash-visitor.ts
+++ b/packages/zero-protocol/src/query-hash-visitor.ts
@@ -61,6 +61,7 @@ import type {
   Condition,
   CorrelatedSubquery,
   Ordering,
+  System,
   ValuePosition,
 } from './ast.ts';
 
@@ -142,6 +143,12 @@ const TAG_AND = 0x2006;
 const TAG_OR = 0x2007;
 const TAG_FORMAT = 0x2008;
 const TAG_NAME_ARGS = 0x2009;
+// `System` is a closed set of three, so it folds as one word rather than as a
+// string. The switch below is exhaustive, so adding a member is a type error
+// rather than a silent collision with an existing one.
+const TAG_SYSTEM_PERMISSIONS = 0x200a;
+const TAG_SYSTEM_CLIENT = 0x200b;
+const TAG_SYSTEM_TEST = 0x200c;
 
 // Set on a string's length word. High enough that no array length reaches it.
 const STR_MARK = 0x40000000;
@@ -233,6 +240,22 @@ function visitOptionalString(s: string | undefined): void {
     mix(TAG_UNDEF);
   } else {
     mixString(s);
+  }
+}
+
+function mixSystem(system: System): void {
+  switch (system) {
+    case 'permissions':
+      mix(TAG_SYSTEM_PERMISSIONS);
+      break;
+    case 'client':
+      mix(TAG_SYSTEM_CLIENT);
+      break;
+    case 'test':
+      mix(TAG_SYSTEM_TEST);
+      break;
+    default:
+      unreachable(system);
   }
 }
 
@@ -409,20 +432,29 @@ export function hashNameAndArgs(
 
 /**
  * The identity of a query as the client sees it: its AST, the shape it returns,
- * and -- for a custom query -- the name and arguments it was declared with.
+ * the system it was built for, and -- for a custom query -- the name and
+ * arguments it was declared with.
  *
- * The name and args have to be in here because they are the one part of a
- * query's identity that leaves no trace in its AST: `nameAndArgs` reuses the
- * AST it is given and only attaches a `CustomQueryID`, so without this two
- * different named queries over the same table would be indistinguishable.
+ * Everything past the AST is here because it is part of what makes two queries
+ * different while leaving no trace, or an incomplete one, in the AST itself:
  *
- * They are taken apart rather than as a `CustomQueryID` because that type lives
- * in `zql`, which is above this package; `hashNameAndArgs` splits them the same
- * way.
+ * - **name and args**: `nameAndArgs` reuses the AST it is given and only
+ *   attaches a `CustomQueryID`, so without these two different named queries
+ *   over the same table would be indistinguishable.
+ * - **system**: a query stamps it onto every `related` entry and every `exists`
+ *   correlation it builds, so it is already hashed via
+ *   {@link visitCorrelatedSubquery} -- but a query with neither has nowhere to
+ *   put it, and would otherwise hash the same whether it was built for the
+ *   client or for permissions.
+ *
+ * The name and args are taken apart rather than as a `CustomQueryID` because
+ * that type lives in `zql`, which is above this package; `hashNameAndArgs`
+ * splits them the same way.
  */
 export function hashOfQueryInternals(
   ast: AST,
   format: Format,
+  system: System,
   customQueryName: string | undefined,
   customQueryArgs: readonly unknown[] | undefined,
 ): string {
@@ -433,6 +465,7 @@ export function hashOfQueryInternals(
     visitAST(ast);
     mix(TAG_FORMAT);
     visitValue(format);
+    mixSystem(system);
     if (customQueryName === undefined) {
       mix(TAG_UNDEF);
     } else {

--- a/packages/zql/src/query/query-impl.test.ts
+++ b/packages/zql/src/query/query-impl.test.ts
@@ -1,5 +1,6 @@
 import {describe, expect, test} from 'vitest';
 import {newQuery} from './query-impl.ts';
+import {asQueryInternals} from './query-internals.ts';
 import {schema} from './test/test-schemas.ts';
 
 describe('QueryImpl run/preload/materialize', () => {
@@ -48,5 +49,36 @@ describe('QueryImpl run/preload/materialize', () => {
   test('one() on non-runnable query still throws on run()', () => {
     const issueQuery = newQuery(schema, 'issue').one();
     expect(() => issueQuery.run()).toThrow('Query is not runnable');
+  });
+});
+
+describe('QueryImpl.hash covers custom query identity', () => {
+  const base = newQuery(schema, 'issue').where('closed', false);
+  const bi = asQueryInternals(base);
+
+  test('a named query differs from its unnamed base', () => {
+    // `nameAndArgs` leaves the AST untouched, so the hash has to pick the name
+    // and args up from somewhere else or these two are indistinguishable.
+    expect(asQueryInternals(bi.nameAndArgs('foo', [1])).hash()).not.toBe(
+      bi.hash(),
+    );
+  });
+
+  test('different names differ', () => {
+    expect(asQueryInternals(bi.nameAndArgs('foo', [1])).hash()).not.toBe(
+      asQueryInternals(bi.nameAndArgs('bar', [1])).hash(),
+    );
+  });
+
+  test('different args differ', () => {
+    expect(asQueryInternals(bi.nameAndArgs('foo', [1])).hash()).not.toBe(
+      asQueryInternals(bi.nameAndArgs('foo', [2])).hash(),
+    );
+  });
+
+  test('the same name and args agree', () => {
+    expect(asQueryInternals(bi.nameAndArgs('foo', [1])).hash()).toBe(
+      asQueryInternals(bi.nameAndArgs('foo', [1])).hash(),
+    );
   });
 });

--- a/packages/zql/src/query/query-impl.test.ts
+++ b/packages/zql/src/query/query-impl.test.ts
@@ -1,6 +1,7 @@
 import {describe, expect, test} from 'vitest';
 import {newQuery} from './query-impl.ts';
 import {asQueryInternals} from './query-internals.ts';
+import {newStaticQuery} from './static-query.ts';
 import {schema} from './test/test-schemas.ts';
 
 describe('QueryImpl run/preload/materialize', () => {
@@ -79,6 +80,22 @@ describe('QueryImpl.hash covers custom query identity', () => {
   test('the same name and args agree', () => {
     expect(asQueryInternals(bi.nameAndArgs('foo', [1])).hash()).toBe(
       asQueryInternals(bi.nameAndArgs('foo', [1])).hash(),
+    );
+  });
+});
+
+describe('QueryImpl.hash covers the system', () => {
+  test('a client query differs from a permissions query over the same table', () => {
+    // With no relationship and no `exists`, there is nowhere in the AST for the
+    // system to be stamped, so the hash has to carry it.
+    expect(asQueryInternals(newQuery(schema, 'issue')).hash()).not.toBe(
+      asQueryInternals(newStaticQuery(schema, 'issue')).hash(),
+    );
+  });
+
+  test('the same system agrees', () => {
+    expect(asQueryInternals(newQuery(schema, 'issue')).hash()).toBe(
+      asQueryInternals(newQuery(schema, 'issue')).hash(),
     );
   });
 });

--- a/packages/zql/src/query/query-impl.ts
+++ b/packages/zql/src/query/query-impl.ts
@@ -209,7 +209,12 @@ export class QueryImpl<
 
   hash(): string {
     if (!this.#hash) {
-      this.#hash = hashOfQueryInternals(this.#ast, this.format);
+      this.#hash = hashOfQueryInternals(
+        this.#ast,
+        this.format,
+        this.customQueryID?.name,
+        this.customQueryID?.args,
+      );
     }
     return this.#hash;
   }

--- a/packages/zql/src/query/query-impl.ts
+++ b/packages/zql/src/query/query-impl.ts
@@ -212,6 +212,7 @@ export class QueryImpl<
       this.#hash = hashOfQueryInternals(
         this.#ast,
         this.format,
+        this.#system,
         this.customQueryID?.name,
         this.customQueryID?.args,
       );

--- a/packages/zql/src/query/query-internals.ts
+++ b/packages/zql/src/query/query-internals.ts
@@ -36,11 +36,13 @@ export interface QueryInternals<
    * if two queries are the same, i.e. whether they would produce the same
    * result from the same data.
    *
-   * It covers the AST, the {@linkcode format} the results take, and, for a
-   * custom query, the name and arguments it was declared with. That last part
-   * has to be hashed explicitly because {@linkcode nameAndArgs} reuses the AST
-   * it is given -- two custom queries over the same table would otherwise share
-   * a hash, and anything keyed by it (a view, for one) would conflate them.
+   * It covers the AST, the {@linkcode format} the results take, the system the
+   * query was built for, and, for a custom query, the name and arguments it was
+   * declared with. The last two are hashed explicitly because they leave no
+   * trace in the AST -- {@linkcode nameAndArgs} reuses the AST it is given, and
+   * a query with no relationship and no `exists` has nowhere to stamp its
+   * system. Without them, two such queries would share a hash and anything
+   * keyed by it (a view, for one) would conflate them.
    *
    * This is not the ID the server knows a custom query by; that one is the hash
    * of just its name and args, so that client queries with divergent ASTs can

--- a/packages/zql/src/query/query-internals.ts
+++ b/packages/zql/src/query/query-internals.ts
@@ -35,6 +35,16 @@ export interface QueryInternals<
    * A string that uniquely identifies this query. This can be used to determine
    * if two queries are the same, i.e. whether they would produce the same
    * result from the same data.
+   *
+   * It covers the AST, the {@linkcode format} the results take, and, for a
+   * custom query, the name and arguments it was declared with. That last part
+   * has to be hashed explicitly because {@linkcode nameAndArgs} reuses the AST
+   * it is given -- two custom queries over the same table would otherwise share
+   * a hash, and anything keyed by it (a view, for one) would conflate them.
+   *
+   * This is not the ID the server knows a custom query by; that one is the hash
+   * of just its name and args, so that client queries with divergent ASTs can
+   * pin to the same backend query.
    */
   hash(): string;
 


### PR DESCRIPTION
`hashOfQueryInternals` covered a query's AST and the format its results take, but not the two other things that make two queries different while leaving **no trace in the AST**: a custom query's name and args, and the system the query was built for.

## The bug

Three queries that hashed identically before this change:

| | |
| --- | --- |
| `q` vs `q.nameAndArgs('foo', [1])` | a custom query and its unnamed base |
| `foo([1])` vs `bar([1])` | different names, same AST |
| `foo([1])` vs `foo([2])` | different args, same AST |
| `newQuery` vs `newStaticQuery` | different system, same AST |

`ViewStore` keys on `hash() + clientID`, so two custom queries over the same table shared one view. `materializeImpl` takes the server `queryID` from whichever query created the view — so the other one was subscribed under the wrong name.

## The fix

**Name and args** are mixed in after the format, with an explicit `TAG_UNDEF` for the absent case so a query with no custom ID cannot fold like one that has an empty name. They are passed apart rather than as a `CustomQueryID` because that type lives in `zql`, which is above `zero-protocol`; `hashNameAndArgs` already splits them the same way.

**System** is stamped onto every `related` entry and every `exists` correlation a query builds, so it is already hashed via `visitCorrelatedSubquery`. A query with neither has nowhere to put it — that is the only gap, and it is the one this closes. Since `System` is a closed set of three it folds as one word rather than as a string, and the switch is exhaustive, so adding a member is a type error rather than a silent collision with an existing one (verified by deleting a case and watching `tsc` fail).

## No wire-visible IDs change

`hash()` has exactly three consumers: the `ViewStore` key in zero-react and zero-solid, and `queryHash` in `materializeImpl`. In that last one its value is **discarded** whenever `customQueryID` exists — `queryID` comes from `hashOfNameAndArgs` in that branch either way:

```ts
const queryID = customQueryID
  ? hashOfNameAndArgs(customQueryID.name, customQueryID.args)
  : queryHash;
```

So no query IDs on the wire move, and there is no deploy churn. The only behavioral change is the ViewStore key, which is the thing being fixed.

This is deliberately *not* the ID the server knows a custom query by — that one stays the hash of just name and args, so client queries with divergent ASTs still pin to a single backend query. Noted on `hash()`'s doc comment.

## Tests

- **zero-protocol** (5): name/args separation over a table of name/args pairs; system separation across all three members; the existing AST corpus still fully separated under the new signature; order-independence against interleaved `hashAST`/`hashNameAndArgs` calls; absent-vs-named not confusable.
- **zql** (6): the four name/args cases and both system cases, through `QueryImpl.hash()`.

## Test plan

Full suites, all passing: `zero-protocol` 80, `zql` 1329, `zero-client` 650, `zero-react` 74, `zero-solid` 59, `zero-server` 433, `shared` 762, `zero-schema` 23.

`zero-cache` has 9 failures that are identical with and without this change (no native `zero-sqlite3` build for this runtime); verified by stashing.

`lint`, `format`, `check-types` clean across the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
