### PR TITLE
fix(replicache): serialize expo-sqlite prepared statement calls to prevent corrupted reads

### DIFF
--- a/packages/replicache/src/kv/expo-sqlite/store.test.node.ts
+++ b/packages/replicache/src/kv/expo-sqlite/store.test.node.ts
@@ -27,51 +27,77 @@ vi.mock('expo-sqlite', () => ({
       execSync: (sql: string) => db.exec(sql),
       prepareSync: (sql: string) => {
         const stmt = db.prepare(sql);
+        const isSelectQuery = /^\s*select/i.test(sql);
+
+        // Model expo-sqlite's stateful native statement. In expo-sqlite the
+        // bindings and cursor position live on the single sqlite3_stmt, and
+        // are shared by every result object created from it:
+        // - `executeForRawResultAsync` is one native round trip that resets
+        //   the statement, binds params and steps the first row (cached in JS).
+        // - the result's `getAllAsync` is a second native round trip that
+        //   steps the *remaining* rows of whatever the statement is currently
+        //   bound to, with no check that the binding still belongs to this
+        //   result.
+        // The store must therefore not let two callers interleave these two
+        // calls on the same statement.
+        let rows: unknown[][] = [];
+        let pos = 0;
+        const bridgeHop = () => new Promise(resolve => setImmediate(resolve));
+
+        const run = (params: unknown[]) => {
+          if (isSelectQuery) {
+            rows = stmt.raw(true).all(...params) as unknown[][];
+          } else {
+            stmt.run(...params);
+            rows = [];
+          }
+          pos = 0;
+          return rows.length > 0 ? rows[pos++] : null;
+        };
+
+        const makeResult = (firstRow: unknown[] | null, async: boolean) => {
+          let stepped = false;
+          const getAll = () => {
+            if (stepped) {
+              throw new Error('The SQLite cursor has been shifted');
+            }
+            stepped = true;
+            if (firstRow === null) {
+              return [];
+            }
+            const rest = rows.slice(pos);
+            pos = rows.length;
+            return [firstRow, ...rest];
+          };
+          return async
+            ? {
+                getFirstAsync: () => Promise.resolve(firstRow),
+                getAllAsync: async () => {
+                  if (firstRow !== null) {
+                    await bridgeHop();
+                  }
+                  return getAll();
+                },
+              }
+            : {
+                getFirstSync: () => firstRow,
+                getAllSync: getAll,
+              };
+        };
+
         return {
-          executeAsync: (params: unknown[] = []) => {
-            try {
-              let result: unknown[];
-              const isSelectQuery = /^\s*select/i.test(sql);
-              if (isSelectQuery) {
-                result = params.length ? stmt.all(...params) : stmt.all();
-              } else {
-                stmt.run(...params);
-                result = [];
-              }
-              return Promise.resolve({
-                getAllAsync: () => Promise.resolve(result),
-              });
-            } catch (error) {
-              return Promise.reject(error);
-            }
+          executeAsync: async (params: unknown[] = []) => {
+            await bridgeHop();
+            return makeResult(run(params), true);
           },
-          executeForRawResultAsync: (params: unknown[] = []) => {
-            try {
-              const isSelectQuery = /^\s*select/i.test(sql);
-              if (isSelectQuery) {
-                const rows = stmt.raw(true).all(...params) as unknown[][];
-                return Promise.resolve({
-                  getFirstAsync: () =>
-                    Promise.resolve(rows.length > 0 ? rows[0] : null),
-                  getAllAsync: () => Promise.resolve(rows),
-                });
-              }
-              stmt.run(...params);
-              return Promise.resolve({
-                getFirstAsync: () => Promise.resolve(null),
-                getAllAsync: () => Promise.resolve([]),
-              });
-            } catch (error) {
-              return Promise.reject(error);
-            }
+          executeForRawResultAsync: async (params: unknown[] = []) => {
+            await bridgeHop();
+            return makeResult(run(params), true);
           },
-          executeSync: (params: unknown[] = []) => {
-            const isSelectQuery = /^\s*select/i.test(sql);
-            if (isSelectQuery) {
-              return stmt.all(...params);
-            }
-            return stmt.run(...params);
-          },
+          executeSync: (params: unknown[] = []) =>
+            makeResult(run(params), false),
+          executeForRawResultSync: (params: unknown[] = []) =>
+            makeResult(run(params), false),
           finalizeSync: () => {
             // SQLite3 statements don't need explicit finalization
           },

--- a/packages/replicache/src/kv/expo-sqlite/store.ts
+++ b/packages/replicache/src/kv/expo-sqlite/store.ts
@@ -1,3 +1,4 @@
+import {Lock} from '@rocicorp/lock';
 import {
   deleteDatabaseSync,
   openDatabaseSync,
@@ -36,20 +37,44 @@ export function expoSQLiteStoreProvider(
   };
 }
 
+/**
+ * An expo-sqlite prepared statement is a stateful cursor over a single
+ * `sqlite3_stmt`: `executeForRawResultAsync` resets, rebinds and steps the
+ * first row, and the returned result's `getAllAsync` then steps the *remaining*
+ * rows of whatever the statement is currently bound to. Both are separate
+ * native round trips.
+ *
+ * `SQLiteStore` shares one prepared statement per SQL across all concurrent
+ * readers, so without serialization reader B's `executeForRawResultAsync` can
+ * rebind the statement inside reader A's await gap, and A's `getAllAsync` then
+ * returns B's rows (and B is starved of them). That yields wrong or missing
+ * values and, when a ref count delta is computed from such a read and written,
+ * a persistently corrupted store.
+ *
+ * Every call on a statement is therefore run under a per-statement lock so the
+ * execute + fetch pair is atomic with respect to other users of that statement.
+ */
 class ExpoSQLitePreparedStatement implements PreparedStatement {
   readonly #statement: SQLiteStatement;
+  readonly #lock = new Lock();
 
   constructor(statement: SQLiteStatement) {
     this.#statement = statement;
   }
 
-  async exec(params: string[]): Promise<void> {
-    await this.#statement.executeForRawResultAsync(params);
+  exec(params: string[]): Promise<void> {
+    return this.#lock.withLock(async () => {
+      await this.#statement.executeForRawResultAsync(params);
+    });
   }
 
-  async all(params: string[]): Promise<unknown[][]> {
-    const result = await this.#statement.executeForRawResultAsync(params);
-    return result.getAllAsync() as Promise<unknown[][]>;
+  all(params: string[]): Promise<unknown[][]> {
+    return this.#lock.withLock(async () => {
+      const result = await this.#statement.executeForRawResultAsync(params);
+      // Must be awaited inside the lock so that no other caller can reset the
+      // statement before all rows have been stepped.
+      return (await result.getAllAsync()) as unknown[][];
+    });
   }
 }
 

--- a/packages/replicache/src/kv/sqlite-store-test-util.ts
+++ b/packages/replicache/src/kv/sqlite-store-test-util.ts
@@ -152,6 +152,58 @@ export function runSQLiteStoreTests<TOptions = unknown>(
     await store.close();
   });
 
+  test('concurrent readers batching multiple keys do not interleave', async () => {
+    // Regression test: SQLiteStore shares one prepared statement per SQL
+    // across all concurrent readers. A delegate whose statement execution is
+    // not atomic (e.g. expo-sqlite's execute + getAll cursor pair) can have one
+    // reader's fetch return rows bound by another reader, so keys read back as
+    // undefined or as another key's value. Each reader batches several keys
+    // in one microtask so the store uses getMany/hasMany, which return multiple
+    // rows and are therefore sensitive to cursor interleaving.
+    const store = createStoreWithDefaults(`interleave-test-${++storeCounter}`);
+
+    const readerCount = 4;
+    const keysPerReader = 3;
+    const keysFor = (r: number) =>
+      Array.from({length: keysPerReader}, (_, i) => `r${r}/k${i}`);
+
+    await withWrite(store, async wt => {
+      for (let r = 0; r < readerCount; r++) {
+        for (const key of keysFor(r)) {
+          await wt.put(key, `value-${key}`);
+        }
+      }
+    });
+
+    for (let round = 0; round < 5; round++) {
+      const reads = await Promise.all(
+        Array.from({length: readerCount}, () => store.read()),
+      );
+      try {
+        const results = await Promise.all(
+          reads.map((rt, r) => {
+            const keys = keysFor(r);
+            return Promise.all([
+              Promise.all(keys.map(k => rt.get(k))),
+              Promise.all([...keys.map(k => rt.has(k)), rt.has(`r${r}/nope`)]),
+            ]);
+          }),
+        );
+        for (let r = 0; r < readerCount; r++) {
+          const [values, has] = results[r];
+          expect(values).toEqual(keysFor(r).map(k => `value-${k}`));
+          expect(has).toEqual([...keysFor(r).map(() => true), false]);
+        }
+      } finally {
+        for (const rt of reads) {
+          rt.release();
+        }
+      }
+    }
+
+    await store.close();
+  });
+
   test('concurrent reads with write blocking', async () => {
     const store = createStoreWithDefaults(`concurrent-test-${++storeCounter}`);
 

--- a/packages/replicache/src/kv/sqlite-store.ts
+++ b/packages/replicache/src/kv/sqlite-store.ts
@@ -11,6 +11,13 @@ import {deleteSentinel, WriteImplBase} from './write-impl-base.ts';
 
 /**
  * A SQLite prepared statement.
+ *
+ * `SQLiteStore` prepares one statement per SQL and shares it across all
+ * concurrent readers, so implementations must make each call atomic with
+ * respect to other callers of the same statement: `all()` must not let another
+ * `exec()`/`all()` rebind or reset the underlying statement between executing
+ * it and fetching its rows. Delegates whose native API splits execute and fetch
+ * into separate round trips (e.g. expo-sqlite) must serialize per statement.
  */
 export interface PreparedStatement {
   exec(params: string[]): Promise<void>;


### PR DESCRIPTION
## What

Every call on an `ExpoSQLitePreparedStatement` now runs under a per-statement `Lock`, with the row fetch awaited inside the lock, so the execute + fetch pair is atomic with respect to other users of that statement.

## Why

expo-sqlite's `executeForRawResultAsync` and the result's `getAllAsync` are two separate native round trips on one stateful `sqlite3_stmt`. The first resets, rebinds and steps the first row; the second steps the *remaining* rows of whatever the statement is currently bound to. `SQLiteStore` shares one prepared statement per SQL across all concurrent readers (which `RWLock.read()` deliberately allows), so reader B's execute could rebind the statement inside reader A's await gap, and A's fetch then returned B's rows while B was starved of them.

Symptoms: keys read back as `undefined` or as another key's value (`Invalid type: null, expected number`, `Refs must be an array`, `ChunkNotFoundError`), and when a ref count delta computed from such a read was written, the store was persistently corrupted (`Invalid ref count -N`). This is the bug Margins hit on their Android launch day (64 devices in one hour); their repro and analysis are on the Margins burndown page in Notion.

Only the expo-sqlite delegate is affected. op-sqlite's `executeRaw` is a single native call and zero-sqlite is synchronous, so both were already atomic.

## Why a per-statement lock rather than per-transaction statements

- Per-statement scope is the narrowest fix: reads never wait on writes (already ordered by the `RWLock`), and nothing awaits another statement's turn while holding one, so no deadlock path.
- All calls go through one SQLite connection and Expo Modules dispatch async native functions serially, so concurrent readers were already queueing natively. The lock only moves the queueing to a point where the cursor cannot be clobbered. Uncontended cost is two microtask hops per call.
- Preparing statements per read transaction would add four synchronous `prepareSync`/`finalizeSync` JNI calls per transaction on the JS thread, which is worse for hydration.

## Also in this PR

- Documents the atomicity requirement on the `PreparedStatement` interface so future delegates don't repeat this.
- Rewrites the expo-sqlite test mock to model the shared native cursor with an async hop between execute and fetch. The old mock captured all rows synchronously at execute time and could never expose this class of bug.
- Adds a shared regression test (runs for expo-sqlite and op-sqlite) with several concurrent readers each batching multiple keys so the store uses `getMany`/`hasMany`. It fails on the old code with the reported signature (`['value-r0/k0', undefined, undefined]`) and passes with the fix.

## Verification

- `pnpm --filter replicache run test kv/`: 171 passed. Lint, format, and check-types clean.
- Real device: Expo 57 app with expo-sqlite 57.0.2 on an Android 16 emulator, four concurrent readers × 20 rounds.
