### PR TITLE
chore(litestream): bump to litestream with faster restore decode

### DIFF
--- a/packages/zero/Dockerfile
+++ b/packages/zero/Dockerfile
@@ -18,7 +18,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 
 FROM golang:1.25.10@sha256:cd05a378aaf011e8056745363e5c40f4f2bef0fa4d9bf19b9c38316079c332ff AS litestream-v5
 
-ARG LITESTREAM_V5_VERSION=0.5.18-zero.6
+ARG LITESTREAM_V5_VERSION=0.5.18-zero.7
 
 WORKDIR /src/
 RUN git clone --depth 1 --branch v${LITESTREAM_V5_VERSION} https://github.com/rocicorp/litestream.git


### PR DESCRIPTION
## Summary

Bumps the v5 litestream to `v0.5.18-zero.7`, which includes [rocicorp/litestream#35](https://github.com/rocicorp/litestream/pull/35): the restore decode pipeline is buffered and single snapshots are decoded directly (1.8 s vs 9.6 s for a 2 GB restore from local disk), plus debug-level download progress lines that report network wait against consumer lag so a pod's restore log shows which side is the bottleneck.

Context: parallel restore downloads had barely moved restore throughput in the cluster while multipart uploads got 4-5x. The decode side, not the network, was the ceiling.

## Test plan

- [x] litestream tests pass under the race detector on the tagged commit
- [x] Local restore of the staging zmail snapshot with this build
- [ ] After deploy, compare restore throughput on the cloud-zero-metrics dashboard and read the `download progress` lines from a replication-manager restore

🤖 Generated with [Claude Code](https://claude.com/claude-code)
