### PR TITLE
perf(zql): probe the last view entry before binary-searching

### DIFF
--- a/packages/zql/src/ivm/data.ts
+++ b/packages/zql/src/ivm/data.ts
@@ -89,11 +89,24 @@ export function normalizeUndefined(v: Value): NormalizedValue {
 export type Comparator = (r1: Row, r2: Row) => number;
 
 export function makeComparator(order: Ordering, reverse?: boolean): Comparator {
+  // A single ascending field is the common shape -- it is what every source
+  // ordered by a single-column primary key gets -- and specializing it drops
+  // the loop, the direction test and the reverse test from the hottest
+  // function in hydration.
+  if (order.length === 1 && order[0][1] === 'asc' && !reverse) {
+    const field = order[0][0];
+    return (a, b) => compareValues(a[field], b[field]);
+  }
+
+  const length = order.length;
   return (a, b) => {
-    // Skip destructuring here since it is hot code.
-    for (const ord of order) {
-      const field = ord[0];
-      const comp = compareValues(a[field], b[field]);
+    // Skip destructuring here since it is hot code. An indexed loop rather
+    // than `for...of` for the same reason: Hermes allocates an iterator and
+    // calls `next()` per element, which costs more than the comparison for an
+    // ordering this short.
+    for (let i = 0; i < length; i++) {
+      const ord = order[i];
+      const comp = compareValues(a[ord[0]], b[ord[0]]);
       if (comp !== 0) {
         const result = ord[1] === 'asc' ? comp : -comp;
         return reverse ? -result : result;

--- a/packages/zql/src/ivm/view-apply-change.ts
+++ b/packages/zql/src/ivm/view-apply-change.ts
@@ -768,11 +768,31 @@ function binarySearch(
   target: Row,
   comparator: Comparator,
 ): number {
-  let low = 0;
   let high = view.length - 1;
+  if (high < 0) {
+    return ~0;
+  }
+
+  // Probe the last entry before searching. Hydration feeds the view rows in
+  // the query's sort order, so every insert belongs at the end and the plain
+  // search spends log2(n) comparisons to rediscover that -- about eleven per
+  // row for a view of a couple of thousand. Row comparison is the single
+  // largest cost in hydration on Hermes, so collapsing those eleven to one is
+  // worth the one extra comparison this costs when the row does land inside
+  // the view, which is a single push rather than a bulk load.
+  // MetaEntry has all Row props; comparator only reads string keys
+  const last = comparator(view[high] as Row, target);
+  if (last < 0) {
+    return ~(high + 1);
+  }
+  if (last === 0) {
+    return high;
+  }
+
+  let low = 0;
+  high -= 1;
   while (low <= high) {
     const mid = (low + high) >>> 1;
-    // MetaEntry has all Row props; comparator only reads string keys
     const comparison = comparator(view[mid] as Row, target);
     if (comparison < 0) {
       low = mid + 1;


### PR DESCRIPTION
Two changes to row comparison in the IVM view, found by profiling the ZQL
benchmarks on Hermes (harness in #6507).

### Where the time goes

I profiled `hydrate: issues only` on an Android emulator and attributed
samples through the call tree rather than reading self-time. **55.5% of the
entire benchmark is row comparisons made underneath one binary search** —
`view-apply-change.ts`'s.

The reason is structural: hydration feeds the view its rows in the query's
sort order, so every insert belongs at the end. `add()` ran a full binary
search anyway, spending log2(n) comparisons per row — about nine for the
500-row benchmark — to rediscover that.

### The changes

1. **Probe `view[length - 1]` before searching.** Nine comparisons become one
   on the append path. It costs one extra comparison when the row does land
   inside the view. This is not a heuristic that can be wrong: it's an early
   exit that returns exactly what the search would have.

2. **Specialize `makeComparator` for a single ascending field**, which is what
   any source ordered by a single-column primary key gets. That closure was
   16.5% self time — more than `compareUTF8` itself. The general path also
   swaps `for...of` for an indexed loop; Hermes allocates an iterator and calls
   `next()` per element, which for an ordering this short costs more than the
   comparison.

### Measurements

Android emulator, median of 3 runs (`rn-bench --repeat 3`), app data cleared
between runs. Run-to-run spread was 0.5–6.4%.

| benchmark | before | after | |
|---|---|---|---|
| hydrate: issues only | 189.70 | 79.63 | **−58.0%** |
| hydrate: issues filtered open | 162.38 | 88.64 | **−45.4%** |
| hydrate: issues limit 50 | 18.19 | 11.75 | **−35.4%** |
| hydrate: issues with creator | 527.81 | 412.05 | −21.9% |
| hydrate: issues with creator + comments | 1035.63 | 895.32 | −13.5% |
| push: add issue (no join) | 14.84 | 11.35 | −23.5% |
| push: add issue (with creator join) | 25.83 | 21.36 | −17.3% |
| push: edit issue title | 35.52 | 35.81 | +0.8% |
| push: add issue inside limit(50) | 15.60 | 15.63 | +0.2% |
| push: add comment (child relation) | 32.43 | 33.64 | +3.7% |
| push: add issue outside limit(50) | 10.93 | 11.58 | +5.9% |

**The regressions are real and expected.** They're the extra comparison, on
pushes where the row lands inside the view rather than at the end. They're
small in absolute terms — a single push's search is microseconds — and two
other push cases improve by 17–24% because their rows *do* land at the end. I
think the trade is clearly right, but it is a trade and worth a look.

I did not touch `shared/src/binary-search.ts`, which has the same shape. Its
callers (Replicache subscriptions, the BTree, tdigest, flipped-join) aren't
obviously append-heavy and I haven't measured them.

### Verification

- All 1448 `zql` tests pass; `check-types` and `lint` clean.
- `zero-client` has one failing test (`logged-out client uses a private storage
  sentinel for idb naming`). It fails identically with these changes reverted —
  pre-existing, not from this PR.

### A note on the numbers

My first end-to-end measurement of change (1) said "no change". The benchmark
runner only rebuilt the bundle under `--profile`, so it had measured the
previous revision. The runner fix is in #6507. Usefully, the accident doubles
as a harness sanity check: identical code measured 189.01 vs 189.73 ms.
