### PR TITLE
fix(zero-client): carry the connect abort reason on the attempt, not …

### DIFF
--- a/packages/zero-client/src/client/zero.test.ts
+++ b/packages/zero-client/src/client/zero.test.ts
@@ -2955,6 +2955,55 @@ test('slow setup does not spend the server acknowledgement budget', async () => 
   expect(z.connectionStatus).toBe(ConnectionStatus.Connected);
 });
 
+test('connect timeout retries when AbortController drops abort reasons', async () => {
+  // React Native's bundled `abort-controller@3` polyfill predates the 2021
+  // `signal.reason` spec addition: `abort(reason)` silently discards the
+  // reason and `signal.reason` reads `undefined`. The run loop used to read
+  // the abort reason exclusively off the signal, so on such runtimes every
+  // retryable connect failure surfaced as `undefined`, was wrapped as a
+  // non-retryable internal error, and permanently paused the run loop.
+  // The polyfill leaves `signal.reason` undefined; a spec `abort()` with no
+  // argument leaves a generic AbortError. Either way the typed retryable
+  // error passed to `abort(reason)` is lost, which is the mechanism under
+  // test. Subclassing keeps `signal` a real AbortSignal so DOM listeners
+  // that take `{signal}` still work.
+  class LegacyAbortController extends AbortController {
+    override abort(): void {
+      super.abort();
+    }
+  }
+  vi.stubGlobal('AbortController', LegacyAbortController);
+
+  try {
+    const z = zeroForTest({logLevel: 'debug'});
+    await z.waitForConnectionStatus(ConnectionStatus.Connecting);
+    const firstSocket = await z.socket;
+    for (let i = 0; i < 10; i++) {
+      await vi.advanceTimersByTimeAsync(0);
+    }
+
+    // Time out the first connect attempt.
+    await vi.advanceTimersByTimeAsync(CONNECT_TIMEOUT_MS);
+    expectLogMessages(z).contain(connectTimeoutMessage);
+
+    // The timeout is retryable: the run loop must schedule another attempt
+    // rather than pausing in the error state.
+    expect(z.connectionStatus).toBe(ConnectionStatus.Connecting);
+    const nextSocketPromise = z.socket;
+    await vi.advanceTimersByTimeAsync(RUN_LOOP_INTERVAL_MS);
+    for (let i = 0; i < 10; i++) {
+      await vi.advanceTimersByTimeAsync(0);
+    }
+    expect(await nextSocketPromise).not.equal(firstSocket);
+
+    // And the retried attempt can then succeed.
+    await z.triggerConnected();
+    await z.waitForConnectionStatus(ConnectionStatus.Connected);
+  } finally {
+    vi.unstubAllGlobals();
+  }
+});
+
 test('connect timeout during setup retries without an unhandled rejection', async () => {
   const unhandledRejections: PromiseRejectionEvent[] = [];
   const onUnhandled = (event: PromiseRejectionEvent) => {

--- a/packages/zero-client/src/client/zero.test.ts
+++ b/packages/zero-client/src/client/zero.test.ts
@@ -2875,6 +2875,55 @@ test('slow setup does not spend the server acknowledgement budget', async () => 
   expect(z.connectionStatus).toBe(ConnectionStatus.Connected);
 });
 
+test('connect timeout retries when AbortController drops abort reasons', async () => {
+  // React Native's bundled `abort-controller@3` polyfill predates the 2021
+  // `signal.reason` spec addition: `abort(reason)` silently discards the
+  // reason and `signal.reason` reads `undefined`. The run loop used to read
+  // the abort reason exclusively off the signal, so on such runtimes every
+  // retryable connect failure surfaced as `undefined`, was wrapped as a
+  // non-retryable internal error, and permanently paused the run loop.
+  // The polyfill leaves `signal.reason` undefined; a spec `abort()` with no
+  // argument leaves a generic AbortError. Either way the typed retryable
+  // error passed to `abort(reason)` is lost, which is the mechanism under
+  // test. Subclassing keeps `signal` a real AbortSignal so DOM listeners
+  // that take `{signal}` still work.
+  class LegacyAbortController extends AbortController {
+    override abort(): void {
+      super.abort();
+    }
+  }
+  vi.stubGlobal('AbortController', LegacyAbortController);
+
+  try {
+    const z = zeroForTest({logLevel: 'debug'});
+    await z.waitForConnectionStatus(ConnectionStatus.Connecting);
+    const firstSocket = await z.socket;
+    for (let i = 0; i < 10; i++) {
+      await vi.advanceTimersByTimeAsync(0);
+    }
+
+    // Time out the first connect attempt.
+    await vi.advanceTimersByTimeAsync(CONNECT_TIMEOUT_MS);
+    expectLogMessages(z).contain(connectTimeoutMessage);
+
+    // The timeout is retryable: the run loop must schedule another attempt
+    // rather than pausing in the error state.
+    expect(z.connectionStatus).toBe(ConnectionStatus.Connecting);
+    const nextSocketPromise = z.socket;
+    await vi.advanceTimersByTimeAsync(RUN_LOOP_INTERVAL_MS);
+    for (let i = 0; i < 10; i++) {
+      await vi.advanceTimersByTimeAsync(0);
+    }
+    expect(await nextSocketPromise).not.equal(firstSocket);
+
+    // And the retried attempt can then succeed.
+    await z.triggerConnected();
+    await z.waitForConnectionStatus(ConnectionStatus.Connected);
+  } finally {
+    vi.unstubAllGlobals();
+  }
+});
+
 test('connect timeout during setup retries without an unhandled rejection', async () => {
   const unhandledRejections: PromiseRejectionEvent[] = [];
   const onUnhandled = (event: PromiseRejectionEvent) => {

--- a/packages/zero-client/src/client/zero.test.ts
+++ b/packages/zero-client/src/client/zero.test.ts
@@ -2924,6 +2924,37 @@ test('connect timeout retries when AbortController drops abort reasons', async (
   }
 });
 
+test('slow setup does not spend the server acknowledgement budget', async () => {
+  // Setup that finishes just inside its own deadline. Before the deadlines
+  // were split this left the server almost no time, and a healthy server was
+  // reported as unreachable.
+  const realCreate = ActiveClientsManager.create;
+  vi.spyOn(ActiveClientsManager, 'create').mockImplementation(
+    async (...args: Parameters<typeof ActiveClientsManager.create>) => {
+      await sleep(CONNECT_TIMEOUT_MS - 1_000);
+      return realCreate(...args);
+    },
+  );
+
+  const z = zeroForTest();
+  await z.waitForConnectionStatus(ConnectionStatus.Connecting);
+
+  // Wait out the slow setup.
+  await vi.advanceTimersByTimeAsync(CONNECT_TIMEOUT_MS - 1_000);
+  await tickAFewTimes(vi);
+  expect(z.connectionStatus).toBe(ConnectionStatus.Connecting);
+
+  // The old single budget would have expired 1s from here. The server gets a
+  // full budget of its own instead.
+  await vi.advanceTimersByTimeAsync(CONNECT_TIMEOUT_MS - 1_000);
+  await tickAFewTimes(vi);
+  expect(connectTimeoutErrors(z)).toEqual([]);
+  expect(z.connectionStatus).toBe(ConnectionStatus.Connecting);
+
+  await z.triggerConnected();
+  expect(z.connectionStatus).toBe(ConnectionStatus.Connected);
+});
+
 test('connect timeout during setup retries without an unhandled rejection', async () => {
   const unhandledRejections: PromiseRejectionEvent[] = [];
   const onUnhandled = (event: PromiseRejectionEvent) => {

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -224,6 +224,18 @@ type ConnectAttemptControl = {
    * attempt stops setting up locally and starts waiting for the server.
    */
   clearTimeout?: (() => void) | undefined;
+
+  /**
+   * The error this attempt was aborted with. Read this instead of
+   * `controller.signal.reason`: on runtimes whose `AbortController` predates
+   * the 2021 `signal.reason` spec addition (e.g. React Native's bundled
+   * `abort-controller@3` polyfill), `abort(reason)` silently discards the
+   * reason and `signal.reason` reads `undefined` — the run loop then wraps
+   * that `undefined` as a non-retryable internal error, so every retryable
+   * connect failure (e.g. `ConnectTimeout`) permanently pauses the run loop
+   * instead of retrying.
+   */
+  abortReason?: ZeroError | undefined;
 };
 
 function connectionReadyResolver(): Resolver<void> {
@@ -1780,7 +1792,7 @@ export class Zero<
     // The run loop has already stopped waiting for this attempt if it was
     // canceled. Do not let setup that completed late create a socket.
     if (signal.aborted) {
-      throw signal.reason;
+      throw attempt.abortReason ?? signal.reason;
     }
 
     const [ws, initConnectionQueries, deletedClients] = await createSocket(
@@ -1813,7 +1825,7 @@ export class Zero<
     // still belongs to this attempt and must be closed.
     if (signal.aborted) {
       ws.close();
-      throw signal.reason;
+      throw attempt.abortReason ?? signal.reason;
     }
 
     if (this.closed) {
@@ -1842,7 +1854,7 @@ export class Zero<
     attempt.clearTimeout = this.#armConnectTimeout(lc, attempt, 'ack');
     await attempt.connected.promise;
     if (signal.aborted) {
-      throw signal.reason;
+      throw attempt.abortReason ?? signal.reason;
     }
     this.#mutationTracker.onConnected(this.#lastMutationIDReceived);
     // push any outstanding mutations on reconnect.
@@ -1912,7 +1924,14 @@ export class Zero<
   }
 
   #disconnect(lc: LogContext, reason: ZeroError, closeCode?: CloseCode): void {
-    this.#currentConnectAttempt?.controller.abort(reason);
+    const attempt = this.#currentConnectAttempt;
+    if (attempt) {
+      // Recorded on the attempt as well as passed to abort() — see
+      // ConnectAttemptControl.abortReason for why signal.reason alone is not
+      // sufficient on every runtime.
+      attempt.abortReason = reason;
+      attempt.controller.abort(reason);
+    }
 
     if (shouldReportConnectError(reason)) {
       this.#connectErrorCount++;
@@ -2237,7 +2256,9 @@ export class Zero<
             );
             const canceled = resolver<never>();
             const abortHandler = () =>
-              canceled.reject(attempt.controller.signal.reason);
+              canceled.reject(
+                attempt.abortReason ?? attempt.controller.signal.reason,
+              );
             attempt.controller.signal.addEventListener('abort', abortHandler, {
               once: true,
             });

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -219,6 +219,7 @@ type ConnectAttemptControl = {
   readonly controller: AbortController;
   readonly connected: Resolver<void>;
   readonly events: [date: Date, event: string][];
+
   /**
    * Cancels whichever phase deadline is currently running. Swapped when the
    * attempt stops setting up locally and starts waiting for the server.


### PR DESCRIPTION
…only signal.reason

On runtimes whose AbortController predates the 2021 signal.reason spec addition — React Native's bundled abort-controller@3 polyfill being the big one — abort(reason) silently discards the reason and signal.reason reads undefined. The connection run loop reads the abort reason exclusively off the signal, so on those runtimes every retryable connect failure (ConnectTimeout included) surfaces as undefined, gets wrapped as a non-retryable internal ClientError, and permanently pauses the run loop in the error state. Zero's own retry/backoff never runs.

Record the reason on the ConnectAttemptControl in #disconnect and prefer it at the four read sites, falling back to signal.reason. Behavior on spec-compliant platforms is unchanged.

Regression test stubs an AbortController whose abort() drops the reason argument and asserts a connect timeout still retries instead of pausing: red on the previous code ('error' where 'connecting' was expected), green with the fix.