### PR TITLE
perf(zql): Defer hydration until source is ready.

### DIFF
--- a/packages/zero-client/src/client/context-deferred.test.ts
+++ b/packages/zero-client/src/client/context-deferred.test.ts
@@ -122,3 +122,27 @@ test('a view destroyed while deferred is not hydrated', () => {
   expect(listener).toHaveBeenCalledTimes(1);
   expect(view.data).toEqual([]);
 });
+
+test('a deferred pipeline that fails to build is logged and does not strand the others', async () => {
+  const {context} = newContext();
+  context.deferPipelines();
+  // t2 is not in the context's schema, so buildPipeline throws Source not found.
+  const otherSchema = createSchema({
+    tables: [table('t2').columns({id: string()}).primaryKey('id')],
+  });
+  const bad = context.materialize(newQuery(otherSchema, 't2'));
+  const good = context.materialize(newQuery(schema, 't1'));
+  let badType = 'unknown';
+  bad.addListener((_d, type) => {
+    badType = type;
+  });
+
+  context.processChanges(undefined, 'h1' as Hash, [add('e1', 'one')]);
+  expect(() => context.markPipelinesReady()).not.toThrow();
+
+  expect(good.data).toMatchObject([{id: 'e1'}]);
+  await vi.waitFor(() => expect(badType).toBe('error'));
+
+  bad.destroy();
+  good.destroy();
+});

--- a/packages/zero-client/src/client/context-deferred.test.ts
+++ b/packages/zero-client/src/client/context-deferred.test.ts
@@ -1,0 +1,124 @@
+import {LogContext} from '@rocicorp/logger';
+import {expect, test, vi} from 'vitest';
+import type {Hash} from '../../../replicache/src/hash.ts';
+import {createSchema} from '../../../zero-schema/src/builder/schema-builder.ts';
+import {string, table} from '../../../zero-schema/src/builder/table-builder.ts';
+import {newQuery} from '../../../zql/src/query/query-impl.ts';
+import {
+  ZeroContext,
+  type AddCustomQuery,
+  type AddQuery,
+  type FlushQueryChanges,
+  type UpdateCustomQuery,
+  type UpdateQuery,
+} from './context.ts';
+import {IVMSourceBranch} from './ivm-branch.ts';
+import {ENTITIES_KEY_PREFIX} from './keys.ts';
+
+const schema = createSchema({
+  tables: [
+    table('t1')
+      .columns({
+        id: string(),
+        name: string(),
+      })
+      .primaryKey('id'),
+  ],
+});
+
+function newContext() {
+  let batchCalls = 0;
+  const context = new ZeroContext(
+    new LogContext('info'),
+    new IVMSourceBranch(schema.tables),
+    (() => () => {}) as unknown as AddQuery,
+    (() => () => {}) as unknown as AddCustomQuery,
+    (() => {}) as unknown as UpdateQuery,
+    (() => {}) as unknown as UpdateCustomQuery,
+    (() => {}) as unknown as FlushQueryChanges,
+    applyViewUpdates => {
+      batchCalls++;
+      applyViewUpdates();
+    },
+    () => {},
+    () => {},
+  );
+  return {context, batchCalls: () => batchCalls};
+}
+
+const add = (id: string, name: string) => ({
+  key: `${ENTITIES_KEY_PREFIX}t1/${id}`,
+  op: 'add' as const,
+  newValue: {id, name},
+});
+
+test('pipelines are ready by default', () => {
+  const {context} = newContext();
+  expect(context.pipelinesReady).toBe(true);
+  context.processChanges(undefined, 'h1' as Hash, [add('e1', 'one')]);
+  const view = context.materialize(newQuery(schema, 't1'));
+  expect(view.data).toMatchObject([{id: 'e1'}]);
+  view.destroy();
+});
+
+test('views materialized while deferred hydrate when pipelines become ready', () => {
+  const {context, batchCalls} = newContext();
+  context.deferPipelines();
+  expect(context.pipelinesReady).toBe(false);
+
+  const view = context.materialize(newQuery(schema, 't1'));
+  const listener = vi.fn();
+  view.addListener(listener);
+  expect(view.data).toEqual([]);
+
+  // The replica is loaded into the sources. No pipeline is connected, so the
+  // view does not change yet.
+  context.processChanges(undefined, 'h1' as Hash, [
+    add('e1', 'one'),
+    add('e2', 'two'),
+  ]);
+  expect(view.data).toEqual([]);
+  expect(listener).toHaveBeenCalledTimes(1);
+
+  const batchesBefore = batchCalls();
+  context.markPipelinesReady();
+  expect(context.pipelinesReady).toBe(true);
+  expect(batchCalls()).toBe(batchesBefore + 1);
+  expect(view.data).toMatchObject([{id: 'e1'}, {id: 'e2'}]);
+  expect(listener).toHaveBeenCalledTimes(2);
+
+  // The attached pipeline receives later changes incrementally.
+  context.processChanges('h1' as Hash, 'h2' as Hash, [add('e3', 'three')]);
+  expect(view.data).toMatchObject([{id: 'e1'}, {id: 'e2'}, {id: 'e3'}]);
+  expect(listener).toHaveBeenCalledTimes(3);
+
+  view.destroy();
+});
+
+test('markPipelinesReady is idempotent and materialize after it is immediate', () => {
+  const {context, batchCalls} = newContext();
+  context.deferPipelines();
+  context.processChanges(undefined, 'h1' as Hash, [add('e1', 'one')]);
+  context.markPipelinesReady();
+  const batches = batchCalls();
+  context.markPipelinesReady();
+  expect(batchCalls()).toBe(batches);
+
+  const view = context.materialize(newQuery(schema, 't1'));
+  expect(view.data).toMatchObject([{id: 'e1'}]);
+  view.destroy();
+});
+
+test('a view destroyed while deferred is not hydrated', () => {
+  const {context} = newContext();
+  context.deferPipelines();
+  const view = context.materialize(newQuery(schema, 't1'));
+  const listener = vi.fn();
+  view.addListener(listener);
+  view.destroy();
+
+  context.processChanges(undefined, 'h1' as Hash, [add('e1', 'one')]);
+  context.markPipelinesReady();
+  expect(listener).toHaveBeenCalledTimes(1);
+  expect(view.data).toEqual([]);
+});

--- a/packages/zero-client/src/client/context-deferred.test.ts
+++ b/packages/zero-client/src/client/context-deferred.test.ts
@@ -123,26 +123,39 @@ test('a view destroyed while deferred is not hydrated', () => {
   expect(view.data).toEqual([]);
 });
 
-test('a deferred pipeline that fails to build is logged and does not strand the others', async () => {
+test('a query for an unknown table throws from materialize, as before deferral', () => {
   const {context} = newContext();
   context.deferPipelines();
-  // t2 is not in the context's schema, so buildPipeline throws Source not found.
   const otherSchema = createSchema({
     tables: [table('t2').columns({id: string()}).primaryKey('id')],
   });
-  const bad = context.materialize(newQuery(otherSchema, 't2'));
-  const good = context.materialize(newQuery(schema, 't1'));
-  let badType = 'unknown';
-  bad.addListener((_d, type) => {
-    badType = type;
+
+  expect(() => context.materialize(newQuery(otherSchema, 't2'))).toThrow();
+});
+
+test('a deferred pipeline that fails at attach is logged and does not strand the others', async () => {
+  const {context} = newContext();
+  context.deferPipelines();
+  const view = context.materialize(newQuery(schema, 't1'));
+  let type = 'unknown';
+  view.addListener((_d, t) => {
+    type = t;
   });
 
-  context.processChanges(undefined, 'h1' as Hash, [add('e1', 'one')]);
+  // A diff for a table the schema does not know poisons the source branch, so
+  // rebuilding the pipeline at attach time fails.
+  expect(() =>
+    context.processChanges(undefined, 'h1' as Hash, [
+      {
+        key: `${ENTITIES_KEY_PREFIX}nosuch/e1`,
+        op: 'add',
+        newValue: {id: 'e1'},
+      },
+    ]),
+  ).toThrow();
+
   expect(() => context.markPipelinesReady()).not.toThrow();
+  await vi.waitFor(() => expect(type).toBe('error'));
 
-  expect(good.data).toMatchObject([{id: 'e1'}]);
-  await vi.waitFor(() => expect(badType).toBe('error'));
-
-  bad.destroy();
-  good.destroy();
+  view.destroy();
 });

--- a/packages/zero-client/src/client/context.ts
+++ b/packages/zero-client/src/client/context.ts
@@ -44,6 +44,14 @@ export class ZeroContext extends QueryDelegateBase {
   readonly #batchViewUpdates: (applyViewUpdates: () => void) => void;
   readonly #commitListeners: Set<CommitListener> = new Set();
 
+  // Pipeline construction is deferred between `deferPipelines()` and
+  // `markPipelinesReady()`. Zero calls the former at construction and the
+  // latter once the replica has been loaded into the IVM sources, so cold
+  // boot loads the sources once instead of pushing every row through every
+  // already-materialized pipeline.
+  #pipelinesReady = true;
+  readonly #pendingPipelines: Set<() => void> = new Set();
+
   readonly assertValidRunOptions: (options?: RunOptions) => void;
 
   /**
@@ -85,6 +93,55 @@ export class ZeroContext extends QueryDelegateBase {
 
   getSource(name: string): Source | undefined {
     return this.#mainSources.getSource(name);
+  }
+
+  override get pipelinesReady(): boolean {
+    return this.#pipelinesReady;
+  }
+
+  override onPipelinesReady(cb: () => void): () => void {
+    assert(
+      !this.#pipelinesReady,
+      'onPipelinesReady called while pipelines are ready',
+    );
+    this.#pendingPipelines.add(cb);
+    return () => {
+      this.#pendingPipelines.delete(cb);
+    };
+  }
+
+  /**
+   * Stop building pipelines for materialized queries until
+   * {@link markPipelinesReady} is called. Views materialized in the meantime
+   * are empty and `unknown`, exactly as they would be over empty sources.
+   */
+  deferPipelines(): void {
+    this.#pipelinesReady = false;
+  }
+
+  /**
+   * Build and hydrate every pipeline deferred since {@link deferPipelines},
+   * in materialization order, as a single view-update batch.
+   */
+  markPipelinesReady(): void {
+    if (this.#pipelinesReady) {
+      return;
+    }
+    this.#pipelinesReady = true;
+    if (this.#pendingPipelines.size === 0) {
+      return;
+    }
+    const pending = [...this.#pendingPipelines];
+    this.#pendingPipelines.clear();
+    this.batchViewUpdates(() => {
+      try {
+        for (const attach of pending) {
+          attach();
+        }
+      } finally {
+        this.#endTransaction();
+      }
+    });
   }
 
   mapAst(ast: AST): AST {

--- a/packages/zero-client/src/client/context.ts
+++ b/packages/zero-client/src/client/context.ts
@@ -121,7 +121,9 @@ export class ZeroContext extends QueryDelegateBase {
 
   /**
    * Build and hydrate every pipeline deferred since {@link deferPipelines},
-   * in materialization order, as a single view-update batch.
+   * in materialization order, as a single view-update batch. A pipeline that
+   * fails to build is logged and its view reports an error; the rest are
+   * still built.
    */
   markPipelinesReady(): void {
     if (this.#pipelinesReady) {
@@ -136,7 +138,17 @@ export class ZeroContext extends QueryDelegateBase {
     this.batchViewUpdates(() => {
       try {
         for (const attach of pending) {
-          attach();
+          try {
+            attach();
+          } catch (e) {
+            // The failing view has already been marked as errored; keep
+            // building the others rather than aborting startup.
+            this.#lc.error?.(
+              ErrorKind.Internal,
+              'Failed to build a deferred query pipeline',
+              e,
+            );
+          }
         }
       } finally {
         this.#endTransaction();

--- a/packages/zero-client/src/client/zero-rep.ts
+++ b/packages/zero-client/src/client/zero-rep.ts
@@ -78,6 +78,10 @@ export class ZeroRep implements ZeroOption {
     this.#store = store;
 
     this.#context.processChanges(undefined, hash, diffs);
+    // Pipelines for queries materialized before this point were deferred so
+    // the replica above was loaded into the sources without fanning out to
+    // them. Build and hydrate them now that the sources are populated.
+    this.#context.markPipelinesReady();
   }
 
   getTxData = (

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -668,6 +668,10 @@ export class Zero<
       assertValidRunOptions,
     );
 
+    // Defer building query pipelines until ZeroRep.init has loaded the replica
+    // into the IVM sources (see ZeroContext.markPipelinesReady).
+    this.#zeroContext.deferPipelines();
+
     this.query = createRunnableBuilder(this.#zeroContext, schema);
 
     const replicacheImplOptions: ReplicacheImplOptions = {

--- a/packages/zql-benchmarks/src/cold-boot-hydration.bench.ts
+++ b/packages/zql-benchmarks/src/cold-boot-hydration.bench.ts
@@ -1,0 +1,235 @@
+/**
+ * Cold-boot hydration: N queries are materialized before the replica has been
+ * loaded into the IVM sources (what happens on the client when `useQuery`
+ * runs before `ZeroRep.init` completes).
+ *
+ * - "live pipelines": every row of the replica is pushed through every
+ *   already-connected pipeline.
+ * - "deferred pipelines": pipelines are built after the load and each view is
+ *   hydrated once, via `QueryDelegate.pipelinesReady` / `onPipelinesReady`.
+ *
+ * Run with:
+ *   pnpm --filter zql-benchmarks run bench cold-boot-hydration
+ */
+
+import {bench, describe} from '../../shared/src/bench.ts';
+import type {Row} from '../../zero-protocol/src/data.ts';
+import {MemorySource} from '../../zql/src/ivm/memory-source.ts';
+import {makeSourceChangeAdd} from '../../zql/src/ivm/source.ts';
+import {consume} from '../../zql/src/ivm/stream.ts';
+import type {AnyQuery} from '../../zql/src/query/query.ts';
+import {QueryDelegateImpl} from '../../zql/src/query/test/query-delegate.ts';
+import type {TypedView} from '../../zql/src/query/typed-view.ts';
+import {builder, schema} from './schema.ts';
+
+const NUM_USERS = 200;
+const NUM_ISSUES = 5_000;
+const NUM_COMMENTS = 15_000;
+const NUM_LABELS = 50;
+const NUM_ISSUE_LABELS = 10_000;
+
+function makeSources(): Record<string, MemorySource> {
+  const sources: Record<string, MemorySource> = {};
+  for (const [name, tableSchema] of Object.entries(schema.tables)) {
+    sources[name] = new MemorySource(
+      tableSchema.name,
+      tableSchema.columns,
+      tableSchema.primaryKey,
+    );
+  }
+  return sources;
+}
+
+function* rows(): Generator<[string, Row]> {
+  for (let i = 0; i < NUM_USERS; i++) {
+    yield [
+      'user',
+      {
+        id: `user-${i}`,
+        login: `user${i}`,
+        name: `User ${i}`,
+        avatar: `avatar${i}`,
+        role: i % 10 === 0 ? 'crew' : 'user',
+      },
+    ];
+  }
+  for (let i = 0; i < 5; i++) {
+    yield [
+      'project',
+      {id: `proj-${i}`, name: `Project ${i}`, lowerCaseName: `project ${i}`},
+    ];
+  }
+  for (let i = 0; i < NUM_ISSUES; i++) {
+    yield [
+      'issue',
+      {
+        id: `issue-${String(i).padStart(6, '0')}`,
+        shortID: i,
+        title: `Issue ${i}: ${i % 7 === 0 ? 'bug' : 'feature'} request`,
+        open: i % 3 !== 0,
+        modified: 1_700_000_000_000 - i * 1000,
+        created: 1_700_000_000_000 - i * 2000,
+        projectID: `proj-${i % 5}`,
+        creatorID: `user-${i % NUM_USERS}`,
+        assigneeID: i % 4 === 0 ? undefined : `user-${(i + 1) % NUM_USERS}`,
+        description: `Description for issue ${i}`,
+        visibility: i % 5 === 0 ? 'internal' : 'public',
+      },
+    ];
+  }
+  for (let i = 0; i < NUM_COMMENTS; i++) {
+    yield [
+      'comment',
+      {
+        id: `comment-${String(i).padStart(6, '0')}`,
+        issueID: `issue-${String(i % NUM_ISSUES).padStart(6, '0')}`,
+        created: 1_700_000_000_000 - i * 500,
+        body: `Comment body ${i}`,
+        creatorID: `user-${i % NUM_USERS}`,
+      },
+    ];
+  }
+  for (let i = 0; i < NUM_LABELS; i++) {
+    yield [
+      'label',
+      {id: `label-${i}`, name: `label-${i}`, projectID: `proj-${i % 5}`},
+    ];
+  }
+  for (let n = 0; n < NUM_ISSUE_LABELS; n++) {
+    yield [
+      'issueLabel',
+      {
+        issueID: `issue-${String(n % NUM_ISSUES).padStart(6, '0')}`,
+        labelID: `label-${(n * 13 + Math.floor(n / NUM_ISSUES)) % NUM_LABELS}`,
+        projectID: `proj-${n % 5}`,
+      },
+    ];
+  }
+}
+
+function load(sources: Record<string, MemorySource>) {
+  for (const [table, row] of rows()) {
+    consume(sources[table].push(makeSourceChangeAdd(row)));
+  }
+}
+
+// A representative set of queries an app registers at startup.
+const QUERIES: (() => AnyQuery)[] = [
+  () =>
+    builder.issue
+      .orderBy('modified', 'desc')
+      .limit(100)
+      .related('creator')
+      .related('assignee')
+      .related('labels'),
+  () =>
+    builder.issue
+      .where('open', true)
+      .orderBy('modified', 'desc')
+      .limit(100)
+      .related('creator')
+      .related('labels'),
+  () =>
+    builder.issue
+      .where('projectID', 'proj-0')
+      .limit(100)
+      .related('labels')
+      .related('comments', q => q.limit(10).related('creator')),
+  () => builder.issue.where('creatorID', 'user-1').related('project'),
+  () => builder.user,
+  () => builder.label,
+  () => builder.comment.where('issueID', 'issue-000001').related('creator'),
+  () =>
+    builder.issue
+      .where('id', 'issue-000005')
+      .related('comments', q => q.related('creator'))
+      .related('labels')
+      .related('creator'),
+  () => builder.issue.orderBy('created', 'asc').limit(50),
+  () => builder.issue.orderBy('title', 'asc').limit(50),
+  () => builder.comment.orderBy('created', 'desc').limit(200).related('issue'),
+  () => builder.issue.whereExists('comments').limit(100),
+  () => builder.issue.related('comments', q => q.limit(1)).limit(100),
+];
+
+class DeferredDelegate extends QueryDelegateImpl {
+  #ready = false;
+  readonly #pending = new Set<() => void>();
+
+  override get pipelinesReady(): boolean {
+    return this.#ready;
+  }
+
+  override onPipelinesReady(cb: () => void): () => void {
+    this.#pending.add(cb);
+    return () => {
+      this.#pending.delete(cb);
+    };
+  }
+
+  markReady(): void {
+    this.#ready = true;
+    const pending = [...this.#pending];
+    this.#pending.clear();
+    this.batchViewUpdates(() => {
+      for (const attach of pending) {
+        attach();
+      }
+    });
+    this.commit();
+  }
+}
+
+const opts = {max_samples: 20};
+
+describe('cold boot hydration', () => {
+  bench(
+    'materialize then load: live pipelines',
+    () => {
+      const sources = makeSources();
+      const delegate = new QueryDelegateImpl({sources});
+      const views: TypedView<unknown>[] = QUERIES.map(q =>
+        delegate.materialize(q()),
+      );
+      load(sources);
+      delegate.commit();
+      for (const v of views) {
+        v.destroy();
+      }
+    },
+    opts,
+  );
+
+  bench(
+    'materialize then load: deferred pipelines',
+    () => {
+      const sources = makeSources();
+      const delegate = new DeferredDelegate({sources});
+      const views: TypedView<unknown>[] = QUERIES.map(q =>
+        delegate.materialize(q()),
+      );
+      load(sources);
+      delegate.markReady();
+      for (const v of views) {
+        v.destroy();
+      }
+    },
+    opts,
+  );
+
+  bench(
+    'load then materialize (lower bound)',
+    () => {
+      const sources = makeSources();
+      load(sources);
+      const delegate = new QueryDelegateImpl({sources});
+      const views: TypedView<unknown>[] = QUERIES.map(q =>
+        delegate.materialize(q()),
+      );
+      for (const v of views) {
+        v.destroy();
+      }
+    },
+    opts,
+  );
+});

--- a/packages/zql/src/ivm/array-view.ts
+++ b/packages/zql/src/ivm/array-view.ts
@@ -50,7 +50,9 @@ function changeToViewChange(change: Change): ViewChange {
 export class ArrayView<V extends View> implements Output, TypedView<V> {
   readonly #input: Input;
   readonly #listeners = new Set<Listener<V>>();
-  readonly #schema: SourceSchema;
+  // Read lazily: a DeferredInput has no schema until its pipeline is attached,
+  // and the schema is only needed once there is a change to apply.
+  #schema: SourceSchema | undefined;
   readonly #format: Format;
 
   // Synthetic "root" entry that has a single "" relationship, so that we can
@@ -82,7 +84,6 @@ export class ArrayView<V extends View> implements Output, TypedView<V> {
     updateTTL: (ttl: TTL) => void,
   ) {
     this.#input = input;
-    this.#schema = input.getSchema();
     this.#format = format;
     this.#updateTTL = updateTTL;
     this.#root = {'': format.singular ? undefined : []};
@@ -110,6 +111,10 @@ export class ArrayView<V extends View> implements Output, TypedView<V> {
 
   get data() {
     return this.#root[''] as V;
+  }
+
+  #getSchema(): SourceSchema {
+    return (this.#schema ??= this.#input.getSchema());
   }
 
   addListener(listener: Listener<V>) {
@@ -143,7 +148,7 @@ export class ArrayView<V extends View> implements Output, TypedView<V> {
       this.#root = applyChange(
         this.#root,
         {type: 'add', node},
-        this.#schema,
+        this.#getSchema(),
         '',
         this.#format,
         false /* withIDs */,
@@ -161,7 +166,7 @@ export class ArrayView<V extends View> implements Output, TypedView<V> {
     this.#root = applyChange(
       this.#root,
       changeToViewChange(change),
-      this.#schema,
+      this.#getSchema(),
       '',
       this.#format,
       false /* withIDs */,

--- a/packages/zql/src/ivm/deferred-input.ts
+++ b/packages/zql/src/ivm/deferred-input.ts
@@ -1,0 +1,78 @@
+import {assert} from '../../../shared/src/asserts.ts';
+import {makeAddChange} from './change.ts';
+import type {Node} from './data.ts';
+import type {FetchRequest, Input, Output} from './operator.ts';
+import type {SourceSchema} from './schema.ts';
+import {consume, type Stream} from './stream.ts';
+
+/**
+ * A placeholder `Input` for a view whose pipeline cannot be built yet.
+ *
+ * Until {@link attach} is called it behaves like an empty pipeline: `fetch`
+ * yields nothing and pushes never happen. When the real pipeline is attached
+ * the view is hydrated by pushing every row of the pipeline's initial fetch
+ * through the normal `Output.push` path, so the view sees the data exactly as
+ * it would see rows arriving incrementally.
+ *
+ * This lets `materialize()` stay synchronous and return a view immediately
+ * while the expensive pipeline construction and hydration are postponed, for
+ * example until the client's replica has been loaded into the IVM sources.
+ */
+export class DeferredInput implements Input {
+  #output: Output | undefined;
+  #input: Input | undefined;
+  #destroyed = false;
+
+  get attached(): boolean {
+    return this.#input !== undefined;
+  }
+
+  get destroyed(): boolean {
+    return this.#destroyed;
+  }
+
+  setOutput(output: Output): void {
+    this.#output = output;
+    this.#input?.setOutput(output);
+  }
+
+  getSchema(): SourceSchema {
+    assert(
+      this.#input,
+      'DeferredInput: schema is not available before the pipeline is attached',
+    );
+    return this.#input.getSchema();
+  }
+
+  *fetch(req: FetchRequest): Stream<Node | 'yield'> {
+    if (this.#input) {
+      yield* this.#input.fetch(req);
+    }
+  }
+
+  destroy(): void {
+    this.#destroyed = true;
+    this.#input?.destroy();
+  }
+
+  /**
+   * Attach the real pipeline and hydrate the output with its current contents.
+   *
+   * Must be called inside the delegate's `batchViewUpdates`; the delegate is
+   * responsible for notifying commit listeners afterwards so views flush.
+   */
+  attach(input: Input): void {
+    assert(!this.#input, 'DeferredInput: pipeline already attached');
+    assert(!this.#destroyed, 'DeferredInput: cannot attach after destroy');
+    this.#input = input;
+    const output = this.#output;
+    assert(output, 'DeferredInput: attach called before setOutput');
+    input.setOutput(output);
+    for (const node of input.fetch({})) {
+      if (node === 'yield') {
+        continue;
+      }
+      consume(output.push(makeAddChange(node), input));
+    }
+  }
+}

--- a/packages/zql/src/ivm/deferred-input.ts
+++ b/packages/zql/src/ivm/deferred-input.ts
@@ -6,30 +6,33 @@ import type {SourceSchema} from './schema.ts';
 import {consume, type Stream} from './stream.ts';
 
 /**
- * A placeholder `Input` for a view whose pipeline cannot be built yet.
+ * A placeholder `Input` for a view whose pipeline has not been built yet.
  *
  * Until {@link attach} is called it behaves like an empty pipeline: `fetch`
  * yields nothing and pushes never happen. When the real pipeline is attached
- * the view is hydrated by pushing every row of the pipeline's initial fetch
- * through the normal `Output.push` path, so the view sees the data exactly as
- * it would see rows arriving incrementally.
+ * the view is hydrated with a single `fetch`, whose rows are delivered to the
+ * view as add changes, so the view sees the data exactly as it would see rows
+ * arriving incrementally.
  *
  * This lets `materialize()` stay synchronous and return a view immediately
  * while the expensive pipeline construction and hydration are postponed, for
  * example until the client's replica has been loaded into the IVM sources.
  */
 export class DeferredInput implements Input {
+  readonly #schema: SourceSchema;
   readonly #build: () => Input;
   #output: Output | undefined;
   #input: Input | undefined;
   #destroyed = false;
 
   /**
-   * @param build Builds the real pipeline. Called at most once, either from
-   *   {@link attach} or, if the view needs the schema before the delegate is
-   *   ready, from {@link getSchema}.
+   * @param schema The schema the built pipeline reports. Passed in so this
+   *   input can answer `getSchema()` unconditionally, as the `Input` contract
+   *   requires, before its pipeline exists.
+   * @param build Builds the real pipeline. Called once, from {@link attach}.
    */
-  constructor(build: () => Input) {
+  constructor(schema: SourceSchema, build: () => Input) {
+    this.#schema = schema;
     this.#build = build;
   }
 
@@ -47,19 +50,7 @@ export class DeferredInput implements Input {
   }
 
   getSchema(): SourceSchema {
-    if (!this.#input) {
-      // Honor the Input contract for views that read the schema before the
-      // delegate is ready: build the pipeline now. The view has not fetched
-      // yet, so it hydrates through the normal fetch path and receives later
-      // pushes as usual. Only the cold-boot optimization is lost for this view.
-      assert(!this.#destroyed, 'DeferredInput: destroyed');
-      const input = this.#build();
-      this.#input = input;
-      if (this.#output) {
-        input.setOutput(this.#output);
-      }
-    }
-    return this.#input.getSchema();
+    return this.#schema;
   }
 
   *fetch(req: FetchRequest): Stream<Node | 'yield'> {
@@ -75,26 +66,21 @@ export class DeferredInput implements Input {
 
   /**
    * Build the real pipeline and hydrate the output with its current contents.
-   * A no-op if the pipeline was already built by {@link getSchema}.
    *
    * Must be called inside the delegate's `batchViewUpdates`; the delegate is
    * responsible for notifying commit listeners afterwards so views flush.
    *
-   * If building or hydrating throws, the pipeline is torn down again and the
+   * If building or hydrating throws, the pipeline is torn down again and this
    * input stays unattached so the caller can report the failure.
    */
   attach(): void {
+    assert(!this.#input, 'DeferredInput: pipeline already attached');
     assert(!this.#destroyed, 'DeferredInput: cannot attach after destroy');
-    if (this.#input) {
-      return;
-    }
     const input = this.#build();
-    // Assign before hydrating: the view may call getSchema() while applying
-    // the pushed rows and must see this pipeline, not build another.
-    this.#input = input;
     const output = this.#output;
     if (!output) {
       // The view never asked for output; there is nothing to hydrate.
+      this.#input = input;
       return;
     }
     try {
@@ -106,9 +92,9 @@ export class DeferredInput implements Input {
         consume(output.push(makeAddChange(node), input));
       }
     } catch (e) {
-      this.#input = undefined;
       input.destroy();
       throw e;
     }
+    this.#input = input;
   }
 }

--- a/packages/zql/src/ivm/deferred-input.ts
+++ b/packages/zql/src/ivm/deferred-input.ts
@@ -19,9 +19,19 @@ import {consume, type Stream} from './stream.ts';
  * example until the client's replica has been loaded into the IVM sources.
  */
 export class DeferredInput implements Input {
+  readonly #build: () => Input;
   #output: Output | undefined;
   #input: Input | undefined;
   #destroyed = false;
+
+  /**
+   * @param build Builds the real pipeline. Called at most once, either from
+   *   {@link attach} or, if the view needs the schema before the delegate is
+   *   ready, from {@link getSchema}.
+   */
+  constructor(build: () => Input) {
+    this.#build = build;
+  }
 
   get attached(): boolean {
     return this.#input !== undefined;
@@ -37,10 +47,18 @@ export class DeferredInput implements Input {
   }
 
   getSchema(): SourceSchema {
-    assert(
-      this.#input,
-      'DeferredInput: schema is not available before the pipeline is attached',
-    );
+    if (!this.#input) {
+      // Honor the Input contract for views that read the schema before the
+      // delegate is ready: build the pipeline now. The view has not fetched
+      // yet, so it hydrates through the normal fetch path and receives later
+      // pushes as usual. Only the cold-boot optimization is lost for this view.
+      assert(!this.#destroyed, 'DeferredInput: destroyed');
+      const input = this.#build();
+      this.#input = input;
+      if (this.#output) {
+        input.setOutput(this.#output);
+      }
+    }
     return this.#input.getSchema();
   }
 
@@ -56,23 +74,41 @@ export class DeferredInput implements Input {
   }
 
   /**
-   * Attach the real pipeline and hydrate the output with its current contents.
+   * Build the real pipeline and hydrate the output with its current contents.
+   * A no-op if the pipeline was already built by {@link getSchema}.
    *
    * Must be called inside the delegate's `batchViewUpdates`; the delegate is
    * responsible for notifying commit listeners afterwards so views flush.
+   *
+   * If building or hydrating throws, the pipeline is torn down again and the
+   * input stays unattached so the caller can report the failure.
    */
-  attach(input: Input): void {
-    assert(!this.#input, 'DeferredInput: pipeline already attached');
+  attach(): void {
     assert(!this.#destroyed, 'DeferredInput: cannot attach after destroy');
+    if (this.#input) {
+      return;
+    }
+    const input = this.#build();
+    // Assign before hydrating: the view may call getSchema() while applying
+    // the pushed rows and must see this pipeline, not build another.
     this.#input = input;
     const output = this.#output;
-    assert(output, 'DeferredInput: attach called before setOutput');
-    input.setOutput(output);
-    for (const node of input.fetch({})) {
-      if (node === 'yield') {
-        continue;
+    if (!output) {
+      // The view never asked for output; there is nothing to hydrate.
+      return;
+    }
+    try {
+      input.setOutput(output);
+      for (const node of input.fetch({})) {
+        if (node === 'yield') {
+          continue;
+        }
+        consume(output.push(makeAddChange(node), input));
       }
-      consume(output.push(makeAddChange(node), input));
+    } catch (e) {
+      this.#input = undefined;
+      input.destroy();
+      throw e;
     }
   }
 }

--- a/packages/zql/src/query/materialize-deferred.test.ts
+++ b/packages/zql/src/query/materialize-deferred.test.ts
@@ -2,6 +2,7 @@ import {expect, test, vi} from 'vitest';
 import {must} from '../../../shared/src/must.ts';
 import type {ErroredQuery} from '../../../zero-protocol/src/custom-queries.ts';
 import {ArrayView} from '../ivm/array-view.ts';
+import type {SourceSchema} from '../ivm/schema.ts';
 import {makeSourceChangeAdd, type Source} from '../ivm/source.ts';
 import {consume} from '../ivm/stream.ts';
 import type {MetricMap} from './metrics-delegate.ts';
@@ -19,7 +20,8 @@ class DeferredDelegate extends QueryDelegateImpl {
   #ready = false;
   readonly #pending = new Set<() => void>();
   readonly metrics: string[] = [];
-  getSourceCalls = 0;
+  /** Connections currently open against the sources. */
+  liveConnections = 0;
 
   override get pipelinesReady(): boolean {
     return this.#ready;
@@ -37,11 +39,31 @@ class DeferredDelegate extends QueryDelegateImpl {
   }
 
   override getSource(name: string): Source {
-    this.getSourceCalls++;
     if (this.failingTables.has(name)) {
       throw new Error(`boom: ${name}`);
     }
-    return super.getSource(name);
+    const source = super.getSource(name);
+    // Wrapped so tests can assert that nothing is connected to the sources
+    // while hydration is deferred.
+    const counting: Source = {
+      get tableSchema() {
+        return source.tableSchema;
+      },
+      connect: (sort, filters, splitEditKeys, debug) => {
+        this.liveConnections++;
+        const input = source.connect(sort, filters, splitEditKeys, debug);
+        return {
+          ...input,
+          destroy: () => {
+            this.liveConnections--;
+            input.destroy();
+          },
+        };
+      },
+      push: change => source.push(change),
+      genPush: change => source.genPush(change),
+    };
+    return counting;
   }
 
   override addMetric<K extends keyof MetricMap>(
@@ -74,13 +96,9 @@ class DeferredDelegate extends QueryDelegateImpl {
 
 function newDelegate() {
   const delegate = new DeferredDelegate();
-  // Load sources directly, bypassing getSource counting, as ZeroRep.init does.
-  const issues = must(
-    QueryDelegateImpl.prototype.getSource.call(delegate, 'issue'),
-  );
-  const comments = must(
-    QueryDelegateImpl.prototype.getSource.call(delegate, 'comment'),
-  );
+  // Loaded directly into the sources, as ZeroRep.init does.
+  const issues = must(delegate.getSource('issue'));
+  const comments = must(delegate.getSource('comment'));
   const addIssue = (id: string) =>
     consume(
       issues.push(
@@ -119,7 +137,7 @@ test('materialize before ready returns an empty, unknown view and registers the 
   expect(listener).toHaveBeenCalledTimes(1);
   expect(listener.mock.calls[0][1]).toBe('unknown');
   expect(delegate.addedServerQueries).toHaveLength(1);
-  expect(delegate.getSourceCalls).toBe(0);
+  expect(delegate.liveConnections).toBe(0);
   expect(delegate.pendingCount).toBe(1);
   expect(delegate.metrics).not.toContain('query-materialization-client');
 
@@ -140,7 +158,7 @@ test('rows loaded while deferred appear once pipelines are ready', () => {
   delegate.markReady();
 
   expect(delegate.pendingCount).toBe(0);
-  expect(delegate.getSourceCalls).toBeGreaterThan(0);
+  expect(delegate.liveConnections).toBeGreaterThan(0);
   expect(view.data).toMatchObject([{id: 'i1'}, {id: 'i2'}]);
   expect(listener).toHaveBeenCalledTimes(2);
   expect(listener.mock.calls[1][1]).toBe('unknown');
@@ -157,7 +175,7 @@ test('destroy before ready never builds the pipeline', () => {
 
   expect(delegate.pendingCount).toBe(0);
   delegate.markReady();
-  expect(delegate.getSourceCalls).toBe(0);
+  expect(delegate.liveConnections).toBe(0);
 });
 
 test('complete is gated on both got and the pipeline being attached', async () => {
@@ -258,7 +276,7 @@ test('materialize after ready builds the pipeline immediately', () => {
 
   const view = delegate.materialize(newQuery(schema, 'issue'));
   expect(delegate.pendingCount).toBe(0);
-  expect(delegate.getSourceCalls).toBeGreaterThan(0);
+  expect(delegate.liveConnections).toBeGreaterThan(0);
   expect(view.data).toMatchObject([{id: 'i1'}]);
   expect(delegate.metrics).toContain('query-materialization-client');
 
@@ -299,11 +317,11 @@ test('end-to-end metric is recorded once the view is hydrated, not on got alone'
   view.destroy();
 });
 
-test('a factory that reads the schema before ready gets a live pipeline', () => {
-  const {delegate, addIssue} = newDelegate();
-  let schemaTable: string | undefined;
+test('a factory can read the schema before ready, and stays deferred', () => {
+  const {delegate, addIssue, addComment} = newDelegate();
+  let deferredSchema: SourceSchema | undefined;
   const view = delegate.materialize(
-    newQuery(schema, 'issue'),
+    newQuery(schema, 'issue').related('comments'),
     (
       _q,
       input,
@@ -314,25 +332,29 @@ test('a factory that reads the schema before ready gets a live pipeline', () => 
       updateTTL,
     ) => {
       // Reads the schema at construction, as ArrayView did before deferral.
-      schemaTable = input.getSchema().tableName;
+      deferredSchema = input.getSchema();
       const v = new ArrayView(input, format, queryComplete, updateTTL);
       v.onDestroy = onDestroy;
       onTransactionCommit(() => v.flush());
       return v;
     },
   );
-  expect(schemaTable).toBe('issue');
-  expect(delegate.getSourceCalls).toBeGreaterThan(0);
 
-  // The pipeline was built eagerly and is connected: rows pushed before ready
-  // arrive through the normal push path.
+  // The schema is the one the pipeline reports, relationships included.
+  expect(deferredSchema?.tableName).toBe('issue');
+  expect(Object.keys(must(deferredSchema).relationships)).toEqual(['comments']);
+  // It came from a pipeline that was destroyed again, so the view is still
+  // deferred: nothing is connected and rows do not reach it yet.
+  expect(delegate.liveConnections).toBe(0);
+
   addIssue('i1');
+  addComment('c1', 'i1');
   delegate.commit();
-  expect(view.data).toMatchObject([{id: 'i1'}]);
+  expect(view.data).toEqual([]);
 
-  // markReady is a no-op for this view.
   delegate.markReady();
-  expect(view.data).toMatchObject([{id: 'i1'}]);
+  expect(view.data).toMatchObject([{id: 'i1', comments: [{id: 'c1'}]}]);
+
   view.destroy();
 });
 
@@ -349,9 +371,19 @@ test('a factory that never calls setOutput does not break the drain', () => {
   view.destroy();
 });
 
-test('a pipeline that fails to build marks its view as errored and does not block others', async () => {
-  const {delegate, addIssue} = newDelegate();
+test('a query that cannot be built throws from materialize, as before deferral', () => {
+  const {delegate} = newDelegate();
   delegate.failingTables.add('comment');
+
+  expect(() => delegate.materialize(newQuery(schema, 'comment'))).toThrow(
+    'boom: comment',
+  );
+  // Nothing was queued for the drain.
+  expect(delegate.pendingCount).toBe(0);
+});
+
+test('a pipeline that fails at attach errors its own view and does not block others', async () => {
+  const {delegate, addIssue} = newDelegate();
   const bad = delegate.materialize(newQuery(schema, 'comment'));
   const good = delegate.materialize(newQuery(schema, 'issue'));
   let badType: ResultType = 'unknown';
@@ -362,6 +394,8 @@ test('a pipeline that fails to build marks its view as errored and does not bloc
   });
   addIssue('i1');
 
+  // Both probes succeeded; only the rebuild at attach time fails.
+  delegate.failingTables.add('comment');
   delegate.markReady();
 
   expect(good.data).toMatchObject([{id: 'i1'}]);

--- a/packages/zql/src/query/materialize-deferred.test.ts
+++ b/packages/zql/src/query/materialize-deferred.test.ts
@@ -1,5 +1,7 @@
 import {expect, test, vi} from 'vitest';
 import {must} from '../../../shared/src/must.ts';
+import type {ErroredQuery} from '../../../zero-protocol/src/custom-queries.ts';
+import {ArrayView} from '../ivm/array-view.ts';
 import {makeSourceChangeAdd, type Source} from '../ivm/source.ts';
 import {consume} from '../ivm/stream.ts';
 import type {MetricMap} from './metrics-delegate.ts';
@@ -36,6 +38,9 @@ class DeferredDelegate extends QueryDelegateImpl {
 
   override getSource(name: string): Source {
     this.getSourceCalls++;
+    if (this.failingTables.has(name)) {
+      throw new Error(`boom: ${name}`);
+    }
     return super.getSource(name);
   }
 
@@ -47,13 +52,20 @@ class DeferredDelegate extends QueryDelegateImpl {
     this.metrics.push(metric);
   }
 
+  /** Tables for which getSource throws, to simulate a pipeline build failure. */
+  readonly failingTables = new Set<string>();
+
   markReady(): void {
     this.#ready = true;
     const pending = [...this.#pending];
     this.#pending.clear();
     this.batchViewUpdates(() => {
       for (const attach of pending) {
-        attach();
+        try {
+          attach();
+        } catch {
+          // mirrors ZeroContext.markPipelinesReady: log and continue
+        }
       }
     });
     this.commit();
@@ -271,4 +283,91 @@ test('deferred pipelines attach in materialization order', () => {
 
   a.destroy();
   b.destroy();
+});
+
+test('end-to-end metric is recorded once the view is hydrated, not on got alone', () => {
+  const {delegate, addIssue} = newDelegate();
+  const view = delegate.materialize(newQuery(schema, 'issue'));
+  addIssue('i1');
+
+  delegate.callAllGotCallbacks();
+  expect(delegate.metrics).not.toContain('query-materialization-end-to-end');
+
+  delegate.markReady();
+  expect(delegate.metrics).toContain('query-materialization-end-to-end');
+
+  view.destroy();
+});
+
+test('a factory that reads the schema before ready gets a live pipeline', () => {
+  const {delegate, addIssue} = newDelegate();
+  let schemaTable: string | undefined;
+  const view = delegate.materialize(
+    newQuery(schema, 'issue'),
+    (
+      _q,
+      input,
+      format,
+      onDestroy,
+      onTransactionCommit,
+      queryComplete,
+      updateTTL,
+    ) => {
+      // Reads the schema at construction, as ArrayView did before deferral.
+      schemaTable = input.getSchema().tableName;
+      const v = new ArrayView(input, format, queryComplete, updateTTL);
+      v.onDestroy = onDestroy;
+      onTransactionCommit(() => v.flush());
+      return v;
+    },
+  );
+  expect(schemaTable).toBe('issue');
+  expect(delegate.getSourceCalls).toBeGreaterThan(0);
+
+  // The pipeline was built eagerly and is connected: rows pushed before ready
+  // arrive through the normal push path.
+  addIssue('i1');
+  delegate.commit();
+  expect(view.data).toMatchObject([{id: 'i1'}]);
+
+  // markReady is a no-op for this view.
+  delegate.markReady();
+  expect(view.data).toMatchObject([{id: 'i1'}]);
+  view.destroy();
+});
+
+test('a factory that never calls setOutput does not break the drain', () => {
+  const {delegate, addIssue} = newDelegate();
+  const view = delegate.materialize(
+    newQuery(schema, 'issue'),
+    (_q, _input, _f, onDestroy) => ({
+      destroy: onDestroy,
+    }),
+  );
+  addIssue('i1');
+  expect(() => delegate.markReady()).not.toThrow();
+  view.destroy();
+});
+
+test('a pipeline that fails to build marks its view as errored and does not block others', async () => {
+  const {delegate, addIssue} = newDelegate();
+  delegate.failingTables.add('comment');
+  const bad = delegate.materialize(newQuery(schema, 'comment'));
+  const good = delegate.materialize(newQuery(schema, 'issue'));
+  let badType: ResultType = 'unknown';
+  let badError: ErroredQuery | undefined;
+  bad.addListener((_d, type, error) => {
+    badType = type;
+    badError = error;
+  });
+  addIssue('i1');
+
+  delegate.markReady();
+
+  expect(good.data).toMatchObject([{id: 'i1'}]);
+  await vi.waitFor(() => expect(badType).toBe('error'));
+  expect(badError).toMatchObject({error: 'app', message: 'boom: comment'});
+
+  bad.destroy();
+  good.destroy();
 });

--- a/packages/zql/src/query/materialize-deferred.test.ts
+++ b/packages/zql/src/query/materialize-deferred.test.ts
@@ -1,0 +1,274 @@
+import {expect, test, vi} from 'vitest';
+import {must} from '../../../shared/src/must.ts';
+import {makeSourceChangeAdd, type Source} from '../ivm/source.ts';
+import {consume} from '../ivm/stream.ts';
+import type {MetricMap} from './metrics-delegate.ts';
+import {newQuery} from './query-impl.ts';
+import {QueryDelegateImpl} from './test/query-delegate.ts';
+import {schema} from './test/test-schemas.ts';
+import type {ResultType} from './typed-view.ts';
+
+/**
+ * A delegate whose pipelines are not ready until `markReady()` is called,
+ * mirroring what ZeroContext does between construction and the replica being
+ * loaded into the IVM sources.
+ */
+class DeferredDelegate extends QueryDelegateImpl {
+  #ready = false;
+  readonly #pending = new Set<() => void>();
+  readonly metrics: string[] = [];
+  getSourceCalls = 0;
+
+  override get pipelinesReady(): boolean {
+    return this.#ready;
+  }
+
+  override onPipelinesReady(cb: () => void): () => void {
+    this.#pending.add(cb);
+    return () => {
+      this.#pending.delete(cb);
+    };
+  }
+
+  get pendingCount(): number {
+    return this.#pending.size;
+  }
+
+  override getSource(name: string): Source {
+    this.getSourceCalls++;
+    return super.getSource(name);
+  }
+
+  override addMetric<K extends keyof MetricMap>(
+    metric: K,
+    _value: number,
+    ..._args: MetricMap[K]
+  ): void {
+    this.metrics.push(metric);
+  }
+
+  markReady(): void {
+    this.#ready = true;
+    const pending = [...this.#pending];
+    this.#pending.clear();
+    this.batchViewUpdates(() => {
+      for (const attach of pending) {
+        attach();
+      }
+    });
+    this.commit();
+  }
+}
+
+function newDelegate() {
+  const delegate = new DeferredDelegate();
+  // Load sources directly, bypassing getSource counting, as ZeroRep.init does.
+  const issues = must(
+    QueryDelegateImpl.prototype.getSource.call(delegate, 'issue'),
+  );
+  const comments = must(
+    QueryDelegateImpl.prototype.getSource.call(delegate, 'comment'),
+  );
+  const addIssue = (id: string) =>
+    consume(
+      issues.push(
+        makeSourceChangeAdd({
+          id,
+          title: `issue ${id}`,
+          description: '',
+          closed: false,
+          ownerId: null,
+          createdAt: 1,
+        }),
+      ),
+    );
+  const addComment = (id: string, issueId: string) =>
+    consume(
+      comments.push(
+        makeSourceChangeAdd({
+          id,
+          authorId: 'u1',
+          issueId,
+          text: `comment ${id}`,
+          createdAt: 1,
+        }),
+      ),
+    );
+  return {delegate, addIssue, addComment};
+}
+
+test('materialize before ready returns an empty, unknown view and registers the server query', () => {
+  const {delegate} = newDelegate();
+  const view = delegate.materialize(newQuery(schema, 'issue'));
+  const listener = vi.fn();
+  view.addListener(listener);
+
+  expect(view.data).toEqual([]);
+  expect(listener).toHaveBeenCalledTimes(1);
+  expect(listener.mock.calls[0][1]).toBe('unknown');
+  expect(delegate.addedServerQueries).toHaveLength(1);
+  expect(delegate.getSourceCalls).toBe(0);
+  expect(delegate.pendingCount).toBe(1);
+  expect(delegate.metrics).not.toContain('query-materialization-client');
+
+  view.destroy();
+});
+
+test('rows loaded while deferred appear once pipelines are ready', () => {
+  const {delegate, addIssue} = newDelegate();
+  const view = delegate.materialize(newQuery(schema, 'issue'));
+  const listener = vi.fn();
+  view.addListener(listener);
+
+  addIssue('i1');
+  addIssue('i2');
+  expect(view.data).toEqual([]);
+  expect(listener).toHaveBeenCalledTimes(1);
+
+  delegate.markReady();
+
+  expect(delegate.pendingCount).toBe(0);
+  expect(delegate.getSourceCalls).toBeGreaterThan(0);
+  expect(view.data).toMatchObject([{id: 'i1'}, {id: 'i2'}]);
+  expect(listener).toHaveBeenCalledTimes(2);
+  expect(listener.mock.calls[1][1]).toBe('unknown');
+  expect(delegate.metrics).toContain('query-materialization-client');
+
+  view.destroy();
+});
+
+test('destroy before ready never builds the pipeline', () => {
+  const {delegate, addIssue} = newDelegate();
+  const view = delegate.materialize(newQuery(schema, 'issue'));
+  addIssue('i1');
+  view.destroy();
+
+  expect(delegate.pendingCount).toBe(0);
+  delegate.markReady();
+  expect(delegate.getSourceCalls).toBe(0);
+});
+
+test('complete is gated on both got and the pipeline being attached', async () => {
+  const {delegate, addIssue} = newDelegate();
+  const view = delegate.materialize(newQuery(schema, 'issue'));
+  let resultType: ResultType = 'unknown';
+  view.addListener((_data, type) => {
+    resultType = type;
+  });
+  addIssue('i1');
+
+  // got arrives before the sources are loaded
+  delegate.callAllGotCallbacks();
+  await Promise.resolve();
+  expect(resultType).toBe('unknown');
+
+  delegate.markReady();
+  await vi.waitFor(() => expect(resultType).toBe('complete'));
+  expect(view.data).toMatchObject([{id: 'i1'}]);
+
+  view.destroy();
+});
+
+test('got after ready completes as before', async () => {
+  const {delegate, addIssue} = newDelegate();
+  const view = delegate.materialize(newQuery(schema, 'issue'));
+  let resultType: ResultType = 'unknown';
+  view.addListener((_data, type) => {
+    resultType = type;
+  });
+  addIssue('i1');
+
+  delegate.markReady();
+  await Promise.resolve();
+  expect(resultType).toBe('unknown');
+
+  delegate.callAllGotCallbacks();
+  await vi.waitFor(() => expect(resultType).toBe('complete'));
+
+  view.destroy();
+});
+
+test('run({type: complete}) resolves with data once ready and got', async () => {
+  const {delegate, addIssue} = newDelegate();
+  addIssue('i1');
+  const p = delegate.run(newQuery(schema, 'issue'), {type: 'complete'});
+
+  delegate.callAllGotCallbacks();
+  delegate.markReady();
+
+  expect(await p).toMatchObject([{id: 'i1'}]);
+});
+
+test('updateTTL before ready is forwarded to the server query', () => {
+  const {delegate} = newDelegate();
+  const view = delegate.materialize(newQuery(schema, 'issue'));
+  view.updateTTL(12_345);
+  expect(delegate.addedServerQueries[0].ttl).toBe(12_345);
+  view.destroy();
+});
+
+test('limit and related hydrate correctly after ready and stay incremental', () => {
+  const {delegate, addIssue, addComment} = newDelegate();
+  const view = delegate.materialize(
+    newQuery(schema, 'issue').related('comments').limit(2),
+  );
+
+  addIssue('i1');
+  addIssue('i2');
+  addIssue('i3');
+  addComment('c1', 'i1');
+  addComment('c2', 'i1');
+  addComment('c3', 'i3');
+  expect(view.data).toEqual([]);
+
+  delegate.markReady();
+  expect(view.data).toMatchObject([
+    {id: 'i1', comments: [{id: 'c1'}, {id: 'c2'}]},
+    {id: 'i2', comments: []},
+  ]);
+
+  // The attached pipeline is live: a new first row pushes i2 out of the limit.
+  addIssue('i0');
+  addComment('c4', 'i0');
+  delegate.commit();
+  expect(view.data).toMatchObject([
+    {id: 'i0', comments: [{id: 'c4'}]},
+    {id: 'i1', comments: [{id: 'c1'}, {id: 'c2'}]},
+  ]);
+
+  view.destroy();
+});
+
+test('materialize after ready builds the pipeline immediately', () => {
+  const {delegate, addIssue} = newDelegate();
+  addIssue('i1');
+  delegate.markReady();
+
+  const view = delegate.materialize(newQuery(schema, 'issue'));
+  expect(delegate.pendingCount).toBe(0);
+  expect(delegate.getSourceCalls).toBeGreaterThan(0);
+  expect(view.data).toMatchObject([{id: 'i1'}]);
+  expect(delegate.metrics).toContain('query-materialization-client');
+
+  view.destroy();
+});
+
+test('deferred pipelines attach in materialization order', () => {
+  const {delegate, addIssue} = newDelegate();
+  const order: string[] = [];
+  const a = delegate.materialize(newQuery(schema, 'issue'));
+  const b = delegate.materialize(newQuery(schema, 'issue').where('id', 'i1'));
+  a.addListener(data => {
+    if (data.length > 0) order.push('a');
+  });
+  b.addListener(data => {
+    if (data.length > 0) order.push('b');
+  });
+  addIssue('i1');
+
+  delegate.markReady();
+  expect(order).toEqual(['a', 'b']);
+
+  a.destroy();
+  b.destroy();
+});

--- a/packages/zql/src/query/query-delegate-base.ts
+++ b/packages/zql/src/query/query-delegate-base.ts
@@ -8,6 +8,7 @@ import {
 import type {Schema} from '../../../zero-types/src/schema.ts';
 import {buildPipeline} from '../builder/builder.ts';
 import {ArrayView} from '../ivm/array-view.ts';
+import {DeferredInput} from '../ivm/deferred-input.ts';
 import type {FilterInput} from '../ivm/filter-operators.ts';
 import {MemoryStorage} from '../ivm/memory-storage.ts';
 import type {Input, InputBase, Storage} from '../ivm/operator.ts';
@@ -244,6 +245,20 @@ export abstract class QueryDelegateBase implements QueryDelegate {
 
   abstract readonly defaultQueryComplete: boolean;
 
+  /**
+   * Default: pipelines can always be built immediately. Override (together
+   * with `onPipelinesReady`) to defer pipeline construction.
+   */
+  get pipelinesReady(): boolean {
+    return true;
+  }
+
+  onPipelinesReady(_cb: () => void): () => void {
+    throw new Error(
+      'onPipelinesReady called on a delegate whose pipelines are always ready',
+    );
+  }
+
   // BuilderDelegate methods - must be implemented
   abstract getSource(name: string): Source | undefined;
 }
@@ -353,11 +368,25 @@ export function materializeImpl<
     ? hashOfNameAndArgs(customQueryID.name, customQueryID.args)
     : hashOfAST(qi.ast);
   const queryCompleteResolver = resolver<true>();
-  let queryComplete: boolean | ErroredQuery = delegate.defaultQueryComplete;
+  // When the delegate cannot build pipelines yet, the view starts over an
+  // empty DeferredInput and is hydrated later. A view must not report
+  // `complete` until it has actually been hydrated, so completion is gated on
+  // both the server's "got" and the pipeline being attached.
+  const deferPipeline = !delegate.pipelinesReady;
+  let attached = !deferPipeline;
+  let gotQueries = delegate.defaultQueryComplete;
+  let queryComplete: boolean | ErroredQuery = attached && gotQueries;
   let endToEndMetricRecorded = false;
   const updateTTL = customQueryID
     ? (newTTL: TTL) => delegate.updateCustomQuery(customQueryID, newTTL)
     : (newTTL: TTL) => delegate.updateServerQuery(ast, newTTL);
+
+  const maybeResolveComplete = () => {
+    if (attached && gotQueries && queryComplete !== true) {
+      queryComplete = true;
+      queryCompleteResolver.resolve(true);
+    }
+  };
 
   const gotCallback: GotCallback = (got, error) => {
     if (error) {
@@ -376,13 +405,16 @@ export function materializeImpl<
         );
         endToEndMetricRecorded = true;
       }
-      queryComplete = true;
-      queryCompleteResolver.resolve(true);
+      gotQueries = true;
+      maybeResolveComplete();
     }
   };
 
   let removeCommitObserver: (() => void) | undefined;
+  let removePendingAttach: (() => void) | undefined;
   const onDestroy = () => {
+    removePendingAttach?.();
+    removePendingAttach = undefined;
     input.destroy();
     removeCommitObserver?.();
     removeAddedQuery();
@@ -394,7 +426,28 @@ export function materializeImpl<
     ? delegate.addCustomQuery(ast, customQueryID, ttl, gotCallback)
     : delegate.addServerQuery(ast, ttl, gotCallback);
 
-  const input = buildPipeline(ast, delegate, queryID);
+  let input: Input;
+  if (!deferPipeline) {
+    input = buildPipeline(ast, delegate, queryID);
+  } else {
+    const deferred = new DeferredInput();
+    input = deferred;
+    removePendingAttach = delegate.onPipelinesReady(() => {
+      removePendingAttach = undefined;
+      if (deferred.destroyed) {
+        return;
+      }
+      const t1 = performance.now();
+      deferred.attach(buildPipeline(ast, delegate, queryID));
+      attached = true;
+      delegate.addMetric(
+        'query-materialization-client',
+        performance.now() - t1,
+        queryID,
+      );
+      maybeResolveComplete();
+    });
+  }
 
   const view = delegate.batchViewUpdates(() =>
     (factory ?? arrayViewFactory)(
@@ -410,11 +463,13 @@ export function materializeImpl<
     ),
   );
 
-  delegate.addMetric(
-    'query-materialization-client',
-    performance.now() - t0,
-    queryID,
-  );
+  if (!deferPipeline) {
+    delegate.addMetric(
+      'query-materialization-client',
+      performance.now() - t0,
+      queryID,
+    );
+  }
 
   return view as T;
 }

--- a/packages/zql/src/query/query-delegate-base.ts
+++ b/packages/zql/src/query/query-delegate-base.ts
@@ -427,7 +427,11 @@ export function materializeImpl<
   const deferred = deferPipeline
     ? newDeferredInput(ast, delegate, queryID)
     : undefined;
-  const input: Input = deferred ?? buildPipeline(ast, delegate, queryID);
+  // No type annotation here: annotating this as `Input` widens it enough that
+  // the view type loses the pipeline's concrete schema, and `Zero.run` then
+  // stops rejecting a query built from a schema with legacy queries enabled
+  // (custom.test.ts covers that rejection).
+  const input = deferred ?? buildPipeline(ast, delegate, queryID);
 
   const view = delegate.batchViewUpdates(() =>
     (factory ?? arrayViewFactory)(

--- a/packages/zql/src/query/query-delegate-base.ts
+++ b/packages/zql/src/query/query-delegate-base.ts
@@ -425,7 +425,7 @@ export function materializeImpl<
     : delegate.addServerQuery(ast, ttl, gotCallback);
 
   const deferred = deferPipeline
-    ? new DeferredInput(() => buildPipeline(ast, delegate, queryID))
+    ? newDeferredInput(ast, delegate, queryID)
     : undefined;
   const input: Input = deferred ?? buildPipeline(ast, delegate, queryID);
 
@@ -484,6 +484,33 @@ export function materializeImpl<
   }
 
   return view as T;
+}
+
+/**
+ * Creates the placeholder input for a query whose pipeline cannot be built yet.
+ *
+ * `Input.getSchema()` is unconditional, so the placeholder needs the schema up
+ * front. It is captured by building a pipeline and immediately destroying it:
+ * building only connects to the sources, while the indexes and rows -- the
+ * expensive part this deferral exists to postpone -- are read on the first
+ * fetch. Measured at ~5us against ~500us for a single 100 row fetch.
+ *
+ * Building here also means a query that cannot be built at all (an unknown
+ * table, `not(exists())` on the client) still throws from `materialize()`,
+ * as it did before hydration was deferred.
+ */
+function newDeferredInput(
+  ast: AST,
+  delegate: QueryDelegate,
+  queryID: string,
+): DeferredInput {
+  const build = () => buildPipeline(ast, delegate, queryID);
+  const probe = build();
+  try {
+    return new DeferredInput(probe.getSchema(), build);
+  } finally {
+    probe.destroy();
+  }
 }
 
 function arrayViewFactory<

--- a/packages/zql/src/query/query-delegate-base.ts
+++ b/packages/zql/src/query/query-delegate-base.ts
@@ -376,13 +376,20 @@ export function materializeImpl<
   let attached = !deferPipeline;
   let gotQueries = delegate.defaultQueryComplete;
   let queryComplete: boolean | ErroredQuery = attached && gotQueries;
-  let endToEndMetricRecorded = false;
   const updateTTL = customQueryID
     ? (newTTL: TTL) => delegate.updateCustomQuery(customQueryID, newTTL)
     : (newTTL: TTL) => delegate.updateServerQuery(ast, newTTL);
 
+  // Completion, and the end-to-end metric, require both the server's "got"
+  // and the pipeline being attached: until then the view is still empty.
   const maybeResolveComplete = () => {
     if (attached && gotQueries && queryComplete !== true) {
+      delegate.addMetric(
+        'query-materialization-end-to-end',
+        performance.now() - t0,
+        queryID,
+        ast,
+      );
       queryComplete = true;
       queryCompleteResolver.resolve(true);
     }
@@ -396,15 +403,6 @@ export function materializeImpl<
     }
 
     if (got) {
-      if (!endToEndMetricRecorded) {
-        delegate.addMetric(
-          'query-materialization-end-to-end',
-          performance.now() - t0,
-          queryID,
-          ast,
-        );
-        endToEndMetricRecorded = true;
-      }
       gotQueries = true;
       maybeResolveComplete();
     }
@@ -426,28 +424,10 @@ export function materializeImpl<
     ? delegate.addCustomQuery(ast, customQueryID, ttl, gotCallback)
     : delegate.addServerQuery(ast, ttl, gotCallback);
 
-  let input: Input;
-  if (!deferPipeline) {
-    input = buildPipeline(ast, delegate, queryID);
-  } else {
-    const deferred = new DeferredInput();
-    input = deferred;
-    removePendingAttach = delegate.onPipelinesReady(() => {
-      removePendingAttach = undefined;
-      if (deferred.destroyed) {
-        return;
-      }
-      const t1 = performance.now();
-      deferred.attach(buildPipeline(ast, delegate, queryID));
-      attached = true;
-      delegate.addMetric(
-        'query-materialization-client',
-        performance.now() - t1,
-        queryID,
-      );
-      maybeResolveComplete();
-    });
-  }
+  const deferred = deferPipeline
+    ? new DeferredInput(() => buildPipeline(ast, delegate, queryID))
+    : undefined;
+  const input: Input = deferred ?? buildPipeline(ast, delegate, queryID);
 
   const view = delegate.batchViewUpdates(() =>
     (factory ?? arrayViewFactory)(
@@ -463,12 +443,44 @@ export function materializeImpl<
     ),
   );
 
-  if (!deferPipeline) {
+  if (!deferred) {
     delegate.addMetric(
       'query-materialization-client',
       performance.now() - t0,
       queryID,
     );
+  } else {
+    // Registered after the factory ran so a throwing factory leaves nothing
+    // behind.
+    removePendingAttach = delegate.onPipelinesReady(() => {
+      removePendingAttach = undefined;
+      if (deferred.destroyed) {
+        return;
+      }
+      const t1 = performance.now();
+      try {
+        deferred.attach();
+      } catch (e) {
+        // Surface the failure on this view and let the delegate decide how
+        // to log it. Other pending pipelines are unaffected.
+        const error: ErroredQuery = {
+          error: 'app',
+          id: queryID,
+          name: customQueryID?.name ?? '',
+          message: e instanceof Error ? e.message : String(e),
+        };
+        queryComplete = error;
+        queryCompleteResolver.reject(error);
+        throw e;
+      }
+      attached = true;
+      delegate.addMetric(
+        'query-materialization-client',
+        performance.now() - t1,
+        queryID,
+      );
+      maybeResolveComplete();
+    });
   }
 
   return view as T;

--- a/packages/zql/src/query/query-delegate.ts
+++ b/packages/zql/src/query/query-delegate.ts
@@ -76,6 +76,30 @@ export interface QueryDelegate extends BuilderDelegate, MetricsDelegate {
    */
   readonly defaultQueryComplete: boolean;
 
+  /**
+   * Whether query pipelines can be built against the sources right now.
+   *
+   * When `false`, `materialize` registers the query with the server as usual
+   * but returns a view over an empty placeholder input. The pipeline is built
+   * and the view hydrated when the delegate invokes the callbacks registered
+   * with {@link onPipelinesReady}. Zero uses this during cold boot so the
+   * replica is loaded into the IVM sources once, instead of being pushed row
+   * by row through every already-materialized pipeline.
+   *
+   */
+  readonly pipelinesReady: boolean;
+
+  /**
+   * Register a callback to build a deferred pipeline once
+   * {@link pipelinesReady} becomes `true`. Callbacks are invoked in
+   * registration order inside `batchViewUpdates`, and the delegate notifies
+   * its commit listeners after the batch so views flush.
+   *
+   * Returns a function that unregisters the callback (used when the view is
+   * destroyed before the pipeline is built).
+   */
+  onPipelinesReady(cb: () => void): () => void;
+
   /** Using the default view factory creates a TypedView */
   materialize<
     TTable extends keyof TSchema['tables'] & string,


### PR DESCRIPTION


A common case (especially on React Native) is that `useQuery` gets called
before `Replicache.init` has completed. Therefore the view gets materialized
and registered before the source has any data.

This leads to us pushing every row from the data source through every
already-connected pipeline instead of pulling only the desired rows once
the data is there. The push path is also superlinear: doubling the rows
cost 4.7x the time on Hermes.

`materialize()` stays synchronous. When the delegate reports
`pipelinesReady === false`, the view is created over a `DeferredInput`
placeholder and the server query is registered as before. `ZeroRep.init`
loads the replica into the sources with no pipelines connected, then calls
`ZeroContext.markPipelinesReady()`, which builds each pending pipeline in
materialization order and hydrates it with a single `fetch({})`, delivering
the fetched rows to the existing view as add changes. A view reports
`complete` only once it is both hydrated and the server has sent got.

21 queries materialized before the replica loads, Android emulator
(Hermes, Expo SDK 57) and Node 24 (V8):

| Rows | Engine | Before    | After    | Speedup |
| ---- | ------ | --------: | -------: | ------: |
| 40k  | Hermes | 7,275 ms  | 1,473 ms | 4.9x    |
| 80k  | Hermes | 33,981 ms | 3,075 ms | 11x     |
| 40k  | V8     | 549 ms    | 120 ms   | 4.6x    |
| 80k  | V8     | 1,140 ms  | 235 ms   | 4.9x    |

`zql-benchmarks` `cold-boot-hydration` (13 queries, 30k rows, V8):

| Scenario                           | Time    |
| ---------------------------------- | ------: |
| Live pipelines (before)            | 380 ms  |
| Deferred pipelines (after)         | 60.6 ms |
| Load then materialize (lower bound)| 60.7 ms |

