### PR TITLE
chore(litestream): enable parallel download in litestream v5

### DIFF
--- a/packages/zero-cache/src/services/litestream/config-v5.yml
+++ b/packages/zero-cache/src/services/litestream/config-v5.yml
@@ -39,6 +39,8 @@ dbs:
       auto-recover: true
       concurrency: ${ZERO_LITESTREAM_MULTIPART_CONCURRENCY}
       part-size: ${ZERO_LITESTREAM_MULTIPART_SIZE}
+      download-concurrency: ${ZERO_LITESTREAM_MULTIPART_CONCURRENCY}
+      download-part-size: ${ZERO_LITESTREAM_MULTIPART_SIZE}
 
 logging:
   level: ${ZERO_LITESTREAM_LOG_LEVEL}


### PR DESCRIPTION
Sets the configuration values for parallel download introduced in https://github.com/rocicorp/litestream/pull/28.