### PR TITLE
feat(zero-cache): support partial indices that use `in`

### DIFF
--- a/packages/zero-cache/src/services/change-source/pg/schema/index-predicate.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/index-predicate.test.ts
@@ -137,14 +137,41 @@ describe('PostgreSQL partial-index predicate translation', () => {
   });
 
   test.each([
+    `status IN ('in_progress', 'want_to_read')`,
+    `status = ANY (ARRAY['in_progress'::character varying, ` +
+      `'want_to_read'::character varying]::character varying[])`,
+  ])('translates a literal list: %s', sql => {
+    expect(translatePostgresIndexPredicate(sql, supportedTable)).toEqual({
+      supported: true,
+      predicate: {
+        type: 'or',
+        conditions: [
+          {
+            type: 'comparison',
+            column: 'status',
+            op: '=',
+            value: {type: 'string', value: 'in_progress'},
+          },
+          {
+            type: 'comparison',
+            column: 'status',
+            op: '=',
+            value: {type: 'string', value: 'want_to_read'},
+          },
+        ],
+      },
+    });
+  });
+
+  test.each([
     [`missing = 1`, 'unpublished-column'],
     [`lower(status) = 'open'`, 'unsupported-function'],
     [`coalesce(status, 'open') = 'x'`, 'unsupported-function'],
-    [`attempts IN (1, 2)`, 'unsupported-operator'],
     [`attempts = large`, 'unsupported-syntax'],
     [`attempts::int2 = 1`, 'unsupported-cast'],
     [`status < 'open'`, 'unsupported-operator'],
     [`status COLLATE "C" = 'open'`, 'non-deterministic-collation'],
+    [`status ~ '^open'`, 'unsupported-operator'],
   ] as const)('rejects %s as %s', (sql, reason) => {
     expect(translatePostgresIndexPredicate(sql, supportedTable)).toEqual({
       supported: false,

--- a/packages/zero-cache/src/services/change-source/pg/schema/index-predicate.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/index-predicate.ts
@@ -10,6 +10,7 @@ const UUID_RE =
 const INTEGER_RE = /^[+-]?\d+$/;
 const WHITESPACE_RE = /\s/;
 const OPERATOR_TOKEN_RE = /^(?:::|<>|!=|<=|>=|=|<|>)/;
+const UNSUPPORTED_OPERATOR_TOKEN_RE = /^(?:!~\*|!~|~\*|~)/;
 const INTEGER_TOKEN_RE = /^[+-]?\d+/;
 const WORD_TOKEN_RE = /^[A-Za-z_][A-Za-z0-9_$]*/;
 const SIMPLE_ESCAPES: Readonly<Record<string, string>> = {
@@ -82,6 +83,9 @@ type Token =
       readonly type:
         | '('
         | ')'
+        | '['
+        | ']'
+        | ','
         | '.'
         | '::'
         | '='
@@ -94,6 +98,7 @@ type Token =
         | 'AND'
         | 'OR'
         | 'NOT'
+        | 'IN'
         | 'IS'
         | 'EOF';
     }
@@ -173,9 +178,18 @@ class Parser {
       }
       return {type: 'null-test', expression: left, not};
     }
+    if (this.#take('IN')) {
+      this.expect('(');
+      const values = this.#parseOperandList(')');
+      this.expect(')');
+      return comparisons(left, values);
+    }
     const op = this.#tokens[this.#position]?.type;
     if (isComparison(op)) {
       this.#position++;
+      if (op === '=' && this.#takeIdentifier('ANY')) {
+        return comparisons(left, this.#parseLiteralArray());
+      }
       return {
         type: 'comparison',
         left,
@@ -188,12 +202,41 @@ class Parser {
       throw new UnsupportedPredicateError('non-deterministic-collation');
     }
     if (
+      next?.type === 'unsupported' &&
+      UNSUPPORTED_OPERATOR_TOKEN_RE.test(next.value)
+    ) {
+      throw new UnsupportedPredicateError('unsupported-operator');
+    }
+    if (
       next?.type === 'identifier' &&
       unsupportedOperatorWords.has(next.value.toUpperCase())
     ) {
       throw new UnsupportedPredicateError('unsupported-operator');
     }
     return left;
+  }
+
+  #parseLiteralArray(): readonly Expr[] {
+    this.expect('(');
+    this.#expectIdentifier('ARRAY');
+    this.expect('[');
+    const values = this.#parseOperandList(']');
+    this.expect(']');
+    if (this.#take('::')) {
+      this.#parseCastName();
+      this.expect('[');
+      this.expect(']');
+    }
+    this.expect(')');
+    return values;
+  }
+
+  #parseOperandList(end: ')' | ']'): readonly Expr[] {
+    const values: Expr[] = [];
+    if (this.#tokens[this.#position]?.type === end) return values;
+    values.push(this.#parseOperand());
+    while (this.#take(',')) values.push(this.#parseOperand());
+    return values;
   }
 
   #parseOperand(): Expr {
@@ -240,6 +283,7 @@ class Parser {
   #parseCastName(): string {
     const first = this.#expectIdentifier();
     const parts = [first];
+    let separator = '.';
     while (this.#take('.')) parts.push(this.#expectIdentifier());
     const next = this.#tokens[this.#position];
     if (
@@ -248,19 +292,35 @@ class Parser {
       next.value.toLowerCase() === 'varying'
     ) {
       parts.push(this.#expectIdentifier());
+      separator = ' ';
     }
     if (this.#tokens[this.#position]?.type === '(') {
       throw new UnsupportedPredicateError('unsupported-cast');
     }
-    return parts.join('.');
+    return parts.join(separator);
   }
 
-  #expectIdentifier(): string {
+  #expectIdentifier(expected?: string): string {
     const token = this.#tokens[this.#position++];
-    if (token?.type !== 'identifier') {
+    if (
+      token?.type !== 'identifier' ||
+      (expected !== undefined && token.value.toUpperCase() !== expected)
+    ) {
       throw new UnsupportedPredicateError('unsupported-cast');
     }
     return token.value;
+  }
+
+  #takeIdentifier(expected: string): boolean {
+    const token = this.#tokens[this.#position];
+    if (
+      token?.type !== 'identifier' ||
+      token.value.toUpperCase() !== expected
+    ) {
+      return false;
+    }
+    this.#position++;
+    return true;
   }
 
   #take(type: Token['type']): boolean {
@@ -278,13 +338,21 @@ class Parser {
 
 const unsupportedOperatorWords = new Set([
   'ALL',
-  'ANY',
   'BETWEEN',
   'ILIKE',
-  'IN',
   'LIKE',
   'SIMILAR',
 ]);
+
+function comparisons(left: Expr, values: readonly Expr[]): Expr {
+  if (values.length === 0) {
+    throw new UnsupportedPredicateError('unsupported-syntax');
+  }
+  const expressions = values.map(
+    right => ({type: 'comparison', left, op: '=', right}) as const,
+  );
+  return expressions.length === 1 ? expressions[0] : {type: 'or', expressions};
+}
 
 function normalize(
   expression: Expr,
@@ -661,7 +729,22 @@ function tokenize(sql: string): readonly Token[] {
       i += operator.length;
       continue;
     }
-    if (char === '(' || char === ')' || char === '.') {
+    const unsupportedOperator = UNSUPPORTED_OPERATOR_TOKEN_RE.exec(
+      sql.slice(i),
+    )?.[0];
+    if (unsupportedOperator) {
+      tokens.push({type: 'unsupported', value: unsupportedOperator});
+      i += unsupportedOperator.length;
+      continue;
+    }
+    if (
+      char === '(' ||
+      char === ')' ||
+      char === '[' ||
+      char === ']' ||
+      char === ',' ||
+      char === '.'
+    ) {
       tokens.push({type: char});
       i++;
       continue;
@@ -690,6 +773,7 @@ function tokenize(sql: string): readonly Token[] {
         keyword === 'AND' ||
         keyword === 'OR' ||
         keyword === 'NOT' ||
+        keyword === 'IN' ||
         keyword === 'IS'
       ) {
         tokens.push({type: keyword});

--- a/packages/zero-cache/src/services/change-source/pg/schema/published.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/published.pg.test.ts
@@ -2,7 +2,11 @@ import type postgres from 'postgres';
 import {beforeEach, describe, expect} from 'vitest';
 import * as PostgresTypeClass from '../../../../db/postgres-type-class-enum.ts';
 import {test, type PgTest} from '../../../../test/db.ts';
-import {getPublicationInfo, type PublicationInfo} from './published.ts';
+import {
+  getPublicationInfo,
+  getSkippedIndexDiagnostics,
+  type PublicationInfo,
+} from './published.ts';
 
 describe('tables/published', () => {
   let db: postgres.Sql;
@@ -1853,6 +1857,83 @@ describe('tables/published', () => {
         }
       ]"
     `);
+  });
+
+  test('production partial-index predicate shapes', async () => {
+    await db.unsafe(/*sql*/ `
+      CREATE SCHEMA test;
+      CREATE TABLE test.items (
+        id INT PRIMARY KEY,
+        language TEXT,
+        is_primary BOOL,
+        nullable_id INT,
+        status TEXT,
+        end_date TEXT,
+        following BOOL,
+        is_reciprocal_follow BOOL,
+        closed_at TIMESTAMPTZ
+      );
+      CREATE INDEX boolean_false ON test.items (id) WHERE is_primary = false;
+      CREATE INDEX text_equality ON test.items (id) WHERE language = 'en-US';
+      CREATE INDEX boolean_true ON test.items (id) WHERE is_primary = true;
+      CREATE INDEX bare_boolean ON test.items (id) WHERE following;
+      CREATE INDEX null_test ON test.items (id) WHERE nullable_id IS NOT NULL;
+      CREATE INDEX and_predicate ON test.items (id)
+        WHERE following AND is_reciprocal_follow = false;
+      CREATE INDEX is_null ON test.items (id) WHERE closed_at IS NULL;
+      CREATE INDEX literal_list ON test.items (id)
+        WHERE status IN ('in_progress', 'want_to_read');
+      CREATE INDEX regex ON test.items (id)
+        WHERE end_date ~ '^[0-9]{4}-[0-9]{2}-[0-9]{2}$';
+      CREATE PUBLICATION zero_data FOR TABLE test.items;
+    `);
+
+    const published = await getPublicationInfo(db, ['zero_data']);
+    const partialIndexes = published.indexes.filter(
+      index => index.name !== 'items_pkey',
+    );
+    expect(partialIndexes.map(index => index.name).sort()).toEqual([
+      'and_predicate',
+      'bare_boolean',
+      'boolean_false',
+      'boolean_true',
+      'is_null',
+      'literal_list',
+      'null_test',
+      'text_equality',
+    ]);
+    expect(partialIndexes.every(index => index.predicate !== undefined)).toBe(
+      true,
+    );
+    expect(
+      published.indexes.find(index => index.name === 'literal_list'),
+    ).toMatchObject({
+      predicate: {
+        type: 'or',
+        conditions: [
+          {
+            type: 'comparison',
+            column: 'status',
+            op: '=',
+            value: {type: 'string', value: 'in_progress'},
+          },
+          {
+            type: 'comparison',
+            column: 'status',
+            op: '=',
+            value: {type: 'string', value: 'want_to_read'},
+          },
+        ],
+      },
+    });
+    expect(getSkippedIndexDiagnostics(published)).toEqual([
+      {
+        schema: 'test',
+        index: 'regex',
+        predicate: "(end_date ~ '^[0-9]{4}-[0-9]{2}-[0-9]{2}$'::text)",
+        reason: 'unsupported-operator',
+      },
+    ]);
   });
 
   test('includes generated columns for pg 18+', async ({skip}) => {


### PR DESCRIPTION
Margins has a few partial indices that use `in`

e.g.,

```
 idx_unique_active_readthrough   readthroughs(user_id, work_id)                                     status IN ('in_progress', 'want_to_read')
   
```