### PR TITLE
fix(replicache): abandon a failed rebase prediction instead of the sync

### DIFF
--- a/packages/replicache/src/db/rebase.test.ts
+++ b/packages/replicache/src/db/rebase.test.ts
@@ -7,8 +7,13 @@ import type {Read} from '../dag/store.ts';
 import {TestStore} from '../dag/test-store.ts';
 import * as FormatVersion from '../format-version-enum.ts';
 import type {Hash} from '../hash.ts';
+import type {ZeroTxData} from '../replicache-options.ts';
 import {SYNC_HEAD_NAME} from '../sync/sync-head-name.ts';
-import type {WriteTransaction} from '../transactions.ts';
+import {
+  type WriteTransaction,
+  type WriteTransactionImpl,
+  zeroData,
+} from '../transactions.ts';
 import {withRead, withWriteNoImplicitCommit} from '../with-transactions.ts';
 import {
   type Commit,
@@ -203,6 +208,98 @@ async function createMissingMutatorFixture() {
   return fixture;
 }
 
+async function createThrowingMutatorFixture() {
+  const formatVersion = FormatVersion.Latest;
+  const consoleInfoStub = vi.spyOn(console, 'info');
+  const clientID = 'test_client_id';
+  const store = new TestStore();
+  const b = new ChainBuilder(store, undefined, formatVersion);
+  await b.addGenesis(clientID);
+  await b.addSnapshot([['foo', 'bar']], clientID);
+  await b.addLocal(clientID);
+  const localCommit = b.chain.at(-1) as Commit<LocalMetaDD31>;
+  const syncChain = await b.addSyncSnapshot(1, clientID);
+  const syncSnapshotCommit = syncChain[0] as Commit<SnapshotMetaDD31>;
+
+  const error = new Error('mutator precondition no longer holds');
+
+  // Writes before throwing, so the test shows the staged write is discarded
+  // rather than never made.
+  const throwingMutator = async (tx: WriteTransaction) => {
+    await tx.set('whiz', 'bang');
+    fixture.throwingMutatorCallCount++;
+    throw error;
+  };
+
+  const fixture = {
+    formatVersion: formatVersion as FormatVersion,
+    clientID,
+    store,
+    localCommit,
+    syncSnapshotCommit,
+    error,
+    throwingMutatorCallCount: 0,
+    mutators: {
+      [localCommit.meta.mutatorName]: throwingMutator,
+    },
+    expectRebasedCommit: async (
+      rebasedCommit: Commit<Meta>,
+      btreeRead: BTreeRead,
+    ) => {
+      // The fixture pins formatVersion to Latest, so this is always a local
+      // DD31 commit. Asserting rather than branching means a commit of the
+      // wrong shape fails here instead of skipping every check below it.
+      assertLocalCommitDD31(rebasedCommit);
+      assertLocalCommitDD31(localCommit);
+      const meta = rebasedCommit.meta;
+      expect(meta.basisHash).toBe(syncSnapshotCommit.chunk.hash);
+      expect(meta.mutationID).toBe(localCommit.meta.mutationID);
+      expect(meta.mutatorName).toBe(localCommit.meta.mutatorName);
+      expect(meta.originalHash).toBe(localCommit.chunk.hash);
+      expect(meta.timestamp).toBe(localCommit.meta.timestamp);
+      expect(meta.clientID).toBe(localCommit.meta.clientID);
+      // The value tree equals the basis: the mutation predicts nothing, and
+      // the write staged before the throw is gone.
+      expect(await btreeRead.get('foo')).toBe('bar');
+      expect(await btreeRead.get('whiz')).toBeUndefined();
+    },
+    expectThrowingMutatorInfoLog: () => {
+      expect(fixture.throwingMutatorCallCount).toBe(1);
+      expect(consoleInfoStub).toBeCalledTimes(1);
+      const args = consoleInfoStub.mock.calls[0];
+      expect(args[0]).toBe(
+        `Rebase of mutator ${localCommit.meta.mutatorName} threw, abandoning its prediction`,
+      );
+      // The browser runner serializes console arguments, so match on the
+      // message rather than on error identity.
+      expect(String(args[1])).toContain(error.message);
+    },
+  };
+  return fixture;
+}
+
+/**
+ * Stands in for an IVMSourceBranch. `fork` copies, so a write to the copy is
+ * invisible to the original, which is the property `rebaseMutation` relies on.
+ */
+function makeTxData(rows: ReadonlySet<string>): ZeroTxData {
+  return {
+    ivmSources: new Set(rows),
+    token: undefined,
+    context: undefined,
+    fork(): ZeroTxData {
+      return makeTxData(this.ivmSources as Set<string>);
+    },
+  };
+}
+
+const rowsOf = (tx: WriteTransaction) =>
+  (tx as WriteTransactionImpl)[zeroData]?.ivmSources as Set<string>;
+
+const rowsIn = (data: ZeroTxData | undefined) => [
+  ...((data?.ivmSources as Set<string>) ?? []),
+];
+
 async function commitAndBTree(
   name = SYNC_HEAD_NAME,
   read: Read,
@@ -213,10 +310,104 @@ async function commitAndBTree(
   return [commit, btreeRead];
 }
 
+describe('zero tx data', () => {
+  // The contract the callers depend on: each replayed mutation runs against
+  // its own fork, and what comes back is the branch the next mutation should
+  // use. Every caller does nothing with it but pass it along, so this is where
+  // the behavior itself is pinned.
+  test('a mutation that succeeds runs against a fork, which is returned', async () => {
+    const fixture = await createMutationSequenceFixture();
+    const passedIn = makeTxData(new Set(['before']));
+    const mutators = {
+      ...fixture.mutators,
+      [fixture.localCommit1.meta.mutatorName]: async (tx: WriteTransaction) => {
+        rowsOf(tx).add('written');
+        await tx.set('written', true);
+      },
+    };
+
+    const {zeroData: returned} = await withWriteNoImplicitCommit(
+      fixture.store,
+      write =>
+        rebaseMutationAndCommit(
+          fixture.localCommit1,
+          write,
+          fixture.syncSnapshotCommit.chunk.hash,
+          SYNC_HEAD_NAME,
+          mutators,
+          new LogContext(),
+          fixture.clientID,
+          fixture.formatVersion,
+          passedIn,
+        ),
+    );
+
+    // The write landed on the fork that came back, not on the one passed in.
+    expect(returned).not.toBe(passedIn);
+    expect(rowsIn(returned)).toEqual(['before', 'written']);
+    expect(rowsIn(passedIn)).toEqual(['before']);
+  });
+
+  test('a mutation that throws gives back the branch it was handed', async () => {
+    const fixture = await createThrowingMutatorFixture();
+    vi.spyOn(console, 'info').mockImplementation(() => undefined);
+    const passedIn = makeTxData(new Set(['before']));
+    const mutators = {
+      [fixture.localCommit.meta.mutatorName]: async (tx: WriteTransaction) => {
+        // Writes to its fork before throwing, so the test shows the write is
+        // discarded rather than never made.
+        rowsOf(tx).add('written');
+        await tx.set('written', true);
+        throw fixture.error;
+      },
+    };
+
+    const {zeroData: returned} = await withWriteNoImplicitCommit(
+      fixture.store,
+      write =>
+        rebaseMutationAndCommit(
+          fixture.localCommit,
+          write,
+          fixture.syncSnapshotCommit.chunk.hash,
+          SYNC_HEAD_NAME,
+          mutators,
+          new LogContext(),
+          fixture.clientID,
+          fixture.formatVersion,
+          passedIn,
+        ),
+    );
+
+    // The fork went away with the failed mutation.
+    expect(returned).toBe(passedIn);
+    expect(rowsIn(returned)).toEqual(['before']);
+  });
+
+  test('undefined zero tx data stays undefined', async () => {
+    const fixture = await createMutationSequenceFixture();
+    const {zeroData: returned} = await withWriteNoImplicitCommit(
+      fixture.store,
+      write =>
+        rebaseMutationAndCommit(
+          fixture.localCommit1,
+          write,
+          fixture.syncSnapshotCommit.chunk.hash,
+          SYNC_HEAD_NAME,
+          fixture.mutators,
+          new LogContext(),
+          fixture.clientID,
+          fixture.formatVersion,
+          undefined,
+        ),
+    );
+    expect(returned).toBeUndefined();
+  });
+});
+
 describe('rebaseMutationAndCommit', () => {
   test('with sequence of mutations', async () => {
     const fixture = await createMutationSequenceFixture();
-    const hashOfRebasedLocalCommit1 = await withWriteNoImplicitCommit(
+    const {result: hashOfRebasedLocalCommit1} = await withWriteNoImplicitCommit(
       fixture.store,
       write =>
         rebaseMutationAndCommit(
@@ -242,7 +433,7 @@ describe('rebaseMutationAndCommit', () => {
       expect(hashOfRebasedLocalCommit1).toBe(rebasedLocalCommit1.chunk.hash);
       await fixture.expectRebasedCommit1(rebasedLocalCommit1, btreeRead);
     });
-    const hashOfRebasedLocalCommit2 = await withWriteNoImplicitCommit(
+    const {result: hashOfRebasedLocalCommit2} = await withWriteNoImplicitCommit(
       fixture.store,
       write =>
         rebaseMutationAndCommit(
@@ -276,7 +467,7 @@ describe('rebaseMutationAndCommit', () => {
 
   test("with missing mutator, still rebases but doesn't modify btree", async () => {
     const fixture = await createMissingMutatorFixture();
-    const hashOfRebasedLocalCommit = await withWriteNoImplicitCommit(
+    const {result: hashOfRebasedLocalCommit} = await withWriteNoImplicitCommit(
       fixture.store,
       write =>
         rebaseMutationAndCommit(
@@ -303,6 +494,105 @@ describe('rebaseMutationAndCommit', () => {
     });
   });
 
+  test('with a mutator that throws, abandons its prediction but still rebases', async () => {
+    const fixture = await createThrowingMutatorFixture();
+    const {result: hashOfRebasedLocalCommit} = await withWriteNoImplicitCommit(
+      fixture.store,
+      write =>
+        rebaseMutationAndCommit(
+          fixture.localCommit,
+          write,
+          fixture.syncSnapshotCommit.chunk.hash,
+          SYNC_HEAD_NAME,
+          fixture.mutators,
+          new LogContext(),
+          fixture.clientID,
+          fixture.formatVersion,
+          undefined,
+        ),
+    );
+    await withRead(fixture.store, async read => {
+      const [rebasedLocalCommit, btreeRead] = await commitAndBTree(
+        SYNC_HEAD_NAME,
+        read,
+        fixture.formatVersion,
+      );
+      expect(hashOfRebasedLocalCommit).toBe(rebasedLocalCommit.chunk.hash);
+      await fixture.expectRebasedCommit(rebasedLocalCommit, btreeRead);
+      fixture.expectThrowingMutatorInfoLog();
+    });
+  });
+
+  test('a mutator that throws does not block replay of later mutations', async () => {
+    const fixture = await createMutationSequenceFixture();
+    vi.spyOn(console, 'info').mockImplementation(() => undefined);
+    const mutators = {
+      ...fixture.mutators,
+      [fixture.localCommit1.meta.mutatorName]: async (tx: WriteTransaction) => {
+        await tx.set('whiz', 'bang');
+        throw new Error('mutator precondition no longer holds');
+      },
+    };
+
+    const {result: hashOfRebasedLocalCommit1} = await withWriteNoImplicitCommit(
+      fixture.store,
+      write =>
+        rebaseMutationAndCommit(
+          fixture.localCommit1,
+          write,
+          fixture.syncSnapshotCommit.chunk.hash,
+          SYNC_HEAD_NAME,
+          mutators,
+          new LogContext(),
+          fixture.clientID,
+          fixture.formatVersion,
+          undefined,
+        ),
+    );
+    const {result: hashOfRebasedLocalCommit2} = await withWriteNoImplicitCommit(
+      fixture.store,
+      write =>
+        rebaseMutationAndCommit(
+          fixture.localCommit2,
+          write,
+          hashOfRebasedLocalCommit1,
+          SYNC_HEAD_NAME,
+          mutators,
+          new LogContext(),
+          fixture.clientID,
+          fixture.formatVersion,
+          undefined,
+        ),
+    );
+    expect(fixture.testMutator2CallCount).toBe(1);
+
+    await withRead(fixture.store, async read => {
+      const [rebasedLocalCommit2, btreeRead] = await commitAndBTree(
+        SYNC_HEAD_NAME,
+        read,
+        fixture.formatVersion,
+      );
+      expect(hashOfRebasedLocalCommit2).toBe(rebasedLocalCommit2.chunk.hash);
+      assert(
+        commitIsLocalDD31(rebasedLocalCommit2),
+        'expected a local DD31 commit',
+      );
+      // Mutation 2 is chained onto the abandoned mutation 1, so the replay
+      // runs to completion and sync moves forward.
+      expect(rebasedLocalCommit2.meta.basisHash).toBe(
+        hashOfRebasedLocalCommit1,
+      );
+      expect(rebasedLocalCommit2.meta.mutationID).toBe(
+        fixture.localCommit2.meta.mutationID,
+      );
+      expect(await btreeRead.get('foo')).toBe('bar');
+      // Mutation 1's prediction was abandoned ...
+      expect(await btreeRead.get('whiz')).toBeUndefined();
+      // ... but mutation 2's was kept.
+      expect(await btreeRead.get('fuzzy')).toBe('wuzzy');
+    });
+  });
+
   test("throws error if DD31 and mutationClientID does not match mutation's clientID", async () => {
     await testThrowsErrorOnClientIDMismatch('commit', FormatVersion.Latest);
   });
@@ -319,7 +609,7 @@ describe('rebaseMutationAndPutCommit', () => {
     const hashOfRebasedLocalCommit1 = await withWriteNoImplicitCommit(
       fixture.store,
       async (write): Promise<Hash> => {
-        const commit = await rebaseMutationAndPutCommit(
+        const {result: commit} = await rebaseMutationAndPutCommit(
           fixture.localCommit1,
           write,
           fixture.syncSnapshotCommit.chunk.hash,
@@ -352,7 +642,7 @@ describe('rebaseMutationAndPutCommit', () => {
     const hashOfRebasedLocalCommit2 = await withWriteNoImplicitCommit(
       fixture.store,
       async write => {
-        const commit = await rebaseMutationAndPutCommit(
+        const {result: commit} = await rebaseMutationAndPutCommit(
           fixture.localCommit2,
           write,
           hashOfRebasedLocalCommit1,
@@ -395,7 +685,7 @@ describe('rebaseMutationAndPutCommit', () => {
     const hashOfRebasedLocalCommit = await withWriteNoImplicitCommit(
       fixture.store,
       async write => {
-        const commit = await rebaseMutationAndPutCommit(
+        const {result: commit} = await rebaseMutationAndPutCommit(
           fixture.localCommit,
           write,
           fixture.syncSnapshotCommit.chunk.hash,

--- a/packages/replicache/src/db/rebase.ts
+++ b/packages/replicache/src/db/rebase.ts
@@ -22,6 +22,19 @@ import {newWriteLocal} from './write.ts';
 
 type FormatVersion = Enum<typeof FormatVersion>;
 
+/**
+ * The result of replaying one mutation.
+ *
+ * `zeroData` is the Zero transaction data to use for the next mutation in the
+ * same replay. Each mutation runs against its own fork. On success that fork is
+ * returned, and if the mutator throws the caller gets back the one it passed
+ * in, without the failed mutation's IVM writes. See `rebaseMutation`.
+ */
+export type RebaseResult<T> = {
+  result: T;
+  zeroData: ZeroTxData | undefined;
+};
+
 async function rebaseMutation(
   mutation: Commit<LocalMetaDD31>,
   dagWrite: DagWrite,
@@ -31,7 +44,7 @@ async function rebaseMutation(
   mutationClientID: ClientID,
   formatVersion: FormatVersion,
   zeroData: ZeroTxData | undefined,
-): Promise<Write> {
+): Promise<RebaseResult<Write>> {
   const localMeta = mutation.meta;
   const name = localMeta.mutatorName;
   if (isLocalMetaDD31(localMeta)) {
@@ -75,27 +88,59 @@ async function rebaseMutation(
     assertLocalMetaDD31(localMeta);
   }
 
-  const dbWrite = await newWriteLocal(
-    basisHash,
-    name,
-    args,
-    mutation.chunk.hash,
-    dagWrite,
-    localMeta.timestamp,
-    mutationClientID,
-    formatVersion,
-  );
+  const newWrite = () =>
+    newWriteLocal(
+      basisHash,
+      name,
+      args,
+      mutation.chunk.hash,
+      dagWrite,
+      localMeta.timestamp,
+      mutationClientID,
+      formatVersion,
+    );
+
+  const dbWrite = await newWrite();
+
+  // Run the mutator against a fork so that if it throws, its IVM writes are
+  // discarded along with its `Write`.
+  const txData = zeroData?.fork();
 
   const tx = new WriteTransactionImpl(
     mutationClientID,
     await dbWrite.getMutationID(),
     'rebase',
-    zeroData,
+    txData,
     dbWrite,
     lc,
   );
-  await mutatorImpl(tx, args);
-  return dbWrite;
+
+  try {
+    await mutatorImpl(tx, args);
+  } catch (e) {
+    // A mutator can throw here without anything being wrong: it is being run
+    // again against a newer server snapshot, so a check that passed when the
+    // user first ran it can fail now. Rethrowing fails the whole rebase, which
+    // in Zero fails the poke and disconnects the client. The mutation stays
+    // pending, so the next poke fails the same way.
+    //
+    // Only the local prediction is dropped. The mutation is still pending and
+    // is still sent to the server, which decides whether it applied.
+    //
+    // `dbWrite` is dropped rather than closed: it shares `dagWrite` with the
+    // caller. Dropping it is enough because a `Write` does not modify anything
+    // outside itself and only writes chunks when it is committed.
+    //
+    // Engine errors raised inside the mutator are retired the same way, rather
+    // than being sorted out here. A client whose state was garbage collected
+    // throws ChunkNotFoundError from its reads, and that is detected on its
+    // next mutation, where replicache-impl converts it to a
+    // ClientStateNotFoundError and calls onClientStateNotFound.
+    lc.info?.(`Rebase of mutator ${name} threw, abandoning its prediction`, e);
+    return {result: await newWrite(), zeroData};
+  }
+
+  return {result: dbWrite, zeroData: txData};
 }
 
 export async function rebaseMutationAndPutCommit(
@@ -109,8 +154,8 @@ export async function rebaseMutationAndPutCommit(
   mutationClientID: ClientID,
   formatVersion: FormatVersion,
   zeroData: ZeroTxData | undefined,
-): Promise<Commit<Meta>> {
-  const tx = await rebaseMutation(
+): Promise<RebaseResult<Commit<Meta>>> {
+  const {result: tx, zeroData: next} = await rebaseMutation(
     mutation,
     dagWrite,
     basis,
@@ -120,7 +165,7 @@ export async function rebaseMutationAndPutCommit(
     formatVersion,
     zeroData,
   );
-  return tx.putCommit();
+  return {result: await tx.putCommit(), zeroData: next};
 }
 
 export async function rebaseMutationAndCommit(
@@ -135,8 +180,8 @@ export async function rebaseMutationAndCommit(
   mutationClientID: ClientID,
   formatVersion: FormatVersion,
   zeroData: ZeroTxData | undefined,
-): Promise<Hash> {
-  const dbWrite = await rebaseMutation(
+): Promise<RebaseResult<Hash>> {
+  const {result: dbWrite, zeroData: next} = await rebaseMutation(
     mutation,
     dagWrite,
     basis,
@@ -146,5 +191,5 @@ export async function rebaseMutationAndCommit(
     formatVersion,
     zeroData,
   );
-  return dbWrite.commit(headName);
+  return {result: await dbWrite.commit(headName), zeroData: next};
 }

--- a/packages/replicache/src/persist/persist.test.ts
+++ b/packages/replicache/src/persist/persist.test.ts
@@ -27,8 +27,13 @@ import {
 } from '../db/test-helpers.ts';
 import * as FormatVersion from '../format-version-enum.ts';
 import {type Hash, assertHash, makeNewFakeHashFunction} from '../hash.ts';
+import type {ZeroTxData} from '../replicache-options.ts';
 import type {ClientGroupID, ClientID} from '../sync/ids.ts';
-import type {WriteTransaction} from '../transactions.ts';
+import {
+  type WriteTransaction,
+  type WriteTransactionImpl,
+  zeroData,
+} from '../transactions.ts';
 import type {MutatorDefs} from '../types.ts';
 import {withRead, withWriteNoImplicitCommit} from '../with-transactions.ts';
 import {
@@ -817,6 +822,71 @@ describe('persistDD31', () => {
         afterPersistPerdagClientGroupBaseSnapshotHash,
       ),
     ).toEqual(updatedPerdagClientGroupSnapshot);
+  });
+
+  // persistDD31 replays in two batches: the perdag client group's own local
+  // mutations, then the new memdag ones on top. The second batch has to
+  // continue from the branch the first ended on, or its mutators read rows the
+  // first batch never wrote.
+  test('the second rebase batch continues from the first batch branch', async () => {
+    const memdagMutationIDs = {
+      [clients[0].clientID]: 1,
+      [clients[2].clientID]: 2,
+    };
+    await setupSnapshots({
+      perdagClientGroupCookie: 'cookie1',
+      memdagCookie: 'cookie2',
+      memdagValueMap: [['k1', 'value1']],
+      memdagMutationIDs,
+    });
+    await setupPerdagClientGroupLocals();
+    await memdagChainBuilder.addLocal(clients[1].clientID);
+    await memdagChainBuilder.addLocal(clients[0].clientID);
+    await perdagClientGroupChainBuilder.removeHead();
+
+    // Stands in for an IVMSourceBranch: `fork` copies, writes go to the copy.
+    const makeTxData = (rows: ReadonlySet<string>): ZeroTxData => ({
+      ivmSources: new Set(rows),
+      token: undefined,
+      context: undefined,
+      fork(): ZeroTxData {
+        return makeTxData(this.ivmSources as Set<string>);
+      },
+    });
+
+    const rowsOf = (tx: WriteTransaction) =>
+      (tx as WriteTransactionImpl)[zeroData]?.ivmSources as Set<string>;
+    const seen: string[][] = [];
+
+    const zeroMutators: MutatorDefs = {};
+    for (let i = 0; i < 10; i++) {
+      const name = createMutatorName(i);
+      zeroMutators[name] = async (tx: WriteTransaction, args: JSONValue) => {
+        seen.push([...rowsOf(tx)]);
+        rowsOf(tx).add(name);
+        await tx.set(`key-${i}`, args);
+      };
+    }
+
+    await persistDD31(
+      new LogContext(),
+      clients[0].clientID,
+      memdag,
+      perdag,
+      zeroMutators,
+      () => false,
+      FormatVersion.Latest,
+      () => Promise.resolve(makeTxData(new Set())),
+    );
+
+    // Every replayed mutation after the first sees what the ones before it
+    // wrote, across the batch boundary as well as within a batch. Without the
+    // branch being carried out of the first batch, the counts restart at 0
+    // partway through.
+    expect(seen.length).toBeGreaterThan(1);
+    expect(seen.map(rows => rows.length)).toEqual(
+      seen.map((_, index) => index),
+    );
   });
 
   test('persist throws a ClientStateNotFoundError if client is missing', async () => {

--- a/packages/replicache/src/persist/persist.ts
+++ b/packages/replicache/src/persist/persist.ts
@@ -145,7 +145,9 @@ export async function persistDD31(
   }
 
   let memdagBaseSnapshotPersisted = false;
-  const zeroDataForMemdagBaseSnapshot =
+  // Carried across both rebase batches below: each batch continues from the
+  // branch the previous one ended on.
+  let zeroDataForRebase =
     getZeroData && (await getZeroData(memdagBaseSnapshot.chunk.hash));
 
   await withWrite(perdag, async perdagWrite => {
@@ -207,7 +209,7 @@ export async function persistDD31(
         lastServerAckdMutationIDs = memdagBaseSnapshot.meta.lastMutationIDs;
         mutationIDs = {...lastServerAckdMutationIDs};
 
-        newMainClientGroupHeadHash = await rebase(
+        const rebased = await rebase(
           mainClientGroupLocalMutations,
           newMainClientGroupHeadHash,
           perdagWrite,
@@ -215,8 +217,12 @@ export async function persistDD31(
           mutationIDs,
           lc,
           formatVersion,
-          zeroDataForMemdagBaseSnapshot,
+          zeroDataForRebase,
         );
+        newMainClientGroupHeadHash = rebased.hash;
+        // The mutations rebased below run after these, so they have to see
+        // what these wrote.
+        zeroDataForRebase = rebased.zeroData;
       }
     }
 
@@ -230,16 +236,18 @@ export async function persistDD31(
     }
 
     // rebase new memdag mutations onto perdag
-    newMainClientGroupHeadHash = await rebase(
-      newMemdagMutations,
-      newMainClientGroupHeadHash,
-      perdagWrite,
-      mutators,
-      mutationIDs,
-      lc,
-      formatVersion,
-      zeroDataForPerdagHeadCommit ?? zeroDataForMemdagBaseSnapshot,
-    );
+    newMainClientGroupHeadHash = (
+      await rebase(
+        newMemdagMutations,
+        newMainClientGroupHeadHash,
+        perdagWrite,
+        mutators,
+        mutationIDs,
+        lc,
+        formatVersion,
+        zeroDataForPerdagHeadCommit ?? zeroDataForRebase,
+      )
+    ).hash;
 
     const newMainClientGroup = {
       ...mainClientGroup,
@@ -267,6 +275,11 @@ async function getClientGroupInfo(
   return [clientGroup, await commitFromHash(clientGroup.headHash, perdagRead)];
 }
 
+type RebasedBatch = {
+  hash: Hash;
+  zeroData: ZeroTxData | undefined;
+};
+
 async function rebase(
   mutations: Commit<LocalMetaDD31>[],
   basis: Hash,
@@ -276,7 +289,7 @@ async function rebase(
   lc: LogContext,
   formatVersion: FormatVersion,
   zeroData: ZeroTxData | undefined,
-): Promise<Hash> {
+): Promise<RebasedBatch> {
   const basisMutationIDs = new Map<Hash, Map<ClientID, Promise<number>>>();
   const getBasisMutationID = (
     basisHash: Hash,
@@ -295,19 +308,19 @@ async function rebase(
     const {meta} = mutationCommit;
     if (meta.mutationID > (await getBasisMutationID(basis, meta.clientID))) {
       mutationIDs[meta.clientID] = meta.mutationID;
-      basis = (
-        await rebaseMutationAndPutCommit(
-          mutationCommit,
-          write,
-          basis,
-          mutators,
-          lc,
-          meta.clientID,
-          formatVersion,
-          zeroData,
-        )
-      ).chunk.hash;
+      const {result, zeroData: next} = await rebaseMutationAndPutCommit(
+        mutationCommit,
+        write,
+        basis,
+        mutators,
+        lc,
+        meta.clientID,
+        formatVersion,
+        zeroData,
+      );
+      basis = result.chunk.hash;
+      zeroData = next;
     }
   }
-  return basis;
+  return {hash: basis, zeroData};
 }

--- a/packages/replicache/src/persist/refresh.test.ts
+++ b/packages/replicache/src/persist/refresh.test.ts
@@ -38,9 +38,14 @@ import {
   getClient,
   setClient,
 } from '../persist/clients.ts';
+import type {ZeroOption, ZeroTxData} from '../replicache-options.ts';
 import type {ClientID} from '../sync/ids.ts';
 import {addData, testSubscriptionsManagerOptions} from '../test-util.ts';
-import type {WriteTransaction} from '../transactions.ts';
+import {
+  type WriteTransaction,
+  type WriteTransactionImpl,
+  zeroData,
+} from '../transactions.ts';
 import type {MutatorDefs} from '../types.ts';
 import {withRead, withWriteNoImplicitCommit} from '../with-transactions.ts';
 import {refresh} from './refresh.ts';
@@ -294,6 +299,72 @@ describe('refresh', () => {
     await assertRefreshHashes(perdag, clientID, [
       perdagChainBuilder.chain.at(-1)?.chunk.hash,
     ]);
+  });
+
+  // refresh replays its memdag mutations in one inline loop. All it uniquely
+  // does with the zero tx data is hand each mutation what the previous one
+  // returned; `rebaseMutation` itself is covered in db/rebase.test.ts.
+  test('each replayed mutation is handed what the previous one returned', async () => {
+    const {perdag, memdag} = makeStores();
+    const clientID = 'client-id-1';
+
+    const makeTxData = (rows: ReadonlySet<string>): ZeroTxData => ({
+      ivmSources: new Set(rows),
+      token: undefined,
+      context: undefined,
+      fork(): ZeroTxData {
+        return makeTxData(this.ivmSources as Set<string>);
+      },
+    });
+    const rowsOf = (tx: WriteTransaction) =>
+      (tx as WriteTransactionImpl)[zeroData]?.ivmSources as Set<string>;
+    const seen: string[][] = [];
+
+    const mutators: MutatorDefs = new Proxy(
+      {},
+      {
+        get(_target, prop) {
+          return async (tx: WriteTransaction, args: JSONValue) => {
+            seen.push([...rowsOf(tx)]);
+            rowsOf(tx).add(String(prop));
+            await tx.set(`from ${String(prop)}`, args);
+          };
+        },
+      },
+    );
+
+    await makePerdagChainAndSetClientsAndClientGroup(perdag, clientID, 1);
+    const {chainBuilder: memdagChainBuilder} = await makeMemdagChain(
+      memdag,
+      clientID,
+      1,
+    );
+    // Two mutations to replay, so the handoff between them is observable.
+    await memdagChainBuilder.addLocal(clientID, []);
+    await memdagChainBuilder.addLocal(clientID, []);
+
+    const zero = {
+      getTxData: () => Promise.resolve(makeTxData(new Set())),
+      advance: () => undefined,
+    } as unknown as ZeroOption;
+
+    const refreshResult = await refresh(
+      new LogContext(),
+      memdag,
+      perdag,
+      clientID,
+      mutators,
+      testSubscriptionsManagerOptions,
+      () => false,
+      formatVersion,
+      zero,
+    );
+    assert(refreshResult, 'Expected refreshResult to be defined');
+
+    // The second mutation sees what the first wrote. Without the handoff both
+    // entries are empty.
+    expect(seen.length).toBe(2);
+    expect(seen.map(rows => rows.length)).toEqual([0, 1]);
   });
 
   test('memdag has a newer cookie', async () => {

--- a/packages/replicache/src/persist/refresh.ts
+++ b/packages/replicache/src/persist/refresh.ts
@@ -217,22 +217,22 @@ export async function refresh(
 
         let newMemdagHeadHash = perdagClientGroupHeadHash;
         if (newMemdagMutations.length > 0) {
-          const zeroData = await zero?.getTxData?.(newMemdagHeadHash, {
+          let zeroData = await zero?.getTxData?.(newMemdagHeadHash, {
             openLazyRead: memdagWrite,
           });
           for (let i = newMemdagMutations.length - 1; i >= 0; i--) {
-            newMemdagHeadHash = (
-              await rebaseMutationAndPutCommit(
-                newMemdagMutations[i],
-                memdagWrite,
-                newMemdagHeadHash,
-                mutators,
-                lc,
-                newMemdagMutations[i].meta.clientID,
-                formatVersion,
-                zeroData,
-              )
-            ).chunk.hash;
+            const {result, zeroData: next} = await rebaseMutationAndPutCommit(
+              newMemdagMutations[i],
+              memdagWrite,
+              newMemdagHeadHash,
+              mutators,
+              lc,
+              newMemdagMutations[i].meta.clientID,
+              formatVersion,
+              zeroData,
+            );
+            newMemdagHeadHash = result.chunk.hash;
+            zeroData = next;
           }
         }
 

--- a/packages/replicache/src/replicache-impl.ts
+++ b/packages/replicache/src/replicache-impl.ts
@@ -807,7 +807,7 @@ export class ReplicacheImpl<MD extends MutatorDefs = {}> {
       }
 
       // Replay.
-      const zeroData = await this.#zero?.getTxData?.(syncHead);
+      let zeroData = await this.#zero?.getTxData?.(syncHead);
       for (const mutation of replayMutations) {
         // TODO(greg): I'm not sure why this was in Replicache#_mutate...
         // Ensure that we run initial pending subscribe functions before starting a
@@ -816,19 +816,25 @@ export class ReplicacheImpl<MD extends MutatorDefs = {}> {
           await Promise.resolve();
         }
         const {meta} = mutation;
-        syncHead = await withWriteNoImplicitCommit(this.memdag, dagWrite =>
-          rebaseMutationAndCommit(
-            mutation,
-            dagWrite,
-            syncHead,
-            SYNC_HEAD_NAME,
-            this.#mutatorRegistry,
-            lc,
-            isLocalMetaDD31(meta) ? meta.clientID : clientID,
-            FormatVersion.Latest,
-            zeroData,
-          ),
+        const {result, zeroData: next} = await withWriteNoImplicitCommit(
+          this.memdag,
+          dagWrite =>
+            rebaseMutationAndCommit(
+              mutation,
+              dagWrite,
+              syncHead,
+              SYNC_HEAD_NAME,
+              this.#mutatorRegistry,
+              lc,
+              isLocalMetaDD31(meta) ? meta.clientID : clientID,
+              FormatVersion.Latest,
+              zeroData,
+            ),
         );
+        syncHead = result;
+        // The fork the mutation ran against when it succeeded, or the branch we
+        // came in with when it threw.
+        zeroData = next;
       }
     }
   }

--- a/packages/replicache/src/replicache-options.ts
+++ b/packages/replicache/src/replicache-options.ts
@@ -255,6 +255,16 @@ export interface ZeroTxData {
   ivmSources: unknown;
   token: string | undefined;
   context: unknown;
+
+  /**
+   * A cheap copy, used for one mutation's speculative writes.
+   *
+   * Replaying a mutation writes to two places: Replicache's `Write` and the
+   * IVM sources held here. If the mutator throws, the `Write` is discarded,
+   * and the fork lets the IVM writes be discarded with it. The caller adopts
+   * the fork when the mutator succeeds and drops it when it throws.
+   */
+  fork(): ZeroTxData;
 }
 
 export type ZeroReadOptions = {

--- a/packages/replicache/src/replicache-poke.test.ts
+++ b/packages/replicache/src/replicache-poke.test.ts
@@ -1,5 +1,11 @@
 import {expect, test, vi} from 'vitest';
+import {promiseVoid} from '../../shared/src/resolved-promises.ts';
 import type {VersionNotSupportedResponse} from './error-responses.ts';
+import type {
+  EphemeralID,
+  ZeroOption,
+  ZeroTxData,
+} from './replicache-options.ts';
 import {
   addData,
   disableAllBackgroundProcesses,
@@ -7,7 +13,11 @@ import {
   makePullResponseV1,
   replicacheForTesting,
 } from './test-util.ts';
-import type {WriteTransaction} from './transactions.ts';
+import {
+  type WriteTransaction,
+  type WriteTransactionImpl,
+  zeroData,
+} from './transactions.ts';
 import type {Poke, UpdateNeededReason} from './types.ts';
 
 initReplicacheTesting();
@@ -205,4 +215,78 @@ test('Version not supported on server', async () => {
     {error: 'VersionNotSupported', versionType: 'schema'},
     {type: 'VersionNotSupported', versionType: 'schema'},
   );
+});
+
+// The replay loop in replicache-impl hands each mutation the zero tx data the
+// previous one returned. That handoff is all this layer does with it;
+// `rebaseMutation`'s own behavior is covered in db/rebase.test.ts.
+test('each replayed mutation is handed what the previous one returned', async () => {
+  const makeTxData = (rows: ReadonlySet<string>): ZeroTxData => ({
+    ivmSources: new Set(rows),
+    token: undefined,
+    context: undefined,
+    fork(): ZeroTxData {
+      return makeTxData(this.ivmSources as Set<string>);
+    },
+  });
+
+  const zero = {
+    auth: '',
+    init: () => promiseVoid,
+    getTxData: () => Promise.resolve(makeTxData(new Set())),
+    advance: () => undefined,
+    trackMutation: () => ({
+      ephemeralID: 0 as EphemeralID,
+      serverPromise: Promise.resolve(),
+    }),
+    mutationIDAssigned: () => undefined,
+    rejectMutation: () => undefined,
+  } as unknown as ZeroOption;
+
+  const rowsOf = (tx: WriteTransaction) =>
+    (tx as WriteTransactionImpl)[zeroData]?.ivmSources as Set<string>;
+  const seen: string[][] = [];
+
+  const rep = await replicacheForTesting(
+    'poke-zero-tx-data-handoff',
+    {
+      mutators: {
+        first: async (tx: WriteTransaction) => {
+          if (tx.reason === 'rebase') {
+            seen.push([...rowsOf(tx)]);
+          }
+          rowsOf(tx)?.add('first');
+          await tx.set('/first', true);
+        },
+        second: async (tx: WriteTransaction) => {
+          if (tx.reason === 'rebase') {
+            seen.push([...rowsOf(tx)]);
+          }
+          rowsOf(tx)?.add('second');
+          await tx.set('/second', true);
+        },
+      },
+      ...disableAllBackgroundProcesses,
+    },
+    {zero},
+  );
+  const {clientID} = rep;
+
+  await rep.mutate.first();
+  await rep.mutate.second();
+
+  // Acks neither mutation, so both are replayed.
+  await rep.poke({
+    baseCookie: null,
+    pullResponse: makePullResponseV1(
+      clientID,
+      0,
+      [{op: 'put', key: '/server', value: true}],
+      'c1',
+    ),
+  } as Poke);
+
+  // The second replayed mutation sees what the first wrote. Without the
+  // handoff both entries are empty.
+  expect(seen).toEqual([[], ['first']]);
 });

--- a/packages/zero-client/src/client/rebase-throw.test.ts
+++ b/packages/zero-client/src/client/rebase-throw.test.ts
@@ -1,0 +1,146 @@
+import {beforeEach, expect, test, vi} from 'vitest';
+import type {InsertValue} from '../../../zql/src/mutate/crud.ts';
+import type {Transaction} from '../../../zql/src/mutate/custom.ts';
+import {createBuilder} from '../../../zql/src/query/create-builder.ts';
+import {legacySchema} from '../../../zql/src/query/test/test-schemas.ts';
+import {ConnectionStatus} from './connection-status.ts';
+import {
+  asCustomQuery,
+  MockSocket,
+  tickAFewTimes,
+  zeroForTest,
+} from './test-utils.ts';
+
+type Schema = typeof legacySchema;
+type MutatorTx = Transaction<Schema>;
+type Issue = InsertValue<typeof legacySchema.tables.issue>;
+
+const issue = (id: string): Issue => ({
+  id,
+  title: `title ${id}`,
+  description: '',
+  closed: false,
+  createdAt: 42,
+});
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.stubGlobal('WebSocket', MockSocket as unknown as typeof WebSocket);
+  return () => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  };
+});
+
+/**
+ * A custom mutator body runs again on every rebase, so a guard that passed when
+ * the user made the mutation can fail when it is replayed onto a newer server
+ * snapshot. That race is normal, and this is the contract it has to meet.
+ *
+ * Before the fix in db/rebase.ts the throw escaped the rebase, which failed the
+ * poke and disconnected the client, and the mutation stayed pending so the next
+ * poke failed the same way. `addUnlessFull` writes before it throws, which is
+ * the other half: each replayed mutation runs against its own fork of Zero's
+ * IVM sources, so a mutator that throws takes its writes to them down with it.
+ * Without the fork the mutations replayed after it read rows that were never
+ * committed.
+ */
+test('a mutator whose guard fails on rebase does not break the client', async () => {
+  let replays = 0;
+  const idsSeenOnReplay: string[][] = [];
+
+  const z = zeroForTest({
+    schema: legacySchema,
+    mutators: {
+      issue: {
+        // Writes, then throws once the server snapshot pushes it over a limit.
+        addUnlessFull: async (tx: MutatorTx, args: Issue) => {
+          if (tx.reason === 'rebase') {
+            replays++;
+          }
+          await tx.mutate.issue.insert(args);
+          const all = await tx.run(tx.query.issue);
+          if (all.length > 2) {
+            throw new Error('too many issues');
+          }
+        },
+        // Reads through ZQL, so it sees whatever branch it was handed.
+        addAndRecord: async (tx: MutatorTx, args: Issue) => {
+          const all = await tx.run(tx.query.issue.orderBy('id', 'asc'));
+          if (tx.reason === 'rebase') {
+            idsSeenOnReplay.push(all.map(r => r.id));
+          }
+          await tx.mutate.issue.insert(args);
+        },
+      },
+    } as const,
+  });
+
+  await z.triggerConnected();
+  await z.waitForConnectionStatus(ConnectionStatus.Connected);
+
+  const zql = createBuilder(legacySchema);
+  const q = asCustomQuery(zql.issue.orderBy('id', 'asc'), 'allIssues', []);
+  const view = z.materialize(q);
+
+  try {
+    await z.triggerGotQueriesPatch(q);
+    await tickAFewTimes(vi);
+
+    // Both pass optimistically against an empty store.
+    await z.mutate.issue.addUnlessFull(issue('a')).client;
+    await z.mutate.issue.addAndRecord(issue('c')).client;
+    await tickAFewTimes(vi);
+    expect(view.data.map(r => r.id)).toEqual(['a', 'c']);
+
+    // Two rows arrive without acking either mutation, so both are replayed and
+    // the first one's limit is now exceeded.
+    await z.triggerPoke({
+      rowsPatch: [
+        {op: 'put', tableName: 'issues', value: issue('x')},
+        {op: 'put', tableName: 'issues', value: issue('y')},
+      ],
+    });
+    await tickAFewTimes(vi);
+
+    // The contract the old code broke: the throw must not take the poke, and
+    // with it the connection, down.
+    expect(z.connectionStatus).toBe(ConnectionStatus.Connected);
+    expect(replays).toBe(1);
+
+    // The abandoned mutation's row is not visible to the mutation replayed
+    // after it. Without the per-mutation fork this is ['a', 'x', 'y'].
+    expect(idsSeenOnReplay).toEqual([['x', 'y']]);
+
+    // It leaves nothing behind in the view either, while the mutation replayed
+    // after it still applies.
+    expect(view.data.map(r => r.id)).toEqual(['c', 'x', 'y']);
+
+    // Abandoning the prediction does not abandon the mutation. It is still
+    // pending and still the server's to decide on, so this poke, which also
+    // does not ack it, replays it again.
+    await z.triggerPoke({
+      rowsPatch: [{op: 'put', tableName: 'issues', value: issue('z')}],
+    });
+    await tickAFewTimes(vi);
+    expect(replays).toBe(2);
+    expect(idsSeenOnReplay).toEqual([
+      ['x', 'y'],
+      ['x', 'y', 'z'],
+    ]);
+    expect(view.data.map(r => r.id)).toEqual(['c', 'x', 'y', 'z']);
+    expect(z.connectionStatus).toBe(ConnectionStatus.Connected);
+
+    // Once the server acks them they retire: no cycle that repeats forever.
+    await z.triggerPoke({
+      lastMutationIDChanges: {[z.clientID]: 2},
+      rowsPatch: [{op: 'put', tableName: 'issues', value: issue('w')}],
+    });
+    await tickAFewTimes(vi);
+    expect(replays).toBe(2);
+    expect(z.connectionStatus).toBe(ConnectionStatus.Connected);
+  } finally {
+    view.destroy();
+    await z.close();
+  }
+});

--- a/packages/zero-client/src/client/zero-rep.ts
+++ b/packages/zero-client/src/client/zero-rep.ts
@@ -33,6 +33,7 @@ type TxData = {
   ivmSources: IVMSourceBranch;
   token: string | undefined;
   context: unknown;
+  fork: () => TxData;
 };
 
 export class ZeroRep implements ZeroOption {
@@ -97,12 +98,15 @@ export class ZeroRep implements ZeroOption {
 
     return this.#ivmMain
       .forkToHead(must(this.#store), desiredHead, readOptions)
-      .then(branch => ({
-        ivmSources: branch,
-        token: fromReplicacheAuthToken(this.#auth),
-        context: this.#context,
-      }));
+      .then(branch => this.#makeTxData(branch));
   };
+
+  #makeTxData = (branch: IVMSourceBranch): TxData => ({
+    ivmSources: branch,
+    token: fromReplicacheAuthToken(this.#auth),
+    context: this.#context,
+    fork: () => this.#makeTxData(branch.fork()),
+  });
 
   advance = (expectedHash: Hash, newHash: Hash, diffs: InternalDiff): void => {
     this.#context.processChanges(expectedHash, newHash, diffs);


### PR DESCRIPTION
A custom mutator body runs three times: optimistically at the gesture, again on every client rebase, and authoritatively on the server. A guard that held at the gesture can legitimately fail on rebase, because the server has since told the client something it did not know.

`rebaseMutation` had no catch around the mutator call, and there is none anywhere else on the rebase path (rebase.ts -> maybeEndPull -> poke -> PokeHandler.#processPokesForFrame). So that throw surfaced as a poke processing failure, and the poke handler's answer is to disconnect with ClientError{kind: Internal}. The mutation stays pending, so the next poke fails the same way and the client never stays connected.

Catch the throw and retire that one mutation as a no-op prediction: discard the partially staged `Write` and return a fresh `newWriteLocal` off the same basis, so the caller commits a well formed local commit whose value tree equals the basis. Discarding is safe because a `Write` stages nothing outside itself and only creates chunks at commit time. The mutation is not abandoned -- it stays pending, is still pushed, and the server remains the authority on whether it applied.

This mirrors the existing handling of an unknown mutator name a few lines above, which already stubs in a no-op so sync can move forward. It is logged at info rather than error: a mutator throwing on replay is expected, and an error level log would reach the app's error reporting as though something were wrong. The unknown mutator case stays at error, since that one is a deployment mistake.

Engine errors raised inside the mutator are retired the same way rather than being sorted out here, which would mean naming error classes in a module that has no business knowing about client lifecycle. A garbage collected client throws ChunkNotFoundError from its reads; that condition persists, so it is detected on the client's next mutation, where replicache-impl already converts it to a ClientStateNotFoundError and calls onClientStateNotFound.

Discarding the `Write` is not sufficient on its own. In Zero a mutator writes to two places: that `Write` and the IVM sources carried in `zeroData`. A rebase shares one `zeroData` across every mutation in the replay, which is what keeps it in step with the b-tree: each mutator writes to both. Dropping only the `Write` breaks that, and mutations replayed after an abandoned one could read rows it never committed, then either mispredict or trip `assert(!exists(row))` in MemorySource.

So give the IVM sources the same lifecycle the `Write` already has. Each replayed mutation runs against its own fork, adopted when the mutator succeeds and dropped when it throws, which takes the failed mutation's IVM writes with it. This needs one method on the `ZeroTxData` contract, `fork()`, implemented by Zero on `IVMSourceBranch.fork` -- copy on write, so a handful of pointer copies. `ivmSources` stays `unknown` to Replicache.

`rebaseMutation` returns the branch to use for the next mutation: the fork on success, the one it was handed on failure. Callers assign what comes back, so none of them has to know abandonment exists.

The replicache tests cover this with a stand-in for the IVM sources, since that package cannot see `IVMSourceBranch`. zero-client/rebase-ivm.test.ts covers the same ground against the real ones: mutators writing through `crud-impl` to both the b-tree and a real branch, and a real ZQL read of what the next mutation sees.


Claude-Session: https://claude.ai/code/session_01KmdF59DV8QN3Tm9FtoxF91