### PR TITLE
feat(zero-cache): per-query hydration timeout with a circuit breaker

### DIFF
--- a/packages/zero-cache/src/config/zero-config.test.ts
+++ b/packages/zero-cache/src/config/zero-config.test.ts
@@ -302,6 +302,16 @@ test('zero-cache --help', () => {
                                                                                    have kept it warm are both dropped. A value of 0 disables                                                                  
                                                                                    hydration-budget eviction.                                                                                                 
                                                                                                                                                                                                               
+     --view-syncer-query-hydration-timeout-ms number                               default: 0                                                                                                                 
+       ZERO_VIEW_SYNCER_QUERY_HYDRATION_TIMEOUT_MS env                                                                                                                                                        
+                                                                                   The maximum processing time in milliseconds that a view-syncer spends                                                      
+                                                                                   hydrating a single client query. Time spent yielding to other work is                                                      
+                                                                                   not counted. A query whose hydration exceeds this limit is aborted and                                                     
+                                                                                   removed from the client's view, and affected clients receive an error                                                      
+                                                                                   for the query. The query is then rejected without being run again for                                                      
+                                                                                   a cooldown period, after which a retry is allowed. Internal queries are                                                    
+                                                                                   never aborted. A value of 0 disables the limit.                                                                            
+                                                                                                                                                                                                              
      --change-db string                                                            optional                                                                                                                   
        ZERO_CHANGE_DB env                                                                                                                                                                                     
                                                                                    The Postgres database used to store recent replication log entries, in order                                               
@@ -931,6 +941,39 @@ test('view-syncer hydration budget defaults to disabled and accepts milliseconds
   });
   expect(configured.config.viewSyncerHydrationBudgetMs).toBe(250);
 });
+
+test('view-syncer query hydration timeout', () => {
+  const defaults = parseOptionsAdvanced(zeroOptions, {
+    envNamePrefix: 'ZERO_',
+    allowUnknown: false,
+    allowPartial: true,
+  });
+  expect(defaults.config.viewSyncerQueryHydrationTimeoutMs).toBe(0);
+
+  const configured = parseOptionsAdvanced(zeroOptions, {
+    envNamePrefix: 'ZERO_',
+    allowUnknown: false,
+    allowPartial: true,
+    env: {ZERO_VIEW_SYNCER_QUERY_HYDRATION_TIMEOUT_MS: '5000'},
+  });
+  expect(configured.config.viewSyncerQueryHydrationTimeoutMs).toBe(5000);
+});
+
+test.each(['-1', '1.5'])(
+  'view-syncer query hydration timeout rejects %s',
+  queryHydrationTimeoutMs => {
+    expect(() =>
+      parseOptionsAdvanced(zeroOptions, {
+        envNamePrefix: 'ZERO_',
+        allowUnknown: false,
+        allowPartial: true,
+        env: {
+          ZERO_VIEW_SYNCER_QUERY_HYDRATION_TIMEOUT_MS: queryHydrationTimeoutMs,
+        },
+      }),
+    ).toThrow();
+  },
+);
 
 test.each(['-1', '1.5'])(
   'view-syncer hydration budget rejects %s',

--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -580,6 +580,25 @@ export const zeroOptions = {
     ],
   },
 
+  viewSyncerQueryHydrationTimeoutMs: {
+    type: v
+      .number()
+      .assert(
+        value => Number.isSafeInteger(value) && value >= 0,
+        'must be a nonnegative integer',
+      )
+      .default(0),
+    desc: [
+      `The maximum processing time in milliseconds that a view-syncer spends`,
+      `hydrating a single client query. Time spent yielding to other work is`,
+      `not counted. A query whose hydration exceeds this limit is aborted and`,
+      `removed from the client's view, and affected clients receive an error`,
+      `for the query. The query is then rejected without being run again for`,
+      `a cooldown period, after which a retry is allowed. Internal queries are`,
+      `never aborted. A value of 0 disables the limit.`,
+    ],
+  },
+
   change: {
     db: {
       type: v.string().optional(),

--- a/packages/zero-cache/src/services/view-syncer/cvr.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.ts
@@ -807,7 +807,7 @@ export class CVRQueryDrivenUpdater extends CVRUpdater {
     for (const queryID of aborted) {
       assert(
         this.#executedQueryIDs.has(queryID),
-        () => `Query ${queryID} was not tracked as executed`,
+        `Query ${queryID} was not tracked as executed`,
       );
       const query = must(this._cvr.queries[queryID]);
       assertNotInternal(query);

--- a/packages/zero-cache/src/services/view-syncer/cvr.ts
+++ b/packages/zero-cache/src/services/view-syncer/cvr.ts
@@ -779,6 +779,80 @@ export class CVRQueryDrivenUpdater extends CVRUpdater {
   }
 
   /**
+   * Aborts queries that were tracked as executed but whose hydration was cut
+   * short (see the view-syncer's hydration circuit breaker).
+   *
+   * Rows received for an aborted query in this update have that query's
+   * references stripped: a row left with no references is deleted, and the
+   * 'del' patch cancels the 'put' the client has already received, while a
+   * row still referenced by other queries keeps its patch version. The query
+   * is then removed from the CVR. It stays tracked as executed, so
+   * {@link deleteUnreferencedRows} also drops the references held by rows that
+   * were synced for it before this update, exactly as for a removed query.
+   *
+   * Like {@link removeTrackedQueries}, this must be called after
+   * {@link trackQueries} has established the final version, and after all
+   * rows of the aborted queries have been {@link received}.
+   */
+  async abortExecutedQueries(
+    lc: LogContext,
+    queryIDs: readonly string[],
+  ): Promise<PatchToVersion[]> {
+    assert(this.#existingRows !== undefined, 'trackQueries() was not called');
+    assert(
+      cmpVersions(this._orig.version, this._cvr.version) < 0,
+      'A final CVR version must be set before aborting executed queries',
+    );
+    const aborted = new Set(queryIDs);
+    for (const queryID of aborted) {
+      assert(
+        this.#executedQueryIDs.has(queryID),
+        () => `Query ${queryID} was not tracked as executed`,
+      );
+      const query = must(this._cvr.queries[queryID]);
+      assertNotInternal(query);
+    }
+
+    // Unref the rows received for the aborted queries. The version of each
+    // unref is the version the row currently has in this update, so a row that
+    // stays referenced does not get a spurious patch version bump.
+    const existingRows = await this._cvrStore.getRowRecords();
+    const unrefs = new CustomKeyMap<RowID, RowUpdate>(rowIDString);
+    for (const [id, refCounts] of this.#receivedRows) {
+      if (refCounts === null) {
+        continue;
+      }
+      let unref: RowUpdate | undefined;
+      for (const queryID of aborted) {
+        const count = refCounts[queryID];
+        if (!count) {
+          continue;
+        }
+        if (!unref) {
+          const version =
+            this.#lastPatches.get(id)?.rowVersion ??
+            existingRows.get(id)?.rowVersion;
+          unref = {refCounts: {}, ...(version && {version})};
+          unrefs.set(id, unref);
+        }
+        unref.refCounts[queryID] = -count;
+      }
+    }
+    const patches =
+      unrefs.size > 0
+        ? await this.received(lc, unrefs)
+        : ([] as PatchToVersion[]);
+
+    for (const queryID of aborted) {
+      delete this._cvr.queries[queryID];
+      const patch = {type: 'query', op: 'del', id: queryID} as const;
+      this._cvrStore.markQueryAsDeleted(this._cvr.version, patch);
+      patches.push({patch, toVersion: this._cvr.version});
+    }
+    return patches;
+  }
+
+  /**
    * Tracks a query removed from the "gotten" set. In addition to producing the
    * appropriate patches for deleting the query, the removed query is taken into
    * account when computing the final row records in

--- a/packages/zero-cache/src/services/view-syncer/hydration-circuit-breaker.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/hydration-circuit-breaker.test.ts
@@ -56,6 +56,20 @@ test('tripping again restarts the cooldown', () => {
   expect(breaker.isOpen('h1')).toBe(false);
 });
 
+test('tripping sweeps expired entries', () => {
+  let now = 0;
+  const breaker = new HydrationCircuitBreaker(100, 1000, () => now);
+
+  breaker.trip('h1');
+  now = 1000;
+  breaker.trip('h2');
+  // h1 expired and was swept by the trip of h2: winding the clock back would
+  // otherwise make it look open again.
+  now = 0;
+  expect(breaker.isOpen('h1')).toBe(false);
+  expect(breaker.isOpen('h2')).toBe(true);
+});
+
 test('defaults to a five minute cooldown', () => {
   expect(DEFAULT_CIRCUIT_BREAKER_OPEN_MS).toBe(300_000);
   expect(new HydrationCircuitBreaker(100).openMs).toBe(300_000);

--- a/packages/zero-cache/src/services/view-syncer/hydration-circuit-breaker.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/hydration-circuit-breaker.test.ts
@@ -1,0 +1,68 @@
+import {expect, test} from 'vitest';
+import {
+  DEFAULT_CIRCUIT_BREAKER_OPEN_MS,
+  HydrationCircuitBreaker,
+} from './hydration-circuit-breaker.ts';
+
+test('disabled breaker never exceeds and never opens', () => {
+  let now = 0;
+  const breaker = new HydrationCircuitBreaker(0, 1000, () => now);
+
+  expect(breaker.enabled).toBe(false);
+  expect(breaker.exceeded(Number.MAX_SAFE_INTEGER)).toBe(false);
+
+  breaker.trip('h1');
+  now = 10;
+  expect(breaker.isOpen('h1')).toBe(true);
+});
+
+test('exceeded is inclusive of the timeout', () => {
+  const breaker = new HydrationCircuitBreaker(100, 1000, () => 0);
+
+  expect(breaker.enabled).toBe(true);
+  expect(breaker.exceeded(99.9)).toBe(false);
+  expect(breaker.exceeded(100)).toBe(true);
+  expect(breaker.exceeded(1000)).toBe(true);
+});
+
+test('a tripped hash is open until the cooldown elapses', () => {
+  let now = 50;
+  const breaker = new HydrationCircuitBreaker(100, 1000, () => now);
+
+  expect(breaker.isOpen('h1')).toBe(false);
+  breaker.trip('h1');
+  expect(breaker.isOpen('h1')).toBe(true);
+  expect(breaker.isOpen('h2')).toBe(false);
+
+  now = 1049;
+  expect(breaker.isOpen('h1')).toBe(true);
+  now = 1050;
+  expect(breaker.isOpen('h1')).toBe(false);
+  // The expired entry was dropped, so it does not come back.
+  now = 0;
+  expect(breaker.isOpen('h1')).toBe(false);
+});
+
+test('tripping again restarts the cooldown', () => {
+  let now = 0;
+  const breaker = new HydrationCircuitBreaker(100, 1000, () => now);
+
+  breaker.trip('h1');
+  now = 900;
+  breaker.trip('h1');
+  now = 1500;
+  expect(breaker.isOpen('h1')).toBe(true);
+  now = 1900;
+  expect(breaker.isOpen('h1')).toBe(false);
+});
+
+test('defaults to a five minute cooldown', () => {
+  expect(DEFAULT_CIRCUIT_BREAKER_OPEN_MS).toBe(300_000);
+  expect(new HydrationCircuitBreaker(100).openMs).toBe(300_000);
+});
+
+test('rejects invalid timeouts', () => {
+  expect(() => new HydrationCircuitBreaker(-1)).toThrow();
+  expect(() => new HydrationCircuitBreaker(1.5)).toThrow();
+  expect(() => new HydrationCircuitBreaker(100, -1)).toThrow();
+});

--- a/packages/zero-cache/src/services/view-syncer/hydration-circuit-breaker.ts
+++ b/packages/zero-cache/src/services/view-syncer/hydration-circuit-breaker.ts
@@ -62,15 +62,24 @@ export class HydrationCircuitBreaker {
     return this.enabled && elapsedMs >= this.timeoutMs;
   }
 
-  /** Records that hydrating `transformationHash` was aborted. */
+  /**
+   * Records that hydrating `transformationHash` was aborted.
+   *
+   * Trips are rare, so this is also when expired entries are swept, which
+   * keeps the map bounded by the number of hashes tripped within one cooldown
+   * rather than by every hash ever tripped.
+   */
   trip(transformationHash: string): void {
-    this.#openedAt.set(transformationHash, this.#now());
+    const now = this.#now();
+    for (const [hash, openedAt] of this.#openedAt) {
+      if (now - openedAt >= this.openMs) {
+        this.#openedAt.delete(hash);
+      }
+    }
+    this.#openedAt.set(transformationHash, now);
   }
 
-  /**
-   * Whether `transformationHash` is currently rejected. Expired entries are
-   * dropped as they are encountered so the map does not grow without bound.
-   */
+  /** Whether `transformationHash` is currently rejected. */
   isOpen(transformationHash: string): boolean {
     const openedAt = this.#openedAt.get(transformationHash);
     if (openedAt === undefined) {

--- a/packages/zero-cache/src/services/view-syncer/hydration-circuit-breaker.ts
+++ b/packages/zero-cache/src/services/view-syncer/hydration-circuit-breaker.ts
@@ -1,0 +1,85 @@
+import {assert} from '../../../../shared/src/asserts.ts';
+import type {MonotonicClock} from './hydration-budget.ts';
+
+/**
+ * How long a tripped query stays rejected before a retry is allowed.
+ *
+ * A query that blows the timeout is almost always slow because of the shape
+ * of its data rather than because of transient load, so retrying it on every
+ * reconnect would burn a full timeout each time. The cooldown keeps that cost
+ * to at most one timeout per cooldown period per query.
+ */
+export const DEFAULT_CIRCUIT_BREAKER_OPEN_MS = 5 * 60_000;
+
+/**
+ * A per-query circuit breaker for view-syncer hydration.
+ *
+ * Hydration of a single query is aborted once its processing time exceeds
+ * {@link timeoutMs}. Callers check {@link exceeded} at the yield points of a
+ * hydration, so a query is only ever aborted between time slices.
+ *
+ * Once a query has been aborted the breaker is "open" for its transformation
+ * hash: {@link isOpen} reports true for {@link openMs}, and callers reject the
+ * query up front instead of hydrating it again. After that the breaker is
+ * implicitly half-open: the next hydration attempt runs, and either succeeds
+ * or trips the breaker again.
+ *
+ * The breaker is keyed by transformation hash rather than query hash because
+ * the transformation (permissions, auth context) determines the pipeline that
+ * runs, and a different transformation of the same query may well be fast.
+ */
+export class HydrationCircuitBreaker {
+  readonly timeoutMs: number;
+  readonly openMs: number;
+  readonly #now: MonotonicClock;
+  readonly #openedAt = new Map<string, number>();
+
+  constructor(
+    timeoutMs: number,
+    openMs: number = DEFAULT_CIRCUIT_BREAKER_OPEN_MS,
+    now: MonotonicClock = performance.now.bind(performance),
+  ) {
+    assert(
+      Number.isSafeInteger(timeoutMs) && timeoutMs >= 0,
+      'Hydration timeout must be a nonnegative integer',
+    );
+    assert(openMs >= 0, 'Circuit breaker open duration must be nonnegative');
+    this.timeoutMs = timeoutMs;
+    this.openMs = openMs;
+    this.#now = now;
+  }
+
+  /** Whether the breaker does anything at all. */
+  get enabled(): boolean {
+    return this.timeoutMs > 0;
+  }
+
+  /**
+   * Whether a hydration that has consumed `elapsedMs` of processing time must
+   * be aborted. Always false when the breaker is disabled.
+   */
+  exceeded(elapsedMs: number): boolean {
+    return this.enabled && elapsedMs >= this.timeoutMs;
+  }
+
+  /** Records that hydrating `transformationHash` was aborted. */
+  trip(transformationHash: string): void {
+    this.#openedAt.set(transformationHash, this.#now());
+  }
+
+  /**
+   * Whether `transformationHash` is currently rejected. Expired entries are
+   * dropped as they are encountered so the map does not grow without bound.
+   */
+  isOpen(transformationHash: string): boolean {
+    const openedAt = this.#openedAt.get(transformationHash);
+    if (openedAt === undefined) {
+      return false;
+    }
+    if (this.#now() - openedAt >= this.openMs) {
+      this.#openedAt.delete(transformationHash);
+      return false;
+    }
+    return true;
+  }
+}

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
@@ -818,6 +818,27 @@ describe('view-syncer/pipeline-driver', () => {
     });
   });
 
+  test('abandoned hydration tears down its pipeline', () => {
+    pipelines.init(clientSchema);
+    const hydration = pipelines
+      .addQuery('hash1', 'queryID1', ISSUES_AND_COMMENTS, startTimer())
+      [Symbol.iterator]();
+    // Consume the first row, then abandon the hydration, as a consumer that
+    // stops iterating early does.
+    expect(hydration.next().done).toBe(false);
+    hydration.return?.();
+
+    expect(pipelines.queries().has('queryID1')).toBe(false);
+
+    // The abandoned pipeline is disconnected from its sources, so a change to
+    // a table it was reading no longer produces output for it.
+    replicator.processTransaction(
+      '134',
+      messages.insert('issues', {id: '4', closed: 0}),
+    );
+    expect(changes()).toEqual([]);
+  });
+
   test('insert', () => {
     pipelines.init(clientSchema);
     [

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
@@ -1,5 +1,13 @@
 import {LogContext} from '@rocicorp/logger';
-import {afterEach, beforeEach, describe, expect, test} from 'vitest';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  type MockInstance,
+  test,
+  vi,
+} from 'vitest';
 import {testLogConfig} from '../../../../otel/src/test-log-config.ts';
 import {TestLogSink} from '../../../../shared/src/logging-test-utils.ts';
 import type {
@@ -20,6 +28,7 @@ import {
 } from '../../../../zqlite/src/database-storage.ts';
 import type {Database as DB} from '../../../../zqlite/src/db.ts';
 import {Database} from '../../../../zqlite/src/db.ts';
+import {TableSource} from '../../../../zqlite/src/table-source.ts';
 import {listTables} from '../../db/lite-tables.ts';
 import {InspectorDelegate} from '../../server/inspector-delegate.ts';
 import {DbFile} from '../../test/lite.ts';
@@ -153,8 +162,33 @@ describe('view-syncer/pipeline-driver', () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     dbFile.delete();
   });
+
+  /**
+   * Spies on the `destroy` of every source connection made from now on, so a
+   * test can check that a pipeline built for a query was torn down. The
+   * `failFetchOf` connection (1-based) throws when fetched.
+   */
+  function trackSourceConnections(failFetchOf?: number): MockInstance[] {
+    const destroys: MockInstance[] = [];
+    const connect = TableSource.prototype.connect;
+    vi.spyOn(TableSource.prototype, 'connect').mockImplementation(function (
+      this: TableSource,
+      ...args: Parameters<TableSource['connect']>
+    ) {
+      const input = connect.apply(this, args);
+      destroys.push(vi.spyOn(input, 'destroy'));
+      if (destroys.length === failFetchOf) {
+        vi.spyOn(input, 'fetch').mockImplementation(() => {
+          throw new Error('simulated fetch failure');
+        });
+      }
+      return input;
+    });
+    return destroys;
+  }
 
   const issues = table('issues')
     .columns({
@@ -829,6 +863,8 @@ describe('view-syncer/pipeline-driver', () => {
     hydration.return?.();
 
     expect(pipelines.queries().has('queryID1')).toBe(false);
+    // The rows it yielded must not leave a partial signature behind.
+    expect(pipelines.rowSetSignature('queryID1')).toBeUndefined();
 
     // The abandoned pipeline is disconnected from its sources, so a change to
     // a table it was reading no longer produces output for it.
@@ -837,6 +873,30 @@ describe('view-syncer/pipeline-driver', () => {
       messages.insert('issues', {id: '4', closed: 0}),
     );
     expect(changes()).toEqual([]);
+  });
+
+  test('failed scalar subquery resolution tears down earlier companions', () => {
+    pipelines.init(clientSchema);
+    const scalar =
+      ISSUES_WITH_SCALAR_SUBQUERY.where as CorrelatedSubqueryCondition;
+    // Two scalar subqueries: the first resolves and connects a companion
+    // pipeline to `comments`; executing the second fails at fetch time.
+    const ast: AST = {
+      ...ISSUES_WITH_SCALAR_SUBQUERY,
+      where: {type: 'and', conditions: [scalar, scalar]},
+    };
+    const destroys = trackSourceConnections(2);
+    expect(() => [
+      ...pipelines.addQuery('hash1', 'queryID1', ast, startTimer()),
+    ]).toThrow('simulated fetch failure');
+    expect(pipelines.queries().has('queryID1')).toBe(false);
+
+    // Both companions connected before the second one failed, and both
+    // connections were torn down.
+    expect(destroys).toHaveLength(2);
+    for (const destroy of destroys) {
+      expect(destroy).toHaveBeenCalledTimes(1);
+    }
   });
 
   test('insert', () => {

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
@@ -552,6 +552,10 @@ export class PipelineDriver {
         },
         'scalar-subquery',
       );
+      // Tracked before it is fetched so that a failure in this or a later
+      // subquery can tear it down below. A companion with no result is kept
+      // alive too: it detects a future insert that creates the row.
+      companionInputs.push(input);
       // Consume the full stream rather than using first() to avoid
       // triggering early return on Take's #initialFetch assertion.
       // The subquery AST already has limit: 1, so at most one row is produced.
@@ -560,21 +564,27 @@ export class PipelineDriver {
         node ??= n;
       }
       if (!node) {
-        // Keep the companion alive even with no results — it will
-        // detect a future insert that creates the row.
-        companionInputs.push(input);
         return undefined;
       }
       companionRows.push({table: subqueryAST.table, row: node.row as Row});
-      companionInputs.push(input);
       return (node.row[childField] as LiteralValue) ?? null;
     };
 
-    const {
-      ast: resolved,
-      companions,
-      ignoredScalarHints,
-    } = resolveSimpleScalarSubqueries(ast, this.#tableSpecs, executor);
+    let resolved: AST;
+    let companions: CompanionSubquery[];
+    let ignoredScalarHints: IgnoredScalarHint[];
+    try {
+      ({
+        ast: resolved,
+        companions,
+        ignoredScalarHints,
+      } = resolveSimpleScalarSubqueries(ast, this.#tableSpecs, executor));
+    } catch (e) {
+      for (const input of companionInputs) {
+        input.destroy();
+      }
+      throw e;
+    }
     return {
       ast: resolved,
       companionRows,
@@ -864,6 +874,10 @@ export class PipelineDriver {
         for (const input of builtInputs) {
           input.destroy();
         }
+        // Rows may already have been yielded through #trackRowSetSignatures,
+        // and rowSetSignature() must not report a signature for a query
+        // without an active pipeline.
+        this.#rowSetSignatures.delete(queryID);
       }
       this.#hydrateContext = null;
     }

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
@@ -659,6 +659,10 @@ export class PipelineDriver {
     let hydrationFinished = false;
     let hydrationFailed = false;
     let hydrationRowCount = 0;
+    // The inputs built so far, held outside the try so that a hydration that
+    // does not finish (aborted by the consumer or failed) can tear them down.
+    // Only a finished hydration hands them over to #pipelines.
+    let builtInputs: Input[] = [];
     try {
       const {
         ast: resolvedQuery,
@@ -667,6 +671,7 @@ export class PipelineDriver {
         companionInputs,
         ignoredScalarHints,
       } = this.#resolveScalarSubqueries(query);
+      builtInputs = [...companionInputs];
 
       this.#warnIgnoredScalarHints(queryID, ignoredScalarHints);
 
@@ -697,6 +702,7 @@ export class PipelineDriver {
         queryID,
         costModel,
       );
+      builtInputs.push(input);
       const schema = input.getSchema();
       input.setOutput({
         push: change => {
@@ -853,6 +859,11 @@ export class PipelineDriver {
           hydrationTimeMs: timer.totalElapsed(),
           hydrationRowCount,
         });
+      }
+      if (!hydrationFinished) {
+        for (const input of builtInputs) {
+          input.destroy();
+        }
       }
       this.#hydrateContext = null;
     }

--- a/packages/zero-cache/src/services/view-syncer/view-syncer-hydration-timeout.pg.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer-hydration-timeout.pg.test.ts
@@ -6,6 +6,7 @@ import type {UpQueriesPatch} from '../../../../zero-protocol/src/queries-patch.t
 import {type PgTest, test} from '../../test/db.ts';
 import type {MonotonicClock} from './hydration-budget.ts';
 import {DEFAULT_CIRCUIT_BREAKER_OPEN_MS} from './hydration-circuit-breaker.ts';
+import {PipelineDriver} from './pipeline-driver.ts';
 import {
   addQuery,
   ALL_ISSUES_QUERY,
@@ -47,6 +48,8 @@ const SYNC_CONTEXT: SyncContext = {
 const FAST = 'fast';
 const SLOW = 'slow';
 const FAST2 = 'fast2';
+/** A second query with the same AST as `SLOW`, so the same transformation. */
+const SLOW2 = 'slow2';
 
 const TIMEOUT_MS = 450;
 const SLOW_ROW_MS = 100;
@@ -109,7 +112,7 @@ async function liveQueries(initial: Harness): Promise<string[]> {
       FROM "this_app_2/cvr".queries
      WHERE "clientGroupID" = ${serviceID}
        AND deleted = false
-       AND "queryHash" IN (${FAST}, ${SLOW}, ${FAST2})
+       AND "queryHash" IN (${FAST}, ${SLOW}, ${SLOW2}, ${FAST2})
      ORDER BY "queryHash"`;
   return rows.map(({queryHash}) => queryHash);
 }
@@ -190,6 +193,16 @@ function hasTransformError(messages: Downstream[]): boolean {
 const slowEvicted = (messages: Downstream[]) =>
   hasGot('del', SLOW)(messages) && hasTransformError(messages);
 
+const bothSlowEvicted = (messages: Downstream[]) =>
+  hasGot('del', SLOW)(messages) &&
+  hasGot('del', SLOW2)(messages) &&
+  transformErrors(messages).length >= 2;
+
+/** The query IDs that `PipelineDriver.addQuery` was called with. */
+function hydratedQueryIDs(spy: {mock: {calls: unknown[][]}}): string[] {
+  return spy.mock.calls.map(call => call[1] as string);
+}
+
 function pokeParts(messages: Downstream[]): PokePartBody[] {
   return messages
     .filter(msg => msg[0] === 'pokePart')
@@ -221,13 +234,17 @@ function issueIDsAfter(messages: Downstream[]): string[] {
   return [...ids].toSorted();
 }
 
-const HYDRATION_TIMEOUT_ERROR = {
-  error: 'app',
-  id: SLOW,
-  name: 'legacy',
-  message: expect.stringContaining(`${TIMEOUT_MS}ms`),
-  details: {kind: 'HydrationTimeout', timeoutMs: TIMEOUT_MS},
-};
+function hydrationTimeoutError(id: string) {
+  return {
+    error: 'app',
+    id,
+    name: 'legacy',
+    message: expect.stringContaining(`${TIMEOUT_MS}ms`),
+    details: {kind: 'HydrationTimeout', timeoutMs: TIMEOUT_MS},
+  };
+}
+
+const HYDRATION_TIMEOUT_ERROR = hydrationTimeoutError(SLOW);
 
 test<PgTest>('aborts a slow hydration, evicts the query, and errors it to the client', async ({
   testDBs,
@@ -377,6 +394,126 @@ test<PgTest>('aborts a slow rehydration of an unchanged query on restart', async
       {id: '3'},
       {id: '4'},
     ]);
+    expect(restarted.vs.pipelineHashes().filter(q => !q.internal)).toHaveLength(
+      2,
+    );
+  } finally {
+    initial.clearMocks();
+    await (restarted ?? initial).vs.stop();
+    await (restarted ?? initial).viewSyncerDone;
+    await testDBs.drop(initial.cvrDB, initial.upstreamDb);
+    initial.replicaDbFile.delete();
+  }
+});
+
+test<PgTest>('a query sharing a tripped transformation is rejected in the same pass', async ({
+  testDBs,
+}) => {
+  const initial = await setup(
+    testDBs,
+    'vs_hydration_timeout_shared_hash',
+    permissionsAll,
+    {queryHydrationTimeoutMs: TIMEOUT_MS},
+  );
+  slowRows({rowMs: SLOW_ROW_MS});
+  const addQuerySpy = vi.spyOn(PipelineDriver.prototype, 'addQuery');
+  try {
+    const client = initial.connect(SYNC_CONTEXT, [
+      ...DESIRED,
+      {op: 'put', hash: SLOW2, ast: ALL_ISSUES_QUERY},
+    ]);
+    await nextPoke(client); // desired queries
+    initial.stateChanges.push({state: 'version-ready'});
+    const messages = await collectUntil(client, bothSlowEvicted);
+
+    // Whichever of the two came first tripped the breaker; the other was
+    // never hydrated at all.
+    const slowHydrations = hydratedQueryIDs(addQuerySpy).filter(
+      id => id === SLOW || id === SLOW2,
+    );
+    expect(slowHydrations).toHaveLength(1);
+
+    expect(transformErrors(messages)).toEqual(
+      expect.arrayContaining([
+        hydrationTimeoutError(SLOW),
+        hydrationTimeoutError(SLOW2),
+      ]),
+    );
+    expect(issueIDsAfter(messages)).toEqual(['1', '2', '3', '4']);
+    await vi.waitFor(async () => {
+      expect(await liveQueries(initial)).toEqual([FAST, FAST2]);
+    });
+    expect(await rowsReferencing(initial, SLOW)).toEqual([]);
+    expect(await rowsReferencing(initial, SLOW2)).toEqual([]);
+    expect(initial.vs.pipelineHashes().filter(q => !q.internal)).toHaveLength(
+      2,
+    );
+  } finally {
+    initial.clearMocks();
+    await initial.vs.stop();
+    await initial.viewSyncerDone;
+    await testDBs.drop(initial.cvrDB, initial.upstreamDb);
+    initial.replicaDbFile.delete();
+  }
+});
+
+test<PgTest>('a gotten query sharing a tripped transformation is not rehydrated on restart', async ({
+  testDBs,
+}) => {
+  const initial = await setup(
+    testDBs,
+    'vs_hydration_timeout_shared_hash_restart',
+    permissionsAll,
+    {queryHydrationTimeoutMs: TIMEOUT_MS},
+  );
+  let restarted: ReturnType<typeof restartViewSyncer> | undefined;
+  try {
+    const client = initial.connect(SYNC_CONTEXT, [
+      ...DESIRED,
+      {op: 'put', hash: SLOW2, ast: ALL_ISSUES_QUERY},
+    ]);
+    await nextPoke(client); // desired queries
+    initial.stateChanges.push({state: 'version-ready'});
+    await collectUntil(
+      client,
+      m => hasGot('put', SLOW)(m) && hasGot('put', SLOW2)(m),
+    );
+    await vi.waitFor(async () => {
+      expect(await liveQueries(initial)).toEqual([FAST, FAST2, SLOW, SLOW2]);
+    });
+    await initial.vs.stop();
+    await initial.viewSyncerDone;
+
+    slowRows({rowMs: SLOW_ROW_MS});
+    const addQuerySpy = vi.spyOn(PipelineDriver.prototype, 'addQuery');
+    restarted = restartViewSyncer({
+      databaseStorage: initial.databaseStorage,
+      replicaDbFile: initial.replicaDbFile,
+      cvrDB: initial.cvrDB,
+      config: initial.config,
+      customQueryTransformer: initial.customQueryTransformer,
+      setTimeoutFn: initial.setTimeoutFn,
+    });
+    const reconnected = restarted.connect({...SYNC_CONTEXT, wsID: 'ws2'}, []);
+    restarted.stateChanges.push({state: 'version-ready'});
+    const afterRestart = await collectUntil(reconnected, bothSlowEvicted);
+
+    // Only one of the two shared-transformation queries burned a timeout.
+    const slowHydrations = hydratedQueryIDs(addQuerySpy).filter(
+      id => id === SLOW || id === SLOW2,
+    );
+    expect(slowHydrations).toHaveLength(1);
+
+    expect(transformErrors(afterRestart)).toEqual(
+      expect.arrayContaining([
+        hydrationTimeoutError(SLOW),
+        hydrationTimeoutError(SLOW2),
+      ]),
+    );
+    expect(issueIDsAfter(afterRestart)).toEqual(['1', '2', '3', '4']);
+    await vi.waitFor(async () => {
+      expect(await liveQueries(initial)).toEqual([FAST, FAST2]);
+    });
     expect(restarted.vs.pipelineHashes().filter(q => !q.internal)).toHaveLength(
       2,
     );

--- a/packages/zero-cache/src/services/view-syncer/view-syncer-hydration-timeout.pg.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer-hydration-timeout.pg.test.ts
@@ -1,0 +1,428 @@
+import {afterEach, expect, vi} from 'vitest';
+import type {Downstream} from '../../../../zero-protocol/src/down.ts';
+import type {PokePartBody} from '../../../../zero-protocol/src/poke.ts';
+import {PROTOCOL_VERSION} from '../../../../zero-protocol/src/protocol-version.ts';
+import type {UpQueriesPatch} from '../../../../zero-protocol/src/queries-patch.ts';
+import {type PgTest, test} from '../../test/db.ts';
+import type {MonotonicClock} from './hydration-budget.ts';
+import {DEFAULT_CIRCUIT_BREAKER_OPEN_MS} from './hydration-circuit-breaker.ts';
+import {
+  addQuery,
+  ALL_ISSUES_QUERY,
+  ISSUES_QUERY,
+  nextPoke,
+  permissionsAll,
+  restartViewSyncer,
+  serviceID,
+  setup,
+  USERS_QUERY,
+  YIELD_THRESHOLD_MS,
+} from './view-syncer-test-util.ts';
+import {type SyncContext, TimeSliceTimer} from './view-syncer.ts';
+
+const SYNC_CONTEXT: SyncContext = {
+  clientID: 'foo',
+  profileID: 'p0000g00000003203',
+  wsID: 'ws1',
+  baseCookie: null,
+  protocolVersion: PROTOCOL_VERSION,
+  httpCookie: undefined,
+  origin: undefined,
+  userID: 'bar',
+  auth: undefined,
+};
+
+/**
+ * Queries used by the tests in this file:
+ *
+ * - `FAST` matches issues '1' through '4'.
+ * - `SLOW` matches all five issues, so it shares '1' through '4' with `FAST`
+ *   and holds '5' exclusively.
+ * - `FAST2` matches the three users.
+ *
+ * Hydration is made to yield after every row, and each row is made to cost
+ * {@link SLOW_ROW_MS} of processing time, so with a timeout of
+ * {@link TIMEOUT_MS} only the five-row `SLOW` query trips the breaker.
+ */
+const FAST = 'fast';
+const SLOW = 'slow';
+const FAST2 = 'fast2';
+
+const TIMEOUT_MS = 450;
+const SLOW_ROW_MS = 100;
+const FAST_ROW_MS = 50;
+
+const DESIRED: UpQueriesPatch = [
+  {op: 'put', hash: FAST, ast: ISSUES_QUERY},
+  {op: 'put', hash: SLOW, ast: ALL_ISSUES_QUERY},
+  {op: 'put', hash: FAST2, ast: USERS_QUERY},
+];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+/** A settable clock, used to expire the breaker's cooldown. */
+function settableClock(): MonotonicClock & {set(ms: number): void} {
+  let now = 0;
+  const clock = () => now;
+  clock.set = (ms: number) => {
+    now = ms;
+  };
+  return clock;
+}
+
+/**
+ * Makes every hydrated row yield and cost `rowMs` of processing time, as
+ * measured by the timer the view-syncer consults at each yield.
+ *
+ * Returns the number of rows hydrated so far, for asserting that a rejected
+ * query was not hydrated at all.
+ */
+function slowRows(rowMsRef: {rowMs: number}): () => number {
+  let rowsThisQuery = 0;
+  let totalRows = 0;
+  const start = TimeSliceTimer.prototype.startWithoutYielding;
+  vi.spyOn(TimeSliceTimer.prototype, 'startWithoutYielding').mockImplementation(
+    function (this: TimeSliceTimer) {
+      rowsThisQuery = 0;
+      return start.call(this);
+    },
+  );
+  vi.spyOn(TimeSliceTimer.prototype, 'elapsedLap').mockImplementation(() => {
+    rowsThisQuery++;
+    totalRows++;
+    return YIELD_THRESHOLD_MS + 1;
+  });
+  vi.spyOn(TimeSliceTimer.prototype, 'totalElapsed').mockImplementation(
+    () => rowsThisQuery * rowMsRef.rowMs,
+  );
+  return () => totalRows;
+}
+
+type Harness = Awaited<ReturnType<typeof setup>>;
+
+/** Query hashes that are not deleted in the persisted CVR. */
+async function liveQueries(initial: Harness): Promise<string[]> {
+  const rows = await initial.cvrDB<{queryHash: string}[]>`
+    SELECT "queryHash"
+      FROM "this_app_2/cvr".queries
+     WHERE "clientGroupID" = ${serviceID}
+       AND deleted = false
+       AND "queryHash" IN (${FAST}, ${SLOW}, ${FAST2})
+     ORDER BY "queryHash"`;
+  return rows.map(({queryHash}) => queryHash);
+}
+
+/** Row keys in the persisted CVR that still reference `queryHash`. */
+function rowsReferencing(
+  initial: Harness,
+  queryHash: string,
+): Promise<{table: string; rowKey: unknown}[]> {
+  return initial.cvrDB<{table: string; rowKey: unknown}[]>`
+    SELECT "table", "rowKey"
+      FROM "this_app_2/cvr".rows
+     WHERE "clientGroupID" = ${serviceID}
+       AND "refCounts" ? ${queryHash}
+     ORDER BY "table", "rowKey"`;
+}
+
+/** Row keys in the persisted CVR that are still referenced by any query. */
+async function liveRowKeys(initial: Harness): Promise<unknown[]> {
+  const rows = await initial.cvrDB<{rowKey: unknown}[]>`
+    SELECT "rowKey"
+      FROM "this_app_2/cvr".rows
+     WHERE "clientGroupID" = ${serviceID}
+       AND "table" = 'issues'
+       AND "refCounts" IS NOT NULL
+     ORDER BY "rowKey"`;
+  return rows.map(({rowKey}) => rowKey);
+}
+
+type Client = ReturnType<Harness['connect']>;
+
+/** Whether `messages` ends inside a poke that has not been ended yet. */
+function inOpenPoke(messages: Downstream[]): boolean {
+  const starts = messages.filter(([type]) => type === 'pokeStart').length;
+  const ends = messages.filter(([type]) => type === 'pokeEnd').length;
+  return starts > ends;
+}
+
+/**
+ * Dequeues messages until `done` holds and the current poke, if any, has
+ * ended. A hydration timeout sends its `transformError` directly to the
+ * client, so it can land on either side of a poke's end, and a rejected query
+ * can span two pokes (the desired-queries poke and the removal poke).
+ */
+async function collectUntil(
+  client: Client,
+  done: (messages: Downstream[]) => boolean,
+  timeoutMs = 5000,
+): Promise<Downstream[]> {
+  const messages: Downstream[] = [];
+  const deadline = Date.now() + timeoutMs;
+  const timedOut = 'nothing' as unknown as Downstream;
+  while (!done(messages) || inOpenPoke(messages)) {
+    const remaining = deadline - Date.now();
+    const msg =
+      remaining > 0 ? await client.dequeue(timedOut, remaining) : timedOut;
+    if (msg === timedOut) {
+      throw new Error(
+        `Timed out waiting for messages. Received: ${JSON.stringify(messages)}`,
+      );
+    }
+    messages.push(msg);
+  }
+  return messages;
+}
+
+function hasGot(op: 'put' | 'del', hash: string) {
+  return (messages: Downstream[]) =>
+    gotQueriesPatch(messages).some(
+      p => p.op !== 'clear' && p.op === op && p.hash === hash,
+    );
+}
+
+function hasTransformError(messages: Downstream[]): boolean {
+  return transformErrors(messages).length > 0;
+}
+
+const slowEvicted = (messages: Downstream[]) =>
+  hasGot('del', SLOW)(messages) && hasTransformError(messages);
+
+function pokeParts(messages: Downstream[]): PokePartBody[] {
+  return messages
+    .filter(msg => msg[0] === 'pokePart')
+    .map(([, body]) => body as PokePartBody);
+}
+
+function gotQueriesPatch(messages: Downstream[]) {
+  return pokeParts(messages).flatMap(part => part.gotQueriesPatch ?? []);
+}
+
+function transformErrors(messages: Downstream[]) {
+  return messages
+    .filter(msg => msg[0] === 'transformError')
+    .flatMap(([, errors]) => errors);
+}
+
+/** The issue ids the client holds after applying every row patch in order. */
+function issueIDsAfter(messages: Downstream[]): string[] {
+  const ids = new Set<string>();
+  for (const part of pokeParts(messages)) {
+    for (const patch of part.rowsPatch ?? []) {
+      if (patch.op === 'put' && patch.tableName === 'issues') {
+        ids.add(patch.value.id as string);
+      } else if (patch.op === 'del' && patch.tableName === 'issues') {
+        ids.delete(patch.id.id as string);
+      }
+    }
+  }
+  return [...ids].toSorted();
+}
+
+const HYDRATION_TIMEOUT_ERROR = {
+  error: 'app',
+  id: SLOW,
+  name: 'legacy',
+  message: expect.stringContaining(`${TIMEOUT_MS}ms`),
+  details: {kind: 'HydrationTimeout', timeoutMs: TIMEOUT_MS},
+};
+
+test<PgTest>('aborts a slow hydration, evicts the query, and errors it to the client', async ({
+  testDBs,
+}) => {
+  const clock = settableClock();
+  const initial = await setup(
+    testDBs,
+    'vs_hydration_timeout_abort',
+    permissionsAll,
+    {queryHydrationTimeoutMs: TIMEOUT_MS, monotonicClock: clock},
+  );
+  const rowMs = {rowMs: SLOW_ROW_MS};
+  const hydratedRows = slowRows(rowMs);
+  try {
+    const client = initial.connect(SYNC_CONTEXT, DESIRED);
+    await nextPoke(client); // desired queries
+    initial.stateChanges.push({state: 'version-ready'});
+    const messages = await collectUntil(client, slowEvicted);
+
+    // The slow query is announced as gotten before its hydration starts and
+    // retracted in the same poke once it is aborted.
+    const patches = gotQueriesPatch(messages);
+    expect(patches).toEqual(
+      expect.arrayContaining([
+        {op: 'put', hash: FAST},
+        {op: 'put', hash: FAST2},
+        {op: 'put', hash: SLOW},
+        {op: 'del', hash: SLOW},
+      ]),
+    );
+    const indexOf = (op: 'put' | 'del') =>
+      patches.findIndex(
+        p => p.op !== 'clear' && p.op === op && p.hash === SLOW,
+      );
+    expect(indexOf('put')).toBeLessThan(indexOf('del'));
+    // Issue '5' is held only by the slow query, so its put is canceled. The
+    // issues it shares with the fast query survive.
+    expect(issueIDsAfter(messages)).toEqual(['1', '2', '3', '4']);
+    expect(transformErrors(messages)).toEqual([HYDRATION_TIMEOUT_ERROR]);
+
+    await vi.waitFor(async () => {
+      expect(await liveQueries(initial)).toEqual([FAST, FAST2]);
+    });
+    expect(await rowsReferencing(initial, SLOW)).toEqual([]);
+    expect(await liveRowKeys(initial)).toEqual([
+      {id: '1'},
+      {id: '2'},
+      {id: '3'},
+      {id: '4'},
+    ]);
+    expect(initial.vs.pipelineHashes().filter(q => !q.internal)).toHaveLength(
+      2,
+    );
+
+    // While the breaker is open, re-requesting the query rejects it without
+    // hydrating a single row.
+    const rowsBefore = hydratedRows();
+    await addQuery(initial.vs, SYNC_CONTEXT, SLOW, ALL_ISSUES_QUERY);
+    const rejected = await collectUntil(client, slowEvicted);
+    expect(transformErrors(rejected)).toEqual([HYDRATION_TIMEOUT_ERROR]);
+    expect(gotQueriesPatch(rejected)).not.toContainEqual({
+      op: 'put',
+      hash: SLOW,
+    });
+    expect(hydratedRows()).toBe(rowsBefore);
+    expect(await liveQueries(initial)).toEqual([FAST, FAST2]);
+
+    // Once the cooldown has passed the query is tried again, and this time it
+    // fits within the timeout.
+    clock.set(DEFAULT_CIRCUIT_BREAKER_OPEN_MS);
+    rowMs.rowMs = FAST_ROW_MS;
+    await addQuery(initial.vs, SYNC_CONTEXT, SLOW, ALL_ISSUES_QUERY);
+    const retried = await collectUntil(client, hasGot('put', SLOW));
+    expect(transformErrors(retried)).toEqual([]);
+    expect(gotQueriesPatch(retried)).toEqual([{op: 'put', hash: SLOW}]);
+    expect(issueIDsAfter(retried)).toEqual(['5']);
+    expect(hydratedRows()).toBeGreaterThan(rowsBefore);
+    await vi.waitFor(async () => {
+      expect(await liveQueries(initial)).toEqual([FAST, FAST2, SLOW]);
+    });
+    expect(initial.vs.pipelineHashes().filter(q => !q.internal)).toHaveLength(
+      3,
+    );
+  } finally {
+    initial.clearMocks();
+    await initial.vs.stop();
+    await initial.viewSyncerDone;
+    await testDBs.drop(initial.cvrDB, initial.upstreamDb);
+    initial.replicaDbFile.delete();
+  }
+});
+
+test<PgTest>('aborts a slow rehydration of an unchanged query on restart', async ({
+  testDBs,
+}) => {
+  const initial = await setup(
+    testDBs,
+    'vs_hydration_timeout_restart',
+    permissionsAll,
+    {queryHydrationTimeoutMs: TIMEOUT_MS},
+  );
+  let restarted: ReturnType<typeof restartViewSyncer> | undefined;
+  try {
+    // Hydrate everything at full speed first.
+    const client = initial.connect(SYNC_CONTEXT, DESIRED);
+    await nextPoke(client); // desired queries
+    initial.stateChanges.push({state: 'version-ready'});
+    const messages = await collectUntil(client, hasGot('put', SLOW));
+    expect(transformErrors(messages)).toEqual([]);
+    expect(issueIDsAfter(messages)).toEqual(['1', '2', '3', '4', '5']);
+    await vi.waitFor(async () => {
+      expect(await liveQueries(initial)).toEqual([FAST, FAST2, SLOW]);
+    });
+    await initial.vs.stop();
+    await initial.viewSyncerDone;
+
+    // On restart the gotten queries are rehydrated as unchanged queries. The
+    // slow one is aborted there, and the following pipeline sync removes it.
+    slowRows({rowMs: SLOW_ROW_MS});
+    restarted = restartViewSyncer({
+      databaseStorage: initial.databaseStorage,
+      replicaDbFile: initial.replicaDbFile,
+      cvrDB: initial.cvrDB,
+      config: initial.config,
+      customQueryTransformer: initial.customQueryTransformer,
+      setTimeoutFn: initial.setTimeoutFn,
+    });
+    const reconnected = restarted.connect({...SYNC_CONTEXT, wsID: 'ws2'}, []);
+    restarted.stateChanges.push({state: 'version-ready'});
+    const afterRestart = await collectUntil(reconnected, slowEvicted);
+
+    // The fresh connection is caught up with the surviving gotten queries.
+    const patches = gotQueriesPatch(afterRestart);
+    expect(patches).toContainEqual({op: 'del', hash: SLOW});
+    expect(patches).not.toContainEqual({op: 'put', hash: SLOW});
+    expect(transformErrors(afterRestart)).toEqual([HYDRATION_TIMEOUT_ERROR]);
+    // The issue that only the slow query held is gone from the client.
+    expect(issueIDsAfter(afterRestart)).toEqual(['1', '2', '3', '4']);
+
+    await vi.waitFor(async () => {
+      expect(await liveQueries(initial)).toEqual([FAST, FAST2]);
+    });
+    expect(await rowsReferencing(initial, SLOW)).toEqual([]);
+    expect(await liveRowKeys(initial)).toEqual([
+      {id: '1'},
+      {id: '2'},
+      {id: '3'},
+      {id: '4'},
+    ]);
+    expect(restarted.vs.pipelineHashes().filter(q => !q.internal)).toHaveLength(
+      2,
+    );
+  } finally {
+    initial.clearMocks();
+    await (restarted ?? initial).vs.stop();
+    await (restarted ?? initial).viewSyncerDone;
+    await testDBs.drop(initial.cvrDB, initial.upstreamDb);
+    initial.replicaDbFile.delete();
+  }
+});
+
+test<PgTest>('a disabled timeout never aborts a hydration', async ({
+  testDBs,
+}) => {
+  const initial = await setup(
+    testDBs,
+    'vs_hydration_timeout_disabled',
+    permissionsAll,
+  );
+  slowRows({rowMs: SLOW_ROW_MS});
+  try {
+    const client = initial.connect(SYNC_CONTEXT, DESIRED);
+    await nextPoke(client); // desired queries
+    initial.stateChanges.push({state: 'version-ready'});
+    const messages = await collectUntil(client, m =>
+      [FAST, SLOW, FAST2].every(hash => hasGot('put', hash)(m)),
+    );
+
+    expect(transformErrors(messages)).toEqual([]);
+    expect(gotQueriesPatch(messages)).not.toContainEqual({
+      op: 'del',
+      hash: SLOW,
+    });
+    expect(issueIDsAfter(messages)).toEqual(['1', '2', '3', '4', '5']);
+    await vi.waitFor(async () => {
+      expect(await liveQueries(initial)).toEqual([FAST, FAST2, SLOW]);
+    });
+    expect(initial.vs.pipelineHashes().filter(q => !q.internal)).toHaveLength(
+      3,
+    );
+  } finally {
+    initial.clearMocks();
+    await initial.vs.stop();
+    await initial.viewSyncerDone;
+    await testDBs.drop(initial.cvrDB, initial.upstreamDb);
+    initial.replicaDbFile.delete();
+  }
+});

--- a/packages/zero-cache/src/services/view-syncer/view-syncer-test-util.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer-test-util.ts
@@ -588,6 +588,7 @@ export const TEST_ADMIN_PASSWORD = 'test-pwd';
 type SetupOptions = Readonly<{
   authConfig?: Partial<NormalizedZeroConfig['auth']> | undefined;
   hydrationBudgetMs?: number | undefined;
+  queryHydrationTimeoutMs?: number | undefined;
   lc?: LogContext | undefined;
   monotonicClock?: MonotonicClock | undefined;
   /**
@@ -643,6 +644,7 @@ export async function setup(
   const {
     authConfig = {},
     hydrationBudgetMs = 0,
+    queryHydrationTimeoutMs = 0,
     lc = createSilentLogContext(),
     monotonicClock,
     queryFetchMode = 'none',
@@ -778,6 +780,7 @@ export async function setup(
       level: 'error',
     },
     viewSyncerHydrationBudgetMs: hydrationBudgetMs,
+    viewSyncerQueryHydrationTimeoutMs: queryHydrationTimeoutMs,
   } as NormalizedZeroConfig;
 
   // Create the custom query transformer if configured

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -1845,6 +1845,19 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     } of transformedQueries) {
       const query = cvr.queries[queryID];
       const queryName = query.type === 'custom' ? query.name : undefined;
+      if (
+        query.type !== 'internal' &&
+        this.#hydrationCircuitBreaker.isOpen(transformationHash)
+      ) {
+        // The breaker is open for this transformation (typically tripped by a
+        // query earlier in this loop that shares it). Not hydrating leaves the
+        // pipeline missing, so #syncQueryPipelineSet removes and errors the
+        // query like any circuit-broken query, without burning a timeout.
+        lc.info?.(
+          `skipping hydration of ${queryID}: hydration circuit breaker open`,
+        );
+        continue;
+      }
       const covered = queryCoveringIndex
         ? this.#findQueryCoverageShadowHit(
             queryCoveringIndex,
@@ -1886,8 +1899,10 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
                 this.#hydrationCircuitBreaker.exceeded(timer.totalElapsed())
               ) {
                 // Breaking out returns the addQuery generator, which tears
-                // down the partially built pipeline.
+                // down the partially built pipeline. The time slice that
+                // exposed the timeout still ends with a yield.
                 timedOut = true;
+                await timer.yieldProcess('yield in hydrateUnchangedQueries');
                 break;
               }
               await timer.yieldProcess('yield in hydrateUnchangedQueries');
@@ -2384,10 +2399,15 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
       // Queries whose hydration circuit breaker is open are not hydrated.
       // They are removed from the CVR like transform-errored queries, and the
       // affected clients receive an error for them.
+      // Only queries that would otherwise be hydrated are subject to the
+      // breaker; a query whose pipeline is already running with this
+      // transformation needs no hydration and is left alone.
       const circuitBrokenQueries = transformedQueries
         .filter(
-          ({origQuery, transformed}) =>
+          ({id, origQuery, transformed}) =>
             origQuery.type !== 'internal' &&
+            this.#pipelines.queries().get(id)?.transformationHash !==
+              transformed.transformationHash &&
             this.#hydrationCircuitBreaker.isOpen(
               transformed.transformationHash,
             ),
@@ -2520,7 +2540,6 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
   ): void {
     this.#hydrationCircuitBreaker.trip(query.transformationHash);
     this.#hydrationTimeouts.add(1);
-    this.#queryEvictions.add(1, {reason: 'hydration-timeout'});
     lc.warn?.('Query hydration aborted for exceeding the hydration timeout', {
       clientGroupID: this.id,
       queryHash: query.id,
@@ -2529,6 +2548,22 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
       hydrationTimeoutMs: this.#hydrationCircuitBreaker.timeoutMs,
       hydrationElapsedMs: elapsedMs,
       ...(rowCount !== undefined && {hydrationRowCount: rowCount}),
+      circuitBreakerOpenMs: this.#hydrationCircuitBreaker.openMs,
+    });
+  }
+
+  /** Records that `query` was rejected without hydration by its open breaker. */
+  #recordCircuitBreakerRejection(
+    lc: LogContext,
+    query: {id: string; transformationHash: string; name?: string | undefined},
+  ): void {
+    this.#hydrationCircuitBreakerRejections.add(1);
+    lc.warn?.('Query rejected by its open hydration circuit breaker', {
+      clientGroupID: this.id,
+      queryHash: query.id,
+      transformationHash: query.transformationHash,
+      ...(query.name !== undefined && {queryName: query.name}),
+      hydrationTimeoutMs: this.#hydrationCircuitBreaker.timeoutMs,
       circuitBreakerOpenMs: this.#hydrationCircuitBreaker.openMs,
     });
   }
@@ -2547,20 +2582,12 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
       name?: string | undefined;
     }[],
   ): void {
-    this.#hydrationCircuitBreakerRejections.add(queries.length);
+    for (const query of queries) {
+      this.#recordCircuitBreakerRejection(lc, query);
+    }
     this.#queryEvictions.add(queries.length, {
       reason: 'hydration-circuit-breaker',
     });
-    for (const query of queries) {
-      lc.warn?.('Query rejected by its open hydration circuit breaker', {
-        clientGroupID: this.id,
-        queryHash: query.id,
-        transformationHash: query.transformationHash,
-        ...(query.name !== undefined && {queryName: query.name}),
-        hydrationTimeoutMs: this.#hydrationCircuitBreaker.timeoutMs,
-        circuitBreakerOpenMs: this.#hydrationCircuitBreaker.openMs,
-      });
-    }
     this.#sendHydrationTimeoutErrors(cvr, queries);
   }
 
@@ -2754,6 +2781,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
       const hydratedQueryIDs: string[] = [];
       const budgetEvictedQueryIDs: string[] = [];
       const timedOutQueries: HydrationQuery[] = [];
+      const rejectedQueries: HydrationQuery[] = [];
       const circuitBreaker = this.#hydrationCircuitBreaker;
       // oxlint-disable-next-line @typescript-eslint/no-this-alias
       const self = this;
@@ -2786,6 +2814,17 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
           }
           queryLC.debug?.(`adding pipeline for query`, q.ast);
 
+          // Internal queries are never aborted.
+          const breakable = cvr.queries[q.id]?.type !== 'internal';
+          if (breakable && circuitBreaker.isOpen(q.transformationHash)) {
+            // The breaker was opened by a query earlier in this pass that
+            // shares this transformation. The query is aborted without
+            // hydrating, so one transformation burns at most one timeout.
+            rejectedQueries.push(q);
+            self.#recordCircuitBreakerRejection(queryLC, q);
+            continue;
+          }
+
           const covered = queryCoveringIndex
             ? self.#findQueryCoverageShadowHit(
                 queryCoveringIndex,
@@ -2800,8 +2839,6 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
             coveredHydratedQueries++;
             firstCoveredQuery ??= covered;
           }
-          // Internal queries are never aborted.
-          const breakable = cvr.queries[q.id]?.type !== 'internal';
           let timedOut = false;
           for (const change of pipelines.addQuery(
             q.transformationHash,
@@ -2818,8 +2855,10 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
             ) {
               // Breaking out returns the addQuery generator, which tears down
               // the partially built pipeline. The rows already streamed for
-              // the query are unreferenced after #processChanges.
+              // the query are unreferenced after #processChanges. The time
+              // slice that exposed the timeout still ends with a yield.
               timedOut = true;
+              yield change;
               break;
             }
             yield change;
@@ -2873,20 +2912,31 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
         pokers,
       );
 
-      if (timedOutQueries.length > 0) {
-        const timedOutQueryIDs = timedOutQueries.map(({id}) => id);
+      const abortedQueries = [...timedOutQueries, ...rejectedQueries];
+      if (abortedQueries.length > 0) {
+        const abortedQueryIDs = abortedQueries.map(({id}) => id);
         for (const patch of await updater.abortExecutedQueries(
           lc,
-          timedOutQueryIDs,
+          abortedQueryIDs,
         )) {
           await pokers.addPatch(patch);
         }
-        for (const queryID of timedOutQueryIDs) {
+        for (const queryID of abortedQueryIDs) {
           this.#pipelines.removeQuery(queryID);
           this.#inspectorDelegate.removeQuery(queryID);
           this.#queryReplacements.delete(queryID);
         }
-        this.#sendHydrationTimeoutErrors(cvr, timedOutQueries);
+        if (timedOutQueries.length > 0) {
+          this.#queryEvictions.add(timedOutQueries.length, {
+            reason: 'hydration-timeout',
+          });
+        }
+        if (rejectedQueries.length > 0) {
+          this.#queryEvictions.add(rejectedQueries.length, {
+            reason: 'hydration-circuit-breaker',
+          });
+        }
+        this.#sendHydrationTimeoutErrors(cvr, abortedQueries);
       }
 
       for (const patch of updater.removeTrackedQueries(budgetEvictedQueryIDs)) {

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -97,6 +97,7 @@ import {
 import type {DrainCoordinator} from './drain-coordinator.ts';
 import {E2EServingLagTracker} from './e2e-serving-lag.ts';
 import {HydrationBudget, type MonotonicClock} from './hydration-budget.ts';
+import {HydrationCircuitBreaker} from './hydration-circuit-breaker.ts';
 import {handleInspect} from './inspect-handler.ts';
 import type {PipelineDriver} from './pipeline-driver.ts';
 import {type RowChange} from './pipeline-driver.ts';
@@ -264,6 +265,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
   readonly #drainCoordinator: DrainCoordinator;
   readonly #keepaliveMs: number;
   readonly #slowHydrateThreshold: number;
+  readonly #hydrationCircuitBreaker: HydrationCircuitBreaker;
 
   // The ViewSyncerService is only started in response to a connection,
   // so #lastConnectTime is always initialized to now(). This is necessary
@@ -490,6 +492,24 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     description: 'Number of inactive queries evicted, grouped by reason.',
     unit: '{query}',
   });
+  readonly #hydrationTimeouts = getOrCreateCounter(
+    'sync',
+    'hydration_timeouts',
+    {
+      description:
+        'Number of query hydrations aborted for exceeding the query hydration timeout.',
+      unit: '{query}',
+    },
+  );
+  readonly #hydrationCircuitBreakerRejections = getOrCreateCounter(
+    'sync',
+    'hydration_circuit_breaker_rejections',
+    {
+      description:
+        'Number of queries rejected without hydration because their hydration circuit breaker was open.',
+      unit: '{query}',
+    },
+  );
 
   readonly #inspectorDelegate: InspectorDelegate;
 
@@ -547,6 +567,11 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     );
     this.#setTimeout = setTimeoutFn;
     this.#now = now;
+    this.#hydrationCircuitBreaker = new HydrationCircuitBreaker(
+      config.viewSyncerQueryHydrationTimeoutMs ?? 0,
+      undefined,
+      now,
+    );
     this.#runPriorityOp = runPriorityOp;
     // Wait for the first connection to init.
     this.keepalive();
@@ -1836,6 +1861,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
       }
       const timer = new TimeSliceTimer(lc);
       let count = 0;
+      let timedOut = false;
       await startAsyncSpan(
         tracer,
         'vs.#hydrateUnchangedQueries.addQuery',
@@ -1855,6 +1881,15 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
             'unchanged-query-rehydrate',
           )) {
             if (change === 'yield') {
+              if (
+                query.type !== 'internal' &&
+                this.#hydrationCircuitBreaker.exceeded(timer.totalElapsed())
+              ) {
+                // Breaking out returns the addQuery generator, which tears
+                // down the partially built pipeline.
+                timedOut = true;
+                break;
+              }
               await timer.yieldProcess('yield in hydrateUnchangedQueries');
             } else {
               count++;
@@ -1864,6 +1899,18 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
       );
 
       const elapsed = timer.totalElapsed();
+      if (timedOut) {
+        // No pipeline was registered, so #syncQueryPipelineSet sees the query
+        // as missing. The breaker is now open for it, so that pass removes
+        // the query and errors it to the client instead of hydrating it again.
+        this.#recordHydrationTimeout(
+          lc,
+          {id: queryID, transformationHash, name: queryName},
+          elapsed,
+          count,
+        );
+        continue;
+      }
       hydrationPassStats.activeHydratedQueries++;
       this.#hydrations.add(1);
       this.#hydrationTime.recordMs(elapsed);
@@ -2334,9 +2381,30 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
         ),
       );
 
+      // Queries whose hydration circuit breaker is open are not hydrated.
+      // They are removed from the CVR like transform-errored queries, and the
+      // affected clients receive an error for them.
+      const circuitBrokenQueries = transformedQueries
+        .filter(
+          ({origQuery, transformed}) =>
+            origQuery.type !== 'internal' &&
+            this.#hydrationCircuitBreaker.isOpen(
+              transformed.transformationHash,
+            ),
+        )
+        .map(({id, origQuery, transformed}) => ({
+          id,
+          transformationHash: transformed.transformationHash,
+          name: origQuery.type === 'custom' ? origQuery.name : undefined,
+        }));
+      if (circuitBrokenQueries.length > 0) {
+        this.#rejectCircuitBrokenQueries(lc, cvr, circuitBrokenQueries);
+      }
+
       const removeQueriesQueryIds: Set<string> = new Set([
         ...naturallyExpiredQueryIDs,
         ...erroredQueryIDs,
+        ...circuitBrokenQueries.map(({id}) => id),
       ]);
       const addQueries = transformedQueries
         .map(({id, origQuery, transformed}) => ({
@@ -2369,6 +2437,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
         `syncQueryPipelineSet: ${cvrQueryEntires.length} CVR queries, ` +
           `${transformedCustomQueryCount} custom re-transformed, ` +
           `${erroredQueryIDs.length} errored, ` +
+          `${circuitBrokenQueries.length} circuit-broken, ` +
           `${removeQueriesQueryIds.size} to remove, ` +
           `${addQueries.length} to add`,
       );
@@ -2436,6 +2505,102 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
       this.#lc.warn?.(
         `Query thrashing detected for query ${queryID}. ${record.count} replacements in 60s. This may indicate clients with different auth contexts connecting to the same client group.`,
       );
+    }
+  }
+
+  /**
+   * Records that hydrating `query` was aborted for exceeding the query
+   * hydration timeout, and opens its circuit breaker.
+   */
+  #recordHydrationTimeout(
+    lc: LogContext,
+    query: {id: string; transformationHash: string; name?: string | undefined},
+    elapsedMs: number,
+    rowCount?: number,
+  ): void {
+    this.#hydrationCircuitBreaker.trip(query.transformationHash);
+    this.#hydrationTimeouts.add(1);
+    this.#queryEvictions.add(1, {reason: 'hydration-timeout'});
+    lc.warn?.('Query hydration aborted for exceeding the hydration timeout', {
+      clientGroupID: this.id,
+      queryHash: query.id,
+      transformationHash: query.transformationHash,
+      ...(query.name !== undefined && {queryName: query.name}),
+      hydrationTimeoutMs: this.#hydrationCircuitBreaker.timeoutMs,
+      hydrationElapsedMs: elapsedMs,
+      ...(rowCount !== undefined && {hydrationRowCount: rowCount}),
+      circuitBreakerOpenMs: this.#hydrationCircuitBreaker.openMs,
+    });
+  }
+
+  /**
+   * Handles queries whose hydration circuit breaker is open: they are counted,
+   * logged, and errored to the affected clients. The caller removes them from
+   * the CVR.
+   */
+  #rejectCircuitBrokenQueries(
+    lc: LogContext,
+    cvr: CVRSnapshot,
+    queries: readonly {
+      id: string;
+      transformationHash: string;
+      name?: string | undefined;
+    }[],
+  ): void {
+    this.#hydrationCircuitBreakerRejections.add(queries.length);
+    this.#queryEvictions.add(queries.length, {
+      reason: 'hydration-circuit-breaker',
+    });
+    for (const query of queries) {
+      lc.warn?.('Query rejected by its open hydration circuit breaker', {
+        clientGroupID: this.id,
+        queryHash: query.id,
+        transformationHash: query.transformationHash,
+        ...(query.name !== undefined && {queryName: query.name}),
+        hydrationTimeoutMs: this.#hydrationCircuitBreaker.timeoutMs,
+        circuitBreakerOpenMs: this.#hydrationCircuitBreaker.openMs,
+      });
+    }
+    this.#sendHydrationTimeoutErrors(cvr, queries);
+  }
+
+  /**
+   * Sends a per-query error to every client that desires one of `queries`.
+   * The error goes out as a `transformError` application error, which every
+   * client understands as "this query errored" without affecting the
+   * connection or the client's other queries.
+   */
+  #sendHydrationTimeoutErrors(
+    cvr: CVRSnapshot,
+    queries: readonly {id: string; name?: string | undefined}[],
+  ): void {
+    const timeoutMs = this.#hydrationCircuitBreaker.timeoutMs;
+    const errorsByClient = new Map<string, ErroredQuery[]>();
+    for (const {id, name} of queries) {
+      const query = cvr.queries[id];
+      if (query === undefined || query.type === 'internal') {
+        continue;
+      }
+      const error: ErroredQuery = {
+        error: 'app',
+        id,
+        name: name ?? (query.type === 'custom' ? query.name : 'legacy'),
+        message:
+          `Query hydration exceeded the ${timeoutMs}ms limit ` +
+          `(ZERO_VIEW_SYNCER_QUERY_HYDRATION_TIMEOUT_MS) and was aborted`,
+        details: {kind: 'HydrationTimeout', timeoutMs},
+      };
+      for (const clientID of Object.keys(query.clientState)) {
+        let errors = errorsByClient.get(clientID);
+        if (!errors) {
+          errors = [];
+          errorsByClient.set(clientID, errors);
+        }
+        errors.push(error);
+      }
+    }
+    for (const [clientID, errors] of errorsByClient) {
+      this.#clients.get(clientID)?.sendQueryTransformApplicationErrors(errors);
     }
   }
 
@@ -2588,6 +2753,8 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
       let firstCoveredQuery: QueryCoverageShadowHit | undefined;
       const hydratedQueryIDs: string[] = [];
       const budgetEvictedQueryIDs: string[] = [];
+      const timedOutQueries: HydrationQuery[] = [];
+      const circuitBreaker = this.#hydrationCircuitBreaker;
       // oxlint-disable-next-line @typescript-eslint/no-this-alias
       const self = this;
 
@@ -2633,16 +2800,37 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
             coveredHydratedQueries++;
             firstCoveredQuery ??= covered;
           }
-          yield* pipelines.addQuery(
+          // Internal queries are never aborted.
+          const breakable = cvr.queries[q.id]?.type !== 'internal';
+          let timedOut = false;
+          for (const change of pipelines.addQuery(
             q.transformationHash,
             q.id,
             q.ast,
             timer.startWithoutYielding(),
             q.name,
             'query-set-sync',
-          );
+          )) {
+            if (
+              change === 'yield' &&
+              breakable &&
+              circuitBreaker.exceeded(timer.totalElapsed())
+            ) {
+              // Breaking out returns the addQuery generator, which tears down
+              // the partially built pipeline. The rows already streamed for
+              // the query are unreferenced after #processChanges.
+              timedOut = true;
+              break;
+            }
+            yield change;
+          }
           const elapsed = timer.stop();
           totalProcessTime += elapsed;
+          if (timedOut) {
+            timedOutQueries.push(q);
+            self.#recordHydrationTimeout(queryLC, q, elapsed);
+            continue;
+          }
           hydratedQueryIDs.push(q.id);
           if (optional) {
             hydrationPassStats.inactiveHydratedQueries++;
@@ -2684,6 +2872,22 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
         updater,
         pokers,
       );
+
+      if (timedOutQueries.length > 0) {
+        const timedOutQueryIDs = timedOutQueries.map(({id}) => id);
+        for (const patch of await updater.abortExecutedQueries(
+          lc,
+          timedOutQueryIDs,
+        )) {
+          await pokers.addPatch(patch);
+        }
+        for (const queryID of timedOutQueryIDs) {
+          this.#pipelines.removeQuery(queryID);
+          this.#inspectorDelegate.removeQuery(queryID);
+          this.#queryReplacements.delete(queryID);
+        }
+        this.#sendHydrationTimeoutErrors(cvr, timedOutQueries);
+      }
 
       for (const patch of updater.removeTrackedQueries(budgetEvictedQueryIDs)) {
         await pokers.addPatch(patch);

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -489,7 +489,11 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     },
   );
   readonly #queryEvictions = getOrCreateCounter('sync', 'query_evictions', {
-    description: 'Number of inactive queries evicted, grouped by reason.',
+    description:
+      'Number of queries evicted from the CVR ahead of their removal by the ' +
+      'client, grouped by reason. Inactive queries are evicted by ttl and ' +
+      'hydration-budget; hydration-timeout and hydration-circuit-breaker ' +
+      'evict active queries as well.',
     unit: '{query}',
   });
   readonly #hydrationTimeouts = getOrCreateCounter(


### PR DESCRIPTION
## What

Adds `ZERO_VIEW_SYNCER_QUERY_HYDRATION_TIMEOUT_MS` (default `0`, off): the maximum processing time a view-syncer spends hydrating a single client query. Time spent yielding is not counted, and internal queries are exempt.

When a hydration exceeds the limit (checked at yield points):

- The hydration is aborted and the partially built pipeline is torn down.
- Rows already streamed for the query are unreferenced via the new `CVRQueryDrivenUpdater.abortExecutedQueries`. A row left with no other references gets a `del` patch that cancels the `put` the client already received; rows shared with other queries keep their patch version.
- The query is removed from the CVR, and every client that desires it receives a `transformError` app error with `details.kind = 'HydrationTimeout'`. Existing clients already treat that message as a per-query error, so no client change is needed.
- A circuit breaker keyed by transformation hash (`hydration-circuit-breaker.ts`) rejects the query up front for five minutes, so reconnects do not re-burn the timeout. After that one real retry is allowed.

A gotten query that trips during unchanged-query rehydration on restart is not re-registered; the following pipeline sync sees the open breaker, removes it, and errors it.

Stacked on #6500, which makes `PipelineDriver` tear down the pipeline of an abandoned hydration.

New metrics: `sync.hydration_timeouts`, `sync.hydration_circuit_breaker_rejections`, and `query_evictions` reasons `hydration-timeout` / `hydration-circuit-breaker`.

## Why

Follow-up to the hydration budget (#6477), which only bounds batches of *inactive* queries. Margins still saw single active queries hydrate for 20+ seconds and monopolize a view-syncer. This is the "circuitbreaker to stop very slow hydrations" item on the Margins launch burndown.

## Reviewer notes

- Default is off; CloudZero needs to set it per deployment.
- The error is sent as an `'app'` transform error because older clients treat any unknown `error` kind in `transformError` as fatal.
- The breaker's cooldown is a constant (5 min) rather than a second config knob; happy to expose it if wanted.

## Tests

- `hydration-circuit-breaker.test.ts`: breaker unit tests.
- `view-syncer-hydration-timeout.pg.test.ts`: abort with row cleanup, rejection while open, retry after cooldown, restart path, disabled mode.
- Config parsing tests and help snapshot.

