### PR TITLE
perf(zero-cache): stop re-encoding the same json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,6 @@ packages/zql-integration-tests/Chinook_Sqlite.sqlite
 *.ignore.*
 package-lock-commit-deps-report.html
 packages/zql-integration-tests/Pagila_PostgreSql-5ba5a57aeb15.sql
+
+apps/zbugs/.litestream/
+apps/zbugs/.soak/

--- a/packages/zero-cache/src/services/change-streamer/change-log-codec.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-log-codec.test.ts
@@ -4,6 +4,7 @@ import {
   extractChangeSubstring,
   reconstructWatermarkedChange,
   serializeChangeStreamData,
+  serializeChangeStreamDataWithChange,
   type ChangeLogEntry,
 } from './change-log-codec.ts';
 import type {ChangeTag, WatermarkedChange} from './change-streamer.ts';
@@ -146,8 +147,10 @@ describe('change log codec', () => {
       const {watermark, data, json, change} = fixture;
       const tag = data[1].tag;
       const serialized = serializeChangeStreamData(data);
+      const parts = serializeChangeStreamDataWithChange(data);
 
       expect(serialized).toBe(json);
+      expect(parts).toEqual({json, change});
       expect(extractChangeSubstring(serialized, tag)).toBe(change);
 
       const entry = {watermark, tag, change};

--- a/packages/zero-cache/src/services/change-streamer/change-log-codec.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-log-codec.ts
@@ -8,16 +8,49 @@ export type ChangeLogEntry = {
   change: string;
 };
 
+export type SerializedChangeStreamData = {
+  /** The canonical downstream representation forwarded to subscribers. */
+  readonly json: string;
+  /** The already-serialized change tuple element stored in change logs. */
+  readonly change: string;
+};
+
+/**
+ * Serializes a data-plane message and its stored change payload in one pass.
+ *
+ * Change logs retain only the second tuple element for backwards
+ * compatibility. Serializing that element first avoids stringifying the full
+ * message and then copying the payload back out of the resulting string on the
+ * replication hot path.
+ */
+export function serializeChangeStreamDataWithChange(
+  data: ChangeStreamData,
+): SerializedChangeStreamData {
+  const change = BigIntJSON.stringify(data[1]);
+  const type = data[0];
+  switch (type) {
+    case 'begin':
+    case 'commit':
+      return {
+        json: `[${JSON.stringify(type)},${change},${BigIntJSON.stringify(data[2])}]`,
+        change,
+      };
+    case 'data':
+    case 'rollback':
+      return {json: `[${JSON.stringify(type)},${change}]`, change};
+  }
+}
+
 /** Serializes a data-plane message to the canonical downstream JSON form. */
 export function serializeChangeStreamData(data: ChangeStreamData): string {
-  return BigIntJSON.stringify(data);
+  return serializeChangeStreamDataWithChange(data).json;
 }
 
 /**
- * Extracts the stringified change message from the stringified stream message
- * (the second tuple element). This allows the stream message to be stringified
- * once while storing only the change message in the change log for backwards
- * compatibility.
+ * Extracts the second tuple element for callers that only have the canonical
+ * downstream JSON. The live write path uses
+ * {@link serializeChangeStreamDataWithChange} and does not scan or copy the
+ * completed message.
  */
 export function extractChangeSubstring(
   streamMessageJSON: string,

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -38,7 +38,7 @@ import {
   RunningState,
   UnrecoverableError,
 } from '../running-state.ts';
-import {serializeChangeStreamData} from './change-log-codec.ts';
+import {serializeChangeStreamDataWithChange} from './change-log-codec.ts';
 import {
   ChangeLogInitializer,
   replicaInitializationSource,
@@ -809,9 +809,11 @@ class ChangeStreamerImpl implements ChangeStreamerService {
               break;
           }
 
-          const json = this.#pgChangeLogEnabled
-            ? this.#storer.store(watermark, change)
-            : serializeChangeStreamData(change);
+          const serialized = serializeChangeStreamDataWithChange(change);
+          const {json} = serialized;
+          if (this.#pgChangeLogEnabled) {
+            this.#storer.store(watermark, change, serialized);
+          }
           // The SQLite change log commits at transaction boundaries, and its
           // commit for this transaction lands here -- before the forward of the
           // `commit` message, and before #recordForwardedTransactionBoundary
@@ -821,7 +823,7 @@ class ChangeStreamerImpl implements ChangeStreamerService {
           // same loop iteration always precedes anything that can advance the
           // watermark this stream would resume from. Never throws; a write
           // failure disables the writer rather than stopping replication.
-          this.#changeLogWriter?.write(change, json);
+          this.#changeLogWriter?.write(change, json, serialized.change);
           const entry: WatermarkedChange = [watermark, change[1].tag, json];
           unflushedBytes += json.length;
           if (unflushedBytes < flushBytesThreshold) {

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-writer.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-writer.test.ts
@@ -53,7 +53,11 @@ function resumeAt(
   return {resumeWatermark, cookies};
 }
 
-function setup(name: string, resumeWatermark = '02') {
+function setup(
+  name: string,
+  resumeWatermark = '02',
+  shadowValidationPercent = 100,
+) {
   const sink = new TestLogSink();
   const lc = new LogContext('debug', undefined, sink);
   const file = new DbFile(name);
@@ -68,6 +72,7 @@ function setup(name: string, resumeWatermark = '02') {
     onDisabled: () => disabled++,
     onRebuilt: () => rebuilt++,
     now: () => 1_700_000_000_000,
+    shadowValidationPercent,
   });
   writer.reconcile(resumeAt(resumeWatermark));
   return {
@@ -131,6 +136,24 @@ describe('change-streamer/sqlite-change-log-writer', () => {
       headLag: 0,
       invariantFailures: 0,
       hashMatches: 2,
+      hashMismatches: 0,
+      hashUnpaired: 0,
+    });
+  });
+
+  test('can skip rollout-only shadow validation', () => {
+    using fixture = setup('change-log-writer-no-shadow-validation', '02', 0);
+
+    transaction(fixture.writer, '04', [
+      'data',
+      messages.insert('foo', {id: 'one'}),
+    ]);
+
+    expect(fixture.head()).toBe('04');
+    expect(fixture.writer.state()).toMatchObject({
+      sqliteHead: '04',
+      receivedHead: '04',
+      hashMatches: 0,
       hashMismatches: 0,
       hashUnpaired: 0,
     });

--- a/packages/zero-cache/src/services/change-streamer/sqlite-change-log-writer.ts
+++ b/packages/zero-cache/src/services/change-streamer/sqlite-change-log-writer.ts
@@ -1,5 +1,7 @@
 import type {LogContext} from '@rocicorp/logger';
 import {SqliteError} from '@rocicorp/zero-sqlite3';
+import {assert} from '../../../../shared/src/asserts.ts';
+import {h32} from '../../../../shared/src/hash.ts';
 import {must} from '../../../../shared/src/must.ts';
 import type {Database} from '../../../../zqlite/src/db.ts';
 import {
@@ -35,6 +37,7 @@ import {
   type ChangeLogCommit,
   type SQLiteChangeLogObservabilityState,
 } from '../replicator/sqlite-change-log-observability.ts';
+import {extractChangeSubstring} from './change-log-codec.ts';
 
 export type SQLiteChangeLogWriterOptions = {
   /** The replica file the log is named after, i.e. `${replicaFile}-change-log`. */
@@ -58,7 +61,14 @@ export type SQLiteChangeLogWriterOptions = {
   onRebuilt?: (() => void) | undefined;
   /** Overridable for tests. */
   now?: (() => number) | undefined;
+  /**
+   * Percentage of transactions that retain the rollout-only per-message
+   * timing and source-vs-stored hash validation. Defaults to 1.
+   */
+  shadowValidationPercent?: number | undefined;
 };
+
+const DEFAULT_SHADOW_VALIDATION_PERCENT = 1;
 
 /**
  * Appends the canonical change stream to the SQLite change log, from the
@@ -94,16 +104,26 @@ export class SQLiteChangeLogWriter {
   readonly #lc: LogContext;
   readonly #opts: SQLiteChangeLogWriterOptions;
   readonly #now: () => number;
+  readonly #shadowValidationPercent: number;
 
   #db: Database | undefined;
   #writer: ChangeLogStreamWriter | undefined;
   #observer: SQLiteChangeLogObserver | undefined;
   #disabled = false;
+  #validateTransaction = false;
 
   constructor(lc: LogContext, opts: SQLiteChangeLogWriterOptions) {
     this.#lc = lc.withContext('component', 'sqlite-change-log-writer');
     this.#opts = opts;
     this.#now = opts.now ?? Date.now;
+    this.#shadowValidationPercent =
+      opts.shadowValidationPercent ?? DEFAULT_SHADOW_VALIDATION_PERCENT;
+    assert(
+      Number.isInteger(this.#shadowValidationPercent) &&
+        this.#shadowValidationPercent >= 0 &&
+        this.#shadowValidationPercent <= 100,
+      'SQLite change-log shadow validation percentage must be an integer between 0 and 100',
+    );
   }
 
   /** False once the writer has failed soft, or after {@link close}. */
@@ -269,26 +289,46 @@ export class SQLiteChangeLogWriter {
    * Writes one stream message, committing at transaction boundaries. Never
    * throws: a write failure disables the writer instead of failing the stream.
    */
-  write(change: ChangeStreamData, json: string): void {
+  write(
+    change: ChangeStreamData,
+    json: string,
+    storedChange = extractChangeSubstring(json, change[1].tag),
+  ): void {
     const writer = this.#writer;
     const db = this.#db;
     if (this.#disabled || writer === undefined || db === undefined) {
       return;
     }
-    const observer = this.#observer;
-    observer?.messageReceived(change, json);
     const [type, msg] = change;
-    const startedAt = performance.now();
+    if (type === 'begin') {
+      this.#validateTransaction = this.#isSelectedForShadowValidation(
+        change[2].commitWatermark,
+      );
+    }
+    const validateTransaction = this.#validateTransaction;
+    const observer = this.#observer;
+    observer?.messageReceived(change, json, validateTransaction, storedChange);
+    const startedAt = validateTransaction ? performance.now() : undefined;
     try {
       let commit: ChangeLogCommit | null = null;
       switch (type) {
         case 'begin':
-          writer.begin(change[2].commitWatermark, json);
+          writer.begin(
+            change[2].commitWatermark,
+            json,
+            storedChange,
+            validateTransaction,
+          );
           break;
         case 'commit': {
           const {watermark} = change[2];
           const commitStart = performance.now();
-          const stats = writer.commit(watermark, json, this.#now());
+          const stats = writer.commit(
+            watermark,
+            json,
+            this.#now(),
+            storedChange,
+          );
           commit = {
             watermark,
             stats,
@@ -300,10 +340,14 @@ export class SQLiteChangeLogWriter {
           writer.rollback();
           break;
         default:
-          writer.append(json, msg);
+          writer.append(json, msg, storedChange);
           break;
       }
-      observer?.messageProcessed(change, commit, performance.now() - startedAt);
+      observer?.messageProcessed(
+        change,
+        commit,
+        startedAt === undefined ? undefined : performance.now() - startedAt,
+      );
       if (commit !== null && commit.stats.cookieMutations.length > 0) {
         // Only re-counted when a schema change actually moved the cookie jar,
         // which keeps the count off the forward path of every other
@@ -319,8 +363,16 @@ export class SQLiteChangeLogWriter {
         // what makes its poll interval a backstop rather than the mechanism.
         this.#opts.onCommit?.(commit.watermark);
       }
+      if (type === 'commit' || type === 'rollback') {
+        this.#validateTransaction = false;
+      }
     } catch (e) {
-      observer?.messageFailed(change, e, performance.now() - startedAt);
+      observer?.messageFailed(
+        change,
+        e,
+        startedAt === undefined ? undefined : performance.now() - startedAt,
+      );
+      this.#validateTransaction = false;
       if (isConstraintViolation(e)) {
         // Reconciliation should have truncated whatever this collided with.
         // Report it as an invariant failure before failing soft, so that a
@@ -335,12 +387,26 @@ export class SQLiteChangeLogWriter {
     }
   }
 
+  #isSelectedForShadowValidation(watermark: string): boolean {
+    const percent = this.#shadowValidationPercent;
+    return (
+      percent >= 100 ||
+      (percent > 0 &&
+        h32(
+          `${this.#opts.identity.generation}/${this.#opts.identity.replicaID ?? ''}:${watermark}`,
+        ) %
+          100 <
+          percent)
+    );
+  }
+
   /**
    * Discards the open transaction, if any. Called when the change stream is
    * interrupted mid-transaction.
    */
   abort(): void {
     const writer = this.#writer;
+    this.#validateTransaction = false;
     if (this.#disabled || writer === undefined) {
       return;
     }
@@ -354,6 +420,7 @@ export class SQLiteChangeLogWriter {
 
   close(): void {
     this.#disabled = true;
+    this.#validateTransaction = false;
     this.#writer = undefined;
     this.#observer = undefined;
     const db = this.#db;

--- a/packages/zero-cache/src/services/change-streamer/storer.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.ts
@@ -44,10 +44,10 @@ import {
 import type {ReplicatorMode} from '../replicator/replicator.ts';
 import type {Service} from '../service.ts';
 import {
-  extractChangeSubstring,
   reconstructWatermarkedChange,
-  serializeChangeStreamData,
+  serializeChangeStreamDataWithChange,
   type ChangeLogEntry,
+  type SerializedChangeStreamData,
 } from './change-log-codec.ts';
 import * as ErrorType from './error-type-enum.ts';
 import {
@@ -77,6 +77,7 @@ type QueueEntry =
       'change',
       watermark: string,
       json: string,
+      storedChange: string,
       orig: Exclude<Change, DataChange> | null, // null for DataChanges
     ]
   | ['ready', callback: () => void]
@@ -488,11 +489,17 @@ export class Storer implements Service {
   /**
    * @returns The JSON stringified stream message to be sent downstream.
    */
-  store(watermark: string, data: ChangeStreamData) {
+  store(
+    watermark: string,
+    data: ChangeStreamData,
+    serialized: SerializedChangeStreamData = serializeChangeStreamDataWithChange(
+      data,
+    ),
+  ) {
     // Eagerly stringify the JSON payload to:
     // - avoid redundant stringification when fanning out to subscribers
     // - efficiently estimate the amount of memory the payload consumes
-    const json = serializeChangeStreamData(data);
+    const {json, change: storedChange} = serialized;
     this.#approximateQueuedBytes += json.length;
 
     const change = data[1];
@@ -500,6 +507,7 @@ export class Storer implements Service {
       'change',
       watermark,
       json,
+      storedChange,
       isDataChange(change) ? null : change, // drop DataChanges to save memory
     ]);
 
@@ -703,7 +711,7 @@ export class Storer implements Service {
           }
         }
         // msgType === 'change'
-        const [_, watermark, json, change] = msg;
+        const [_, watermark, json, storedChange, change] = msg;
         const tag = change?.tag;
         this.#approximateQueuedBytes -= json.length;
 
@@ -744,8 +752,9 @@ export class Storer implements Service {
           precommit: tag === 'commit' ? tx.preCommitWatermark : null,
           pos: tx.pos,
           // For backwards compatibility, only the change message is stored
-          // in the cdc changeLog.
-          change: extractChangeSubstring(json, tag),
+          // in the cdc changeLog. It was serialized separately with the
+          // downstream envelope, so no full-message scan is needed here.
+          change: storedChange,
         };
 
         if (change !== null && isSchemaChange(change)) {

--- a/packages/zero-cache/src/services/replicator/change-log-stream-writer.ts
+++ b/packages/zero-cache/src/services/replicator/change-log-stream-writer.ts
@@ -15,7 +15,8 @@ import {
 export type ChangeLogStreamTransactionStats = {
   readonly rows: number;
   readonly estimatedBytes: number;
-  readonly hash: string;
+  /** Present only for transactions selected for shadow-write validation. */
+  readonly hash?: string | undefined;
   /**
    * The cookie mutations this transaction's schema changes folded in, in stream
    * order. Empty for the overwhelming majority of transactions.
@@ -79,7 +80,12 @@ export class ChangeLogStreamWriter {
     this.#cookies = new ChangeLogCookieWriter(db.db);
   }
 
-  begin(watermark: string, json: string): void {
+  begin(
+    watermark: string,
+    json: string,
+    storedChange = extractChangeSubstring(json, 'begin'),
+    hash = true,
+  ): void {
     assertInvariant(
       this.#watermark === undefined,
       `change-log stream transaction already open at ${this.#watermark}`,
@@ -90,7 +96,7 @@ export class ChangeLogStreamWriter {
     this.#db.beginImmediate();
     this.#watermark = watermark;
     this.#pos = 0;
-    const change = extractChangeSubstring(json, 'begin');
+    const change = storedChange;
     const estimatedBytes = estimateChangeLogStreamRowBytes(
       watermark,
       'begin',
@@ -103,14 +109,16 @@ export class ChangeLogStreamWriter {
       estimatedBytes,
       change,
     );
-    this.#hasher = new ChangeLogTransactionHasher();
-    this.#hasher.add({
-      watermark,
-      pos: this.#pos,
-      tag: 'begin',
-      change,
-      precommit: null,
-    });
+    if (hash) {
+      this.#hasher = new ChangeLogTransactionHasher();
+      this.#hasher.add({
+        watermark,
+        pos: this.#pos,
+        tag: 'begin',
+        change,
+        precommit: null,
+      });
+    }
     this.#estimatedBytes = estimatedBytes;
   }
 
@@ -124,17 +132,21 @@ export class ChangeLogStreamWriter {
    * has to flush its buffered batch to get the same ordering
    * (`Storer.#processQueue()`); SQLite gets it from statement order.
    */
-  append(json: string, change: DataOrSchemaChange): void {
+  append(
+    json: string,
+    change: DataOrSchemaChange,
+    storedChange = extractChangeSubstring(json, change.tag),
+  ): void {
     const watermark = this.#requireWatermark();
     const {tag} = change;
-    const stored = extractChangeSubstring(json, tag);
+    const stored = storedChange;
     const estimatedBytes = estimateChangeLogStreamRowBytes(
       watermark,
       tag,
       stored,
     );
     this.#insertChange.run(watermark, ++this.#pos, tag, estimatedBytes, stored);
-    this.#requireHasher().add({
+    this.#hasher?.add({
       watermark,
       pos: this.#pos,
       tag,
@@ -154,13 +166,14 @@ export class ChangeLogStreamWriter {
     watermark: string,
     json: string,
     writeTimeMs: number,
+    storedChange = extractChangeSubstring(json, 'commit'),
   ): ChangeLogStreamTransactionStats {
     const precommit = this.#requireWatermark();
     assertInvariant(
       watermark === precommit,
       `change-log stream commit ${watermark} does not match begin ${precommit}`,
     );
-    const change = extractChangeSubstring(json, 'commit');
+    const change = storedChange;
     const estimatedBytes = estimateChangeLogStreamRowBytes(
       watermark,
       'commit',
@@ -176,8 +189,8 @@ export class ChangeLogStreamWriter {
       precommit,
       writeTimeMs,
     );
-    const hasher = this.#requireHasher();
-    hasher.add({
+    const hasher = this.#hasher;
+    hasher?.add({
       watermark,
       pos: this.#pos,
       tag: 'commit',
@@ -187,7 +200,7 @@ export class ChangeLogStreamWriter {
     const stats = {
       rows: this.#pos + 1,
       estimatedBytes: this.#estimatedBytes + estimatedBytes,
-      hash: hasher.digest(),
+      hash: hasher?.digest(),
       cookieMutations: this.#cookieMutations,
     };
     // The log is durable at `watermark` from here on, and nothing that can
@@ -228,13 +241,5 @@ export class ChangeLogStreamWriter {
       'change-log stream message received outside of a transaction',
     );
     return this.#watermark;
-  }
-
-  #requireHasher(): ChangeLogTransactionHasher {
-    assertInvariant(
-      this.#hasher !== undefined,
-      'change-log stream hash received outside of a transaction',
-    );
-    return this.#hasher;
   }
 }

--- a/packages/zero-cache/src/services/replicator/replication-throughput.bench.pg.ts
+++ b/packages/zero-cache/src/services/replicator/replication-throughput.bench.pg.ts
@@ -1,9 +1,10 @@
 // Benchmarks end-to-end logical replication throughput from upstream Postgres
 // writes through the change-streamer and into the SQLite replica.
 //
-// The change log is written by the change-streamer rather than by this write
-// path, so there is no writer axis here any more: this measures the replicator's
-// baseline, which is what slice 7I returned it to.
+// The change log is written by the change-streamer rather than by the
+// replicator. The three modes below measure the complete PG-to-RM path with the
+// legacy PG log, both logs, and only the SQLite log. No view-syncer subscribes,
+// so its backpressure cannot hide the change-streamer's throughput ceiling.
 //
 //   pnpm --filter zero-cache run bench:pg replication-throughput
 
@@ -12,6 +13,7 @@ import {createManualBenchmarkRecorder} from '../../../../shared/src/bench.ts';
 import {BigIntJSON} from '../../../../shared/src/bigint-json.ts';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
 import {sleep} from '../../../../shared/src/sleep.ts';
+import {Database} from '../../../../zqlite/src/db.ts';
 import {getConnectionURI, type PgTest, test} from '../../test/db.ts';
 import {DbFile} from '../../test/lite.ts';
 import {
@@ -27,7 +29,10 @@ import type {PostgresDB} from '../../types/pg.ts';
 import type {Source} from '../../types/streams.ts';
 import {getPragmaConfig, setupReplica} from '../../workers/replicator.ts';
 import {initializePostgresChangeSource} from '../change-source/pg/change-source.ts';
-import {initializeStreamer} from '../change-streamer/change-streamer-service.ts';
+import {
+  initializeStreamer,
+  type TuningOptions,
+} from '../change-streamer/change-streamer-service.ts';
 import {
   type ChangeStreamer,
   type ChangeStreamerService,
@@ -35,13 +40,11 @@ import {
   type SizedDownstream,
 } from '../change-streamer/change-streamer.ts';
 import {initChangeStreamerSchema} from '../change-streamer/schema/init.ts';
+import {changeLogFileName, deleteChangeLogDB} from './change-log-db.ts';
 import {ReplicationStatusPublisher} from './replication-status.ts';
 import {ReplicatorService} from './replicator.ts';
 import {ThreadWriteWorkerClient} from './write-worker-client.ts';
 
-const WARMUP_ROWS = 25_000;
-const MEASURED_ROWS = 100_000;
-const ROWS_PER_TRANSACTION = 500;
 const CHANGE_LOG_BATCH_SIZE = 2000;
 const MEASURED_WARMUP_REPS = 1;
 const REPS = 10;
@@ -58,13 +61,41 @@ const shard = {
   publications: [BENCHMARK_FIXTURE_PUBLICATION],
 };
 const benchmarkRecorder = createManualBenchmarkRecorder();
-const streamerOptions = {
-  pgChangeLogEnabled: true,
+const baseStreamerOptions = {
   backPressureLimitHeapProportion: 0.04,
   flowControlConsensusTimeoutProportion: 2,
   statementTimeoutMs: 60_000,
   changeLogBatchSize: CHANGE_LOG_BATCH_SIZE,
-};
+} satisfies Omit<TuningOptions, 'pgChangeLogEnabled'>;
+
+const changeLogModes = [
+  {name: 'pg-only', pgChangeLogEnabled: true, sqliteChangeLogEnabled: false},
+  {name: 'dual', pgChangeLogEnabled: true, sqliteChangeLogEnabled: true},
+  {
+    name: 'sqlite-only',
+    pgChangeLogEnabled: false,
+    sqliteChangeLogEnabled: true,
+  },
+] as const;
+
+type ChangeLogMode = (typeof changeLogModes)[number];
+
+const workloads = [
+  {
+    name: 'single-row-transactions',
+    warmupRows: 2_500,
+    measuredRows: 5_000,
+    rowsPerTransaction: 1,
+  },
+  {
+    name: '500-row-transactions',
+    warmupRows: 25_000,
+    measuredRows: 100_000,
+    rowsPerTransaction: 500,
+  },
+] as const;
+
+type Workload = (typeof workloads)[number];
 
 let cleanup: (() => Promise<void>)[] = [];
 
@@ -122,15 +153,63 @@ async function waitForReplicaRows(replicaPath: string, expected: number) {
   );
 }
 
-async function startReplicationPipeline(testDBs: PgTest['testDBs']) {
-  const upstream = await testDBs.create('logical_replication_bench_upstream');
-  const changeDB = await testDBs.create('logical_replication_bench_change', {
-    typeOpts: {sendStringAsJson: true},
-  });
-  const replicaDbFile = new DbFile('logical-replication-throughput-bench');
+async function waitForPGChangeLog(
+  changeDB: PostgresDB,
+  targetWatermark: string,
+): Promise<void> {
+  const deadline = performance.now() + TEST_TIMEOUT_MS;
+  let lastWatermark = '';
+  while (performance.now() < deadline) {
+    [{lastWatermark}] = await changeDB<{lastWatermark: string}[]> /*sql*/ `
+      SELECT "lastWatermark"
+        FROM ${changeDB(`${shard.appID}_${shard.shardNum}/cdc`)}."replicationState"`;
+    if (lastWatermark >= targetWatermark) {
+      return;
+    }
+    await sleep(50);
+  }
+  throw new Error(
+    `timed out waiting for PG change log: expected ${targetWatermark}, got ${lastWatermark}`,
+  );
+}
+
+async function waitForReplication(
+  replicaPath: string,
+  expectedRows: number,
+  changeDB: PostgresDB,
+  mode: ChangeLogMode,
+): Promise<number> {
+  const actualRows = await waitForReplicaRows(replicaPath, expectedRows);
+  if (mode.pgChangeLogEnabled) {
+    using replica = new Database(lc, replicaPath, {readonly: true});
+    const {stateVersion} = replica
+      .prepare(`SELECT "stateVersion" FROM "_zero.replicationState"`)
+      .get<{stateVersion: string}>();
+    await waitForPGChangeLog(changeDB, stateVersion);
+  }
+  return actualRows;
+}
+
+async function startReplicationPipeline(
+  testDBs: PgTest['testDBs'],
+  mode: ChangeLogMode,
+) {
+  const upstream = await testDBs.create(
+    `logical_replication_bench_upstream_${mode.name}`,
+  );
+  const changeDB = await testDBs.create(
+    `logical_replication_bench_change_${mode.name}`,
+    {typeOpts: {sendStringAsJson: true}},
+  );
+  const replicaDbFile = new DbFile(
+    `logical-replication-throughput-bench-${mode.name}`,
+  );
 
   // oxlint-disable require-await
-  cleanup.push(async () => replicaDbFile.delete());
+  cleanup.push(async () => {
+    deleteChangeLogDB(replicaDbFile.path);
+    replicaDbFile.delete();
+  });
   cleanup.push(async () => {
     await testDBs.drop(upstream, changeDB);
   });
@@ -139,7 +218,7 @@ async function startReplicationPipeline(testDBs: PgTest['testDBs']) {
     publication: BENCHMARK_FIXTURE_PUBLICATION,
   });
   const upstreamURI = getConnectionURI(upstream);
-  const {subscriptionState, changeSource} =
+  const {subscriptionState, changeSource, replicaID} =
     await initializePostgresChangeSource(
       lc,
       upstreamURI,
@@ -151,6 +230,29 @@ async function startReplicationPipeline(testDBs: PgTest['testDBs']) {
 
   await setupReplica(lc, 'serving', {file: replicaDbFile.path});
   await initChangeStreamerSchema(lc, changeDB, shard);
+  const sqliteOptions = mode.sqliteChangeLogEnabled
+    ? {
+        sqliteChangeLogWriter: {
+          replicaFile: replicaDbFile.path,
+          identity: {
+            epoch: null,
+            generation: subscriptionState.replicaVersion,
+            replicaID,
+          },
+        },
+        sqliteChangeLogPurge: {retentionMs: 60_000, batchRows: 1_000},
+        sqliteCatchup: {
+          changeLogFile: changeLogFileName(replicaDbFile.path),
+          readBatchRows: 1_000,
+          barrierTimeoutMs: 300_000,
+        },
+        sqliteChangeLogServe: {
+          readPercent: 100,
+          coldReadPercent: 100,
+          retentionMs: 60_000,
+        },
+      }
+    : {};
   const changeStreamer = await initializeStreamer(
     lc,
     shard,
@@ -163,10 +265,17 @@ async function startReplicationPipeline(testDBs: PgTest['testDBs']) {
       Promise.resolve(),
     ),
     subscriptionState,
-    null,
+    // This satisfies the SQLite-only production guard and gives every mode
+    // the same ACK policy. The benchmark deliberately does not report backup
+    // watermarks: it isolates PG-to-RM replication from Litestream and purge.
+    {backupURL: 's3://logical-replication-bench', litestreamVersion: 'v5'},
     null,
     true,
-    streamerOptions,
+    {
+      ...baseStreamerOptions,
+      pgChangeLogEnabled: mode.pgChangeLogEnabled,
+      ...sqliteOptions,
+    },
   );
   const streamerDone = changeStreamer.run();
   cleanup.push(async () => {
@@ -195,79 +304,122 @@ async function startReplicationPipeline(testDBs: PgTest['testDBs']) {
     await replicatorDone;
   });
 
-  return {upstream, replicaPath: replicaDbFile.path};
+  return {upstream, changeDB, replicaPath: replicaDbFile.path};
 }
 
-describe('replicator/logical replication throughput', () => {
-  test(
-    'end-to-end payload MB/sec',
-    {timeout: TEST_TIMEOUT_MS},
-    async ({testDBs}: PgTest) => {
-      const {upstream, replicaPath} = await startReplicationPipeline(testDBs);
-      const samples: {elapsedMs: number; operations: number}[] = [];
+describe.each(changeLogModes)(
+  'replicator/logical replication throughput ($name)',
+  mode => {
+    describe.each(workloads)('$name', workload => {
+      test(
+        'end-to-end throughput',
+        {timeout: TEST_TIMEOUT_MS},
+        async ({testDBs}: PgTest) => {
+          const {upstream, changeDB, replicaPath} =
+            await startReplicationPipeline(testDBs, mode);
+          const samples: {elapsedMs: number; operations: number}[] = [];
 
-      expect(replicaRowCount(replicaPath)).toBe(0);
+          expect(replicaRowCount(replicaPath)).toBe(0);
 
-      await insertBenchmarkFixtureRows(
-        upstream,
-        1,
-        WARMUP_ROWS,
-        ROWS_PER_TRANSACTION,
+          await insertBenchmarkFixtureRows(
+            upstream,
+            1,
+            workload.warmupRows,
+            workload.rowsPerTransaction,
+          );
+          expect(
+            await waitForReplication(
+              replicaPath,
+              workload.warmupRows,
+              changeDB,
+              mode,
+            ),
+          ).toBe(workload.warmupRows);
+
+          for (
+            let warmupRep = 0;
+            warmupRep < MEASURED_WARMUP_REPS;
+            warmupRep++
+          ) {
+            const startID =
+              workload.warmupRows + warmupRep * workload.measuredRows + 1;
+            const expectedRows =
+              workload.warmupRows + (warmupRep + 1) * workload.measuredRows;
+            await insertPrecomputedFixtureRows(upstream, startID, workload);
+            expect(
+              await waitForReplication(
+                replicaPath,
+                expectedRows,
+                changeDB,
+                mode,
+              ),
+            ).toBe(expectedRows);
+          }
+
+          for (let rep = 0; rep < REPS; rep++) {
+            const startID =
+              workload.warmupRows +
+              (MEASURED_WARMUP_REPS + rep) * workload.measuredRows +
+              1;
+            const expectedRows =
+              workload.warmupRows +
+              (MEASURED_WARMUP_REPS + rep + 1) * workload.measuredRows;
+
+            const batches = makeBenchmarkFixtureRowBatches(
+              startID,
+              workload.measuredRows,
+              workload.rowsPerTransaction,
+            );
+            const start = performance.now();
+            await insertBenchmarkFixtureRowBatches(upstream, batches);
+            expect(
+              await waitForReplication(
+                replicaPath,
+                expectedRows,
+                changeDB,
+                mode,
+              ),
+            ).toBe(expectedRows);
+            samples.push({
+              elapsedMs: performance.now() - start,
+              operations: benchmarkFixturePayloadMB(
+                startID,
+                workload.measuredRows,
+              ),
+            });
+          }
+
+          const dimensions =
+            `changeLog=${mode.name} ` +
+            `rowsPerTransaction=${workload.rowsPerTransaction}`;
+          benchmarkRecorder.recordThroughputSamples(
+            `replicator/logical replication end-to-end payload MB ` +
+              dimensions,
+            samples,
+          );
+          benchmarkRecorder.recordThroughputSamples(
+            `replicator/logical replication end-to-end transactions ` +
+              dimensions,
+            samples.map(({elapsedMs}) => ({
+              elapsedMs,
+              operations: workload.measuredRows / workload.rowsPerTransaction,
+            })),
+          );
+        },
       );
-      expect(await waitForReplicaRows(replicaPath, WARMUP_ROWS)).toBe(
-        WARMUP_ROWS,
-      );
-
-      for (let warmupRep = 0; warmupRep < MEASURED_WARMUP_REPS; warmupRep++) {
-        const startID = WARMUP_ROWS + warmupRep * MEASURED_ROWS + 1;
-        const expectedRows = WARMUP_ROWS + (warmupRep + 1) * MEASURED_ROWS;
-        await insertPrecomputedFixtureRows(upstream, startID, MEASURED_ROWS);
-        expect(await waitForReplicaRows(replicaPath, expectedRows)).toBe(
-          expectedRows,
-        );
-      }
-
-      for (let rep = 0; rep < REPS; rep++) {
-        const startID =
-          WARMUP_ROWS + (MEASURED_WARMUP_REPS + rep) * MEASURED_ROWS + 1;
-        const expectedRows =
-          WARMUP_ROWS + (MEASURED_WARMUP_REPS + rep + 1) * MEASURED_ROWS;
-
-        const batches = makeBenchmarkFixtureRowBatches(
-          startID,
-          MEASURED_ROWS,
-          ROWS_PER_TRANSACTION,
-        );
-        const start = performance.now();
-        await insertBenchmarkFixtureRowBatches(upstream, batches);
-        expect(await waitForReplicaRows(replicaPath, expectedRows)).toBe(
-          expectedRows,
-        );
-        samples.push({
-          elapsedMs: performance.now() - start,
-          operations: benchmarkFixturePayloadMB(startID, MEASURED_ROWS),
-        });
-      }
-
-      // The change-log writer is no longer on this path: it lives in the
-      // change-streamer, so this is the write path's baseline again.
-      benchmarkRecorder.recordThroughputSamples(
-        'replicator/logical replication end-to-end payload MB',
-        samples,
-      );
-    },
-  );
-});
+    });
+  },
+);
 
 async function insertPrecomputedFixtureRows(
   upstream: PostgresDB,
   startID: number,
-  count: number,
+  workload: Workload,
 ) {
   const batches = makeBenchmarkFixtureRowBatches(
     startID,
-    count,
-    ROWS_PER_TRANSACTION,
+    workload.measuredRows,
+    workload.rowsPerTransaction,
   );
   await insertBenchmarkFixtureRowBatches(upstream, batches);
 }

--- a/packages/zero-cache/src/services/replicator/sqlite-change-log-observability.ts
+++ b/packages/zero-cache/src/services/replicator/sqlite-change-log-observability.ts
@@ -240,12 +240,12 @@ export class SQLiteChangeLogObserver {
   readonly #messageProcessing = getOrCreateLatencyHistogram(
     'replica',
     'sqlite_change_log.message_processing_duration',
-    'Time to write a replication message to the SQLite change log.',
+    'Sampled time to write a replication message to the SQLite change log.',
   );
   // The commit that sits on the forward path. There is no second commit to
   // order against any more: the replica's belongs to a subscriber downstream of
   // this loop, so `sqlite_change_log.replica_commit_duration` and the phantom
-  // window it measured are gone. A failed commit is still timed, by
+  // window it measured are gone. Sampled failed commits are still timed by
   // `message_processing_duration` keyed `tag="commit"`.
   readonly #logCommitDuration = getOrCreateLatencyHistogram(
     'replica',
@@ -276,7 +276,7 @@ export class SQLiteChangeLogObserver {
   readonly #hashComparisonCounter = getOrCreateCounter(
     'replica',
     'sqlite_change_log.hash_comparisons',
-    'Ephemeral transaction hash comparisons between the received change stream and SQLite change-log writes.',
+    'Sampled ephemeral transaction hash comparisons between the received change stream and SQLite change-log writes.',
   );
   readonly #hashUnpairedCounter = getOrCreateCounter(
     'replica',
@@ -361,11 +361,16 @@ export class SQLiteChangeLogObserver {
   }
 
   /**
-   * Called as each message arrives, before it is written. Hashes the *received*
-   * stream, which is compared against the hash the writer computes over what it
-   * *stored*.
+   * Called as each message arrives, before it is written. For a sampled
+   * transaction, hashes the *received* stream and compares it with the hash the
+   * writer computes over what it *stored*.
    */
-  messageReceived(data: ChangeStreamData, json: string): void {
+  messageReceived(
+    data: ChangeStreamData,
+    json: string,
+    validateHash = true,
+    storedChange = extractChangeSubstring(json, data[1].tag),
+  ): void {
     const tag = data[1].tag;
     if (data[0] === 'begin') {
       if (this.#sourceHasher !== undefined) {
@@ -375,14 +380,16 @@ export class SQLiteChangeLogObserver {
         );
       }
       const watermark = data[2].commitWatermark;
-      this.#sourceHasher = new ChangeLogTransactionHasher();
+      this.#sourceHasher = validateHash
+        ? new ChangeLogTransactionHasher()
+        : undefined;
       this.#sourcePos = 0;
       this.#sourceCommitHash = undefined;
-      this.#sourceHasher.add({
+      this.#sourceHasher?.add({
         watermark,
         pos: this.#sourcePos,
         tag,
-        change: extractChangeSubstring(json, tag),
+        change: storedChange,
         precommit: null,
       });
       return;
@@ -395,6 +402,10 @@ export class SQLiteChangeLogObserver {
 
     if (data[0] === 'commit') {
       this.#receivedHead = data[2].watermark;
+    }
+
+    if (!validateHash) {
+      return;
     }
 
     const watermark = this.#transactionWatermark;
@@ -412,7 +423,7 @@ export class SQLiteChangeLogObserver {
       watermark: commitWatermark,
       pos: ++this.#sourcePos,
       tag,
-      change: extractChangeSubstring(json, tag),
+      change: storedChange,
       precommit: data[0] === 'commit' ? watermark : null,
     });
     if (data[0] === 'commit') {
@@ -425,10 +436,12 @@ export class SQLiteChangeLogObserver {
   messageProcessed(
     data: ChangeStreamData,
     commit: ChangeLogCommit | null,
-    durationMs: number,
+    durationMs: number | undefined,
   ): void {
     const tag = data[1].tag;
-    this.#messageProcessing.recordMs(durationMs, {tag, outcome: 'success'});
+    if (durationMs !== undefined) {
+      this.#messageProcessing.recordMs(durationMs, {tag, outcome: 'success'});
+    }
 
     if (data[0] === 'begin') {
       if (this.#transactionWatermark !== undefined) {
@@ -478,7 +491,16 @@ export class SQLiteChangeLogObserver {
       this.#rows += commit.stats.rows;
       this.#estimatedBytes += commit.stats.estimatedBytes;
       this.#transactionRows.record(commit.stats.rows);
-      this.#compareHashes(watermark, this.#sourceCommitHash, commit.stats.hash);
+      if (
+        this.#sourceCommitHash !== undefined ||
+        commit.stats.hash !== undefined
+      ) {
+        this.#compareHashes(
+          watermark,
+          this.#sourceCommitHash,
+          commit.stats.hash,
+        );
+      }
     }
     if (watermark < this.#sqliteHead) {
       this.#invariantFailure('SQLite change-log head regressed', {
@@ -494,11 +516,13 @@ export class SQLiteChangeLogObserver {
   messageFailed(
     data: ChangeStreamData,
     error: unknown,
-    durationMs: number,
+    durationMs: number | undefined,
   ): void {
     const tag = data[1].tag;
-    this.#messageProcessing.recordMs(durationMs, {tag, outcome: 'error'});
-    if (data[0] === 'commit') {
+    if (durationMs !== undefined) {
+      this.#messageProcessing.recordMs(durationMs, {tag, outcome: 'error'});
+    }
+    if (data[0] === 'commit' && this.#sourceCommitHash !== undefined) {
       // No commit duration here: a failed commit produces no statistics, so
       // there is nothing to attribute. The attempt is timed by
       // `message_processing_duration{tag="commit",outcome="error"}` above.
@@ -593,10 +617,14 @@ export class SQLiteChangeLogObserver {
   #compareHashes(
     watermark: string,
     sourceHash: string | undefined,
-    sqliteHash: string,
+    sqliteHash: string | undefined,
   ): void {
     if (sourceHash === undefined) {
       this.#recordUnpaired(watermark, 'missing-source-hash');
+      return;
+    }
+    if (sqliteHash === undefined) {
+      this.#recordUnpaired(watermark, 'missing-sqlite-hash');
       return;
     }
     if (sourceHash === sqliteHash) {


### PR DESCRIPTION
Each database change is a package:

  ["data", {the change}, ...]

  Previously, Zero would:

  1. Convert the whole package to JSON.
  2. Search that JSON to copy out the inner change.
  3. Sometimes convert the same data again for storage.

  Now it:

  1. Converts the inner change to JSON once.
  2. Builds the full package around it.
  3. Passes both JSON strings along to whoever needs them.