### PR TITLE
fix(zero-cache): replication bugs

### DIFF
--- a/packages/zero-cache/src/services/change-source/pg/change-source.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.test.ts
@@ -214,7 +214,7 @@ test('acker', () => {
     expect(sink.push).toBeCalledTimes(acks);
   };
 
-  const acker = new Acker(sink);
+  const acker = new Acker(sink, null);
 
   acker.onChange(['status', {ack: false}, {watermark: '0a'}]);
   expectAck(10n);
@@ -248,6 +248,29 @@ test('acker', () => {
   // Now that downstream is caught up, this should respond
   acker.onChange(['status', {ack: false}, {watermark: '0h'}]);
   expectAck(17n);
+});
+
+// A stream resumes from the change-streamer's change log, which can be ahead of
+// what it has persisted durably (its backup). Until the change-streamer acks
+// the resume watermark, a keepalive past it is not acked: the slot would move
+// past transactions that a task restored from that backup still needs.
+test('acker waits for the resume watermark before acking keepalives', () => {
+  const sink = {push: vi.fn()};
+  const acker = new Acker(sink, '0c');
+
+  acker.onChange(['status', {ack: false}, {watermark: '0d'}]);
+  expect(sink.push).not.toHaveBeenCalled();
+
+  // The backup is behind the resume watermark: acked, but still waiting.
+  acker.ack('0a');
+  expect(sink.push).toHaveBeenLastCalledWith(10n);
+  acker.onChange(['status', {ack: false}, {watermark: '0e'}]);
+  expect(sink.push).toHaveBeenCalledTimes(1);
+
+  acker.ack('0c');
+  expect(sink.push).toHaveBeenLastCalledWith(12n);
+  acker.onChange(['status', {ack: false}, {watermark: '0f'}]);
+  expect(sink.push).toHaveBeenLastCalledWith(15n);
 });
 
 test('lag reporter retries missing reports', async () => {

--- a/packages/zero-cache/src/services/change-source/pg/change-source.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.ts
@@ -506,7 +506,7 @@ export class PostgresChangeSource implements ChangeSource {
       undefined,
       this.#streamInboundTimeoutMs,
     );
-    const acker = new Acker(acks);
+    const acker = new Acker(acks, clientWatermark);
 
     // The ChangeStreamMultiplexer facilitates cooperative streaming from
     // the main replication stream and backfill streams initiated by the
@@ -762,10 +762,19 @@ export class PostgresChangeSource implements ChangeSource {
 // Exported for testing.
 export class Acker implements Listener {
   #acks: Sink<bigint>;
-  #waitingForDownstreamAck: string | null = null;
+  #waitingForDownstreamAck: string | null;
 
-  constructor(acks: Sink<bigint>) {
+  /**
+   * @param resumeWatermark the watermark the stream resumes after. What came
+   *     before it was received on an earlier connection, and only the
+   *     change-streamer knows whether it has persisted it, so keepalives are
+   *     not acked until the change-streamer has acked it. A change-streamer
+   *     whose SQLite change log is ahead of its backup would otherwise have
+   *     the slot moved past transactions that only that log holds.
+   */
+  constructor(acks: Sink<bigint>, resumeWatermark: string | null) {
     this.#acks = acks;
+    this.#waitingForDownstreamAck = resumeWatermark;
   }
 
   onChange(change: ChangeStreamMessage): void {

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.pg.test.ts
@@ -1,4 +1,5 @@
 import {existsSync, writeFileSync} from 'node:fs';
+import {getDefaultHighWaterMark, setDefaultHighWaterMark} from 'node:stream';
 import {PG_LOCK_NOT_AVAILABLE} from '@drdgvhbh/postgres-error-codes';
 import {LogContext} from '@rocicorp/logger';
 import {resolver} from '@rocicorp/resolver';
@@ -4571,6 +4572,106 @@ describe('change-streamer/service', () => {
     });
 
     await streamer.stop();
+  });
+
+  // A commit forwarded with flow control is whole while the streamer waits for
+  // a slow subscriber to consume it. A source that dies during that wait must
+  // not roll it back: the subscriber would be sent a rollback after the commit,
+  // and the streamer's transaction bookkeeping failed its run.
+  test('a source that dies while a forwarded commit awaits flow control does not roll it back', async () => {
+    const highWaterMark = getDefaultHighWaterMark(false);
+    // Read by run() as the flush threshold: every forward awaits flow control.
+    setDefaultHighWaterMark(false, 1);
+    try {
+      const changes1 = Subscription.create<ChangeStreamMessage>();
+      const reconnected = resolver<void>();
+      const startStream = vi
+        .fn()
+        .mockImplementationOnce(() =>
+          Promise.resolve({
+            initialWatermark: '01',
+            changes: changes1,
+            acks: {push: () => {}},
+          }),
+        )
+        .mockImplementation(() => {
+          reconnected.resolve();
+          return resolver().promise;
+        });
+      const source = {
+        startStream,
+        startLagReporter: () => null,
+        stop: () => Promise.resolve(),
+      } satisfies ChangeSource;
+
+      const streamer = await initializeStreamer(
+        lc,
+        shard,
+        'task-id',
+        'change.streamer:54321',
+        'ws',
+        sql,
+        source,
+        ReplicationStatusPublisher.forTesting(),
+        replicaConfig,
+        null,
+        null,
+        true,
+        opts,
+      );
+      await run(streamer);
+
+      const sub = await streamer.subscribe({
+        protocolVersion: PROTOCOL_VERSION,
+        taskID: 'task-id',
+        id: 'myid',
+        mode: 'serving',
+        watermark: '01',
+        replicaVersion: REPLICA_VERSION,
+        initial: true,
+        logsChangeStream: false,
+      });
+      // Pulled one at a time. A message is consumed, which is what completes
+      // its flow control, only when the next one is pulled.
+      const downstream = sub[Symbol.asyncIterator]();
+      const next = async () => {
+        const {value} = await downstream.next();
+        return (BigIntJSON.parse(value) as Downstream)[1];
+      };
+
+      expect(await next()).toMatchObject({tag: 'status'});
+      // Until its catchup ends, a subscriber buffers live changes in a backlog,
+      // which does not wait for them to be consumed.
+      await vi.waitFor(() =>
+        expect(
+          logSink.messages.some(
+            ([, , [msg]]) =>
+              typeof msg === 'string' &&
+              msg.includes('myid') &&
+              (msg.startsWith('caught up') ||
+                msg.includes('ahead of the latest durable watermark')),
+          ),
+        ).toBe(true),
+      );
+
+      changes1.push(['begin', messages.begin(), {commitWatermark: '09'}]);
+      changes1.push(['data', messages.insert('foo', {id: 'hello'})]);
+      changes1.push(['commit', messages.commit(), {watermark: '09'}]);
+
+      expect(await next()).toMatchObject({tag: 'begin'});
+      expect(await next()).toMatchObject({tag: 'insert'});
+      expect(await next()).toMatchObject({tag: 'commit'});
+
+      // The commit is not consumed, so the streamer is waiting on it.
+      changes1.fail(new Error('source died'));
+
+      expect(await orTimeout(reconnected.promise, 2_000)).toBeUndefined();
+      expect(await orTimeout(downstream.next(), 100)).toBe('timed-out');
+
+      await streamer.stop();
+    } finally {
+      setDefaultHighWaterMark(false, highWaterMark);
+    }
   });
 
   test('ownership takeover before tx begins', async () => {

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -761,7 +761,15 @@ class ChangeStreamerImpl implements ChangeStreamerService {
         }
         watermark = null;
 
-        this.#acker.reset(stream.acks);
+        // With the PG change log enabled, the stream resumes from what it has
+        // persisted, so nothing before the stream is outstanding. Otherwise it
+        // resumes from the SQLite change log's head, which the backup can
+        // trail.
+        this.#acker.reset(
+          stream.acks,
+          this.#pgChangeLogEnabled ? '' : lastWatermark,
+        );
+
         for await (const change of stream.changes) {
           this.#acker.trackDownstream(change);
 

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-service.ts
@@ -834,10 +834,10 @@ class ChangeStreamerImpl implements ChangeStreamerService {
           this.#changeLogWriter?.write(change, json, serialized.change);
           const entry: WatermarkedChange = [watermark, change[1].tag, json];
           unflushedBytes += json.length;
+          let flowControl: Promise<void> | undefined;
           if (unflushedBytes < flushBytesThreshold) {
             // pipeline changes until flushBytesThreshold
             this.#forwarder.forward(entry);
-            this.#recordForwardedTransactionBoundary(type, entry[0]);
           } else {
             // Wait for messages to clear socket buffers to ensure that they
             // make their way to subscribers. Without this `await`, the
@@ -846,22 +846,25 @@ class ChangeStreamerImpl implements ChangeStreamerService {
             // (2) prevents subscribers from processing the messages as they
             //     arrive, instead getting them in a large batch after being
             //     idle while they were queued (causing further delays).
-            const forwarded = this.#forwarder.forwardWithFlowControl(entry);
-            // forwardWithFlowControl synchronously sends the entry and updates
-            // the Forwarder's transaction state before returning its flow-
-            // control promise. Record the boundary before awaiting that promise
-            // so registrations during the wait observe the forwarded state.
-            this.#recordForwardedTransactionBoundary(type, entry[0]);
+            flowControl = this.#forwarder.forwardWithFlowControl(entry);
+          }
+          // Both forwards send the entry and update the Forwarder's transaction
+          // state synchronously. Record the boundary, and end the transaction at
+          // its commit or rollback, before awaiting flow control: registrations
+          // during the wait then observe the forwarded state, and a stream that
+          // is interrupted during the wait does not roll back a transaction
+          // that was already forwarded whole.
+          this.#recordForwardedTransactionBoundary(type, entry[0]);
+          if (type === 'commit' || type === 'rollback') {
+            watermark = null;
+          }
+          if (flowControl) {
             await promiseOrAbort(
-              forwarded,
+              flowControl,
               stream.changes.signal,
               this.#state.signal,
             );
             unflushedBytes = 0;
-          }
-
-          if (type === 'commit' || type === 'rollback') {
-            watermark = null;
           }
 
           // Allow the PG storer to exert back pressure when it is enabled.

--- a/packages/zero-cache/src/services/change-streamer/upstream-acker.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/upstream-acker.test.ts
@@ -37,7 +37,7 @@ describe('change-streamer/upstream-acker', () => {
       trackBackup: false,
     });
     const {sink: upstream, acked} = sink();
-    acker.reset(upstream);
+    acker.reset(upstream, '01');
 
     acker.trackDownstream(commit('05'));
     expect(acked).toEqual([]);
@@ -52,7 +52,7 @@ describe('change-streamer/upstream-acker', () => {
       trackBackup: true,
     });
     const {sink: upstream, acked} = sink();
-    acker.reset(upstream);
+    acker.reset(upstream, '01');
 
     acker.trackDownstream(commit('05'));
     expect(acked).toEqual([]);
@@ -67,7 +67,7 @@ describe('change-streamer/upstream-acker', () => {
       trackBackup: true,
     });
     const {sink: upstream, acked} = sink();
-    acker.reset(upstream);
+    acker.reset(upstream, '01');
 
     acker.trackDownstream(commit('05'));
 
@@ -87,7 +87,7 @@ describe('change-streamer/upstream-acker', () => {
       trackBackup: true,
     });
     const {sink: upstream, acked} = sink();
-    acker.reset(upstream);
+    acker.reset(upstream, '01');
 
     acker.trackDownstream(commit('05'));
     acker.trackDownstream(commit('0a'));
@@ -111,7 +111,7 @@ describe('change-streamer/upstream-acker', () => {
       trackBackup: false,
     });
     const {sink: upstream, acked} = sink();
-    acker.reset(upstream);
+    acker.reset(upstream, '01');
 
     acker.trackDownstream(commit('05'));
     acker.trackPgChangeLog('05');
@@ -125,7 +125,7 @@ describe('change-streamer/upstream-acker', () => {
       trackBackup: false,
     });
     const {sink: upstream, acked} = sink();
-    acker.reset(upstream);
+    acker.reset(upstream, '01');
 
     acker.trackDownstream(commit('05'));
     acker.trackDownstream(status('06'));
@@ -139,16 +139,45 @@ describe('change-streamer/upstream-acker', () => {
     ]);
   });
 
-  test('acks a status watermark immediately if there are no outstanding commits', () => {
+  test('acks a status watermark immediately if the stores are at the resume watermark', () => {
     const acker = new UpstreamAcker({
       trackPgChangeLog: true,
       trackBackup: false,
     });
+    acker.trackPgChangeLog('01');
     const {sink: upstream, acked} = sink();
-    acker.reset(upstream);
+    acker.reset(upstream, '01');
 
     acker.trackDownstream(status('06'));
-    expect(acked).toEqual([['status', {ack: true}, {watermark: '06'}]]);
+    expect(acked).toEqual([
+      ['status', {tag: 'commit'}, {watermark: '01'}],
+      ['status', {ack: true}, {watermark: '06'}],
+    ]);
+  });
+
+  // A stream resumes from the head of the SQLite change log, which is normally
+  // ahead of its backup. The transactions in between were committed on an
+  // earlier connection, and only the log holds them. A keepalive past them is
+  // not acked until the backup has them: acking it would move the slot past
+  // them, and a task restored from the backup would resume below the slot.
+  test('does not ack a status watermark past a resume watermark that the stores have not reached', () => {
+    const acker = new UpstreamAcker({
+      trackPgChangeLog: false,
+      trackBackup: true,
+    });
+    acker.trackBackup('03');
+    const {sink: upstream, acked} = sink();
+    acker.reset(upstream, '05');
+
+    acker.trackDownstream(status('06'));
+    expect(acked).toEqual([['status', {tag: 'commit'}, {watermark: '03'}]]);
+
+    acker.trackBackup('05');
+    expect(acked).toEqual([
+      ['status', {tag: 'commit'}, {watermark: '03'}],
+      ['status', {tag: 'commit'}, {watermark: '05'}],
+      ['status', {ack: true}, {watermark: '06'}],
+    ]);
   });
 
   test('ignores status messages that do not request an ack', () => {
@@ -157,7 +186,7 @@ describe('change-streamer/upstream-acker', () => {
       trackBackup: false,
     });
     const {sink: upstream, acked} = sink();
-    acker.reset(upstream);
+    acker.reset(upstream, '01');
 
     acker.trackDownstream(status('06', false));
     expect(acked).toEqual([]);
@@ -169,7 +198,7 @@ describe('change-streamer/upstream-acker', () => {
       trackBackup: false,
     });
     const {sink: upstream1, acked: acked1} = sink();
-    acker.reset(upstream1);
+    acker.reset(upstream1, '01');
 
     acker.trackDownstream(commit('0a'));
     acker.trackPgChangeLog('0a');
@@ -182,7 +211,7 @@ describe('change-streamer/upstream-acker', () => {
     // without waiting for another trackPgChangeLog() call, which may never
     // come for a watermark that was already processed.
     const {sink: upstream2, acked: acked2} = sink();
-    acker.reset(upstream2);
+    acker.reset(upstream2, '05');
     acker.trackDownstream(commit('05'));
     expect(acked2).toEqual([['status', {tag: 'commit'}, {watermark: '0a'}]]);
   });
@@ -193,7 +222,7 @@ describe('change-streamer/upstream-acker', () => {
       trackBackup: false,
     });
     const {sink: upstream1, acked: acked1} = sink();
-    acker.reset(upstream1);
+    acker.reset(upstream1, '01');
 
     acker.trackDownstream(commit('05'));
     acker.trackPgChangeLog('05');
@@ -203,7 +232,7 @@ describe('change-streamer/upstream-acker', () => {
     // watermark once persisted, since the store watermarks (unlike the
     // per-connection tracking) survive the reset.
     const {sink: upstream2, acked: acked2} = sink();
-    acker.reset(upstream2);
+    acker.reset(upstream2, '05');
     expect(acked2).toEqual([]);
 
     acker.trackPgChangeLog('05');

--- a/packages/zero-cache/src/services/change-streamer/upstream-acker.ts
+++ b/packages/zero-cache/src/services/change-streamer/upstream-acker.ts
@@ -50,9 +50,25 @@ export class UpstreamAcker {
     this.#trackBackup = trackBackup;
   }
 
-  reset(upstream: Sink<ChangeSourceUpstream>) {
+  /**
+   * Starts tracking a new upstream connection, which resumes the change stream
+   * after `resumeWatermark`.
+   *
+   * Everything at or before `resumeWatermark` was committed on an earlier
+   * connection, so it counts as committed on this one: a status watermark past
+   * it waits for the tracked stores to reach it, as it would for a commit on
+   * this connection. Otherwise the first keepalive of a stream that resumes
+   * ahead of the stores -- a SQLite change log ahead of its backup, which is
+   * the normal state -- would move the replication slot past transactions that
+   * no store has persisted, and a task restored from the backup would then
+   * resume below the slot, which the upstream moves forward without a word.
+   *
+   * Pass `''` when the stream resumes from what a tracked store has itself
+   * persisted, which leaves nothing before it outstanding.
+   */
+  reset(upstream: Sink<ChangeSourceUpstream>, resumeWatermark: string) {
     this.#upstream = upstream;
-    this.#lastTx = '';
+    this.#lastTx = resumeWatermark;
     this.#lastStatus = '';
     this.#lastAck = '';
   }
@@ -67,7 +83,8 @@ export class UpstreamAcker {
         this.#maybeAck();
         break;
       case 'commit':
-        this.#lastTx = downstream[2].watermark;
+        // A commit replayed from below the resume watermark does not lower it.
+        this.#lastTx = max(this.#lastTx, downstream[2].watermark);
         this.#maybeAck();
         break;
     }

--- a/packages/zero-cache/src/services/replicator/change-processor.test.ts
+++ b/packages/zero-cache/src/services/replicator/change-processor.test.ts
@@ -3832,6 +3832,72 @@ describe('replicator/change-processor-errors', () => {
     expect(replica.inTransaction).toBe(false);
   });
 
+  // A rollback message ends a transaction that the stream interrupted. When
+  // that transaction had changed the schema, the processor kept the table
+  // specs of the schema the rollback undid, so the replayed transaction failed
+  // on a table or column that, as far as it knew, no longer existed.
+  test('a rolled back schema change leaves the table specs as they were', () => {
+    const failures: unknown[] = [];
+    const processor = createChangeProcessor(replica, (_, err) =>
+      failures.push(err),
+    );
+    const bar = new ReplicationMessages({bar: 'id'});
+
+    processor.processMessage(lc, [
+      'begin',
+      bar.begin(),
+      {commitWatermark: '0a'},
+    ]);
+    processor.processMessage(lc, [
+      'data',
+      bar.createTable({
+        schema: 'public',
+        name: 'bar',
+        columns: {
+          id: {pos: 0, dataType: 'int8'},
+          value: {pos: 1, dataType: 'text'},
+        },
+        primaryKey: ['id'],
+      }),
+    ]);
+    processor.processMessage(lc, ['commit', bar.commit(), {watermark: '0a'}]);
+
+    // Interrupted: a rename, then the rollback the change-streamer sends.
+    processor.processMessage(lc, [
+      'begin',
+      bar.begin(),
+      {commitWatermark: '0b'},
+    ]);
+    processor.processMessage(lc, ['data', bar.renameTable('bar', 'baz')]);
+    processor.processMessage(lc, ['rollback', {tag: 'rollback'}]);
+
+    // Interrupted: a dropped column, then the rollback.
+    processor.processMessage(lc, [
+      'begin',
+      bar.begin(),
+      {commitWatermark: '0b'},
+    ]);
+    processor.processMessage(lc, ['data', bar.dropColumn('bar', 'value')]);
+    processor.processMessage(lc, ['rollback', {tag: 'rollback'}]);
+
+    // The replayed transaction writes to the schema as it still is.
+    processor.processMessage(lc, [
+      'begin',
+      bar.begin(),
+      {commitWatermark: '0b'},
+    ]);
+    processor.processMessage(lc, [
+      'data',
+      bar.insert('bar', {id: 1, value: 'kept'}),
+    ]);
+    processor.processMessage(lc, ['commit', bar.commit(), {watermark: '0b'}]);
+
+    expect(failures).toEqual([]);
+    expectTables(replica, {
+      bar: [{id: 1, value: 'kept', ['_0_version']: '0b'}],
+    });
+  });
+
   test('wraps oversized update binding errors with context', () => {
     const failures: unknown[] = [];
     const processor = new ChangeProcessor(

--- a/packages/zero-cache/src/services/replicator/change-processor.ts
+++ b/packages/zero-cache/src/services/replicator/change-processor.ts
@@ -1013,6 +1013,10 @@ class TransactionProcessor {
   abort(lc: LogContext) {
     lc.info?.(`aborting transaction ${this.#version}`);
     this.#db.rollback();
+    // A schema change in the transaction reloaded the table specs, which now
+    // describe the schema that the rollback undid. Clearing them makes the
+    // next transaction reload them from the database.
+    this.#tableSpecs.clear();
   }
 }
 


### PR DESCRIPTION
Had Claude write and run deterministic simulation tests all night. It found 2 pre-existing RM bugs and 1 new RMv2 bug.

----

`mlaw/replication-fixes` adds 3 commits on top of `origin/main`. Each one fixes a separate bug, and the replication simulation found all three. Each bug happens when a change stream is cut off and then starts again.

```text
Postgres slot ──changes──► change-source ──► change-streamer ──► replicator
      ▲                     Acker ①           UpstreamAcker ①     TransactionProcessor ③
      └────── acks ─────────┘                 run() loop ②
```

## ① The slot is acked past what the backup holds, which leaves a silent gap (`13a539ed2`)

This happens when the PG change log is off. On reconnect, the stream resumes after the SQLite log's head, and the backup is normally behind that head.

```text
LSN ─────────●────────────────────●────────────────────●──────►
           backup          SQLite log head        first status
             └── only the log has these ──┘       or keepalive
                                                       ▲
                                     before: both ackers ack here at once
task dies → restored from backup → startStream(after backup)
  Postgres starts at the slot → (backup … head] is never sent, and nothing errors
```

```diff
 UpstreamAcker.reset(upstream, resumeWatermark)
-  lastTx = ''                                // nothing looks outstanding
+  lastTx = resumeWatermark                   // log head, or '' with the PG change log on
 on commit
-  lastTx = commit.watermark
+  lastTx = max(lastTx, commit.watermark)     // a replayed commit can't lower it

 new Acker(acks, clientWatermark)             // change-source side
-  waitingForDownstreamAck = null             // keepalives acked at once
+  waitingForDownstreamAck = clientWatermark  // wait for the streamer's first ack ≥ it
```

`#maybeAck` acks a status only when `lastAck ≥ lastTx`. With this fix, it waits until the backup has reached the log head.

## ② A commit that already went out is followed by a rollback (`cf196bd01`)

Past the flush threshold, the loop waits on flow control for a slow subscriber. `watermark` was only cleared after that wait finished.

```diff
 for await change of stream
   begin → watermark = commitWatermark
   forward(entry) or forwardWithFlowControl(entry)
   recordForwardedTransactionBoundary(type)
+  if commit/rollback: watermark = null
   if past flush threshold
     await flowControl                     ← the source fails during this wait
-  if commit/rollback: watermark = null    ← never reached
 after the stream is cut off
   if watermark: forward rollback
```

```text
subscriber before:  begin 09 · insert · commit 09 · rollback 09   (the streamer's boundary bookkeeping also failed the run)
subscriber after:   begin 09 · insert · commit 09
```

## ③ The replayed transaction fails on a schema the rollback undid (`23fee46aa`)

`ChangeProcessor` has one `tableSpecs` map that all transactions share. So specs loaded by a transaction that was rolled back were still there for the next one.

```text
tx 0b (cut off)
  rename bar → baz      specs reloaded            specs {baz}
rollback → abort()
  db.rollback()         replica {bar}             specs {baz}  ← stale
tx 0b (replayed)
  insert into bar       no spec for bar → replicator stops
```

```diff
 abort()
   db.rollback()
+  tableSpecs.clear()    // the next tx sees an empty map and reloads from the replica
```