### PR TITLE
perf(zql): stop MemorySource#fetch being a generator

### DIFF
--- a/packages/zql/src/ivm/memory-source.ts
+++ b/packages/zql/src/ivm/memory-source.ts
@@ -94,6 +94,107 @@ export type Connection = {
  * This data is kept in sorted order as downstream pipelines will always expect
  * the data they receive from `pull` to be in sorted order.
  */
+const DONE: IteratorReturnResult<undefined> = {done: true, value: undefined};
+
+/**
+ * A stream whose work starts on the first `next()`, like a generator body.
+ *
+ * Chained generators are the most expensive way to move a row on Hermes: a
+ * four-deep pipeline measured ~2x a hand-written iterator chain and ~30x a
+ * plain loop. This is the shim that lets `#fetch` stop being a generator
+ * without moving its setup earlier -- setup still runs on first `next()`, the
+ * stream is still single-use, and `[Symbol.iterator]()` still returns itself.
+ */
+class LazyStream<T> implements IterableIterator<T> {
+  #start: (() => Iterator<T>) | undefined;
+  #inner: Iterator<T> | undefined;
+
+  constructor(start: () => Iterator<T>) {
+    this.#start = start;
+  }
+
+  next(): IteratorResult<T> {
+    let inner = this.#inner;
+    if (inner === undefined) {
+      const start = this.#start;
+      if (start === undefined) {
+        return DONE;
+      }
+      this.#start = undefined;
+      inner = this.#inner = start();
+    }
+    return inner.next();
+  }
+
+  /**
+   * Propagates early termination, as `yield*` does. Sources hold real
+   * resources -- SQLite cursors -- and leaking one leaves later writes on the
+   * same connection failing with "database connection is busy".
+   */
+  return(value?: unknown): IteratorResult<T> {
+    this.#start = undefined;
+    const inner = this.#inner;
+    this.#inner = undefined;
+    return inner?.return?.(value) ?? DONE;
+  }
+
+  [Symbol.iterator](): IterableIterator<T> {
+    return this;
+  }
+}
+
+/**
+ * Rows from an index scan, wrapped as Nodes, stopping at the first row that
+ * fails `constraint`.
+ *
+ * Rows are sorted by the constraint key first, so matches are contiguous and
+ * the first miss ends the scan. This is `#fetch`'s hot path -- no overlay, no
+ * `start`, no filters -- which is what a plain scan and every join
+ * child-lookup take.
+ */
+class ConstrainedRowIterator implements Iterator<Node> {
+  readonly #rows: Iterator<Row>;
+  readonly #constraint: Constraint | undefined;
+  #done = false;
+
+  constructor(rows: Iterator<Row>, constraint: Constraint | undefined) {
+    this.#rows = rows;
+    this.#constraint = constraint;
+  }
+
+  next(): IteratorResult<Node> {
+    if (this.#done) {
+      return DONE;
+    }
+    const result = this.#rows.next();
+    if (result.done) {
+      this.#done = true;
+      return DONE;
+    }
+    const row = result.value;
+    const constraint = this.#constraint;
+    if (constraint !== undefined && !constraintMatchesRow(constraint, row)) {
+      // `break` out of the old `for...of` closed the underlying scan; do the
+      // same explicitly.
+      this.#done = true;
+      this.#rows.return?.();
+      return DONE;
+    }
+    return {done: false, value: {row, relationships: {}}};
+  }
+
+  return(value?: unknown): IteratorResult<Node> {
+    this.#done = true;
+    // Close the scan for its side effect; its result is a Row, not a Node.
+    this.#rows.return?.(value);
+    return DONE;
+  }
+
+  [Symbol.iterator](): Iterator<Node> {
+    return this;
+  }
+}
+
 export class MemorySource implements Source {
   readonly #tableName: string;
   readonly #columns: Record<string, SchemaValue>;
@@ -258,7 +359,16 @@ export class MemorySource implements Source {
     return [...this.#indexes.keys()];
   }
 
-  *#fetch(req: FetchRequest, conn: Connection): Stream<Node | 'yield'> {
+  #fetch(req: FetchRequest, conn: Connection): Stream<Node | 'yield'> {
+    // A generator body does not run until the first `next()`, and this one
+    // reads `#overlay` and `conn.lastPushedEpoch` -- a caller may legitimately
+    // call `fetch()` and only iterate after a push. `LazyStream` keeps that
+    // exact timing while letting the branches below return hand-written
+    // iterators instead of generators.
+    return new LazyStream(() => this.#startFetch(req, conn));
+  }
+
+  #startFetch(req: FetchRequest, conn: Connection): Iterator<Node | 'yield'> {
     // multiConstraints is handled by driving sub-fetches off the first
     // entry's values and post-filtering matches against any remaining
     // entries. TableSource implements multi-IN natively via SQL `AND` of
@@ -269,8 +379,7 @@ export class MemorySource implements Source {
       req.multiConstraints &&
       req.multiConstraints.some(mc => mc.length > 0)
     ) {
-      yield* this.#fetchMulti(req, conn);
-      return;
+      return this.#fetchMulti(req, conn)[Symbol.iterator]();
     }
     const requestedSort = must(conn.sort);
     const {compareRows} = conn;
@@ -369,14 +478,7 @@ export class MemorySource implements Source {
     const overlayActive =
       this.#overlay && conn.lastPushedEpoch >= this.#overlay.epoch;
     if (!overlayActive && !req.start && !conn.filters && !req.filter) {
-      const {constraint} = req;
-      for (const row of rowsIterable) {
-        if (constraint && !constraintMatchesRow(constraint, row)) {
-          break;
-        }
-        yield {row, relationships: {}};
-      }
-      return;
+      return new ConstrainedRowIterator(rowsIterable, req.constraint);
     }
 
     const withOverlay = generateWithOverlay(
@@ -419,9 +521,11 @@ export class MemorySource implements Source {
       req.constraint,
     );
 
-    yield* mergedFilterPredicate
-      ? generateWithFilter(withConstraint, mergedFilterPredicate)
-      : withConstraint;
+    return (
+      mergedFilterPredicate
+        ? generateWithFilter(withConstraint, mergedFilterPredicate)
+        : withConstraint
+    )[Symbol.iterator]();
   }
 
   *#fetchMulti(req: FetchRequest, conn: Connection): Stream<Node | 'yield'> {
@@ -1086,14 +1190,23 @@ function compareBounds(a: Bound, b: Bound): number {
   return compareValues(a, b);
 }
 
-function* generateRows(
+/**
+ * Rows from `scanStart` onwards.
+ *
+ * Returns the BTree's own iterator rather than delegating to it from a
+ * generator. `yield*` over an iterable that is already an `IterableIterator`
+ * buys nothing and costs a generator resume per row, which on Hermes is the
+ * most expensive way to move a value. Single-use semantics are unchanged: an
+ * `IterableIterator` returns itself from `[Symbol.iterator]()`, exactly as a
+ * generator does.
+ */
+function generateRows(
   data: BTreeSet<Row>,
   scanStart: RowBound | undefined,
   reverse: boolean | undefined,
-) {
-  yield* data[reverse ? 'valuesFromReversed' : 'valuesFrom'](
-    scanStart as Row | undefined,
-  );
+): IterableIterator<Row> {
+  const from = scanStart as Row | undefined;
+  return reverse ? data.valuesFromReversed(from) : data.valuesFrom(from);
 }
 
 export function stringify(change: SourceChange) {


### PR DESCRIPTION
Chained generators are the most expensive way to move a row through the IVM
pipeline, on both engines we care about. This removes them from
`MemorySource`'s fetch path.

### Why

Profiling the ZQL benchmarks on Hermes (harness in #6507) put **5.4%** of
`hydrate: issues with creator` in generator resume plumbing alone — `next` and
`generatorPrototypeResume` frames — before counting what hides inside the
generator bodies themselves. A four-deep pipeline over 5000 rows, measured in
the app's own runtime:

| | Hermes | V8 |
|---|---|---|
| 4 chained generators | 31.9 ms | 4.0 ms |
| 4 chained manual iterators | 16.2 ms (−49%) | 1.2 ms (−69%) |
| 4 chained push callbacks | 12.5 ms | 0.8 ms |

Relative to a plain loop, four chained generators cost 31x on Hermes and
**74x on V8**. V8 optimizes plain loops and hand-written iterators very
aggressively and generators are a barrier it will not cross, so removing a
generator layer pays *more* there. This is not a Hermes-specific fix.

### What changed

All of it confined to the fetch path in `memory-source.ts`:

- **`generateRows` was a pure `yield*` passthrough** over something that is
  already an `IterableIterator`. That whole generator layer bought nothing and
  cost a resume per row. It now returns the BTree's iterator directly.
  Single-use semantics are unchanged: an `IterableIterator` returns itself from
  `[Symbol.iterator]()`, exactly as a generator does.

- **`#fetch` is no longer a generator.** Its setup contains no yields, so the
  three exits become plain returns. The hot path — no overlay, no `start`, no
  filters, which is what a plain scan and every join child-lookup take — is now
  a hand-written `ConstrainedRowIterator` rather than a generator loop.

- **`generateRows` picked its method with `data[reverse ? a : b]()`.** The
  computed member forces a dynamic lookup Hermes cannot inline-cache; the
  ternary-of-calls form measured 18% faster there. See the caveat below.

### The part worth reviewing closely

`#fetch` keeps its laziness. A generator body does not run until the first
`next()`, and this one reads `#overlay` and `conn.lastPushedEpoch` — a caller
may legitimately `fetch()` and only iterate after a push. Making `#fetch` an
ordinary eager function would move that snapshot earlier and change overlay
behaviour in exactly the cases the surrounding comments warn about. `LazyStream`
preserves the timing exactly: setup on first `next()`, single-use,
`[Symbol.iterator]()` returns itself.

It also forwards `return()`, so early termination still closes the underlying
scan. The `mergeSortedStreams` comment is explicit about why that matters: a
leaked SQLite cursor makes later writes on the same connection fail with
"database connection is busy executing a query".

### Measurements

Android emulator, median of 3 runs (`rn-bench --repeat 3`, both sides rebuilt;
baseline spreads 0.3–3.5% except `add comment` at 6.9%). V8 is
`pnpm --filter zql-benchmarks run bench ivm-memory -t hydration`, median of 3.

| benchmark | Hermes | V8 |
|---|---|---|
| hydrate: issues filtered open | −13.1% | −17.4% |
| hydrate: issues only | −6.6% | −14.7% |
| hydrate: issues with creator + comments | −4.5% | −9.0% |
| hydrate: issues with creator | −3.8% | −19.6% |
| hydrate: issues limit 50 | −2.0% | −10.4% |

Push is flat on Hermes (−1.2% to +3.7%, inside the noise) — it does not run
this path.

### Caveat on the third change

The `o[b ? 'a' : 'b']()` → `b ? o.a() : o.b()` result is **Hermes-measured
only**. I could not get a trustworthy V8 number: the computed form timed 1.0 ms
for one branch and 19.9 ms for the other while the ternary sat at ~9.6 ms both
ways, stable across runs and two probe designs. 1.0 ms for 2M allocating calls
is 0.5 ns each, so V8's escape analysis is scalar-replacing the returned object
asymmetrically and the microbenchmark is not measuring the property access.
Treat that edit as Hermes-motivated and V8-unknown. It is subsumed by the
end-to-end numbers above, which do show a V8 win overall.

### Verification

- `zql` 1448 · `zqlite` 199 · `zero-cache` 5078 · `zero-client` 659 tests pass.
- `check-types`, `lint`, `check-format` clean.
- `zero-client` has one pre-existing failure (`logged-out client uses a private
  storage sentinel for idb naming`) that fails identically on `main`.

### Scope

Deliberately limited to `memory-source.ts`'s fetch path — that is where the
profile pointed and where the measurement confirms the win.
`generateWithOverlay`, `mergeSortedStreams` and the operator-level generators
are untouched; the repo has ~120 `yield*` sites and sweeping them would be a
separate change needing its own measurement.
