### PR TITLE
fix(vitest): re-enable zero-client's 41 test files, silently skipped in CI since #5688

### DIFF
--- a/packages/zero-client/src/client/zero-idb.test.ts
+++ b/packages/zero-client/src/client/zero-idb.test.ts
@@ -1,8 +1,6 @@
 import {expect, test} from 'vitest';
 import {hasMemStore} from '../../../replicache/src/kv/mem-store.ts';
-import {makeIDBName} from '../../../replicache/src/make-idb-name.ts';
 import {h64} from '../../../shared/src/hash.ts';
-import {PROTOCOL_VERSION} from '../../../zero-protocol/src/protocol-version.ts';
 import {createSchema} from '../../../zero-schema/src/builder/schema-builder.ts';
 import {string, table} from '../../../zero-schema/src/builder/table-builder.ts';
 import {LOGGED_OUT_STORAGE_USER_ID, Zero} from './zero.ts';
@@ -167,18 +165,8 @@ test('logged-out client uses a private storage sentinel for idb naming', async (
     kvStore: 'mem',
   });
 
-  // Derive everything that moves on its own (the format version, the protocol
-  // version, the name hash) so a bump elsewhere cannot silently rot this
-  // expectation. Only the ClientSchema hash of `schema` is pinned.
-  const hashedKey = h64(
-    JSON.stringify({storageKey, mutateUrl: '', queryUrl: ''}),
-  ).toString(36);
-
   expect(zero.idbName).toEqual(
-    makeIDBName(
-      `zero-${LOGGED_OUT_STORAGE_USER_ID}-${hashedKey}`,
-      `${PROTOCOL_VERSION}.32bj126fs2e3f`,
-    ),
+    `rep:zero-${LOGGED_OUT_STORAGE_USER_ID}-o92aeop6ci3f:7:53.32bj126fs2e3f`,
   );
 
   await zero.close();

--- a/packages/zero-client/src/client/zero-idb.test.ts
+++ b/packages/zero-client/src/client/zero-idb.test.ts
@@ -1,6 +1,8 @@
 import {expect, test} from 'vitest';
 import {hasMemStore} from '../../../replicache/src/kv/mem-store.ts';
+import {makeIDBName} from '../../../replicache/src/make-idb-name.ts';
 import {h64} from '../../../shared/src/hash.ts';
+import {PROTOCOL_VERSION} from '../../../zero-protocol/src/protocol-version.ts';
 import {createSchema} from '../../../zero-schema/src/builder/schema-builder.ts';
 import {string, table} from '../../../zero-schema/src/builder/table-builder.ts';
 import {LOGGED_OUT_STORAGE_USER_ID, Zero} from './zero.ts';
@@ -165,8 +167,18 @@ test('logged-out client uses a private storage sentinel for idb naming', async (
     kvStore: 'mem',
   });
 
+  // Derive everything that moves on its own (the format version, the protocol
+  // version, the name hash) so a bump elsewhere cannot silently rot this
+  // expectation. Only the ClientSchema hash of `schema` is pinned.
+  const hashedKey = h64(
+    JSON.stringify({storageKey, mutateUrl: '', queryUrl: ''}),
+  ).toString(36);
+
   expect(zero.idbName).toEqual(
-    `rep:zero-${LOGGED_OUT_STORAGE_USER_ID}-o92aeop6ci3f:7:52.32bj126fs2e3f`,
+    makeIDBName(
+      `zero-${LOGGED_OUT_STORAGE_USER_ID}-${hashedKey}`,
+      `${PROTOCOL_VERSION}.32bj126fs2e3f`,
+    ),
   );
 
   await zero.close();

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -30,8 +30,15 @@ function* getProjects(): Iterable<string> {
 
     // Process files in this directory first
     const fileNames = entries.filter(e => e.isFile()).map(e => e.name);
-    const configNames = fileNames.filter(name =>
-      /^vitest\.config.*\.ts$/.test(name),
+    const configNames = fileNames.filter(
+      name =>
+        /^vitest\.config.*\.ts$/.test(name) &&
+        // Drop bench configs up front — those are run separately via
+        // `pnpm run bench`. They must not count towards `hasSuffixed` below,
+        // or a package whose only suffixed config is a bench one (e.g.
+        // zero-client) would have its base config suppressed by a config that
+        // is then itself skipped, silently contributing no projects at all.
+        !name.includes('.bench'),
     );
     const hasSuffixed = configNames.some(name =>
       /^vitest\.config\.[^.]+\.ts$/.test(name),
@@ -42,8 +49,6 @@ function* getProjects(): Iterable<string> {
       if (basePath === '' && name === 'vitest.config.ts') continue;
       // If any suffixed config exists in this dir, exclude the base config
       if (name === 'vitest.config.ts' && hasSuffixed) continue;
-      // Skip bench configs — those are run separately via `pnpm run bench`
-      if (name.includes('.bench')) continue;
       yield `${basePath}${name}`;
     }
 


### PR DESCRIPTION
## Motivation

`packages/zero-client` has contributed **zero projects** to the root vitest config since #5688 (2026-03-26), so none of its 41 test files have run in CI. This was a silent gap, not a visible failure — `main` stayed green the whole time.

Two rules in `getProjects` interact badly:

1. `hasSuffixed` is true if any config matches `^vitest\.config\.[^.]+\.ts$`. `vitest.config.bench.ts` matches it.
2. When `hasSuffixed` is true, the plain `vitest.config.ts` is skipped — the intent being that suffixed configs supersede it.
3. Then `if (name.includes('.bench')) continue;` skips the bench config too, since bench runs via `pnpm run bench`.

Net effect for `zero-client`: the base config was suppressed by a config that was then itself skipped, and the package yielded nothing.

`hasSuffixed` came from #4782 (2025-08-20), written for `zero-cache`'s `pg-15/16/17/18` split, where the suffixed configs genuinely do replace the base. #5688 added bench configs to four packages and the `.bench` skip — but placed it *after* the `hasSuffixed` check. Of those four, `shared` (node/web), `zero-cache` (pg-*) and `zql-benchmarks` (pg-17/18) each had a real suffixed config keeping them in the set. `zero-client`'s only suffixed config was the bench one.

## Changes

**`vitest.config.ts`** — filter `.bench` configs out before computing `hasSuffixed`, so a bench-only sibling can no longer suppress a base config it doesn't replace.

**`packages/zero-client/src/client/zero-idb.test.ts`** — the logged-out sentinel test expected a protocol version of `52` in the IDB name. `PROTOCOL_VERSION` was bumped to `53` in d47978b94 while the suite was unobserved, so the test had rotted. Carried the literal forward to `53`.

## Verification

Evaluated old and new `getProjects` side by side against the tree: **50 → 51 projects**, `packages/zero-client/vitest.config.ts` the only addition, nothing removed. No other package's project set changes.

Confirmed the stale expectation genuinely failed by stashing the test fix and re-running (`52` vs `53`).

- `zero-client` now collects all 41 files: **664 tests, all passing**.
- Full `TEST_PG_MODE=nopg` suite: **562 files / 8142 tests passing**.

## Notes for reviewers

**This turns on ~41 previously-unrun test files, so it changes what CI covers.** Two things worth knowing:

- CI sets `CI=true`, which makes the shared config run browser tests in chromium **plus firefox and webkit**. The dev container used here only has chromium and can't reach `cdn.playwright.dev`, so firefox/webkit are unverified after ~6 months of drift. All 41 files are green on chromium.
- `src/client/worker.test.ts` timed out once when the whole monorepo ran unsharded on 4 cores (it has a hardcoded 9s `Promise.race` around browser worker startup), and passed on re-run and in isolation. CI shards 3 ways, so this is likely fine, but it's the one newly-enabled test with a wall-clock assumption.

The only failure in the local full-suite run was `zero-cache/src/services/http-service.test.ts` (`listen EAFNOSUPPORT: address family not supported ::`), which fails identically on a clean tree in this container — no IPv6 — and is unrelated to this change.

## Not included

Auditing this (via `vitest list --filesOnly` diffed against every test file on disk: 536 on disk, 495 collected) turned up two more test files that are accidentally not collected, both of which pass when run directly:

- `packages/datadog/src/datadog-log-sink.test.ts` — the package's config is named `vite.config.ts`, not `vitest.config.ts`, so root discovery never sees it. `pnpm --filter datadog test` works, which is likely why it went unnoticed. (14 tests, passing.)
- `packages/zero-cache/tool/replace-node-util.test.ts` — every `zero-cache` project's `include` is `src/**` only; this lives under `tool/`. (3 tests, passing.)

Left out to keep this change scoped; happy to fold them in or send a follow-up, whichever you prefer. (`apps/zbugs/playwright/smoke.spec.ts` and `tools/tsnapi/api.test.ts` are also uncollected, but deliberately so — separate runners.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCd1G6Uv8E5abD7eYnSaYS