### PR TITLE
fix(zero-cache): close a pipelined stream on an unexpected ack instead of rejecting unhandled

### DIFF
--- a/packages/zero-cache/src/types/streams.test.ts
+++ b/packages/zero-cache/src/types/streams.test.ts
@@ -388,6 +388,33 @@ describe('streams with internal acks', () => {
     ]);
   });
 
+  test('pipelined: an unexpected ack closes the stream', async () => {
+    // A bad ack used to throw inside a void-ed async closure, which surfaced
+    // as an unhandled rejection instead of closing the stream.
+    const unhandled: unknown[] = [];
+    const onUnhandled = (e: unknown) => unhandled.push(e);
+    process.on('unhandledRejection', onUnhandled);
+    try {
+      const result = producer.push({from: 0, to: 1, str: 'foo'}).result;
+
+      ws = new WebSocket(`http://localhost:${port}/`);
+      const closed = resolver<void>();
+      ws.on('close', () => closed.resolve());
+      // Acknowledge the first message with the wrong id.
+      ws.once('message', () => ws.send(JSON.stringify({ack: 42})));
+
+      await closed.promise;
+      expect(await cleanedUp).toEqual([{from: 0, to: 1, str: 'foo'}]);
+      expect(await result).toBe('unconsumed');
+
+      // Give a would-be unhandled rejection a chance to surface.
+      await sleep(10);
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off('unhandledRejection', onUnhandled);
+    }
+  });
+
   test('coalesce and cleanup', async () => {
     producer = Subscription.create({
       consumed: m => consumed.enqueue(m),

--- a/packages/zero-cache/src/types/streams.ts
+++ b/packages/zero-cache/src/types/streams.ts
@@ -283,6 +283,10 @@ async function streamOutInternal<T extends JSONValue>(
         // lc.debug?.(`pipelining`, data);
         sink.send(data);
 
+        // The ack is awaited off the send loop so that the next message can be
+        // sent without waiting for it. A bad ack is a protocol error like in
+        // the synchronous path below: close the socket (which cancels the
+        // source) rather than leaving the rejection unhandled.
         void (async () => {
           const {ack} = await acks.dequeue();
           // lc.debug?.(`received ack`, ack);
@@ -290,7 +294,7 @@ async function streamOutInternal<T extends JSONValue>(
             throw new Error(`Unexpected ack for ${id}: ${ack}`);
           }
           consumed();
-        })();
+        })().catch(e => closer.close(e));
       }
     } else {
       lc.debug?.(`started synchronous outbound stream`);


### PR DESCRIPTION
## Problem

In `streamOut`'s pipelined path the ack for each message is awaited in a void-ed async closure. A mismatched ack threw inside that closure, which became an unhandled rejection (crashing the process under Node's default policy) while the stream itself stayed open. This is a crash path rather than a leak, but it came out of the same audit.

## Fix

Route the error to the `WebSocketCloser` like the synchronous path does, so the socket is closed and the source canceled.

## Tests

`streams.test.ts`: `pipelined: an unexpected ack closes the stream`. A raw client acks the first message with the wrong id; the socket must close, the message must be reported unconsumed, and no `unhandledRejection` may fire. Without the fix the socket never closes and the test times out.

Ran the whole streams test file, plus `lint`, `format`, `check-types`.

From the lower-severity section of the zero-cache memory-leak audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UPJiVV1Wekmk8U9r3WMMdx

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPJiVV1Wekmk8U9r3WMMdx)_