### PR TITLE
fix(oxlint-plugin-zero): load the plugin by path, and match includes on either separator

### DIFF
--- a/oxlint.base.ts
+++ b/oxlint.base.ts
@@ -1,9 +1,12 @@
+import {fileURLToPath} from 'node:url';
 import type {OxlintConfig} from 'oxlint';
 
-const zeroPlugin = new URL(
-  './tools/oxlint-plugin-zero/index.js',
-  import.meta.url,
-).pathname;
+// fileURLToPath, not URL.pathname: pathname is a URL path, so on Windows it is
+// '/C:/…' and oxlint cannot load the plugin from it — which aborts the whole
+// lint run rather than degrading.
+const zeroPlugin = fileURLToPath(
+  new URL('./tools/oxlint-plugin-zero/index.js', import.meta.url),
+);
 
 /**
  * Shared oxlint configuration for all packages in the monorepo.

--- a/oxlint.base.ts
+++ b/oxlint.base.ts
@@ -1,11 +1,14 @@
-import {fileURLToPath} from 'node:url';
+import {join} from 'node:path';
 import type {OxlintConfig} from 'oxlint';
 
-// fileURLToPath, not URL.pathname: pathname is a URL path, so on Windows it is
-// '/C:/…' and oxlint cannot load the plugin from it — which aborts the whole
-// lint run rather than degrading.
-const zeroPlugin = fileURLToPath(
-  new URL('./tools/oxlint-plugin-zero/index.js', import.meta.url),
+// `import.meta.dirname`, not a file: URL's `.pathname`: a pathname is a URL path,
+// so on Windows it is '/C:/…' and oxlint cannot load a plugin from it — which
+// aborts the whole lint run rather than degrading. Taking the directory directly
+// means no URL is constructed, so there is nothing to convert and nothing to get
+// wrong.
+const zeroPlugin = join(
+  import.meta.dirname,
+  'tools/oxlint-plugin-zero/index.js',
 );
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1887,6 +1887,21 @@ importers:
         specifier: workspace:*
         version: link:../../packages/shared
 
+  tools/oxlint-plugin-zero:
+    devDependencies:
+      oxfmt:
+        specifier: ^0.65.0
+        version: 0.65.0
+      oxlint:
+        specifier: ^1.80.0
+        version: 1.80.0(oxlint-tsgolint@7.0.2001)
+      typescript:
+        specifier: ~7.0.2
+        version: 7.0.2
+      vitest:
+        specifier: ^4.1.6
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/browser-playwright@5.0.0(playwright@1.60.0)(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0))(vitest@5.0.0))(@vitest/coverage-v8@5.0.0(@vitest/browser@5.0.0)(vitest@5.0.0))(@vitest/ui@5.0.0(vitest@5.0.0))(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0))
+
   tools/process-tracker:
     dependencies:
       '@rocicorp/logger':
@@ -6455,6 +6470,9 @@ packages:
       '@vitest/browser':
         optional: true
 
+  '@vitest/expect@4.1.11':
+    resolution: {integrity: sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==}
+
   '@vitest/istanbul-lib-coverage@1.0.1':
     resolution: {integrity: sha512-k3DJZ8LhMBK9NS4SclF1ASD3OgXEWDorbIcPTRDK0/Zae6fRvu+fJRxtFdLfHsa9Y24beCdPnoNZ4LviTNstfA==}
     engines: {node: '>=22'}
@@ -6462,6 +6480,17 @@ packages:
   '@vitest/istanbul-lib-report@1.0.1':
     resolution: {integrity: sha512-1EOLRfsTMnyAr3+kEAsP4o9dhaDlGPpD7H5iLBBeq//YpNB1VIahkPhB+eRp9N2Dkfw8oySROjE3yf9XDeaIkQ==}
     engines: {node: '>=22'}
+
+  '@vitest/mocker@4.1.11':
+    resolution: {integrity: sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
 
   '@vitest/mocker@5.0.0':
     resolution: {integrity: sha512-66PGTMIiVJP3t4a5yxU9qPtf7MdTBs8jmToMvy+HVflB3Yy13WJZTtPePdvU+wjRV02SKK5doLbSA6o9pwOmiA==}
@@ -6474,11 +6503,23 @@ packages:
       vite:
         optional: true
 
+  '@vitest/pretty-format@4.1.11':
+    resolution: {integrity: sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==}
+
   '@vitest/pretty-format@4.1.6':
     resolution: {integrity: sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==}
 
   '@vitest/pretty-format@5.0.0':
     resolution: {integrity: sha512-PVRNuB3wpReb4SQEs4zTKM4KWFhQ5pw3spE8naoDJNB5T5aWRzGKHwXcLUllr0WeOTXpB6bSr3CJLo5+7XQSSQ==}
+
+  '@vitest/runner@4.1.11':
+    resolution: {integrity: sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==}
+
+  '@vitest/snapshot@4.1.11':
+    resolution: {integrity: sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==}
+
+  '@vitest/spy@4.1.11':
+    resolution: {integrity: sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==}
 
   '@vitest/spy@5.0.0':
     resolution: {integrity: sha512-uy+luWBAPw9XfthoHi5AkfHUnuPYEESjl0p/r+meoBnU8bxg5GDQ3Ey8MjcJ6sqahkL4PFyrvfMJJBw7LbU06g==}
@@ -6487,6 +6528,9 @@ packages:
     resolution: {integrity: sha512-h2FIFwggCY2GxUd2UdQoYNVQkOIqEQLPhNREcl3FUiRsdzQep7NWwYbSmhGEA9nFLPDq5pXzRMcBZQU8Py83sg==}
     peerDependencies:
       vitest: 5.0.0
+
+  '@vitest/utils@4.1.11':
+    resolution: {integrity: sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==}
 
   '@vitest/utils@4.1.6':
     resolution: {integrity: sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==}
@@ -8132,9 +8176,6 @@ packages:
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
-
-  es-module-lexer@2.1.0:
-    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
   es-module-lexer@2.3.2:
     resolution: {integrity: sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==}
@@ -12339,6 +12380,9 @@ packages:
   tiny-warning@1.0.3:
     resolution: {integrity: sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinybench@6.1.4:
     resolution: {integrity: sha512-9APumHG7r4yOk4X4WlkmE71aZcv1gvin1czO3OQ1U9iJcFA5Ja/ygyb0vPOVHTthFozUYs8CLoLUlM8grb2lTQ==}
     engines: {node: '>=20.0.0'}
@@ -12780,6 +12824,47 @@ packages:
       vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       vite:
+        optional: true
+
+  vitest@4.1.11:
+    resolution: {integrity: sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^22.10.5
+      '@vitest/browser-playwright': 4.1.11
+      '@vitest/browser-preview': 4.1.11
+      '@vitest/browser-webdriverio': 4.1.11
+      '@vitest/coverage-istanbul': 4.1.11
+      '@vitest/coverage-v8': 4.1.11
+      '@vitest/ui': 4.1.11
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
         optional: true
 
   vitest@5.0.0:
@@ -13530,7 +13615,7 @@ snapshots:
 
   '@babel/code-frame@7.29.0':
     dependencies:
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-validator-identifier': 7.29.7
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
@@ -13543,10 +13628,10 @@ snapshots:
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
       '@babel/helpers': 7.29.2
-      '@babel/parser': 7.29.3
+      '@babel/parser': 7.29.8
       '@babel/template': 7.28.6
       '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.8
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
       debug: 4.4.3
@@ -13558,15 +13643,15 @@ snapshots:
 
   '@babel/generator@7.29.1':
     dependencies:
-      '@babel/parser': 7.29.3
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
 
   '@babel/helper-annotate-as-pure@7.27.3':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.8
 
   '@babel/helper-compilation-targets@7.28.6':
     dependencies:
@@ -13612,7 +13697,7 @@ snapshots:
   '@babel/helper-member-expression-to-functions@7.28.5':
     dependencies:
       '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.8
     transitivePeerDependencies:
       - supports-color
 
@@ -13623,7 +13708,7 @@ snapshots:
   '@babel/helper-module-imports@7.28.6':
     dependencies:
       '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.8
     transitivePeerDependencies:
       - supports-color
 
@@ -13631,14 +13716,14 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-module-imports': 7.28.6
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-validator-identifier': 7.29.7
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-optimise-call-expression@7.27.1':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.8
 
   '@babel/helper-plugin-utils@7.28.6': {}
 
@@ -13663,7 +13748,7 @@ snapshots:
   '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
     dependencies:
       '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.8
     transitivePeerDependencies:
       - supports-color
 
@@ -13681,14 +13766,14 @@ snapshots:
     dependencies:
       '@babel/template': 7.28.6
       '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.8
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helpers@7.29.2':
     dependencies:
       '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.8
 
   '@babel/parser@7.29.3':
     dependencies:
@@ -14121,7 +14206,7 @@ snapshots:
       '@babel/helper-module-imports': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.8
     transitivePeerDependencies:
       - supports-color
 
@@ -14337,17 +14422,17 @@ snapshots:
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
-      '@babel/parser': 7.29.3
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
 
   '@babel/traverse@7.29.0':
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/generator': 7.29.1
       '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.29.3
+      '@babel/parser': 7.29.8
       '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.8
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
@@ -16366,7 +16451,7 @@ snapshots:
       node-forge: 1.4.0
       npm-package-arg: 11.0.3
       ora: 3.4.0
-      picomatch: 4.0.4
+      picomatch: 4.0.7
       pretty-format: 29.7.0
       progress: 2.0.3
       prompts: 2.4.2
@@ -16380,7 +16465,7 @@ snapshots:
       terminal-link: 2.1.1
       toqr: 0.1.1
       wrap-ansi: 7.0.0
-      ws: 8.20.1
+      ws: 8.21.3
       zod: 3.25.76
     optionalDependencies:
       react-native: 0.85.3(@babel/core@7.29.0)(@types/react@19.2.15)(react@19.2.6)
@@ -16547,7 +16632,7 @@ snapshots:
       hermes-parser: 0.32.1
       jsc-safe-url: 0.2.4
       lightningcss: 1.32.0
-      picomatch: 4.0.4
+      picomatch: 4.0.7
       postcss: 8.5.15
       resolve-from: 5.0.0
     optionalDependencies:
@@ -16902,7 +16987,7 @@ snapshots:
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/sourcemap-codec': 1.6.0
       '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/remapping@2.3.5':
@@ -18540,7 +18625,7 @@ snapshots:
   '@react-native/codegen@0.83.6(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/parser': 7.29.3
+      '@babel/parser': 7.29.8
       glob: 7.2.3
       hermes-parser: 0.32.0
       invariant: 2.2.4
@@ -18550,11 +18635,11 @@ snapshots:
   '@react-native/codegen@0.85.3(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/parser': 7.29.3
+      '@babel/parser': 7.29.8
       hermes-parser: 0.33.3
       invariant: 2.2.4
       nullthrows: 1.1.1
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       yargs: 17.7.2
 
   '@react-native/community-cli-plugin@0.85.3':
@@ -19549,11 +19634,28 @@ snapshots:
     optionalDependencies:
       '@vitest/browser': 5.0.0(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0))(vitest@5.0.0)
 
+  '@vitest/expect@4.1.11':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
+      chai: 6.2.2
+      tinyrainbow: 3.1.1
+
   '@vitest/istanbul-lib-coverage@1.0.1': {}
 
   '@vitest/istanbul-lib-report@1.0.1':
     dependencies:
       '@vitest/istanbul-lib-coverage': 1.0.1
+
+  '@vitest/mocker@4.1.11(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.11
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0)
 
   '@vitest/mocker@5.0.0(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0))':
     dependencies:
@@ -19573,13 +19675,31 @@ snapshots:
     optionalDependencies:
       vite: 8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0)
 
+  '@vitest/pretty-format@4.1.11':
+    dependencies:
+      tinyrainbow: 3.1.1
+
   '@vitest/pretty-format@4.1.6':
     dependencies:
-      tinyrainbow: 3.1.0
+      tinyrainbow: 3.1.1
 
   '@vitest/pretty-format@5.0.0':
     dependencies:
       tinyrainbow: 3.1.1
+
+  '@vitest/runner@4.1.11':
+    dependencies:
+      '@vitest/utils': 4.1.11
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.11':
+    dependencies:
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/utils': 4.1.11
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.11': {}
 
   '@vitest/spy@5.0.0': {}
 
@@ -19592,6 +19712,12 @@ snapshots:
       sirv: 3.0.2
       tinyrainbow: 3.1.1
       vitest: 5.0.0(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/browser-playwright@5.0.0)(@vitest/coverage-v8@5.0.0)(@vitest/ui@5.0.0)(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0))
+
+  '@vitest/utils@4.1.11':
+    dependencies:
+      '@vitest/pretty-format': 4.1.11
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.1
 
   '@vitest/utils@4.1.6':
     dependencies:
@@ -20035,7 +20161,7 @@ snapshots:
 
   babel-plugin-react-compiler@1.0.0:
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.8
 
   babel-plugin-react-native-web@0.21.2: {}
 
@@ -21271,8 +21397,6 @@ snapshots:
 
   es-errors@1.3.0: {}
 
-  es-module-lexer@2.1.0: {}
-
   es-module-lexer@2.3.2: {}
 
   es-object-atoms@1.1.1:
@@ -21710,6 +21834,10 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fdir@6.5.0(picomatch@4.0.7):
+    optionalDependencies:
+      picomatch: 4.0.7
 
   feed@4.2.2:
     dependencies:
@@ -23234,7 +23362,7 @@ snapshots:
   metro-source-map@0.83.7:
     dependencies:
       '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.8
       flow-enums-runtime: 0.0.6
       invariant: 2.2.4
       metro-symbolicate: 0.83.7
@@ -23248,7 +23376,7 @@ snapshots:
   metro-source-map@0.84.4:
     dependencies:
       '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.8
       flow-enums-runtime: 0.0.6
       invariant: 2.2.4
       metro-symbolicate: 0.84.4
@@ -23307,8 +23435,8 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
-      '@babel/parser': 7.29.3
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
       flow-enums-runtime: 0.0.6
       metro: 0.83.7
       metro-babel-transformer: 0.83.7
@@ -23327,8 +23455,8 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
-      '@babel/parser': 7.29.3
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
       flow-enums-runtime: 0.0.6
       metro: 0.84.4
       metro-babel-transformer: 0.84.4
@@ -23348,10 +23476,10 @@ snapshots:
       '@babel/code-frame': 7.29.0
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
-      '@babel/parser': 7.29.3
+      '@babel/parser': 7.29.8
       '@babel/template': 7.28.6
       '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.8
       accepts: 2.0.0
       ci-info: 2.0.0
       connect: 3.7.0
@@ -23394,10 +23522,10 @@ snapshots:
       '@babel/code-frame': 7.29.0
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
-      '@babel/parser': 7.29.3
+      '@babel/parser': 7.29.8
       '@babel/template': 7.28.6
       '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.8
       accepts: 2.0.0
       ci-info: 2.0.0
       connect: 3.7.0
@@ -25402,7 +25530,7 @@ snapshots:
       scheduler: 0.27.0
       semver: 7.8.0
       stacktrace-parser: 0.1.11
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       whatwg-fetch: 3.6.20
       ws: 7.5.10
       yargs: 17.7.2
@@ -26539,6 +26667,8 @@ snapshots:
 
   tiny-warning@1.0.3: {}
 
+  tinybench@2.9.0: {}
+
   tinybench@6.1.4: {}
 
   tinyexec@1.3.0: {}
@@ -26550,8 +26680,8 @@ snapshots:
 
   tinyglobby@0.2.17:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
+      fdir: 6.5.0(picomatch@4.0.7)
+      picomatch: 4.0.7
 
   tinypool@1.1.1: {}
 
@@ -26922,10 +27052,10 @@ snapshots:
   vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
-      picomatch: 4.0.4
+      picomatch: 4.0.7
       postcss: 8.5.15
       rolldown: 1.0.1
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 22.19.19
       esbuild: 0.27.7
@@ -26938,10 +27068,10 @@ snapshots:
   vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
-      picomatch: 4.0.4
+      picomatch: 4.0.7
       postcss: 8.5.15
       rolldown: 1.0.1
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 22.19.19
       esbuild: 0.27.7
@@ -26954,6 +27084,37 @@ snapshots:
   vitefu@1.1.3(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0)):
     optionalDependencies:
       vite: 8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0)
+
+  vitest@4.1.11(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/browser-playwright@5.0.0(playwright@1.60.0)(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0))(vitest@5.0.0))(@vitest/coverage-v8@5.0.0(@vitest/browser@5.0.0)(vitest@5.0.0))(@vitest/ui@5.0.0(vitest@5.0.0))(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.11
+      '@vitest/mocker': 4.1.11(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/runner': 4.1.11
+      '@vitest/snapshot': 4.1.11
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
+      es-module-lexer: 2.3.2
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.2.1
+      pathe: 2.0.3
+      picomatch: 4.0.7
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.1
+      vite: 8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 22.19.19
+      '@vitest/browser-playwright': 5.0.0(playwright@1.60.0)(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0))(vitest@5.0.0)
+      '@vitest/coverage-v8': 5.0.0(@vitest/browser@5.0.0)(vitest@5.0.0)
+      '@vitest/ui': 5.0.0(vitest@5.0.0)
+    transitivePeerDependencies:
+      - msw
 
   vitest@5.0.0(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/browser-playwright@5.0.0)(@vitest/coverage-v8@5.0.0)(@vitest/ui@5.0.0)(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0)):
     dependencies:
@@ -27125,7 +27286,7 @@ snapshots:
       browserslist: 4.28.2
       chrome-trace-event: 1.0.4
       enhanced-resolve: 5.21.3
-      es-module-lexer: 2.1.0
+      es-module-lexer: 2.3.2
       eslint-scope: 5.1.1
       events: 3.3.0
       glob-to-regexp: 0.4.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1899,8 +1899,8 @@ importers:
         specifier: ~7.0.2
         version: 7.0.2
       vitest:
-        specifier: ^4.1.6
-        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/browser-playwright@5.0.0(playwright@1.60.0)(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0))(vitest@5.0.0))(@vitest/coverage-v8@5.0.0(@vitest/browser@5.0.0)(vitest@5.0.0))(@vitest/ui@5.0.0(vitest@5.0.0))(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0))
+        specifier: ^5.0.0
+        version: 5.0.0(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/browser-playwright@5.0.0)(@vitest/coverage-v8@5.0.0)(@vitest/ui@5.0.0)(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0))
 
   tools/process-tracker:
     dependencies:
@@ -6470,9 +6470,6 @@ packages:
       '@vitest/browser':
         optional: true
 
-  '@vitest/expect@4.1.11':
-    resolution: {integrity: sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==}
-
   '@vitest/istanbul-lib-coverage@1.0.1':
     resolution: {integrity: sha512-k3DJZ8LhMBK9NS4SclF1ASD3OgXEWDorbIcPTRDK0/Zae6fRvu+fJRxtFdLfHsa9Y24beCdPnoNZ4LviTNstfA==}
     engines: {node: '>=22'}
@@ -6480,17 +6477,6 @@ packages:
   '@vitest/istanbul-lib-report@1.0.1':
     resolution: {integrity: sha512-1EOLRfsTMnyAr3+kEAsP4o9dhaDlGPpD7H5iLBBeq//YpNB1VIahkPhB+eRp9N2Dkfw8oySROjE3yf9XDeaIkQ==}
     engines: {node: '>=22'}
-
-  '@vitest/mocker@4.1.11':
-    resolution: {integrity: sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==}
-    peerDependencies:
-      msw: ^2.4.9
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
-    peerDependenciesMeta:
-      msw:
-        optional: true
-      vite:
-        optional: true
 
   '@vitest/mocker@5.0.0':
     resolution: {integrity: sha512-66PGTMIiVJP3t4a5yxU9qPtf7MdTBs8jmToMvy+HVflB3Yy13WJZTtPePdvU+wjRV02SKK5doLbSA6o9pwOmiA==}
@@ -6503,23 +6489,11 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.1.11':
-    resolution: {integrity: sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==}
-
   '@vitest/pretty-format@4.1.6':
     resolution: {integrity: sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==}
 
   '@vitest/pretty-format@5.0.0':
     resolution: {integrity: sha512-PVRNuB3wpReb4SQEs4zTKM4KWFhQ5pw3spE8naoDJNB5T5aWRzGKHwXcLUllr0WeOTXpB6bSr3CJLo5+7XQSSQ==}
-
-  '@vitest/runner@4.1.11':
-    resolution: {integrity: sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==}
-
-  '@vitest/snapshot@4.1.11':
-    resolution: {integrity: sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==}
-
-  '@vitest/spy@4.1.11':
-    resolution: {integrity: sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==}
 
   '@vitest/spy@5.0.0':
     resolution: {integrity: sha512-uy+luWBAPw9XfthoHi5AkfHUnuPYEESjl0p/r+meoBnU8bxg5GDQ3Ey8MjcJ6sqahkL4PFyrvfMJJBw7LbU06g==}
@@ -6528,9 +6502,6 @@ packages:
     resolution: {integrity: sha512-h2FIFwggCY2GxUd2UdQoYNVQkOIqEQLPhNREcl3FUiRsdzQep7NWwYbSmhGEA9nFLPDq5pXzRMcBZQU8Py83sg==}
     peerDependencies:
       vitest: 5.0.0
-
-  '@vitest/utils@4.1.11':
-    resolution: {integrity: sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==}
 
   '@vitest/utils@4.1.6':
     resolution: {integrity: sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==}
@@ -12380,9 +12351,6 @@ packages:
   tiny-warning@1.0.3:
     resolution: {integrity: sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==}
 
-  tinybench@2.9.0:
-    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
-
   tinybench@6.1.4:
     resolution: {integrity: sha512-9APumHG7r4yOk4X4WlkmE71aZcv1gvin1czO3OQ1U9iJcFA5Ja/ygyb0vPOVHTthFozUYs8CLoLUlM8grb2lTQ==}
     engines: {node: '>=20.0.0'}
@@ -12824,47 +12792,6 @@ packages:
       vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       vite:
-        optional: true
-
-  vitest@4.1.11:
-    resolution: {integrity: sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==}
-    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
-    hasBin: true
-    peerDependencies:
-      '@edge-runtime/vm': '*'
-      '@opentelemetry/api': ^1.9.0
-      '@types/node': ^22.10.5
-      '@vitest/browser-playwright': 4.1.11
-      '@vitest/browser-preview': 4.1.11
-      '@vitest/browser-webdriverio': 4.1.11
-      '@vitest/coverage-istanbul': 4.1.11
-      '@vitest/coverage-v8': 4.1.11
-      '@vitest/ui': 4.1.11
-      happy-dom: '*'
-      jsdom: '*'
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
-    peerDependenciesMeta:
-      '@edge-runtime/vm':
-        optional: true
-      '@opentelemetry/api':
-        optional: true
-      '@types/node':
-        optional: true
-      '@vitest/browser-playwright':
-        optional: true
-      '@vitest/browser-preview':
-        optional: true
-      '@vitest/browser-webdriverio':
-        optional: true
-      '@vitest/coverage-istanbul':
-        optional: true
-      '@vitest/coverage-v8':
-        optional: true
-      '@vitest/ui':
-        optional: true
-      happy-dom:
-        optional: true
-      jsdom:
         optional: true
 
   vitest@5.0.0:
@@ -17009,7 +16936,7 @@ snapshots:
   '@jridgewell/trace-mapping@0.3.31':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/sourcemap-codec': 1.6.0
 
   '@js-sdsl/ordered-map@4.4.2': {}
 
@@ -18808,7 +18735,7 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.9
       estree-walker: 2.0.2
-      picomatch: 4.0.4
+      picomatch: 4.0.7
 
   '@rushstack/node-core-library@5.18.0(@types/node@22.19.19)':
     dependencies:
@@ -19634,28 +19561,11 @@ snapshots:
     optionalDependencies:
       '@vitest/browser': 5.0.0(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0))(vitest@5.0.0)
 
-  '@vitest/expect@4.1.11':
-    dependencies:
-      '@standard-schema/spec': 1.1.0
-      '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.11
-      '@vitest/utils': 4.1.11
-      chai: 6.2.2
-      tinyrainbow: 3.1.1
-
   '@vitest/istanbul-lib-coverage@1.0.1': {}
 
   '@vitest/istanbul-lib-report@1.0.1':
     dependencies:
       '@vitest/istanbul-lib-coverage': 1.0.1
-
-  '@vitest/mocker@4.1.11(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0))':
-    dependencies:
-      '@vitest/spy': 4.1.11
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0)
 
   '@vitest/mocker@5.0.0(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0))':
     dependencies:
@@ -19675,10 +19585,6 @@ snapshots:
     optionalDependencies:
       vite: 8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0)
 
-  '@vitest/pretty-format@4.1.11':
-    dependencies:
-      tinyrainbow: 3.1.1
-
   '@vitest/pretty-format@4.1.6':
     dependencies:
       tinyrainbow: 3.1.1
@@ -19686,20 +19592,6 @@ snapshots:
   '@vitest/pretty-format@5.0.0':
     dependencies:
       tinyrainbow: 3.1.1
-
-  '@vitest/runner@4.1.11':
-    dependencies:
-      '@vitest/utils': 4.1.11
-      pathe: 2.0.3
-
-  '@vitest/snapshot@4.1.11':
-    dependencies:
-      '@vitest/pretty-format': 4.1.11
-      '@vitest/utils': 4.1.11
-      magic-string: 0.30.21
-      pathe: 2.0.3
-
-  '@vitest/spy@4.1.11': {}
 
   '@vitest/spy@5.0.0': {}
 
@@ -19712,12 +19604,6 @@ snapshots:
       sirv: 3.0.2
       tinyrainbow: 3.1.1
       vitest: 5.0.0(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/browser-playwright@5.0.0)(@vitest/coverage-v8@5.0.0)(@vitest/ui@5.0.0)(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0))
-
-  '@vitest/utils@4.1.11':
-    dependencies:
-      '@vitest/pretty-format': 4.1.11
-      convert-source-map: 2.0.0
-      tinyrainbow: 3.1.1
 
   '@vitest/utils@4.1.6':
     dependencies:
@@ -26435,7 +26321,7 @@ snapshots:
       lines-and-columns: 1.2.4
       mz: 2.7.0
       pirates: 4.0.7
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       ts-interface-checker: 0.1.13
 
   supports-color@5.5.0:
@@ -26666,8 +26552,6 @@ snapshots:
   tiny-invariant@1.3.3: {}
 
   tiny-warning@1.0.3: {}
-
-  tinybench@2.9.0: {}
 
   tinybench@6.1.4: {}
 
@@ -27084,37 +26968,6 @@ snapshots:
   vitefu@1.1.3(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0)):
     optionalDependencies:
       vite: 8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0)
-
-  vitest@4.1.11(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/browser-playwright@5.0.0(playwright@1.60.0)(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0))(vitest@5.0.0))(@vitest/coverage-v8@5.0.0(@vitest/browser@5.0.0)(vitest@5.0.0))(@vitest/ui@5.0.0(vitest@5.0.0))(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0)):
-    dependencies:
-      '@vitest/expect': 4.1.11
-      '@vitest/mocker': 4.1.11(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.11
-      '@vitest/runner': 4.1.11
-      '@vitest/snapshot': 4.1.11
-      '@vitest/spy': 4.1.11
-      '@vitest/utils': 4.1.11
-      es-module-lexer: 2.3.2
-      expect-type: 1.4.0
-      magic-string: 0.30.21
-      obug: 2.2.1
-      pathe: 2.0.3
-      picomatch: 4.0.7
-      std-env: 4.2.0
-      tinybench: 2.9.0
-      tinyexec: 1.3.0
-      tinyglobby: 0.2.17
-      tinyrainbow: 3.1.1
-      vite: 8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.1
-      '@types/node': 22.19.19
-      '@vitest/browser-playwright': 5.0.0(playwright@1.60.0)(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0))(vitest@5.0.0)
-      '@vitest/coverage-v8': 5.0.0(@vitest/browser@5.0.0)(vitest@5.0.0)
-      '@vitest/ui': 5.0.0(vitest@5.0.0)
-    transitivePeerDependencies:
-      - msw
 
   vitest@5.0.0(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(@vitest/browser-playwright@5.0.0)(@vitest/coverage-v8@5.0.0)(@vitest/ui@5.0.0)(vite@8.0.13(@types/node@22.19.19)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0)):
     dependencies:

--- a/tools/oxlint-plugin-zero/index.js
+++ b/tools/oxlint-plugin-zero/index.js
@@ -1,5 +1,47 @@
 const selectStar = /\bselect\b[\s\S]*?\*(?=\s*(?:,|\bfrom\b))[\s\S]*?\bfrom\b/i;
 
+// Commands that resolve to a `.CMD`/`.bat` shim on Windows rather than a real
+// executable image. `CreateProcess` only ever appends `.exe`, so spawning one of
+// these by bare name throws ENOENT on Windows even when the shim is on PATH.
+// `shell: true` "fixes" it but concatenates arguments instead of escaping them
+// (Node DEP0190), so the portable answer is to resolve the JS entrypoint and
+// spawn that with `process.execPath`.
+// Limited to what this repo actually runs: the two sites that prompted the rule
+// (`npm` from the release scripts, `tsc` from the zero build), the package manager
+// and Node's own launchers, and the CLIs it depends on. Names it has no
+// relationship with are left out — an error-level rule should not be enumerating
+// tools nobody here spawns.
+const shimCommands = new Set([
+  'npm',
+  'npx',
+  'pnpm',
+  'tsc',
+  'tsx',
+  'vite',
+  'vitest',
+  'oxlint',
+  'oxfmt',
+  'turbo',
+  'prisma',
+  'drizzle-kit',
+  'playwright',
+  'sst',
+]);
+
+// `exec` and `execSync` are absent because they always go through a shell, which
+// resolves `npm.cmd` itself.
+//
+// Reach: the command must be a string literal and the callee a plain or member
+// identifier, and the callee's origin is not tracked.
+const spawnFunctions = new Set([
+  'spawn',
+  'spawnSync',
+  'execFile',
+  'execFileSync',
+]);
+
+const whitespace = /\s+/;
+
 const plugin = {
   meta: {
     name: 'zero',
@@ -56,6 +98,35 @@ const plugin = {
         };
       },
     },
+
+    'no-bare-shim-spawn': {
+      meta: {
+        type: 'problem',
+        docs: {
+          description:
+            'Disallow spawning a command that is a .CMD shim on Windows by bare name; resolve its JS entrypoint and spawn it with process.execPath.',
+        },
+        schema: [],
+        messages: {
+          resolveEntrypoint:
+            "Spawning '{{command}}' by bare name throws ENOENT on Windows: it is a .CMD shim and CreateProcess only appends .exe. Do not reach for `shell: true` — it concatenates arguments instead of escaping them (Node DEP0190). Resolve the JS entrypoint (createRequire(...).resolve) and spawn it with process.execPath.",
+        },
+      },
+      create(context) {
+        return {
+          CallExpression(node) {
+            const command = bareShimSpawnCommand(node);
+            if (command !== undefined) {
+              context.report({
+                node,
+                messageId: 'resolveEntrypoint',
+                data: {command},
+              });
+            }
+          },
+        };
+      },
+    },
   },
 };
 
@@ -73,14 +144,117 @@ function hasSelectStar(source) {
   return selectStar.test(source);
 }
 
+/**
+ * Normalize a filesystem path to forward slashes, so the `/`-bearing comparisons
+ * in `shouldCheck` mean the same thing wherever the linter runs.
+ *
+ * Comparing against a raw filename makes every one of them false where paths use
+ * backslashes, and a rule that never matches a path never runs — which reads
+ * exactly like a codebase with nothing to report.
+ */
+function toPosixPath(filename) {
+  return filename.replaceAll('\\', '/');
+}
+
 function shouldCheck(filename, include) {
+  const path = toPosixPath(filename);
   return (
-    include.some(path => filename.includes(path)) &&
-    !filename.endsWith('.test.ts') &&
-    !filename.includes('/test/') &&
-    !filename.includes('/__snapshots__/') &&
-    !filename.endsWith('_generated.ts')
+    include.some(included => path.includes(toPosixPath(included))) &&
+    !path.endsWith('.test.ts') &&
+    !path.includes('/test/') &&
+    !path.includes('/__snapshots__/') &&
+    !path.endsWith('_generated.ts')
   );
 }
 
+function isStaticallyFalsy(node) {
+  if (node?.type === 'Literal') {
+    return !node.value;
+  }
+  if (node?.type === 'Identifier') {
+    return node.name === 'undefined';
+  }
+  return node?.type === 'UnaryExpression' && node.operator === 'void';
+}
+
+/**
+ * Returns the offending command name when `node` spawns a Windows shim command
+ * by bare name without a shell, otherwise undefined.
+ */
+function bareShimSpawnCommand(node) {
+  // Both spellings count: a bare `spawn(…)` and a `childProcess.spawn(…)` member
+  // call are equally common, and `cp['spawn'](…)` is out of reach either way.
+  const callee = node.callee;
+  const calleeName =
+    callee?.type === 'Identifier'
+      ? callee.name
+      : callee?.type === 'MemberExpression' && !callee.computed
+        ? callee.property?.name
+        : undefined;
+  if (calleeName === undefined || !spawnFunctions.has(calleeName)) {
+    return undefined;
+  }
+  const [commandArgument, ...rest] = node.arguments ?? [];
+  if (
+    commandArgument?.type !== 'Literal' ||
+    typeof commandArgument.value !== 'string'
+  ) {
+    return undefined;
+  }
+  const command = commandArgument.value.trim().split(whitespace)[0];
+  if (!shimCommands.has(command)) {
+    return undefined;
+  }
+  // The rule name is the scope: a shim spawned by bare name WITHOUT a shell
+  // cannot be resolved at all. `shell: true` does resolve it, at the different
+  // cost DEP0190 describes, which is Node's warning to give and not this rule's.
+  // So an explicit `shell` is a deliberate opt-out.
+  if (rest.some(hasShellOption)) {
+    return undefined;
+  }
+  return command;
+}
+
+/**
+ * Whether an argument is an options object that opts into a shell.
+ *
+ * The options bag is located by shape, not by position: `args` is optional in
+ * every one of these signatures, so `spawn('npm', {shell: true})` puts it at
+ * index 1 — reading index 2 reported those calls despite the opt-out. A spread
+ * is treated as opting in, because its contents are not knowable here and a
+ * false negative is cheaper than an error on correct code.
+ *
+ * The VALUE decides, not the key's presence: `{shell: false}` is exactly the
+ * configuration that fails, so reading only the key would exempt the call this
+ * rule exists to report.
+ */
+function hasShellOption(argument) {
+  if (argument?.type !== 'ObjectExpression') {
+    return false;
+  }
+  return argument.properties.some(property => {
+    if (property.type === 'SpreadElement') {
+      return true;
+    }
+    if (
+      property.type !== 'Property' ||
+      (property.key?.name !== 'shell' && property.key?.value !== 'shell')
+    ) {
+      return false;
+    }
+    // A statically falsy value is not an opt-out — `{shell: false}` is the very
+    // configuration that fails, and `{shell: undefined}` / `{shell: void 0}` are
+    // that same configuration spelled differently. Anything else — `true`, a
+    // variable, a call — is not knowably falsy, so it counts as deliberate.
+    return !isStaticallyFalsy(property.value);
+  });
+}
+
 export default plugin;
+export {
+  bareShimSpawnCommand,
+  hasSelectStar,
+  shouldCheck,
+  stripCommentOnlyLines,
+  toPosixPath,
+};

--- a/tools/oxlint-plugin-zero/index.test.js
+++ b/tools/oxlint-plugin-zero/index.test.js
@@ -1,0 +1,329 @@
+import {describe, expect, test} from 'vitest';
+import {
+  bareShimSpawnCommand,
+  hasSelectStar,
+  shouldCheck,
+  stripCommentOnlyLines,
+  toPosixPath,
+} from './index.js';
+
+// These tests are deliberately platform-independent: they feed Windows-shaped
+// input explicitly rather than depending on the host separator, so a regression
+// is caught on a POSIX CI runner too. That matters because every bug fixed here
+// is invisible on POSIX by construction.
+
+describe('toPosixPath', () => {
+  test('rewrites Windows separators', () => {
+    expect(toPosixPath('C:\\repo\\packages\\zero-cache\\src\\db.ts')).toBe(
+      'C:/repo/packages/zero-cache/src/db.ts',
+    );
+  });
+
+  test('leaves a POSIX path untouched', () => {
+    expect(toPosixPath('/repo/packages/zero-cache/src/db.ts')).toBe(
+      '/repo/packages/zero-cache/src/db.ts',
+    );
+  });
+});
+
+describe('shouldCheck', () => {
+  const include = ['packages/zero-cache/src/'];
+
+  test('matches a Windows path against a POSIX include prefix', () => {
+    // Before normalization this returned false, so no-select-star silently did
+    // not run on Windows at all.
+    expect(
+      shouldCheck('C:\\repo\\packages\\zero-cache\\src\\query.ts', include),
+    ).toBe(true);
+  });
+
+  test('matches a POSIX path against a POSIX include prefix', () => {
+    expect(shouldCheck('/repo/packages/zero-cache/src/query.ts', include)).toBe(
+      true,
+    );
+  });
+
+  test('tolerates a Windows-shaped include prefix', () => {
+    expect(
+      shouldCheck('/repo/packages/zero-cache/src/query.ts', [
+        'packages\\zero-cache\\src\\',
+      ]),
+    ).toBe(true);
+  });
+
+  test('skips a file outside the include prefixes', () => {
+    expect(shouldCheck('C:\\repo\\packages\\zql\\src\\query.ts', include)).toBe(
+      false,
+    );
+  });
+
+  test('skips test files on both separators', () => {
+    expect(
+      shouldCheck('C:\\repo\\packages\\zero-cache\\src\\a.test.ts', include),
+    ).toBe(false);
+    expect(
+      shouldCheck('/repo/packages/zero-cache/src/a.test.ts', include),
+    ).toBe(false);
+  });
+
+  test('skips test directories on both separators', () => {
+    // This exclusion was also dead on Windows: '/test/' never matched a
+    // backslash path, so test-directory files were linted there but not on CI.
+    expect(
+      shouldCheck('C:\\repo\\packages\\zero-cache\\src\\test\\a.ts', include),
+    ).toBe(false);
+    expect(
+      shouldCheck('/repo/packages/zero-cache/src/test/a.ts', include),
+    ).toBe(false);
+  });
+
+  test('skips snapshots and generated files on both separators', () => {
+    expect(
+      shouldCheck(
+        'C:\\repo\\packages\\zero-cache\\src\\__snapshots__\\a.ts',
+        include,
+      ),
+    ).toBe(false);
+    expect(
+      shouldCheck(
+        'C:\\repo\\packages\\zero-cache\\src\\a_generated.ts',
+        include,
+      ),
+    ).toBe(false);
+  });
+
+  test('an empty include list never matches', () => {
+    expect(shouldCheck('C:\\repo\\packages\\zero-cache\\src\\a.ts', [])).toBe(
+      false,
+    );
+  });
+});
+
+// Minimal ESTree-shaped literals; only the fields the predicates read.
+const literal = value => ({type: 'Literal', value});
+
+const spawnCall = (name, commandValue, options) => ({
+  type: 'CallExpression',
+  callee: {type: 'Identifier', name},
+  arguments: [
+    commandValue === undefined ? undefined : literal(commandValue),
+    {type: 'ArrayExpression', elements: []},
+    options,
+  ],
+});
+const objectWith = (keyName, value = {type: 'Literal', value: true}) => ({
+  type: 'ObjectExpression',
+  properties: [{type: 'Property', key: {name: keyName}, value}],
+});
+
+describe('bareShimSpawnCommand', () => {
+  test.each(['spawn', 'spawnSync', 'execFile', 'execFileSync'])(
+    'flags a bare shim command via %s',
+    name => {
+      expect(bareShimSpawnCommand(spawnCall(name, 'npm'))).toBe('npm');
+    },
+  );
+
+  test('flags tsc, the case that breaks the build', () => {
+    expect(bareShimSpawnCommand(spawnCall('spawn', 'tsc'))).toBe('tsc');
+  });
+
+  test('reads only the leading word of a command string', () => {
+    expect(
+      bareShimSpawnCommand(spawnCall('spawn', 'tsc -p tsconfig.json')),
+    ).toBe('tsc');
+  });
+
+  test('ignores a real executable', () => {
+    expect(bareShimSpawnCommand(spawnCall('spawn', 'git'))).toBeUndefined();
+    expect(bareShimSpawnCommand(spawnCall('spawn', 'docker'))).toBeUndefined();
+  });
+
+  test('ignores a call that already passes an explicit shell option', () => {
+    expect(
+      bareShimSpawnCommand(spawnCall('spawn', 'npm', objectWith('shell'))),
+    ).toBeUndefined();
+  });
+
+  test('finds the shell option in the two-argument form, where args is omitted', () => {
+    // `args` is optional in every one of these signatures, so the options bag can
+    // sit at index 1. Reading it positionally at index 2 reported these despite
+    // the opt-out — an error on code that had already made the choice.
+    for (const name of ['spawn', 'spawnSync', 'execFile', 'execFileSync']) {
+      const node = {
+        type: 'CallExpression',
+        callee: {type: 'Identifier', name},
+        arguments: [literal('npm'), objectWith('shell')],
+      };
+      expect(bareShimSpawnCommand(node)).toBeUndefined();
+    }
+  });
+
+  test('still flags the two-argument form when the options do not opt in', () => {
+    const node = {
+      type: 'CallExpression',
+      callee: {type: 'Identifier', name: 'spawn'},
+      arguments: [literal('npm'), objectWith('cwd')],
+    };
+    expect(bareShimSpawnCommand(node)).toBe('npm');
+  });
+
+  test.each([false, null, 0, ''])(
+    'flags a call whose shell option is the falsy literal %p',
+    value => {
+      // `shell: false` is the configuration that fails on Windows, so treating
+      // the key's presence as the opt-out would exempt exactly the call this
+      // rule exists to report.
+      expect(
+        bareShimSpawnCommand(
+          spawnCall(
+            'spawn',
+            'npm',
+            objectWith('shell', {
+              type: 'Literal',
+              value,
+            }),
+          ),
+        ),
+      ).toBe('npm');
+    },
+  );
+
+  test.each([
+    ['undefined', {type: 'Identifier', name: 'undefined'}],
+    ['void 0', {type: 'UnaryExpression', operator: 'void'}],
+  ])('flags a shell option written as %s', (_name, value) => {
+    // Neither is a Literal, so a Literal-only falsy check exempts them — and both
+    // are byte-for-byte the configuration that fails, same as `shell: false`.
+    expect(
+      bareShimSpawnCommand(
+        spawnCall('spawn', 'npm', objectWith('shell', value)),
+      ),
+    ).toBe('npm');
+  });
+
+  test('exempts a shell option whose value is not statically falsy', () => {
+    // A variable could be either; assuming it is falsy would report code that
+    // may well be correct.
+    expect(
+      bareShimSpawnCommand(
+        spawnCall(
+          'spawn',
+          'npm',
+          objectWith('shell', {
+            type: 'Identifier',
+            name: 'useShell',
+          }),
+        ),
+      ),
+    ).toBeUndefined();
+  });
+
+  test('treats a spread options object as opting in', () => {
+    // Its contents are not knowable here, so staying quiet is the cheaper error:
+    // a missed finding costs less than an error on correct code.
+    const node = {
+      type: 'CallExpression',
+      callee: {type: 'Identifier', name: 'spawn'},
+      arguments: [
+        literal('npm'),
+        {type: 'ArrayExpression', elements: []},
+        {
+          type: 'ObjectExpression',
+          properties: [
+            {
+              type: 'SpreadElement',
+              argument: {type: 'Identifier', name: 'base'},
+            },
+          ],
+        },
+      ],
+    };
+    expect(bareShimSpawnCommand(node)).toBeUndefined();
+  });
+
+  test('an unrelated option does not exempt the call', () => {
+    expect(
+      bareShimSpawnCommand(spawnCall('spawn', 'npm', objectWith('stdio'))),
+    ).toBe('npm');
+  });
+
+  test('ignores a non-literal command, which it cannot resolve statically', () => {
+    const node = spawnCall('spawn', undefined);
+    node.arguments[0] = {type: 'Identifier', name: 'litestream'};
+    expect(bareShimSpawnCommand(node)).toBeUndefined();
+  });
+
+  test('ignores unrelated calls', () => {
+    expect(bareShimSpawnCommand(spawnCall('execSync', 'npm'))).toBeUndefined();
+  });
+});
+
+test('bareShimSpawnCommand flags the member form childProcess.spawn(...)', () => {
+  const node = spawnCall('spawn', 'npm');
+  node.callee = {
+    type: 'MemberExpression',
+    computed: false,
+    object: {type: 'Identifier', name: 'childProcess'},
+    property: {type: 'Identifier', name: 'spawn'},
+  };
+  expect(bareShimSpawnCommand(node)).toBe('npm');
+});
+
+test('bareShimSpawnCommand ignores a computed member callee it cannot read', () => {
+  const node = spawnCall('spawn', 'npm');
+  node.callee = {
+    type: 'MemberExpression',
+    computed: true,
+    object: {type: 'Identifier', name: 'childProcess'},
+    property: {type: 'Identifier', name: 'spawn'},
+  };
+  expect(bareShimSpawnCommand(node)).toBeUndefined();
+});
+
+// `no-select-star`'s two halves. Exported and, until now, covered only through
+// the rule — so a change to either was visible to nothing but a smoke fixture
+// that happens to exercise the one path it takes.
+
+test('a comment-only line cannot carry a SELECT * into the match', () => {
+  // The point of stripping: a rule that read commented-out SQL would fire on
+  // prose, and the one that matters is a `--` line, which is SQL's own comment
+  // inside a template literal.
+  expect(hasSelectStar(stripCommentOnlyLines('-- SELECT * FROM t'))).toBe(
+    false,
+  );
+  expect(hasSelectStar(stripCommentOnlyLines('   // SELECT * FROM t'))).toBe(
+    false,
+  );
+  // Only comment-ONLY lines go. A trailing comment leaves the statement intact,
+  // which is deliberate: the code before it still runs.
+  expect(hasSelectStar(stripCommentOnlyLines('SELECT * FROM t -- why'))).toBe(
+    true,
+  );
+  // Line-preserving, so a reported line number still points at the right line.
+  expect(stripCommentOnlyLines('a\n// b\nc')).toBe('a\n\nc');
+});
+
+test('select-star matching is about the projection, not the word', () => {
+  for (const yes of [
+    'SELECT * FROM t',
+    'select * from t',
+    'SELECT *, id FROM t',
+    'SELECT\n  *\nFROM t',
+    'select a.* from t as a',
+  ]) {
+    expect(hasSelectStar(yes), yes).toBe(true);
+  }
+  for (const no of [
+    'SELECT id FROM t',
+    // Multiplication, not a projection: nothing follows the star that makes it
+    // one, which is what the lookahead is for.
+    'SELECT 2 * price FROM t',
+    'SELECT count(*) FROM t',
+    // No FROM at all, so there is no result shape to break.
+    'SELECT *',
+    '',
+  ]) {
+    expect(hasSelectStar(no), no).toBe(false);
+  }
+});

--- a/tools/oxlint-plugin-zero/package.json
+++ b/tools/oxlint-plugin-zero/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "oxlint-plugin-zero",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "index.js",
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest watch",
+    "format": "oxfmt .",
+    "check-format": "oxfmt --check .",
+    "check-types": "tsc",
+    "lint": "oxlint --quiet --config ../../oxlint.config.ts",
+    "fmt": "oxfmt .",
+    "check-fmt": "oxfmt --check ."
+  },
+  "devDependencies": {
+    "oxfmt": "^0.65.0",
+    "oxlint": "^1.80.0",
+    "typescript": "~7.0.2",
+    "vitest": "^4.1.6"
+  },
+  "engines": {
+    "node": ">=22"
+  },
+  "packageManager": "pnpm@11.11.0"
+}

--- a/tools/oxlint-plugin-zero/package.json
+++ b/tools/oxlint-plugin-zero/package.json
@@ -18,7 +18,7 @@
     "oxfmt": "^0.65.0",
     "oxlint": "^1.80.0",
     "typescript": "~7.0.2",
-    "vitest": "^4.1.6"
+    "vitest": "^5.0.0"
   },
   "engines": {
     "node": ">=22"

--- a/tools/oxlint-plugin-zero/plugin.smoke.test.js
+++ b/tools/oxlint-plugin-zero/plugin.smoke.test.js
@@ -1,0 +1,256 @@
+import {spawnSync} from 'node:child_process';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import {createRequire} from 'node:module';
+import {tmpdir} from 'node:os';
+import {dirname, join, resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {afterEach, expect, test} from 'vitest';
+
+/**
+ * Smoke tests for the rules as the linter runs them, not for their predicates.
+ *
+ * The unit tests next door cover the predicates directly. They cannot catch the
+ * failure that actually happened: no-select-star's include prefixes never
+ * matched, so the rule quietly did not run and the only symptom was an
+ * "unused disable directive" elsewhere. A rule that cannot report is
+ * indistinguishable from a clean codebase, so each rule is exercised end to end
+ * against known-bad input.
+ */
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PLUGIN = join(HERE, 'index.js');
+
+/**
+ * Where oxlint's CLI actually lives, resolved through its manifest.
+ *
+ * Not a hardcoded hop into the root node_modules: that assumes a hoisted layout,
+ * which a filtered install does not give. Not `resolve('oxlint/bin/oxlint')`
+ * either — oxlint has an `exports` map that does not list that subpath, so
+ * requesting it directly throws ERR_PACKAGE_PATH_NOT_EXPORTED. `./package.json`
+ * is exported, and its `bin` says where the entry is.
+ */
+function resolveOxlint() {
+  const require = createRequire(import.meta.url);
+  const manifestPath = require.resolve('oxlint/package.json');
+  const {bin} = JSON.parse(readFileSync(manifestPath, 'utf8'));
+  const entry = typeof bin === 'string' ? bin : bin?.oxlint;
+  if (typeof entry !== 'string' || entry.length === 0) {
+    throw new Error(`no usable oxlint bin in ${manifestPath}`);
+  }
+  const packageDir = dirname(manifestPath);
+  const resolved = resolve(packageDir, entry);
+  if (!resolved.startsWith(packageDir)) {
+    throw new Error(`oxlint bin points outside its package: ${entry}`);
+  }
+  return resolved;
+}
+
+const OXLINT = resolveOxlint();
+
+/**
+ * Rules from THIS plugin that always report, with a file that violates each.
+ *
+ * A built-in rule would prove only that oxlint ran. oxlint's plugin loader
+ * returns a failure rather than throwing, so the day it warns-and-continues
+ * instead of aborting, a built-in canary would still fire while none of the
+ * plugin's rules existed — and every "stays quiet" assertion below would pass
+ * over a plugin that never loaded.
+ *
+ * Two, so the canary is never the rule under test: a rule cannot vouch for its
+ * own registration while also being what the case is measuring.
+ */
+const CANARIES = [
+  {
+    rule: 'zero/no-select-star',
+    file: join('packages', 'zero-cache', 'src', '__canary_select.ts'),
+    source: 'export const q = `SELECT * FROM t`;\n',
+    options: {include: ['packages/zero-cache/src/']},
+  },
+  {
+    rule: 'zero/no-bare-shim-spawn',
+    file: '__canary_spawn.ts',
+    source:
+      "import {spawnSync} from 'node:child_process';\n" +
+      "export const r = spawnSync('npm', ['--version']);\n",
+  },
+];
+
+/** The canary for a case, which is any of them that is not under test. */
+function canaryFor(ruleName) {
+  const canary = CANARIES.find(candidate => candidate.rule !== ruleName);
+  if (canary === undefined) {
+    throw new Error(`no canary available while testing ${ruleName}`);
+  }
+  return canary;
+}
+
+/** oxlint's `--format=json` report, as the codes and severities it reported. */
+function parseReport(stdout, context) {
+  let report;
+  try {
+    report = JSON.parse(stdout);
+  } catch (cause) {
+    throw new Error(`oxlint did not emit a JSON report: ${context}`, {cause});
+  }
+  const diagnostics = report.diagnostics ?? [];
+  return {
+    // `zero(no-select-star)` — the plugin name oxlint reports a rule under.
+    codes: diagnostics.map(diagnostic => diagnostic.code),
+    errors: diagnostics
+      .filter(diagnostic => diagnostic.severity === 'error')
+      .map(diagnostic => diagnostic.code),
+    filesLinted: report.number_of_files ?? 0,
+  };
+}
+
+/** The code oxlint reports a rule under, from the name a config enables it by. */
+function codeOf(ruleName) {
+  const [plugin, rule] = ruleName.split('/');
+  return rule === undefined ? `eslint(${plugin})` : `${plugin}(${rule})`;
+}
+
+const fixtureRoots = [];
+
+afterEach(() => {
+  // Each case writes a workspace to run the real linter against; without this
+  // they accumulate in the temp directory for the life of the machine.
+  for (const root of fixtureRoots.splice(0)) {
+    rmSync(root, {recursive: true, force: true});
+  }
+});
+
+/** Writes a fixture file plus a config enabling only this plugin's rules. */
+function lintFixture(relativeFilePath, source, ruleName, ruleOptions) {
+  const root = mkdtempSync(join(tmpdir(), 'zero-plugin-smoke-'));
+  fixtureRoots.push(root);
+  const filePath = join(root, relativeFilePath);
+  mkdirSync(dirname(filePath), {recursive: true});
+  writeFileSync(filePath, source);
+
+  // At WARNING level, so it never moves the exit code the assertions read. Its
+  // diagnostic is the proof that this plugin's rules are registered and firing.
+  const canary = canaryFor(ruleName);
+  // Nested, because a rule scoped by an `include` prefix only fires on a path
+  // inside it — so the canary has to sit where the rule actually looks.
+  const canaryPath = join(root, canary.file);
+  mkdirSync(dirname(canaryPath), {recursive: true});
+  writeFileSync(canaryPath, canary.source);
+
+  writeFileSync(
+    join(root, '.oxlintrc.json'),
+    JSON.stringify({
+      plugins: ['eslint', 'typescript'],
+      jsPlugins: [PLUGIN],
+      categories: {
+        correctness: 'off',
+        suspicious: 'off',
+        pedantic: 'off',
+        style: 'off',
+        restriction: 'off',
+        nursery: 'off',
+        perf: 'off',
+      },
+      rules: {
+        // The canary carries its own options: a rule scoped by `include` reports
+        // nothing when enabled bare, and a silent canary is indistinguishable
+        // from a plugin that never loaded — which is the one thing this harness
+        // exists to tell apart.
+        [canary.rule]:
+          canary.options === undefined ? 'warn' : ['warn', canary.options],
+        [ruleName]:
+          ruleOptions === undefined ? 'error' : ['error', ruleOptions],
+      },
+    }),
+  );
+
+  const result = spawnSync(process.execPath, [OXLINT, '.', '--format=json'], {
+    cwd: root,
+    encoding: 'utf8',
+  });
+  const report = parseReport(
+    result.stdout ?? '',
+    `status ${result.status}: ${result.stderr ?? ''}`,
+  );
+
+  // A harness that cannot lint would satisfy every "does not report" assertion
+  // below — a plugin that fails to load, a rejected config, a wrong oxlint path.
+  // So each run proves the PLUGIN linted the fixture before its own assertion is
+  // allowed to mean anything. This is the same failure the rule under test had
+  // (silence is indistinguishable from clean), reintroduced one level up.
+  if (!report.codes.includes(codeOf(canary.rule))) {
+    throw new Error(
+      `${canary.rule} did not report, so the plugin's rules are not running ` +
+        `(status ${result.status}, ${report.filesLinted} file(s) linted): ` +
+        `${result.stdout ?? ''}${result.stderr ?? ''}`,
+    );
+  }
+  return {report, status: result.status};
+}
+
+/** Asserts the rule fired on a fixture that violates it. */
+function expectReported(result, ruleName) {
+  // The reported code, not a substring of oxlint's prose: the config it echoes on
+  // a rejection contains the rule names, so a grep passes on a run that linted
+  // nothing.
+  expect(result.report.errors).toContain(codeOf(`zero/${ruleName}`));
+  expect(result.status).not.toBe(0);
+}
+
+/** Asserts the rule stayed silent on a fixture that does not violate it. */
+function expectSilent(result, ruleName) {
+  expect(result.report.codes).not.toContain(codeOf(`zero/${ruleName}`));
+  // The canary is a warning, so a clean fixture leaves the exit code at 0. That
+  // is asserted rather than assumed: a change in how oxlint treats warnings would
+  // otherwise turn every quiet case red and point at the plugin.
+  expect(result.status).toBe(0);
+}
+
+test('no-select-star reports SELECT * inside an included path', () => {
+  const result = lintFixture(
+    join('packages', 'zero-cache', 'src', 'query.ts'),
+    'const sql = `SELECT * FROM issues`;\nexport default sql;\n',
+    'zero/no-select-star',
+    {include: ['packages/zero-cache/src/']},
+  );
+
+  // The regression this guards: the include prefix stopped matching, the rule
+  // silently did not run, and the lint reported a clean file.
+  expectReported(result, 'no-select-star');
+});
+
+test('no-select-star stays quiet outside the included paths', () => {
+  const result = lintFixture(
+    join('packages', 'other', 'src', 'query.ts'),
+    'const sql = `SELECT * FROM issues`;\nexport default sql;\n',
+    'zero/no-select-star',
+    {include: ['packages/zero-cache/src/']},
+  );
+
+  expectSilent(result, 'no-select-star');
+});
+
+test('no-bare-shim-spawn reports spawning a shim command by bare name', () => {
+  const result = lintFixture(
+    join('packages', 'thing', 'src', 'a.ts'),
+    "import {spawn} from 'node:child_process';\nspawn('tsc', ['-p', 'tsconfig.json'], {stdio: 'inherit'});\n",
+    'zero/no-bare-shim-spawn',
+  );
+
+  expectReported(result, 'no-bare-shim-spawn');
+});
+
+test('no-bare-shim-spawn leaves a real executable alone', () => {
+  const result = lintFixture(
+    join('packages', 'thing', 'src', 'a.ts'),
+    "import {spawn} from 'node:child_process';\nspawn('git', ['--version'], {stdio: 'inherit'});\n",
+    'zero/no-bare-shim-spawn',
+  );
+
+  expectSilent(result, 'no-bare-shim-spawn');
+});

--- a/tools/oxlint-plugin-zero/tsconfig.json
+++ b/tools/oxlint-plugin-zero/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  // Covers this package's TypeScript, which is its vitest config. The plugin
+  // and its tests are JavaScript, and oxlint does not export the Rule or
+  // Plugin types a checked `.js` file would need, so they are covered by
+  // running them rather than by checking them.
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["node"]
+  },
+  "include": ["*.ts"]
+}

--- a/tools/oxlint-plugin-zero/vitest.config.ts
+++ b/tools/oxlint-plugin-zero/vitest.config.ts
@@ -1,0 +1,17 @@
+import {defineConfig} from 'vitest/config';
+
+// Standalone rather than merging the shared tool config: these are pure unit
+// tests over plain-JS predicates, so none of the shared browser/database setup
+// applies, and reaching across packages for it would mean declaring a
+// dependency this plugin does not otherwise have.
+export default defineConfig({
+  test: {
+    // The plugin entry is a root-level index.js — that path is what
+    // oxlint.base.ts loads — so tests sit beside it rather than under src/.
+    include: ['*.test.js'],
+    // Matches the shared config's 10s. The smoke tests run the real linter out of
+    // process, so vitest's 5s default leaves less margin than anything else here,
+    // and a blocking spawn cannot be interrupted by a timeout anyway.
+    testTimeout: 10_000,
+  },
+});


### PR DESCRIPTION
## Problem

Two defects in the plugin, and they compound.

The plugin is loaded through `URL.pathname`:

```ts
const zeroPlugin = new URL('./tools/oxlint-plugin-zero/index.js', import.meta.url).pathname;
```

A pathname is a URL path, not a filesystem one — on Windows it is `/C:/…`. oxlint
cannot load a plugin from that, and a plugin that fails to load **aborts the whole
lint run**: `pnpm run lint` exits 1 before checking anything.

Fix only that, and lint fails differently:

```
change-log.ts:161:5: error: Unused oxlint-disable directive (no problems were reported)
```

That is the second defect surfacing. `no-select-star` scopes itself with
`include: ['packages/zero-cache/src/']`, matched by `filename.includes(...)`. On
POSIX the absolute path contains that substring and the rule runs; on Windows the
separators are backslashes, so it matches nothing and **the rule never fires** —
which makes its one live `oxlint-disable-next-line` read as an unused directive.

So on Windows `pnpm run lint` is unusable, and `no-select-star` has been silently
inert there since it was written. On Linux CI the rule has been running fine.

## Why it isn't caught today

The package has no tests at all, so a rule that never fires is indistinguishable
from a codebase with nothing to report. Both defects are invisible on the platform
CI runs on.

## The fix

`import.meta.dirname` for the plugin path, and `shouldCheck` compares
POSIX-normalised paths so an `include` prefix means the same thing wherever the
linter runs.

Taking the directory directly is the point: `fileURLToPath(new URL(...))` also
works, but constructing a URL at all is what creates the `.pathname` temptation.
There is nothing to convert, so there is nothing to get wrong — and Node ≥22.12,
which this repo already requires, has it. `packages/zero/tool/build.ts` uses it
already.

Together these take `pnpm run lint` from exit 1 to exit 0 on Windows.

## What this also adds

One rule, so the class that has no idiom-level answer cannot come back:

**`no-bare-shim-spawn`** — spawning a command that resolves to a `.CMD` shim by
bare name. `CreateProcess` only appends `.exe`, so it throws ENOENT on Windows;
`shell: true` "fixes" it but concatenates arguments instead of escaping them
(Node DEP0190). The command set is limited to what this repo actually spawns.

It is defined here but **not enabled** — nothing in this PR turns it on, so this
PR changes no verdict. A follow-up registers it at `error` in the same commit as
the fixes for the call sites it flags, so it goes live with the tree already
clean. I will open that against this branch; if you would rather the rule did not
land at all, the fixes here stand without it.

There is deliberately no rule for the `.pathname` shape. `import.meta.dirname`
makes it unwritable at the only site the repo had, and a rule guarding a pattern
nothing uses is upkeep without a defect behind it.

## Tests

First tests for the package: the predicates directly, plus a smoke run of
the real binary over fixtures. The smoke cases parse `--format=json` and assert
rule **codes** rather than grepping oxlint's prose, and they canary on a
plugin-supplied rule rather than a built-in one — so they fail if the plugin does
not load, instead of passing on the echoed config.

## Verification

`check-fmt` · `lint` (type-aware) · `verify-deps` clean on this branch alone.

No worse than `main`, which fails these on this platform: `check-types` (zbugs#build).

The files this PR touches: Tests 39 passed (39).
