### PR TITLE
perf(zql): de-generator the pure-passthrough push delegations

### DIFF
--- a/packages/shared/src/btree-set.bench.ts
+++ b/packages/shared/src/btree-set.bench.ts
@@ -19,7 +19,8 @@ const midKey = NUM_ENTRIES / 2;
 describe('BTreeSet iterators', () => {
   bench('values() full scan', () => {
     let sum = 0;
-    for (const v of tree.values()) {
+    const it = tree.values();
+    for (let v = it.nextValue(); v !== undefined; v = it.nextValue()) {
       sum += v;
     }
     use(sum);
@@ -27,7 +28,8 @@ describe('BTreeSet iterators', () => {
 
   bench('valuesFrom() from mid', () => {
     let sum = 0;
-    for (const v of tree.valuesFrom(midKey)) {
+    const it = tree.valuesFrom(midKey);
+    for (let v = it.nextValue(); v !== undefined; v = it.nextValue()) {
       sum += v;
     }
     use(sum);
@@ -35,7 +37,8 @@ describe('BTreeSet iterators', () => {
 
   bench('valuesReversed() full scan', () => {
     let sum = 0;
-    for (const v of tree.valuesReversed()) {
+    const it = tree.valuesReversed();
+    for (let v = it.nextValue(); v !== undefined; v = it.nextValue()) {
       sum += v;
     }
     use(sum);
@@ -43,64 +46,17 @@ describe('BTreeSet iterators', () => {
 
   bench('valuesFromReversed() from mid', () => {
     let sum = 0;
-    for (const v of tree.valuesFromReversed(midKey)) {
+    const it = tree.valuesFromReversed(midKey);
+    for (let v = it.nextValue(); v !== undefined; v = it.nextValue()) {
       sum += v;
     }
     use(sum);
   });
 
-  bench('[Symbol.iterator]() full scan', () => {
+  bench('toArray() full scan', () => {
     let sum = 0;
-    for (const v of tree) {
+    for (const v of tree.toArray()) {
       sum += v;
-    }
-    use(sum);
-  });
-});
-
-// Isolate just the iterator step cost by calling next() directly,
-// with no work in the "loop body" beyond consuming the value.
-describe('BTreeSet iterator next() in isolation', () => {
-  bench('forward iterator next()', () => {
-    const iter = tree.values();
-    let result = iter.next();
-    let sum = 0;
-    while (!result.done) {
-      sum += result.value;
-      result = iter.next();
-    }
-    use(sum);
-  });
-
-  bench('forward iterator next() from mid', () => {
-    const iter = tree.valuesFrom(midKey);
-    let result = iter.next();
-    let sum = 0;
-    while (!result.done) {
-      sum += result.value;
-      result = iter.next();
-    }
-    use(sum);
-  });
-
-  bench('reverse iterator next()', () => {
-    const iter = tree.valuesReversed();
-    let result = iter.next();
-    let sum = 0;
-    while (!result.done) {
-      sum += result.value;
-      result = iter.next();
-    }
-    use(sum);
-  });
-
-  bench('reverse iterator next() from mid', () => {
-    const iter = tree.valuesFromReversed(midKey);
-    let result = iter.next();
-    let sum = 0;
-    while (!result.done) {
-      sum += result.value;
-      result = iter.next();
     }
     use(sum);
   });

--- a/packages/shared/src/btree-set.test.ts
+++ b/packages/shared/src/btree-set.test.ts
@@ -1,7 +1,7 @@
 import {compareUTF8} from 'compare-utf8';
 import fc, {assert, property} from 'fast-check';
 import {describe, expect, test} from 'vitest';
-import {BTreeSet} from './btree-set.ts';
+import {BTreeSet, drainValues} from './btree-set.ts';
 
 test('delete', () => {
   const t = new BTreeSet<number>((a, b) => a - b);
@@ -64,41 +64,41 @@ describe('iterators', () => {
   t.add(2);
 
   test('values', () => {
-    expect([...t.values()]).toEqual([2, 5, 10, 15]);
+    expect(drainValues(t.values())).toEqual([2, 5, 10, 15]);
   });
 
   test('valuesReversed', () => {
-    expect([...t.valuesReversed()]).toEqual([15, 10, 5, 2]);
+    expect(drainValues(t.valuesReversed())).toEqual([15, 10, 5, 2]);
   });
 
   test('valuesFrom 5', () => {
-    expect([...t.valuesFrom(5)]).toEqual([5, 10, 15]);
-    expect([...t.valuesFrom(5, false)]).toEqual([10, 15]);
+    expect(drainValues(t.valuesFrom(5))).toEqual([5, 10, 15]);
+    expect(drainValues(t.valuesFrom(5, false))).toEqual([10, 15]);
   });
 
   test('valuesFrom 6', () => {
-    expect([...t.valuesFrom(6)]).toEqual([10, 15]);
-    expect([...t.valuesFrom(6, false)]).toEqual([10, 15]);
+    expect(drainValues(t.valuesFrom(6))).toEqual([10, 15]);
+    expect(drainValues(t.valuesFrom(6, false))).toEqual([10, 15]);
   });
 
   test('valuesFrom 4', () => {
-    expect([...t.valuesFrom(4)]).toEqual([5, 10, 15]);
-    expect([...t.valuesFrom(4, false)]).toEqual([5, 10, 15]);
+    expect(drainValues(t.valuesFrom(4))).toEqual([5, 10, 15]);
+    expect(drainValues(t.valuesFrom(4, false))).toEqual([5, 10, 15]);
   });
 
   test('valuesFromReversed 10', () => {
-    expect([...t.valuesFromReversed(10)]).toEqual([10, 5, 2]);
-    expect([...t.valuesFromReversed(10, false)]).toEqual([5, 2]);
+    expect(drainValues(t.valuesFromReversed(10))).toEqual([10, 5, 2]);
+    expect(drainValues(t.valuesFromReversed(10, false))).toEqual([5, 2]);
   });
 
   test('valuesFromReversed 6', () => {
-    expect([...t.valuesFromReversed(6)]).toEqual([5, 2]);
-    expect([...t.valuesFromReversed(6, false)]).toEqual([5, 2]);
+    expect(drainValues(t.valuesFromReversed(6))).toEqual([5, 2]);
+    expect(drainValues(t.valuesFromReversed(6, false))).toEqual([5, 2]);
   });
 
   test('valuesFromReversed 11', () => {
-    expect([...t.valuesFromReversed(11)]).toEqual([10, 5, 2]);
-    expect([...t.valuesFromReversed(11, false)]).toEqual([10, 5, 2]);
+    expect(drainValues(t.valuesFromReversed(11))).toEqual([10, 5, 2]);
+    expect(drainValues(t.valuesFromReversed(11, false))).toEqual([10, 5, 2]);
   });
 });
 
@@ -168,14 +168,14 @@ test('add should allow replacing equal entry', () => {
   t.add(['b', 2]);
   t.add(['c', 3]);
 
-  expect([...t]).toEqual([
+  expect(t.toArray()).toEqual([
     ['a', 1],
     ['b', 2],
     ['c', 3],
   ]);
 
   t.add(['b', 4]);
-  expect([...t]).toEqual([
+  expect(t.toArray()).toEqual([
     ['a', 1],
     ['b', 4],
     ['c', 3],
@@ -188,7 +188,7 @@ describe('class-based iterators', () => {
     for (let i = 0; i < 100; i++) {
       t.add(i);
     }
-    const forward = [...t.valuesFrom()];
+    const forward = drainValues(t.valuesFrom());
     expect(forward).toEqual(Array.from({length: 100}, (_, i) => i));
   });
 
@@ -197,33 +197,21 @@ describe('class-based iterators', () => {
     for (let i = 0; i < 100; i++) {
       t.add(i);
     }
-    const reversed = [...t.valuesReversed()];
+    const reversed = drainValues(t.valuesReversed());
     expect(reversed).toEqual(Array.from({length: 100}, (_, i) => 99 - i));
   });
 
-  test('empty tree iterator returns done immediately', () => {
+  test('empty tree iterator is exhausted immediately', () => {
     const t = new BTreeSet<number>((a, b) => a - b);
-    const fwd = t.values();
-    expect(fwd.next()).toEqual({done: true, value: undefined});
-    const rev = t.valuesReversed();
-    expect(rev.next()).toEqual({done: true, value: undefined});
+    expect(t.values().nextValue()).toBeUndefined();
+    expect(t.valuesReversed().nextValue()).toBeUndefined();
   });
 
   test('single element tree works', () => {
     const t = new BTreeSet<number>((a, b) => a - b);
     t.add(42);
-    expect([...t.values()]).toEqual([42]);
-    expect([...t.valuesReversed()]).toEqual([42]);
-  });
-
-  test('iterator protocol: [Symbol.iterator] returns self', () => {
-    const t = new BTreeSet<number>((a, b) => a - b);
-    t.add(1);
-    t.add(2);
-    const fwd = t.values();
-    expect(fwd[Symbol.iterator]()).toBe(fwd);
-    const rev = t.valuesReversed();
-    expect(rev[Symbol.iterator]()).toBe(rev);
+    expect(drainValues(t.values())).toEqual([42]);
+    expect(drainValues(t.valuesReversed())).toEqual([42]);
   });
 });
 
@@ -276,7 +264,7 @@ describe('fast-check', () => {
 
     for (const [operation, value] of operations) {
       const oldOrderedSet = orderedSet;
-      const oldOrderedSetValues = [...oldOrderedSet];
+      const oldOrderedSetValues = oldOrderedSet.toArray();
       switch (operation) {
         case 'insert':
           orderedSet.add(value);
@@ -298,7 +286,7 @@ describe('fast-check', () => {
           set.add(value);
           break;
       }
-      const oldOrderedSetValuesPostModification = [...oldOrderedSet];
+      const oldOrderedSetValuesPostModification = oldOrderedSet.toArray();
 
       // immutable OrderedSet should not be modified in place.
       if (!mutable) {
@@ -315,7 +303,7 @@ describe('fast-check', () => {
 
     // 2. The OrderedSet returns items in sorted order when iterating.
     let lastValue = Number.NEGATIVE_INFINITY;
-    for (const value of orderedSet) {
+    for (const value of orderedSet.toArray()) {
       expect(value).toBeGreaterThan(lastValue);
       lastValue = value;
     }

--- a/packages/shared/src/btree-set.ts
+++ b/packages/shared/src/btree-set.ts
@@ -88,11 +88,11 @@ export class BTreeSet<K> {
     }
   }
 
-  keys(): IterableIterator<K> {
+  keys(): ValueIterator<K> {
     return valuesFrom(this.#root, this.comparator, undefined, true);
   }
 
-  values(): IterableIterator<K> {
+  values(): ValueIterator<K> {
     return valuesFrom(this.#root, this.comparator, undefined, true);
   }
 
@@ -100,7 +100,7 @@ export class BTreeSet<K> {
     return valuesFrom(this.#root, this.comparator, lowestKey, inclusive);
   }
 
-  valuesReversed(): IterableIterator<K> {
+  valuesReversed(): ValueIterator<K> {
     return valuesFromReversed(
       this.#maxKey(),
       this.#root,
@@ -128,21 +128,14 @@ export class BTreeSet<K> {
     return this.#root.maxKey();
   }
 
-  [Symbol.iterator](): IterableIterator<K> {
-    return this.keys();
-  }
-
   /**
-   * Collects every key into an array without going through the iterator
-   * protocol, so building an index does not allocate a result object per row.
+   * Collects every key into an array. BTreeSet is deliberately not iterable:
+   * the iterator protocol allocates a result object per value, which is the
+   * cost the IVM fetch path exists to avoid, and an iterable API is an easy
+   * way to reintroduce it by accident.
    */
   toArray(): K[] {
-    const result: K[] = [];
-    const it = this.valuesFrom();
-    for (let v = it.nextValue(); v !== undefined; v = it.nextValue()) {
-      result.push(v);
-    }
-    return result;
+    return drainValues(this.valuesFrom());
   }
 
   /**
@@ -205,8 +198,17 @@ export class BTreeSet<K> {
  * per-value result object. `nextValue()` returns `undefined` once exhausted,
  * so it is only meaningful for sets whose keys are never `undefined`.
  */
-export interface ValueIterator<K> extends IterableIterator<K> {
+export interface ValueIterator<K> {
   nextValue(): K | undefined;
+}
+
+/** Collects the rest of `it` into an array. */
+export function drainValues<K>(it: ValueIterator<K>): K[] {
+  const result: K[] = [];
+  for (let v = it.nextValue(); v !== undefined; v = it.nextValue()) {
+    result.push(v);
+  }
+  return result;
 }
 
 class BTreeForwardIterator<K> implements ValueIterator<K> {
@@ -254,18 +256,8 @@ class BTreeForwardIterator<K> implements ValueIterator<K> {
     }
   }
 
-  next(): IteratorResult<K> {
-    return this.#advance()
-      ? {done: false, value: this.#leaf.keys[this.#i]}
-      : {done: true, value: undefined as unknown as K};
-  }
-
   nextValue(): K | undefined {
     return this.#advance() ? this.#leaf.keys[this.#i] : undefined;
-  }
-
-  [Symbol.iterator]() {
-    return this;
   }
 }
 
@@ -315,18 +307,8 @@ class BTreeReverseIterator<K> implements ValueIterator<K> {
     }
   }
 
-  next(): IteratorResult<K> {
-    return this.#advance()
-      ? {done: false, value: this.#leaf.keys[this.#i]}
-      : {done: true, value: undefined as unknown as K};
-  }
-
   nextValue(): K | undefined {
     return this.#advance() ? this.#leaf.keys[this.#i] : undefined;
-  }
-
-  [Symbol.iterator]() {
-    return this;
   }
 }
 
@@ -416,13 +398,7 @@ function findPath<K>(
 }
 
 function emptyValueIterator<K>(): ValueIterator<K> {
-  return {
-    next: () => ({done: true, value: undefined as unknown as K}),
-    nextValue: () => undefined,
-    [Symbol.iterator]() {
-      return this;
-    },
-  };
+  return {nextValue: () => undefined};
 }
 
 /** Leaf node / base class. **************************************************/

--- a/packages/shared/src/btree-set.ts
+++ b/packages/shared/src/btree-set.ts
@@ -133,6 +133,19 @@ export class BTreeSet<K> {
   }
 
   /**
+   * Collects every key into an array without going through the iterator
+   * protocol, so building an index does not allocate a result object per row.
+   */
+  toArray(): K[] {
+    const result: K[] = [];
+    const it = this.valuesFrom();
+    for (let v = it.nextValue(); v !== undefined; v = it.nextValue()) {
+      result.push(v);
+    }
+    return result;
+  }
+
+  /**
    * Builds a BTreeSet from a pre-sorted iterable in O(N) by constructing
    * the tree bottom-up. The caller must ensure entries are sorted by
    * `comparator`; violating this produces an invalid tree.

--- a/packages/shared/src/btree-set.ts
+++ b/packages/shared/src/btree-set.ts
@@ -1,10 +1,11 @@
 import {assert} from './asserts.ts';
+import type {Defined} from './defined.ts';
 
 const MAX_NODE_SIZE = 32;
 
 type Comparator<K> = (a: K, b: K) => number;
 
-export class BTreeSet<K> {
+export class BTreeSet<K extends Defined> {
   #root: BNode<K> = emptyLeaf as BNode<K>;
   size: number = 0;
 
@@ -143,7 +144,7 @@ export class BTreeSet<K> {
    * the tree bottom-up. The caller must ensure entries are sorted by
    * `comparator`; violating this produces an invalid tree.
    */
-  static fromSorted<K>(
+  static fromSorted<K extends Defined>(
     comparator: Comparator<K>,
     sortedEntries: Iterable<K>,
   ): BTreeSet<K> {
@@ -198,12 +199,12 @@ export class BTreeSet<K> {
  * per-value result object. `nextValue()` returns `undefined` once exhausted,
  * so it is only meaningful for sets whose keys are never `undefined`.
  */
-export interface ValueIterator<K> {
+export interface ValueIterator<K extends Defined> {
   nextValue(): K | undefined;
 }
 
 /** Collects the rest of `it` into an array. */
-export function drainValues<K>(it: ValueIterator<K>): K[] {
+export function drainValues<K extends Defined>(it: ValueIterator<K>): K[] {
   const result: K[] = [];
   for (let v = it.nextValue(); v !== undefined; v = it.nextValue()) {
     result.push(v);
@@ -211,7 +212,7 @@ export function drainValues<K>(it: ValueIterator<K>): K[] {
   return result;
 }
 
-class BTreeForwardIterator<K> implements ValueIterator<K> {
+class BTreeForwardIterator<K extends Defined> implements ValueIterator<K> {
   readonly #nodeQueue: BNode<K>[][];
   readonly #nodeIndex: number[];
   #leaf: BNode<K>;
@@ -261,7 +262,7 @@ class BTreeForwardIterator<K> implements ValueIterator<K> {
   }
 }
 
-class BTreeReverseIterator<K> implements ValueIterator<K> {
+class BTreeReverseIterator<K extends Defined> implements ValueIterator<K> {
   readonly #nodeQueue: BNode<K>[][];
   readonly #nodeIndex: number[];
   #leaf: BNode<K>;
@@ -312,7 +313,7 @@ class BTreeReverseIterator<K> implements ValueIterator<K> {
   }
 }
 
-function valuesFrom<K>(
+function valuesFrom<K extends Defined>(
   root: BNode<K>,
   comparator: Comparator<K>,
   lowestKey: K | undefined,
@@ -342,7 +343,7 @@ function valuesFrom<K>(
   return new BTreeForwardIterator(nodeQueue, nodeIndex, leaf, i);
 }
 
-function valuesFromReversed<K>(
+function valuesFromReversed<K extends Defined>(
   maxKey: K | undefined,
   root: BNode<K>,
   comparator: Comparator<K>,
@@ -374,7 +375,7 @@ function valuesFromReversed<K>(
   return new BTreeReverseIterator(nodeQueue, nodeIndex, leaf, i);
 }
 
-function findPath<K>(
+function findPath<K extends Defined>(
   key: K | undefined,
   root: BNode<K>,
   comparator: Comparator<K>,
@@ -397,12 +398,12 @@ function findPath<K>(
   return [nodeQueue, nodeIndex, nextNode];
 }
 
-function emptyValueIterator<K>(): ValueIterator<K> {
+function emptyValueIterator<K extends Defined>(): ValueIterator<K> {
   return {nextValue: () => undefined};
 }
 
 /** Leaf node / base class. **************************************************/
-class BNode<K> {
+class BNode<K extends Defined> {
   // If this is an internal node, _keys[i] is the highest key in children[i].
   keys: K[];
   // True if this node might be within multiple `BTree`s (or have multiple parents).
@@ -518,7 +519,7 @@ class BNode<K> {
 }
 
 /** Internal node (non-leaf node) ********************************************/
-class BNodeInternal<K> extends BNode<K> {
+class BNodeInternal<K extends Defined> extends BNode<K> {
   // Note: conventionally B+ trees have one fewer key than the number of
   // children, but I find it easier to keep the array lengths equal: each
   // keys[i] caches the value of children[i].maxKey().

--- a/packages/shared/src/defined.ts
+++ b/packages/shared/src/defined.ts
@@ -1,0 +1,6 @@
+/**
+ * A value that can be distinguished from "absent" by an `!== undefined` check.
+ * `undefined` itself is excluded, so APIs that use it as a sentinel -- a
+ * `Map.get` miss, an exhausted {@linkcode ValueIterator} -- stay unambiguous.
+ */
+export type Defined = {} | null;

--- a/packages/shared/src/map.ts
+++ b/packages/shared/src/map.ts
@@ -1,8 +1,4 @@
-/**
- * A value that {@link Map.get} can distinguish from a missing entry.  `undefined`
- * is excluded because these helpers use `get() !== undefined` to detect absence.
- */
-type Defined = {} | null;
+import type {Defined} from './defined.ts';
 
 const nativeSupport =
   typeof (Map.prototype as unknown as MapES2026<unknown, Defined>)

--- a/packages/zero-solid/src/solid-view.ts
+++ b/packages/zero-solid/src/solid-view.ts
@@ -3,13 +3,9 @@ import {emptyArray} from '../../shared/src/sentinels.ts';
 import {ChangeIndex} from '../../zql/src/ivm/change-index.ts';
 import {ChangeType} from '../../zql/src/ivm/change-type.ts';
 import type {RelationshipStream} from '../../zql/src/ivm/data.ts';
+import {forEachSkippingYields} from '../../zql/src/ivm/skip-yields.ts';
 import {pullOf} from '../../zql/src/ivm/stream.ts';
-import {
-  applyChange,
-  idSymbol,
-  skipYields,
-  type ViewChange,
-} from './bindings.ts';
+import {applyChange, idSymbol, type ViewChange} from './bindings.ts';
 import {
   type AnyViewFactory,
   type Change,
@@ -115,21 +111,9 @@ export class SolidView implements Output {
     const initialRoot = this.#createEmptyRoot();
     // Lazy, as ArrayView#hydrate is: expanding a node's relationships triggers
     // child fetches, so draining the parent scan first would reorder them.
-    const hydrate = input.fetch({});
-    try {
-      for (
-        let node = hydrate.next();
-        node !== undefined;
-        node = hydrate.next()
-      ) {
-        if (node === 'yield') {
-          continue;
-        }
-        this.#applyChangeToRoot({type: 'add', node}, initialRoot);
-      }
-    } finally {
-      hydrate.close();
-    }
+    forEachSkippingYields(input.fetch({}), node => {
+      this.#applyChangeToRoot({type: 'add', node}, initialRoot);
+    });
 
     this.#setState = setState;
     this.#setState(
@@ -302,14 +286,9 @@ function materializeNodeRelationships(node: Node): Node {
   const relationships: Record<string, () => RelationshipStream> = {};
   for (const relationship in node.relationships) {
     const materialized: Node[] = [];
-    const children = skipYields(node.relationships[relationship]());
-    try {
-      for (let n = children.next(); n !== undefined; n = children.next()) {
-        materialized.push(materializeNodeRelationships(n));
-      }
-    } finally {
-      children.close();
-    }
+    forEachSkippingYields(node.relationships[relationship](), n => {
+      materialized.push(materializeNodeRelationships(n));
+    });
     relationships[relationship] = () => pullOf(materialized);
   }
   return {

--- a/packages/zql/src/ivm/catch.ts
+++ b/packages/zql/src/ivm/catch.ts
@@ -7,7 +7,7 @@ import {ChangeType} from './change-type.ts';
 import type {Change} from './change.ts';
 import type {Node} from './data.ts';
 import {type FetchRequest, type Input, type Output} from './operator.ts';
-import {drainPullMap} from './stream.ts';
+import {drainPullMap, forEachPull} from './stream.ts';
 
 export type CaughtNode =
   | {
@@ -132,17 +132,9 @@ export function expandNode(node: Node | 'yield'): CaughtNode {
           const children: CaughtNode[] = [];
 
           const childStream = getChildren();
-          try {
-            for (
-              let child = childStream.next();
-              child !== undefined;
-              child = childStream.next()
-            ) {
-              children.push(expandNode(child));
-            }
-          } finally {
-            childStream.close();
-          }
+          forEachPull(childStream, child => {
+            children.push(expandNode(child));
+          });
           return children;
         }),
       };

--- a/packages/zql/src/ivm/data.ts
+++ b/packages/zql/src/ivm/data.ts
@@ -1,6 +1,7 @@
 import {compareUTF8} from 'compare-utf8';
 import type {Ordering} from '../../../zero-protocol/src/ast.ts';
 import type {Row, Value} from '../../../zero-protocol/src/data.ts';
+import {forEachPull} from './stream.ts';
 import type {PullStream} from './stream.ts';
 
 /**
@@ -143,16 +144,8 @@ export function drainStreams(node: Node | 'yield') {
   }
   for (const stream of Object.values(node.relationships)) {
     const children = stream();
-    try {
-      for (
-        let node = children.next();
-        node !== undefined;
-        node = children.next()
-      ) {
-        drainStreams(node);
-      }
-    } finally {
-      children.close();
-    }
+    forEachPull(children, node => {
+      drainStreams(node);
+    });
   }
 }

--- a/packages/zql/src/ivm/deferred-input.ts
+++ b/packages/zql/src/ivm/deferred-input.ts
@@ -3,6 +3,7 @@ import {makeAddChange} from './change.ts';
 import type {Node} from './data.ts';
 import type {FetchRequest, Input, Output} from './operator.ts';
 import type {SourceSchema} from './schema.ts';
+import {forEachSkippingYields} from './skip-yields.ts';
 import {consume, emptyPullStream, type PullStream} from './stream.ts';
 
 /**
@@ -83,21 +84,9 @@ export class DeferredInput implements Input {
     }
     try {
       input.setOutput(output);
-      const stream = input.fetch({});
-      try {
-        for (
-          let node = stream.next();
-          node !== undefined;
-          node = stream.next()
-        ) {
-          if (node === 'yield') {
-            continue;
-          }
-          consume(output.push(makeAddChange(node), input));
-        }
-      } finally {
-        stream.close();
-      }
+      forEachSkippingYields(input.fetch({}), node => {
+        consume(output.push(makeAddChange(node), input));
+      });
     } catch (e) {
       input.destroy();
       throw e;

--- a/packages/zql/src/ivm/filter-operators.ts
+++ b/packages/zql/src/ivm/filter-operators.ts
@@ -59,7 +59,7 @@ export interface FilterOperator extends FilterInput, FilterOutput {}
  * set.
  */
 export const throwFilterOutput: FilterOutput = {
-  *push(_change: Change): Stream<'yield'> {
+  push(_change: Change): Stream<'yield'> {
     throw new Error('Output not set');
   },
 
@@ -94,8 +94,8 @@ export class FilterStart implements FilterInput, Output {
     return this.#input.getSchema();
   }
 
-  *push(change: Change) {
-    yield* this.#output.push(change, this);
+  push(change: Change): Stream<'yield'> {
+    return this.#output.push(change, this);
   }
 
   fetch(req: FetchRequest): PullStream<Node | 'yield'> {
@@ -158,8 +158,8 @@ export class FilterEnd implements Input, FilterOutput {
     return this.#input.getSchema();
   }
 
-  *push(change: Change) {
-    yield* this.#output.push(change, this);
+  push(change: Change): Stream<'yield'> {
+    return this.#output.push(change, this);
   }
 }
 

--- a/packages/zql/src/ivm/filter-push.ts
+++ b/packages/zql/src/ivm/filter-push.ts
@@ -5,33 +5,26 @@ import {ChangeType} from './change-type.ts';
 import type {Change} from './change.ts';
 import {maybeSplitAndPushEditChange} from './maybe-split-and-push-edit-change.ts';
 import type {InputBase, Output} from './operator.ts';
-import type {Stream} from './stream.ts';
+import {EMPTY_YIELDS, type Stream} from './stream.ts';
 
-export function* filterPush(
+export function filterPush(
   change: Change,
   output: Output,
   pusher: InputBase,
   predicate?: (row: Row) => boolean,
 ): Stream<'yield'> {
   if (!predicate) {
-    yield* output.push(change, pusher);
-    return;
+    return output.push(change, pusher);
   }
   switch (change[ChangeIndex.TYPE]) {
     case ChangeType.ADD:
     case ChangeType.REMOVE:
-      if (predicate(change[ChangeIndex.NODE].row)) {
-        yield* output.push(change, pusher);
-      }
-      break;
     case ChangeType.CHILD:
-      if (predicate(change[ChangeIndex.NODE].row)) {
-        yield* output.push(change, pusher);
-      }
-      break;
+      return predicate(change[ChangeIndex.NODE].row)
+        ? output.push(change, pusher)
+        : EMPTY_YIELDS;
     case ChangeType.EDIT:
-      yield* maybeSplitAndPushEditChange(change, predicate, output, pusher);
-      break;
+      return maybeSplitAndPushEditChange(change, predicate, output, pusher);
     default:
       unreachable(change);
   }

--- a/packages/zql/src/ivm/filter.ts
+++ b/packages/zql/src/ivm/filter.ts
@@ -9,6 +9,7 @@ import {
 } from './filter-operators.ts';
 import {filterPush} from './filter-push.ts';
 import type {SourceSchema} from './schema.ts';
+import type {Stream} from './stream.ts';
 
 /**
  * The Filter operator filters data through a predicate. It is stateless.
@@ -51,7 +52,7 @@ export class Filter implements FilterOperator {
     return this.#input.getSchema();
   }
 
-  *push(change: Change) {
-    yield* filterPush(change, this.#output, this, this.#predicate);
+  push(change: Change): Stream<'yield'> {
+    return filterPush(change, this.#output, this, this.#predicate);
   }
 }

--- a/packages/zql/src/ivm/maybe-split-and-push-edit-change.ts
+++ b/packages/zql/src/ivm/maybe-split-and-push-edit-change.ts
@@ -2,26 +2,30 @@ import type {Row} from '../../../zero-protocol/src/data.ts';
 import {ChangeIndex} from './change-index.ts';
 import {makeAddChange, makeRemoveChange, type EditChange} from './change.ts';
 import type {InputBase, Output} from './operator.ts';
+import {EMPTY_YIELDS, type Stream} from './stream.ts';
 
 /**
  * This takes an {@linkcode EditChange} and a predicate that determines if a row
  * should be present based on the row's data. It then splits the change and
  * pushes the appropriate changes to the output based on the predicate.
  */
-export function* maybeSplitAndPushEditChange(
+export function maybeSplitAndPushEditChange(
   change: EditChange,
   predicate: (row: Row) => boolean,
   output: Output,
   pusher: InputBase,
-) {
+): Stream<'yield'> {
   const oldWasPresent = predicate(change[ChangeIndex.OLD_NODE].row);
   const newIsPresent = predicate(change[ChangeIndex.NODE].row);
 
   if (oldWasPresent && newIsPresent) {
-    yield* output.push(change, pusher);
-  } else if (oldWasPresent && !newIsPresent) {
-    yield* output.push(makeRemoveChange(change[ChangeIndex.OLD_NODE]), pusher);
-  } else if (!oldWasPresent && newIsPresent) {
-    yield* output.push(makeAddChange(change[ChangeIndex.NODE]), pusher);
+    return output.push(change, pusher);
   }
+  if (oldWasPresent) {
+    return output.push(makeRemoveChange(change[ChangeIndex.OLD_NODE]), pusher);
+  }
+  if (newIsPresent) {
+    return output.push(makeAddChange(change[ChangeIndex.NODE]), pusher);
+  }
+  return EMPTY_YIELDS;
 }

--- a/packages/zql/src/ivm/memory-source.ts
+++ b/packages/zql/src/ivm/memory-source.ts
@@ -1,7 +1,6 @@
 import {assert, unreachable} from '../../../shared/src/asserts.ts';
 import {BTreeSet, type ValueIterator} from '../../../shared/src/btree-set.ts';
 import {hasOwn} from '../../../shared/src/has-own.ts';
-import {toSorted} from '../../../shared/src/iterables.ts';
 import {must} from '../../../shared/src/must.ts';
 import type {
   Condition,
@@ -266,7 +265,7 @@ export class MemorySource implements Source {
     // a different library.)
     // 3. We could even theoretically do (2) on multiple threads and then merge the
     // results!
-    const rows = toSorted(this.#getPrimaryIndex().data, comparator);
+    const rows = this.#getPrimaryIndex().data.toArray().sort(comparator);
     const data = BTreeSet.fromSorted(comparator, rows);
 
     const newIndex = {comparator, data};

--- a/packages/zql/src/ivm/memory-source.ts
+++ b/packages/zql/src/ivm/memory-source.ts
@@ -639,10 +639,7 @@ class RowScan implements PullStream<Row> {
   }
 
   close(): void {
-    if (!this.#done) {
-      this.#done = true;
-      this.#rows.return?.();
-    }
+    this.#done = true;
   }
 }
 

--- a/packages/zql/src/ivm/memory-storage.test.ts
+++ b/packages/zql/src/ivm/memory-storage.test.ts
@@ -45,31 +45,3 @@ test('other types', () => {
   expect(ms.get('qux')).toStrictEqual({a: 1});
   expect(ms.get('quux')).toStrictEqual([1, 2, 3]);
 });
-
-test('scan', () => {
-  const ms = new MemoryStorage();
-  ms.set('foo', 1);
-  ms.set('bar', true);
-  ms.set('baz', null);
-  ms.set('qux', {a: 1});
-  ms.set('quux', [1, 2, 3]);
-
-  expect([...ms.scan()]).toEqual([
-    ['bar', true],
-    ['baz', null],
-    ['foo', 1],
-    ['quux', [1, 2, 3]],
-    ['qux', {a: 1}],
-  ]);
-  expect([...ms.scan({prefix: 'ba'})]).toEqual([
-    ['bar', true],
-    ['baz', null],
-  ]);
-
-  expect([...ms.scan({prefix: 'qu'})]).toEqual([
-    ['quux', [1, 2, 3]],
-    ['qux', {a: 1}],
-  ]);
-
-  expect([...ms.scan({prefix: 'quu'})]).toEqual([['quux', [1, 2, 3]]]);
-});

--- a/packages/zql/src/ivm/memory-storage.ts
+++ b/packages/zql/src/ivm/memory-storage.ts
@@ -2,7 +2,6 @@ import {compareUTF8} from 'compare-utf8';
 import {BTreeSet} from '../../../shared/src/btree-set.ts';
 import type {JSONValue} from '../../../shared/src/json.ts';
 import type {Storage} from './operator.ts';
-import type {Stream} from './stream.ts';
 
 type Entry = [key: string, value: JSONValue];
 
@@ -31,17 +30,6 @@ export class MemoryStorage implements Storage {
 
   del(key: string) {
     this.#data.delete([key, null]);
-  }
-
-  *scan(options?: {prefix: string}): Stream<[string, JSONValue]> {
-    for (const entry of this.#data.valuesFrom(
-      options && [options.prefix, null],
-    )) {
-      if (options && !entry[0].startsWith(options.prefix)) {
-        return;
-      }
-      yield entry;
-    }
   }
 
   cloneData(): Record<string, JSONValue> {

--- a/packages/zql/src/ivm/memory-storage.ts
+++ b/packages/zql/src/ivm/memory-storage.ts
@@ -45,6 +45,6 @@ export class MemoryStorage implements Storage {
   }
 
   cloneData(): Record<string, JSONValue> {
-    return structuredClone(Object.fromEntries(this.#data.values()));
+    return structuredClone(Object.fromEntries(this.#data.toArray()));
   }
 }

--- a/packages/zql/src/ivm/operator.ts
+++ b/packages/zql/src/ivm/operator.ts
@@ -173,9 +173,5 @@ export interface Operator extends Input, Output {}
 export interface Storage {
   set(key: string, value: JSONValue): void;
   get(key: string, def?: JSONValue): JSONValue | undefined;
-  /**
-   * If options is not specified, defaults to scanning all entries.
-   */
-  scan(options?: {prefix: string}): Stream<[string, JSONValue]>;
   del(key: string): void;
 }

--- a/packages/zql/src/ivm/skip-yields.ts
+++ b/packages/zql/src/ivm/skip-yields.ts
@@ -23,7 +23,7 @@ export function skipYields(
  */
 export function forEachSkippingYields(
   stream: PullStream<Node | 'yield'>,
-  fn: (node: Node) => void | 'break',
+  fn: (node: Node) => unknown,
 ): void {
   forEachPull(skipYields(stream), fn);
 }

--- a/packages/zql/src/ivm/skip-yields.ts
+++ b/packages/zql/src/ivm/skip-yields.ts
@@ -1,5 +1,5 @@
 import type {Node} from './data.ts';
-import {filterPull, type PullStream} from './stream.ts';
+import {filterPull, forEachPull, type PullStream} from './stream.ts';
 
 /**
  * Drops the 'yield' markers from a stream.
@@ -11,4 +11,19 @@ export function skipYields(
   stream: PullStream<Node | 'yield'>,
 ): PullStream<Node> {
   return filterPull(stream, v => v !== 'yield') as PullStream<Node>;
+}
+
+/**
+ * `forEachPull` over the nodes of a stream, dropping the 'yield' markers and
+ * closing the stream when the scan ends, breaks or throws.
+ *
+ * Named for what it discards. A consumer that can suspend must propagate the
+ * markers rather than drop them, so reaching for this in a suspendable context
+ * is a bug -- it should be obvious at the call site which one you picked.
+ */
+export function forEachSkippingYields(
+  stream: PullStream<Node | 'yield'>,
+  fn: (node: Node) => void | 'break',
+): void {
+  forEachPull(skipYields(stream), fn);
 }

--- a/packages/zql/src/ivm/stream-close.test.ts
+++ b/packages/zql/src/ivm/stream-close.test.ts
@@ -62,9 +62,7 @@ describe('forEachPull', () => {
   test('visits every value then closes', () => {
     const {stream, state} = tracked([1, 2, 3]);
     const seen: number[] = [];
-    forEachPull(stream, v => {
-      seen.push(v);
-    });
+    forEachPull(stream, v => seen.push(v));
     expect(seen).toEqual([1, 2, 3]);
     expect(state.closes).toBe(1);
   });
@@ -145,12 +143,20 @@ describe('forEachPull early exit', () => {
     expect(state.closes).toBe(1);
   });
 
-  test('a falsy return is not a break', () => {
+  test('a shorthand arrow returning a value is not a break', () => {
+    const {stream} = tracked([1, 2, 3]);
+    const seen: number[] = [];
+    // `push` returns a number; only the exact string 'break' stops the scan.
+    forEachPull(stream, v => seen.push(v));
+    expect(seen).toEqual([1, 2, 3]);
+  });
+
+  test('a return that is not exactly “break” does not stop the scan', () => {
     const {stream} = tracked([1, 2, 3]);
     const seen: number[] = [];
     forEachPull(stream, v => {
       seen.push(v);
-      return undefined;
+      return 'brake';
     });
     expect(seen).toEqual([1, 2, 3]);
   });

--- a/packages/zql/src/ivm/stream-close.test.ts
+++ b/packages/zql/src/ivm/stream-close.test.ts
@@ -1,0 +1,157 @@
+import {expect, test, describe} from 'vitest';
+import {
+  drainPull,
+  drainPullMap,
+  filterPull,
+  forEachPull,
+  limitedScan,
+  mapPull,
+  takeWhilePull,
+  withPull,
+  type PullStream,
+} from './stream.ts';
+
+/** A stream that records whether it was closed, and how often. */
+function tracked<T>(values: readonly T[]) {
+  let i = 0;
+  const state = {
+    closes: 0,
+    get closed() {
+      return state.closes > 0;
+    },
+  };
+  const stream: PullStream<T> = {
+    next: () => (i < values.length ? values[i++] : undefined),
+    close: () => {
+      state.closes++;
+    },
+  };
+  return {stream, state};
+}
+
+const boom = new Error('boom');
+const throwing = () => {
+  throw boom;
+};
+
+describe('withPull', () => {
+  test('closes on the normal path and returns the value', () => {
+    const {stream, state} = tracked([1, 2]);
+    expect(withPull(stream, s => s.next())).toBe(1);
+    expect(state.closes).toBe(1);
+  });
+
+  test('closes when fn throws, and raises fn’s error', () => {
+    const {stream, state} = tracked([1]);
+    expect(() => withPull(stream, throwing)).toThrow(boom);
+    expect(state.closes).toBe(1);
+  });
+
+  test('a failing close does not mask the original error', () => {
+    const stream: PullStream<number> = {
+      next: () => undefined,
+      close: () => {
+        throw new Error('close failed');
+      },
+    };
+    expect(() => withPull(stream, throwing)).toThrow(boom);
+  });
+});
+
+describe('forEachPull', () => {
+  test('visits every value then closes', () => {
+    const {stream, state} = tracked([1, 2, 3]);
+    const seen: number[] = [];
+    forEachPull(stream, v => {
+      seen.push(v);
+    });
+    expect(seen).toEqual([1, 2, 3]);
+    expect(state.closes).toBe(1);
+  });
+
+  test('closes when the body throws', () => {
+    const {stream, state} = tracked([1, 2, 3]);
+    expect(() => forEachPull(stream, throwing)).toThrow(boom);
+    expect(state.closes).toBe(1);
+  });
+});
+
+describe('drains own their stream', () => {
+  test('drainPull closes after a full read', () => {
+    const {stream, state} = tracked([1, 2]);
+    expect(drainPull(stream)).toEqual([1, 2]);
+    expect(state.closes).toBe(1);
+  });
+
+  test('drainPullMap closes when map throws', () => {
+    const {stream, state} = tracked([1, 2]);
+    expect(() => drainPullMap(stream, throwing)).toThrow(boom);
+    expect(state.closes).toBe(1);
+  });
+});
+
+describe('combinators release the source when a callback throws', () => {
+  test('filterPull', () => {
+    const {stream, state} = tracked([1, 2]);
+    expect(() => filterPull(stream, throwing).next()).toThrow(boom);
+    expect(state.closed).toBe(true);
+  });
+
+  test('takeWhilePull', () => {
+    const {stream, state} = tracked([1, 2]);
+    expect(() => takeWhilePull(stream, throwing).next()).toThrow(boom);
+    expect(state.closed).toBe(true);
+  });
+
+  test('mapPull', () => {
+    const {stream, state} = tracked([1, 2]);
+    expect(() => mapPull(stream, throwing).next()).toThrow(boom);
+    expect(state.closed).toBe(true);
+  });
+});
+
+test('limitedScan releases the source when the scan throws', () => {
+  let closed = false;
+  const stream: PullStream<number> = {
+    next: throwing,
+    close: () => {
+      closed = true;
+    },
+  };
+  const scan = limitedScan(
+    stream,
+    10,
+    () => true,
+    () => {},
+    () => {},
+    () => {},
+  );
+  expect(() => scan.next()).toThrow(boom);
+  // The caller's close() sees `done` and skips the source, so the scan itself
+  // must have released it -- this is the shape of the FilterStartPull bug.
+  scan.close();
+  expect(closed).toBe(true);
+});
+
+describe('forEachPull early exit', () => {
+  test("'break' stops the scan and still closes", () => {
+    const {stream, state} = tracked([1, 2, 3]);
+    const seen: number[] = [];
+    forEachPull(stream, v => {
+      seen.push(v);
+      return v === 2 ? 'break' : undefined;
+    });
+    expect(seen).toEqual([1, 2]);
+    expect(state.closes).toBe(1);
+  });
+
+  test('a falsy return is not a break', () => {
+    const {stream} = tracked([1, 2, 3]);
+    const seen: number[] = [];
+    forEachPull(stream, v => {
+      seen.push(v);
+      return undefined;
+    });
+    expect(seen).toEqual([1, 2, 3]);
+  });
+});

--- a/packages/zql/src/ivm/stream.ts
+++ b/packages/zql/src/ivm/stream.ts
@@ -275,6 +275,13 @@ export function pullOf<T>(items: readonly T[]): PullStream<T> {
   return items.length === 0 ? emptyPullStream<T>() : new ArrayPull(items);
 }
 
+/**
+ * The empty push stream. `push` returns `Stream<'yield'>` purely so a slow push
+ * can suspend; the operators that never suspend on their own share this one
+ * frozen array rather than each allocating a generator.
+ */
+export const EMPTY_YIELDS: Stream<'yield'> = Object.freeze([]);
+
 export function emptyPullStream<T>(): PullStream<T> {
   return EMPTY;
 }

--- a/packages/zql/src/ivm/stream.ts
+++ b/packages/zql/src/ivm/stream.ts
@@ -76,6 +76,55 @@ const EMPTY: PullStream<never> = {
  * stream carrying 'yield' markers passes them through by accepting them in
  * the predicate.
  */
+/**
+ * Runs `fn` with `stream` and closes it afterwards, on the normal path and on
+ * a throw.
+ *
+ * `close()` is what `for...of` used to do implicitly on abrupt completion, so
+ * anything that takes ownership of a stream for the length of a scope should
+ * go through here rather than hand-writing try/finally. If `fn` throws, that
+ * error is the one raised: a failure to close is a symptom, not the cause.
+ */
+export function withPull<T, R>(
+  stream: PullStream<T>,
+  fn: (stream: PullStream<T>) => R,
+): R {
+  let result: R;
+  try {
+    result = fn(stream);
+  } catch (e) {
+    try {
+      stream.close();
+    } catch {
+      // Preserve the original failure.
+    }
+    throw e;
+  }
+  stream.close();
+  return result;
+}
+
+/**
+ * Calls `fn` for each value, closing the stream when the scan ends, when `fn`
+ * returns `'break'`, or when `fn` throws.
+ *
+ * The `'break'` sentinel is the point: a `break` out of a hand-written loop is
+ * exactly the abrupt completion that `for...of` used to close for, and the
+ * case most likely to be written without a `finally`.
+ */
+export function forEachPull<T>(
+  stream: PullStream<T>,
+  fn: (value: T) => void | 'break',
+): void {
+  withPull(stream, s => {
+    for (let v = s.next(); v !== undefined; v = s.next()) {
+      if (fn(v) === 'break') {
+        return;
+      }
+    }
+  });
+}
+
 export function filterPull<T>(
   stream: PullStream<T>,
   keep: (value: T) => boolean,
@@ -84,13 +133,34 @@ export function filterPull<T>(
     next() {
       for (;;) {
         const v = stream.next();
-        if (v === undefined || keep(v)) {
+        if (v === undefined) {
+          return v;
+        }
+        if (callOrClose(stream, keep, v)) {
           return v;
         }
       }
     },
     close: () => stream.close(),
   };
+}
+
+/**
+ * Applies a caller-supplied callback, closing `stream` if it throws. A
+ * combinator has no scope to close in, and the exception propagates past the
+ * caller's own `close()`, so the release has to happen here.
+ */
+function callOrClose<T, R>(
+  stream: PullStream<unknown>,
+  fn: (value: T) => R,
+  value: T,
+): R {
+  try {
+    return fn(value);
+  } catch (e) {
+    stream.close();
+    throw e;
+  }
 }
 
 /** Ends the stream at the first value `keep` rejects, closing the source. */
@@ -109,7 +179,7 @@ export function takeWhilePull<T>(
         done = true;
         return undefined;
       }
-      if (!keep(v)) {
+      if (!callOrClose(stream, keep, v)) {
         done = true;
         stream.close();
         return undefined;
@@ -133,7 +203,7 @@ export function mapPull<T, U>(
   return {
     next() {
       const v = stream.next();
-      return v === undefined ? undefined : map(v);
+      return v === undefined ? undefined : callOrClose(stream, map, v);
     },
     close: () => stream.close(),
   };
@@ -176,8 +246,11 @@ export function limitedScan<T>(
       try {
         v = stream.next();
       } catch (e) {
-        // As the generators did: an exception records no state.
+        // As the generators did: an exception records no state. The source
+        // still has to be released -- setting `done` makes the caller's
+        // close() skip it, which is the bug FilterStartPull had.
         done = true;
+        stream.close();
         throw e;
       }
       if (v === undefined) {
@@ -256,18 +329,18 @@ export function drainPullMap<T, U>(
   map: (value: T) => U,
 ): U[] {
   const out: U[] = [];
-  for (let v = stream.next(); v !== undefined; v = stream.next()) {
+  forEachPull(stream, v => {
     out.push(map(v));
-  }
+  });
   return out;
 }
 
 /** Reads a pull stream to completion. For tests and for `Catch`. */
 export function drainPull<T>(stream: PullStream<T>): T[] {
   const out: T[] = [];
-  for (let v = stream.next(); v !== undefined; v = stream.next()) {
+  forEachPull(stream, v => {
     out.push(v);
-  }
+  });
   return out;
 }
 

--- a/packages/zql/src/ivm/stream.ts
+++ b/packages/zql/src/ivm/stream.ts
@@ -111,10 +111,15 @@ export function withPull<T, R>(
  * The `'break'` sentinel is the point: a `break` out of a hand-written loop is
  * exactly the abrupt completion that `for...of` used to close for, and the
  * case most likely to be written without a `finally`.
+ *
+ * `fn` returns `unknown` rather than `void | 'break'` so that a shorthand
+ * arrow whose body happens to produce a value -- `v => rows.push(v)` -- is
+ * still accepted. The cost is that only the exact string `'break'` stops the
+ * scan: any other return, including a misspelling, is ignored.
  */
 export function forEachPull<T>(
   stream: PullStream<T>,
-  fn: (value: T) => void | 'break',
+  fn: (value: T) => unknown,
 ): void {
   withPull(stream, s => {
     for (let v = s.next(); v !== undefined; v = s.next()) {

--- a/packages/zql/src/ivm/view-apply-change.ts
+++ b/packages/zql/src/ivm/view-apply-change.ts
@@ -9,7 +9,7 @@ import type {Writable} from '../../../shared/src/writable.ts';
 import type {Row} from '../../../zero-protocol/src/data.ts';
 import {type Comparator, type Node} from './data.ts';
 import {skipYields} from './operator.ts';
-import {pullOf, type PullStream} from './stream.ts';
+import {forEachPull, pullOf, type PullStream} from './stream.ts';
 
 import type {SourceSchema} from './schema.ts';
 import type {Entry, Format} from './view.ts';
@@ -231,25 +231,17 @@ export function applyChangeInternal<M extends Mutate>(
         for (const relationship of Object.keys(change.node.relationships)) {
           const childSchema = must(schema.relationships[relationship]);
           const children = childNodes(change.node, relationship);
-          try {
-            for (
-              let node = children.next();
-              node !== undefined;
-              node = children.next()
-            ) {
-              currentParent = applyChangeInternal(
-                currentParent,
-                {type: change.type, node},
-                childSchema,
-                relationship,
-                format,
-                withIDs,
-                mutate,
-              );
-            }
-          } finally {
-            children.close();
-          }
+          forEachPull(children, node => {
+            currentParent = applyChangeInternal(
+              currentParent,
+              {type: change.type, node},
+              childSchema,
+              relationship,
+              format,
+              withIDs,
+              mutate,
+            );
+          });
         }
         return currentParent;
       }
@@ -658,64 +650,48 @@ function initializeRelationshipsForNewEntryIfAny(
       result[relationship] = newView;
 
       const children = childNodes(node, relationship);
-      try {
-        for (
-          let childNode = children.next();
-          childNode !== undefined;
-          childNode = children.next()
-        ) {
-          applyChangeInternal(
-            result,
-            {type: 'add', node: childNode},
-            childSchema,
-            relationship,
-            childFormat,
-            withIDs,
-            true, // this is a new entry, so we can mutate
-          );
-        }
-      } finally {
-        children.close();
-      }
+      forEachPull(children, childNode => {
+        applyChangeInternal(
+          result,
+          {type: 'add', node: childNode},
+          childSchema,
+          relationship,
+          childFormat,
+          withIDs,
+          true, // this is a new entry, so we can mutate
+        );
+      });
     } else {
       // Plural non-hidden: build array in-place for efficiency
       const childArray: MutableMetaEntryList = track([]);
 
       const children = childNodes(node, relationship);
-      try {
-        for (
-          let childNode = children.next();
-          childNode !== undefined;
-          childNode = children.next()
-        ) {
-          const newEntry = makeNewMetaEntry(
-            childNode.row,
-            childSchema,
-            withIDs,
-            1,
-          );
-          const rawPos = binarySearch(
-            childArray,
-            childNode.row,
-            childSchema.compareRows,
-          );
+      forEachPull(children, childNode => {
+        const newEntry = makeNewMetaEntry(
+          childNode.row,
+          childSchema,
+          withIDs,
+          1,
+        );
+        const rawPos = binarySearch(
+          childArray,
+          childNode.row,
+          childSchema.compareRows,
+        );
 
-          if (rawPos >= 0) {
-            childArray[rawPos][refCountSymbol]++;
-          } else {
-            childArray.splice(~rawPos, 0, newEntry);
-            initializeRelationshipsForNewEntryIfAny(
-              newEntry,
-              childNode,
-              childSchema,
-              childFormat.relationships,
-              withIDs,
-            );
-          }
+        if (rawPos >= 0) {
+          childArray[rawPos][refCountSymbol]++;
+        } else {
+          childArray.splice(~rawPos, 0, newEntry);
+          initializeRelationshipsForNewEntryIfAny(
+            newEntry,
+            childNode,
+            childSchema,
+            childFormat.relationships,
+            withIDs,
+          );
         }
-      } finally {
-        children.close();
-      }
+      });
 
       result[relationship] = childArray;
     }

--- a/packages/zqlite/src/database-storage.test.ts
+++ b/packages/zqlite/src/database-storage.test.ts
@@ -96,31 +96,9 @@ describe('view-syncer/database-storage', () => {
 
     store.del('bar');
     store.del('bo'); // non-existent
-    expect([...store.scan()]).toEqual([
-      ['boo', 'doo'],
-      ['foo', 'bar'],
-    ]);
-  });
-
-  test('scan prefix', () => {
-    const store = storage.createClientGroupStorage('foo-bar').createStorage();
-    store.set('c/', 1);
-    store.set('ba/7', 2);
-    store.set('b/7', 3);
-    store.set('b/5/6', 4);
-    store.set('b/4', 5);
-    store.set('b/', 6);
-    store.set('b', 7);
-    store.set('a/2/3', 8);
-    store.set('a/1', 9);
-    store.set('a/', 10);
-
-    expect([...store.scan({prefix: 'b/'})]).toEqual([
-      ['b/', 6],
-      ['b/4', 5],
-      ['b/5/6', 4],
-      ['b/7', 3],
-    ]);
+    expect(store.get('bar')).toBeUndefined();
+    expect(store.get('boo')).toBe('doo');
+    expect(store.get('foo')).toBe('bar');
   });
 
   test('client group / operator isolation and destroy', () => {

--- a/packages/zqlite/src/database-storage.ts
+++ b/packages/zqlite/src/database-storage.ts
@@ -1,7 +1,6 @@
 import type {LogContext} from '@rocicorp/logger';
 import type {JSONValue} from '../../shared/src/json.ts';
 import type {Storage} from '../../zql/src/ivm/operator.ts';
-import type {Stream} from '../../zql/src/ivm/stream.ts';
 import type {Statement} from './db.ts';
 import {Database} from './db.ts';
 
@@ -144,23 +143,6 @@ export class DatabaseStorage {
     this.#numWrites = 0;
   }
 
-  *#scan(
-    cgID: string,
-    opID: number,
-    opts: {prefix: string} = {prefix: ''},
-  ): Stream<[string, JSONValue]> {
-    const {prefix} = opts;
-    for (const {key, val} of this.#stmts.scan.iterate<{
-      key: string;
-      val: string;
-    }>(cgID, opID, prefix)) {
-      if (!key.startsWith(prefix)) {
-        return;
-      }
-      yield [key, JSON.parse(val)];
-    }
-  }
-
   createClientGroupStorage(cgID: string): ClientGroupStorage {
     const destroy = () => {
       this.#stmts.clear.run(cgID);
@@ -177,7 +159,6 @@ export class DatabaseStorage {
           get: (key, def?) => this.#get(cgID, opID, key, def),
           set: (key, val) => this.#set(cgID, opID, key, val),
           del: key => this.#del(cgID, opID, key),
-          scan: opts => this.#scan(cgID, opID, opts),
         };
       },
 


### PR DESCRIPTION
Stacked on `mlaw/ivm-pull-fns` (was #6523 / `arv/ivm-pull-fns`).

> **Rebased onto the cleanup fixes.** `mlaw/ivm-pull-fns` carries a475ecc34
> (14 reproductions of pull-protocol cleanup regressions) and d3fbd4c2f (their
> fixes) on top of the fetch-path conversion. These three commits rebase onto
> it cleanly and the whole suite passes, including the 14 new tests.
>
> **The results below predate that base and need re-taking.** d3fbd4c2f
> restores the single-row cap on primary-key scans in `MemorySource#fetch`,
> which the conversion had dropped -- a PK lookup was walking to the end of the
> index and rejecting every remaining row through the filter predicate. The
> push benchmarks materialize a view before pushing, so they ran that path.

Two changes to what is left of the iterator protocol after the fetch path moved
to pull functions.

### 1. The filter chain's push path was pure `yield*`

`Output.push` returns `Stream<'yield'>` so that a slow push can *suspend*. But
`Filter`, `FilterStart`, `FilterEnd`, `filterPush` and
`maybeSplitAndPushEditChange` never yield on their own — every branch of all
five is a plain delegation. Each was a generator layer costing a resume per
yield and buying nothing, the same shape as the old `generateRows`.

They are now ordinary functions that return the downstream stream:

```ts
push(change: Change): Stream<'yield'> {
  return filterPush(change, this.#output, this, this.#predicate);
}
```

Downstream stays lazy — calling a generator function does not run its body —
and the empty cases share one frozen `EMPTY_YIELDS` instead of each allocating
a generator. `buildFilterPipeline` inserts a FilterStart/FilterEnd pair into
*every* pipeline, so this removes at least two generator layers from every
push, filtered or not.

The operators that genuinely suspend (`take`, `exists`, `cap`, `skip`,
`union-fan-in`, the sources) are untouched. Replacing `Stream<'yield'>` itself
wants a resumable-continuation type rather than `PullStream<T>` — push carries
no values — and is a separate design.

**One semantic change:** the predicate now runs at `push()` call time rather
than at first `next()`. No call site anywhere stores a push stream without
consuming it at the same site — all 67 consumers are inline `yield*`/`for...of`/
`consume` — and the predicate is required pure, so it is not observable.

### 2. BTreeSet is no longer iterable

The iterator protocol allocates a result object per value, which is the cost
the fetch path exists to avoid, and an iterable API is an easy way to
reintroduce it by accident.

Finding the real callers by making `next()` throw turned up one on a hot path:

```
BTreeForwardIterator.next → toSorted (iterables.ts) → MemorySource#getOrCreateIndex → fetch
```

`toSorted(tree, cmp)` is `[...tree].sort()`, so **every secondary-index build
allocated one `IteratorResult` per row**. That is now `BTreeSet#toArray()`,
which drains via `nextValue()`.

With that gone, `next()` had no production callers left, so `ValueIterator` is
pull-only, `[Symbol.iterator]` is gone from the iterators and from `BTreeSet`,
and `drainValues()` collects a scan where a test needs an array.

Two things fell out:

- **`Storage#scan` is deleted.** It had no production callers — only its own
  tests — and was the last thing in zql iterating a BTreeSet. zqlite's `del`
  test used it only to verify deletion and now asserts with `get`.
- **`RowScan#close()` was calling `this.#rows.return?.()`, which was always a
  no-op** — the BTree iterators never defined `return`. Removing iterability
  made that visible. An index scan holds no external resource, so `close()`
  now just sets `#done`. Worth noting given how load-bearing `close()` is for
  the *SQLite* cursors; this particular call never did anything.

### Results

Android emulator (Hermes), `--run push`, 4 paired interleaved rounds, medians.
ops/sec, so **higher is better**:

| benchmark | base | this | | in-run noise |
|---|---|---|---|---|
| Filter / push add open issue (passes filter) | 391.2 | 423.9 | **+8.7%** | ±0.4% |
| Filter / push add closed issue (filtered out) | 417.9 | 441.0 | **+5.7%** | ±0.3% |
| MemorySource push: add/remove 1000 rows, sort 4 keys | 416.8 | 438.8 | +5.2% | ±0.4% |
| MemorySource push: add/remove 1000 rows, sort 2 keys | 424.9 | 440.9 | +4.1% | ±1.2% |
| MemorySource push: add/remove 1000 rows, sort 1 key | 426.6 | 441.4 | +3.9% | ±0.3% |

The two `Filter / push` benchmarks are the direct target and every round was
positive. The `MemorySource push` gains follow from the same cause: even a
filterless push crosses the FilterStart/FilterEnd pair.

Everything dominated by join or relationship work is flat — `Join / push edit
issue title` −0.3%, `push: add issue (with creator join)` −0.2%, the
relationship-heavy view 2.2–2.5% against ±3% noise. Those layers still suspend
for real and were untouched.

**This does not fix #6523's push regression.** `push: add comment (child
relation)` is +0.6% against ±2.4% noise — flat, not recovered.

### On the measurement

V8 could not resolve this at all. Five paired rounds on the host produced
nothing usable: `push: add issue (no join)` read −12.4% with all four of the
first rounds negative, then round five came back **+13.0%**. One
`hydrate: issues with creator` round swung +40.4%. Had I stopped at four rounds
I would have reported a win that is not there. The emulator's in-run spreads
are ±0.3–0.4% on the benchmarks that matter here, so the Android numbers are
the ones to trust.

Caveat: one `add open issue` round came in at +16.3% against +6.7/+8.4/+9.0.
The median ignores it, but treat 8.7% as approximate.

### Verification

shared 772 · zql 1447 · zqlite 198 — each down by exactly the tests removed
(two iterator-protocol tests, the `MemoryStorage.scan` test, the `scan prefix`
test). Types and lint clean.

The hydration A/B did not produce a usable result: the Android emulator was
too degraded after hours of benchmarking, with in-run noise at a median of
±23.9% and a uniform -76% swing across all ten benchmarks in one round. It
needs a cold emulator and a `pm clear` between arms, and should be re-run
together with the push suite against the new base.

