### PR TITLE
fix(zero-cache): release the catchup pool when the snapshot read fails

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/storer.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.pg.test.ts
@@ -1978,6 +1978,71 @@ describe('change-streamer/storer', () => {
     });
   });
 
+  describe('catchup snapshot failure', () => {
+    let catchupDB: PostgresDB;
+
+    beforeEach<PgTest>(async ({testDBs}) => {
+      // A database without the cdc tables, so that the catchup pool's
+      // snapshot read fails.
+      catchupDB = await testDBs.create('change_streamer_storer_catchup');
+      const catchupProvider: PostgresDBProvider = (applicationName, maxConns) =>
+        pgClient(
+          lc,
+          getConnectionURI(
+            applicationName === 'subscriber-catchup' ? catchupDB : db,
+          ),
+          applicationName,
+          {max: maxConns},
+          {sendStringAsJson: true},
+        );
+      storer = new Storer(
+        lc,
+        shard,
+        'task-id',
+        'change-streamer:12345',
+        'ws',
+        catchupProvider,
+        REPLICA_VERSION,
+        msg => consumed.enqueue(msg),
+        err => fatalErrors.enqueue(err),
+        opts,
+      );
+      await storer.assumeOwnership();
+      done = storer.run();
+
+      return async () => {
+        await testDBs.drop(catchupDB);
+      };
+    });
+
+    async function catchupConnections(): Promise<number> {
+      const [{count}] = await db<{count: bigint}[]>`
+        SELECT COUNT(*) AS count FROM pg_stat_activity
+          WHERE datname = ${catchupDB.options.database}`;
+      return Number(count);
+    }
+
+    test('failed snapshot read tears down the catchup pool', async () => {
+      const [sub, _, stream] = createSubscriber('03');
+      storer.catchup(sub, 'serving');
+
+      await expect(done).rejects.toThrow('replicationState');
+      // Prevent the beforeEach cleanup from re-throwing the rejected done.
+      done = Promise.resolve();
+
+      // The subscriber is failed (closed without a downstream error) ...
+      const iterator = stream[Symbol.asyncIterator]();
+      expect((await iterator.next()).done).toBe(true);
+
+      // ... and the catchup pool, whose workers each hold an open READ ONLY
+      // transaction, is released rather than left dangling.
+      for (let i = 0; (await catchupConnections()) > 0 && i < 100; i++) {
+        await sleep(50);
+      }
+      expect(await catchupConnections()).toBe(0);
+    });
+  });
+
   test('purge lock on empty change-log (e.g. before initial sync)', async () => {
     await db`TRUNCATE "xero_5/cdc"."changeLog"`;
     const purgeLocker = new PurgeLocker(lc, shard, db);

--- a/packages/zero-cache/src/services/change-streamer/storer.ts
+++ b/packages/zero-cache/src/services/change-streamer/storer.ts
@@ -882,6 +882,11 @@ export class Storer implements Service {
       );
     } catch (e) {
       subs.map(({subscriber}) => subscriber.fail(e));
+      // Nothing will run the catchup tasks that normally finalize the pool
+      // (below), so tear it down here. Otherwise its workers (each holding an
+      // open READ ONLY transaction) and the connection pool are leaked.
+      reader.abort();
+      void catchupConns.end().catch(() => {});
       throw e;
     } finally {
       catchupSnapshotted();


### PR DESCRIPTION
## Problem

`Storer.#startCatchup()` creates a `READONLY` `TransactionPool` and a dedicated connection pool (sized to the number of subscribers) for each catchup, and relies on the catchup tasks' completion to call `setDone()` and `end()` the connections. If the initial snapshot read (`SELECT "lastWatermark" FROM replicationState`) failed, the `catch` block failed the subscribers and rethrew without tearing the pools down. `processReadTask()` errors do not fail the pool, so its workers stayed parked, each holding an open `READ ONLY` transaction, together with their connections.

## Fix

Abort the transaction pool and end the connection pool on that path.

## Tests

`storer.pg.test.ts`: `failed snapshot read tears down the catchup pool`. It points the `subscriber-catchup` pool at a database without the CDC tables, and asserts via `pg_stat_activity` that no connection to that database survives after the failure. Without the fix one connection (idle in transaction) stays open indefinitely.

Ran `lint`, `format`, `check-types`, the full `storer.pg.test.ts` (33 tests) against a local Postgres 16, and the `no-pg` `change-streamer` tests.

Finding 9 from the zero-cache memory-leak audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UPJiVV1Wekmk8U9r3WMMdx

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPJiVV1Wekmk8U9r3WMMdx)_