### PR TITLE
fix: update query hash to include current junction

### DIFF
--- a/packages/zero-protocol/src/query-hash-visitor.test.ts
+++ b/packages/zero-protocol/src/query-hash-visitor.test.ts
@@ -562,7 +562,7 @@ test('hashOfQueryInternals separates queries that differ only by name or args', 
   ];
   for (const [name, args] of cases) {
     const key = `${name} ${JSON.stringify(args)}`;
-    const h = hashOfQueryInternals(a, fmt, 'client', name, args);
+    const h = hashOfQueryInternals(a, fmt, 'client', undefined, name, args);
     const existing = seen.get(h);
     expect(
       existing,
@@ -575,7 +575,7 @@ test('hashOfQueryInternals separates queries that differ only by name or args', 
 test('hashOfQueryInternals still separates every AST in the corpus', () => {
   const byHash = new Map<string, number>();
   CORPUS.forEach((a, i) => {
-    const h = hashOfQueryInternals(a, fmt, 'client', 'q', [1]);
+    const h = hashOfQueryInternals(a, fmt, 'client', undefined, 'q', [1]);
     expect(byHash.get(h), `collision at corpus ${i}`).toBeUndefined();
     byHash.set(h, i);
   });
@@ -583,21 +583,28 @@ test('hashOfQueryInternals still separates every AST in the corpus', () => {
 
 test('hashOfQueryInternals depends only on the values, not call order', () => {
   const a = CORPUS[0];
-  const h = hashOfQueryInternals(a, fmt, 'client', 'foo', [1, {b: 2}]);
+  const h = hashOfQueryInternals(a, fmt, 'client', undefined, 'foo', [
+    1,
+    {b: 2},
+  ]);
   hashAST(CORPUS[1]);
   hashNameAndArgs('other', [9]);
-  expect(hashOfQueryInternals(a, fmt, 'client', 'foo', [1, {b: 2}])).toBe(h);
+  expect(
+    hashOfQueryInternals(a, fmt, 'client', undefined, 'foo', [1, {b: 2}]),
+  ).toBe(h);
   // Structurally equal but distinct args hash the same.
-  expect(hashOfQueryInternals(a, fmt, 'client', 'foo', [1, {b: 2}])).toBe(h);
+  expect(
+    hashOfQueryInternals(a, fmt, 'client', undefined, 'foo', [1, {b: 2}]),
+  ).toBe(h);
 });
 
 test('an absent custom query is not confusable with a named one', () => {
   const a = CORPUS[0];
   // The absent case mixes its own tag rather than nothing at all, so a query
   // with no name cannot fold like some query that has one.
-  expect(hashOfQueryInternals(a, fmt, 'client', undefined, undefined)).not.toBe(
-    hashOfQueryInternals(a, fmt, 'client', '', []),
-  );
+  expect(
+    hashOfQueryInternals(a, fmt, 'client', undefined, undefined, undefined),
+  ).not.toBe(hashOfQueryInternals(a, fmt, 'client', undefined, '', []));
 });
 
 test('hashOfQueryInternals separates queries that differ only by system', () => {
@@ -605,15 +612,30 @@ test('hashOfQueryInternals separates queries that differ only by system', () => 
   // system, so the AST is identical whether it was built for the client or for
   // permissions. This is the only place system is not already covered.
   const a = CORPUS[0];
-  const client = hashOfQueryInternals(a, fmt, 'client', undefined, undefined);
+  const client = hashOfQueryInternals(
+    a,
+    fmt,
+    'client',
+    undefined,
+    undefined,
+    undefined,
+  );
   const perms = hashOfQueryInternals(
     a,
     fmt,
     'permissions',
     undefined,
     undefined,
+    undefined,
   );
-  const test_ = hashOfQueryInternals(a, fmt, 'test', undefined, undefined);
+  const test_ = hashOfQueryInternals(
+    a,
+    fmt,
+    'test',
+    undefined,
+    undefined,
+    undefined,
+  );
   expect(new Set([client, perms, test_]).size).toBe(3);
 });
 
@@ -707,4 +729,17 @@ test('every system on a correlated subquery hashes distinctly', () => {
     byHash.set(h, String(system));
   }
   expect(byHash.size).toBe(variants.length);
+});
+
+test('hashOfQueryInternals separates queries that differ only by currentJunction', () => {
+  // Set on the sub-query handed to a two-hop relationship's callback, where it
+  // makes `limit` and `orderBy` throw. It leaves no trace in the AST, so this is
+  // the only thing telling these apart.
+  const a = CORPUS[0];
+  const seen = new Set(
+    [undefined, 'labels', 'issues'].map(j =>
+      hashOfQueryInternals(a, fmt, 'client', j, undefined, undefined),
+    ),
+  );
+  expect(seen.size).toBe(3);
 });

--- a/packages/zero-protocol/src/query-hash-visitor.ts
+++ b/packages/zero-protocol/src/query-hash-visitor.ts
@@ -150,6 +150,7 @@ const TAG_NAME_ARGS = 0x2009;
 const TAG_SYSTEM_PERMISSIONS = 0x200a;
 const TAG_SYSTEM_CLIENT = 0x200b;
 const TAG_SYSTEM_TEST = 0x200c;
+const TAG_JUNCTION = 0x200d;
 
 // Set on a string's length word. High enough that no array length reaches it.
 const STR_MARK = 0x40000000;
@@ -455,6 +456,10 @@ export function hashNameAndArgs(
  *   {@link visitCorrelatedSubquery} -- but a query with neither has nowhere to
  *   put it, and would otherwise hash the same whether it was built for the
  *   client or for permissions.
+ * - **currentJunction**: builder state, set on the sub-query handed to a
+ *   two-hop relationship's callback, which makes `limit` and `orderBy` throw.
+ *   It leaves no trace in the AST at all, so two queries that differ only in
+ *   whether those methods work would otherwise be indistinguishable.
  *
  * The name and args are taken apart rather than as a `CustomQueryID` because
  * that type lives in `zql`, which is above this package; `hashNameAndArgs`
@@ -464,6 +469,7 @@ export function hashOfQueryInternals(
   ast: AST,
   format: Format,
   system: System,
+  currentJunction: string | undefined,
   customQueryName: string | undefined,
   customQueryArgs: readonly unknown[] | undefined,
 ): string {
@@ -475,6 +481,12 @@ export function hashOfQueryInternals(
     mix(TAG_FORMAT);
     visitValue(format);
     mixSystem(system);
+    if (currentJunction === undefined) {
+      mix(TAG_UNDEF);
+    } else {
+      mix(TAG_JUNCTION);
+      mixString(currentJunction);
+    }
     if (customQueryName === undefined) {
       mix(TAG_UNDEF);
     } else {

--- a/packages/zql/src/query/query-impl.test.ts
+++ b/packages/zql/src/query/query-impl.test.ts
@@ -1,6 +1,7 @@
 import {describe, expect, test} from 'vitest';
-import {newQuery} from './query-impl.ts';
+import {newQuery, newQueryImpl} from './query-impl.ts';
 import {asQueryInternals} from './query-internals.ts';
+import type {AnyQuery} from './query.ts';
 import {newStaticQuery} from './static-query.ts';
 import {schema} from './test/test-schemas.ts';
 
@@ -97,5 +98,70 @@ describe('QueryImpl.hash covers the system', () => {
     expect(asQueryInternals(newQuery(schema, 'issue')).hash()).toBe(
       asQueryInternals(newQuery(schema, 'issue')).hash(),
     );
+  });
+});
+
+describe('QueryImpl.hash covers the junction', () => {
+  // The sub-query handed to a two-hop callback carries the junction, which
+  // decides whether `limit` and `orderBy` throw but leaves no trace in the AST.
+  // Rebuilding a query from that sub-query's own AST and format gives one that
+  // is identical in every way the AST can see, so only the junction is left to
+  // tell them apart.
+  function capture(
+    build: (cb: (q: AnyQuery) => AnyQuery) => unknown,
+  ): AnyQuery {
+    let captured: AnyQuery | undefined;
+    build(q => {
+      captured = q;
+      return q;
+    });
+    expect(captured).toBeDefined();
+    return captured!;
+  }
+
+  function withoutJunction(q: AnyQuery): AnyQuery {
+    const {ast, format} = asQueryInternals(q);
+    return newQueryImpl(
+      schema,
+      ast.table as keyof typeof schema.tables,
+      ast,
+      format,
+      'client',
+    ) as AnyQuery;
+  }
+
+  test('the sub-query of a two-hop related differs from the same query without the junction', () => {
+    const inner = capture(cb =>
+      newQuery(schema, 'issue').related('labels', cb),
+    );
+    expect(() => inner.limit(1)).toThrow('Limit is not supported');
+    expect(asQueryInternals(inner).hash()).not.toBe(
+      asQueryInternals(withoutJunction(inner)).hash(),
+    );
+  });
+
+  test('the sub-query of a two-hop exists differs from the same query without the junction', () => {
+    const inner = capture(cb =>
+      newQuery(schema, 'issue').whereExists('labels', cb),
+    );
+    expect(() => inner.orderBy('id', 'asc')).toThrow(
+      'Order by is not supported',
+    );
+    expect(asQueryInternals(inner).hash()).not.toBe(
+      asQueryInternals(withoutJunction(inner)).hash(),
+    );
+  });
+
+  test('the sub-query of a one-hop related has no junction', () => {
+    const inner = capture(cb => newQuery(schema, 'issue').related('owner', cb));
+    expect(asQueryInternals(inner).hash()).toBe(
+      asQueryInternals(withoutJunction(inner)).hash(),
+    );
+  });
+
+  test('the same junction agrees', () => {
+    const a = capture(cb => newQuery(schema, 'issue').related('labels', cb));
+    const b = capture(cb => newQuery(schema, 'issue').related('labels', cb));
+    expect(asQueryInternals(a).hash()).toBe(asQueryInternals(b).hash());
   });
 });

--- a/packages/zql/src/query/query-impl.ts
+++ b/packages/zql/src/query/query-impl.ts
@@ -213,6 +213,7 @@ export class QueryImpl<
         this.#ast,
         this.format,
         this.#system,
+        this.#currentJunction,
         this.customQueryID?.name,
         this.customQueryID?.args,
       );

--- a/packages/zql/src/query/query-internals.ts
+++ b/packages/zql/src/query/query-internals.ts
@@ -32,21 +32,27 @@ export interface QueryInternals<
   readonly format: Format;
 
   /**
-   * A string that uniquely identifies this query. This can be used to determine
-   * if two queries are the same, i.e. whether they would produce the same
-   * result from the same data.
+   * A string that uniquely identifies this query object: two queries share it
+   * exactly when they are interchangeable, down to how their builder methods
+   * behave.
    *
    * It covers the AST, the {@linkcode format} the results take, the system the
-   * query was built for, and, for a custom query, the name and arguments it was
-   * declared with. The last two are hashed explicitly because they leave no
-   * trace in the AST -- {@linkcode nameAndArgs} reuses the AST it is given, and
-   * a query with no relationship and no `exists` has nowhere to stamp its
-   * system. Without them, two such queries would share a hash and anything
-   * keyed by it (a view, for one) would conflate them.
+   * query was built for, the junction relationship it is being built inside,
+   * and, for a custom query, the name and arguments it was declared with.
+   * Everything past the AST is hashed explicitly because it leaves no trace
+   * there: {@linkcode nameAndArgs} reuses the AST it is given, a query with no
+   * relationship and no `exists` has nowhere to stamp its system, and the
+   * junction flag -- which decides whether `limit` and `orderBy` throw --
+   * appears nowhere in the AST at all. Without them, such queries would share a
+   * hash and anything keyed by it would conflate them.
    *
-   * This is not the ID the server knows a custom query by; that one is the hash
-   * of just its name and args, so that client queries with divergent ASTs can
-   * pin to the same backend query.
+   * It does *not* cover the schema, which has no stable identity to hash.
+   * Anything keyed by this that could see more than one schema has to scope
+   * itself by schema as well.
+   *
+   * This is entirely client-side and never reaches the server. The server knows
+   * a custom query by the hash of its name and args, and any other query by the
+   * hash of its AST alone -- see `materializeImpl`.
    */
   hash(): string;
 


### PR DESCRIPTION
This and #6461, #6462 were exposed because I want q1.equals(q2) to imply q1.hash === q2.hash but historically q.hash has only been the hash of the AST