### PR TITLE
perf(zql): key `start` transitions by the row

### DIFF
--- a/packages/zql/src/query/query-impl.interning.test.ts
+++ b/packages/zql/src/query/query-impl.interning.test.ts
@@ -640,11 +640,39 @@ test('start rows are exact keys, so paging to a new row never scans', () => {
   );
   // An undefined property is absent, as it is to `deepEqual`.
   expect(sorted.start({id: 1, x: undefined})).toBe(sorted.start({id: 1}));
-  // Non-primitive values are serialized, so they are exact as well.
+  // Non-primitive values are encoded recursively, so they are exact as well.
   expect(sorted.start({tags: ['a', 'b']})).toBe(
     sorted.start({tags: ['a', 'b']}),
   );
   expect(sorted.start({tags: ['a', 'b']})).not.toBe(
     sorted.start({tags: ['b', 'a']}),
+  );
+  expect(sorted.start({j: {a: 1, b: 'x'}})).toBe(
+    sorted.start({j: {a: 1, b: 'x'}}),
+  );
+  expect(sorted.start({j: {a: 1}})).not.toBe(sorted.start({j: {a: '1'}}));
+  expect(sorted.start({j: [1, [2]]})).not.toBe(sorted.start({j: [1, 2]}));
+  expect(sorted.start({j: [['ab'], 'c']})).not.toBe(
+    sorted.start({j: ['a', ['bc']]}),
+  );
+});
+
+test('values that JSON would write alike are told apart', () => {
+  // `JSON.stringify` writes Infinity, NaN and null all as `null`. The encoding
+  // is trusted as exact, so it cannot lean on it: a page whose cursor had
+  // Infinity in a nested value would otherwise come back with null in its AST.
+  const root = freshRoot('lossy-json');
+  const inf = root.start({j: {x: Infinity}});
+  expect(root.start({j: {x: null}})).not.toBe(inf);
+  expect(root.start({j: {x: -Infinity}})).not.toBe(inf);
+  expect(root.start({j: {x: NaN}})).not.toBe(inf);
+  expect(asQueryImpl(inf).ast.start!.row).toEqual({j: {x: Infinity}});
+  expect(root.start({j: [Infinity]})).not.toBe(root.start({j: [null]}));
+  // The same tags key an `IN` list.
+  expect(root.where('id', 'IN', [1, Infinity])).not.toBe(
+    root.where('id', 'IN', [1, null]),
+  );
+  expect(root.where('id', 'IN', [1, Infinity])).toBe(
+    root.where('id', 'IN', [1, Infinity]),
   );
 });

--- a/packages/zql/src/query/query-impl.interning.test.ts
+++ b/packages/zql/src/query/query-impl.interning.test.ts
@@ -612,3 +612,39 @@ test('flip and scalar options are not collapsed', () => {
   expect(q.whereExists('comments', cb)).not.toBe(scalarFalse);
   expect(scalarFalse).toBe(q.whereExists('comments', cb, {scalar: false}));
 });
+
+test('start rows are exact keys, so paging to a new row never scans', () => {
+  const root = freshRoot('start-rows');
+  const sorted = root.orderBy('id', 'asc');
+  const pages = Array.from({length: MAX_SCAN * 2}, (_, i) =>
+    sorted.start({id: `row-${i}`}),
+  );
+  pages.forEach((q, i) => expect(sorted.start({id: `row-${i}`})).toBe(q));
+  // One weak entry per row, none of them sharing a bucket: the first page sits
+  // in the strong slot and the rest are keyed by the encoded row.
+  const t = asQueryImpl(sorted).transitionsForTesting!;
+  expect(t.first).toBe(pages[0]);
+  expect(t.restSize).toBe(MAX_SCAN * 2 - 1);
+  expect(t.rest!.get('start:exclusive')!.size).toBe(MAX_SCAN * 2 - 1);
+
+  // Rows that could run together under a naive concatenation are told apart:
+  // every key and value in the encoding is self-delimiting.
+  expect(sorted.start({a: 'x1:c:sy'})).not.toBe(sorted.start({a: 'x', c: 'y'}));
+  expect(sorted.start({id: 1, x: 2})).not.toBe(sorted.start({id: 12}));
+  expect(sorted.start({id: '1'})).not.toBe(sorted.start({id: 1}));
+  expect(sorted.start({id: 1})).not.toBe(
+    sorted.start({id: 1}, {inclusive: true}),
+  );
+  expect(sorted.start({id: 1}, {inclusive: true})).toBe(
+    sorted.start({id: 1}, {inclusive: true}),
+  );
+  // An undefined property is absent, as it is to `deepEqual`.
+  expect(sorted.start({id: 1, x: undefined})).toBe(sorted.start({id: 1}));
+  // Non-primitive values are serialized, so they are exact as well.
+  expect(sorted.start({tags: ['a', 'b']})).toBe(
+    sorted.start({tags: ['a', 'b']}),
+  );
+  expect(sorted.start({tags: ['a', 'b']})).not.toBe(
+    sorted.start({tags: ['b', 'a']}),
+  );
+});

--- a/packages/zql/src/query/query-impl.ts
+++ b/packages/zql/src/query/query-impl.ts
@@ -731,11 +731,16 @@ export class QueryImpl<
     row: Partial<Record<string, ReadonlyJSONValue | undefined>>,
     opts?: {inclusive: boolean},
   ): Query<TTable, TSchema, TReturn> {
-    // The row is folded into the transition value so that paging to a row
-    // never seen before is one lookup, not a scan of every sibling row's
-    // delta. Key order is part of the encoding: a row spelled in another order
-    // interns separately, and the hash index folds the two together once they
-    // are hashed.
+    // Interned like every other builder method (see `#derive`): if this query
+    // has already been paged from this row, the same query object comes back.
+    // The row is encoded into a string and looked up in a `Map`, so paging to
+    // a row never seen before costs one lookup. The alternative, keeping the
+    // row object and comparing it with `deepEqual` against every row already
+    // paged from here, made a new page slower than not interning at all.
+    //
+    // The encoding keeps property order, so `{a, b}` and `{b, a}` are looked
+    // up separately. They still end up as one object once either is hashed,
+    // since their ASTs are equal; see `#canonicalize`.
     return this.#derive(
       opts?.inclusive ? 'start:inclusive' : 'start:exclusive',
       valueTag(row as ReadonlyJSONValue),

--- a/packages/zql/src/query/query-impl.ts
+++ b/packages/zql/src/query/query-impl.ts
@@ -692,16 +692,11 @@ export class QueryImpl<
     if (cond.type === 'simple' && cond.left.type === 'column') {
       key = whereKey(cond.left.name, cond.op);
       const right = cond.right;
-      if (right.type === 'literal' && isPrimitive(right.value)) {
-        tValue = right.value;
-        delta = undefined;
-      } else {
-        const tag = rightTag(right);
-        if (tag !== undefined) {
-          tValue = tag;
-          delta = undefined;
-        }
-      }
+      tValue =
+        right.type === 'literal' && isPrimitive(right.value)
+          ? right.value
+          : rightTag(right);
+      delta = undefined;
     } else {
       // A sub-query an `exists` correlates to is itself interned, so its
       // identity settles that part of the tree without walking it.
@@ -732,10 +727,15 @@ export class QueryImpl<
     row: Partial<Record<string, ReadonlyJSONValue | undefined>>,
     opts?: {inclusive: boolean},
   ): Query<TTable, TSchema, TReturn> {
+    // The row is folded into the transition value so that paging to a row
+    // never seen before is one lookup, not a scan of every sibling row's
+    // delta. Key order is part of the encoding: a row spelled in another order
+    // interns separately, and the hash index folds the two together once they
+    // are hashed.
     return this.#derive(
       opts?.inclusive ? 'start:inclusive' : 'start:exclusive',
+      rowTag(row),
       undefined,
-      row,
       () =>
         this.#newQuery(
           this.#tableName,
@@ -1007,30 +1007,55 @@ function isPrimitive(v: LiteralValue): v is string | number | boolean | null {
 }
 
 /**
+ * Folds a JSON value into a self-delimiting token: strings and serialized
+ * values are length-prefixed, a number is terminated, and the rest are fixed
+ * width. Tokens can therefore be concatenated into a key with no way for one
+ * to run into the next, and the leading tag keeps `'1'` and `1` apart.
+ */
+function valueTag(v: ReadonlyJSONValue): string {
+  switch (typeof v) {
+    case 'string':
+      return `:s${enc(v)}`;
+    case 'number':
+      return `:n${v};`;
+    case 'boolean':
+      return v ? ':t' : ':f';
+    default:
+      return v === null ? ':z' : `:a${enc(JSON.stringify(v))}`;
+  }
+}
+
+/**
  * Folds the right-hand side of a simple condition into a transition value, so
  * that the transition is exact and the lookup needs no comparison at all.
  *
- * The leading tag keeps `'1'` and `1` apart. Arrays (`IN`) and parameter
- * references are serialized: that is one pass over a small value, where leaving
- * them in the delta would instead cost a `deepEqual` over the whole condition
- * for every sibling a lookup walks past.
+ * Arrays (`IN`) and parameter references are serialized: that is one pass
+ * over a small value, where leaving them in the delta would instead cost a
+ * `deepEqual` over the whole condition for every sibling a lookup walks past.
  */
-function rightTag(right: SimpleCondition['right']): string | undefined {
+function rightTag(right: SimpleCondition['right']): string {
   if (right.type !== 'literal') {
-    return `:p${JSON.stringify(right)}`;
+    return `:p${enc(JSON.stringify(right))}`;
   }
-  const v = right.value;
-  switch (typeof v) {
-    case 'string':
-      return `:s${v}`;
-    case 'number':
-      return `:n${v}`;
-    case 'boolean':
-      return `:b${v}`;
-    case 'object':
-      return v === null ? ':z' : `:a${JSON.stringify(v)}`;
+  return valueTag(right.value);
+}
+
+/**
+ * Folds a `start` row into a transition value. Keys and values are both
+ * self-delimiting, so two rows encode alike only if they are the same row. An
+ * `undefined` property is skipped, as `deepEqual` would skip it.
+ */
+function rowTag(
+  row: Partial<Record<string, ReadonlyJSONValue | undefined>>,
+): string {
+  let out = '';
+  for (const key in row) {
+    const v = row[key];
+    if (v !== undefined && Object.hasOwn(row, key)) {
+      out += enc(key) + valueTag(v);
+    }
   }
-  return undefined;
+  return out;
 }
 
 /**
@@ -1062,10 +1087,7 @@ function condKey(cond: Condition): string | undefined {
       if (cond.left.type !== 'column') {
         return undefined;
       }
-      const tag = rightTag(cond.right);
-      return tag === undefined
-        ? undefined
-        : `S${enc(cond.left.name)}${enc(cond.op)}${tag}`;
+      return `S${enc(cond.left.name)}${enc(cond.op)}${rightTag(cond.right)}`;
     }
     case 'correlatedSubquery': {
       const id = astIDs.get(cond.related.subquery);

--- a/packages/zql/src/query/query-impl.ts
+++ b/packages/zql/src/query/query-impl.ts
@@ -731,16 +731,8 @@ export class QueryImpl<
     row: Partial<Record<string, ReadonlyJSONValue | undefined>>,
     opts?: {inclusive: boolean},
   ): Query<TTable, TSchema, TReturn> {
-    // Interned like every other builder method (see `#derive`): if this query
-    // has already been paged from this row, the same query object comes back.
-    // The row is encoded into a string and looked up in a `Map`, so paging to
-    // a row never seen before costs one lookup. The alternative, keeping the
-    // row object and comparing it with `deepEqual` against every row already
-    // paged from here, made a new page slower than not interning at all.
-    //
-    // The encoding keeps property order, so `{a, b}` and `{b, a}` are looked
-    // up separately. They still end up as one object once either is hashed,
-    // since their ASTs are equal; see `#canonicalize`.
+    // The row is an object, so it is encoded to a string to serve as the
+    // lookup key. Property order is part of that string.
     return this.#derive(
       opts?.inclusive ? 'start:inclusive' : 'start:exclusive',
       valueTag(row as ReadonlyJSONValue),

--- a/packages/zql/src/query/query-impl.ts
+++ b/packages/zql/src/query/query-impl.ts
@@ -1,6 +1,10 @@
 // oxlint-disable no-explicit-any
 import {assert} from '../../../shared/src/asserts.ts';
-import {deepEqual, type ReadonlyJSONValue} from '../../../shared/src/json.ts';
+import {
+  deepEqual,
+  type ReadonlyJSONObject,
+  type ReadonlyJSONValue,
+} from '../../../shared/src/json.ts';
 import {
   type AST,
   type CompoundKey,
@@ -734,7 +738,7 @@ export class QueryImpl<
     // are hashed.
     return this.#derive(
       opts?.inclusive ? 'start:inclusive' : 'start:exclusive',
-      rowTag(row),
+      valueTag(row as ReadonlyJSONValue),
       undefined,
       () =>
         this.#newQuery(
@@ -1007,10 +1011,19 @@ function isPrimitive(v: LiteralValue): v is string | number | boolean | null {
 }
 
 /**
- * Folds a JSON value into a self-delimiting token: strings and serialized
- * values are length-prefixed, a number is terminated, and the rest are fixed
+ * Folds a JSON value into a self-delimiting token: a string is
+ * length-prefixed, a number is terminated, an array or object is
+ * count-prefixed and encodes its members recursively, and the rest are fixed
  * width. Tokens can therefore be concatenated into a key with no way for one
  * to run into the next, and the leading tag keeps `'1'` and `1` apart.
+ *
+ * Not `JSON.stringify`: it writes `Infinity`, `NaN` and `null` all as `null`,
+ * and this token is trusted as exact, so a nested value that serialized like
+ * another's would hand back a query with the wrong value in its AST. Numbers
+ * are written the way `String` writes them, which keeps those apart. An
+ * `undefined` property is skipped, as `deepEqual` would skip it; property
+ * order is part of the encoding, so an object spelled in another order
+ * interns separately.
  */
 function valueTag(v: ReadonlyJSONValue): string {
   switch (typeof v) {
@@ -1020,8 +1033,30 @@ function valueTag(v: ReadonlyJSONValue): string {
       return `:n${v};`;
     case 'boolean':
       return v ? ':t' : ':f';
-    default:
-      return v === null ? ':z' : `:a${enc(JSON.stringify(v))}`;
+    default: {
+      if (v === null) {
+        return ':z';
+      }
+      if (Array.isArray(v)) {
+        let out = `:a${v.length}:`;
+        for (const e of v) {
+          out += valueTag(e);
+        }
+        return out;
+      }
+      // `Array.isArray` does not narrow a readonly array out of the union.
+      const o = v as ReadonlyJSONObject;
+      let body = '';
+      let n = 0;
+      for (const key in o) {
+        const e = o[key];
+        if (e !== undefined && Object.hasOwn(o, key)) {
+          body += enc(key) + valueTag(e);
+          n++;
+        }
+      }
+      return `:o${n}:${body}`;
+    }
   }
 }
 
@@ -1035,27 +1070,9 @@ function valueTag(v: ReadonlyJSONValue): string {
  */
 function rightTag(right: SimpleCondition['right']): string {
   if (right.type !== 'literal') {
-    return `:p${enc(JSON.stringify(right))}`;
+    return `:p${valueTag(right as unknown as ReadonlyJSONValue)}`;
   }
   return valueTag(right.value);
-}
-
-/**
- * Folds a `start` row into a transition value. Keys and values are both
- * self-delimiting, so two rows encode alike only if they are the same row. An
- * `undefined` property is skipped, as `deepEqual` would skip it.
- */
-function rowTag(
-  row: Partial<Record<string, ReadonlyJSONValue | undefined>>,
-): string {
-  let out = '';
-  for (const key in row) {
-    const v = row[key];
-    if (v !== undefined && Object.hasOwn(row, key)) {
-      out += enc(key) + valueTag(v);
-    }
-  }
-  return out;
 }
 
 /**


### PR DESCRIPTION
Every `start` off one node landed in a single bucket, keyed by nothing and compared by `deepEqual` on the row, so paging to a row never seen before scanned every live sibling page -- up to `MAX_SCAN` deep comparisons -- before building anything. On a warm root that made a cold page ten times slower than not interning at all.

The row is now folded into the transition value, so a new page is one map lookup. Every key and value in the encoding is self-delimiting -- strings are length-prefixed and numbers terminated -- so two rows can only encode alike if they are the same row. The value tags the `where` path already used are tightened the same way, since `condKey` concatenates them.

Measured in plain node with the event loop yielding and GC running, a new page under a warm chain, per query:

| | before | after | uninterned |
|---|---|---|---|
| build only | 2496 ns | 350 ns | 241 ns |
| build + hash | 3351 ns | 1103 ns | 872 ns |

Stacked on #6470.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
