### PR TITLE
feat(.github): automate immutable dev tags with commit SHA

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -3,19 +3,20 @@ name: Dev Release Zero
 on:
   workflow_dispatch:
     inputs:
-      ref:
-        description: 'Git ref to release (branch name, PR ref, or commit SHA)'
+      branch:
+        description: 'Git branch to release'
         required: true
+        default: 'main'
         type: string
-      image_tag:
-        description: 'Docker image tag (optional; defaults to 0.0.0-pr-<sanitized-branch> or 0.0.0-dev-<sha8>)'
+      commit_sha:
+        description: 'Commit SHA (optional; defaults to HEAD of branch)'
         required: false
         type: string
 
 permissions: {}
 
 concurrency:
-  group: zero-dev-release-${{ inputs.ref }}
+  group: zero-dev-release-${{ inputs.branch }}-${{ inputs.commit_sha || 'head' }}
   cancel-in-progress: false
 
 jobs:
@@ -44,8 +45,8 @@ jobs:
       - name: Plan dev release
         id: plan
         env:
-          IMAGE_TAG_INPUT: ${{ inputs.image_tag }}
-          TARGET_REF: ${{ inputs.ref }}
+          BRANCH_INPUT: ${{ inputs.branch }}
+          COMMIT_SHA_INPUT: ${{ inputs.commit_sha }}
           WORKFLOW_REF_NAME: ${{ github.ref_name }}
         run: node scripts/src/dev-release-plan.ts
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1850,17 +1850,10 @@ importers:
         version: 0.65.0
 
   scripts:
-    dependencies:
-      semver:
-        specifier: ^7.5.4
-        version: 7.8.0
     devDependencies:
       '@types/node':
         specifier: ^22.10.5
         version: 22.19.19
-      '@types/semver':
-        specifier: ^7.5.1
-        version: 7.7.1
       oxfmt:
         specifier: ^0.65.0
         version: 0.65.0
@@ -19518,9 +19511,9 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0))
+      vitest: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0))
     optionalDependencies:
-      '@vitest/browser': 4.1.6(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0))(vitest@4.1.6)
+      '@vitest/browser': 4.1.6(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0))(vitest@4.1.6)
 
   '@vitest/expect@4.1.6':
     dependencies:

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -13,12 +13,8 @@
     "fmt": "oxfmt .",
     "check-fmt": "oxfmt --check ."
   },
-  "dependencies": {
-    "semver": "^7.5.4"
-  },
   "devDependencies": {
     "@types/node": "^22.10.5",
-    "@types/semver": "^7.5.1",
     "oxfmt": "^0.65.0",
     "typescript": "~7.0.2",
     "vitest": "^4.1.6"

--- a/scripts/src/dev-release/plan.test.ts
+++ b/scripts/src/dev-release/plan.test.ts
@@ -232,11 +232,18 @@ test('resolveUniqueShortSha queries git rev-parse with --short and expands on co
   });
 });
 
-test('resolveUniqueShortSha falls back to full sourceSha if git rev-parse fails', () => {
+test('resolveUniqueShortSha throws if git rev-parse fails or returns invalid output', () => {
   const failingExec: Exec = () => {
     throw new Error('git rev-parse failed');
   };
-  expect(resolveUniqueShortSha(dummySha, failingExec)).toBe(dummySha);
+  expect(() => resolveUniqueShortSha(dummySha, failingExec)).toThrow(
+    'git rev-parse failed',
+  );
+
+  const invalidExec: Exec = () => 'not-a-valid-sha!';
+  expect(() => resolveUniqueShortSha(dummySha, invalidExec)).toThrow(
+    /Failed to resolve short SHA/,
+  );
 });
 
 test('planDevRelease incorporates expanded short SHA when git detects collision', () => {

--- a/scripts/src/dev-release/plan.test.ts
+++ b/scripts/src/dev-release/plan.test.ts
@@ -4,13 +4,14 @@ import {
   deriveDevImageTag,
   planDevRelease,
   resolveSourceSha,
+  resolveUniqueShortSha,
   sanitizeBranchName,
   validateImageTag,
 } from './plan.ts';
 
 const dummySha = 'e8cc6889fa6bc2a364e8cb80776991c308601212';
 
-function makeMockExec(resolvedSha = dummySha) {
+function makeMockExec(resolvedSha = dummySha, shortSha?: string) {
   const calls: Array<{
     command: Command;
     args: readonly string[];
@@ -19,6 +20,9 @@ function makeMockExec(resolvedSha = dummySha) {
   const exec: Exec = (command, args, options) => {
     calls.push({command, args, options});
     if (command === 'git' && args[0] === 'rev-parse') {
+      if (args[1]?.startsWith('--short')) {
+        return `${shortSha ?? resolvedSha.slice(0, 8)}\n`;
+      }
       return `${resolvedSha}\n`;
     }
     return '';
@@ -213,4 +217,37 @@ test('resolveSourceSha rejects invalid commitSha format', () => {
       exec,
     }),
   ).toThrowError(/Invalid commit SHA/);
+});
+
+test('resolveUniqueShortSha queries git rev-parse with --short and expands on collision', () => {
+  const expandedSha = 'e8cc6889fa';
+  const {calls, exec} = makeMockExec(dummySha, expandedSha);
+
+  const shortSha = resolveUniqueShortSha(dummySha, exec);
+  expect(shortSha).toBe('e8cc6889fa');
+  expect(calls).toContainEqual({
+    command: 'git',
+    args: ['rev-parse', '--short=8', `${dummySha}^{commit}`],
+    options: undefined,
+  });
+});
+
+test('resolveUniqueShortSha falls back to slicing if git rev-parse fails', () => {
+  const failingExec: Exec = () => {
+    throw new Error('git rev-parse failed');
+  };
+  expect(resolveUniqueShortSha(dummySha, failingExec)).toBe('e8cc6889');
+});
+
+test('planDevRelease incorporates expanded short SHA when git detects collision', () => {
+  const expandedSha = 'e8cc6889fa';
+  const {exec} = makeMockExec(dummySha, expandedSha);
+
+  const plan = planDevRelease({
+    exec,
+    branchInput: 'main',
+    workflowRefName: 'main',
+  });
+
+  expect(plan.image_tag).toBe('0.0.0-dev-main-e8cc6889fa');
 });

--- a/scripts/src/dev-release/plan.test.ts
+++ b/scripts/src/dev-release/plan.test.ts
@@ -232,11 +232,11 @@ test('resolveUniqueShortSha queries git rev-parse with --short and expands on co
   });
 });
 
-test('resolveUniqueShortSha falls back to slicing if git rev-parse fails', () => {
+test('resolveUniqueShortSha falls back to full sourceSha if git rev-parse fails', () => {
   const failingExec: Exec = () => {
     throw new Error('git rev-parse failed');
   };
-  expect(resolveUniqueShortSha(dummySha, failingExec)).toBe('e8cc6889');
+  expect(resolveUniqueShortSha(dummySha, failingExec)).toBe(dummySha);
 });
 
 test('planDevRelease incorporates expanded short SHA when git detects collision', () => {

--- a/scripts/src/dev-release/plan.test.ts
+++ b/scripts/src/dev-release/plan.test.ts
@@ -1,8 +1,7 @@
 import {expect, test} from 'vitest';
 import {type Command, type Exec, type ExecOptions} from '../shared.ts';
 import {
-  deriveDefaultTag,
-  normalizeDevImageTag,
+  deriveDevImageTag,
   planDevRelease,
   resolveSourceSha,
   sanitizeBranchName,
@@ -27,39 +26,49 @@ function makeMockExec(resolvedSha = dummySha) {
   return {calls, exec};
 }
 
-test('sanitizeBranchName strips refs prefix and sanitizes special characters to hyphens', () => {
+test('sanitizeBranchName strips refs prefix, formats PR refs, and sanitizes special characters to hyphens', () => {
+  expect(sanitizeBranchName('main')).toBe('main');
   expect(sanitizeBranchName('refs/heads/greg/sync-opt')).toBe('greg-sync-opt');
-  expect(sanitizeBranchName('refs/pull/123/head')).toBe('123-head');
+  expect(sanitizeBranchName('refs/pull/123/head')).toBe('pr-123');
+  expect(sanitizeBranchName('pull/456')).toBe('pr-456');
   expect(sanitizeBranchName('feat/my_cool.branch!')).toBe(
     'feat-my-cool-branch',
   );
   expect(sanitizeBranchName('---messy--branch---')).toBe('messy-branch');
 });
 
-test('deriveDefaultTag generates 0.0.0-pr-* or 0.0.0-dev-* SemVer tags', () => {
-  expect(deriveDefaultTag(dummySha, dummySha)).toBe('0.0.0-dev-e8cc6889');
-  expect(deriveDefaultTag('greg/sync-opt', dummySha)).toBe(
-    '0.0.0-pr-greg-sync-opt',
+test('deriveDevImageTag generates 0.0.0-dev-<branch>-<shortSha> SemVer tags', () => {
+  expect(deriveDevImageTag('main', dummySha)).toBe('0.0.0-dev-main-e8cc6889');
+  expect(deriveDevImageTag('greg/sync-opt', dummySha)).toBe(
+    '0.0.0-dev-greg-sync-opt-e8cc6889',
   );
-  expect(deriveDefaultTag('pr-1234', dummySha)).toBe('0.0.0-pr-1234');
-  expect(deriveDefaultTag('dev-test', dummySha)).toBe('0.0.0-dev-test');
-  expect(deriveDefaultTag('0.0.0-pr-test', dummySha)).toBe('0.0.0-pr-test');
+  expect(deriveDevImageTag('refs/pull/123/head', dummySha)).toBe(
+    '0.0.0-dev-pr-123-e8cc6889',
+  );
+  expect(deriveDevImageTag(dummySha, dummySha)).toBe('0.0.0-dev-e8cc6889');
+  expect(deriveDevImageTag('dev-benchmark', dummySha)).toBe(
+    '0.0.0-dev-benchmark-e8cc6889',
+  );
+  expect(deriveDevImageTag('sync-opt-e8cc6889', dummySha)).toBe(
+    '0.0.0-dev-sync-opt-e8cc6889',
+  );
 });
 
-test('normalizeDevImageTag ensures 0.0.0- prefix for custom tags', () => {
-  expect(normalizeDevImageTag('custom-bench-1')).toBe(
-    '0.0.0-dev-custom-bench-1',
-  );
-  expect(normalizeDevImageTag('dev-bench-1')).toBe('0.0.0-dev-bench-1');
-  expect(normalizeDevImageTag('pr-1234')).toBe('0.0.0-pr-1234');
-  expect(normalizeDevImageTag('0.0.0-dev-mytest')).toBe('0.0.0-dev-mytest');
+test('deriveDevImageTag truncates excessively long branch names while preserving the short SHA suffix within 128 chars', () => {
+  const longBranch = 'a'.repeat(150);
+  const tag = deriveDevImageTag(longBranch, dummySha);
+  expect(tag.length).toBeLessThanOrEqual(128);
+  expect(tag.endsWith('-e8cc6889')).toBe(true);
+  expect(tag.startsWith('0.0.0-dev-')).toBe(true);
+  expect(() => validateImageTag(tag)).not.toThrow();
 });
 
 test('validateImageTag accepts valid 0.0.0- SemVer tags and blocks invalid/protected tags', () => {
-  expect(() => validateImageTag('0.0.0-pr-1234')).not.toThrow();
+  expect(() => validateImageTag('0.0.0-dev-main-e8cc6889')).not.toThrow();
+  expect(() =>
+    validateImageTag('0.0.0-dev-greg-sync-opt-e8cc6889'),
+  ).not.toThrow();
   expect(() => validateImageTag('0.0.0-dev-e8cc6889')).not.toThrow();
-  expect(() => validateImageTag('0.0.0-pr-greg-sync-opt')).not.toThrow();
-  expect(() => validateImageTag('0.0.0-dev-custom-bench-1')).not.toThrow();
 
   expect(() => validateImageTag('latest')).toThrowError(/protected/);
   expect(() => validateImageTag('HEAD')).toThrowError(/protected/);
@@ -70,9 +79,6 @@ test('validateImageTag accepts valid 0.0.0- SemVer tags and blocks invalid/prote
     /must start with "0.0.0-"/,
   );
   expect(() => validateImageTag('v1.8.0')).toThrowError(
-    /must start with "0.0.0-"/,
-  );
-  expect(() => validateImageTag('pr-1234')).toThrowError(
     /must start with "0.0.0-"/,
   );
   expect(() => validateImageTag('dev-e8cc6889')).toThrowError(
@@ -99,33 +105,53 @@ test('planDevRelease requires workflowRefName to be main', () => {
   expect(() =>
     planDevRelease({
       exec,
-      targetRef: 'greg/test',
+      branchInput: 'greg/test',
       workflowRefName: 'feature-branch',
     }),
   ).toThrow(/must be run from main/);
 });
 
-test('planDevRelease rejects empty target ref', () => {
+test('planDevRelease rejects empty branch', () => {
   const {exec} = makeMockExec();
   expect(() =>
     planDevRelease({
       exec,
-      targetRef: '   ',
+      branchInput: '   ',
       workflowRefName: 'main',
     }),
-  ).toThrow(/Target ref must not be empty/);
+  ).toThrow(/Branch must not be empty/);
 });
 
-test('planDevRelease plans dev release with default 0.0.0-pr-* tag', () => {
+test('planDevRelease defaults to main and derives 0.0.0-dev-main-<shortSha>', () => {
   const {calls, exec} = makeMockExec();
   const plan = planDevRelease({
     exec,
-    targetRef: 'greg/sync-opt',
     workflowRefName: 'main',
   });
 
   expect(plan).toEqual({
-    image_tag: '0.0.0-pr-greg-sync-opt',
+    image_tag: '0.0.0-dev-main-e8cc6889',
+    ref: 'main',
+    source_sha: dummySha,
+  });
+
+  expect(calls).toContainEqual({
+    command: 'git',
+    args: ['fetch', 'origin', 'main'],
+    options: {stdio: 'inherit'},
+  });
+});
+
+test('planDevRelease plans dev release for feature branch with short SHA suffix', () => {
+  const {calls, exec} = makeMockExec();
+  const plan = planDevRelease({
+    exec,
+    branchInput: 'greg/sync-opt',
+    workflowRefName: 'main',
+  });
+
+  expect(plan).toEqual({
+    image_tag: '0.0.0-dev-greg-sync-opt-e8cc6889',
     ref: 'greg/sync-opt',
     source_sha: dummySha,
   });
@@ -137,42 +163,54 @@ test('planDevRelease plans dev release with default 0.0.0-pr-* tag', () => {
   });
 });
 
-test('planDevRelease accepts custom image tag and normalizes to 0.0.0-dev-*', () => {
-  const {exec} = makeMockExec();
+test('planDevRelease accepts optional commitShaInput', () => {
+  const specificSha = '1234567890abcdef1234567890abcdef12345678';
+  const {calls, exec} = makeMockExec(specificSha);
   const plan = planDevRelease({
     exec,
-    targetRef: dummySha,
-    imageTagInput: 'custom-bench-1',
+    branchInput: 'main',
+    commitShaInput: specificSha,
     workflowRefName: 'main',
   });
 
   expect(plan).toEqual({
-    image_tag: '0.0.0-dev-custom-bench-1',
-    ref: dummySha,
-    source_sha: dummySha,
+    image_tag: '0.0.0-dev-main-12345678',
+    ref: 'main',
+    source_sha: specificSha,
+  });
+
+  expect(calls).toContainEqual({
+    command: 'git',
+    args: ['rev-parse', '--verify', `${specificSha}^{commit}`],
+    options: undefined,
   });
 });
 
-test('planDevRelease rejects protected tags in imageTagInput', () => {
+test('resolveSourceSha rejects option-like branch starting with -', () => {
   const {exec} = makeMockExec();
-  for (const tag of ['latest', 'HEAD', 'staging', 'canary']) {
-    expect(() =>
-      planDevRelease({
-        exec,
-        targetRef: dummySha,
-        imageTagInput: tag,
-        workflowRefName: 'main',
-      }),
-    ).toThrowError(/protected/);
-  }
+  expect(() => resolveSourceSha({branch: '--force', exec})).toThrowError(
+    'Branch must not start with "-"',
+  );
 });
 
-test('resolveSourceSha rejects option-like refs starting with -', () => {
+test('resolveSourceSha rejects option-like commitSha starting with -', () => {
   const {exec} = makeMockExec();
-  expect(() => resolveSourceSha('--force', exec)).toThrowError(
-    'Target ref must not start with "-"',
-  );
-  expect(() => resolveSourceSha('-v', exec)).toThrowError(
-    'Target ref must not start with "-"',
-  );
+  expect(() =>
+    resolveSourceSha({
+      branch: 'main',
+      commitSha: '-v',
+      exec,
+    }),
+  ).toThrowError('Commit SHA must not start with "-"');
+});
+
+test('resolveSourceSha rejects invalid commitSha format', () => {
+  const {exec} = makeMockExec();
+  expect(() =>
+    resolveSourceSha({
+      branch: 'main',
+      commitSha: 'not-a-valid-sha!',
+      exec,
+    }),
+  ).toThrowError(/Invalid commit SHA/);
 });

--- a/scripts/src/dev-release/plan.ts
+++ b/scripts/src/dev-release/plan.ts
@@ -63,7 +63,8 @@ export function planDevRelease({
   });
   assertGitSha(sourceSha, 'source SHA');
 
-  const imageTag = deriveDevImageTag(trimmedBranch, sourceSha);
+  const shortSha = resolveUniqueShortSha(sourceSha, exec);
+  const imageTag = deriveDevImageTag(trimmedBranch, sourceSha, shortSha);
   validateImageTag(imageTag);
 
   return {
@@ -92,8 +93,31 @@ export function sanitizeBranchName(branch: string): string {
     .replace(edgeHyphenPattern, '');
 }
 
-export function deriveDevImageTag(branch: string, sourceSha: string): string {
-  const shortSha = sourceSha.slice(0, 8);
+export function resolveUniqueShortSha(
+  sourceSha: string,
+  exec: Exec,
+  minLen = 8,
+): string {
+  try {
+    const shortSha = exec('git', [
+      'rev-parse',
+      `--short=${minLen}`,
+      `${sourceSha}^{commit}`,
+    ]).trim();
+    if (shortSha && hexShaPattern.test(shortSha)) {
+      return shortSha;
+    }
+  } catch {
+    // Fallback if git rev-parse fails for any reason
+  }
+  return sourceSha.slice(0, minLen);
+}
+
+export function deriveDevImageTag(
+  branch: string,
+  sourceSha: string,
+  shortSha = sourceSha.slice(0, 8),
+): string {
   if (gitShaPattern.test(branch.trim())) {
     return `0.0.0-dev-${shortSha}`;
   }
@@ -113,6 +137,8 @@ export function deriveDevImageTag(branch: string, sourceSha: string): string {
 
   if (base.endsWith(`-${shortSha}`)) {
     base = base.slice(0, -`-${shortSha}`.length);
+  } else if (base.endsWith(`-${sourceSha.slice(0, 8)}`)) {
+    base = base.slice(0, -`-${sourceSha.slice(0, 8)}`.length);
   }
 
   if (!base) {

--- a/scripts/src/dev-release/plan.ts
+++ b/scripts/src/dev-release/plan.ts
@@ -1,6 +1,5 @@
 // oxlint-disable no-console
 
-import semver from 'semver';
 import {
   assertGitSha,
   assertMainWorkflowRef,
@@ -13,6 +12,8 @@ import {
 const gitShaPattern = /^[0-9a-f]{40}$/;
 const hexShaPattern = /^[0-9a-f]{7,40}$/i;
 const dockerTagPattern = /^[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,127}$/;
+const semverRegex =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
 const protectedTags = new Set(['latest', 'head', 'staging', 'canary']);
 
 export type DevReleasePlan = {
@@ -167,7 +168,7 @@ export function validateImageTag(tag: string): void {
       `Tag "${tag}" must start with "0.0.0-" to ensure CloudZero SemVer compatibility and prevent colliding with official releases.`,
     );
   }
-  if (!semver.valid(tag)) {
+  if (!semverRegex.test(tag)) {
     throw new Error(
       `Tag "${tag}" is not a valid semantic version (SemVer 2.0.0). Prerelease identifiers may only contain alphanumerics and hyphens.`,
     );

--- a/scripts/src/dev-release/plan.ts
+++ b/scripts/src/dev-release/plan.ts
@@ -98,19 +98,17 @@ export function resolveUniqueShortSha(
   exec: Exec,
   minLen = 8,
 ): string {
-  try {
-    const shortSha = exec('git', [
-      'rev-parse',
-      `--short=${minLen}`,
-      `${sourceSha}^{commit}`,
-    ]).trim();
-    if (shortSha && hexShaPattern.test(shortSha)) {
-      return shortSha;
-    }
-  } catch {
-    // Fallback to full SHA to guarantee uniqueness without collision
+  const shortSha = exec('git', [
+    'rev-parse',
+    `--short=${minLen}`,
+    `${sourceSha}^{commit}`,
+  ]).trim();
+  if (!shortSha || !hexShaPattern.test(shortSha)) {
+    throw new Error(
+      `Failed to resolve short SHA for "${sourceSha}": git returned "${shortSha}"`,
+    );
   }
-  return sourceSha;
+  return shortSha;
 }
 
 export function deriveDevImageTag(

--- a/scripts/src/dev-release/plan.ts
+++ b/scripts/src/dev-release/plan.ts
@@ -108,9 +108,9 @@ export function resolveUniqueShortSha(
       return shortSha;
     }
   } catch {
-    // Fallback if git rev-parse fails for any reason
+    // Fallback to full SHA to guarantee uniqueness without collision
   }
-  return sourceSha.slice(0, minLen);
+  return sourceSha;
 }
 
 export function deriveDevImageTag(

--- a/scripts/src/dev-release/plan.ts
+++ b/scripts/src/dev-release/plan.ts
@@ -11,6 +11,7 @@ import {
 } from '../shared.ts';
 
 const gitShaPattern = /^[0-9a-f]{40}$/;
+const hexShaPattern = /^[0-9a-f]{7,40}$/i;
 const dockerTagPattern = /^[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,127}$/;
 const protectedTags = new Set(['latest', 'head', 'staging', 'canary']);
 
@@ -21,16 +22,16 @@ export type DevReleasePlan = {
 };
 
 export type PlanDevReleaseOptions = {
+  branchInput?: string | undefined;
+  commitShaInput?: string | undefined;
   exec?: Exec | undefined;
-  imageTagInput?: string | undefined;
-  targetRef: string;
   workflowRefName: string;
 };
 
 export function runDevReleasePlanCli() {
   const plan = planDevRelease({
-    imageTagInput: process.env.IMAGE_TAG_INPUT || undefined,
-    targetRef: mustEnv('TARGET_REF'),
+    branchInput: process.env.BRANCH_INPUT || 'main',
+    commitShaInput: process.env.COMMIT_SHA_INPUT || undefined,
     workflowRefName: mustEnv('WORKFLOW_REF_NAME'),
   });
 
@@ -41,46 +42,49 @@ export function runDevReleasePlanCli() {
 }
 
 export function planDevRelease({
+  branchInput = 'main',
+  commitShaInput,
   exec = defaultExec,
-  imageTagInput,
-  targetRef,
   workflowRefName,
 }: PlanDevReleaseOptions): DevReleasePlan {
   assertMainWorkflowRef('Dev release', workflowRefName);
 
-  if (!targetRef.trim()) {
-    throw new Error('Target ref must not be empty');
+  const trimmedBranch = branchInput.trim();
+  if (!trimmedBranch) {
+    throw new Error('Branch must not be empty');
   }
 
-  const rawInput = imageTagInput?.trim();
-  if (rawInput && protectedTags.has(rawInput.toLowerCase())) {
-    throw new Error(
-      `Tag "${rawInput}" is protected and cannot be overwritten by dev releases.`,
-    );
-  }
+  const trimmedCommitSha = commitShaInput?.trim() || undefined;
 
-  const sourceSha = resolveSourceSha(targetRef.trim(), exec);
+  const sourceSha = resolveSourceSha({
+    branch: trimmedBranch,
+    commitSha: trimmedCommitSha,
+    exec,
+  });
   assertGitSha(sourceSha, 'source SHA');
 
-  const imageTag = rawInput
-    ? normalizeDevImageTag(rawInput)
-    : deriveDefaultTag(targetRef.trim(), sourceSha);
-
+  const imageTag = deriveDevImageTag(trimmedBranch, sourceSha);
   validateImageTag(imageTag);
 
   return {
     image_tag: imageTag,
-    ref: targetRef.trim(),
+    ref: trimmedBranch,
     source_sha: sourceSha,
   };
 }
 
-const gitRefPrefixPattern = /^refs\/(heads|remotes\/origin|remotes|pull)\//;
+const gitRefPrefixPattern = /^refs\/(heads|remotes\/origin|remotes)\//;
+const prRefPattern = /(?:refs\/)?pull\/(\d+)(?:\/head)?/;
 const invalidSemVerPrereleaseCharPattern = /[^a-zA-Z0-9-]/g;
 const consecutiveHyphenPattern = /-+/g;
 const edgeHyphenPattern = /^-+|-+$/g;
+const trailingHyphenPattern = /-+$/;
 
 export function sanitizeBranchName(branch: string): string {
+  const prMatch = branch.match(prRefPattern);
+  if (prMatch) {
+    return `pr-${prMatch[1]}`;
+  }
   return branch
     .replace(gitRefPrefixPattern, '')
     .replace(invalidSemVerPrereleaseCharPattern, '-')
@@ -88,35 +92,39 @@ export function sanitizeBranchName(branch: string): string {
     .replace(edgeHyphenPattern, '');
 }
 
-export function deriveDefaultTag(targetRef: string, sourceSha: string): string {
+export function deriveDevImageTag(branch: string, sourceSha: string): string {
   const shortSha = sourceSha.slice(0, 8);
-  if (gitShaPattern.test(targetRef)) {
+  if (gitShaPattern.test(branch.trim())) {
     return `0.0.0-dev-${shortSha}`;
   }
-  const rawClean = targetRef.replace(gitRefPrefixPattern, '');
-  if (rawClean.startsWith('0.0.0-')) {
-    const prerelease = sanitizeBranchName(rawClean.slice('0.0.0-'.length));
-    return `0.0.0-${prerelease}`.slice(0, 128);
-  }
-  const clean = sanitizeBranchName(targetRef);
-  if (!clean) {
-    return `0.0.0-dev-${shortSha}`;
-  }
-  if (clean.startsWith('pr-') || clean.startsWith('dev-')) {
-    return `0.0.0-${clean}`.slice(0, 128);
-  }
-  return `0.0.0-pr-${clean}`.slice(0, 128);
-}
 
-export function normalizeDevImageTag(input: string): string {
-  const trimmed = input.trim();
-  if (trimmed.startsWith('0.0.0-')) {
-    return trimmed;
+  const rawClean = branch.trim().replace(gitRefPrefixPattern, '');
+
+  let base: string;
+  if (rawClean.startsWith('0.0.0-')) {
+    base = sanitizeBranchName(rawClean.slice('0.0.0-'.length));
+  } else {
+    base = sanitizeBranchName(rawClean);
   }
-  if (trimmed.startsWith('dev-') || trimmed.startsWith('pr-')) {
-    return `0.0.0-${trimmed}`;
+
+  if (base.startsWith('dev-')) {
+    base = base.slice('dev-'.length);
   }
-  return `0.0.0-dev-${trimmed}`;
+
+  if (base.endsWith(`-${shortSha}`)) {
+    base = base.slice(0, -`-${shortSha}`.length);
+  }
+
+  if (!base) {
+    return `0.0.0-dev-${shortSha}`;
+  }
+
+  const maxBaseLen = 128 - '0.0.0-dev-'.length - 1 - shortSha.length;
+  const trimmedBase = base
+    .slice(0, maxBaseLen)
+    .replace(trailingHyphenPattern, '');
+
+  return `0.0.0-dev-${trimmedBase}-${shortSha}`;
 }
 
 export function validateImageTag(tag: string): void {
@@ -142,21 +150,41 @@ export function validateImageTag(tag: string): void {
   }
 }
 
-export function resolveSourceSha(targetRef: string, exec: Exec): string {
-  if (targetRef.startsWith('-')) {
-    throw new Error('Target ref must not start with "-"');
+export type ResolveSourceShaOptions = {
+  branch: string;
+  commitSha?: string | undefined;
+  exec: Exec;
+};
+
+export function resolveSourceSha({
+  branch,
+  commitSha,
+  exec,
+}: ResolveSourceShaOptions): string {
+  if (branch.startsWith('-')) {
+    throw new Error('Branch must not start with "-"');
   }
 
-  if (gitShaPattern.test(targetRef)) {
+  if (commitSha) {
+    if (commitSha.startsWith('-')) {
+      throw new Error('Commit SHA must not start with "-"');
+    }
+    if (!hexShaPattern.test(commitSha)) {
+      throw new Error(`Invalid commit SHA "${commitSha}"`);
+    }
+
+    if (!gitShaPattern.test(branch)) {
+      exec('git', ['fetch', 'origin', branch], {stdio: 'inherit'});
+    }
+
     try {
       return exec('git', [
         'rev-parse',
         '--verify',
-        `${targetRef}^{commit}`,
+        `${commitSha}^{commit}`,
       ]).trim();
     } catch {
-      // If the commit is not present locally, attempt to fetch it.
-      exec('git', ['fetch', 'origin', targetRef], {stdio: 'inherit'});
+      exec('git', ['fetch', 'origin', commitSha], {stdio: 'inherit'});
       return exec('git', [
         'rev-parse',
         '--verify',
@@ -165,7 +193,23 @@ export function resolveSourceSha(targetRef: string, exec: Exec): string {
     }
   }
 
-  // Target ref is a branch, tag, or PR ref (e.g. refs/pull/123/head).
-  exec('git', ['fetch', 'origin', targetRef], {stdio: 'inherit'});
+  if (gitShaPattern.test(branch)) {
+    try {
+      return exec('git', [
+        'rev-parse',
+        '--verify',
+        `${branch}^{commit}`,
+      ]).trim();
+    } catch {
+      exec('git', ['fetch', 'origin', branch], {stdio: 'inherit'});
+      return exec('git', [
+        'rev-parse',
+        '--verify',
+        'FETCH_HEAD^{commit}',
+      ]).trim();
+    }
+  }
+
+  exec('git', ['fetch', 'origin', branch], {stdio: 'inherit'});
   return exec('git', ['rev-parse', '--verify', 'FETCH_HEAD^{commit}']).trim();
 }


### PR DESCRIPTION
### Summary
Derives immutable dev image tags (`0.0.0-dev-<branch>-<shortSha>`) to prevent tag clobbering and container pull caching issues across multiple releases from the same branch, and simplifies workflow inputs to `branch` (default `main`) and optional `commit_sha`.
### Changes
- **Inputs**: Replaced `ref` and `image_tag` inputs with `branch` (default `main`) and optional `commit_sha`. Removed tag overriding to guarantee immutability.
- **Tag derivation**: Derives `0.0.0-dev-<branch>-<shortSha>` (e.g. `0.0.0-dev-main-e8cc6889`, `0.0.0-dev-sync-opt-e8cc6889`). Uses `git rev-parse --short=8` to dynamically expand characters if an object collision occurs in git. Truncates branch names to stay under Docker's 128-char limit while preserving the SHA suffix.
- **Validation & Dependencies**: Validates SemVer with a standalone spec regex so the plan job runs in pure Node without `node_modules`. Added option-injection (`-`) guards for `branch` and `commit_sha`. Removed unused `semver` dependency from `scripts`.