### PR TITLE
feat(zero-cache): cap how long a snapshot reservation may hold the ch…

### DIFF
--- a/apps/zbugs/scripts/rmv2-soak/chaos.ts
+++ b/apps/zbugs/scripts/rmv2-soak/chaos.ts
@@ -1565,6 +1565,12 @@ export const CHAOS_ACTIONS: readonly ChaosAction[] = [
       // This holds a reservation without restoring anything, which is the only
       // way to ask the question without a replica big enough to take minutes
       // to download.
+      //
+      // The hold must stay under
+      // `--change-streamer-snapshot-reservation-max-age-ms` (an hour by
+      // default), which is the cap that takes a reservation back. Past it the
+      // change-streamer is *supposed* to purge, and this action would report
+      // that as a violation.
       const holdSeconds = Math.max(60, Math.round(300 * ctx.config.scale));
       const load = ctx.traffic.runStage({
         rate: 25,

--- a/packages/zero-cache/src/config/zero-config.ts
+++ b/packages/zero-cache/src/config/zero-config.ts
@@ -801,6 +801,23 @@ export const zeroOptions = {
       hidden: true,
     },
 
+    snapshotReservationMaxAgeMs: {
+      type: v.number().default(60 * 60 * 1000),
+      desc: [
+        `How long a view-syncer's snapshot reservation may hold the change`,
+        `log before the change-streamer takes it back. A reservation keeps the`,
+        `purge floor -- and the purge scheduler itself -- from moving past the`,
+        `watermark a restoring view-syncer was promised, and lives as long as`,
+        `its connection, so a restore that never finishes would otherwise pin`,
+        `the log until the disk filled.`,
+        ``,
+        `Taking a reservation back costs that view-syncer a repeated restore,`,
+        `so this must stay well above the time a restore actually takes: a`,
+        `value below it turns every restore into a loop.`,
+      ],
+      hidden: true,
+    },
+
     pgChangeLogEnabled: {
       type: v.boolean().default(true),
       desc: [

--- a/packages/zero-cache/src/server/change-streamer.ts
+++ b/packages/zero-cache/src/server/change-streamer.ts
@@ -71,6 +71,7 @@ export default async function runWorker(
       backPressureLimitHeapProportion,
       flowControlConsensusTimeoutProportion,
       flowControlSlowSubscriberGracePeriodSeconds,
+      snapshotReservationMaxAgeMs,
       backfillResume,
       backfillResumeMinCorrelation,
       pgChangeLogEnabled,
@@ -238,6 +239,7 @@ export default async function runWorker(
             flowControlSlowSubscriberGracePeriodSeconds > 0
               ? flowControlSlowSubscriberGracePeriodSeconds * 1000
               : undefined,
+          snapshotReservationMaxAgeMs,
           statementTimeoutMs: change.statementTimeoutMs,
           changeLogBatchSize: change.logBatchSize,
           sqliteCatchup: {

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -165,6 +165,11 @@ export type TuningOptions = StorerOptions & {
   pgChangeLogEnabled: boolean;
   flowControlConsensusTimeoutProportion: number;
   flowControlSlowSubscriberGracePeriodMs?: number | undefined;
+  /**
+   * How long a snapshot reservation may hold the change log before it is
+   * taken back. Defaults to {@link DEFAULT_MAX_RESERVATION_AGE_MS}.
+   */
+  snapshotReservationMaxAgeMs?: number | undefined;
   sqliteCatchup?: SQLiteCatchupOptions | undefined;
   /**
    * Supplied when `sqliteChangeLogMode != off`, i.e. this is the gate on the
@@ -606,10 +611,18 @@ class ChangeStreamerImpl implements ChangeStreamerService {
           })
         : undefined;
     this.#reservations = backupConfig
-      ? new SnapshotReservations(lc, backupConfig, taskID => {
-          this.#readRouter?.release(taskID);
-          this.#purgeScheduler?.resume(taskID);
-        })
+      ? new SnapshotReservations(
+          lc,
+          backupConfig,
+          taskID => {
+            this.#readRouter?.release(taskID);
+            this.#purgeScheduler?.resume(taskID);
+          },
+          // Deliberately not the service's injected `setTimeoutFn`: tests
+          // drive the cleanup pass through that mock by index, and an
+          // hour-scale safety valve does not belong in the same queue.
+          {maxAgeMs: opts.snapshotReservationMaxAgeMs},
+        )
       : undefined;
     this.#replicationStatusPublisher = replicationStatusPublisher;
     this.#changeLogWriter = opts.sqliteChangeLogWriter

--- a/packages/zero-cache/src/services/change-streamer/snapshot-reservations.metrics.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/snapshot-reservations.metrics.test.ts
@@ -137,3 +137,41 @@ test('a reservation that never confirmed is distinguishable at close', async () 
     await provider.shutdown();
   }
 });
+
+test('an expired reservation is distinguishable from one that was closed', async () => {
+  const {exporter, provider} = withProvider();
+  try {
+    const {SnapshotReservations} = await import('./snapshot-reservations.ts');
+    let expire: (() => void) | undefined;
+    const reservations = new SnapshotReservations(
+      createSilentLogContext(),
+      BACKUP_CONFIG,
+      undefined,
+      {
+        maxAgeMs: 60_000,
+        setTimeoutFn: ((fn: () => void) => {
+          expire = fn;
+          return {} as unknown as ReturnType<typeof setTimeout>;
+        }) as unknown as typeof setTimeout,
+      },
+    );
+
+    reservations.open('slow-task');
+    reservations.confirmFor('slow-task', 'replica-v1', 'sqlite-min', 'sqlite');
+    expect(expire).toBeDefined();
+    expire?.();
+
+    await provider.forceFlush();
+    // A reservation taken back for holding the log too long is a different
+    // event from a follower that subscribed or went away, and the whole point
+    // of the cap is being able to see how often it happens.
+    expect(
+      pointsFor(exporter, RESERVATION_DURATION).map(({attributes}) => [
+        attributes.result,
+        attributes.confirmed,
+      ]),
+    ).toEqual([['expired', true]]);
+  } finally {
+    await provider.shutdown();
+  }
+});

--- a/packages/zero-cache/src/services/change-streamer/snapshot-reservations.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/snapshot-reservations.test.ts
@@ -1,5 +1,5 @@
 import {resolver} from '@rocicorp/resolver';
-import {describe, expect, test} from 'vitest';
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
 import {createSilentLogContext} from '../../../../shared/src/logging-test-utils.ts';
 import type {Source} from '../../types/streams.ts';
 import {SnapshotReservations} from './snapshot-reservations.ts';
@@ -234,5 +234,92 @@ describe('change-streamer/snapshot-reservations', () => {
   test('noteConfirmationDelayed() is false for an unknown taskID', () => {
     const reservations = newReservations();
     expect(reservations.noteConfirmationDelayed('unknown-task')).toBe(false);
+  });
+
+  describe('expiry', () => {
+    const MAX_AGE_MS = 60_000;
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    function newExpiringReservations(closed: string[]) {
+      return new SnapshotReservations(
+        createSilentLogContext(),
+        {backupURL: 's3://foo/bar', litestreamVersion: 'v5'},
+        taskID => closed.push(taskID),
+        {maxAgeMs: MAX_AGE_MS},
+      );
+    }
+
+    test('a reservation that outlives maxAgeMs is taken back', async () => {
+      // A restore that never finishes would otherwise hold the purge floor --
+      // and the purge scheduler's pause -- for as long as its socket stayed
+      // open. `closed` stands in for the release of both.
+      const closed: string[] = [];
+      const reservations = newExpiringReservations(closed);
+      const sub = reservations.open('task-1');
+      reservations.confirmFor('task-1', 'replica-v1', 'watermark-1', 'sqlite');
+      expect(reservations.getReservedWatermarks()).toEqual(['watermark-1']);
+
+      vi.advanceTimersByTime(MAX_AGE_MS);
+
+      expect(closed).toEqual(['task-1']);
+      expect(reservations.getReservedWatermarks()).toEqual([]);
+      expect(reservations.confirmationsRequired()).toBe(false);
+      expect(await isCancelled(sub)).toBe(true);
+    });
+
+    test('a reservation is held for the whole of maxAgeMs', () => {
+      const closed: string[] = [];
+      const reservations = newExpiringReservations(closed);
+      reservations.open('task-1');
+      reservations.confirmFor('task-1', 'replica-v1', 'watermark-1', 'sqlite');
+
+      vi.advanceTimersByTime(MAX_AGE_MS - 1);
+
+      expect(closed).toEqual([]);
+      expect(reservations.getReservedWatermarks()).toEqual(['watermark-1']);
+    });
+
+    test('a reservation that ends normally is not expired afterwards', () => {
+      const closed: string[] = [];
+      const reservations = newExpiringReservations(closed);
+      reservations.open('task-1');
+      reservations.close('task-1');
+      expect(closed).toEqual(['task-1']);
+
+      // The timer is cleared with the reservation, so the release does not
+      // fire a second time for a task that is long gone -- or, worse, for a
+      // later reservation that reused the id.
+      vi.advanceTimersByTime(MAX_AGE_MS * 2);
+      expect(closed).toEqual(['task-1']);
+    });
+
+    test('a replacement reservation gets its own deadline', async () => {
+      const closed: string[] = [];
+      const reservations = newExpiringReservations(closed);
+      reservations.open('task-1');
+      vi.advanceTimersByTime(MAX_AGE_MS - 1);
+
+      // A retry for the same task supersedes the first, which is closed here
+      // rather than by its own deadline.
+      const replacement = reservations.open('task-1');
+      expect(closed).toEqual(['task-1']);
+
+      // Past the *first* reservation's deadline: the replacement is still
+      // held, because its own clock started when it opened.
+      vi.advanceTimersByTime(2);
+      expect(closed).toEqual(['task-1']);
+      expect(reservations.isCurrent('task-1', replacement)).toBe(true);
+
+      vi.advanceTimersByTime(MAX_AGE_MS);
+      expect(closed).toEqual(['task-1', 'task-1']);
+      expect(await isCancelled(replacement)).toBe(true);
+    });
   });
 });

--- a/packages/zero-cache/src/services/change-streamer/snapshot-reservations.ts
+++ b/packages/zero-cache/src/services/change-streamer/snapshot-reservations.ts
@@ -10,20 +10,55 @@ import type {BackupConfig} from './change-streamer-service.ts';
 import type {SnapshotMessage} from './snapshot.ts';
 import type {ChangeLogReadSource} from './sqlite-change-log-read-router.ts';
 
+/**
+ * How long a snapshot reservation may hold the change log, by default.
+ *
+ * A reservation keeps the purge floor -- and, for as long as it is open, the
+ * purge scheduler itself, which `startSnapshotReservation` pauses -- from
+ * moving past the `minWatermark` a restoring view-syncer was promised. It
+ * lives exactly as long as its WebSocket. A client that has *died* is already
+ * cleaned up by that socket's liveness pings; one that is alive and never
+ * finishes -- a wedged restore, or one slower than anybody expected -- would
+ * otherwise pin the log for as long as it stays connected, bounded by nothing
+ * but the change log's disk.
+ *
+ * The cap is deliberately far above any plausible restore. Taking a
+ * reservation back hands that follower a log that no longer covers its backup,
+ * which costs it a `WatermarkTooOld` and another restore -- and a cap below
+ * the time a restore actually takes turns that into a loop. An hour bounds the
+ * pin at an hour of changes while leaving even a very large replica room to
+ * land.
+ */
+export const DEFAULT_MAX_RESERVATION_AGE_MS = 60 * 60 * 1000;
+
+export type SnapshotReservationOptions = {
+  /**
+   * How long a reservation may hold the change log before it is taken back.
+   * Defaults to {@link DEFAULT_MAX_RESERVATION_AGE_MS}.
+   */
+  maxAgeMs?: number | undefined;
+  setTimeoutFn?: typeof setTimeout | undefined;
+};
+
 export class SnapshotReservations {
   readonly #lc: LogContext;
   readonly #backupConfig: BackupConfig;
   readonly #onClose: ((taskID: string) => void) | undefined;
   readonly #reservations = new Map<string, Reservation>();
+  readonly #maxAgeMs: number;
+  readonly #setTimeoutFn: typeof setTimeout;
 
   constructor(
     lc: LogContext,
     backupConfig: BackupConfig,
     onClose?: ((taskID: string) => void) | undefined,
+    options: SnapshotReservationOptions = {},
   ) {
     this.#lc = lc.withContext('component', 'snapshot-reserver');
     this.#backupConfig = backupConfig;
     this.#onClose = onClose;
+    this.#maxAgeMs = options.maxAgeMs ?? DEFAULT_MAX_RESERVATION_AGE_MS;
+    this.#setTimeoutFn = options.setTimeoutFn ?? setTimeout;
   }
 
   open(taskID: string): Source<SnapshotMessage> {
@@ -33,7 +68,20 @@ export class SnapshotReservations {
     const downstream = Subscription.create<SnapshotMessage>({
       cleanup: () => this.#close(taskID, instanceID),
     });
-    this.#reservations.set(taskID, new Reservation(instanceID, downstream));
+    // Armed from `open()` rather than from the confirmation: the purge pause
+    // that `startSnapshotReservation` takes begins here, so this is when the
+    // log starts being held.
+    const expiry = this.#setTimeoutFn(
+      () => this.#expire(taskID, instanceID),
+      this.#maxAgeMs,
+    );
+    // An hour-scale timer must not be the thing that keeps a stopping process
+    // alive. (Optional because a test may inject a plainer timer.)
+    expiry.unref?.();
+    this.#reservations.set(
+      taskID,
+      new Reservation(instanceID, downstream, expiry),
+    );
     this.#lc.info?.(`created snasphot reservation for ${taskID}`);
     return downstream;
   }
@@ -54,7 +102,37 @@ export class SnapshotReservations {
     );
   }
 
-  #close(taskID: string, cancelledInstanceID: InstanceID | undefined) {
+  /**
+   * Takes back a reservation that has held the change log for longer than
+   * `maxAgeMs`, releasing the purge pause and the floor with it.
+   *
+   * The follower is not told: its `/snapshot` stream simply ends, which is
+   * what the change-streamer does when a task subscribes, and its client
+   * proceeds with the bounds it was already given. What it has lost is the
+   * guarantee behind them, so its subscription may be answered with
+   * `WatermarkTooOld` and it will restore again.
+   */
+  #expire(taskID: string, instanceID: InstanceID) {
+    const res = this.#reservations.get(taskID);
+    if (res?.instanceID !== instanceID) {
+      return; // already closed, or superseded by a retry for the same task
+    }
+    this.#lc.warn?.(
+      `releasing the snapshot reservation for ${taskID}, which has held the ` +
+        `change log for more than ${this.#maxAgeMs}ms. Its restore is no ` +
+        `longer covered and may have to be repeated; raise ` +
+        `--change-streamer-snapshot-reservation-max-age-ms if restores ` +
+        `legitimately take this long.`,
+      {reservedWatermark: res.reservedWatermark},
+    );
+    this.#close(taskID, instanceID, 'expired');
+  }
+
+  #close(
+    taskID: string,
+    cancelledInstanceID: InstanceID | undefined,
+    result?: 'expired' | undefined,
+  ) {
     const res = this.#reservations.get(taskID);
     if (
       res &&
@@ -62,6 +140,7 @@ export class SnapshotReservations {
     ) {
       // Note: delete first, so that the reservation is gone when close() is called.
       this.#reservations.delete(taskID);
+      clearTimeout(res.expiry);
       this.#onClose?.(taskID);
       res.close();
 
@@ -76,7 +155,7 @@ export class SnapshotReservations {
       // attribute cannot distinguish from a client that simply went away.
       litestreamSnapshotReservationDuration().recordMs(duration, {
         ...this.#metricAttrs(),
-        result: cancelledInstanceID ? 'cancelled' : 'closed',
+        result: result ?? (cancelledInstanceID ? 'cancelled' : 'closed'),
         confirmed: res.confirmed(),
       });
     }
@@ -141,6 +220,8 @@ type InstanceID = {};
 class Reservation {
   readonly instanceID: InstanceID;
   readonly startTime: Date = new Date();
+  /** Cleared when the reservation ends for any other reason. */
+  readonly expiry: ReturnType<typeof setTimeout>;
   readonly #downstream: Subscription<SnapshotMessage>;
   #watermark: string | null = null;
   #delayNoted = false;
@@ -148,9 +229,11 @@ class Reservation {
   constructor(
     instanceID: InstanceID,
     downstream: Subscription<SnapshotMessage>,
+    expiry: ReturnType<typeof setTimeout>,
   ) {
     this.instanceID = instanceID;
     this.#downstream = downstream;
+    this.expiry = expiry;
   }
 
   get reservedWatermark() {


### PR DESCRIPTION
…ange log

A reservation keeps the purge floor -- and, for as long as it is open, the purge scheduler itself, which `startSnapshotReservation` pauses -- from moving past the `minWatermark` a restoring view-syncer was promised. That is what makes a slow restore safe. It lives exactly as long as its WebSocket, and until now nothing bounded that: a client that is alive but never finishes pinned the log for as long as it stayed connected, with disk as the only limit.

A client that has *died* is already cleaned up by the socket's liveness pings, so this is aimed at the live-but-stuck case, and at a restore that is simply slower than anyone planned for.

`SnapshotReservations` now arms a timer when a reservation opens -- when the purge pause begins, not when the bounds are confirmed -- and releases the reservation if it is still open when the timer fires. The follower is not told: its `/snapshot` stream ends, which is exactly what happens when a task subscribes, and its client proceeds with the bounds it already has. What it has lost is the guarantee behind them, so its subscription may be answered with `WatermarkTooOld` and it will restore again.

That is also why the default is an hour rather than something tighter: a cap below the time a restore actually takes turns every restore into a loop. `--change-streamer-snapshot-reservation-max-age-ms` raises it for a deployment whose replicas take longer, and the warning that fires names the flag.

The expiry is reported as `result=expired` on the existing reservation duration histogram, distinct from a follower that subscribed (`closed`) or went away (`cancelled`), so the rate is visible rather than inferred.

Two things it deliberately does not do. It does not use the service's injected `setTimeoutFn`: tests drive the cleanup pass through that mock by index, and an hour-scale safety valve does not belong in the same queue. And it unrefs its timer, so a pending expiry never keeps a stopping process alive.

The soak's C16 holds a reservation for five minutes, well inside the default; its comment now says so, since past the cap the change-streamer is supposed to purge and C16 would report that as a violation.


Claude-Session: https://claude.ai/code/session_013jdBVFyXyX2KixRSjJR7ai