### PR TITLE
fix(zero-cache): do not untrack a replacement service when its predecessor exits

### DIFF
--- a/packages/zero-cache/src/services/runner.test.ts
+++ b/packages/zero-cache/src/services/runner.test.ts
@@ -66,6 +66,28 @@ describe('services/runner', () => {
     expect(s1).not.toBe(s2);
   });
 
+  test('replacement created during teardown stays tracked', async () => {
+    const s1 = runner.getService('foo');
+    // The instance becomes invalid (e.g. its last ref was dropped) but is
+    // still running its (async) shutdown.
+    s1.valid = false;
+    const s2 = runner.getService('foo');
+    expect(s2).not.toBe(s1);
+
+    // The old instance finishes shutting down after the replacement was
+    // created under the same id.
+    s1.resolver.resolve();
+    await sleep(1);
+
+    // The replacement must still be the tracked instance.
+    expect(runner.getService('foo')).toBe(s2);
+    expect([...runner.getServices()]).toContain(s2);
+
+    s2.resolver.resolve();
+    await sleep(1);
+    expect([...runner.getServices()]).not.toContain(s2);
+  });
+
   // Models the zombie ViewSyncer scenario: a service whose run() blocks on
   // an unresolved initialization promise should be cleaned up when that
   // promise is rejected (e.g. when all clients disconnect before

--- a/packages/zero-cache/src/services/runner.ts
+++ b/packages/zero-cache/src/services/runner.ts
@@ -41,7 +41,15 @@ export class ServiceRunner<S extends Service> {
         ),
       )
       .finally(() => {
-        this.#instances.delete(id);
+        // Only remove the instance that just finished. If it was already
+        // replaced (e.g. because it became invalid and a new instance was
+        // created under the same id while it was still shutting down), the
+        // replacement must stay tracked; otherwise the next getService()
+        // would spawn a duplicate and the untracked one would never be
+        // stopped by this runner.
+        if (this.#instances.get(id) === service) {
+          this.#instances.delete(id);
+        }
       });
     return service;
   }


### PR DESCRIPTION
## Problem

`ServiceRunner` removed instances from its map by id in the old instance's `finally`. When an instance became invalid (a `Mutagen` or `Pusher` whose last ref was dropped, or a stopped `ViewSyncer`) and a new instance was created under the same id while the old one was still shutting down, the old instance's completion deleted the *replacement* from the map. The next `getService()` then created a duplicate, and the untracked instance was never stopped or drained by the runner (it is not reachable via `getServices()` either).

## Fix

Only delete the map entry if it still points at the instance that finished.

## Tests

`runner.test.ts`: `replacement created during teardown stays tracked`. Fails without the fix (a third instance is created).

Ran `lint`, `format`, `check-types`.

Finding 7 from the zero-cache memory-leak audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UPJiVV1Wekmk8U9r3WMMdx

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPJiVV1Wekmk8U9r3WMMdx)_