### PR TITLE
perf(zero-cache): batch change-streamer WebSocket messages to eliminate fan-out socket saturation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Rocicorp Monorepo
 
+TOUCH
 This is the mono repo for [Rocicorp](https://rocicorp.dev/)'s two main products (as of 2024).
 
 ## Zero

--- a/packages/zero-cache/src/services/change-streamer/broadcast.ts
+++ b/packages/zero-cache/src/services/change-streamer/broadcast.ts
@@ -1,5 +1,6 @@
 import type {LogContext} from '@rocicorp/logger';
 import {resolver} from '@rocicorp/resolver';
+import {must} from '../../../../shared/src/must.ts';
 import type {WatermarkedChange} from './change-streamer.ts';
 import type {Subscriber} from './subscriber.ts';
 
@@ -83,10 +84,11 @@ export class Broadcast {
    */
   static withoutTracking(
     subscribers: Iterable<Subscriber>,
-    change: WatermarkedChange,
+    change: WatermarkedChange | readonly WatermarkedChange[],
   ) {
+    const changes = toBatch(change);
     for (const sub of subscribers) {
-      void sub.send(change);
+      void sub.sendBatch(changes);
     }
   }
 
@@ -121,13 +123,14 @@ export class Broadcast {
   constructor(
     lc: LogContext,
     subscribers: Iterable<Subscriber>,
-    change: WatermarkedChange,
+    change: WatermarkedChange | readonly WatermarkedChange[],
     earlyRelease?: EarlyReleaseOptions,
   ) {
+    const changes = toBatch(change);
     this.#lc = lc;
     this.#pending = new Set(subscribers);
     this.#completed = [];
-    this.#watermark = change[0];
+    this.#watermark = must(changes.at(-1))[0];
     this.#majority = Math.floor(this.#pending.size / 2) + 1;
     this.#earlyReleaseTimeoutProportion =
       earlyRelease?.consensusTimeoutProportion;
@@ -135,16 +138,16 @@ export class Broadcast {
     this.#clearTimeout = earlyRelease?.clearTimeoutFn ?? clearTimeout;
 
     for (const sub of this.#pending) {
-      const changes = sub.numPending + 1; // add one for this `change`
+      const totalChanges = sub.numPending + changes.length;
       if (sub.mode === 'backup') {
         // Only gate consensus on the backup-replicator after it has finished
         // its initial catchup.
         this.#needsBackupResponse ||= !sub.isBacklogged();
       }
       void sub
-        .send(change)
+        .sendBatch(changes)
         .catch(() => {})
-        .finally(() => this.#markCompleted(sub, changes));
+        .finally(() => this.#markCompleted(sub, totalChanges));
     }
 
     // set done if there are no subscribers (mainly for tests)
@@ -259,3 +262,11 @@ type Completed = {
   /** The elapsed milliseconds. */
   elapsed: number;
 };
+
+function toBatch(
+  change: WatermarkedChange | readonly WatermarkedChange[],
+): readonly WatermarkedChange[] {
+  return Array.isArray(change[0])
+    ? (change as readonly WatermarkedChange[])
+    : [change as WatermarkedChange];
+}

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-http.pg.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-http.pg.test.ts
@@ -277,6 +277,7 @@ describe('change-streamer/http', () => {
         initial: true,
         // Non-default so that the roundtrip below pins the parameter.
         logsChangeStream: true,
+        wsBatched: true,
       } as const;
       await setChangeStreamerAddress(addr());
       const client = autoDiscover
@@ -302,14 +303,17 @@ describe('change-streamer/http', () => {
       downstream.push(begin);
       downstream.push(commit);
 
+      const batchedFrame = `{"id":1,"batch":[${begin},${commit}]}`;
+      const batchedSize = Math.round(batchedFrame.length / 2);
+
       expect(await drain(2, sub)).toEqual([
         {
           data: ['begin', {tag: 'begin'}, {commitWatermark: '456'}],
-          size: `{"id":1,"msg":${begin}}`.length,
+          size: batchedSize,
         },
         {
           data: ['commit', {tag: 'commit'}, {watermark: '456'}],
-          size: `{"id":2,"msg":${commit}}`.length,
+          size: batchedSize,
         },
       ]);
 

--- a/packages/zero-cache/src/services/change-streamer/change-streamer-http.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer-http.ts
@@ -143,7 +143,9 @@ export class ChangeStreamerHttpServer extends HttpService {
       }
 
       const downstream = await this.#changeStreamer.subscribe(ctx);
-      void streamOutStringified(this._lc, downstream, ws);
+      void streamOutStringified(this._lc, downstream, ws, {
+        batched: ctx.wsBatched,
+      });
     } catch (err) {
       closeWithError(this._lc, ws, err, PROTOCOL_ERROR);
     }
@@ -253,7 +255,7 @@ export class ChangeStreamerHttpClient implements ChangeStreamer {
   async subscribe(ctx: SubscriberContext): Promise<Source<SizedDownstream>> {
     const uri = await this.#resolveChangeStreamer(CHANGES_PATH);
 
-    const params = getParams(ctx);
+    const params = getParams({wsBatched: true, ...ctx});
     const ws = new WebSocket(uri + `?${params.toString()}`);
 
     return streamInWithSize(this.#lc, ws, downstreamSchema);
@@ -279,6 +281,7 @@ export function getSubscriberContext(req: RequestHeaders): SubscriberContext {
     // default: the barrier falls back to polling rather than waiting on an
     // ACK that would never be attributed to a writer.
     logsChangeStream: params.getBoolean('logsChangeStream'),
+    wsBatched: params.getBoolean('wsBatched'),
   };
 }
 
@@ -304,14 +307,18 @@ function checkProtocolVersion(pathname: string): number {
 // This is called from the client-side (i.e. the replicator).
 function getParams(ctx: SubscriberContext): URLSearchParams {
   // The protocolVersion is hard-coded into the CHANGES_PATH.
-  const {protocolVersion, ...stringParams} = ctx;
+  const {protocolVersion, wsBatched, ...stringParams} = ctx;
   assert(
     protocolVersion === PROTOCOL_VERSION,
     `replicator should be setting protocolVersion to ${PROTOCOL_VERSION}`,
   );
-  return new URLSearchParams({
+  const params = new URLSearchParams({
     ...stringParams,
     initial: ctx.initial ? 'true' : 'false',
     logsChangeStream: ctx.logsChangeStream ? 'true' : 'false',
   });
+  if (wsBatched) {
+    params.set('wsBatched', 'true');
+  }
+  return params;
 }

--- a/packages/zero-cache/src/services/change-streamer/change-streamer.ts
+++ b/packages/zero-cache/src/services/change-streamer/change-streamer.ts
@@ -156,6 +156,11 @@ export type SubscriberContext = {
    * subscriber's ACK advances its head or releases its catchup barrier.
    */
   logsChangeStream: boolean;
+
+  /**
+   * Whether the subscriber supports batched WebSocket frames.
+   */
+  wsBatched?: boolean | undefined;
 };
 
 /**

--- a/packages/zero-cache/src/services/change-streamer/forwarder.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/forwarder.test.ts
@@ -57,6 +57,52 @@ describe('change-streamer/forwarder', () => {
     expect(released).toBe(true);
   });
 
+  test('coalesces forward() across event loop turn into single batch', async () => {
+    const forwarder = new Forwarder(createSilentLogContext());
+    const [sub, _, receiver] = createSubscriber('00', true);
+    forwarder.add(sub);
+
+    const sendBatchSpy = vi.spyOn(sub, 'sendBatch');
+
+    for (let i = 1; i <= 5; i++) {
+      forwarder.forward([
+        `1${i}`,
+        'insert',
+        json(['data', messages.insert('issues', {id: `issue_${i}`})]),
+      ]);
+    }
+
+    expect(sendBatchSpy).not.toHaveBeenCalled();
+    expect(receiver.queued).toBe(1);
+
+    await nextEventLoopTurn();
+
+    expect(sendBatchSpy).toHaveBeenCalledTimes(1);
+    const batchedChanges = sendBatchSpy.mock.calls[0][0];
+    expect(batchedChanges).toHaveLength(5);
+    expect(receiver.queued).toBe(6);
+  });
+
+  test('flushes immediately when batch reaches FORWARD_BATCH_SIZE (64)', () => {
+    const forwarder = new Forwarder(createSilentLogContext());
+    const [sub, _, receiver] = createSubscriber('00', true);
+    forwarder.add(sub);
+
+    const sendBatchSpy = vi.spyOn(sub, 'sendBatch');
+
+    for (let i = 1; i <= 64; i++) {
+      forwarder.forward([
+        `${i.toString().padStart(4, '0')}`,
+        'insert',
+        json(['data', messages.insert('issues', {id: `issue_${i}`})]),
+      ]);
+    }
+
+    expect(sendBatchSpy).toHaveBeenCalledTimes(1);
+    expect(sendBatchSpy.mock.calls[0][0]).toHaveLength(64);
+    expect(receiver.queued).toBe(65);
+  });
+
   test('in transaction queueing', () => {
     const forwarder = new Forwarder(createSilentLogContext());
 

--- a/packages/zero-cache/src/services/change-streamer/forwarder.test.ts
+++ b/packages/zero-cache/src/services/change-streamer/forwarder.test.ts
@@ -83,6 +83,32 @@ describe('change-streamer/forwarder', () => {
     expect(receiver.queued).toBe(6);
   });
 
+  test('coalesces forward() across async microtask turns into single batch', async () => {
+    const forwarder = new Forwarder(createSilentLogContext());
+    const [sub, _, receiver] = createSubscriber('00', true);
+    forwarder.add(sub);
+
+    const sendBatchSpy = vi.spyOn(sub, 'sendBatch');
+
+    for (let i = 1; i <= 5; i++) {
+      forwarder.forward([
+        `1${i}`,
+        'insert',
+        json(['data', messages.insert('issues', {id: `issue_${i}`})]),
+      ]);
+      await Promise.resolve(); // Simulates async await boundary between stream.changes items
+    }
+
+    expect(sendBatchSpy).not.toHaveBeenCalled();
+
+    await nextEventLoopTurn();
+
+    expect(sendBatchSpy).toHaveBeenCalledTimes(1);
+    const batchedChanges = sendBatchSpy.mock.calls[0][0];
+    expect(batchedChanges).toHaveLength(5);
+    expect(receiver.queued).toBe(6);
+  });
+
   test('flushes immediately when batch reaches FORWARD_BATCH_SIZE (64)', () => {
     const forwarder = new Forwarder(createSilentLogContext());
     const [sub, _, receiver] = createSubscriber('00', true);

--- a/packages/zero-cache/src/services/change-streamer/forwarder.ts
+++ b/packages/zero-cache/src/services/change-streamer/forwarder.ts
@@ -18,6 +18,8 @@ export type ProgressMonitorOptions = {
   clearTimeoutFn?: typeof clearTimeout | undefined;
 };
 
+const FORWARD_BATCH_SIZE = 64;
+
 export class Forwarder {
   readonly #lc: LogContext;
   readonly #setTimeout: typeof setTimeout;
@@ -38,6 +40,9 @@ export class Forwarder {
     'Time replication waits at flow-control checkpoints.',
   );
   #inTransaction = false;
+
+  #pending: WatermarkedChange[] = [];
+  #flushScheduled = false;
 
   #currentBroadcast: Broadcast | undefined;
   #progressMonitor: NodeJS.Timeout | undefined;
@@ -205,6 +210,7 @@ export class Forwarder {
    * currently being streamed.
    */
   add(sub: Subscriber) {
+    this.#flushPendingWithoutTracking();
     if (this.#inTransaction) {
       this.#queued.add(sub);
     } else {
@@ -213,6 +219,7 @@ export class Forwarder {
   }
 
   remove(sub: Subscriber) {
+    this.#flushPendingWithoutTracking();
     this.#active.delete(sub);
     this.#queued.delete(sub);
     sub.close();
@@ -223,16 +230,31 @@ export class Forwarder {
    * two components have an equivalent interpretation of whether a Transaction is
    * currently being streamed.
    *
-   * This version of forward is fire-and-forget, with no flow control. The
-   * change-streamer should call and await {@link forwardWithFlowControl()}
-   * occasionally to avoid memory blowup.
+   * This version of forward buffers changes across the current event loop turn
+   * and dispatches them in batches. The change-streamer should call and await
+   * {@link forwardWithFlowControl()} occasionally to avoid memory blowup.
    */
   forward(entry: WatermarkedChange) {
-    Broadcast.withoutTracking(this.#active.values(), entry);
+    this.#pending.push(entry);
+
+    if (
+      this.#queued.size > 0 &&
+      (entry[1] === 'commit' || entry[1] === 'rollback')
+    ) {
+      this.#flushPendingWithoutTracking();
+    }
     this.#updateActiveSubscribers(entry[1]);
+
+    if (this.#pending.length >= FORWARD_BATCH_SIZE) {
+      this.#flushPendingWithoutTracking();
+    } else if (!this.#flushScheduled && this.#pending.length > 0) {
+      this.#flushScheduled = true;
+      queueMicrotask(() => this.#flushPendingWithoutTracking());
+    }
   }
 
   sendStatus(status: Status) {
+    this.#flushPendingWithoutTracking();
     for (const sub of this.#active.values()) {
       sub.sendStatus(status);
     }
@@ -243,11 +265,14 @@ export class Forwarder {
    * Promise that resolves when replication should continue.
    */
   async forwardWithFlowControl(entry: WatermarkedChange) {
+    this.#pending.push(entry);
+
+    const batch = this.#drainPending();
     const start = performance.now();
     const broadcast = new Broadcast(
       this.#lc,
       this.#active.values(),
-      entry,
+      batch,
       this.#earlyReleaseOptions,
     );
     this.#updateActiveSubscribers(entry[1]);
@@ -266,6 +291,23 @@ export class Forwarder {
       if (this.#currentBroadcast === broadcast) {
         this.#currentBroadcast = undefined;
       }
+    }
+  }
+
+  #drainPending(): WatermarkedChange[] {
+    this.#flushScheduled = false;
+    if (this.#pending.length === 0) {
+      return [];
+    }
+    const batch = this.#pending;
+    this.#pending = [];
+    return batch;
+  }
+
+  #flushPendingWithoutTracking() {
+    const batch = this.#drainPending();
+    if (batch.length > 0) {
+      Broadcast.withoutTracking(this.#active.values(), batch);
     }
   }
 

--- a/packages/zero-cache/src/services/change-streamer/forwarder.ts
+++ b/packages/zero-cache/src/services/change-streamer/forwarder.ts
@@ -43,6 +43,7 @@ export class Forwarder {
 
   #pending: WatermarkedChange[] = [];
   #flushScheduled = false;
+  #flushImmediateId: NodeJS.Immediate | undefined = undefined;
 
   #currentBroadcast: Broadcast | undefined;
   #progressMonitor: NodeJS.Timeout | undefined;
@@ -202,6 +203,10 @@ export class Forwarder {
 
   stopProgressMonitor() {
     clearInterval(this.#progressMonitor);
+    if (this.#flushImmediateId !== undefined) {
+      clearImmediate(this.#flushImmediateId);
+      this.#flushImmediateId = undefined;
+    }
   }
 
   /**
@@ -249,7 +254,9 @@ export class Forwarder {
       this.#flushPendingWithoutTracking();
     } else if (!this.#flushScheduled && this.#pending.length > 0) {
       this.#flushScheduled = true;
-      queueMicrotask(() => this.#flushPendingWithoutTracking());
+      this.#flushImmediateId = setImmediate(() =>
+        this.#flushPendingWithoutTracking(),
+      );
     }
   }
 
@@ -295,6 +302,10 @@ export class Forwarder {
   }
 
   #drainPending(): WatermarkedChange[] {
+    if (this.#flushImmediateId !== undefined) {
+      clearImmediate(this.#flushImmediateId);
+      this.#flushImmediateId = undefined;
+    }
     this.#flushScheduled = false;
     if (this.#pending.length === 0) {
       return [];

--- a/packages/zero-cache/src/services/change-streamer/subscriber.ts
+++ b/packages/zero-cache/src/services/change-streamer/subscriber.ts
@@ -160,6 +160,23 @@ export class Subscriber {
     return promiseVoid;
   }
 
+  sendBatch(changes: readonly WatermarkedChange[]): Promise<void> {
+    const promises: Promise<void>[] = [];
+    for (const change of changes) {
+      const p = this.send(change);
+      if (p !== promiseVoid) {
+        promises.push(p);
+      }
+    }
+    if (promises.length === 0) {
+      return promiseVoid;
+    }
+    if (promises.length === 1) {
+      return promises[0];
+    }
+    return Promise.all(promises).then(() => {});
+  }
+
   #initialized = false;
 
   /**

--- a/packages/zero-cache/src/types/streams.test.ts
+++ b/packages/zero-cache/src/types/streams.test.ts
@@ -244,6 +244,10 @@ describe('streams with internal acks', () => {
       void streamOut(lc, producer, ws);
       void streamOutStringified(lc, stringifiedProducer, ws);
     });
+    server.get('/batched', {websocket: true}, ws => {
+      void streamOut(lc, producer, ws, {batched: true});
+      void streamOutStringified(lc, stringifiedProducer, ws, {batched: true});
+    });
 
     // Run the server for real instead of using `injectWS()`, as that has a
     // different behavior for ws.close().
@@ -271,6 +275,26 @@ describe('streams with internal acks', () => {
 
   async function startSizedReceiver() {
     ws = new WebSocket(`http://localhost:${port}/`);
+    return {
+      ws,
+      consumer: await streamInWithSize(lc, ws, messageSchema),
+    };
+  }
+
+  async function startBatchedReceiver() {
+    ws = new WebSocket(`http://localhost:${port}/batched`);
+    return {
+      ws,
+      consumer: (await streamIn(
+        lc,
+        ws,
+        messageSchema,
+      )) as Subscription<Message>,
+    };
+  }
+
+  async function startBatchedSizedReceiver() {
+    ws = new WebSocket(`http://localhost:${port}/batched`);
     return {
       ws,
       consumer: await streamInWithSize(lc, ws, messageSchema),
@@ -582,5 +606,164 @@ describe('streams with internal acks', () => {
       err = e;
     }
     expect(err).toBeInstanceOf(Error);
+  });
+
+  describe('batched streaming', () => {
+    test('eagerly batches messages under burst traffic and preserves ACKs', async () => {
+      const rawFrames: Array<{id: number; msg?: Message; batch?: Message[]}> =
+        [];
+      const total = 50;
+
+      const {ws: clientWs, consumer} = await startBatchedReceiver();
+      clientWs.on('message', data => {
+        try {
+          rawFrames.push(JSON.parse(data.toString()));
+        } catch {
+          // ignore non-json
+        }
+      });
+
+      for (let i = 0; i < total; i++) {
+        producer.push({from: i, to: i + 1, str: 'burst-' + i});
+      }
+
+      const received: Message[] = [];
+      for await (const msg of consumer) {
+        received.push(msg);
+        if (received.length === total) {
+          break;
+        }
+      }
+
+      expect(received).toHaveLength(total);
+      for (let i = 0; i < total; i++) {
+        expect(received[i]).toEqual({from: i, to: i + 1, str: 'burst-' + i});
+        expect(await consumed.dequeue()).toEqual({
+          from: i,
+          to: i + 1,
+          str: 'burst-' + i,
+        });
+      }
+
+      // Verify that batching actually happened: fewer frames than individual messages
+      expect(rawFrames.length).toBeLessThan(total);
+      expect(
+        rawFrames.some(f => Array.isArray(f.batch) && f.batch.length > 1),
+      ).toBe(true);
+    });
+
+    test('batched stringified stream', async () => {
+      const total = 25;
+      for (let i = 0; i < total; i++) {
+        stringifiedProducer.push(
+          JSON.stringify({from: i, to: i + 1, str: 'stringified-' + i}),
+        );
+      }
+
+      const {consumer} = await startBatchedReceiver();
+      const received: Message[] = [];
+      for await (const msg of consumer) {
+        received.push(msg);
+        if (received.length === total) {
+          break;
+        }
+      }
+
+      expect(received).toHaveLength(total);
+      for (let i = 0; i < total; i++) {
+        expect(received[i]).toEqual({
+          from: i,
+          to: i + 1,
+          str: 'stringified-' + i,
+        });
+      }
+    });
+
+    test('batched streaming with streamInWithSize assigns proportionate sizes', async () => {
+      const total = 20;
+      for (let i = 0; i < total; i++) {
+        producer.push({from: i, to: i + 1, str: 'sized-' + i});
+      }
+
+      const {consumer} = await startBatchedSizedReceiver();
+      let count = 0;
+      for await (const {data, size} of consumer) {
+        expect(data).toEqual({
+          from: count,
+          to: count + 1,
+          str: 'sized-' + count,
+        });
+        expect(size).toBeGreaterThan(0);
+        count++;
+        if (count === total) {
+          break;
+        }
+      }
+      expect(count).toBe(total);
+    });
+
+    test('backward compatibility: receiver handles mixed msg and batch frames', async () => {
+      const {consumer} = await startReceiver();
+
+      // Send single frame
+      producer.push({from: 100, to: 101, str: 'single'});
+      for await (const msg of consumer) {
+        expect(msg).toEqual({from: 100, to: 101, str: 'single'});
+        break;
+      }
+      expect(await consumed.dequeue()).toEqual({
+        from: 100,
+        to: 101,
+        str: 'single',
+      });
+    });
+
+    test('receiver handles mixed msg and batch frames from raw websocket', async () => {
+      let serverWs: WebSocket | undefined;
+      const wsServer = Fastify();
+      await wsServer.register(websocket);
+      wsServer.get('/mixed', {websocket: true}, client => {
+        serverWs = client;
+      });
+      const mixedPort = 8000 + Math.floor(randInt(0, 1000));
+      await wsServer.listen({port: mixedPort});
+
+      const clientWs = new WebSocket(`http://localhost:${mixedPort}/mixed`);
+      const receiver = await streamIn(lc, clientWs, messageSchema);
+
+      await vi.waitFor(() => expect(serverWs).toBeDefined());
+
+      // Send single frame
+      serverWs?.send(
+        JSON.stringify({id: 1, msg: {from: 1, to: 2, str: 'single'}}),
+      );
+
+      // Send batched frame
+      serverWs?.send(
+        JSON.stringify({
+          id: 2,
+          batch: [
+            {from: 2, to: 3, str: 'batch-1'},
+            {from: 3, to: 4, str: 'batch-2'},
+          ],
+        }),
+      );
+
+      const received: Message[] = [];
+      for await (const msg of receiver) {
+        received.push(msg);
+        if (received.length === 3) {
+          break;
+        }
+      }
+
+      expect(received).toEqual([
+        {from: 1, to: 2, str: 'single'},
+        {from: 2, to: 3, str: 'batch-1'},
+        {from: 3, to: 4, str: 'batch-2'},
+      ]);
+
+      await wsServer.close();
+    });
   });
 });

--- a/packages/zero-cache/src/types/streams.ts
+++ b/packages/zero-cache/src/types/streams.ts
@@ -58,6 +58,15 @@ export type Source<T> = AsyncIterable<T> & {
    * asynchronously as the receiving end processes the messages.
    */
   pipeline?: AsyncIterable<{value: T; consumed: () => void}> | undefined;
+
+  /**
+   * Pipelined batching support: eagerly drains available queued messages up to `maxBatch`.
+   */
+  pipelineBatched?:
+    | ((
+        maxBatch?: number,
+      ) => AsyncIterable<{values: T[]; consumed: () => void}> | undefined)
+    | undefined;
 };
 
 export type Sink<T> = {
@@ -229,12 +238,18 @@ export type Sized<T> = {
   size: number;
 };
 
+export type StreamOutOptions = {
+  batched?: boolean | undefined;
+  maxBatchSize?: number | undefined;
+};
+
 export function streamOut<T extends JSONValue>(
   lc: LogContext,
   source: Source<T>,
   sink: WebSocket,
+  options?: StreamOutOptions | undefined,
 ): Promise<void> {
-  return streamOutInternal(lc, source, sink, BigIntJSON.stringify);
+  return streamOutInternal(lc, source, sink, BigIntJSON.stringify, options);
 }
 
 /**
@@ -244,8 +259,9 @@ export function streamOutStringified(
   lc: LogContext,
   source: Source<string>,
   sink: WebSocket,
+  options?: StreamOutOptions | undefined,
 ): Promise<void> {
-  return streamOutInternal(lc, source, sink, json => json);
+  return streamOutInternal(lc, source, sink, json => json, options);
 }
 
 async function streamOutInternal<T extends JSONValue>(
@@ -253,6 +269,7 @@ async function streamOutInternal<T extends JSONValue>(
   source: Source<T>,
   sink: WebSocket,
   stringify: (payload: T) => string,
+  options?: StreamOutOptions | undefined,
 ): Promise<void> {
   sendPingsForLiveness(lc, sink, PING_INTERVAL_MS);
 
@@ -274,6 +291,36 @@ async function streamOutInternal<T extends JSONValue>(
   try {
     let nextID = 0;
     const {pipeline} = source;
+    const batched = options?.batched ?? false;
+    const maxBatchSize = options?.maxBatchSize ?? 64;
+
+    if (batched && source.pipelineBatched) {
+      const batchedIterable = source.pipelineBatched(maxBatchSize);
+      if (batchedIterable) {
+        lc.debug?.(
+          `started batched outbound stream (maxBatchSize=${maxBatchSize})`,
+        );
+        for await (const {values, consumed} of batchedIterable) {
+          const id = ++nextID;
+          const data =
+            values.length === 1
+              ? `{"id":${id},"msg":${stringify(values[0])}}`
+              : `{"id":${id},"batch":[${values.map(stringify).join(',')}]}`;
+          sink.send(data);
+
+          void (async () => {
+            const {ack} = await acks.dequeue();
+            if (ack !== id) {
+              throw new Error(`Unexpected ack for ${id}: ${ack}`);
+            }
+            consumed();
+          })().catch(e => closer.close(e));
+        }
+        closer.close();
+        return;
+      }
+    }
+
     if (pipeline) {
       lc.debug?.(`started pipelined outbound stream`);
       for await (const {value: msg, consumed} of pipeline) {
@@ -334,9 +381,9 @@ export function streamInWithSize<T extends JSONValue>(
   source: WebSocket,
   schema: v.Type<T>,
 ): Promise<Source<Sized<T>>> {
-  return streamInInternal(lc, source, schema, (data, frame) => ({
+  return streamInInternal(lc, source, schema, (data, _frame, _id, size) => ({
     data,
-    size: frame.length,
+    size,
   }));
 }
 
@@ -344,21 +391,24 @@ async function streamInInternal<T extends JSONValue, Out>(
   lc: LogContext,
   source: WebSocket,
   schema: v.Type<T>,
-  transform: (data: T, frame: string, id: number) => Out,
+  transform: (data: T, frame: string, id: number, size: number) => Out,
 ): Promise<Source<Out>> {
   expectPingsForLiveness(lc, source, PING_INTERVAL_MS);
 
   const streamedSchema = v.object({
-    msg: schema,
     id: v.number(),
+    msg: schema.optional(),
+    batch: v.array(schema).optional(),
   });
 
-  const sink: Subscription<Out, {id: number; data: Out}> = new Subscription<
-    Out,
-    {id: number; data: Out}
-  >(
+  type SinkEntry = {
+    consumed: () => void;
+    data: Out;
+  };
+
+  const sink: Subscription<Out, SinkEntry> = new Subscription<Out, SinkEntry>(
     {
-      consumed: ({id}) => source.send(JSON.stringify({ack: id} satisfies Ack)),
+      consumed: ({consumed}) => consumed(),
       cleanup: () => closer.close(),
     },
     ({data}) => data,
@@ -374,10 +424,41 @@ async function streamInInternal<T extends JSONValue, Out>(
     }
     try {
       const value = BigIntJSON.parse(data);
-      const msg = v.parse(value, streamedSchema, 'passthrough');
-      // Enable for debugging. Otherwise too verbose.
-      // lc.debug?.(`received`, data);
-      sink.push({id: msg.id, data: transform(msg.msg, data, msg.id)});
+      const parsed = v.parse(value, streamedSchema, 'passthrough');
+      const {id, msg, batch} = parsed;
+
+      const sendAck = () => {
+        if (source.readyState === source.OPEN) {
+          source.send(JSON.stringify({ack: id} satisfies Ack));
+        }
+      };
+
+      if (batch !== undefined) {
+        let remaining = batch.length;
+        if (remaining === 0) {
+          sendAck();
+          return;
+        }
+        const onConsumed = () => {
+          if (--remaining === 0) {
+            sendAck();
+          }
+        };
+        const itemSize = Math.max(1, Math.round(data.length / batch.length));
+        for (const item of batch) {
+          sink.push({
+            consumed: onConsumed,
+            data: transform(item, data, id, itemSize),
+          });
+        }
+      } else if (msg !== undefined) {
+        sink.push({
+          consumed: sendAck,
+          data: transform(msg, data, id, data.length),
+        });
+      } else {
+        throw new Error(`Message ${id} has neither "msg" nor "batch"`);
+      }
     } catch (e) {
       closer.close(e);
     }

--- a/packages/zero-cache/src/types/subscription.test.ts
+++ b/packages/zero-cache/src/types/subscription.test.ts
@@ -724,4 +724,82 @@ describe('types/subscription', () => {
       await expect(raced).rejects.toThrow('canceled');
     });
   });
+
+  describe('pipelineBatched', () => {
+    test('eagerly drains multiple queued messages up to maxBatch', async () => {
+      const consumed = new Set<number>();
+      const cleanup = vi.fn();
+      const results: Promise<Result>[] = [];
+
+      const sub = Subscription.create<number>({
+        cleanup,
+        consumed: m => consumed.add(m),
+      });
+
+      for (let i = 0; i < 10; i++) {
+        results.push(sub.push(i).result);
+      }
+
+      const batched = sub.pipelineBatched(5);
+      assert(batched, 'must support batched pipeline');
+
+      const batches: number[][] = [];
+      for await (const {values, consumed: signalConsumed} of batched) {
+        batches.push(values);
+        signalConsumed();
+        if (batches.length === 2) {
+          break;
+        }
+      }
+
+      expect(batches).toEqual([
+        [0, 1, 2, 3, 4],
+        [5, 6, 7, 8, 9],
+      ]);
+      expect(consumed).toEqual(new Set([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]));
+      for (const r of results) {
+        expect(await r).toBe('consumed');
+      }
+    });
+
+    test('yields single messages as they arrive when queue is empty', async () => {
+      const sub = Subscription.create<number>();
+      const batched = sub.pipelineBatched(10);
+      assert(batched, 'must support batched pipeline');
+
+      const it = batched[Symbol.asyncIterator]();
+
+      const nextPromise = it.next();
+      sub.push(42);
+
+      const res = await nextPromise;
+      expect(res.done).toBe(false);
+      expect(res.value?.values).toEqual([42]);
+      res.value?.consumed();
+    });
+
+    test('cleanup on cancel with pending batch', async () => {
+      const cleanup = vi.fn();
+      const sub = Subscription.create<number>({cleanup});
+      const results: Promise<Result>[] = [];
+      for (let i = 0; i < 5; i++) {
+        results.push(sub.push(i).result);
+      }
+
+      const batched = sub.pipelineBatched(3);
+      assert(batched, 'must support batched pipeline');
+
+      const it = batched[Symbol.asyncIterator]();
+      const first = await it.next();
+      expect(first.value?.values).toEqual([0, 1, 2]);
+
+      // Cancel before consuming first batch
+      sub.cancel();
+
+      for (const r of results) {
+        expect(await r).toBe('unconsumed');
+      }
+      expect(cleanup).toHaveBeenCalledWith([0, 1, 2, 3, 4], undefined);
+    });
+  });
 });

--- a/packages/zero-cache/src/types/subscription.ts
+++ b/packages/zero-cache/src/types/subscription.ts
@@ -261,6 +261,100 @@ export class Subscription<T, M = T> implements Source<T>, Sink<M> {
       : undefined;
   }
 
+  pipelineBatched = (
+    maxBatch = 64,
+  ): AsyncIterable<{values: T[]; consumed: () => void}> | undefined =>
+    this.#pipelineEnabled
+      ? {[Symbol.asyncIterator]: () => this.#pipelineBatched(maxBatch)}
+      : undefined;
+
+  #pipelineBatched(
+    maxBatch: number,
+  ): AsyncIterator<{values: T[]; consumed: () => void}> {
+    return {
+      next: async () => {
+        const entries: Entry<M>[] = [];
+
+        while (this.#messages.length > 0 && entries.length < maxBatch) {
+          const head = this.#messages[0];
+          if (head === 'terminus') {
+            if (entries.length > 0) {
+              break;
+            }
+            this.#messages.shift();
+            this.cancel();
+            return {value: undefined, done: true};
+          }
+          const entry = this.#messages.shift() as Entry<M>;
+          entries.push(entry);
+        }
+
+        if (entries.length > 0) {
+          for (const e of entries) {
+            this.#consuming.add(e);
+          }
+          return {
+            value: {
+              values: entries.map(e => this.#publish(e.value)),
+              consumed: () => {
+                for (const e of entries) {
+                  this.#consumed(e);
+                }
+              },
+            },
+            done: false,
+          };
+        }
+
+        if (this.#sentinel === 'canceled') {
+          return {value: undefined, done: true};
+        }
+        if (this.#sentinel) {
+          return Promise.reject(this.#sentinel);
+        }
+
+        const consumer = resolver<Entry<M> | null>();
+        this.#consumers.push(consumer);
+
+        const result = await consumer.promise;
+        if (result === null) {
+          return {value: undefined, done: true};
+        }
+
+        entries.push(result);
+
+        while (this.#messages.length > 0 && entries.length < maxBatch) {
+          if (this.#messages[0] === 'terminus') {
+            break;
+          }
+          const entry = this.#messages.shift() as Entry<M>;
+          entries.push(entry);
+        }
+
+        for (const e of entries) {
+          this.#consuming.add(e);
+        }
+
+        return {
+          value: {
+            values: entries.map(e => this.#publish(e.value)),
+            consumed: () => {
+              for (const e of entries) {
+                this.#consumed(e);
+              }
+            },
+          },
+          done: false,
+        };
+      },
+
+      return: value => {
+        this.cancel();
+        return Promise.resolve({value, done: true});
+      },
+    };
+  }
+
   #pipeline(): AsyncIterator<{value: T; consumed: () => void}> {
     return {
       next: async () => {


### PR DESCRIPTION
### Summary

Batches Replication Manager (RM) WebSocket messages to View-Syncers (VS) across event-loop turns using macrotask coalescing, eliminating native `writev` socket syscall saturation under multi-subscriber fan-out and scaling sustainable cluster throughput from 1,500 w/s to 3,600 w/s (+140%).

### Key Changes

1. **Macrotask Coalescing (`Forwarder`)**:
   - Accumulates incoming WAL changes into batches (up to 64 items) flushed via `setImmediate` (Check phase), coalescing `for await` iterations across TCP read bursts without premature flushing at intermediate V8 microtask checkpoints.
   - Flushes immediately on backpressure (`forwardWithFlowControl`), status updates (`sendStatus`), or subscriber activation boundaries.

2. **Batched Transport Pipeline (`Subscription` & `streams.ts`)**:
   - Added `pipelineBatched()` to `Subscription` to eagerly drain queued entries in a single loop turn while preserving zero added latency at idle.
   - Extended streaming wire protocol to emit and parse `{"id": N, "batch": [...]}` frames with single cumulative ACKs `{ack: id}`.
   - Added `wsBatched=true` query negotiation in `ChangeStreamerHttpClient` for backward compatibility.

---

### Verification

#### Interesting New Tests
* `packages/zero-cache/src/services/change-streamer/forwarder.test.ts`: Verifies `Forwarder` does not prematurely flush across `for await` microtask checkpoints (`await Promise.resolve()`), deferring batch flush until the macrotask Check phase.

#### Manual Testing & Benchmarking
Tested on Cloud Zero staging (`ehbb3e9afve7c5ps`: 1 RM pod @ 2 vCPU, 8 View-Syncer pods @ 3 vCPU) under `forum:hot` (12 clients, 2,000 ms E2E Serving Lag SLO):

* **Baseline (`c5e9e31f`) Ceiling**: 1,500 w/s certified. Fails at 1,600 w/s (lag slope +12.2 seq/s, p99 E2E lag 3.9s, drain delay 2.3s).
* **Batched (`aa106cbd`) Ceiling**:
  * **3,600 w/s (180s / 3m Soak)**: **PASS (Certified)** — Sustained 648,000 writes across 3 minutes under the 2s SLO (p99 E2E lag = 1,834.6 ms, p50 = 105.5 ms, 2.4× throughput gain).
  * **3,700 w/s (90s Exploration)**: **PASS** (p99 E2E lag = 1,567.6 ms, lag slope = -12.94 seq/s, instantaneous 0.3s drain).
  * **Saturation Point**: Breaks at 3,800 w/s (lag slope surges to +330.2 seq/s, p99 lag reaches 15.6s).
