### PR TITLE
perf(replicache): bind commit parameters instead of routing writes through json_each

### DIFF
--- a/packages/replicache/src/kv/sqlite-store.test.node.ts
+++ b/packages/replicache/src/kv/sqlite-store.test.node.ts
@@ -23,6 +23,8 @@ function makeMockStatements(
   const stmts: PreparedStatements = {
     put: {async exec() {}, all: () => Promise.resolve([])},
     del: {async exec() {}, all: () => Promise.resolve([])},
+    putN: () => ({async exec() {}, all: () => Promise.resolve([])}),
+    delN: () => ({async exec() {}, all: () => Promise.resolve([])}),
     get: {
       async exec() {},
       // oxlint-disable-next-line require-await

--- a/packages/replicache/src/kv/sqlite-store.test.ts
+++ b/packages/replicache/src/kv/sqlite-store.test.ts
@@ -70,6 +70,53 @@ test('SQLiteWrite batches deletes and upserts into one bound statement each', as
   expect(release).toHaveBeenCalledTimes(1);
 });
 
+test('SQLiteWrite splits a commit wider than MAX_BATCH across statement widths', async () => {
+  const release = vi.fn();
+  const db: SQLiteDatabase = {
+    close: vi.fn(),
+    destroy: vi.fn(),
+    prepare: vi.fn(),
+    execSync: vi.fn(),
+  };
+  const preparedStatements = makePreparedStatements();
+  const write = new SQLiteWrite(release, db, preparedStatements);
+
+  // 129 is deliberately just past MAX_BATCH and not a power of two, so it has
+  // to split into a full 128-wide statement plus a 1-wide remainder.
+  const n = 129;
+  for (let i = 0; i < n; i++) {
+    await write.put(`put-${i}`, i);
+    await write.del(`del-${i}`);
+  }
+  await write.commit();
+  write.release();
+
+  for (const [width, calls] of [
+    [128, 1],
+    [1, 1],
+  ] as const) {
+    expect(preparedStatements.putN(width).exec).toHaveBeenCalledTimes(calls);
+    expect(preparedStatements.delN(width).exec).toHaveBeenCalledTimes(calls);
+  }
+
+  // Every key reaches SQLite exactly once, in order, with its value alongside.
+  const putParams = [128, 1].flatMap(
+    w => vi.mocked(preparedStatements.putN(w).exec).mock.calls[0][0],
+  );
+  expect(putParams).toEqual(
+    Array.from({length: n}, (_, i) => [`put-${i}`, String(i)]).flat(),
+  );
+
+  const delParams = [128, 1].flatMap(
+    w => vi.mocked(preparedStatements.delN(w).exec).mock.calls[0][0],
+  );
+  expect(delParams).toEqual(Array.from({length: n}, (_, i) => `del-${i}`));
+
+  // The single-shot json_each statements are no longer used at all.
+  expect(preparedStatements.put.exec).not.toHaveBeenCalled();
+  expect(preparedStatements.del.exec).not.toHaveBeenCalled();
+});
+
 test('SQLiteStoreRead rejects pending get and has operations when closed', async () => {
   const release = vi.fn();
   const preparedStatements = makePreparedStatements();

--- a/packages/replicache/src/kv/sqlite-store.test.ts
+++ b/packages/replicache/src/kv/sqlite-store.test.ts
@@ -13,6 +13,19 @@ function makePreparedStatement() {
   };
 }
 
+/** One shared statement per width, so assertions can inspect a stable object. */
+function makeBatchStatement() {
+  const cache = new Map<number, ReturnType<typeof makePreparedStatement>>();
+  return (n: number) => {
+    let s = cache.get(n);
+    if (!s) {
+      s = makePreparedStatement();
+      cache.set(n, s);
+    }
+    return s;
+  };
+}
+
 function makePreparedStatements(): PreparedStatements {
   return {
     has: makePreparedStatement(),
@@ -21,10 +34,12 @@ function makePreparedStatements(): PreparedStatements {
     getMany: makePreparedStatement(),
     del: makePreparedStatement(),
     put: makePreparedStatement(),
+    putN: makeBatchStatement(),
+    delN: makeBatchStatement(),
   };
 }
 
-test('SQLiteWrite batches deletes and upserts into one statement each', async () => {
+test('SQLiteWrite batches deletes and upserts into one bound statement each', async () => {
   const release = vi.fn();
   const db: SQLiteDatabase = {
     close: vi.fn(),
@@ -43,13 +58,18 @@ test('SQLiteWrite batches deletes and upserts into one statement each', async ()
   await write.commit();
   write.release();
 
-  // 2 deletes → cached del[1]
-  expect(preparedStatements.del.exec).toHaveBeenCalledWith([
-    '["delete-1","delete-2"]',
+  // Both pairs go out as one 2-wide statement each, with the key and the
+  // JSON-encoded value bound as real parameters rather than routed through a
+  // single JSON document for json_each() to parse back out.
+  expect(preparedStatements.putN(2).exec).toHaveBeenCalledWith([
+    'upsert-1',
+    '"value-1"',
+    'upsert-2',
+    '{"nested":true}',
   ]);
-  // 2 upserts → cached upserts[1]
-  expect(preparedStatements.put.exec).toHaveBeenCalledWith([
-    '[["upsert-1","value-1"],["upsert-2",{"nested":true}]]',
+  expect(preparedStatements.delN(2).exec).toHaveBeenCalledWith([
+    'delete-1',
+    'delete-2',
   ]);
   expect(db.execSync).toHaveBeenCalledWith('COMMIT');
   expect(release).toHaveBeenCalledTimes(1);

--- a/packages/replicache/src/kv/sqlite-store.test.ts
+++ b/packages/replicache/src/kv/sqlite-store.test.ts
@@ -1,4 +1,5 @@
 import {expect, test, vi} from 'vitest';
+import {getOrInsertComputed} from '../../../shared/src/map.ts';
 import {
   SQLiteWrite,
   SQLiteStoreRead,
@@ -16,14 +17,8 @@ function makePreparedStatement() {
 /** One shared statement per width, so assertions can inspect a stable object. */
 function makeBatchStatement() {
   const cache = new Map<number, ReturnType<typeof makePreparedStatement>>();
-  return (n: number) => {
-    let s = cache.get(n);
-    if (!s) {
-      s = makePreparedStatement();
-      cache.set(n, s);
-    }
-    return s;
-  };
+  return (n: number) =>
+    getOrInsertComputed(cache, n, () => makePreparedStatement());
 }
 
 function makePreparedStatements(): PreparedStatements {

--- a/packages/replicache/src/kv/sqlite-store.ts
+++ b/packages/replicache/src/kv/sqlite-store.ts
@@ -148,7 +148,59 @@ export type PreparedStatements = {
   getMany: PreparedStatement;
   put: PreparedStatement;
   del: PreparedStatement;
+  /** Multi-row INSERT with the values bound as parameters, n rows wide. */
+  putN: (n: number) => PreparedStatement;
+  /** Multi-key DELETE with the keys bound as parameters, n keys wide. */
+  delN: (n: number) => PreparedStatement;
 };
+
+/**
+ * Widest batch we bind in one statement. SQLite's SQLITE_MAX_VARIABLE_NUMBER is
+ * 32766, and a put costs two parameters per row, so this is far below the cap;
+ * it exists to bound how many distinct statements we prepare and cache.
+ */
+const MAX_BATCH = 128;
+
+/**
+ * Prepares (and caches) a statement of each width on demand. Callers only ever
+ * ask for powers of two, so the cache holds at most log2(MAX_BATCH)+1 entries
+ * however many rows a commit turns out to have.
+ */
+function batchStatements(
+  delegate: SQLiteDatabase,
+  sqlFor: (n: number) => string,
+): (n: number) => PreparedStatement {
+  const cache = new Map<number, PreparedStatement>();
+  return (n: number) => {
+    let stmt = cache.get(n);
+    if (!stmt) {
+      stmt = delegate.prepare(sqlFor(n));
+      cache.set(n, stmt);
+    }
+    return stmt;
+  };
+}
+
+/**
+ * Runs `items` through `getStatement` in power-of-two sized batches, so any
+ * length is covered by a handful of cached statement widths.
+ */
+async function execInBatches<T>(
+  items: readonly T[],
+  getStatement: (n: number) => PreparedStatement,
+  toParams: (item: T, out: string[]) => void,
+): Promise<void> {
+  for (let i = 0; i < items.length;) {
+    const remaining = Math.min(MAX_BATCH, items.length - i);
+    const n = 1 << (31 - Math.clz32(remaining));
+    const params: string[] = [];
+    for (let j = 0; j < n; j++) {
+      toParams(items[i + j], params);
+    }
+    await getStatement(n).exec(params);
+    i += n;
+  }
+}
 
 export interface SQLiteStoreOptions {
   // Common options
@@ -201,6 +253,22 @@ export function setupDatabase(
     ),
     del: delegate.prepare(
       `DELETE FROM entry WHERE key IN (SELECT value FROM json_each(?))`,
+    ),
+    putN: batchStatements(
+      delegate,
+      n =>
+        `INSERT OR REPLACE INTO entry (key, value) VALUES ${Array.from({
+          length: n,
+        })
+          .fill('(?,?)')
+          .join(',')}`,
+    ),
+    delN: batchStatements(
+      delegate,
+      n =>
+        `DELETE FROM entry WHERE key IN (${Array.from({length: n})
+          .fill('?')
+          .join(',')})`,
     ),
   };
 }
@@ -411,19 +479,28 @@ export class SQLiteWrite extends WriteImplBase implements Write {
       }
     }
 
-    const delP =
-      deleteKeys.length > 0
-        ? this.#preparedStatements.del.exec([JSON.stringify(deleteKeys)])
-        : undefined;
-    const putP =
-      this._pending.size > 0
-        ? this.#preparedStatements.put.exec([
-            JSON.stringify([...this._pending]),
-          ])
-        : undefined;
-
-    if (putP) await putP;
-    if (delP) await delP;
+    // Bind real parameters rather than serializing the whole pending set into
+    // one JSON document for json_each() to parse back out. That serialize, and
+    // pushing the resulting (often megabyte-scale) string across the native
+    // bridge, measured as roughly a quarter of persist on device.
+    if (this._pending.size > 0) {
+      await execInBatches(
+        [...this._pending] as [string, ReadonlyJSONValue][],
+        this.#preparedStatements.putN,
+        ([key, value], out) => {
+          out.push(key, JSON.stringify(value));
+        },
+      );
+    }
+    if (deleteKeys.length > 0) {
+      await execInBatches(
+        deleteKeys,
+        this.#preparedStatements.delN,
+        (key, out) => {
+          out.push(key);
+        },
+      );
+    }
 
     this.#dbDelegate.execSync('COMMIT');
     this._pending.clear();

--- a/packages/replicache/src/kv/sqlite-store.ts
+++ b/packages/replicache/src/kv/sqlite-store.ts
@@ -162,6 +162,11 @@ export type PreparedStatements = {
  */
 const MAX_BATCH = 128;
 
+/** `repeatList('?', 3)` -> `'?,?,?'`. */
+function repeatList(item: string, n: number): string {
+  return `${item},`.repeat(n).slice(0, -1);
+}
+
 /**
  * Prepares (and caches) a statement of each width on demand. Callers only ever
  * ask for powers of two, so the cache holds at most log2(MAX_BATCH)+1 entries
@@ -252,18 +257,11 @@ export function setupDatabase(
     putN: batchStatements(
       delegate,
       n =>
-        `INSERT OR REPLACE INTO entry (key, value) VALUES ${Array.from({
-          length: n,
-        })
-          .fill('(?,?)')
-          .join(',')}`,
+        `INSERT OR REPLACE INTO entry (key, value) VALUES ${repeatList('(?,?)', n)}`,
     ),
     delN: batchStatements(
       delegate,
-      n =>
-        `DELETE FROM entry WHERE key IN (${Array.from({length: n})
-          .fill('?')
-          .join(',')})`,
+      n => `DELETE FROM entry WHERE key IN (${repeatList('?', n)})`,
     ),
   };
 }
@@ -475,27 +473,40 @@ export class SQLiteWrite extends WriteImplBase implements Write {
     }
 
     // Bind real parameters rather than serializing the whole pending set into
-    // one JSON document for json_each() to parse back out. That serialize, and
+    // one JSON document for json_each() to parse back out. Serializing it, and
     // pushing the resulting (often megabyte-scale) string across the native
     // bridge, measured as roughly a quarter of persist on device.
-    if (this._pending.size > 0) {
-      await execInBatches(
-        [...this._pending] as [string, ReadonlyJSONValue][],
-        this.#preparedStatements.putN,
-        ([key, value], out) => {
-          out.push(key, JSON.stringify(value));
-        },
-      );
-    }
-    if (deleteKeys.length > 0) {
-      await execInBatches(
-        deleteKeys,
-        this.#preparedStatements.delN,
-        (key, out) => {
-          out.push(key);
-        },
-      );
-    }
+    //
+    // Puts and deletes use different statements over disjoint keys (deletes
+    // were removed from _pending above), so they overlap. The batches *within*
+    // each must not: the power-of-two split reuses a width when a commit is
+    // wide enough (300 rows -> 128, 128, 32, 8, 4), and running two of those
+    // concurrently would have two callers on one prepared statement — the
+    // rebind-during-execute hazard described in kv/expo-sqlite/store.ts, which
+    // op-sqlite has no per-statement lock to absorb.
+    const putP =
+      this._pending.size > 0
+        ? execInBatches(
+            [...this._pending] as [string, ReadonlyJSONValue][],
+            this.#preparedStatements.putN,
+            ([key, value], out) => {
+              out.push(key, JSON.stringify(value));
+            },
+          )
+        : undefined;
+    const delP =
+      deleteKeys.length > 0
+        ? execInBatches(
+            deleteKeys,
+            this.#preparedStatements.delN,
+            (key, out) => {
+              out.push(key);
+            },
+          )
+        : undefined;
+
+    if (putP) await putP;
+    if (delP) await delP;
 
     this.#dbDelegate.execSync('COMMIT');
     this._pending.clear();

--- a/packages/replicache/src/kv/sqlite-store.ts
+++ b/packages/replicache/src/kv/sqlite-store.ts
@@ -1,5 +1,6 @@
 import {RWLock} from '@rocicorp/lock';
 import type {ReadonlyJSONValue} from '../../../shared/src/json.ts';
+import {getOrInsertComputed} from '../../../shared/src/map.ts';
 import {deepFreeze} from '../frozen-json.ts';
 import type {Read, Store, Write} from './store.ts';
 import {
@@ -171,14 +172,8 @@ function batchStatements(
   sqlFor: (n: number) => string,
 ): (n: number) => PreparedStatement {
   const cache = new Map<number, PreparedStatement>();
-  return (n: number) => {
-    let stmt = cache.get(n);
-    if (!stmt) {
-      stmt = delegate.prepare(sqlFor(n));
-      cache.set(n, stmt);
-    }
-    return stmt;
-  };
+  return (n: number) =>
+    getOrInsertComputed(cache, n, () => delegate.prepare(sqlFor(n)));
 }
 
 /**

--- a/packages/shared/src/map.ts
+++ b/packages/shared/src/map.ts
@@ -1,5 +1,11 @@
+/**
+ * A value that {@link Map.get} can distinguish from a missing entry.  `undefined`
+ * is excluded because these helpers use `get() !== undefined` to detect absence.
+ */
+type Defined = {} | null;
+
 const nativeSupport =
-  typeof (Map.prototype as unknown as MapES2026<unknown, unknown>)
+  typeof (Map.prototype as unknown as MapES2026<unknown, Defined>)
     .getOrInsert === 'function';
 
 interface MapES2026<K, V> {
@@ -13,7 +19,11 @@ interface MapES2026<K, V> {
  *
  * Mirrors the ES2026 `Map.prototype.getOrInsert` proposal.
  */
-function getOrInsertPolyfill<K, V>(map: Map<K, V>, key: K, defaultValue: V): V {
+function getOrInsertPolyfill<K, V extends Defined>(
+  map: Map<K, V>,
+  key: K,
+  defaultValue: V,
+): V {
   const existing = map.get(key);
   if (existing !== undefined) {
     return existing;
@@ -28,7 +38,7 @@ function getOrInsertPolyfill<K, V>(map: Map<K, V>, key: K, defaultValue: V): V {
  *
  * Mirrors the ES2026 `Map.prototype.getOrInsertComputed` proposal.
  */
-function getOrInsertComputedPolyfill<K, V>(
+function getOrInsertComputedPolyfill<K, V extends Defined>(
   map: Map<K, V>,
   key: K,
   compute: (key: K) => V,
@@ -42,11 +52,15 @@ function getOrInsertComputedPolyfill<K, V>(
   return value;
 }
 
-function getOrInsertNative<K, V>(map: Map<K, V>, key: K, defaultValue: V): V {
+function getOrInsertNative<K, V extends Defined>(
+  map: Map<K, V>,
+  key: K,
+  defaultValue: V,
+): V {
   return (map as unknown as MapES2026<K, V>).getOrInsert(key, defaultValue);
 }
 
-function getOrInsertComputedNative<K, V>(
+function getOrInsertComputedNative<K, V extends Defined>(
   map: Map<K, V>,
   key: K,
   compute: (key: K) => V,


### PR DESCRIPTION
## What

`SQLiteStore.commit()` serialized the entire pending write set into one JSON document and let SQLite parse it back out via `json_each(?)`. One statement regardless of key count is the right instinct, but it means a commit's whole payload — often megabyte-scale — is built as a JS string and pushed across the native bridge, then re-parsed as JSON on the other side.

This binds keys and JSON-encoded values as real parameters instead, in power-of-two batches up to 128 rows.

## Why

A Hermes CPU profile of `persist 1024x1000` on an Android emulator (release build, expo-sqlite), windowed to the region the bencher actually times:

| frame | share |
|---|---|
| `(idle)` — genuinely waiting on SQLite | 31.7% |
| `runAsync` **self** time — marshalling on the JS thread | 22.3% |
| `jsonStringify` | 9.5% |
| `execSync` (pragmas, BEGIN/COMMIT) | 8.1% |
| BTree work, combined | ~4% |

Only the first is database work. `jsonStringify` plus a large share of `runAsync`'s self time is the cost of getting the data *to* SQLite, and both scale with that one JSON string.

## Numbers

`persist 1024x1000 (indexes: 0)`, p50, Android release build, 8-core/8 GB emulator:

| backend | before | after | |
|---|---|---|---|
| expo-sqlite | 85.6 ms | **77.4 ms** | −10% |
| op-sqlite | 66.4 ms | **52.8 ms** | −20% |

`populate` and `scan` are unchanged, as expected — they don't commit large sets. op-sqlite gains more because once the JSON document is gone, what's left is each binding's own marshalling, and its bridge is cheaper.

## Details

- 128 rows costs 256 variables, far below SQLite's `SQLITE_MAX_VARIABLE_NUMBER` of 32766. The width is bounded to limit how many distinct statements get prepared and cached, not to satisfy SQLite.
- Power-of-two decomposition means any commit size is covered by at most 8 cached statement widths.
- `sqlite-store.test.ts` asserted the `json_each` payload shape directly, so it now asserts the bound parameters. The two mock statement bags gain `putN`/`delN`.

## Testing

806/806 replicache tests pass (browser + node), plus lint, format and check-types. Measured on device via the harness in the companion PR.

## Caveat

Measured on one emulator with one commit shape (1000×1 KB → a few hundred chunks). The win should grow with commit size and shrink toward nothing for small commits, where a single `json_each` call was already cheap — I have not measured the small-commit case, and it's the one where this could plausibly be marginally worse.

