### PR TITLE
fix(zero-cache): unblock backfills when the change stream is canceled

### DIFF
--- a/packages/zero-cache/src/services/change-source/common/backfill-manager.test.ts
+++ b/packages/zero-cache/src/services/change-source/common/backfill-manager.test.ts
@@ -1,5 +1,5 @@
 import type {LogContext} from '@rocicorp/logger';
-import {beforeEach, describe, expect, test} from 'vitest';
+import {beforeEach, describe, expect, test, vi} from 'vitest';
 import {createSilentLogContext} from '../../../../../shared/src/logging-test-utils.ts';
 import {must} from '../../../../../shared/src/must.ts';
 import {Queue} from '../../../../../shared/src/queue.ts';
@@ -26,6 +26,7 @@ describe('backfill-manager', () => {
   let backfillRequests: BackfillRequest[];
   let testStreams: (TestStreamItem[] | Error)[];
   let changes: Queue<ChangeStreamMessage>;
+  let finalizedStreams: number;
   let lc: LogContext;
 
   function initBackfillManager(commitThresholdBytes?: number) {
@@ -54,6 +55,7 @@ describe('backfill-manager', () => {
     lc = createSilentLogContext();
     backfillRequests = [];
     testStreams = [];
+    finalizedStreams = 0;
     initBackfillManager();
   });
 
@@ -71,8 +73,15 @@ describe('backfill-manager', () => {
       throw stream; // For testing backfill errors
     }
 
-    for (const item of stream) {
-      yield 'message' in item ? item : {message: item, byteSize: 0};
+    try {
+      for (const item of stream) {
+        yield 'message' in item ? item : {message: item, byteSize: 0};
+      }
+    } finally {
+      // Tracks that the stream was finalized, i.e. that the consumer either
+      // exhausted it or exited early (via `return()`), which is what releases
+      // the upstream resources held by real backfill streams.
+      finalizedStreams++;
     }
   }
 
@@ -2081,5 +2090,113 @@ describe('backfill-manager', () => {
         },
       },
     ]);
+  });
+
+  test('change stream cancelation unblocks a backfill awaiting a reservation', async () => {
+    testStreams.push([
+      {
+        tag: 'backfill',
+        relation: {schema: 'foo', name: 'bar', rowKey: {columns: ['a']}},
+        watermark: '130',
+        columns: ['b'],
+        rowValues: [[1, 2]],
+      },
+      {
+        tag: 'backfill-completed',
+        relation: {schema: 'foo', name: 'bar', rowKey: {columns: ['a']}},
+        columns: ['b'],
+        watermark: '130',
+      },
+    ]);
+
+    // The main stream holds the reservation for the rest of the test,
+    // simulating a stream that was canceled in the middle of a transaction.
+    await changeStream.reserve('main');
+
+    backfillManager.run('123', [
+      {
+        columns: {a: {id: '123'}, b: {id: '234'}},
+        table: {
+          metadata: {rowKey: {a: 123}},
+          name: 'bar',
+          schema: 'foo',
+        },
+      },
+    ]);
+
+    // Let the backfill start and block on the reservation.
+    await sleep(10);
+    expect(backfillRequests).toHaveLength(1);
+    expect(finalizedStreams).toBe(0);
+
+    // Canceling the change stream must unblock the backfill so that its
+    // stream (and the upstream resources it holds) is finalized.
+    changeStream.asSource().cancel();
+    await vi.waitFor(() => expect(finalizedStreams).toBe(1));
+
+    // The backfill must not be retried after cancelation.
+    await sleep(100);
+    expect(backfillRequests).toHaveLength(1);
+  });
+
+  test('change stream cancelation unblocks a backfill awaiting the stream watermark', async () => {
+    testStreams.push([
+      {
+        tag: 'backfill',
+        relation: {schema: 'foo', name: 'bar', rowKey: {columns: ['a']}},
+        watermark: '130',
+        columns: ['b'],
+        rowValues: [[1, 2]],
+      },
+      {
+        tag: 'backfill-completed',
+        relation: {schema: 'foo', name: 'bar', rowKey: {columns: ['a']}},
+        columns: ['b'],
+        watermark: '130',
+      },
+    ]);
+
+    backfillManager.run('123', [
+      {
+        columns: {a: {id: '123'}, b: {id: '234'}},
+        table: {
+          metadata: {rowKey: {a: 123}},
+          name: 'bar',
+          schema: 'foo',
+        },
+      },
+    ]);
+
+    // The first message is streamed, after which the backfill waits for
+    // the change stream (at '123') to reach the backfill watermark ('130')
+    // before sending the `backfill-completed` message.
+    await expectChanges([
+      [
+        'begin',
+        {tag: 'begin', json: 'p', skipAck: true},
+        {commitWatermark: '123.01'},
+      ],
+      [
+        'data',
+        {
+          tag: 'backfill',
+          relation: {schema: 'foo', name: 'bar', rowKey: {columns: ['a']}},
+          watermark: '130',
+          columns: ['b'],
+          rowValues: [[1, 2]],
+        },
+      ],
+      ['commit', {tag: 'commit'}, {watermark: '123.01'}],
+    ]);
+    expect(finalizedStreams).toBe(0);
+
+    // The change stream never reaches the watermark. Canceling it must
+    // unblock the backfill so that its stream is finalized.
+    changeStream.asSource().cancel();
+    await vi.waitFor(() => expect(finalizedStreams).toBe(1));
+
+    // The backfill must not be retried after cancelation.
+    await sleep(100);
+    expect(backfillRequests).toHaveLength(1);
   });
 });

--- a/packages/zero-cache/src/services/change-source/common/backfill-manager.ts
+++ b/packages/zero-cache/src/services/change-source/common/backfill-manager.ts
@@ -111,6 +111,9 @@ export class BackfillManager implements Cancelable, Listener {
 
   readonly #commitThresholdBytes: number;
 
+  /** Set when the change stream is canceled. No further backfills are run. */
+  #canceled = false;
+
   constructor(
     lc: LogContext,
     changeStreamer: ChangeStreamMultiplexer,
@@ -180,6 +183,7 @@ export class BackfillManager implements Cancelable, Listener {
 
   #checkAndStartBackfill() {
     if (
+      !this.#canceled &&
       !this.#backfillRetryTimer &&
       !this.#runningBackfill &&
       this.#requiredBackfills.size
@@ -209,6 +213,10 @@ export class BackfillManager implements Cancelable, Listener {
   }
 
   #retryBackfillWithBackoff(e: unknown) {
+    if (this.#canceled) {
+      this.#lc.debug?.(`not retrying backfill: change stream canceled`, e);
+      return;
+    }
     const log = this.#retryDelayMs === this.#maxBackoffMs ? 'error' : 'warn';
     this.#lc[log]?.(
       `Error running backfill. Retrying in ${this.#retryDelayMs} ms`,
@@ -296,6 +304,13 @@ export class BackfillManager implements Cancelable, Listener {
     for await (const {message: msg, byteSize} of this.#backfillStreamer(
       state.request,
     )) {
+      if (this.#canceled) {
+        // Exiting the loop finalizes the backfill stream (and the upstream
+        // resources it holds). The reservation, if held, does not need to be
+        // released since the change stream is gone.
+        lc.info?.(`backfill stream canceled: change stream canceled`);
+        return;
+      }
       // Before sending `backfill-completed`, the main replication stream
       // may need to catch up, and/or the current transaction may need to be
       // committed to open a new transaction that's up to backfill watermark.
@@ -595,8 +610,18 @@ export class BackfillManager implements Cancelable, Listener {
   }
 
   cancel(): void {
+    this.#canceled = true;
     this.#stopRunningBackfill(`change stream canceled`);
     clearTimeout(this.#backfillRetryTimer);
+    this.#backfillRetryTimer = undefined;
+
+    // Wake up a backfill that is waiting for the change stream to reach a
+    // watermark. The change stream never will, and the backfill must be
+    // allowed to unwind (and release its upstream resources) rather than
+    // remain suspended forever.
+    for (const {reached} of this.#awaitingStatusWatermarks.splice(0)) {
+      reached();
+    }
   }
 }
 

--- a/packages/zero-cache/src/services/change-source/common/change-stream-multiplexer.test.ts
+++ b/packages/zero-cache/src/services/change-source/common/change-stream-multiplexer.test.ts
@@ -6,6 +6,7 @@ import {
   test,
   vi,
 } from 'vitest';
+import {AbortError} from '../../../../../shared/src/abort-error.ts';
 import {createSilentLogContext} from '../../../../../shared/src/logging-test-utils.ts';
 import type {
   ChangeStreamMessage,
@@ -87,6 +88,28 @@ describe('change-stream-multiplexer', () => {
 
     expect(cancelFn1).toHaveBeenCalledOnce();
     expect(cancelFn2).toHaveBeenCalledOnce();
+  });
+
+  test('cancelation rejects pending and subsequent reservations', async () => {
+    expect(stream.reserve('foo')).toBe('123');
+
+    // Already reserved, so this producer waits in line.
+    const res2 = stream.reserve('bar');
+    expect(res2).toBeInstanceOf(Promise);
+    expect(stream.waiterDelay()).toBeGreaterThan(0);
+
+    stream.asSource().cancel();
+
+    expect(cancelFn1).toHaveBeenCalledOnce();
+    expect(cancelFn2).toHaveBeenCalledOnce();
+
+    // The reservation held by 'foo' is never released, so the pending
+    // request must be rejected rather than left waiting forever.
+    await expect(res2).rejects.toBeInstanceOf(AbortError);
+    expect(stream.waiterDelay()).toBeLessThan(0);
+
+    // Subsequent reservation requests are also rejected.
+    await expect(stream.reserve('baz')).rejects.toBeInstanceOf(AbortError);
   });
 
   test('listeners', () => {

--- a/packages/zero-cache/src/services/change-source/common/change-stream-multiplexer.ts
+++ b/packages/zero-cache/src/services/change-source/common/change-stream-multiplexer.ts
@@ -1,5 +1,6 @@
 import type {LogContext} from '@rocicorp/logger';
 import {resolver} from '@rocicorp/resolver';
+import {AbortError} from '../../../../../shared/src/abort-error.ts';
 import {assert} from '../../../../../shared/src/asserts.ts';
 import type {Source} from '../../../types/streams.ts';
 import {Subscription} from '../../../types/subscription.ts';
@@ -20,6 +21,7 @@ type Waiter = {
   producer: string;
   startTime: number;
   grantReservation: (watermark: string) => void;
+  rejectReservation: (err: Error) => void;
 };
 
 /**
@@ -45,12 +47,31 @@ export class ChangeStreamMultiplexer {
    */
   readonly #waiters: Waiter[] = [];
 
+  #canceled = false;
+
   constructor(lc: LogContext, lastWatermark: string) {
     this.#lc = lc;
     this.#sub = Subscription.create<ChangeStreamMessage>({
-      cleanup: () => this.#producers.forEach(p => p.cancel()),
+      cleanup: () => this.#cancel(),
     });
     this.#lastWatermark = lastWatermark;
+  }
+
+  #cancel() {
+    this.#canceled = true;
+    this.#producers.forEach(p => p.cancel());
+
+    // A producer awaiting a reservation would otherwise remain suspended
+    // forever, since the reservation held when the stream was canceled is
+    // never released. Reject the pending reservations so that the producers
+    // unwind and release the resources (e.g. upstream connections and
+    // transactions) that they were holding for the stream.
+    for (const {producer, rejectReservation} of this.#waiters.splice(0)) {
+      this.#lc.info?.(
+        `rejecting reservation request from ${producer}: stream canceled`,
+      );
+      rejectReservation(new AbortError('change stream canceled'));
+    }
   }
 
   addProducers(...p: Cancelable[]): this {
@@ -74,6 +95,9 @@ export class ChangeStreamMultiplexer {
    * @param producer The name of the producer, purely for debugging output
    */
   reserve(producer: string): string | Promise<string> {
+    if (this.#canceled) {
+      return Promise.reject(new AbortError('change stream canceled'));
+    }
     if (this.#lastWatermark !== null) {
       // If the stream is not reserved, reserve it and return the
       // watermark.
@@ -84,8 +108,17 @@ export class ChangeStreamMultiplexer {
 
     // Otherwise, wait for the current reservation to be released.
     const startTime = performance.now();
-    const {promise, resolve: grantReservation} = resolver<string>();
-    this.#waiters.push({producer, startTime, grantReservation});
+    const {
+      promise,
+      resolve: grantReservation,
+      reject: rejectReservation,
+    } = resolver<string>();
+    this.#waiters.push({
+      producer,
+      startTime,
+      grantReservation,
+      rejectReservation,
+    });
 
     return promise;
   }


### PR DESCRIPTION
## Problem

When the change stream is canceled (reconnect, backoff or shutdown) while a backfill is in progress, the backfill could be left suspended forever:

- If the backfill was awaiting `ChangeStreamMultiplexer.reserve('backfill')` while the replication loop held the reservation mid-transaction, the replication loop exits its `for await` on cancel without releasing, so the reservation promise never settles.
- If the backfill was awaiting `#changeStreamReached()` before sending `backfill-completed`, nothing resolves that waiter after cancel.

`BackfillManager.cancel()` only set `canceledReason`, which is checked *after* the reservation is granted. The stranded `#runBackfill` kept the `streamBackfill` async generator suspended at a `yield`, so its `finally` never ran: `tx.setDone()` and `db.end()` were never called. Each occurrence leaked an upstream Postgres connection holding a `REPEATABLE READ` snapshot transaction, kept alive indefinitely by the `TransactionPool` keepalives (pinning xmin on upstream). Each reconnect during a long backfill on a busy source could add another.

## Fix

- `ChangeStreamMultiplexer`: on cancel, reject all pending reservation requests (and any subsequent ones) with an `AbortError`, so waiting producers unwind.
- `BackfillManager.cancel()`: mark the manager canceled, wake any watermark waiters, and clear the retry timer. The running backfill exits at the next message (finalizing its stream via `for await` teardown), and no retries are scheduled after cancelation.

## Tests

- `change-stream-multiplexer.test.ts`: cancelation rejects pending and subsequent reservations.
- `backfill-manager.test.ts`: two new tests covering a backfill blocked on a reservation and one blocked on the stream watermark. Both verify the backfill stream is finalized after cancel and that no retry is started. Both fail without the fix (timeouts / stream never finalized).

Ran `lint`, `format`, `check-types`, the `no-pg` tests for `change-source/common`, and the `pg-16` `change-source` suite against a local Postgres 16 (3 pre-existing failures there are environmental: they depend on the DB user being named `test`, and reproduce identically on unmodified `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UPJiVV1Wekmk8U9r3WMMdx

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPJiVV1Wekmk8U9r3WMMdx)_