### PR TITLE
fix(zero-solid): materialize with the current ttl, not the initial one

### DIFF
--- a/packages/zero-solid/src/use-query.test.tsx
+++ b/packages/zero-solid/src/use-query.test.tsx
@@ -191,6 +191,36 @@ test('useQuery with ttl', () => {
   expect(materializeSpy).toHaveBeenCalledTimes(0);
 });
 
+test('a view materialized after a ttl change uses the current ttl', () => {
+  // The ttl the hook starts with is read once. A view built later -- because
+  // the query changed -- must still be materialized with whatever ttl is in
+  // effect by then, not the one the hook happened to start with.
+  const {tableQuery, queryDelegate} = setupTestEnvironment();
+  const [ttl, setTTL] = createSignal<TTL>('1m');
+  const [query, setQuery] = createSignal(tableQuery);
+
+  const zero = newMockZero('solid-ttl-on-rematerialize', queryDelegate);
+  const materializeSpy = vi.spyOn(queryDelegate, 'materialize');
+
+  useQueryWithZeroProvider(
+    zero,
+    () => query(),
+    () => ({ttl: ttl()}),
+  );
+
+  expect(materializeSpy).toHaveBeenCalledTimes(1);
+  expect(materializeSpy.mock.calls[0][2]).toEqual({ttl: '1m'});
+
+  // Changing the ttl updates the live view rather than building a new one.
+  setTTL('10m');
+  expect(materializeSpy).toHaveBeenCalledTimes(1);
+
+  // Changing the query does build a new one, which must carry '10m'.
+  setQuery(() => tableQuery.where('a', 1));
+  expect(materializeSpy).toHaveBeenCalledTimes(2);
+  expect(materializeSpy.mock.calls[1][2]).toEqual({ttl: '10m'});
+});
+
 test('useQuery gets an error', async () => {
   const {tableQuery, queryDelegate} = setupTestEnvironment();
   const querySignal = vi.fn(() => tableQuery);

--- a/packages/zero-solid/src/use-query.ts
+++ b/packages/zero-solid/src/use-query.ts
@@ -160,8 +160,6 @@ export function useQuery<
   });
   const ttl = createMemo(() => normalize(options)?.ttl ?? DEFAULT_TTL_MS);
 
-  const initialTTL = ttl();
-
   const view = createMemo(() => {
     // Depend on hash instead of query to avoid recreating the view when the
     // query object changes but the hash is the same.
@@ -184,7 +182,13 @@ export function useQuery<
       untrackedQuery,
       createSolidViewFactory(setState, refetch),
       {
-        ttl: initialTTL,
+        // Untracked: a ttl change updates the live view through the effect
+        // below, and depending on it here would tear the view down and build
+        // a new one instead. Read at materialize time rather than once at
+        // setup, so a view built later -- because the query changed -- gets
+        // the ttl in effect by then rather than the one this hook started
+        // with.
+        ttl: untrack(ttl),
       },
     );
 


### PR DESCRIPTION
Found while checking whether zero-solid needed the memoization in #6496. It
does not — Solid's reactivity already covers both parts of that change — but
this turned up next to it.

### The bug

`useQuery` read the ttl once at setup:

```ts
const ttl = createMemo(() => normalize(options)?.ttl ?? DEFAULT_TTL_MS);
const initialTTL = ttl();
```

and passed `initialTTL` to every `materialize`. The `createEffect(on(ttl, …))`
below keeps a *live* view's ttl up to date, so the first view is always right.
But a view built later — because the query changed, so the `view` memo
recomputed — was materialized with the ttl the hook started with, and the
effect does not fire again to correct it, because the ttl did not change at
that moment.

So: change the ttl, then change the query, and the new view silently runs with
the old ttl for the rest of its life.

### The fix

Read it at materialize time instead, untracked. Tracking it there would make a
ttl change tear the view down and rebuild it, which is exactly what the effect
exists to avoid — `untrack` was already imported and used two lines above for
the query.

### Testing

New test, verified to fail before the fix with
`expected { ttl: '1m' } to deeply equal { ttl: '10m' }`: materialize once at
`'1m'`, change the ttl to `'10m'` and confirm no new view is built, then change
the query and assert the second `materialize` carries `'10m'`.
