### PR TITLE
fix(replicache): always reject a negative ref count update, even in production

### DIFF
--- a/packages/replicache/src/dag/gc.test.ts
+++ b/packages/replicache/src/dag/gc.test.ts
@@ -325,3 +325,31 @@ test('computeRefCountUpdates for heads updating to same hash should have no refc
   );
   expectRefCountUpdates(refCountUpdates, {});
 });
+
+test('computeRefCountUpdates rejects a negative ref count instead of returning it', async () => {
+  // The store says R is a head but reports its ref count as 0. That can only
+  // happen if the stored count was lost or misread (a corrupted store), and
+  // decrementing it would write -1 to the store, wedging it for good.
+  //
+  //   R
+  //   |
+  //   A
+  const {hashes, delegate} = createGraph({
+    graph: {
+      '000': ['a'],
+      'a': [],
+    },
+    heads: [],
+    allZeroRefCounts: true,
+  });
+
+  await expect(
+    computeRefCountUpdates(
+      [{old: hashes['000'], new: undefined}],
+      new Set(),
+      delegate,
+    ),
+  ).rejects.toThrow(
+    `ref count update must be non-negative. ${hashes['000']}:-1`,
+  );
+});

--- a/packages/replicache/src/dag/gc.ts
+++ b/packages/replicache/src/dag/gc.ts
@@ -129,10 +129,17 @@ class RefCountUpdates {
       await this.#changeRefCount(o, -1);
     }
 
-    if (!skipGCAsserts) {
-      for (const [hash, update] of this.#refCountUpdates) {
-        assert(
-          update >= 0,
+    // This check is deliberately not gated on `skipGCAsserts`. A negative
+    // ref count can only come from a corrupted read of the store (for example
+    // a kv delegate returning the wrong row), and if the caller writes it the
+    // store is corrupted for good: every later write that touches the chunk
+    // fails with an invalid ref count. Throwing here instead makes the caller
+    // roll back the transaction, so a transient bad read costs one failed
+    // write rather than a wedged database. The cost is one pass over the
+    // update map per commit.
+    for (const [hash, update] of this.#refCountUpdates) {
+      if (update < 0) {
+        throw new Error(
           `ref count update must be non-negative. ${hash}:${update}`,
         );
       }

--- a/packages/replicache/src/dag/store-impl.test.ts
+++ b/packages/replicache/src/dag/store-impl.test.ts
@@ -280,6 +280,34 @@ describe('write', () => {
     await t(true, true);
   });
 
+  test('commit with a missing ref count for an old head rolls back', async () => {
+    // A head whose ref count key is missing means the store is corrupt: moving
+    // the head would decrement 0 to -1. The commit must fail before anything
+    // reaches the kv store so that the corruption does not become permanent.
+    const chunkHasher = makeNewFakeHashFunction();
+    const kv = new TestMemStore();
+    const h0 = fakeHash('0');
+    const h1 = fakeHash('1');
+    await withWrite(kv, async kvw => {
+      await kvw.put(headKey('test'), h0);
+      await kvw.put(chunkDataKey(h0), 'old');
+      // Note: no ref count key for h0.
+    });
+    const before = kv.snapshot();
+
+    await expect(
+      withWriteNoImplicitCommit(kv, async kvw => {
+        const w = new WriteImpl(kvw, chunkHasher, assertHash);
+        await w.putChunk(new Chunk(h1, deepFreeze('new'), []));
+        await w.setHead('test', h1);
+        await w.commit();
+      }),
+    ).rejects.toThrow(`ref count update must be non-negative. ${h0}:-1`);
+
+    // Nothing from the failed write, and no negative ref count, was persisted.
+    expect(kv.snapshot()).toEqual(before);
+  });
+
   test('roundtrip', async () => {
     const chunkHasher = makeNewFakeHashFunction();
     const t = async (name: string, data: ReadonlyJSONValue, refs: Refs) => {


### PR DESCRIPTION
## Problem

`computeRefCountUpdates` already checked that no ref count goes negative, but the check was behind `skipGCAsserts`, which is `true` in production builds. So in production a corrupted read of a live chunk's ref count (the expo-sqlite shared-statement race fixed in #6495 produced exactly this: `getRefCount` returned `undefined` for a chunk that was a head) computed `0 - 1` and wrote `-1` to the store. From then on every write that touched that chunk failed with `Invalid ref count -1`, and the device never recovered without a manual wipe.

## Fix

The non-negative check now always runs. When it fires, the dag write throws before `#applyRefCountUpdates`, nothing reaches the kv store, and the transaction rolls back. A transient bad read costs one failed persist instead of a permanently corrupted database.

Cost: one pass over the ref count update map per commit. The other GC asserts (`refs must be defined`) stay gated as before.

## What this does and does not cover

This is a guard at one chokepoint. It catches the shape of corruption we have actually seen (a live count read as 0, then decremented). It does not catch a misread that yields a plausible non-negative number, writes that bypass the dag layer, or corruption below the kv API. The detection-and-reset lane in #6558 remains the safety net for those. Both should land.

## Tests

- `gc.test.ts`: a head whose stored count is 0 is removed; `computeRefCountUpdates` rejects instead of returning `-1`.
- `store-impl.test.ts`: a `StoreImpl` commit that would produce `-1` throws and the kv snapshot is unchanged afterwards.
- Both tests were run with `NODE_ENV=production` to confirm the check is no longer gated. This actually caught a bad edit during development: with the gate still in place the tests pass in dev mode and fail in production mode.

Full replicache suite (76 files, 833 tests), `check-types`, `lint` and `format` pass.
