### PR TITLE
chore(zero): bump litestream v5 to 0.5.18-zero.4

### DIFF
--- a/packages/zero/Dockerfile
+++ b/packages/zero/Dockerfile
@@ -18,7 +18,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 
 FROM golang:1.25.10@sha256:cd05a378aaf011e8056745363e5c40f4f2bef0fa4d9bf19b9c38316079c332ff AS litestream-v5
 
-ARG LITESTREAM_V5_VERSION=0.5.18-zero.3
+ARG LITESTREAM_V5_VERSION=0.5.18-zero.4
 
 WORKDIR /src/
 RUN git clone --depth 1 --branch v${LITESTREAM_V5_VERSION} https://github.com/rocicorp/litestream.git


### PR DESCRIPTION
Bumps the litestream v5 pin from `0.5.18-zero.3` to [`v0.5.18-zero.4`](https://github.com/rocicorp/litestream/compare/v0.5.18-zero.3...v0.5.18-zero.4). The tag is on the `zero-v5` merge commit of #31; the fork's release workflow does not run on tag pushes, so there is no GitHub release page, same as the previous zero tags.

## What this picks up

**[rocicorp/litestream#31](https://github.com/rocicorp/litestream/pull/31) — share the download pool by remaining bytes, stream unbuffered chunks.** Follow-up to the parallel S3 download in #28, prompted by Darick's staging measurement of only ~1.5x.

The cause was the allocator. The ltx compactor merges every input by page number, so incremental files stay open until the last page and are drained at a trickle beside the snapshot. The old equal split gave the snapshot `pool / (readers + 1)` buffers for the whole restore, which is the two-buffer floor once ~15 files register: two concurrent GETs on a 64 GB object.

Now each reader's share is proportional to how much of its file is still to be read, recomputed as files drain, and a chunk that has no buffer is streamed live rather than waited for. No reader ever waits on the pool, so the reservations and the fairness cap are gone. A lone reader takes the whole pool; on the staging plan the snapshot goes from 2 buffers to 47 of 48.

## Effect on zero-cache

Restore-only, no configuration change. `ZERO_LITESTREAM_MULTIPART_CONCURRENCY` / `_SIZE` already reach `download-concurrency` / `download-part-size` since #6491, so pool and part size can be tuned per stack once this is measured. The memory ceiling is unchanged at `download-concurrency * download-part-size`.

## Verification

`go test -race ./...` is green on the litestream side. Not yet measured on staging: the plan is to rerun Darick's restore on zmail with this build before tuning the pool.

