### PR TITLE
perf(zql): intern Query objects with a V8-style transition tree

### DIFF
--- a/packages/zql/src/query/query-impl.interning.test.ts
+++ b/packages/zql/src/query/query-impl.interning.test.ts
@@ -1,0 +1,485 @@
+import {beforeEach, expect, test, vi} from 'vitest';
+import * as queryHash from '../../../zero-protocol/src/query-hash-visitor.ts';
+import {defaultFormat} from '../ivm/default-format.ts';
+import {createBuilder} from './create-builder.ts';
+import {asQueryImpl, newQuery, newQueryImpl} from './query-impl.ts';
+import {asQueryInternals} from './query-internals.ts';
+import {MAX_SCAN} from './query-transitions.ts';
+import type {AnyQuery} from './query.ts';
+import {newRunnableQuery} from './runnable-query-impl.ts';
+import {newStaticQuery} from './static-query.ts';
+import {QueryDelegateImpl} from './test/query-delegate.ts';
+import {schema} from './test/test-schemas.ts';
+
+let issue: ReturnType<typeof newQuery<'issue', typeof schema>>;
+
+beforeEach(() => {
+  issue = newQuery(schema, 'issue');
+});
+
+test('the same chain built twice is the same instance', () => {
+  const build = () =>
+    newQuery(schema, 'issue')
+      .where('closed', false)
+      .orderBy('createdAt', 'desc')
+      .limit(10);
+
+  expect(build()).toBe(build());
+});
+
+test.each([
+  ['where, 2-arg', (q: AnyQuery) => q.where('closed', false)],
+  ['where, 3-arg', (q: AnyQuery) => q.where('title', '=', 'hi')],
+  [
+    'where, expression',
+    (q: AnyQuery) => q.where(({cmp}) => cmp('closed', true)),
+  ],
+  ['limit', (q: AnyQuery) => q.limit(10)],
+  ['orderBy', (q: AnyQuery) => q.orderBy('createdAt', 'desc')],
+  ['one', (q: AnyQuery) => q.one()],
+  ['start', (q: AnyQuery) => q.start({id: 'a'})],
+  ['start inclusive', (q: AnyQuery) => q.start({id: 'a'}, {inclusive: true})],
+  ['related', (q: AnyQuery) => q.related('owner')],
+  ['related with cb', (q: AnyQuery) => q.related('comments', c => c.limit(3))],
+  ['related two-hop', (q: AnyQuery) => q.related('labels')],
+  ['whereExists', (q: AnyQuery) => q.whereExists('comments')],
+  [
+    'whereExists with cb',
+    (q: AnyQuery) => q.whereExists('comments', c => c.where('text', '=', 'x')),
+  ],
+  ['whereExists two-hop', (q: AnyQuery) => q.whereExists('labels')],
+])('%s is interned', (_name, op) => {
+  expect(op(issue as AnyQuery)).toBe(op(issue as AnyQuery));
+});
+
+test('nameAndArgs is interned', () => {
+  const withName = (args: readonly [number]) =>
+    asQueryInternals(issue).nameAndArgs('issues', args);
+  expect(withName([1])).toBe(withName([1]));
+  expect(withName([1])).not.toBe(withName([2]));
+});
+
+test('different arguments produce different instances', () => {
+  expect(issue.limit(10)).not.toBe(issue.limit(11));
+  expect(issue.orderBy('createdAt', 'asc')).not.toBe(
+    issue.orderBy('createdAt', 'desc'),
+  );
+  expect(issue.orderBy('createdAt', 'asc')).not.toBe(
+    issue.orderBy('title', 'asc'),
+  );
+  expect(issue.where('closed', false)).not.toBe(issue.where('closed', true));
+  expect(issue.where('closed', false)).not.toBe(issue.where('title', '=', 'a'));
+  expect(issue.start({id: 'a'})).not.toBe(issue.start({id: 'b'}));
+  expect(issue.start({id: 'a'})).not.toBe(
+    issue.start({id: 'a'}, {inclusive: true}),
+  );
+  expect(issue.related('comments', c => c.limit(3))).not.toBe(
+    issue.related('comments', c => c.limit(4)),
+  );
+});
+
+test('`one` and `limit(1)` differ, because their formats do', () => {
+  // Same AST, different format.
+  expect(issue.one()).not.toBe(issue.limit(1));
+  expect(asQueryImpl(issue.one() as AnyQuery).ast).toEqual(
+    asQueryImpl(issue.limit(1) as AnyQuery).ast,
+  );
+});
+
+test('interning is order sensitive even where hashing is not', () => {
+  const a = issue.where('closed', false).where('title', '=', 'x');
+  const b = issue.where('title', '=', 'x').where('closed', false);
+
+  // `normalizeAST` sorts conditions, so these two hash the same...
+  expect(asQueryInternals(a).hash()).toBe(asQueryInternals(b).hash());
+  // ...but they are distinct nodes in the transition tree. Identity implies an
+  // equal hash; the converse does not hold.
+  expect(a).not.toBe(b);
+});
+
+test('sub-queries handed to callbacks are themselves interned', () => {
+  const seen: AnyQuery[] = [];
+  const capture = (q: AnyQuery) => {
+    seen.push(q);
+    return q.limit(3);
+  };
+
+  issue.related('comments', capture);
+  issue.related('comments', capture);
+  expect(seen).toHaveLength(2);
+  // This is what makes the outer `related` comparison a pointer compare.
+  expect(seen[0]).toBe(seen[1]);
+
+  const existsSeen: AnyQuery[] = [];
+  const captureExists = (q: AnyQuery) => {
+    existsSeen.push(q);
+    return q;
+  };
+  issue.whereExists('comments', captureExists);
+  issue.whereExists('comments', captureExists);
+  expect(existsSeen[0]).toBe(existsSeen[1]);
+});
+
+test('a non-deterministic callback simply misses the cache', () => {
+  let n = 0;
+  const build = () => issue.related('comments', c => c.limit(++n));
+  expect(build()).not.toBe(build());
+});
+
+test('derived queries retain their parent', () => {
+  const q = asQueryImpl(issue.where('closed', false).limit(5) as AnyQuery);
+  const parent = q.derivedFrom;
+  expect(parent).toBeDefined();
+  expect(parent!.derivedFrom).toBe(asQueryImpl(issue as AnyQuery));
+  expect(asQueryImpl(issue as AnyQuery).derivedFrom).toBe(undefined);
+});
+
+test('roots are interned per schema and system', () => {
+  expect(newQuery(schema, 'issue')).toBe(newQuery(schema, 'issue'));
+  expect(newQuery(schema, 'issue')).not.toBe(newQuery(schema, 'comment'));
+  // `newStaticQuery` uses the 'permissions' system.
+  expect(newStaticQuery(schema, 'issue')).toBe(newStaticQuery(schema, 'issue'));
+  expect(newStaticQuery(schema, 'issue')).not.toBe(newQuery(schema, 'issue'));
+});
+
+test('separate createBuilder calls share roots', () => {
+  expect(createBuilder(schema).issue).toBe(createBuilder(schema).issue);
+});
+
+test('a caller-supplied AST is not interned', () => {
+  const ast = {table: 'issue', limit: 5} as const;
+  expect(newQueryImpl(schema, 'issue', ast, defaultFormat, 'client')).not.toBe(
+    newQueryImpl(schema, 'issue', ast, defaultFormat, 'client'),
+  );
+  // Nor is a non-default format, even with a root AST.
+  const format = {relationships: {}, singular: true};
+  expect(
+    newQueryImpl(schema, 'issue', {table: 'issue'}, format, 'client'),
+  ).not.toBe(newQueryImpl(schema, 'issue', {table: 'issue'}, format, 'client'));
+});
+
+test('runnable roots are interned per delegate', () => {
+  const a = new QueryDelegateImpl();
+  const b = new QueryDelegateImpl();
+
+  expect(newRunnableQuery(a, schema, 'issue')).toBe(
+    newRunnableQuery(a, schema, 'issue'),
+  );
+  expect(newRunnableQuery(a, schema, 'issue')).not.toBe(
+    newRunnableQuery(b, schema, 'issue'),
+  );
+  // ...and the transition tree below them is shared too.
+  expect(newRunnableQuery(a, schema, 'issue').limit(3)).toBe(
+    newRunnableQuery(a, schema, 'issue').limit(3),
+  );
+});
+
+test('hash is computed once for a repeatedly rebuilt chain', () => {
+  const spy = vi.spyOn(queryHash, 'hashOfQueryInternals');
+  try {
+    const build = () =>
+      asQueryInternals(
+        newQuery(schema, 'issue').where('closed', false).limit(10),
+      ).hash();
+
+    const first = build();
+    const callsAfterFirst = spy.mock.calls.length;
+    expect(callsAfterFirst).toBeGreaterThan(0);
+
+    for (let i = 0; i < 10; i++) {
+      expect(build()).toBe(first);
+    }
+    expect(spy.mock.calls).toHaveLength(callsAfterFirst);
+  } finally {
+    spy.mockRestore();
+  }
+});
+
+test('a list of live sibling row queries all stay interned', () => {
+  const zql = createBuilder(schema);
+  const ids = Array.from({length: MAX_SCAN * 4}, (_, i) => `row-${i}`);
+
+  // Hold them all alive, the way a rendered list would, then rebuild the whole
+  // list the way the next render would. Every row must still be shared: the
+  // discriminating value is in the transition key, so none of these siblings
+  // compete for one bucket.
+  const first = ids.map(id => zql.issue.where('id', '=', id));
+  const second = ids.map(id => zql.issue.where('id', '=', id));
+  expect(second).toEqual(first.map(q => q));
+  first.forEach((q, i) => expect(second[i]).toBe(q));
+});
+
+test('primitive where values are distinguished by type, not coerced', () => {
+  const q = newQuery(schema, 'issue');
+  expect(q.where('title', '=', '1')).not.toBe(
+    q.where('title', '=', 1 as unknown as string),
+  );
+  expect(q.where('closed', '=', false)).not.toBe(
+    q.where('closed', '=', 'false' as unknown as boolean),
+  );
+});
+
+test('array and parameter comparisons are interned too', () => {
+  const q = newQuery(schema, 'issue');
+  expect(q.where('id', 'IN', ['a', 'b'])).toBe(q.where('id', 'IN', ['a', 'b']));
+  expect(q.where('id', 'IN', ['a', 'b'])).not.toBe(
+    q.where('id', 'IN', ['a', 'c']),
+  );
+  // Element order is part of the value, not a set.
+  expect(q.where('id', 'IN', ['a', 'b'])).not.toBe(
+    q.where('id', 'IN', ['b', 'a']),
+  );
+});
+
+test('a list of live sibling IN queries all stay interned', () => {
+  const zql = createBuilder(schema);
+  const lists = Array.from({length: MAX_SCAN * 2}, (_, i) => [
+    `a${i}`,
+    `b${i}`,
+  ]);
+  const first = lists.map(l => zql.issue.where('id', 'IN', l));
+  const second = lists.map(l => zql.issue.where('id', 'IN', l));
+  first.forEach((q, i) => expect(second[i]).toBe(q));
+});
+
+test('expression-factory trees are interned, and split by relationship', () => {
+  const q = newQuery(schema, 'issue');
+  const byOwner = (name: string) =>
+    q.whereExists('owner', o => o.where('name', '=', name));
+
+  expect(byOwner('alice')).toBe(byOwner('alice'));
+  expect(byOwner('alice')).not.toBe(byOwner('bob'));
+  // A different relationship keys differently rather than sharing a bucket.
+  expect(q.whereExists('comments')).not.toBe(q.whereExists('owner'));
+  expect(q.whereExists('comments')).toBe(q.whereExists('comments'));
+});
+
+test('interning does not change the AST or format a query produces', () => {
+  const q = newQuery(schema, 'issue')
+    .related('comments', c => c.orderBy('createdAt', 'desc').limit(5))
+    .related('labels')
+    .whereExists('owner', o => o.where('name', '=', 'alice'))
+    .where('closed', false)
+    .orderBy('createdAt', 'desc')
+    .limit(20);
+
+  const qi = asQueryInternals(q);
+  expect(qi.ast).toMatchInlineSnapshot(`
+    {
+      "alias": undefined,
+      "limit": 20,
+      "orderBy": [
+        [
+          "createdAt",
+          "desc",
+        ],
+      ],
+      "related": [
+        {
+          "correlation": {
+            "childField": [
+              "issueId",
+            ],
+            "parentField": [
+              "id",
+            ],
+          },
+          "hidden": undefined,
+          "subquery": {
+            "alias": "comments",
+            "limit": 5,
+            "orderBy": [
+              [
+                "createdAt",
+                "desc",
+              ],
+            ],
+            "related": undefined,
+            "schema": undefined,
+            "start": undefined,
+            "table": "comment",
+            "where": undefined,
+          },
+          "system": "client",
+        },
+        {
+          "correlation": {
+            "childField": [
+              "issueId",
+            ],
+            "parentField": [
+              "id",
+            ],
+          },
+          "hidden": true,
+          "subquery": {
+            "alias": "labels",
+            "limit": undefined,
+            "orderBy": undefined,
+            "related": [
+              {
+                "correlation": {
+                  "childField": [
+                    "id",
+                  ],
+                  "parentField": [
+                    "labelId",
+                  ],
+                },
+                "hidden": undefined,
+                "subquery": {
+                  "alias": "labels",
+                  "limit": undefined,
+                  "orderBy": undefined,
+                  "related": undefined,
+                  "schema": undefined,
+                  "start": undefined,
+                  "table": "label",
+                  "where": undefined,
+                },
+                "system": "client",
+              },
+            ],
+            "schema": undefined,
+            "start": undefined,
+            "table": "issueLabel",
+            "where": undefined,
+          },
+          "system": "client",
+        },
+      ],
+      "schema": undefined,
+      "start": undefined,
+      "table": "issue",
+      "where": {
+        "conditions": [
+          {
+            "left": {
+              "name": "closed",
+              "type": "column",
+            },
+            "op": "=",
+            "right": {
+              "type": "literal",
+              "value": false,
+            },
+            "type": "simple",
+          },
+          {
+            "flip": undefined,
+            "op": "EXISTS",
+            "related": {
+              "correlation": {
+                "childField": [
+                  "id",
+                ],
+                "parentField": [
+                  "ownerId",
+                ],
+              },
+              "hidden": undefined,
+              "subquery": {
+                "alias": "zsubq_owner",
+                "limit": undefined,
+                "orderBy": undefined,
+                "related": undefined,
+                "schema": undefined,
+                "start": undefined,
+                "table": "user",
+                "where": {
+                  "left": {
+                    "name": "name",
+                    "type": "column",
+                  },
+                  "op": "=",
+                  "right": {
+                    "type": "literal",
+                    "value": "alice",
+                  },
+                  "type": "simple",
+                },
+              },
+              "system": "client",
+            },
+            "scalar": undefined,
+            "type": "correlatedSubquery",
+          },
+        ],
+        "type": "and",
+      },
+    }
+  `);
+  expect(qi.format).toMatchInlineSnapshot(`
+    {
+      "relationships": {
+        "comments": {
+          "relationships": {},
+          "singular": false,
+        },
+        "labels": {
+          "relationships": {},
+          "singular": false,
+        },
+      },
+      "singular": false,
+    }
+  `);
+});
+
+test('interning holds only schema-shaped things strongly', () => {
+  // The safety property behind the strong first-child slot and the bounded
+  // store: what is retained strongly is keyed by program structure — a
+  // relationship name, one first child per node — never by data. Every axis that
+  // grows with what an app queries *for* stays weak and collectible.
+  //
+  // A non-root AST is never interned, so this starts from a node no other test
+  // has derived from.
+  const root = newQueryImpl(
+    schema,
+    'issue',
+    {table: 'issue', alias: 'retention'},
+    defaultFormat,
+    'client',
+  ) as unknown as AnyQuery;
+
+  // One value-keyed sibling takes the first slot; the other 49 go to the weak
+  // store, where they can be collected.
+  const built = Array.from({length: 50}, (_, i) =>
+    root.where('id', '=', `row-${i}`),
+  );
+  const t = asQueryImpl(root).transitionsForTesting!;
+  expect(t.first).toBe(built[0]);
+  // 49 in the weak store, all under one key — the row id is the transition
+  // *value*, never concatenated into the key.
+  expect(t.restSize).toBe(49);
+  expect(t.rest!.size).toBe(1);
+
+  // Relationship bases are bounded by the schema, so they are strong — and they
+  // do not compete for the first slot or spill into the weak store.
+  root.related('comments');
+  root.related('labels');
+  expect(t.lookupBounded('relatedBase:comments')).toBeDefined();
+  expect(t.lookupBounded('relatedBase:labels')).toBeDefined();
+  expect(t.first).toBe(built[0]);
+});
+
+test('flip and scalar options are not collapsed', () => {
+  const q = newQuery(schema, 'issue');
+  const plain = q.whereExists('comments');
+  const flipFalse = q.whereExists('comments', {flip: false});
+  const flipTrue = q.whereExists('comments', {flip: true});
+
+  // `#exists` only sets the property when it is defined, so absent and `false`
+  // are genuinely different ASTs and must not intern to each other.
+  expect(plain).not.toBe(flipFalse);
+  expect(plain).not.toBe(flipTrue);
+  expect(flipFalse).not.toBe(flipTrue);
+  expect(flipFalse).toBe(q.whereExists('comments', {flip: false}));
+  expect(flipTrue).toBe(q.whereExists('comments', {flip: true}));
+
+  // Same three-state handling for `scalar`.
+  const cb = (c: AnyQuery) => c;
+  const scalarFalse = q.whereExists('comments', cb, {scalar: false});
+  expect(q.whereExists('comments', cb)).not.toBe(scalarFalse);
+  expect(scalarFalse).toBe(q.whereExists('comments', cb, {scalar: false}));
+});

--- a/packages/zql/src/query/query-impl.interning.test.ts
+++ b/packages/zql/src/query/query-impl.interning.test.ts
@@ -10,6 +10,7 @@ import {newRunnableQuery} from './runnable-query-impl.ts';
 import {newStaticQuery} from './static-query.ts';
 import {QueryDelegateImpl} from './test/query-delegate.ts';
 import {schema} from './test/test-schemas.ts';
+import {withStubbedWeakRef} from './test/weak-ref-stub.ts';
 
 let issue: ReturnType<typeof newQuery<'issue', typeof schema>>;
 
@@ -426,41 +427,68 @@ test('interning does not change the AST or format a query produces', () => {
   `);
 });
 
-test('interning holds only schema-shaped things strongly', () => {
-  // The safety property behind the strong first-child slot and the bounded
-  // store: what is retained strongly is keyed by program structure — a
-  // relationship name, one first child per node — never by data. Every axis that
-  // grows with what an app queries *for* stays weak and collectible.
-  //
-  // A non-root AST is never interned, so this starts from a node no other test
-  // has derived from.
-  const root = newQueryImpl(
-    schema,
-    'issue',
-    {table: 'issue', alias: 'retention'},
-    defaultFormat,
-    'client',
-  ) as unknown as AnyQuery;
+test('queries keyed by data are held weakly, and collectible', () => {
+  // The safety property behind the strong first-child slot: what is retained
+  // strongly is keyed by program structure — one first child per node — never
+  // by data. Every axis that grows with what an app queries *for* stays weak.
+  withStubbedWeakRef(weak => {
+    // A non-root AST is never interned, so this starts from a node no other
+    // test has derived from.
+    const root = newQueryImpl(
+      schema,
+      'issue',
+      {table: 'issue', alias: 'retention'},
+      defaultFormat,
+      'client',
+    ) as unknown as AnyQuery;
 
-  // One value-keyed sibling takes the first slot; the other 49 go to the weak
-  // store, where they can be collected.
-  const built = Array.from({length: 50}, (_, i) =>
-    root.where('id', '=', `row-${i}`),
-  );
-  const t = asQueryImpl(root).transitionsForTesting!;
-  expect(t.first).toBe(built[0]);
-  // 49 in the weak store, all under one key — the row id is the transition
-  // *value*, never concatenated into the key.
-  expect(t.restSize).toBe(49);
-  expect(t.rest!.size).toBe(1);
+    // One value-keyed sibling takes the strong first slot; the other 49 are
+    // weak, so a WeakRef is allocated for each of those and none for the first.
+    const built = Array.from({length: 50}, (_, i) =>
+      root.where('id', '=', `row-${i}`),
+    );
+    expect(weak.created()).toBe(49);
 
-  // Relationship bases are bounded by the schema, so they are strong — and they
-  // do not compete for the first slot or spill into the weak store.
-  root.related('comments');
-  root.related('labels');
-  expect(t.lookupBounded('relatedBase:comments')).toBeDefined();
-  expect(t.lookupBounded('relatedBase:labels')).toBeDefined();
-  expect(t.first).toBe(built[0]);
+    built.forEach(q => weak.collect(q));
+
+    // The first child is held in a field, so it survives...
+    expect(root.where('id', '=', 'row-0')).toBe(built[0]);
+    // ...and everything keyed by a row id is gone, rebuilt fresh rather than
+    // pinning a query per id an app has ever asked for.
+    for (let i = 1; i < built.length; i++) {
+      expect(root.where('id', '=', `row-${i}`)).not.toBe(built[i]);
+    }
+  });
+});
+
+test('relationship bases are held strongly, bounded by the schema', () => {
+  withStubbedWeakRef(weak => {
+    const root = newQueryImpl(
+      schema,
+      'issue',
+      {table: 'issue', alias: 'bounded-retention'},
+      defaultFormat,
+      'client',
+    ) as unknown as AnyQuery;
+    const bases: AnyQuery[] = [];
+    const capture = (q: AnyQuery) => {
+      bases.push(q);
+      return q;
+    };
+
+    root.related('comments', capture);
+    root.related('comments', capture);
+    // The same base comes back, and holding it costs no WeakRef: it is keyed
+    // by a relationship name, so what it retains is bounded by the schema
+    // rather than by what an app queries for.
+    expect(bases[1]).toBe(bases[0]);
+    const createdBeforeCollect = weak.created();
+
+    bases.forEach(q => weak.collect(q));
+    root.related('comments', capture);
+    expect(bases[2]).toBe(bases[0]);
+    expect(weak.created()).toBe(createdBeforeCollect);
+  });
 });
 
 test('flip and scalar options are not collapsed', () => {

--- a/packages/zql/src/query/query-impl.interning.test.ts
+++ b/packages/zql/src/query/query-impl.interning.test.ts
@@ -483,3 +483,43 @@ test('flip and scalar options are not collapsed', () => {
   expect(q.whereExists('comments', cb)).not.toBe(scalarFalse);
   expect(scalarFalse).toBe(q.whereExists('comments', cb, {scalar: false}));
 });
+
+test('condition keys cannot collide: every token is self-delimiting', () => {
+  // A non-root AST is never interned, so this starts from a node no other
+  // test has derived from.
+  const root = newQueryImpl(
+    schema,
+    'issue',
+    {table: 'issue', alias: 'collision'},
+    defaultFormat,
+    'client',
+  ) as unknown as AnyQuery;
+
+  // Two different trees whose keys ran together when a string value was
+  // written bare: the first value swallowed the start of the next condition.
+  const a = root.where(({cmp, and}) =>
+    and(cmp('title', '=', 'S2:id1:=:sfoo'), cmp('id', '=', 'bar')),
+  );
+  const b = root.where(({cmp, and}) =>
+    and(cmp('title', '=', ''), cmp('id', '=', 'fooS2:id1:=:sbar')),
+  );
+  expect(a).not.toBe(b);
+  expect(asQueryImpl(a).ast.where).not.toEqual(asQueryImpl(b).ast.where);
+  expect(
+    root.where(({cmp, and}) =>
+      and(cmp('title', '=', ''), cmp('id', '=', 'fooS2:id1:=:sbar')),
+    ),
+  ).toBe(b);
+
+  // The same holds for a value that JSON would write like another: Infinity,
+  // NaN and null all serialize as `null`.
+  expect(root.where('id', 'IN', [1, Infinity])).not.toBe(
+    root.where('id', 'IN', [1, null]),
+  );
+  expect(root.where('id', 'IN', [1, Infinity])).toBe(
+    root.where('id', 'IN', [1, Infinity]),
+  );
+  expect(root.where('id', 'IN', [[1], 2])).not.toBe(
+    root.where('id', 'IN', [1, [2]]),
+  );
+});

--- a/packages/zql/src/query/query-impl.interning.test.ts
+++ b/packages/zql/src/query/query-impl.interning.test.ts
@@ -244,14 +244,6 @@ test('a non-deterministic callback simply misses the cache', () => {
   expect(build()).not.toBe(build());
 });
 
-test('derived queries retain their parent', () => {
-  const q = asQueryImpl(issue.where('closed', false).limit(5) as AnyQuery);
-  const parent = q.derivedFrom;
-  expect(parent).toBeDefined();
-  expect(parent!.derivedFrom).toBe(asQueryImpl(issue as AnyQuery));
-  expect(asQueryImpl(issue as AnyQuery).derivedFrom).toBe(undefined);
-});
-
 test('roots are interned per schema and system', () => {
   expect(newQuery(schema, 'issue')).toBe(newQuery(schema, 'issue'));
   expect(newQuery(schema, 'issue')).not.toBe(newQuery(schema, 'comment'));

--- a/packages/zql/src/query/query-impl.interning.test.ts
+++ b/packages/zql/src/query/query-impl.interning.test.ts
@@ -87,15 +87,132 @@ test('`one` and `limit(1)` differ, because their formats do', () => {
   );
 });
 
-test('interning is order sensitive even where hashing is not', () => {
-  const a = issue.where('closed', false).where('title', '=', 'x');
-  const b = issue.where('title', '=', 'x').where('closed', false);
+/**
+ * A root no other test has derived from. The interned root is shared by every
+ * test in this file, and what hangs off it -- including its hash index --
+ * survives from one test to the next, so tests about convergence start from a
+ * root of their own. A caller-supplied AST is never interned.
+ */
+function freshRoot(alias: string): AnyQuery {
+  return newQueryImpl(
+    schema,
+    'issue',
+    {table: 'issue', alias},
+    defaultFormat,
+    'client',
+  ) as unknown as AnyQuery;
+}
+
+test('paths that build the same query converge once it is hashed', () => {
+  const root = freshRoot('converge');
+  const a = root.where('closed', false).where('title', '=', 'x');
+  const b = root.where('title', '=', 'x').where('closed', false);
 
   // `normalizeAST` sorts conditions, so these two hash the same...
   expect(asQueryInternals(a).hash()).toBe(asQueryInternals(b).hash());
-  // ...but they are distinct nodes in the transition tree. Identity implies an
-  // equal hash; the converse does not hold.
+  // ...but the tree keyed them by path, so they were built as distinct nodes.
   expect(a).not.toBe(b);
+
+  // Hashing `b` found `a` in the root's hash index and re-pointed `b`'s
+  // transition at it. `b` keeps its identity, since it has been handed out,
+  // but the next rebuild along either path yields `a`.
+  expect(root.where('title', '=', 'x').where('closed', false)).toBe(a);
+  expect(root.where('closed', false).where('title', '=', 'x')).toBe(a);
+
+  // The same for anything else normalization reorders: `related` is sorted.
+  const c = root.related('comments').related('labels');
+  const d = root.related('labels').related('comments');
+  expect(c).not.toBe(d);
+  asQueryInternals(c).hash();
+  asQueryInternals(d).hash();
+  expect(root.related('labels').related('comments')).toBe(c);
+});
+
+test('convergence waits for a hash; building alone changes nothing', () => {
+  const root = freshRoot('unhashed');
+  const a = root.where('closed', false).limit(5);
+  const b = root.limit(5).where('closed', false);
+  expect(a).not.toBe(b);
+  // Nothing has been hashed, so nothing has been redirected.
+  expect(root.limit(5).where('closed', false)).toBe(b);
+
+  // Hashing `a` alone indexes it but redirects nothing: `b` has not been
+  // hashed, so its path is unchanged.
+  asQueryInternals(a).hash();
+  expect(root.limit(5).where('closed', false)).toBe(b);
+
+  // Hashing `b` is what redirects its path.
+  asQueryInternals(b).hash();
+  expect(root.limit(5).where('closed', false)).toBe(a);
+});
+
+test('the hash index is scoped by root', () => {
+  // Two schema objects, structurally identical, get separate interned roots
+  // and so separate indexes. The hash does not cover the schema, so this
+  // scoping is what keeps equal-looking queries against different schemas
+  // apart.
+  const other = {...schema};
+  const a = issue.where('closed', false).where('title', '=', 'scoped');
+  const b = newQuery(other, 'issue')
+    .where('title', '=', 'scoped')
+    .where('closed', false);
+  expect(asQueryInternals(a).hash()).toBe(asQueryInternals(b).hash());
+  expect(
+    newQuery(other, 'issue')
+      .where('title', '=', 'scoped')
+      .where('closed', false),
+  ).toBe(b);
+  expect(b).not.toBe(a);
+});
+
+test('runnable queries converge per delegate', () => {
+  const d1 = new QueryDelegateImpl();
+  const d2 = new QueryDelegateImpl();
+  const r1 = newRunnableQuery(d1, schema, 'issue');
+  const r2 = newRunnableQuery(d2, schema, 'issue');
+
+  const a = r1.where('closed', false).where('title', '=', 'z');
+  const b = r1.where('title', '=', 'z').where('closed', false);
+  const c = r2.where('title', '=', 'z').where('closed', false);
+  for (const q of [a, b, c]) {
+    asQueryInternals(q).hash();
+  }
+  expect(r1.where('title', '=', 'z').where('closed', false)).toBe(a);
+  // Same hash, different delegate: a separate root, so a separate index.
+  expect(asQueryInternals(c).hash()).toBe(asQueryInternals(a).hash());
+  expect(r2.where('title', '=', 'z').where('closed', false)).toBe(c);
+  expect(c).not.toBe(a);
+});
+
+test('a hash collision is checked structurally and not adopted', () => {
+  const spy = vi
+    .spyOn(queryHash, 'hashOfQueryInternals')
+    .mockReturnValue('collision');
+  try {
+    const root = freshRoot('collision');
+    const a = root.where('closed', false);
+    const b = root.where('closed', true);
+    expect(asQueryInternals(a).hash()).toBe(asQueryInternals(b).hash());
+    // `b` is not `a`, so hashing it must not redirect its path to `a`.
+    expect(root.where('closed', true)).toBe(b);
+    expect(root.where('closed', false)).toBe(a);
+  } finally {
+    spy.mockRestore();
+  }
+});
+
+test('a redirected path re-points the strong first slot too', () => {
+  // The first transition out of a node is held in a field rather than the
+  // weak map; `replace` has to cover that slot as well as the map.
+  const root = freshRoot('first-slot');
+  const a = root.where('closed', false).where('title', '=', 'f');
+  const via = root.where('title', '=', 'f');
+  // `b` is the first transition out of `via`, so it occupies that slot.
+  const b = via.where('closed', false);
+  expect(via.where('closed', false)).toBe(b);
+  asQueryInternals(a).hash();
+  asQueryInternals(b).hash();
+  expect(via.where('closed', false)).toBe(a);
 });
 
 test('sub-queries handed to callbacks are themselves interned', () => {
@@ -510,6 +627,66 @@ test('flip and scalar options are not collapsed', () => {
   const scalarFalse = q.whereExists('comments', cb, {scalar: false});
   expect(q.whereExists('comments', cb)).not.toBe(scalarFalse);
   expect(scalarFalse).toBe(q.whereExists('comments', cb, {scalar: false}));
+});
+
+test('start rows are exact keys, so paging to a new row never scans', () => {
+  const root = freshRoot('start-rows');
+  const sorted = root.orderBy('id', 'asc');
+  const pages = Array.from({length: MAX_SCAN * 2}, (_, i) =>
+    sorted.start({id: `row-${i}`}),
+  );
+  // Every page stays interned, well past the point where a bucket stops
+  // growing: each row is its own key rather than a delta sharing one bucket.
+  pages.forEach((q, i) => expect(sorted.start({id: `row-${i}`})).toBe(q));
+
+  // Rows that could run together under a naive concatenation are told apart:
+  // every key and value in the encoding is self-delimiting.
+  expect(sorted.start({a: 'x1:c:sy'})).not.toBe(sorted.start({a: 'x', c: 'y'}));
+  expect(sorted.start({id: 1, x: 2})).not.toBe(sorted.start({id: 12}));
+  expect(sorted.start({id: '1'})).not.toBe(sorted.start({id: 1}));
+  expect(sorted.start({id: 1})).not.toBe(
+    sorted.start({id: 1}, {inclusive: true}),
+  );
+  expect(sorted.start({id: 1}, {inclusive: true})).toBe(
+    sorted.start({id: 1}, {inclusive: true}),
+  );
+  // An undefined property is absent, as it is to `deepEqual`.
+  expect(sorted.start({id: 1, x: undefined})).toBe(sorted.start({id: 1}));
+  // Non-primitive values are encoded recursively, so they are exact as well.
+  expect(sorted.start({tags: ['a', 'b']})).toBe(
+    sorted.start({tags: ['a', 'b']}),
+  );
+  expect(sorted.start({tags: ['a', 'b']})).not.toBe(
+    sorted.start({tags: ['b', 'a']}),
+  );
+  expect(sorted.start({j: {a: 1, b: 'x'}})).toBe(
+    sorted.start({j: {a: 1, b: 'x'}}),
+  );
+  expect(sorted.start({j: {a: 1}})).not.toBe(sorted.start({j: {a: '1'}}));
+  expect(sorted.start({j: [1, [2]]})).not.toBe(sorted.start({j: [1, 2]}));
+  expect(sorted.start({j: [['ab'], 'c']})).not.toBe(
+    sorted.start({j: ['a', ['bc']]}),
+  );
+});
+
+test('values that JSON would write alike are told apart', () => {
+  // `JSON.stringify` writes Infinity, NaN and null all as `null`. The encoding
+  // is trusted as exact, so it cannot lean on it: a page whose cursor had
+  // Infinity in a nested value would otherwise come back with null in its AST.
+  const root = freshRoot('lossy-json');
+  const inf = root.start({j: {x: Infinity}});
+  expect(root.start({j: {x: null}})).not.toBe(inf);
+  expect(root.start({j: {x: -Infinity}})).not.toBe(inf);
+  expect(root.start({j: {x: NaN}})).not.toBe(inf);
+  expect(asQueryImpl(inf).ast.start!.row).toEqual({j: {x: Infinity}});
+  expect(root.start({j: [Infinity]})).not.toBe(root.start({j: [null]}));
+  // The same tags key an `IN` list.
+  expect(root.where('id', 'IN', [1, Infinity])).not.toBe(
+    root.where('id', 'IN', [1, null]),
+  );
+  expect(root.where('id', 'IN', [1, Infinity])).toBe(
+    root.where('id', 'IN', [1, Infinity]),
+  );
 });
 
 test('condition keys cannot collide: every token is self-delimiting', () => {

--- a/packages/zql/src/query/query-impl.ts
+++ b/packages/zql/src/query/query-impl.ts
@@ -1,6 +1,9 @@
 // oxlint-disable no-explicit-any
 import {assert} from '../../../shared/src/asserts.ts';
-import type {ReadonlyJSONValue} from '../../../shared/src/json.ts';
+import type {
+  ReadonlyJSONObject,
+  ReadonlyJSONValue,
+} from '../../../shared/src/json.ts';
 import {
   type AST,
   type CompoundKey,
@@ -634,16 +637,11 @@ export class QueryImpl<
     if (cond.type === 'simple' && cond.left.type === 'column') {
       key = whereKey(cond.left.name, cond.op);
       const right = cond.right;
-      if (right.type === 'literal' && isPrimitive(right.value)) {
-        tValue = right.value;
-        delta = undefined;
-      } else {
-        const tag = rightTag(right);
-        if (tag !== undefined) {
-          tValue = tag;
-          delta = undefined;
-        }
-      }
+      tValue =
+        right.type === 'literal' && isPrimitive(right.value)
+          ? right.value
+          : rightTag(right);
+      delta = undefined;
     } else {
       // A sub-query an `exists` correlates to is itself interned, so its
       // identity settles that part of the tree without walking it.
@@ -949,30 +947,69 @@ function isPrimitive(v: LiteralValue): v is string | number | boolean | null {
 }
 
 /**
+ * Folds a JSON value into a self-delimiting token: a string is
+ * length-prefixed, a number is terminated, an array or object is
+ * count-prefixed and encodes its members recursively, and the rest are fixed
+ * width. Tokens can therefore be concatenated into a key with no way for one
+ * to run into the next, and the leading tag keeps `'1'` and `1` apart.
+ *
+ * Not `JSON.stringify`: it writes `Infinity`, `NaN` and `null` all as `null`,
+ * and this token is trusted as exact, so a nested value that serialized like
+ * another's would hand back a query with the wrong value in its AST. Numbers
+ * are written the way `String` writes them, which keeps those apart. An
+ * `undefined` property is skipped, as `deepEqual` would skip it; property
+ * order is part of the encoding, so an object spelled in another order
+ * interns separately.
+ */
+function valueTag(v: ReadonlyJSONValue): string {
+  switch (typeof v) {
+    case 'string':
+      return `:s${enc(v)}`;
+    case 'number':
+      return `:n${v};`;
+    case 'boolean':
+      return v ? ':t' : ':f';
+    default: {
+      if (v === null) {
+        return ':z';
+      }
+      if (Array.isArray(v)) {
+        let out = `:a${v.length}:`;
+        for (const e of v) {
+          out += valueTag(e);
+        }
+        return out;
+      }
+      // `Array.isArray` does not narrow a readonly array out of the union.
+      const o = v as ReadonlyJSONObject;
+      let body = '';
+      let n = 0;
+      for (const key in o) {
+        const e = o[key];
+        if (e !== undefined && Object.hasOwn(o, key)) {
+          body += enc(key) + valueTag(e);
+          n++;
+        }
+      }
+      return `:o${n}:${body}`;
+    }
+  }
+}
+
+/**
  * Folds the right-hand side of a simple condition into a transition value, so
  * that the transition is exact and the lookup needs no comparison at all.
  *
- * The leading tag keeps `'1'` and `1` apart. Arrays (`IN`) and parameter
- * references are serialized: that is one pass over a small value, where leaving
- * them in the delta would instead cost a `deepEqual` over the whole condition
- * for every sibling a lookup walks past.
+ * Arrays (`IN`) and parameter references are encoded in full: that is one
+ * pass over a small value, where leaving them in the delta would instead cost
+ * a `deepEqual` over the whole condition for every sibling a lookup walks
+ * past.
  */
-function rightTag(right: SimpleCondition['right']): string | undefined {
+function rightTag(right: SimpleCondition['right']): string {
   if (right.type !== 'literal') {
-    return `:p${JSON.stringify(right)}`;
+    return `:p${valueTag(right as unknown as ReadonlyJSONValue)}`;
   }
-  const v = right.value;
-  switch (typeof v) {
-    case 'string':
-      return `:s${v}`;
-    case 'number':
-      return `:n${v}`;
-    case 'boolean':
-      return `:b${v}`;
-    case 'object':
-      return v === null ? ':z' : `:a${JSON.stringify(v)}`;
-  }
-  return undefined;
+  return valueTag(right.value);
 }
 
 /**
@@ -1004,10 +1041,7 @@ function condKey(cond: Condition): string | undefined {
       if (cond.left.type !== 'column') {
         return undefined;
       }
-      const tag = rightTag(cond.right);
-      return tag === undefined
-        ? undefined
-        : `S${enc(cond.left.name)}${enc(cond.op)}${tag}`;
+      return `S${enc(cond.left.name)}${enc(cond.op)}${rightTag(cond.right)}`;
     }
     case 'correlatedSubquery': {
       const id = astIDs.get(cond.related.subquery);

--- a/packages/zql/src/query/query-impl.ts
+++ b/packages/zql/src/query/query-impl.ts
@@ -1,8 +1,9 @@
 // oxlint-disable no-explicit-any
 import {assert} from '../../../shared/src/asserts.ts';
-import type {
-  ReadonlyJSONObject,
-  ReadonlyJSONValue,
+import {
+  deepEqual,
+  type ReadonlyJSONObject,
+  type ReadonlyJSONValue,
 } from '../../../shared/src/json.ts';
 import {
   type AST,
@@ -36,6 +37,7 @@ import {
 import type {CustomQueryID} from './named.ts';
 import {type QueryInternals, queryInternalsTag} from './query-internals.ts';
 import {
+  HashIndex,
   Transitions,
   type Delta,
   type TransitionValue,
@@ -228,6 +230,12 @@ export class QueryImpl<
   #transitions: Transitions<QueryImpl<any, any, any>> | undefined;
 
   /**
+   * The second level of interning, keyed by hash; see `HashIndex`. Set on the
+   * root only, which is what scopes it to one schema and one delegate.
+   */
+  #byHash: HashIndex<QueryImpl<any, any, any>> | undefined;
+
+  /**
    * Memoized because a query is interned: the same node serves every rebuild of
    * a chain, so building this once rather than per `where(fn)` call takes the
    * whole thing -- the builder and the bound `#exists` -- off the repeat path.
@@ -374,8 +382,54 @@ export class QueryImpl<
         this.customQueryID?.name,
         this.customQueryID?.args,
       );
+      this.#canonicalize();
     }
     return this.#hash;
+  }
+
+  /**
+   * Folds this query into its root's hash index, now that its hash is known.
+   *
+   * If an equal query is already indexed, the transition that produced this
+   * one is re-pointed at it, so the next rebuild along this path yields that
+   * instance rather than a second copy. This query itself is left alone: its
+   * identity has already been handed out. Content is verified with `#sameAs`
+   * before anything is redirected, so a hash collision costs nothing worse
+   * than a missed unification.
+   */
+  #canonicalize(): void {
+    const parent = this.#parent;
+    if (parent === undefined) {
+      // A root has no path to redirect and is its own canonical form.
+      return;
+    }
+    let root = parent;
+    while (root.#parent !== undefined) {
+      root = root.#parent;
+    }
+    const index = (root.#byHash ??= new HashIndex());
+    const existing = index.get(this.#hash);
+    if (existing === undefined) {
+      index.set(this.#hash, this);
+    } else if (existing !== this && this.#sameAs(existing)) {
+      parent.#transitions?.replace(this, existing);
+    }
+  }
+
+  /**
+   * Whether `other` is interchangeable with this query: everything `hash()`
+   * covers, compared structurally. Schema and delegate are not compared. Both
+   * are fixed by the root, and this only ever compares queries under one root.
+   */
+  #sameAs(other: QueryImpl<any, any, any>): boolean {
+    return (
+      this.#system === other.#system &&
+      this.#currentJunction === other.#currentJunction &&
+      this.customQueryID?.name === other.customQueryID?.name &&
+      deepEqual(this.customQueryID?.args, other.customQueryID?.args) &&
+      deepEqual(this.format, other.format) &&
+      deepEqual(this.#ast, other.#ast)
+    );
   }
 
   one(): Query<TTable, TSchema, TReturn | undefined> {
@@ -665,10 +719,12 @@ export class QueryImpl<
     row: Partial<Record<string, ReadonlyJSONValue | undefined>>,
     opts?: {inclusive: boolean},
   ): Query<TTable, TSchema, TReturn> {
+    // The row is an object, so it is encoded to a string to serve as the
+    // lookup key. Property order is part of that string.
     return this.#derive(
       opts?.inclusive ? 'start:inclusive' : 'start:exclusive',
+      valueTag(row as ReadonlyJSONValue),
       undefined,
-      row,
       () =>
         this.#newQuery(
           this.#tableName,

--- a/packages/zql/src/query/query-impl.ts
+++ b/packages/zql/src/query/query-impl.ts
@@ -242,16 +242,6 @@ export class QueryImpl<
    */
   #expressionBuilder: ExpressionBuilder<TTable, TSchema> | undefined;
 
-  /**
-   * The query this one was derived from, or `undefined` for a root query.
-   *
-   * @internal Exposed for tests and debugging. The field behind it exists to
-   * keep the ancestor spine alive, not to be navigated.
-   */
-  get derivedFrom(): QueryImpl<any, any, any> | undefined {
-    return this.#parent;
-  }
-
   constructor(
     schema: TSchema,
     tableName: TTable,

--- a/packages/zql/src/query/query-impl.ts
+++ b/packages/zql/src/query/query-impl.ts
@@ -244,13 +244,6 @@ export class QueryImpl<
     return this.#parent;
   }
 
-  /** @internal Exposed so tests can assert what is retained strongly. */
-  get transitionsForTesting():
-    | Transitions<QueryImpl<any, any, any>>
-    | undefined {
-    return this.#transitions;
-  }
-
   constructor(
     schema: TSchema,
     tableName: TTable,

--- a/packages/zql/src/query/query-impl.ts
+++ b/packages/zql/src/query/query-impl.ts
@@ -7,6 +7,8 @@ import {
   type Condition,
   type NormalizedAST,
   type Parameter,
+  type LiteralValue,
+  type SimpleCondition,
   type SimpleOperator,
   type System,
   insertRelated,
@@ -30,6 +32,11 @@ import {
 } from './expression.ts';
 import type {CustomQueryID} from './named.ts';
 import {type QueryInternals, queryInternalsTag} from './query-internals.ts';
+import {
+  Transitions,
+  type Delta,
+  type TransitionValue,
+} from './query-transitions.ts';
 import type {
   AnyQuery,
   ExistsOptions,
@@ -86,6 +93,35 @@ export function newQueryImpl<
   return newQueryInternal(schema, tableName, normalizeAST(ast), format, system);
 }
 
+/**
+ * Root queries are interned per schema so that two `createBuilder(schema)` calls
+ * hand out the same starting point, and therefore share the whole transition
+ * tree below it. Only cleared entries accumulate here, at most one per
+ * system/table pair, so no sweeping is needed.
+ */
+const rootsBySchema = new WeakMap<
+  Schema,
+  Map<string, WeakRef<QueryImpl<any, any, any>>>
+>();
+
+/**
+ * Whether this is the AST `tableAST(tableName)` produces -- the whole table,
+ * nothing else. A normalized AST carries every field, so this cannot be a key
+ * count; each one has to be checked.
+ */
+function isRootAST(ast: NormalizedAST, tableName: string): boolean {
+  return (
+    ast.table === tableName &&
+    ast.schema === undefined &&
+    ast.alias === undefined &&
+    ast.where === undefined &&
+    ast.related === undefined &&
+    ast.start === undefined &&
+    ast.limit === undefined &&
+    ast.orderBy === undefined
+  );
+}
+
 function newQueryInternal<
   TTable extends keyof TSchema['tables'] & string,
   TSchema extends Schema,
@@ -97,6 +133,20 @@ function newQueryInternal<
   format: Format,
   system: System,
 ): QueryImpl<TTable, TSchema, TReturn> {
+  // Callers that hand in a pre-built AST -- benchmarks and the integration-test
+  // harnesses -- are not roots and are not interned.
+  const interned = format === defaultFormat && isRootAST(ast, tableName);
+  const key = `${system}:${tableName}`;
+  let roots: Map<string, WeakRef<QueryImpl<any, any, any>>> | undefined;
+
+  if (interned) {
+    roots = rootsBySchema.get(schema);
+    const existing = roots?.get(key)?.deref();
+    if (existing) {
+      return existing as QueryImpl<TTable, TSchema, TReturn>;
+    }
+  }
+
   const inner: NewQueryFunction<TSchema> = (
     tableName,
     ast,
@@ -115,7 +165,23 @@ function newQueryInternal<
       inner,
     );
 
-  return inner(tableName, ast, format, undefined, undefined);
+  const created = inner<TTable, TReturn>(
+    tableName,
+    ast,
+    format,
+    undefined,
+    undefined,
+  );
+
+  if (interned) {
+    if (!roots) {
+      roots = new Map();
+      rootsBySchema.set(schema, roots);
+    }
+    roots.set(key, new WeakRef(created));
+  }
+
+  return created;
 }
 
 /**
@@ -148,6 +214,40 @@ export class QueryImpl<
   readonly customQueryID: CustomQueryID | undefined;
   readonly #newQuery: NewQueryFunction<TSchema>;
 
+  /**
+   * The query this one was derived from, held *strongly*, and the queries
+   * derived from this one, held *weakly*. This is the arrangement V8 uses for
+   * hidden-class transitions, and it is what makes interning stable: as long as
+   * a query is reachable its whole ancestor spine is too, so re-deriving it from
+   * the root yields the same instance. See `query-transitions.ts`.
+   */
+  #parent: QueryImpl<any, any, any> | undefined;
+  #transitions: Transitions<QueryImpl<any, any, any>> | undefined;
+
+  /**
+   * Memoized because a query is interned: the same node serves every rebuild of
+   * a chain, so building this once rather than per `where(fn)` call takes the
+   * whole thing -- the builder and the bound `#exists` -- off the repeat path.
+   */
+  #expressionBuilder: ExpressionBuilder<TTable, TSchema> | undefined;
+
+  /**
+   * The query this one was derived from, or `undefined` for a root query.
+   *
+   * @internal Exposed for tests and debugging. The field behind it exists to
+   * keep the ancestor spine alive, not to be navigated.
+   */
+  get derivedFrom(): QueryImpl<any, any, any> | undefined {
+    return this.#parent;
+  }
+
+  /** @internal Exposed so tests can assert what is retained strongly. */
+  get transitionsForTesting():
+    | Transitions<QueryImpl<any, any, any>>
+    | undefined {
+    return this.#transitions;
+  }
+
   constructor(
     schema: TSchema,
     tableName: TTable,
@@ -166,6 +266,65 @@ export class QueryImpl<
     this.#currentJunction = currentJunction;
     this.customQueryID = customQueryID;
     this.#newQuery = newQuery;
+  }
+
+  /**
+   * Interns a transition whose key space is finite and schema-derived; see
+   * {@linkcode Transitions.storeBounded}. Used for the base sub-query handed to
+   * a `related`/`exists` callback, which is determined entirely by the
+   * relationship name.
+   */
+  #deriveBounded<T>(key: string, build: () => T): T {
+    const existing = this.#transitions?.lookupBounded(key);
+    if (existing !== undefined) {
+      return existing as T;
+    }
+    return this.#record(key, undefined, undefined, build(), true);
+  }
+
+  /**
+   * Interns the result of applying a builder operation to this query.
+   *
+   * `key` names the operation and `value` carries its varying argument, kept
+   * apart so the key stays a string V8 has already hashed. When the two do not
+   * settle it, `delta` carries the rest and is compared with `deepEqual`. Only
+   * the delta is compared, never the whole AST: this query is already canonical,
+   * so two of its children are equal exactly when the operations that produced
+   * them are.
+   *
+   * `T` is deliberately unconstrained so that the contextual return type at each
+   * call site still drives `#newQuery`'s inference, exactly as it did when the
+   * call sites returned `this.#newQuery(...)` directly.
+   */
+  #derive<T>(
+    key: string,
+    value: TransitionValue,
+    delta: Delta,
+    build: () => T,
+  ): T {
+    const existing = this.#transitions?.lookup(key, value, delta);
+    if (existing !== undefined) {
+      return existing as T;
+    }
+    return this.#record(key, value, delta, build(), false);
+  }
+
+  #record<T>(
+    key: string,
+    value: TransitionValue,
+    delta: Delta,
+    created: T,
+    bounded: boolean,
+  ): T {
+    const q = created as unknown as QueryImpl<any, any, any>;
+    q.#parent = this;
+    const transitions = (this.#transitions ??= new Transitions());
+    if (bounded) {
+      transitions.storeBounded(key, q);
+    } else {
+      transitions.store(key, value, delta, q);
+    }
+    return created;
   }
 
   run(_options?: RunOptions): Promise<HumanReadable<TReturn>> {
@@ -195,15 +354,17 @@ export class QueryImpl<
     name: string,
     args: ReadonlyArray<ReadonlyJSONValue>,
   ): Query<TTable, TSchema, TReturn> {
-    return this.#newQuery(
-      this.#tableName,
-      this.#ast,
-      this.format,
-      {
-        name,
-        args,
-      },
-      this.#currentJunction,
+    return this.#derive('nameAndArgs', name, args, () =>
+      this.#newQuery(
+        this.#tableName,
+        this.#ast,
+        this.format,
+        {
+          name,
+          args,
+        },
+        this.#currentJunction,
+      ),
     );
   }
 
@@ -221,23 +382,26 @@ export class QueryImpl<
     return this.#hash;
   }
 
-  one = (): Query<TTable, TSchema, TReturn | undefined> =>
-    this.#newQuery(
-      this.#tableName,
-      {...this.#ast, limit: 1},
-      {
-        ...this.format,
-        singular: true,
-      },
-      this.customQueryID,
-      this.#currentJunction,
+  one(): Query<TTable, TSchema, TReturn | undefined> {
+    return this.#derive('one', undefined, undefined, () =>
+      this.#newQuery(
+        this.#tableName,
+        {...this.#ast, limit: 1},
+        {
+          ...this.format,
+          singular: true,
+        },
+        this.customQueryID,
+        this.#currentJunction,
+      ),
     );
+  }
 
-  whereExists = (
+  whereExists(
     relationship: string,
     cbOrOptions?: ((q: AnyQuery) => AnyQuery) | ExistsOptions,
     options?: ExistsOptions,
-  ): Query<TTable, TSchema, TReturn> => {
+  ): Query<TTable, TSchema, TReturn> {
     const cb = typeof cbOrOptions === 'function' ? cbOrOptions : undefined;
     const opts = typeof cbOrOptions === 'function' ? options : cbOrOptions;
     return this.where(({exists}) => exists(relationship, cb, opts)) as Query<
@@ -245,12 +409,12 @@ export class QueryImpl<
       TSchema,
       TReturn
     >;
-  };
+  }
 
-  related = (
+  related(
     relationship: string,
     cb?: (q: AnyQuery) => AnyQuery,
-  ): Query<TTable, TSchema, any> => {
+  ): Query<TTable, TSchema, any> {
     if (relationship.startsWith(SUBQ_PREFIX)) {
       throw new Error(
         `Relationship names may not start with "${SUBQ_PREFIX}". That is a reserved prefix.`,
@@ -262,15 +426,22 @@ export class QueryImpl<
     assert(related, 'Invalid relationship');
     if (isOneHop(related)) {
       const {destSchema, destField, sourceField, cardinality} = related[0];
-      const q: AnyQuery = this.#newQuery(
-        destSchema,
-        tableAST(destSchema, relationship),
-        {
-          relationships: {},
-          singular: cardinality === 'one',
-        },
-        this.customQueryID,
-        undefined,
+      // Intern the base handed to the callback too. A deterministic callback
+      // then walks the same interned chain and hands back the *same* sub-query,
+      // which makes the comparison below a pointer compare.
+      const q: AnyQuery = this.#deriveBounded(
+        `relatedBase:${relationship}`,
+        () =>
+          this.#newQuery(
+            destSchema,
+            tableAST(destSchema, relationship),
+            {
+              relationships: {},
+              singular: cardinality === 'one',
+            },
+            this.customQueryID,
+            undefined,
+          ),
       ) as AnyQuery;
       // Intentionally not setting to `one` as it is a perf degradation
       // and the user should not be making the mistake of setting cardinality to
@@ -292,28 +463,38 @@ export class QueryImpl<
         'The source and destination of a relationship must have the same number of fields',
       );
 
-      return this.#newQuery(
-        this.#tableName,
-        {
-          ...this.#ast,
-          related: insertRelated(this.#ast.related, {
-            correlation: {
-              parentField: sourceField,
-              childField: destField,
+      // Keyed by the sub-query's identity. Each query owns its AST object, so
+      // this distinguishes even `q.one()` from `q.limit(1)`, whose ASTs are
+      // structurally equal but whose formats differ. Comparing them as a delta
+      // instead would put every sibling under one key and scan.
+      return this.#derive(
+        relatedKey(relationship),
+        astID(subQuery.#ast),
+        undefined,
+        () =>
+          this.#newQuery(
+            this.#tableName,
+            {
+              ...this.#ast,
+              related: insertRelated(this.#ast.related, {
+                correlation: {
+                  parentField: sourceField,
+                  childField: destField,
+                },
+                subquery: subQuery.#ast,
+                system: this.#system,
+              }),
             },
-            subquery: subQuery.#ast,
-            system: this.#system,
-          }),
-        },
-        {
-          ...this.format,
-          relationships: {
-            ...this.format.relationships,
-            [relationship]: subQuery.format,
-          },
-        },
-        this.customQueryID,
-        this.#currentJunction,
+            {
+              ...this.format,
+              relationships: {
+                ...this.format.relationships,
+                [relationship]: subQuery.format,
+              },
+            },
+            this.customQueryID,
+            this.#currentJunction,
+          ),
       ) as AnyQuery;
     }
 
@@ -323,72 +504,83 @@ export class QueryImpl<
       const junctionSchema = firstRelation.destSchema;
       const sq = asQueryImpl(
         cb(
-          this.#newQuery(
-            destSchema,
-            tableAST(destSchema, relationship),
-            {
-              relationships: {},
-              singular: secondRelation.cardinality === 'one',
-            },
-            this.customQueryID,
-            relationship,
+          this.#deriveBounded(`relatedBase:${relationship}`, () =>
+            this.#newQuery(
+              destSchema,
+              tableAST(destSchema, relationship),
+              {
+                relationships: {},
+                singular: secondRelation.cardinality === 'one',
+              },
+              this.customQueryID,
+              relationship,
+            ),
           ) as AnyQuery,
         ),
       );
 
-      assert(isCompoundKey(firstRelation.sourceField), 'Invalid relationship');
-      assert(isCompoundKey(firstRelation.destField), 'Invalid relationship');
-      assert(isCompoundKey(secondRelation.sourceField), 'Invalid relationship');
-      assert(isCompoundKey(secondRelation.destField), 'Invalid relationship');
+      // Bound to consts so the `isCompoundKey` narrowing survives into the
+      // closure below; TypeScript drops narrowing of property accesses there.
+      const {sourceField: firstSource, destField: firstDest} = firstRelation;
+      const {sourceField: secondSource, destField: secondDest} = secondRelation;
+      assert(isCompoundKey(firstSource), 'Invalid relationship');
+      assert(isCompoundKey(firstDest), 'Invalid relationship');
+      assert(isCompoundKey(secondSource), 'Invalid relationship');
+      assert(isCompoundKey(secondDest), 'Invalid relationship');
 
-      return this.#newQuery(
-        this.#tableName,
-        {
-          ...this.#ast,
-          related: insertRelated(this.#ast.related, {
-            correlation: {
-              parentField: firstRelation.sourceField,
-              childField: firstRelation.destField,
+      return this.#derive(
+        relatedKey(relationship),
+        astID(sq.#ast),
+        undefined,
+        () =>
+          this.#newQuery(
+            this.#tableName,
+            {
+              ...this.#ast,
+              related: insertRelated(this.#ast.related, {
+                correlation: {
+                  parentField: firstSource,
+                  childField: firstDest,
+                },
+                hidden: true,
+                subquery: {
+                  ...tableAST(junctionSchema, relationship),
+                  // A single subquery is sorted.
+                  related: [
+                    normalizedRelated({
+                      correlation: {
+                        parentField: secondSource,
+                        childField: secondDest,
+                      },
+                      subquery: sq.#ast,
+                      system: this.#system,
+                    }),
+                  ],
+                },
+                system: this.#system,
+              }),
             },
-            hidden: true,
-            subquery: {
-              ...tableAST(junctionSchema, relationship),
-              // A single subquery is sorted.
-              related: [
-                normalizedRelated({
-                  correlation: {
-                    parentField: secondRelation.sourceField,
-                    childField: secondRelation.destField,
-                  },
-                  subquery: sq.#ast,
-                  system: this.#system,
-                }),
-              ],
+            {
+              ...this.format,
+              relationships: {
+                ...this.format.relationships,
+                [relationship]: sq.format,
+              },
             },
-            system: this.#system,
-          }),
-        },
-        {
-          ...this.format,
-          relationships: {
-            ...this.format.relationships,
-            [relationship]: sq.format,
-          },
-        },
-        this.customQueryID,
-        this.#currentJunction,
+            this.customQueryID,
+            this.#currentJunction,
+          ),
       ) as AnyQuery;
     }
 
     throw new Error(`Invalid relationship ${relationship}`);
-  };
+  }
 
   // The declared return is the *bottom* of the pinned dimension, which is
   // assignable to every `where` overload's declared return. The overloads
   // refine `TPinned` for callers only; a single non-generic implementation
   // signature cannot express that refinement.
-  where = function (
-    this: QueryImpl<TTable, TSchema, TReturn>,
+  where(
     fieldOrExpressionFactory: string | ExpressionFactory<TTable, TSchema>,
     opOrValue?: SimpleOperator | GetFilterTypeAny | Parameter,
     value?: GetFilterTypeAny | Parameter,
@@ -401,46 +593,109 @@ export class QueryImpl<
       assert(arguments.length >= 2, 'Invalid condition. Too few arguments.');
       // Distinguish between 2-arg form (field, value) and 3-arg form (field, op, value)
       // using arguments.length to allow explicit undefined in 3-arg form.
-      if (arguments.length === 2) {
-        cond = cmp(fieldOrExpressionFactory, opOrValue);
+      const twoArg = arguments.length === 2;
+      const op = (twoArg ? '=' : opOrValue) as SimpleOperator;
+      const raw = twoArg ? opOrValue : value;
+
+      // Comparing a column to a primitive is by far the most common thing anyone
+      // does with a query, and the transition it names is fully determined by
+      // (column, op, value) -- so check for it before building anything. On a hit
+      // this returns without allocating the `Condition` at all. Objects are
+      // excluded, which covers both parameter references and `IN` arrays; `cmp`
+      // maps a missing value to null, so this must too.
+      if (raw === null || typeof raw !== 'object') {
+        const hit = this.#transitions?.lookup(
+          whereKey(fieldOrExpressionFactory, op),
+          (raw ?? null) as TransitionValue,
+          undefined,
+        );
+        if (hit !== undefined) {
+          return hit as unknown as Query<TTable, TSchema, TReturn, any>;
+        }
+      }
+
+      cond = twoArg
+        ? cmp(fieldOrExpressionFactory, opOrValue)
+        : cmp(fieldOrExpressionFactory, opOrValue, value);
+    }
+
+    // The delta is the condition as built here, *before* it is merged with the
+    // existing where and normalized. Both steps are deterministic and the
+    // existing where is fixed by this query, so an equal `cond` always produces
+    // an equal result.
+    //
+    // A simple comparison against a column splits cleanly: the column and
+    // operator come from a small fixed set and give a memoized, stable key,
+    // while the compared value -- the part that varies per call -- is handed
+    // through as the transition value and never concatenated into a string.
+    let key: string;
+    let tValue: TransitionValue;
+    let delta: Delta = cond;
+    if (cond.type === 'simple' && cond.left.type === 'column') {
+      key = whereKey(cond.left.name, cond.op);
+      const right = cond.right;
+      if (right.type === 'literal' && isPrimitive(right.value)) {
+        tValue = right.value;
+        delta = undefined;
       } else {
-        cond = cmp(fieldOrExpressionFactory, opOrValue, value);
+        const tag = rightTag(right);
+        if (tag !== undefined) {
+          tValue = tag;
+          delta = undefined;
+        }
+      }
+    } else {
+      // A sub-query an `exists` correlates to is itself interned, so its
+      // identity settles that part of the tree without walking it.
+      const exact = condKey(cond);
+      if (exact === undefined) {
+        key = treeKey(cond);
+      } else {
+        key = 'where:tree';
+        tValue = exact;
+        delta = undefined;
       }
     }
 
-    const existingWhere = this.#ast.where;
-    if (existingWhere) {
-      cond = and(existingWhere, cond);
-    }
+    return this.#derive(key, tValue, delta, () => {
+      const existingWhere = this.#ast.where;
+      const merged = existingWhere ? and(existingWhere, cond) : cond;
+      return this.#newQuery(
+        this.#tableName,
+        {...this.#ast, where: normalizeCondition(simplifyCondition(merged))},
+        this.format,
+        this.customQueryID,
+        this.#currentJunction,
+      );
+    }) as unknown as Query<TTable, TSchema, TReturn, any>;
+  }
 
-    return this.#newQuery(
-      this.#tableName,
-      {...this.#ast, where: normalizeCondition(simplifyCondition(cond))},
-      this.format,
-      this.customQueryID,
-      this.#currentJunction,
-    ) as unknown as Query<TTable, TSchema, TReturn, any>;
-  }.bind(this);
-
-  start = (
+  start(
     row: Partial<Record<string, ReadonlyJSONValue | undefined>>,
     opts?: {inclusive: boolean},
-  ): Query<TTable, TSchema, TReturn> =>
-    this.#newQuery(
-      this.#tableName,
-      {
-        ...this.#ast,
-        start: {
-          row,
-          exclusive: !opts?.inclusive,
-        },
-      },
-      this.format,
-      this.customQueryID,
-      this.#currentJunction,
+  ): Query<TTable, TSchema, TReturn> {
+    return this.#derive(
+      opts?.inclusive ? 'start:inclusive' : 'start:exclusive',
+      undefined,
+      row,
+      () =>
+        this.#newQuery(
+          this.#tableName,
+          {
+            ...this.#ast,
+            start: {
+              row,
+              exclusive: !opts?.inclusive,
+            },
+          },
+          this.format,
+          this.customQueryID,
+          this.#currentJunction,
+        ),
     );
+  }
 
-  limit = (limit: number): Query<TTable, TSchema, TReturn> => {
+  limit(limit: number): Query<TTable, TSchema, TReturn> {
     if (limit < 0) {
       throw new Error('Limit must be non-negative');
     }
@@ -454,42 +709,53 @@ export class QueryImpl<
       );
     }
 
-    return this.#newQuery(
-      this.#tableName,
-      {...this.#ast, limit},
-      this.format,
-      this.customQueryID,
-      this.#currentJunction,
+    return this.#derive('limit', limit, undefined, () =>
+      this.#newQuery(
+        this.#tableName,
+        {...this.#ast, limit},
+        this.format,
+        this.customQueryID,
+        this.#currentJunction,
+      ),
     );
-  };
+  }
 
-  orderBy = <TSelector extends keyof TSchema['tables'][TTable]['columns']>(
+  orderBy<TSelector extends keyof TSchema['tables'][TTable]['columns']>(
     field: TSelector,
     direction: 'asc' | 'desc',
-  ): Query<TTable, TSchema, TReturn> => {
+  ): Query<TTable, TSchema, TReturn> {
     if (this.#currentJunction) {
       throw new NotImplementedError(
         'Order by is not supported in junction relationships yet. Junction relationship being ordered: ' +
           this.#currentJunction,
       );
     }
-    return this.#newQuery(
-      this.#tableName,
-      {
-        ...this.#ast,
-        orderBy: [...(this.#ast.orderBy ?? []), [field as string, direction]],
-      },
-      this.format,
-      this.customQueryID,
-      this.#currentJunction,
+    return this.#derive(
+      direction === 'asc' ? 'orderBy:asc' : 'orderBy:desc',
+      field as string,
+      undefined,
+      () =>
+        this.#newQuery(
+          this.#tableName,
+          {
+            ...this.#ast,
+            orderBy: [
+              ...(this.#ast.orderBy ?? []),
+              [field as string, direction],
+            ],
+          },
+          this.format,
+          this.customQueryID,
+          this.#currentJunction,
+        ),
     );
-  };
+  }
 
-  #exists = (
+  #exists(
     relationship: string,
     cb: ((query: AnyQuery) => AnyQuery) | undefined,
     options?: ExistsOptions,
-  ): Condition => {
+  ): Condition {
     cb = cb ?? (q => q);
     const flip = options?.flip;
     const scalar = options?.scalar;
@@ -503,15 +769,20 @@ export class QueryImpl<
 
       const subQuery = asQueryImpl(
         cb(
-          this.#newQuery(
-            destTableName,
-            tableAST(destTableName, `${SUBQ_PREFIX}${relationship}`),
-            defaultFormat,
-            this.customQueryID,
-            undefined,
+          this.#deriveBounded(`existsBase:${relationship}`, () =>
+            this.#newQuery(
+              destTableName,
+              tableAST(destTableName, `${SUBQ_PREFIX}${relationship}`),
+              defaultFormat,
+              this.customQueryID,
+              undefined,
+            ),
           ) as AnyQuery,
         ),
       );
+      // Give the sub-query's AST an id so the enclosing `where` can key on it
+      // exactly rather than comparing the sub-tree.
+      astID(subQuery.#ast);
       // Unlike the entries of `related`, the correlated subqueries of a
       // condition keep the order their fields are written in: normalization
       // does not reorder them either.
@@ -540,12 +811,14 @@ export class QueryImpl<
       const {destSchema} = secondRelation;
       const junctionSchema = firstRelation.destSchema;
       const queryToDest = cb(
-        this.#newQuery(
-          destSchema,
-          tableAST(destSchema, `${SUBQ_PREFIX}zhidden_${relationship}`),
-          defaultFormat,
-          this.customQueryID,
-          relationship,
+        this.#deriveBounded(`existsJunctionBase:${relationship}`, () =>
+          this.#newQuery(
+            destSchema,
+            tableAST(destSchema, `${SUBQ_PREFIX}zhidden_${relationship}`),
+            defaultFormat,
+            this.customQueryID,
+            relationship,
+          ),
         ) as AnyQuery,
       );
 
@@ -583,18 +856,21 @@ export class QueryImpl<
     }
 
     throw new Error(`Invalid relationship ${relationship}`);
-  };
+  }
 
   get ast(): NormalizedAST {
     return this.#ast;
   }
 
   expressionBuilder(): ExpressionBuilder<TTable, TSchema> {
-    return new ExpressionBuilder<TTable, TSchema>(
-      this.#exists as ConstructorParameters<
+    // Built on demand rather than held as an eagerly initialized field: a field
+    // would cost a closure on every query constructed, where this costs one only
+    // for queries that actually use an expression factory.
+    return (this.#expressionBuilder ??= new ExpressionBuilder<TTable, TSchema>(
+      this.#exists.bind(this) as ConstructorParameters<
         typeof ExpressionBuilder<TTable, TSchema>
       >[0],
-    );
+    ));
   }
 }
 
@@ -605,6 +881,173 @@ export function asQueryImpl<
 >(q: Query<TTable, TSchema, TReturn>): QueryImpl<TTable, TSchema, TReturn> {
   assert(q instanceof QueryImpl, 'Expected QueryImpl instance');
   return q;
+}
+
+/**
+ * A stable id per query AST.
+ *
+ * Every `QueryImpl` allocates its own AST object, so these are one-to-one with
+ * queries, and interning makes the object identity stable across rebuilds. That
+ * lets a `related` or `exists` transition key on *which* sub-query it points at
+ * rather than comparing the sub-tree.
+ *
+ * Assigned only where it is needed. A `WeakMap.set` costs on the order of a
+ * hundred nanoseconds, so doing this for every query rather than for the few
+ * that are sub-queries was one of the largest single costs of building a query
+ * from cold. ASTs that never pass through here -- including the junction AST a
+ * two-hop `exists` builds inline -- are absent, and fall back to a delta.
+ */
+const astIDs = new WeakMap<AST, number>();
+let nextASTID = 0;
+
+function astID(ast: AST): number {
+  let id = astIDs.get(ast);
+  if (id === undefined) {
+    id = ++nextASTID;
+    astIDs.set(ast, id);
+  }
+  return id;
+}
+
+/**
+ * Memoized transition keys.
+ *
+ * A transition key must be a string V8 has already hashed, or the `Map` lookup
+ * has to hash it from scratch -- measured at ~148ns against ~10ns, which dwarfs
+ * everything else a lookup does. Both tables are keyed by schema-derived names,
+ * so they are bounded by the schema.
+ */
+const whereKeys = new Map<string, Map<string, string>>();
+
+function whereKey(column: string, op: string): string {
+  let byOp = whereKeys.get(column);
+  if (byOp === undefined) {
+    byOp = new Map();
+    whereKeys.set(column, byOp);
+  }
+  let key = byOp.get(op);
+  if (key === undefined) {
+    key = `where:${column}:${op}`;
+    byOp.set(op, key);
+  }
+  return key;
+}
+
+const relatedKeys = new Map<string, string>();
+
+function relatedKey(relationship: string): string {
+  let key = relatedKeys.get(relationship);
+  if (key === undefined) {
+    key = `related:${relationship}`;
+    relatedKeys.set(relationship, key);
+  }
+  return key;
+}
+
+function isPrimitive(v: LiteralValue): v is string | number | boolean | null {
+  return v === null || typeof v !== 'object';
+}
+
+/**
+ * Folds the right-hand side of a simple condition into a transition value, so
+ * that the transition is exact and the lookup needs no comparison at all.
+ *
+ * The leading tag keeps `'1'` and `1` apart. Arrays (`IN`) and parameter
+ * references are serialized: that is one pass over a small value, where leaving
+ * them in the delta would instead cost a `deepEqual` over the whole condition
+ * for every sibling a lookup walks past.
+ */
+function rightTag(right: SimpleCondition['right']): string | undefined {
+  if (right.type !== 'literal') {
+    return `:p${JSON.stringify(right)}`;
+  }
+  const v = right.value;
+  switch (typeof v) {
+    case 'string':
+      return `:s${v}`;
+    case 'number':
+      return `:n${v}`;
+    case 'boolean':
+      return `:b${v}`;
+    case 'object':
+      return v === null ? ':z' : `:a${JSON.stringify(v)}`;
+  }
+  return undefined;
+}
+
+/**
+ * Length-prefixes a free-form string so it can be concatenated into a key
+ * without a separator being ambiguous with the content.
+ */
+function enc(s: string): string {
+  return `${s.length}:${s}`;
+}
+
+/** Encodes an optional boolean without collapsing `undefined` into `false`. */
+function tri(b: boolean | undefined): string {
+  return b === undefined ? '-' : b ? 't' : 'f';
+}
+
+/**
+ * An exact key for a whole condition tree, or `undefined` for a shape we cannot
+ * encode (which falls back to {@linkcode treeKey} plus a delta).
+ *
+ * Everything variable-length is length-prefixed, so distinct trees cannot
+ * produce the same string and the key needs no `deepEqual` to back it up. That
+ * matters because the alternative -- one coarse bucket per shape -- turns N
+ * sibling conditions off the same parent into an N-deep scan of tree
+ * comparisons, which measured far slower than not interning at all.
+ */
+function condKey(cond: Condition): string | undefined {
+  switch (cond.type) {
+    case 'simple': {
+      if (cond.left.type !== 'column') {
+        return undefined;
+      }
+      const tag = rightTag(cond.right);
+      return tag === undefined
+        ? undefined
+        : `S${enc(cond.left.name)}${enc(cond.op)}${tag}`;
+    }
+    case 'correlatedSubquery': {
+      const id = astIDs.get(cond.related.subquery);
+      return id === undefined
+        ? undefined
+        : `E${id}:${enc(cond.op)}${tri(cond.flip)}${tri(cond.scalar)}`;
+    }
+    case 'and':
+    case 'or': {
+      let out = `${cond.type === 'and' ? 'A' : 'O'}${cond.conditions.length}:`;
+      for (const c of cond.conditions) {
+        const k = condKey(c);
+        if (k === undefined) {
+          return undefined;
+        }
+        out += k;
+      }
+      return out;
+    }
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * A coarse bucket key for the conditions {@linkcode condKey} cannot encode --
+ * a two-hop `exists`, whose junction AST is built inline and so has no identity
+ * of its own. Reads only the top of the tree, so it is cheap; the delta tells
+ * apart what shares it.
+ */
+function treeKey(cond: Condition): string {
+  switch (cond.type) {
+    case 'correlatedSubquery':
+      return `where:e:${cond.related.subquery.alias}:${cond.op}`;
+    case 'and':
+    case 'or':
+      return `where:${cond.type}:${cond.conditions.length}`;
+    default:
+      return 'where:*';
+  }
 }
 
 function throwQueryNotRunnable(): never {

--- a/packages/zql/src/query/query-transitions.test.ts
+++ b/packages/zql/src/query/query-transitions.test.ts
@@ -1,0 +1,226 @@
+import {expect, test} from 'vitest';
+import {
+  MAX_SCAN,
+  Transitions,
+  type TransitionValue,
+} from './query-transitions.ts';
+
+function make(name: string): {name: string} {
+  return {name};
+}
+
+const emptyRef = {deref: () => undefined} as unknown as WeakRef<object>;
+
+/** Fills the strong first slot so later stores land in the weak store. */
+function fill(t: Transitions<object>): void {
+  t.store('first', undefined, undefined, make('first'));
+}
+
+/**
+ * Values are held weakly, so to simulate collection we swap in an entry whose
+ * `WeakRef` is already empty. Only reaches the weak store — the strongly held
+ * first child and the bounded store are by definition never collected.
+ */
+function kill(t: Transitions<object>, key: string, v: TransitionValue): void {
+  const byValue = t.rest!.get(key)!;
+  const bucket = byValue.get(v)!;
+  if (bucket instanceof Set) {
+    byValue.set(
+      v,
+      new Set(Array.from(bucket, e => ({delta: e.delta, ref: emptyRef}))),
+    );
+  } else {
+    byValue.set(v, {delta: bucket.delta, ref: emptyRef});
+  }
+}
+
+function bucketOf(t: Transitions<object>, key: string, v: TransitionValue) {
+  const bucket = t.rest!.get(key)!.get(v);
+  expect(bucket).toBeInstanceOf(Set);
+  return bucket as Set<{delta: unknown; ref: WeakRef<object>}>;
+}
+
+test('round trips a transition', () => {
+  const t = new Transitions<object>();
+  const a = make('a');
+  expect(t.lookup('one', undefined, undefined)).toBe(undefined);
+  t.store('one', undefined, undefined, a);
+  expect(t.lookup('one', undefined, undefined)).toBe(a);
+  expect(t.lookup('other', undefined, undefined)).toBe(undefined);
+});
+
+test('the first transition is held strongly, with no weak store at all', () => {
+  const t = new Transitions<object>();
+  const a = make('a');
+  t.store('one', undefined, undefined, a);
+
+  expect(t.first).toBe(a);
+  // The whole point: a node with a single child allocates no WeakRef and no Map.
+  expect(t.rest).toBe(undefined);
+});
+
+test('the value is part of a transition’s identity', () => {
+  const t = new Transitions<object>();
+  const a = make('a');
+  const b = make('b');
+  t.store('limit', 10, undefined, a);
+  t.store('limit', 20, undefined, b);
+
+  expect(t.lookup('limit', 10, undefined)).toBe(a);
+  expect(t.lookup('limit', 20, undefined)).toBe(b);
+  expect(t.lookup('limit', 30, undefined)).toBe(undefined);
+  // Same key, different value: the first slot must not match on key alone.
+  expect(t.first).toBe(a);
+});
+
+test('values are distinguished by type, not coerced', () => {
+  const t = new Transitions<object>();
+  const num = make('num');
+  const str = make('str');
+  t.store('where:id:=', 1, undefined, num);
+  t.store('where:id:=', '1', undefined, str);
+
+  expect(t.lookup('where:id:=', 1, undefined)).toBe(num);
+  expect(t.lookup('where:id:=', '1', undefined)).toBe(str);
+});
+
+test('the first slot still checks its delta', () => {
+  const t = new Transitions<object>();
+  const a = make('a');
+  t.store('k', undefined, {id: 1}, a);
+
+  expect(t.lookup('k', undefined, {id: 1})).toBe(a);
+  // Structurally equal but distinct object still matches.
+  expect(t.lookup('k', undefined, {id: 1, extra: undefined})).toBe(a);
+  // A different delta must not match; it falls through to the empty weak store.
+  expect(t.lookup('k', undefined, {id: 2})).toBe(undefined);
+});
+
+test('bounded transitions are held strongly and never collected', () => {
+  const t = new Transitions<object>();
+  const a = make('a');
+  const b = make('b');
+  t.storeBounded('relatedBase:comments', a);
+  t.storeBounded('relatedBase:labels', b);
+
+  expect(t.lookupBounded('relatedBase:comments')).toBe(a);
+  expect(t.lookupBounded('relatedBase:labels')).toBe(b);
+  // Bounded storage is separate: it does not consume the first-child slot, and
+  // does not spill into the weak store.
+  expect(t.first).toBe(undefined);
+  expect(t.rest).toBe(undefined);
+});
+
+test('distinguishes entries in a bucket by deepEqual on the delta', () => {
+  const t = new Transitions<object>();
+  const a = make('a');
+  const b = make('b');
+  fill(t);
+  t.store('where:tree', undefined, {id: 1}, a);
+  t.store('where:tree', undefined, {id: 2}, b);
+
+  expect(t.lookup('where:tree', undefined, {id: 1})).toBe(a);
+  expect(t.lookup('where:tree', undefined, {id: 2})).toBe(b);
+  expect(t.lookup('where:tree', undefined, {id: 3})).toBe(undefined);
+});
+
+test('a single-entry bucket stays unwrapped and is promoted on collision', () => {
+  const t = new Transitions<object>();
+  fill(t);
+  t.store('k', undefined, 1, make('a'));
+  expect(t.rest!.get('k')!.get(undefined)).not.toBeInstanceOf(Set);
+  t.store('k', undefined, 2, make('b'));
+  expect(t.rest!.get('k')!.get(undefined)).toBeInstanceOf(Set);
+});
+
+test('lookup prunes a collected single entry', () => {
+  const t = new Transitions<object>();
+  fill(t);
+  t.store('k', 'v', undefined, make('a'));
+  kill(t, 'k', 'v');
+
+  expect(t.lookup('k', 'v', undefined)).toBe(undefined);
+  expect(t.rest!.get('k')!.has('v')).toBe(false);
+});
+
+test('lookup prunes collected entries out of a bucket as it walks', () => {
+  const t = new Transitions<object>();
+  const live = make('live');
+  fill(t);
+  t.store('k', undefined, 1, make('dead'));
+  t.store('k', undefined, 2, live);
+
+  const bucket = bucketOf(t, 'k', undefined);
+  const [dead] = [...bucket];
+  bucket.delete(dead);
+  bucket.add({delta: dead.delta, ref: emptyRef});
+
+  expect(t.lookup('k', undefined, 1)).toBe(undefined);
+  expect(bucket.size).toBe(1);
+  expect(t.lookup('k', undefined, 2)).toBe(live);
+});
+
+test('a hit stops early instead of walking the whole bucket', () => {
+  const t = new Transitions<object>();
+  fill(t);
+  const values = Array.from({length: 10}, (_, i) => make(`v${i}`));
+  values.forEach((v, i) => t.store('k', undefined, i, v));
+
+  const bucket = bucketOf(t, 'k', undefined);
+  // Kill every entry *after* the one we are about to ask for. A lookup that
+  // walked the whole bucket would prune them; stopping at the match leaves them.
+  [...bucket].slice(3).forEach(e => {
+    bucket.delete(e);
+    bucket.add({delta: e.delta, ref: emptyRef});
+  });
+
+  expect(t.lookup('k', undefined, 2)).toBe(values[2]);
+  expect(bucket.size).toBe(10);
+});
+
+test('a bucket stops growing at MAX_SCAN without evicting', () => {
+  const t = new Transitions<object>();
+  fill(t);
+  const values = Array.from({length: MAX_SCAN + 4}, (_, i) => make(`v${i}`));
+  values.forEach((v, i) => t.store('k', undefined, i, v));
+
+  expect(bucketOf(t, 'k', undefined).size).toBe(MAX_SCAN);
+  // Everything that fit stays shared...
+  for (let i = 0; i < MAX_SCAN; i++) {
+    expect(t.lookup('k', undefined, i)).toBe(values[i]);
+  }
+  // ...and the surplus is simply not interned, rather than displacing a live
+  // entry. This is what keeps a sequential sweep from thrashing to a 0% hit rate.
+  for (let i = MAX_SCAN; i < values.length; i++) {
+    expect(t.lookup('k', undefined, i)).toBe(undefined);
+  }
+});
+
+test('a node sweeps dead entries once its weak store has grown', () => {
+  const t = new Transitions<object>();
+  fill(t);
+
+  // Every value distinct and every node collected: the shape of a search box
+  // typing into `where:title:=` off a root that never dies. Nothing ever looks
+  // these up again, so only a sweep can reclaim them.
+  for (let i = 0; i < 1000; i++) {
+    t.store('where:title:=', `text-${i}`, undefined, make(`v${i}`));
+    t.rest!.get('where:title:=')!.set(`text-${i}`, {
+      delta: undefined,
+      ref: emptyRef,
+    });
+  }
+
+  expect(t.restSize).toBeLessThan(200);
+  expect(t.rest!.get('where:title:=')!.size).toBeLessThan(200);
+});
+
+test('sweeping keeps live entries', () => {
+  const t = new Transitions<object>();
+  fill(t);
+  const live = Array.from({length: 300}, (_, i) => make(`v${i}`));
+  live.forEach((v, i) => t.store('k', i, undefined, v));
+
+  expect(t.rest!.get('k')!.size).toBe(300);
+  live.forEach((v, i) => expect(t.lookup('k', i, undefined)).toBe(v));
+});

--- a/packages/zql/src/query/query-transitions.test.ts
+++ b/packages/zql/src/query/query-transitions.test.ts
@@ -1,43 +1,14 @@
 import {expect, test} from 'vitest';
-import {
-  MAX_SCAN,
-  Transitions,
-  type TransitionValue,
-} from './query-transitions.ts';
+import {MAX_SCAN, Transitions} from './query-transitions.ts';
+import {withStubbedWeakRef} from './test/weak-ref-stub.ts';
 
 function make(name: string): {name: string} {
   return {name};
 }
 
-const emptyRef = {deref: () => undefined} as unknown as WeakRef<object>;
-
 /** Fills the strong first slot so later stores land in the weak store. */
 function fill(t: Transitions<object>): void {
   t.store('first', undefined, undefined, make('first'));
-}
-
-/**
- * Values are held weakly, so to simulate collection we swap in an entry whose
- * `WeakRef` is already empty. Only reaches the weak store — the strongly held
- * first child and the bounded store are by definition never collected.
- */
-function kill(t: Transitions<object>, key: string, v: TransitionValue): void {
-  const byValue = t.rest!.get(key)!;
-  const bucket = byValue.get(v)!;
-  if (bucket instanceof Set) {
-    byValue.set(
-      v,
-      new Set(Array.from(bucket, e => ({delta: e.delta, ref: emptyRef}))),
-    );
-  } else {
-    byValue.set(v, {delta: bucket.delta, ref: emptyRef});
-  }
-}
-
-function bucketOf(t: Transitions<object>, key: string, v: TransitionValue) {
-  const bucket = t.rest!.get(key)!.get(v);
-  expect(bucket).toBeInstanceOf(Set);
-  return bucket as Set<{delta: unknown; ref: WeakRef<object>}>;
 }
 
 test('round trips a transition', () => {
@@ -50,13 +21,17 @@ test('round trips a transition', () => {
 });
 
 test('the first transition is held strongly, with no weak store at all', () => {
-  const t = new Transitions<object>();
-  const a = make('a');
-  t.store('one', undefined, undefined, a);
+  withStubbedWeakRef(weak => {
+    const t = new Transitions<object>();
+    const a = make('a');
+    t.store('one', undefined, undefined, a);
 
-  expect(t.first).toBe(a);
-  // The whole point: a node with a single child allocates no WeakRef and no Map.
-  expect(t.rest).toBe(undefined);
+    // The whole point: a node with a single child allocates no WeakRef.
+    expect(weak.created()).toBe(0);
+    // ...and holds it strongly, so it outlives collection.
+    weak.collect(a);
+    expect(t.lookup('one', undefined, undefined)).toBe(a);
+  });
 });
 
 test('the value is part of a transition’s identity', () => {
@@ -68,9 +43,8 @@ test('the value is part of a transition’s identity', () => {
 
   expect(t.lookup('limit', 10, undefined)).toBe(a);
   expect(t.lookup('limit', 20, undefined)).toBe(b);
-  expect(t.lookup('limit', 30, undefined)).toBe(undefined);
   // Same key, different value: the first slot must not match on key alone.
-  expect(t.first).toBe(a);
+  expect(t.lookup('limit', 30, undefined)).toBe(undefined);
 });
 
 test('values are distinguished by type, not coerced', () => {
@@ -97,18 +71,26 @@ test('the first slot still checks its delta', () => {
 });
 
 test('bounded transitions are held strongly and never collected', () => {
-  const t = new Transitions<object>();
-  const a = make('a');
-  const b = make('b');
-  t.storeBounded('relatedBase:comments', a);
-  t.storeBounded('relatedBase:labels', b);
+  withStubbedWeakRef(weak => {
+    const t = new Transitions<object>();
+    const a = make('a');
+    const b = make('b');
+    t.storeBounded('relatedBase:comments', a);
+    t.storeBounded('relatedBase:labels', b);
 
-  expect(t.lookupBounded('relatedBase:comments')).toBe(a);
-  expect(t.lookupBounded('relatedBase:labels')).toBe(b);
-  // Bounded storage is separate: it does not consume the first-child slot, and
-  // does not spill into the weak store.
-  expect(t.first).toBe(undefined);
-  expect(t.rest).toBe(undefined);
+    weak.collect(a);
+    weak.collect(b);
+    expect(t.lookupBounded('relatedBase:comments')).toBe(a);
+    expect(t.lookupBounded('relatedBase:labels')).toBe(b);
+    // Bounded storage is separate: no WeakRef for either, and it leaves the
+    // first-child slot free for an ordinary transition.
+    expect(weak.created()).toBe(0);
+    const c = make('c');
+    t.store('one', undefined, undefined, c);
+    expect(weak.created()).toBe(0);
+    weak.collect(c);
+    expect(t.lookup('one', undefined, undefined)).toBe(c);
+  });
 });
 
 test('distinguishes entries in a bucket by deepEqual on the delta', () => {
@@ -124,58 +106,56 @@ test('distinguishes entries in a bucket by deepEqual on the delta', () => {
   expect(t.lookup('where:tree', undefined, {id: 3})).toBe(undefined);
 });
 
-test('a single-entry bucket stays unwrapped and is promoted on collision', () => {
-  const t = new Transitions<object>();
-  fill(t);
-  t.store('k', undefined, 1, make('a'));
-  expect(t.rest!.get('k')!.get(undefined)).not.toBeInstanceOf(Set);
-  t.store('k', undefined, 2, make('b'));
-  expect(t.rest!.get('k')!.get(undefined)).toBeInstanceOf(Set);
-});
-
 test('lookup prunes a collected single entry', () => {
-  const t = new Transitions<object>();
-  fill(t);
-  t.store('k', 'v', undefined, make('a'));
-  kill(t, 'k', 'v');
+  withStubbedWeakRef(weak => {
+    const t = new Transitions<object>();
+    fill(t);
+    const a = make('a');
+    t.store('k', 'v', undefined, a);
+    weak.collect(a);
 
-  expect(t.lookup('k', 'v', undefined)).toBe(undefined);
-  expect(t.rest!.get('k')!.has('v')).toBe(false);
+    expect(t.lookup('k', 'v', undefined)).toBe(undefined);
+    // The entry is gone rather than merely empty: a second lookup finds
+    // nothing left to deref.
+    weak.resetDerefs();
+    expect(t.lookup('k', 'v', undefined)).toBe(undefined);
+    expect(weak.derefs()).toBe(0);
+  });
 });
 
 test('lookup prunes collected entries out of a bucket as it walks', () => {
-  const t = new Transitions<object>();
-  const live = make('live');
-  fill(t);
-  t.store('k', undefined, 1, make('dead'));
-  t.store('k', undefined, 2, live);
+  withStubbedWeakRef(weak => {
+    const t = new Transitions<object>();
+    const dead = make('dead');
+    const live = make('live');
+    fill(t);
+    t.store('k', undefined, 1, dead);
+    t.store('k', undefined, 2, live);
+    weak.collect(dead);
 
-  const bucket = bucketOf(t, 'k', undefined);
-  const [dead] = [...bucket];
-  bucket.delete(dead);
-  bucket.add({delta: dead.delta, ref: emptyRef});
-
-  expect(t.lookup('k', undefined, 1)).toBe(undefined);
-  expect(bucket.size).toBe(1);
-  expect(t.lookup('k', undefined, 2)).toBe(live);
+    expect(t.lookup('k', undefined, 1)).toBe(undefined);
+    // Walking past the collected entry dropped it, so finding `live` now
+    // derefs one entry rather than two.
+    weak.resetDerefs();
+    expect(t.lookup('k', undefined, 2)).toBe(live);
+    expect(weak.derefs()).toBe(1);
+  });
 });
 
 test('a hit stops early instead of walking the whole bucket', () => {
-  const t = new Transitions<object>();
-  fill(t);
-  const values = Array.from({length: 10}, (_, i) => make(`v${i}`));
-  values.forEach((v, i) => t.store('k', undefined, i, v));
+  withStubbedWeakRef(weak => {
+    const t = new Transitions<object>();
+    fill(t);
+    const values = Array.from({length: 10}, (_, i) => make(`v${i}`));
+    values.forEach((v, i) => t.store('k', undefined, i, v));
 
-  const bucket = bucketOf(t, 'k', undefined);
-  // Kill every entry *after* the one we are about to ask for. A lookup that
-  // walked the whole bucket would prune them; stopping at the match leaves them.
-  [...bucket].slice(3).forEach(e => {
-    bucket.delete(e);
-    bucket.add({delta: e.delta, ref: emptyRef});
+    // Entries are walked in insertion order, so the third one is found after
+    // three derefs. A lookup that walked the whole bucket first would spend
+    // ten.
+    weak.resetDerefs();
+    expect(t.lookup('k', undefined, 2)).toBe(values[2]);
+    expect(weak.derefs()).toBe(3);
   });
-
-  expect(t.lookup('k', undefined, 2)).toBe(values[2]);
-  expect(bucket.size).toBe(10);
 });
 
 test('a bucket stops growing at MAX_SCAN without evicting', () => {
@@ -184,7 +164,6 @@ test('a bucket stops growing at MAX_SCAN without evicting', () => {
   const values = Array.from({length: MAX_SCAN + 4}, (_, i) => make(`v${i}`));
   values.forEach((v, i) => t.store('k', undefined, i, v));
 
-  expect(bucketOf(t, 'k', undefined).size).toBe(MAX_SCAN);
   // Everything that fit stays shared...
   for (let i = 0; i < MAX_SCAN; i++) {
     expect(t.lookup('k', undefined, i)).toBe(values[i]);
@@ -197,30 +176,41 @@ test('a bucket stops growing at MAX_SCAN without evicting', () => {
 });
 
 test('a node sweeps dead entries once its weak store has grown', () => {
-  const t = new Transitions<object>();
-  fill(t);
+  withStubbedWeakRef(weak => {
+    const t = new Transitions<object>();
+    fill(t);
 
-  // Every value distinct and every node collected: the shape of a search box
-  // typing into `where:title:=` off a root that never dies. Nothing ever looks
-  // these up again, so only a sweep can reclaim them.
-  for (let i = 0; i < 1000; i++) {
-    t.store('where:title:=', `text-${i}`, undefined, make(`v${i}`));
-    t.rest!.get('where:title:=')!.set(`text-${i}`, {
-      delta: undefined,
-      ref: emptyRef,
-    });
-  }
+    // Every value distinct and every node collected: the shape of a search box
+    // typing into `where:title:=` off a root that never dies. Nothing ever
+    // looks these up again, so only a sweep can reclaim them.
+    const n = 1000;
+    for (let i = 0; i < n; i++) {
+      const v = make(`v${i}`);
+      t.store('where:title:=', `text-${i}`, undefined, v);
+      weak.collect(v);
+    }
 
-  expect(t.restSize).toBeLessThan(200);
-  expect(t.rest!.get('where:title:=')!.size).toBeLessThan(200);
+    // Storing never derefs on its own, so any deref at all is the sweep
+    // running -- and its total cost stays proportional to the inserts rather
+    // than to the whole map each time, which is what the doubling threshold
+    // buys.
+    expect(weak.derefs()).toBeGreaterThan(0);
+    expect(weak.derefs()).toBeLessThan(n * 4);
+    // Nothing collected is handed back.
+    for (let i = 0; i < n; i++) {
+      expect(t.lookup('where:title:=', `text-${i}`, undefined)).toBe(undefined);
+    }
+  });
 });
 
 test('sweeping keeps live entries', () => {
-  const t = new Transitions<object>();
-  fill(t);
-  const live = Array.from({length: 300}, (_, i) => make(`v${i}`));
-  live.forEach((v, i) => t.store('k', i, undefined, v));
+  withStubbedWeakRef(() => {
+    const t = new Transitions<object>();
+    fill(t);
+    // Enough to cross the sweep threshold several times over.
+    const live = Array.from({length: 300}, (_, i) => make(`v${i}`));
+    live.forEach((v, i) => t.store('k', i, undefined, v));
 
-  expect(t.rest!.get('k')!.size).toBe(300);
-  live.forEach((v, i) => expect(t.lookup('k', i, undefined)).toBe(v));
+    live.forEach((v, i) => expect(t.lookup('k', i, undefined)).toBe(v));
+  });
 });

--- a/packages/zql/src/query/query-transitions.test.ts
+++ b/packages/zql/src/query/query-transitions.test.ts
@@ -1,5 +1,5 @@
 import {expect, test} from 'vitest';
-import {MAX_SCAN, Transitions} from './query-transitions.ts';
+import {HashIndex, MAX_SCAN, Transitions} from './query-transitions.ts';
 import {withStubbedWeakRef} from './test/weak-ref-stub.ts';
 
 function make(name: string): {name: string} {
@@ -212,5 +212,87 @@ test('sweeping keeps live entries', () => {
     live.forEach((v, i) => t.store('k', i, undefined, v));
 
     live.forEach((v, i) => expect(t.lookup('k', i, undefined)).toBe(v));
+  });
+});
+
+test('replace re-points the strong first slot', () => {
+  withStubbedWeakRef(weak => {
+    const t = new Transitions<object>();
+    const from = make('from');
+    const to = make('to');
+    t.store('k', 1, undefined, from);
+    expect(t.replace(from, to)).toBe(true);
+    expect(t.lookup('k', 1, undefined)).toBe(to);
+    // Still the strong slot afterwards: no WeakRef, and it survives
+    // collection.
+    expect(weak.created()).toBe(0);
+    weak.collect(to);
+    expect(t.lookup('k', 1, undefined)).toBe(to);
+  });
+});
+
+test('replace re-points a weak entry, bare or in a bucket', () => {
+  const t = new Transitions<object>();
+  fill(t);
+  const from = make('from');
+  const to = make('to');
+  t.store('k', 1, undefined, from);
+  expect(t.replace(from, to)).toBe(true);
+  expect(t.lookup('k', 1, undefined)).toBe(to);
+
+  const from2 = make('from2');
+  const to2 = make('to2');
+  const other = make('other');
+  t.store('k', 2, {d: 1}, other);
+  t.store('k', 2, {d: 2}, from2);
+  expect(t.replace(from2, to2)).toBe(true);
+  expect(t.lookup('k', 2, {d: 2})).toBe(to2);
+  // Replacing one entry of a bucket leaves its neighbour alone.
+  expect(t.lookup('k', 2, {d: 1})).toBe(other);
+});
+
+test('replace of a node this map never stored is a no-op', () => {
+  const t = new Transitions<object>();
+  expect(t.replace(make('x'), make('y'))).toBe(false);
+  fill(t);
+  const stored = make('other');
+  t.store('k', 1, undefined, stored);
+  expect(t.replace(make('x'), make('y'))).toBe(false);
+  // ...and leaves what is stored untouched.
+  expect(t.lookup('k', 1, undefined)).toBe(stored);
+});
+
+test('a hash index round trips and forgets a collected entry', () => {
+  withStubbedWeakRef(({collect}) => {
+    const h = new HashIndex<object>();
+    const a = make('a');
+    h.set('h1', a);
+    expect(h.get('h1')).toBe(a);
+    expect(h.get('h2')).toBeUndefined();
+
+    collect(a);
+    expect(h.get('h1')).toBeUndefined();
+    // A collected entry does not shadow a later one under the same hash.
+    const b = make('b');
+    h.set('h1', b);
+    expect(h.get('h1')).toBe(b);
+  });
+});
+
+test('a hash index keeps live entries through any amount of dead ones', () => {
+  withStubbedWeakRef(({collect}) => {
+    const h = new HashIndex<object>();
+    const live = Array.from({length: 300}, (_, i) => make(`live${i}`));
+    live.forEach((v, i) => h.set(`live-${i}`, v));
+    // Enough dead inserts to cross several sweeps.
+    for (let i = 0; i < 1000; i++) {
+      const v = make(`v${i}`);
+      h.set(`dead-${i}`, v);
+      collect(v);
+    }
+    live.forEach((v, i) => expect(h.get(`live-${i}`)).toBe(v));
+    for (let i = 0; i < 1000; i++) {
+      expect(h.get(`dead-${i}`)).toBeUndefined();
+    }
   });
 });

--- a/packages/zql/src/query/query-transitions.ts
+++ b/packages/zql/src/query/query-transitions.ts
@@ -67,11 +67,13 @@ import {deepEqual, type ReadonlyJSONValue} from '../../../shared/src/json.ts';
  *
  * ## Identity vs. hash
  *
- * Identity implies an equal query hash, but not the other way around.
- * `normalizeAST` sorts `related` and `and`/`or` conditions, so
+ * Identity implies an equal query hash, but the tree alone does not give the
+ * converse. `normalizeAST` sorts `related` and `and`/`or` conditions, so
  * `q.where(a).where(b)` and `q.where(b).where(a)` hash the same while being
- * distinct nodes in this tree. Callers that need the normalizing behavior must
- * keep using the hash.
+ * distinct paths, and so distinct nodes. {@linkcode HashIndex} is the second
+ * level that folds those together once they have been hashed. Callers that
+ * need the normalizing behavior for a query that may not have been must keep
+ * using the hash.
  */
 
 /**
@@ -247,6 +249,47 @@ export class Transitions<T extends object> {
   }
 
   /**
+   * Re-points the transition that produced `from` at `to`, so the next lookup
+   * along that path yields `to` instead. This is how {@linkcode HashIndex}
+   * converges two paths on one node: `from` keeps its identity, since it has
+   * already been handed out, and its path is redirected for the rebuilds that
+   * follow.
+   *
+   * Scans rather than taking a key. This runs once per redirected path, so a
+   * walk here is cheaper than the fields every node would need to carry to
+   * name its own transition.
+   */
+  replace(from: T, to: T): boolean {
+    if (this.#first === from) {
+      this.#first = to;
+      return true;
+    }
+    const rest = this.#rest;
+    if (rest === undefined) {
+      return false;
+    }
+    for (const byValue of rest.values()) {
+      for (const [value, bucket] of byValue) {
+        if (!(bucket instanceof Set)) {
+          if (bucket.ref.deref() === from) {
+            byValue.set(value, {delta: bucket.delta, ref: new WeakRef(to)});
+            return true;
+          }
+          continue;
+        }
+        for (const entry of bucket) {
+          if (entry.ref.deref() === from) {
+            bucket.delete(entry);
+            bucket.add({delta: entry.delta, ref: new WeakRef(to)});
+            return true;
+          }
+        }
+      }
+    }
+    return false;
+  }
+
+  /**
    * Drops entries for collected values, if the map has grown enough to be worth
    * walking.
    *
@@ -290,5 +333,66 @@ export class Transitions<T extends object> {
     }
     this.#restSize = live;
     this.#sweepAt = Math.max(SWEEP_INITIAL, live * 2);
+  }
+}
+
+/**
+ * The second level of interning: nodes keyed by *content* rather than by the
+ * path that built them.
+ *
+ * The transition tree cannot see that `q.where(a).where(b)` and
+ * `q.where(b).where(a)` are the same query. `normalizeAST` sorts conditions
+ * and `related` entries, so the two build byte-identical ASTs, but they are
+ * different paths and so different nodes. This index closes that gap, keyed by
+ * the query's hash.
+ *
+ * It is consulted when a query is *hashed*, not when it is built. Hashing on
+ * every tree miss would make a cold chain pay for a hash per node, where the
+ * uninterned code paid for one at the end, if at all -- and server-side queries
+ * are built cold, once, per request. The consumers that key by hash already
+ * hash the queries they care about, so doing the work there costs one map
+ * lookup on top of a hash that was being computed anyway, and nothing at all
+ * for a query nobody hashes.
+ *
+ * On a hit the query being hashed keeps its identity, since it has already
+ * been handed out. Its *transition* is re-pointed at the existing node instead
+ * (see {@linkcode Transitions.replace}), so the next rebuild along that path
+ * yields the shared instance. As with the tree this is a cache: the rebuild
+ * after a redirect is what converges, not the call that found the duplicate.
+ *
+ * One index per root, which is what scopes it. Two roots never share an index,
+ * so queries against different schemas or different delegates -- neither of
+ * which the hash covers -- can never be conflated. Entries are weak: a cleared
+ * one is dropped by the lookup that finds it, or by a sweep once the map has
+ * doubled since the last one.
+ */
+export class HashIndex<T extends object> {
+  readonly #byHash = new Map<string, WeakRef<T>>();
+  #sweepAt = SWEEP_INITIAL;
+
+  get(hash: string): T | undefined {
+    const ref = this.#byHash.get(hash);
+    if (ref === undefined) {
+      return undefined;
+    }
+    const node = ref.deref();
+    if (node === undefined) {
+      this.#byHash.delete(hash);
+    }
+    return node;
+  }
+
+  set(hash: string, node: T): void {
+    const byHash = this.#byHash;
+    byHash.set(hash, new WeakRef(node));
+    if (byHash.size < this.#sweepAt) {
+      return;
+    }
+    for (const [h, ref] of byHash) {
+      if (ref.deref() === undefined) {
+        byHash.delete(h);
+      }
+    }
+    this.#sweepAt = Math.max(SWEEP_INITIAL, byHash.size * 2);
   }
 }

--- a/packages/zql/src/query/query-transitions.ts
+++ b/packages/zql/src/query/query-transitions.ts
@@ -142,21 +142,6 @@ export class Transitions<T extends object> {
   #sweepAt = SWEEP_INITIAL;
   #restSize = 0;
 
-  /** The strongly held first child. Exposed for tests. */
-  get first(): T | undefined {
-    return this.#first;
-  }
-
-  /** The weakly held remainder. Exposed for tests. */
-  get rest(): Map<string, Map<TransitionValue, Bucket<T>>> | undefined {
-    return this.#rest;
-  }
-
-  /** Total weak entries across all keys. Exposed for tests. */
-  get restSize(): number {
-    return this.#restSize;
-  }
-
   lookupBounded(key: string): T | undefined {
     return this.#bounded?.get(key);
   }

--- a/packages/zql/src/query/query-transitions.ts
+++ b/packages/zql/src/query/query-transitions.ts
@@ -1,0 +1,309 @@
+import {deepEqual, type ReadonlyJSONValue} from '../../../shared/src/json.ts';
+
+/**
+ * A transition tree for interning immutable builder objects, modelled on V8's
+ * hidden-class transitions.
+ *
+ * Each node keeps a map from a *transition* (an operation plus its arguments) to
+ * the node that operation produces. Applying the same operation to the same node
+ * twice therefore yields the same object both times.
+ *
+ * ## Why not hash?
+ *
+ * Hashing the resulting AST would work but is far too expensive to do on every
+ * builder call. Instead a transition is identified by three things, in
+ * decreasing order of how cheap they are to compare:
+ *
+ * 1. `key` — a short string naming the operation. Callers are expected to hand
+ *    in a *stable* string rather than build one per call; see below.
+ * 2. `value` — the operation's varying argument, when it is a primitive, used
+ *    directly as a `Map` key.
+ * 3. `delta` — anything left over, compared with {@linkcode deepEqual}.
+ *
+ * Splitting 1 from 2 is what makes this fast. Folding the value into the key
+ * instead means building a fresh string on every call, and a fresh string has to
+ * be hashed from scratch before a `Map` can look it up: measured at ~148ns,
+ * against ~10ns to look up the caller's own string, whose hash V8 has already
+ * cached on the string object. That difference is larger than everything else a
+ * transition does.
+ *
+ * Comparing only the delta is sound because the parent node is already canonical:
+ * two children of the same parent are equal exactly when the operations that
+ * produced them are equal. We never deep-compare a whole AST.
+ *
+ * ## Liveness
+ *
+ * Children point back at their parents strongly (see `QueryImpl`), so holding a
+ * query holds its whole ancestor spine and re-deriving it from the root gives
+ * the same object back. The other direction has to be weak, or an interned root
+ * — which lives as long as its schema — would retain every query ever derived
+ * from it.
+ *
+ * Weak is expensive, though: `new WeakRef` costs on the order of a hundred
+ * nanoseconds, more than everything else a transition does put together, and it
+ * adds GC work later. So the *first* transition out of a node is held strongly
+ * instead, in fields on this object, with no `WeakRef` at all.
+ *
+ * That is safe because strong first-children form a path, not a tree: each node
+ * pins at most one child, which pins at most one of its own. The retained set
+ * per root is bounded by the depth of a builder chain — a handful of queries —
+ * rather than by how many distinct queries an app builds. Everything past the
+ * first child is weak, so the unbounded cases (a search box typing into
+ * `where:title:=:s<text>`, a row id per list item) stay collectible.
+ *
+ * It is also where the wins are: a chain like `q.where(…).orderBy(…).limit(…)`
+ * gives every node exactly one child, so building it allocates no `WeakRef`s and
+ * looks up through a field compare rather than a hash lookup.
+ *
+ * What a collected child leaves behind is a cleared `WeakRef` and its map key. A
+ * lookup drops those as it walks, which covers every key that is asked for
+ * again. A key that is *never* asked for again is handled by the sweep.
+ *
+ * ## Best effort
+ *
+ * Interning is a cache, not a guarantee: a missed lookup only costs an extra
+ * object. See {@linkcode MAX_SCAN} for the one case where we deliberately give
+ * up.
+ *
+ * ## Identity vs. hash
+ *
+ * Identity implies an equal query hash, but not the other way around.
+ * `normalizeAST` sorts `related` and `and`/`or` conditions, so
+ * `q.where(a).where(b)` and `q.where(b).where(a)` hash the same while being
+ * distinct nodes in this tree. Callers that need the normalizing behavior must
+ * keep using the hash.
+ */
+
+/**
+ * The delta identifying a transition, or `undefined` when the key already
+ * determines the result on its own.
+ */
+export type Delta = ReadonlyJSONValue | undefined;
+
+type Entry<T extends object> = {
+  readonly delta: Delta;
+  readonly ref: WeakRef<T>;
+};
+
+/**
+ * A bucket holds a bare entry in the common single-entry case and is promoted to
+ * a `Set` only on collision, so the usual transition allocates no container.
+ *
+ * A `Set` rather than an array: deleting during iteration is well defined, so a
+ * lookup prunes collected entries and stops at its match in a single pass, and
+ * removing an entry is O(1) rather than a scan.
+ */
+type Bucket<T extends object> = Entry<T> | Set<Entry<T>>;
+
+/** The varying argument of a transition, when it is one. */
+export type TransitionValue = string | number | boolean | null | undefined;
+
+/**
+ * The longest `deepEqual` scan we are willing to do on a lookup.
+ *
+ * This is a *latency* bound, not a memory bound — memory is already handled,
+ * since entries are weak and are pruned both by the sweep and by any lookup that
+ * walks past them, so a bucket only ever holds children that are still alive.
+ *
+ * Note what happens at the limit: we stop *storing*, we do not evict. Evicting
+ * would de-intern objects that are still in use, and on a sequential sweep of a
+ * live set larger than the limit it drives the hit rate to zero — each lookup
+ * throws out the entry the next one needs. Refusing to store instead leaves
+ * every already-shared sibling shared and degrades the surplus to the old
+ * behavior of a fresh instance per call.
+ *
+ * Buckets should rarely get near this. Keys carry the discriminating value
+ * wherever it is cheap to, and a key that carries it is *exact*, so it costs no
+ * comparison at all: every simple comparison goes that way, and so does a
+ * one-hop `exists`, via its sub-query's identity. What is left sharing a bucket
+ * is two-hop `exists`, the `and`/`or` trees an expression factory builds, and
+ * relationships whose callback varies.
+ */
+export const MAX_SCAN = 64;
+
+/** How large the weak map must get before its first sweep. */
+const SWEEP_INITIAL = 64;
+
+/** The transitions out of one node. */
+export class Transitions<T extends object> {
+  // The first transition, held strongly and in place. See "Liveness" above.
+  #firstKey: string | undefined;
+  #firstValue: TransitionValue;
+  #firstDelta: Delta;
+  #first: T | undefined;
+
+  // Transitions whose key space is finite and comes from the schema rather than
+  // from user data, held strongly. See `storeBounded`.
+  #bounded: Map<string, T> | undefined;
+
+  // Everything else, weakly. Allocated only if there is a second. Nested so the
+  // value stays a `Map` key of its own rather than part of the string.
+  #rest: Map<string, Map<TransitionValue, Bucket<T>>> | undefined;
+  #sweepAt = SWEEP_INITIAL;
+  #restSize = 0;
+
+  /** The strongly held first child. Exposed for tests. */
+  get first(): T | undefined {
+    return this.#first;
+  }
+
+  /** The weakly held remainder. Exposed for tests. */
+  get rest(): Map<string, Map<TransitionValue, Bucket<T>>> | undefined {
+    return this.#rest;
+  }
+
+  /** Total weak entries across all keys. Exposed for tests. */
+  get restSize(): number {
+    return this.#restSize;
+  }
+
+  lookupBounded(key: string): T | undefined {
+    return this.#bounded?.get(key);
+  }
+
+  /**
+   * Records a transition whose key space is finite and schema-derived — the base
+   * sub-query handed to a `related`/`exists` callback, keyed by relationship
+   * name.
+   *
+   * These are held strongly. Retention is bounded by the number of relationships
+   * on the table, so it cannot grow with what an app queries for, and in exchange
+   * a relationship traversal allocates no `WeakRef`. Anything keyed by a *value*
+   * — a row id, a search string, a limit — must not come through here.
+   */
+  storeBounded(key: string, value: T): void {
+    (this.#bounded ??= new Map()).set(key, value);
+  }
+
+  lookup(key: string, value: TransitionValue, delta: Delta): T | undefined {
+    if (
+      this.#firstKey === key &&
+      this.#firstValue === value &&
+      deepEqual(this.#firstDelta, delta)
+    ) {
+      return this.#first;
+    }
+    const byValue = this.#rest?.get(key);
+    if (byValue === undefined) {
+      return undefined;
+    }
+    const bucket = byValue.get(value);
+    if (bucket === undefined) {
+      return undefined;
+    }
+
+    if (!(bucket instanceof Set)) {
+      const found = bucket.ref.deref();
+      if (found === undefined) {
+        byValue.delete(value);
+        this.#restSize--;
+        return undefined;
+      }
+      // deepEqual short-circuits on reference equality, which is the fast path
+      // we rely on for deltas built out of already-interned sub-queries.
+      return deepEqual(bucket.delta, delta) ? found : undefined;
+    }
+
+    // One pass: drop what has been collected, stop at the match. Deleting from a
+    // Set while iterating it is well defined — the iterator simply skips what is
+    // gone — so this stays O(n) with no compaction step, and returns early on a
+    // hit rather than walking the whole bucket first.
+    for (const entry of bucket) {
+      const found = entry.ref.deref();
+      if (found === undefined) {
+        bucket.delete(entry);
+        this.#restSize--;
+        continue;
+      }
+      if (deepEqual(entry.delta, delta)) {
+        return found;
+      }
+    }
+    if (bucket.size === 0) {
+      byValue.delete(value);
+    }
+    return undefined;
+  }
+
+  store(key: string, value: TransitionValue, delta: Delta, node: T): void {
+    if (this.#firstKey === undefined) {
+      this.#firstKey = key;
+      this.#firstValue = value;
+      this.#firstDelta = delta;
+      this.#first = node;
+      return;
+    }
+
+    const rest = (this.#rest ??= new Map());
+    let byValue = rest.get(key);
+    if (byValue === undefined) {
+      byValue = new Map();
+      rest.set(key, byValue);
+    }
+
+    const entry: Entry<T> = {delta, ref: new WeakRef(node)};
+    const bucket = byValue.get(value);
+
+    if (bucket === undefined) {
+      byValue.set(value, entry);
+    } else if (!(bucket instanceof Set)) {
+      byValue.set(value, new Set([bucket, entry]));
+    } else {
+      if (bucket.size >= MAX_SCAN) {
+        // Leave the bucket alone; see MAX_SCAN. `node` is simply not shared.
+        // A store only follows a failed lookup, which has just pruned, so this
+        // is measured against entries that are actually still alive.
+        return;
+      }
+      bucket.add(entry);
+    }
+    this.#restSize++;
+    this.#maybeSweep(rest);
+  }
+
+  /**
+   * Drops entries for collected values, if the map has grown enough to be worth
+   * walking.
+   *
+   * A lookup already prunes whatever it walks past, which covers every key that
+   * is asked for again. This is for the key that is not: a miss on a fresh key
+   * returns without touching any existing entry, so nothing would ever notice
+   * that those had died. Doubling the threshold off whatever survives keeps this
+   * amortized O(1) per insert whether or not there was anything to reclaim, and
+   * it is self-limiting — only a node that keeps taking inserts can keep
+   * accumulating, and taking inserts is what triggers the sweep.
+   */
+  #maybeSweep(rest: Map<string, Map<TransitionValue, Bucket<T>>>): void {
+    if (this.#restSize < this.#sweepAt) {
+      return;
+    }
+    let live = 0;
+    for (const [key, byValue] of rest) {
+      for (const [value, bucket] of byValue) {
+        if (!(bucket instanceof Set)) {
+          if (bucket.ref.deref() === undefined) {
+            byValue.delete(value);
+          } else {
+            live++;
+          }
+          continue;
+        }
+        for (const entry of bucket) {
+          if (entry.ref.deref() === undefined) {
+            bucket.delete(entry);
+          } else {
+            live++;
+          }
+        }
+        if (bucket.size === 0) {
+          byValue.delete(value);
+        }
+      }
+      if (byValue.size === 0) {
+        rest.delete(key);
+      }
+    }
+    this.#restSize = live;
+    this.#sweepAt = Math.max(SWEEP_INITIAL, live * 2);
+  }
+}

--- a/packages/zql/src/query/runnable-query-impl.ts
+++ b/packages/zql/src/query/runnable-query-impl.ts
@@ -20,6 +20,17 @@ import type {
 import type {TTL} from './ttl.ts';
 import type {TypedView} from './typed-view.ts';
 
+/**
+ * Runnable roots are interned per delegate *and* schema -- a query is only
+ * interchangeable with another if it would run against the same delegate. See
+ * `query-transitions.ts` for why roots need to be shared at all.
+ */
+const rootsByDelegate = new WeakMap<
+  QueryDelegate,
+  // oxlint-disable-next-line no-explicit-any
+  WeakMap<Schema, Map<string, WeakRef<RunnableQueryImpl<any, any, any>>>>
+>();
+
 export function newRunnableQuery<
   TTable extends keyof TSchema['tables'] & string,
   TSchema extends Schema,
@@ -28,7 +39,23 @@ export function newRunnableQuery<
   schema: TSchema,
   table: TTable,
 ): Query<TTable, TSchema> {
-  return new RunnableQueryImpl(
+  let bySchema = rootsByDelegate.get(delegate);
+  if (!bySchema) {
+    bySchema = new WeakMap();
+    rootsByDelegate.set(delegate, bySchema);
+  }
+  let roots = bySchema.get(schema);
+  if (!roots) {
+    roots = new Map();
+    bySchema.set(schema, roots);
+  }
+
+  const existing = roots.get(table)?.deref();
+  if (existing) {
+    return existing as RunnableQueryImpl<TTable, TSchema>;
+  }
+
+  const created = new RunnableQueryImpl<TTable, TSchema>(
     delegate,
     schema,
     table,
@@ -36,6 +63,8 @@ export function newRunnableQuery<
     defaultFormat,
     undefined,
   );
+  roots.set(table, new WeakRef(created));
+  return created;
 }
 
 export class RunnableQueryImpl<

--- a/packages/zql/src/query/test/weak-ref-stub.ts
+++ b/packages/zql/src/query/test/weak-ref-stub.ts
@@ -1,0 +1,73 @@
+import {vi} from 'vitest';
+
+/**
+ * Controls over the stubbed `WeakRef` installed by
+ * {@linkcode withStubbedWeakRef}.
+ */
+export type WeakRefControl = {
+  /**
+   * Marks `target` collected: every `WeakRef` to it derefs to `undefined` from
+   * now on. Stands in for the garbage collector, which cannot be driven
+   * portably from a test.
+   */
+  collect(target: object): void;
+
+  /**
+   * How many `WeakRef`s have been constructed. A structure that holds
+   * something strongly constructs none, which is how a test tells the two
+   * apart without reading its fields.
+   */
+  created(): number;
+
+  /**
+   * How many times `deref` has been called. A lookup that stops at its match
+   * derefs fewer entries than one that walks a whole bucket.
+   */
+  derefs(): number;
+
+  /** Resets {@linkcode derefs} to zero. */
+  resetDerefs(): void;
+};
+
+/**
+ * Runs `fn` with `WeakRef` replaced by a stub whose targets are collected on
+ * demand and whose use is counted.
+ *
+ * Retention is the property these structures are built around, and asserting
+ * it otherwise means either exposing their internals or waiting on a real GC.
+ * Counting construction and deref calls gets at the same facts from outside:
+ * what is held weakly, and how much of a bucket a lookup walked.
+ */
+export function withStubbedWeakRef(
+  fn: (control: WeakRefControl) => void,
+): void {
+  const dead = new WeakSet<object>();
+  let created = 0;
+  let derefs = 0;
+
+  class StubWeakRef<T extends object> {
+    readonly #target: T;
+
+    constructor(target: T) {
+      this.#target = target;
+      created++;
+    }
+
+    deref(): T | undefined {
+      derefs++;
+      return dead.has(this.#target) ? undefined : this.#target;
+    }
+  }
+
+  vi.stubGlobal('WeakRef', StubWeakRef);
+  try {
+    fn({
+      collect: target => void dead.add(target),
+      created: () => created,
+      derefs: () => derefs,
+      resetDerefs: () => void (derefs = 0),
+    });
+  } finally {
+    vi.unstubAllGlobals();
+  }
+}


### PR DESCRIPTION
Building the same query twice allocated two structurally identical objects, so `#hash` -- and every other per-instance memo -- never hit. `useQuery` rebuilds its whole chain on every render, so it paid for a fresh AST and a fresh hash each time.

Each node now keys the queries derived from it by the operation that produced them, the way V8 keys hidden-class transitions, so applying the same operation twice returns the same object and no AST is built at all on the second pass. A transition is identified by a memoized key naming the operation, the varying argument as a `Map` key rather than concatenated into a string, and -- only where those two do not settle it -- a small delta compared with `deepEqual`. Never the whole AST: the parent is already canonical, so two of its children are equal exactly when the operations that produced them are.

Children hold their parent strongly and parents hold children weakly, so holding a query holds its ancestor spine and re-deriving it gives the same object back. The first transition out of a node is held strongly instead, in fields: `new WeakRef` costs more than everything else a transition does, and strong first-children form a path rather than a tree, so what is retained is bounded by the depth of a builder chain. Relationship bases get a separate strong store, bounded by the schema. Nothing keyed by data is ever held strongly. No `FinalizationRegistry`: cleared entries are dropped by the lookup that walks past them and by a sweep once a node's weak store has doubled.

Interning is by construction path, so `q.where(a).where(b)` and `q.where(b).where(a)` are still distinct instances here; the next PR in the stack folds those together.

Measured in plain node, per query. "Warm" is a rebuild of a chain that already exists, which is what every render does; "cold" is a new value under a warm root, the weak path.

| | before | after |
|---|---|---|
| warm chain, build + hash | 2564 ns | 446 ns |
| warm 200-row list, build + hash | 124,753 ns | 12,266 ns |
| warm chain, build only | 982 ns | 447 ns |
| cold row, build only | 124 ns | 350 ns |
| cold row, build + hash | 636 ns | 872 ns |
| fresh root chain, build + hash | 1509 ns | 1332 ns |

Cold numbers are with the event loop yielding and GC running; a synchronous loop overstates the weak path, because `new WeakRef` keeps its target alive for the rest of the job.

Stacked on #6464.

