### PR TITLE
fix(replicache-perf): stop the benchmarks passing their dataset as mutator args

### DIFF
--- a/packages/replicache-perf/src/benchmarks/replicache.ts
+++ b/packages/replicache-perf/src/benchmarks/replicache.ts
@@ -9,6 +9,8 @@ import {
   range,
   ReplicachePerfTest,
   sampleSize,
+  setPopulateValues,
+  setPutMapEntries,
   setupPersistedData,
   sleep,
   type ReplicacheImpl,
@@ -55,14 +57,12 @@ export function benchmarkPopulate(opts: {
       await rep.clientGroupID;
 
       if (!opts.clean) {
-        await rep.mutate.populate({
-          numKeys: opts.numKeys,
-          randomValues: jsonArrayTestData(opts.numKeys, valSize),
-        });
+        setPopulateValues(jsonArrayTestData(opts.numKeys, valSize));
+        await rep.mutate.populate({numKeys: opts.numKeys});
       }
-      const randomValues = jsonArrayTestData(opts.numKeys, valSize);
+      setPopulateValues(jsonArrayTestData(opts.numKeys, valSize));
       bencher.reset();
-      await rep.mutate.populate({numKeys: opts.numKeys, randomValues});
+      await rep.mutate.populate({numKeys: opts.numKeys});
       bencher.stop();
     },
   };
@@ -87,8 +87,8 @@ export function benchmarkPersist(opts: {
         opts.indexes ?? 0,
       );
       const rep = (repToClose = makeRepWithPopulate({indexes}));
-      const randomValues = jsonArrayTestData(opts.numKeys, valSize);
-      await rep.mutate.populate({numKeys: opts.numKeys, randomValues});
+      setPopulateValues(jsonArrayTestData(opts.numKeys, valSize));
+      await rep.mutate.populate({numKeys: opts.numKeys});
       bencher.reset();
       await rep.persist();
       bencher.stop();
@@ -192,7 +192,8 @@ export function benchmarkRefresh(opts: {
             range(opts.numKeysPersisted),
             opts.numKeysPerMutation,
           ).map(i => [`key${i}`, jsonObjectTestData(valSize)]);
-          await rep.mutate.putMap(Object.fromEntries(entries));
+          setPutMapEntries(Object.fromEntries(entries));
+          await rep.mutate.putMap();
         }
       }
 
@@ -276,7 +277,7 @@ export function benchmarkRebase(opts: {
       }));
 
       // Create a bunch of keys.
-      await rep.mutate.putMap(
+      setPutMapEntries(
         Object.fromEntries(
           Array.from({length: numKeys}).map((_, i) => [
             `key${i}`,
@@ -284,11 +285,11 @@ export function benchmarkRebase(opts: {
           ]),
         ),
       );
+      await rep.mutate.putMap();
 
       for (let i = 0; i < mutations; i++) {
-        await rep.mutate.putMap({
-          key: jsonObjectTestData(targetSizePerMutation),
-        });
+        setPutMapEntries({key: jsonObjectTestData(targetSizePerMutation)});
+        await rep.mutate.putMap();
       }
 
       const {promise, resolve} = resolver<void>();
@@ -436,10 +437,8 @@ export function benchmarkReadTransaction(opts: {
     byteSize: opts.numKeys * valSize,
     async setup() {
       rep = makeRepWithPopulate();
-      await rep.mutate.populate({
-        numKeys: opts.numKeys,
-        randomValues: jsonArrayTestData(opts.numKeys, valSize),
-      });
+      setPopulateValues(jsonArrayTestData(opts.numKeys, valSize));
+      await rep.mutate.populate({numKeys: opts.numKeys});
     },
     async teardown() {
       await closeAndCleanupRep(rep);
@@ -472,10 +471,8 @@ export function benchmarkScan(opts: {numKeys: number}): Benchmark {
 
     async setup() {
       rep = makeRepWithPopulate();
-      await rep.mutate.populate({
-        numKeys: opts.numKeys,
-        randomValues: jsonArrayTestData(opts.numKeys, valSize),
-      });
+      setPopulateValues(jsonArrayTestData(opts.numKeys, valSize));
+      await rep.mutate.populate({numKeys: opts.numKeys});
     },
     async teardown() {
       await closeAndCleanupRep(rep);
@@ -575,7 +572,8 @@ export function benchmarkWriteSubRead(opts: {
         },
       }));
 
-      await rep.mutate.putMap(initData);
+      setPutMapEntries(initData);
+      await rep.mutate.putMap();
       let onDataCallCount = 0;
 
       const subs = Array.from({length: numSubsTotal}, (_, i) => {
@@ -616,11 +614,13 @@ export function benchmarkWriteSubRead(opts: {
         ]),
       );
 
+      setPutMapEntries(changes);
+
       // OK time the below!
       bencher.reset();
 
       // In a single transaction, invalidate numSubsDirty subscriptions.
-      await rep.mutate.putMap(changes);
+      await rep.mutate.putMap();
 
       bencher.stop();
 

--- a/packages/replicache/src/bench-util.ts
+++ b/packages/replicache/src/bench-util.ts
@@ -71,20 +71,44 @@ export function makeRep<MD extends MutatorDefs>(
   } as Omit<ReplicacheOptions<MD>, 'licenseKey'>);
 }
 
+/**
+ * Payload for the benchmark mutators, handed over out of band rather than as
+ * mutator arguments.
+ *
+ * A local mutation stores its arguments in the commit as `mutatorArgsJSON` so
+ * the mutation can be rebased, and `persist` then serializes that to disk.
+ * Passing the dataset as an argument therefore made every benchmark write its
+ * own test data twice — measured on device, roughly half of what
+ * `persist 1024x1000` serialized was the harness handing itself its data, not
+ * storage work. Real mutations take small arguments; these now do too.
+ *
+ * Set these outside the timed region, exactly where the data used to be
+ * generated.
+ */
+let populateValues: readonly TestDataObject[] = [];
+
+export function setPopulateValues(values: readonly TestDataObject[]): void {
+  populateValues = values;
+}
+
 export async function populate(
   tx: WriteTransaction,
-  {numKeys, randomValues}: {numKeys: number; randomValues: TestDataObject[]},
+  {numKeys}: {numKeys: number},
 ): Promise<void> {
   for (let i = 0; i < numKeys; i++) {
-    await tx.set(`key${i}`, randomValues[i]);
+    await tx.set(`key${i}`, populateValues[i]);
   }
 }
 
-export async function putMap(
-  tx: WriteTransaction,
-  map: Record<string, TestDataObject>,
-): Promise<void> {
-  for (const [key, value] of Object.entries(map)) {
+/** See {@link setPopulateValues} for why this is not a mutator argument. */
+let putMapEntries: Record<string, TestDataObject> = {};
+
+export function setPutMapEntries(map: Record<string, TestDataObject>): void {
+  putMapEntries = map;
+}
+
+export async function putMap(tx: WriteTransaction): Promise<void> {
+  for (const [key, value] of Object.entries(putMapEntries)) {
     await tx.set(key, value);
   }
 }

--- a/packages/replicache/src/replicache.bench.ts
+++ b/packages/replicache/src/replicache.bench.ts
@@ -16,6 +16,8 @@ import {
   makeRepName,
   makeRepWithPopulate,
   putMap,
+  setPopulateValues,
+  setPutMapEntries,
   range,
   ReplicachePerfTest,
   sampleSize,
@@ -92,7 +94,8 @@ describe('replicache', () => {
           mutators: {putMap},
         });
 
-        await rep.mutate.putMap(initData);
+        setPutMapEntries(initData);
+        await rep.mutate.putMap();
         let onDataCallCount = 0;
 
         const subs = Array.from({length: numSubsTotal}, (_, i) => {
@@ -130,9 +133,11 @@ describe('replicache', () => {
           ]),
         );
 
+        setPutMapEntries(changes);
+
         try {
           yield async () => {
-            await rep.mutate.putMap(changes);
+            await rep.mutate.putMap();
           };
         } finally {
           subs.forEach(c => c());
@@ -201,11 +206,11 @@ describe('replicache', () => {
           const indexes = createIndexDefinitions(numIndexes);
           const rep = makeRepWithPopulate({indexes});
           await rep.clientGroupID;
-          const randomValues = jsonArrayTestData(numKeys, valSize);
+          setPopulateValues(jsonArrayTestData(numKeys, valSize));
 
           try {
             yield async () => {
-              await rep.mutate.populate({numKeys, randomValues});
+              await rep.mutate.populate({numKeys});
             };
           } finally {
             await closeAndCleanupRep(rep);
@@ -226,10 +231,8 @@ describe('replicache', () => {
 
       beforeAll(async () => {
         rep = makeRepWithPopulate();
-        await rep.mutate.populate({
-          numKeys,
-          randomValues: jsonArrayTestData(numKeys, valSize),
-        });
+        setPopulateValues(jsonArrayTestData(numKeys, valSize));
+        await rep.mutate.populate({numKeys});
       });
 
       afterAll(async () => {
@@ -389,8 +392,8 @@ describe('replicache', () => {
         async function* () {
           const indexes = createIndexDefinitions(numIndexes);
           const rep = makeRepWithPopulate({indexes});
-          const randomValues = jsonArrayTestData(numKeys, valSize);
-          await rep.mutate.populate({numKeys, randomValues});
+          setPopulateValues(jsonArrayTestData(numKeys, valSize));
+          await rep.mutate.populate({numKeys});
 
           try {
             yield async () => {
@@ -505,7 +508,8 @@ describe('replicache', () => {
               range(numKeysPersisted),
               numKeysPerMutation,
             ).map(i => [`key${i}`, jsonObjectTestData(valSize)]);
-            await rep.mutate.putMap(Object.fromEntries(entries));
+            setPutMapEntries(Object.fromEntries(entries));
+            await rep.mutate.putMap();
           }
         }
 
@@ -679,7 +683,7 @@ describe('replicache', () => {
             },
           }),
         });
-        await rep.mutate.putMap(
+        setPutMapEntries(
           Object.fromEntries(
             Array.from({length: numKeys}).map((_, i) => [
               `key${i}`,
@@ -687,10 +691,10 @@ describe('replicache', () => {
             ]),
           ),
         );
+        await rep.mutate.putMap();
         for (let i = 0; i < mutations; i++) {
-          await rep.mutate.putMap({
-            key: jsonObjectTestData(targetSizePerMutation),
-          });
+          setPutMapEntries({key: jsonObjectTestData(targetSizePerMutation)});
+          await rep.mutate.putMap();
         }
         return rep;
       }


### PR DESCRIPTION
## The bug

`populate` took `{numKeys, randomValues}` and `putMap` took the whole map, so the benchmarks handed their test data to the mutator **as arguments**. A local mutation stores its arguments in the commit as `mutatorArgsJSON` so it can be rebased, and `persist` then serializes that to disk.

So every benchmark wrote its own test data a second time, and `persist` was measuring it.

## How much

Instrumenting `JSON.stringify` during a real persist:

```
one persist: 277 calls, 3501 KB serialized
  array    145 calls   1766 KB  (50.4%)   BTree nodes — real work
  object     2 calls   1735 KB  (49.5%)   <-- ?
  number   129 calls      0.1 KB           refcounts
```

Two calls carrying 1.7 MB, when a BTree node caps at 16 KB. They were commit chunks:

```
{"meta":{"type":4,"basisHash":…,"mutationID":1,"mutatorArgsJSON":…
```

— the whole 1 MB dataset, embedded in the commit. At the 12.2 ms/2 MB that `JSON.stringify` costs on this device, that's ~10 ms of a 77 ms result.

## The fix

Both mutators take their payload out of band via `setPopulateValues` / `setPutMapEntries`, registered exactly where the data used to be generated so it still lands **outside** the timed region. Real mutations take small arguments; these now do too.

## Effect

`persist 1024x1000 (indexes: 0)`, p50, Android release, 8-core/8 GB emulator:

| backend | before | after |
|---|---|---|
| expo-sqlite | 77.4 ms | **49.5 ms** |
| op-sqlite | 52.8 ms | **33.2 ms** |
| mem | 16.0 ms | 16.7 ms |

**These are not a speedup** — nothing got faster. The benchmark stopped measuring itself. `mem` is unchanged, which is the control: `MemStore` doesn't serialize, so it never paid the cost. `populate` and `scan` are unchanged.

The practical consequence is that persist optimisations were being evaluated against a workload that was ~50% harness overhead, so any measured win was diluted by roughly half.

## Scope

Both consumers of `bench-util`: `replicache-perf` (device + browser) and `replicache.bench.ts` (vitest/mitata).

## Testing

807/807 replicache tests pass; `check-types`, `lint`, `oxfmt` clean on both packages; the numbers above are from a device run on a freshly cleared emulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)