### PR TITLE
fix(zero-cache): do not re-arm view-syncer timers after cleanup

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg.test.ts
@@ -6314,6 +6314,7 @@ describe('view-syncer/service', () => {
     ]);
 
     await flushStarted;
+    const timersScheduledBeforeStop = setTimeoutFn.mock.calls.length;
     const stopPromise = vs.stop();
     flushReleased = true;
     allowFlush.resolve();
@@ -6323,6 +6324,13 @@ describe('view-syncer/service', () => {
     expect(failSpy).not.toHaveBeenCalled();
     expect(destroySpy).toHaveBeenCalled();
     expect(destroyCalledAfterRelease).toBe(true);
+
+    // The in-flight update flushes the CVR after the view-syncer has been
+    // stopped. It must not re-arm any timers (e.g. the ttlClock interval),
+    // which would outlive the service, retain it, and keep updating the CVR.
+    expect(
+      setTimeoutFn.mock.calls.slice(timersScheduledBeforeStop),
+    ).toHaveLength(0);
   });
 
   // Regression test: a client that disconnects before initConnection's async

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -309,6 +309,14 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
   readonly #lock = new Lock();
   readonly #cvrStore: CVRStore;
   readonly #stopped = resolver();
+
+  /**
+   * Set when {@link #cleanup} begins. Lock tasks that were in flight when the
+   * view-syncer was stopped may still complete after the timers have been
+   * cleared; this flag prevents them from scheduling new timers, which would
+   * otherwise outlive the service (and retain everything it references).
+   */
+  #shuttingDown = false;
   readonly #initialized = resolver<'initialized'>();
 
   #cvr: CVRSnapshot | undefined;
@@ -974,6 +982,9 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
   #shutdownTimer: NodeJS.Timeout | null = null;
 
   #scheduleShutdown(delayMs = 0) {
+    if (this.#shuttingDown) {
+      return;
+    }
     this.#shutdownTimer ??= this.#setTimeout(() => {
       this.#shutdownTimer = null;
 
@@ -1055,6 +1066,9 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
    */
   #scheduleAuthMaintenance(lc: LogContext) {
     this.#stopAuthMaintenanceTimer();
+    if (this.#shuttingDown) {
+      return;
+    }
 
     const plan = this.connContextManager.planMaintenance();
     if (plan.earliestDeadlineAt === undefined) {
@@ -1353,6 +1367,9 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
 
   #startTTLClockInterval(lc: LogContext): void {
     this.#stopTTLClockInterval();
+    if (this.#shuttingDown) {
+      return;
+    }
     this.#ttlClockInterval = this.#setTimeout(() => {
       this.#updateTTLClockInCVRWithoutLock(lc);
       this.#startTTLClockInterval(lc);
@@ -1659,6 +1676,9 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
   #scheduleExpireEviction(lc: LogContext, cvr: CVRSnapshot): void {
     const {ttlClock} = cvr;
     this.#stopExpireTimer();
+    if (this.#shuttingDown) {
+      return;
+    }
 
     // first see if there is any inactive query with a ttl.
     const next = nextEvictionTime(cvr);
@@ -3453,6 +3473,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
   }
 
   async #cleanup(err?: unknown) {
+    this.#shuttingDown = true;
     this.connContextManager.setSharedRetransformReady(false);
     this.#stopTTLClockInterval();
     this.#stopExpireTimer();

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -978,8 +978,14 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     return true;
   }
 
-  // oxlint-disable-next-line no-unused-private-class-members -- False positive, used in #scheduleShutdown
   #shutdownTimer: NodeJS.Timeout | null = null;
+
+  #stopShutdownTimer() {
+    if (this.#shutdownTimer !== null) {
+      clearTimeout(this.#shutdownTimer);
+      this.#shutdownTimer = null;
+    }
+  }
 
   #scheduleShutdown(delayMs = 0) {
     if (this.#shuttingDown) {
@@ -3478,6 +3484,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     this.#stopTTLClockInterval();
     this.#stopExpireTimer();
     this.#stopAuthMaintenanceTimer();
+    this.#stopShutdownTimer();
     // The InspectorDelegate shares this transformer and may still use it
     // after cleanup; a destroyed transformer is safe to use (it just stops
     // caching and never restarts its cleanup interval).


### PR DESCRIPTION
## Problem

`ViewSyncerService.#cleanup()` clears the ttlClock, expire and auth-maintenance timers and then waits for in-flight lock tasks to finish (`await this.#lock.withLock(() => {})`). A task that was already past the `#stateChanges.active` check when the view-syncer was stopped (via `stop()` on a forced drain, or via the `CVRStore` failure callback) could still complete its CVR flush after the timers were cleared. `#flushUpdater` then calls `#startTTLClockInterval()`, which re-schedules itself unconditionally every 60 s with no stop guard.

The orphaned interval retained the entire `ViewSyncerService` graph (pipeline driver, CVR store and its in-memory row-record cache, connection context manager, inspector delegate) for the life of the process, and each tick issued an `UPDATE cvr.instances SET lastActive ...` that kept the CVR from ever becoming eligible for `CVRPurger`. The expire-eviction, auth-maintenance and shutdown timers had the same re-arm hole (bounded in duration, but retaining the graph until they fired).

## Fix

Track that cleanup has begun (`#shuttingDown`) and refuse to schedule any timer after that point in `#startTTLClockInterval`, `#scheduleExpireEviction`, `#scheduleAuthMaintenance` and `#scheduleShutdown`.

## Tests

Extended the existing `stop waits for in-flight changeDesiredQueries` test (which exercises exactly this ordering) to assert that no timers are scheduled once `stop()` has been called. Without the fix it fails with three timers armed after stop (ttlClock, shutdown, and one more); with the fix, zero.

Ran `lint`, `format`, `check-types`, and the full `view-syncer` `pg-16` suite (14 files, 191 tests) against a local Postgres 16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UPJiVV1Wekmk8U9r3WMMdx

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPJiVV1Wekmk8U9r3WMMdx)_