### PR TITLE
fix(zero-cache): no-op the unshipped v14 replica migration

### DIFF
--- a/packages/zero-cache/src/services/change-source/common/replica-schema.test.ts
+++ b/packages/zero-cache/src/services/change-source/common/replica-schema.test.ts
@@ -457,8 +457,8 @@ describe('replica-schema-migrations', () => {
       },
     },
     {
-      // v14 creates and seeds the change-log stream table; v16 drops it. Both
-      // run here, in that order.
+      // v14 is empty; v16's cleanup is harmless when no pre-release table
+      // exists.
       fromSchemaVersion: 13,
       fromDataVersion: 11,
       desc: 'preserves writeTimeMs after rollback and rollforward',
@@ -491,8 +491,8 @@ describe('replica-schema-migrations', () => {
       },
     },
     {
-      // A replica that a v14 zero-cache created, seed included. v16 drops the
-      // table out from under it.
+      // A replica that a pre-release v14 zero-cache created, seed included.
+      // v16 drops the table out from under it.
       fromSchemaVersion: 14,
       fromDataVersion: 14,
       desc: 'drops the change-log stream table a v14 zero-cache created',
@@ -541,11 +541,11 @@ describe('replica-schema-migrations', () => {
       },
     },
     {
-      // Rolled back to v14 code, which reset dataVersion to 14 while leaving
-      // schemaVersion at 16, then rolled forward. Migration 16 re-runs with
-      // its schema step skipped, so it must not resurrect the table.
+      // Rolled back to v13 code, which reset dataVersion to 13 while leaving
+      // schemaVersion at 16, then rolled forward. Empty migration 14 lets the
+      // data version catch up without requiring the pre-release table.
       fromSchemaVersion: 16,
-      fromDataVersion: 14,
+      fromDataVersion: 13,
       desc: 'stays dropped after rollback and rollforward',
       // writeTimeMs is NOT NULL because a v16 schema has been through v15.
       replicaSetup:

--- a/packages/zero-cache/src/services/change-source/common/replica-schema.ts
+++ b/packages/zero-cache/src/services/change-source/common/replica-schema.ts
@@ -1,6 +1,5 @@
 import {existsSync, renameSync} from 'node:fs';
 import type {LogContext} from '@rocicorp/logger';
-import {assert} from '../../../../../shared/src/asserts.ts';
 import type {Database} from '../../../../../zqlite/src/db.ts';
 import {deleteLiteDB} from '../../../db/delete-lite-db.ts';
 import {listTables} from '../../../db/lite-tables.ts';
@@ -133,16 +132,14 @@ export const CREATE_V9_TABLE_METADATA_TABLE = /*sql*/ `
 `;
 
 // Deliberately shadows the same names in `replicator/change-log-db.ts`: these
-// are the v14 replica's, that module's are the change-log database's, and the
-// two are frozen apart.
+// describe replica files created by pre-release v14 builds, while that module
+// describes the separate change-log database. The two are frozen apart.
 export const V14_CHANGE_LOG_STREAM_TABLE = '_zero.changeLogStream';
 const V14_CHANGE_LOG_STREAM_WRITE_TIME_INDEX =
   '_zero.changeLogStream_writeTimeMs';
 
-// The change-log stream table, as migration 14 created it and migration 16
-// drops it. Frozen at its v14 shape: a migration is history, so this must not
-// be kept in sync with the live definition in `replicator/change-log-db.ts`,
-// which now describes a table in a different database.
+// The change-log stream table created by pre-release v14 builds and dropped by
+// migration 16. Retained at its old shape for migration tests only.
 export const CREATE_V14_CHANGE_LOG_STREAM = /*sql*/ `
   CREATE TABLE "${V14_CHANGE_LOG_STREAM_TABLE}" (
     "watermark"   TEXT NOT NULL,
@@ -157,32 +154,6 @@ export const CREATE_V14_CHANGE_LOG_STREAM = /*sql*/ `
     ON "${V14_CHANGE_LOG_STREAM_TABLE}" ("writeTimeMs", "watermark")
     WHERE "writeTimeMs" IS NOT NULL;
 `;
-
-// Idempotent because migrateData may run again after a rollback followed by a
-// roll-forward, and both rows go in with one statement so a partial seed is
-// not reachable.
-const SEED_V14_CHANGE_LOG_STREAM = /*sql*/ `
-  INSERT INTO "${V14_CHANGE_LOG_STREAM_TABLE}"
-    ("watermark", "pos", "change", "precommit", "writeTimeMs")
-  VALUES
-    (@stateVersion, 0, '{"tag":"begin"}', NULL, NULL),
-    (@stateVersion, 1, '{"tag":"commit"}', @stateVersion, @writeTimeMs)
-  ON CONFLICT ("watermark", "pos") DO NOTHING
-`;
-
-function seedV14ChangeLogStream(db: Database): void {
-  const state = db
-    .prepare(/*sql*/ `
-      SELECT "stateVersion", "writeTimeMs" FROM "_zero.replicationState"
-    `)
-    .get<{stateVersion: string; writeTimeMs: number | null} | undefined>();
-  assert(state !== undefined, 'replication state must be initialized');
-  assert(
-    state.writeTimeMs !== null,
-    'replication state writeTimeMs must be initialized',
-  );
-  db.prepare(SEED_V14_CHANGE_LOG_STREAM).run(state);
-}
 
 export const schemaVersionMigrationMap: IncrementalMigrationMap = {
   // There's no incremental migration from v1. Just reset the replica.
@@ -311,18 +282,8 @@ export const schemaVersionMigrationMap: IncrementalMigrationMap = {
     },
   },
 
-  // Deliberately left as it shipped, even though v16 immediately undoes it.
-  // Rewriting it to a no-op would strand replicas already at v14: they roll
-  // back to v14 code, which expects the table this created.
-  14: {
-    migrateSchema: (_, db) => {
-      db.exec(CREATE_V14_CHANGE_LOG_STREAM);
-    },
-
-    migrateData: (_, db) => {
-      seedV14ChangeLogStream(db);
-    },
-  },
+  // The replica-local change log moved to its own database before v14 shipped.
+  14: {},
 
   15: {
     migrateSchema: (_, db) => {
@@ -351,10 +312,8 @@ export const schemaVersionMigrationMap: IncrementalMigrationMap = {
   // every file the backup ships and every follower downloads. Nothing reads it
   // as of this version.
   //
-  // `IF EXISTS` because a fresh replica never runs the incremental migrations
-  // at all — its setup migration creates the current schema directly, which no
-  // longer includes this table — and because a rollback to v14 followed by a
-  // roll-forward re-runs `migrateData` while skipping `migrateSchema`.
+  // `IF EXISTS` because fresh and post-v13 replicas never create this table.
+  // Pre-release v14 builds did, so keep their cleanup idempotent.
   //
   // The freed pages are reclaimed by the existing `vacuumIntervalHours`
   // trigger in `workers/replicator.ts`; no special handling here.

--- a/packages/zero-cache/src/services/replicator/change-log-db.test.ts
+++ b/packages/zero-cache/src/services/replicator/change-log-db.test.ts
@@ -303,9 +303,9 @@ describe('replicator/change-log-db', () => {
       ]);
     });
 
-    // The replica's migration is history and must not acquire columns added to
-    // the separate, disposable change-log database after the split.
-    test('keeps the replica migration 14 shape frozen apart', () => {
+    // The pre-release replica shape must not acquire columns added to the
+    // separate, disposable change-log database after the split.
+    test('keeps the pre-release replica shape frozen apart', () => {
       using changeLog = new Database(lc, ':memory:');
       changeLog.exec(CREATE_CHANGE_LOG_STREAM_SCHEMA);
       using replica = new Database(lc, ':memory:');

--- a/packages/zero-cache/src/services/replicator/change-log-db.ts
+++ b/packages/zero-cache/src/services/replicator/change-log-db.ts
@@ -115,10 +115,10 @@ export function estimateChangeLogStreamRowBytes(
 // holds one entry per transaction rather than one per change. It is what the
 // purger scans to find transactions older than the retention window.
 //
-// The replica carried this table's original shape through versions 14 and 15;
-// see `CREATE_V14_CHANGE_LOG_STREAM` in
-// `change-source/common/replica-schema.ts`, which is frozen at the v14 shape
-// and must not be kept in sync with this one.
+// Pre-release builds briefly carried this table in the replica; see the test
+// fixture `CREATE_V14_CHANGE_LOG_STREAM` in
+// `change-source/common/replica-schema.ts`. Its old shape must not be kept in
+// sync with this one.
 export const CREATE_CHANGE_LOG_STREAM_SCHEMA = /*sql*/ `
   CREATE TABLE "${CHANGE_LOG_STREAM_TABLE}" (
     "watermark"      TEXT NOT NULL,


### PR DESCRIPTION

### What

Make the unshipped v14 replica migration a no-op while retaining cleanup for replica files created by pre-release builds.

### Why

Migration v14 temporarily added a change-log table to the replica, but the change log moved to a separate database before the migration shipped.

During Zero 1.10 smoke testing, rolling back to 1.9 reset the replica’s data version to 13 while retaining its newer schema. Rolling forward reran the v14 data migration without its schema migration and failed because the obsolete table did not exist.

### Changes

- Replace the v14 schema and data migrations with an empty migration.
- Remove the obsolete change-log seeding path.
- Keep the v16 `DROP IF EXISTS` cleanup for pre-release replica files.
- Cover rolling forward from data version 13 with a newer replica schema.