### PR TITLE
feat(zero-client): add an initializing connection state before connecting

### DIFF
--- a/packages/zero-client/src/client/connection-manager.test.ts
+++ b/packages/zero-client/src/client/connection-manager.test.ts
@@ -42,15 +42,19 @@ describe('ConnectionManager', () => {
 
   describe('constructor', () => {
     test('starts in initializing state without a timeout', () => {
-      using setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
-      const manager = new ConnectionManager({
-        disconnectTimeout: DEFAULT_TIMEOUT_MS,
-      });
+      const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
+      try {
+        const manager = new ConnectionManager({
+          disconnectTimeout: DEFAULT_TIMEOUT_MS,
+        });
 
-      expect(manager.state).toEqual({name: ConnectionStatus.Initializing});
-      expect(manager.shouldContinueRunLoop()).toBe(true);
-      expect(manager.isInTerminalState()).toBe(false);
-      expect(setIntervalSpy).not.toHaveBeenCalled();
+        expect(manager.state).toEqual({name: ConnectionStatus.Initializing});
+        expect(manager.shouldContinueRunLoop()).toBe(true);
+        expect(manager.isInTerminalState()).toBe(false);
+        expect(setIntervalSpy).not.toHaveBeenCalled();
+      } finally {
+        setIntervalSpy.mockRestore();
+      }
     });
 
     test('never times out while initializing', () => {

--- a/packages/zero-client/src/client/connection-manager.test.ts
+++ b/packages/zero-client/src/client/connection-manager.test.ts
@@ -41,29 +41,93 @@ describe('ConnectionManager', () => {
   };
 
   describe('constructor', () => {
-    test('starts in connecting state with default timeout', () => {
+    test('starts in initializing state without a timeout', () => {
+      const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
+      try {
+        const manager = new ConnectionManager({
+          disconnectTimeout: DEFAULT_TIMEOUT_MS,
+        });
+
+        expect(manager.state).toEqual({name: ConnectionStatus.Initializing});
+        expect(manager.shouldContinueRunLoop()).toBe(true);
+        expect(manager.isInTerminalState()).toBe(false);
+        expect(setIntervalSpy).not.toHaveBeenCalled();
+      } finally {
+        setIntervalSpy.mockRestore();
+      }
+    });
+
+    test('never times out while initializing', () => {
+      const manager = new ConnectionManager({
+        disconnectTimeout: 1_000,
+        timeoutCheckIntervalMs: 100,
+      });
+      const listener = subscribe(manager);
+
+      vi.advanceTimersByTime(10_000);
+
+      expect(manager.is(ConnectionStatus.Initializing)).toBe(true);
+      expect(listener).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('initialized', () => {
+    test('starts the connecting window when initialization finishes', () => {
       vi.setSystemTime(1_000);
       const manager = new ConnectionManager({
         disconnectTimeout: DEFAULT_TIMEOUT_MS,
       });
+      const listener = subscribe(manager);
 
-      expect(manager.state).toEqual({
+      // Initialization took 30 seconds, none of which counts against the
+      // connecting window.
+      vi.setSystemTime(31_000);
+      manager.initialized();
+
+      const expected = {
         name: ConnectionStatus.Connecting,
         attempt: 0,
-        disconnectAt: 1_000 + DEFAULT_TIMEOUT_MS,
-      });
-      expect(manager.shouldContinueRunLoop()).toBe(true);
+        disconnectAt: 31_000 + DEFAULT_TIMEOUT_MS,
+      };
+      expect(manager.state).toEqual(expected);
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(listener).toHaveBeenCalledWith(expected);
     });
 
     test('respects custom disconnect timeout', () => {
       vi.setSystemTime(5_000);
-      const manager = new ConnectionManager({disconnectTimeout: 10_000});
+      const manager = new ConnectionManager({
+        disconnectTimeout: 10_000,
+        timeoutCheckIntervalMs: 100,
+      });
+      manager.initialized();
 
       expect(
         manager.state.name === ConnectionStatus.Connecting
           ? manager.state.disconnectAt
           : -1,
       ).toEqual(5_000 + 10_000);
+
+      vi.advanceTimersByTime(9_900);
+      expect(manager.is(ConnectionStatus.Connecting)).toBe(true);
+      vi.advanceTimersByTime(200);
+      expect(manager.is(ConnectionStatus.Disconnected)).toBe(true);
+    });
+
+    test('does nothing once the state has moved on', () => {
+      const manager = new ConnectionManager({
+        disconnectTimeout: DEFAULT_TIMEOUT_MS,
+      });
+      manager.disconnected(sharedDisconnectError);
+      const listener = subscribe(manager);
+
+      manager.initialized();
+
+      expect(manager.state).toEqual({
+        name: ConnectionStatus.Disconnected,
+        reason: sharedDisconnectError,
+      });
+      expect(listener).not.toHaveBeenCalled();
     });
   });
 
@@ -151,6 +215,7 @@ describe('ConnectionManager', () => {
       const manager = new ConnectionManager({
         disconnectTimeout: DEFAULT_TIMEOUT_MS,
       });
+      manager.initialized();
       const listener = subscribe(manager);
 
       const reason = new ClientError({
@@ -233,6 +298,7 @@ describe('ConnectionManager', () => {
       const manager = new ConnectionManager({
         disconnectTimeout: DEFAULT_TIMEOUT_MS,
       });
+      manager.initialized();
 
       vi.advanceTimersByTime(DEFAULT_TIMEOUT_MS + 100);
       expect(manager.is(ConnectionStatus.Disconnected)).toBe(true);
@@ -491,6 +557,7 @@ describe('ConnectionManager', () => {
         disconnectTimeout: 1_000,
         timeoutCheckIntervalMs: 100,
       });
+      manager.initialized();
       const listener = subscribe(manager);
 
       vi.advanceTimersByTime(900);
@@ -516,6 +583,7 @@ describe('ConnectionManager', () => {
         disconnectTimeout: 5_000,
         timeoutCheckIntervalMs: 2_500,
       });
+      manager.initialized();
 
       try {
         expect(setIntervalSpy).toHaveBeenCalledTimes(1);
@@ -549,6 +617,7 @@ describe('ConnectionManager', () => {
         disconnectTimeout: 1_000,
         timeoutCheckIntervalMs: 100,
       });
+      manager.initialized();
       const listener = subscribe(manager);
 
       // Let the timeout happen naturally (transitions to Disconnected)
@@ -571,11 +640,14 @@ describe('ConnectionManager', () => {
     const CHECK_INTERVAL_MS = 100;
     const FREEZE_MS = 60_000;
 
-    const newManager = () =>
-      new ConnectionManager({
+    const newManager = () => {
+      const manager = new ConnectionManager({
         disconnectTimeout: 1_000,
         timeoutCheckIntervalMs: CHECK_INTERVAL_MS,
       });
+      manager.initialized();
+      return manager;
+    };
 
     // Simulates the event loop not running for `ms`: wall-clock jumps forward
     // with no reconnect attempt able to run, which is what a suspended React
@@ -683,6 +755,7 @@ describe('ConnectionManager', () => {
       const manager = new ConnectionManager({
         disconnectTimeout: DEFAULT_TIMEOUT_MS,
       });
+      manager.initialized();
       const listener = subscribe(manager);
 
       expect(manager.state).toEqual({
@@ -846,11 +919,9 @@ describe('ConnectionManager', () => {
       const waitPromise = manager.waitForStateChange();
       manager.cleanup();
 
-      await expect(waitPromise).resolves.toEqual(
-        expect.objectContaining({
-          name: ConnectionStatus.Connecting,
-        }),
-      );
+      await expect(waitPromise).resolves.toEqual({
+        name: ConnectionStatus.Initializing,
+      });
     });
   });
 

--- a/packages/zero-client/src/client/connection-manager.test.ts
+++ b/packages/zero-client/src/client/connection-manager.test.ts
@@ -42,19 +42,15 @@ describe('ConnectionManager', () => {
 
   describe('constructor', () => {
     test('starts in initializing state without a timeout', () => {
-      const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
-      try {
-        const manager = new ConnectionManager({
-          disconnectTimeout: DEFAULT_TIMEOUT_MS,
-        });
+      using setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
+      const manager = new ConnectionManager({
+        disconnectTimeout: DEFAULT_TIMEOUT_MS,
+      });
 
-        expect(manager.state).toEqual({name: ConnectionStatus.Initializing});
-        expect(manager.shouldContinueRunLoop()).toBe(true);
-        expect(manager.isInTerminalState()).toBe(false);
-        expect(setIntervalSpy).not.toHaveBeenCalled();
-      } finally {
-        setIntervalSpy.mockRestore();
-      }
+      expect(manager.state).toEqual({name: ConnectionStatus.Initializing});
+      expect(manager.shouldContinueRunLoop()).toBe(true);
+      expect(manager.isInTerminalState()).toBe(false);
+      expect(setIntervalSpy).not.toHaveBeenCalled();
     });
 
     test('never times out while initializing', () => {

--- a/packages/zero-client/src/client/connection-manager.test.ts
+++ b/packages/zero-client/src/client/connection-manager.test.ts
@@ -131,6 +131,42 @@ describe('ConnectionManager', () => {
     });
   });
 
+  describe('closing from a connecting notification', () => {
+    const closeOnConnecting = (manager: ConnectionManager) =>
+      manager.subscribe(state => {
+        if (state.name === ConnectionStatus.Connecting) {
+          manager.closed();
+        }
+      });
+
+    test('initialized() leaves no timeout interval behind', () => {
+      const timersBefore = vi.getTimerCount();
+      const manager = new ConnectionManager({
+        disconnectTimeout: DEFAULT_TIMEOUT_MS,
+      });
+      closeOnConnecting(manager);
+
+      manager.initialized();
+
+      expect(manager.is(ConnectionStatus.Closed)).toBe(true);
+      expect(vi.getTimerCount()).toBe(timersBefore);
+    });
+
+    test('connecting() leaves no timeout interval behind', () => {
+      const timersBefore = vi.getTimerCount();
+      const manager = new ConnectionManager({
+        disconnectTimeout: DEFAULT_TIMEOUT_MS,
+      });
+      manager.connected();
+      closeOnConnecting(manager);
+
+      manager.connecting();
+
+      expect(manager.is(ConnectionStatus.Closed)).toBe(true);
+      expect(vi.getTimerCount()).toBe(timersBefore);
+    });
+  });
+
   describe('connect request', () => {
     test('waitForConnectRequest resolves after requestConnect', async () => {
       const manager = new ConnectionManager({

--- a/packages/zero-client/src/client/connection-manager.ts
+++ b/packages/zero-client/src/client/connection-manager.ts
@@ -15,6 +15,9 @@ const DEFAULT_TIMEOUT_CHECK_INTERVAL_MS = 1_000;
 
 export type ConnectionManagerState =
   | {
+      name: ConnectionStatus.Initializing;
+    }
+  | {
       name: ConnectionStatus.Disconnected;
       reason: DisconnectedReason;
     }
@@ -106,19 +109,13 @@ export class ConnectionManager extends Subscribable<ConnectionManagerState> {
   constructor(options: ConnectionManagerOptions) {
     super();
 
-    const now = Date.now();
-
     this.#disconnectTimeout = options.disconnectTimeout;
     this.#timeoutCheckIntervalMs =
       options.timeoutCheckIntervalMs ?? DEFAULT_TIMEOUT_CHECK_INTERVAL_MS;
-    this.#state = {
-      name: ConnectionStatus.Connecting,
-      attempt: 0,
-      disconnectAt: now + this.#disconnectTimeout,
-    };
-    this.#connectingStartedAt = now;
-    this.#lastTimeoutCheckAt = now;
-    this.#maybeStartTimeoutInterval();
+    // The connecting window, and the timer that enforces it, start in
+    // initialized(), once the local store is loaded.
+    this.#state = {name: ConnectionStatus.Initializing};
+    this.#lastTimeoutCheckAt = Date.now();
   }
 
   get state(): ConnectionManagerState {
@@ -205,6 +202,38 @@ export class ConnectionManager extends Subscribable<ConnectionManagerState> {
     }
     this.connecting();
     return true;
+  }
+
+  /**
+   * Transition from initializing to connecting, once the local store is
+   * loaded.
+   *
+   * This is where the connecting window starts. Loading the local store can
+   * take tens of seconds on a slow device with a large replica, and none of
+   * that says anything about whether the server is reachable, so it is not
+   * charged against the disconnect timeout. No connect attempt has been made
+   * yet, so `attempt` is 0.
+   *
+   * A no-op in any other state: something else, like `close()`, has already
+   * moved the state on.
+   *
+   * @returns An object containing a promise that resolves on the next state change.
+   */
+  initialized(): {nextStatePromise: Promise<ConnectionManagerState>} {
+    if (this.#state.name !== ConnectionStatus.Initializing) {
+      return {nextStatePromise: this.#nextStatePromise()};
+    }
+
+    const now = Date.now();
+    this.#connectingStartedAt = now;
+    this.#state = {
+      name: ConnectionStatus.Connecting,
+      attempt: 0,
+      disconnectAt: now + this.#disconnectTimeout,
+    };
+    const nextStatePromise = this.#publishStateAndGetPromise();
+    this.#maybeStartTimeoutInterval();
+    return {nextStatePromise};
   }
 
   /**

--- a/packages/zero-client/src/client/connection-manager.ts
+++ b/packages/zero-client/src/client/connection-manager.ts
@@ -231,8 +231,10 @@ export class ConnectionManager extends Subscribable<ConnectionManagerState> {
       attempt: 0,
       disconnectAt: now + this.#disconnectTimeout,
     };
-    const nextStatePromise = this.#publishStateAndGetPromise();
+    // Start the interval before publishing: a subscriber may close the manager
+    // synchronously, and closed() can only stop an interval that exists.
     this.#maybeStartTimeoutInterval();
+    const nextStatePromise = this.#publishStateAndGetPromise();
     return {nextStatePromise};
   }
 
@@ -282,8 +284,9 @@ export class ConnectionManager extends Subscribable<ConnectionManagerState> {
         attempt: this.#state.attempt + 1,
         reason,
       };
-      const nextStatePromise = this.#publishStateAndGetPromise();
+      // See initialized() for why the interval starts before publishing.
       this.#maybeStartTimeoutInterval();
+      const nextStatePromise = this.#publishStateAndGetPromise();
       return {nextStatePromise};
     }
 
@@ -302,8 +305,10 @@ export class ConnectionManager extends Subscribable<ConnectionManagerState> {
       disconnectAt,
       reason,
     };
-    const nextStatePromise = this.#publishStateAndGetPromise();
+    // Start the interval before publishing: a subscriber may close the manager
+    // synchronously, and closed() can only stop an interval that exists.
     this.#maybeStartTimeoutInterval();
+    const nextStatePromise = this.#publishStateAndGetPromise();
     return {nextStatePromise};
   }
 

--- a/packages/zero-client/src/client/connection-status-enum.ts
+++ b/packages/zero-client/src/client/connection-status-enum.ts
@@ -1,3 +1,4 @@
+export const Initializing = 'initializing';
 export const Disconnected = 'disconnected';
 export const Connecting = 'connecting';
 export const Connected = 'connected';
@@ -5,6 +6,7 @@ export const NeedsAuth = 'needs-auth';
 export const Error = 'error';
 export const Closed = 'closed';
 
+export type Initializing = typeof Initializing;
 export type Disconnected = typeof Disconnected;
 export type Connecting = typeof Connecting;
 export type Connected = typeof Connected;

--- a/packages/zero-client/src/client/connection.test.ts
+++ b/packages/zero-client/src/client/connection.test.ts
@@ -186,6 +186,26 @@ describe('ConnectionSource', () => {
     expect(source.current).toStrictEqual({name: 'connected'});
   });
 
+  test('exposes initializing, then notifies when it becomes connecting', () => {
+    manager = {
+      state: {name: ConnectionStatus.Initializing},
+      subscribe: subscribeMock,
+    } as unknown as ConnectionManager;
+    const source = new ConnectionSource(manager);
+    const listener = vi.fn();
+    source.subscribe(listener);
+
+    expect(source.current).toStrictEqual({name: 'initializing'});
+
+    for (const l of managerListeners) {
+      l({name: ConnectionStatus.Connecting, attempt: 0, disconnectAt: 0});
+    }
+
+    expect(source.current).toStrictEqual({name: 'connecting'});
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith({name: 'connecting'});
+  });
+
   test('subscribes to manager in constructor', () => {
     new ConnectionSource(manager);
 

--- a/packages/zero-client/src/client/connection.ts
+++ b/packages/zero-client/src/client/connection.ts
@@ -12,6 +12,10 @@ import {ConnectionStatus} from './connection-status.ts';
 /**
  * The current connection state of the Zero instance. One of the following states:
  *
+ * - `initializing`: The client is loading its local store. Nothing has been
+ *   sent to the server yet, so time spent here depends on the device and the
+ *   amount of local data, not on the network. Entered once, when the Zero
+ *   instance is created, and followed by `connecting`.
  * - `connecting`: The client is actively trying to connect every 5 seconds.
  * - `disconnected`: The client is now in an "offline" state. It will continue
  *   to try to connect every 5 seconds.
@@ -24,6 +28,9 @@ import {ConnectionStatus} from './connection-status.ts';
  *   a terminal state, and a new Zero instance must be created to reconnect.
  */
 export type ConnectionState =
+  | {
+      name: 'initializing';
+    }
   | {
       name: 'disconnected';
       reason: string;
@@ -197,6 +204,10 @@ export class ConnectionSource
 
   #mapConnectionManagerState(state: ConnectionManagerState): ConnectionState {
     switch (state.name) {
+      case ConnectionStatus.Initializing:
+        return {
+          name: 'initializing',
+        };
       case ConnectionStatus.Closed:
         return {
           name: 'closed',

--- a/packages/zero-client/src/client/mutator-proxy.ts
+++ b/packages/zero-client/src/client/mutator-proxy.ts
@@ -93,6 +93,7 @@ export class MutatorProxy {
         };
         this.#mutationTracker.rejectAllOutstandingMutations(state.reason);
         break;
+      case ConnectionStatus.Initializing:
       case ConnectionStatus.Connected:
       case ConnectionStatus.Connecting:
       case ConnectionStatus.NeedsAuth:

--- a/packages/zero-client/src/client/zero.test.ts
+++ b/packages/zero-client/src/client/zero.test.ts
@@ -3096,6 +3096,28 @@ test('a hung initialization stays initializing and makes no connect attempt', as
   ).toEqual([]);
 });
 
+test('close() while initialization is hung ends the run loop', async () => {
+  vi.spyOn(ActiveClientsManager, 'create').mockReturnValue(
+    new Promise(() => {}),
+  );
+
+  const z = zeroForTest({logLevel: 'debug'});
+  await tickAFewTimes(vi, 0);
+  expect(z.connectionStatus).toBe(ConnectionStatus.Initializing);
+
+  await z.close();
+  await tickAFewTimes(vi, 0);
+
+  expect(z.connectionStatus).toBe(ConnectionStatus.Closed);
+  expect(
+    z.testLogSink.messages.some(
+      ([level, _context, messages]) =>
+        level === 'debug' &&
+        messages.includes('Closed while initializing, not connecting'),
+    ),
+  ).toBe(true);
+});
+
 test('socketOrigin', async () => {
   const cases: {
     name: string;

--- a/packages/zero-client/src/client/zero.test.ts
+++ b/packages/zero-client/src/client/zero.test.ts
@@ -97,6 +97,7 @@ import {
 } from './test-utils.ts'; // Why use fakes when we can use the real thing!
 import {
   CONNECT_TIMEOUT_MS,
+  DEFAULT_DISCONNECT_TIMEOUT_MS,
   createSocket,
   DEFAULT_DISCONNECT_HIDDEN_DELAY_MS,
   DEFAULT_PING_TIMEOUT_MS,
@@ -2767,7 +2768,11 @@ test('Connect timeout', async () => {
   await z.waitForConnectionStatus(ConnectionStatus.Connecting);
   let currentSocket = await z.socket;
 
+  // Leaving initializing, then the first connect attempt.
   expect(connectionStates).toEqual([
+    {
+      name: 'connecting',
+    },
     {
       name: 'connecting',
     },
@@ -2832,9 +2837,10 @@ test('Connect timeout', async () => {
   // watchdog fires. Assert a small range rather than an exact count to avoid
   // depending on that ordering, while still requiring the loop to have made
   // the expected number of connect attempts (each contributing at least one
-  // "connecting" state) and to have ended up disconnected.
-  expect(connectionStates.length).toBeGreaterThanOrEqual(1 + 4 * 2);
-  expect(connectionStates.length).toBeLessThanOrEqual(1 + 4 * 2 + 1);
+  // "connecting" state) and to have ended up disconnected. The leading 2 is
+  // leaving initializing plus the first attempt.
+  expect(connectionStates.length).toBeGreaterThanOrEqual(2 + 4 * 2);
+  expect(connectionStates.length).toBeLessThanOrEqual(2 + 4 * 2 + 1);
   expect(connectionStates.at(-1)?.name).toEqual('disconnected');
   expect([...new Set(connectionStates.map(s => s.name))]).toEqual([
     'connecting',
@@ -2858,13 +2864,15 @@ test('slow setup does not spend the server acknowledgement budget', async () => 
   // Setup that finishes just inside its own deadline. Before the deadlines
   // were split this left the server almost no time, and a healthy server was
   // reported as unreachable.
-  const realCreate = ActiveClientsManager.create;
-  vi.spyOn(ActiveClientsManager, 'create').mockImplementation(
-    async (...args: Parameters<typeof ActiveClientsManager.create>) => {
-      await sleep(CONNECT_TIMEOUT_MS - 1_000);
-      return realCreate(...args);
-    },
-  );
+  const realGetDeletedClients =
+    DeleteClientsManager.prototype.getDeletedClients;
+  vi.spyOn(
+    DeleteClientsManager.prototype,
+    'getDeletedClients',
+  ).mockImplementation(async function (this: DeleteClientsManager) {
+    await sleep(CONNECT_TIMEOUT_MS - 1_000);
+    return realGetDeletedClients.call(this);
+  });
 
   const z = zeroForTest();
   await z.waitForConnectionStatus(ConnectionStatus.Connecting);
@@ -2879,6 +2887,36 @@ test('slow setup does not spend the server acknowledgement budget', async () => 
   await vi.advanceTimersByTimeAsync(CONNECT_TIMEOUT_MS - 1_000);
   await tickAFewTimes(vi);
   expect(connectTimeoutErrors(z)).toEqual([]);
+  expect(z.connectionStatus).toBe(ConnectionStatus.Connecting);
+
+  await z.triggerConnected();
+  expect(z.connectionStatus).toBe(ConnectionStatus.Connected);
+});
+
+test('slow initialization does not spend any connect budget', async () => {
+  // Loading the local store can take tens of seconds on a slow device with a
+  // large replica. None of that says anything about the server, so it happens
+  // in `initializing`, before the connecting window and the setup deadline
+  // start.
+  const realCreate = ActiveClientsManager.create;
+  vi.spyOn(ActiveClientsManager, 'create').mockImplementation(
+    async (...args: Parameters<typeof ActiveClientsManager.create>) => {
+      await sleep(DEFAULT_DISCONNECT_TIMEOUT_MS * 2);
+      return realCreate(...args);
+    },
+  );
+
+  const z = zeroForTest();
+  expect(z.connectionStatus).toBe(ConnectionStatus.Initializing);
+
+  // Longer than both the setup deadline and the whole connecting window.
+  await vi.advanceTimersByTimeAsync(DEFAULT_DISCONNECT_TIMEOUT_MS * 2 - 1);
+  await tickAFewTimes(vi, 0);
+  expect(z.connectionStatus).toBe(ConnectionStatus.Initializing);
+  expect(connectTimeoutErrors(z)).toEqual([]);
+
+  await vi.advanceTimersByTimeAsync(1);
+  await tickAFewTimes(vi, 0);
   expect(z.connectionStatus).toBe(ConnectionStatus.Connecting);
 
   await z.triggerConnected();
@@ -2932,37 +2970,6 @@ test('connect timeout retries when AbortController drops abort reasons', async (
   } finally {
     vi.unstubAllGlobals();
   }
-});
-
-test('slow setup does not spend the server acknowledgement budget', async () => {
-  // Setup that finishes just inside its own deadline. Before the deadlines
-  // were split this left the server almost no time, and a healthy server was
-  // reported as unreachable.
-  const realCreate = ActiveClientsManager.create;
-  vi.spyOn(ActiveClientsManager, 'create').mockImplementation(
-    async (...args: Parameters<typeof ActiveClientsManager.create>) => {
-      await sleep(CONNECT_TIMEOUT_MS - 1_000);
-      return realCreate(...args);
-    },
-  );
-
-  const z = zeroForTest();
-  await z.waitForConnectionStatus(ConnectionStatus.Connecting);
-
-  // Wait out the slow setup.
-  await vi.advanceTimersByTimeAsync(CONNECT_TIMEOUT_MS - 1_000);
-  await tickAFewTimes(vi);
-  expect(z.connectionStatus).toBe(ConnectionStatus.Connecting);
-
-  // The old single budget would have expired 1s from here. The server gets a
-  // full budget of its own instead.
-  await vi.advanceTimersByTimeAsync(CONNECT_TIMEOUT_MS - 1_000);
-  await tickAFewTimes(vi);
-  expect(connectTimeoutErrors(z)).toEqual([]);
-  expect(z.connectionStatus).toBe(ConnectionStatus.Connecting);
-
-  await z.triggerConnected();
-  expect(z.connectionStatus).toBe(ConnectionStatus.Connected);
 });
 
 test('connect timeout retries when AbortController drops abort reasons', async () => {
@@ -3022,7 +3029,7 @@ test('connect timeout during setup retries without an unhandled rejection', asyn
   };
   window.addEventListener('unhandledrejection', onUnhandled);
 
-  vi.spyOn(ActiveClientsManager, 'create').mockReturnValue(
+  vi.spyOn(DeleteClientsManager.prototype, 'getDeletedClients').mockReturnValue(
     new Promise(() => {}),
   );
 
@@ -3057,6 +3064,8 @@ test('connect timeout during setup retries without an unhandled rejection', asyn
       'reading the cookie',
       'reading the client group ID',
       'initializing active clients',
+      'reading the profile ID',
+      'reading deleted clients',
     ]);
 
     await tickAFewTimes(vi, RUN_LOOP_INTERVAL_MS);
@@ -3064,6 +3073,27 @@ test('connect timeout during setup retries without an unhandled rejection', asyn
   } finally {
     window.removeEventListener('unhandledrejection', onUnhandled);
   }
+});
+
+test('a hung initialization stays initializing and makes no connect attempt', async () => {
+  // Retrying cannot unstick the local store, since every attempt would await
+  // the same promise, and the server has not been asked anything, so there is
+  // nothing to time out.
+  vi.spyOn(ActiveClientsManager, 'create').mockReturnValue(
+    new Promise(() => {}),
+  );
+
+  const z = zeroForTest({logLevel: 'debug'});
+  await vi.advanceTimersByTimeAsync(DEFAULT_DISCONNECT_TIMEOUT_MS * 2);
+  await tickAFewTimes(vi, 0);
+
+  expect(z.connectionStatus).toBe(ConnectionStatus.Initializing);
+  expect(
+    z.testLogSink.messages.filter(
+      ([level, _context, messages]) =>
+        level === 'info' && messages.includes('Connecting...'),
+    ),
+  ).toEqual([]);
 });
 
 test('socketOrigin', async () => {
@@ -4983,11 +5013,15 @@ test('We should send a deleteClient when a Zero instance is closed', async () =>
 
 describe('Zero replicache refresh integration', () => {
   describe('enableRefresh', () => {
-    test('enableRefresh is false when Connecting or Connected, true when Error', async () => {
+    test('enableRefresh is false when Initializing, Connecting or Connected, true when Error', async () => {
       const z = zeroForTest();
 
-      // Initial state: Connecting
-      expect(z.connectionStatus).toBe(ConnectionStatus.Connecting);
+      // Initial state: Initializing
+      expect(z.connectionStatus).toBe(ConnectionStatus.Initializing);
+      // enableRefresh should be false while about to connect
+      expect(z.enableRefresh()).toBe(false);
+
+      await z.waitForConnectionStatus(ConnectionStatus.Connecting);
       // enableRefresh should be false during connecting
       expect(z.enableRefresh()).toBe(false);
 

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -920,14 +920,15 @@ export class Zero<
   }
 
   #enableRefresh(): boolean {
-    // Don't refresh if connected or connecting, unless #forceEnableRefresh to
-    // avoid receiving new snapshots from refresh before receiving the new
-    // snapshot via poke from the connection (which results in a "unexpected
-    // base cookie for poke" error).
+    // Don't refresh if connected, connecting, or about to connect, unless
+    // #forceEnableRefresh to avoid receiving new snapshots from refresh before
+    // receiving the new snapshot via poke from the connection (which results
+    // in a "unexpected base cookie for poke" error).
     return (
       this.#forceEnableRefresh ||
       (!this.#connectionManager.is(ConnectionStatus.Connected) &&
-        !this.#connectionManager.is(ConnectionStatus.Connecting))
+        !this.#connectionManager.is(ConnectionStatus.Connecting) &&
+        !this.#connectionManager.is(ConnectionStatus.Initializing))
     );
   }
 
@@ -1972,6 +1973,7 @@ export class Zero<
         lc.debug?.('disconnect() called while closed');
         return;
 
+      case ConnectionStatus.Initializing:
       case ConnectionStatus.Disconnected:
       case ConnectionStatus.Connecting:
       case ConnectionStatus.NeedsAuth:
@@ -2196,6 +2198,24 @@ export class Zero<
     const {auth} = this.#options;
     this.#setAuth(auth);
 
+    // Wait for the local work every connect attempt starts with: the replica
+    // loaded (the cookie is read once it is), the client group ID and the
+    // active clients. On a slow device with a large replica this takes tens of
+    // seconds, and none of it depends on the server, so it happens in
+    // `initializing` instead of spending the connecting window and the setup
+    // deadline of the first attempts.
+    try {
+      await Promise.all([
+        this.#rep.cookie,
+        this.clientGroupID,
+        this.#activeClientsManager,
+      ]);
+    } catch {
+      // The first connect attempt awaits the same promises and reports the
+      // failure through the usual disconnect path.
+    }
+    this.#connectionManager.initialized();
+
     let backoffMs: number | undefined;
     let additionalConnectParams: Record<string, string> | undefined;
 
@@ -2404,6 +2424,10 @@ export class Zero<
           case ConnectionStatus.Closed:
             // run loop will terminate
             break;
+
+          case ConnectionStatus.Initializing:
+            // initialized() is called before the loop starts.
+            unreachable();
 
           default:
             unreachable(currentState);

--- a/packages/zero-client/src/client/zero.ts
+++ b/packages/zero-client/src/client/zero.ts
@@ -2204,15 +2204,30 @@ export class Zero<
     // seconds, and none of it depends on the server, so it happens in
     // `initializing` instead of spending the connecting window and the setup
     // deadline of the first attempts.
+    // A local store that never finishes loading must not keep the run loop
+    // alive past close().
+    const {signal: closeSignal} = this.#closeAbortController;
+    const closed = resolver<void>();
+    const onClose = () => closed.resolve();
+    closeSignal.addEventListener('abort', onClose, {once: true});
     try {
-      await Promise.all([
-        this.#rep.cookie,
-        this.clientGroupID,
-        this.#activeClientsManager,
-      ]);
+      const result = await promiseRace({
+        initialized: Promise.all([
+          this.#rep.cookie,
+          this.clientGroupID,
+          this.#activeClientsManager,
+        ]),
+        closed: closed.promise,
+      });
+      if (result.key === 'closed') {
+        this.#lc.debug?.('Closed while initializing, not connecting');
+        return;
+      }
     } catch {
       // The first connect attempt awaits the same promises and reports the
       // failure through the usual disconnect path.
+    } finally {
+      closeSignal.removeEventListener('abort', onClose);
     }
     this.#connectionManager.initialized();
 

--- a/packages/zero-client/tsconfig.json
+++ b/packages/zero-client/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "lib": ["ES2023", "DOM", "DOM.Iterable", "ESNext.Disposable"],
     "declaration": true,
     "declarationMap": true,
     "rootDir": "../",

--- a/packages/zero-client/tsconfig.json
+++ b/packages/zero-client/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "lib": ["ES2023", "DOM", "DOM.Iterable", "ESNext.Disposable"],
     "declaration": true,
     "declarationMap": true,
     "rootDir": "../",


### PR DESCRIPTION
## The defect

Zero's first connect attempt starts by loading the local store: the replica is opened and loaded into the IVM sources before the cookie can be read, and then the client group ID and active clients are read. On a slow Android device with a few thousand rows that takes 23–33 s. All of it happened in `connecting`:

- `ConnectionManager` started the 60 s connecting window in its constructor, so local loading used up the time the server was supposed to get before Zero reported `disconnected`.
- The setup deadline from #6475 expired during the load, so the first few attempts timed out with `ConnectTimeout` against a server that had not been asked anything yet.
- From outside, a loading store and an unreachable server looked the same. Host availability logic that starts a timer at the first `connecting` showed "service down" on every cold launch while production was healthy.

## The change

A new `initializing` state comes before `connecting`, on both `ConnectionManager` and the public `ConnectionState`.

- `ConnectionManager` starts in `initializing`, with no connecting window and no timeout interval.
- The run loop waits for the local store before it starts: the cookie (which Replicache only yields once the replica is loaded), the client group ID and the active clients. It then calls the new `initialized()`, which moves to exactly the state the constructor used to create: `connecting`, `attempt: 0`, window starting now.
- `initialized()` does nothing if something else, like `close()`, has already moved the state on.
- If loading fails, the error is not handled there. The first connect attempt awaits the same promises and reports the failure through the usual disconnect path, as before.
- `initializing` is entered once per instance. Reconnects never go back to it, because the store is already loaded.
- Refresh stays disabled in `initializing`, as it was while this window was `connecting`. Mutations are not rejected in it.

Hosts can now tell a loading replica from an unreachable server by starting their timers at `connecting` instead of at creation.

## Compatibility

`ConnectionState` gains a member, so user code with an exhaustive `switch` on `state.name` will fail to compile until it handles `'initializing'`. A non-breaking alternative would have been a `phase` field on `connecting`. I went with a separate state because the two phases fail for unrelated reasons and should read differently.

## Trade-off

A local store that never finishes loading now stays in `initializing` forever with no retries, where it used to retry every 10 s and eventually report `disconnected`. The retries could never succeed, since every attempt awaited the same promise, and `disconnected` blamed the network. Hosts that want to cap it can put their own timeout on `initializing`.

## Tests

- `ConnectionManager`: tests that the constructor starts in `initializing` with no timer and never times out there, that `initialized()` starts the window when it is called, respects a custom timeout, and does nothing once the state has moved on. Existing tests that assumed a `connecting` start now call `initialized()` first.
- New: slow initialization (longer than both the setup deadline and the connecting window) stays `initializing`, produces no connect timeouts, then connects.
- New: a hung initialization stays `initializing` and makes no connect attempt.
- The #6475 setup-deadline tests used to make `ActiveClientsManager.create` slow or hang, and that is now part of initialization. They now stall `getDeletedClients` inside socket preparation instead, which the setup deadline still covers.
- `slow setup does not spend the server acknowledgement budget` was in `zero.test.ts` twice, verbatim. The copy is removed.
