### PR TITLE
fix(zero-cache): handle missing background connection and catch up pipelines on reconnect

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/view-syncer-auth-maintenance.pg.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer-auth-maintenance.pg.test.ts
@@ -921,7 +921,7 @@ describe('view-syncer/auth maintenance', () => {
         }
       })();
 
-      // Wait for async initConnection validation to complete.
+      // Wait for async initConnection validation and pipeline init to complete.
       await vi.waitFor(() => {
         expect(validateSpy).toHaveBeenCalledTimes(2);
         expect(
@@ -932,11 +932,11 @@ describe('view-syncer/auth maintenance', () => {
         });
       });
 
-      // 6. Next version-ready arrives now that replacement connection is validated.
-      stateChanges.push({state: 'version-ready'});
+      // Pipeline init and catchup ran immediately during initConnection,
+      // delivering both the config patch and query rows in a single catchup poke.
+      const pokes = await nextPoke(client2);
+      expect(pokes).toBeDefined();
 
-      // Pipeline init now completes successfully, transforming custom queries using replacement credentials.
-      await nextPoke(client2);
       expect(transformSpy).toHaveBeenCalledTimes(1);
       expect(transformSpy.mock.calls[0][0].auth?.raw).toBe('token-2');
     });

--- a/packages/zero-cache/src/services/view-syncer/view-syncer-auth-maintenance.pg.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer-auth-maintenance.pg.test.ts
@@ -1,6 +1,7 @@
 import {resolver} from '@rocicorp/resolver';
 import {afterEach, beforeEach, describe, expect, vi} from 'vitest';
-import type {Queue} from '../../../../shared/src/queue.ts';
+import {Queue} from '../../../../shared/src/queue.ts';
+import {sleep} from '../../../../shared/src/sleep.ts';
 import type {Downstream} from '../../../../zero-protocol/src/down.ts';
 import {ErrorKind} from '../../../../zero-protocol/src/error-kind.ts';
 import {ErrorOrigin} from '../../../../zero-protocol/src/error-origin.ts';
@@ -13,7 +14,9 @@ import type {
 } from '../../custom-queries/transform-query.ts';
 import {type PgTest, test} from '../../test/db.ts';
 import type {DbFile} from '../../test/lite.ts';
+import type {ViewSyncerDownstream} from '../../types/downstream.ts';
 import type {PostgresDB} from '../../types/pg.ts';
+import type {Source} from '../../types/streams.ts';
 import type {Subscription} from '../../types/subscription.ts';
 import type {ReplicaState} from '../replicator/replicator.ts';
 import type {ConnectionValidation} from './connection-context-manager.ts';
@@ -21,6 +24,7 @@ import {
   ISSUES_QUERY,
   nextPoke,
   permissionsAll,
+  serviceID,
   setup,
   USERS_QUERY,
 } from './view-syncer-test-util.ts';
@@ -720,6 +724,289 @@ describe('view-syncer/auth maintenance', () => {
         timeout: 2_000,
       });
       expect(client.size()).toBe(0);
+    });
+  });
+
+  describe('background connection unavailable during pipeline sync', () => {
+    let replicaDbFile: DbFile;
+    let cvrDB: PostgresDB;
+    let upstreamDb: PostgresDB;
+    let stateChanges: Subscription<ReplicaState>;
+    let vs: ViewSyncerService;
+    let viewSyncerDone: Promise<void>;
+    let connectWithQueueAndSource: (
+      ctx: SyncContext,
+      desiredQueriesPatch: UpQueriesPatch,
+    ) => {
+      queue: Queue<Downstream>;
+      source: Source<ViewSyncerDownstream>;
+    };
+    let clearMocks: () => void;
+    let customQueryTransformer: Awaited<
+      ReturnType<typeof setup>
+    >['customQueryTransformer'];
+
+    beforeEach<PgTest>(async ({testDBs}) => {
+      vi.setSystemTime(Date.UTC(2025, 0, 1));
+      ({
+        replicaDbFile,
+        cvrDB,
+        upstreamDb,
+        stateChanges,
+        vs,
+        viewSyncerDone,
+        connectWithQueueAndSource,
+        customQueryTransformer,
+        clearMocks,
+      } = await setup(
+        testDBs,
+        'view_syncer_auth_maintenance_reconnect_race_test',
+        permissionsAll,
+        {
+          authConfig: {
+            retransformIntervalSeconds: MAINTENANCE_INTERVAL_MS / 1000,
+          },
+          queryFetchMode: 'empty-validation',
+        },
+      ));
+
+      return async () => {
+        clearMocks();
+        await vs.stop();
+        await viewSyncerDone;
+        await testDBs.drop(cvrDB, upstreamDb);
+        replicaDbFile.delete();
+      };
+    });
+
+    test('defers pipeline init when background connection disconnects and replacement is not yet validated', async () => {
+      const transformer = customQueryTransformer;
+      expect(transformer).toBeDefined();
+      using validateSpy = vi
+        .spyOn(transformer!, 'validate')
+        .mockResolvedValue(validationSuccess('user-1'));
+      using transformSpy = vi
+        .spyOn(transformer!, 'transform')
+        .mockResolvedValue(
+          transformSuccess([
+            {
+              id: 'custom-1',
+              transformedAst: ISSUES_QUERY,
+              transformationHash: 'hash-1',
+            },
+          ]),
+        );
+
+      const ctx1: SyncContext = {
+        ...SYNC_CONTEXT,
+        clientID: 'foo',
+        wsID: 'ws1',
+        auth: {type: 'opaque', raw: 'token-1'},
+      };
+
+      // 1. Client 1 connects and receives config poke.
+      const {queue: client1, source: source1} = connectWithQueueAndSource(
+        ctx1,
+        [
+          {
+            op: 'put',
+            hash: 'custom-1',
+            name: 'named-query-1',
+            args: ['thing'],
+          },
+        ],
+      );
+      await nextPoke(client1);
+
+      // Client 1 has validated and is now the background connection.
+      expect(validateSpy).toHaveBeenCalledTimes(1);
+      expect(
+        vs.connContextManager.getBackgroundConnectionContext(),
+      ).toMatchObject({
+        clientID: 'foo',
+        wsID: 'ws1',
+      });
+
+      // 2. Client 1 disconnects.
+      source1.cancel();
+      // Disconnect cleanup closes the connection in connContextManager.
+      await vi.waitFor(() => {
+        expect(
+          vs.connContextManager.getBackgroundConnectionContext(),
+        ).toBeUndefined();
+      });
+
+      // 3. Replacement connection registers on connContextManager, but has NOT
+      // validated yet (remains in provisional state).
+      const ctx2: SyncContext = {
+        ...SYNC_CONTEXT,
+        clientID: 'foo',
+        wsID: 'ws2',
+        auth: {type: 'opaque', raw: 'token-2'},
+      };
+      const selector2 = {clientID: ctx2.clientID, wsID: ctx2.wsID};
+      vs.connContextManager.registerConnection(
+        selector2,
+        {
+          protocolVersion: ctx2.protocolVersion,
+          clientID: ctx2.clientID,
+          clientGroupID: serviceID,
+          profileID: ctx2.profileID,
+          baseCookie: ctx2.baseCookie,
+          timestamp: Date.now(),
+          lmID: 0,
+          wsID: ctx2.wsID,
+          debugPerf: false,
+          auth: ctx2.auth?.raw,
+          userID: ctx2.userID,
+          initConnectionMsg: undefined,
+          httpCookie: ctx2.httpCookie,
+          origin: ctx2.origin,
+        },
+        ctx2.auth,
+      );
+
+      // Verify replacement is registered in provisional state without a background connection.
+      expect(vs.connContextManager.getConnectionContext(selector2)?.state).toBe(
+        'provisional',
+      );
+      expect(
+        vs.connContextManager.getBackgroundConnectionContext(),
+      ).toBeUndefined();
+
+      // 4. Version-ready arrives while background connection is unavailable.
+      // Before the fix, run() would call mustGetBackgroundConnectionContext()
+      // and crash the entire ViewSyncer with "No validated connection is available for shared query work."
+      stateChanges.push({state: 'version-ready'});
+
+      // Give run() a moment to acquire the lock and execute.
+      await sleep(50);
+
+      // Verify pipeline init was deferred: custom queries were not transformed,
+      // and the service is still running without crashing.
+      expect(transformSpy).toHaveBeenCalledTimes(0);
+
+      // 5. Replacement connection completes initConnection and validates.
+      vs.connContextManager.initConnection(selector2, {
+        desiredQueriesPatch: [
+          {
+            op: 'put',
+            hash: 'custom-1',
+            name: 'named-query-1',
+            args: ['thing'],
+          },
+        ],
+      });
+      const source2 = vs.initConnection(selector2, [
+        'initConnection',
+        {
+          desiredQueriesPatch: [
+            {
+              op: 'put',
+              hash: 'custom-1',
+              name: 'named-query-1',
+              args: ['thing'],
+            },
+          ],
+        },
+      ]);
+      const client2 = new Queue<Downstream>();
+      void (async function () {
+        try {
+          for await (const {message} of source2) {
+            client2.enqueue(message);
+          }
+        } catch (e) {
+          client2.enqueueRejection(e);
+        }
+      })();
+
+      // Wait for async initConnection validation to complete.
+      await vi.waitFor(() => {
+        expect(validateSpy).toHaveBeenCalledTimes(2);
+        expect(
+          vs.connContextManager.getBackgroundConnectionContext(),
+        ).toMatchObject({
+          clientID: 'foo',
+          wsID: 'ws2',
+        });
+      });
+
+      // 6. Next version-ready arrives now that replacement connection is validated.
+      stateChanges.push({state: 'version-ready'});
+
+      // Pipeline init now completes successfully, transforming custom queries using replacement credentials.
+      await nextPoke(client2);
+      expect(transformSpy).toHaveBeenCalledTimes(1);
+      expect(transformSpy.mock.calls[0][0].auth?.raw).toBe('token-2');
+    });
+
+    test('does not crash when version-ready arrives after all clients disconnect', async () => {
+      const transformer = customQueryTransformer;
+      expect(transformer).toBeDefined();
+      using validateSpy = vi
+        .spyOn(transformer!, 'validate')
+        .mockResolvedValue(validationSuccess('user-1'));
+      using transformSpy = vi
+        .spyOn(transformer!, 'transform')
+        .mockResolvedValue(
+          transformSuccess([
+            {
+              id: 'custom-1',
+              transformedAst: ISSUES_QUERY,
+              transformationHash: 'hash-1',
+            },
+          ]),
+        );
+
+      const ctx1: SyncContext = {
+        ...SYNC_CONTEXT,
+        clientID: 'foo',
+        wsID: 'ws1',
+        auth: {type: 'opaque', raw: 'token-1'},
+      };
+
+      // 1. Client connects and receives config poke.
+      const {queue: client1, source: source1} = connectWithQueueAndSource(
+        ctx1,
+        [
+          {
+            op: 'put',
+            hash: 'custom-1',
+            name: 'named-query-1',
+            args: ['thing'],
+          },
+        ],
+      );
+      await nextPoke(client1);
+      expect(validateSpy).toHaveBeenCalledTimes(1);
+
+      // 2. Client disconnects and NO replacement arrives.
+      source1.cancel();
+      await vi.waitFor(() => {
+        expect(
+          vs.connContextManager.getBackgroundConnectionContext(),
+        ).toBeUndefined();
+      });
+
+      // 3. Version-ready arrives while no clients are connected.
+      // Before the fix, run() would call mustGetBackgroundConnectionContext()
+      // and crash with "No validated connection is available for shared query work."
+      stateChanges.push({state: 'version-ready'});
+
+      // Give run() a moment to process the version-ready.
+      await sleep(50);
+
+      // The service must not crash and custom query transforms must not run without credentials.
+      expect(transformSpy).toHaveBeenCalledTimes(0);
+
+      // Verify that viewSyncerDone is still pending (not crashed or failed).
+      const timeout = sleep(50).then(() => 'still-running' as const);
+      const status = await Promise.race([
+        viewSyncerDone.then(() => 'stopped' as const),
+        timeout,
+      ]);
+      expect(status).toBe('still-running');
     });
   });
 });

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -2027,10 +2027,10 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
 
       if (this.#ttlClock === undefined) {
         // Get it from the CVR or initialize it to now.
-        const now = Date.now();
-        this.#ttlClock = this.#getTTLClock(now);
+        this.#ttlClock = cvr.ttlClock;
       }
-      const ttlClock = this.#ttlClock;
+      const now = Date.now();
+      const ttlClock = this.#getTTLClock(now);
 
       // group cvr queries into:
       // 1. custom queries

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -606,46 +606,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
             this.connContextManager.setSharedRetransformReady(false);
           }
 
-          // Advance the snapshot to the current version.
-          const version = this.#pipelines.advanceWithoutDiff();
-          const cvrVer = versionString(cvr.version);
-
-          if (version < cvr.version.stateVersion) {
-            lc.debug?.(`replica@${version} is behind cvr@${cvrVer}`);
-            return; // Wait for the next advancement.
-          }
-
-          // stateVersion is at or beyond CVR version for the first time.
-          lc.info?.(`init pipelines@${version} (cvr@${cvrVer})`);
-
-          // A validated background connection is needed to transform queries
-          // with the correct auth context. If the background connection
-          // disappeared (e.g. reconnect race where the old connection closed
-          // before the replacement validated), defer init until the next
-          // version-ready signal when the replacement has validated.
-          if (!this.connContextManager.getBackgroundConnectionContext()) {
-            lc.info?.(
-              'No validated background connection; deferring pipeline init',
-            );
-            return;
-          }
-
-          const driftedQueryIDs = await this.#hydrateUnchangedQueries(lc, cvr);
-          // hydrateUnchangedQueries just transformed
-          // all the custom queries, this #syncQueryPipelineSet call
-          // should retransform those that are missing from #pipelines, which
-          // are those which errored or changed transform hash, plus those
-          // removed because their rowSetSignature drifted (Cap re-execution
-          // chose a different N-row subset).
-          await this.#syncQueryPipelineSet(
-            lc,
-            cvr,
-            'missing',
-            undefined,
-            driftedQueryIDs,
-          );
-          this.#pipelinesSynced = true;
-          this.connContextManager.setSharedRetransformReady(true);
+          await this.#maybeInitPipelines(lc, cvr);
         });
       }
 
@@ -670,6 +631,66 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
       this.#lc.info?.(`view-syncer ${this.id} finished`);
       this.#stopped.resolve();
     }
+  }
+
+  /**
+   * Initializes and syncs pipelines when the snapshotter is initialized
+   * and a validated connection context is available.
+   *
+   * Returns true if pipelines were successfully initialized and synced,
+   * or false if initialization was deferred (e.g. replica behind CVR, or no
+   * validated connection available).
+   *
+   * Must be called from within the #lock.
+   */
+  async #maybeInitPipelines(
+    lc: LogContext,
+    cvr: CVRSnapshot,
+    connCtx?: ConnectionContext,
+  ): Promise<boolean> {
+    if (!this.#pipelines.initialized()) {
+      return false;
+    }
+    const resolvedConnCtx =
+      connCtx ?? this.connContextManager.getBackgroundConnectionContext();
+    if (!resolvedConnCtx) {
+      lc.info?.('No validated background connection; deferring pipeline init');
+      return false;
+    }
+
+    const version = this.#pipelines.advanceWithoutDiff();
+    const cvrVer = versionString(cvr.version);
+
+    if (version < cvr.version.stateVersion) {
+      lc.debug?.(`replica@${version} is behind cvr@${cvrVer}`);
+      return false; // Wait for the next advancement.
+    }
+
+    lc.info?.(`init pipelines@${version} (cvr@${cvrVer})`);
+
+    const driftedQueryIDs = await this.#hydrateUnchangedQueries(
+      lc,
+      cvr,
+      resolvedConnCtx,
+    );
+    // hydrateUnchangedQueries just transformed all the custom queries;
+    // this #syncQueryPipelineSet call should retransform those that are
+    // missing from #pipelines (errored, changed transform hash, or drifted).
+    const synced = await this.#syncQueryPipelineSet(
+      lc,
+      cvr,
+      'missing',
+      resolvedConnCtx,
+      driftedQueryIDs,
+    );
+    if (!synced) {
+      lc.info?.('Pipeline sync deferred; waiting for validated connection');
+      return false;
+    }
+
+    this.#pipelinesSynced = true;
+    this.connContextManager.setSharedRetransformReady(true);
+    return true;
   }
 
   // must be called from within #lock
@@ -1264,7 +1285,11 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
       );
     }
 
-    if (this.#pipelinesSynced) {
+    if (!this.#pipelinesSynced) {
+      if (this.#pipelines.initialized()) {
+        await this.#maybeInitPipelines(lc, this.#cvr, connCtx);
+      }
+    } else {
       await this.#syncQueryPipelineSet(
         lc,
         this.#cvr,
@@ -1553,6 +1578,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
   async #hydrateUnchangedQueries(
     lc: LogContext,
     cvr: CVRSnapshot,
+    connCtx?: ConnectionContext,
   ): Promise<Set<string>> {
     assert(this.#pipelines.initialized(), 'pipelines must be initialized');
 
@@ -1602,7 +1628,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
       );
     }
     const backgroundContext =
-      this.connContextManager.getBackgroundConnectionContext();
+      connCtx ?? this.connContextManager.getBackgroundConnectionContext();
     const customQueryTransformer = this.#customQueryTransformer;
     if (backgroundContext && customQueryTransformer && customQueries.size > 0) {
       // Always transform custom queries during initialization to ensure
@@ -1987,7 +2013,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     customQueryTransformMode: CustomQueryTransformMode,
     connCtx: ConnectionContext | undefined,
     driftedQueryIDs: Set<string> = new Set(),
-  ) {
+  ): Promise<boolean> {
     return startAsyncSpan(tracer, 'vs.#syncQueryPipelineSet', async span => {
       const start = performance.now();
       span.setAttribute('clientGroupID', this.id);
@@ -1998,10 +2024,10 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
 
       if (this.#ttlClock === undefined) {
         // Get it from the CVR or initialize it to now.
-        this.#ttlClock = cvr.ttlClock;
+        const now = Date.now();
+        this.#ttlClock = this.#getTTLClock(now);
       }
-      const now = Date.now();
-      const ttlClock = this.#getTTLClock(now);
+      const ttlClock = this.#ttlClock;
 
       // group cvr queries into:
       // 1. custom queries
@@ -2028,7 +2054,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
         lc.info?.(
           'No validated background connection for shared pipeline sync; deferring',
         );
-        return;
+        return false;
       }
 
       for (const [id, query] of cvrQueryEntires) {
@@ -2229,6 +2255,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
       } else {
         await this.#catchupClients(lc, cvr);
       }
+      return true;
     });
   }
 

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -302,7 +302,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
    *
    * - When `false`: The syncer is in its initial catch-up phase. The replica
    *   advances without diffs until it reaches `cvr.version.stateVersion`,
-   *   after which `#maybeInitPipelines` hydrates queries.
+   *   after which `#maybeHydratePipelines` hydrates queries.
    * - When `true`: Pipelines are fully populated and in steady-state; replica
    *   changes advance incrementally via `#advancePipelines`, and client query
    *   updates are processed via `#syncQueryPipelineSet`.
@@ -310,7 +310,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
    * Resets to `false` if `#advancePipelines` returns a `ResetPipelinesSignal`
    * and pipelines must be reset and rehydrated.
    */
-  #pipelinesReady = false;
+  #pipelinesHydrated = false;
   #servedVersion: LexiVersion | null = null;
   readonly #e2eServingLagTracker = new E2EServingLagTracker();
 
@@ -608,7 +608,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
             throw new ClientNotFoundError(message);
           }
 
-          if (this.#pipelinesReady) {
+          if (this.#pipelinesHydrated) {
             const result = await this.#advancePipelines(lc, cvr);
             if (result === 'success') {
               return;
@@ -616,11 +616,19 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
             lc.info?.(`resetting pipelines: ${result.message}`);
             this.#pipelineResets.add(1, {reason: result.reason});
             this.#pipelines.reset(clientSchema);
-            this.#pipelinesReady = false;
+            this.#pipelinesHydrated = false;
             this.connContextManager.setSharedRetransformReady(false);
           }
 
-          await this.#maybeInitPipelines(lc, cvr);
+          const backgroundConnCtx =
+            this.connContextManager.getBackgroundConnectionContext();
+          if (backgroundConnCtx) {
+            await this.#maybeHydratePipelines(lc, cvr, backgroundConnCtx);
+          } else {
+            lc.info?.(
+              'No validated background connection; deferring pipeline init',
+            );
+          }
         });
       }
 
@@ -648,23 +656,34 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
   }
 
   /**
-   * Initializes and syncs pipelines when the snapshotter is initialized
-   * and a validated connection context is available.
+   * Ensures that query pipelines are hydrated and ready for steady-state
+   * operation.
    *
-   * Must be called from within the #lock.
+   * Preconditions:
+   * 1. Must be called from within the `#lock`.
+   * 2. The caller must provide an active, validated `ConnectionContext` for
+   *    evaluating custom query transforms and permissions.
+   *
+   * Readiness prerequisites:
+   * - The underlying `QueryPipelineDriver` must be initialized with the schema
+   *   (i.e. `this.#pipelines.initialized()` is true).
+   * - The SQLite replica must have caught up to at least the CVR's
+   *   `stateVersion` (`version >= cvr.version.stateVersion`).
+   *
+   * If either prerequisite is not met, this method returns early as a no-op,
+   * waiting for the replica to catch up or the driver to initialize.
+   *
+   * Once ready:
+   * - Hydrates unchanged queries from the CVR snapshot without full row diffing.
+   * - Syncs missing, errored, or drifted queries via `#syncQueryPipelineSet`.
+   * - Sets `#pipelinesHydrated = true` and enables shared retransformations.
    */
-  async #maybeInitPipelines(
+  async #maybeHydratePipelines(
     lc: LogContext,
     cvr: CVRSnapshot,
-    connCtx?: ConnectionContext,
+    connCtx: ConnectionContext,
   ): Promise<void> {
     if (!this.#pipelines.initialized()) {
-      return;
-    }
-    const resolvedConnCtx =
-      connCtx ?? this.connContextManager.getBackgroundConnectionContext();
-    if (!resolvedConnCtx) {
-      lc.info?.('No validated background connection; deferring pipeline init');
       return;
     }
 
@@ -681,7 +700,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     const driftedQueryIDs = await this.#hydrateUnchangedQueries(
       lc,
       cvr,
-      resolvedConnCtx,
+      connCtx,
     );
     // hydrateUnchangedQueries just transformed all the custom queries;
     // this #syncQueryPipelineSet call should retransform those that are
@@ -690,11 +709,11 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
       lc,
       cvr,
       'missing',
-      resolvedConnCtx,
+      connCtx,
       driftedQueryIDs,
     );
 
-    this.#pipelinesReady = true;
+    this.#pipelinesHydrated = true;
     this.connContextManager.setSharedRetransformReady(true);
   }
 
@@ -707,7 +726,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
       lc = lc.withContext('method', '#removeExpiredQueries');
       lc.debug?.('Queries have expired');
       // #syncQueryPipelineSet() will remove the expired queries.
-      if (this.#pipelinesReady) {
+      if (this.#pipelinesHydrated) {
         const connCtx =
           this.connContextManager.getBackgroundConnectionContext();
         if (connCtx) {
@@ -1146,7 +1165,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
 
         // If pipelines are not yet ready, there is no transform request that
         // can absorb validation, so validate immediately.
-        if (!this.#pipelinesReady) {
+        if (!this.#pipelinesHydrated) {
           if (!(await this.#validateConnection(connCtx))) {
             return;
           }
@@ -1298,8 +1317,8 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
       );
     }
 
-    if (!this.#pipelinesReady) {
-      await this.#maybeInitPipelines(lc, this.#cvr, connCtx);
+    if (!this.#pipelinesHydrated) {
+      await this.#maybeHydratePipelines(lc, this.#cvr, connCtx);
     } else {
       await this.#syncQueryPipelineSet(
         lc,

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -618,6 +618,18 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
           // stateVersion is at or beyond CVR version for the first time.
           lc.info?.(`init pipelines@${version} (cvr@${cvrVer})`);
 
+          // A validated background connection is needed to transform queries
+          // with the correct auth context. If the background connection
+          // disappeared (e.g. reconnect race where the old connection closed
+          // before the replacement validated), defer init until the next
+          // version-ready signal when the replacement has validated.
+          if (!this.connContextManager.getBackgroundConnectionContext()) {
+            lc.info?.(
+              'No validated background connection; deferring pipeline init',
+            );
+            return;
+          }
+
           const driftedQueryIDs = await this.#hydrateUnchangedQueries(lc, cvr);
           // hydrateUnchangedQueries just transformed
           // all the custom queries, this #syncQueryPipelineSet call
@@ -1590,9 +1602,9 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
       );
     }
     const backgroundContext =
-      this.connContextManager.mustGetBackgroundConnectionContext();
+      this.connContextManager.getBackgroundConnectionContext();
     const customQueryTransformer = this.#customQueryTransformer;
-    if (customQueryTransformer && customQueries.size > 0) {
+    if (backgroundContext && customQueryTransformer && customQueries.size > 0) {
       // Always transform custom queries during initialization to ensure
       // authorization validation with current auth context.
       const transformedCustomQueries = await this.#runPriorityOp(
@@ -1645,7 +1657,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
         must(this.#pipelines.currentPermissions()).permissions ?? {
           tables: {},
         },
-        backgroundContext.auth?.type === 'jwt'
+        backgroundContext?.auth?.type === 'jwt'
           ? backgroundContext.auth
           : undefined,
         q.type === 'internal',
@@ -2011,7 +2023,13 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
       // Only background/shared sync work falls back to the selected
       // validated connection.
       const resolvedConnCtx =
-        connCtx ?? this.connContextManager.mustGetBackgroundConnectionContext();
+        connCtx ?? this.connContextManager.getBackgroundConnectionContext();
+      if (!resolvedConnCtx) {
+        lc.info?.(
+          'No validated background connection for shared pipeline sync; deferring',
+        );
+        return;
+      }
 
       for (const [id, query] of cvrQueryEntires) {
         if (query.type === 'custom') {

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -296,7 +296,21 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
   readonly #initialized = resolver<'initialized'>();
 
   #cvr: CVRSnapshot | undefined;
-  #pipelinesSynced = false;
+  /**
+   * Indicates whether the query pipelines have completed initial catch-up and
+   * hydration with the CVR snapshot, and are ready for steady-state operation.
+   *
+   * - When `false`: The syncer is in its initial catch-up phase. The replica
+   *   advances without diffs until it reaches `cvr.version.stateVersion`,
+   *   after which `#maybeInitPipelines` hydrates queries.
+   * - When `true`: Pipelines are fully populated and in steady-state; replica
+   *   changes advance incrementally via `#advancePipelines`, and client query
+   *   updates are processed via `#syncQueryPipelineSet`.
+   *
+   * Resets to `false` if `#advancePipelines` returns a `ResetPipelinesSignal`
+   * and pipelines must be reset and rehydrated.
+   */
+  #pipelinesReady = false;
   #servedVersion: LexiVersion | null = null;
   readonly #e2eServingLagTracker = new E2EServingLagTracker();
 
@@ -594,7 +608,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
             throw new ClientNotFoundError(message);
           }
 
-          if (this.#pipelinesSynced) {
+          if (this.#pipelinesReady) {
             const result = await this.#advancePipelines(lc, cvr);
             if (result === 'success') {
               return;
@@ -602,7 +616,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
             lc.info?.(`resetting pipelines: ${result.message}`);
             this.#pipelineResets.add(1, {reason: result.reason});
             this.#pipelines.reset(clientSchema);
-            this.#pipelinesSynced = false;
+            this.#pipelinesReady = false;
             this.connContextManager.setSharedRetransformReady(false);
           }
 
@@ -637,25 +651,21 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
    * Initializes and syncs pipelines when the snapshotter is initialized
    * and a validated connection context is available.
    *
-   * Returns true if pipelines were successfully initialized and synced,
-   * or false if initialization was deferred (e.g. replica behind CVR, or no
-   * validated connection available).
-   *
    * Must be called from within the #lock.
    */
   async #maybeInitPipelines(
     lc: LogContext,
     cvr: CVRSnapshot,
     connCtx?: ConnectionContext,
-  ): Promise<boolean> {
+  ): Promise<void> {
     if (!this.#pipelines.initialized()) {
-      return false;
+      return;
     }
     const resolvedConnCtx =
       connCtx ?? this.connContextManager.getBackgroundConnectionContext();
     if (!resolvedConnCtx) {
       lc.info?.('No validated background connection; deferring pipeline init');
-      return false;
+      return;
     }
 
     const version = this.#pipelines.advanceWithoutDiff();
@@ -663,7 +673,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
 
     if (version < cvr.version.stateVersion) {
       lc.debug?.(`replica@${version} is behind cvr@${cvrVer}`);
-      return false; // Wait for the next advancement.
+      return; // Wait for the next advancement.
     }
 
     lc.info?.(`init pipelines@${version} (cvr@${cvrVer})`);
@@ -676,21 +686,16 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     // hydrateUnchangedQueries just transformed all the custom queries;
     // this #syncQueryPipelineSet call should retransform those that are
     // missing from #pipelines (errored, changed transform hash, or drifted).
-    const synced = await this.#syncQueryPipelineSet(
+    await this.#syncQueryPipelineSet(
       lc,
       cvr,
       'missing',
       resolvedConnCtx,
       driftedQueryIDs,
     );
-    if (!synced) {
-      lc.info?.('Pipeline sync deferred; waiting for validated connection');
-      return false;
-    }
 
-    this.#pipelinesSynced = true;
+    this.#pipelinesReady = true;
     this.connContextManager.setSharedRetransformReady(true);
-    return true;
   }
 
   // must be called from within #lock
@@ -702,8 +707,16 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
       lc = lc.withContext('method', '#removeExpiredQueries');
       lc.debug?.('Queries have expired');
       // #syncQueryPipelineSet() will remove the expired queries.
-      if (this.#pipelinesSynced) {
-        await this.#syncQueryPipelineSet(lc, cvr, 'missing', undefined);
+      if (this.#pipelinesReady) {
+        const connCtx =
+          this.connContextManager.getBackgroundConnectionContext();
+        if (connCtx) {
+          await this.#syncQueryPipelineSet(lc, cvr, 'missing', connCtx);
+        } else {
+          lc.info?.(
+            'No validated background connection to remove expired queries; deferring',
+          );
+        }
       }
     }
 
@@ -1131,9 +1144,9 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
         const connCtx =
           this.connContextManager.mustGetConnectionContext(selector);
 
-        // If pipelines are not yet synced, there is no transform request that
+        // If pipelines are not yet ready, there is no transform request that
         // can absorb validation, so validate immediately.
-        if (!this.#pipelinesSynced) {
+        if (!this.#pipelinesReady) {
           if (!(await this.#validateConnection(connCtx))) {
             return;
           }
@@ -1251,7 +1264,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     cvr: CVRSnapshot,
     clientID: string,
     customQueryTransformMode: CustomQueryTransformMode,
-    connCtx: ConnectionContext | undefined,
+    connCtx: ConnectionContext,
     fn: (updater: CVRConfigDrivenUpdater) => PatchToVersion[],
   ): Promise<CVRSnapshot> {
     const updater = new CVRConfigDrivenUpdater(
@@ -1285,10 +1298,8 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
       );
     }
 
-    if (!this.#pipelinesSynced) {
-      if (this.#pipelines.initialized()) {
-        await this.#maybeInitPipelines(lc, this.#cvr, connCtx);
-      }
+    if (!this.#pipelinesReady) {
+      await this.#maybeInitPipelines(lc, this.#cvr, connCtx);
     } else {
       await this.#syncQueryPipelineSet(
         lc,
@@ -1578,7 +1589,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
   async #hydrateUnchangedQueries(
     lc: LogContext,
     cvr: CVRSnapshot,
-    connCtx?: ConnectionContext,
+    connCtx: ConnectionContext,
   ): Promise<Set<string>> {
     assert(this.#pipelines.initialized(), 'pipelines must be initialized');
 
@@ -1627,20 +1638,14 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
         'Custom/named queries were requested but no `ZERO_QUERY_URL` is configured for Zero Cache.',
       );
     }
-    const backgroundContext =
-      connCtx ?? this.connContextManager.getBackgroundConnectionContext();
     const customQueryTransformer = this.#customQueryTransformer;
-    if (backgroundContext && customQueryTransformer && customQueries.size > 0) {
+    if (customQueryTransformer && customQueries.size > 0) {
       // Always transform custom queries during initialization to ensure
       // authorization validation with current auth context.
       const transformedCustomQueries = await this.#runPriorityOp(
         lc,
         '#hydrateUnchangedQueries transforming custom queries',
-        () =>
-          customQueryTransformer.transform(
-            backgroundContext,
-            customQueries.values(),
-          ),
+        () => customQueryTransformer.transform(connCtx, customQueries.values()),
       );
       // Uncached results can also return the authoritative server userID
       // for that snapshot.
@@ -1649,8 +1654,8 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
         !transformedCustomQueries.cached
       ) {
         this.connContextManager.validateConnection(
-          backgroundContext,
-          backgroundContext.revision,
+          connCtx,
+          connCtx.revision,
           transformedCustomQueries.validation,
         );
       }
@@ -1683,9 +1688,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
         must(this.#pipelines.currentPermissions()).permissions ?? {
           tables: {},
         },
-        backgroundContext?.auth?.type === 'jwt'
-          ? backgroundContext.auth
-          : undefined,
+        connCtx.auth?.type === 'jwt' ? connCtx.auth : undefined,
         q.type === 'internal',
       );
       if (transformed.transformationHash === q.transformationHash) {
@@ -2011,9 +2014,9 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     lc: LogContext,
     cvr: CVRSnapshot,
     customQueryTransformMode: CustomQueryTransformMode,
-    connCtx: ConnectionContext | undefined,
+    connCtx: ConnectionContext,
     driftedQueryIDs: Set<string> = new Set(),
-  ): Promise<boolean> {
+  ): Promise<void> {
     return startAsyncSpan(tracer, 'vs.#syncQueryPipelineSet', async span => {
       const start = performance.now();
       span.setAttribute('clientGroupID', this.id);
@@ -2045,17 +2048,6 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
         origQuery: QueryRecord;
         transformed: TransformedAndHashed;
       }[] = [];
-      // When a specific connection triggered this work, use its context.
-      // Only background/shared sync work falls back to the selected
-      // validated connection.
-      const resolvedConnCtx =
-        connCtx ?? this.connContextManager.getBackgroundConnectionContext();
-      if (!resolvedConnCtx) {
-        lc.info?.(
-          'No validated background connection for shared pipeline sync; deferring',
-        );
-        return false;
-      }
 
       for (const [id, query] of cvrQueryEntires) {
         if (query.type === 'custom') {
@@ -2077,9 +2069,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
           must(this.#pipelines.currentPermissions()).permissions ?? {
             tables: {},
           },
-          resolvedConnCtx.auth?.type === 'jwt'
-            ? resolvedConnCtx.auth
-            : undefined,
+          connCtx.auth?.type === 'jwt' ? connCtx.auth : undefined,
           origQuery.type === 'internal',
         );
         transformedQueries.push({
@@ -2116,7 +2106,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
             '#syncQueryPipelineSet transforming custom queries',
             () =>
               customQueryTransformer.transform(
-                resolvedConnCtx,
+                connCtx,
                 customQueriesToTransform,
               ),
           );
@@ -2134,8 +2124,8 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
             // revision check so auth races do not validate stale credentials.
             if (!transformedCustomQueries.cached) {
               this.connContextManager.validateConnection(
-                resolvedConnCtx,
-                resolvedConnCtx.revision,
+                connCtx,
+                connCtx.revision,
                 transformedCustomQueries.validation,
               );
             }
@@ -2255,7 +2245,6 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
       } else {
         await this.#catchupClients(lc, cvr);
       }
-      return true;
     });
   }
 
@@ -2709,7 +2698,9 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
    *
    * Must be called from within the #lock.
    *
-   * Returns false if the advancement failed due to a schema change.
+   * Returns 'success' if changes were successfully processed and poked,
+   * or a `ResetPipelinesSignal` if advancement aborted (e.g. schema change,
+   * timeout) and pipelines need to be reset and rehydrated.
    */
   #advancePipelines(
     lc: LogContext,


### PR DESCRIPTION
### Problem
When a client reconnects, the replacement connection is initially unvalidated (`provisional`). If a `version-ready` signal arrived while the background connection was unavailable:
1. `ViewSyncer` called `mustGetBackgroundConnectionContext()`, crashing the entire service.
2. If pipeline init was deferred, an idle database (no subsequent Postgres transactions) left the reconnected client stalled indefinitely without receiving query rows.
3. Query pipeline methods relied on ambient fallbacks to `getBackgroundConnectionContext()`.
### Solution
- **Defer without crashing**: In `run()`, safely defer pipeline hydration if no validated background connection is available when `version-ready` arrives.
- **Catch up immediately on reconnect**: In `#updateCVRConfig`, if `!this.#pipelinesHydrated`, immediately invoke `#maybeHydratePipelines(lc, this.#cvr, connCtx)` using the newly validated client's context.
- **Explicit context passing**: Made `connCtx: ConnectionContext` mandatory across `#maybeHydratePipelines`, `#hydrateUnchangedQueries`, and `#syncQueryPipelineSet`.
- **Graceful expiry handling**: `#removeExpiredQueries` cleanly defers query cleanup when a background connection is unavailable while keeping the next eviction deadline scheduled.
### Verification
- **New automated test cases** in `view-syncer-auth-maintenance.pg.test.ts`:
  - `defers pipeline init when background connection disconnects and replacement is not yet validated`
  - `does not crash when version-ready arrives after all clients disconnect`
- **Manual End-to-End Testing**: Verified locally on `zbugs` 