### PR TITLE
feat(.github): Add dev release workflow

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -8,7 +8,7 @@ on:
         required: true
         type: string
       image_tag:
-        description: 'Docker image tag (optional; defaults to pr-<sanitized-branch>)'
+        description: 'Docker image tag (optional; defaults to 0.0.0-pr-<sanitized-branch> or 0.0.0-dev-<sha8>)'
         required: false
         type: string
 
@@ -261,6 +261,7 @@ jobs:
             printf '### Docker Images:\n'
             printf '- Docker Hub: `rocicorp/zero:%s`\n' "$IMAGE_TAG"
             printf '- GHCR: `ghcr.io/rocicorp/zero:%s`\n\n' "$IMAGE_TAG"
-            printf '### CloudZero Staging Deployment:\n'
-            printf 'Select `rocicorp/zero:%s` in the CloudZero god mode picker for your staging stack.\n' "$IMAGE_TAG"
+            printf '### Deploy to CloudZero Staging:\n'
+            printf 'Deploy this dev image to your staging stack via the CloudZero controller script:\n'
+            printf '```bash\nnode update-stack-zero-version.ts %s stack-ids <stack-id>\n```\n' "$IMAGE_TAG"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -64,7 +64,7 @@ jobs:
           persist-credentials: false
 
       - name: Verify Signed Commit Authors
-        uses: rocicorp/.github/.github/actions/verify-signed-commit-authors@main
+        uses: rocicorp/.github/.github/actions/verify-signed-commit-authors@c49caa1498b8cf402992126969f2d7c8adc9ca4b # main
         with:
           enforce: 'true'
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -210,6 +210,9 @@ jobs:
     name: Publish Docker images
     runs-on: ubuntu-latest
     needs: [plan, verify-signed-commit-authors, build, archive-cloudzero-source]
+    concurrency:
+      group: zero-dev-release-tag-${{ needs.plan.outputs.image_tag }}
+      cancel-in-progress: false
     environment:
       name: zero-release-docker
     permissions:

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -1,0 +1,249 @@
+name: Dev Release Zero
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref to release (branch name, PR ref, or commit SHA)'
+        required: true
+        type: string
+      image_tag:
+        description: 'Docker image tag (optional; defaults to pr-<sanitized-branch>)'
+        required: false
+        type: string
+
+permissions: {}
+
+concurrency:
+  group: zero-dev-release-${{ inputs.ref }}
+  cancel-in-progress: false
+
+jobs:
+  plan:
+    name: Plan dev release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: read
+    outputs:
+      image_tag: ${{ steps.plan.outputs.image_tag }}
+      ref: ${{ steps.plan.outputs.ref }}
+      source_sha: ${{ steps.plan.outputs.source_sha }}
+    steps:
+      - name: Checkout workflow repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: main
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24.x
+
+      - name: Plan dev release
+        id: plan
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IMAGE_TAG_INPUT: ${{ inputs.image_tag }}
+          TARGET_REF: ${{ inputs.ref }}
+          WORKFLOW_REF_NAME: ${{ github.ref_name }}
+        run: node scripts/src/dev-release-plan.ts
+
+  archive-cloudzero-source:
+    name: Archive source for Cloud Zero (staging)
+    runs-on: ubuntu-latest
+    needs: plan
+    environment: staging-source-archive
+    permissions:
+      contents: read
+      id-token: write # For AWS OIDC.
+    steps:
+      - name: Checkout release source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ needs.plan.outputs.source_sha }}
+          persist-credentials: false
+
+      - name: Configure archive credentials
+        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
+        with:
+          role-to-assume: arn:aws:iam::946232032425:role/github-archive-zero-source
+          role-session-name: archive-zero-source-dev-${{ github.run_id }}
+          aws-region: us-east-1
+          mask-aws-account-id: true
+          unset-current-credentials: true
+
+      - name: Archive source revision
+        env:
+          SOURCE_ARCHIVE_BUCKET: cloudzero-source-archives-946232032425
+          SOURCE_REPOSITORY: rocicorp/mono
+          SOURCE_REVISION: ${{ needs.plan.outputs.source_sha }}
+        run: |
+          set -euo pipefail
+          revision=$(git rev-parse --verify "${SOURCE_REVISION}^{commit}")
+          if [[ ! "$revision" =~ ^[0-9a-f]{40}$ ]] || [ "$revision" != "$SOURCE_REVISION" ]; then
+            echo "Expected exact commit SHA, got $SOURCE_REVISION -> $revision" >&2
+            exit 1
+          fi
+          archive="$RUNNER_TEMP/source.tar.gz"
+          git archive --format=tar "$revision" | gzip -n > "$archive"
+          key="repositories/$SOURCE_REPOSITORY/$revision/source.tar.gz"
+          if aws s3api head-object --bucket "$SOURCE_ARCHIVE_BUCKET" --key "$key" >/dev/null 2>&1; then
+            echo "Already archived $SOURCE_REPOSITORY@$revision"
+          else
+            aws s3api put-object \
+              --bucket "$SOURCE_ARCHIVE_BUCKET" \
+              --key "$key" \
+              --body "$archive" \
+              --content-type application/gzip \
+              --checksum-algorithm SHA256 >/dev/null
+          fi
+
+  build:
+    name: Build artifacts
+    runs-on: ubuntu-latest
+    needs: plan
+    permissions:
+      contents: read
+    outputs:
+      tarball_name: ${{ steps.pack.outputs.filename }}
+    env:
+      IMAGE_TAG: ${{ needs.plan.outputs.image_tag }}
+      SCRIPTS: ${{ github.workspace }}/ci/scripts/src
+      SOURCE_SHA: ${{ needs.plan.outputs.source_sha }}
+    steps:
+      - name: Checkout workflow scripts
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: main
+          path: ci
+          persist-credentials: false
+          sparse-checkout: scripts
+
+      - name: Checkout release source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          path: source
+          ref: ${{ needs.plan.outputs.source_sha }}
+          persist-credentials: false
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: 11.11.0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24.x
+          cache: 'pnpm'
+          cache-dependency-path: source/pnpm-lock.yaml
+
+      - name: Install dependencies
+        working-directory: source
+        run: pnpm install --frozen-lockfile
+
+      - name: Build Zero
+        working-directory: source
+        run: pnpm --filter @rocicorp/zero run build
+
+      - name: Pack Zero
+        id: pack
+        working-directory: source/packages/zero
+        env:
+          PACK_DEST: ${{ runner.temp }}/npm
+        run: node "$SCRIPTS/release-pack.ts"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Build Docker image archive
+        env:
+          IMAGE_ARCHIVE: ${{ runner.temp }}/docker/zero-image.tar
+          TARBALL: ${{ steps.pack.outputs.filename }}
+          TARBALL_PATH: ${{ runner.temp }}/npm/${{ steps.pack.outputs.filename }}
+        run: |
+          set -euo pipefail
+          mkdir -p source/packages/zero/pkgs "$(dirname "$IMAGE_ARCHIVE")"
+          cp "$TARBALL_PATH" "source/packages/zero/pkgs/$TARBALL"
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
+            --build-context monogo=source/go \
+            --build-arg ZERO_VERSION="$IMAGE_TAG" \
+            --build-arg ZERO_PACKAGE="$TARBALL" \
+            --label org.opencontainers.image.revision="$SOURCE_SHA" \
+            --label org.opencontainers.image.version="$IMAGE_TAG" \
+            --sbom=true \
+            --provenance=mode=max \
+            --output=type=oci,dest="$IMAGE_ARCHIVE" \
+            source/packages/zero
+
+      - name: Upload Docker image artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: zero-docker-${{ needs.plan.outputs.image_tag }}
+          if-no-files-found: error
+          retention-days: 1
+          path: ${{ runner.temp }}/docker/zero-image.tar
+
+  publish-docker:
+    name: Publish Docker images
+    runs-on: ubuntu-latest
+    needs: [plan, build, archive-cloudzero-source]
+    environment:
+      name: zero-release-docker
+    permissions:
+      id-token: write # For Docker Hub OIDC.
+      packages: write # For GHCR pushes.
+    env:
+      IMAGE_TAG: ${{ needs.plan.outputs.image_tag }}
+      SOURCE_SHA: ${{ needs.plan.outputs.source_sha }}
+    steps:
+      - name: Download Docker image artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: zero-docker-${{ needs.plan.outputs.image_tag }}
+          path: dist/docker
+
+      - name: Push GHCR Docker image
+        uses: docker://quay.io/containers/skopeo:v1.22.2-immutable@sha256:ca4fd94dba8cab15cf79c4c156bfc26d28e2265411294e9bba87756942e739ad
+        with:
+          args: >-
+            copy --all
+            --dest-creds ${{ github.actor }}:${{ github.token }}
+            oci-archive:dist/docker/zero-image.tar
+            docker://ghcr.io/rocicorp/zero:${{ needs.plan.outputs.image_tag }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        env:
+          DOCKER_CONFIG: ${{ runner.temp }}/docker-auth
+          DOCKERHUB_OIDC_CONNECTIONID: 2b3442aa-9cf7-4a13-afce-535dece25f7a
+        with:
+          username: rocicorp
+
+      - name: Push Docker Hub image
+        uses: docker://quay.io/containers/skopeo:v1.22.2-immutable@sha256:ca4fd94dba8cab15cf79c4c156bfc26d28e2265411294e9bba87756942e739ad
+        env:
+          REGISTRY_AUTH_FILE: ${{ runner.temp }}/docker-auth/config.json
+        with:
+          args: >-
+            copy --all
+            oci-archive:dist/docker/zero-image.tar
+            docker://docker.io/rocicorp/zero:${{ needs.plan.outputs.image_tag }}
+
+      - name: Summarize dev release
+        run: |
+          {
+            printf '## Dev Release Ready\n\n'
+            printf 'Target Image Tag: `%s`\n' "$IMAGE_TAG"
+            printf 'Source Revision: `%s`\n\n' "$SOURCE_SHA"
+            printf '### Docker Images:\n'
+            printf '- Docker Hub: `rocicorp/zero:%s`\n' "$IMAGE_TAG"
+            printf '- GHCR: `ghcr.io/rocicorp/zero:%s`\n\n' "$IMAGE_TAG"
+            printf '### CloudZero Staging Deployment:\n'
+            printf 'Select `rocicorp/zero:%s` in the CloudZero god mode picker for your staging stack.\n' "$IMAGE_TAG"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -24,7 +24,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      checks: read
     outputs:
       image_tag: ${{ steps.plan.outputs.image_tag }}
       ref: ${{ steps.plan.outputs.ref }}
@@ -45,17 +44,35 @@ jobs:
       - name: Plan dev release
         id: plan
         env:
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           IMAGE_TAG_INPUT: ${{ inputs.image_tag }}
           TARGET_REF: ${{ inputs.ref }}
           WORKFLOW_REF_NAME: ${{ github.ref_name }}
         run: node scripts/src/dev-release-plan.ts
 
+  verify-signed-commit-authors:
+    name: Verify signed commit authors
+    runs-on: ubuntu-latest
+    needs: plan
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout target commit
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ needs.plan.outputs.source_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify Signed Commit Authors
+        uses: rocicorp/.github/.github/actions/verify-signed-commit-authors@main
+        with:
+          enforce: 'true'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
   archive-cloudzero-source:
     name: Archive source for Cloud Zero (staging)
     runs-on: ubuntu-latest
-    needs: plan
+    needs: [plan, verify-signed-commit-authors]
     environment: staging-source-archive
     permissions:
       contents: read
@@ -105,7 +122,7 @@ jobs:
   build:
     name: Build artifacts
     runs-on: ubuntu-latest
-    needs: plan
+    needs: [plan, verify-signed-commit-authors]
     permissions:
       contents: read
     outputs:
@@ -192,7 +209,7 @@ jobs:
   publish-docker:
     name: Publish Docker images
     runs-on: ubuntu-latest
-    needs: [plan, build, archive-cloudzero-source]
+    needs: [plan, verify-signed-commit-authors, build, archive-cloudzero-source]
     environment:
       name: zero-release-docker
     permissions:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1841,10 +1841,17 @@ importers:
         version: 0.65.0
 
   scripts:
+    dependencies:
+      semver:
+        specifier: ^7.5.4
+        version: 7.8.0
     devDependencies:
       '@types/node':
         specifier: ^22.10.5
         version: 22.19.19
+      '@types/semver':
+        specifier: ^7.5.1
+        version: 7.7.1
       oxfmt:
         specifier: ^0.65.0
         version: 0.65.0

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -13,8 +13,12 @@
     "fmt": "oxfmt .",
     "check-fmt": "oxfmt --check ."
   },
+  "dependencies": {
+    "semver": "^7.5.4"
+  },
   "devDependencies": {
     "@types/node": "^22.10.5",
+    "@types/semver": "^7.5.1",
     "oxfmt": "^0.65.0",
     "typescript": "~7.0.2",
     "vitest": "^4.1.6"

--- a/scripts/src/dev-release-plan.ts
+++ b/scripts/src/dev-release-plan.ts
@@ -1,3 +1,3 @@
 import {runDevReleasePlanCli} from './dev-release/plan.ts';
 
-await runDevReleasePlanCli();
+runDevReleasePlanCli();

--- a/scripts/src/dev-release-plan.ts
+++ b/scripts/src/dev-release-plan.ts
@@ -1,0 +1,3 @@
+import {runDevReleasePlanCli} from './dev-release/plan.ts';
+
+await runDevReleasePlanCli();

--- a/scripts/src/dev-release/plan.test.ts
+++ b/scripts/src/dev-release/plan.test.ts
@@ -1,0 +1,224 @@
+import {expect, test} from 'vitest';
+import {type Command, type Exec, type ExecOptions} from '../shared.ts';
+import {
+  deriveDefaultTag,
+  planDevRelease,
+  sanitizeBranchName,
+  validateImageTag,
+} from './plan.ts';
+
+const dummySha = 'e8cc6889fa6bc2a364e8cb80776991c308601212';
+
+function makeMockExec(resolvedSha = dummySha) {
+  const calls: Array<{
+    command: Command;
+    args: readonly string[];
+    options?: ExecOptions;
+  }> = [];
+  const exec: Exec = (command, args, options) => {
+    calls.push({command, args, options});
+    if (command === 'git' && args[0] === 'rev-parse') {
+      return `${resolvedSha}\n`;
+    }
+    return '';
+  };
+  return {calls, exec};
+}
+
+test('sanitizeBranchName strips refs prefix and sanitizes special characters', () => {
+  expect(sanitizeBranchName('refs/heads/greg/sync-opt')).toBe('greg-sync-opt');
+  expect(sanitizeBranchName('refs/pull/123/head')).toBe('123-head');
+  expect(sanitizeBranchName('feat/my_cool.branch!')).toBe(
+    'feat-my_cool.branch',
+  );
+  expect(sanitizeBranchName('---messy--branch---')).toBe('messy-branch');
+});
+
+test('deriveDefaultTag generates pr- or dev- prefixed tags', () => {
+  expect(deriveDefaultTag(dummySha, dummySha)).toBe('dev-e8cc6889');
+  expect(deriveDefaultTag('greg/sync-opt', dummySha)).toBe('pr-greg-sync-opt');
+  expect(deriveDefaultTag('pr-1234', dummySha)).toBe('pr-1234');
+  expect(deriveDefaultTag('dev-test', dummySha)).toBe('dev-test');
+});
+
+test('validateImageTag accepts valid tags and blocks protected/semver tags', () => {
+  expect(() => validateImageTag('pr-1234')).not.toThrow();
+  expect(() => validateImageTag('bench_view-syncer.v1')).not.toThrow();
+
+  expect(() => validateImageTag('latest')).toThrowError(/protected/);
+  expect(() => validateImageTag('HEAD')).toThrowError(/protected/);
+  expect(() => validateImageTag('staging')).toThrowError(/protected/);
+  expect(() => validateImageTag('canary')).toThrowError(/protected/);
+
+  expect(() => validateImageTag('1.8.0')).toThrowError(/semantic version/);
+  expect(() => validateImageTag('v1.8.0')).toThrowError(/semantic version/);
+  expect(() => validateImageTag('v0.18.0')).toThrowError(/semantic version/);
+
+  expect(() => validateImageTag('invalid:tag')).toThrowError(
+    /Invalid Docker image tag/,
+  );
+  expect(() => validateImageTag('invalid/tag')).toThrowError(
+    /Invalid Docker image tag/,
+  );
+});
+
+test('planDevRelease requires workflowRefName to be main', async () => {
+  const {exec} = makeMockExec();
+  await expect(
+    planDevRelease({
+      exec,
+      targetRef: 'greg/test',
+      workflowRefName: 'feature-branch',
+      requireCommitVerification: false,
+    }),
+  ).rejects.toThrow(/must be run from main/);
+});
+
+test('planDevRelease rejects empty target ref', async () => {
+  const {exec} = makeMockExec();
+  await expect(
+    planDevRelease({
+      exec,
+      targetRef: '   ',
+      workflowRefName: 'main',
+      requireCommitVerification: false,
+    }),
+  ).rejects.toThrow(/Target ref must not be empty/);
+});
+
+test('planDevRelease plans dev release with default tag', async () => {
+  const {calls, exec} = makeMockExec();
+  const plan = await planDevRelease({
+    exec,
+    targetRef: 'greg/sync-opt',
+    workflowRefName: 'main',
+    requireCommitVerification: false,
+  });
+
+  expect(plan).toEqual({
+    image_tag: 'pr-greg-sync-opt',
+    ref: 'greg/sync-opt',
+    source_sha: dummySha,
+  });
+
+  expect(calls).toContainEqual({
+    command: 'git',
+    args: ['fetch', 'origin', 'greg/sync-opt'],
+    options: {stdio: 'inherit'},
+  });
+});
+
+test('planDevRelease accepts custom image tag', async () => {
+  const {exec} = makeMockExec();
+  const plan = await planDevRelease({
+    exec,
+    targetRef: dummySha,
+    imageTagInput: 'custom-bench-1',
+    workflowRefName: 'main',
+    requireCommitVerification: false,
+  });
+
+  expect(plan).toEqual({
+    image_tag: 'custom-bench-1',
+    ref: dummySha,
+    source_sha: dummySha,
+  });
+});
+
+test('verifyCommit passes with Signed Commit Authors check run', async () => {
+  const {exec} = makeMockExec();
+  const mockFetch: typeof fetch = url => {
+    const urlStr = String(url);
+    if (urlStr.includes('/check-runs')) {
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            check_runs: [
+              {name: 'Signed Commit Authors', conclusion: 'success'},
+            ],
+          }),
+          {status: 200},
+        ),
+      );
+    }
+    return Promise.resolve(new Response('Not found', {status: 404}));
+  };
+
+  const plan = await planDevRelease({
+    exec,
+    fetchFn: mockFetch,
+    githubRepository: 'rocicorp/mono',
+    githubToken: 'dummy-token',
+    requireCommitVerification: true,
+    targetRef: 'main',
+    workflowRefName: 'main',
+  });
+
+  expect(plan.source_sha).toBe(dummySha);
+});
+
+test('verifyCommit rejects commit when Signed Commit Authors check failed', async () => {
+  const {exec} = makeMockExec();
+  const mockFetch: typeof fetch = url => {
+    const urlStr = String(url);
+    if (urlStr.includes('/check-runs')) {
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            check_runs: [
+              {name: 'Signed Commit Authors', conclusion: 'failure'},
+            ],
+          }),
+          {status: 200},
+        ),
+      );
+    }
+    return Promise.resolve(new Response('Not found', {status: 404}));
+  };
+
+  await expect(
+    planDevRelease({
+      exec,
+      fetchFn: mockFetch,
+      githubRepository: 'rocicorp/mono',
+      githubToken: 'dummy-token',
+      requireCommitVerification: true,
+      targetRef: 'main',
+      workflowRefName: 'main',
+    }),
+  ).rejects.toThrow(
+    /Commit .* has not passed the "Signed Commit Authors" check \(conclusion was "failure"\)/,
+  );
+});
+
+test('verifyCommit rejects commit when Signed Commit Authors check is missing', async () => {
+  const {exec} = makeMockExec();
+  const mockFetch: typeof fetch = url => {
+    const urlStr = String(url);
+    if (urlStr.includes('/check-runs')) {
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            check_runs: [{name: 'Other Check', conclusion: 'success'}],
+          }),
+          {status: 200},
+        ),
+      );
+    }
+    return Promise.resolve(new Response('Not found', {status: 404}));
+  };
+
+  await expect(
+    planDevRelease({
+      exec,
+      fetchFn: mockFetch,
+      githubRepository: 'rocicorp/mono',
+      githubToken: 'dummy-token',
+      requireCommitVerification: true,
+      targetRef: 'main',
+      workflowRefName: 'main',
+    }),
+  ).rejects.toThrow(
+    /Commit .* has not passed the "Signed Commit Authors" check \(check run was not found\)/,
+  );
+});

--- a/scripts/src/dev-release/plan.test.ts
+++ b/scripts/src/dev-release/plan.test.ts
@@ -2,6 +2,7 @@ import {expect, test} from 'vitest';
 import {type Command, type Exec, type ExecOptions} from '../shared.ts';
 import {
   deriveDefaultTag,
+  normalizeDevImageTag,
   planDevRelease,
   sanitizeBranchName,
   validateImageTag,
@@ -25,34 +26,64 @@ function makeMockExec(resolvedSha = dummySha) {
   return {calls, exec};
 }
 
-test('sanitizeBranchName strips refs prefix and sanitizes special characters', () => {
+test('sanitizeBranchName strips refs prefix and sanitizes special characters to hyphens', () => {
   expect(sanitizeBranchName('refs/heads/greg/sync-opt')).toBe('greg-sync-opt');
   expect(sanitizeBranchName('refs/pull/123/head')).toBe('123-head');
   expect(sanitizeBranchName('feat/my_cool.branch!')).toBe(
-    'feat-my_cool.branch',
+    'feat-my-cool-branch',
   );
   expect(sanitizeBranchName('---messy--branch---')).toBe('messy-branch');
 });
 
-test('deriveDefaultTag generates pr- or dev- prefixed tags', () => {
-  expect(deriveDefaultTag(dummySha, dummySha)).toBe('dev-e8cc6889');
-  expect(deriveDefaultTag('greg/sync-opt', dummySha)).toBe('pr-greg-sync-opt');
-  expect(deriveDefaultTag('pr-1234', dummySha)).toBe('pr-1234');
-  expect(deriveDefaultTag('dev-test', dummySha)).toBe('dev-test');
+test('deriveDefaultTag generates 0.0.0-pr-* or 0.0.0-dev-* SemVer tags', () => {
+  expect(deriveDefaultTag(dummySha, dummySha)).toBe('0.0.0-dev-e8cc6889');
+  expect(deriveDefaultTag('greg/sync-opt', dummySha)).toBe(
+    '0.0.0-pr-greg-sync-opt',
+  );
+  expect(deriveDefaultTag('pr-1234', dummySha)).toBe('0.0.0-pr-1234');
+  expect(deriveDefaultTag('dev-test', dummySha)).toBe('0.0.0-dev-test');
+  expect(deriveDefaultTag('0.0.0-pr-test', dummySha)).toBe('0.0.0-pr-test');
 });
 
-test('validateImageTag accepts valid tags and blocks protected/semver tags', () => {
-  expect(() => validateImageTag('pr-1234')).not.toThrow();
-  expect(() => validateImageTag('bench_view-syncer.v1')).not.toThrow();
+test('normalizeDevImageTag ensures 0.0.0- prefix for custom tags', () => {
+  expect(normalizeDevImageTag('custom-bench-1')).toBe(
+    '0.0.0-dev-custom-bench-1',
+  );
+  expect(normalizeDevImageTag('dev-bench-1')).toBe('0.0.0-dev-bench-1');
+  expect(normalizeDevImageTag('pr-1234')).toBe('0.0.0-pr-1234');
+  expect(normalizeDevImageTag('0.0.0-dev-mytest')).toBe('0.0.0-dev-mytest');
+});
+
+test('validateImageTag accepts valid 0.0.0- SemVer tags and blocks invalid/protected tags', () => {
+  expect(() => validateImageTag('0.0.0-pr-1234')).not.toThrow();
+  expect(() => validateImageTag('0.0.0-dev-e8cc6889')).not.toThrow();
+  expect(() => validateImageTag('0.0.0-pr-greg-sync-opt')).not.toThrow();
+  expect(() => validateImageTag('0.0.0-dev-custom-bench-1')).not.toThrow();
 
   expect(() => validateImageTag('latest')).toThrowError(/protected/);
   expect(() => validateImageTag('HEAD')).toThrowError(/protected/);
   expect(() => validateImageTag('staging')).toThrowError(/protected/);
   expect(() => validateImageTag('canary')).toThrowError(/protected/);
 
-  expect(() => validateImageTag('1.8.0')).toThrowError(/semantic version/);
-  expect(() => validateImageTag('v1.8.0')).toThrowError(/semantic version/);
-  expect(() => validateImageTag('v0.18.0')).toThrowError(/semantic version/);
+  expect(() => validateImageTag('1.8.0')).toThrowError(
+    /must start with "0.0.0-"/,
+  );
+  expect(() => validateImageTag('v1.8.0')).toThrowError(
+    /must start with "0.0.0-"/,
+  );
+  expect(() => validateImageTag('pr-1234')).toThrowError(
+    /must start with "0.0.0-"/,
+  );
+  expect(() => validateImageTag('dev-e8cc6889')).toThrowError(
+    /must start with "0.0.0-"/,
+  );
+
+  expect(() => validateImageTag('0.0.0-dev_underscore')).toThrowError(
+    /not a valid semantic version/,
+  );
+  expect(() => validateImageTag('0.0.0-dev.0123')).toThrowError(
+    /not a valid semantic version/,
+  );
 
   expect(() => validateImageTag('invalid:tag')).toThrowError(
     /Invalid Docker image tag/,
@@ -84,7 +115,7 @@ test('planDevRelease rejects empty target ref', () => {
   ).toThrow(/Target ref must not be empty/);
 });
 
-test('planDevRelease plans dev release with default tag', () => {
+test('planDevRelease plans dev release with default 0.0.0-pr-* tag', () => {
   const {calls, exec} = makeMockExec();
   const plan = planDevRelease({
     exec,
@@ -93,7 +124,7 @@ test('planDevRelease plans dev release with default tag', () => {
   });
 
   expect(plan).toEqual({
-    image_tag: 'pr-greg-sync-opt',
+    image_tag: '0.0.0-pr-greg-sync-opt',
     ref: 'greg/sync-opt',
     source_sha: dummySha,
   });
@@ -105,7 +136,7 @@ test('planDevRelease plans dev release with default tag', () => {
   });
 });
 
-test('planDevRelease accepts custom image tag', () => {
+test('planDevRelease accepts custom image tag and normalizes to 0.0.0-dev-*', () => {
   const {exec} = makeMockExec();
   const plan = planDevRelease({
     exec,
@@ -115,8 +146,22 @@ test('planDevRelease accepts custom image tag', () => {
   });
 
   expect(plan).toEqual({
-    image_tag: 'custom-bench-1',
+    image_tag: '0.0.0-dev-custom-bench-1',
     ref: dummySha,
     source_sha: dummySha,
   });
+});
+
+test('planDevRelease rejects protected tags in imageTagInput', () => {
+  const {exec} = makeMockExec();
+  for (const tag of ['latest', 'HEAD', 'staging', 'canary']) {
+    expect(() =>
+      planDevRelease({
+        exec,
+        targetRef: dummySha,
+        imageTagInput: tag,
+        workflowRefName: 'main',
+      }),
+    ).toThrowError(/protected/);
+  }
 });

--- a/scripts/src/dev-release/plan.test.ts
+++ b/scripts/src/dev-release/plan.test.ts
@@ -4,6 +4,7 @@ import {
   deriveDefaultTag,
   normalizeDevImageTag,
   planDevRelease,
+  resolveSourceSha,
   sanitizeBranchName,
   validateImageTag,
 } from './plan.ts';
@@ -14,7 +15,7 @@ function makeMockExec(resolvedSha = dummySha) {
   const calls: Array<{
     command: Command;
     args: readonly string[];
-    options?: ExecOptions;
+    options?: ExecOptions | undefined;
   }> = [];
   const exec: Exec = (command, args, options) => {
     calls.push({command, args, options});
@@ -164,4 +165,14 @@ test('planDevRelease rejects protected tags in imageTagInput', () => {
       }),
     ).toThrowError(/protected/);
   }
+});
+
+test('resolveSourceSha rejects option-like refs starting with -', () => {
+  const {exec} = makeMockExec();
+  expect(() => resolveSourceSha('--force', exec)).toThrowError(
+    'Target ref must not start with "-"',
+  );
+  expect(() => resolveSourceSha('-v', exec)).toThrowError(
+    'Target ref must not start with "-"',
+  );
 });

--- a/scripts/src/dev-release/plan.test.ts
+++ b/scripts/src/dev-release/plan.test.ts
@@ -62,37 +62,34 @@ test('validateImageTag accepts valid tags and blocks protected/semver tags', () 
   );
 });
 
-test('planDevRelease requires workflowRefName to be main', async () => {
+test('planDevRelease requires workflowRefName to be main', () => {
   const {exec} = makeMockExec();
-  await expect(
+  expect(() =>
     planDevRelease({
       exec,
       targetRef: 'greg/test',
       workflowRefName: 'feature-branch',
-      requireCommitVerification: false,
     }),
-  ).rejects.toThrow(/must be run from main/);
+  ).toThrow(/must be run from main/);
 });
 
-test('planDevRelease rejects empty target ref', async () => {
+test('planDevRelease rejects empty target ref', () => {
   const {exec} = makeMockExec();
-  await expect(
+  expect(() =>
     planDevRelease({
       exec,
       targetRef: '   ',
       workflowRefName: 'main',
-      requireCommitVerification: false,
     }),
-  ).rejects.toThrow(/Target ref must not be empty/);
+  ).toThrow(/Target ref must not be empty/);
 });
 
-test('planDevRelease plans dev release with default tag', async () => {
+test('planDevRelease plans dev release with default tag', () => {
   const {calls, exec} = makeMockExec();
-  const plan = await planDevRelease({
+  const plan = planDevRelease({
     exec,
     targetRef: 'greg/sync-opt',
     workflowRefName: 'main',
-    requireCommitVerification: false,
   });
 
   expect(plan).toEqual({
@@ -108,14 +105,13 @@ test('planDevRelease plans dev release with default tag', async () => {
   });
 });
 
-test('planDevRelease accepts custom image tag', async () => {
+test('planDevRelease accepts custom image tag', () => {
   const {exec} = makeMockExec();
-  const plan = await planDevRelease({
+  const plan = planDevRelease({
     exec,
     targetRef: dummySha,
     imageTagInput: 'custom-bench-1',
     workflowRefName: 'main',
-    requireCommitVerification: false,
   });
 
   expect(plan).toEqual({
@@ -123,102 +119,4 @@ test('planDevRelease accepts custom image tag', async () => {
     ref: dummySha,
     source_sha: dummySha,
   });
-});
-
-test('verifyCommit passes with Signed Commit Authors check run', async () => {
-  const {exec} = makeMockExec();
-  const mockFetch: typeof fetch = url => {
-    const urlStr = String(url);
-    if (urlStr.includes('/check-runs')) {
-      return Promise.resolve(
-        new Response(
-          JSON.stringify({
-            check_runs: [
-              {name: 'Signed Commit Authors', conclusion: 'success'},
-            ],
-          }),
-          {status: 200},
-        ),
-      );
-    }
-    return Promise.resolve(new Response('Not found', {status: 404}));
-  };
-
-  const plan = await planDevRelease({
-    exec,
-    fetchFn: mockFetch,
-    githubRepository: 'rocicorp/mono',
-    githubToken: 'dummy-token',
-    requireCommitVerification: true,
-    targetRef: 'main',
-    workflowRefName: 'main',
-  });
-
-  expect(plan.source_sha).toBe(dummySha);
-});
-
-test('verifyCommit rejects commit when Signed Commit Authors check failed', async () => {
-  const {exec} = makeMockExec();
-  const mockFetch: typeof fetch = url => {
-    const urlStr = String(url);
-    if (urlStr.includes('/check-runs')) {
-      return Promise.resolve(
-        new Response(
-          JSON.stringify({
-            check_runs: [
-              {name: 'Signed Commit Authors', conclusion: 'failure'},
-            ],
-          }),
-          {status: 200},
-        ),
-      );
-    }
-    return Promise.resolve(new Response('Not found', {status: 404}));
-  };
-
-  await expect(
-    planDevRelease({
-      exec,
-      fetchFn: mockFetch,
-      githubRepository: 'rocicorp/mono',
-      githubToken: 'dummy-token',
-      requireCommitVerification: true,
-      targetRef: 'main',
-      workflowRefName: 'main',
-    }),
-  ).rejects.toThrow(
-    /Commit .* has not passed the "Signed Commit Authors" check \(conclusion was "failure"\)/,
-  );
-});
-
-test('verifyCommit rejects commit when Signed Commit Authors check is missing', async () => {
-  const {exec} = makeMockExec();
-  const mockFetch: typeof fetch = url => {
-    const urlStr = String(url);
-    if (urlStr.includes('/check-runs')) {
-      return Promise.resolve(
-        new Response(
-          JSON.stringify({
-            check_runs: [{name: 'Other Check', conclusion: 'success'}],
-          }),
-          {status: 200},
-        ),
-      );
-    }
-    return Promise.resolve(new Response('Not found', {status: 404}));
-  };
-
-  await expect(
-    planDevRelease({
-      exec,
-      fetchFn: mockFetch,
-      githubRepository: 'rocicorp/mono',
-      githubToken: 'dummy-token',
-      requireCommitVerification: true,
-      targetRef: 'main',
-      workflowRefName: 'main',
-    }),
-  ).rejects.toThrow(
-    /Commit .* has not passed the "Signed Commit Authors" check \(check run was not found\)/,
-  );
 });

--- a/scripts/src/dev-release/plan.ts
+++ b/scripts/src/dev-release/plan.ts
@@ -144,6 +144,10 @@ export function validateImageTag(tag: string): void {
 }
 
 export function resolveSourceSha(targetRef: string, exec: Exec): string {
+  if (targetRef.startsWith('-')) {
+    throw new Error('Target ref must not start with "-"');
+  }
+
   if (gitShaPattern.test(targetRef)) {
     try {
       return exec('git', [

--- a/scripts/src/dev-release/plan.ts
+++ b/scripts/src/dev-release/plan.ts
@@ -11,7 +11,8 @@ import {
 
 const gitShaPattern = /^[0-9a-f]{40}$/;
 const dockerTagPattern = /^[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,127}$/;
-const semverPattern = /^v?\d+\.\d+\.\d+$/;
+const semverRegex =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
 const protectedTags = new Set(['latest', 'head', 'staging', 'canary']);
 
 export type DevReleasePlan = {
@@ -52,11 +53,18 @@ export function planDevRelease({
     throw new Error('Target ref must not be empty');
   }
 
+  const rawInput = imageTagInput?.trim();
+  if (rawInput && protectedTags.has(rawInput.toLowerCase())) {
+    throw new Error(
+      `Tag "${rawInput}" is protected and cannot be overwritten by dev releases.`,
+    );
+  }
+
   const sourceSha = resolveSourceSha(targetRef.trim(), exec);
   assertGitSha(sourceSha, 'source SHA');
 
-  const imageTag = imageTagInput?.trim()
-    ? imageTagInput.trim()
+  const imageTag = rawInput
+    ? normalizeDevImageTag(rawInput)
     : deriveDefaultTag(targetRef.trim(), sourceSha);
 
   validateImageTag(imageTag);
@@ -69,30 +77,47 @@ export function planDevRelease({
 }
 
 const gitRefPrefixPattern = /^refs\/(heads|remotes\/origin|remotes|pull)\//;
-const invalidTagCharPattern = /[^a-zA-Z0-9_.-]/g;
+const invalidSemVerPrereleaseCharPattern = /[^a-zA-Z0-9-]/g;
 const consecutiveHyphenPattern = /-+/g;
 const edgeHyphenPattern = /^-+|-+$/g;
 
 export function sanitizeBranchName(branch: string): string {
   return branch
     .replace(gitRefPrefixPattern, '')
-    .replace(invalidTagCharPattern, '-')
+    .replace(invalidSemVerPrereleaseCharPattern, '-')
     .replace(consecutiveHyphenPattern, '-')
     .replace(edgeHyphenPattern, '');
 }
 
 export function deriveDefaultTag(targetRef: string, sourceSha: string): string {
+  const shortSha = sourceSha.slice(0, 8);
   if (gitShaPattern.test(targetRef)) {
-    return `dev-${sourceSha.slice(0, 8)}`;
+    return `0.0.0-dev-${shortSha}`;
+  }
+  const rawClean = targetRef.replace(gitRefPrefixPattern, '');
+  if (rawClean.startsWith('0.0.0-')) {
+    const prerelease = sanitizeBranchName(rawClean.slice('0.0.0-'.length));
+    return `0.0.0-${prerelease}`.slice(0, 128);
   }
   const clean = sanitizeBranchName(targetRef);
   if (!clean) {
-    return `dev-${sourceSha.slice(0, 8)}`;
+    return `0.0.0-dev-${shortSha}`;
   }
   if (clean.startsWith('pr-') || clean.startsWith('dev-')) {
-    return clean.slice(0, 128);
+    return `0.0.0-${clean}`.slice(0, 128);
   }
-  return `pr-${clean}`.slice(0, 128);
+  return `0.0.0-pr-${clean}`.slice(0, 128);
+}
+
+export function normalizeDevImageTag(input: string): string {
+  const trimmed = input.trim();
+  if (trimmed.startsWith('0.0.0-')) {
+    return trimmed;
+  }
+  if (trimmed.startsWith('dev-') || trimmed.startsWith('pr-')) {
+    return `0.0.0-${trimmed}`;
+  }
+  return `0.0.0-dev-${trimmed}`;
 }
 
 export function validateImageTag(tag: string): void {
@@ -106,9 +131,14 @@ export function validateImageTag(tag: string): void {
       `Tag "${tag}" is protected and cannot be overwritten by dev releases.`,
     );
   }
-  if (semverPattern.test(tag)) {
+  if (!tag.startsWith('0.0.0-')) {
     throw new Error(
-      `Tag "${tag}" looks like a semantic version release. Dev releases must not use version numbers.`,
+      `Tag "${tag}" must start with "0.0.0-" to ensure CloudZero SemVer compatibility and prevent colliding with official releases.`,
+    );
+  }
+  if (!semverRegex.test(tag)) {
+    throw new Error(
+      `Tag "${tag}" is not a valid semantic version (SemVer 2.0.0). Prerelease identifiers may only contain alphanumerics and hyphens.`,
     );
   }
 }

--- a/scripts/src/dev-release/plan.ts
+++ b/scripts/src/dev-release/plan.ts
@@ -1,5 +1,6 @@
 // oxlint-disable no-console
 
+import semver from 'semver';
 import {
   assertGitSha,
   assertMainWorkflowRef,
@@ -11,8 +12,6 @@ import {
 
 const gitShaPattern = /^[0-9a-f]{40}$/;
 const dockerTagPattern = /^[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,127}$/;
-const semverRegex =
-  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
 const protectedTags = new Set(['latest', 'head', 'staging', 'canary']);
 
 export type DevReleasePlan = {
@@ -136,7 +135,7 @@ export function validateImageTag(tag: string): void {
       `Tag "${tag}" must start with "0.0.0-" to ensure CloudZero SemVer compatibility and prevent colliding with official releases.`,
     );
   }
-  if (!semverRegex.test(tag)) {
+  if (!semver.valid(tag)) {
     throw new Error(
       `Tag "${tag}" is not a valid semantic version (SemVer 2.0.0). Prerelease identifiers may only contain alphanumerics and hyphens.`,
     );

--- a/scripts/src/dev-release/plan.ts
+++ b/scripts/src/dev-release/plan.ts
@@ -22,19 +22,13 @@ export type DevReleasePlan = {
 
 export type PlanDevReleaseOptions = {
   exec?: Exec | undefined;
-  fetchFn?: typeof fetch | undefined;
-  githubRepository?: string | undefined;
-  githubToken?: string | undefined;
   imageTagInput?: string | undefined;
-  requireCommitVerification?: boolean | undefined;
   targetRef: string;
   workflowRefName: string;
 };
 
-export async function runDevReleasePlanCli() {
-  const plan = await planDevRelease({
-    githubRepository: process.env.GITHUB_REPOSITORY,
-    githubToken: process.env.GITHUB_TOKEN,
+export function runDevReleasePlanCli() {
+  const plan = planDevRelease({
     imageTagInput: process.env.IMAGE_TAG_INPUT || undefined,
     targetRef: mustEnv('TARGET_REF'),
     workflowRefName: mustEnv('WORKFLOW_REF_NAME'),
@@ -46,16 +40,12 @@ export async function runDevReleasePlanCli() {
   console.log(`Planned image tag: ${plan.image_tag}`);
 }
 
-export async function planDevRelease({
+export function planDevRelease({
   exec = defaultExec,
-  fetchFn = fetch,
-  githubRepository,
-  githubToken,
   imageTagInput,
-  requireCommitVerification = true,
   targetRef,
   workflowRefName,
-}: PlanDevReleaseOptions): Promise<DevReleasePlan> {
+}: PlanDevReleaseOptions): DevReleasePlan {
   assertMainWorkflowRef('Dev release', workflowRefName);
 
   if (!targetRef.trim()) {
@@ -70,15 +60,6 @@ export async function planDevRelease({
     : deriveDefaultTag(targetRef.trim(), sourceSha);
 
   validateImageTag(imageTag);
-
-  if (requireCommitVerification && githubToken && githubRepository) {
-    await verifyCommit({
-      fetchFn,
-      githubRepository,
-      githubToken,
-      sourceSha,
-    });
-  }
 
   return {
     image_tag: imageTag,
@@ -154,56 +135,4 @@ export function resolveSourceSha(targetRef: string, exec: Exec): string {
   // Target ref is a branch, tag, or PR ref (e.g. refs/pull/123/head).
   exec('git', ['fetch', 'origin', targetRef], {stdio: 'inherit'});
   return exec('git', ['rev-parse', '--verify', 'FETCH_HEAD^{commit}']).trim();
-}
-
-export async function verifyCommit({
-  fetchFn,
-  githubRepository,
-  githubToken,
-  sourceSha,
-}: {
-  fetchFn: typeof fetch;
-  githubRepository: string;
-  githubToken: string;
-  sourceSha: string;
-}): Promise<void> {
-  const headers = {
-    'Accept': 'application/vnd.github+json',
-    'Authorization': `Bearer ${githubToken}`,
-    'User-Agent': 'rocicorp-dev-release',
-  };
-
-  const checksUrl = `https://api.github.com/repos/${githubRepository}/commits/${sourceSha}/check-runs?per_page=100`;
-  const checksRes = await fetchFn(checksUrl, {headers});
-  if (!checksRes.ok) {
-    throw new Error(
-      `Failed to fetch check runs for ${sourceSha}: ${checksRes.status} ${checksRes.statusText}`,
-    );
-  }
-
-  const checksData = (await checksRes.json()) as {
-    check_runs?:
-      | Array<{
-          conclusion?: string | null | undefined;
-          name?: string | undefined;
-        }>
-      | undefined;
-  };
-
-  const signedCommitCheck = checksData.check_runs?.find(
-    c => c.name?.trim().toLowerCase() === 'signed commit authors',
-  );
-
-  if (signedCommitCheck?.conclusion === 'success') {
-    console.log(`Commit ${sourceSha} passed "${signedCommitCheck.name}" check`);
-    return;
-  }
-
-  const status = signedCommitCheck
-    ? `conclusion was "${signedCommitCheck.conclusion}"`
-    : 'check run was not found';
-
-  throw new Error(
-    `Commit ${sourceSha} has not passed the "Signed Commit Authors" check (${status}). Dev releases require the "Signed Commit Authors" check to pass.`,
-  );
 }

--- a/scripts/src/dev-release/plan.ts
+++ b/scripts/src/dev-release/plan.ts
@@ -1,0 +1,209 @@
+// oxlint-disable no-console
+
+import {
+  assertGitSha,
+  assertMainWorkflowRef,
+  defaultExec,
+  mustEnv,
+  writeGithubOutput,
+  type Exec,
+} from '../shared.ts';
+
+const gitShaPattern = /^[0-9a-f]{40}$/;
+const dockerTagPattern = /^[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,127}$/;
+const semverPattern = /^v?\d+\.\d+\.\d+$/;
+const protectedTags = new Set(['latest', 'head', 'staging', 'canary']);
+
+export type DevReleasePlan = {
+  image_tag: string;
+  ref: string;
+  source_sha: string;
+};
+
+export type PlanDevReleaseOptions = {
+  exec?: Exec | undefined;
+  fetchFn?: typeof fetch | undefined;
+  githubRepository?: string | undefined;
+  githubToken?: string | undefined;
+  imageTagInput?: string | undefined;
+  requireCommitVerification?: boolean | undefined;
+  targetRef: string;
+  workflowRefName: string;
+};
+
+export async function runDevReleasePlanCli() {
+  const plan = await planDevRelease({
+    githubRepository: process.env.GITHUB_REPOSITORY,
+    githubToken: process.env.GITHUB_TOKEN,
+    imageTagInput: process.env.IMAGE_TAG_INPUT || undefined,
+    targetRef: mustEnv('TARGET_REF'),
+    workflowRefName: mustEnv('WORKFLOW_REF_NAME'),
+  });
+
+  writeGithubOutput(plan);
+  console.log(`Target ref: ${plan.ref}`);
+  console.log(`Source SHA: ${plan.source_sha}`);
+  console.log(`Planned image tag: ${plan.image_tag}`);
+}
+
+export async function planDevRelease({
+  exec = defaultExec,
+  fetchFn = fetch,
+  githubRepository,
+  githubToken,
+  imageTagInput,
+  requireCommitVerification = true,
+  targetRef,
+  workflowRefName,
+}: PlanDevReleaseOptions): Promise<DevReleasePlan> {
+  assertMainWorkflowRef('Dev release', workflowRefName);
+
+  if (!targetRef.trim()) {
+    throw new Error('Target ref must not be empty');
+  }
+
+  const sourceSha = resolveSourceSha(targetRef.trim(), exec);
+  assertGitSha(sourceSha, 'source SHA');
+
+  const imageTag = imageTagInput?.trim()
+    ? imageTagInput.trim()
+    : deriveDefaultTag(targetRef.trim(), sourceSha);
+
+  validateImageTag(imageTag);
+
+  if (requireCommitVerification && githubToken && githubRepository) {
+    await verifyCommit({
+      fetchFn,
+      githubRepository,
+      githubToken,
+      sourceSha,
+    });
+  }
+
+  return {
+    image_tag: imageTag,
+    ref: targetRef.trim(),
+    source_sha: sourceSha,
+  };
+}
+
+const gitRefPrefixPattern = /^refs\/(heads|remotes\/origin|remotes|pull)\//;
+const invalidTagCharPattern = /[^a-zA-Z0-9_.-]/g;
+const consecutiveHyphenPattern = /-+/g;
+const edgeHyphenPattern = /^-+|-+$/g;
+
+export function sanitizeBranchName(branch: string): string {
+  return branch
+    .replace(gitRefPrefixPattern, '')
+    .replace(invalidTagCharPattern, '-')
+    .replace(consecutiveHyphenPattern, '-')
+    .replace(edgeHyphenPattern, '');
+}
+
+export function deriveDefaultTag(targetRef: string, sourceSha: string): string {
+  if (gitShaPattern.test(targetRef)) {
+    return `dev-${sourceSha.slice(0, 8)}`;
+  }
+  const clean = sanitizeBranchName(targetRef);
+  if (!clean) {
+    return `dev-${sourceSha.slice(0, 8)}`;
+  }
+  if (clean.startsWith('pr-') || clean.startsWith('dev-')) {
+    return clean.slice(0, 128);
+  }
+  return `pr-${clean}`.slice(0, 128);
+}
+
+export function validateImageTag(tag: string): void {
+  if (!dockerTagPattern.test(tag)) {
+    throw new Error(
+      `Invalid Docker image tag "${tag}". Tag must contain only letters, numbers, underscores, periods, and hyphens.`,
+    );
+  }
+  if (protectedTags.has(tag.toLowerCase())) {
+    throw new Error(
+      `Tag "${tag}" is protected and cannot be overwritten by dev releases.`,
+    );
+  }
+  if (semverPattern.test(tag)) {
+    throw new Error(
+      `Tag "${tag}" looks like a semantic version release. Dev releases must not use version numbers.`,
+    );
+  }
+}
+
+export function resolveSourceSha(targetRef: string, exec: Exec): string {
+  if (gitShaPattern.test(targetRef)) {
+    try {
+      return exec('git', [
+        'rev-parse',
+        '--verify',
+        `${targetRef}^{commit}`,
+      ]).trim();
+    } catch {
+      // If the commit is not present locally, attempt to fetch it.
+      exec('git', ['fetch', 'origin', targetRef], {stdio: 'inherit'});
+      return exec('git', [
+        'rev-parse',
+        '--verify',
+        'FETCH_HEAD^{commit}',
+      ]).trim();
+    }
+  }
+
+  // Target ref is a branch, tag, or PR ref (e.g. refs/pull/123/head).
+  exec('git', ['fetch', 'origin', targetRef], {stdio: 'inherit'});
+  return exec('git', ['rev-parse', '--verify', 'FETCH_HEAD^{commit}']).trim();
+}
+
+export async function verifyCommit({
+  fetchFn,
+  githubRepository,
+  githubToken,
+  sourceSha,
+}: {
+  fetchFn: typeof fetch;
+  githubRepository: string;
+  githubToken: string;
+  sourceSha: string;
+}): Promise<void> {
+  const headers = {
+    'Accept': 'application/vnd.github+json',
+    'Authorization': `Bearer ${githubToken}`,
+    'User-Agent': 'rocicorp-dev-release',
+  };
+
+  const checksUrl = `https://api.github.com/repos/${githubRepository}/commits/${sourceSha}/check-runs?per_page=100`;
+  const checksRes = await fetchFn(checksUrl, {headers});
+  if (!checksRes.ok) {
+    throw new Error(
+      `Failed to fetch check runs for ${sourceSha}: ${checksRes.status} ${checksRes.statusText}`,
+    );
+  }
+
+  const checksData = (await checksRes.json()) as {
+    check_runs?:
+      | Array<{
+          conclusion?: string | null | undefined;
+          name?: string | undefined;
+        }>
+      | undefined;
+  };
+
+  const signedCommitCheck = checksData.check_runs?.find(
+    c => c.name?.trim().toLowerCase() === 'signed commit authors',
+  );
+
+  if (signedCommitCheck?.conclusion === 'success') {
+    console.log(`Commit ${sourceSha} passed "${signedCommitCheck.name}" check`);
+    return;
+  }
+
+  const status = signedCommitCheck
+    ? `conclusion was "${signedCommitCheck.conclusion}"`
+    : 'check run was not found';
+
+  throw new Error(
+    `Commit ${sourceSha} has not passed the "Signed Commit Authors" check (${status}). Dev releases require the "Signed Commit Authors" check to pass.`,
+  );
+}


### PR DESCRIPTION
### Summary
Adds a dedicated manual GitHub Actions workflow (`dev-release.yml`) and planning script to build and publish Zero multi-arch container images (`linux/amd64`, `linux/arm64`) from PR or feature branches to Docker Hub and GHCR.
This enables benchmarking and deploying experimental builds to CloudZero staging without publishing to npm, tagging git releases, or modifying production release infrastructure.
### Key Changes
- **Workflow** ([.github/workflows/dev-release.yml](file:///Users/gregorybaker/github/mono/.github/workflows/dev-release.yml)):
  - Dispatched manually via `workflow_dispatch` taking a target git `ref` (branch, PR ref, or SHA) and an optional `image_tag`.
  - Enforces execution from `main`.
  - **Signed Commit Verification**: Pinned to SHA `c49caa1498b8cf402992126969f2d7c8adc9ca4b` (`rocicorp/.github/.github/actions/verify-signed-commit-authors`) with `enforce: 'true'` to verify commit signatures before any build or deploy steps.
  - **Concurrency Control**: Added tag-level concurrency to `publish-docker` (`group: zero-dev-release-tag-${{ needs.plan.outputs.image_tag }}`, `cancel-in-progress: false`) to prevent race conditions and split-brain pushes across registries.
  - **Hardened Build & Publish**: Uncredentialed builder builds the multi-arch OCI archive; credentialed publisher pushes to both Docker Hub (`rocicorp/zero:<tag>`) and GHCR (`ghcr.io/rocicorp/zero:<tag>`).
  - **Source Archiving**: Archives the git source tarball to the CloudZero Staging AWS S3 bucket (`cloudzero-source-archives-946232032425`) via AWS OIDC.
- **Planning Logic & Validation** ([scripts/src/dev-release/plan.ts](file:///Users/gregorybaker/github/mono/scripts/src/dev-release/plan.ts), [scripts/src/dev-release-plan.ts](file:///Users/gregorybaker/github/mono/scripts/src/dev-release-plan.ts)):
  - Resolves target ref to an exact 40-character commit SHA.
  - **Option Injection Defense**: Explicitly rejects ref inputs beginning with `-` before invoking `git fetch`.
  - Derives default SemVer tags: `0.0.0-pr-<sanitized-branch>` or `0.0.0-dev-<sha8>`.
  - Normalizes custom tags (e.g. `bench-1` -> `0.0.0-dev-bench-1`) to ensure strict SemVer compliance required by CloudZero's Kubernetes deployment generator.
  - Prohibits overwriting protected tags (`latest`, `staging`, `canary`) and official release versions.