### PR TITLE
feat(zero-cache): Default CVR garbage collection threshold to 1 week

### DIFF
--- a/packages/zero-cache/src/config/zero-config.test.ts
+++ b/packages/zero-cache/src/config/zero-config.test.ts
@@ -238,9 +238,12 @@ test('zero-cache --help', () => {
                                                                                    Note that this number must allow for at least one connection per                                                           
                                                                                    sync worker, or zero-cache will fail to start. See num-sync-workers                                                        
                                                                                                                                                                                                               
-     --cvr-garbage-collection-inactivity-threshold-hours number                    default: 48                                                                                                                
+     --cvr-garbage-collection-inactivity-threshold-hours number                    default: 168                                                                                                               
        ZERO_CVR_GARBAGE_COLLECTION_INACTIVITY_THRESHOLD_HOURS env                                                                                                                                             
                                                                                    The duration after which an inactive CVR is eligible for garbage collection.                                               
+                                                                                   Purging a CVR forces the next connection from that client group to                                                         
+                                                                                   re-sync from scratch, so this should comfortably exceed how long a                                                         
+                                                                                   typical user goes between sessions.                                                                                        
                                                                                    Note that garbage collection is an incremental, periodic process which does not                                            
                                                                                    necessarily purge all eligible CVRs immediately.                                                                           
                                                                                                                                                                                                               

--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -477,9 +477,12 @@ export const zeroOptions = {
     },
 
     garbageCollectionInactivityThresholdHours: {
-      type: v.number().default(48),
+      type: v.number().default(24 * 7),
       desc: [
         `The duration after which an inactive CVR is eligible for garbage collection.`,
+        `Purging a CVR forces the next connection from that client group to`,
+        `re-sync from scratch, so this should comfortably exceed how long a`,
+        `typical user goes between sessions.`,
         `Note that garbage collection is an incremental, periodic process which does not`,
         `necessarily purge all eligible CVRs immediately.`,
       ],


### PR DESCRIPTION
Raises `--cvr-garbage-collection-inactivity-threshold-hours` (`ZERO_CVR_GARBAGE_COLLECTION_INACTIVITY_THRESHOLD_HOURS`) from 48 to 168 (`24 * 7`).

## Why

Purging a CVR disables the client group, so the next connection from that client re-downloads everything (`ClientStateNotFound` → local store dropped → full cold sync). At 48h, any app whose users come back weekly rather than daily pays that cold start on most sessions. This came up with a customer whose per-user dataset is large enough that the cold path is very visible.

The short lifetime dates from a period when this machinery was less stable; `deleteClient` and the purger have been reliable for a while now. Queries are not run for disconnected clients, so a longer retention costs CVR database storage, not compute.

## Changes

- `packages/zero-cache/src/config/zero-config.ts`: default `48` → `24 * 7`, plus a note in the option description about what a purge costs the client.
- `packages/zero-cache/src/config/zero-config.test.ts`: `--help` snapshot updated.

Cloud Zero will additionally expose this per stack as an advanced setting (separate PR in `rocicorp/cloudzero`).
