### PR TITLE
fix(zero-cache): ignore the exit of a replaced vfs-query child

### DIFF
--- a/packages/zero-cache/src/services/change-streamer/vfs-watermark-poller.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/vfs-watermark-poller.test.ts
@@ -217,6 +217,42 @@ describe('change-streamer/vfs-watermark-poller', () => {
     expect(spawnMock).toHaveBeenCalledTimes(1);
   });
 
+  test('a replacement spawned before the old child exits is not orphaned', async () => {
+    setUp();
+    const poller = makePoller(
+      fakeVfsQuery(
+        `echo '${line('01', 100, '2025-01-01T00:00:00Z')}'\n${BLOCK}`,
+      ),
+    );
+    poller.checkLocalWatermark();
+    await vi.waitFor(() => expect(pushed).toHaveLength(1));
+    const child1 = spawnMock.mock.results[0].value as childProcess.ChildProcess;
+    const child1Closed = new Promise<void>(resolve =>
+      child1.once('close', () => resolve()),
+    );
+
+    // Catch up (which stops the poller) and fall behind again (which restarts
+    // it) before the first child has had a chance to exit.
+    setLocalWatermark('01');
+    poller.checkLocalWatermark();
+    expect(child1.killed).toBe(true);
+    setLocalWatermark('02');
+    poller.checkLocalWatermark();
+    expect(spawnMock).toHaveBeenCalledTimes(2);
+    const child2 = spawnMock.mock.results[1].value as childProcess.ChildProcess;
+
+    // The stale child's exit must not schedule a respawn next to the
+    // replacement (the initial backoff is 2s).
+    await child1Closed;
+    await new Promise(resolve => setTimeout(resolve, 2_500));
+    expect(spawnMock).toHaveBeenCalledTimes(2);
+
+    // ...and the replacement is still tracked: catching up stops it.
+    setLocalWatermark('01');
+    poller.checkLocalWatermark();
+    expect(child2.killed).toBe(true);
+  });
+
   test('an unexpected exit while still behind schedules a respawn', async () => {
     setUp();
     const poller = makePoller(fakeVfsQuery('exit 1'), {

--- a/packages/zero-cache/src/services/change-streamer/vfs-watermark-poller.ts
+++ b/packages/zero-cache/src/services/change-streamer/vfs-watermark-poller.ts
@@ -173,6 +173,12 @@ export class VfsWatermarkPoller {
         this.#lc.error?.(`received error from vfs-query process`, err);
       })
       .on('close', (code, signal) => {
+        if (this.#remotePoller !== child) {
+          // This child was already stopped by #disableRemotePoller(), and a
+          // replacement may have been spawned since. Its exit must neither
+          // untrack that replacement nor schedule a respawn next to it.
+          return;
+        }
         this.#remotePoller = undefined;
         if (this.#shouldPollRemote) {
           if (code !== 0) {


### PR DESCRIPTION
## Problem

`VfsWatermarkPoller` kills its `vfs-query` child when the local watermark catches up with the backup, and spawns a replacement as soon as it falls behind again. The child exits asynchronously, and its `close` handler unconditionally cleared `#remotePoller` and, since polling was wanted again, scheduled a backoff respawn. That orphaned the replacement (it could no longer be stopped by `#disableRemotePoller()`, and every later disable/enable spawned another child next to it) and started a third child after the backoff.

## Fix

The `close` handler ignores a child that is no longer the tracked poller.

## Tests

`vfs-watermark-poller.test.ts`: `a replacement spawned before the old child exits is not orphaned`. Catches up and falls behind again before the first child has exited, then checks that no third child is spawned after the backoff and that the replacement is still killed when the poller catches up. Fails without the fix (three spawns).

Ran the whole poller test file, plus `lint`, `format`, `check-types`.

From the lower-severity section of the zero-cache memory-leak audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UPJiVV1Wekmk8U9r3WMMdx

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPJiVV1Wekmk8U9r3WMMdx)_