### PR TITLE
feat(zero-cache): gate `ensureShardSchema` on `ZERO_UPSTREAM_PG_PARTIAL_INDEX_TRIGGERS=true`

### DIFF
--- a/packages/zero-cache/src/config/zero-config.test.ts
+++ b/packages/zero-cache/src/config/zero-config.test.ts
@@ -912,21 +912,21 @@ test('ZERO_ALLOW_LEGACY_QUERIES enables legacy queries', () => {
   expect(config.allowLegacyQueries).toBe(true);
 });
 
-test('partial-index trigger migration defaults on and can be disabled', () => {
+test('partial-index trigger migration defaults off and can be enabled', () => {
   const defaults = parseOptionsAdvanced(zeroOptions, {
     envNamePrefix: 'ZERO_',
     allowUnknown: false,
     allowPartial: true,
   });
-  expect(defaults.config.upstream.pgPartialIndexTriggers).toBe(true);
+  expect(defaults.config.upstream.pgPartialIndexTriggers).toBe(false);
 
-  const disabled = parseOptionsAdvanced(zeroOptions, {
+  const enabled = parseOptionsAdvanced(zeroOptions, {
     envNamePrefix: 'ZERO_',
     allowUnknown: false,
     allowPartial: true,
-    env: {ZERO_UPSTREAM_PG_PARTIAL_INDEX_TRIGGERS: 'false'},
+    env: {ZERO_UPSTREAM_PG_PARTIAL_INDEX_TRIGGERS: 'true'},
   });
-  expect(disabled.config.upstream.pgPartialIndexTriggers).toBe(false);
+  expect(enabled.config.upstream.pgPartialIndexTriggers).toBe(true);
 });
 
 test('--shard-id disallowed', () => {

--- a/packages/zero-cache/src/config/zero-config.test.ts
+++ b/packages/zero-cache/src/config/zero-config.test.ts
@@ -912,6 +912,23 @@ test('ZERO_ALLOW_LEGACY_QUERIES enables legacy queries', () => {
   expect(config.allowLegacyQueries).toBe(true);
 });
 
+test('partial-index trigger migration defaults on and can be disabled', () => {
+  const defaults = parseOptionsAdvanced(zeroOptions, {
+    envNamePrefix: 'ZERO_',
+    allowUnknown: false,
+    allowPartial: true,
+  });
+  expect(defaults.config.upstream.pgPartialIndexTriggers).toBe(true);
+
+  const disabled = parseOptionsAdvanced(zeroOptions, {
+    envNamePrefix: 'ZERO_',
+    allowUnknown: false,
+    allowPartial: true,
+    env: {ZERO_UPSTREAM_PG_PARTIAL_INDEX_TRIGGERS: 'false'},
+  });
+  expect(disabled.config.upstream.pgPartialIndexTriggers).toBe(false);
+});
+
 test('--shard-id disallowed', () => {
   const logger = {info: vi.fn()};
   expect(() =>

--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -394,6 +394,14 @@ export const zeroOptions = {
       ],
     },
 
+    // Temporary rollout gate. Disable this for the compatibility deployment,
+    // then enable it after all replication managers can consume partial-index
+    // schema snapshots.
+    pgPartialIndexTriggers: {
+      type: v.boolean().default(true),
+      hidden: true,
+    },
+
     pgStreamInboundTimeoutMs: {
       type: v.number().optional(),
       desc: [

--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -394,11 +394,11 @@ export const zeroOptions = {
       ],
     },
 
-    // Temporary rollout gate. Disable this for the compatibility deployment,
-    // then enable it after all replication managers can consume partial-index
-    // schema snapshots.
+    // Temporary rollout gate. This defaults off for the compatibility
+    // deployment; enable it after all replication managers can consume
+    // partial-index schema snapshots.
     pgPartialIndexTriggers: {
-      type: v.boolean().default(true),
+      type: v.boolean().default(false),
       hidden: true,
     },
 

--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -180,6 +180,7 @@ export default async function runWorker(
               {
                 ...initialSync,
                 replicationSlotFailover: upstream.pgReplicationSlotFailover,
+                installPartialIndexTriggers: upstream.pgPartialIndexTriggers,
               },
               context,
               replicationLag.reportIntervalMs,

--- a/packages/zero-cache/src/services/change-source/pg/change-source.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.ts
@@ -148,7 +148,12 @@ export async function initializePostgresChangeSource(
 ): Promise<InitializeResult> {
   const db = await connectPgClient(lc, upstreamURI, 'change-source-init');
   try {
-    await ensureShardSchema(lc, db, shard);
+    await ensureShardSchema(
+      lc,
+      db,
+      shard,
+      syncOptions.installPartialIndexTriggers,
+    );
 
     const restoredReplica = await selectAndRestoreReplica(
       lc,

--- a/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
+++ b/packages/zero-cache/src/services/change-source/pg/initial-sync.ts
@@ -73,6 +73,7 @@ export type InitialSyncOptions = {
   profileCopy?: boolean | undefined;
   textCopy?: boolean | undefined;
   replicationSlotFailover?: boolean | undefined;
+  installPartialIndexTriggers?: boolean | undefined;
   /**
    * When set, run initial sync in "shadow" mode for verification: skip all
    * upstream mutations (no replication slot, no addReplica, no dropShard, no
@@ -123,6 +124,7 @@ export async function initialSync(
     profileCopy,
     textCopy = false,
     replicationSlotFailover = false,
+    installPartialIndexTriggers = true,
     shadow,
   } = syncOptions;
   const syncMode: InitialSyncMode = shadow ? 'shadow' : 'initial';
@@ -147,7 +149,12 @@ export async function initialSync(
     // happen during a shadow run.
     const {publications} = shadow
       ? await getInternalShardConfig(sql, shard)
-      : await ensurePublishedTables(lc, sql, shard);
+      : await ensurePublishedTables(
+          lc,
+          sql,
+          shard,
+          installPartialIndexTriggers,
+        );
     lc.info?.(`Upstream is setup with publications [${publications}]`);
 
     const {database, host} = sql.options;
@@ -479,6 +486,7 @@ async function ensurePublishedTables(
   lc: LogContext,
   sql: PostgresDB,
   shard: ShardConfig,
+  installPartialIndexTriggers: boolean,
   validate = true,
 ): Promise<{publications: string[]}> {
   const {database, host} = sql.options;
@@ -489,7 +497,7 @@ async function ensurePublishedTables(
   // but harmless. On the contrary, it makes initial sync more
   // self-contained (for test setup), and also plays a role in
   // recovering from corruption (below) after the shard is dropped.
-  await ensureShardSchema(lc, sql, shard);
+  await ensureShardSchema(lc, sql, shard, installPartialIndexTriggers);
   const {publications} = await getInternalShardConfig(sql, shard);
 
   if (validate) {
@@ -517,7 +525,13 @@ async function ensurePublishedTables(
     }
     if (!valid) {
       await sql.unsafe(dropShard(shard.appID, shard.shardNum));
-      return ensurePublishedTables(lc, sql, shard, false);
+      return ensurePublishedTables(
+        lc,
+        sql,
+        shard,
+        installPartialIndexTriggers,
+        false,
+      );
     }
   }
   return {publications};

--- a/packages/zero-cache/src/services/change-source/pg/schema/ddl.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/ddl.ts
@@ -168,7 +168,10 @@ const DDL_SERIALIZATION_LOCK = 0x3c6b8468f1bac0b0n;
  * Instead, we opt for the simplicity and isolation of having each shard
  * completely own (and maintain) the entirety of its trigger/function stack.
  */
-export function createEventFunctionStatements(shard: ShardConfig) {
+export function createEventFunctionStatements(
+  shard: ShardConfig,
+  includePartialIndexes = true,
+) {
   const {appID, shardNum, publications} = shard;
   const schema = id(upstreamSchema(shard)); // e.g. "{APP_ID}_{SHARD_ID}"
   return /*sql*/ `
@@ -202,7 +205,7 @@ CREATE FUNCTION ${schema}.schema_specs()
 RETURNS JSON 
 STABLE
 AS $$
-  ${publishedSchemaQuery(publications)}
+  ${publishedSchemaQuery(publications, includePartialIndexes)}
 $$ LANGUAGE sql;
 
 

--- a/packages/zero-cache/src/services/change-source/pg/schema/init.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/init.pg.test.ts
@@ -211,17 +211,23 @@ describe('change-streamer/pg/schema/init', () => {
       publications: [`${APP_ID}_foo`],
     };
     const schema = id(`${APP_ID}_${SHARD_NUM}`);
-    await ensureShardSchema(lc, upstream, shard);
+    await ensureShardSchema(lc, upstream, shard, false);
 
-    // Simulate a v25 shard: its schema_specs() predates partial index
-    // support, and the stored "publishedSchema" reflects that output.
-    await upstream.unsafe(`
-      CREATE OR REPLACE FUNCTION ${schema}.schema_specs() RETURNS JSON STABLE AS $$
-        SELECT '{"tables":[],"indexes":[]}'::json
-      $$ LANGUAGE sql;
-      UPDATE ${schema}."publishedSchema" SET current = ${schema}.schema_specs();
-      UPDATE ${schema}."versionHistory" SET "schemaVersion" = 25, "dataVersion" = 25;
-    `);
+    const [{specs: v25Specs, current: v25Current}] = (await upstream.unsafe(`
+        SELECT ${schema}.schema_specs() AS specs, current
+          FROM ${schema}."publishedSchema"`)) as unknown as {
+      specs: {indexes: {name: string; tableName: string}[]};
+      current: unknown;
+    }[];
+    expect(
+      v25Specs.indexes.filter(index => index.tableName === 'foo'),
+    ).toMatchObject([{name: 'foo_pkey'}]);
+    expect(v25Current).toEqual(v25Specs);
+    await expectTablesToMatch(upstream, {
+      [`${APP_ID}_${SHARD_NUM}.versionHistory`]: [
+        {...CURRENT_SCHEMA_VERSIONS, dataVersion: 25, schemaVersion: 25},
+      ],
+    });
 
     await ensureShardSchema(lc, upstream, shard);
 

--- a/packages/zero-cache/src/services/change-source/pg/schema/init.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/init.ts
@@ -26,9 +26,11 @@ export async function ensureShardSchema(
   lc: LogContext,
   db: PostgresDB,
   shard: ShardConfig,
+  installPartialIndexTriggers = true,
 ): Promise<void> {
   const initialSetup: Migration = {
-    migrateSchema: (lc, tx) => setupTablesAndReplication(lc, tx, shard),
+    migrateSchema: (lc, tx) =>
+      setupTablesAndReplication(lc, tx, shard, installPartialIndexTriggers),
     minSafeVersion: 1,
   };
   await runSchemaMigrations(
@@ -40,11 +42,14 @@ export async function ensureShardSchema(
     // The incremental migration of any existing replicas will be replaced by
     // the incoming replica being synced, so the replicaVersion here is
     // unnecessary.
-    getIncrementalMigrations(shard),
+    getIncrementalMigrations(shard, installPartialIndexTriggers),
   );
 }
 
-function getIncrementalMigrations(shard: ShardConfig): IncrementalMigrationMap {
+function getIncrementalMigrations(
+  shard: ShardConfig,
+  installPartialIndexTriggers: boolean,
+): IncrementalMigrationMap {
   const shardConfigTable = `${upstreamSchema(shard)}.shardConfig`;
 
   return {
@@ -243,26 +248,33 @@ function getIncrementalMigrations(shard: ShardConfig): IncrementalMigrationMap {
       },
     },
 
-    // v26: Upgrade the DDL event triggers to include partial indexes in
-    // schema snapshots. Note that setupTriggers() also refreshes the stored
-    // "publishedSchema" so that the change in format does not manifest as a
-    // spurious schema change.
-    26: {
-      migrateSchema: async (lc, sql) => {
-        const [{publications}] = await sql<{publications: string[]}[]>`
-          SELECT publications FROM ${sql(shardConfigTable)}`;
-        await setupTriggers(lc, sql, {...shard, publications});
-        lc.info?.(`Upgraded DDL event triggers`);
-      },
-    },
+    ...(installPartialIndexTriggers
+      ? {
+          // v26: Upgrade the DDL event triggers to include partial indexes in
+          // schema snapshots. Note that setupTriggers() also refreshes the
+          // stored "publishedSchema" so that the change in format does not
+          // manifest as a spurious schema change.
+          26: {
+            migrateSchema: async (lc, sql) => {
+              const [{publications}] = await sql<{publications: string[]}[]>`
+                SELECT publications FROM ${sql(shardConfigTable)}`;
+              await setupTriggers(lc, sql, {...shard, publications});
+              lc.info?.(`Upgraded DDL event triggers`);
+            },
+          },
+        }
+      : {}),
   };
 }
 
 // Referenced in tests.
 export const CURRENT_SCHEMA_VERSION = Object.keys(
-  getIncrementalMigrations({
-    appID: 'unused',
-    shardNum: 0,
-    publications: ['foo'],
-  }),
+  getIncrementalMigrations(
+    {
+      appID: 'unused',
+      shardNum: 0,
+      publications: ['foo'],
+    },
+    true,
+  ),
 ).reduce((prev, curr) => Math.max(prev, parseInt(curr)), 0);

--- a/packages/zero-cache/src/services/change-source/pg/schema/published.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/published.ts
@@ -23,7 +23,10 @@ import {
   type UnsupportedPredicateReason,
 } from './index-predicate.ts';
 
-export function publishedSchemaQuery(publications: readonly string[]) {
+export function publishedSchemaQuery(
+  publications: readonly string[],
+  includePartialIndexes = true,
+) {
   // Notes:
   // * There's a bug in PG15 in which generated columns are incorrectly
   //   included in pg_publication_tables.attnames, (even though the generated
@@ -167,6 +170,7 @@ tables AS (SELECT json_build_object(
     LEFT JOIN pg_constraint ON pg_constraint.conindid = pc.oid
     WHERE pb.pubname IN (${literal(publications)})
       AND pg_index.indexprs IS NULL
+      AND (${includePartialIndexes} OR pg_index.indpred IS NULL)
       AND (pg_constraint.contype IS NULL OR pg_constraint.contype IN ('p', 'u'))
       AND indexed.attnames <@ pb.attnames
       AND (current_setting('server_version_num')::int >= 160000 OR false = ALL(indexed.generated))

--- a/packages/zero-cache/src/services/change-source/pg/schema/shard.ts
+++ b/packages/zero-cache/src/services/change-source/pg/schema/shard.ts
@@ -451,6 +451,7 @@ export async function setupTablesAndReplication(
   lc: LogContext,
   sql: PostgresTransaction,
   requested: ShardConfig,
+  includePartialIndexes = true,
 ) {
   const {publications} = requested;
   // Validate requested publications.
@@ -506,13 +507,14 @@ export async function setupTablesAndReplication(
   const pubs = await getPublicationInfo(sql, allPublications);
   await replicaIdentitiesForTablesWithoutPrimaryKeys(pubs)?.apply(lc, sql);
 
-  await setupTriggers(lc, sql, shard);
+  await setupTriggers(lc, sql, shard, includePartialIndexes);
 }
 
 export async function setupTriggers(
   lc: LogContext,
   tx: PostgresTransaction,
   shard: ShardConfig,
+  includePartialIndexes = true,
 ) {
   const schema = upstreamSchema(shard);
   const [{ddlDetection}] = await tx<InternalShardConfig[]> /*sql*/ `
@@ -522,7 +524,7 @@ export async function setupTriggers(
   // event triggers are not supported/allowed by the db provider.
   // This allows users to manually invoke the update_schemas() function
   // as a workaround.
-  await tx.unsafe(createEventFunctionStatements(shard));
+  await tx.unsafe(createEventFunctionStatements(shard, includePartialIndexes));
   try {
     await tx.savepoint(sub => sub.unsafe(triggerSetup(shard)));
   } catch (e) {


### PR DESCRIPTION
We have to roll out partial index support in two different releases. This lets us just flip a flag between releases as well as let customers who want/need partial indices now to just turn it on now.