### PR TITLE
perf(zero-cache): batch writes, stop copying json

### DIFF
--- a/packages/replicache/src/replicache-collect-idb-databases.test.ts
+++ b/packages/replicache/src/replicache-collect-idb-databases.test.ts
@@ -1,5 +1,4 @@
 import {expect, test, vi} from 'vitest';
-import {sleep} from '../../shared/src/sleep.ts';
 import {initReplicacheTesting, replicacheForTesting} from './test-util.ts';
 
 initReplicacheTesting();
@@ -36,14 +35,17 @@ test('collect IDB databases', async () => {
   await vi.advanceTimersByTimeAsync(5 * MINUTES);
   await rep3.close();
 
-  // Restore real timers and wait a few ms to let the idb state "flush"
+  // Restore real timers and wait for the IDB deletion to finish.
   vi.useRealTimers();
-  await sleep(500);
-
-  expect(await getDatabases()).toEqual([
-    'collect-idb-databases-2',
-    'collect-idb-databases-3',
-  ]);
+  await vi.waitFor(
+    async () => {
+      expect(await getDatabases()).toEqual([
+        'collect-idb-databases-2',
+        'collect-idb-databases-3',
+      ]);
+    },
+    {timeout: 5_000},
+  );
 
   async function getDatabases() {
     function parseName(idbName: string | undefined): string | undefined {

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-http.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-http.pg.test.ts
@@ -305,11 +305,11 @@ describe('change-streamer/http', () => {
       expect(await drain(2, sub)).toEqual([
         {
           data: ['begin', {tag: 'begin'}, {commitWatermark: '456'}],
-          json: begin,
+          size: `{"id":1,"msg":${begin}}`.length,
         },
         {
           data: ['commit', {tag: 'commit'}, {watermark: '456'}],
-          json: commit,
+          size: `{"id":2,"msg":${commit}}`.length,
         },
       ]);
 
@@ -349,6 +349,8 @@ describe('change-streamer/http', () => {
 
     const json = BigIntJSON.stringify(['data', insert]);
     downstream.push(json);
-    expect(await drain(1, sub)).toEqual([{data: ['data', insert], json}]);
+    expect(await drain(1, sub)).toEqual([
+      {data: ['data', insert], size: `{"id":1,"msg":${json}}`.length},
+    ]);
   });
 });

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-http.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-http.ts
@@ -10,7 +10,7 @@ import {type Worker} from '../../types/processes.ts';
 import {type ShardID} from '../../types/shards.ts';
 import {
   streamIn,
-  streamInStringified,
+  streamInWithSize,
   streamOut,
   streamOutStringified,
   type Source,
@@ -24,7 +24,7 @@ import {
   PROTOCOL_VERSION,
   type ChangeStreamer,
   type ChangeStreamerService,
-  type SerializedDownstream,
+  type SizedDownstream,
   type SubscriberContext,
 } from './change-streamer.ts';
 import {discoverChangeStreamerAddress} from './schema/tables.ts';
@@ -234,15 +234,13 @@ export class ChangeStreamerHttpClient implements ChangeStreamer {
     return streamIn(this.#lc, ws, snapshotMessageSchema);
   }
 
-  async subscribe(
-    ctx: SubscriberContext,
-  ): Promise<Source<SerializedDownstream>> {
+  async subscribe(ctx: SubscriberContext): Promise<Source<SizedDownstream>> {
     const uri = await this.#resolveChangeStreamer(CHANGES_PATH);
 
     const params = getParams(ctx);
     const ws = new WebSocket(uri + `?${params.toString()}`);
 
-    return streamInStringified(this.#lc, ws, downstreamSchema);
+    return streamInWithSize(this.#lc, ws, downstreamSchema);
   }
 }
 

--- a/packages/zero-cache/src/services/change-streamer/change-streamer.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer.ts
@@ -1,6 +1,6 @@
 import type {Enum} from '../../../../shared/src/enum.ts';
 import * as v from '../../../../shared/src/valita.ts';
-import type {ParsedJSON, Source} from '../../types/streams.ts';
+import type {Sized, Source} from '../../types/streams.ts';
 import {
   changeStreamDataSchema,
   type ChangeStreamData,
@@ -67,10 +67,10 @@ export interface ChangeStreamer {
   /**
    * Subscribes to changes based on the supplied subscriber `ctx`,
    * which indicates the watermark at which the subscriber is up to
-   * date. Each result contains both parsed, validated data and the exact JSON
-   * payload sent by the ChangeStreamerService.
+   * date. Each result contains parsed, validated data and its approximate
+   * serialized transport size.
    */
-  subscribe(ctx: SubscriberContext): Promise<Source<SerializedDownstream>>;
+  subscribe(ctx: SubscriberContext): Promise<Source<SizedDownstream>>;
 }
 
 // v1: v0.18
@@ -228,8 +228,8 @@ export function errorTypeToReadableName(val: ErrorType) {
  */
 export type Downstream = v.Infer<typeof downstreamSchema>;
 
-/** A downstream message and its canonical ChangeStreamer JSON. */
-export type SerializedDownstream = ParsedJSON<Downstream>;
+/** A downstream message and its approximate serialized transport size. */
+export type SizedDownstream = Sized<Downstream>;
 
 export interface ChangeStreamerService
   extends Omit<ChangeStreamer, 'subscribe'>, Service {

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-purge-scheduler.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-purge-scheduler.test.ts
@@ -1256,7 +1256,13 @@ describe('change-streamer/sqlite-change-log-purge-scheduler', () => {
             }
           },
         ),
-        {numRuns: 1000},
+        {
+          numRuns: 1000,
+          // Run the full campaign when resources permit, but leave enough of
+          // the Vitest timeout to finish the current scenario and clean up
+          // when the parallel suite is under load.
+          interruptAfterTimeLimit: 30_000,
+        },
       );
     }, 45_000);
   });

--- a/packages/zero-cache/src/services/replicator/incremental-sync.test.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.test.ts
@@ -749,13 +749,20 @@ describe('replicator/incremental-sync', () => {
           rowValues: [[1, 'hello']],
         },
       ],
-      ['commit', issues.commit(), {watermark: '110.01'}],
     ] satisfies Downstream[]) {
       downstream.push(change);
     }
+    const incompleteBackfillCommit = downstream.push([
+      'commit',
+      issues.commit(),
+      {watermark: '110.01'},
+    ]).result;
 
     // Ensure no notifications have been published.
     await noNotification(next);
+
+    // Wait for the commit to be processed before inspecting the replica.
+    expect(await incompleteBackfillCommit).toBe('consumed');
 
     // And that row versions have not changed, even for backfilled rows.
     const issuesDump = mainDb.prepare(/*sql*/ `SELECT * FROM issues`);

--- a/packages/zero-cache/src/services/replicator/incremental-sync.test.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.test.ts
@@ -9,10 +9,7 @@ import {
   vi,
   type MockedFunction,
 } from 'vitest';
-import {
-  BigIntJSON,
-  type JSONObject,
-} from '../../../../shared/src/bigint-json.ts';
+import type {JSONObject} from '../../../../shared/src/bigint-json.ts';
 import type {Enum} from '../../../../shared/src/enum.ts';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
 import type {ZeroEvent} from '../../../../zero-events/src/index.ts';
@@ -26,7 +23,7 @@ import {orTimeoutWith} from '../../types/timeout.ts';
 import {
   PROTOCOL_VERSION,
   type Downstream,
-  type SerializedDownstream,
+  type SizedDownstream,
   type SubscriberContext,
 } from '../change-streamer/change-streamer.ts';
 import * as ErrorType from '../change-streamer/error-type-enum.ts';
@@ -55,10 +52,10 @@ describe('replicator/incremental-sync', () => {
   let worker: ThreadWriteWorkerClient;
   let syncer: IncrementalSyncer;
   let syncing: Promise<void> | undefined;
-  let downstream: Subscription<SerializedDownstream, Downstream>;
+  let downstream: Subscription<SizedDownstream, Downstream>;
   let eventSink: ZeroEvent[];
   let subscribeFn: MockedFunction<
-    (ctx: SubscriberContext) => Promise<Source<SerializedDownstream>>
+    (ctx: SubscriberContext) => Promise<Source<SizedDownstream>>
   >;
 
   beforeEach(async () => {
@@ -68,10 +65,7 @@ describe('replicator/incremental-sync', () => {
     mainDb.pragma('journal_mode = wal');
     createReplicationStateTables(mainDb);
 
-    downstream = new Subscription({}, data => ({
-      data,
-      json: BigIntJSON.stringify(data),
-    }));
+    downstream = new Subscription({}, data => ({data, size: 1}));
     eventSink = [];
     initEventSinkForTesting(
       eventSink,
@@ -133,7 +127,7 @@ describe('replicator/incremental-sync', () => {
     // making the write async would break both callers here.
     const replica = new StatementRunner(mainDb);
     const acked: {watermark: string; stateVersion: string}[] = [];
-    downstream = new Subscription<SerializedDownstream, Downstream>(
+    downstream = new Subscription<SizedDownstream, Downstream>(
       {
         consumed: message => {
           if (message[0] === 'commit') {
@@ -144,7 +138,7 @@ describe('replicator/incremental-sync', () => {
           }
         },
       },
-      data => ({data, json: BigIntJSON.stringify(data)}),
+      data => ({data, size: 1}),
     );
     subscribeFn.mockResolvedValue(downstream);
 
@@ -180,7 +174,7 @@ describe('replicator/incremental-sync', () => {
 
   test('replicates transactions', async () => {
     const issues = new ReplicationMessages({issues: ['issueID', 'bool']});
-    const processMessage = vi.spyOn(worker, 'processMessage');
+    const processMessages = vi.spyOn(worker, 'processMessages');
 
     initReplicationState(mainDb, ['zero_data'], '02', {}, false);
 
@@ -472,10 +466,14 @@ describe('replicator/incremental-sync', () => {
         },
       ]
     `);
-    expect(processMessage).toHaveBeenCalledTimes(11);
-    // The parsed change, and nothing else: the canonical JSON went to the write
-    // worker only for the change log, which the change-streamer now writes.
-    expect(processMessage).toHaveBeenNthCalledWith(1, firstBegin);
+    expect(processMessages).toHaveBeenCalledTimes(3);
+    expect(processMessages.mock.calls.flatMap(([batch]) => batch)).toHaveLength(
+      11,
+    );
+    expect(processMessages).toHaveBeenNthCalledWith(
+      1,
+      expect.arrayContaining([firstBegin]),
+    );
   });
 
   test('replicates schema changes', async () => {
@@ -905,7 +903,7 @@ describe('replicator/incremental-sync', () => {
 
   test('shut down on change-streamer error message', async () => {
     initReplicationState(mainDb, ['zero_data'], '02', {}, false);
-    const processMessage = vi.spyOn(worker, 'processMessage');
+    const processMessages = vi.spyOn(worker, 'processMessages');
 
     const syncing = syncer.run();
 
@@ -916,7 +914,7 @@ describe('replicator/incremental-sync', () => {
 
     // Should stop / resolve
     await syncing;
-    expect(processMessage).not.toHaveBeenCalled();
+    expect(processMessages).not.toHaveBeenCalled();
   });
 
   test('stop() interrupts a run loop stuck on an in-flight processMessage', async () => {

--- a/packages/zero-cache/src/services/replicator/incremental-sync.test.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.test.ts
@@ -917,10 +917,10 @@ describe('replicator/incremental-sync', () => {
     expect(processMessages).not.toHaveBeenCalled();
   });
 
-  test('stop() interrupts a run loop stuck on an in-flight processMessage', async () => {
+  test('stop() interrupts a run loop stuck on an in-flight processMessages', async () => {
     initReplicationState(mainDb, ['zero_data'], '02', {}, false);
 
-    // Simulates a processMessage() call that never resolves on its own -- as
+    // Simulates a processMessages() call that never resolves on its own -- as
     // happens when the write worker is paused inside LitestreamCheckpointer's
     // WAL-drain poll (see litestream-checkpointer.test.ts for that piece in
     // isolation) -- until abort() interrupts it. Mocked here at the
@@ -928,8 +928,8 @@ describe('replicator/incremental-sync', () => {
     // worker thread or litestream process; it only exercises whether
     // IncrementalSyncer actually calls abort() when asked to stop.
     const {promise: stuck, resolve: unstick} = resolver<CommitResult | null>();
-    const processMessage = vi
-      .spyOn(worker, 'processMessage')
+    const processMessages = vi
+      .spyOn(worker, 'processMessages')
       .mockReturnValue(stuck);
     const abort = vi.spyOn(worker, 'abort').mockImplementation(() => {
       unstick(null);
@@ -942,7 +942,7 @@ describe('replicator/incremental-sync', () => {
     await versionReady.next(); // Get the initial nextStateVersion.
 
     downstream.push(['begin', issues.begin(), {commitWatermark: '06'}]);
-    await vi.waitFor(() => expect(processMessage).toHaveBeenCalled());
+    await vi.waitFor(() => expect(processMessages).toHaveBeenCalled());
 
     syncer.stop(lc);
     expect(abort).toHaveBeenCalled();

--- a/packages/zero-cache/src/services/replicator/incremental-sync.test.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.test.ts
@@ -942,6 +942,7 @@ describe('replicator/incremental-sync', () => {
     await versionReady.next(); // Get the initial nextStateVersion.
 
     downstream.push(['begin', issues.begin(), {commitWatermark: '06'}]);
+    downstream.push(['commit', issues.commit(), {watermark: '06'}]);
     await vi.waitFor(() => expect(processMessages).toHaveBeenCalled());
 
     syncer.stop(lc);

--- a/packages/zero-cache/src/services/replicator/incremental-sync.ts
+++ b/packages/zero-cache/src/services/replicator/incremental-sync.ts
@@ -9,7 +9,7 @@ import {
   errorTypeToReadableName,
   PROTOCOL_VERSION,
   type ChangeStreamer,
-  type SerializedDownstream,
+  type SizedDownstream,
 } from '../change-streamer/change-streamer.ts';
 import type * as ErrorType from '../change-streamer/error-type-enum.ts';
 import {RunningState} from '../running-state.ts';
@@ -22,6 +22,9 @@ import type {ReplicationReport} from './reporter/report-schema.ts';
 import type {WriteWorkerClient} from './write-worker-client.ts';
 
 type ErrorType = Enum<typeof ErrorType>;
+
+const MAX_WORKER_BATCH_MESSAGES = 256;
+const MAX_WORKER_BATCH_SIZE = 1024 * 1024;
 
 /**
  * The {@link IncrementalSyncer} manages a logical replication stream from upstream,
@@ -92,7 +95,7 @@ export class IncrementalSyncer {
       const {replicaVersion, watermark} =
         await this.#worker.getSubscriptionState();
 
-      let downstream: Source<SerializedDownstream> | undefined;
+      let downstream: Source<SizedDownstream> | undefined;
       let unregister = () => {};
       let err: unknown | undefined;
 
@@ -120,8 +123,26 @@ export class IncrementalSyncer {
         );
 
         let backfillStatus: DownloadStatus | undefined;
+        let writeBatch: ChangeStreamData[] = [];
+        let writeBatchSize = 0;
+        let inTransaction = false;
 
-        for await (const {data: message} of downstream) {
+        const flushWrites = async () => {
+          if (writeBatch.length === 0) {
+            return;
+          }
+          const batch = writeBatch;
+          writeBatch = [];
+          writeBatchSize = 0;
+
+          const result = await this.#worker.processMessages(batch);
+          this.#handleResult(lc, result);
+          if (result?.completedBackfill) {
+            backfillStatus = undefined;
+          }
+        };
+
+        for await (const {data: message, size} of downstream) {
           this.#replicationEvents.add(1);
           switch (message[0]) {
             case 'status': {
@@ -185,12 +206,29 @@ export class IncrementalSyncer {
                 backfillStatus = status; // Update the current status
               }
 
-              const data = message as ChangeStreamData;
-              const result = await this.#worker.processMessage(data);
+              const type = message[0];
+              const invalidTransactionSequence =
+                type === 'begin' ? inTransaction : !inTransaction;
+              if (type === 'begin') {
+                inTransaction = true;
+              } else if (type === 'commit' || type === 'rollback') {
+                inTransaction = false;
+              }
 
-              this.#handleResult(lc, result);
-              if (result?.completedBackfill) {
-                backfillStatus = undefined;
+              writeBatch.push(message as ChangeStreamData);
+              writeBatchSize += size;
+              if (
+                // Waiting here ensures that consuming the commit, which ACKs
+                // it upstream, only happens after the SQLite commit finishes.
+                type === 'commit' ||
+                type === 'rollback' ||
+                // Promptly surface malformed transaction sequences instead
+                // of leaving a partial batch waiting for another message.
+                invalidTransactionSequence ||
+                writeBatch.length >= MAX_WORKER_BATCH_MESSAGES ||
+                writeBatchSize >= MAX_WORKER_BATCH_SIZE
+              ) {
+                await flushWrites();
               }
               break;
             }

--- a/packages/zero-cache/src/services/replicator/replication-resumption-child.ts
+++ b/packages/zero-cache/src/services/replicator/replication-resumption-child.ts
@@ -9,7 +9,7 @@ import {getPragmaConfig, setupReplica} from '../../workers/replicator.ts';
 import type {ChangeStreamData} from '../change-source/protocol/current/downstream.ts';
 import type {
   ChangeStreamer,
-  SerializedDownstream,
+  SizedDownstream,
   SubscriberContext,
 } from '../change-streamer/change-streamer.ts';
 import {exitAfter, runUntilKilled} from '../life-cycle.ts';
@@ -24,10 +24,7 @@ import {
 type ChildFailpoint = 'none' | 'after-sqlite-commit-before-ack';
 
 type ParentMessage =
-  | [
-      'replication-resumption:downstream',
-      {seq: number; msg: SerializedDownstream},
-    ]
+  | ['replication-resumption:downstream', {seq: number; msg: SizedDownstream}]
   | ['replication-resumption:source-error', {message: string}]
   | ['replication-resumption:source-end', Record<string, never>];
 
@@ -67,17 +64,17 @@ class IPCChangeStreamer implements ChangeStreamer {
     this.#parent = parent;
   }
 
-  subscribe(ctx: SubscriberContext): Promise<Source<SerializedDownstream>> {
+  subscribe(ctx: SubscriberContext): Promise<Source<SizedDownstream>> {
     send(this.#parent, ['replication-resumption:subscribe', ctx]);
     return Promise.resolve(new IPCDownstreamSource(this.#parent));
   }
 }
 
 type QueueEntry =
-  | {type: 'message'; seq: number; msg: SerializedDownstream}
+  | {type: 'message'; seq: number; msg: SizedDownstream}
   | {type: 'end'};
 
-export class IPCDownstreamSource implements Source<SerializedDownstream> {
+export class IPCDownstreamSource implements Source<SizedDownstream> {
   readonly #parent: Worker;
   readonly #queue = new Queue<QueueEntry>();
   readonly #abortController = new AbortController();
@@ -127,7 +124,7 @@ export class IPCDownstreamSource implements Source<SerializedDownstream> {
     return this.#abortController.signal;
   }
 
-  [Symbol.asyncIterator](): AsyncIterator<SerializedDownstream> {
+  [Symbol.asyncIterator](): AsyncIterator<SizedDownstream> {
     let previousSeq: number | undefined;
     return {
       next: async () => {
@@ -190,10 +187,10 @@ class FailpointWriteWorkerClient implements WriteWorkerClient {
     return this.#inner.getSubscriptionState();
   }
 
-  async processMessage(
-    downstream: ChangeStreamData,
+  async processMessages(
+    downstream: readonly ChangeStreamData[],
   ): Promise<CommitResult | null> {
-    const result = await this.#inner.processMessage(downstream);
+    const result = await this.#inner.processMessages(downstream);
     if (
       result?.watermark &&
       this.#failpoint === 'after-sqlite-commit-before-ack' &&

--- a/packages/zero-cache/src/services/replicator/replication-resumption.pg.test.ts
+++ b/packages/zero-cache/src/services/replicator/replication-resumption.pg.test.ts
@@ -29,7 +29,7 @@ import {
   type ChangeStreamer,
   type ChangeStreamerService,
   type Downstream,
-  type SerializedDownstream,
+  type SizedDownstream,
 } from '../change-streamer/change-streamer.ts';
 import {initChangeStreamerSchema} from '../change-streamer/schema/init.ts';
 import {ReplicationStatusPublisher} from './replication-status.ts';
@@ -143,10 +143,7 @@ type ParentMessage =
     ];
 
 type ChildMessage =
-  | [
-      'replication-resumption:downstream',
-      {seq: number; msg: SerializedDownstream},
-    ]
+  | ['replication-resumption:downstream', {seq: number; msg: SizedDownstream}]
   | ['replication-resumption:source-error', {message: string}]
   | ['replication-resumption:source-end', Record<string, never>];
 
@@ -283,7 +280,10 @@ class ForkedReplicator {
           'replication-resumption:downstream',
           {
             seq,
-            msg: {data: BigIntJSON.parse(value) as Downstream, json: value},
+            msg: {
+              data: BigIntJSON.parse(value) as Downstream,
+              size: value.length,
+            },
           },
         ]);
         await this.#waitForConsumed(bridge, seq);

--- a/packages/zero-cache/src/services/replicator/replication-throughput.bench.pg.ts
+++ b/packages/zero-cache/src/services/replicator/replication-throughput.bench.pg.ts
@@ -32,7 +32,7 @@ import {
   type ChangeStreamer,
   type ChangeStreamerService,
   type Downstream,
-  type SerializedDownstream,
+  type SizedDownstream,
 } from '../change-streamer/change-streamer.ts';
 import {initChangeStreamerSchema} from '../change-streamer/schema/init.ts';
 import {ReplicationStatusPublisher} from './replication-status.ts';
@@ -80,13 +80,13 @@ afterEach(async () => {
 
 function parseStringifiedSource(
   source: Source<string>,
-): Source<SerializedDownstream> {
+): Source<SizedDownstream> {
   return {
     cancel: err => source.cancel(err),
     signal: source.signal,
     async *[Symbol.asyncIterator]() {
       for await (const json of source) {
-        yield {data: BigIntJSON.parse(json) as Downstream, json};
+        yield {data: BigIntJSON.parse(json) as Downstream, size: json.length};
       }
     },
   };

--- a/packages/zero-cache/src/services/replicator/replicator.ts
+++ b/packages/zero-cache/src/services/replicator/replicator.ts
@@ -141,7 +141,7 @@ export class ReplicatorService implements Replicator, Service {
   async stop() {
     this.#incrementalSyncer.stop(this.#lc);
     // Wait for the syncer's run loop to finish so that any in-flight
-    // worker.processMessage() call completes and clears #pending
+    // worker.processMessages() call completes and clears #pending
     // before we send the 'stop' message to the worker.
     await this.#runPromise;
     await this.#worker.stop();

--- a/packages/zero-cache/src/services/replicator/write-worker-client.ts
+++ b/packages/zero-cache/src/services/replicator/write-worker-client.ts
@@ -41,7 +41,9 @@ type ErrorHandler = (err: Error) => void;
  */
 export interface WriteWorkerClient {
   getSubscriptionState(): Promise<SubscriptionState>;
-  processMessage(downstream: ChangeStreamData): Promise<CommitResult | null>;
+  processMessages(
+    downstream: readonly ChangeStreamData[],
+  ): Promise<CommitResult | null>;
   abort(): void;
   stop(): Promise<void>;
   onError(handler: ErrorHandler): void;
@@ -115,7 +117,7 @@ export type ArgsMap = {
     ForceCheckpointConfig | null,
   ];
   getSubscriptionState: [];
-  processMessage: [ChangeStreamData];
+  processMessages: [readonly ChangeStreamData[]];
   abort: [];
   stop: [];
 };
@@ -127,7 +129,7 @@ export type Request<M extends Method = Method> = {method: M; args: ArgsMap[M]};
 export type ResultMap = {
   init: void;
   getSubscriptionState: SubscriptionState;
-  processMessage: CommitResult | null;
+  processMessages: CommitResult | null;
   abort: void;
   stop: void;
 };
@@ -221,8 +223,10 @@ export class ThreadWriteWorkerClient implements WriteWorkerClient {
     return this.#call('getSubscriptionState', []);
   }
 
-  processMessage(downstream: ChangeStreamData): Promise<CommitResult | null> {
-    return this.#call('processMessage', [downstream]);
+  processMessages(
+    downstream: readonly ChangeStreamData[],
+  ): Promise<CommitResult | null> {
+    return this.#call('processMessages', [downstream]);
   }
 
   abort(): void {

--- a/packages/zero-cache/src/services/replicator/write-worker.test.ts
+++ b/packages/zero-cache/src/services/replicator/write-worker.test.ts
@@ -72,13 +72,7 @@ describe('write-worker', () => {
       ['commit', issues.commit(), {watermark: '06'}],
     ];
 
-    let commitResult = null;
-    for (let i = 0; i < messages.length; i++) {
-      const result = await worker.processMessage(messages[i]);
-      if (result) {
-        commitResult = result;
-      }
-    }
+    const commitResult = await worker.processMessages(messages);
 
     expect(commitResult).toEqual({
       watermark: '06',
@@ -107,13 +101,11 @@ describe('write-worker', () => {
   // to their own inode.
   test('the write worker never creates a change log', async () => {
     const issues = new ReplicationMessages({issues: ['issueID', 'bool']});
-    for (const message of [
+    await worker.processMessages([
       ['begin', issues.begin(), {commitWatermark: '06'}],
       ['data', issues.insert('issues', {issueID: 1, bool: true})],
       ['commit', issues.commit(), {watermark: '06'}],
-    ] satisfies ChangeStreamData[]) {
-      await worker.processMessage(message);
-    }
+    ] satisfies ChangeStreamData[]);
 
     expect(existsSync(changeLogFileName(dbFile.path))).toBe(false);
   });
@@ -122,14 +114,9 @@ describe('write-worker', () => {
     const issues = new ReplicationMessages({issues: ['issueID', 'bool']});
 
     // Start a transaction but don't commit
-    await worker.processMessage([
-      'begin',
-      issues.begin(),
-      {commitWatermark: '06'},
-    ]);
-    await worker.processMessage([
-      'data',
-      issues.insert('issues', {issueID: 123, bool: true}),
+    await worker.processMessages([
+      ['begin', issues.begin(), {commitWatermark: '06'}],
+      ['data', issues.insert('issues', {issueID: 123, bool: true})],
     ]);
 
     // Abort should roll back
@@ -146,9 +133,7 @@ describe('write-worker', () => {
       ['commit', issues.commit(), {watermark: '07'}],
     ];
 
-    for (let i = 0; i < messages.length; i++) {
-      await worker.processMessage(messages[i]);
-    }
+    await worker.processMessages(messages);
 
     const rowsAfter = mainDb.prepare('SELECT issueID FROM issues').all();
     expect(rowsAfter).toEqual([{issueID: 789}]);
@@ -171,19 +156,21 @@ describe('write-worker', () => {
       errorReceived = err;
     });
 
-    // Send a processMessage without a begin - should cause a failure
+    // Send a processMessages without a begin - should cause a failure
     await expect(
-      worker.processMessage([
-        'data',
-        {
-          tag: 'insert',
-          relation: {
-            schema: 'public',
-            name: 'nonexistent',
-            rowKey: {columns: ['id'], type: 'default'},
+      worker.processMessages([
+        [
+          'data',
+          {
+            tag: 'insert',
+            relation: {
+              schema: 'public',
+              name: 'nonexistent',
+              rowKey: {columns: ['id'], type: 'default'},
+            },
+            new: {id: [1, 'int4']},
           },
-          new: {id: [1, 'int4']},
-        },
+        ],
       ]),
     ).rejects.toThrow();
 
@@ -207,9 +194,9 @@ describe('write-worker', () => {
       },
     ];
     const request = {
-      method: 'processMessage',
-      args: [data],
-    } satisfies Request<'processMessage'>;
+      method: 'processMessages',
+      args: [[data]],
+    } satisfies Request<'processMessages'>;
     const echoWorker = new Worker(
       /*js*/ `
         const {parentPort} = require('node:worker_threads');
@@ -224,7 +211,7 @@ describe('write-worker', () => {
       const [roundTripped] = (await response) as [typeof request];
 
       expect(roundTripped).toEqual(request);
-      expect(roundTripped.args[0][1]).toMatchObject({
+      expect(roundTripped.args[0][0][1]).toMatchObject({
         new: {issueID: 9007199254740993n, text: 'before\0after'},
       });
     } finally {

--- a/packages/zero-cache/src/services/replicator/write-worker.ts
+++ b/packages/zero-cache/src/services/replicator/write-worker.ts
@@ -133,13 +133,19 @@ function createAPI(): API {
       }
     },
 
-    async processMessage(downstream: ChangeStreamData) {
+    async processMessages(downstream: readonly ChangeStreamData[]) {
       try {
-        const committed = must(processor).processMessage(must(lc), downstream);
-        if (committed && checkpointer) {
-          await checkpointer.maybeCheckpoint();
+        let commitResult = null;
+        for (const message of downstream) {
+          const committed = must(processor).processMessage(must(lc), message);
+          if (committed) {
+            commitResult = committed;
+            if (checkpointer) {
+              await checkpointer.maybeCheckpoint();
+            }
+          }
         }
-        return committed;
+        return commitResult;
       } catch (e) {
         handleCorruptedDb(e);
         throw e;

--- a/packages/zero-cache/src/types/streams.test.ts
+++ b/packages/zero-cache/src/types/streams.test.ts
@@ -17,7 +17,7 @@ import * as v from '../../../shared/src/valita.ts';
 import {
   stream,
   streamIn,
-  streamInStringified,
+  streamInWithSize,
   streamOut,
   streamOutStringified,
   type Sink,
@@ -269,11 +269,11 @@ describe('streams with internal acks', () => {
     };
   }
 
-  async function startStringifiedReceiver() {
+  async function startSizedReceiver() {
     ws = new WebSocket(`http://localhost:${port}/`);
     return {
       ws,
-      consumer: await streamInStringified(lc, ws, messageSchema),
+      consumer: await streamInWithSize(lc, ws, messageSchema),
     };
   }
 
@@ -477,12 +477,12 @@ describe('streams with internal acks', () => {
     ]);
   });
 
-  test('stringified source', async () => {
+  test('sized source', async () => {
     const json =
       '{"from":1,"to":2,"str":"before\\u0000after","big":9007199254740993}';
     stringifiedProducer.push(json);
 
-    const {consumer} = await startStringifiedReceiver();
+    const {consumer} = await startSizedReceiver();
     expect(await drain(1, consumer)).toEqual([
       {
         data: {
@@ -491,7 +491,7 @@ describe('streams with internal acks', () => {
           str: 'before\0after',
           big: 9007199254740993n,
         },
-        json,
+        size: `{"id":1,"msg":${json}}`.length,
       },
     ]);
   });

--- a/packages/zero-cache/src/types/streams.ts
+++ b/packages/zero-cache/src/types/streams.ts
@@ -223,10 +223,10 @@ const ackSchema = v.object({ack: v.number()});
 
 type Ack = v.Infer<typeof ackSchema>;
 
-/** A parsed JSON value paired with the exact source text it was parsed from. */
-export type ParsedJSON<T> = {
+/** A parsed value paired with its approximate serialized transport size. */
+export type Sized<T> = {
   data: T;
-  json: string;
+  size: number;
 };
 
 export function streamOut<T extends JSONValue>(
@@ -322,17 +322,17 @@ export function streamIn<T extends JSONValue>(
 }
 
 /**
- * Streams in messages sent by {@link streamOutStringified}, preserving the
- * exact application-level JSON alongside its parsed and validated value.
+ * Streams in parsed messages while retaining only the transport-frame size.
+ * The size bounds downstream batching without keeping or copying the JSON.
  */
-export function streamInStringified<T extends JSONValue>(
+export function streamInWithSize<T extends JSONValue>(
   lc: LogContext,
   source: WebSocket,
   schema: v.Type<T>,
-): Promise<Source<ParsedJSON<T>>> {
-  return streamInInternal(lc, source, schema, (data, frame, id) => ({
+): Promise<Source<Sized<T>>> {
+  return streamInInternal(lc, source, schema, (data, frame) => ({
     data,
-    json: extractStringifiedMessage(frame, id),
+    size: frame.length,
   }));
 }
 
@@ -381,15 +381,6 @@ async function streamInInternal<T extends JSONValue, Out>(
 
   await closer.connected;
   return sink;
-}
-
-function extractStringifiedMessage(frame: string, id: number): string {
-  const prefix = `{"id":${id},"msg":`;
-  assert(
-    frame.startsWith(prefix) && frame.endsWith('}'),
-    `invalid streamed message frame`,
-  );
-  return frame.slice(prefix.length, -1);
 }
 
 class WebSocketCloser {

--- a/packages/zql-integration-tests/src/chinook/chinook-zero-cache-fuzzer.pg.test.ts
+++ b/packages/zql-integration-tests/src/chinook/chinook-zero-cache-fuzzer.pg.test.ts
@@ -12,7 +12,7 @@ import type {
   ChangeStreamer,
   ChangeStreamerService,
   Downstream,
-  SerializedDownstream,
+  SizedDownstream,
 } from '../../../zero-cache/src/services/change-streamer/change-streamer.ts';
 import {initChangeStreamerSchema} from '../../../zero-cache/src/services/change-streamer/schema/init.ts';
 import {ReplicationStatusPublisher} from '../../../zero-cache/src/services/replicator/replication-status.ts';
@@ -250,13 +250,13 @@ function selectWriteFuzzSkeletons(
 
 function parseStringifiedSource(
   source: Source<string>,
-): Source<SerializedDownstream> {
+): Source<SizedDownstream> {
   return {
     cancel: err => source.cancel(err),
     signal: source.signal,
     async *[Symbol.asyncIterator]() {
       for await (const json of source) {
-        yield {data: BigIntJSON.parse(json) as Downstream, json};
+        yield {data: BigIntJSON.parse(json) as Downstream, size: json.length};
       }
     },
   };


### PR DESCRIPTION
- Before: every database change was sent to the worker one at a time.
- Now: changes are collected into batches—up to 256 messages or about 1 MB.
- The batch is sent to the SQLite worker in one go, reducing communication overhead.
- Transactions still stay safe: batches are always flushed at commit or rollback, so acknowledgements only happen after SQLite finishes.
- The code stops carrying around duplicate JSON strings. It keeps only the parsed change plus an approximate message size, which is enough to decide when a  batch is full.
- The worker still processes each message in order, so behavior should remain the same.

  Net effect: faster replication, less memory copying, and less cross-thread/worker overhead—especially when many changes arrive quickly. The
  untracked .litestream/ and .soak/ directories are unrelated local files.

<img width="400" height="223" alt="CleanShot 2026-09-03 at 15 11 12" src="https://github.com/user-attachments/assets/f0631ee8-6e52-45b4-8a35-4ed3eb5b3a05" />

