### PR TITLE
chore(litestream): account for long /sync requests

### DIFF
--- a/packages/zero-cache/src/services/litestream/litestream-checkpointer.test.ts
+++ b/packages/zero-cache/src/services/litestream/litestream-checkpointer.test.ts
@@ -1,10 +1,14 @@
+import {resolver} from '@rocicorp/resolver';
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {AbortError} from '../../../../shared/src/abort-error.ts';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
 import type {Database} from '../../../../zqlite/src/db.ts';
 import {DbFile} from '../../test/lite.ts';
 import type {ForceCheckpointConfig} from '../replicator/write-worker-client.ts';
-import {LitestreamCheckpointer} from './litestream-checkpointer.ts';
+import {
+  LitestreamCheckpointer,
+  SOFT_CHECKPOINT_WAIT_MS,
+} from './litestream-checkpointer.ts';
 import type {
   LitestreamController,
   SyncResponse,
@@ -160,6 +164,47 @@ describe('litestream/litestream-checkpointer', () => {
     insertRows(1, 14);
     await checkpointer.maybeCheckpoint();
     expect(litestream.sync).toHaveBeenCalledTimes(2);
+  });
+
+  test('releases the writer after the soft wait budget without abandoning or re-issuing a slow sync', async () => {
+    vi.useFakeTimers();
+
+    // A sync that only completes (and drains) once the test opens the gate,
+    // simulating litestream being slow to seal the WAL.
+    const gate = resolver<void>();
+    const litestream = fakeController(async () => {
+      await gate.promise;
+      drainWal();
+      return SYNC_RESPONSE;
+    });
+    const checkpointer = new LitestreamCheckpointer(
+      lc,
+      db,
+      litestream,
+      config(),
+    );
+
+    insertRows(10); // over the threshold (5)
+    const first = checkpointer.maybeCheckpoint();
+    // The budget elapses before the sync completes, so the writer is released
+    // while the sync keeps running (not cancelled, not drained).
+    await vi.advanceTimersByTimeAsync(SOFT_CHECKPOINT_WAIT_MS);
+    await first;
+    expect(litestream.sync).toHaveBeenCalledTimes(1);
+    expect(numWalPages(db)).toBe(10);
+
+    // A second attempt while that sync is still in flight reuses it rather than
+    // stacking another /sync (which would just pile up in litestream).
+    insertRows(6, 10); // crosses the backed-off threshold (10 + 5 = 15)
+    const second = checkpointer.maybeCheckpoint();
+    await vi.advanceTimersByTimeAsync(SOFT_CHECKPOINT_WAIT_MS);
+    await second;
+    expect(litestream.sync).toHaveBeenCalledTimes(1);
+
+    // When the single in-flight sync finally completes, it drains the WAL.
+    gate.resolve();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(numWalPages(db)).toBe(0);
   });
 
   test('backs off the same way when sync() rejects', async () => {

--- a/packages/zero-cache/src/services/litestream/litestream-checkpointer.ts
+++ b/packages/zero-cache/src/services/litestream/litestream-checkpointer.ts
@@ -8,7 +8,18 @@ import type {
   SyncResponse,
 } from './litestream-controller.ts';
 
-const LITESTREAM_SYNC_TIMEOUT_MS = 10_000;
+// How long the soft path blocks the write path waiting for an in-flight sync
+// before letting the writer proceed. This is a backpressure knob, *not* a
+// request timeout: letting it elapse leaves the sync running (see #pendingSync)
+// rather than abandoning it. In normal operation litestream seals + runs its
+// PASSIVE checkpoint well within this budget; a sync that regularly exceeds it
+// indicates a litestream-side problem to fix (e.g. unintended snapshot), not a
+// value to raise.
+export const SOFT_CHECKPOINT_WAIT_MS = 10_000;
+// Liveness bound on the /sync request itself, well above the soft wait budget.
+// It exists only to recover from a genuinely wedged litestream (so #pendingSync
+// can't hang forever).
+const LITESTREAM_SYNC_TIMEOUT_MS = 5 * 60_000;
 const PAUSE_POLL_INTERVAL_MS = 1_000;
 const PAUSE_LOG_INTERVAL_POLLS = 30;
 
@@ -21,11 +32,17 @@ const PAUSE_LOG_INTERVAL_POLLS = 30;
  *  - Soft (`checkpointThresholdPages`): after each committed transaction,
  *    once the un-checkpointed WAL backlog reaches the threshold, force an
  *    immediate litestream sync (which seals the WAL to LTX and attempts
- *    litestream's own PASSIVE checkpoint). Non-blocking beyond the sync call
- *    itself. Backs off by a full threshold's worth of WAL growth whenever an
- *    attempt fails to drain the WAL (e.g. litestream is mid-snapshot and its
- *    checkpoints are being skipped), so repeated failures don't reattempt on
- *    every commit.
+ *    litestream's own PASSIVE checkpoint) and block the write path until it
+ *    completes, but only up to {@link SOFT_CHECKPOINT_WAIT_MS}. Waiting is the
+ *    backpressure: it throttles upstream reads to litestream's WAL-seal rate
+ *    and, in the common case, gives litestream a window to checkpoint without
+ *    writer interference. A single sync is kept in flight at a time
+ *    (`#pendingSync`): if one is still running when the budget elapses, the
+ *    writer proceeds and the next commit waits for that sync rather than
+ *    issuing (and orphaning) another. Backs off by a full threshold's worth of
+ *    WAL growth whenever an attempt fails to drain the WAL (e.g. litestream
+ *    is mid-snapshot and its checkpoints are being skipped), so repeated
+ *    failures don't reattempt on every commit.
  *  - Hard (`walMaxPages`, optional): if the WAL still exceeds this cap after
  *    a soft attempt, pause (block the caller) polling litestream until the
  *    WAL drains below it. This is the fail-safe against unbounded WAL growth
@@ -41,6 +58,7 @@ export class LitestreamCheckpointer {
   readonly #maxWalPages: number | undefined;
   readonly #state = new RunningState('litestream-checkpointer');
   #nextWalThreshold: number;
+  #pendingSync: Promise<void> | undefined;
 
   constructor(
     lc: LogContext,
@@ -79,60 +97,92 @@ export class LitestreamCheckpointer {
    * that litestream's (disabled) truncate-page-n would have served.
    */
   async maybeCheckpoint(): Promise<void> {
-    const walPages = this.#getNumWalPages();
+    let walPages = this.#getNumWalPages();
     if (walPages < this.#nextWalThreshold) {
       return;
     }
 
-    const start = performance.now();
-    let result: SyncResponse | undefined;
-    let err: unknown;
-    try {
-      result = await this.#litestream.sync(
-        {
-          wait: false,
-          timeoutMs: LITESTREAM_SYNC_TIMEOUT_MS,
-        },
-        this.#state.signal,
-      );
-    } catch (e) {
-      err = e;
-    }
+    // Single-flight: reuse the outstanding sync if one is already running.
+    this.#pendingSync ??= this.#sync(walPages);
 
-    const elapsed = performance.now() - start;
-    let newWalPages = this.#getNumWalPages();
-    if (newWalPages < this.#nextWalThreshold) {
-      this.#lc.info?.(
-        `checkpointed ${walPages} -> ${newWalPages} wal pages (${elapsed.toFixed(2)} ms)`,
-        result,
-      );
-    } else if (result) {
-      this.#lc.warn?.(
-        `checkpoint skipped ${walPages} -> ${newWalPages}. a snapshot may be in progress (${elapsed.toFixed(2)} ms)`,
-        result,
-      );
-    } else {
-      this.#lc.warn?.(
-        `checkpoint failed ${walPages} -> ${newWalPages} (${elapsed.toFixed(2)} ms)`,
-        err,
-      );
-    }
+    // Soft backpressure: block the write path until the sync completes, but no
+    // longer than the wait budget. Letting the budget elapse lets the writer
+    // proceed *without* cancelling the sync (it keeps running, tracked by
+    // #pendingSync); unbounded WAL growth is caught by the hard cap below.
+    await this.#waitFor(this.#pendingSync, SOFT_CHECKPOINT_WAIT_MS);
 
-    if (this.#maxWalPages !== undefined && newWalPages > this.#maxWalPages) {
+    walPages = this.#getNumWalPages();
+    if (this.#maxWalPages !== undefined && walPages > this.#maxWalPages) {
       // Emergency brake when best-effort checkpoints are being skipped
       // (i.e. during a snapshot) and the WAL is approaching disk capacity.
       // Pausing replication is favorable to litestream's truncate-page-n
       // because the latter involves re-encoding the database under the lock
       // (https://github.com/benbjohnson/litestream/issues/1332), which would
       // incur the full latency of an additional snapshot.
-      newWalPages = await this.#pauseUntilWalDrained(this.#maxWalPages);
+      walPages = await this.#pauseUntilWalDrained(this.#maxWalPages);
     }
 
     // In the common case where checkpoints are successful, this is always
     // just `attemptChunk`. When a checkpoint doesn't drain the WAL (e.g.
     // litestream is performing a snapshot), wait for another chunk of growth
     // before the next attempt.
-    this.#nextWalThreshold = newWalPages + this.#attemptChunk;
+    this.#nextWalThreshold = walPages + this.#attemptChunk;
+  }
+
+  async #waitFor(p: Promise<void>, timeoutMs: number): Promise<void> {
+    const result = await Promise.race([
+      p,
+      this.#state.sleep(timeoutMs).then(() => 'timed-out' as const),
+    ]);
+    if (result === 'timed-out') {
+      this.#lc.warn?.(`timed out waiting for /sync result (${timeoutMs}ms)`);
+    }
+  }
+
+  /**
+   * Runs a single litestream sync, logs its outcome, and clears
+   * {@link #pendingSync} when it settles. Never rejects: sync failures and
+   * post-sync bookkeeping errors (e.g. the db being closed during shutdown)
+   * are caught and logged, so the shared promise can be awaited from multiple
+   * places without risking an unhandled rejection.
+   */
+  async #sync(walPagesBefore: number): Promise<void> {
+    const start = performance.now();
+    let result: SyncResponse | undefined;
+    let err: unknown;
+    try {
+      try {
+        result = await this.#litestream.sync(
+          {wait: false, timeoutMs: LITESTREAM_SYNC_TIMEOUT_MS},
+          this.#state.signal,
+        );
+      } catch (e) {
+        err = e;
+      }
+
+      const elapsed = performance.now() - start;
+      const newWalPages = this.#getNumWalPages();
+      if (newWalPages < this.#nextWalThreshold) {
+        this.#lc.info?.(
+          `checkpointed ${walPagesBefore} -> ${newWalPages} wal pages (${elapsed.toFixed(2)} ms)`,
+          result,
+        );
+      } else if (result) {
+        this.#lc.warn?.(
+          `checkpoint skipped ${walPagesBefore} -> ${newWalPages}. a snapshot may be in progress (${elapsed.toFixed(2)} ms)`,
+          result,
+        );
+      } else {
+        this.#lc.warn?.(
+          `checkpoint failed ${walPagesBefore} -> ${newWalPages} (${elapsed.toFixed(2)} ms)`,
+          err,
+        );
+      }
+    } catch (e) {
+      this.#lc.warn?.('litestream-checkpointer sync post-processing failed', e);
+    } finally {
+      this.#pendingSync = undefined;
+    }
   }
 
   async #pauseUntilWalDrained(maxWalPages: number): Promise<number> {
@@ -152,12 +202,10 @@ export class LitestreamCheckpointer {
         );
       }
       await this.#state.sleep(PAUSE_POLL_INTERVAL_MS);
-      await this.#litestream
-        .sync(
-          {wait: false, timeoutMs: LITESTREAM_SYNC_TIMEOUT_MS},
-          this.#state.signal,
-        )
-        .catch(e => this.#lc.warn?.(`litestream /sync failed`, e));
+      // Single-flight: reuse the outstanding sync if one is already running.
+      this.#pendingSync ??= this.#sync(this.#getNumWalPages());
+      // await the full liveness timeout configured in #sync()
+      await this.#pendingSync;
     }
     throw new AbortError('litestream-controller stopped');
   }


### PR DESCRIPTION
Set a longer timeout for the request sent to litestream "/sync" in case it is blocked by another sync (e.g. a snapshot).

The per-soft-threshold checkpoint wait still happens at the previous cadence, waiting for the checkpoint but continuing if it times out. However, it leaves the sync request running instead of accumulating more in litestream. This is mainly to avoid a buildup of unnecessary requests in litestream if it is already busy syncing.