### PR TITLE
fix(zql): drop write-only Index.usedBy that retained torn-down pipelines

### DIFF
--- a/packages/zql/src/ivm/memory-source.ts
+++ b/packages/zql/src/ivm/memory-source.ts
@@ -69,7 +69,6 @@ export type Overlays = {
 type Index = {
   comparator: Comparator;
   data: BTreeSet<Row>;
-  usedBy: Set<Connection>;
 };
 
 export type Connection = {
@@ -120,7 +119,6 @@ export class MemorySource implements Source {
     this.#indexes.set(JSON.stringify(this.#primaryIndexSort), {
       comparator,
       data: primaryIndexData ?? new BTreeSet<Row>(comparator),
-      usedBy: new Set(),
     });
   }
 
@@ -207,6 +205,13 @@ export class MemorySource implements Source {
     assert(idx !== -1, 'Connection not found');
     this.#connections.splice(idx, 1);
 
+    // Indexes deliberately hold no reference back to the connections that use
+    // them. They used to, to support deleting an index once its last user went
+    // away. That deletion is gone (see below) but the `usedBy` set outlived it,
+    // so an index kept every `Connection` — and through its `input` and
+    // `output`, the whole torn-down pipeline — reachable for as long as the
+    // source lived.
+    //
     // TODO: We used to delete unused indexes here. But in common cases like
     // navigating into issue detail pages it caused a ton of constantly
     // building and destroying indexes.
@@ -222,13 +227,12 @@ export class MemorySource implements Source {
     return index;
   }
 
-  #getOrCreateIndex(sort: Ordering, usedBy: Connection): Index {
+  #getOrCreateIndex(sort: Ordering): Index {
     const key = JSON.stringify(sort);
     const index = this.#indexes.get(key);
     // Future optimization could use existing index if it's the same just sorted
     // in reverse of needed.
     if (index) {
-      index.usedBy.add(usedBy);
       return index;
     }
 
@@ -244,7 +248,7 @@ export class MemorySource implements Source {
     const rows = toSorted(this.#getPrimaryIndex().data, comparator);
     const data = BTreeSet.fromSorted(comparator, rows);
 
-    const newIndex = {comparator, data, usedBy: new Set([usedBy])};
+    const newIndex = {comparator, data};
     this.#indexes.set(key, newIndex);
     return newIndex;
   }
@@ -313,7 +317,7 @@ export class MemorySource implements Source {
       indexSort.push(...requestedSort);
     }
 
-    const index = this.#getOrCreateIndex(indexSort, conn);
+    const index = this.#getOrCreateIndex(indexSort);
     const {data, comparator: compare} = index;
     // Avoid allocating a new closure when not reversing (the common case).
     const indexComparator: Comparator = req.reverse


### PR DESCRIPTION
Each index held a `Set<Connection>` of the connections that had fetched through
it, and `#disconnect` never removed the departing one. An index therefore kept
every `Connection` — and through its `input` and `output`, the whole torn-down
pipeline — reachable for as long as the source lived.

The cost is paid per screen: every query a user navigates away from leaves its
operators, their `MemoryStorage`, and any rows those operators had buffered
reachable from the source. The retained graph grows with the number of distinct
queries visited over a session rather than with the number that are live.
Sources outlive views by design, which is what makes this unbounded rather than
merely delayed.

The set had no readers. It existed to support deleting an index once its last
user went away; that deletion was removed and the set outlived it. So rather
than maintain it correctly, this drops it — nothing can be retained by a
structure that no longer exists — and `#getOrCreateIndex` no longer needs to be
told which connection is asking.

Index data is still kept for the lifetime of the source, so the TODO about an
LRU stands. Whoever implements it will need usage tracking again and can
reintroduce it with a reader attached.

### Testing

Deleting a field with no readers has no observable behavior to assert, so there
is no new test; the existing suites cover that nothing changed. zql 1372 pass,
zero-client 649 pass. Lint, format and types clean.

`zero-idb.test.ts > logged-out client uses a private storage sentinel for idb
naming` fails, expecting `:7:52` and getting `:7:53`. It fails identically on
6c2ea7405 with this change stashed, so it is pre-existing and unrelated.
