### PR TITLE
fix(zero-client): carry the connect abort reason on the attempt, not only signal.reason

### DIFF
--- a/packages/zero-client/src/client/zero.test.ts
+++ b/packages/zero-client/src/client/zero.test.ts
@@ -2843,6 +2843,55 @@ test('Connect timeout', async () => {
   connectionStatusCleanup();
 });
 
+test('connect timeout retries when AbortController drops abort reasons', async () => {
+  // React Native's bundled `abort-controller@3` polyfill predates the 2021
+  // `signal.reason` spec addition: `abort(reason)` silently discards the
+  // reason and `signal.reason` reads `undefined`. The run loop used to read
+  // the abort reason exclusively off the signal, so on such runtimes every
+  // retryable connect failure surfaced as `undefined`, was wrapped as a
+  // non-retryable internal error, and permanently paused the run loop.
+  // The polyfill leaves `signal.reason` undefined; a spec `abort()` with no
+  // argument leaves a generic AbortError. Either way the typed retryable
+  // error passed to `abort(reason)` is lost, which is the mechanism under
+  // test. Subclassing keeps `signal` a real AbortSignal so DOM listeners
+  // that take `{signal}` still work.
+  class LegacyAbortController extends AbortController {
+    override abort(): void {
+      super.abort();
+    }
+  }
+  vi.stubGlobal('AbortController', LegacyAbortController);
+
+  try {
+    const z = zeroForTest({logLevel: 'debug'});
+    await z.waitForConnectionStatus(ConnectionStatus.Connecting);
+    const firstSocket = await z.socket;
+    for (let i = 0; i < 10; i++) {
+      await vi.advanceTimersByTimeAsync(0);
+    }
+
+    // Time out the first connect attempt.
+    await vi.advanceTimersByTimeAsync(CONNECT_TIMEOUT_MS);
+    expectLogMessages(z).contain(connectTimeoutMessage);
+
+    // The timeout is retryable: the run loop must schedule another attempt
+    // rather than pausing in the error state.
+    expect(z.connectionStatus).toBe(ConnectionStatus.Connecting);
+    const nextSocketPromise = z.socket;
+    await vi.advanceTimersByTimeAsync(RUN_LOOP_INTERVAL_MS);
+    for (let i = 0; i < 10; i++) {
+      await vi.advanceTimersByTimeAsync(0);
+    }
+    expect(await nextSocketPromise).not.equal(firstSocket);
+
+    // And the retried attempt can then succeed.
+    await z.triggerConnected();
+    await z.waitForConnectionStatus(ConnectionStatus.Connected);
+  } finally {
+    vi.unstubAllGlobals();
+  }
+});
+
 test('connect timeout during setup retries without an unhandled rejection', async () => {
   const unhandledRejections: PromiseRejectionEvent[] = [];
   const onUnhandled = (event: PromiseRejectionEvent) => {

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -219,6 +219,17 @@ type ConnectAttemptControl = {
   readonly controller: AbortController;
   readonly connected: Resolver<void>;
   readonly events: [date: Date, event: string][];
+  /**
+   * The error this attempt was aborted with. Read this instead of
+   * `controller.signal.reason`: on runtimes whose `AbortController` predates
+   * the 2021 `signal.reason` spec addition (e.g. React Native's bundled
+   * `abort-controller@3` polyfill), `abort(reason)` silently discards the
+   * reason and `signal.reason` reads `undefined` — the run loop then wraps
+   * that `undefined` as a non-retryable internal error, so every retryable
+   * connect failure (e.g. `ConnectTimeout`) permanently pauses the run loop
+   * instead of retrying.
+   */
+  abortReason?: ZeroError | undefined;
 };
 
 function connectionReadyResolver(): Resolver<void> {
@@ -1764,7 +1775,7 @@ export class Zero<
     // The run loop has already stopped waiting for this attempt if it was
     // canceled. Do not let setup that completed late create a socket.
     if (signal.aborted) {
-      throw signal.reason;
+      throw attempt.abortReason ?? signal.reason;
     }
 
     const [ws, initConnectionQueries, deletedClients] = await createSocket(
@@ -1797,7 +1808,7 @@ export class Zero<
     // still belongs to this attempt and must be closed.
     if (signal.aborted) {
       ws.close();
-      throw signal.reason;
+      throw attempt.abortReason ?? signal.reason;
     }
 
     if (this.closed) {
@@ -1822,7 +1833,7 @@ export class Zero<
     lc.debug?.('Waiting for connection to be acknowledged');
     await attempt.connected.promise;
     if (signal.aborted) {
-      throw signal.reason;
+      throw attempt.abortReason ?? signal.reason;
     }
     this.#mutationTracker.onConnected(this.#lastMutationIDReceived);
     // push any outstanding mutations on reconnect.
@@ -1839,7 +1850,14 @@ export class Zero<
   }
 
   #disconnect(lc: LogContext, reason: ZeroError, closeCode?: CloseCode): void {
-    this.#currentConnectAttempt?.controller.abort(reason);
+    const attempt = this.#currentConnectAttempt;
+    if (attempt) {
+      // Recorded on the attempt as well as passed to abort() — see
+      // ConnectAttemptControl.abortReason for why signal.reason alone is not
+      // sufficient on every runtime.
+      attempt.abortReason = reason;
+      attempt.controller.abort(reason);
+    }
 
     if (shouldReportConnectError(reason)) {
       this.#connectErrorCount++;
@@ -2159,7 +2177,9 @@ export class Zero<
             this.#addConnectEvent(lc, attempt, 'starting the connection');
             const canceled = resolver<never>();
             const abortHandler = () =>
-              canceled.reject(attempt.controller.signal.reason);
+              canceled.reject(
+                attempt.abortReason ?? attempt.controller.signal.reason,
+              );
             attempt.controller.signal.addEventListener('abort', abortHandler, {
               once: true,
             });


### PR DESCRIPTION
## The bug

On runtimes whose `AbortController` predates the 2021 `signal.reason` spec addition, the connection run loop converts **every retryable connect failure into the permanent `error` pause**, so Zero's own retry/backoff never runs.

React Native is the big affected runtime: RN bundles the `abort-controller@3` polyfill, whose `abort(reason)` silently discards the reason and whose signal has no `reason` property at all.

The mechanism:

1. `#disconnect(lc, reason)` passes a typed, retryable `ZeroError` (e.g. `ClientError({kind: ConnectTimeout})`) to `attempt.controller.abort(reason)`.
2. The run loop reads it back exclusively off the signal — the `abortHandler` rejects with `attempt.controller.signal.reason`, and `#connectAttempt` has three `throw signal.reason` sites.
3. On a reason-less `AbortController`, all four sites read `undefined`. The run loop's catch wraps it — `isZeroError(undefined)` is false — as `ClientError({kind: Internal})`, which is non-retryable, and the run loop pauses in the `error` state forever ("Run loop paused in error state", with `undefined` as the logged reason).

We hit this in production with our React Native app (Margins): on a mid-range Android device, cold boots that hit a legitimate `ConnectTimeout` during a large initial hydration wedged permanently instead of retrying, and an airplane-mode boot produced several fatal pauses within seconds. With a spec-compliant AbortController polyfill patched in downstream, the wedge disappears and the run loop retries itself to `Connected` — device-verified against production, which is how we isolated the cause to exactly this read.

## The fix

Record the reason on the `ConnectAttemptControl` in `#disconnect`, and prefer it at the four read sites with `attempt.abortReason ?? signal.reason`. Behavior on spec-compliant platforms is unchanged (the two values are identical there); on legacy runtimes the typed error now survives the abort and the existing retry/backoff classification handles it as designed.

This also makes the run loop robust independent of platform `AbortController` fidelity, rather than relying on a polyfill detail for correctness of the retry path.

## Test

New test in `zero.test.ts`, modeled on the existing `Connect timeout` test: stubs `AbortController` with a subclass whose `abort()` drops the reason argument (the legacy polyfill's behavior), times out a connect attempt, and asserts the run loop schedules another attempt rather than pausing.

- Red on the previous code: `expected 'error' to be 'connecting'` — the permanent pause.
- Green with the fix, and the retried attempt proceeds to `Connected`.

`zero.test.ts`, `zero.connection.test.ts`, `connection-manager.test.ts`, `connection.test.ts`: 196/196 passing; `tsc` and `oxlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018RpmRy5DquXDnZ325PEphZ
