### PR TITLE
fix(zero-cache): drop sync connections whose socket closed during auth

### DIFF
--- a/packages/zero-cache/src/workers/syncer.test.ts
+++ b/packages/zero-cache/src/workers/syncer.test.ts
@@ -823,6 +823,94 @@ describe('jwt auth missing options and missing endpoints', () => {
   });
 });
 
+describe('websocket closed while resolving auth', () => {
+  let syncer: Syncer;
+  let mutagens: MutagenService[];
+  let pushers: PusherService[];
+  let contextManagers: Map<string, ConnectionContextManagerImpl>;
+  let verifySpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    verifySpy = vi.spyOn(jwt, 'verifyToken');
+    verifySpy.mockReset();
+    const env = setupSyncer(lc, {
+      auth: {
+        secret: 'test-secret',
+      },
+    } as ZeroConfig);
+    syncer = env.syncer;
+    mutagens = env.mutagens;
+    pushers = env.pushers;
+    contextManagers = env.contextManagers;
+  });
+
+  afterEach(async () => {
+    await syncer.stop();
+  });
+
+  test('does not create a connection or services for the closed socket', async () => {
+    const ws = new MockWebSocket() as unknown as WebSocket;
+
+    // The client disconnects while its token is being verified.
+    verifySpy.mockImplementationOnce(() => {
+      (ws as unknown as MockWebSocket).close();
+      return Promise.resolve({sub: 'user-1'});
+    });
+
+    await receiver(
+      ws,
+      {
+        clientGroupID: '1',
+        clientID: 'client-1',
+        userID: 'user-1',
+        wsID: 'ws-1',
+        protocolVersion: 30,
+        auth: 'dummy-token',
+      },
+      {} as any,
+    );
+
+    expect(verifySpy).toHaveBeenCalledOnce();
+    expect(vi.mocked(recordConnectionSuccess)).not.toHaveBeenCalled();
+
+    // No per-client-group services are created, and no connection is
+    // registered, for the socket that closed during auth resolution.
+    expect(mutagens).toHaveLength(0);
+    expect(pushers).toHaveLength(0);
+    expect(contextManagers.size).toBe(0);
+  });
+
+  test('registers the connection when the socket is still open', async () => {
+    const ws = new MockWebSocket() as unknown as WebSocket;
+    verifySpy.mockResolvedValueOnce({sub: 'user-1'});
+
+    await receiver(
+      ws,
+      {
+        clientGroupID: '1',
+        clientID: 'client-1',
+        userID: 'user-1',
+        wsID: 'ws-1',
+        protocolVersion: 30,
+        auth: 'dummy-token',
+      },
+      {} as any,
+    );
+
+    expect(vi.mocked(recordConnectionSuccess)).toHaveBeenCalledOnce();
+    expect(mutagens).toHaveLength(1);
+    expect(pushers).toHaveLength(1);
+    expect(mutagens[0].hasRefs()).toBe(true);
+    expect(pushers[0].hasRefs()).toBe(true);
+    expect(
+      contextManagers
+        .get('1')
+        ?.getConnectionContext({clientID: 'client-1', wsID: 'ws-1'}),
+    ).toBeDefined();
+  });
+});
+
 describe('connection hijacking prevention', () => {
   let syncer: Syncer;
   let contextManagers: Map<string, ConnectionContextManagerImpl>;

--- a/packages/zero-cache/src/workers/syncer.ts
+++ b/packages/zero-cache/src/workers/syncer.ts
@@ -2,7 +2,7 @@ import {pid} from 'node:process';
 import type {MessagePort} from 'node:worker_threads';
 import type {LogContext} from '@rocicorp/logger';
 import {resolver} from '@rocicorp/resolver';
-import {WebSocketServer, type ServerOptions, type WebSocket} from 'ws';
+import {WebSocket, WebSocketServer, type ServerOptions} from 'ws';
 import {promiseVoid} from '../../../shared/src/resolved-promises.ts';
 import {ErrorKind} from '../../../zero-protocol/src/error-kind.ts';
 import {ErrorOrigin} from '../../../zero-protocol/src/error-origin.ts';
@@ -745,6 +745,21 @@ export class Syncer implements SingletonService {
       }
       recordConnectionFailure('internal');
       throw e;
+    }
+
+    // Resolving auth can take a while (e.g. a remote JWKS fetch), during
+    // which the client may have disconnected. A Connection created for a
+    // closed socket never receives the 'close' event and is thus never
+    // cleaned up, leaking its timer, its registrations in the connection
+    // context manager and its refs on the mutagen and pusher services.
+    if (ws.readyState !== WebSocket.OPEN) {
+      this.#lc.debug?.('websocket closed while resolving auth', {
+        clientGroupID,
+        clientID,
+        readyState: ws.readyState,
+      });
+      recordConnectionFailure('closed_during_auth');
+      return;
     }
 
     const viewSyncer = this.#viewSyncers.getService(clientGroupID);


### PR DESCRIPTION
## Problem

`Syncer.#createConnection` awaits `resolveAuth()` (JWT verification, possibly a remote JWKS fetch) before creating the `Connection`. `installWebSocketReceiver` checks `ws.readyState` before handing the socket over, but nothing re-checks it after the await. If the client disconnected in the meantime, the `'close'` event had already fired, so:

- the `Connection` attached its `'close'`/`'error'` listeners and `createWebSocketStream` to a dead socket, and `Connection.close()` never ran;
- the initial `connected` message is sent with `'ignore-backpressure'` and is silently dropped on a non-open socket, so nothing surfaced the failure.

Each occurrence leaked the `Connection` (with its 3 s pong `setInterval`, the `ConnectParams` including the auth token, and the socket), its entry in the `ConnectionContextManager`, its `ref()`s on the `Mutagen` and `Pusher` services (so they were never stopped by the `ServiceRunner`), and a `ViewSyncerService` for the client group, until the same `clientID` happened to reconnect to the same syncer worker. When `initConnection` is sent as a WebSocket frame rather than in the `sec-websocket-protocol` header (query-heavy apps), no downstream stream is ever created that could surface the dead socket, so the leak was permanent.

## Fix

After auth resolves, bail out if the socket is no longer `OPEN`, before creating any per-connection or per-client-group state. Records a `closed_during_auth` connection-failure metric.

## Tests

New `websocket closed while resolving auth` tests in `syncer.test.ts`: the socket closes from within the mocked `verifyToken`, and the test asserts that no mutagen/pusher is created, no connection is registered, and no success metric is recorded. The control test verifies a still-open socket is registered as before. Without the fix, the first test fails (a success is recorded and services are created for the dead socket).

Ran `lint`, `format`, `check-types`, and the `workers` `no-pg` tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UPJiVV1Wekmk8U9r3WMMdx

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPJiVV1Wekmk8U9r3WMMdx)_