### PR TITLE
chore: Flip #pipelinesReady to false

### DIFF
--- a/packages/zero-client/src/client/context-deferred.test.ts
+++ b/packages/zero-client/src/client/context-deferred.test.ts
@@ -52,8 +52,10 @@ const add = (id: string, name: string) => ({
   newValue: {id, name},
 });
 
-test('pipelines are ready by default', () => {
+test('pipelines are ready once marked ready', () => {
   const {context} = newContext();
+  expect(context.pipelinesReady).toBe(false);
+  context.markPipelinesReady();
   expect(context.pipelinesReady).toBe(true);
   context.processChanges(undefined, 'h1' as Hash, [add('e1', 'one')]);
   const view = context.materialize(newQuery(schema, 't1'));
@@ -63,7 +65,6 @@ test('pipelines are ready by default', () => {
 
 test('views materialized while deferred hydrate when pipelines become ready', () => {
   const {context, batchCalls} = newContext();
-  context.deferPipelines();
   expect(context.pipelinesReady).toBe(false);
 
   const view = context.materialize(newQuery(schema, 't1'));
@@ -97,7 +98,6 @@ test('views materialized while deferred hydrate when pipelines become ready', ()
 
 test('markPipelinesReady is idempotent and materialize after it is immediate', () => {
   const {context, batchCalls} = newContext();
-  context.deferPipelines();
   context.processChanges(undefined, 'h1' as Hash, [add('e1', 'one')]);
   context.markPipelinesReady();
   const batches = batchCalls();
@@ -111,7 +111,6 @@ test('markPipelinesReady is idempotent and materialize after it is immediate', (
 
 test('a view destroyed while deferred is not hydrated', () => {
   const {context} = newContext();
-  context.deferPipelines();
   const view = context.materialize(newQuery(schema, 't1'));
   const listener = vi.fn();
   view.addListener(listener);
@@ -125,7 +124,6 @@ test('a view destroyed while deferred is not hydrated', () => {
 
 test('a query for an unknown table throws from materialize, as before deferral', () => {
   const {context} = newContext();
-  context.deferPipelines();
   const otherSchema = createSchema({
     tables: [table('t2').columns({id: string()}).primaryKey('id')],
   });
@@ -135,7 +133,6 @@ test('a query for an unknown table throws from materialize, as before deferral',
 
 test('a deferred pipeline that fails at attach is logged and does not strand the others', async () => {
   const {context} = newContext();
-  context.deferPipelines();
   const view = context.materialize(newQuery(schema, 't1'));
   let type = 'unknown';
   view.addListener((_d, t) => {

--- a/packages/zero-client/src/client/context.test.ts
+++ b/packages/zero-client/src/client/context.test.ts
@@ -52,7 +52,7 @@ test('getSource', () => {
     testBatchViewUpdates,
     () => {},
     assertValidRunOptions,
-  );
+  ).markPipelinesReady();
 
   const source = context.getSource('users');
   assert(
@@ -132,7 +132,7 @@ test('processChanges', () => {
     testBatchViewUpdates,
     () => {},
     assertValidRunOptions,
-  );
+  ).markPipelinesReady();
   const out = new Catch(
     // oxlint-disable-next-line no-non-null-assertion
     context.getSource('t1')!.connect([
@@ -203,7 +203,7 @@ test('processChanges wraps source updates with batchViewUpdates', () => {
     batchViewUpdates,
     () => {},
     assertValidRunOptions,
-  );
+  ).markPipelinesReady();
   const out = new Catch(
     // oxlint-disable-next-line no-non-null-assertion
     context.getSource('t1')!.connect([
@@ -263,7 +263,7 @@ test('transactions', () => {
     testBatchViewUpdates,
     () => {},
     assertValidRunOptions,
-  );
+  ).markPipelinesReady();
   const servers = context.getSource('server')!;
   const flair = context.getSource('flair')!;
   const join = new Join({
@@ -346,7 +346,7 @@ test('batchViewUpdates errors if applyViewUpdates is not called', () => {
     batchViewUpdates,
     () => {},
     assertValidRunOptions,
-  );
+  ).markPipelinesReady();
 
   expect(batchViewUpdatesCalls).toEqual(0);
   expect(() => context.batchViewUpdates(() => {})).toThrowError();
@@ -371,7 +371,7 @@ test('batchViewUpdates returns value', () => {
     batchViewUpdates,
     () => {},
     assertValidRunOptions,
-  );
+  ).markPipelinesReady();
 
   expect(batchViewUpdatesCalls).toEqual(0);
   expect(context.batchViewUpdates(() => 'test value')).toEqual('test value');

--- a/packages/zero-client/src/client/context.ts
+++ b/packages/zero-client/src/client/context.ts
@@ -44,12 +44,13 @@ export class ZeroContext extends QueryDelegateBase {
   readonly #batchViewUpdates: (applyViewUpdates: () => void) => void;
   readonly #commitListeners: Set<CommitListener> = new Set();
 
-  // Pipeline construction is deferred between `deferPipelines()` and
-  // `markPipelinesReady()`. Zero calls the former at construction and the
-  // latter once the replica has been loaded into the IVM sources, so cold
-  // boot loads the sources once instead of pushing every row through every
-  // already-materialized pipeline.
-  #pipelinesReady = true;
+  // Pipeline construction is deferred until `markPipelinesReady()` is called.
+  // Zero calls it once the replica has been loaded into the IVM sources, so
+  // cold boot loads the sources once instead of pushing every row through
+  // every already-materialized pipeline. Contexts whose sources are already
+  // populated at construction (custom mutator transactions, tests) call it
+  // right away.
+  #pipelinesReady = false;
   readonly #pendingPipelines: Set<() => void> = new Set();
 
   readonly assertValidRunOptions: (options?: RunOptions) => void;
@@ -111,27 +112,21 @@ export class ZeroContext extends QueryDelegateBase {
   }
 
   /**
-   * Stop building pipelines for materialized queries until
-   * {@link markPipelinesReady} is called. Views materialized in the meantime
-   * are empty and `unknown`, exactly as they would be over empty sources.
+   * Build and hydrate every pipeline deferred since construction, in
+   * materialization order, as a single view-update batch. Views materialized
+   * before this is called are empty and `unknown` in the meantime, exactly as
+   * they would be over empty sources. A pipeline that fails to build is
+   * logged and its view reports an error; the rest are still built.
+   *
+   * Returns `this` so it can be chained onto the constructor call.
    */
-  deferPipelines(): void {
-    this.#pipelinesReady = false;
-  }
-
-  /**
-   * Build and hydrate every pipeline deferred since {@link deferPipelines},
-   * in materialization order, as a single view-update batch. A pipeline that
-   * fails to build is logged and its view reports an error; the rest are
-   * still built.
-   */
-  markPipelinesReady(): void {
+  markPipelinesReady(): this {
     if (this.#pipelinesReady) {
-      return;
+      return this;
     }
     this.#pipelinesReady = true;
     if (this.#pendingPipelines.size === 0) {
-      return;
+      return this;
     }
     const pending = [...this.#pendingPipelines];
     this.#pendingPipelines.clear();
@@ -154,6 +149,7 @@ export class ZeroContext extends QueryDelegateBase {
         this.#endTransaction();
       }
     });
+    return this;
   }
 
   mapAst(ast: AST): AST {

--- a/packages/zero-client/src/client/custom.ts
+++ b/packages/zero-client/src/client/custom.ts
@@ -207,6 +207,7 @@ function assertValidRunOptions(options: RunOptions | undefined): void {
 }
 
 function newZeroContext(lc: LogContext, ivmBranch: IVMSourceBranch) {
+  // The forked branch is already populated, so there is nothing to defer.
   return new ZeroContext(
     lc,
     ivmBranch,
@@ -218,5 +219,5 @@ function newZeroContext(lc: LogContext, ivmBranch: IVMSourceBranch) {
     applyViewUpdates => applyViewUpdates(),
     emptyFunction,
     assertValidRunOptions,
-  );
+  ).markPipelinesReady();
 }

--- a/packages/zero-client/src/client/query-materialization-metrics.test.ts
+++ b/packages/zero-client/src/client/query-materialization-metrics.test.ts
@@ -125,7 +125,7 @@ describe('query materialization metrics', () => {
       testBatchViewUpdates,
       addMetricSpy as ZeroContext['addMetric'],
       assertValidRunOptions,
-    );
+    ).markPipelinesReady();
   });
 
   describe('query-materialization-client metric', () => {
@@ -595,7 +595,7 @@ describe('query materialization metrics', () => {
         testBatchViewUpdates,
         addMetricSpy as ZeroContext['addMetric'],
         assertValidRunOptions,
-      );
+      ).markPipelinesReady();
     });
 
     test('handles rapid materialization and destruction', () => {

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -692,10 +692,6 @@ export class Zero<
       assertValidRunOptions,
     );
 
-    // Defer building query pipelines until ZeroRep.init has loaded the replica
-    // into the IVM sources (see ZeroContext.markPipelinesReady).
-    this.#zeroContext.deferPipelines();
-
     this.query = createRunnableBuilder(this.#zeroContext, schema);
 
     const replicacheImplOptions: ReplicacheImplOptions = {


### PR DESCRIPTION
This commit changes the initial value of the `#pipelinesReady` property to `false` in the ZeroContext class, ensuring that pipelines are not considered ready until `markPipelinesReady()` is explicitly called.

Follow up to #6472