### PR TITLE
fix(zero-cache): do not retain every view-syncer from the DrainCoordinator

### DIFF
--- a/packages/zero-cache/src/services/view-syncer/drain-coordinator.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/drain-coordinator.test.ts
@@ -1,0 +1,55 @@
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest';
+import {DrainCoordinator} from './drain-coordinator.ts';
+
+describe('view-syncer/drain-coordinator', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test('onDraining fires once draining starts', () => {
+    const coordinator = new DrainCoordinator();
+    const listener = vi.fn();
+
+    coordinator.onDraining(listener);
+    expect(listener).not.toHaveBeenCalled();
+    expect(coordinator.drainListenerCount).toBe(1);
+
+    coordinator.drainNextIn(0);
+    expect(listener).toHaveBeenCalledTimes(1);
+    // Fired listeners are released.
+    expect(coordinator.drainListenerCount).toBe(0);
+
+    // A later drain does not fire it again.
+    vi.advanceTimersByTime(1);
+    coordinator.drainNextIn(0);
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  test('onDraining fires immediately when already draining', () => {
+    const coordinator = new DrainCoordinator();
+    coordinator.drainNextIn(0);
+
+    const listener = vi.fn();
+    coordinator.onDraining(listener);
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(coordinator.drainListenerCount).toBe(0);
+  });
+
+  test('an unsubscribed listener is released and never called', () => {
+    const coordinator = new DrainCoordinator();
+    const listener = vi.fn();
+
+    const unsubscribe = coordinator.onDraining(listener);
+    expect(coordinator.drainListenerCount).toBe(1);
+
+    unsubscribe();
+    expect(coordinator.drainListenerCount).toBe(0);
+
+    coordinator.drainNextIn(0);
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/packages/zero-cache/src/services/view-syncer/drain-coordinator.ts
+++ b/packages/zero-cache/src/services/view-syncer/drain-coordinator.ts
@@ -1,6 +1,8 @@
 import {resolver} from '@rocicorp/resolver';
 import {assert} from '../../../../shared/src/asserts.ts';
 
+type DrainListener = () => void;
+
 // The target (additional) utilization to impose on the server
 // that receives the drained connections.
 const TARGET_UTILIZATION = 0.6;
@@ -29,13 +31,36 @@ const TARGET_UTILIZATION = 0.6;
  * for the next elective or forced drain.
  */
 export class DrainCoordinator {
-  readonly #draining = resolver<'draining'>();
+  #draining = false;
+  readonly #drainListeners = new Set<DrainListener>();
   #nextDrainTime = 0;
   #timeout = resolver();
   #timeoutID: NodeJS.Timeout | undefined;
 
-  get draining(): Promise<'draining'> {
-    return this.#draining.promise;
+  /**
+   * Calls `listener` once draining has started (immediately if it already
+   * has) and returns a function that unsubscribes it.
+   *
+   * This is a subscription rather than a Promise so that a caller that stops
+   * caring (e.g. a view-syncer that finished initializing) can let go of it.
+   * A reaction attached to a Promise that may never settle would otherwise
+   * be retained by the coordinator for the lifetime of the server, once per
+   * view-syncer ever created.
+   */
+  onDraining(listener: DrainListener): () => void {
+    if (this.#draining) {
+      listener();
+      return () => {};
+    }
+    this.#drainListeners.add(listener);
+    return () => {
+      this.#drainListeners.delete(listener);
+    };
+  }
+
+  // Exposed for testing.
+  get drainListenerCount() {
+    return this.#drainListeners.size;
   }
 
   shouldDrain() {
@@ -43,7 +68,14 @@ export class DrainCoordinator {
   }
 
   drainNextIn(interval: number) {
-    this.#draining.resolve('draining');
+    if (!this.#draining) {
+      this.#draining = true;
+      const listeners = [...this.#drainListeners];
+      this.#drainListeners.clear();
+      for (const listener of listeners) {
+        listener();
+      }
+    }
     // Increase the timeout between drains to give the receiving
     // server space to perform normal processing.
     interval /= TARGET_UTILIZATION;

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.pg.test.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.pg.test.ts
@@ -6034,6 +6034,28 @@ describe('view-syncer/service', () => {
     expect(drainCoordinator.nextDrainTime).toBeGreaterThan(now);
   });
 
+  test('readyState() releases its drain listener once initialized', async () => {
+    // run() is waiting on readyState() until the first client initializes.
+    expect(drainCoordinator.drainListenerCount).toBe(1);
+
+    const client = connect(SYNC_CONTEXT, [
+      {op: 'put', hash: 'query-hash1', ast: ISSUES_QUERY},
+    ]);
+    await nextPoke(client); // desired queries
+    stateChanges.push({state: 'version-ready'});
+    await nextPoke(client); // hydration, from the run loop
+
+    // The coordinator outlives the view-syncer, so it must not keep a
+    // reference to it after initialization.
+    expect(drainCoordinator.drainListenerCount).toBe(0);
+  });
+
+  test('a drain requested before initialization stops the view-syncer', async () => {
+    drainCoordinator.drainNextIn(0);
+    await viewSyncerDone;
+    expect(drainCoordinator.drainListenerCount).toBe(0);
+  });
+
   test('retracting an exists relationship', async () => {
     const client = connect(SYNC_CONTEXT, [
       {op: 'put', hash: 'query-hash1', ast: ISSUES_QUERY_WITH_RELATED},

--- a/packages/zero-cache/src/services/view-syncer/view-syncer.ts
+++ b/packages/zero-cache/src/services/view-syncer/view-syncer.ts
@@ -657,10 +657,25 @@ export class ViewSyncerService implements ViewSyncer, ActivityBasedService {
   }
 
   readyState(): Promise<'initialized' | 'draining'> {
-    return Promise.race([
-      this.#initialized.promise,
-      this.#drainCoordinator.draining,
-    ]);
+    return new Promise((resolve, reject) => {
+      // Subscribe to the drain rather than racing against a Promise for it:
+      // the coordinator outlives every view-syncer, and a race reaction on a
+      // promise that may never settle would keep this closure alive for the
+      // lifetime of the server. Unsubscribe once initialization settles.
+      const unsubscribe = this.#drainCoordinator.onDraining(() =>
+        resolve('draining'),
+      );
+      this.#initialized.promise.then(
+        state => {
+          unsubscribe();
+          resolve(state);
+        },
+        err => {
+          unsubscribe();
+          reject(err);
+        },
+      );
+    });
   }
 
   async run(): Promise<void> {


### PR DESCRIPTION
## Problem

`ViewSyncerService.readyState()` raced the per-instance `#initialized` promise against `DrainCoordinator.draining`, a single promise per syncer worker that never settles unless the server drains. Each `Promise.race()` attaches a reaction to that promise, and reactions are only released when the promise settles, so the coordinator accumulated one reaction (and the race closure behind it) for every view-syncer ever created.

## Fix

Replace the promise with a subscription, `DrainCoordinator.onDraining(listener)`, which returns an unsubscribe function. `readyState()` subscribes and unsubscribes as soon as `#initialized` settles either way. A listener registered after draining has started is called immediately, preserving the old promise semantics for a drain that begins before a view-syncer initializes.

## Tests

- New `drain-coordinator.test.ts`: listener fires once draining starts and is then released; fires immediately when already draining; an unsubscribed listener is released and never called.
- `view-syncer.pg.test.ts`: `readyState() releases its drain listener once initialized` (listener count goes from 1 to 0 after the first hydration) and `a drain requested before initialization stops the view-syncer` (the pre-existing behavior).

Ran the whole `view-syncer.pg.test.ts` against Postgres 16, plus `lint`, `format`, `check-types`.

From the lower-severity section of the zero-cache memory-leak audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UPJiVV1Wekmk8U9r3WMMdx

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPJiVV1Wekmk8U9r3WMMdx)_