### PR TITLE
perf(zero-protocol): fold a correlated subquery's system as a tag, not a string

### DIFF
--- a/packages/zero-protocol/src/query-hash-visitor.test.ts
+++ b/packages/zero-protocol/src/query-hash-visitor.test.ts
@@ -618,9 +618,12 @@ test('hashOfQueryInternals separates queries that differ only by system', () => 
 });
 
 test('every simple operator hashes distinctly', () => {
-  // The operator is looked up in a Record rather than switched on, so a
-  // duplicated tag would be silent -- two operators would hash alike and the
-  // Record's type would still be satisfied. Pin every one apart.
+  // `visitCondition` folds the operator with `mixString`, so what has to hold
+  // is that no two operator strings fold to the same words -- `mixString`
+  // length-prefixes, which is what keeps 'IS' and 'IS NOT' apart. Nothing in
+  // the walk enumerates the operators, so a member added to `SimpleOperator`
+  // would be hashed without anyone touching this file; pinning all fourteen
+  // apart is what would catch a folding change that collapsed any of them.
   const ops = [
     '=',
     '!=',

--- a/packages/zero-protocol/src/query-hash-visitor.test.ts
+++ b/packages/zero-protocol/src/query-hash-visitor.test.ts
@@ -333,6 +333,20 @@ test('hashAST reads every field of the AST', () => {
       ...full,
       related: [{...full.related![0], system: 'permissions'}, full.related![1]],
     },
+    // The remaining member, and the absent case. `System` folds as a tag rather
+    // than as a string, so these are the pairs that would collide if a tag were
+    // ever duplicated or reused.
+    'related system test': {
+      ...full,
+      related: [{...full.related![0], system: 'test'}, full.related![1]],
+    },
+    // Clearing it, which has to come off the *second* entry: normalizeAST sorts
+    // related by alias, so `related[0]` is `assignee`, which has no system to
+    // begin with, and `related[1]` is `creator`, which does.
+    'related system absent': {
+      ...full,
+      related: [full.related![0], {...full.related![1], system: undefined}],
+    },
     'related subquery': {
       ...full,
       related: [

--- a/packages/zero-protocol/src/query-hash-visitor.test.ts
+++ b/packages/zero-protocol/src/query-hash-visitor.test.ts
@@ -615,3 +615,63 @@ test('hashOfQueryInternals separates queries that differ only by system', () => 
   const test_ = hashOfQueryInternals(a, fmt, 'test', undefined, undefined);
   expect(new Set([client, perms, test_]).size).toBe(3);
 });
+
+test('every simple operator hashes distinctly', () => {
+  // The operator is looked up in a Record rather than switched on, so a
+  // duplicated tag would be silent -- two operators would hash alike and the
+  // Record's type would still be satisfied. Pin every one apart.
+  const ops = [
+    '=',
+    '!=',
+    'IS',
+    'IS NOT',
+    '<',
+    '>',
+    '<=',
+    '>=',
+    'LIKE',
+    'NOT LIKE',
+    'ILIKE',
+    'NOT ILIKE',
+    'IN',
+    'NOT IN',
+  ] as const;
+  const byHash = new Map<string, string>();
+  for (const op of ops) {
+    const h = hashAST(
+      where({
+        type: 'simple',
+        op,
+        left: {type: 'column', name: 'title'},
+        right: {type: 'literal', value: 'x'},
+      }),
+    );
+    const existing = byHash.get(h);
+    expect(existing, `${op} collided with ${existing}`).toBeUndefined();
+    byHash.set(h, op);
+  }
+  expect(byHash.size).toBe(ops.length);
+});
+
+test('both exists operators hash distinctly', () => {
+  const related = {
+    correlation: {parentField: ['id'], childField: ['issueId']},
+    subquery: {table: 'comment', alias: 'c'},
+  } as const;
+  const cond = (op: 'EXISTS' | 'NOT EXISTS') =>
+    hashAST(where({type: 'correlatedSubquery', op, related}));
+  expect(cond('EXISTS')).not.toBe(cond('NOT EXISTS'));
+});
+
+test('both parameter anchors hash distinctly', () => {
+  const cond = (anchor: 'authData' | 'preMutationRow') =>
+    hashAST(
+      where({
+        type: 'simple',
+        op: '=',
+        left: {type: 'column', name: 'ownerID'},
+        right: {type: 'static', anchor, field: 'sub'},
+      }),
+    );
+  expect(cond('authData')).not.toBe(cond('preMutationRow'));
+});

--- a/packages/zero-protocol/src/query-hash-visitor.test.ts
+++ b/packages/zero-protocol/src/query-hash-visitor.test.ts
@@ -333,9 +333,10 @@ test('hashAST reads every field of the AST', () => {
       ...full,
       related: [{...full.related![0], system: 'permissions'}, full.related![1]],
     },
-    // The remaining member, and the absent case. `System` folds as a tag rather
-    // than as a string, so these are the pairs that would collide if a tag were
-    // ever duplicated or reused.
+    // The remaining member, and the absent case. Each of these only has to
+    // differ from `full`; that two systems also differ from *each other* is
+    // what the pairwise test below covers, since this loop compares against
+    // `baseHash` alone.
     'related system test': {
       ...full,
       related: [{...full.related![0], system: 'test'}, full.related![1]],
@@ -674,4 +675,33 @@ test('both parameter anchors hash distinctly', () => {
       }),
     );
   expect(cond('authData')).not.toBe(cond('preMutationRow'));
+});
+
+test('every system on a correlated subquery hashes distinctly', () => {
+  // The mutation test above compares each variant against one baseline, so two
+  // systems sharing a tag by accident would satisfy it. Pin all four against
+  // each other.
+  const variants = [undefined, 'client', 'permissions', 'test'] as const;
+  const byHash = new Map<string, string>();
+  for (const system of variants) {
+    const h = hashAST(
+      normalizeAST({
+        table: 'issue',
+        related: [
+          {
+            correlation: {parentField: ['id'], childField: ['issueId']},
+            subquery: {table: 'comment', alias: 'c'},
+            system,
+          },
+        ],
+      }),
+    );
+    const existing = byHash.get(h);
+    expect(
+      existing,
+      `system ${system} collided with ${existing}`,
+    ).toBeUndefined();
+    byHash.set(h, String(system));
+  }
+  expect(byHash.size).toBe(variants.length);
 });

--- a/packages/zero-protocol/src/query-hash-visitor.ts
+++ b/packages/zero-protocol/src/query-hash-visitor.ts
@@ -144,8 +144,9 @@ const TAG_OR = 0x2007;
 const TAG_FORMAT = 0x2008;
 const TAG_NAME_ARGS = 0x2009;
 // `System` is a closed set of three, so it folds as one word rather than as a
-// string. The switch below is exhaustive, so adding a member is a type error
-// rather than a silent collision with an existing one.
+// string -- on an AST it appears once per correlated subquery, so this is on
+// the walk's hot path. The switch below is exhaustive, so adding a member is a
+// type error rather than a silent collision with an existing one.
 const TAG_SYSTEM_PERMISSIONS = 0x200a;
 const TAG_SYSTEM_CLIENT = 0x200b;
 const TAG_SYSTEM_TEST = 0x200c;
@@ -243,6 +244,14 @@ function visitOptionalString(s: string | undefined): void {
   }
 }
 
+function mixOptionalSystem(system: System | undefined): void {
+  if (system === undefined) {
+    mix(TAG_UNDEF);
+  } else {
+    mixSystem(system);
+  }
+}
+
 function mixSystem(system: System): void {
   switch (system) {
     case 'permissions':
@@ -336,7 +345,7 @@ function visitCorrelatedSubquery(csq: CorrelatedSubquery): void {
   visitCompoundKey(csq.correlation.parentField);
   visitCompoundKey(csq.correlation.childField);
   mix(csq.hidden === undefined ? TAG_UNDEF : csq.hidden ? TAG_TRUE : TAG_FALSE);
-  visitOptionalString(csq.system);
+  mixOptionalSystem(csq.system);
   visitAST(csq.subquery);
 }
 


### PR DESCRIPTION
Stacked on #6461 (base is `arv/hash-name-args`), because that one reuses `mixSystem`. **Unlike #6461, this one moves wire-visible query IDs** — see below before merging.

`System` is a closed set of three, and it appears once per correlated subquery, so `visitOptionalString(csq.system)` walked characters for a value that fits in a single word. This folds it as a tag instead.

## The measured win is small

I oversold this when I suggested it. `hashAST`, two runs each:

| | string | tag | |
| --- | --- | --- | --- |
| 6 relationships | 713k ops/s | 748k ops/s | +4.9% |
| 1 relationship | 2,145k ops/s | 2,269k ops/s | +5.8% |

~5%, not a step change. The perf argument alone probably does not carry a query-ID churn event.

## The stronger argument is type-level

`visitOptionalString(csq.system)` accepts any string, so adding a fourth `System` member would hash it without complaint — exactly the silent-collision failure mode `query-hash-visitor.test.ts` exists to guard against. The exhaustive switch makes it a compile error instead:

```
error TS2345: Argument of type '"test"' is not assignable to parameter of type 'never'.
```

Verified by deleting a case and watching `tsc` fail.

## Churn

Query IDs and `transformationHash` values change **for any query that has a relationship or an `exists`** — `QueryImpl` stamps the system onto every one it builds. A query with neither has no system in its AST and is unaffected (absent hashes as `TAG_UNDEF` both before and after).

The same reasoning as #6450 applies: nothing compares a hash against one computed elsewhere, query IDs are opaque to the server, and persisted desired queries reconcile themselves via `getQueriesPatch`. Cost is one re-registration and one re-transformation per query on deploy.

If that is not worth ~5% plus the type guard, this is fine to drop — #6461 stands on its own.

## Test gap this closes

No test broke, which was itself the finding: the mutation test covered `client` → `permissions` but not the third member, nor clearing a system that was set. Both added. The second one needs the *second* related entry — `normalizeAST` sorts by alias, so `related[0]` is `assignee`, which has no system to begin with. That mis-targeting is why my first attempt failed.

## Test plan

`zero-protocol` 80, `zql` 1329, `zero-client` 650, `zero-react` 74, `zero-solid` 59, `zero-server` 433, `shared` 762 — all passing.

`zero-cache` 9 failures, identical with and without the branch (no native `zero-sqlite3` build for this runtime).

`lint`, `format`, `check-types` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
