### PR TITLE
fix(zero-cache): destroy the pipeline of an abandoned or failed hydration

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
@@ -818,6 +818,27 @@ describe('view-syncer/pipeline-driver', () => {
     });
   });
 
+  test('abandoned hydration tears down its pipeline', () => {
+    pipelines.init(clientSchema);
+    const hydration = pipelines
+      .addQuery('hash1', 'queryID1', ISSUES_AND_COMMENTS, startTimer())
+      [Symbol.iterator]();
+    // Consume the first row, then abandon the hydration, as a consumer that
+    // stops iterating early does.
+    expect(hydration.next().done).toBe(false);
+    hydration.return?.();
+
+    expect(pipelines.queries().has('queryID1')).toBe(false);
+
+    // The abandoned pipeline is disconnected from its sources, so a change to
+    // a table it was reading no longer produces output for it.
+    replicator.processTransaction(
+      '134',
+      messages.insert('issues', {id: '4', closed: 0}),
+    );
+    expect(changes()).toEqual([]);
+  });
+
   test('insert', () => {
     pipelines.init(clientSchema);
     [

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.test.ts
@@ -1,5 +1,13 @@
 import {LogContext} from '@rocicorp/logger';
-import {afterEach, beforeEach, describe, expect, test} from 'vitest';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  type MockInstance,
+  test,
+  vi,
+} from 'vitest';
 import {testLogConfig} from '../../../../otel/src/test-log-config.ts';
 import {TestLogSink} from '../../../../shared/src/logging-test-utils.ts';
 import type {
@@ -20,6 +28,7 @@ import {
 } from '../../../../zqlite/src/database-storage.ts';
 import type {Database as DB} from '../../../../zqlite/src/db.ts';
 import {Database} from '../../../../zqlite/src/db.ts';
+import {TableSource} from '../../../../zqlite/src/table-source.ts';
 import {listTables} from '../../db/lite-tables.ts';
 import {InspectorDelegate} from '../../server/inspector-delegate.ts';
 import {DbFile} from '../../test/lite.ts';
@@ -153,8 +162,33 @@ describe('view-syncer/pipeline-driver', () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     dbFile.delete();
   });
+
+  /**
+   * Spies on the `destroy` of every source connection made from now on, so a
+   * test can check that a pipeline built for a query was torn down. The
+   * `failFetchOf` connection (1-based) throws when fetched.
+   */
+  function trackSourceConnections(failFetchOf?: number): MockInstance[] {
+    const destroys: MockInstance[] = [];
+    const connect = TableSource.prototype.connect;
+    vi.spyOn(TableSource.prototype, 'connect').mockImplementation(function (
+      this: TableSource,
+      ...args: Parameters<TableSource['connect']>
+    ) {
+      const input = connect.apply(this, args);
+      destroys.push(vi.spyOn(input, 'destroy'));
+      if (destroys.length === failFetchOf) {
+        vi.spyOn(input, 'fetch').mockImplementation(() => {
+          throw new Error('simulated fetch failure');
+        });
+      }
+      return input;
+    });
+    return destroys;
+  }
 
   const issues = table('issues')
     .columns({
@@ -829,6 +863,8 @@ describe('view-syncer/pipeline-driver', () => {
     hydration.return?.();
 
     expect(pipelines.queries().has('queryID1')).toBe(false);
+    // The rows it yielded must not leave a partial signature behind.
+    expect(pipelines.rowSetSignature('queryID1')).toBeUndefined();
 
     // The abandoned pipeline is disconnected from its sources, so a change to
     // a table it was reading no longer produces output for it.
@@ -837,6 +873,30 @@ describe('view-syncer/pipeline-driver', () => {
       messages.insert('issues', {id: '4', closed: 0}),
     );
     expect(changes()).toEqual([]);
+  });
+
+  test('failed scalar subquery resolution tears down earlier companions', () => {
+    pipelines.init(clientSchema);
+    const scalar =
+      ISSUES_WITH_SCALAR_SUBQUERY.where as CorrelatedSubqueryCondition;
+    // Two scalar subqueries: the first resolves and connects a companion
+    // pipeline to `comments`; executing the second fails at fetch time.
+    const ast: AST = {
+      ...ISSUES_WITH_SCALAR_SUBQUERY,
+      where: {type: 'and', conditions: [scalar, scalar]},
+    };
+    const destroys = trackSourceConnections(2);
+    expect(() => [
+      ...pipelines.addQuery('hash1', 'queryID1', ast, startTimer()),
+    ]).toThrow('simulated fetch failure');
+    expect(pipelines.queries().has('queryID1')).toBe(false);
+
+    // Both companions connected before the second one failed, and both
+    // connections were torn down.
+    expect(destroys).toHaveLength(2);
+    for (const destroy of destroys) {
+      expect(destroy).toHaveBeenCalledTimes(1);
+    }
   });
 
   test('insert', () => {

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
@@ -552,6 +552,10 @@ export class PipelineDriver {
         },
         'scalar-subquery',
       );
+      // Tracked before it is fetched so that a failure in this or a later
+      // subquery can tear it down below. A companion with no result is kept
+      // alive too: it detects a future insert that creates the row.
+      companionInputs.push(input);
       // Consume the full stream rather than using first() to avoid
       // triggering early return on Take's #initialFetch assertion.
       // The subquery AST already has limit: 1, so at most one row is produced.
@@ -560,21 +564,27 @@ export class PipelineDriver {
         node ??= n;
       }
       if (!node) {
-        // Keep the companion alive even with no results — it will
-        // detect a future insert that creates the row.
-        companionInputs.push(input);
         return undefined;
       }
       companionRows.push({table: subqueryAST.table, row: node.row as Row});
-      companionInputs.push(input);
       return (node.row[childField] as LiteralValue) ?? null;
     };
 
-    const {
-      ast: resolved,
-      companions,
-      ignoredScalarHints,
-    } = resolveSimpleScalarSubqueries(ast, this.#tableSpecs, executor);
+    let resolved: AST;
+    let companions: CompanionSubquery[];
+    let ignoredScalarHints: IgnoredScalarHint[];
+    try {
+      ({
+        ast: resolved,
+        companions,
+        ignoredScalarHints,
+      } = resolveSimpleScalarSubqueries(ast, this.#tableSpecs, executor));
+    } catch (e) {
+      for (const input of companionInputs) {
+        input.destroy();
+      }
+      throw e;
+    }
     return {
       ast: resolved,
       companionRows,
@@ -864,6 +874,10 @@ export class PipelineDriver {
         for (const input of builtInputs) {
           input.destroy();
         }
+        // Rows may already have been yielded through #trackRowSetSignatures,
+        // and rowSetSignature() must not report a signature for a query
+        // without an active pipeline.
+        this.#rowSetSignatures.delete(queryID);
       }
       this.#hydrateContext = null;
     }

--- a/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
+++ b/packages/zero-cache/src/services/view-syncer/pipeline-driver.ts
@@ -659,6 +659,10 @@ export class PipelineDriver {
     let hydrationFinished = false;
     let hydrationFailed = false;
     let hydrationRowCount = 0;
+    // The inputs built so far, held outside the try so that a hydration that
+    // does not finish (aborted by the consumer or failed) can tear them down.
+    // Only a finished hydration hands them over to #pipelines.
+    let builtInputs: Input[] = [];
     try {
       const {
         ast: resolvedQuery,
@@ -667,6 +671,7 @@ export class PipelineDriver {
         companionInputs,
         ignoredScalarHints,
       } = this.#resolveScalarSubqueries(query);
+      builtInputs = [...companionInputs];
 
       this.#warnIgnoredScalarHints(queryID, ignoredScalarHints);
 
@@ -697,6 +702,7 @@ export class PipelineDriver {
         queryID,
         costModel,
       );
+      builtInputs.push(input);
       const schema = input.getSchema();
       input.setOutput({
         push: change => {
@@ -853,6 +859,11 @@ export class PipelineDriver {
           hydrationTimeMs: timer.totalElapsed(),
           hydrationRowCount,
         });
+      }
+      if (!hydrationFinished) {
+        for (const input of builtInputs) {
+          input.destroy();
+        }
       }
       this.#hydrateContext = null;
     }


### PR DESCRIPTION
## What

`PipelineDriver.addQuery` builds a query's pipeline and connects it to its table sources before hydration streams rows, but only a *finished* hydration registers the pipeline in `#pipelines`. A hydration that is abandoned by its consumer (the generator is returned early) or that throws left the partially built pipeline connected to its sources, where it kept receiving pushes on every advance.

The built inputs (the query pipeline plus any scalar-subquery companion pipelines) are now held outside the `try` and destroyed in the `finally` block when the hydration did not finish.

## Why

Extracted from #6499, which aborts slow hydrations on purpose and needs the abandoned pipeline torn down. The leak also applies to the existing failure path.

## Tests

`pipeline-driver.test.ts`: abandons a hydration after its first row and checks that a later change to a table it was reading no longer produces output for it. Fails without the fix.
