### PR TITLE
test(zbugs): add C16, a held snapshot reservation, to the soak

### DIFF
--- a/apps/zbugs/scripts/rmv2-soak.ts
+++ b/apps/zbugs/scripts/rmv2-soak.ts
@@ -41,8 +41,9 @@ import {mixedPhase, workloadPhases} from './rmv2-soak/workload.ts';
 const ROLLBACK_DRILLS = new Set(['C10', 'C11', 'C12']);
 
 /**
- * Everything except C9 (a five-minute minio outage) and the rollback drills,
- * which leave the change log rolled back to `off`. `--chaos all` adds them.
+ * Everything except the two five-minute actions -- C9 (a minio outage) and C16
+ * (a held snapshot reservation) -- and the rollback drills, which leave the
+ * change log rolled back to `off`. `--chaos all` adds them.
  */
 const DEFAULT_CHAOS = 'C1,C2,C3,C4,C5,C6,C7,C8,C13,C14,C15';
 

--- a/apps/zbugs/scripts/rmv2-soak.ts
+++ b/apps/zbugs/scripts/rmv2-soak.ts
@@ -44,7 +44,7 @@ const ROLLBACK_DRILLS = new Set(['C10', 'C11', 'C12']);
  * Everything except C9 (a five-minute minio outage) and the rollback drills,
  * which leave the change log rolled back to `off`. `--chaos all` adds them.
  */
-const DEFAULT_CHAOS = 'C1,C2,C3,C4,C5,C6,C7,C8,C13,C14';
+const DEFAULT_CHAOS = 'C1,C2,C3,C4,C5,C6,C7,C8,C13,C14,C15';
 
 const USAGE = `
 A local, reproducible end-to-end exercise of the SQLite change log in serve
@@ -71,7 +71,7 @@ Options:
                             retention floor, not a routing knob.
   --scale <f>               Multiplies every phase duration. Default: 1
   --chaos <list>            Comma-separated action ids, or "none", or "all".
-                            Default: C1-C8, C13 and C14. "all" adds C9 (a
+                            Default: C1-C8 and C13-C15. "all" adds C9 (a
                             long minio outage) and the C10-C12 rollback
                             drills, which run last and leave the log off.
   --baseline                Also run the mode=off A/B control pass first
@@ -548,6 +548,7 @@ async function main(): Promise<void> {
       const ctx: ChaosContext = {
         config,
         cluster: soakCluster,
+        lc,
         log: soakLog,
         metrics,
         sql,

--- a/apps/zbugs/scripts/rmv2-soak/README.md
+++ b/apps/zbugs/scripts/rmv2-soak/README.md
@@ -177,25 +177,27 @@ consistently held is the evidence that the check can be tightened.
 
 ## Chaos matrix
 
-`--chaos` takes ids, `none`, or `all`. The default is C1-C8 and C13-C15.
+`--chaos` takes ids, `none`, or `all`. The default is C1-C8 and C13-C15; C9
+and C16 each hold a five-minute condition, so `all` is what adds them.
 
-| #   | Action                                                               | Expected route                                                      |
-| --- | -------------------------------------------------------------------- | ------------------------------------------------------------------- |
-| C1  | SIGTERM a view-syncer (graceful drain), restart                      | `sqlite/selected`                                                   |
-| C2  | SIGQUIT a view-syncer (abrupt), restart                              | `sqlite/selected`                                                   |
-| C3  | Kill a view-syncer, delete its replica, restart                      | restore, then `sqlite`; **must not demote**                         |
-| C4  | Kill mid-burst; a short outage, then one past retention              | `sqlite/selected`; stale long-gap replica discarded and restored    |
-| C5  | SIGTERM the replication-manager, restart                             | a valid log resumes from its own head                               |
-| C6  | Delete only the change log, restart, then wipe a view-syncer replica | `sqlite/selected-cold`, or `pg/cold-log` when cold reads are off    |
-| C7  | SIGSTOP the replication-manager 30s, then SIGCONT                    | disconnect and reconnect, no data gap                               |
-| C8  | SIGKILL the replication-manager mid-burst, restart                   | reconcile by _truncation_, not reseed                               |
-| C9  | Stop minio for five minutes under sustained writes, then restart it  | live log pages and app-scoped slot WAL grow, then drain             |
-| C10 | `readPercent` 100 -> 0, restart                                      | every route becomes `pg/percentage`                                 |
-| C11 | `serve` -> `compare` -> `write`, restart each time                   | the writer stays, reads stop, comparison stops                      |
-| C12 | `write` -> `off`, restart                                            | does turning it off actually free the disk                          |
-| C13 | C4 and C6 together                                                   | a follower already behind, meeting a reseed                         |
-| C14 | Wipe the RM's whole volume (replica, litestream state, change log)   | restore from backup into a fresh generation; no follower demoted    |
-| C15 | Restart the RM mid-backfill                                          | the run resumes from the replica's mark; nobody demoted or restored |
+| #   | Action                                                               | Expected route                                                        |
+| --- | -------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| C1  | SIGTERM a view-syncer (graceful drain), restart                      | `sqlite/selected`                                                     |
+| C2  | SIGQUIT a view-syncer (abrupt), restart                              | `sqlite/selected`                                                     |
+| C3  | Kill a view-syncer, delete its replica, restart                      | restore, then `sqlite`; **must not demote**                           |
+| C4  | Kill mid-burst; a short outage, then one past retention              | `sqlite/selected`; stale long-gap replica discarded and restored      |
+| C5  | SIGTERM the replication-manager, restart                             | a valid log resumes from its own head                                 |
+| C6  | Delete only the change log, restart, then wipe a view-syncer replica | `sqlite/selected-cold`, or `pg/cold-log` when cold reads are off      |
+| C7  | SIGSTOP the replication-manager 30s, then SIGCONT                    | disconnect and reconnect, no data gap                                 |
+| C8  | SIGKILL the replication-manager mid-burst, restart                   | reconcile by _truncation_, not reseed                                 |
+| C9  | Stop minio for five minutes under sustained writes, then restart it  | live log pages and app-scoped slot WAL grow, then drain               |
+| C10 | `readPercent` 100 -> 0, restart                                      | every route becomes `pg/percentage`                                   |
+| C11 | `serve` -> `compare` -> `write`, restart each time                   | the writer stays, reads stop, comparison stops                        |
+| C12 | `write` -> `off`, restart                                            | does turning it off actually free the disk                            |
+| C13 | C4 and C6 together                                                   | a follower already behind, meeting a reseed                           |
+| C14 | Wipe the RM's whole volume (replica, litestream state, change log)   | restore from backup into a fresh generation; no follower demoted      |
+| C15 | Restart the RM mid-backfill                                          | the run resumes from the replica's mark; nobody demoted or restored   |
+| C16 | Hold a snapshot reservation open for five minutes under writes       | the log is retained for the whole hold, then drains; the ACK advances |
 
 `GRACEFUL_SHUTDOWN = ['SIGTERM','SIGINT']` and `FORCEFUL_SHUTDOWN =
 ['SIGQUIT','SIGABRT']` are genuinely different paths in `life-cycle.ts`, which
@@ -204,6 +206,20 @@ is why C1 and C2 are two actions and not the same test twice.
 C10-C12 always run last regardless of the order they are requested in: C11 and
 C12 leave the change log rolled back to `write` and then `off`, which is not a
 state the rest of the run can continue from.
+
+**C16 is the slow-restore test.** A view-syncer reserves its snapshot before it
+restores and holds the reservation until it subscribes, so a restore that takes
+minutes -- a large replica coming out of S3 -- pins the purge floor at the
+`minWatermark` it was promised for that whole time, and pauses the purge
+scheduler outright (`startSnapshotReservation` takes a `pause(taskID)` that only
+the reservation's close releases). Every hold this harness has otherwise
+observed is 1-11 ms, so nothing else in the matrix asks that question. C16 holds
+one without restoring anything and asserts that the log was retained while it
+was open, that it drained afterwards, and that backup watermarks kept arriving
+throughout -- a reservation pins the floor but not the upstream ACK, which is
+`min(pgChangeLogWatermark, backupWatermark)`. The slot is reported rather than
+gated: WAL is retained in whole segments, which makes it too lumpy to assert on
+over a short run.
 
 ## Gotchas worth knowing
 

--- a/apps/zbugs/scripts/rmv2-soak/README.md
+++ b/apps/zbugs/scripts/rmv2-soak/README.md
@@ -177,24 +177,25 @@ consistently held is the evidence that the check can be tightened.
 
 ## Chaos matrix
 
-`--chaos` takes ids, `none`, or `all`. The default is C1-C8, C13 and C14.
+`--chaos` takes ids, `none`, or `all`. The default is C1-C8 and C13-C15.
 
-| #   | Action                                                               | Expected route                                                   |
-| --- | -------------------------------------------------------------------- | ---------------------------------------------------------------- |
-| C1  | SIGTERM a view-syncer (graceful drain), restart                      | `sqlite/selected`                                                |
-| C2  | SIGQUIT a view-syncer (abrupt), restart                              | `sqlite/selected`                                                |
-| C3  | Kill a view-syncer, delete its replica, restart                      | restore, then `sqlite`; **must not demote**                      |
-| C4  | Kill mid-burst; a short outage, then one past retention              | `sqlite/selected`; stale long-gap replica discarded and restored |
-| C5  | SIGTERM the replication-manager, restart                             | a valid log resumes from its own head                            |
-| C6  | Delete only the change log, restart, then wipe a view-syncer replica | `sqlite/selected-cold`, or `pg/cold-log` when cold reads are off |
-| C7  | SIGSTOP the replication-manager 30s, then SIGCONT                    | disconnect and reconnect, no data gap                            |
-| C8  | SIGKILL the replication-manager mid-burst, restart                   | reconcile by _truncation_, not reseed                            |
-| C9  | Stop minio for five minutes under sustained writes, then restart it  | live log pages and app-scoped slot WAL grow, then drain          |
-| C10 | `readPercent` 100 -> 0, restart                                      | every route becomes `pg/percentage`                              |
-| C11 | `serve` -> `compare` -> `write`, restart each time                   | the writer stays, reads stop, comparison stops                   |
-| C12 | `write` -> `off`, restart                                            | does turning it off actually free the disk                       |
-| C13 | C4 and C6 together                                                   | a follower already behind, meeting a reseed                      |
-| C14 | Wipe the RM's whole volume (replica, litestream state, change log)   | restore from backup into a fresh generation; no follower demoted |
+| #   | Action                                                               | Expected route                                                      |
+| --- | -------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| C1  | SIGTERM a view-syncer (graceful drain), restart                      | `sqlite/selected`                                                   |
+| C2  | SIGQUIT a view-syncer (abrupt), restart                              | `sqlite/selected`                                                   |
+| C3  | Kill a view-syncer, delete its replica, restart                      | restore, then `sqlite`; **must not demote**                         |
+| C4  | Kill mid-burst; a short outage, then one past retention              | `sqlite/selected`; stale long-gap replica discarded and restored    |
+| C5  | SIGTERM the replication-manager, restart                             | a valid log resumes from its own head                               |
+| C6  | Delete only the change log, restart, then wipe a view-syncer replica | `sqlite/selected-cold`, or `pg/cold-log` when cold reads are off    |
+| C7  | SIGSTOP the replication-manager 30s, then SIGCONT                    | disconnect and reconnect, no data gap                               |
+| C8  | SIGKILL the replication-manager mid-burst, restart                   | reconcile by _truncation_, not reseed                               |
+| C9  | Stop minio for five minutes under sustained writes, then restart it  | live log pages and app-scoped slot WAL grow, then drain             |
+| C10 | `readPercent` 100 -> 0, restart                                      | every route becomes `pg/percentage`                                 |
+| C11 | `serve` -> `compare` -> `write`, restart each time                   | the writer stays, reads stop, comparison stops                      |
+| C12 | `write` -> `off`, restart                                            | does turning it off actually free the disk                          |
+| C13 | C4 and C6 together                                                   | a follower already behind, meeting a reseed                         |
+| C14 | Wipe the RM's whole volume (replica, litestream state, change log)   | restore from backup into a fresh generation; no follower demoted    |
+| C15 | Restart the RM mid-backfill                                          | the run resumes from the replica's mark; nobody demoted or restored |
 
 `GRACEFUL_SHUTDOWN = ['SIGTERM','SIGINT']` and `FORCEFUL_SHUTDOWN =
 ['SIGQUIT','SIGABRT']` are genuinely different paths in `life-cycle.ts`, which

--- a/apps/zbugs/scripts/rmv2-soak/chaos.test.ts
+++ b/apps/zbugs/scripts/rmv2-soak/chaos.test.ts
@@ -53,9 +53,10 @@ test('reports an unavailable C9 live-page sample and an unpinned slot', () => {
 const c15 = (overrides: Partial<C15Observations> = {}): C15Observations => ({
   table: 'c15_backfill_run1',
   fixtureRows: 200_000,
+  fixtureRowsSettled: true,
   runAnnounced: true,
   markedBeforeRestart: true,
-  rowsBeforeRestart: 40_000,
+  rowsFilledBeforeRestart: 40_000,
   resumedStart: 'resumed',
   demotions: 0,
   restores: 0,
@@ -84,21 +85,24 @@ test('reports a backfill that was dropped rather than resumed', () => {
   ]);
 });
 
-test('reports a fixture too small to interrupt instead of judging the resume', () => {
+test('reports a missing mark as unordered-or-too-small, not as a resume failure', () => {
   // The run finished before the RM was killed, so `resumedStart` says
   // nothing -- reporting it as a resume failure would be a false negative.
   expect(
     c15Findings(
       c15({
         markedBeforeRestart: false,
-        rowsBeforeRestart: 200_000,
+        rowsFilledBeforeRestart: 200_000,
         resumedStart: 'none-observed',
       }),
     ),
   ).toEqual([
-    'C15 could not observe a mark for c15_backfill_run1 before the run ' +
-      'finished (200000 of 200000 rows replicated); the fixture is too small ' +
-      'to interrupt, so the restart proved nothing',
+    'C15 never saw a mark for c15_backfill_run1 (200000 of 200000 rows ' +
+      'backfilled). Either the run was not ordered -- check that ' +
+      '`ZERO_CHANGE_STREAMER_BACKFILL_RESUME=on` reached the RM and that the ' +
+      'key cleared the correlation gate -- or it finished before the restart, ' +
+      'which makes the fixture too small. The restart proved nothing either ' +
+      'way.',
   ]);
 });
 
@@ -131,5 +135,23 @@ test('reports demotions, restores and a short replica alongside the resume', () 
       'was interrupted; a backfill restart is not a replication gap',
     "C15's resumed backfill of c15_backfill_run1 left 1 replica(s) short of " +
       '200000 rows: vs-0=199998',
+  ]);
+});
+
+test('reports an unsettled fixture instead of judging the run', () => {
+  // The column was added while the rows were still arriving, so nothing after
+  // that is worth reading: report the setup, not a resume verdict.
+  expect(
+    c15Findings(
+      c15({
+        fixtureRowsSettled: false,
+        runAnnounced: false,
+        markedBeforeRestart: false,
+        resumedStart: 'none-observed',
+      }),
+    ),
+  ).toEqual([
+    "C15's 200000 fixture rows did not reach every replica before the column " +
+      'was added; the run it measured started from an unsettled table',
   ]);
 });

--- a/apps/zbugs/scripts/rmv2-soak/chaos.test.ts
+++ b/apps/zbugs/scripts/rmv2-soak/chaos.test.ts
@@ -1,5 +1,9 @@
 import {expect, test} from 'vitest';
-import {c9ResourceFindings} from './chaos.ts';
+import {
+  c15Findings,
+  c9ResourceFindings,
+  type C15Observations,
+} from './chaos.ts';
 
 test('accepts C9 recovery when earlier fat payloads make live pages decrease', () => {
   expect(
@@ -43,5 +47,89 @@ test('reports an unavailable C9 live-page sample and an unpinned slot', () => {
   ).toEqual([
     'C9: change-log live-page usage was not measurable',
     'C9: the minio outage did not grow retained WAL',
+  ]);
+});
+
+const c15 = (overrides: Partial<C15Observations> = {}): C15Observations => ({
+  table: 'c15_backfill_run1',
+  fixtureRows: 200_000,
+  runAnnounced: true,
+  markedBeforeRestart: true,
+  rowsBeforeRestart: 40_000,
+  resumedStart: 'resumed',
+  demotions: 0,
+  restores: 0,
+  rowsAfterResume: [
+    {node: 'rm', rows: 200_000},
+    {node: 'vs-0', rows: 200_000},
+  ],
+  ...overrides,
+});
+
+test('accepts a backfill that resumed from the mark and completed', () => {
+  expect(c15Findings(c15())).toEqual([]);
+});
+
+test('reports a restarted run that started over instead of resuming', () => {
+  expect(c15Findings(c15({resumedStart: 'zero'}))).toEqual([
+    "C15's restarted run of c15_backfill_run1 started from zero rather than " +
+      "resuming from the replica's mark; the whole table is being copied again",
+  ]);
+});
+
+test('reports a backfill that was dropped rather than resumed', () => {
+  expect(c15Findings(c15({resumedStart: 'none-observed'}))).toEqual([
+    'C15 restarted the RM mid-backfill but c15_backfill_run1 never announced ' +
+      'another run; the backfill was dropped rather than resumed',
+  ]);
+});
+
+test('reports a fixture too small to interrupt instead of judging the resume', () => {
+  // The run finished before the RM was killed, so `resumedStart` says
+  // nothing -- reporting it as a resume failure would be a false negative.
+  expect(
+    c15Findings(
+      c15({
+        markedBeforeRestart: false,
+        rowsBeforeRestart: 200_000,
+        resumedStart: 'none-observed',
+      }),
+    ),
+  ).toEqual([
+    'C15 could not observe a mark for c15_backfill_run1 before the run ' +
+      'finished (200000 of 200000 rows replicated); the fixture is too small ' +
+      'to interrupt, so the restart proved nothing',
+  ]);
+});
+
+test('reports a run that never announced itself', () => {
+  expect(
+    c15Findings(c15({runAnnounced: false, markedBeforeRestart: false})),
+  ).toEqual([
+    'C15 created c15_backfill_run1 with 200000 rows but no backfill run ' +
+      'announced itself; either the change source did not pick the table up, ' +
+      'or run announcements are not being logged',
+  ]);
+});
+
+test('reports demotions, restores and a short replica alongside the resume', () => {
+  expect(
+    c15Findings(
+      c15({
+        demotions: 1,
+        restores: 2,
+        rowsAfterResume: [
+          {node: 'rm', rows: 200_000},
+          {node: 'vs-0', rows: 199_998},
+        ],
+      }),
+    ),
+  ).toEqual([
+    'C15 demoted 1 follower(s) to PG after a backfill was interrupted; a ' +
+      'backfill restart is not a replication gap',
+    'C15 sent 2 follower(s) back to a litestream restore after a backfill ' +
+      'was interrupted; a backfill restart is not a replication gap',
+    "C15's resumed backfill of c15_backfill_run1 left 1 replica(s) short of " +
+      '200000 rows: vs-0=199998',
   ]);
 });

--- a/apps/zbugs/scripts/rmv2-soak/chaos.test.ts
+++ b/apps/zbugs/scripts/rmv2-soak/chaos.test.ts
@@ -1,8 +1,10 @@
 import {expect, test} from 'vitest';
 import {
   c15Findings,
+  c16Findings,
   c9ResourceFindings,
   type C15Observations,
+  type C16Observations,
 } from './chaos.ts';
 
 test('accepts C9 recovery when earlier fat payloads make live pages decrease', () => {
@@ -153,5 +155,78 @@ test('reports an unsettled fixture instead of judging the run', () => {
   ).toEqual([
     "C15's 200000 fixture rows did not reach every replica before the column " +
       'was added; the run it measured started from an unsettled table',
+  ]);
+});
+
+const c16 = (overrides: Partial<C16Observations> = {}): C16Observations => ({
+  reservedWatermark: '691l5n60',
+  rowsPurgedDuringHold: 0,
+  passesAboveReservedWatermark: 0,
+  backupWatermarksDuringHold: 140,
+  changeLogLiveBytesBefore: 4_194_304,
+  changeLogLiveBytesDuring: 22_020_096,
+  changeLogLiveBytesAfter: 5_242_880,
+  rowsPurgedAfterRelease: 30_604,
+  ...overrides,
+});
+
+test('accepts a reservation that held the floor and drained after release', () => {
+  expect(c16Findings(c16())).toEqual([]);
+});
+
+test('reports a change log purged under an open reservation', () => {
+  expect(
+    c16Findings(
+      c16({rowsPurgedDuringHold: 1_200, passesAboveReservedWatermark: 2}),
+    ),
+  ).toEqual([
+    'C16: 1200 change-log row(s) were purged while a snapshot reservation ' +
+      'was open',
+    'C16: 2 purge pass(es) ran with a floor above the reserved watermark ' +
+      '691l5n60',
+  ]);
+});
+
+test('reports an unconfirmed reservation without judging anything else', () => {
+  // Nothing was reserved, so growth, drain and the ACK path are all about a
+  // floor that was never asked to hold.
+  expect(
+    c16Findings(
+      c16({
+        reservedWatermark: undefined,
+        changeLogLiveBytesDuring: 4_194_304,
+        backupWatermarksDuringHold: 0,
+      }),
+    ),
+  ).toEqual(['C16: the snapshot reservation was never confirmed']);
+});
+
+test('reports a hold that retained nothing and never drained', () => {
+  expect(
+    c16Findings(
+      c16({
+        changeLogLiveBytesDuring: 4_194_304,
+        changeLogLiveBytesAfter: 4_194_304,
+        rowsPurgedAfterRelease: 0,
+      }),
+    ),
+  ).toEqual([
+    'C16: the held reservation retained no change-log pages, so nothing was ' +
+      'asked of the floor',
+    'C16: live change-log pages did not drain after the reservation was ' +
+      'released',
+    'C16: no change-log rows were purged after the reservation was released',
+  ]);
+});
+
+test('reports an unmeasurable live-page sample and a silent ACK path', () => {
+  expect(
+    c16Findings(
+      c16({changeLogLiveBytesDuring: -1, backupWatermarksDuringHold: 0}),
+    ),
+  ).toEqual([
+    'C16: change-log live-page usage was not measurable',
+    'C16: no backup watermark arrived while the reservation was held, so the ' +
+      'upstream ACK path was never observed',
   ]);
 });

--- a/apps/zbugs/scripts/rmv2-soak/chaos.ts
+++ b/apps/zbugs/scripts/rmv2-soak/chaos.ts
@@ -410,16 +410,24 @@ async function restartViewSyncer(
  * C15's fixture size. Backfill transactions are cut at 8MB
  * (`COMMIT_THRESHOLD_BYTES` in `backfill-manager.ts`), so the table has to be
  * several times that for the run to have committed a mark *and* still have
- * work left when the RM is killed. 200k rows at ~200 bytes is ~40MB, i.e.
- * about five backfill transactions.
+ * work left when the RM is killed.
  *
- * `scale` shrinks it for a smoke run, but only to a floor: below a couple of
+ * Measured, not guessed: 100k rows at 200 bytes (~20MB, ~2.5 transactions) ran
+ * to completion before the action could interrupt it at all. 400k at 400 bytes
+ * is ~160MB, i.e. about twenty transactions, which is a window measured in
+ * seconds rather than in poll intervals.
+ *
+ * `scale` shrinks it for a smoke run, but only to a floor: below a handful of
  * commit thresholds there is no mark to resume from and the action can only
  * report that its own fixture was too small.
  */
-const BACKFILL_FIXTURE_MAX_ROWS = 200_000;
-const BACKFILL_FIXTURE_MIN_ROWS = 100_000;
-const BACKFILL_FIXTURE_PAYLOAD_BYTES = 200;
+const BACKFILL_FIXTURE_MAX_ROWS = 400_000;
+const BACKFILL_FIXTURE_MIN_ROWS = 250_000;
+const BACKFILL_FIXTURE_PAYLOAD_BYTES = 400;
+/** Tight, because the whole point is to catch the run before it ends. */
+const BACKFILL_PROGRESS_POLL_MS = 50;
+/** The column C15 adds, and whose values the run has to carry. */
+const BACKFILL_COLUMN = 'payload';
 
 function backfillFixtureRows(config: SoakConfig): number {
   return Math.max(
@@ -431,16 +439,21 @@ const BACKFILL_START_TIMEOUT_MS = 120_000;
 const BACKFILL_RESUME_TIMEOUT_MS = 120_000;
 const BACKFILL_COMPLETION_TIMEOUT_MS = 300_000;
 /**
- * A table the change source will want to backfill, with a key it can actually
- * resume from.
+ * The table whose column C15 will have backfilled, with a key the change
+ * source can actually resume from.
  *
- * Two properties matter and neither is incidental. The key is `int4`, which is
- * on the resumable-literal allowlist; and the rows are inserted in key order
- * and then `ANALYZE`d, so `pg_stats.correlation` is 1 and the run clears the
- * `backfillResumeMinCorrelation` gate. The zbugs `issue` table satisfies
- * neither -- its ids are `change-log-traffic-<run>-<n>`, whose text order and
- * insertion order diverge as soon as the sequence crosses a decade -- so C15
- * brings its own table rather than borrowing the workload's.
+ * The key is `int4`, which is on the resumable-literal allowlist, and the rows
+ * are inserted in key order and then `ANALYZE`d, so `pg_stats.correlation` is
+ * 1 and the run clears the `backfillResumeMinCorrelation` gate. The zbugs
+ * `issue` table satisfies neither -- its ids are
+ * `change-log-traffic-<run>-<n>`, whose text order and insertion order diverge
+ * as soon as the sequence crosses a decade -- so C15 brings its own table
+ * rather than borrowing the workload's.
+ *
+ * Only the key is created here. The rows replicate as ordinary inserts, which
+ * is *not* a backfill; a backfill is what carries the values a column already
+ * had when it was published, and those are not in the WAL. {@link addBackfillColumn}
+ * is what triggers the run.
  */
 async function createBackfillFixture(
   ctx: ChaosContext,
@@ -449,26 +462,47 @@ async function createBackfillFixture(
 ): Promise<number> {
   const rows = backfillFixtureRows(ctx.config);
   const started = Date.now();
+  await ctx.sql.unsafe(`CREATE TABLE "${table}" ("id" int4 PRIMARY KEY)`);
   await ctx.sql.unsafe(`
-    CREATE TABLE "${table}" (
-      "id" int4 PRIMARY KEY,
-      "payload" text NOT NULL
-    )`);
-  await ctx.sql.unsafe(`
-    INSERT INTO "${table}" ("id", "payload")
-      SELECT g, repeat('x', ${BACKFILL_FIXTURE_PAYLOAD_BYTES})
-        FROM generate_series(1, ${rows}) g`);
+    INSERT INTO "${table}" ("id")
+      SELECT g FROM generate_series(1, ${rows}) g`);
   await ctx.sql.unsafe(`ANALYZE "${table}"`);
   out.measurements['fixtureRows'] = rows;
   out.measurements['fixtureBuildMs'] = Date.now() - started;
-  const [{correlation}] = await ctx.sql.unsafe<{correlation: number}[]>(`
+  // Recorded rather than asserted: if the gate ever stops admitting a
+  // perfectly correlated key, the resume verdict says so, and this says why.
+  const stats = await ctx.sql.unsafe<{correlation: number | null}[]>(`
     SELECT correlation FROM pg_stats
-      WHERE tablename = '${table}' AND attname = 'id'`);
+      WHERE schemaname = 'public' AND tablename = '${table}'
+        AND attname = 'id'`);
+  const correlation = stats[0]?.correlation ?? 'unknown';
   out.measurements['fixtureKeyCorrelation'] = correlation;
   out.notes.push(
     `created ${table} with ${rows} rows (key correlation ${correlation})`,
   );
   return rows;
+}
+
+/**
+ * Adds the column whose existing values the change source has to backfill.
+ *
+ * A constant `DEFAULT` is metadata-only in PG11+, so every existing row gains
+ * a value without a single WAL row change -- which is exactly the situation
+ * the backfill exists for, and why C15 triggers its run this way rather than
+ * by creating a populated table (whose rows would simply replicate).
+ */
+async function addBackfillColumn(
+  ctx: ChaosContext,
+  table: string,
+  out: MutableOutcome,
+): Promise<void> {
+  const started = Date.now();
+  await ctx.sql.unsafe(`
+    ALTER TABLE "${table}"
+      ADD COLUMN "payload" text NOT NULL
+      DEFAULT repeat('x', ${BACKFILL_FIXTURE_PAYLOAD_BYTES})`);
+  out.measurements['addColumnMs'] = Date.now() - started;
+  out.notes.push(`added ${table}.payload, which needs a backfill`);
 }
 
 async function dropBackfillFixture(
@@ -484,11 +518,14 @@ export type FixtureRowCount = {readonly node: string; readonly rows: number};
 export type C15Observations = {
   readonly table: string;
   readonly fixtureRows: number;
+  /** Did every replica hold the fixture's rows before the column was added? */
+  readonly fixtureRowsSettled: boolean;
   /** Did any run announce itself for the table at all? */
   readonly runAnnounced: boolean;
   /** Had the replica recorded a mark when the RM was killed? */
   readonly markedBeforeRestart: boolean;
-  readonly rowsBeforeRestart: number;
+  /** Rows whose backfilled column had a value when the RM was killed. */
+  readonly rowsFilledBeforeRestart: number;
   /** `zero`, `resumed`, or `none-observed`. */
   readonly resumedStart: string;
   readonly demotions: number;
@@ -510,26 +547,42 @@ export type C15Observations = {
 export function c15Findings({
   table,
   fixtureRows,
+  fixtureRowsSettled,
   runAnnounced,
   markedBeforeRestart,
-  rowsBeforeRestart,
+  rowsFilledBeforeRestart,
   resumedStart,
   demotions,
   restores,
   rowsAfterResume,
 }: C15Observations): string[] {
   const findings: string[] = [];
-  if (!runAnnounced) {
+  if (!fixtureRowsSettled) {
+    findings.push(
+      `C15's ${fixtureRows} fixture rows did not reach every replica before ` +
+        'the column was added; the run it measured started from an ' +
+        'unsettled table',
+    );
+  } else if (!runAnnounced) {
     findings.push(
       `C15 created ${table} with ${fixtureRows} rows but no backfill run ` +
         'announced itself; either the change source did not pick the table ' +
         'up, or run announcements are not being logged',
     );
   } else if (!markedBeforeRestart) {
+    // Two causes, and they are worth naming together, because the harness
+    // cannot tell them apart from here and one of them is a *product*
+    // condition rather than a fixture problem. An unordered run carries no
+    // `lastKey`, so no mark ever appears no matter how long the run takes --
+    // which looks identical to a run that finished too fast.
     findings.push(
-      `C15 could not observe a mark for ${table} before the run finished ` +
-        `(${rowsBeforeRestart} of ${fixtureRows} rows replicated); the ` +
-        'fixture is too small to interrupt, so the restart proved nothing',
+      `C15 never saw a mark for ${table} ` +
+        `(${rowsFilledBeforeRestart} of ${fixtureRows} rows backfilled). ` +
+        'Either the run was not ordered -- check that ' +
+        '`ZERO_CHANGE_STREAMER_BACKFILL_RESUME=on` reached the RM and that ' +
+        'the key cleared the correlation gate -- or it finished before the ' +
+        'restart, which makes the fixture too small. The restart proved ' +
+        'nothing either way.',
     );
   } else if (resumedStart === 'none-observed') {
     findings.push(
@@ -586,49 +639,85 @@ function waitForRunAnnouncement(
 }
 
 /**
+ * Waits until every replica holds the fixture's rows, before the column that
+ * needs backfilling is added. The rows arrive as ordinary inserts, so this is
+ * setup rather than the thing under test -- but the backfill has to start from
+ * a settled table, or "the column is not filled in yet" and "the row is not
+ * here yet" become the same observation.
+ */
+async function waitForFixtureRows(
+  ctx: ChaosContext,
+  table: string,
+  fixtureRows: number,
+): Promise<boolean> {
+  const deadline = Date.now() + BACKFILL_START_TIMEOUT_MS;
+  const handles = ctx.cluster.replicaHandles();
+  for (;;) {
+    const counts = handles.map(h =>
+      readTableRowCount(ctx.lc, h.replicaFile, table),
+    );
+    if (counts.every(rows => rows === fixtureRows)) {
+      return true;
+    }
+    if (Date.now() >= deadline) {
+      return false;
+    }
+    await sleep(500);
+  }
+}
+
+/**
  * Waits until the RM's own replica has recorded a mark for `table` -- which is
  * what a restarted manager resumes from -- while the run still has rows left.
+ *
+ * Progress is the mark, not the row count: every row is already there, and it
+ * is the *column* that is being filled in.
  */
 async function waitForBackfillProgress(
   ctx: ChaosContext,
   table: string,
   fixtureRows: number,
   out: MutableOutcome,
-): Promise<{marked: boolean; rows: number}> {
+): Promise<{marked: boolean; filled: number}> {
   const replicaFile = ctx.cluster.rm.replicaFile;
   const deadline = Date.now() + BACKFILL_START_TIMEOUT_MS;
-  let rows = -1;
+  let filled = -1;
   for (;;) {
     const state = readBackfillState(ctx.lc, replicaFile, table);
-    rows = readTableRowCount(ctx.lc, replicaFile, table);
-    // `mark` is `null` when the run is unordered and `undefined` when the
-    // row is gone, and only a real mark counts.
-    if (
-      state?.mark !== null &&
-      state?.mark !== undefined &&
-      rows > 0 &&
-      rows < fixtureRows
-    ) {
-      out.measurements['rowsBeforeRestart'] = rows;
+    // The row exists only while the backfill is in flight -- a completion
+    // deletes it -- so a real mark on it *is* "still running, and resumable".
+    // `filled` is read for the record afterwards, never as the condition: it
+    // is a second query, and racing it against the first is one of the ways
+    // the earlier version managed to miss a run entirely.
+    // (`mark` is `null` for an unordered run and `undefined` when the row is
+    // gone; neither is a mark.)
+    if (state?.mark !== null && state?.mark !== undefined) {
+      filled = readTableRowCount(ctx.lc, replicaFile, table, BACKFILL_COLUMN);
+      out.measurements['rowsFilledBeforeRestart'] = filled;
       out.measurements['markBeforeRestart'] = state.mark;
       out.measurements['runIDBeforeRestart'] = str(state.runID);
-      return {marked: true, rows};
+      return {marked: true, filled};
     }
-    // The `_zero.backfilling` row is deleted on completion, so a missing row
-    // beside a full table means the run finished before we could interrupt it.
-    if (state === undefined && rows >= fixtureRows) {
+    filled = readTableRowCount(ctx.lc, replicaFile, table, BACKFILL_COLUMN);
+    // No row beside a filled column means the run finished before we could
+    // interrupt it.
+    if (state === undefined && filled >= fixtureRows) {
       break;
     }
     if (Date.now() >= deadline) {
       break;
     }
-    await sleep(200);
+    await sleep(BACKFILL_PROGRESS_POLL_MS);
   }
-  out.measurements['rowsBeforeRestart'] = rows;
-  return {marked: false, rows};
+  out.measurements['rowsFilledBeforeRestart'] = filled;
+  return {marked: false, filled};
 }
 
-/** Every replica's row count for `table`, once they settle or time out. */
+/**
+ * Every replica's count of rows that have the backfilled column, once they
+ * settle or time out. A resume that skipped its suffix shows up here and
+ * nowhere else.
+ */
 async function waitForBackfillCompletion(
   ctx: ChaosContext,
   table: string,
@@ -639,7 +728,7 @@ async function waitForBackfillCompletion(
   for (;;) {
     const counts = handles.map(h => ({
       node: h.node,
-      rows: readTableRowCount(ctx.lc, h.replicaFile, table),
+      rows: readTableRowCount(ctx.lc, h.replicaFile, table, BACKFILL_COLUMN),
     }));
     if (counts.every(c => c.rows === fixtureRows) || Date.now() >= deadline) {
       return counts;
@@ -1183,12 +1272,16 @@ export const CHAOS_ACTIONS: readonly ChaosAction[] = [
       // with the process. What survives is the mark the replica recorded, and
       // the whole point of R7 is that the next run picks up from it.
       const table = `c15_backfill_${ctx.config.runID.replace(/[^a-z0-9]/gi, '')}`;
-      const windowStart = Date.now();
       const fixtureRows = await createBackfillFixture(ctx, table, out);
       try {
-        // The fixture appears in the `FOR TABLES IN SCHEMA public` publication
-        // as soon as it exists, so the change source picks it up and starts a
-        // run without anything else being asked of it.
+        // Settle the rows first. They replicate as ordinary inserts -- adding
+        // a column is what needs a backfill, because the values it already
+        // has for every existing row are not in the WAL.
+        const settled = await waitForFixtureRows(ctx, table, fixtureRows);
+        out.measurements['fixtureRowsSettled'] = settled ? 'yes' : 'no';
+
+        const windowStart = Date.now();
+        await addBackfillColumn(ctx, table, out);
         const announced = await waitForRunAnnouncement(
           ctx,
           table,
@@ -1243,8 +1336,15 @@ export const CHAOS_ACTIONS: readonly ChaosAction[] = [
         const demotions = ctx.log.events.filter(
           e => e.tsMs >= since && e.kind === 'reservation-demoted',
         ).length;
+        // Followers only. The replication-manager restores its own replica on
+        // every start -- that is the restart path C5 exercises, not a
+        // subscriber being thrown back to the backup.
+        const rmNode = ctx.cluster.rm.name;
         const restores = ctx.log.events.filter(
-          e => e.tsMs >= since && e.kind === 'restore-started',
+          e =>
+            e.tsMs >= since &&
+            e.kind === 'restore-started' &&
+            e.node !== rmNode,
         ).length;
         out.measurements['demotions'] = demotions;
         out.measurements['restoresAfterBackfillRestart'] = restores;
@@ -1253,9 +1353,10 @@ export const CHAOS_ACTIONS: readonly ChaosAction[] = [
           ...c15Findings({
             table,
             fixtureRows,
+            fixtureRowsSettled: settled,
             runAnnounced: announced !== undefined,
             markedBeforeRestart: progress.marked,
-            rowsBeforeRestart: progress.rows,
+            rowsFilledBeforeRestart: progress.filled,
             resumedStart: resumed
               ? str(resumed.detail.start, 'unknown')
               : 'none-observed',

--- a/apps/zbugs/scripts/rmv2-soak/chaos.ts
+++ b/apps/zbugs/scripts/rmv2-soak/chaos.ts
@@ -1,6 +1,8 @@
 import {stat} from 'node:fs/promises';
 import type {LogContext} from '@rocicorp/logger';
 import type postgres from 'postgres';
+import {ChangeStreamerHttpClient} from '../../../../packages/zero-cache/src/services/change-streamer/change-streamer-http.ts';
+import type {SnapshotStatus} from '../../../../packages/zero-cache/src/services/change-streamer/snapshot.ts';
 import type {TrafficDriver} from '../change-log-traffic.ts';
 import type {SoakCluster} from './cluster.ts';
 import type {SoakConfig} from './config.ts';
@@ -133,6 +135,11 @@ function str(value: unknown, dflt = 'unknown'): string {
     default:
       return JSON.stringify(value) ?? dflt;
   }
+}
+
+/** A numeric field of an event's detail, or `dflt` when it is not one. */
+function num(value: unknown, dflt = 0): number {
+  return typeof value === 'number' ? value : dflt;
 }
 
 async function fileSize(path: string): Promise<number> {
@@ -735,6 +742,176 @@ async function waitForBackfillCompletion(
     }
     await sleep(500);
   }
+}
+
+/**
+ * The task id C16 reserves under. Deliberately not one of the cluster's node
+ * names: `SnapshotReservations.open()` closes whatever reservation the task
+ * already holds, so reusing a view-syncer's id would tear down that follower's
+ * own reservation instead of adding one.
+ */
+const C16_TASK_ID = 'c16-slow-restore';
+
+/** How long to wait for the change-streamer to confirm C16's reservation. */
+const RESERVATION_CONFIRM_TIMEOUT_MS = 120_000;
+
+/**
+ * How long to wait for the purger to run once C16 releases its reservation.
+ * The coordinator is level-triggered on a `CLEANUP_DELAY_MS` (30s) cadence, so
+ * a pass is not immediate even though the floor is free.
+ */
+const RESERVATION_DRAIN_TIMEOUT_MS = 180_000;
+
+export type C16Observations = {
+  readonly reservedWatermark: string | undefined;
+  readonly rowsPurgedDuringHold: number;
+  readonly passesAboveReservedWatermark: number;
+  readonly backupWatermarksDuringHold: number;
+  readonly changeLogLiveBytesBefore: number;
+  readonly changeLogLiveBytesDuring: number;
+  readonly changeLogLiveBytesAfter: number;
+  readonly rowsPurgedAfterRelease: number;
+};
+
+/**
+ * C16's gate: what a held reservation must and must not do.
+ *
+ * The `must not` is the interesting half. A reservation is the mechanism that
+ * makes a slow restore safe -- the follower is promised catchup from
+ * `minWatermark`, and the floor
+ * (`min(backupWatermark, ...acks, ...reservations)`) may not pass it while the
+ * socket is open -- so a purge that ran anyway is a follower that would meet
+ * `WatermarkTooOld` at the end of its restore.
+ *
+ * The retained/drained pair is what keeps the action honest: without growth
+ * during the hold there was nothing to purge, and "no rows purged" would pass
+ * for the wrong reason.
+ */
+export function c16Findings({
+  reservedWatermark,
+  rowsPurgedDuringHold,
+  passesAboveReservedWatermark,
+  backupWatermarksDuringHold,
+  changeLogLiveBytesBefore,
+  changeLogLiveBytesDuring,
+  changeLogLiveBytesAfter,
+  rowsPurgedAfterRelease,
+}: C16Observations): string[] {
+  const findings: string[] = [];
+  if (reservedWatermark === undefined) {
+    // Every other check is a statement about a reservation that was actually
+    // held, so none of them mean anything here.
+    return ['C16: the snapshot reservation was never confirmed'];
+  }
+  if (rowsPurgedDuringHold > 0) {
+    findings.push(
+      `C16: ${rowsPurgedDuringHold} change-log row(s) were purged while a ` +
+        'snapshot reservation was open',
+    );
+  }
+  if (passesAboveReservedWatermark > 0) {
+    findings.push(
+      `C16: ${passesAboveReservedWatermark} purge pass(es) ran with a floor ` +
+        `above the reserved watermark ${reservedWatermark}`,
+    );
+  }
+  if (
+    [
+      changeLogLiveBytesBefore,
+      changeLogLiveBytesDuring,
+      changeLogLiveBytesAfter,
+    ].some(bytes => bytes < 0)
+  ) {
+    findings.push('C16: change-log live-page usage was not measurable');
+  } else {
+    if (changeLogLiveBytesDuring <= changeLogLiveBytesBefore) {
+      findings.push(
+        'C16: the held reservation retained no change-log pages, so nothing ' +
+          'was asked of the floor',
+      );
+    }
+    if (changeLogLiveBytesAfter >= changeLogLiveBytesDuring) {
+      findings.push(
+        'C16: live change-log pages did not drain after the reservation was ' +
+          'released',
+      );
+    }
+  }
+  if (rowsPurgedAfterRelease === 0) {
+    findings.push(
+      'C16: no change-log rows were purged after the reservation was released',
+    );
+  }
+  if (backupWatermarksDuringHold === 0) {
+    findings.push(
+      'C16: no backup watermark arrived while the reservation was held, so ' +
+        'the upstream ACK path was never observed',
+    );
+  }
+  return findings;
+}
+
+type HeldReservation = {
+  /** The bounds the change-streamer advertised, or `undefined` if it never did. */
+  readonly status: SnapshotStatus | undefined;
+  readonly confirmMs: number;
+  /** Ends the reservation, the way subscribing to `/changes` would. */
+  readonly release: () => Promise<void>;
+};
+
+/**
+ * Opens a snapshot reservation and holds it, the way a view-syncer holds one
+ * for the whole of a litestream restore.
+ *
+ * The reservation lives exactly as long as its WebSocket, so the stream is
+ * *iterated* rather than read once and broken out of -- breaking cancels the
+ * subscription, which is precisely the release this is trying to defer. The
+ * real client does the same thing (`reserveAndGetSnapshotStatus`), and the
+ * change-streamer is what normally ends the stream, when the task subscribes.
+ */
+async function holdSnapshotReservation(
+  ctx: ChaosContext,
+  taskID: string,
+): Promise<HeldReservation> {
+  const client = new ChangeStreamerHttpClient(
+    ctx.lc,
+    // Only used for change-streamer discovery through the change DB, which an
+    // explicit URI skips.
+    {appID: ctx.config.appID, shardNum: 0},
+    ctx.config.upstreamDB,
+    `ws://127.0.0.1:${ctx.config.rmPort + 1}/`,
+  );
+  const openedAt = Date.now();
+  const stream = await client.reserveSnapshot(taskID);
+
+  let confirm: (status: SnapshotStatus | undefined) => void = () => {};
+  const confirmed = new Promise<SnapshotStatus | undefined>(resolve => {
+    confirm = resolve;
+  });
+  const ended = (async () => {
+    try {
+      for await (const msg of stream) {
+        confirm(msg[1]);
+      }
+    } finally {
+      // A stream that ends without a status leaves the wait unresolved
+      // otherwise; resolving twice is a no-op.
+      confirm(undefined);
+    }
+  })().catch(() => {});
+
+  const timer = setTimeout(confirm, RESERVATION_CONFIRM_TIMEOUT_MS, undefined);
+  const status = await confirmed;
+  clearTimeout(timer);
+
+  return {
+    status,
+    confirmMs: Date.now() - openedAt,
+    release: async () => {
+      stream.cancel();
+      await ended;
+    },
+  };
 }
 
 export const CHAOS_ACTIONS: readonly ChaosAction[] = [
@@ -1368,6 +1545,143 @@ export const CHAOS_ACTIONS: readonly ChaosAction[] = [
       } finally {
         await dropBackfillFixture(ctx, table);
       }
+    },
+  },
+  {
+    id: 'C16',
+    title: 'Hold a snapshot reservation open under sustained writes',
+    expected:
+      'the change log is retained for the whole hold and drains after it; the upstream ACK keeps advancing',
+    async run(ctx, out) {
+      // Every other action leaves a reservation open for milliseconds -- the
+      // holds observed in a soak are 1-11ms, because the follower restores a
+      // small local replica. A production restore of a large replica out of S3
+      // is minutes, and for all of them the purge floor is pinned at the
+      // `minWatermark` the follower was promised. It is more than pinned:
+      // `startSnapshotReservation` takes a `pause(taskID)` on the purge
+      // scheduler that is only released when the reservation closes, so no
+      // pass deletes anything at all while one is open.
+      //
+      // This holds a reservation without restoring anything, which is the only
+      // way to ask the question without a replica big enough to take minutes
+      // to download.
+      const holdSeconds = Math.max(60, Math.round(300 * ctx.config.scale));
+      const load = ctx.traffic.runStage({
+        rate: 25,
+        durationSeconds: holdSeconds + 60,
+        label: 'C16-sustained',
+      });
+      const before = await ctx.sampler.sample();
+      const reservation = await holdSnapshotReservation(ctx, C16_TASK_ID);
+      const heldFrom = Date.now();
+      const reservedWatermark = reservation.status?.minWatermark;
+      out.notes.push(
+        `holding a snapshot reservation as ${C16_TASK_ID} for ${holdSeconds}s`,
+      );
+      out.measurements['holdSeconds'] = holdSeconds;
+      out.measurements['reservationConfirmMs'] = reservation.confirmMs;
+      out.measurements['reservedWatermark'] =
+        reservedWatermark ?? 'unconfirmed';
+
+      let during: ResourceSample | undefined;
+      let releasedAt = heldFrom;
+      try {
+        await sleep(holdSeconds * 1000);
+        during = await ctx.sampler.sample();
+      } finally {
+        // A reservation left open would pin the floor for the rest of the run,
+        // so it is released even if the hold itself failed. The boundary is
+        // taken *before* the release rather than after it: a purge in the
+        // milliseconds it takes the socket to close would then be read as an
+        // ordinary post-release pass rather than as a violation, and a
+        // spurious finding is worse here than an unobservable one.
+        releasedAt = Date.now();
+        await reservation.release();
+        out.notes.push('released the snapshot reservation');
+      }
+
+      const passes = ctx.log.events.filter(
+        e =>
+          e.kind === 'purge-pass' && e.tsMs >= heldFrom && e.tsMs < releasedAt,
+      );
+      const rowsPurgedDuringHold = passes.reduce(
+        (sum, e) => sum + num(e.detail.deletedRows),
+        0,
+      );
+      // A floor above the reservation would mean the floor formula dropped it;
+      // an absent floor field cannot be above anything.
+      const passesAboveReservedWatermark =
+        reservedWatermark === undefined
+          ? 0
+          : passes.filter(e => str(e.detail.floor, '') > reservedWatermark)
+              .length;
+      const backupWatermarksDuringHold = ctx.log.events.filter(
+        e =>
+          e.kind === 'backup-watermark' &&
+          e.tsMs >= heldFrom &&
+          e.tsMs < releasedAt,
+      ).length;
+      out.measurements['purgePassesDuringHold'] = passes.length;
+      out.measurements['purgePassesPausedDuringHold'] = passes.filter(
+        e => e.detail.stopped === 'paused',
+      ).length;
+      out.measurements['rowsPurgedDuringHold'] = rowsPurgedDuringHold;
+      out.measurements['passesAboveReservedWatermark'] =
+        passesAboveReservedWatermark;
+      out.measurements['backupWatermarksDuringHold'] =
+        backupWatermarksDuringHold;
+
+      // Let the writes stop before measuring the drain, so that the recovery
+      // is the purger catching up rather than a race with the workload.
+      await load;
+      const drainPass = await ctx.log
+        .waitFor(
+          'a purge pass after the reservation was released',
+          e => e.kind === 'purge-pass' && num(e.detail.deletedRows) > 0,
+          RESERVATION_DRAIN_TIMEOUT_MS,
+          releasedAt,
+        )
+        .catch(() => undefined);
+      const after = await ctx.sampler.sample();
+      const rowsPurgedAfterRelease = ctx.log.events
+        .filter(e => e.kind === 'purge-pass' && e.tsMs >= releasedAt)
+        .reduce((sum, e) => sum + num(e.detail.deletedRows), 0);
+      out.measurements['drainPassObserved'] = drainPass ? 'yes' : 'no';
+      out.measurements['rowsPurgedAfterRelease'] = rowsPurgedAfterRelease;
+
+      const liveBytes = (s: ResourceSample | undefined) =>
+        s?.changeLogLiveBytes ?? -1;
+      const slotBytes = (s: ResourceSample | undefined) =>
+        (s?.slots ?? []).reduce((acc, slot) => acc + slot.retainedBytes, 0);
+      out.measurements['changeLogBytesBefore'] = before?.changeLogBytes ?? -1;
+      out.measurements['changeLogBytesDuring'] = during?.changeLogBytes ?? -1;
+      out.measurements['changeLogBytesAfter'] = after?.changeLogBytes ?? -1;
+      out.measurements['changeLogLiveBytesBefore'] = liveBytes(before);
+      out.measurements['changeLogLiveBytesDuring'] = liveBytes(during);
+      out.measurements['changeLogLiveBytesAfter'] = liveBytes(after);
+      // The slot is recorded rather than gated. A reservation pins the purge
+      // floor but not the upstream ACK -- that is
+      // `min(pgChangeLogWatermark, backupWatermark)`, which no reservation
+      // enters, and which is the whole difference between this and C9. WAL is
+      // retained in segments, though, so a short run's slot numbers are too
+      // lumpy to assert on; the ACK-path evidence that *is* gated is
+      // `backupWatermarksDuringHold`.
+      out.measurements['slotRetainedBytesBefore'] = slotBytes(before);
+      out.measurements['slotRetainedBytesDuring'] = slotBytes(during);
+      out.measurements['slotRetainedBytesAfter'] = slotBytes(after);
+
+      out.findings.push(
+        ...c16Findings({
+          reservedWatermark,
+          rowsPurgedDuringHold,
+          passesAboveReservedWatermark,
+          backupWatermarksDuringHold,
+          changeLogLiveBytesBefore: liveBytes(before),
+          changeLogLiveBytesDuring: liveBytes(during),
+          changeLogLiveBytesAfter: liveBytes(after),
+          rowsPurgedAfterRelease,
+        }),
+      );
     },
   },
 ];

--- a/apps/zbugs/scripts/rmv2-soak/chaos.ts
+++ b/apps/zbugs/scripts/rmv2-soak/chaos.ts
@@ -1,10 +1,12 @@
 import {stat} from 'node:fs/promises';
+import type {LogContext} from '@rocicorp/logger';
 import type postgres from 'postgres';
 import type {TrafficDriver} from '../change-log-traffic.ts';
 import type {SoakCluster} from './cluster.ts';
 import type {SoakConfig} from './config.ts';
 import {backupGenerations, sleep, startMinio, stopMinio} from './infra.ts';
 import type {SoakEvent, SoakLog} from './logs.ts';
+import {readBackfillState, readTableRowCount} from './oracle.ts';
 import type {MetricStore} from './otlp.ts';
 import type {ResourceSample, ResourceSampler} from './resources.ts';
 
@@ -24,6 +26,8 @@ import type {ResourceSample, ResourceSampler} from './resources.ts';
 export type ChaosContext = {
   readonly config: SoakConfig;
   readonly cluster: SoakCluster;
+  /** For the oracle's replica readers, which open SQLite directly. */
+  readonly lc: LogContext;
   readonly log: SoakLog;
   readonly metrics: MetricStore;
   readonly sql: postgres.Sql;
@@ -400,6 +404,248 @@ async function restartViewSyncer(
   out.measurements[`restartMs.${vs.name}`] = Date.now() - since;
   measureReservationHold(ctx.log, since, vs.name, out);
   recordConfirmationEvidence(ctx.log, since, out);
+}
+
+/**
+ * C15's fixture size. Backfill transactions are cut at 8MB
+ * (`COMMIT_THRESHOLD_BYTES` in `backfill-manager.ts`), so the table has to be
+ * several times that for the run to have committed a mark *and* still have
+ * work left when the RM is killed. 200k rows at ~200 bytes is ~40MB, i.e.
+ * about five backfill transactions.
+ *
+ * `scale` shrinks it for a smoke run, but only to a floor: below a couple of
+ * commit thresholds there is no mark to resume from and the action can only
+ * report that its own fixture was too small.
+ */
+const BACKFILL_FIXTURE_MAX_ROWS = 200_000;
+const BACKFILL_FIXTURE_MIN_ROWS = 100_000;
+const BACKFILL_FIXTURE_PAYLOAD_BYTES = 200;
+
+function backfillFixtureRows(config: SoakConfig): number {
+  return Math.max(
+    BACKFILL_FIXTURE_MIN_ROWS,
+    Math.round(BACKFILL_FIXTURE_MAX_ROWS * config.scale),
+  );
+}
+const BACKFILL_START_TIMEOUT_MS = 120_000;
+const BACKFILL_RESUME_TIMEOUT_MS = 120_000;
+const BACKFILL_COMPLETION_TIMEOUT_MS = 300_000;
+/**
+ * A table the change source will want to backfill, with a key it can actually
+ * resume from.
+ *
+ * Two properties matter and neither is incidental. The key is `int4`, which is
+ * on the resumable-literal allowlist; and the rows are inserted in key order
+ * and then `ANALYZE`d, so `pg_stats.correlation` is 1 and the run clears the
+ * `backfillResumeMinCorrelation` gate. The zbugs `issue` table satisfies
+ * neither -- its ids are `change-log-traffic-<run>-<n>`, whose text order and
+ * insertion order diverge as soon as the sequence crosses a decade -- so C15
+ * brings its own table rather than borrowing the workload's.
+ */
+async function createBackfillFixture(
+  ctx: ChaosContext,
+  table: string,
+  out: MutableOutcome,
+): Promise<number> {
+  const rows = backfillFixtureRows(ctx.config);
+  const started = Date.now();
+  await ctx.sql.unsafe(`
+    CREATE TABLE "${table}" (
+      "id" int4 PRIMARY KEY,
+      "payload" text NOT NULL
+    )`);
+  await ctx.sql.unsafe(`
+    INSERT INTO "${table}" ("id", "payload")
+      SELECT g, repeat('x', ${BACKFILL_FIXTURE_PAYLOAD_BYTES})
+        FROM generate_series(1, ${rows}) g`);
+  await ctx.sql.unsafe(`ANALYZE "${table}"`);
+  out.measurements['fixtureRows'] = rows;
+  out.measurements['fixtureBuildMs'] = Date.now() - started;
+  const [{correlation}] = await ctx.sql.unsafe<{correlation: number}[]>(`
+    SELECT correlation FROM pg_stats
+      WHERE tablename = '${table}' AND attname = 'id'`);
+  out.measurements['fixtureKeyCorrelation'] = correlation;
+  out.notes.push(
+    `created ${table} with ${rows} rows (key correlation ${correlation})`,
+  );
+  return rows;
+}
+
+async function dropBackfillFixture(
+  ctx: ChaosContext,
+  table: string,
+): Promise<void> {
+  await ctx.sql.unsafe(`DROP TABLE IF EXISTS "${table}"`);
+}
+
+/** One replica's row count for the fixture table. */
+export type FixtureRowCount = {readonly node: string; readonly rows: number};
+
+export type C15Observations = {
+  readonly table: string;
+  readonly fixtureRows: number;
+  /** Did any run announce itself for the table at all? */
+  readonly runAnnounced: boolean;
+  /** Had the replica recorded a mark when the RM was killed? */
+  readonly markedBeforeRestart: boolean;
+  readonly rowsBeforeRestart: number;
+  /** `zero`, `resumed`, or `none-observed`. */
+  readonly resumedStart: string;
+  readonly demotions: number;
+  readonly restores: number;
+  readonly rowsAfterResume: readonly FixtureRowCount[];
+};
+
+/**
+ * C15's verdict, separated from the driving so that each way it can fail is
+ * a case rather than a run.
+ *
+ * The ordering is deliberate: a run that never announced itself, or a fixture
+ * too small to interrupt, makes the resume verdict meaningless, so those are
+ * reported *instead of* it rather than alongside it. Only the demotion,
+ * restore and completeness checks always apply -- they are about the rest of
+ * the system's reaction, which is worth judging even when the backfill itself
+ * did something unexpected.
+ */
+export function c15Findings({
+  table,
+  fixtureRows,
+  runAnnounced,
+  markedBeforeRestart,
+  rowsBeforeRestart,
+  resumedStart,
+  demotions,
+  restores,
+  rowsAfterResume,
+}: C15Observations): string[] {
+  const findings: string[] = [];
+  if (!runAnnounced) {
+    findings.push(
+      `C15 created ${table} with ${fixtureRows} rows but no backfill run ` +
+        'announced itself; either the change source did not pick the table ' +
+        'up, or run announcements are not being logged',
+    );
+  } else if (!markedBeforeRestart) {
+    findings.push(
+      `C15 could not observe a mark for ${table} before the run finished ` +
+        `(${rowsBeforeRestart} of ${fixtureRows} rows replicated); the ` +
+        'fixture is too small to interrupt, so the restart proved nothing',
+    );
+  } else if (resumedStart === 'none-observed') {
+    findings.push(
+      `C15 restarted the RM mid-backfill but ${table} never announced ` +
+        'another run; the backfill was dropped rather than resumed',
+    );
+  } else if (resumedStart !== 'resumed') {
+    findings.push(
+      `C15's restarted run of ${table} started from ${resumedStart} rather ` +
+        "than resuming from the replica's mark; the whole table is being " +
+        'copied again',
+    );
+  }
+  if (demotions > 0) {
+    findings.push(
+      `C15 demoted ${demotions} follower(s) to PG after a backfill was ` +
+        'interrupted; a backfill restart is not a replication gap',
+    );
+  }
+  if (restores > 0) {
+    findings.push(
+      `C15 sent ${restores} follower(s) back to a litestream restore after ` +
+        'a backfill was interrupted; a backfill restart is not a ' +
+        'replication gap',
+    );
+  }
+  const short = rowsAfterResume.filter(c => c.rows !== fixtureRows);
+  if (short.length > 0) {
+    // A resume that skipped its suffix would satisfy every check above.
+    findings.push(
+      `C15's resumed backfill of ${table} left ${short.length} replica(s) ` +
+        `short of ${fixtureRows} rows: ` +
+        short.map(c => `${c.node}=${c.rows}`).join(', '),
+    );
+  }
+  return findings;
+}
+
+/** The run announcement for `table` at or after `sinceMs`, if one arrives. */
+function waitForRunAnnouncement(
+  ctx: ChaosContext,
+  table: string,
+  sinceMs: number,
+  timeoutMs: number,
+): Promise<SoakEvent | undefined> {
+  return ctx.log
+    .waitFor(
+      `a backfill run announcement for ${table}`,
+      e => e.kind === 'backfill-run-started' && e.detail.table === table,
+      timeoutMs,
+      sinceMs,
+    )
+    .catch(() => undefined);
+}
+
+/**
+ * Waits until the RM's own replica has recorded a mark for `table` -- which is
+ * what a restarted manager resumes from -- while the run still has rows left.
+ */
+async function waitForBackfillProgress(
+  ctx: ChaosContext,
+  table: string,
+  fixtureRows: number,
+  out: MutableOutcome,
+): Promise<{marked: boolean; rows: number}> {
+  const replicaFile = ctx.cluster.rm.replicaFile;
+  const deadline = Date.now() + BACKFILL_START_TIMEOUT_MS;
+  let rows = -1;
+  for (;;) {
+    const state = readBackfillState(ctx.lc, replicaFile, table);
+    rows = readTableRowCount(ctx.lc, replicaFile, table);
+    // `mark` is `null` when the run is unordered and `undefined` when the
+    // row is gone, and only a real mark counts.
+    if (
+      state?.mark !== null &&
+      state?.mark !== undefined &&
+      rows > 0 &&
+      rows < fixtureRows
+    ) {
+      out.measurements['rowsBeforeRestart'] = rows;
+      out.measurements['markBeforeRestart'] = state.mark;
+      out.measurements['runIDBeforeRestart'] = str(state.runID);
+      return {marked: true, rows};
+    }
+    // The `_zero.backfilling` row is deleted on completion, so a missing row
+    // beside a full table means the run finished before we could interrupt it.
+    if (state === undefined && rows >= fixtureRows) {
+      break;
+    }
+    if (Date.now() >= deadline) {
+      break;
+    }
+    await sleep(200);
+  }
+  out.measurements['rowsBeforeRestart'] = rows;
+  return {marked: false, rows};
+}
+
+/** Every replica's row count for `table`, once they settle or time out. */
+async function waitForBackfillCompletion(
+  ctx: ChaosContext,
+  table: string,
+  fixtureRows: number,
+): Promise<FixtureRowCount[]> {
+  const deadline = Date.now() + BACKFILL_COMPLETION_TIMEOUT_MS;
+  const handles = ctx.cluster.replicaHandles();
+  for (;;) {
+    const counts = handles.map(h => ({
+      node: h.node,
+      rows: readTableRowCount(ctx.lc, h.replicaFile, table),
+    }));
+    if (counts.every(c => c.rows === fixtureRows) || Date.now() >= deadline) {
+      return counts;
+    }
+    await sleep(500);
+  }
 }
 
 export const CHAOS_ACTIONS: readonly ChaosAction[] = [
@@ -923,6 +1169,104 @@ export const CHAOS_ACTIONS: readonly ChaosAction[] = [
         );
       }
       await load;
+    },
+  },
+  {
+    id: 'C15',
+    title: 'Interrupt a backfill mid-run by restarting the replication-manager',
+    expected:
+      "the run resumes from the replica's mark rather than starting over, and nobody is demoted or restored",
+    async run(ctx, out) {
+      // The other actions all interrupt *replication*. This one interrupts a
+      // *backfill*, which is the one piece of RM state a restart cannot resume
+      // from the change log: the run lives in a snapshot transaction that dies
+      // with the process. What survives is the mark the replica recorded, and
+      // the whole point of R7 is that the next run picks up from it.
+      const table = `c15_backfill_${ctx.config.runID.replace(/[^a-z0-9]/gi, '')}`;
+      const windowStart = Date.now();
+      const fixtureRows = await createBackfillFixture(ctx, table, out);
+      try {
+        // The fixture appears in the `FOR TABLES IN SCHEMA public` publication
+        // as soon as it exists, so the change source picks it up and starts a
+        // run without anything else being asked of it.
+        const announced = await waitForRunAnnouncement(
+          ctx,
+          table,
+          windowStart,
+          BACKFILL_START_TIMEOUT_MS,
+        );
+        out.measurements['firstRunStart'] = str(
+          announced?.detail.start,
+          'none-observed',
+        );
+
+        // A mark exists only once a backfill transaction has landed, so this
+        // is what makes the restart interesting rather than a no-op.
+        const progress = await waitForBackfillProgress(
+          ctx,
+          table,
+          fixtureRows,
+          out,
+        );
+
+        const since = Date.now();
+        await ctx.cluster.rm.stop('SIGTERM');
+        out.notes.push('SIGTERM rm mid-backfill');
+        await ctx.cluster.startReplicationManager();
+        out.measurements['rmRestartMs'] = Date.now() - since;
+
+        const resumed = await waitForRunAnnouncement(
+          ctx,
+          table,
+          since,
+          BACKFILL_RESUME_TIMEOUT_MS,
+        );
+        out.measurements['resumedRunStart'] = str(
+          resumed?.detail.start,
+          'none-observed',
+        );
+        out.measurements['resumedFrom'] = JSON.stringify(
+          resumed?.detail.resumeFrom ?? null,
+        );
+
+        const rowsAfter = await waitForBackfillCompletion(
+          ctx,
+          table,
+          fixtureRows,
+        );
+        out.measurements['rowsAfterResume'] = rowsAfter
+          .map(c => `${c.node}=${c.rows}`)
+          .join(',');
+
+        // A backfill restart must not look like a replication gap to anyone:
+        // no follower demoted to PG, and none thrown back to a restore.
+        const demotions = ctx.log.events.filter(
+          e => e.tsMs >= since && e.kind === 'reservation-demoted',
+        ).length;
+        const restores = ctx.log.events.filter(
+          e => e.tsMs >= since && e.kind === 'restore-started',
+        ).length;
+        out.measurements['demotions'] = demotions;
+        out.measurements['restoresAfterBackfillRestart'] = restores;
+
+        out.findings.push(
+          ...c15Findings({
+            table,
+            fixtureRows,
+            runAnnounced: announced !== undefined,
+            markedBeforeRestart: progress.marked,
+            rowsBeforeRestart: progress.rows,
+            resumedStart: resumed
+              ? str(resumed.detail.start, 'unknown')
+              : 'none-observed',
+            demotions,
+            restores,
+            rowsAfterResume: rowsAfter,
+          }),
+        );
+      } finally {
+        await dropBackfillFixture(ctx, table);
+      }
     },
   },
 ];

--- a/apps/zbugs/scripts/rmv2-soak/config.ts
+++ b/apps/zbugs/scripts/rmv2-soak/config.ts
@@ -195,7 +195,12 @@ export function replicationManagerEnv(
     // so the harness always runs it on. The correlation gate still applies:
     // only C15's own fixture table clears it, so the zbugs tables keep
     // today's unordered behavior either way.
-    ZERO_BACKFILL_RESUME: 'on',
+    //
+    // The option lives under `changeStreamer`, so the prefix is not optional:
+    // `ZERO_BACKFILL_RESUME` is silently ignored and every run comes out
+    // unordered, which looks exactly like a backfill that was too fast to
+    // interrupt.
+    ZERO_CHANGE_STREAMER_BACKFILL_RESUME: 'on',
     ...changeLogEnv({...config.changeLog, ...overrides}),
   };
 }

--- a/apps/zbugs/scripts/rmv2-soak/config.ts
+++ b/apps/zbugs/scripts/rmv2-soak/config.ts
@@ -190,6 +190,12 @@ export function replicationManagerEnv(
       config.snapshotBackupIntervalHours,
     ),
     ZERO_LITESTREAM_VFS_POLL_INTERVAL_MS: String(config.vfsPollIntervalMs),
+    // Resumable backfills, which C15 is the test of. The flag ships `off`
+    // and the soak is where the decision to ship it `on` gets its evidence,
+    // so the harness always runs it on. The correlation gate still applies:
+    // only C15's own fixture table clears it, so the zbugs tables keep
+    // today's unordered behavior either way.
+    ZERO_BACKFILL_RESUME: 'on',
     ...changeLogEnv({...config.changeLog, ...overrides}),
   };
 }

--- a/apps/zbugs/scripts/rmv2-soak/logs.ts
+++ b/apps/zbugs/scripts/rmv2-soak/logs.ts
@@ -42,7 +42,15 @@ export type SoakEventKind =
   // reservation's `minWatermark` was above it, and restored instead.
   | 'replica-discarded'
   | 'barrier-timeout'
-  | 'registration-failed';
+  | 'registration-failed'
+  // A backfill run announced itself on the change stream, from the beginning
+  // or from a mark. C15 is entirely about which of the two.
+  | 'backfill-run-started'
+  // A subscriber's declared backfill progress that catchup did not cover, so
+  // the change-streamer asked the change source to do something about it.
+  | 'backfill-declarations-forwarded'
+  // A row key change voided the marks on a table.
+  | 'backfill-marks-invalidated';
 
 export type SoakEvent = {
   readonly kind: SoakEventKind;
@@ -285,6 +293,32 @@ export class SoakLog {
       this.#emit('change-log-startup', record, {
         ...(fields.sqliteChangeLog as Record<string, unknown>),
       });
+      return;
+    }
+
+    const backfillRun = fields.backfillRun as
+      | Record<string, unknown>
+      | undefined;
+    if (backfillRun) {
+      this.#emit('backfill-run-started', record, {...backfillRun});
+      return;
+    }
+
+    const backfillDeclarations = fields.backfillDeclarations as
+      | Record<string, unknown>[]
+      | undefined;
+    if (backfillDeclarations) {
+      this.#emit('backfill-declarations-forwarded', record, {
+        declarations: backfillDeclarations,
+      });
+      return;
+    }
+
+    const minSnapshot = fields.minSnapshot as
+      | Record<string, unknown>
+      | undefined;
+    if (minSnapshot) {
+      this.#emit('backfill-marks-invalidated', record, {...minSnapshot});
       return;
     }
 

--- a/apps/zbugs/scripts/rmv2-soak/oracle.ts
+++ b/apps/zbugs/scripts/rmv2-soak/oracle.ts
@@ -326,6 +326,62 @@ export function readStateVersion(lc: LogContext, replicaFile: string): string {
   }
 }
 
+/**
+ * One table's in-flight backfill state on a replica, as C15 reads it.
+ *
+ * `mark` is how far an ordered run has been applied. It exists only while the
+ * backfill is in flight -- a completion deletes the row -- so `undefined`
+ * means either "never started" or "already finished", which the caller
+ * distinguishes by when it asked.
+ */
+export type BackfillState = {
+  readonly mark: string | null;
+  readonly markWatermark: string | null;
+  readonly runID: string | null;
+};
+
+export function readBackfillState(
+  lc: LogContext,
+  replicaFile: string,
+  table: string,
+): BackfillState | undefined {
+  let db: Database | undefined;
+  try {
+    db = openReplica(lc, replicaFile);
+    // Every in-flight column of one table shares a mark, so any row answers.
+    return db
+      .prepare(
+        `SELECT "mark", "markWatermark", "runID"
+           FROM "_zero.backfilling" WHERE "table" = ? LIMIT 1`,
+      )
+      .get<BackfillState | undefined>(table);
+  } catch {
+    return undefined;
+  } finally {
+    db?.close();
+  }
+}
+
+/** A replica's row count for `table`, or -1 if it does not have it yet. */
+export function readTableRowCount(
+  lc: LogContext,
+  replicaFile: string,
+  table: string,
+): number {
+  let db: Database | undefined;
+  try {
+    db = openReplica(lc, replicaFile);
+    const row = db
+      .prepare(`SELECT COUNT(*) AS "rows" FROM "${table}"`)
+      .get<{rows: number} | undefined>();
+    return row?.rows ?? -1;
+  } catch {
+    return -1;
+  } finally {
+    db?.close();
+  }
+}
+
 export function readReplicaVersion(
   lc: LogContext,
   replicaFile: string,

--- a/apps/zbugs/scripts/rmv2-soak/oracle.ts
+++ b/apps/zbugs/scripts/rmv2-soak/oracle.ts
@@ -362,17 +362,26 @@ export function readBackfillState(
   }
 }
 
-/** A replica's row count for `table`, or -1 if it does not have it yet. */
+/**
+ * A replica's row count for `table`, or -1 if it does not have the table (or
+ * the column) yet -- which is itself an answer while a backfill is in flight.
+ *
+ * `column`, when given, counts only the rows that have a value for it. That is
+ * how C15 tells a finished backfill from a table that merely exists: the
+ * column is added NULL and filled as the run's rows arrive.
+ */
 export function readTableRowCount(
   lc: LogContext,
   replicaFile: string,
   table: string,
+  column?: string,
 ): number {
   let db: Database | undefined;
   try {
     db = openReplica(lc, replicaFile);
+    const where = column === undefined ? '' : ` WHERE "${column}" IS NOT NULL`;
     const row = db
-      .prepare(`SELECT COUNT(*) AS "rows" FROM "${table}"`)
+      .prepare(`SELECT COUNT(*) AS "rows" FROM "${table}"${where}`)
       .get<{rows: number} | undefined>();
     return row?.rows ?? -1;
   } catch {


### PR DESCRIPTION
A view-syncer reserves its snapshot before it restores and holds the reservation until it subscribes, so a restore that takes minutes -- a large replica coming out of S3 -- pins the purge floor at the `minWatermark` it was promised for that whole time. It is more than pinned: `startSnapshotReservation` takes a `pause(taskID)` on the purge scheduler that only the reservation's close releases, so no pass deletes anything at all while one is open.

Nothing in the matrix asked that question. Every hold this harness has observed is 1-11ms, because the follower restores a small local replica.

C16 holds a reservation for five minutes under sustained writes without restoring anything, and asserts that the log was retained while it was open (no rows purged, no pass with a floor above the reserved watermark), that it drained afterwards, and that backup watermarks kept arriving throughout: a reservation pins the floor but not the upstream ACK, which is `min(pgChangeLogWatermark, backupWatermark)`. That is the whole difference between this and C9, where a stopped minio freezes both.

The slot is reported rather than gated. WAL is retained in whole segments, which makes it too lumpy to assert on over a short run -- and C9 has already had two assertions that failed for the wrong reason.

Out of `DEFAULT_CHAOS` alongside C9, for the same reason: it is five minutes long. `--chaos all` runs it.


Claude-Session: https://claude.ai/code/session_013jdBVFyXyX2KixRSjJR7ai