### PR TITLE
fix(zero-cache): record rehydrated unchanged queries in the inspector by query id

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/view-syncer-inspect.pg.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer-inspect.pg.test.ts
@@ -32,6 +32,7 @@ import {
   nextPoke,
   permissions,
   permissionsAll,
+  restartViewSyncer,
   serviceID,
   setup,
   TEST_ADMIN_PASSWORD,
@@ -89,6 +90,9 @@ describe('view-syncer/service', () => {
   let delegate: InspectorDelegate;
   let customQueryTransformer: CustomQueryTransformer | undefined;
   let clearMocks: () => void;
+  let databaseStorage: Awaited<ReturnType<typeof setup>>['databaseStorage'];
+  let config: Awaited<ReturnType<typeof setup>>['config'];
+  let setTimeoutFn: Awaited<ReturnType<typeof setup>>['setTimeoutFn'];
 
   beforeEach<PgTest>(async ({testDBs}) => {
     ({
@@ -103,6 +107,9 @@ describe('view-syncer/service', () => {
       inspectorDelegate: delegate,
       customQueryTransformer,
       clearMocks,
+      databaseStorage,
+      config,
+      setTimeoutFn,
     } = await setup(testDBs, 'view_syncer_inspect_test', permissionsAll, {
       queryFetchMode: 'empty-validation',
     }));
@@ -165,6 +172,52 @@ describe('view-syncer/service', () => {
         },
       },
     ]);
+  });
+
+  test('unchanged queries rehydrated on restart are recorded by query id', async () => {
+    const {queue: client} = connectWithQueueAndSource(SYNC_CONTEXT, [
+      {op: 'put', hash: 'query-hash1', ast: ISSUES_QUERY},
+    ]);
+    await nextPoke(client); // desired queries
+    stateChanges.push({state: 'version-ready'});
+    await nextPoke(client); // hydrated
+    const ast = delegate.getASTForQuery('query-hash1');
+    expect(ast).toBeDefined();
+
+    await vs.stop();
+    await viewSyncerDone;
+
+    // A fresh view-syncer (with a fresh InspectorDelegate) rehydrates the
+    // gotten query as an unchanged query, which is a different code path
+    // from the initial hydration.
+    const restarted = restartViewSyncer({
+      databaseStorage,
+      replicaDbFile,
+      cvrDB,
+      config,
+      customQueryTransformer,
+      setTimeoutFn,
+    });
+    try {
+      restarted.connect({...SYNC_CONTEXT, wsID: 'ws2'}, []);
+      restarted.stateChanges.push({state: 'version-ready'});
+
+      // The inspector looks up ASTs and metrics by query id.
+      await vi.waitFor(
+        () => {
+          expect(
+            restarted.inspectorDelegate.getASTForQuery('query-hash1'),
+          ).toEqual(ast);
+        },
+        {timeout: 5_000},
+      );
+      expect(
+        restarted.inspectorDelegate.getMetricsJSONForQuery('query-hash1'),
+      ).toMatchObject({'query-hydration-server-ms': expect.any(Number)});
+    } finally {
+      await restarted.vs.stop();
+      await restarted.viewSyncerDone;
+    }
   });
 
   test('inspect queries sharing a transformationHash have metrics per query id', async () => {

--- a/packages/zero-cache/src/services/view-syncer/view-syncer-test-util.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer-test-util.ts
@@ -1085,7 +1085,14 @@ export function restartViewSyncer(params: {
     return queue;
   }
 
-  return {vs, stateChanges, viewSyncerDone, drainCoordinator, connect};
+  return {
+    vs,
+    stateChanges,
+    viewSyncerDone,
+    drainCoordinator,
+    inspectorDelegate,
+    connect,
+  };
 }
 
 /**

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -1969,8 +1969,10 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
       hydrationPassStats.activeHydratedQueries++;
       this.#hydrations.add(1);
       this.#hydrationTime.recordMs(elapsed);
-      this.#addQueryMaterializationServerMetric(transformationHash, elapsed);
-      this.#inspectorDelegate.addQuery(transformationHash, transformedAst);
+      // Keyed by query id like the other hydration path: the inspector looks
+      // metrics and ASTs up by query id, and removeQuery() is keyed by it too.
+      this.#addQueryMaterializationServerMetric(queryID, elapsed);
+      this.#inspectorDelegate.addQuery(queryID, transformedAst);
       lc.debug?.(`hydrated ${count} rows for ${queryID} (${elapsed} ms)`);
 
       let drifted = false;


### PR DESCRIPTION
## Problem

When a view-syncer restarts, `#hydrateUnchangedQueries` rehydrates the gotten queries and recorded their hydration metric and AST in the `InspectorDelegate` under the `transformationHash`. The initial hydration path in `#syncQueryPipelineSet`, `removeQuery()` and the inspector's lookups (`getASTForQuery`, `getMetricsJSONForQuery`) all use the query id. Those entries were therefore unreadable by the inspector and never removed, accumulating in the delegate's maps for the lifetime of the syncer worker.

## Fix

Key them by query id like the other path.

## Tests

`view-syncer-inspect.pg.test.ts`: `unchanged queries rehydrated on restart are recorded by query id`. Hydrates a query, stops the view-syncer, restarts it with a fresh `InspectorDelegate` (`restartViewSyncer` now returns the delegate) and checks that the AST and hydration metric are found under the query id. Fails without the fix (the AST is `undefined`).

Ran the full inspect pg test file against Postgres 16, plus `lint`, `format`, `check-types`.

From the lower-severity section of the zero-cache memory-leak audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UPJiVV1Wekmk8U9r3WMMdx

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPJiVV1Wekmk8U9r3WMMdx)_