### PR TITLE
fix(zero-cache): remove snapshot-reservation signal listeners when done

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/snapshot.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/snapshot.test.ts
@@ -1,7 +1,9 @@
+import {resolver} from '@rocicorp/resolver';
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {AbortError} from '../../../../shared/src/abort-error.ts';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
 import type {NormalizedZeroConfig} from '../../config/normalize.ts';
+import type {Source} from '../../types/streams.ts';
 import {Subscription} from '../../types/subscription.ts';
 import {
   reserveAndGetSnapshotStatus,
@@ -36,6 +38,16 @@ describe('change-streamer/snapshot', () => {
   function expectListenersAdded(n: number) {
     expect(process.listenerCount('SIGINT')).toBe(sigintBefore + n);
     expect(process.listenerCount('SIGTERM')).toBe(sigtermBefore + n);
+  }
+
+  // Invokes the SIGTERM listener added since `listenersBefore` directly
+  // (emitting a real SIGTERM would also reach the test runner's handlers).
+  function sendSigterm(listenersBefore: Set<Function>) {
+    const added = process
+      .listeners('SIGTERM')
+      .find(l => !listenersBefore.has(l));
+    expect(added).toBeDefined();
+    (added as () => void)();
   }
 
   test('signal listeners are removed once the reservation completes', async () => {
@@ -79,15 +91,54 @@ describe('change-streamer/snapshot', () => {
     await vi.advanceTimersByTimeAsync(1000);
     expectListenersAdded(1);
 
-    // Invoke the newly added SIGTERM listener directly (emitting a real
-    // SIGTERM would also reach the test runner's own handlers).
-    const added = process
-      .listeners('SIGTERM')
-      .find(l => !sigtermListeners.has(l));
-    expect(added).toBeDefined();
-    (added as () => void)();
+    sendSigterm(sigtermListeners);
 
     await expect(result).rejects.toBeInstanceOf(AbortError);
     expectListenersAdded(0);
+  });
+
+  test('signal while the reservation is pending rejects and removes the listeners', async () => {
+    const reservation = resolver<Source<SnapshotMessage>>();
+    const reserve: ReserveSnapshot = vi
+      .fn<ReserveSnapshot>()
+      .mockReturnValue(reservation.promise);
+
+    const sigtermListeners = new Set(process.listeners('SIGTERM'));
+    const result = reserveAndGetSnapshotStatus(lc, config, reserve);
+    result.catch(() => {});
+    await vi.advanceTimersByTimeAsync(0);
+    expectListenersAdded(1);
+
+    sendSigterm(sigtermListeners);
+
+    await expect(result).rejects.toBeInstanceOf(AbortError);
+    expectListenersAdded(0);
+
+    // A reservation that completes after the abort is not held open.
+    const stream = Subscription.create<SnapshotMessage>();
+    reservation.resolve(stream);
+    await vi.advanceTimersByTimeAsync(0);
+    expect((await stream[Symbol.asyncIterator]().next()).done).toBe(true);
+  });
+
+  test('signal while the stream is open cancels it and removes the listeners', async () => {
+    const stream = Subscription.create<SnapshotMessage>();
+    const reserve: ReserveSnapshot = vi
+      .fn<ReserveSnapshot>()
+      .mockResolvedValue(stream);
+
+    const sigtermListeners = new Set(process.listeners('SIGTERM'));
+    const result = reserveAndGetSnapshotStatus(lc, config, reserve);
+    stream.push(['status', status]);
+    expect(await result).toEqual(status);
+    expectListenersAdded(1);
+
+    sendSigterm(sigtermListeners);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expectListenersAdded(0);
+    await expect(stream[Symbol.asyncIterator]().next()).rejects.toBeInstanceOf(
+      AbortError,
+    );
   });
 });

--- a/packages/zero-cache/src/services/change-streamer/snapshot.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/snapshot.test.ts
@@ -1,0 +1,93 @@
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
+import {AbortError} from '../../../../shared/src/abort-error.ts';
+import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
+import type {NormalizedZeroConfig} from '../../config/normalize.ts';
+import {Subscription} from '../../types/subscription.ts';
+import {
+  reserveAndGetSnapshotStatus,
+  type ReserveSnapshot,
+  type SnapshotMessage,
+  type SnapshotStatus,
+} from './snapshot.ts';
+
+describe('change-streamer/snapshot', () => {
+  const lc = createSilentLogContext();
+  const config = {} as NormalizedZeroConfig;
+  const status: SnapshotStatus = {
+    tag: 'status',
+    backupURL: 's3://bucket/backup',
+    replicaVersion: '123',
+    minWatermark: '0a',
+  };
+
+  let sigintBefore: number;
+  let sigtermBefore: number;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    sigintBefore = process.listenerCount('SIGINT');
+    sigtermBefore = process.listenerCount('SIGTERM');
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function expectListenersAdded(n: number) {
+    expect(process.listenerCount('SIGINT')).toBe(sigintBefore + n);
+    expect(process.listenerCount('SIGTERM')).toBe(sigtermBefore + n);
+  }
+
+  test('signal listeners are removed once the reservation completes', async () => {
+    const stream = Subscription.create<SnapshotMessage>();
+    const reserve: ReserveSnapshot = vi
+      .fn<ReserveSnapshot>()
+      // The first attempt fails (e.g. incompatible replication-manager).
+      .mockRejectedValueOnce(new Error('not yet'))
+      .mockResolvedValueOnce(stream);
+
+    const result = reserveAndGetSnapshotStatus(lc, config, reserve);
+    // The listeners are registered while the reservation is in progress...
+    expectListenersAdded(1);
+
+    // ... including across the retry sleep.
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(reserve).toHaveBeenCalledTimes(2);
+    expectListenersAdded(1);
+
+    stream.push(['status', status]);
+    expect(await result).toEqual(status);
+
+    // The change-streamer closes the stream when the subscription starts.
+    stream.cancel();
+    await vi.advanceTimersByTimeAsync(0);
+
+    // ... and are gone once the reservation is over, so that repeated
+    // reservations do not accumulate process listeners.
+    expectListenersAdded(0);
+  });
+
+  test('signal during retry rejects and removes the listeners', async () => {
+    const reserve: ReserveSnapshot = vi
+      .fn<ReserveSnapshot>()
+      .mockRejectedValue(new Error('not yet'));
+
+    const sigtermListeners = new Set(process.listeners('SIGTERM'));
+    const result = reserveAndGetSnapshotStatus(lc, config, reserve);
+    // Attach a rejection handler immediately to prevent unhandledRejections.
+    result.catch(() => {});
+    await vi.advanceTimersByTimeAsync(1000);
+    expectListenersAdded(1);
+
+    // Invoke the newly added SIGTERM listener directly (emitting a real
+    // SIGTERM would also reach the test runner's own handlers).
+    const added = process
+      .listeners('SIGTERM')
+      .find(l => !sigtermListeners.has(l));
+    expect(added).toBeDefined();
+    (added as () => void)();
+
+    await expect(result).rejects.toBeInstanceOf(AbortError);
+    expectListenersAdded(0);
+  });
+});

--- a/packages/zero-cache/src/services/change-streamer/snapshot.ts
+++ b/packages/zero-cache/src/services/change-streamer/snapshot.ts
@@ -54,54 +54,68 @@ export const snapshotMessageSchema = v.union(statusMessageSchema);
 
 export type SnapshotMessage = v.Infer<typeof statusMessageSchema>;
 
+export type ReserveSnapshot = (
+  lc: LogContext,
+  config: NormalizedZeroConfig,
+) => Promise<Source<SnapshotMessage>>;
+
 export function reserveAndGetSnapshotStatus(
   lc: LogContext,
   config: NormalizedZeroConfig,
+  reserve: ReserveSnapshot = reserveSnapshot, // for testing
 ): Promise<SnapshotStatus> {
   const {promise: status, resolve, reject} = resolver<SnapshotStatus>();
 
   void (async function () {
     const abort = new AbortController();
-    process.on('SIGINT', () => abort.abort());
-    process.on('SIGTERM', () => abort.abort());
+    const onSignal = () => abort.abort();
+    process.on('SIGINT', onSignal);
+    process.on('SIGTERM', onSignal);
 
-    for (let i = 0; ; i++) {
-      let err: unknown;
-      try {
-        let resolved = false;
-        const stream = await reserveSnapshot(lc, config);
-        for await (const msg of stream) {
-          // Capture the value of the status message that the change-streamer
-          // backup monitor returns, and hold the connection open to
-          // "reserve" the snapshot and prevent change log cleanup.
-          resolve(msg[1]);
-          resolved = true;
+    try {
+      for (let i = 0; ; i++) {
+        let err: unknown;
+        try {
+          let resolved = false;
+          const stream = await reserve(lc, config);
+          for await (const msg of stream) {
+            // Capture the value of the status message that the change-streamer
+            // backup monitor returns, and hold the connection open to
+            // "reserve" the snapshot and prevent change log cleanup.
+            resolve(msg[1]);
+            resolved = true;
+          }
+          // The change-streamer itself closes the connection when the
+          // subscription is started (or the reservation retried).
+          if (resolved) {
+            break;
+          }
+        } catch (e) {
+          err = e;
         }
-        // The change-streamer itself closes the connection when the
-        // subscription is started (or the reservation retried).
-        if (resolved) {
-          break;
+        // Retry in the view-syncer since it cannot proceed until it connects
+        // to a (compatible) replication-manager. In particular, a
+        // replication-manager that does not support the view-syncer's
+        // change-streamer protocol will close the stream with an error; this
+        // retry logic essentially delays the startup of a view-syncer until
+        // a compatible replication-manager has been rolled out, allowing
+        // replication-manager and view-syncer services to be updated in
+        // parallel.
+        lc.warn?.(
+          `Unable to reserve snapshot (attempt ${i + 1}). Retrying in 5 seconds.`,
+          String(err),
+        );
+        try {
+          await sleep(5000, abort.signal);
+        } catch (e) {
+          return reject(e);
         }
-      } catch (e) {
-        err = e;
       }
-      // Retry in the view-syncer since it cannot proceed until it connects
-      // to a (compatible) replication-manager. In particular, a
-      // replication-manager that does not support the view-syncer's
-      // change-streamer protocol will close the stream with an error; this
-      // retry logic essentially delays the startup of a view-syncer until
-      // a compatible replication-manager has been rolled out, allowing
-      // replication-manager and view-syncer services to be updated in
-      // parallel.
-      lc.warn?.(
-        `Unable to reserve snapshot (attempt ${i + 1}). Retrying in 5 seconds.`,
-        String(err),
-      );
-      try {
-        await sleep(5000, abort.signal);
-      } catch (e) {
-        return reject(e);
-      }
+    } finally {
+      // This function is called repeatedly (e.g. by the replicator's restore
+      // loop), so the signal handlers must not outlive the reservation.
+      process.off('SIGINT', onSignal);
+      process.off('SIGTERM', onSignal);
     }
   })();
 

--- a/packages/zero-cache/src/services/change-streamer/snapshot.ts
+++ b/packages/zero-cache/src/services/change-streamer/snapshot.ts
@@ -14,6 +14,7 @@
 
 import type {LogContext} from '@rocicorp/logger';
 import {resolver} from '@rocicorp/resolver';
+import {AbortError} from '../../../../shared/src/abort-error.ts';
 import {sleep} from '../../../../shared/src/sleep.ts';
 import * as v from '../../../../shared/src/valita.ts';
 import {type NormalizedZeroConfig} from '../../config/normalize.ts';
@@ -68,6 +69,7 @@ export function reserveAndGetSnapshotStatus(
 
   void (async function () {
     const abort = new AbortController();
+    const {signal} = abort;
     const onSignal = () => abort.abort();
     process.on('SIGINT', onSignal);
     process.on('SIGTERM', onSignal);
@@ -77,13 +79,21 @@ export function reserveAndGetSnapshotStatus(
         let err: unknown;
         try {
           let resolved = false;
-          const stream = await reserve(lc, config);
-          for await (const msg of stream) {
-            // Capture the value of the status message that the change-streamer
-            // backup monitor returns, and hold the connection open to
-            // "reserve" the snapshot and prevent change log cleanup.
-            resolve(msg[1]);
-            resolved = true;
+          const stream = await untilAborted(reserve(lc, config), signal);
+          // A signal while the stream is open cancels it, which ends the
+          // iteration below with an AbortError.
+          const cancelStream = () => stream.cancel(new AbortError('Aborted'));
+          signal.addEventListener('abort', cancelStream, {once: true});
+          try {
+            for await (const msg of stream) {
+              // Capture the value of the status message that the change-streamer
+              // backup monitor returns, and hold the connection open to
+              // "reserve" the snapshot and prevent change log cleanup.
+              resolve(msg[1]);
+              resolved = true;
+            }
+          } finally {
+            signal.removeEventListener('abort', cancelStream);
           }
           // The change-streamer itself closes the connection when the
           // subscription is started (or the reservation retried).
@@ -92,6 +102,12 @@ export function reserveAndGetSnapshotStatus(
           }
         } catch (e) {
           err = e;
+        }
+        if (signal.aborted) {
+          // (A no-op if the status was already resolved.)
+          return reject(
+            err instanceof AbortError ? err : new AbortError('Aborted'),
+          );
         }
         // Retry in the view-syncer since it cannot proceed until it connects
         // to a (compatible) replication-manager. In particular, a
@@ -120,6 +136,35 @@ export function reserveAndGetSnapshotStatus(
   })();
 
   return status;
+}
+
+/**
+ * Resolves with the reserved stream, or rejects with an AbortError if the
+ * `signal` is aborted while the reservation is pending (in which case a
+ * stream that arrives later is canceled rather than held open).
+ */
+function untilAborted<T>(
+  reservation: Promise<Source<T>>,
+  signal: AbortSignal,
+): Promise<Source<T>> {
+  return new Promise((resolve, reject) => {
+    const onAbort = () => reject(new AbortError('Aborted'));
+    signal.addEventListener('abort', onAbort, {once: true});
+    reservation.then(
+      stream => {
+        signal.removeEventListener('abort', onAbort);
+        if (signal.aborted) {
+          stream.cancel();
+        } else {
+          resolve(stream);
+        }
+      },
+      e => {
+        signal.removeEventListener('abort', onAbort);
+        reject(e);
+      },
+    );
+  });
 }
 
 function reserveSnapshot(


### PR DESCRIPTION
## Problem

`reserveAndGetSnapshotStatus()` registered `SIGINT` and `SIGTERM` listeners on `process` on every call and never removed them. The replicator's `restoreReplica()` loop calls it every 3 seconds while waiting for the replication-manager to publish a restorable backup, which can take many minutes on a fresh stack, so each iteration added two more permanent process listeners (each retaining its `AbortController` and the closure's config and log context), and Node starts warning about a possible EventEmitter leak after ten.

## Fix

Register a single handler and remove it in a `finally` once the reservation resolves, is aborted, or the stream ends. The reservation function is now injectable for testing (defaults to the real `reserveSnapshot`).

## Tests

New `snapshot.test.ts` (fake timers, no network):
- listeners are present during the reservation and across a retry, and gone once the stream ends;
- a signal during the retry sleep rejects the promise and removes the listeners.

Both fail without the fix.

Ran `lint`, `format`, `check-types`.

Finding 8 from the zero-cache memory-leak audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UPJiVV1Wekmk8U9r3WMMdx

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPJiVV1Wekmk8U9r3WMMdx)_