### PR TITLE
chore(litestream): bump to litestream that applies restore deltas in place

### DIFF
--- a/apps/zbugs/scripts/build-litestream.sh
+++ b/apps/zbugs/scripts/build-litestream.sh
@@ -4,7 +4,7 @@
 # apps/zbugs/.litestream/bin (gitignored):
 #
 #   litestream-v3  rocicorp/litestream @ zero@v0.0.10        (packages/zero/Dockerfile)
-#   litestream-v5  rocicorp/litestream @ v0.5.17-zero.1      (packages/zero/Dockerfile)
+#   litestream-v5  rocicorp/litestream @ v0.5.18-zero.8      (packages/zero/Dockerfile)
 #   vfs-query      mono/go, `make build` (cgo, -tags vfs)    (go/Makefile)
 #
 # The v3 binary is needed even though v5 does all of the backing up: the
@@ -18,7 +18,7 @@
 set -euo pipefail
 
 LITESTREAM_V3_REF="zero@v0.0.10"
-LITESTREAM_V5_VERSION="0.5.17-zero.1"
+LITESTREAM_V5_VERSION="0.5.18-zero.8"
 LITESTREAM_REPO="https://github.com/rocicorp/litestream.git"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -58,7 +58,8 @@ needs_build() {
   [[ "$(cat "${stamp}")" != "${want}" ]]
 }
 
-# $1 ref, $2 checkout dir
+# $1 ref, $2 checkout dir. Callers key the dir by ref, so bumping a pin
+# clones the new ref instead of rebuilding a stale checkout.
 clone_litestream() {
   local ref="$1" dir="$2"
   if [[ -d "${dir}/.git" ]]; then
@@ -77,7 +78,7 @@ build_litestream_v3() {
     log "litestream-v3 up to date (${LITESTREAM_V3_REF})"
     return
   fi
-  local dir="${SRC_DIR}/litestream-v3"
+  local dir="${SRC_DIR}/litestream-v3-${LITESTREAM_V3_REF}"
   clone_litestream "${LITESTREAM_V3_REF}" "${dir}"
   log "building litestream-v3"
   # The Dockerfile pins GOTOOLCHAIN=local so the vendored `toolchain`
@@ -102,7 +103,7 @@ build_litestream_v5() {
     log "litestream-v5 up to date (${LITESTREAM_V5_VERSION})"
     return
   fi
-  local dir="${SRC_DIR}/litestream-v5"
+  local dir="${SRC_DIR}/litestream-v5-${LITESTREAM_V5_VERSION}"
   clone_litestream "v${LITESTREAM_V5_VERSION}" "${dir}"
   log "building litestream-v5"
   (

--- a/apps/zbugs/scripts/rmv2-soak/README.md
+++ b/apps/zbugs/scripts/rmv2-soak/README.md
@@ -48,7 +48,7 @@ pnpm run build-litestream        # idempotent; --force to rebuild
 | Binary          | Source                                   | Why                                                                                                                                              |
 | --------------- | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `litestream-v3` | `rocicorp/litestream` @ `zero@v0.0.10`   | the `PurgeLocker` branch is gated on `litestream.executable` -- the _v3_ path. Omitting it silently skips the purge lock and diverges from prod. |
-| `litestream-v5` | `rocicorp/litestream` @ `v0.5.17-zero.1` | does all of the backing up and restoring                                                                                                         |
+| `litestream-v5` | `rocicorp/litestream` @ `v0.5.18-zero.8` | does all of the backing up and restoring                                                                                                         |
 | `vfs-query`     | `mono/go`, `make build`                  | reads the backup watermark back out of S3 through the litestream VFS                                                                             |
 
 Both litestream binaries link `mattn/go-sqlite3` via cgo, so they must be built

--- a/packages/zero/Dockerfile
+++ b/packages/zero/Dockerfile
@@ -18,7 +18,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 
 FROM golang:1.25.10@sha256:cd05a378aaf011e8056745363e5c40f4f2bef0fa4d9bf19b9c38316079c332ff AS litestream-v5
 
-ARG LITESTREAM_V5_VERSION=0.5.18-zero.7
+ARG LITESTREAM_V5_VERSION=0.5.18-zero.8
 
 WORKDIR /src/
 RUN git clone --depth 1 --branch v${LITESTREAM_V5_VERSION} https://github.com/rocicorp/litestream.git


### PR DESCRIPTION
## Summary

Bumps the v5 litestream to `v0.5.18-zero.8`, which includes [rocicorp/litestream#38](https://github.com/rocicorp/litestream/pull/38).

#35 only sped up restores whose plan is a single snapshot. Production plans are a snapshot plus 13-17 delta files, so they still went through the slow merge. This version decodes the snapshot directly and writes each delta's pages in place.

Restoring the zmail staging backup locally, a 15 GB database with a 7-file plan:

|  | User CPU | Max RSS |
|---|---|---|
| Before (`zero.7`) | 38 s | 1.6-1.9 GiB |
| After (`zero.8`) | 13 s | 0.7 GiB |

The restored database is byte-identical to the old build's.

## Test plan

- [x] litestream tests pass under the race detector on the merged code
- [x] Local restore of the zmail staging backup, byte-identical to the previous build
- [ ] After deploy, check that a restore with a multi-file plan succeeds and that its `download progress` lines show lower consumer-lag

🤖 Generated with [Claude Code](https://claude.com/claude-code)
