### PR TITLE
feat(zero-client): 'cached' result type — persisted, fingerprint-verified complete results at boot

### DIFF
--- a/packages/zero-client/src/client/query-manager.test.ts
+++ b/packages/zero-client/src/client/query-manager.test.ts
@@ -1239,7 +1239,8 @@ test('handleClosed marks queries as errored exactly once', () => {
 
   const ast: AST = {table: 'issue'};
   const queryHash = hashOfAST(ast);
-  const gotCallback = vi.fn<(got: boolean, error?: ErroredQuery) => void>();
+  const gotCallback =
+    vi.fn<(got: boolean | 'cached', error?: ErroredQuery) => void>();
 
   queryManager.addLegacy(ast, 0, gotCallback);
   queryManager.flushBatch();
@@ -1304,7 +1305,7 @@ test('gotCallback, query already got', () => {
     orderBy: [['id', 'asc']],
   };
 
-  const gotCallback1 = vi.fn<(got: boolean) => void>();
+  const gotCallback1 = vi.fn<(got: boolean | 'cached') => void>();
   const ttl = 200;
   queryManager.addLegacy(ast, ttl, gotCallback1);
   queryManager.flushBatch();
@@ -1334,7 +1335,7 @@ test('gotCallback, query already got', () => {
 
   expect(gotCallback1).nthCalledWith(1, true);
 
-  const gotCallback2 = vi.fn<(got: boolean) => void>();
+  const gotCallback2 = vi.fn<(got: boolean | 'cached') => void>();
   queryManager.addLegacy(ast, ttl, gotCallback2);
   queryManager.flushBatch();
   expect(send).toBeCalledTimes(1);
@@ -1370,7 +1371,7 @@ test('gotCallback, query got after add', () => {
     orderBy: [['id', 'asc']],
   };
 
-  const gotCalback1 = vi.fn<(got: boolean) => void>();
+  const gotCalback1 = vi.fn<(got: boolean | 'cached') => void>();
   const ttl = 'forever';
   queryManager.addLegacy(ast, ttl, gotCalback1);
   queryManager.flushBatch();
@@ -1438,7 +1439,7 @@ test('gotCallback, query got after add then removed', () => {
     orderBy: [['id', 'asc']],
   };
 
-  const gotCalback1 = vi.fn<(got: boolean) => void>();
+  const gotCalback1 = vi.fn<(got: boolean | 'cached') => void>();
   const ttl = 100;
   queryManager.addLegacy(ast, ttl, gotCalback1);
   queryManager.flushBatch();
@@ -1515,7 +1516,7 @@ test('gotCallback, query got after subscription removed', () => {
     orderBy: [['id', 'asc']],
   };
 
-  const gotCalback1 = vi.fn<(got: boolean) => void>();
+  const gotCalback1 = vi.fn<(got: boolean | 'cached') => void>();
   const ttl = 50;
   const remove = queryManager.addLegacy(ast, ttl, gotCalback1);
   queryManager.flushBatch();
@@ -1719,9 +1720,9 @@ describe('query transform errors', () => {
       onFatalErrorMock,
     );
 
-    const gotCallback1 = vi.fn<(got: boolean | Error) => void>();
-    const gotCallback2 = vi.fn<(got: boolean | Error) => void>();
-    const gotCallback1Dupe = vi.fn<(got: boolean | Error) => void>();
+    const gotCallback1 = vi.fn<(got: boolean | 'cached' | Error) => void>();
+    const gotCallback2 = vi.fn<(got: boolean | 'cached' | Error) => void>();
+    const gotCallback1Dupe = vi.fn<(got: boolean | 'cached' | Error) => void>();
 
     queryManager.addCustom(stubAst, nameAndArgs, 0, gotCallback1);
     // duplicate addition of same query
@@ -1729,7 +1730,9 @@ describe('query transform errors', () => {
     queryManager.addCustom(stubAst, nameAndArgs2, 0, gotCallback2);
     queryManager.flushBatch();
 
-    function checkInitialGots(cb: Mock<(got: boolean | Error) => void>) {
+    function checkInitialGots(
+      cb: Mock<(got: boolean | 'cached' | Error) => void>,
+    ) {
       expect(cb).toBeCalledTimes(1);
       expect(cb).toBeCalledWith(false);
     }
@@ -1749,7 +1752,9 @@ describe('query transform errors', () => {
     // set an error
     queryManager.handleTransformErrors([err]);
 
-    function checkFinalGots(cb: Mock<(got: boolean | Error) => void>) {
+    function checkFinalGots(
+      cb: Mock<(got: boolean | 'cached' | Error) => void>,
+    ) {
       expect(cb).toBeCalledTimes(2);
       expect(cb).nthCalledWith(2, false, err);
     }
@@ -1788,8 +1793,8 @@ describe('query transform errors', () => {
       onFatalErrorMock,
     );
 
-    const gotCallback1 = vi.fn<(got: boolean | Error) => void>();
-    const gotCallback2 = vi.fn<(got: boolean | Error) => void>();
+    const gotCallback1 = vi.fn<(got: boolean | 'cached' | Error) => void>();
+    const gotCallback2 = vi.fn<(got: boolean | 'cached' | Error) => void>();
 
     queryManager.addCustom(stubAst, nameAndArgs, 0, gotCallback1);
     queryManager.addCustom(stubAst, nameAndArgs2, 0, gotCallback2);
@@ -1952,7 +1957,7 @@ test('gotCallback, add same got callback twice', () => {
     orderBy: [['id', 'asc']],
   };
 
-  const gotCallback = vi.fn<(got: boolean) => void>();
+  const gotCallback = vi.fn<(got: boolean | 'cached') => void>();
   const rem1 = queryManager.addLegacy(ast, -1, gotCallback);
   queryManager.flushBatch();
   expect(gotCallback).toBeCalledTimes(1);
@@ -2455,7 +2460,7 @@ describe('gotCallback, persisted got is not trusted until authoritative', () => 
     const {queryManager} = setup();
 
     // In the persisted got set, but not yet authoritative -> reported not-got.
-    const gotCallback = vi.fn<(got: boolean) => void>();
+    const gotCallback = vi.fn<(got: boolean | 'cached') => void>();
     queryManager.addLegacy(ast, 200, gotCallback);
     expect(gotCallback).toBeCalledTimes(1);
     expect(gotCallback).nthCalledWith(1, false);
@@ -2469,7 +2474,7 @@ describe('gotCallback, persisted got is not trusted until authoritative', () => 
   test('query evicted before authoritative is never reported got (the race)', () => {
     const {queryManager, watchCallback} = setup();
 
-    const gotCallback = vi.fn<(got: boolean) => void>();
+    const gotCallback = vi.fn<(got: boolean | 'cached') => void>();
     queryManager.addLegacy(ast, 200, gotCallback);
     expect(gotCallback).nthCalledWith(1, false);
 
@@ -2508,7 +2513,7 @@ describe('gotCallback, persisted got is not trusted until authoritative', () => 
     // next connect reconciles it.
     queryManager.clearGotQueriesAuthoritative();
 
-    const gotCallback = vi.fn<(got: boolean) => void>();
+    const gotCallback = vi.fn<(got: boolean | 'cached') => void>();
     queryManager.addLegacy(ast, 200, gotCallback);
     expect(gotCallback).nthCalledWith(1, false);
 

--- a/packages/zero-client/src/client/query-manager.ts
+++ b/packages/zero-client/src/client/query-manager.ts
@@ -51,6 +51,8 @@ type Entry = {
   count: number;
   gotCallbacks: GotCallback[];
   ttl: TTL;
+  // Lazily computed `hashOfAST(normalized)`; see `#fingerprintOf`.
+  astFingerprint?: string | undefined;
 };
 
 type ClientMetric = {
@@ -78,6 +80,13 @@ export class QueryManager implements InspectorDelegate {
   readonly #recentQueriesMaxSize: number;
   readonly #recentQueries: Set<string> = new Set();
   readonly #gotQueries: Set<string> = new Set();
+  // The value each got-queries key was written with — the AST fingerprint of
+  // the registration that earned it (or null when unknown, e.g. keys written
+  // by an older client). A 'cached' claim requires the CURRENT registration's
+  // fingerprint to match, so a query-body edit under an unchanged name/args
+  // reads 'unknown' (safe) instead of vouching for rows a different body
+  // synced.
+  readonly #gotQueryValues: Map<string, ReadonlyJSONValue | null> = new Map();
   // Whether `#gotQueries` can be trusted. The persisted set loaded from
   // IndexedDB may be stale (a query 'got' in a previous session can be evicted
   // server-side); see `markGotQueriesAuthoritative`.
@@ -134,14 +143,26 @@ export class QueryManager implements InspectorDelegate {
         for (const diffOp of diff) {
           const queryHash = diffOp.key.substring(GOT_QUERIES_KEY_PREFIX.length);
           switch (diffOp.op) {
+            case 'change':
+              // A fingerprint refresh (see `gotFingerprintRefreshEntries`)
+              // rewrites the value of an existing got key.
+              this.#gotQueryValues.set(queryHash, diffOp.newValue ?? null);
+              break;
             case 'add':
               this.#gotQueries.add(queryHash);
+              this.#gotQueryValues.set(queryHash, diffOp.newValue ?? null);
               if (this.#gotQueriesAuthoritative) {
                 this.#fireGotCallbacks(queryHash, true);
+              } else {
+                const entry = this.#queries.get(queryHash);
+                if (entry && this.#hasCachedClaim(queryHash, entry)) {
+                  this.#fireGotCallbacks(queryHash, 'cached');
+                }
               }
               break;
             case 'del':
               this.#gotQueries.delete(queryHash);
+              this.#gotQueryValues.delete(queryHash);
               this.#fireGotCallbacks(queryHash, false);
               break;
           }
@@ -152,6 +173,61 @@ export class QueryManager implements InspectorDelegate {
         initialValuesInFirstDiff: true,
       },
     );
+  }
+
+  /**
+   * Lazily computed `hashOfAST` of the entry's (server-mapped) AST — eager
+   * hashing would put a full AST walk + stringify on every registration at
+   * cold start, paid before any consumer asked.
+   */
+  #fingerprintOf(entry: Entry): string {
+    return (entry.astFingerprint ??= hashOfAST(entry.normalized));
+  }
+
+  /**
+   * The one spelling of "the stored got value was earned by this entry's
+   * body" — both 'cached' fire sites and the refresh scan share it.
+   */
+  #hasCachedClaim(queryHash: string, entry: Entry): boolean {
+    return this.#gotQueryValues.get(queryHash) === this.#fingerprintOf(entry);
+  }
+
+  /**
+   * Fingerprint-refresh entries the poke handler appends to a poke it is
+   * about to apply. A registered query whose stored got value disagrees with
+   * its current body's fingerprint is refreshed to the current one — the
+   * server never re-sends a got put for an already-got hash, so without this
+   * a body-edit release would refuse the 'cached' claim on every subsequent
+   * boot, forever, for a never-evicted query. No authoritative gate: this
+   * only runs from `mergePokes`, i.e. while building a server poke, and
+   * APPLYING that poke is exactly what marks the session authoritative —
+   * gating on the flag (set only after apply) would make the refresh miss
+   * the first poke and land one poke late. The refresh rides the same
+   * transaction as the poke's own rows, so it commits iff the catch-up it
+   * vouches for commits.
+   */
+  gotFingerprintRefreshEntries(): {hash: string; value: string}[] {
+    const refresh: {hash: string; value: string}[] = [];
+    for (const [hash, entry] of this.#queries) {
+      if (!this.#gotQueries.has(hash)) {
+        continue;
+      }
+      if (!this.#hasCachedClaim(hash, entry)) {
+        refresh.push({hash, value: this.#fingerprintOf(entry)});
+      }
+    }
+    return refresh;
+  }
+
+  /**
+   * The current registration's AST fingerprint for a query hash, or null —
+   * the value the poke handler writes into the got-queries key so a later
+   * boot can tell whether the bit was earned by the SAME body it is about to
+   * vouch for.
+   */
+  astFingerprintForHash(queryID: string): string | null {
+    const entry = this.#queries.get(queryID);
+    return entry ? this.#fingerprintOf(entry) : null;
   }
 
   getAST(queryID: string): AST | undefined {
@@ -169,7 +245,7 @@ export class QueryManager implements InspectorDelegate {
     return mapAST(ast, this.#clientToServer);
   }
 
-  #fireGotCallbacks(queryHash: string, got: boolean) {
+  #fireGotCallbacks(queryHash: string, got: boolean | 'cached') {
     const gotCallbacks = this.#queries.get(queryHash)?.gotCallbacks ?? [];
     for (const gotCallback of gotCallbacks) {
       gotCallback(got);
@@ -387,9 +463,16 @@ export class QueryManager implements InspectorDelegate {
     }
 
     if (gotCallback) {
-      gotCallback(
-        this.#gotQueriesAuthoritative && this.#gotQueries.has(queryId),
-      );
+      if (
+        !this.#gotQueriesAuthoritative &&
+        this.#hasCachedClaim(queryId, entry)
+      ) {
+        gotCallback('cached');
+      } else {
+        gotCallback(
+          this.#gotQueriesAuthoritative && this.#gotQueries.has(queryId),
+        );
+      }
     }
 
     let removed = false;

--- a/packages/zero-client/src/client/zero-poke-handler.ts
+++ b/packages/zero-client/src/client/zero-poke-handler.ts
@@ -72,6 +72,8 @@ export class PokeHandler {
   readonly #schema: Schema;
   readonly #serverToClient: NameMapper;
   readonly #mutationTracker: MutationTracker;
+  readonly #gotValueForHash: GotValueForHash | undefined;
+  readonly #gotRefreshEntries: GotRefreshEntries | undefined;
 
   constructor(
     replicachePoke: (poke: PokeInternal) => Promise<void>,
@@ -80,7 +82,11 @@ export class PokeHandler {
     schema: Schema,
     lc: LogContext,
     mutationTracker: MutationTracker,
+    gotValueForHash?: GotValueForHash,
+    gotRefreshEntries?: GotRefreshEntries,
   ) {
+    this.#gotValueForHash = gotValueForHash;
+    this.#gotRefreshEntries = gotRefreshEntries;
     this.#replicachePoke = replicachePoke;
     this.#onPokeError = onPokeError;
     this.#clientID = clientID;
@@ -216,6 +222,8 @@ export class PokeHandler {
           this.#pokeBuffer,
           this.#schema,
           this.#serverToClient,
+          this.#gotValueForHash,
+          this.#gotRefreshEntries,
         );
         this.#pokeBuffer.length = 0;
         if (merged === undefined) {
@@ -286,13 +294,31 @@ function summarizePoke(
   return {lastMutationIDChangeForSelf, hasRows};
 }
 
+/**
+ * The current registration's AST fingerprint for a got-queries hash, or null
+ * when the query is not registered — the value written into the got-queries
+ * key so a later boot can tell whether the bit was earned by the SAME body it
+ * is about to vouch for.
+ */
+export type GotValueForHash = (hash: string) => string | null;
+
+/**
+ * Fingerprint-refresh entries to append to a poke being applied; see
+ * `QueryManager.gotFingerprintRefreshEntries`.
+ */
+export type GotRefreshEntries = () => {hash: string; value: string}[];
+
 export function mergePokes(
   pokeBuffer: PokeAccumulator[],
   schema: Schema,
   serverToClient: NameMapper,
+  gotValueForHash?: GotValueForHash,
+  gotRefreshEntries?: GotRefreshEntries,
 ):
   | (PokeInternal & {mutationResults?: MutationPatch[] | undefined})
   | undefined {
+  const deletedGotHashes = new Set<string>();
+  let sawGotClear = false;
   if (pokeBuffer.length === 0) {
     return undefined;
   }
@@ -341,6 +367,22 @@ export function mergePokes(
       }
       if (pokePart.gotQueriesPatch) {
         for (const op of pokePart.gotQueriesPatch) {
+          if (op.op === 'put') {
+            // The got key's value carries the registered body's AST
+            // fingerprint (null when unknown), so the 'cached' claim can
+            // require body identity, not just key existence.
+            mergedPatch.push({
+              op: 'put',
+              key: toGotQueriesKey(op.hash),
+              value: gotValueForHash?.(op.hash) ?? null,
+            });
+            continue;
+          }
+          if (op.op === 'del') {
+            deletedGotHashes.add(op.hash);
+          } else if (op.op === 'clear') {
+            sawGotClear = true;
+          }
           mergedPatch.push(
             queryPatchOpToReplicachePatchOp(op, toGotQueriesKey),
           );
@@ -365,6 +407,25 @@ export function mergePokes(
       }
     }
   }
+  // Converge stale body fingerprints inside a real poke transaction, so the
+  // value only ever changes with the same atomicity the bit itself has. Never
+  // for a hash THIS merged poke deletes or clears — the entries were computed
+  // from pre-poke state, and a refresh put appended after the del would
+  // reinsert the bit while the rows delete, the exact torn state the design
+  // forbids.
+  if (gotRefreshEntries && !sawGotClear) {
+    for (const entry of gotRefreshEntries()) {
+      if (deletedGotHashes.has(entry.hash)) {
+        continue;
+      }
+      mergedPatch.push({
+        op: 'put',
+        key: toGotQueriesKey(entry.hash),
+        value: entry.value,
+      });
+    }
+  }
+
   const ret: PokeInternal & {mutationResults?: MutationPatch[] | undefined} = {
     baseCookie,
     pullResponse: {

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -75,6 +75,7 @@ import type {
 } from '../../../zero-protocol/src/pull.ts';
 import type {PushMessage} from '../../../zero-protocol/src/push.ts';
 import type {UpQueriesPatchOp} from '../../../zero-protocol/src/queries-patch.ts';
+import {hashOfNameAndArgs} from '../../../zero-protocol/src/query-hash.ts';
 import type {Upstream} from '../../../zero-protocol/src/up.ts';
 import type {NullableVersion} from '../../../zero-protocol/src/version.ts';
 import {nullableVersionSchema} from '../../../zero-protocol/src/version.ts';
@@ -158,6 +159,7 @@ import {
 } from './http-string.ts';
 import {Inspector} from './inspector/inspector.ts';
 import {IVMSourceBranch} from './ivm-branch.ts';
+import {toGotQueriesKey} from './keys.ts';
 import {type LogOptions, createLogOptions} from './log-options.ts';
 import type {MakeMutatePropertyType} from './make-mutate-property.ts';
 import {addCustomMutatorsProperties} from './make-mutate-property.ts';
@@ -864,6 +866,8 @@ export class Zero<
       schema,
       this.#lc,
       this.#mutationTracker,
+      hash => this.#queryManager.astFingerprintForHash(hash),
+      () => this.#queryManager.gotFingerprintRefreshEntries(),
     );
 
     this.#visibilityWatcher = getDocumentVisibilityWatcher(
@@ -978,6 +982,32 @@ export class Zero<
       }
     }
     return createLogOptions(options);
+  }
+
+  /**
+   * Reports whether the store CURRENTLY holds the server-confirmed complete
+   * result of the named query (name + args) on this client group — i.e.
+   * whether the persisted got-queries key exists. Readable at construction,
+   * before any connection. Eviction (deregistration + TTL expiry),
+   * client-group reset, and resync delete the key, reverting the answer to
+   * false — the "never asked" reading, which is the safe direction. The key
+   * and its rows only change together inside applied-poke transactions, and
+   * eviction deletes them together, so a `true` never vouches for torn local
+   * data.
+   *
+   * Materialized views surface the same fact natively — and STRONGER: a view
+   * additionally verifies the stored body fingerprint, so after a query-body
+   * edit this existence read can be true while views correctly hold at
+   * 'unknown'. Gate rendering on the view's resultType; use this for boot
+   * probes and diagnostics.
+   */
+  hasCachedResult(
+    name: string,
+    args: readonly ReadonlyJSONValue[],
+  ): Promise<boolean> {
+    return this.#rep.query(tx =>
+      tx.has(toGotQueriesKey(hashOfNameAndArgs(name, args))),
+    );
   }
 
   /**

--- a/packages/zero-client/src/types/query-result.ts
+++ b/packages/zero-client/src/types/query-result.ts
@@ -8,6 +8,9 @@ export type QueryResultDetails =
       readonly type: 'unknown';
     }
   | {
+      readonly type: 'cached';
+    }
+  | {
       readonly type: 'error';
       readonly retry: () => void;
       /** @deprecated Use `retry` instead */

--- a/packages/zero-react/src/use-query.test.tsx
+++ b/packages/zero-react/src/use-query.test.tsx
@@ -531,6 +531,92 @@ describe('ViewStore', () => {
       cleanup();
     });
   });
+
+  describe('cached result type', () => {
+    test('plural: empty cached snapshots are shared and stable', () => {
+      const viewStore = new ViewStore();
+      const q = newMockQuery('query1');
+      const zero = newMockZero('client1');
+      const view = viewStore.getView(zero, q, true, 'forever');
+
+      const {listeners} = vi.mocked(zero.materialize).mock.results[0]
+        .value as unknown as {
+        listeners: Set<(...args: unknown[]) => void>;
+      };
+
+      const cleanup = view.subscribeReactInternals(() => {});
+
+      listeners.forEach(cb => cb([], 'cached'));
+      const snapshot1 = view.getSnapshot();
+      expect(snapshot1).toEqual([[], {type: 'cached'}]);
+
+      listeners.forEach(cb => cb([], 'cached'));
+      const snapshot2 = view.getSnapshot();
+      expect(snapshot1).toBe(snapshot2);
+
+      listeners.forEach(cb => cb([{a: 1}], 'cached'));
+      expect(view.getSnapshot()).toEqual([[{a: 1}], {type: 'cached'}]);
+
+      listeners.forEach(cb => cb([{a: 1}], 'complete'));
+      expect(view.getSnapshot()).toEqual([[{a: 1}], {type: 'complete'}]);
+
+      cleanup();
+    });
+
+    test('singular: empty cached snapshots are shared and stable', () => {
+      const viewStore = new ViewStore();
+      const q = newMockQuery('query1', true);
+      const zero = newMockZero('client1');
+      const view = viewStore.getView(zero, q, true, 'forever');
+
+      const {listeners} = vi.mocked(zero.materialize).mock.results[0]
+        .value as unknown as {
+        listeners: Set<(...args: unknown[]) => void>;
+      };
+
+      const cleanup = view.subscribeReactInternals(() => {});
+
+      listeners.forEach(cb => cb(undefined, 'cached'));
+      const snapshot1 = view.getSnapshot();
+      expect(snapshot1).toEqual([undefined, {type: 'cached'}]);
+
+      listeners.forEach(cb => cb(undefined, 'cached'));
+      const snapshot2 = view.getSnapshot();
+      expect(snapshot1).toBe(snapshot2);
+
+      listeners.forEach(cb => cb({a: 1}, 'cached'));
+      expect(view.getSnapshot()).toEqual([{a: 1}, {type: 'cached'}]);
+
+      listeners.forEach(cb => cb({a: 1}, 'complete'));
+      expect(view.getSnapshot()).toEqual([{a: 1}, {type: 'complete'}]);
+
+      cleanup();
+    });
+
+    test('cached does not satisfy complete-waiters', () => {
+      const viewStore = new ViewStore();
+      const q = newMockQuery('query1');
+      const zero = newMockZero('client1');
+      const view = viewStore.getView(zero, q, true, 'forever');
+
+      const {listeners} = vi.mocked(zero.materialize).mock.results[0]
+        .value as unknown as {
+        listeners: Set<(...args: unknown[]) => void>;
+      };
+
+      const cleanup = view.subscribeReactInternals(() => {});
+
+      listeners.forEach(cb => cb([{a: 1}], 'cached'));
+      // 'cached' is last session's server-confirmed answer; only a
+      // confirmation on THIS connection may report complete.
+      expect(view.complete).toBe(false);
+
+      listeners.forEach(cb => cb([{a: 1}], 'complete'));
+      expect(view.complete).toBe(true);
+
+      cleanup();
+    });
+  });
 });
 
 describe('useSuspenseQuery', () => {

--- a/packages/zero-react/src/use-query.tsx
+++ b/packages/zero-react/src/use-query.tsx
@@ -246,6 +246,7 @@ const emptyArray: unknown[] = [];
 const disabledSubscriber = () => () => {};
 
 const resultTypeUnknown = {type: 'unknown'} as const;
+const resultTypeCached = {type: 'cached'} as const;
 const resultTypeComplete = {type: 'complete'} as const;
 const resultTypeError = {type: 'error'} as const;
 
@@ -253,9 +254,11 @@ const disabledQuerySnapshot = [undefined, resultTypeUnknown] as const;
 const getDisabledSnapshot = () => disabledQuerySnapshot;
 
 const emptySnapshotSingularUnknown = [undefined, resultTypeUnknown] as const;
+const emptySnapshotSingularCached = [undefined, resultTypeCached] as const;
 const emptySnapshotSingularComplete = [undefined, resultTypeComplete] as const;
 const emptySnapshotSingularErrorUnknown = [undefined, resultTypeError] as const;
 const emptySnapshotPluralUnknown = [emptyArray, resultTypeUnknown] as const;
+const emptySnapshotPluralCached = [emptyArray, resultTypeCached] as const;
 const emptySnapshotPluralComplete = [emptyArray, resultTypeComplete] as const;
 const emptySnapshotErrorUnknown = [emptyArray, resultTypeError] as const;
 
@@ -290,6 +293,8 @@ function getSnapshot<TReturn>(
         return emptySnapshotSingularComplete as unknown as QueryResult<TReturn>;
       case 'unknown':
         return emptySnapshotSingularUnknown as unknown as QueryResult<TReturn>;
+      case 'cached':
+        return emptySnapshotSingularCached as unknown as QueryResult<TReturn>;
     }
   }
 
@@ -307,6 +312,8 @@ function getSnapshot<TReturn>(
         return emptySnapshotPluralComplete as unknown as QueryResult<TReturn>;
       case 'unknown':
         return emptySnapshotPluralUnknown as unknown as QueryResult<TReturn>;
+      case 'cached':
+        return emptySnapshotPluralCached as unknown as QueryResult<TReturn>;
     }
   }
 
@@ -328,6 +335,8 @@ function getSnapshot<TReturn>(
       return [data, resultTypeComplete];
     case 'unknown':
       return [data, resultTypeUnknown];
+    case 'cached':
+      return [data, resultTypeCached];
   }
 }
 

--- a/packages/zql/src/ivm/array-view.ts
+++ b/packages/zql/src/ivm/array-view.ts
@@ -185,4 +185,28 @@ export class ArrayView<V extends View> implements Output, TypedView<V> {
   updateTTL(ttl: TTL) {
     this.#updateTTL(ttl);
   }
+
+  /**
+   * The store holds the server-confirmed complete result of this query from a
+   * previous sync (the persisted got-queries key exists, pre-authoritative).
+   * Never downgrades 'complete'/'error', and never resolves anything that
+   * waits on 'complete' — freshness stays a promise only the connection can
+   * keep.
+   */
+  markCached(): void {
+    if (this.#resultType !== 'unknown') {
+      return;
+    }
+    this.#resultType = 'cached';
+    this.#fireListeners();
+  }
+
+  /** The got key was deleted (eviction) while still pre-authoritative. */
+  unmarkCached(): void {
+    if (this.#resultType !== 'cached') {
+      return;
+    }
+    this.#resultType = 'unknown';
+    this.#fireListeners();
+  }
 }

--- a/packages/zql/src/query/query-delegate-base.ts
+++ b/packages/zql/src/query/query-delegate-base.ts
@@ -306,7 +306,9 @@ export function preloadImpl<
   const {customQueryID, ast} = qi;
   if (customQueryID) {
     const cleanup = delegate.addCustomQuery(ast, customQueryID, ttl, got => {
-      if (got) {
+      // 'cached' never satisfies complete-waiters; only a server confirmation
+      // on this connection resolves `complete`.
+      if (got === true) {
         resolve();
       }
     });
@@ -317,7 +319,7 @@ export function preloadImpl<
   }
 
   const cleanup = delegate.addServerQuery(ast, ttl, got => {
-    if (got) {
+    if (got === true) {
       resolve();
     }
   });
@@ -366,6 +368,23 @@ export function materializeImpl<
       return;
     }
 
+    if (got === 'cached') {
+      // The registration path fires this SYNCHRONOUSLY when the got set is
+      // already loaded (a view materialized mid-session), before the view
+      // below exists — buffer it, and apply it right after construction.
+      if (viewForCached === undefined) {
+        isCachedPending = true;
+      } else {
+        viewForCached.markCached?.();
+      }
+      return;
+    }
+    if (got === false) {
+      isCachedPending = false;
+      viewForCached?.unmarkCached?.();
+      return;
+    }
+
     if (got) {
       if (!endToEndMetricRecorded) {
         delegate.addMetric(
@@ -382,6 +401,11 @@ export function materializeImpl<
   };
 
   let removeCommitObserver: (() => void) | undefined;
+  // The view, seen as the optional cached-marking surface. Only views that
+  // implement `markCached`/`unmarkCached` (e.g. ArrayView) surface 'cached';
+  // for any other factory the optional calls are no-ops.
+  let viewForCached: CachedMarkableView | undefined;
+  let isCachedPending = false;
   const onDestroy = () => {
     input.destroy();
     removeCommitObserver?.();
@@ -416,8 +440,23 @@ export function materializeImpl<
     queryID,
   );
 
+  viewForCached = view as CachedMarkableView;
+  if (isCachedPending) {
+    isCachedPending = false;
+    viewForCached.markCached?.();
+  }
+
   return view as T;
 }
+
+/**
+ * The optional surface a view exposes to be marked 'cached'. Views that do
+ * not implement it (custom factories) simply never surface the state.
+ */
+type CachedMarkableView = {
+  markCached?: (() => void) | undefined;
+  unmarkCached?: (() => void) | undefined;
+};
 
 function arrayViewFactory<
   TTable extends string,

--- a/packages/zql/src/query/query-delegate.ts
+++ b/packages/zql/src/query/query-delegate.ts
@@ -16,7 +16,20 @@ import type {TTL} from './ttl.ts';
 import type {TypedView} from './typed-view.ts';
 
 export type CommitListener = () => void;
-export type GotCallback = (got: boolean, error?: ErroredQuery) => void;
+/**
+ * `got` reports what the client knows about the query's server result:
+ * - `true`: the server confirmed the complete result on this connection.
+ * - `false`: the result is not (or no longer) known to be complete.
+ * - `'cached'`: the store holds the server-confirmed complete result from a
+ *   previous sync (the persisted got-queries key exists, pre-authoritative,
+ *   and its stored AST fingerprint matches the current registration's body).
+ *   Never satisfies complete-waiters — freshness stays a promise only the
+ *   connection can keep.
+ */
+export type GotCallback = (
+  got: boolean | 'cached',
+  error?: ErroredQuery,
+) => void;
 
 export interface NewQueryDelegate {
   newQuery<

--- a/packages/zql/src/query/typed-view.ts
+++ b/packages/zql/src/query/typed-view.ts
@@ -2,7 +2,7 @@ import type {Immutable} from '../../../shared/src/immutable.ts';
 import type {ErroredQuery} from '../../../zero-protocol/src/custom-queries.ts';
 import type {TTL} from './ttl.ts';
 
-export type ResultType = 'unknown' | 'complete' | 'error';
+export type ResultType = 'unknown' | 'cached' | 'complete' | 'error';
 
 /**
  * Called when the view changes. The received data should be considered


### PR DESCRIPTION
## Summary

This PR adds a fourth `ResultType`, `'cached'`: a materialized view whose complete result the local store already holds from a previous sync boots at `'cached'` instead of `'unknown'`, and graduates to `'complete'` on the first applied poke. We have been running this in production (React Native + expo-sqlite store, and web) as a patch on `@rocicorp/zero@1.9.0` across our whole app, and are upstreaming it now that it has survived a full consumer migration plus on-device verification.

## Motivation

With a persistent kvStore, the replica routinely holds the *complete* result of last session's queries at construction time — but a freshly materialized view can only say `'unknown'`, which is indistinguishable from "partially hydrated replica". Application code that needs trustworthy data (empty states, entitlement gates, client-side derivations) must therefore wait for the first poke on every single app open.

That wait is not just flicker. Measured on device (mid-range Android, production backend): Zero's socket does not survive app backgrounding (AbruptClose ~20s after home-press), so **every reopen pays a fresh connect** — 132/169ms time-to-first-poke on a good network, 1124/1129ms on post-background resume, worse on typical LTE. `'cached'` lets the app paint real content instantly on every warm or offline boot and treat it as settled, while still knowing the server has not yet spoken on this connection.

A second motivation is client-side derivations: ZQL has no aggregates, so count-like UI (badges, stats) is derived in app code from full result sets. That derivation is only sound when the set is known complete. `'unknown'` cannot make that claim; `'cached'` can ("the full set as of last sync"), which extends soundness to boot time.

## Semantics

| resultType | claim | may render as settled? | satisfies complete-waiters (`preload().complete`, `run({type:'complete'})`)? |
|---|---|---|---|
| `'unknown'` | No claim; the replica may be partially hydrated. | app's choice (loading) | no |
| `'cached'` | The store holds the server-confirmed **complete** result of this exact query body from a previous sync. | yes (app's choice) | **no** |
| `'complete'` | The server confirmed the result **on this connection**. | yes | yes |
| `'error'` | The query errored. | error state | rejects |

Transitions: `'cached'` is only ever entered from `'unknown'` (pre-authoritative), never downgrades `'complete'`/`'error'`, graduates to `'complete'` when `markGotQueriesAuthoritative()` fires after the first applied poke, and reverts to `'unknown'` if the got key is deleted (eviction) while still pre-authoritative. Freshness stays a promise only the connection can keep: nothing that waits on `'complete'` resolves at `'cached'`.

## Mechanism

- **The got-queries key's value carries the registered body's AST fingerprint** (`hashOfAST` of the server-mapped normalized AST; `null` when unknown, e.g. keys written by an older client). A `'cached'` claim requires the *current* registration's fingerprint to match the stored value, so a query-body edit under an unchanged name/args reads `'unknown'` (the safe direction) instead of vouching for rows a different body synced. The fingerprint is computed lazily per entry, so cold-start registration pays no extra AST walk unless asked.
- **Stale fingerprints converge via refresh puts appended to the first applied poke.** The server never re-sends a got put for an already-got hash, so without this a body-edit release would refuse the cached claim on every subsequent boot, forever, for a never-evicted query. The refresh entries are computed while merging (`mergePokes`) and ride the same transaction as the poke's own rows — they commit iff the catch-up they vouch for commits. There is deliberately no authoritative gate on the refresh: applying that very poke is what marks the session authoritative, and gating on the flag would make the refresh land one poke late.
- **Torn-state rule:** a refresh put is never emitted for a hash the same merged poke deletes or clears — the entries were computed from pre-poke state, and a put appended after the del would reinsert the bit while the rows delete.
- **`Zero.hasCachedResult(name, args)`** exposes the bare existence read of the persisted got key (usable at construction, before any connection) for boot probes and diagnostics. The view surface is strictly stronger — it additionally verifies the body fingerprint — so rendering should gate on the view's resultType.
- **View plumbing:** `ArrayView` gains `markCached()`/`unmarkCached()`; `materializeImpl` buffers a synchronous cached signal that fires during registration (before the view exists) and applies it right after construction. Custom view factories that do not implement the optional methods simply never surface the state — `zero-solid` is untouched and its suite passes as-is.

One operational observation worth recording: a short-TTL per-view query (our `workById`) can age out of the CVR while the app is closed. The store still holds its got key, so on reboot the view briefly boots `'cached'`, and the connection's own catch-up poke delivers the `del` that reverts it — the "desire aged out while offline" shape. That is exactly the merge where a got del and a refresh put can coexist, which is why the torn-state rule above exists and is exercised in our integration harness.

## Evidence

All suites in this repo, at `zero/v1.9.0`:

- `zql`: 1302 passed
- `zero-client`: 647 passed
- `zero-react`: 77 passed (74 existing + 3 new `'cached'` snapshot/waiter tests added here)
- `zero-solid`: 59 passed (no changes needed)
- `replicache`: 798 passed (typecheck included)

`check-types` clean on every touched package; `oxfmt --check` clean; `oxlint --type-aware` 0 errors.

Downstream, in our app: a six-scenario integration harness driving a real v51 fake sync server (born-cached boot, graduation on first poke, body-edit fingerprint mismatch, fingerprint refresh convergence with the masking heartbeat removed, eviction-while-offline staging the got del inside the catch-up poke, and complete-waiter pinning) passes against this exact logic, and all three device arms were verified on Android against production: fresh sign-in boots false/`'unknown'`, warm boot and airplane-mode boot both paint real content at `'cached'` with no loading state.

## Design notes for upstream (where you may want to go further than this PR does)

1. **Server-supplied body fingerprint.** This PR stamps the fingerprint client-side while applying the poke, from the current registration's AST. That is internally consistent, but the server is the natural authority: if the `gotQueriesPatch` put carried the query's fingerprint (e.g. the transformation hash for custom queries), the stored value would be authoritative rather than inferred, and server-side changes to a custom query's transformation would invalidate cached claims without any client involvement.
2. **Born-cached as a view-factory parameter.** The port reaches views through optional `markCached()`/`unmarkCached()` methods after construction, because `ViewFactory` only communicates `queryComplete: true | ErroredQuery | Promise<true>`. A first-class initial-result-state parameter (e.g. `queryComplete: true | 'cached' | ErroredQuery | Promise<true>`) would let every view implementation (solid included) surface the state natively instead of via the optional-method retrofit, at the cost of touching the factory signature.

Related footgun we hit while adopting this (not changed by this PR): `DEFAULT_PRELOAD_TTL` is `'none'` while materialize's default is `5m`. For an app leaning on preload precisely to have data cached for the *next* boot, a defaulted preload's desire expires as soon as it is released — deleting the got key and with it the cached claim — which is the opposite of what "preload" suggests. Worth considering alongside this feature.

Happy to adjust semantics, naming (`'cached'` vs alternatives), or split the `hasCachedResult` accessor out if you'd rather take the view-level state alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
