### PR TITLE
chore(zero): bump litestream v5 to 0.5.18-zero.2

### DIFF
--- a/packages/zero/Dockerfile
+++ b/packages/zero/Dockerfile
@@ -18,7 +18,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 
 FROM golang:1.25.10@sha256:cd05a378aaf011e8056745363e5c40f4f2bef0fa4d9bf19b9c38316079c332ff AS litestream-v5
 
-ARG LITESTREAM_V5_VERSION=0.5.18-zero.1
+ARG LITESTREAM_V5_VERSION=0.5.18-zero.2
 
 WORKDIR /src/
 RUN git clone --depth 1 --branch v${LITESTREAM_V5_VERSION} https://github.com/rocicorp/litestream.git


### PR DESCRIPTION
Bumps the litestream v5 pin from `0.5.18-zero.1` to [`v0.5.18-zero.2`](https://github.com/rocicorp/litestream/releases/tag/v0.5.18-zero.2).

## What this picks up

**[rocicorp/litestream#28](https://github.com/rocicorp/litestream/pull/28) — parallel multipart S3 downloads.** A single S3 GET stream is bandwidth-limited well below what an instance can pull, so restore was bound by one connection rather than by the network. LTX files larger than one part are now fetched as several ranged GETs in parallel and reassembled in order, with a process-wide buffer pool shared across concurrent downloads.

Also in the tag: [#26](https://github.com/rocicorp/litestream/pull/26) (pass the known file size to `OpenLTXFile`, which the download planner needs) and [#27](https://github.com/rocicorp/litestream/pull/27) (missing `SetLogger` on the vfs test mocks).

## Effect on zero-cache

`ZERO_LITESTREAM_RESTORE_USING_V5` already defaults to `true`, so **restores get this with no configuration change** — that is the path that benefits. Backups are unaffected; the new options are download-only and deliberately separate from the upload `part-size` / `concurrency`, which carry provider-specific overrides.

Defaults are 48 x 16 MiB, matching what the v3 fork has used for snapshot downloads. That is a shared ceiling for the whole process, not per file, so the memory ceiling is `download-concurrency * download-part-size` regardless of how many databases a process replicates. Pods already running the v3 binary have been sized against the same budget.

## Sizing, from production

I pulled the LTX size distribution from S3 for our largest stack (~1.2 TB in the active replica generation, ~40 hours of history) to check the allocation policy:

| level | files | total | avg | max | >16 MiB |
|---|---|---|---|---|---|
| L0 | 1872 | 4.2 GiB | 2.3 MiB | 1.2 GiB | 12 |
| L1 | 686 | 270 GiB | 403 MiB | 61 GiB | 238 |
| L2 | 127 | 205 GiB | 1.6 GiB | 61 GiB | 127 |
| L3 | 23 | 191 GiB | 8.3 GiB | 61 GiB | 23 |
| L9 (snapshot) | 7 | 423 GiB | 60.5 GiB | 61 GiB | 7 |

L0 files average 2.3 MiB, so the ~1,900 incremental files stay on the plain single-GET path and never touch the pool. A restore plan is roughly a dozen files over one part totalling ~115 GiB, which is what the pool's fair-share allocation is tuned for.

## Not in this PR

`ZERO_LITESTREAM_MULTIPART_CONCURRENCY` / `_SIZE` still only reach the **upload** keys in `packages/zero-cache/src/services/litestream/config-v5.yml`. Pointing them at the new `download-concurrency` / `download-part-size` options is two lines and worth doing next, since at ~12 registered readers the default pool gives each about 3 buffers — a 48 MiB look-ahead on files averaging 8 GiB. Raising the pool is likely the bigger win, and needs that wiring first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
