### PR TITLE
chore(zero-cache): increase default consensus timeout

### DIFF
--- a/packages/zero-cache/src/config/zero-config.test.ts
+++ b/packages/zero-cache/src/config/zero-config.test.ts
@@ -477,7 +477,7 @@ test('zero-cache --help', () => {
                                                                                    rather, it protects the system when the upstream throughput exceeds the downstream                                         
                                                                                    throughput.                                                                                                                
                                                                                                                                                                                                               
-     --change-streamer-flow-control-consensus-timeout-proportion number            default: 2                                                                                                                 
+     --change-streamer-flow-control-consensus-timeout-proportion number            default: 4                                                                                                                 
        ZERO_CHANGE_STREAMER_FLOW_CONTROL_CONSENSUS_TIMEOUT_PROPORTION env                                                                                                                                     
                                                                                    During periodic flow control checks (every 64kb), the amount of time to wait after the majority                            
                                                                                    of subscribers have acked, proportional to that interval, after which replication will continue                            
@@ -491,7 +491,7 @@ test('zero-cache --help', () => {
                                                                                                                                                                                                               
                                                                                    For example, if the majority of subscribers ack a message in 2.5ms, a padding proportion of                                
                                                                                    1.0 instructs replication to continue after an additional 2.5ms; for a proportion of 2.0, an                               
-                                                                                   additional 5.0ms, etc. The default value of 2.0 allows for a subscriber to be 3x slower than the                           
+                                                                                   additional 5.0ms, etc. The default value of 4.0 allows for a subscriber to be 5x slower than the                           
                                                                                    majority in the steady state, while similarly bounding the extent to which a temporarily lagging                           
                                                                                    subscriber (e.g. due to catchup) slows down the fleet.                                                                     
                                                                                                                                                                                                               

--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -871,7 +871,7 @@ export const zeroOptions = {
     },
 
     flowControlConsensusTimeoutProportion: {
-      type: v.number().default(2.0),
+      type: v.number().default(4.0),
       desc: [
         `During periodic flow control checks (every 64kb), the amount of time to wait after the majority`,
         `of subscribers have acked, proportional to that interval, after which replication will continue`,
@@ -885,7 +885,7 @@ export const zeroOptions = {
         ``,
         `For example, if the majority of subscribers ack a message in 2.5ms, a padding proportion of`,
         `1.0 instructs replication to continue after an additional 2.5ms; for a proportion of 2.0, an`,
-        `additional 5.0ms, etc. The default value of 2.0 allows for a subscriber to be 3x slower than the`,
+        `additional 5.0ms, etc. The default value of 4.0 allows for a subscriber to be 5x slower than the`,
         `majority in the steady state, while similarly bounding the extent to which a temporarily lagging`,
         `subscriber (e.g. due to catchup) slows down the fleet.`,
         ``,


### PR DESCRIPTION
Increase the default consensus proportion from 2x to 4x. 

Real world production data on heterogeneous machines shows the 2x threshold to be regularly hit, and not during catchup phases, indicating that it is within the realm of realistic variance. Bumping the default threshold to 4x makes the policy safer and decreases log spam.