### PR TITLE
fix(zero-cache): wait for a backup that covers the replica before serving

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/backup-monitor.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/backup-monitor.test.ts
@@ -1,5 +1,8 @@
+import {tmpdir} from 'node:os';
+import path from 'node:path';
 import {beforeEach, describe, expect, test, vi} from 'vitest';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
+import {Database} from '../../../../zqlite/src/db.ts';
 import {Subscription} from '../../types/subscription.ts';
 import {BackupMonitor, type BackedUpWatermark} from './backup-monitor.ts';
 import type {ChangeStreamerService} from './change-streamer.ts';
@@ -87,6 +90,99 @@ describe('change-streamer/backup-monitor', () => {
 
     watermarks.cancel();
     await run;
+  });
+
+  /**
+   * A new backup destination starts empty and fills by re-uploading the local
+   * LTX chain, so the first watermarks read back out of it are real but far
+   * behind the replica. The gate must wait for coverage, or the task serves
+   * against a backup that does not cover it and demotes restoring
+   * view-syncers to Postgres catchup.
+   */
+  describe('coverage gate', () => {
+    function makeReplica(stateVersion: string): string {
+      const file = path.join(
+        tmpdir(),
+        `backup-monitor-coverage-${stateVersion}-${Math.random()
+          .toString(36)
+          .slice(2)}.db`,
+      );
+      const db = new Database(createSilentLogContext(), file);
+      db.exec(/*sql*/ `
+        CREATE TABLE "_zero.replicationState" (
+          stateVersion TEXT NOT NULL,
+          writeTimeMs INTEGER NOT NULL,
+          lock INTEGER PRIMARY KEY DEFAULT 1 CHECK (lock=1)
+        );
+      `);
+      db.prepare(
+        /*sql*/ `INSERT INTO "_zero.replicationState" (stateVersion, writeTimeMs) VALUES (?, ?)`,
+      ).run(stateVersion, 1000);
+      db.close();
+      return file;
+    }
+
+    function monitorFor(replicaFile: string) {
+      return new BackupMonitor(
+        createSilentLogContext(),
+        watermarks,
+        changeStreamer,
+        replicaFile,
+      );
+    }
+
+    test('does not resolve on a watermark behind the replica', async () => {
+      const monitor = monitorFor(makeReplica('05'));
+      const run = monitor.run();
+      let resolved = false;
+      void monitor.firstBackupReceived().then(() => (resolved = true));
+
+      // Mid-backfill readings: real watermarks, but behind the replica.
+      watermarks.push(backedUp('01'));
+      watermarks.push(backedUp('03'));
+      await vi.waitFor(() =>
+        expect(trackBackupWatermark).toHaveBeenCalledTimes(2),
+      );
+
+      // Tracked for the purge floor, but the gate is still closed.
+      expect(trackBackupWatermark.mock.calls).toEqual([['01'], ['03']]);
+      expect(resolved).toBe(false);
+
+      watermarks.push(backedUp('05'));
+      await monitor.firstBackupReceived();
+      expect(resolved).toBe(true);
+
+      watermarks.cancel();
+      await run;
+    });
+
+    test('resolves on a watermark past the replica', async () => {
+      const monitor = monitorFor(makeReplica('05'));
+      const run = monitor.run();
+
+      watermarks.push(backedUp('09'));
+      await monitor.firstBackupReceived();
+
+      watermarks.cancel();
+      await run;
+    });
+
+    test('stays resolved once covered, even if later watermarks are tracked', async () => {
+      const monitor = monitorFor(makeReplica('05'));
+      const run = monitor.run();
+
+      watermarks.push(backedUp('05'));
+      await monitor.firstBackupReceived();
+
+      watermarks.push(backedUp('06'));
+      await vi.waitFor(() =>
+        expect(trackBackupWatermark).toHaveBeenCalledTimes(2),
+      );
+      await monitor.firstBackupReceived();
+
+      watermarks.cancel();
+      await run;
+    });
   });
 
   test('stop() cancels the watermark source and run() completes', async () => {

--- a/packages/zero-cache/src/services/change-streamer/backup-monitor.ts
+++ b/packages/zero-cache/src/services/change-streamer/backup-monitor.ts
@@ -22,6 +22,14 @@ export class BackupMonitor implements SingletonService {
   readonly #firstBackupReceived = resolver();
 
   #latestBackup: BackedUpWatermark | undefined;
+  #firstBackupResolved = false;
+  /**
+   * The replica's `stateVersion` when the monitor started, i.e. the point the
+   * backup has to reach before it covers what this task is about to serve.
+   * `undefined` when the replica could not be read, which degrades the gate to
+   * "any watermark" rather than hanging startup forever.
+   */
+  #coverageTarget: string | undefined;
 
   constructor(
     lc: LogContext,
@@ -42,22 +50,76 @@ export class BackupMonitor implements SingletonService {
   async run() {
     this.#lc.info?.('starting backup monitor');
     this.#initBackupLagMetric();
+    this.#coverageTarget = this.#readReplicaStateVersion();
 
     for await (const backedUp of this.#watermarks) {
-      if (!this.#latestBackup) {
-        this.#firstBackupReceived.resolve();
-      } else if (backedUp.watermark < this.#latestBackup.watermark) {
-        this.#lc.warn?.(`ignoring earlier backup watermark`, {backedUp});
-        continue;
-      } else if (backedUp.watermark === this.#latestBackup.watermark) {
-        this.#lc.debug?.(`ignoring redundant backup watermark`, {backedUp});
-        continue;
+      if (this.#latestBackup) {
+        if (backedUp.watermark < this.#latestBackup.watermark) {
+          this.#lc.warn?.(`ignoring earlier backup watermark`, {backedUp});
+          continue;
+        }
+        if (backedUp.watermark === this.#latestBackup.watermark) {
+          this.#lc.debug?.(`ignoring redundant backup watermark`, {backedUp});
+          continue;
+        }
       }
       this.#lc.info?.(`received backup watermark`, {backedUp});
       this.#latestBackup = backedUp;
       this.#changeStreamer.trackBackupWatermark(backedUp.watermark);
+      this.#checkFirstBackupCovers(backedUp);
     }
     this.#lc.info?.('watermark stream closed. BackupMonitor stopped.');
+  }
+
+  /**
+   * Resolves {@link firstBackupReceived} once the backup actually covers the
+   * replica, rather than on the first watermark of any value.
+   *
+   * A new backup destination starts empty and is filled by re-uploading the
+   * local LTX chain, so the first watermarks read back out of it are real but
+   * far behind the replica. Releasing the readiness gate on one of those lets
+   * the task serve against a backup that does not yet cover it, which is what
+   * demotes a restoring view-syncer to Postgres catchup.
+   *
+   * The target is pinned at startup rather than compared against the replica's
+   * current position, which keeps the gate satisfiable under sustained writes.
+   */
+  #checkFirstBackupCovers(backedUp: BackedUpWatermark) {
+    if (this.#firstBackupResolved) {
+      return;
+    }
+    const target = this.#coverageTarget;
+    if (target !== undefined && backedUp.watermark < target) {
+      this.#lc.info?.(`backup does not yet cover the replica`, {
+        backedUp,
+        coverageTarget: target,
+      });
+      return;
+    }
+    this.#firstBackupResolved = true;
+    this.#firstBackupReceived.resolve();
+  }
+
+  #readReplicaStateVersion(): string | undefined {
+    let db;
+    try {
+      db = new Database(this.#lc, this.#replicaFile, {readonly: true});
+      const {stateVersion} = db
+        .prepare(/*sql*/ `SELECT stateVersion FROM "_zero.replicationState"`)
+        .get<{stateVersion: string}>();
+      return stateVersion;
+    } catch (e) {
+      // Without a target the gate degrades to its previous behavior. That is
+      // strictly better than blocking startup on a replica we cannot read.
+      this.#lc.warn?.(
+        `unable to read the replica's stateVersion; ` +
+          `the initial backup gate will accept the first watermark`,
+        e,
+      );
+      return undefined;
+    } finally {
+      db?.close();
+    }
   }
 
   stop(): Promise<void> {


### PR DESCRIPTION

tldr: if the process restarts and Litestream still has local LTX files, Litestream will upload those to S3. During that time, our `firstBackupReceived` watermark is stale / way behind our replica file.


---


`waitForBackupBeforeServing` gates change-streamer readiness on `backupMonitor.firstBackupReceived()`, but that resolved on the first watermark of any value. The monotonicity guard that follows it only applies *after* the first, so the very first reading was accepted unconditionally.

That reading is routinely stale. Under litestream v5 every non-initial-sync startup mints a fresh backup path (`String(Date.now())`), and litestream fills the new destination by re-uploading its local LTX chain one file per transaction. While that backfill runs, the watermark read back out of the new generation is real but far behind the replica -- observed walking 584zahk -> 5c2nu4w -> 5e26ijs over ~2s. Releasing the gate on the first of those lets the task serve against a backup that does not cover it, which demotes a restoring view-syncer to Postgres catchup.

Pin the replica's `stateVersion` at startup and hold the gate until a watermark reaches it.