### PR TITLE
fix(zero-client): don't count frozen event-loop time against the disconnect deadline

### DIFF
--- a/packages/zero-client/src/client/connection-manager.test.ts
+++ b/packages/zero-client/src/client/connection-manager.test.ts
@@ -568,64 +568,87 @@ describe('ConnectionManager', () => {
   });
 
   describe('frozen event loop', () => {
-    // Simulates the event loop not running: wall-clock jumps forward but no
-    // timer callbacks fire, which is what a suspended React Native app, a
-    // sleeping laptop or a throttled background tab looks like from JS.
-    const freeze = (ms: number) => {
-      vi.setSystemTime(Date.now() + ms);
+    const CHECK_INTERVAL_MS = 100;
+    const FREEZE_MS = 60_000;
+
+    const newManager = () =>
+      new ConnectionManager({
+        disconnectTimeout: 1_000,
+        timeoutCheckIntervalMs: CHECK_INTERVAL_MS,
+      });
+
+    // Simulates the event loop not running for `ms`: wall-clock jumps forward
+    // with no reconnect attempt able to run, which is what a suspended React
+    // Native app, a sleeping laptop or a throttled background tab looks like
+    // from JS.
+    //
+    // Advancing timers is what fires the overdue interval callback, and that
+    // necessarily moves the fake clock by one period. So hold a period back out
+    // of the jump, leaving the callback to observe exactly `ms` of elapsed
+    // wall-clock --- an overdue `setInterval` fires as soon as the loop resumes
+    // rather than waiting out another period.
+    const freezeAndResume = (ms: number) => {
+      vi.setSystemTime(Date.now() + ms - CHECK_INTERVAL_MS);
+      vi.advanceTimersByTime(CHECK_INTERVAL_MS);
     };
 
     test('does not count frozen time against the disconnect deadline', () => {
-      const manager = new ConnectionManager({
-        disconnectTimeout: 1_000,
-        timeoutCheckIntervalMs: 100,
-      });
+      const manager = newManager();
       const listener = subscribe(manager);
 
       // Frozen far longer than the whole disconnect window.
-      freeze(60_000);
-      vi.advanceTimersByTime(100);
+      freezeAndResume(FREEZE_MS);
 
       // The client never got a live chance to retry, so it must not be
       // declared offline.
       expect(manager.is(ConnectionStatus.Connecting)).toBe(true);
       expect(listener).not.toHaveBeenCalled();
 
-      // ...and it still gets the rest of its budget in live time afterwards.
-      vi.advanceTimersByTime(800);
+      // ...and it still gets its whole budget in live time afterwards.
+      vi.advanceTimersByTime(900);
       expect(manager.is(ConnectionStatus.Connecting)).toBe(true);
 
-      vi.advanceTimersByTime(200);
+      vi.advanceTimersByTime(100);
       expect(manager.is(ConnectionStatus.Disconnected)).toBe(true);
     });
 
-    test('pushes disconnectAt forward by the frozen duration', () => {
+    test('pushes disconnectAt forward by the whole frozen duration', () => {
       vi.setSystemTime(0);
-      const manager = new ConnectionManager({
-        disconnectTimeout: 1_000,
-        timeoutCheckIntervalMs: 100,
-      });
+      const manager = newManager();
       assert(
         manager.state.name === ConnectionStatus.Connecting,
         'Expected to start out connecting',
       );
       expect(manager.state.disconnectAt).toBe(1_000);
 
-      freeze(60_000);
-      vi.advanceTimersByTime(100);
+      freezeAndResume(FREEZE_MS);
 
       assert(
         manager.state.name === ConnectionStatus.Connecting,
         'Expected to still be connecting after the freeze',
       );
-      expect(manager.state.disconnectAt).toBe(1_000 + 60_000);
+      expect(manager.state.disconnectAt).toBe(1_000 + FREEZE_MS);
+    });
+
+    test('preserves the remaining budget when frozen right after a tick', () => {
+      const manager = newManager();
+
+      // Burn all but the last period of live budget, so that the freeze starts
+      // immediately after a tick. Netting a period off the credited gap would
+      // put the deadline exactly on `now` here and disconnect on resume ---
+      // the very thing this is meant to prevent.
+      vi.advanceTimersByTime(900);
+      expect(manager.is(ConnectionStatus.Connecting)).toBe(true);
+
+      freezeAndResume(FREEZE_MS);
+      expect(manager.is(ConnectionStatus.Connecting)).toBe(true);
+
+      vi.advanceTimersByTime(100);
+      expect(manager.is(ConnectionStatus.Disconnected)).toBe(true);
     });
 
     test('ordinary ticks are not treated as a freeze', () => {
-      const manager = new ConnectionManager({
-        disconnectTimeout: 1_000,
-        timeoutCheckIntervalMs: 100,
-      });
+      const manager = newManager();
 
       // No jump: the deadline must still fire on schedule.
       vi.advanceTimersByTime(1_100);

--- a/packages/zero-client/src/client/connection-manager.test.ts
+++ b/packages/zero-client/src/client/connection-manager.test.ts
@@ -567,6 +567,72 @@ describe('ConnectionManager', () => {
     });
   });
 
+  describe('frozen event loop', () => {
+    // Simulates the event loop not running: wall-clock jumps forward but no
+    // timer callbacks fire, which is what a suspended React Native app, a
+    // sleeping laptop or a throttled background tab looks like from JS.
+    const freeze = (ms: number) => {
+      vi.setSystemTime(Date.now() + ms);
+    };
+
+    test('does not count frozen time against the disconnect deadline', () => {
+      const manager = new ConnectionManager({
+        disconnectTimeout: 1_000,
+        timeoutCheckIntervalMs: 100,
+      });
+      const listener = subscribe(manager);
+
+      // Frozen far longer than the whole disconnect window.
+      freeze(60_000);
+      vi.advanceTimersByTime(100);
+
+      // The client never got a live chance to retry, so it must not be
+      // declared offline.
+      expect(manager.is(ConnectionStatus.Connecting)).toBe(true);
+      expect(listener).not.toHaveBeenCalled();
+
+      // ...and it still gets the rest of its budget in live time afterwards.
+      vi.advanceTimersByTime(800);
+      expect(manager.is(ConnectionStatus.Connecting)).toBe(true);
+
+      vi.advanceTimersByTime(200);
+      expect(manager.is(ConnectionStatus.Disconnected)).toBe(true);
+    });
+
+    test('pushes disconnectAt forward by the frozen duration', () => {
+      vi.setSystemTime(0);
+      const manager = new ConnectionManager({
+        disconnectTimeout: 1_000,
+        timeoutCheckIntervalMs: 100,
+      });
+      assert(
+        manager.state.name === ConnectionStatus.Connecting,
+        'Expected to start out connecting',
+      );
+      expect(manager.state.disconnectAt).toBe(1_000);
+
+      freeze(60_000);
+      vi.advanceTimersByTime(100);
+
+      assert(
+        manager.state.name === ConnectionStatus.Connecting,
+        'Expected to still be connecting after the freeze',
+      );
+      expect(manager.state.disconnectAt).toBe(1_000 + 60_000);
+    });
+
+    test('ordinary ticks are not treated as a freeze', () => {
+      const manager = new ConnectionManager({
+        disconnectTimeout: 1_000,
+        timeoutCheckIntervalMs: 100,
+      });
+
+      // No jump: the deadline must still fire on schedule.
+      vi.advanceTimersByTime(1_100);
+      expect(manager.is(ConnectionStatus.Disconnected)).toBe(true);
+    });
+  });
+
   describe('shouldContinueRunLoop', () => {
     test('is true until the manager is closed', () => {
       const manager = new ConnectionManager({

--- a/packages/zero-client/src/client/connection-manager.ts
+++ b/packages/zero-client/src/client/connection-manager.ts
@@ -93,6 +93,12 @@ export class ConnectionManager extends Subscribable<ConnectionManagerState> {
   #timeoutCheckIntervalMs: number;
 
   /**
+   * `Date.now()` at the last timeout-interval tick, used to notice that the
+   * JavaScript event loop was not running. See {@linkcode #creditFrozenTime}.
+   */
+  #lastTimeoutCheckAt: number;
+
+  /**
    * Resolver used to signal waiting callers when the state changes.
    */
   #stateChangeResolver: Resolver<ConnectionManagerState> = resolver();
@@ -111,6 +117,7 @@ export class ConnectionManager extends Subscribable<ConnectionManagerState> {
       disconnectAt: now + this.#disconnectTimeout,
     };
     this.#connectingStartedAt = now;
+    this.#lastTimeoutCheckAt = now;
     this.#maybeStartTimeoutInterval();
   }
 
@@ -451,6 +458,53 @@ export class ConnectionManager extends Subscribable<ConnectionManagerState> {
   }
 
   /**
+   * Pushes the disconnect deadline forward by however long the event loop was
+   * not running.
+   *
+   * `disconnectAt` is an absolute wall-clock instant, but what it is meant to
+   * bound is time spent *actually retrying*. Whenever the loop is frozen --- a
+   * suspended React Native app, a sleeping laptop, a throttled background tab
+   * --- wall-clock keeps advancing while no reconnect attempt can run, so
+   * without this the first tick after resume reports `Offline` having given the
+   * client zero live seconds to connect.
+   *
+   * This interval is its own detector: a tick that lands late by more than a
+   * full period means we were not running in between. A merely busy JS thread
+   * can also delay a tick, and we cannot tell the two apart from lateness
+   * alone, but the costs are asymmetric --- crediting a busy period back just
+   * grants a bit more time to connect, whereas failing to credit a real freeze
+   * produces a user-visible bogus disconnect --- so we credit.
+   */
+  #creditFrozenTime(): void {
+    const now = Date.now();
+    const elapsed = now - this.#lastTimeoutCheckAt;
+    this.#lastTimeoutCheckAt = now;
+
+    // Ordinary scheduling jitter, not a freeze.
+    if (elapsed <= 2 * this.#timeoutCheckIntervalMs) {
+      return;
+    }
+    const frozenMs = elapsed - this.#timeoutCheckIntervalMs;
+
+    // Advance the window's origin so that a later `connecting()` that starts a
+    // fresh session recomputes a deadline that also excludes the frozen time.
+    if (this.#connectingStartedAt !== undefined) {
+      this.#connectingStartedAt += frozenMs;
+    }
+
+    if (this.#state.name === ConnectionStatus.Connecting) {
+      // Deliberately not published: the status has not changed, and waking the
+      // run loop's `waitForStateChange` racers here would interrupt an
+      // in-flight connect attempt for no reason. Readers of `state` still see
+      // the corrected deadline.
+      this.#state = {
+        ...this.#state,
+        disconnectAt: this.#state.disconnectAt + frozenMs,
+      };
+    }
+  }
+
+  /**
    * Check if we should transition from connecting to disconnected due to timeout.
    * Returns true if the transition happened.
    */
@@ -477,7 +531,9 @@ export class ConnectionManager extends Subscribable<ConnectionManagerState> {
     if (this.#timeoutInterval !== undefined) {
       return;
     }
+    this.#lastTimeoutCheckAt = Date.now();
     this.#timeoutInterval = setInterval(() => {
+      this.#creditFrozenTime();
       this.#checkTimeout();
     }, this.#timeoutCheckIntervalMs);
   }

--- a/packages/zero-client/src/client/connection-manager.ts
+++ b/packages/zero-client/src/client/connection-manager.ts
@@ -474,6 +474,14 @@ export class ConnectionManager extends Subscribable<ConnectionManagerState> {
    * alone, but the costs are asymmetric --- crediting a busy period back just
    * grants a bit more time to connect, whereas failing to credit a real freeze
    * produces a user-visible bogus disconnect --- so we credit.
+   *
+   * The whole gap is credited, not `elapsed` minus a period. An overdue
+   * `setInterval` callback runs as soon as the loop resumes rather than waiting
+   * out another period, so `elapsed` is already about the frozen duration;
+   * netting off a period would charge up to a full period of frozen time
+   * against the deadline. Freezing just after a tick would then leave the
+   * deadline exactly at `now` on resume and disconnect immediately, which is
+   * the very thing this is here to prevent.
    */
   #creditFrozenTime(): void {
     const now = Date.now();
@@ -484,7 +492,7 @@ export class ConnectionManager extends Subscribable<ConnectionManagerState> {
     if (elapsed <= 2 * this.#timeoutCheckIntervalMs) {
       return;
     }
-    const frozenMs = elapsed - this.#timeoutCheckIntervalMs;
+    const frozenMs = elapsed;
 
     // Advance the window's origin so that a later `connecting()` that starts a
     // fresh session recomputes a deadline that also excludes the frozen time.


### PR DESCRIPTION
## Problem

`ConnectionManager` bounds how long the client may keep retrying with `disconnectAt`, an **absolute wall-clock instant**:

- armed in the constructor — before any connect attempt exists — at [`connection-manager.ts:111`](https://github.com/rocicorp/mono/blob/main/packages/zero-client/src/client/connection-manager.ts#L111)
- recomputed for a fresh retry window at `:261` (retries *within* a window deliberately keep the original instant)
- checked by a 1 Hz `setInterval` at `:462` with a plain `now >= disconnectAt`

What that deadline is meant to bound is time spent *actually retrying*. But whenever the JavaScript event loop is frozen, wall-clock keeps advancing while no reconnect attempt can run. Freeze for longer than `disconnectTimeoutMs` while `Connecting`, and the first tick after resume declares `Offline` — *"Zero was unable to connect for 60 seconds and was disconnected"* — having given the client **zero live seconds** to try.

This is not React Native specific. A sleeping laptop or a throttled background tab hits it on the web too. React Native just makes it deterministic: `JavaTimerManager.onHostPause()` removes the Choreographer callback that pumps the JS timer queue, so timers stop the instant the activity pauses.

## Fix

The timeout interval is its own freeze detector — a tick that lands late by more than a full period means we were not running in between. `#creditFrozenTime()` runs before each `#checkTimeout()` and pushes that gap back onto:

- `#connectingStartedAt`, so a later `connecting()` that starts a fresh session also computes a deadline excluding the frozen time, and
- the current `Connecting` state's `disconnectAt`.

The corrected deadline is deliberately **not** published as a state change: the status has not changed, and waking the run loop's `waitForStateChange` racers here would interrupt an in-flight connect attempt for no reason. Readers of `state` still see the corrected value.

### On the busy-thread case

A merely busy JS thread can also delay a tick, and lateness alone cannot distinguish it from a freeze. The costs are asymmetric, so this credits: giving a busy period its time back just grants slightly more room to connect, whereas failing to credit a real freeze produces a user-visible bogus disconnect. The threshold ignores anything under two full periods, so ordinary jitter never qualifies.

## Tests

Three cases in `connection-manager.test.ts`, simulating a frozen loop by advancing the system clock without firing timers:

- frozen time is not charged against the deadline
- the full live budget still remains after the freeze
- ordinary ticks still time out on schedule (no regression to the existing behaviour)
