### PR TITLE
fix(zero-cache): shut down view-syncers that are never initialized

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg.test.ts
@@ -6454,4 +6454,33 @@ describe('view-syncer/service', () => {
     // Verify that #cleanup ran (pipelines destroyed).
     expect(destroySpy).toHaveBeenCalled();
   });
+
+  test('stopping before the shutdown check fires clears the pending timer', async () => {
+    // Hand out a recognizable handle for timers scheduled from here on, so
+    // that clearing the pending shutdown timer can be observed.
+    const handle = {} as unknown as NodeJS.Timeout;
+    setTimeoutFn.mockReturnValue(handle);
+    const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout');
+    try {
+      // A client connects and disconnects, which schedules the shutdown
+      // check (without firing it).
+      const {source} = connectWithQueueAndSource(SYNC_CONTEXT, [
+        {op: 'put', hash: 'query-hash1', ast: ISSUES_QUERY},
+      ]);
+      source.cancel();
+      await sleep(100);
+      expect(setTimeoutFn).toHaveBeenCalled();
+
+      // Stopping the view-syncer before the check fires must clear the
+      // pending timer, which would otherwise retain the service until it
+      // fired after teardown.
+      await vs.stop();
+      await viewSyncerDone;
+      expect(clearTimeoutSpy.mock.calls.some(([t]) => t === handle)).toBe(
+        true,
+      );
+    } finally {
+      clearTimeoutSpy.mockRestore();
+    }
+  });
 });

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg.test.ts
@@ -6476,9 +6476,7 @@ describe('view-syncer/service', () => {
       // fired after teardown.
       await vs.stop();
       await viewSyncerDone;
-      expect(clearTimeoutSpy.mock.calls.some(([t]) => t === handle)).toBe(
-        true,
-      );
+      expect(clearTimeoutSpy.mock.calls.some(([t]) => t === handle)).toBe(true);
     } finally {
       clearTimeoutSpy.mockRestore();
     }

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg.test.ts
@@ -6407,4 +6407,51 @@ describe('view-syncer/service', () => {
     // Verify that #cleanup ran (pipelines destroyed).
     expect(destroySpy).toHaveBeenCalled();
   });
+
+  // Regression test: a ViewSyncer is created as soon as a client connects to
+  // its client group, but it is only initialized by the client's
+  // `initConnection` message. If that message never arrived (e.g. the socket
+  // closed during connection setup), run() blocked on readyState() forever
+  // and nothing scheduled the idle shutdown, leaving a zombie service in the
+  // ServiceRunner. The fix schedules the idle-shutdown check when run()
+  // starts.
+  test('view-syncer run completes when no client ever initializes it', async () => {
+    const destroySpy = vi.spyOn(PipelineDriver.prototype, 'destroy');
+
+    // Use fake timers starting from *now* so that advancing past the
+    // keepalive window (DEFAULT_KEEPALIVE_MS = 5000, set at construction
+    // time using real Date.now()) works correctly.
+    vi.setSystemTime(vi.getRealSystemTime());
+
+    // No client connects. The idle-shutdown check must still have been
+    // scheduled when run() started.
+    expect(setTimeoutFn).toHaveBeenCalled();
+
+    // Advance time past the keepalive window so that
+    // #checkForShutdownConditionsInLock returns true, and fire all pending
+    // timer callbacks (setTimeout is mocked).
+    vi.setSystemTime(Date.now() + 6000);
+    for (const call of setTimeoutFn.mock.calls) {
+      call[0]();
+    }
+    await sleep(100);
+
+    // Fire any newly scheduled callbacks (shutdown may reschedule).
+    vi.setSystemTime(Date.now() + 6000);
+    for (const call of setTimeoutFn.mock.calls) {
+      call[0]();
+    }
+    await sleep(100);
+
+    // Without the fix, viewSyncerDone would never resolve here.
+    const timeout = sleep(5000).then(() => 'timeout' as const);
+    const result = await Promise.race([
+      viewSyncerDone.then(() => 'done' as const),
+      timeout,
+    ]);
+    expect(result).toBe('done');
+
+    // Verify that #cleanup ran (pipelines destroyed).
+    expect(destroySpy).toHaveBeenCalled();
+  });
 });

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -657,6 +657,16 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
 
   async run(): Promise<void> {
     try {
+      // The service is created when a client connects to its client group,
+      // but it is only initialized by that client's `initConnection`
+      // message. If the message never arrives (e.g. the socket closed during
+      // connection setup, or the protocol version was rejected), nothing
+      // else schedules the idle-shutdown check, and the service would wait
+      // for initialization forever. Schedule the check up front so that the
+      // service shuts down after the keepalive window if no client
+      // initializes it.
+      this.#scheduleShutdown(this.#keepaliveMs);
+
       // Wait for initialization if we need to process queries.
       // This ensures authData and cvr.clientSchema are available before
       // transforming custom queries (dependency on authData) and building

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -980,8 +980,14 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     return true;
   }
 
-  // oxlint-disable-next-line no-unused-private-class-members -- False positive, used in #scheduleShutdown
   #shutdownTimer: NodeJS.Timeout | null = null;
+
+  #stopShutdownTimer() {
+    if (this.#shutdownTimer !== null) {
+      clearTimeout(this.#shutdownTimer);
+      this.#shutdownTimer = null;
+    }
+  }
 
   #scheduleShutdown(delayMs = 0) {
     this.#shutdownTimer ??= this.#setTimeout(() => {
@@ -3467,6 +3473,7 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
     this.#stopTTLClockInterval();
     this.#stopExpireTimer();
     this.#stopAuthMaintenanceTimer();
+    this.#stopShutdownTimer();
     // The InspectorDelegate shares this transformer and may still use it
     // after cleanup; a destroyed transformer is safe to use (it just stops
     // caching and never restarts its cleanup interval).


### PR DESCRIPTION
## Problem

A `ViewSyncerService` is created by the `ServiceRunner` (in `Syncer.#createConnection`) as soon as a client connects to its client group, but it is only initialized by that client's `initConnection` message. If the message never arrives, `run()` waits on `readyState()` forever:

- the idle-shutdown check (`#scheduleShutdown`) is only reachable from `#deleteClientDueToDisconnect` and `#checkForShutdownConditionsInLock`, both of which require a client to have been added;
- `keepalive()` keeps returning `true` while `#stateChanges` is active, so the `ServiceRunner` treats the service as valid and never drops it.

This happens when the socket closes during connection setup before `initConnection` is sent (e.g. when the message is sent as a WebSocket frame rather than in the `sec-websocket-protocol` header), or when the protocol version is rejected by `Connection.init()`. One zombie `ViewSyncerService` leaks per affected client group, together with its `Notifier` subscription (which then receives every `version-ready` for the process lifetime), CVR store, pipeline driver and connection context manager, and the `active-client-groups` gauge is inflated.

## Fix

Schedule the idle-shutdown check when `run()` starts. If no client initializes the service within the keepalive window, `#checkForShutdownConditionsInLock` rejects `#initialized` and cancels `#stateChanges`, so `run()` exits and the `ServiceRunner` drops the service. If a client does connect, the check is a no-op (and `keepalive()` on each `getService` extends the window as before).

## Tests

Added `view-syncer run completes when no client ever initializes it`, modeled on the existing regression test for the disconnect-after-`initConnection` variant. Without the fix it fails (no timer is ever scheduled and `run()` never resolves).

Ran `lint`, `format`, `check-types`, and the full `view-syncer` `pg-16` suite (14 files, 192 tests) against a local Postgres 16, since several of those tests inspect the mocked `setTimeout` calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UPJiVV1Wekmk8U9r3WMMdx

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPJiVV1Wekmk8U9r3WMMdx)_