### PR TITLE
fix(zero-cache): remove per-request worker listeners added by /profz

### DIFF
--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -381,10 +381,16 @@ export default async function runWorker(
     });
   }
 
-  const getProfileWorker =
+  // Create the broadcast facade once: each broadcastWorker() adds permanent
+  // 'message' forwarders to every sub worker, so creating one per /profz
+  // request would leak a forwarder per request.
+  const profileWorker =
     profileSubWorkers.length > 0
-      ? () => Promise.resolve(broadcastWorker(profileSubWorkers))
+      ? broadcastWorker(profileSubWorkers)
       : undefined;
+  const getProfileWorker = profileWorker
+    ? () => Promise.resolve(profileWorker)
+    : undefined;
 
   const changeStreamerWebServer = new ChangeStreamerHttpServer(
     lc,

--- a/packages/zero-cache/src/services/profz.test.ts
+++ b/packages/zero-cache/src/services/profz.test.ts
@@ -2,6 +2,11 @@ import fastify, {type FastifyInstance} from 'fastify';
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {createSilentLogContext} from '../../../shared/src/logging-test-utils.ts';
 import type {NormalizedZeroConfig} from '../config/normalize.ts';
+import {
+  inProcChannel,
+  type ProfileMessage,
+  type ProfileResponseMessage,
+} from '../types/processes.ts';
 import {CpuProfiler} from '../types/profiler.ts';
 import {handleProfrmzRequest, handleProfzRequest} from './profz.ts';
 
@@ -69,6 +74,42 @@ describe('profz', () => {
     expect(body).toHaveProperty('dispatcher');
     expect(body.dispatcher).toEqual(mockProfile);
     expect(profileSpy).toHaveBeenCalledWith(1000);
+  });
+
+  test('worker message listener is removed after the request', async () => {
+    const [dispatcherSide, workerSide] = inProcChannel();
+    workerSide.onMessageType<ProfileMessage>('profile', ({id}) =>
+      workerSide.send<ProfileResponseMessage>([
+        'profileResponse',
+        {id, name: 'syncer-0', profile: mockProfile},
+      ]),
+    );
+    const workerApp = fastify();
+    workerApp.get('/profz', (req, res) =>
+      handleProfzRequest(lc, config, req, res, () =>
+        Promise.resolve(dispatcherSide),
+      ),
+    );
+    await workerApp.ready();
+    try {
+      const before = dispatcherSide.listenerCount('message');
+
+      for (let i = 0; i < 2; i++) {
+        const res = await workerApp.inject({
+          method: 'GET',
+          url: '/profz?duration=1&worker=syncer',
+          headers: authHeader,
+        });
+        expect(res.statusCode).toBe(200);
+        expect(JSON.parse(res.body)).toEqual(mockProfile);
+      }
+
+      // Each request subscribes to the (long-lived) worker's messages for
+      // its own responses; the subscription must not outlive the request.
+      expect(dispatcherSide.listenerCount('message')).toBe(before);
+    } finally {
+      await workerApp.close();
+    }
   });
 
   test('returns single profile when specific worker is requested', async () => {

--- a/packages/zero-cache/src/services/profz.ts
+++ b/packages/zero-cache/src/services/profz.ts
@@ -7,6 +7,7 @@ import type {NormalizedZeroConfig} from '../config/normalize.ts';
 import {isAdminPasswordValid} from '../config/zero-config.ts';
 import {
   singleProcessMode,
+  subscribeToMessageType,
   type ProfileResponse,
   type ProfileResponseMessage,
   type Worker,
@@ -71,22 +72,30 @@ export async function handleProfzRequest(
         }
       };
 
-      worker.onMessageType<ProfileResponseMessage>(
+      // The worker is long-lived (and shared across requests), so the
+      // per-request handler must be removed once this request is done.
+      const unsubscribe = subscribeToMessageType<ProfileResponseMessage>(
+        worker,
         'profileResponse',
         onMessage,
       );
-      worker.send([
-        'profile',
-        {
-          id,
-          durationMs,
-          worker: targetWorker === localProcessName ? '__none__' : targetWorker,
-          workerIndex: targetWorkerIndex,
-        },
-      ]);
+      try {
+        worker.send([
+          'profile',
+          {
+            id,
+            durationMs,
+            worker:
+              targetWorker === localProcessName ? '__none__' : targetWorker,
+            workerIndex: targetWorkerIndex,
+          },
+        ]);
 
-      // Wait for duration plus grace period for IPC transfer
-      await sleep(durationMs + 500);
+        // Wait for duration plus grace period for IPC transfer
+        await sleep(durationMs + 500);
+      } finally {
+        unsubscribe();
+      }
     } catch (err) {
       lc.warn?.('Failed to dispatch profile request to child workers:', err);
     }

--- a/packages/zero-cache/src/types/processes.test.ts
+++ b/packages/zero-cache/src/types/processes.test.ts
@@ -1,6 +1,11 @@
 import type {SendHandle} from 'child_process';
 import {describe, expect, test, vi} from 'vitest';
-import {inProcChannel, shouldStartWorker, type Worker} from './processes.ts';
+import {
+  inProcChannel,
+  shouldStartWorker,
+  subscribeToMessageType,
+  type Worker,
+} from './processes.ts';
 
 describe('types/processes', () => {
   test('in-proc channel', () => {
@@ -88,6 +93,29 @@ describe('types/processes', () => {
       [{foo: 'bar'}, 'sendHandle'],
       [{foo: 'baz'}, undefined],
     ]);
+  });
+
+  test('subscribeToMessageType', () => {
+    const [port1, port2] = inProcChannel();
+    const before = port2.listenerCount('message');
+
+    const handler = vi.fn();
+    const unsubscribe = subscribeToMessageType<NotifyMessage>(
+      port2,
+      'notify',
+      handler,
+    );
+    expect(port2.listenerCount('message')).toBe(before + 1);
+
+    port1.send<NotifyMessage>(['notify', {uuid: 'one'}]);
+    port1.send<SubscribeMessage>(['subscribe', {foo: 'bar'}]);
+    expect(handler.mock.calls).toEqual([[{uuid: 'one'}, undefined]]);
+
+    unsubscribe();
+    expect(port2.listenerCount('message')).toBe(before);
+
+    port1.send<NotifyMessage>(['notify', {uuid: 'two'}]);
+    expect(handler).toHaveBeenCalledTimes(1);
   });
 
   describe('shouldStartWorker', () => {

--- a/packages/zero-cache/src/types/processes.ts
+++ b/packages/zero-cache/src/types/processes.ts
@@ -57,17 +57,37 @@ function getMessage<M extends Message<unknown>>(
   return null;
 }
 
+/**
+ * Subscribes the `handler` to messages of the given `type` and returns a
+ * function that unsubscribes it. Use this (rather than
+ * {@link Receiver.onMessageType()}) for handlers scoped to a request or
+ * operation rather than to the lifetime of the {@link Worker}; the
+ * `'message'` listener is otherwise retained by the Worker forever.
+ */
+export function subscribeToMessageType<M extends Message<unknown>>(
+  e: EventEmitter,
+  type: M[0],
+  handler: (msg: M[1], sendHandle?: SendHandle) => void,
+): () => void {
+  const listener = (data: unknown, sendHandle?: SendHandle) => {
+    const msg = getMessage(type, data);
+    if (msg) {
+      handler(msg, sendHandle);
+    }
+  };
+  e.on('message', listener);
+  return () => {
+    e.off('message', listener);
+  };
+}
+
 function onMessageType<M extends Message<unknown>>(
   e: EventEmitter,
   type: M[0],
   handler: (msg: M[1], sendHandle?: SendHandle) => void,
 ) {
-  return e.on('message', (data, sendHandle) => {
-    const msg = getMessage(type, data);
-    if (msg) {
-      handler(msg, sendHandle);
-    }
-  });
+  subscribeToMessageType(e, type, handler);
+  return e;
 }
 
 function onceMessageType<M extends Message<unknown>>(


### PR DESCRIPTION
## Problem

`handleProfzRequest()` subscribed to the worker's `profileResponse` messages with `Receiver.onMessageType()`, which is a bare `on('message')` with no way to unsubscribe. The worker it targets is long-lived and shared (the memoized syncer worker in the dispatcher, or the change-streamer's sub workers), so every `/profz` and `/profrmz` request left a permanent `'message'` listener behind, each retaining the request's response map, i.e. the captured CPU profiles.

The change-streamer additionally built a fresh `broadcastWorker()` facade per request. Each one adds permanent `'message'` forwarders to every sub worker.

## Fix

- Add `subscribeToMessageType()` to `types/processes.ts`, which returns an unsubscribe function (`onMessageType` is now implemented on top of it), and use it in `handleProfzRequest()` with a `finally`.
- Create the change-streamer's broadcast profile worker once at startup instead of per request.

## Tests

- `processes.test.ts`: `subscribeToMessageType` delivers matching messages and removes the listener on unsubscribe.
- `profz.test.ts`: two `/profz` requests against an in-proc worker leave the worker's `'message'` listener count unchanged. Fails without the fix (2 leaked listeners).

Ran `lint`, `format`, `check-types`, the `no-pg` tests for `services` and `types`, and `server/change-streamer.pg.test.ts` against a local Postgres 16.

Finding 6 from the zero-cache memory-leak audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UPJiVV1Wekmk8U9r3WMMdx

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPJiVV1Wekmk8U9r3WMMdx)_