### PR TITLE
perf(zero-react): keep a resolved query request stable across renders

### DIFF
--- a/packages/zero-react/src/use-query.test.tsx
+++ b/packages/zero-react/src/use-query.test.tsx
@@ -12,6 +12,7 @@ import {
 } from 'vitest';
 import type {Format} from '../../zero-types/src/format.ts';
 import {newQuery} from '../../zql/src/query/query-impl.ts';
+import type {TTL} from '../../zql/src/query/ttl.ts';
 import {queryInternalsTag, type QueryImpl} from './bindings.ts';
 import {
   getAllViewsSizeForTesting,
@@ -390,6 +391,38 @@ describe('ViewStore', () => {
     });
   });
 
+  describe('ttl', () => {
+    test('an unchanged ttl is not forwarded to the view', () => {
+      const viewStore = new ViewStore();
+      const zero = newMockZero('client1');
+
+      viewStore.getView(zero, newMockQuery('query1'), true, 1000);
+      // The wrapper materializes eagerly, so the underlying view is the one
+      // to watch: `getView` calls the wrapper's `updateTTL` either way, and
+      // what the guard changes is whether it forwards.
+      const materialized = vi.mocked(zero.materialize).mock.results[0]
+        .value as {
+        updateTTL: (ttl: TTL) => void;
+      };
+      const updateTTL = vi.spyOn(materialized, 'updateTTL');
+
+      // Same ttl, as every re-render passes: nothing to tell the view, and
+      // nothing to re-derive in the query manager.
+      viewStore.getView(zero, newMockQuery('query1'), true, 1000);
+      viewStore.getView(zero, newMockQuery('query1'), true, 1000);
+      expect(updateTTL).not.toHaveBeenCalled();
+
+      // A different ttl still propagates...
+      viewStore.getView(zero, newMockQuery('query1'), true, 2000);
+      expect(updateTTL).toHaveBeenCalledWith(2000);
+
+      // ...including a change only in how the duration is spelled.
+      updateTTL.mockClear();
+      viewStore.getView(zero, newMockQuery('query1'), true, '2s');
+      expect(updateTTL).toHaveBeenCalledWith('2s');
+    });
+  });
+
   describe('singular vs plural', () => {
     test('the same query hash with different singular flag creates different views', () => {
       const viewStore = new ViewStore();
@@ -578,6 +611,120 @@ describe('ViewStore', () => {
 
       cleanup();
     });
+  });
+});
+
+describe('stable query identity', () => {
+  let root: Root;
+  let element: HTMLDivElement;
+
+  beforeEach(() => {
+    vi.useRealTimers();
+    element = document.createElement('div');
+    document.body.appendChild(element);
+    root = createRoot(element);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(element);
+    root.unmount();
+  });
+
+  /**
+   * A named query as a call site sees it: the `CustomQuery` is a stable
+   * module-level object, and calling it allocates a fresh request each render.
+   */
+  function newMockCustomQuery() {
+    const built = newMockQuery('stable-query');
+    const fn = vi.fn(() => built);
+    const customQuery = {fn};
+    const request = (args: ReadonlyJSONValue) =>
+      ({
+        'query': customQuery,
+        args,
+        '~': 'QueryRequest',
+        // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+      }) as any;
+    return {fn, request};
+  }
+
+  function Comp({
+    n,
+    request,
+  }: {
+    n: number;
+    // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+    request: any;
+  }) {
+    useQuery(request);
+    return <div>{n}</div>;
+  }
+
+  async function render(
+    // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+    zero: any,
+    // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+    request: any,
+    n: number,
+  ) {
+    root.render(
+      <ZeroProvider zero={zero}>
+        <Comp n={n} request={request} />
+      </ZeroProvider>,
+    );
+    await expect.poll(() => element.textContent).toBe(String(n));
+  }
+
+  test('a request with equal args is resolved once across re-renders', async () => {
+    const {fn, request} = newMockCustomQuery();
+    const zero = newMockZero('client-stable');
+
+    await render(zero, request({id: 'a'}), 1);
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    // A fresh request object each render, meaning the same thing: the query
+    // definition -- argument validation and the builder chain -- is not run
+    // again.
+    await render(zero, request({id: 'a'}), 2);
+    await render(zero, request({id: 'a'}), 3);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  test('changing the args resolves again', async () => {
+    const {fn, request} = newMockCustomQuery();
+    const zero = newMockZero('client-stable-args');
+
+    await render(zero, request({id: 'a'}), 1);
+    await render(zero, request({id: 'b'}), 2);
+    expect(fn).toHaveBeenCalledTimes(2);
+
+    // ...and the new args are then themselves stable.
+    await render(zero, request({id: 'b'}), 3);
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  test('a query toggled off and back on reuses what it had', async () => {
+    const {fn, request} = newMockCustomQuery();
+    const zero = newMockZero('client-stable-toggle');
+
+    await render(zero, request({id: 'a'}), 1);
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    await render(zero, undefined, 2);
+    await render(zero, request({id: 'a'}), 3);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  test('changing the Zero instance resolves again', async () => {
+    const {fn, request} = newMockCustomQuery();
+
+    await render(newMockZero('client-stable-z1'), request({id: 'a'}), 1);
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    // A different Zero means a different context and a different view store
+    // entry, so the cached resolution does not carry over.
+    await render(newMockZero('client-stable-z2'), request({id: 'a'}), 2);
+    expect(fn).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/packages/zero-react/src/use-query.tsx
+++ b/packages/zero-react/src/use-query.tsx
@@ -1,5 +1,6 @@
 import {resolver} from '@rocicorp/resolver';
-import React, {useSyncExternalStore} from 'react';
+import React, {useRef, useSyncExternalStore} from 'react';
+import {deepEqual} from '../../shared/src/json.ts';
 import {TESTING} from '../../shared/src/testing.ts';
 import {
   type Immutable,
@@ -29,6 +30,92 @@ import type {
   TypedView,
   Zero,
 } from './zero.ts';
+
+type StableQueryCache = {
+  zero: unknown;
+  context: unknown;
+  /** The last input, so an unchanged one is an identity compare and nothing else. */
+  rawQuery: object;
+  /** The `CustomQuery` a query request names; undefined for a plain query. */
+  customQuery: unknown;
+  args: ReadonlyJSONValue | undefined;
+  // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+  q: Query<any, any, any>;
+};
+
+/**
+ * Resolves a query request against the Zero context, reusing the previous
+ * result while the request means the same thing.
+ *
+ * Interning already makes an unchanged *plain* query come back as the same
+ * object, so this is aimed at the query-request form -- `queries.issue({id})`
+ * -- where every render allocates a fresh request and `addContextToQuery`
+ * re-runs the definition. That costs argument validation (a zod parse of
+ * byte-identical args) plus a walk of the builder chain, neither of which
+ * interning removes: it makes rebuilding the chain cheap and gives the same
+ * object back, but only after the work has been done again.
+ *
+ * A request resolves to the previous query when it names the same
+ * `CustomQuery`, the same context, and deep-equal args. Those are exactly the
+ * inputs the definition is allowed to depend on: a named query is re-derived
+ * on the server from its name and args, so it has to be a pure function of
+ * them, or client and server would build different queries.
+ *
+ * The ref is written during render. That is safe here because it is a pure
+ * cache: an entry is derived only from the inputs, so a StrictMode double
+ * render or a discarded concurrent render leaves it valid either way.
+ */
+function useStableQuery<
+  TTable extends keyof TSchema['tables'] & string,
+  TInput extends ReadonlyJSONValue | undefined,
+  TOutput extends ReadonlyJSONValue | undefined,
+  TSchema extends BaseDefaultSchema,
+  TReturn,
+  TContext extends BaseDefaultContext,
+>(
+  query:
+    | QueryOrQueryRequest<TTable, TInput, TOutput, TSchema, TReturn, TContext>
+    | Falsy,
+  zero: Zero<TSchema, undefined, TContext>,
+): Query<TTable, TSchema, TReturn> | undefined {
+  const cacheRef = useRef<StableQueryCache | undefined>(undefined);
+
+  // Deliberately kept rather than cleared: a query toggled off and back on
+  // reuses what it had.
+  if (!query) {
+    return undefined;
+  }
+
+  const cache = cacheRef.current;
+  if (cache && cache.zero === zero) {
+    if (cache.rawQuery === query) {
+      return cache.q as Query<TTable, TSchema, TReturn>;
+    }
+    if (
+      'query' in query &&
+      cache.customQuery === query.query &&
+      cache.context === zero.context &&
+      deepEqual(cache.args, query.args)
+    ) {
+      // Same meaning, new wrapper object: remember it so the next render is
+      // the identity compare above.
+      cache.rawQuery = query;
+      return cache.q as Query<TTable, TSchema, TReturn>;
+    }
+  }
+
+  const q = addContextToQuery(query, zero.context);
+  const isRequest = 'query' in query;
+  cacheRef.current = {
+    zero: zero,
+    context: zero.context,
+    rawQuery: query,
+    customQuery: isRequest ? query.query : undefined,
+    args: isRequest ? query.args : undefined,
+    q,
+  };
+  return q;
+}
 
 export type QueryResult<TReturn> = readonly [
   HumanReadable<TReturn>,
@@ -137,7 +224,7 @@ export function useQuery<
   const zero = useZero<TSchema, undefined, TContext>();
 
   // When query is falsy, use disabled subscriber/snapshot to maintain hook order
-  const q = query ? addContextToQuery(query, zero.context) : undefined;
+  const q = useStableQuery(query, zero);
   const view = q ? viewStore.getView(zero, q, enabled, ttl) : undefined;
 
   // https://react.dev/reference/react/useSyncExternalStore
@@ -216,7 +303,7 @@ export function useSuspenseQuery<
   const zero = useZero<TSchema, undefined, TContext>();
 
   // When query is falsy, use disabled subscriber/snapshot to maintain hook order
-  const q = query ? addContextToQuery(query, zero.context) : undefined;
+  const q = useStableQuery(query, zero);
   const view = q ? viewStore.getView(zero, q, enabled, ttl) : undefined;
 
   // https://react.dev/reference/react/useSyncExternalStore
@@ -665,6 +752,14 @@ class ViewWrapper<
   };
 
   updateTTL(ttl: TTL): void {
+    // `getView` calls this on every render, and forwarding an unchanged TTL
+    // reaches the query manager, which re-derives the query's id from its AST
+    // to find the entry. Nothing downstream distinguishes a repeat, so skip
+    // it. A change in how the same duration is spelled ('60s' vs 60000) is
+    // still a change here and still propagates, as it did before.
+    if (this.#ttl === ttl) {
+      return;
+    }
     this.#ttl = ttl;
     this.#view?.updateTTL(ttl);
   }


### PR DESCRIPTION
Based on #6305 by @charpeni, reduced to the parts that still pay off now that
query interning (#6469, #6470, #6471) and the nested view-store key (#6487)
have landed.

### What interning already fixed

That PR's premise was that every cache on the `useQuery` render path is keyed
on object identity, the query is rebuilt inline each render, so every cache
misses. Interning made the rebuild return the *same* instance, so those caches
now hit. Measured on current `main`, per render:

| | ns |
| --- | --- |
| `qi.hash()` | 5 |
| `updateTTL` → `normalizeAST` (WeakMap) | 6 |
| `updateTTL` → `hashOfAST` (WeakMap) | 10 |
| rebuild an interned chain | 112 |

So the original PR's view-store key `WeakMap` is superseded — `getView` already
builds no string at all — and its plain-builder branch is redundant, since an
unchanged plain query is already the same object and an identity compare
catches it.

### What interning did not fix

Nothing above touches the query-request form, `queries.issue({id})`, which is
what zbugs uses throughout. Every render allocates a fresh request and
`addContextToQuery` re-runs the definition. Measured on `main` for a
zbugs-shaped named query with a zod validator:

| step | ns |
| --- | --- |
| allocate the request | 7 |
| **`validateInput` (zod)** | **591** |
| build the chain (interned) | 127 |
| `nameAndArgs` | ~165 |
| **total** | **883** |

Two thirds of that is zod re-validating byte-identical args. Interning cannot
remove it — it makes rebuilding cheap and returns the same object, but only
after the work has been done again.

### Changes

- **`useStableQuery`** (internal): a per-hook cache that resolves a request to
  the previous query while it names the same `CustomQuery`, the same context,
  and deep-equal args — ~121ns for the `deepEqual` against 883ns. An unchanged
  input is an identity compare and nothing else. A falsy render keeps the
  cache, so a query toggled off and back on is reused; a different `Zero`
  invalidates.

  This is sound by an existing contract rather than by assumption: the server
  re-derives a named query from its name and args (`process-queries.ts` calls
  `handler(req.name, req.args)`), so a definition already has to be a pure
  function of name, args and context, or client and server would build
  different queries.

  The ref is written during render, which is safe for a pure cache — an entry
  is derived only from the inputs, so a StrictMode double render or a discarded
  concurrent render leaves it valid.

- **`ViewWrapper.updateTTL` early-returns on an unchanged TTL.** `getView`
  calls it every render, and forwarding reaches `QueryManager.updateLegacy`,
  which re-derives the query id from its AST to find the entry. A change in how
  the same duration is spelled (`'60s'` → `60000`) is still a change and still
  propagates.

### Not carried over from #6305

- The view-store key `WeakMap`: #6487 nests the map as client id → hash → view
  and builds no key string, which is strictly less work than caching one.
- The plain-builder branch: interning already returns the same object, and the
  identity check above catches it. Its `deepEqual` over the whole AST would
  only run when interning missed, where it costs more than the ~150ns it saves.
- `symmetricDeepEqual`: the asymmetry it worked around was real at that PR's
  base, but #6430 fixed `deepEqual` to treat undefined values as non-existent.
  Verified on `main` that the exact case it cites,
  `deepEqual({q: undefined, page: 1}, {page: 1, sort: 'x'})`, is now false in
  both directions.

### Testing

5 new tests, each verified to fail against the unchanged source: a request with
equal args resolves once across re-renders; changing args resolves again and is
then itself stable; a toggled-off query reuses its cache; changing the `Zero`
instance re-resolves; an unchanged TTL is not forwarded to the view while a
changed one still is.

`zero-react` 80, `zero-solid` 59, `zql` 1448 pass. Repo-wide `check-types`,
`lint` and `oxfmt --check` clean.
