### PR TITLE
fix(zero-client): measure connect setup and server acknowledgement separately

### DIFF
--- a/packages/replicache/src/replicache-impl.ts
+++ b/packages/replicache/src/replicache-impl.ts
@@ -141,6 +141,13 @@ const REFRESH_IDLE_TIMEOUT_MS = 1000;
 const PERSIST_THROTTLE_MS = 500;
 const REFRESH_THROTTLE_MS = 500;
 
+/**
+ * Opening the database blocks everything Replicache does, including Zero's
+ * first connect attempt, so a slow open is worth a warning rather than a
+ * debug line.
+ */
+const SLOW_DB_OPEN_THRESHOLD_MS = 50;
+
 const LAZY_STORE_SOURCE_CHUNK_CACHE_SIZE_LIMIT = 100 * 2 ** 20; // 100 MB
 
 const RECOVER_MUTATIONS_INTERVAL_MS = 5 * 60 * 1000; // 5 mins
@@ -558,6 +565,12 @@ export class ReplicacheImpl<MD extends MutatorDefs = {}> {
     onClientsDeleted: OnClientsDeleted,
   ): Promise<void> {
     const {clientID} = this;
+    // Everything up to the head write is what it takes to have a usable
+    // database, including waiting out a previous instance of the same name.
+    // The timer stops before the replica is loaded into Zero's IVM sources,
+    // which is separate work and usually the larger of the two: a number that
+    // spanned both would report a slow hydration as a slow disk.
+    const openStart = performance.now();
     // If we are currently closing a Replicache instance with the same name,
     // wait for it to finish closing.
     await closingInstances.get(this.name);
@@ -579,6 +592,15 @@ export class ReplicacheImpl<MD extends MutatorDefs = {}> {
     );
 
     // Now we have a profileID, a clientID, a clientGroupID and DB!
+    const dbOpenMs = performance.now() - openStart;
+    if (dbOpenMs > SLOW_DB_OPEN_THRESHOLD_MS) {
+      this.#lc.warn?.(`Opening the database took ${Math.round(dbOpenMs)}ms`, {
+        name: this.idbName,
+      });
+    } else {
+      this.#lc.debug?.('Opened the database in', Math.round(dbOpenMs), 'ms');
+    }
+
     await this.#zero?.init(headHash, this.memdag);
     resolveReady();
 

--- a/packages/zero-client/src/client/zero.test.ts
+++ b/packages/zero-client/src/client/zero.test.ts
@@ -34,6 +34,7 @@ import {
   overrideBrowserGlobal,
 } from '../../../shared/src/browser-env.ts';
 import {TestLogSink} from '../../../shared/src/logging-test-utils.ts';
+import {sleep} from '../../../shared/src/sleep.ts';
 import * as valita from '../../../shared/src/valita.ts';
 import {changeDesiredQueriesMessageSchema} from '../../../zero-protocol/src/change-desired-queries.ts';
 import type {ClientSchema} from '../../../zero-protocol/src/client-schema.ts';
@@ -2841,6 +2842,37 @@ test('Connect timeout', async () => {
   ]);
 
   connectionStatusCleanup();
+});
+
+test('slow setup does not spend the server acknowledgement budget', async () => {
+  // Setup that finishes just inside its own deadline. Before the deadlines
+  // were split this left the server almost no time, and a healthy server was
+  // reported as unreachable.
+  const realCreate = ActiveClientsManager.create;
+  vi.spyOn(ActiveClientsManager, 'create').mockImplementation(
+    async (...args: Parameters<typeof ActiveClientsManager.create>) => {
+      await sleep(CONNECT_TIMEOUT_MS - 1_000);
+      return realCreate(...args);
+    },
+  );
+
+  const z = zeroForTest();
+  await z.waitForConnectionStatus(ConnectionStatus.Connecting);
+
+  // Wait out the slow setup.
+  await vi.advanceTimersByTimeAsync(CONNECT_TIMEOUT_MS - 1_000);
+  await tickAFewTimes(vi);
+  expect(z.connectionStatus).toBe(ConnectionStatus.Connecting);
+
+  // The old single budget would have expired 1s from here. The server gets a
+  // full budget of its own instead.
+  await vi.advanceTimersByTimeAsync(CONNECT_TIMEOUT_MS - 1_000);
+  await tickAFewTimes(vi);
+  expect(connectTimeoutErrors(z)).toEqual([]);
+  expect(z.connectionStatus).toBe(ConnectionStatus.Connecting);
+
+  await z.triggerConnected();
+  expect(z.connectionStatus).toBe(ConnectionStatus.Connected);
 });
 
 test('connect timeout during setup retries without an unhandled rejection', async () => {

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -219,6 +219,11 @@ type ConnectAttemptControl = {
   readonly controller: AbortController;
   readonly connected: Resolver<void>;
   readonly events: [date: Date, event: string][];
+  /**
+   * Cancels whichever phase deadline is currently running. Swapped when the
+   * attempt stops setting up locally and starts waiting for the server.
+   */
+  clearTimeout?: (() => void) | undefined;
 };
 
 function connectionReadyResolver(): Resolver<void> {
@@ -267,6 +272,12 @@ export const DEFAULT_DISCONNECT_TIMEOUT_MS = 60 * 1_000;
  * consider it timed out.
  */
 export const CONNECT_TIMEOUT_MS = 10_000;
+
+/**
+ * Setting up active-client tracking blocks the first connect attempt. Above
+ * this, say so.
+ */
+const SLOW_ACTIVE_CLIENTS_THRESHOLD_MS = 50;
 
 const CHECK_CONNECTIVITY_ON_ERROR_FREQUENCY = 6;
 
@@ -719,6 +730,7 @@ export class Zero<
         this.#deleteClientsManager.onClientsDeleted([
           {clientGroupID, clientID},
         ]),
+      this.#lc,
     );
 
     const onUpdateNeededCallback = (reason: UpdateNeededReason) => {
@@ -1820,6 +1832,10 @@ export class Zero<
       'waiting for the server acknowledgement',
     );
     lc.debug?.('Waiting for connection to be acknowledged');
+    // Local setup is done; the rest of the wait is the server's, and gets its
+    // own budget rather than whatever the setup left over.
+    attempt.clearTimeout?.();
+    attempt.clearTimeout = this.#armConnectTimeout(lc, attempt, 'ack');
     await attempt.connected.promise;
     if (signal.aborted) {
       throw signal.reason;
@@ -1827,6 +1843,59 @@ export class Zero<
     this.#mutationTracker.onConnected(this.#lastMutationIDReceived);
     // push any outstanding mutations on reconnect.
     this.#rep.push().catch(() => {});
+  }
+
+  /**
+   * Starts the deadline for one phase of a connection attempt, and returns a
+   * function that cancels it.
+   *
+   * The two phases are measured separately because they fail for unrelated
+   * reasons. `setup` covers local work — reading the cookie, the client group
+   * ID and the active clients from IDB, then preparing and opening the socket
+   * — whose duration says nothing about whether the server is reachable.
+   * `ack` covers the wait for the server's response. Running them on one
+   * budget meant a slow cold boot spent the server's time before the socket
+   * existed, and reported a healthy server as unreachable.
+   */
+  #armConnectTimeout(
+    lc: LogContext,
+    attempt: ConnectAttemptControl,
+    phase: 'setup' | 'ack',
+  ): () => void {
+    const {signal} = attempt.controller;
+
+    // A deadline outlives the caller that armed it. The run loop stops waiting
+    // on a canceled attempt and clears whatever deadline was running, but
+    // #connectAttempt keeps going — its in-flight awaits do not all honor the
+    // abort — so it can reach the setup-to-ack handover afterwards. A timer
+    // armed at that point would have no owner left to clear it, and would
+    // disconnect whichever attempt came next. Tying it to the signal means it
+    // is cleared by any abort, whenever it happens and whoever holds it.
+    if (signal.aborted) {
+      return () => {};
+    }
+
+    const timeoutID = setTimeout(() => {
+      lc.debug?.('Connection attempt timed out');
+      this.#disconnect(
+        lc,
+        new ClientError({
+          kind: ClientErrorKind.ConnectTimeout,
+          message:
+            (phase === 'setup'
+              ? `Connection setup timed out after ${CONNECT_TIMEOUT_MS / 1000} seconds. `
+              : `Server did not acknowledge the connection within ${CONNECT_TIMEOUT_MS / 1000} seconds. `) +
+            `Connect events: ${JSON.stringify(attempt.events)}`,
+        }),
+      );
+    }, CONNECT_TIMEOUT_MS);
+
+    const clear = () => {
+      clearTimeout(timeoutID);
+      signal.removeEventListener('abort', clear);
+    };
+    signal.addEventListener('abort', clear, {once: true});
+    return clear;
   }
 
   #addConnectEvent(
@@ -2157,24 +2226,17 @@ export class Zero<
             };
             this.#currentConnectAttempt = attempt;
             this.#addConnectEvent(lc, attempt, 'starting the connection');
+            attempt.clearTimeout = this.#armConnectTimeout(
+              lc,
+              attempt,
+              'setup',
+            );
             const canceled = resolver<never>();
             const abortHandler = () =>
               canceled.reject(attempt.controller.signal.reason);
             attempt.controller.signal.addEventListener('abort', abortHandler, {
               once: true,
             });
-            const timeoutID = setTimeout(() => {
-              lc.debug?.('Connection attempt timed out');
-              this.#disconnect(
-                lc,
-                new ClientError({
-                  kind: ClientErrorKind.ConnectTimeout,
-                  message:
-                    `Connection attempt timed out after ${CONNECT_TIMEOUT_MS / 1000} seconds. ` +
-                    `Connect events: ${JSON.stringify(attempt.events)}`,
-                }),
-              );
-            }, CONNECT_TIMEOUT_MS);
             try {
               try {
                 await Promise.race([
@@ -2203,7 +2265,7 @@ export class Zero<
               ready.resolve();
               additionalConnectParams = undefined;
             } finally {
-              clearTimeout(timeoutID);
+              attempt.clearTimeout?.();
               attempt.controller.signal.removeEventListener(
                 'abort',
                 abortHandler,
@@ -2960,12 +3022,32 @@ async function makeActiveClientsManager(
   clientID: string,
   signal: AbortSignal,
   onDelete: ActiveClientsManager['onDelete'],
+  lc: LogContext,
 ): Promise<ActiveClientsManager> {
-  const manager = await ActiveClientsManager.create(
-    await clientGroupID,
-    clientID,
-    signal,
-  );
+  // Timed from here rather than from the await in #connectAttempt: this runs
+  // at construction, in parallel with everything else, so by the time an
+  // attempt asks for it the wait is usually already over. Waiting for the
+  // client group ID is the database opening, which is timed on its own.
+  const groupID = await clientGroupID;
+  const start = performance.now();
+  const manager = await ActiveClientsManager.create(groupID, clientID, signal);
+  const elapsed = performance.now() - start;
+
+  // navigator.locks does not exist on React Native, where this falls back to
+  // an in-process stand-in that only ever sees this client. That changes both
+  // what the timing means and how much the client list can be trusted, so say
+  // which one produced the number.
+  const locks = getBrowserGlobal('navigator')?.locks ? 'native' : 'fallback';
+  if (elapsed > SLOW_ACTIVE_CLIENTS_THRESHOLD_MS) {
+    lc.warn?.(`Initializing active clients took ${Math.round(elapsed)}ms`, {
+      locks,
+    });
+  } else {
+    lc.debug?.('Initialized active clients in', Math.round(elapsed), 'ms', {
+      locks,
+    });
+  }
+
   manager.onDelete = onDelete;
   return manager;
 }


### PR DESCRIPTION
## The defect

`CONNECT_TIMEOUT_MS` covered an entire connection attempt: reading the cookie, the client group ID and the active clients from IDB, preparing and opening the socket, and only then waiting for the server to acknowledge.

Those fail for unrelated reasons. Sharing one budget means local setup spends the server's time — on a slow cold boot the socket may not exist until most of the 10s is gone, and a perfectly healthy server is then reported as unreachable. The failure is indistinguishable from a real network problem, and `Connection attempt timed out after 10 seconds` is what you get either way.

## The change

Each phase gets its own budget, armed and cancelled at the transition between them.

- **setup** keeps a deadline, so a stuck setup still times out and retries rather than hanging until the 60s disconnect watchdog.
- **ack** starts a fresh budget once setup completes, so what the server is given no longer depends on how slow the disk was.

`#armConnectTimeout(lc, attempt, phase)` builds either one; `ConnectAttemptControl.clearTimeout` holds whichever is currently running and is swapped at the handover, so the run loop's `finally` still has exactly one thing to cancel.

The messages name the phase that expired — `Connection setup timed out after 10 seconds` versus `Server did not acknowledge the connection within 10 seconds`. The kind stays `ConnectTimeout`; a distinct kind per phase would be a public taxonomy change, so it isn't in this PR.

**Trade-off:** an attempt that fails in both phases can now take two budgets rather than one. That is the cost of not having to choose which of the two failures the single budget is for.

## Why not simply move the deadline to socket creation

That was the first attempt, and it broke `connect timeout during setup retries without an unhandled rejection`, which stubs `ActiveClientsManager.create` to hang forever and asserts the attempt times out and retries. Moving the deadline leaves a stuck setup unbounded until the 60s watchdog, with no retry in between — a real regression that the existing test was there to catch. Splitting keeps that bound and still stops setup from spending the server's time.

## Setup timing

The two pieces of local setup most likely to be slow are timed, each warning above 50ms. Both are measured **where the work runs**, not where an attempt awaits it — both start earlier and in parallel, so an await-site number would usually read as zero.

### Opening the database

Instrumented in Replicache's `#open`, warning above 50ms.

The timer stops at the head write, immediately **before** `await this.#zero?.init(headHash, this.memdag)`, so it measures getting to a usable database and excludes loading the replica into Zero's IVM sources — which is separate work and usually the larger of the two.

This has to be instrumented inside `#open`. Measuring it from Zero cannot work: `resolveReady()` is called *after* `#zero.init`, so nothing Zero can await — the cookie included — resolves until hydration has finished, and any number taken from that side reports a slow hydration as a slow disk.

The window starts at the top of `#open`, which includes waiting out a closing instance of the same name. That is rare, but it does delay the database being usable, so it is counted rather than hidden.

### Creating the ActiveClientsManager

This runs at construction, so by the time `#connectAttempt` reaches `await this.#activeClientsManager` the wait is usually already over — timing that await would measure nothing. It is timed around `ActiveClientsManager.create` instead, starting after the client group ID resolves, since waiting for that is the database opening and is already timed on its own.

The log names the lock backend. `navigator.locks` does not exist on React Native, so `getClientLockManager` falls back to `MockClientLockManager`, an in-process stand-in that only ever sees the current client. That changes both what the timing means — no real lock acquisition or `locks.query()` — and how much the resulting client list can be trusted, so a number without the backend beside it would be misleading.

## Tests

`slow setup does not spend the server acknowledgement budget` covers the behavior change directly: setup finishing at 9s, then a full budget for the server, ending in a successful connect. Under the old single budget that connect failed. The existing stuck-setup retry test is unchanged and still passes, which is the evidence that the setup bound survived.

There is no test on the log line — making `#open` deterministically cross 50ms is not worth the fixture.

`zero-client` 650 pass, `replicache` 798 pass; `format`, `lint` and `check-types` clean on both. `zero-idb.test.ts > logged-out client uses a private storage sentinel for idb naming` fails on this branch and fails identically on clean `main`, so CI will be red for a reason unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

