### PR TITLE
chore: Update compare-utf8 to 0.2.1

### DIFF
--- a/apps/zbugs/package.json
+++ b/apps/zbugs/package.json
@@ -53,7 +53,7 @@
     "@rocicorp/zero-virtual": "0.6.3",
     "@schickling/fps-meter": "^0.1.2",
     "classnames": "^2.5.1",
-    "compare-utf8": "^0.2.0",
+    "compare-utf8": "^0.2.1",
     "emoji-picker-element": "^1.22.8",
     "emoji-picker-element-data": "^1.6.1",
     "fastify": "^5.0.0",

--- a/packages/replicache-perf/package.json
+++ b/packages/replicache-perf/package.json
@@ -19,7 +19,7 @@
     "@types/command-line-usage": "^5.0.4",
     "command-line-args": "^6.0.1",
     "command-line-usage": "^7.0.3",
-    "compare-utf8": "^0.2.0",
+    "compare-utf8": "^0.2.1",
     "esbuild": "0.27.7",
     "get-port": "^7.0.0",
     "hash-wasm": "^4.9.0",

--- a/packages/replicache/package.json
+++ b/packages/replicache/package.json
@@ -86,7 +86,7 @@
     "@vitest/runner": "^4.1.6",
     "command-line-args": "^6.0.1",
     "command-line-usage": "^7.0.3",
-    "compare-utf8": "^0.2.0",
+    "compare-utf8": "^0.2.1",
     "esbuild": "0.27.7",
     "expo-sqlite": ">=15",
     "hash-wasm": "^4.9.0",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -45,7 +45,7 @@
     "@types/semver": "^7.5.1",
     "@types/strip-ansi": "^3.0.0",
     "@vitest/runner": "^4.1.6",
-    "compare-utf8": "^0.2.0",
+    "compare-utf8": "^0.2.1",
     "fast-check": "^3.18.0",
     "js-xxhash": "^4.0.0",
     "mitata": "^1.0.34",

--- a/packages/zero-cache/package.json
+++ b/packages/zero-cache/package.json
@@ -61,7 +61,7 @@
     "@types/basic-auth": "^1.1.8",
     "basic-auth": "^2.0.1",
     "cloudevents": "^10.0.0",
-    "compare-utf8": "^0.2.0",
+    "compare-utf8": "^0.2.1",
     "defu": "^6.1.4",
     "eventemitter3": "^5.0.1",
     "fastify": "^5.0.0",

--- a/packages/zero-protocol/package.json
+++ b/packages/zero-protocol/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@badrap/valita": "0.3.11",
-    "compare-utf8": "^0.2.0"
+    "compare-utf8": "^0.2.1"
   },
   "devDependencies": {
     "fast-check": "^3.18.0",

--- a/packages/zero/package.json
+++ b/packages/zero/package.json
@@ -151,7 +151,7 @@
     "cloudevents": "^10.0.0",
     "command-line-args": "^6.0.1",
     "command-line-usage": "^7.0.3",
-    "compare-utf8": "^0.2.0",
+    "compare-utf8": "^0.2.1",
     "defu": "^6.1.4",
     "eventemitter3": "^5.0.1",
     "fastify": "^5.0.0",

--- a/packages/zql/package.json
+++ b/packages/zql/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@rocicorp/resolver": "^1.0.2",
-    "compare-utf8": "^0.2.0"
+    "compare-utf8": "^0.2.1"
   },
   "devDependencies": {
     "@faker-js/faker": "^9.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,8 +145,8 @@ importers:
         specifier: ^2.5.1
         version: 2.5.1
       compare-utf8:
-        specifier: ^0.2.0
-        version: 0.2.0
+        specifier: ^0.2.1
+        version: 0.2.1
       emoji-picker-element:
         specifier: ^1.22.8
         version: 1.29.1
@@ -548,8 +548,8 @@ importers:
         specifier: ^7.0.3
         version: 7.0.4
       compare-utf8:
-        specifier: ^0.2.0
-        version: 0.2.0
+        specifier: ^0.2.1
+        version: 0.2.1
       esbuild:
         specifier: 0.27.7
         version: 0.27.7
@@ -654,8 +654,8 @@ importers:
         specifier: ^7.0.3
         version: 7.0.4
       compare-utf8:
-        specifier: ^0.2.0
-        version: 0.2.0
+        specifier: ^0.2.1
+        version: 0.2.1
       esbuild:
         specifier: 0.27.7
         version: 0.27.7
@@ -755,8 +755,8 @@ importers:
         specifier: ^4.1.6
         version: 4.1.6
       compare-utf8:
-        specifier: ^0.2.0
-        version: 0.2.0
+        specifier: ^0.2.1
+        version: 0.2.1
       fast-check:
         specifier: ^3.18.0
         version: 3.23.2
@@ -930,8 +930,8 @@ importers:
         specifier: ^7.0.3
         version: 7.0.4
       compare-utf8:
-        specifier: ^0.2.0
-        version: 0.2.0
+        specifier: ^0.2.1
+        version: 0.2.1
       defu:
         specifier: ^6.1.4
         version: 6.1.7
@@ -1117,8 +1117,8 @@ importers:
         specifier: ^10.0.0
         version: 10.0.0
       compare-utf8:
-        specifier: ^0.2.0
-        version: 0.2.0
+        specifier: ^0.2.1
+        version: 0.2.1
       defu:
         specifier: ^6.1.4
         version: 6.1.7
@@ -1367,8 +1367,8 @@ importers:
         specifier: 0.3.11
         version: 0.3.11
       compare-utf8:
-        specifier: ^0.2.0
-        version: 0.2.0
+        specifier: ^0.2.1
+        version: 0.2.1
     devDependencies:
       fast-check:
         specifier: ^3.18.0
@@ -1578,8 +1578,8 @@ importers:
         specifier: ^1.0.2
         version: 1.0.2
       compare-utf8:
-        specifier: ^0.2.0
-        version: 0.2.0
+        specifier: ^0.2.1
+        version: 0.2.1
     devDependencies:
       '@faker-js/faker':
         specifier: ^9.6.0
@@ -7345,8 +7345,8 @@ packages:
     resolution: {integrity: sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==}
     engines: {node: '>=4.0.0'}
 
-  compare-utf8@0.2.0:
-    resolution: {integrity: sha512-5BjVs4Be9AwMm4le3Qb3crp44OAn+uuJhvrjPWA8Es/DfVPq5lSc8JaRg/clrrHOMCU+CdDfv/9eBSPh6OOiUQ==}
+  compare-utf8@0.2.1:
+    resolution: {integrity: sha512-DfGo/vn6Aww3SbT1v1qvORR7Mg2P/+8fOWWvyyuiQ0ylXOyF8J6WetAkkveupnw41868OxmC93i6Q5WbNPDiwQ==}
 
   compress-commons@6.0.2:
     resolution: {integrity: sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==}
@@ -20504,7 +20504,7 @@ snapshots:
 
   common-tags@1.8.2: {}
 
-  compare-utf8@0.2.0: {}
+  compare-utf8@0.2.1: {}
 
   compress-commons@6.0.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,18 +15,7 @@ allowBuilds:
   protobufjs: true
   ssh2: false
 minimumReleaseAgeExclude:
-  - playwright@1.55.1
-  - minimatch@10.2.1
-  - minimatch@10.2.3
-  - serialize-javascript@7.0.3
-  - undici@6.24.0
-  - lodash@4.17.24
-  - ajv@8.18.0
-  - '@hono/node-server@1.19.13'
-  - postcss@8.5.10
-  - '@rocicorp/zero-sqlite3'
-  - '@rocicorp/logger@6.1.0'
-  - '@rocicorp/zero-virtual@0.6.3'
+  - compare-utf8@0.2.1
 
 # docusaurus-plugin-typedoc and typedoc-docusaurus-theme both import typedoc
 # without declaring it, so they can only resolve it through pnpm's hoisted


### PR DESCRIPTION
This is to pick up React Native/Hermes optimizations