### PR TITLE
fix(.github): derive dev release tags using next patch version

### DIFF
--- a/scripts/src/dev-release/plan.test.ts
+++ b/scripts/src/dev-release/plan.test.ts
@@ -2,6 +2,7 @@ import {expect, test} from 'vitest';
 import {type Command, type Exec, type ExecOptions} from '../shared.ts';
 import {
   deriveDevImageTag,
+  nextPatchVersion,
   planDevRelease,
   resolveSourceSha,
   resolveUniqueShortSha,
@@ -11,7 +12,11 @@ import {
 
 const dummySha = 'e8cc6889fa6bc2a364e8cb80776991c308601212';
 
-function makeMockExec(resolvedSha = dummySha, shortSha?: string) {
+function makeMockExec(
+  resolvedSha = dummySha,
+  shortSha?: string,
+  packageVersion = '1.11.0',
+) {
   const calls: Array<{
     command: Command;
     args: readonly string[];
@@ -25,10 +30,28 @@ function makeMockExec(resolvedSha = dummySha, shortSha?: string) {
       }
       return `${resolvedSha}\n`;
     }
+    if (
+      command === 'git' &&
+      args[0] === 'show' &&
+      args[1]?.endsWith(':packages/zero/package.json')
+    ) {
+      return `${JSON.stringify({version: packageVersion})}\n`;
+    }
     return '';
   };
   return {calls, exec};
 }
+
+test('nextPatchVersion increments patch component of version string', () => {
+  expect(nextPatchVersion('1.11.0')).toBe('1.11.1');
+  expect(nextPatchVersion('0.25.1')).toBe('0.25.2');
+  expect(nextPatchVersion('0.24.0')).toBe('0.24.1');
+  expect(nextPatchVersion('0.0.0')).toBe('0.0.1');
+  expect(nextPatchVersion('1.2.3-canary.1')).toBe('1.2.4');
+  expect(() => nextPatchVersion('invalid')).toThrow(
+    /Cannot derive next patch version/,
+  );
+});
 
 test('sanitizeBranchName strips refs prefix, formats PR refs, and sanitizes special characters to hyphens', () => {
   expect(sanitizeBranchName('main')).toBe('main');
@@ -41,38 +64,43 @@ test('sanitizeBranchName strips refs prefix, formats PR refs, and sanitizes spec
   expect(sanitizeBranchName('---messy--branch---')).toBe('messy-branch');
 });
 
-test('deriveDevImageTag generates 0.0.0-dev-<branch>-<shortSha> SemVer tags', () => {
-  expect(deriveDevImageTag('main', dummySha)).toBe('0.0.0-dev-main-e8cc6889');
-  expect(deriveDevImageTag('greg/sync-opt', dummySha)).toBe(
-    '0.0.0-dev-greg-sync-opt-e8cc6889',
+test('deriveDevImageTag generates <nextPatch>-dev-<branch>-<shortSha> SemVer tags', () => {
+  expect(deriveDevImageTag('main', dummySha, '1.11.1')).toBe(
+    '1.11.1-dev-main-e8cc6889',
   );
-  expect(deriveDevImageTag('refs/pull/123/head', dummySha)).toBe(
-    '0.0.0-dev-pr-123-e8cc6889',
+  expect(deriveDevImageTag('greg/sync-opt', dummySha, '1.11.1')).toBe(
+    '1.11.1-dev-greg-sync-opt-e8cc6889',
   );
-  expect(deriveDevImageTag(dummySha, dummySha)).toBe('0.0.0-dev-e8cc6889');
-  expect(deriveDevImageTag('dev-benchmark', dummySha)).toBe(
-    '0.0.0-dev-benchmark-e8cc6889',
+  expect(deriveDevImageTag('refs/pull/123/head', dummySha, '1.11.1')).toBe(
+    '1.11.1-dev-pr-123-e8cc6889',
   );
-  expect(deriveDevImageTag('sync-opt-e8cc6889', dummySha)).toBe(
-    '0.0.0-dev-sync-opt-e8cc6889',
+  expect(deriveDevImageTag(dummySha, dummySha, '1.11.1')).toBe(
+    '1.11.1-dev-e8cc6889',
+  );
+  expect(deriveDevImageTag('dev-benchmark', dummySha, '1.11.1')).toBe(
+    '1.11.1-dev-benchmark-e8cc6889',
+  );
+  expect(deriveDevImageTag('sync-opt-e8cc6889', dummySha, '1.11.1')).toBe(
+    '1.11.1-dev-sync-opt-e8cc6889',
   );
 });
 
 test('deriveDevImageTag truncates excessively long branch names while preserving the short SHA suffix within 128 chars', () => {
   const longBranch = 'a'.repeat(150);
-  const tag = deriveDevImageTag(longBranch, dummySha);
+  const tag = deriveDevImageTag(longBranch, dummySha, '1.11.1');
   expect(tag.length).toBeLessThanOrEqual(128);
   expect(tag.endsWith('-e8cc6889')).toBe(true);
-  expect(tag.startsWith('0.0.0-dev-')).toBe(true);
+  expect(tag.startsWith('1.11.1-dev-')).toBe(true);
   expect(() => validateImageTag(tag)).not.toThrow();
 });
 
-test('validateImageTag accepts valid 0.0.0- SemVer tags and blocks invalid/protected tags', () => {
-  expect(() => validateImageTag('0.0.0-dev-main-e8cc6889')).not.toThrow();
+test('validateImageTag accepts valid SemVer dev tags and blocks invalid/protected/stable tags', () => {
+  expect(() => validateImageTag('1.11.1-dev-main-e8cc6889')).not.toThrow();
   expect(() =>
-    validateImageTag('0.0.0-dev-greg-sync-opt-e8cc6889'),
+    validateImageTag('1.11.1-dev-greg-sync-opt-e8cc6889'),
   ).not.toThrow();
-  expect(() => validateImageTag('0.0.0-dev-e8cc6889')).not.toThrow();
+  expect(() => validateImageTag('1.11.1-dev-e8cc6889')).not.toThrow();
+  expect(() => validateImageTag('0.0.0-dev-main-e8cc6889')).not.toThrow();
 
   expect(() => validateImageTag('latest')).toThrowError(/protected/);
   expect(() => validateImageTag('HEAD')).toThrowError(/protected/);
@@ -80,19 +108,19 @@ test('validateImageTag accepts valid 0.0.0- SemVer tags and blocks invalid/prote
   expect(() => validateImageTag('canary')).toThrowError(/protected/);
 
   expect(() => validateImageTag('1.8.0')).toThrowError(
-    /must start with "0.0.0-"/,
+    /must be a prerelease version/,
   );
   expect(() => validateImageTag('v1.8.0')).toThrowError(
-    /must start with "0.0.0-"/,
-  );
-  expect(() => validateImageTag('dev-e8cc6889')).toThrowError(
-    /must start with "0.0.0-"/,
-  );
-
-  expect(() => validateImageTag('0.0.0-dev_underscore')).toThrowError(
     /not a valid semantic version/,
   );
-  expect(() => validateImageTag('0.0.0-dev.0123')).toThrowError(
+  expect(() => validateImageTag('dev-e8cc6889')).toThrowError(
+    /not a valid semantic version/,
+  );
+
+  expect(() => validateImageTag('1.11.1-dev_underscore')).toThrowError(
+    /not a valid semantic version/,
+  );
+  expect(() => validateImageTag('1.11.1-dev.0123')).toThrowError(
     /not a valid semantic version/,
   );
 
@@ -126,7 +154,7 @@ test('planDevRelease rejects empty branch', () => {
   ).toThrow(/Branch must not be empty/);
 });
 
-test('planDevRelease defaults to main and derives 0.0.0-dev-main-<shortSha>', () => {
+test('planDevRelease defaults to main and derives 1.11.1-dev-main-<shortSha>', () => {
   const {calls, exec} = makeMockExec();
   const plan = planDevRelease({
     exec,
@@ -134,7 +162,7 @@ test('planDevRelease defaults to main and derives 0.0.0-dev-main-<shortSha>', ()
   });
 
   expect(plan).toEqual({
-    image_tag: '0.0.0-dev-main-e8cc6889',
+    image_tag: '1.11.1-dev-main-e8cc6889',
     ref: 'main',
     source_sha: dummySha,
   });
@@ -155,7 +183,7 @@ test('planDevRelease plans dev release for feature branch with short SHA suffix'
   });
 
   expect(plan).toEqual({
-    image_tag: '0.0.0-dev-greg-sync-opt-e8cc6889',
+    image_tag: '1.11.1-dev-greg-sync-opt-e8cc6889',
     ref: 'greg/sync-opt',
     source_sha: dummySha,
   });
@@ -178,7 +206,7 @@ test('planDevRelease accepts optional commitShaInput', () => {
   });
 
   expect(plan).toEqual({
-    image_tag: '0.0.0-dev-main-12345678',
+    image_tag: '1.11.1-dev-main-12345678',
     ref: 'main',
     source_sha: specificSha,
   });
@@ -188,6 +216,17 @@ test('planDevRelease accepts optional commitShaInput', () => {
     args: ['rev-parse', '--verify', `${specificSha}^{commit}`],
     options: undefined,
   });
+});
+
+test('planDevRelease derives next patch for older base commits (e.g. 0.24.0 -> 0.24.1-dev)', () => {
+  const {exec} = makeMockExec(dummySha, undefined, '0.24.0');
+  const plan = planDevRelease({
+    exec,
+    branchInput: 'maint/fix',
+    workflowRefName: 'main',
+  });
+
+  expect(plan.image_tag).toBe('0.24.1-dev-maint-fix-e8cc6889');
 });
 
 test('resolveSourceSha rejects option-like branch starting with -', () => {
@@ -256,5 +295,5 @@ test('planDevRelease incorporates expanded short SHA when git detects collision'
     workflowRefName: 'main',
   });
 
-  expect(plan.image_tag).toBe('0.0.0-dev-main-e8cc6889fa');
+  expect(plan.image_tag).toBe('1.11.1-dev-main-e8cc6889fa');
 });

--- a/scripts/src/dev-release/plan.test.ts
+++ b/scripts/src/dev-release/plan.test.ts
@@ -119,6 +119,14 @@ test('validateImageTag accepts valid SemVer dev tags and blocks invalid/protecte
   expect(() => validateImageTag('1.8.0-rc.1')).toThrowError(
     /must be a dev prerelease version/,
   );
+  expect(() => validateImageTag('1.8.0+foo-dev-bar')).toThrowError(
+    /Invalid Docker image tag/,
+  );
+  expect(() => validateImageTag('1.8.0-rc-dev-bar')).toThrowError(
+    /must be a dev prerelease version/,
+  );
+  expect(() => validateImageTag('1.11.1-dev-main-01234567')).not.toThrow();
+  expect(() => validateImageTag('1.11.1-dev-01234567')).not.toThrow();
   expect(() => validateImageTag('v1.8.0')).toThrowError(
     /not a valid semantic version/,
   );
@@ -305,4 +313,18 @@ test('planDevRelease incorporates expanded short SHA when git detects collision'
   });
 
   expect(plan.image_tag).toBe('1.11.1-dev-main-e8cc6889fa');
+});
+
+test('planDevRelease handles short SHA with leading zeroes (e.g. 01234567)', () => {
+  const leadingZeroSha = '0123456789abcdef0123456789abcdef01234567';
+  const {exec} = makeMockExec(leadingZeroSha, '01234567');
+
+  const plan = planDevRelease({
+    exec,
+    branchInput: 'main',
+    workflowRefName: 'main',
+  });
+
+  expect(plan.image_tag).toBe('1.11.1-dev-main-01234567');
+  expect(() => validateImageTag(plan.image_tag)).not.toThrow();
 });

--- a/scripts/src/dev-release/plan.test.ts
+++ b/scripts/src/dev-release/plan.test.ts
@@ -108,7 +108,16 @@ test('validateImageTag accepts valid SemVer dev tags and blocks invalid/protecte
   expect(() => validateImageTag('canary')).toThrowError(/protected/);
 
   expect(() => validateImageTag('1.8.0')).toThrowError(
-    /must be a prerelease version/,
+    /must be a dev prerelease version/,
+  );
+  expect(() => validateImageTag('1.8.0-canary.1')).toThrowError(
+    /must be a dev prerelease version/,
+  );
+  expect(() => validateImageTag('1.8.0-head-e8cc6889-20260708')).toThrowError(
+    /must be a dev prerelease version/,
+  );
+  expect(() => validateImageTag('1.8.0-rc.1')).toThrowError(
+    /must be a dev prerelease version/,
   );
   expect(() => validateImageTag('v1.8.0')).toThrowError(
     /not a valid semantic version/,

--- a/scripts/src/dev-release/plan.ts
+++ b/scripts/src/dev-release/plan.ts
@@ -5,6 +5,7 @@ import {
   assertMainWorkflowRef,
   defaultExec,
   mustEnv,
+  readZeroPackageVersionAt,
   writeGithubOutput,
   type Exec,
 } from '../shared.ts';
@@ -14,6 +15,7 @@ const hexShaPattern = /^[0-9a-f]{7,40}$/i;
 const dockerTagPattern = /^[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,127}$/;
 const semverRegex =
   /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
+const semverPrefixPattern = /^(\d+)\.(\d+)\.(\d+)/;
 const protectedTags = new Set(['latest', 'head', 'staging', 'canary']);
 
 export type DevReleasePlan = {
@@ -28,6 +30,17 @@ export type PlanDevReleaseOptions = {
   exec?: Exec | undefined;
   workflowRefName: string;
 };
+
+export function nextPatchVersion(version: string): string {
+  const match = version.match(semverPrefixPattern);
+  if (!match) {
+    throw new Error(`Cannot derive next patch version from "${version}"`);
+  }
+  const major = match[1];
+  const minor = match[2];
+  const patch = Number(match[3]) + 1;
+  return `${major}.${minor}.${patch}`;
+}
 
 export function runDevReleasePlanCli() {
   const plan = planDevRelease({
@@ -65,7 +78,14 @@ export function planDevRelease({
   assertGitSha(sourceSha, 'source SHA');
 
   const shortSha = resolveUniqueShortSha(sourceSha, exec);
-  const imageTag = deriveDevImageTag(trimmedBranch, sourceSha, shortSha);
+  const sourceVersion = readZeroPackageVersionAt(sourceSha, exec);
+  const nextPatch = nextPatchVersion(sourceVersion);
+  const imageTag = deriveDevImageTag(
+    trimmedBranch,
+    sourceSha,
+    nextPatch,
+    shortSha,
+  );
   validateImageTag(imageTag);
 
   return {
@@ -115,16 +135,20 @@ export function resolveUniqueShortSha(
 export function deriveDevImageTag(
   branch: string,
   sourceSha: string,
+  nextPatch = '0.0.1',
   shortSha = sourceSha.slice(0, 8),
 ): string {
+  const prefix = `${nextPatch}-dev-`;
   if (gitShaPattern.test(branch.trim())) {
-    return `0.0.0-dev-${shortSha}`;
+    return `${prefix}${shortSha}`;
   }
 
   const rawClean = branch.trim().replace(gitRefPrefixPattern, '');
 
   let base: string;
-  if (rawClean.startsWith('0.0.0-')) {
+  if (rawClean.startsWith(prefix)) {
+    base = sanitizeBranchName(rawClean.slice(prefix.length));
+  } else if (rawClean.startsWith('0.0.0-')) {
     base = sanitizeBranchName(rawClean.slice('0.0.0-'.length));
   } else {
     base = sanitizeBranchName(rawClean);
@@ -141,15 +165,15 @@ export function deriveDevImageTag(
   }
 
   if (!base) {
-    return `0.0.0-dev-${shortSha}`;
+    return `${prefix}${shortSha}`;
   }
 
-  const maxBaseLen = 128 - '0.0.0-dev-'.length - 1 - shortSha.length;
+  const maxBaseLen = 128 - prefix.length - 1 - shortSha.length;
   const trimmedBase = base
     .slice(0, maxBaseLen)
     .replace(trailingHyphenPattern, '');
 
-  return `0.0.0-dev-${trimmedBase}-${shortSha}`;
+  return `${prefix}${trimmedBase}-${shortSha}`;
 }
 
 export function validateImageTag(tag: string): void {
@@ -163,14 +187,14 @@ export function validateImageTag(tag: string): void {
       `Tag "${tag}" is protected and cannot be overwritten by dev releases.`,
     );
   }
-  if (!tag.startsWith('0.0.0-')) {
-    throw new Error(
-      `Tag "${tag}" must start with "0.0.0-" to ensure CloudZero SemVer compatibility and prevent colliding with official releases.`,
-    );
-  }
   if (!semverRegex.test(tag)) {
     throw new Error(
       `Tag "${tag}" is not a valid semantic version (SemVer 2.0.0). Prerelease identifiers may only contain alphanumerics and hyphens.`,
+    );
+  }
+  if (!tag.includes('-')) {
+    throw new Error(
+      `Tag "${tag}" must be a prerelease version (e.g. contain a "-dev-" suffix) to prevent colliding with official releases.`,
     );
   }
 }

--- a/scripts/src/dev-release/plan.ts
+++ b/scripts/src/dev-release/plan.ts
@@ -187,14 +187,16 @@ export function validateImageTag(tag: string): void {
       `Tag "${tag}" is protected and cannot be overwritten by dev releases.`,
     );
   }
-  if (!semverRegex.test(tag)) {
+  const match = tag.match(semverRegex);
+  if (!match) {
     throw new Error(
       `Tag "${tag}" is not a valid semantic version (SemVer 2.0.0). Prerelease identifiers may only contain alphanumerics and hyphens.`,
     );
   }
-  if (!tag.includes('-dev-')) {
+  const prerelease = match[4];
+  if (!prerelease?.startsWith('dev-')) {
     throw new Error(
-      `Tag "${tag}" must be a dev prerelease version containing "-dev-" to prevent colliding with official releases.`,
+      `Tag "${tag}" must be a dev prerelease version with a "-dev-" prefix immediately following the core version (e.g. <x>.<y>.<z>-dev-...).`,
     );
   }
 }

--- a/scripts/src/dev-release/plan.ts
+++ b/scripts/src/dev-release/plan.ts
@@ -192,9 +192,9 @@ export function validateImageTag(tag: string): void {
       `Tag "${tag}" is not a valid semantic version (SemVer 2.0.0). Prerelease identifiers may only contain alphanumerics and hyphens.`,
     );
   }
-  if (!tag.includes('-')) {
+  if (!tag.includes('-dev-')) {
     throw new Error(
-      `Tag "${tag}" must be a prerelease version (e.g. contain a "-dev-" suffix) to prevent colliding with official releases.`,
+      `Tag "${tag}" must be a dev prerelease version containing "-dev-" to prevent colliding with official releases.`,
     );
   }
 }


### PR DESCRIPTION
### Problem
1. **SemVer Invalidation & Deployment Failures**: Dev releases hardcoded tags as `0.0.0-dev-...`. Under SemVer 2.0.0 precedence rules, a prerelease has lower precedence than its normal release ($\text{0.0.0-dev-...} < \text{0.0.0}$). Downstream consumers (like CloudZero's deployment controller) comparing against minimum version thresholds failed assertion checks (`assert(best)`), crashing deployments.
2. **Loss of Base Lineage**: Using `0.0.0` discarded all base version lineage. If someone built a dev image from an older maintenance commit (e.g. `0.24.0`), downstream systems could not differentiate it from bleeding-edge code, wrongly applying incompatible configuration flags.
3. **Option Parsing in Workflow Summary**: `printf` in `dev-release.yml` failed when rendering bullet items starting with hyphens (`- Docker Hub:`).

### Solution
* **Next-Patch Prerelease Tagging**: Read `packages/zero/package.json` at `sourceSha` via `readZeroPackageVersionAt` and increment the patch version in memory (e.g. `1.11.0` $\rightarrow$ `1.11.1`).
* **Tag Generation**: Format dev image tags as `<nextPatch>-dev-<branch>-<shortSha>` (e.g. `1.11.1-dev-mybranch-69417d8b`). Because $\text{X.Y.Z} < \text{X.Y.(Z+1)-dev}$, dev builds are strictly higher than their base release, naturally satisfying SemVer comparison thresholds.
* **Tag Validation**: Updated `validateImageTag` to enforce valid SemVer with a prerelease identifier (`-dev-`) to prevent collisions with official releases, replacing the hardcoded `0.0.0-` check.
* **Workflow Fix**: Escape leading hyphens in `dev-release.yml` using `printf --`.

### Verification
* Added unit tests for `nextPatchVersion` covering standard versions (`1.11.0` $\rightarrow$ `1.11.1`), boundary versions (`0.25.1` $\rightarrow$ `0.25.2`), and prerelease bases (`1.2.3-canary.1` $\rightarrow$ `1.2.4`).
* Added unit test in `plan.test.ts` verifying that dev releases from older base commits (e.g. `0.24.0`) correctly derive the next patch (`0.24.1-dev-...`).
* Tested `planDevRelease` locally against commit `a219fa82...` confirming it resolves to `1.11.1-dev-a219fa82`.
