### PR TITLE
fix(zero-cache): close the mutagen's replica handle when the service stops

### DIFF
--- a/packages/zero-cache/src/services/mutagen/mutagen.test.ts
+++ b/packages/zero-cache/src/services/mutagen/mutagen.test.ts
@@ -81,6 +81,9 @@ describe('mutagen/MutagenService', () => {
     await service.run();
 
     expect(closeSpy).toHaveBeenCalledTimes(1);
+    // The replicator maintains the replica's statistics, so the per-client-group
+    // handle must not run PRAGMA optimize on close.
+    expect(closeSpy).toHaveBeenCalledWith({optimize: false});
   });
 
   test('replica stays open while a push holds a ref', async () => {

--- a/packages/zero-cache/src/services/mutagen/mutagen.test.ts
+++ b/packages/zero-cache/src/services/mutagen/mutagen.test.ts
@@ -11,6 +11,7 @@ import {
   DatabaseStorage,
 } from '../../../../zqlite/src/database-storage.ts';
 import {Database} from '../../../../zqlite/src/db.ts';
+import {WriteAuthorizerImpl} from '../../auth/write-authorizer.ts';
 import type {ZeroConfig} from '../../config/zero-config.ts';
 import type {PostgresDB} from '../../types/pg.ts';
 import {CREATE_TABLE_METADATA_TABLE} from '../replicator/schema/table-metadata.ts';
@@ -20,6 +21,7 @@ describe('mutagen/MutagenService', () => {
   const lc = createSilentLogContext();
   let tempDir: string;
   let replicaFile: string;
+  let storageDb: Database;
   let writeAuthzStorage: DatabaseStorage;
   let closeSpy: ReturnType<typeof vi.spyOn>;
 
@@ -34,7 +36,7 @@ describe('mutagen/MutagenService', () => {
     replica.exec(CREATE_TABLE_METADATA_TABLE);
     replica.close();
 
-    const storageDb = new Database(lc, ':memory:');
+    storageDb = new Database(lc, ':memory:');
     storageDb.prepare(CREATE_STORAGE_TABLE).run();
     writeAuthzStorage = new DatabaseStorage(storageDb);
 
@@ -43,6 +45,7 @@ describe('mutagen/MutagenService', () => {
 
   afterEach(async () => {
     closeSpy.mockRestore();
+    storageDb.close();
     await fs.rm(tempDir, {recursive: true, force: true});
   });
 
@@ -80,7 +83,7 @@ describe('mutagen/MutagenService', () => {
     expect(closeSpy).toHaveBeenCalledTimes(1);
   });
 
-  test('replica is closed after an in-flight mutation completes', async () => {
+  test('replica stays open while a push holds a ref', async () => {
     // A fake upstream whose transaction hangs until released, modeling a
     // mutation that is being processed when its connection closes.
     const tx = resolver<void>();
@@ -89,16 +92,37 @@ describe('mutagen/MutagenService', () => {
     } as unknown as PostgresDB;
 
     const service = createService(upstream);
-    service.ref();
+    service.ref(); // the connection
+    service.ref(); // the push (see SyncerWsMessageHandler)
     const result = service.processMutation(mutation, undefined);
 
-    // The last connection goes away while the mutation is in flight.
+    // The connection goes away while the push is in flight.
     service.unref();
-    await service.run();
+    expect(service.hasRefs()).toBe(true);
     expect(closeSpy).not.toHaveBeenCalled();
 
     tx.resolve();
     expect(await result).toBeUndefined();
+    service.unref(); // the push completes
+    await service.run();
     expect(closeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test('replica is closed even if destroying the authorizer storage fails', async () => {
+    const service = createService({} as PostgresDB);
+    const destroySpy = vi
+      .spyOn(WriteAuthorizerImpl.prototype, 'destroy')
+      .mockImplementation(() => {
+        throw new Error('boom');
+      });
+    try {
+      service.ref();
+      service.unref();
+      await service.run();
+      expect(destroySpy).toHaveBeenCalledTimes(1);
+      expect(closeSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      destroySpy.mockRestore();
+    }
   });
 });

--- a/packages/zero-cache/src/services/mutagen/mutagen.test.ts
+++ b/packages/zero-cache/src/services/mutagen/mutagen.test.ts
@@ -1,0 +1,104 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {resolver} from '@rocicorp/resolver';
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
+import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
+import * as MutationType from '../../../../zero-protocol/src/mutation-type-enum.ts';
+import type {Mutation} from '../../../../zero-protocol/src/mutation.ts';
+import {
+  CREATE_STORAGE_TABLE,
+  DatabaseStorage,
+} from '../../../../zqlite/src/database-storage.ts';
+import {Database} from '../../../../zqlite/src/db.ts';
+import type {ZeroConfig} from '../../config/zero-config.ts';
+import type {PostgresDB} from '../../types/pg.ts';
+import {CREATE_TABLE_METADATA_TABLE} from '../replicator/schema/table-metadata.ts';
+import {MutagenService} from './mutagen.ts';
+
+describe('mutagen/MutagenService', () => {
+  const lc = createSilentLogContext();
+  let tempDir: string;
+  let replicaFile: string;
+  let writeAuthzStorage: DatabaseStorage;
+  let closeSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'zero-cache-mutagen'));
+    replicaFile = path.join(tempDir, 'replica.db');
+    const replica = new Database(lc, replicaFile);
+    replica.exec(/*sql*/ `
+      CREATE TABLE "test-app.permissions" (permissions, hash);
+      INSERT INTO "test-app.permissions" (permissions, hash) VALUES (null, 'h');
+    `);
+    replica.exec(CREATE_TABLE_METADATA_TABLE);
+    replica.close();
+
+    const storageDb = new Database(lc, ':memory:');
+    storageDb.prepare(CREATE_STORAGE_TABLE).run();
+    writeAuthzStorage = new DatabaseStorage(storageDb);
+
+    closeSpy = vi.spyOn(Database.prototype, 'close');
+  });
+
+  afterEach(async () => {
+    closeSpy.mockRestore();
+    await fs.rm(tempDir, {recursive: true, force: true});
+  });
+
+  function createService(upstream: PostgresDB) {
+    return new MutagenService(
+      lc,
+      {appID: 'test-app', shardNum: 0},
+      'cg-1',
+      upstream,
+      {
+        replica: {file: replicaFile},
+        perUserMutationLimit: {},
+      } as ZeroConfig,
+      writeAuthzStorage,
+    );
+  }
+
+  const mutation: Mutation = {
+    type: MutationType.CRUD,
+    id: 1,
+    clientID: 'c1',
+    name: '_zero_crud',
+    args: [{ops: []}],
+    timestamp: 0,
+  };
+
+  test('stop() closes the replica handle', async () => {
+    const service = createService({} as PostgresDB);
+    service.ref();
+    expect(closeSpy).not.toHaveBeenCalled();
+
+    service.unref();
+    await service.run();
+
+    expect(closeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test('replica is closed after an in-flight mutation completes', async () => {
+    // A fake upstream whose transaction hangs until released, modeling a
+    // mutation that is being processed when its connection closes.
+    const tx = resolver<void>();
+    const upstream = {
+      begin: () => tx.promise,
+    } as unknown as PostgresDB;
+
+    const service = createService(upstream);
+    service.ref();
+    const result = service.processMutation(mutation, undefined);
+
+    // The last connection goes away while the mutation is in flight.
+    service.unref();
+    await service.run();
+    expect(closeSpy).not.toHaveBeenCalled();
+
+    tx.resolve();
+    expect(await result).toBeUndefined();
+    expect(closeSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/zero-cache/src/services/mutagen/mutagen.ts
+++ b/packages/zero-cache/src/services/mutagen/mutagen.ts
@@ -49,6 +49,11 @@ export type MutationError = [
 ];
 
 export interface Mutagen extends RefCountedService {
+  /**
+   * Callers must hold a {@link ref} for the duration of a push (i.e. across
+   * all of its mutations). The service stops, closing its replica handle,
+   * when its ref count drops to zero.
+   */
   processMutation(
     mutation: Mutation,
     authData: JWTPayload | undefined,
@@ -67,8 +72,6 @@ export class MutagenService implements Mutagen, Service {
   readonly #limiter: SlidingWindowLimiter | undefined;
   #refCount = 0;
   #isStopped = false;
-  #inFlightMutations = 0;
-  #released = false;
 
   readonly #crudMutations = getOrCreateCounter(
     'mutation',
@@ -139,7 +142,6 @@ export class MutagenService implements Mutagen, Service {
     this.#crudMutations.add(1, {
       clientGroupID: this.id,
     });
-    this.#inFlightMutations++;
     return processMutation(
       this.#lc,
       authData,
@@ -150,10 +152,7 @@ export class MutagenService implements Mutagen, Service {
       this.#writeAuthorizer,
       undefined,
       customMutatorsEnabled,
-    ).finally(() => {
-      this.#inFlightMutations--;
-      this.#maybeRelease();
-    });
+    );
   }
 
   run(): Promise<void> {
@@ -165,24 +164,18 @@ export class MutagenService implements Mutagen, Service {
       return this.#stopped.promise;
     }
     this.#isStopped = true;
-    this.#maybeRelease();
+    try {
+      this.#writeAuthorizer.destroy();
+    } catch (e) {
+      this.#lc.error?.('error destroying write authorizer storage', e);
+    } finally {
+      // The replica's statistics are maintained by the replicator, so skip
+      // the `PRAGMA optimize` that closing a writable handle would otherwise
+      // run on every client group churn.
+      this.#replica.close({optimize: false});
+    }
     this.#stopped.resolve();
     return this.#stopped.promise;
-  }
-
-  /**
-   * Releases the replica handle (and the write authorizer's storage) once
-   * the service is stopped and no mutation is using them. A mutation that is
-   * in flight when the last connection unrefs the service must be allowed to
-   * finish its authorization checks against the replica.
-   */
-  #maybeRelease() {
-    if (!this.#isStopped || this.#inFlightMutations > 0 || this.#released) {
-      return;
-    }
-    this.#released = true;
-    this.#writeAuthorizer.destroy();
-    this.#replica.close();
   }
 }
 

--- a/packages/zero-cache/src/services/mutagen/mutagen.ts
+++ b/packages/zero-cache/src/services/mutagen/mutagen.ts
@@ -67,6 +67,8 @@ export class MutagenService implements Mutagen, Service {
   readonly #limiter: SlidingWindowLimiter | undefined;
   #refCount = 0;
   #isStopped = false;
+  #inFlightMutations = 0;
+  #released = false;
 
   readonly #crudMutations = getOrCreateCounter(
     'mutation',
@@ -137,6 +139,7 @@ export class MutagenService implements Mutagen, Service {
     this.#crudMutations.add(1, {
       clientGroupID: this.id,
     });
+    this.#inFlightMutations++;
     return processMutation(
       this.#lc,
       authData,
@@ -147,7 +150,10 @@ export class MutagenService implements Mutagen, Service {
       this.#writeAuthorizer,
       undefined,
       customMutatorsEnabled,
-    );
+    ).finally(() => {
+      this.#inFlightMutations--;
+      this.#maybeRelease();
+    });
   }
 
   run(): Promise<void> {
@@ -158,10 +164,25 @@ export class MutagenService implements Mutagen, Service {
     if (this.#isStopped) {
       return this.#stopped.promise;
     }
-    this.#writeAuthorizer.destroy();
     this.#isStopped = true;
+    this.#maybeRelease();
     this.#stopped.resolve();
     return this.#stopped.promise;
+  }
+
+  /**
+   * Releases the replica handle (and the write authorizer's storage) once
+   * the service is stopped and no mutation is using them. A mutation that is
+   * in flight when the last connection unrefs the service must be allowed to
+   * finish its authorization checks against the replica.
+   */
+  #maybeRelease() {
+    if (!this.#isStopped || this.#inFlightMutations > 0 || this.#released) {
+      return;
+    }
+    this.#released = true;
+    this.#writeAuthorizer.destroy();
+    this.#replica.close();
   }
 }
 

--- a/packages/zero-cache/src/workers/syncer-ws-message-handler.test.ts
+++ b/packages/zero-cache/src/workers/syncer-ws-message-handler.test.ts
@@ -1,7 +1,10 @@
 import {describe, expect, test, vi} from 'vitest';
 import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
 import * as MutationType from '../../../zero-protocol/src/mutation-type-enum.ts';
-import {CRUD_MUTATION_NAME} from '../../../zero-protocol/src/mutation.ts';
+import {
+  CRUD_MUTATION_NAME,
+  type CRUDMutation,
+} from '../../../zero-protocol/src/mutation.ts';
 import type {Auth, ValidateLegacyJWT} from '../auth/auth.ts';
 import type {Mutagen} from '../services/mutagen/mutagen.ts';
 import type {Pusher} from '../services/mutagen/pusher.ts';
@@ -29,6 +32,8 @@ type MockPusher = ReturnType<typeof createMockPusher>;
 function createMockMutagen() {
   return {
     processMutation: vi.fn().mockResolvedValue(undefined),
+    ref: vi.fn(),
+    unref: vi.fn(),
   };
 }
 
@@ -394,6 +399,58 @@ describe('SyncerWsMessageHandler auth handling', () => {
       {sub: 'test-user', iat: 1},
       true,
     );
+  });
+
+  test('holds a mutagen ref for the duration of a push', async () => {
+    const pusher = createMockPusher();
+    const mutagen = createMockMutagen();
+    const connContextManager = new ConnectionContextManagerImpl(lc);
+    const viewSyncer = createMockViewSyncer(connContextManager);
+    const handler = createHandler(
+      viewSyncer,
+      mutagen,
+      pusher,
+      {
+        type: 'jwt',
+        raw: 'jwt-token',
+        decoded: {sub: 'test-user', iat: 1},
+      },
+      {},
+      connContextManager,
+    );
+
+    const mutation = (id: number): CRUDMutation => ({
+      type: MutationType.CRUD,
+      id,
+      clientID: 'test-client',
+      name: CRUD_MUTATION_NAME,
+      args: [{ops: []}],
+      timestamp: Date.now(),
+    });
+    await handler.handleMessage([
+      'push',
+      {
+        clientGroupID: 'test-client-group',
+        mutations: [mutation(1), mutation(2)],
+        pushVersion: 1,
+        schemaVersion: 1,
+        timestamp: Date.now(),
+        requestID: 'req-1',
+      },
+    ]);
+
+    // The ref is taken before the first mutation and released after the
+    // last one, so that the connection closing (and unref-ing the mutagen)
+    // mid-push cannot stop the service between the mutations.
+    expect(mutagen.processMutation).toHaveBeenCalledTimes(2);
+    expect(mutagen.ref).toHaveBeenCalledTimes(1);
+    expect(mutagen.unref).toHaveBeenCalledTimes(1);
+    const [refOrder] = mutagen.ref.mock.invocationCallOrder;
+    const [unrefOrder] = mutagen.unref.mock.invocationCallOrder;
+    for (const order of mutagen.processMutation.mock.invocationCallOrder) {
+      expect(order).toBeGreaterThan(refOrder);
+      expect(order).toBeLessThan(unrefOrder);
+    }
   });
 
   test('rejects CRUD mutations when auth is opaque', async () => {

--- a/packages/zero-cache/src/workers/syncer-ws-message-handler.ts
+++ b/packages/zero-cache/src/workers/syncer-ws-message-handler.ts
@@ -156,31 +156,42 @@ export class SyncerWsMessageHandler implements MessageHandler {
                 'Only JWT auth is supported for CRUD mutations',
               );
 
-              // Hold a connection-level lock while processing mutations so that:
-              // 1. Mutations are processed in the order in which they are received and
-              // 2. A single view syncer connection cannot hog multiple upstream connections.
-              const ret = await this.#mutationLock.withLock(async () => {
-                const errors: ErrorBody[] = [];
-                for (const mutation of mutations) {
-                  const maybeError = await mutagen.processMutation(
-                    mutation,
-                    auth?.decoded,
-                    this.#pusher !== undefined,
-                  );
-                  if (maybeError !== undefined) {
-                    errors.push({
-                      kind: maybeError[0],
-                      message: maybeError[1],
-                      origin: ErrorOrigin.ZeroCache,
-                    });
+              // Hold a ref on the mutagen for the duration of the push so that
+              // the connection closing mid-push does not stop the service
+              // (closing its replica handle) between two of its mutations.
+              // (The connection holds a ref while open, and messages are not
+              // dispatched after it has closed, so the service is running
+              // here.)
+              mutagen.ref();
+              try {
+                // Hold a connection-level lock while processing mutations so that:
+                // 1. Mutations are processed in the order in which they are received and
+                // 2. A single view syncer connection cannot hog multiple upstream connections.
+                const ret = await this.#mutationLock.withLock(async () => {
+                  const errors: ErrorBody[] = [];
+                  for (const mutation of mutations) {
+                    const maybeError = await mutagen.processMutation(
+                      mutation,
+                      auth?.decoded,
+                      this.#pusher !== undefined,
+                    );
+                    if (maybeError !== undefined) {
+                      errors.push({
+                        kind: maybeError[0],
+                        message: maybeError[1],
+                        origin: ErrorOrigin.ZeroCache,
+                      });
+                    }
                   }
-                }
-                if (errors.length > 0) {
-                  return {type: 'transient', errors} satisfies HandlerResult;
-                }
-                return {type: 'ok'} satisfies HandlerResult;
-              });
-              return [ret];
+                  if (errors.length > 0) {
+                    return {type: 'transient', errors} satisfies HandlerResult;
+                  }
+                  return {type: 'ok'} satisfies HandlerResult;
+                });
+                return [ret];
+              } finally {
+                mutagen.unref();
+              }
             },
           ),
         );

--- a/packages/zqlite/src/db.ts
+++ b/packages/zqlite/src/db.ts
@@ -143,9 +143,15 @@ export class Database implements Disposable {
     }
   }
 
-  close(): void {
+  /**
+   * Closes the database. For writable connections, `PRAGMA optimize` is run
+   * first (as recommended by SQLite) unless `optimize` is `false`, which is
+   * appropriate for short-lived handles on a database whose statistics are
+   * maintained by a longer-lived writer.
+   */
+  close({optimize = true}: {optimize?: boolean | undefined} = {}): void {
     const start = Date.now();
-    if (!this.#db.readonly) {
+    if (optimize && !this.#db.readonly) {
       try {
         this.#db.pragma('optimize');
         const elapsed = Date.now() - start;


### PR DESCRIPTION
## Problem

`MutagenService` opens its own SQLite `Database` on the replica file for every client group, but `stop()` only destroyed the write authorizer's operator storage. The native connection, its cached prepared statements, and the file descriptor were left to V8 finalization, which sees no memory pressure from native allocations and so has no reason to run. Every client group that came and went leaked a replica handle for the life of the syncer worker.

## Fix

Close the replica when the service stops (with `optimize: false`, since the replicator maintains the replica's statistics, and in a `finally` so it happens even if destroying the authorizer storage throws).

The last connection can `unref()` the service while a push is still being processed (the ws message handler awaits `processMutation` for each mutation under the mutation lock, and the socket can close in the meantime). So `SyncerWsMessageHandler` now holds a `ref()` on the mutagen for the whole push. The service stays valid (and is reused by a reconnect) until the push completes, so the replica is never closed between two mutations of a push and no second generation is created for the same client group while the first is draining.

## Tests

- `mutagen.test.ts` (new, no Postgres needed): `stop() closes the replica handle`, `replica stays open while a push holds a ref`, `replica is closed even if destroying the authorizer storage fails`.
- `syncer-ws-message-handler.test.ts`: `holds a mutagen ref for the duration of a push` (ref before the first `processMutation`, unref after the last).

All fail without their respective change. Also ran the existing `mutagen` `pg-16` suites and `workers/syncer.test.ts` (which constructs real `MutagenService`s), the zqlite `db` tests, plus `lint`, `format` and `check-types`.

Finding 5 from the zero-cache memory-leak audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UPJiVV1Wekmk8U9r3WMMdx