### PR TITLE
fix(zero-client): log the original error behind a fatal connection error

### DIFF
--- a/packages/shared/src/error.test.ts
+++ b/packages/shared/src/error.test.ts
@@ -193,4 +193,30 @@ describe('getErrorCauses', () => {
     (a as {cause?: unknown}).cause = b;
     expect(getErrorCauses(a)).toEqual([b]);
   });
+
+  test('reads a cause getter exactly once per hop', () => {
+    const root = new Error('root');
+    let reads = 0;
+    const outer = new Error('outer');
+    Object.defineProperty(outer, 'cause', {
+      get() {
+        reads++;
+        return reads === 1 ? root : new Error('a different cause');
+      },
+    });
+    expect(getErrorCauses(outer)).toEqual([root]);
+    expect(reads).toBe(1);
+  });
+
+  test('stops traversal when reading a cause throws', () => {
+    const middle = new Error('middle');
+    Object.defineProperty(middle, 'cause', {
+      get() {
+        throw new Error('getter exploded');
+      },
+    });
+    const outer = new Error('outer', {cause: middle});
+    expect(getErrorCauses(outer)).toEqual([middle]);
+    expect(getErrorCauses(middle)).toEqual([]);
+  });
 });

--- a/packages/shared/src/error.test.ts
+++ b/packages/shared/src/error.test.ts
@@ -1,6 +1,6 @@
 import {describe, expect, test} from 'vitest';
 
-import {getErrorDetails, getErrorMessage} from './error.ts';
+import {getErrorCauses, getErrorDetails, getErrorMessage} from './error.ts';
 import type {ReadonlyJSONValue} from './json.ts';
 
 const UNKNOWN_ERROR_MESSAGE =
@@ -164,5 +164,33 @@ describe('getErrorDetails', () => {
     expect(getErrorDetails(new ErrorWithInvalidDetails('test'))).toEqual({
       name: 'ErrorWithInvalidDetails',
     });
+  });
+});
+
+describe('getErrorCauses', () => {
+  test('returns nothing for errors without a cause', () => {
+    expect(getErrorCauses(new Error('boom'))).toEqual([]);
+    expect(getErrorCauses(undefined)).toEqual([]);
+    expect(getErrorCauses('string')).toEqual([]);
+    expect(getErrorCauses(new Error('boom', {cause: undefined}))).toEqual([]);
+  });
+
+  test('returns the cause chain outermost first', () => {
+    const root = new TypeError('root');
+    const middle = new Error('middle', {cause: root});
+    const outer = new Error('outer', {cause: middle});
+    expect(getErrorCauses(outer)).toEqual([middle, root]);
+  });
+
+  test('includes non-Error causes', () => {
+    const outer = new Error('outer', {cause: 'plain string'});
+    expect(getErrorCauses(outer)).toEqual(['plain string']);
+  });
+
+  test('stops on cycles', () => {
+    const a = new Error('a');
+    const b = new Error('b', {cause: a});
+    (a as {cause?: unknown}).cause = b;
+    expect(getErrorCauses(a)).toEqual([b]);
   });
 });

--- a/packages/shared/src/error.ts
+++ b/packages/shared/src/error.ts
@@ -53,6 +53,34 @@ function getErrorMessageInternal(error: unknown, seen: Set<unknown>): string {
   return `Unknown error of type ${typeof error} was thrown and the message could not be determined. See cause for details.`;
 }
 
+/**
+ * Returns the chain of `cause` values hanging off `error`, outermost first.
+ *
+ * Errors that Zero raises on a fatal path wrap the original exception as
+ * `cause`. Console sinks on some runtimes (React Native's Hermes among them)
+ * print only the outer error's message and stack, so the original error's
+ * name, message and stack are lost unless they are logged as separate
+ * arguments. Spread the result of this function into a log call to keep them
+ * visible.
+ */
+export function getErrorCauses(error: unknown): unknown[] {
+  const causes: unknown[] = [];
+  const seen = new Set<unknown>([error]);
+  let current = error;
+  while (
+    typeof current === 'object' &&
+    current !== null &&
+    'cause' in current &&
+    (current as {cause: unknown}).cause !== undefined &&
+    !seen.has((current as {cause: unknown}).cause)
+  ) {
+    current = (current as {cause: unknown}).cause;
+    seen.add(current);
+    causes.push(current);
+  }
+  return causes;
+}
+
 export function getErrorDetails(error: unknown): ReadonlyJSONValue | undefined {
   if (error instanceof Error) {
     if ('details' in error) {

--- a/packages/shared/src/error.ts
+++ b/packages/shared/src/error.ts
@@ -67,18 +67,30 @@ export function getErrorCauses(error: unknown): unknown[] {
   const causes: unknown[] = [];
   const seen = new Set<unknown>([error]);
   let current = error;
-  while (
-    typeof current === 'object' &&
-    current !== null &&
-    'cause' in current &&
-    (current as {cause: unknown}).cause !== undefined &&
-    !seen.has((current as {cause: unknown}).cause)
-  ) {
-    current = (current as {cause: unknown}).cause;
-    seen.add(current);
-    causes.push(current);
+  for (;;) {
+    const cause = readCause(current);
+    if (cause === undefined || seen.has(cause)) {
+      return causes;
+    }
+    seen.add(cause);
+    causes.push(cause);
+    current = cause;
   }
-  return causes;
+}
+
+/**
+ * Reads `cause` exactly once. `error` is `unknown`, so `cause` may be an
+ * accessor or proxy trap: a stateful getter must not be consulted twice per
+ * hop, and a throwing one must not escape from a log call in an error handler.
+ */
+function readCause(error: unknown): unknown {
+  try {
+    return typeof error === 'object' && error !== null && 'cause' in error
+      ? (error as {cause: unknown}).cause
+      : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 export function getErrorDetails(error: unknown): ReadonlyJSONValue | undefined {

--- a/packages/zero-client/src/client/zero.test.ts
+++ b/packages/zero-client/src/client/zero.test.ts
@@ -4778,6 +4778,29 @@ describe('WebSocket event error handling', () => {
       ),
     ).toBe(true);
 
+    // The run loop wraps the original TypeError as the cause of an Internal
+    // ClientError. Console sinks on some runtimes print only the outer error,
+    // so both run loop log lines must carry the original error as its own
+    // argument.
+    const {cause} = reason;
+    expect(cause).toBeInstanceOf(TypeError);
+    // The state transition happens synchronously in #disconnect; the run loop
+    // logs once it observes the aborted attempt.
+    const findLog = (prefix: string) =>
+      z.testLogSink.messages.find(
+        ([_level, _context, args]) =>
+          typeof args[0] === 'string' && args[0].startsWith(prefix),
+      );
+    await vi.waitUntil(() => findLog('Run loop paused in error state'));
+    expect(findLog('Failed to connect')?.[2].slice(1, 3)).toEqual([
+      reason,
+      cause,
+    ]);
+    expect(findLog('Run loop paused in error state')?.[2].slice(1)).toEqual([
+      reason,
+      cause,
+    ]);
+
     await z.close().catch(() => {});
   });
 

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -28,7 +28,7 @@ import {
   mustGetBrowserGlobal,
 } from '../../../shared/src/browser-env.ts';
 import {getDocumentVisibilityWatcher} from '../../../shared/src/document-visible.ts';
-import {getErrorMessage} from '../../../shared/src/error.ts';
+import {getErrorCauses, getErrorMessage} from '../../../shared/src/error.ts';
 import {h64} from '../../../shared/src/hash.ts';
 import type {ReadonlyJSONValue} from '../../../shared/src/json.ts';
 import {must} from '../../../shared/src/must.ts';
@@ -2393,6 +2393,7 @@ export class Zero<
             lc.info?.(
               `Run loop paused in error state. Call zero.connection.connect() to resume.`,
               currentState.reason,
+              ...getErrorCauses(currentState.reason),
             );
             const resumeResult = await promiseRace({
               connectRequest: this.#connectionManager.waitForConnectRequest(),
@@ -2421,7 +2422,7 @@ export class Zero<
         ) {
           const level = isAuthError(ex) ? 'warn' : 'error';
           const kind = isServerError(ex) ? ex.kind : 'Unknown Error';
-          lc[level]?.('Failed to connect', ex, kind, {
+          lc[level]?.('Failed to connect', ex, ...getErrorCauses(ex), kind, {
             lmid: this.#lastMutationIDReceived,
             baseCookie: this.#connectCookie,
           });


### PR DESCRIPTION
## The defect

Fatal errors in the run loop are wrapped in an Internal `ClientError` with the original exception kept only as `cause`. Console sinks on some runtimes (React Native's Hermes among them) print just the outer error's message and stack, so the wrapper's stack pointed at the wrap site in `zero.ts` and the original error's type, message and stack never reached the log.

This is the "fatal errors laundered" report from Margins (ext-margins, Sep 2, `zero-2-fatal-errors-laundered.md`; also on the Margins Android Launch Burndown as "fatal errors should log the error message").

## The change

- `shared/src/error.ts`: `getErrorCauses(error)` returns the `cause` chain outermost first, with a cycle guard.
- `zero-client/src/client/zero.ts`: the `Failed to connect` and `Run loop paused in error state` log calls spread the cause chain in as separate arguments, so any sink prints each cause in full. The trailing context object stays last for sinks that fold it into the message.

No behavior change beyond the extra log arguments.

## Tests

- Four unit tests for `getErrorCauses` (no cause, chain order, non-Error cause, cycle).
- The existing `onOpen catches unexpected errors` test now asserts both log lines carry the original `TypeError` as its own argument. It waits for the run loop's log line, since the state transition happens synchronously in `#disconnect` and the run loop logs afterwards.
