### PR TITLE
perf(zero-react): key views by client id, then query hash

### DIFF
--- a/packages/zero-react/src/use-query.test.tsx
+++ b/packages/zero-react/src/use-query.test.tsx
@@ -340,6 +340,54 @@ describe('ViewStore', () => {
 
       expect(view1).not.toBe(view2);
     });
+
+    test('one client’s views are destroyed without disturbing another’s', () => {
+      const viewStore = new ViewStore();
+
+      const zero1 = newMockZero('client1');
+      const view1 = viewStore.getView(
+        zero1,
+        newMockQuery('query1'),
+        true,
+        'forever',
+      );
+      const zero2 = newMockZero('client2');
+      const view2 = viewStore.getView(
+        zero2,
+        newMockQuery('query1'),
+        true,
+        'forever',
+      );
+      expect(getAllViewsSizeForTesting(viewStore)).toBe(2);
+
+      const cleanup1 = view1.subscribeReactInternals(() => {});
+      const cleanup2 = view2.subscribeReactInternals(() => {});
+
+      cleanup1();
+      vi.advanceTimersByTime(100);
+
+      // The other client keeps its view, and asking again returns that same
+      // one rather than building a second.
+      expect(getAllViewsSizeForTesting(viewStore)).toBe(1);
+      expect(
+        viewStore.getView(zero2, newMockQuery('query1'), true, 'forever'),
+      ).toBe(view2);
+
+      cleanup2();
+      vi.advanceTimersByTime(100);
+      expect(getAllViewsSizeForTesting(viewStore)).toBe(0);
+
+      // ...and the store still works afterwards, having dropped the per-client
+      // entry it no longer needs.
+      const view3 = viewStore.getView(
+        zero1,
+        newMockQuery('query1'),
+        true,
+        'forever',
+      );
+      expect(view3).not.toBe(view1);
+      expect(getAllViewsSizeForTesting(viewStore)).toBe(1);
+    });
   });
 
   describe('singular vs plural', () => {

--- a/packages/zero-react/src/use-query.tsx
+++ b/packages/zero-react/src/use-query.tsx
@@ -348,11 +348,18 @@ function makeError(retry: () => void, error: ErroredQuery): QueryErrorDetails {
 // oxlint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyViewWrapper = ViewWrapper<any, any, any, any, any>;
 
-const allViews = new WeakMap<ViewStore, Map<string, AnyViewWrapper>>();
+const allViews = new WeakMap<
+  ViewStore,
+  Map<string, Map<string, AnyViewWrapper>>
+>();
 
 export function getAllViewsSizeForTesting(store: ViewStore): number {
   if (TESTING) {
-    return allViews.get(store)?.size ?? 0;
+    let size = 0;
+    for (const byHash of allViews.get(store)?.values() ?? []) {
+      size += byHash.size;
+    }
+    return size;
   }
   return 0;
 }
@@ -406,7 +413,18 @@ export function getAllViewsSizeForTesting(store: ViewStore): number {
  * Swapping `useState` to `useRef` has similar problems.
  */
 export class ViewStore {
-  #views = new Map<string, AnyViewWrapper>();
+  /**
+   * Client id, then query hash.
+   *
+   * Nested rather than keyed by the two joined together, because this is
+   * looked up on every render of every `useQuery`. Joining them builds a
+   * string that V8 has to hash from scratch, where both halves on their own
+   * are strings it has already hashed and cached -- `hash()` is memoized on an
+   * interned query, so the same string comes back each render. Measured over a
+   * rebuild-and-look-up of one chain, that is the difference between 202ns and
+   * 123ns; the join cost more than rebuilding and hashing the whole query.
+   */
+  #views = new Map<string, Map<string, AnyViewWrapper>>();
 
   constructor() {
     if (TESTING) {
@@ -448,18 +466,30 @@ export class ViewStore {
       };
     }
 
-    const hash = qi.hash() + zero.clientID;
-    let existing = this.#views.get(hash);
+    const {clientID} = zero;
+    const hash = qi.hash();
+    let byHash = this.#views.get(clientID);
+    let existing = byHash?.get(hash);
     if (!existing) {
       existing = new ViewWrapper(q, zero, ttl, view => {
-        const currentView = this.#views.get(hash);
+        const views = this.#views.get(clientID);
+        const currentView = views?.get(hash);
         if (currentView && currentView !== view) {
           // we replaced the view with a new one already.
           return;
         }
-        this.#views.delete(hash);
+        views?.delete(hash);
+        if (views?.size === 0) {
+          // Nothing is left for this client, so drop its map rather than
+          // keeping one per client id the page has ever seen.
+          this.#views.delete(clientID);
+        }
       });
-      this.#views.set(hash, existing);
+      if (!byHash) {
+        byHash = new Map();
+        this.#views.set(clientID, byHash);
+      }
+      byHash.set(hash, existing);
     } else {
       existing.updateTTL(ttl);
     }

--- a/packages/zero-solid/src/use-query.ts
+++ b/packages/zero-solid/src/use-query.ts
@@ -149,7 +149,15 @@ export function useQuery<
     return asQueryInternals(query);
   });
 
-  const hash = createMemo(() => qi()?.hash() + zero().clientID);
+  // Undefined rather than the string `undefined` + the client id: this feeds
+  // the guard below, and concatenating a missing hash produced a string that
+  // was never equal to undefined, leaving that guard unreachable.
+  const hash = createMemo(() => {
+    const internals = qi();
+    return internals === undefined
+      ? undefined
+      : internals.hash() + zero().clientID;
+  });
   const ttl = createMemo(() => normalize(options)?.ttl ?? DEFAULT_TTL_MS);
 
   const initialTTL = ttl();


### PR DESCRIPTION
Follow-up to #6469: now that queries are interned, `hash()` is memoized on a
reused instance and is effectively free. That left the *key construction* in
`ViewStore.getView` as the most expensive thing on the `useQuery` render path.

### zero-react

`getView` runs on every render of every `useQuery` and joined its two halves
into one string: `qi.hash() + zero.clientID`. That string is new each render,
so a `Map` has to hash it from scratch, where each half on its own is a string
V8 has already hashed and cached — `hash()` is memoized, and interning means
the same instance, and so the same string, comes back every render.

Nesting the map as client id → hash → view removes the join. Measured in plain
node over rebuilding one chain and looking up its view:

| | ns/op |
| --- | --- |
| rebuild the chain | 113 |
| + `qi.hash()` | 122 |
| + join + `Map.get` (before) | **202** |
| + nested `Map.get` (after) | **123** |

So the join cost 80ns, about 40% of the path — more than rebuilding and hashing
the entire query. `hash()` itself adds 9ns.

The map for a client is dropped once its last view is, so a page that sees
several client ids does not keep an empty map per id.

### Why the hash stays as the key

Worth stating, since interning makes identity keying tempting: interning is a
cache, not a guarantee, and every way it degrades would turn into a duplicate
view and a duplicate pipeline — a bucket at `MAX_SCAN` stops interning the
surplus, weak entries get collected, a non-deterministic callback misses, and
two paths that hash alike converge only after both have been hashed. Builder
roots are also interned per schema rather than per `Zero`, which is what the
client id in the key guards. Those failures are invisible in tests and show up
as extra server queries under load.

An identity `WeakMap` as a *first check* in front of the hash is safe, but
measures at ~17ns saved on a hit and ~8ns lost on a miss out of ~130ns, and
would mean two caches sharing one lifecycle — the identity entry has to be
invalidated exactly where the hash entry is, or it hands back a destroyed
`ViewWrapper`. Not worth it.

### zero-solid

No view map there — it uses the hash as a `createMemo` dependency — but the
memo computed `qi()?.hash() + zero().clientID`, and when `qi()` is undefined
that produces the string `"undefined<clientID>"` rather than `undefined`. The
`if (currentHash === undefined)` guard below it was therefore unreachable. The
next guard already handled the falsy-query case, so behavior is unchanged; this
just removes the trap.

### Testing

New test covers the multi-client lifecycle: the existing suite checked that two
clients get different views, but never that tearing one down leaves the other's
view intact and reusable. zero-react 75, zero-solid 59, zql 1433 pass;
repo-wide types, lint and format clean.

Unrelated: `zero-client`'s `zero-idb.test.ts` "private storage sentinel" test
fails on clean `main` as well — confirmed by stashing this branch's changes and
re-running it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
