### PR TITLE
fix(zero-cache): support RM profiling proxy and external cache benchmarks in zero-throughput

### DIFF
--- a/apps/zero-throughput/src/config.ts
+++ b/apps/zero-throughput/src/config.ts
@@ -37,6 +37,7 @@ const options = {
   profileDir: v.string().default('results/profiles'),
   processLogMode: v.literalUnion('file', 'inherit', 'ignore').default('file'),
   reset: v.boolean().default(true),
+  resetMode: v.literalUnion('all', 'data-only', 'none').optional(),
   cacheURL: v.string().optional(),
   cacheURLs: v.string().optional(),
   appServerPort: v.number().default(3_000),
@@ -71,6 +72,7 @@ const options = {
 export type BenchmarkProfile = 'feed-append' | 'email' | 'forum' | 'relational';
 export type BenchmarkModel = 'hot' | 'realistic';
 export type BenchmarkTopology = 'single' | 'distributed';
+export type BenchmarkResetMode = 'all' | 'data-only' | 'none';
 
 export type BenchmarkConfig = {
   readonly runID: string;
@@ -102,6 +104,7 @@ export type BenchmarkConfig = {
   readonly adminPassword?: string | undefined;
   readonly processLogMode: 'file' | 'inherit' | 'ignore';
   readonly reset: boolean;
+  readonly resetMode: BenchmarkResetMode;
   readonly appServerPort: number;
   readonly cacheURL: string;
   readonly cacheURLs: readonly string[];
@@ -174,6 +177,10 @@ export function loadConfig(): BenchmarkConfig {
   const isPgManaged = parsed.pg.url === undefined;
   const pgURL = parsed.pg.url ?? DEFAULT_PG_URL;
 
+  const resetMode: BenchmarkResetMode =
+    parsed.resetMode ??
+    (!parsed.reset ? 'none' : isZeroManaged ? 'all' : 'data-only');
+
   return {
     runID: new Date().toISOString().replace(/[:.]/g, '-'),
     profile: parsed.profile,
@@ -206,7 +213,8 @@ export function loadConfig(): BenchmarkConfig {
       process.env.ZERO_ADMIN_PASSWORD ??
       process.env.ADMIN_PASSWORD,
     processLogMode: parsed.processLogMode,
-    reset: parsed.reset,
+    reset: resetMode !== 'none',
+    resetMode,
     appServerPort: parsed.appServerPort,
     cacheURL: cacheURLs[0],
     cacheURLs,

--- a/apps/zero-throughput/src/db.ts
+++ b/apps/zero-throughput/src/db.ts
@@ -82,11 +82,13 @@ export async function resetBenchmarkDatabase(
   sql: BenchmarkDB,
   config: BenchmarkConfig,
 ): Promise<void> {
-  const appID = config.zero.appID;
-  const schemas = [appID, `${appID}_0`, `${appID}_0/cvr`, `${appID}_0/cdc`];
+  if (config.resetMode === 'all') {
+    const appID = config.zero.appID;
+    const schemas = [appID, `${appID}_0`, `${appID}_0/cvr`, `${appID}_0/cdc`];
 
-  for (const schema of schemas) {
-    await sql`DROP SCHEMA IF EXISTS ${sql(schema)} CASCADE`;
+    for (const schema of schemas) {
+      await sql`DROP SCHEMA IF EXISTS ${sql(schema)} CASCADE`;
+    }
   }
 
   await sql`DROP TABLE IF EXISTS zero_throughput_event CASCADE`;

--- a/apps/zero-throughput/src/main.ts
+++ b/apps/zero-throughput/src/main.ts
@@ -74,10 +74,12 @@ async function main(): Promise<void> {
     );
     cleanup.push(() => sql.end());
 
-    if (config.reset) {
-      log('Resetting benchmark database...');
+    if (config.resetMode !== 'none') {
+      log(`Resetting benchmark database (${config.resetMode})...`);
       await resetBenchmarkDatabase(sql, config);
-      await removeReplicaFiles(config.zero.replicaFile);
+      if (config.resetMode === 'all') {
+        await removeReplicaFiles(config.zero.replicaFile);
+      }
     }
 
     if (config.zero.start) {
@@ -120,8 +122,14 @@ async function main(): Promise<void> {
     if (config.topology === 'single') {
       log('Analyzing profile query plans...');
       log(`query-plan logs: ${queryPlanAnalysisLogPath(config)}`);
-      const queryPlanAnalysis = await analyzeProfileQueries(config);
-      processes.push(queryPlanAnalysis);
+      try {
+        const queryPlanAnalysis = await analyzeProfileQueries(config);
+        processes.push(queryPlanAnalysis);
+      } catch (err) {
+        warn(
+          `Query plan analysis skipped: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
     }
 
     log(`Starting ${config.users} synthetic clients...`);

--- a/apps/zero-throughput/src/processes.ts
+++ b/apps/zero-throughput/src/processes.ts
@@ -170,6 +170,9 @@ export async function analyzeProfileQueries(
         String(config.rowsPerQuery),
         '--join-plans',
       ];
+      if (config.adminPassword) {
+        args.push('--admin-password', config.adminPassword);
+      }
       await writeLog(
         logStream,
         [

--- a/packages/zero-cache/src/services/profz.test.ts
+++ b/packages/zero-cache/src/services/profz.test.ts
@@ -118,11 +118,11 @@ describe('profz', () => {
     expect(body).toEqual(mockProfile);
   });
 
-  test('profrmz in distributed mode proxies to changeStreamer.uri', async () => {
+  test('profrmz in distributed mode proxies to changeStreamer.uri (converting ws:// to http://)', async () => {
     const distributedConfig = {
       adminPassword: 'secret',
       changeStreamer: {
-        uri: 'http://127.0.0.1:4849',
+        uri: 'ws://127.0.0.1:4849',
       },
     } as unknown as NormalizedZeroConfig;
 

--- a/packages/zero-cache/src/services/profz.ts
+++ b/packages/zero-cache/src/services/profz.ts
@@ -163,6 +163,11 @@ export async function handleProfrmzRequest(
   // In distributed mode, proxy to the upstream Replication Manager
   if (config.changeStreamer.uri) {
     const upstreamURL = new URL('/profz', config.changeStreamer.uri);
+    if (upstreamURL.protocol === 'ws:') {
+      upstreamURL.protocol = 'http:';
+    } else if (upstreamURL.protocol === 'wss:') {
+      upstreamURL.protocol = 'https:';
+    }
     const incomingURL = new URL(req.url, 'http://localhost');
     for (const [key, value] of incomingURL.searchParams.entries()) {
       upstreamURL.searchParams.set(key, value);


### PR DESCRIPTION
### Summary

Fixes Replication Manager CPU profiling over WebSocket change streamer URIs and adds safe database reset handling for external Zero cache benchmarks.

### Changes

- **`zero-cache`**: In `handleProfrmzRequest()`, convert `ws://` and `wss://` URI schemes from `config.changeStreamer.uri` to `http://` and `https://` so Node's native `fetch()` can successfully proxy profiling requests to the upstream Replication Manager.
- **`zero-throughput`**:
  - Add `--reset-mode [all | data-only | none]`, defaulting to `data-only` when targeting an external `--cache-url`. This allows resetting benchmark data tables without dropping Zero's internal metadata schemas or replication slots.
  - Forward `--admin-password` to query plan analysis and gracefully catch errors if plan inspection is unavailable or restricted on remote instances.

### Testing

- `pnpm --filter zero-cache test src/services/profz.test.ts` (added test validating `ws://` to `http://` conversion)
- Live verification against CloudZero:
  - Benchmark run succeeded with `--profile-vs`, capturing V8 CPU profiles across all View-Syncer processes (`dispatcher`, `syncers`, `serving-replicator`, `reaper`).
  - Safe data-only reset verified against external RDS + CloudZero.
