### PR TITLE
fix(replicache-perf): resolve main fields when bundling for React Native

### DIFF
--- a/packages/replicache-perf/tool/build.ts
+++ b/packages/replicache-perf/tool/build.ts
@@ -46,6 +46,10 @@ async function buildRN(): Promise<void> {
     external: ['node:*', 'expo-sqlite', '@op-engineering/op-sqlite'],
     format: 'esm',
     platform: 'neutral',
+    // 'neutral' resolves no main fields at all, so any dependency that ships
+    // only `module`/`main` (rather than an `exports` map esbuild can follow)
+    // fails to resolve. Metro's own order, minus react-native-specific entries.
+    mainFields: ['module', 'main'],
     splitting: false,
     define,
     outfile: path.join(dirname, '..', 'out', 'rn.js'),

--- a/packages/replicache-perf/tool/build.ts
+++ b/packages/replicache-perf/tool/build.ts
@@ -47,9 +47,15 @@ async function buildRN(): Promise<void> {
     format: 'esm',
     platform: 'neutral',
     // 'neutral' resolves no main fields at all, so any dependency that ships
-    // only `module`/`main` (rather than an `exports` map esbuild can follow)
-    // fails to resolve. Metro's own order, minus react-native-specific entries.
-    mainFields: ['module', 'main'],
+    // only a legacy entry (rather than an `exports` map esbuild can follow)
+    // fails to resolve outright.
+    //
+    // Metro resolves `react-native`, `browser`, `main`. We keep that order so a
+    // dependency picks the same entry here as it would if Metro had bundled it,
+    // and add `module` ahead of `main` only: where Metro would fall back to a
+    // CommonJS `main`, esbuild prefers the ESM build so it can tree-shake. A
+    // package that ships `browser` still gets it, as under Metro.
+    mainFields: ['react-native', 'browser', 'module', 'main'],
     splitting: false,
     define,
     outfile: path.join(dirname, '..', 'out', 'rn.js'),


### PR DESCRIPTION
## What

One setting plus a comment in `tool/build.ts` — give the React Native esbuild pass:

```ts
mainFields: ['react-native', 'browser', 'module', 'main'],
```

## Why

`platform: 'neutral'` resolves **no** main fields at all. Any dependency that ships a legacy entry rather than an `exports` map esbuild can follow fails outright:

```
✘ [ERROR] Could not resolve "@msgpack/msgpack"
```

This has bitten twice. It's why `src/rn.ts` can't simply import `perf.ts` — `hash-wasm` won't resolve, so the RN entry hand-picks its benchmark groups instead. And it blocked adding `@msgpack/msgpack` while measuring whether MessagePack beats `JSON.stringify` on Hermes.

The failure reads like a bug in the harness rather than a resolver setting, which is what makes it worth fixing even though nothing needs it today.

## Why this order

Metro resolves `react-native`, `browser`, `main`. Keeping that order means a dependency picks the same entry here as it would if Metro had bundled it:

- **`react-native`** — the entry a package publishes specifically for RN. Without it, a package shipping an RN build would be bundled with its generic one.
- **`browser`** — matches Metro, so browser-shimmed builds win over generic ESM exactly as they would on device.
- **`module` before `main`** — the one deliberate divergence. Where Metro falls back to CommonJS, esbuild takes the ESM build and can tree-shake. This only applies to packages with no `react-native` or `browser` entry, so it never overrides a more specific choice.

## Risk

None today. The emitted bundle is **byte-for-byte identical** to the build without the setting — 133,467 bytes either way — because nothing currently bundled needs a main field.

That was verified by stashing the change and rebuilding on this branch. My first attempt compared against a stale `out/rn.js` left over from another branch and reported a bogus 24-byte delta; the number above is from the real A/B.

Since the artifact is unchanged, I did not re-run the device suite.

## Context

Came out of benchmarking JSON vs MessagePack on device — itself a clear negative result: msgpack is **9–13x slower** than `JSON.stringify`/`parse` on Hermes, since those are C++ VM builtins while the codec is interpreted JS with no JIT. It is 31% smaller on disk, which buys storage rather than time. That benchmark is not included here; only the build fix it exposed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
