### PR TITLE
chore(zero-cache): improved replication slot cleanup

### DIFF
--- a/packages/zero-cache/src/services/change-source/pg/change-source.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.pg.test.ts
@@ -1181,50 +1181,49 @@ describe('change-source/pg', {timeout: 30000, retry: 3}, () => {
       {watermark: expect.stringMatching(WATERMARK_REGEX)},
     ]);
 
-    // Verify that the older replica state has been cleaned up.
-    // The newer replica state should remain.
-    const replicasAfterSource2 = await upstream.unsafe(`
-      SELECT slot FROM "${APP_ID}_${SHARD_NUM}".replicas ORDER BY slot
-    `);
-    expect(replicasAfterSource2).toEqual(replicas3.slice(1));
+    // Taking over on the new slot is non-disruptive: under the time-based
+    // cleanup model, it does NOT proactively delete older replicas or drop
+    // their slots (that is deferred to the ReplicationSlotCleanupMonitor once
+    // a slot has been inactive for the configured timeout, and is covered by
+    // replication-slot-cleanup-monitor.pg.test.ts). All replica rows and
+    // slots therefore remain.
+    const replicaSlotsAfterSource2 = await upstream<{slot: string}[]>`
+      SELECT slot FROM ${upstream(`${APP_ID}_${SHARD_NUM}`)}.replicas
+        ORDER BY slot
+    `.values();
+    expect(replicaSlotsAfterSource2).toEqual(slots2);
 
-    // However, all 3 replication slots should remain because [1] is still
-    // active and [3], although not yet active, is a newer replica.
-    const slots3 = await upstream<{slot: string}[]>`
+    const slotsAfterSource2 = await upstream<{slot: string}[]>`
         SELECT slot_name as slot FROM pg_replication_slots
           WHERE slot_name LIKE ${APP_ID + '\\_' + SHARD_NUM + '\\_%'}
           ORDER BY slot_name
       `.values();
-    expect(slots3).toHaveLength(3);
+    expect(slotsAfterSource2).toEqual(slots2);
 
-    // Shut down the first replica slot and then start the third one.
+    // Shut down the first replica's stream and take over on the third slot.
     changes1.cancel();
     const {changes: changes3} = await startStream('00', source3);
 
-    // Now there should only be one replica left.
-    const replicasAfterSource3 = await upstream.unsafe(`
-      SELECT slot FROM "${APP_ID}_${SHARD_NUM}".replicas ORDER BY slot
-    `);
-    expect(replicasAfterSource3).toEqual(replicas3.slice(2));
+    // Cancelling the first stream and taking over on the third is likewise
+    // non-disruptive: all replica rows and slots still remain. Cleanup of
+    // the now-inactive first slot is left to the inactivity monitor.
+    const replicaSlotsAfterSource3 = await upstream<{slot: string}[]>`
+      SELECT slot FROM ${upstream(`${APP_ID}_${SHARD_NUM}`)}.replicas
+        ORDER BY slot
+    `.values();
+    expect(replicaSlotsAfterSource3).toEqual(slots2);
 
-    // Verify that the two latter slots remain. The first one should have
-    // been dropped because the source stopped subscribing. The second
-    // one is allowed to drain.
-    // (Use waitFor to reduce flakiness because the drop is non-transactional.)
-    await vi.waitFor(
-      async () => {
-        const slots3 = await upstream<{slot: string}[]>`
+    const slotsAfterSource3 = await upstream<{slot: string}[]>`
       SELECT slot_name as slot FROM pg_replication_slots
         WHERE slot_name LIKE ${APP_ID + '\\_' + SHARD_NUM + '\\_%'}
         ORDER BY slot_name
     `.values();
-        expect(slots3).toEqual(slots2.slice(1));
-      },
-      {interval: 100},
-    );
+    expect(slotsAfterSource3).toEqual(slots2);
 
     changes2.cancel();
     changes3.cancel();
+    await source2.stop();
+    await source3.stop();
     replicaFile2.delete();
     replicaFile3.delete();
   });

--- a/packages/zero-cache/src/services/change-source/pg/change-source.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.test.ts
@@ -82,6 +82,7 @@ test('a non-transactional foreign-shard message does not interrupt a running bac
       publications: ['zero_pub'],
       initialSchema: {},
     } as unknown as Replica,
+    170000, // pgVersion (PG 17)
     {backupPath: null, backupV5: false} as unknown as BackupOptions,
     {} as ServerContext,
     0, // lagReportIntervalMs: no LagReporter
@@ -277,24 +278,21 @@ test('lag reporter retries missing reports', async () => {
   vi.useFakeTimers();
   vi.setSystemTime(1_000);
 
-  const dbMock = vi.fn((strings: TemplateStringsArray) => {
-    if (strings.join('').includes('current_setting')) {
-      return [{pgVersion: 170000}];
-    }
-
-    return [
-      {
-        commitTimeMs: Date.now(),
-        lsn: `0/${dbMock.mock.calls.length.toString(16)}`,
-      },
-    ];
-  });
+  // pgVersion is now supplied to the LagReporter constructor, so it no longer
+  // queries current_setting; every call is an emit-message report.
+  const dbMock = vi.fn(() => [
+    {
+      commitTimeMs: Date.now(),
+      lsn: `0/${dbMock.mock.calls.length.toString(16)}`,
+    },
+  ]);
   const db = dbMock as unknown as PostgresDB;
 
   const reporter = new LagReporter(
     createSilentLogContext(),
     {appID: 'test', shardNum: 0},
     db,
+    170000, // pgVersion (PG 17)
     10,
   );
 
@@ -303,16 +301,16 @@ test('lag reporter retries missing reports', async () => {
       firstCommitTimeMs: 1_000,
       nextSendTimeMs: 1_000,
     });
-    expect(dbMock).toHaveBeenCalledTimes(2);
+    expect(dbMock).toHaveBeenCalledTimes(1);
 
     await vi.advanceTimersByTimeAsync(9);
-    expect(dbMock).toHaveBeenCalledTimes(2);
+    expect(dbMock).toHaveBeenCalledTimes(1);
 
     await vi.advanceTimersByTimeAsync(1);
-    expect(dbMock).toHaveBeenCalledTimes(3);
+    expect(dbMock).toHaveBeenCalledTimes(2);
 
     await vi.advanceTimersByTimeAsync(10);
-    expect(dbMock).toHaveBeenCalledTimes(4);
+    expect(dbMock).toHaveBeenCalledTimes(3);
   } finally {
     reporter.stop();
     vi.useRealTimers();

--- a/packages/zero-cache/src/services/change-source/pg/change-source.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.ts
@@ -97,15 +97,15 @@ import type {
 } from './logical-replication/pgoutput.types.ts';
 import {subscribe, type StreamMessage} from './logical-replication/stream.ts';
 import {fromBigInt, toBigInt, toStateVersionString, type LSN} from './lsn.ts';
+import {ReplicationSlotCleanupMonitor} from './replication-slot-cleanup-monitor.ts';
 import {registerReplicationSlotHealthMetrics} from './replication-slot-health.ts';
-import {dropOldReplicasAndSlots} from './replication-slots.ts';
 import {replicationEventSchema, type ReplicationEvent} from './schema/ddl.ts';
 import {ensureShardSchema} from './schema/init.ts';
 import {
   getPublicationInfo,
+  warnForSkippedIndexes,
   type PublishedSchema,
   type PublishedTableWithReplicaIdentity,
-  warnForSkippedIndexes,
 } from './schema/published.ts';
 import {
   dropShard,
@@ -121,8 +121,6 @@ import {
   type ReplicaState,
 } from './schema/shard.ts';
 import {validate} from './schema/validation.ts';
-
-const REPLICA_SLOT_CLEANUP_INTERVAL_MS = 30_000;
 
 interface PurgeLock {
   release(): Promise<void>;
@@ -194,7 +192,7 @@ export async function initializePostgresChangeSource(
 
     // Check that upstream is properly setup, and throw an AutoReset to re-run
     // initial sync if not.
-    const upstreamReplica = await checkAndUpdateUpstream(
+    const {upstreamReplica, pgVersion} = await checkAndUpdateUpstream(
       lc,
       db,
       shard,
@@ -216,6 +214,7 @@ export async function initializePostgresChangeSource(
       upstreamURI,
       shard,
       upstreamReplica,
+      pgVersion,
       {backupPath, backupV5},
       context,
       lagReportIntervalMs,
@@ -360,7 +359,9 @@ async function checkAndUpdateUpstream(
       `replication slot ${slot} has been invalidated for exceeding the max_slot_wal_keep_size`,
     );
   }
-  return upstreamReplica;
+  const [{pgVersion}] = await sql<{pgVersion: number}[]> /*sql*/ `
+    SELECT current_setting('server_version_num')::int as "pgVersion"`;
+  return {upstreamReplica, pgVersion};
 }
 
 // Parameterize this if necessary. In practice starvation may never happen.
@@ -380,6 +381,7 @@ export class PostgresChangeSource implements ChangeSource {
   readonly #upstreamUri: string;
   readonly #shard: ShardID;
   readonly #replica: Replica;
+  readonly #slotCleanupMonitor: ReplicationSlotCleanupMonitor;
   readonly #backupOptions: BackupOptions;
   readonly #context: ServerContext;
   readonly #lagReporter: LagReporter | null;
@@ -394,6 +396,7 @@ export class PostgresChangeSource implements ChangeSource {
     upstreamUri: string,
     shard: ShardID,
     replica: Replica,
+    pgVersion: number,
     backupOptions: BackupOptions,
     context: ServerContext,
     lagReportIntervalMs: number,
@@ -409,14 +412,21 @@ export class PostgresChangeSource implements ChangeSource {
     this.#lc = lc.withContext('component', 'change-source');
     this.#subscribe = deps.subscribe ?? subscribe;
     this.#streamBackfill = deps.streamBackfill ?? streamBackfill;
+    // used for schema changes, lag reporting, and slot cleanup
     this.#db = pgClient(lc, upstreamUri, 'replication-monitor', {
-      max: 1,
-      // used occasionally for schema changes, periodically for lag reporting
-      ['idle_timeout']: 60,
+      max: 3,
+      idle_timeout: 60,
     });
     this.#upstreamUri = upstreamUri;
     this.#shard = shard;
     this.#replica = replica;
+    this.#slotCleanupMonitor = new ReplicationSlotCleanupMonitor(
+      lc.withContext('component', 'replication-slot-monitor'),
+      shard,
+      this.#db,
+      pgVersion,
+      replica.slot,
+    );
     this.#backupOptions = backupOptions;
     this.#context = context;
     this.#textCopy = textCopy ?? false;
@@ -427,6 +437,7 @@ export class PostgresChangeSource implements ChangeSource {
             lc.withContext('component', 'lag-reporter'),
             shard,
             this.#db,
+            pgVersion,
             lagReportIntervalMs,
           )
         : null;
@@ -441,7 +452,6 @@ export class PostgresChangeSource implements ChangeSource {
   async stop(): Promise<void> {
     this.#stopped = true;
     this.#lagReporter?.stop();
-    clearTimeout(this.#cleanupTimer);
     await this.#db.end();
   }
 
@@ -480,12 +490,22 @@ export class PostgresChangeSource implements ChangeSource {
     const config = await getInternalShardConfig(this.#db, this.#shard);
     const {slot} = this.#replica;
     this.#lc.info?.(`starting replication stream@${slot}`);
-    return this.startStreamInternal(
+    const changeStream = await this.startStreamInternal(
       slot,
       clientWatermark,
       config,
       backfillRequests,
     );
+    const {signal} = changeStream.changes;
+    if (!signal.aborted) {
+      // The slot cleanup monitor runs when a replication slot is active.
+      // If no slots are active, they are all available for claiming by a
+      // replication-manager; inactive slots are only cleaned up when at
+      // least one a stream is being processed.
+      this.#slotCleanupMonitor.start();
+      signal.addEventListener('abort', () => this.#slotCleanupMonitor.stop());
+    }
+    return changeStream;
   }
 
   // Exported for testing.
@@ -728,34 +748,6 @@ export class PostgresChangeSource implements ChangeSource {
             "backupPath" = ${this.#backupOptions.backupPath},
             "backupV5" = ${this.#backupOptions.backupV5}
         WHERE id = ${replicaID}`;
-    void this.#cleanUpOlderReplicasAndSlots();
-  }
-
-  #cleanupTimer: NodeJS.Timeout | undefined;
-
-  async #cleanUpOlderReplicasAndSlots() {
-    clearTimeout(this.#cleanupTimer);
-
-    try {
-      const result = await dropOldReplicasAndSlots(
-        this.#lc,
-        this.#db,
-        this.#shard,
-        this.#replica.rank,
-      );
-      if (result.draining === 0) {
-        this.#lc.info?.(`finished cleaning up replicas and slots`, {result});
-        return;
-      }
-      this.#lc.info?.(`old slots still draining`, {result});
-    } catch (e) {
-      this.#lc.warn?.(`error dropping replication slots`, e);
-    }
-
-    this.#cleanupTimer = setTimeout(
-      () => this.#cleanUpOlderReplicasAndSlots(),
-      REPLICA_SLOT_CLEANUP_INTERVAL_MS,
-    );
   }
 }
 
@@ -861,7 +853,7 @@ export class LagReporter {
     },
   );
 
-  #pgVersion: number | undefined;
+  readonly #pgVersion: number;
   #expectingLagReport: InitiatedLagReport | null = null;
   #timer: NodeJS.Timeout | undefined;
 
@@ -869,21 +861,14 @@ export class LagReporter {
     lc: LogContext,
     shard: ShardID,
     db: PostgresDB,
+    pgVersion: number,
     lagIntervalMs: number,
   ) {
     this.#lc = lc;
     this.messagePrefix = `${shard.appID}/${shard.shardNum}${LagReporter.MESSAGE_SUFFIX}`;
     this.#db = db;
+    this.#pgVersion = pgVersion;
     this.#lagIntervalMs = lagIntervalMs;
-  }
-
-  async #getPgVersion() {
-    if (this.#pgVersion === undefined) {
-      const [{pgVersion}] = await this.#db<{pgVersion: number}[]> /*sql*/ `
-        SELECT current_setting('server_version_num')::int as "pgVersion"`;
-      this.#pgVersion = pgVersion;
-    }
-    return this.#pgVersion;
   }
 
   get pgVersion() {
@@ -891,7 +876,6 @@ export class LagReporter {
   }
 
   async initiateLagReport(log = false) {
-    const pgVersion = this.#pgVersion ?? (await this.#getPgVersion());
     const now = Date.now();
     const id = nanoid();
 
@@ -903,7 +887,7 @@ export class LagReporter {
     let lsn: string;
 
     try {
-      if (pgVersion >= PG_17) {
+      if (this.#pgVersion >= PG_17) {
         [{commitTimeMs, lsn}] = await this.#db /*sql*/ `
           WITH CTE AS (SELECT extract(epoch from now()) * 1000 AS "commitTimeMs")
           SELECT "commitTimeMs", pg_logical_emit_message(

--- a/packages/zero-cache/src/services/change-source/pg/change-source.ts
+++ b/packages/zero-cache/src/services/change-source/pg/change-source.ts
@@ -501,7 +501,7 @@ export class PostgresChangeSource implements ChangeSource {
       // The slot cleanup monitor runs when a replication slot is active.
       // If no slots are active, they are all available for claiming by a
       // replication-manager; inactive slots are only cleaned up when at
-      // least one a stream is being processed.
+      // least one stream is being processed.
       this.#slotCleanupMonitor.start();
       signal.addEventListener('abort', () => this.#slotCleanupMonitor.stop());
     }

--- a/packages/zero-cache/src/services/change-source/pg/replication-slot-cleanup-monitor.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/replication-slot-cleanup-monitor.pg.test.ts
@@ -1,0 +1,220 @@
+import {LogContext} from '@rocicorp/logger';
+import {beforeEach, describe, expect, vi} from 'vitest';
+import {
+  createSilentLogContext,
+  TestLogSink,
+} from '../../../../../shared/src/logging-test-utils.ts';
+import {test, type PgTest} from '../../../test/db.ts';
+import {PG_15, PG_17} from '../../../types/pg-versions.ts';
+import {type PostgresDB} from '../../../types/pg.ts';
+import type {ShardID} from '../../../types/shards.ts';
+import {ReplicationSlotCleanupMonitor} from './replication-slot-cleanup-monitor.ts';
+import {
+  createReplicaAndSlot,
+  type ReplicationSlotResult,
+} from './replication-slots.ts';
+import {
+  ensureGlobalTables,
+  metadataPublicationName,
+  shardSetup,
+} from './schema/shard.ts';
+
+describe('ReplicationSlotCleanupMonitor', () => {
+  // Note: use a slot-pool prefix unique to this file. Replication slot names
+  // are cluster-wide unique, so sharing e.g. `zero_18_*` with another pg test
+  // file causes cross-file slot clobbering when vitest runs them in parallel.
+  const APP_ID = 'slotcln';
+  const SHARD_NUM = 18;
+  const shard: ShardID = {appID: APP_ID, shardNum: SHARD_NUM};
+
+  let upstream: PostgresDB;
+  let pgVersion: number;
+  const monitors: ReplicationSlotCleanupMonitor[] = [];
+
+  beforeEach<PgTest>(async ({testDBs}) => {
+    upstream = await testDBs.create('replication_slot_cleanup');
+    [{pgVersion}] =
+      await upstream`SELECT current_setting('server_version_num')::int as "pgVersion"`;
+    await ensureGlobalTables(upstream, shard);
+    const metadataPub = metadataPublicationName(APP_ID, SHARD_NUM);
+    await upstream.unsafe(
+      shardSetup(
+        {...shard, publications: ['foo_pub', metadataPub]},
+        metadataPub,
+      ),
+    );
+    return async () => {
+      monitors.forEach(m => m.stop());
+      monitors.length = 0;
+      await testDBs.drop(upstream);
+    };
+  });
+
+  const results: ReplicationSlotResult<string>[] = [];
+  // Creates a replica + slot (choosing the next name from the shard's pool),
+  // whose replication session is initially active (i.e. `active = true`).
+  async function createSlot(id: string) {
+    const result = await createReplicaAndSlot(
+      createSilentLogContext(),
+      upstream,
+      'initial-sync',
+      shard,
+      id,
+      false,
+      {backupPath: id, backupV5: true},
+      snapshot => Promise.resolve(`captured(${snapshot})`),
+    );
+    results.push(result);
+    return result;
+  }
+
+  async function waitForInactive(slot: string) {
+    await vi.waitFor(async () => {
+      const [row] = await upstream<{active: boolean}[]>`
+        SELECT active FROM pg_replication_slots WHERE slot_name = ${slot}`;
+      expect(row?.active).toBe(false);
+    });
+  }
+
+  beforeEach(() => {
+    results.length = 0;
+  });
+
+  test('getSlotsToCleanup tracks inactivity across polls (manual, PG <17 path)', async () => {
+    // 'a' stays active (the current slot), 'b' goes inactive.
+    await createSlot('rep_a');
+    const other = await createSlot('rep_b');
+    other.initialSession.destroy();
+    await waitForInactive('slotcln_18_b');
+
+    // Force the manual-tracking path regardless of the server version.
+    const monitor = new ReplicationSlotCleanupMonitor(
+      createSilentLogContext(),
+      shard,
+      upstream,
+      PG_15,
+      'slotcln_18_a',
+      {inactiveSlotCleanupTimeoutMs: 60_000},
+    );
+
+    // The first poll only records when the slot was first observed inactive.
+    const t0 = new Date(10_000_000);
+    expect(await monitor.getSlotsToCleanup(t0)).toEqual([]);
+
+    // Still within the timeout window: not yet eligible.
+    expect(
+      await monitor.getSlotsToCleanup(new Date(t0.getTime() + 59_999)),
+    ).toEqual([]);
+
+    // Once the timeout has elapsed, the inactive slot is eligible.
+    expect(
+      await monitor.getSlotsToCleanup(new Date(t0.getTime() + 60_000)),
+    ).toEqual(['slotcln_18_b']);
+
+    // The active current slot is never eligible, no matter how much time
+    // passes.
+    expect(
+      await monitor.getSlotsToCleanup(new Date(t0.getTime() + 60 * 60_000)),
+    ).toEqual(['slotcln_18_b']);
+  });
+
+  test('getSlotsToCleanup uses inactive_since (native, PG 17+ path)', async () => {
+    if (pgVersion < PG_17) {
+      return; // inactive_since only exists on PG 17+
+    }
+    await createSlot('rep_a');
+    const other = await createSlot('rep_b');
+    other.initialSession.destroy();
+    await waitForInactive('slotcln_18_b');
+
+    // A tiny timeout: the slot has been inactive "long enough".
+    const eager = new ReplicationSlotCleanupMonitor(
+      createSilentLogContext(),
+      shard,
+      upstream,
+      PG_17,
+      'slotcln_18_a',
+      {inactiveSlotCleanupTimeoutMs: 0},
+    );
+    expect(await eager.getSlotsToCleanup(new Date())).toEqual(['slotcln_18_b']);
+
+    // A long timeout: the slot has not been inactive long enough yet.
+    const patient = new ReplicationSlotCleanupMonitor(
+      createSilentLogContext(),
+      shard,
+      upstream,
+      PG_17,
+      'slotcln_18_a',
+      {inactiveSlotCleanupTimeoutMs: 60 * 60_000},
+    );
+    expect(await patient.getSlotsToCleanup(new Date())).toEqual([]);
+  });
+
+  test('disables cleanup when the current slot is not active', async () => {
+    // Set up an OTHER slot that would otherwise be eligible for cleanup...
+    const other = await createSlot('rep_a'); // slotcln_18_a
+    other.initialSession.destroy();
+    await waitForInactive('slotcln_18_a');
+
+    // ...but the current slot ('b') is also inactive, so cleanup is disabled.
+    const current = await createSlot('rep_b'); // slotcln_18_b
+    current.initialSession.destroy();
+    await waitForInactive('slotcln_18_b');
+
+    const sink = new TestLogSink();
+    const monitor = new ReplicationSlotCleanupMonitor(
+      new LogContext('debug', {}, sink),
+      shard,
+      upstream,
+      PG_15,
+      'slotcln_18_b', // current slot
+      {inactiveSlotCleanupTimeoutMs: 0},
+    );
+
+    // Even though 'a' is long-inactive, nothing is returned because the
+    // current slot is not active.
+    expect(await monitor.getSlotsToCleanup(new Date(10_000_000))).toEqual([]);
+    expect(
+      sink.messages.some(([, , args]) =>
+        String(args[0]).includes('current slot slotcln_18_b is not active'),
+      ),
+    ).toBe(true);
+  });
+
+  test('start() drops inactive slots and their replica rows', async () => {
+    // 'a' stays active (the current slot), 'b' goes inactive.
+    await createSlot('rep_a');
+    const other = await createSlot('rep_b');
+    other.initialSession.destroy();
+    await waitForInactive('slotcln_18_b');
+
+    const monitor = new ReplicationSlotCleanupMonitor(
+      createSilentLogContext(),
+      shard,
+      upstream,
+      PG_15,
+      'slotcln_18_a',
+      // Zero timeout so the second poll (once the slot's inactivity has been
+      // observed once) treats it as eligible; poll quickly to keep the test
+      // fast.
+      {inactiveSlotCleanupTimeoutMs: 0, pollIntervalMs: 20},
+    );
+    monitors.push(monitor);
+    monitor.start();
+
+    // The inactive slot and its replica row are eventually cleaned up.
+    await vi.waitFor(async () => {
+      const slots = await upstream<{slot: string}[]>`
+        SELECT slot_name as slot FROM pg_replication_slots
+          WHERE slot_name LIKE 'slotcln_18_%' ORDER BY slot_name`.values();
+      expect(slots).toEqual([['slotcln_18_a']]);
+
+      const replicas = await upstream<{slot: string}[]>`
+        SELECT slot FROM ${upstream(`${APP_ID}_${SHARD_NUM}`)}.replicas
+          ORDER BY slot`.values();
+      expect(replicas).toEqual([['slotcln_18_a']]);
+    });
+
+    monitor.stop();
+  });
+});

--- a/packages/zero-cache/src/services/change-source/pg/replication-slot-cleanup-monitor.ts
+++ b/packages/zero-cache/src/services/change-source/pg/replication-slot-cleanup-monitor.ts
@@ -1,0 +1,174 @@
+import type {LogContext} from '@rocicorp/logger';
+import {PG_17} from '../../../types/pg-versions.ts';
+import type {PostgresDB} from '../../../types/pg.ts';
+import type {ShardID} from '../../../types/shards.ts';
+import {dropInactiveSlotsAndReplicas} from './replication-slots.ts';
+import {replicationSlotPrefix} from './schema/shard.ts';
+
+type Options = {
+  inactiveSlotCleanupTimeoutMs?: number | undefined;
+  pollIntervalMs?: number | undefined;
+};
+
+const DEFAULT_INACTIVE_SLOT_CLEANUP_TIMEOUT_MS = 5 * 60 * 1000;
+const DEFAULT_POLL_INTERVAL_MS = 60 * 1000;
+
+export class ReplicationSlotCleanupMonitor {
+  readonly #lc: LogContext;
+
+  /** The shard constrains which slots are monitored (e.g. zero_0_*). */
+  readonly #shard: ShardID;
+  readonly #upstream: PostgresDB;
+  /**
+   * This slot that this task is using. Cleanup of slots is predicated on
+   * this slot remaining active, in order to guarantee at least one healthy
+   * slot in the shard.
+   */
+  readonly #currentSlot: string;
+
+  /**
+   * How long a slot is inactive (while the currentSlot is active) before it
+   * is eligible to be cleaned up. Because new slots are immediately connected
+   * to, even while an initial-sync or replica-restore is in progress, slots
+   * should only be inactive if no server is using it, or if a server was
+   * disconnected (e.g. a pg restart) and is in the process of reconnecting
+   * to it (see `keepSlotActiveUntilTakenOver`).
+   *
+   * As such, this timeout should be long enough to account for a server
+   * reconnecting to upstream. Note again that the cleanup monitor only runs
+   * while at least one replication slot is active, guaranteeing that upstream
+   * replication is working.
+   */
+  readonly #inactiveSlotCleanupTimeoutMs: number;
+  readonly #pollIntervalMs: number;
+
+  /** Manually tracked inactive times for PG < 17. null for PG 17+ */
+  readonly #firstInactiveTimes: Map<string, Date> | null;
+
+  #pollTimer: NodeJS.Timeout | undefined;
+
+  constructor(
+    lc: LogContext,
+    shard: ShardID,
+    upstream: PostgresDB,
+    upstreamPgServerVersionNum: number,
+    currentSlot: string,
+    {inactiveSlotCleanupTimeoutMs, pollIntervalMs}: Options = {},
+  ) {
+    this.#lc = lc.withContext('component', 'replication-slot-cleanup-monitor');
+    this.#shard = shard;
+    this.#upstream = upstream;
+    this.#currentSlot = currentSlot;
+    this.#inactiveSlotCleanupTimeoutMs =
+      inactiveSlotCleanupTimeoutMs ?? DEFAULT_INACTIVE_SLOT_CLEANUP_TIMEOUT_MS;
+    this.#pollIntervalMs = pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+    this.#firstInactiveTimes =
+      upstreamPgServerVersionNum >= PG_17 ? null : new Map();
+  }
+
+  start() {
+    if (this.#pollTimer) {
+      this.#lc.warn?.(`monitor already started`);
+      return;
+    }
+    this.#pollTimer = setInterval(
+      () =>
+        this.#poll(new Date()).catch(e =>
+          this.#lc.warn?.(`error checking replication slots`, e),
+        ),
+      this.#pollIntervalMs,
+    );
+  }
+
+  stop() {
+    clearInterval(this.#pollTimer);
+    this.#pollTimer = undefined;
+    this.#firstInactiveTimes?.clear();
+  }
+
+  async #poll(now: Date) {
+    if (!this.#pollTimer) {
+      return; // concurrently stopped
+    }
+    const slots = await this.getSlotsToCleanup(now);
+    if (slots.length) {
+      await dropInactiveSlotsAndReplicas(
+        this.#lc,
+        this.#upstream,
+        this.#shard,
+        slots,
+      );
+    }
+  }
+
+  async getSlotsToCleanup(now: Date): Promise<string[]> {
+    const slotPoolPrefix = replicationSlotPrefix(this.#shard);
+
+    const slotsToCleanUp: string[] = [];
+    const trackedInactiveTimes = this.#firstInactiveTimes;
+
+    if (trackedInactiveTimes) {
+      // For PG <17, each poll tracks and updates earliest time the slot was
+      // observed to be inactive.
+      const shardSlots = await this.#upstream<{slot: string; active: boolean}[]>
+      /*sql*/ `
+        SELECT slot_name AS slot, active FROM pg_replication_slots
+          WHERE slot_name LIKE ${slotPoolPrefix + '%'};
+      `;
+      for (const {slot, active} of shardSlots) {
+        if (slot === this.#currentSlot && !active) {
+          this.#lc.warn?.(
+            `current slot ${this.#currentSlot} is not active. disabling cleanup.`,
+          );
+          this.stop();
+          return [];
+        }
+        if (active) {
+          trackedInactiveTimes.delete(slot);
+        } else {
+          const inactiveSince = trackedInactiveTimes.get(slot);
+          if (!inactiveSince) {
+            trackedInactiveTimes.set(slot, now);
+          } else if (
+            now.getTime() - inactiveSince.getTime() >=
+            this.#inactiveSlotCleanupTimeoutMs
+          ) {
+            this.#lc.info?.(
+              `slot ${slot} has been inactive since ${inactiveSince.toISOString()} and is eligible for cleanup`,
+            );
+            slotsToCleanUp.push(slot);
+          }
+        }
+      }
+    } else {
+      // PG 17+ is simpler as inactivity time is tracked in the table.
+      const expiration = now.getTime() - this.#inactiveSlotCleanupTimeoutMs;
+      const inactiveSlots = await this.#upstream<
+        {slot: string; inactiveSince: number}[]
+      > /*sql*/ `
+        SELECT slot_name AS slot, inactive_since AS "inactiveSince" FROM pg_replication_slots
+          WHERE slot_name LIKE ${slotPoolPrefix + '%'}
+            AND active = false
+            AND inactive_since IS NOT NULL;
+      `;
+      for (const {slot, inactiveSince} of inactiveSlots) {
+        if (slot === this.#currentSlot) {
+          this.#lc.warn?.(
+            `current slot ${this.#currentSlot} is not active. disabling cleanup.`,
+          );
+          this.stop();
+          return [];
+        }
+        // The slot has been inactive since at or before the expiration cutoff
+        // (now - timeout), i.e. inactive for at least the timeout duration.
+        if (inactiveSince <= expiration) {
+          this.#lc.info?.(
+            `slot ${slot} has been inactive since ${new Date(inactiveSince).toISOString()} and is eligible for cleanup`,
+          );
+          slotsToCleanUp.push(slot);
+        }
+      }
+    }
+    return slotsToCleanUp;
+  }
+}

--- a/packages/zero-cache/src/services/change-source/pg/replication-slots.pg.test.ts
+++ b/packages/zero-cache/src/services/change-source/pg/replication-slots.pg.test.ts
@@ -9,7 +9,7 @@ import type {ShardID} from '../../../types/shards.ts';
 import {
   createReplicaAndSlot,
   createReplicationSlot,
-  dropOldReplicasAndSlots,
+  dropInactiveSlotsAndReplicas,
   slotPoolSuffix,
   type ReplicationSlotResult,
 } from './replication-slots.ts';
@@ -103,7 +103,11 @@ describe('createReplicationSlot', () => {
     }
 
     // Cleanup
-    await dropOldReplicasAndSlots(lc, upstream, shard, 100n);
+    await dropInactiveSlotsAndReplicas(lc, upstream, shard, [
+      'zero_18_a',
+      'zero_18_b',
+      'zero_18_c',
+    ]);
   });
 
   test('createReplicationSlot times out behind an older idle transaction', async () => {
@@ -255,11 +259,11 @@ describe('createReplicationSlot', () => {
     ]);
 
     // Cleanup
-    expect(await dropOldReplicasAndSlots(lc, upstream, shard, 100n)).toEqual({
-      dropped: 0,
-      active: 0,
-      draining: 3,
-    });
+    await dropInactiveSlotsAndReplicas(lc, upstream, shard, [
+      'zero_18_a',
+      'zero_18_b',
+      'zero_18_c',
+    ]);
   });
 
   test('concurrent replica creation uses different slot names', async () => {
@@ -290,11 +294,11 @@ describe('createReplicationSlot', () => {
     expect(new Set(replicaSlots.flat())).toEqual(expectedSlots);
 
     // Cleanup
-    expect(await dropOldReplicasAndSlots(lc, upstream, shard, 100n)).toEqual({
-      dropped: 0,
-      active: 0,
-      draining: 3,
-    });
+    await dropInactiveSlotsAndReplicas(lc, upstream, shard, [
+      'zero_18_a',
+      'zero_18_b',
+      'zero_18_c',
+    ]);
   });
 
   test('failure from captureSnapshot cleans up slot', async () => {
@@ -321,7 +325,7 @@ describe('createReplicationSlot', () => {
     expect(replicaSlots).toEqual([]);
   });
 
-  test('dropReplicaAndSlots', async () => {
+  test('dropInactiveSlotsAndReplicas', async () => {
     const lc = createSilentLogContext();
     const results: ReplicationSlotResult<string>[] = [];
     const create = async (id: string) => {
@@ -332,42 +336,56 @@ describe('createReplicationSlot', () => {
         shard,
         id,
         false,
-        {
-          backupPath: id,
-          backupV5: true,
-        },
+        {backupPath: id, backupV5: true},
         snapshot => Promise.resolve(`captured(${snapshot})`),
       );
       results.push(result);
     };
 
-    await create('rep_1');
-    await create('rep_2');
-    await create('rep_3');
+    // Creates slots zero_18_{a,b,c,d} from the pool, all initially active.
+    await create('rep_a');
+    await create('rep_b');
+    await create('rep_c');
+    await create('rep_d');
 
-    // Close end the first replication slot but leave the second
-    // one active.
-    results[0].initialSession.destroy();
-
-    await vi.waitFor(async () => {
-      expect(await dropOldReplicasAndSlots(lc, upstream, shard, 3n)).toEqual({
-        active: 1,
-        draining: 1,
-        dropped: 1,
-      });
-    });
-
-    // Now close the rest.
+    // Keep 'a' active; make b, c, and d inactive.
     results[1].initialSession.destroy();
     results[2].initialSession.destroy();
+    results[3].initialSession.destroy();
 
     await vi.waitFor(async () => {
-      expect(
-        await dropOldReplicasAndSlots(lc, upstream, shard, 4n),
-      ).toMatchObject({
-        active: 0,
-        draining: 0,
-      });
+      const inactive = await upstream<{slot: string}[]>`
+        SELECT slot_name as slot FROM pg_replication_slots
+          WHERE slot_name LIKE 'zero_18_%' AND NOT active
+          ORDER BY slot_name`.values();
+      expect(inactive).toEqual([['zero_18_b'], ['zero_18_c'], ['zero_18_d']]);
     });
+
+    // Request cleanup of a (active, must be skipped) and b, c. Slot d is
+    // inactive but not in the list, so it must be left alone.
+    await dropInactiveSlotsAndReplicas(lc, upstream, shard, [
+      'zero_18_a',
+      'zero_18_b',
+      'zero_18_c',
+    ]);
+
+    // Only the inactive, listed slots (b, c) were dropped. 'a' remains
+    // because it is still active; 'd' remains because it wasn't listed.
+    expect(
+      await upstream`
+        SELECT slot_name FROM pg_replication_slots
+          WHERE slot_name LIKE 'zero_18_%' ORDER BY slot_name`.values(),
+    ).toEqual([['zero_18_a'], ['zero_18_d']]);
+
+    // The replica rows for the dropped slots (b, c) were deleted; the rows
+    // for the surviving slots (a, d) remain.
+    expect(
+      await upstream`
+        SELECT id, slot FROM ${upstream(`${APP_ID}_${SHARD_NUM}`)}.replicas
+          ORDER BY slot`,
+    ).toMatchObject([
+      {id: 'rep_a', slot: 'zero_18_a'},
+      {id: 'rep_d', slot: 'zero_18_d'},
+    ]);
   });
 });

--- a/packages/zero-cache/src/services/change-source/pg/replication-slots.ts
+++ b/packages/zero-cache/src/services/change-source/pg/replication-slots.ts
@@ -257,33 +257,41 @@ export async function createReplicaAndSlot<T>(
   }
 }
 
-/**
- * Deletes "old" replicas (i.e. those with a lower rank than the current)
- * and attempts to drop replication slots that are not associated with any
- * replica.
- *
- * If a slot could not be dropped because there is still an active subscriber,
- * it will be reflected in the `draining` count that is returned. When there
- * are draining slots, the method should be retried until all orphaned slots
- * have been dropped.
- */
-export async function dropOldReplicasAndSlots(
+export function dropInactiveSlotsAndReplicas(
   lc: LogContext,
   sql: PostgresDB,
   shard: ShardID,
-  beforeRank: bigint,
-): Promise<{dropped: number; active: number; draining: number}> {
+  slots: string[],
+) {
+  const lockName = replicationSlotManagementLock(shard);
   const replicasTable = `${upstreamSchema(shard)}.replicas`;
-  const oldReplicas = await sql`
-    SELECT id, rank::float8, slot, version, "initialSyncContext", "subscriberContext"
-     FROM ${sql(replicasTable)} WHERE rank < ${beforeRank};
-  `;
-  if (oldReplicas.length) {
-    lc.info?.(`Deleting ${oldReplicas.length} old replica(s)`, {oldReplicas});
-    await sql`DELETE FROM ${sql(replicasTable)} WHERE rank < ${beforeRank}`;
-  }
 
-  return dropUnclaimedSlots(lc, sql, shard);
+  return runTx(sql, async tx => {
+    await tx`SELECT pg_advisory_xact_lock(hashtext(${lockName}))`;
+
+    const dropped = await tx<{slot: string; replicaID: string | null}[]>
+    /*sql*/ `
+      SELECT slot_name as slot, replica.id as "replicaID", pg_drop_replication_slot(slot_name) 
+        FROM pg_replication_slots
+        LEFT JOIN ${tx(replicasTable)} replica on slot_name = slot
+        WHERE slot_name IN ${tx(slots)} AND NOT active;
+    `;
+    if (dropped.length) {
+      lc.info?.(`dropped ${dropped.length} inactive replication slot(s)`, {
+        dropped,
+      });
+    }
+
+    const replicas = dropped
+      .map(({replicaID}) => replicaID)
+      .filter(id => id !== null);
+    if (replicas.length) {
+      // Delete replicas associated with the inactive (and now dropped) slots.
+      await tx
+      /*sql*/ `DELETE FROM ${tx(replicasTable)} WHERE id IN ${tx(replicas)}`;
+      lc.info?.(`deleted ${replicas.length} old replica(s)`, {replicas});
+    }
+  });
 }
 
 function dropUnclaimedSlots(


### PR DESCRIPTION
Replace the replica-rank-based replica/slot cleanup logic with an inactivity-based cleanup logic that both:
* supports upcoming multiple-replica semantics (RMv2)
* detects orphaned slots (e.g. due to failed initial-syncs)


### Background

As of https://github.com/rocicorp/mono/pull/6386, a new replication slot is immediately marked active after being created, even if changes are not yet being consumed (e.g. because initial-sync has to complete first). 

This is now the mechanism by which a replication-manager "claims" a replication slot. (The same reservation mechanism will be used to "[resume](https://app.notion.com/p/replicache/RMv2-More-Better-3423bed89545806582a7d8b857a3e9d9?source=copy_link#3533bed89545809aad0cc3197783d34c)" replication slots that are lost by an RM that crashed, for example).

Replication slots can thus be safely cleaned up by monitoring them and deleting ones that have been active for a long enough period of time (e.g. 5 minutes). This cleanup logic only runs while a replication slot is actually active and being processed, guaranteeing that at least one replication-manager is maintaining a live replica.